### PR TITLE
Bug 699687 - Add a configuration option to not display "since last run" ...

### DIFF
--- a/src/gnome/dialog-sx-editor.c
+++ b/src/gnome/dialog-sx-editor.c
@@ -1661,6 +1661,7 @@ sxed_excal_update_adapt_cb(GtkObject *o, gpointer ud)
 void
 on_sx_check_toggled_cb (GtkWidget *togglebutton, gpointer user_data)
 {
+    GtkWidget *widget_auto;
     GtkWidget *widget_notify;
     GHashTable *table;
 
@@ -1669,9 +1670,21 @@ on_sx_check_toggled_cb (GtkWidget *togglebutton, gpointer user_data)
 
     /* We need to use the hash table to find the required widget to activate. */
     table = g_object_get_data(G_OBJECT(user_data), "prefs_widget_hash");
+
+    /* "Auto-create" enables "notify before creation" setting */
+    widget_auto = g_hash_table_lookup(table, "pref/" GNC_PREFS_GROUP_SXED "/" GNC_PREF_CREATE_AUTO);
     widget_notify = g_hash_table_lookup(table, "pref/" GNC_PREFS_GROUP_SXED "/" GNC_PREF_NOTIFY);
 
-    if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(togglebutton)))
+    if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget_auto)))
+        gtk_widget_set_sensitive(widget_notify, TRUE);
+    else
+        gtk_widget_set_sensitive(widget_notify, FALSE);
+
+    /* "Run when opened" enables "show notification window" setting */
+    widget_auto = g_hash_table_lookup(table, "pref/" GNC_PREFS_GROUP_STARTUP "/" GNC_PREF_RUN_AT_FOPEN);
+    widget_notify = g_hash_table_lookup(table, "pref/" GNC_PREFS_GROUP_STARTUP "/" GNC_PREF_SHOW_AT_FOPEN);
+
+    if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget_auto)))
         gtk_widget_set_sensitive(widget_notify, TRUE);
     else
         gtk_widget_set_sensitive(widget_notify, FALSE);

--- a/src/gnome/dialog-sx-editor.h
+++ b/src/gnome/dialog-sx-editor.h
@@ -34,6 +34,10 @@
 #define GNC_PREF_CREATE_AUTO "create-auto"
 #define GNC_PREF_NOTIFY      "notify"
 
+#define GNC_PREFS_GROUP_STARTUP "dialogs.sxs.since-last-run"
+#define GNC_PREF_RUN_AT_FOPEN   "show-at-file-open"
+#define GNC_PREF_SHOW_AT_FOPEN  "show-notify-window-at-file-open"
+
 typedef struct _GncSxEditorDialog GncSxEditorDialog;
 
 GncSxEditorDialog* gnc_ui_scheduled_xaction_editor_dialog_create(SchedXaction *sx,

--- a/src/gnome/dialog-sx-since-last-run.c
+++ b/src/gnome/dialog-sx-since-last-run.c
@@ -63,7 +63,8 @@ G_GNUC_UNUSED static QofLogModule log_module = GNC_MOD_GUI_SX;
 #define DIALOG_SX_SINCE_LAST_RUN_CM_CLASS "dialog-sx-since-last-run"
 
 #define GNC_PREFS_GROUP        "dialogs.sxs.since-last-run"
-#define GNC_PREF_SHOW_AT_FOPEN "show-at-file-open"
+#define GNC_PREF_RUN_AT_FOPEN  "show-at-file-open"
+#define GNC_PREF_SHOW_AT_FOPEN "show-notify-window-at-file-open"
 
 struct _GncSxSinceLastRunDialog
 {
@@ -801,7 +802,7 @@ gnc_sx_sxsincelast_book_opened(void)
     GncSxInstanceModel *inst_model;
     GncSxSummary summary;
 
-    if (!gnc_prefs_get_bool (GNC_PREFS_GROUP, GNC_PREF_SHOW_AT_FOPEN))
+    if (!gnc_prefs_get_bool (GNC_PREFS_GROUP, GNC_PREF_RUN_AT_FOPEN))
         return;
 
     if (qof_book_is_readonly(gnc_get_current_book()))
@@ -824,6 +825,9 @@ gnc_sx_sxsincelast_book_opened(void)
     {
         if (summary.num_auto_create_no_notify_instances != 0)
         {
+            if (!gnc_prefs_get_bool(GNC_PREFS_GROUP, GNC_PREF_SHOW_AT_FOPEN))
+                return;
+
             gnc_info_dialog
             (NULL,
              ngettext

--- a/src/gnome/gschemas/org.gnucash.dialogs.sxs.gschema.xml.in.in
+++ b/src/gnome/gschemas/org.gnucash.dialogs.sxs.gschema.xml.in.in
@@ -14,8 +14,13 @@
     </key>
     <key name="show-at-file-open" type="b">
       <default>true</default>
-      <summary>Show "since last run" dialog when a file is opened.</summary>
-      <description>This setting controls whether the scheduled transactions "since last run" dialog is shown automatically when a data file is opened. This includes the initial opening of the data file when GnuCash starts. If this setting is active, show the dialog, otherwise it is not shown.</description>
+      <summary>Run "since last run" dialog when a file is opened.</summary>
+      <description>This setting controls whether the scheduled transactions "since last run" processing is run automatically when a data file is opened. This includes the initial opening of the data file when GnuCash starts. If this setting is active, run the "since last run" process, otherwise it is not run.</description>
+    </key>
+    <key name="show-notify-window-at-file-open" type="b">
+      <default>true</default>
+      <summary>Show "since last run" notification dialog when a file is opened.</summary>
+      <description>This setting controls whether the scheduled transactions notification-only "since last run" dialog is shown when a data file is opened (if "since last run" processing is enabled on file open).  This includes the initial opening of the data file when GnuCash starts.  If this setting is active, show the dialog, otherwise it is not shown.</description>
     </key>
   </schema>
 

--- a/src/gnome/gtkbuilder/dialog-sx.glade
+++ b/src/gnome/gtkbuilder/dialog-sx.glade
@@ -105,7 +105,7 @@
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="border_width">6</property>
-        <property name="n_rows">8</property>
+        <property name="n_rows">9</property>
         <property name="n_columns">4</property>
         <property name="column_spacing">12</property>
         <child>
@@ -113,7 +113,7 @@
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="xalign">0</property>
-            <property name="label" translatable="yes">&lt;b&gt;Since Last Run Dialog&lt;/b&gt;</property>
+            <property name="label" translatable="yes">&lt;b&gt;Since Last Run&lt;/b&gt;</property>
             <property name="use_markup">True</property>
           </object>
           <packing>
@@ -128,8 +128,8 @@
             <property name="xalign">0</property>
           </object>
           <packing>
-            <property name="top_attach">2</property>
-            <property name="bottom_attach">3</property>
+            <property name="top_attach">3</property>
+            <property name="bottom_attach">4</property>
             <property name="x_options">GTK_FILL</property>
             <property name="y_options"></property>
           </packing>
@@ -143,8 +143,8 @@
             <property name="use_markup">True</property>
           </object>
           <packing>
-            <property name="top_attach">3</property>
-            <property name="bottom_attach">4</property>
+            <property name="top_attach">4</property>
+            <property name="bottom_attach">5</property>
             <property name="x_options">GTK_FILL</property>
             <property name="y_options"></property>
           </packing>
@@ -155,10 +155,11 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
-            <property name="tooltip_text" translatable="yes">Show the "since last run" window when a file is opened.</property>
+            <property name="tooltip_text" translatable="yes">Run the "since last run" process when a file is opened.</property>
             <property name="use_action_appearance">False</property>
             <property name="use_underline">True</property>
             <property name="draw_indicator">True</property>
+            <signal name="toggled" handler="on_sx_check_toggled_cb" swapped="no"/>
           </object>
           <packing>
             <property name="right_attach">4</property>
@@ -167,6 +168,28 @@
             <property name="x_options">GTK_FILL</property>
             <property name="y_options"></property>
             <property name="x_padding">12</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="pref/dialogs.sxs.since-last-run/show-notify-window-at-file-open">
+            <property name="label" translatable="yes">_Show notification window</property>
+            <property name="visible">True</property>
+            <property name="sensitive">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="tooltip_text" translatable="yes">Show the notification window for the "since last run" process when a file is opened.</property>
+            <property name="use_action_appearance">False</property>
+            <property name="use_underline">True</property>
+            <property name="draw_indicator">True</property>
+            <signal name="toggled" handler="on_sx_check_toggled_cb" swapped="no"/>
+          </object>
+          <packing>
+            <property name="right_attach">4</property>
+            <property name="top_attach">2</property>
+            <property name="bottom_attach">3</property>
+            <property name="x_options">GTK_FILL</property>
+            <property name="y_options"></property>
+            <property name="x_padding">30</property>
           </packing>
         </child>
         <child>
@@ -183,8 +206,8 @@
           </object>
           <packing>
             <property name="right_attach">4</property>
-            <property name="top_attach">4</property>
-            <property name="bottom_attach">5</property>
+            <property name="top_attach">5</property>
+            <property name="bottom_attach">6</property>
             <property name="x_options">GTK_FILL</property>
             <property name="y_options"></property>
             <property name="x_padding">12</property>
@@ -207,8 +230,8 @@
             </child>
           </object>
           <packing>
-            <property name="top_attach">6</property>
-            <property name="bottom_attach">7</property>
+            <property name="top_attach">7</property>
+            <property name="bottom_attach">8</property>
             <property name="x_options">GTK_FILL</property>
             <property name="y_options">GTK_FILL</property>
           </packing>
@@ -230,8 +253,8 @@
             </child>
           </object>
           <packing>
-            <property name="top_attach">7</property>
-            <property name="bottom_attach">8</property>
+            <property name="top_attach">8</property>
+            <property name="bottom_attach">9</property>
             <property name="x_options">GTK_FILL</property>
             <property name="y_options">GTK_FILL</property>
           </packing>
@@ -276,8 +299,8 @@
           <packing>
             <property name="left_attach">1</property>
             <property name="right_attach">2</property>
-            <property name="top_attach">7</property>
-            <property name="bottom_attach">8</property>
+            <property name="top_attach">8</property>
+            <property name="bottom_attach">9</property>
             <property name="x_options">GTK_FILL</property>
             <property name="y_options">GTK_FILL</property>
           </packing>
@@ -322,8 +345,8 @@
           <packing>
             <property name="left_attach">1</property>
             <property name="right_attach">2</property>
-            <property name="top_attach">6</property>
-            <property name="bottom_attach">7</property>
+            <property name="top_attach">7</property>
+            <property name="bottom_attach">8</property>
             <property name="x_options">GTK_FILL</property>
             <property name="y_options">GTK_FILL</property>
           </packing>
@@ -339,11 +362,12 @@
             <property name="use_action_appearance">False</property>
             <property name="use_underline">True</property>
             <property name="draw_indicator">True</property>
+            <signal name="toggled" handler="on_sx_check_toggled_cb" swapped="no"/>
           </object>
           <packing>
             <property name="right_attach">4</property>
-            <property name="top_attach">5</property>
-            <property name="bottom_attach">6</property>
+            <property name="top_attach">6</property>
+            <property name="bottom_attach">7</property>
             <property name="x_options">GTK_FILL</property>
             <property name="y_options"></property>
             <property name="x_padding">30</property>


### PR DESCRIPTION
...window when opening a file

In Preferences -> Scheduled Transactions:
  Rename "Since Last Run Dialogue" to "Since Last Run"
  Add "Show notification window" option under "Run when data file opened"
