### PR TITLE
[Bug 742332] - German tax report uses US tax quaters and not real quaters

### DIFF
--- a/src/report/locale-specific/us/taxtxf-de_DE.scm
+++ b/src/report/locale-specific/us/taxtxf-de_DE.scm
@@ -115,9 +115,10 @@
 (define (lx-collector level action arg1 arg2)
   ((vector-ref levelx-collector (- level 1)) action arg1 arg2))
 
-;; IRS asked congress to make the tax quarters the same as real quarters
-;;   This is the year it is effective.  THIS IS A Y10K BUG!
-(define tax-qtr-real-qtr-year 10000)
+;; Unlike to the US the German tax quaters are real quaters.
+;; To allow for easily incorporating changes from the US version
+;; we simply set  tax-qtr-real-qtr-year to 0.
+(define tax-qtr-real-qtr-year 0)
 
 (define (tax-options-generator)
   (define options (gnc:new-options))


### PR DESCRIPTION
Due a copy and paste the German tax report was still using the
US quaters. This wrong as the latter are not real quaters as in
Germany. To fix this we simply set  tax-qtr-real-qtr-year to 0 to
force real quaters. Thus changes to taxtxf.scm can be easily ported
to taxtxf-de_DE.scm