### PR TITLE
adding BYN currency according to ISO 4217 amendment #161

### DIFF
--- a/src/engine/iso-4217-currencies.xml
+++ b/src/engine/iso-4217-currencies.xml
@@ -565,6 +565,19 @@
   smallest-fraction="100"
   local-symbol="Br"
 />
+<!-- "BYN" - "Belarussian Ruble"
+-->
+<currency
+  isocode="BYN"
+  fullname="Belarussian Ruble"
+  unitname="ruble"
+  partname="kapeyka"
+  namespace="ISO4217"
+  exchange-code="933"
+  parts-per-unit="100"
+  smallest-fraction="1"
+  local-symbol="Br"
+/>
 <!-- "BZD" - "Belize Dollar"
 -->
 <currency


### PR DESCRIPTION
This summer BYR currency is going to be deprecated and replaced by BYN. As a result, all Belarussian users (including me) will be unable to use gnucash. To avoid this I'm adding BYN currency according to ISO 4217 amendment #161 http://www.currency-iso.org/en/shared/amendments/iso-4217-amendment.html