### PR TITLE
link gnc-gnome into gncmod-csv-exp

### DIFF
--- a/src/import-export/csv-exp/Makefile.am
+++ b/src/import-export/csv-exp/Makefile.am
@@ -21,6 +21,7 @@ libgncmod_csv_export_la_LIBADD = \
   ${top_builddir}/src/import-export/libgncmod-generic-import.la \
   ${top_builddir}/src/gnome-utils/libgncmod-gnome-utils.la \
   ${top_builddir}/src/app-utils/libgncmod-app-utils.la \
+  ${top_builddir}/src/gnome/libgnc-gnome.la \
   ${top_builddir}/src/engine/libgncmod-engine.la \
   ${top_builddir}/src/core-utils/libgnc-core-utils.la \
   ${top_builddir}/src/gnc-module/libgnc-module.la \


### PR DESCRIPTION
Building on master on Windows fails for me with the error below. The missing symbols are in the gnu-gnome library, so cvs-exp needs to link to it. Adding one line in cvs-exp/Makefile.am to do this link fixes the problem for me.

Error:

  libtool: link: rm -fr  .libs/libgncmod-csv-export.dll.a
  libtool: link: gcc -std=gnu99 -shared  .libs/gncmod-csv-export.o .libs/gnc-plugin-csv-export.o .libs/assistant-csv-export.o .libs/csv-tree-export.o .libs/csv-transactions-export.o  -Wl,--whole-archive ../../../lib/stf/.libs/libgnc-stf.a ../../../lib/libc/.libs/libc-missing.a -Wl,--no-whole-archive  -L/c/gcdev/gnucash/build/src/gnome-utils/.libs -L/c/gcdev/gnucash/build/src/backend/xml/.libs -L/c/gcdev/gnucash/build/src/app-utils/.libs -L/c/gcdev/gnucash/build/src/engine/.libs -L/c/gcdev/gnucash/build/src/gnc-module/.libs -L/c/gcdev/gnucash/build/src/core-utils/.libs -L/c/gcdev/gnucash/build/src/libqof/qof/.libs -L/c/gcdev/regex/lib -L/c/gcdev/gnome/lib -Lc:/gcdev/guile/lib -L/c/gcdev/libdbi/lib -L/c/gcdev/gwenhywfar/lib -L/c/gcdev/hh/lib -L/c/gcdev/sqlite3/lib -L/c/gcdev/enchant/lib -L/c/gcdev/libxslt/lib ../../../src/import-export/.libs/libgncmod-generic-import.dll.a -L/c/gcdev/readline/lib -Lc:/gcdev/gnome/lib -L=/c/gcdev/gnome/lib -L/mingw/lib -L/c/gcdev/boost/lib -L/c/gcdev/dependencies/glib-install/lib -L/c/gcdev/gnome/lib/bin -L/c/gcdev/gnome/lib/lib -L==/c/gcdev/gnome/lib -L===/c/gcdev/gnome/lib -L/c/gcdev/dependencies/glib-install/bin -L/c/gcdev/dependencies/cairo-install/bin -L=/c/gcdev/dependencies/glib-install/lib -L/c/gcdev/gnome/lib/lib/lib -Lc:/gcdev/libxslt/lib -L/c/gcdev/gnutls/lib -Lc:/gcdev/mingw/lib -Lc:/gcdev/mingw/bin/../lib/gcc/mingw32/4.8.1/../../.. /c/gcdev/gnucash/build/src/gnome-utils/.libs/libgncmod-gnome-utils.dll.a ../../../src/gnome-utils/.libs/libgncmod-gnome-utils.dll.a /c/gcdev/gnucash/build/src/backend/xml/.libs/libgnc-backend-xml-utils.dll.a /c/gcdev/gnucash/build/src/app-utils/.libs/libgncmod-app-utils.dll.a ../../../src/app-utils/.libs/libgncmod-app-utils.dll.a /c/gcdev/gnucash/build/src/engine/.libs/libgncmod-engine.dll.a /c/gcdev/libxslt/lib/libxslt.dll.a -lhtmlhelp ../../../src/engine/.libs/libgncmod-engine.dll.a /c/gcdev/gnucash/build/src/gnc-module/.libs/libgnc-module.dll.a ../../../src/core-utils/.libs/libgnc-core-utils.dll.a ../../../src/gnc-module/.libs/libgnc-module.dll.a /c/gcdev/gnucash/build/src/core-utils/.libs/libgnc-core-utils.dll.a /c/gcdev/gnucash/build/src/libqof/qof/.libs/libgnc-qof.dll.a c:/gcdev/guile/lib/libguile.dll.a -lgmp /mingw/lib/libltdl.dll.a -Lc:/gcdev/goffice/lib -L/c/gcdev/pcre/lib -L=c:/gcdev/libgsf/lib -L=c:/gcdev/gnome/lib ../../../src/libqof/qof/.libs/libgnc-qof.dll.a -lboost_date_time -lregex /c/gcdev/goffice/lib/libgoffice-0.8.dll.a -L/c/gcdev/libgsf/lib /c/gcdev/libgsf/lib/libgsf-1.dll.a /c/gcdev/gnome/lib/libxml2.dll.a /c/gcdev/gnome/lib/libgtk-win32-2.0.dll.a -lcomdlg32 -lwinspool -lcomctl32 /c/gcdev/gnome/lib/libgdk-win32-2.0.dll.a -limm32 -lshell32 /c/gcdev/gnome/lib/libatk-1.0.dll.a /c/gcdev/gnome/lib/libpangocairo-1.0.dll.a /c/gcdev/gnome/lib/libgdk_pixbuf-2.0.dll.a /c/gcdev/gnome/lib/libtiff.dll.a /c/gcdev/gnome/lib/libjpeg.dll.a /c/gcdev/gnome/lib/libpangoft2-1.0.dll.a /c/gcdev/gnome/lib/libharfbuzz.dll.a /c/gcdev/gnome/lib/libpangowin32-1.0.dll.a -lusp10 /c/gcdev/gnome/lib/libpango-1.0.dll.a /c/gcdev/gnome/lib/libcairo.dll.a -lpthread /c/gcdev/gnome/lib/libpixman-1.dll.a /c/gcdev/gnome/lib/libfontconfig.dll.a -lexpat /c/gcdev/gnome/lib/libfreetype.dll.a -lpng14 -lgdi32 -lmsimg32 -lpcre /c/gcdev/gnome/lib/libgio-2.0.dll.a -ldnsapi -liphlpapi -lz /c/gcdev/gnome/lib/libgthread-2.0.dll.a /c/gcdev/gnome/lib/libgobject-2.0.dll.a /c/gcdev/gnome/lib/libffi.dll.a /c/gcdev/gnome/lib/libgmodule-2.0.dll.a /c/gcdev/gnome/lib/libglib-2.0.dll.a -lws2_32 -lole32 -lwinmm -lshlwapi /mingw/lib/libintl.dll.a /mingw/lib/libiconv.dll.a  -mms-bitfields -mwindows   -pthread -o .libs/libgncmod-csv-export.dll -Wl,--enable-auto-image-base -Xlinker --out-implib -Xlinker .libs/libgncmod-csv-export.dll.a
.libs/gnc-plugin-csv-export.o: In function `gnc_plugin_csv_export_register_cmd':
  c:/gcdev/gnucash.git/src/import-export/csv-exp/gnc-plugin-csv-export.c:181: undefined reference to `gnc_plugin_page_register_get_type'
  c:/gcdev/gnucash.git/src/import-export/csv-exp/gnc-plugin-csv-export.c:183: undefined reference to `gnc_plugin_page_register_get_query'
  c:/gcdev/gnucash.git/src/import-export/csv-exp/gnc-plugin-csv-export.c:184: undefined reference to `gnc_plugin_page_register_get_type'
  c:/gcdev/gnucash.git/src/import-export/csv-exp/gnc-plugin-csv-export.c:184: undefined reference to `gnc_plugin_page_register_get_account'
  c:/gcdev/gnucash.git/src/import-export/csv-exp/gnc-plugin-csv-export.c:189: undefined reference to `gnc_plugin_page_register2_get_type'
  c:/gcdev/gnucash.git/src/import-export/csv-exp/gnc-plugin-csv-export.c:191: undefined reference to `gnc_plugin_page_register2_get_query'
  c:/gcdev/gnucash.git/src/import-export/csv-exp/gnc-plugin-csv-export.c:192: undefined reference to `gnc_plugin_page_register2_get_type'
  c:/gcdev/gnucash.git/src/import-export/csv-exp/gnc-plugin-csv-export.c:192: undefined reference to `gnc_plugin_page_register2_get_account'
  collect2.exe: error: ld returned 1 exit status
  make[5]: *** [libgncmod-csv-export.la] Error 1
  make[5]: Leaving directory `/c/gcdev/gnucash/build/src/import-export/csv-exp'
  make[4]: *** [all-recursive] Error 1
  make[4]: Leaving directory `/c/gcdev/gnucash/build/src/import-export/csv-exp'
  make[3]: *** [all-recursive] Error 1
  make[3]: Leaving directory `/c/gcdev/gnucash/build/src/import-export'
  make[2]: *** [all-recursive] Error 1
  make[2]: Leaving directory `/c/gcdev/gnucash/build/src'
  make[1]: *** [all-recursive] Error 1
  make[1]: Leaving directory `/c/gcdev/gnucash/build'
  make: *** [all] Error 2