### PR TITLE
Fix spell error in Russian translation

### DIFF
--- a/accounts/ru/acctchrt_common.gnucash-xea
+++ b/accounts/ru/acctchrt_common.gnucash-xea
@@ -322,14 +322,14 @@
   <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
-  <act:name>Кабельное телевиденье</act:name>
+  <act:name>Кабельное телевидение</act:name>
   <act:id type="new">a1393344fb199f08f751ac3154694e87</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>USD</cmdty:id>
   </act:commodity>
-  <act:description>Кабельное телевиденье</act:description>
+  <act:description>Кабельное телевидение</act:description>
   <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">


### PR DESCRIPTION
There is a small typo in a translation of the word "television" into Russian. This commit fixes it.
