### PR TITLE
Additional fields for secondary email address and company ID

### DIFF
--- a/src/app-utils/app-utils.scm
+++ b/src/app-utils/app-utils.scm
@@ -303,10 +303,12 @@
 (define gnc:*company-name* (N_ "Company Name"))
 (define gnc:*company-addy* (N_ "Company Address"))
 (define gnc:*company-id* (N_ "Company ID"))
+(define gnc:*company-id2* (N_ "Company ID 2"))
 (define gnc:*company-phone* (N_ "Company Phone Number"))
 (define gnc:*company-fax* (N_ "Company Fax Number"))
 (define gnc:*company-url* (N_ "Company Website URL"))
 (define gnc:*company-email* (N_ "Company Email Address"))
+(define gnc:*company-email2* (N_ "Company Email Address 2"))
 (define gnc:*company-contact* (N_ "Company Contact Person"))
 
 (define (gnc:company-info key)
@@ -317,8 +319,8 @@
 
 (export gnc:*business-label* gnc:*company-name*  gnc:*company-addy* 
         gnc:*company-id*     gnc:*company-phone* gnc:*company-fax* 
-        gnc:*company-url*    gnc:*company-email* gnc:*company-contact*
-        gnc:company-info)
+        gnc:*company-url*    gnc:*company-email* gnc:*company-email2*
+	gnc:*company-contact* gnc:company-info gnc:*company-id2*)
 
 (define gnc:*option-section-accounts* OPTION-SECTION-ACCOUNTS)
 (define gnc:*option-name-trading-accounts* OPTION-NAME-TRADING-ACCOUNTS)

--- a/src/app-utils/business-prefs.scm
+++ b/src/app-utils/business-prefs.scm
@@ -98,13 +98,24 @@
 
   (reg-option
    (gnc:make-string-option
+    gnc:*business-label* gnc:*company-email2*
+    "c4" (N_ "Alternative email address of your business.") ""))
+
+  (reg-option
+   (gnc:make-string-option
     gnc:*business-label* gnc:*company-url*
-    "c4" (N_ "The URL address of your website.") ""))
+    "c5" (N_ "The URL address of your website.") ""))
 
   (reg-option
    (gnc:make-string-option
     gnc:*business-label* gnc:*company-id*
-    "c5" (N_ "The ID for your company (eg 'Tax-ID: 00-000000).")
+    "c6" (N_ "The ID for your company (eg 'Tax-ID: 00-000000).")
+    ""))
+
+  (reg-option
+   (gnc:make-string-option
+    gnc:*business-label* gnc:*company-id2*
+    "c7" (N_ "Alternative ID for your company.")
     ""))
  
   (reg-option


### PR DESCRIPTION
In some cases, for business/companies an additional field for another email address (and another company ID) can be useful. This commit adds two fields that can be set in preferences and are available for reports.