### PR TITLE
[Bug 759849] - Add Account.AssignLots to python bindings

### DIFF
--- a/src/optional/python-bindings/gnucash_core.i
+++ b/src/optional/python-bindings/gnucash_core.i
@@ -80,6 +80,8 @@
 #include "gncIDSearch.h"
 #include "engine/gnc-pricedb.h"
 #include "app-utils/gnc-prefs-utils.h"
+#include "cap-gains.h"
+#include "Scrub3.h"
 %}
 
 %include <timespec.i>
@@ -209,6 +211,9 @@ static const GncGUID * gncEntryGetGUID(GncEntry *x);
 
 // Commodity prices includes and stuff
 %include <gnc-pricedb.h>
+
+%include <cap-gains.h>
+%include <Scrub3.h>
 
 %init %{
 gnc_environment_setup();

--- a/src/optional/python-bindings/tests/test_account.py
+++ b/src/optional/python-bindings/tests/test_account.py
@@ -1,6 +1,7 @@
 from unittest import main
-
-from gnucash import Book, Account, Split
+from datetime import datetime
+from gnucash import Book, Account, Split, GncCommodity, GncNumeric, \
+    Transaction
 
 from test_book import BookSession
 
@@ -20,6 +21,50 @@ class TestAccount( AccountSession ):
         SPLIT = Split(self.book)
         self.assertTrue(self.account.insert_split(SPLIT))
         self.assertTrue(self.account.remove_split(SPLIT))
+
+    def test_assignlots(self):
+        mbtc = GncCommodity(self.book, 'milli-Bitcoin', 
+            'COMMODITY','mBTC','mBTC',100000)
+        self.table.insert(mbtc)
+        self.account.SetCommodity(mbtc)
+
+        other = Account(self.book)
+        other.SetCommodity(self.currency)
+
+        tx = Transaction(self.book)	
+        tx.BeginEdit()
+        tx.SetCurrency(self.currency)	
+        tx.SetDateEnteredTS(datetime.now())
+        tx.SetDatePostedTS(datetime.now())
+        
+        s1a = Split(self.book)
+        s1a.SetParent(tx)
+        s1a.SetAccount(self.account)
+        s1a.SetAmount(GncNumeric(1.0))
+        s1a.SetValue(GncNumeric(100.0))
+
+        s1b = Split(self.book)
+        s1b.SetParent(tx)
+        s1b.SetAccount(other)
+        s1b.SetAmount(GncNumeric(-100.0))
+        s1b.SetValue(GncNumeric(-100.0))
+        
+        s2a = Split(self.book)
+        s2a.SetParent(tx)
+        s2a.SetAccount(self.account)
+        s2a.SetAmount(GncNumeric(-0.5))
+        s2a.SetValue(GncNumeric(-100.0))
+
+        s2b = Split(self.book)
+        s2b.SetParent(tx)
+        s2b.SetAccount(other)
+        s2b.SetAmount(GncNumeric(100.0))
+        s2b.SetValue(GncNumeric(100.0))
+
+        tx.CommitEdit()
+
+        self.account.ScrubLots()
+        self.assertEqual(len(self.account.GetLotList()),1)
 
 if __name__ == '__main__':
     main()

--- a/src/optional/python-bindings/tests/test_book.py
+++ b/src/optional/python-bindings/tests/test_book.py
@@ -6,8 +6,8 @@ class BookSession( TestCase ):
     def setUp(self):
         self.ses = Session()
         self.book = self.ses.get_book()
-        table = self.book.get_table()
-        self.currency = table.lookup('CURRENCY', 'EUR')
+        self.table = self.book.get_table()
+        self.currency = self.table.lookup('CURRENCY', 'EUR')
 
 class TestBook( BookSession ):
     def test_markclosed(self):


### PR DESCRIPTION
Added functions from cap-gains.h and Scrub3.h to the python bindings. Added ScrubLots instead of the originally requested AssignLots.