### PR TITLE
Fix build issues

### DIFF
--- a/src/backend/sql/gnc-transaction-sql.cpp
+++ b/src/backend/sql/gnc-transaction-sql.cpp
@@ -42,12 +42,12 @@ extern "C"
 #include "gnc-commodity.h"
 #include "gnc-engine.h"
 
-#include "escape.h"
-
 #ifdef S_SPLINT_S
 #include "splint-defs.h"
 #endif
 }
+
+#include "escape.h"
 
 #include "gnc-backend-sql.h"
 #include "gnc-transaction-sql.h"

--- a/src/backend/xml/gnc-backend-xml.cpp
+++ b/src/backend/xml/gnc-backend-xml.cpp
@@ -79,6 +79,7 @@ typedef int ssize_t;
 #include "gnc-uri-utils.h"
 #include "io-gncxml-v2.h"
 #include "gnc-backend-xml.h"
+#include "gnc-prefs.h"
 
 #ifndef HAVE_STRPTIME
 # include "strptime.h"
@@ -87,7 +88,6 @@ typedef int ssize_t;
 
 #include "gnc-xml-helper.h"
 #include "io-gncxml.h"
-#include "gnc-prefs.h"
 
 #include "gnc-address-xml-v2.h"
 #include "gnc-bill-term-xml-v2.h"


### PR DESCRIPTION
src/backend/sql/gnc-transaction-sql.cpp:
   Move inclusion of escape.h out of extern "C" block since
   escape.h is now C++ code.

src/backend/xml/gnc-backend-xml.cpp:
   Move inclusion of gnc-pref.h in to extern "C" block since
   gnc-pref.c is still plain C code.