### PR TITLE
Add Google Test and Google Mock.as CMake external project

### DIFF
--- a/3rdparty/gtest_and_gmock/CMakeLists.txt
+++ b/3rdparty/gtest_and_gmock/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Download and unpack gtest at configure time
+configure_file(gtest_and_gmock_download.cmake ${CMAKE_BINARY_DIR}/gtest_and_gmock_download/CMakeLists.txt)
+execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/gtest_and_gmock_download )
+execute_process(COMMAND ${CMAKE_COMMAND} --build .
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/gtest_and_gmock_download )
+
+# Add gtest directly to our build
+# WARNING: Only add googlemock, googletest will be build as dependency.
+# If you add the two directories build will fail
+add_subdirectory(${CMAKE_BINARY_DIR}/gmock-src/googlemock
+    ${CMAKE_BINARY_DIR}/gmock-build
+    EXCLUDE_FROM_ALL )
+
+# We need both gtest and gmock files to write our tests
+target_include_directories(gtest
+    INTERFACE
+    "${CMAKE_BINARY_DIR}/gmock-src/googletest/include"
+    )
+
+target_include_directories(gmock
+    INTERFACE
+    "${CMAKE_BINARY_DIR}/gmock-src/googlemock/include"
+    )

--- a/3rdparty/gtest_and_gmock/gtest_and_gmock_download.cmake
+++ b/3rdparty/gtest_and_gmock/gtest_and_gmock_download.cmake
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.2)
+
+project(gtest_and_gmock_download LANGUAGES NONE)
+
+include(ExternalProject)
+
+ExternalProject_Add(googletest
+    GIT_REPOSITORY git@github.com:google/googletest.git
+    SOURCE_DIR "${CMAKE_BINARY_DIR}/gmock-src"
+    BINARY_DIR "${CMAKE_BINARY_DIR}/gmock-build"
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND     ""
+    INSTALL_COMMAND   ""
+    TEST_COMMAND      ""
+    )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -516,3 +516,6 @@ IF(UNIX)
 ENDIF(UNIX)
 
 INCLUDE (CPack)
+
+# Google Test and Google Mock library.
+add_subdirectory(3rdparty/gtest_and_gmock)


### PR DESCRIPTION
Sorry for the mess with the previous one, I forgot to create a separate branch for the pull request.. :/

I saw a few days ago that you setup CMake as build system and you want to refactor some part of the code and add unit tests using GTest and probably GMock if you want to unit test c++ class...

I personally hate to install dependencies system wide for development, so as external project GTest and GMock are automatically download from the Google repository and build with the rest of the gnucash by CMake and nothing have to be install at the system level. It's also a good thing since Google recommend to build your own libgtest and libgmock with each project you use it and it's an easy way to keep your library up-to-date (I'm a big fan of TDD and Continious Integration, I like to have the latest features and version :P ). It may also be possible to do the same with boost, because there is a boost-libs package on linux that give boost runtime libs and boost itself is useless on the user machine.

After that, the only thing to do will be to will be add CMakeLists.txt file in test folders with content lookalike that :

    SET(gnc_MODULE_NAME_test_SOURCES source_files_test.cpp)
    ADD_EXECUTABLE(gnd_MODULE_NAME_test ${gnc_MODULE_NAME_test_SOURCES})
    TARGET_LINK_LIBRARIES(gtest_MODULE_NAME_test MODULE_NAME gtest gmock)

I don't know it fallow the philosophy of the project and the way you want to manage your dependencies, but at least you will know there is that possibility. :)

PS : Sorry for my English, It's not my primary language ! :$
