### PR TITLE
Qofcollection C++ implementation

### DIFF
--- a/src/libqof/qof/qofid.cpp
+++ b/src/libqof/qof/qofid.cpp
@@ -177,7 +177,7 @@ collection_compare_cb (QofInstance *ent, gpointer user_data)
     {
         return;
     }
-    value = *(gint*)qof_collection_get_data(target);
+    value = GPOINTER_TO_INT(qof_collection_get_data(target));
     if (value != 0)
     {
         return;
@@ -186,7 +186,7 @@ collection_compare_cb (QofInstance *ent, gpointer user_data)
     if (guid_equal(guid, guid_null()))
     {
         value = -1;
-        qof_collection_set_data(target, &value);
+        qof_collection_set_data(target, GINT_TO_POINTER(value));
         return;
     }
     g_return_if_fail (target->e_type == ent->e_type);
@@ -194,11 +194,11 @@ collection_compare_cb (QofInstance *ent, gpointer user_data)
     if ( e == NULL )
     {
         value = 1;
-        qof_collection_set_data(target, &value);
+        qof_collection_set_data(target, GINT_TO_POINTER(value));
         return;
     }
     value = 0;
-    qof_collection_set_data(target, &value);
+    qof_collection_set_data(target, GINT_TO_POINTER(value));
 }
 
 gint
@@ -227,14 +227,14 @@ qof_collection_compare (QofCollection *target, QofCollection *merge)
     {
         return -1;
     }
-    qof_collection_set_data(target, &value);
+    qof_collection_set_data(target, GINT_TO_POINTER(value));
     qof_collection_foreach(merge, collection_compare_cb, target);
-    value = *(gint*)qof_collection_get_data(target);
+    value = GPOINTER_TO_INT(qof_collection_get_data(target));
     if (value == 0)
     {
-        qof_collection_set_data(merge, &value);
+        qof_collection_set_data(merge, GINT_TO_POINTER(value));
         qof_collection_foreach(target, collection_compare_cb, merge);
-        value = *(gint*)qof_collection_get_data(merge);
+        value = GPOINTER_TO_INT(qof_collection_get_data(merge));
     }
     return value;
 }
@@ -459,9 +459,11 @@ gboolean QofCollectionClass::add_entity (QofInstance* ent)
     return TRUE;
 }
 
+// FIXME: incorrect implementation
 void QofCollectionClass::remove_entity (QofInstance *ent)
 {
     if (!ent) return;
+    // HERE:
     QofCollection *col = qof_instance_get_collection (ent);
     if (!col) return;
 

--- a/src/libqof/qof/qofid.h
+++ b/src/libqof/qof/qofid.h
@@ -260,6 +260,45 @@ qof_collection_from_glist (QofIdType type, const GList *glist);
 }
 #endif
 
+/* QofCollection C++ implementation */
+
+#ifdef __cplusplus
+class QofCollectionClass
+{
+public:
+    QofCollectionClass (QofIdType type);
+    ~QofCollectionClass ();
+
+    static QofCollectionClass *from_glist (QofIdType type, const GList *inst_list);
+
+    guint count () { return g_hash_table_size (m_hash_of_entities); }
+    QofIdType get_type () { return m_e_type; }
+    gpointer get_data () { return m_data; }
+    void set_data (gpointer user_data) { m_data = user_data; }
+
+    gboolean is_dirty () { return m_dirty; }
+    void mark_dirty () { m_dirty = TRUE; }
+    void mark_clean () { m_dirty = FALSE; }
+    void print_dirty (gpointer dummy);
+
+    QofInstance* lookup_entity(const GncGUID *guid);
+    gboolean add_entity (QofInstance *ent);
+    void remove_entity (QofInstance *ent);
+    void insert_entity (QofInstance *ent);
+
+    gint compare_to (QofCollectionClass *rhs);
+    gint compare_to (QofCollectionClass &rhs);
+    void foreach (QofInstanceForeachCB, gpointer user_data);
+
+private:
+    QofIdType m_e_type;
+    gboolean m_dirty;
+    // TODO: replace with std::map
+    GHashTable* m_hash_of_entities;
+    gpointer m_data;
+};
+#endif
+
 #endif /* QOF_ID_H */
 /** @} */
 /** @} */

--- a/src/libqof/qof/qofid.h
+++ b/src/libqof/qof/qofid.h
@@ -263,40 +263,46 @@ qof_collection_from_glist (QofIdType type, const GList *glist);
 /* QofCollection C++ implementation */
 
 #ifdef __cplusplus
-class QofCollectionClass
+namespace gnucash
 {
-public:
-    QofCollectionClass (QofIdType type);
-    ~QofCollectionClass ();
+    namespace qof
+    {
+        class QofCollectionClass
+        {
+        public:
+            QofCollectionClass (QofIdType type);
+            ~QofCollectionClass ();
 
-    static QofCollectionClass *from_glist (QofIdType type, const GList *inst_list);
+            static QofCollectionClass *from_glist (QofIdType type, const GList *inst_list);
 
-    guint count () { return g_hash_table_size (m_hash_of_entities); }
-    QofIdType get_type () { return m_e_type; }
-    gpointer get_data () { return m_data; }
-    void set_data (gpointer user_data) { m_data = user_data; }
+            guint count () { return g_hash_table_size (m_hash_of_entities); }
+            QofIdType get_type () { return m_e_type; }
+            gpointer get_data () { return m_data; }
+            void set_data (gpointer user_data) { m_data = user_data; }
 
-    gboolean is_dirty () { return m_dirty; }
-    void mark_dirty () { m_dirty = TRUE; }
-    void mark_clean () { m_dirty = FALSE; }
-    void print_dirty (gpointer dummy);
+            gboolean is_dirty () { return m_dirty; }
+            void mark_dirty () { m_dirty = TRUE; }
+            void mark_clean () { m_dirty = FALSE; }
+            void print_dirty (gpointer dummy);
 
-    QofInstance* lookup_entity(const GncGUID *guid);
-    gboolean add_entity (QofInstance *ent);
-    void remove_entity (QofInstance *ent);
-    void insert_entity (QofInstance *ent);
+            QofInstance* lookup_entity(const GncGUID *guid);
+            gboolean add_entity (QofInstance *ent);
+            void remove_entity (QofInstance *ent);
+            void insert_entity (QofInstance *ent);
 
-    gint compare_to (QofCollectionClass *rhs);
-    gint compare_to (QofCollectionClass &rhs);
-    void foreach (QofInstanceForeachCB, gpointer user_data);
+            gint compare_to (QofCollectionClass *rhs);
+            gint compare_to (QofCollectionClass &rhs);
+            void foreach (QofInstanceForeachCB, gpointer user_data);
 
-private:
-    QofIdType m_e_type;
-    gboolean m_dirty;
-    // TODO: replace with std::map
-    GHashTable* m_hash_of_entities;
-    gpointer m_data;
-};
+        private:
+            QofIdType m_e_type;
+            gboolean m_dirty;
+            // TODO: replace with std::map
+            GHashTable* m_hash_of_entities;
+            gpointer m_data;
+        };
+    }
+}
 #endif
 
 #endif /* QOF_ID_H */

--- a/src/libqof/qof/qofinstance-p.h
+++ b/src/libqof/qof/qofinstance-p.h
@@ -57,6 +57,11 @@ void qof_instance_set_dirty_flag (gconstpointer inst, gboolean flag);
 /** Set the GncGUID of this instance */
 void qof_instance_set_guid (gpointer inst, const GncGUID *guid);
 
+/* Set a GncGUID of this instance on behalf of you in a convenient way.
+ * If you want to set another GUID by yourself, please call qof_instance_set_guid instead.
+ */
+void qof_instance_set_a_guid (gpointer inst);
+
 /** Copy the GncGUID from one instance to another.  This routine should
  *  be used with extreme caution, since GncGUID values are everywhere
  *  assumed to be unique. */

--- a/src/libqof/qof/qofinstance.cpp
+++ b/src/libqof/qof/qofinstance.cpp
@@ -499,6 +499,15 @@ qof_instance_set_guid (gpointer ptr, const GncGUID *guid)
 }
 
 void
+qof_instance_set_a_guid (gpointer ptr)
+{
+    GncGUID *guid = NULL;
+
+    guid = guid_new ();
+    qof_instance_set_guid (ptr, guid);
+}
+
+void
 qof_instance_copy_guid (gpointer to, gconstpointer from)
 {
     g_return_if_fail(QOF_IS_INSTANCE(to));

--- a/src/libqof/qof/test/Makefile.am
+++ b/src/libqof/qof/test/Makefile.am
@@ -18,6 +18,7 @@ test_qof_SOURCES = \
 	test-qofsession.c \
 	test-qof-string-cache.c \
 	test-gnc-guid.cpp \
+	test-qofcollection.c \
 	${top_srcdir}/src/test-core/unittest-support.c
 
 test_qof_HEADERS = \
@@ -26,6 +27,7 @@ test_qof_HEADERS = \
 	$(top_srcdir)/${MODULEPATH}/kvp_frame.h \
 	$(top_srcdir)/${MODULEPATH}/qofobject.h \
 	$(top_srcdir)/${MODULEPATH}/qofsession.h \
+	$(top_srcdir)/${MODULEPATH}/qofid.h \
 	$(top_srcdir)/src/test-core/unittest-support.h
 
 check_PROGRAMS = \

--- a/src/libqof/qof/test/Makefile.am
+++ b/src/libqof/qof/test/Makefile.am
@@ -19,6 +19,7 @@ test_qof_SOURCES = \
 	test-qof-string-cache.c \
 	test-gnc-guid.cpp \
 	test-qofcollection.c \
+	test-qofcollection-p.cpp \
 	${top_srcdir}/src/test-core/unittest-support.c
 
 test_qof_HEADERS = \

--- a/src/libqof/qof/test/test-qof.c
+++ b/src/libqof/qof/test/test-qof.c
@@ -33,6 +33,7 @@ extern void test_suite_qofsession();
 extern void test_suite_gnc_date();
 extern void test_suite_qof_string_cache();
 extern void test_suite_gnc_guid ( void );
+extern void test_suite_qofcollection();
 
 int
 main (int   argc,
@@ -52,6 +53,7 @@ main (int   argc,
     test_suite_qofsession();
     test_suite_gnc_date();
     test_suite_qof_string_cache();
+    test_suite_qofcollection();
 
     return g_test_run( );
 }

--- a/src/libqof/qof/test/test-qof.c
+++ b/src/libqof/qof/test/test-qof.c
@@ -34,6 +34,7 @@ extern void test_suite_gnc_date();
 extern void test_suite_qof_string_cache();
 extern void test_suite_gnc_guid ( void );
 extern void test_suite_qofcollection();
+extern void test_suite_qofcollection_class(void);
 
 int
 main (int   argc,
@@ -54,6 +55,7 @@ main (int   argc,
     test_suite_gnc_date();
     test_suite_qof_string_cache();
     test_suite_qofcollection();
+    test_suite_qofcollection_class();
 
     return g_test_run( );
 }

--- a/src/libqof/qof/test/test-qofcollection-p.cpp
+++ b/src/libqof/qof/test/test-qofcollection-p.cpp
@@ -1,0 +1,377 @@
+/********************************************************************
+ * test_qofcollection-p.cpp: test suite for qofcollection C++ class.*
+ * Copyright 2014 Chenxiong Qi <qcxhome@gmail.com>                  *
+ *                                                                  *
+ * This program is free software; you can redistribute it and/or    *
+ * modify it under the terms of the GNU General Public License as   *
+ * published by the Free Software Foundation; either version 2 of   *
+ * the License, or (at your option) any later version.              *
+ *                                                                  *
+ * This program is distributed in the hope that it will be useful,  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    *
+ * GNU General Public License for more details.                     *
+ *                                                                  *
+ * You should have received a copy of the GNU General Public License*
+ * along with this program; if not, contact:                        *
+ *                                                                  *
+ * Free Software Foundation           Voice:  +1-617-542-5942       *
+ * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652       *
+ * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
+\********************************************************************/
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "config.h"
+#include <glib.h>
+#include <unittest-support.h>
+
+#ifdef __cplusplus
+}
+#endif
+
+#define GNC_TEST_TYPE "test type"
+
+#include "../qofid.h"
+#include "../qofinstance-p.h"
+
+using namespace gnucash::qof;
+
+static const gchar *suitename = "/qof/qofcollection-class";
+static QofIdType type = "test type";
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+void test_suite_qofcollection_class ( void );
+
+#ifdef __cplusplus
+}
+#endif
+
+typedef struct
+{
+    QofCollectionClass *collection;
+    QofCollectionClass *collection1;
+    /* used for referencing collection created during test */
+    QofCollectionClass *collection2;
+
+    QofInstance *instance0;
+    QofInstance *instance1;
+    QofInstance *instance2;
+    QofInstance *instance3;
+    QofInstance *instance4;
+
+    /* used for testing qof_collection_from_glist */
+    GList *instances;
+} Fixture;
+
+typedef struct
+{
+    QofCollectionClass *coll_same0;
+    QofCollectionClass *coll_same1;
+    QofCollectionClass *coll_diff_instances;
+    QofCollectionClass *coll_diff_type;
+
+    QofInstance *instance0;
+    QofInstance *instance1;
+    QofInstance *instance2;
+    QofInstance *instance3;
+} CompareFixture;
+
+/* === Helper functions === */
+
+static QofInstance *new_qof_instance (QofIdType type)
+{
+    QofInstance *inst = NULL;
+
+    inst = static_cast<QofInstance *>(g_object_new (QOF_TYPE_INSTANCE, NULL));
+    inst->e_type = type;
+    qof_instance_set_a_guid (inst);
+    return inst;
+}
+
+static void
+add_qof_instance_to_collection (QofCollectionClass *col, QofInstance *ent)
+{
+    gboolean ret = FALSE;
+
+    ret = col->add_entity (ent);
+    g_assert_true (ret);
+}
+
+/* === end of help functions === */
+
+static void
+setup (Fixture *fixture, gconstpointer pData)
+{
+    QofIdType e_type;
+
+    fixture->collection = new QofCollectionClass (type);
+    fixture->collection1 = new QofCollectionClass (type);
+    fixture->collection2 = NULL;
+
+    e_type = fixture->collection->get_type ();
+    fixture->instance0 = new_qof_instance (e_type);
+    fixture->instance1 = new_qof_instance (e_type);
+    fixture->instance2 = new_qof_instance (e_type);
+    fixture->instance3 = new_qof_instance (e_type);
+    fixture->instance4 = new_qof_instance (e_type);
+
+    add_qof_instance_to_collection (fixture->collection1, fixture->instance3);
+    add_qof_instance_to_collection (fixture->collection1, fixture->instance4);
+
+    fixture->instances = g_list_append (fixture->instances, new_qof_instance (e_type));
+    fixture->instances = g_list_append (fixture->instances, new_qof_instance (e_type));
+    fixture->instances = g_list_append (fixture->instances, new_qof_instance (e_type));
+    fixture->instances = g_list_append (fixture->instances, new_qof_instance (e_type));
+    fixture->instances = g_list_append (fixture->instances, new_qof_instance (e_type));
+}
+
+static void
+teardown (Fixture *fixture, gconstpointer pData)
+{
+    g_object_unref (fixture->instance0);
+    g_object_unref (fixture->instance1);
+    g_object_unref (fixture->instance2);
+    g_object_unref (fixture->instance3);
+    g_object_unref (fixture->instance4);
+
+    delete fixture->collection;
+    delete fixture->collection1;
+    if (fixture->collection2)
+    {
+        delete fixture->collection2;
+        fixture->collection2 = NULL;
+    }
+    fixture->collection = NULL;
+    fixture->collection1 = NULL;
+
+    g_list_free_full (fixture->instances, g_object_unref);
+}
+
+
+/*
+ * Prepare fixture for testing compare_to
+ *
+ * To create three QofCollectionClass. Two are same and another different one.
+ */
+static void
+setup_for_compare (CompareFixture *fixture, gconstpointer data)
+{
+    QofIdType e_type;
+
+    fixture->coll_diff_type = new QofCollectionClass ("different type");
+
+    fixture->coll_same0 = new QofCollectionClass (type);
+    e_type = fixture->coll_same0->get_type ();
+
+    fixture->instance0 = new_qof_instance (e_type);
+    fixture->instance1 = new_qof_instance (e_type);
+    fixture->instance2 = new_qof_instance (e_type);
+    fixture->instance3 = new_qof_instance (e_type);
+
+    add_qof_instance_to_collection (fixture->coll_same0, fixture->instance0);
+    add_qof_instance_to_collection (fixture->coll_same0, fixture->instance2);
+
+    fixture->coll_same1 = new QofCollectionClass (e_type);
+    add_qof_instance_to_collection (fixture->coll_same1, fixture->instance0);
+    add_qof_instance_to_collection (fixture->coll_same1, fixture->instance2);
+
+    fixture->coll_diff_instances = new QofCollectionClass (e_type);
+    add_qof_instance_to_collection (fixture->coll_diff_instances, fixture->instance0);
+    add_qof_instance_to_collection (fixture->coll_diff_instances, fixture->instance1);
+    add_qof_instance_to_collection (fixture->coll_diff_instances, fixture->instance3);
+}
+
+static void
+teardown_for_compare (CompareFixture *fixture, gconstpointer data)
+{
+    g_object_unref (fixture->instance0);
+    g_object_unref (fixture->instance1);
+    g_object_unref (fixture->instance2);
+    g_object_unref (fixture->instance3);
+
+    delete fixture->coll_same0;
+    delete fixture->coll_same1;
+    delete fixture->coll_diff_instances;
+    delete fixture->coll_diff_type;
+}
+
+static void
+test_qof_collection_new_destroy (void)
+{
+    QofCollectionClass *col = NULL;
+
+    g_test_message ("Test collection initialization");
+
+    col = new QofCollectionClass (GNC_TEST_TYPE);
+    g_assert_nonnull (col);
+
+    g_test_message ("Test collection finalization");
+    delete col;
+}
+
+static void
+test_qof_collection_lookup_entity (Fixture *fixture, gconstpointer pData)
+{
+    const GncGUID *guid = NULL, *another_guid = NULL;
+    QofInstance *inst = NULL;
+    QofCollectionClass *col = fixture->collection;
+
+    col->add_entity (fixture->instance0);
+    col->add_entity (fixture->instance1);
+    col->add_entity (fixture->instance2);
+
+    guid = qof_instance_get_guid (fixture->instance1);
+    inst = col->lookup_entity (guid);
+    g_assert_nonnull (inst);
+
+    another_guid = qof_instance_get_guid (inst);
+    g_assert_true (guid_equal (guid, another_guid));
+
+    another_guid = guid_new ();
+    inst = col->lookup_entity (another_guid);
+    g_assert_null (inst);
+}
+
+static void
+test_qof_collection_add_entity (Fixture *fixture, gconstpointer pData)
+{
+    gboolean ret;
+    const GncGUID *guid = NULL;
+    QofInstance *instance = NULL;
+    guint count = 0;
+
+    ret = fixture->collection->add_entity (fixture->instance0);
+    g_assert_true (ret);
+    guid = qof_instance_get_guid (fixture->instance0);
+    instance = fixture->collection->lookup_entity (guid);
+    g_assert_true (fixture->instance0 == instance);
+
+    ret = fixture->collection->add_entity (fixture->instance1);
+    g_assert_true (ret);
+    guid = qof_instance_get_guid (fixture->instance1);
+    instance = fixture->collection->lookup_entity (guid);
+    g_assert_true (fixture->instance1 == instance);
+
+    count = fixture->collection->count();
+    g_assert_cmpint (count, ==, 2);
+}
+
+static void
+test_qof_collection_remove_entity (Fixture *fixture, gconstpointer pData)
+{
+    const GncGUID *guid = NULL;
+    QofInstance *inst = NULL;
+    QofCollectionClass *col = NULL;
+
+    g_test_message ("Test removing an entity from QofCollectionClass.");
+
+    add_qof_instance_to_collection (fixture->collection, fixture->instance0);
+    add_qof_instance_to_collection (fixture->collection, fixture->instance1);
+
+    fixture->collection->remove_entity (fixture->instance0);
+
+    guid = qof_instance_get_guid (fixture->instance0);
+    inst = fixture->collection->lookup_entity (guid);
+    g_assert_null (inst);
+}
+
+static void
+test_qof_collection_compare (CompareFixture *fixture, gconstpointer pData)
+{
+    gint ret = 0;
+
+    ret = fixture->coll_same0->compare_to (NULL);
+    g_assert_cmpint (ret, ==, 1);
+    ret = fixture->coll_same0->compare_to (fixture->coll_same0);
+    g_assert_cmpint (ret, ==, 0);
+
+    g_test_message ("Test two collections that have different types.");
+    ret = fixture->coll_same0->compare_to (fixture->coll_diff_type);
+    g_assert_cmpint (ret, ==, -1);
+
+    g_test_message ("Test two same collections, with same type and contains same instances.");
+    ret = fixture->coll_same0->compare_to (fixture->coll_same1);
+    g_assert_cmpint (ret, ==, 0);
+
+    g_test_message ("Test two collections with same type, that have different instances.");
+    ret = fixture->coll_same0->compare_to (fixture->coll_diff_instances);
+    g_assert_cmpint (ret, ==, 1);
+
+    g_test_message ("Test two collections with same type, and one instance has invalid guid.");
+    qof_instance_set_guid (fixture->instance0, guid_null ());
+    ret = fixture->coll_same0->compare_to (fixture->coll_same1);
+    g_assert_cmpint (ret, ==, -1);
+}
+
+static void
+test_qof_collection_from_glist (Fixture *fixture, gconstpointer pData)
+{
+    QofIdType type;
+    gpointer data = NULL;
+    const GncGUID *guid = NULL;
+
+    g_test_message ("Test creation from an existing instances within a GList.");
+
+    type = fixture->collection->get_type ();
+    fixture->collection2 = QofCollectionClass::from_glist (type, fixture->instances);
+    g_assert_nonnull (fixture->collection2);
+    g_assert_cmpint (fixture->collection2->count (), ==, 5);
+
+    g_test_message ("Test arbitrary instance existance.");
+
+    data = g_list_nth_data (fixture->instances, 3);
+    g_assert_nonnull (data);
+    guid = qof_instance_get_guid ((QofInstance *)data);
+    g_assert_nonnull (fixture->collection2->lookup_entity (guid));
+}
+
+static void
+test_qof_collection_insert_entity (Fixture *fixture, gconstpointer pData)
+{
+    const GncGUID *guid = NULL;
+    QofCollectionClass *col = fixture->collection;
+
+    g_assert_cmpint (col->count (), ==, 0);
+
+    g_test_message ("Test add a QofInstance that is not added to another QofCollectionClass yet.");
+
+    col->insert_entity (fixture->instance0);
+    g_assert_cmpint (col->count (), ==, 1);
+    col->insert_entity (fixture->instance1);
+    g_assert_cmpint (col->count (), ==, 2);
+
+    g_test_message ("Test add a QofInstance that is already added to another QofCollectionClass.");
+    col->insert_entity (fixture->instance3);
+    g_assert_cmpint (col->count (), ==, 3);
+
+    g_test_message ("instance3 should be removed from original collection.");
+    guid = qof_instance_get_guid (fixture->instance3);
+    g_assert_nonnull (fixture->collection1->lookup_entity (guid));
+}
+
+void
+test_suite_qofcollection_class ( void )
+{
+    GNC_TEST_ADD_FUNC (suitename, "qof collection new and destroy", test_qof_collection_new_destroy);
+
+    GNC_TEST_ADD (suitename, "qof collection add entity", Fixture, NULL,
+                  setup, test_qof_collection_add_entity, teardown);
+    GNC_TEST_ADD (suitename, "qof collection compare", CompareFixture, NULL,
+                  setup_for_compare, test_qof_collection_compare, teardown_for_compare);
+    GNC_TEST_ADD (suitename, "qof collection from glist", Fixture, NULL,
+                  setup, test_qof_collection_from_glist, teardown);
+    GNC_TEST_ADD (suitename, "qof collection inset entity", Fixture, NULL,
+                  setup, test_qof_collection_insert_entity, teardown);
+    GNC_TEST_ADD (suitename, "qof collection lookup entity", Fixture, NULL,
+                  setup, test_qof_collection_lookup_entity, teardown);
+    GNC_TEST_ADD (suitename, "qof collection remove entity", Fixture, NULL,
+                  setup, test_qof_collection_remove_entity, teardown);
+}

--- a/src/libqof/qof/test/test-qofcollection.c
+++ b/src/libqof/qof/test/test-qofcollection.c
@@ -1,0 +1,384 @@
+/********************************************************************
+ * test_qofcollection.c: GLib g_test test suite for qofsession.     *
+ * Copyright 2014 Chenxiong Qi <qcxhome@gmail.com>                  *
+ *                                                                  *
+ * This program is free software; you can redistribute it and/or    *
+ * modify it under the terms of the GNU General Public License as   *
+ * published by the Free Software Foundation; either version 2 of   *
+ * the License, or (at your option) any later version.              *
+ *                                                                  *
+ * This program is distributed in the hope that it will be useful,  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    *
+ * GNU General Public License for more details.                     *
+ *                                                                  *
+ * You should have received a copy of the GNU General Public License*
+ * along with this program; if not, contact:                        *
+ *                                                                  *
+ * Free Software Foundation           Voice:  +1-617-542-5942       *
+ * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652       *
+ * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
+\********************************************************************/
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "config.h"
+#include <glib.h>
+#include <unittest-support.h>
+
+#ifdef __cplusplus
+}
+#endif
+
+#define GNC_TEST_TYPE "test type"
+
+#include "../qofid.h"
+#include "../qofinstance-p.h"
+
+static const gchar *suitename = "/qof/qofcollection";
+static QofIdType type = "test type";
+
+void test_suite_qofcollection ( void );
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+
+#ifdef __cplusplus
+}
+#endif
+
+typedef struct
+{
+    QofCollection *collection;
+    QofCollection *collection1;
+    /* used for referencing collection created during test */
+    QofCollection *collection2;
+
+    QofInstance *instance0;
+    QofInstance *instance1;
+    QofInstance *instance2;
+    QofInstance *instance3;
+    QofInstance *instance4;
+
+    /* used for testing qof_collection_from_glist */
+    GList *instances;
+} Fixture;
+
+typedef struct
+{
+    QofCollection *coll_same0;
+    QofCollection *coll_same1;
+    QofCollection *coll_diff_instances;
+    QofCollection *coll_diff_type;
+
+    QofInstance *instance0;
+    QofInstance *instance1;
+    QofInstance *instance2;
+    QofInstance *instance3;
+} CompareFixture;
+
+/* === Helper functions === */
+
+static QofInstance *new_qof_instance (QofIdType type)
+{
+    QofInstance *inst = NULL;
+
+    inst = g_object_new (QOF_TYPE_INSTANCE, NULL);
+    inst->e_type = type;
+    qof_instance_set_a_guid (inst);
+    return inst;
+}
+
+static void
+add_qof_instance_to_collection (QofCollection *col, QofInstance *ent)
+{
+    gboolean ret = FALSE;
+
+    ret = qof_collection_add_entity (col, ent);
+    g_assert_true (ret);
+
+    qof_instance_set_collection (ent, col);
+}
+
+/* === end of help functions === */
+
+static void
+setup (Fixture *fixture, gconstpointer pData)
+{
+    QofIdType e_type;
+
+    fixture->collection = qof_collection_new (type);
+    fixture->collection1 = qof_collection_new (type);
+    fixture->collection2 = NULL;
+
+    e_type = qof_collection_get_type(fixture->collection);
+    fixture->instance0 = new_qof_instance (e_type);
+    fixture->instance1 = new_qof_instance (e_type);
+    fixture->instance2 = new_qof_instance (e_type);
+    fixture->instance3 = new_qof_instance (e_type);
+    fixture->instance4 = new_qof_instance (e_type);
+
+    add_qof_instance_to_collection (fixture->collection1, fixture->instance3);
+    add_qof_instance_to_collection (fixture->collection1, fixture->instance4);
+
+    fixture->instances = g_list_append (fixture->instances, new_qof_instance (e_type));
+    fixture->instances = g_list_append (fixture->instances, new_qof_instance (e_type));
+    fixture->instances = g_list_append (fixture->instances, new_qof_instance (e_type));
+    fixture->instances = g_list_append (fixture->instances, new_qof_instance (e_type));
+    fixture->instances = g_list_append (fixture->instances, new_qof_instance (e_type));
+}
+
+static void
+teardown (Fixture *fixture, gconstpointer pData)
+{
+    g_object_unref (fixture->instance0);
+    g_object_unref (fixture->instance1);
+    g_object_unref (fixture->instance2);
+    g_object_unref (fixture->instance3);
+    g_object_unref (fixture->instance4);
+
+    qof_collection_destroy (fixture->collection);
+    qof_collection_destroy (fixture->collection1);
+    if (fixture->collection2)
+    {
+        qof_collection_destroy (fixture->collection2);
+        fixture->collection2 = NULL;
+    }
+    fixture->collection = NULL;
+    fixture->collection1 = NULL;
+
+    g_list_free_full (fixture->instances, g_object_unref);
+}
+
+
+/*
+ * Prepare fixture for testing qof_collection_compare
+ *
+ * To create three QofCollections. Two are same and another different one.
+ */
+static void
+setup_for_compare (CompareFixture *fixture, gconstpointer data)
+{
+    QofIdType e_type;
+
+    fixture->coll_diff_type = qof_collection_new ("different type");
+
+    fixture->coll_same0 = qof_collection_new (type);
+    e_type = qof_collection_get_type (fixture->coll_same0);
+
+    fixture->instance0 = new_qof_instance (e_type);
+    fixture->instance1 = new_qof_instance (e_type);
+    fixture->instance2 = new_qof_instance (e_type);
+    fixture->instance3 = new_qof_instance (e_type);
+
+    add_qof_instance_to_collection (fixture->coll_same0, fixture->instance0);
+    add_qof_instance_to_collection (fixture->coll_same0, fixture->instance2);
+
+    fixture->coll_same1 = qof_collection_new (e_type);
+    add_qof_instance_to_collection (fixture->coll_same1, fixture->instance0);
+    add_qof_instance_to_collection (fixture->coll_same1, fixture->instance2);
+
+    fixture->coll_diff_instances = qof_collection_new (e_type);
+    add_qof_instance_to_collection (fixture->coll_diff_instances, fixture->instance0);
+    add_qof_instance_to_collection (fixture->coll_diff_instances, fixture->instance1);
+    add_qof_instance_to_collection (fixture->coll_diff_instances, fixture->instance3);
+}
+
+static void
+teardown_for_compare (CompareFixture *fixture, gconstpointer data)
+{
+    g_object_unref (fixture->instance0);
+    g_object_unref (fixture->instance1);
+    g_object_unref (fixture->instance2);
+    g_object_unref (fixture->instance3);
+
+    qof_collection_destroy (fixture->coll_same0);
+    qof_collection_destroy (fixture->coll_same1);
+    qof_collection_destroy (fixture->coll_diff_instances);
+    qof_collection_destroy (fixture->coll_diff_type);
+}
+
+static void
+test_qof_collection_new_destroy (void)
+{
+    QofCollection *col = NULL;
+
+    g_test_message ("Test collection initialization");
+
+    col = qof_collection_new (GNC_TEST_TYPE);
+    g_assert_nonnull (col);
+
+    g_test_message ("Test collection finalization");
+    qof_collection_destroy (col);
+}
+
+static void
+test_qof_collection_lookup_entity (Fixture *fixture, gconstpointer pData)
+{
+    const GncGUID *guid = NULL, *another_guid = NULL;
+    QofInstance *inst = NULL;
+
+    qof_collection_add_entity (fixture->collection, fixture->instance0);
+    qof_collection_add_entity (fixture->collection, fixture->instance1);
+    qof_collection_add_entity (fixture->collection, fixture->instance2);
+
+    guid = qof_instance_get_guid (fixture->instance1);
+    inst = qof_collection_lookup_entity (fixture->collection, guid);
+    g_assert_nonnull (inst);
+
+    another_guid = qof_instance_get_guid (inst);
+    g_assert_true (guid_equal (guid, another_guid));
+
+    another_guid = guid_new ();
+    inst = qof_collection_lookup_entity (fixture->collection, another_guid);
+    g_assert_null (inst);
+}
+
+static void
+test_qof_collection_add_entity (Fixture *fixture, gconstpointer pData)
+{
+    gboolean ret;
+    const GncGUID *guid = NULL;
+    QofInstance *instance = NULL;
+    guint count = 0;
+
+    ret = qof_collection_add_entity (fixture->collection, fixture->instance0);
+    g_assert_true (ret);
+    guid = qof_instance_get_guid (fixture->instance0);
+    instance = qof_collection_lookup_entity (fixture->collection, guid);
+    g_assert_true (fixture->instance0 == instance);
+
+    ret = qof_collection_add_entity (fixture->collection, fixture->instance1);
+    g_assert_true (ret);
+    guid = qof_instance_get_guid (fixture->instance1);
+    instance = qof_collection_lookup_entity (fixture->collection, guid);
+    g_assert_true (fixture->instance1 == instance);
+
+    count = qof_collection_count (fixture->collection);
+    g_assert_cmpint (count, ==, 2);
+}
+
+static void
+test_qof_collection_remove_entity (Fixture *fixture, gconstpointer pData)
+{
+    const GncGUID *guid = NULL;
+    QofInstance *inst = NULL;
+    QofCollection *col = NULL;
+
+    g_test_message ("Test removing an entity from QofCollection.");
+
+    add_qof_instance_to_collection (fixture->collection, fixture->instance0);
+    add_qof_instance_to_collection (fixture->collection, fixture->instance1);
+
+    col = qof_instance_get_collection (fixture->instance0);
+    g_print ("instance' collection should not be NULL");
+    g_assert_nonnull (col);
+
+    qof_collection_remove_entity (fixture->instance0);
+
+    guid = qof_instance_get_guid (fixture->instance0);
+    inst = qof_collection_lookup_entity (fixture->collection, guid);
+    g_assert_null (inst);
+}
+
+static void
+test_qof_collection_compare (CompareFixture *fixture, gconstpointer pData)
+{
+    gint ret = 0;
+
+    ret = qof_collection_compare (NULL, NULL);
+    g_assert_cmpint (ret, ==, 0);
+    ret = qof_collection_compare (NULL, fixture->coll_same0);
+    g_assert_cmpint (ret, ==, -1);
+    ret = qof_collection_compare (fixture->coll_same0, NULL);
+    g_assert_cmpint (ret, ==, 1);
+    ret = qof_collection_compare (fixture->coll_same0, fixture->coll_same0);
+    g_assert_cmpint (ret, ==, 0);
+
+    g_test_message ("Test two collections that have different types.");
+    ret = qof_collection_compare (fixture->coll_same0, fixture->coll_diff_type);
+    g_assert_cmpint (ret, ==, -1);
+
+    g_test_message ("Test two same collections, with same type and contains same instances.");
+    ret = qof_collection_compare (fixture->coll_same0, fixture->coll_same1);
+    g_assert_cmpint (ret, ==, 0);
+
+    g_test_message ("Test two collections with same type, that have different instances.");
+    ret = qof_collection_compare (fixture->coll_same0, fixture->coll_same1);
+    g_assert_cmpint (ret, ==, 0);
+
+    g_test_message ("Test two collections with same type, and one instance has invalid guid.");
+    qof_instance_set_guid (fixture->instance0, guid_null ());
+    ret = qof_collection_compare (fixture->coll_same0, fixture->coll_same1);
+    g_assert_cmpint (ret, ==, -1);
+}
+
+static void
+test_qof_collection_from_glist (Fixture *fixture, gconstpointer pData)
+{
+    QofIdType type;
+    gpointer data = NULL;
+    const GncGUID *guid = NULL;
+
+    g_test_message ("Test creation from an existing instances within a GList.");
+
+    type = qof_collection_get_type (fixture->collection);
+    fixture->collection2 = qof_collection_from_glist (type, fixture->instances);
+    g_assert_nonnull (fixture->collection2);
+    g_assert_cmpint (qof_collection_count (fixture->collection2), ==, 5);
+
+    g_test_message ("Test arbitrary instance existance.");
+
+    data = g_list_nth_data (fixture->instances, 3);
+    g_assert_nonnull (data);
+    guid = qof_instance_get_guid ((QofInstance *)data);
+    g_assert_nonnull (qof_collection_lookup_entity (fixture->collection2, guid));
+}
+
+static void
+test_qof_collection_insert_entity (Fixture *fixture, gconstpointer pData)
+{
+    const GncGUID *guid = NULL;
+
+    g_assert_cmpint (qof_collection_count (fixture->collection), ==, 0);
+
+    g_test_message ("Test add a QofInstance that is not added to another QofCollection yet.");
+
+    qof_collection_insert_entity (fixture->collection, fixture->instance0);
+    g_assert_cmpint (qof_collection_count (fixture->collection), ==, 1);
+    qof_collection_insert_entity (fixture->collection, fixture->instance1);
+    g_assert_cmpint (qof_collection_count (fixture->collection), ==, 2);
+
+    g_test_message ("Test add a QofInstance that is already added to another QofCollection.");
+    qof_collection_insert_entity (fixture->collection, fixture->instance3);
+    g_assert_cmpint (qof_collection_count (fixture->collection), ==, 3);
+
+    g_test_message ("instance3 should be removed from original collection.");
+    guid = qof_instance_get_guid (fixture->instance3);
+    g_assert_null (qof_collection_lookup_entity (fixture->collection1, guid));
+}
+
+void
+test_suite_qofcollection ( void )
+{
+    GNC_TEST_ADD_FUNC (suitename, "qof collection new and destroy", test_qof_collection_new_destroy);
+
+    GNC_TEST_ADD (suitename, "qof collection add entity", Fixture, NULL,
+                  setup, test_qof_collection_add_entity, teardown);
+    GNC_TEST_ADD (suitename, "qof collection compare", CompareFixture, NULL,
+                  setup_for_compare, test_qof_collection_compare, teardown_for_compare);
+    GNC_TEST_ADD (suitename, "qof collection from glist", Fixture, NULL,
+                  setup, test_qof_collection_from_glist, teardown);
+    GNC_TEST_ADD (suitename, "qof collection inset entity", Fixture, NULL,
+                  setup, test_qof_collection_insert_entity, teardown);
+    GNC_TEST_ADD (suitename, "qof collection lookup entity", Fixture, NULL,
+                  setup, test_qof_collection_lookup_entity, teardown);
+    GNC_TEST_ADD (suitename, "qof collection remove entity", Fixture, NULL,
+                  setup, test_qof_collection_remove_entity, teardown);
+}


### PR DESCRIPTION
Major changes to QofCollection

1. new C++ class of QofCollection in namespace `gnucash::qof`
2. unit tests for legal QofCollection C implementation, and fix type conversion by using Glib's `GPOINTER_TO_INT` and `GINT_TO_POINTER` instead of (gint *).
3. same unit tests in C++ to QofCollection class to ensure C++ implementation does the same things as what C implementation does.