### PR TITLE
Add -Wno-error=format-nonliteral to allow gnc-backend-sql.c to compile

### DIFF
--- a/src/backend/sql/Makefile.am
+++ b/src/backend/sql/Makefile.am
@@ -17,7 +17,12 @@ AM_CPPFLAGS = \
   -I${top_srcdir}/src/libqof/qof \
   ${GLIB_CFLAGS} \
   ${GUILE_CFLAGS} \
-  ${WARN_CFLAGS}
+  ${WARN_CFLAGS} \
+  -Wno-error=format-nonliteral
+
+# Note: -Wno-error=format-noliteral
+# is *only* to allow gnc_sql_convert_timespec_to_string()
+# to use the format string from GncSqlBackend* be->timespec_format
 
 libgnc_backend_sql_la_SOURCES = \
   gnc-backend-sql.c \

--- a/src/backend/sql/gnc-backend-sql.c
+++ b/src/backend/sql/gnc-backend-sql.c
@@ -1892,6 +1892,9 @@ gnc_sql_convert_timespec_to_string( const GncSqlBackend* be, Timespec ts )
 
     year = tm->tm_year + 1900;
 
+    // Note: This implementation will trigger -Wformat-nonliteral and -Werror
+    // Remove -Wno-error=format-nonliteral in Makefile.am if this is resolved
+
     datebuf = g_strdup_printf( be->timespec_format,
                                year, tm->tm_mon + 1, tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec );
     gnc_tm_free (tm);


### PR DESCRIPTION
gnc-backend-sql.c uses a format string from a GncSqlBackend that
is set based on the type of SQL database that is targeted.

At least when compiling with clang, this triggers -Wformat-nonliteral
which -Werror turns into a compiler error.

This patch makes a targeted change in src/backend/sql/Makefile.am
for -Wno-error=format-nonliteral in this scope only