### PR TITLE
Use libsecret if available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1106,6 +1106,13 @@ then
       PKG_CHECK_MODULES(GNOME_KEYRING, gnome-keyring-1 >= "0.6",
           [AC_DEFINE(HAVE_GNOME_KEYRING,1,[System has gnome-keyring 0.6 or better])],
           [AC_DEFINE(HAVE_NO_KEYRING,1,[System has no suitable keyring service])])
+
+      PKG_CHECK_MODULES(LIBSECRET, libsecret-1 >= "0.18",
+          [AC_DEFINE(HAVE_LIBSECRET,1,[System has libsecret 0.18 or better])],
+          [AC_DEFINE(HAVE_NO_LIBSECRET,1,[System has no suitable libsecret service])])
+      AC_SUBST(LIBSECRET_CFLAGS)
+      AC_SUBST(LIBSECRET_LIBS)
+      ;;
   esac
 
   ### ----------------------------------------------------------------------

--- a/src/gnome-utils/Makefile.am
+++ b/src/gnome-utils/Makefile.am
@@ -17,6 +17,7 @@ AM_CPPFLAGS = \
   ${GLIB_CFLAGS} \
   ${GTK_CFLAGS} \
   ${GNOME_KEYRING_CFLAGS} \
+  ${LIBSECRET_CFLAGS} \
   ${GUILE_CFLAGS} \
   ${QOF_CFLAGS} \
   ${LIBGDA_CFLAGS} \
@@ -204,6 +205,7 @@ libgncmod_gnome_utils_la_LIBADD = \
   ${top_builddir}/src/libqof/qof/libgnc-qof.la \
   ${GTK_LIBS} \
   ${GNOME_KEYRING_LIBS} \
+  ${LIBSECRET_LIBS} \
   ${GUILE_LIBS} \
   ${GLIB_LIBS} \
   ${DB_LIBS} \


### PR DESCRIPTION
This patch provides libsecret [1] support to gnucash since gnome-keyring has been deprecated. It will check for an installed libsecret version and will use it in favor of gnome-keyring.

Since it is not recommended to use SECRET_SCHEMA_COMPAT_NETWORK for new uses, it uses its own defined scheme to store the credentials if enable-compat-network-schema is set or gnome-keyring has not been detected. If gnome-keyring and libsecret are both available, it will use libsecret too but with the SECRET_SCHEMA_COMPAT_NETWORK schema.
