### PR TITLE
Minor changes to make tests CMake friendly

### DIFF
--- a/src/app-utils/test/test-scm-query-string.c
+++ b/src/app-utils/test/test-scm-query-string.c
@@ -140,7 +140,7 @@ main (int argc, char **argv)
 /* When built with clang, guile-1.8.8's scm_c_eval_string truncates all
  * integer values to int32, which causes this test to fail.
  */
-#ifndef __clang__
+#if !(defined(__clang__)) || defined(HAVE_GUILE20)
     scm_boot_guile (argc, argv, main_helper, NULL);
 #endif
     return 0;

--- a/src/backend/xml/test/test-real-data.sh.in
+++ b/src/backend/xml/test/test-real-data.sh.in
@@ -3,7 +3,9 @@
 #set -e
 
 EXIT_VALUE=0
-
+if [ "x$TEST_PATH" == "x" ] ; then
+  TEST_PATH=.
+fi
 for i in $SRCDIR/test-files/xml2/*.gml2 ; do
 
   if [ ! -d $i ] ; then
@@ -15,9 +17,9 @@ for i in $SRCDIR/test-files/xml2/*.gml2 ; do
       FILES=`perl $SRCDIR/grab-types.pl "gnc:$j" $i "$j/dataXXX.xml"`
       if [ ! -z "$FILES" ] ; then
 	  if [ "x$VERBOSE" = "xyes" ] ; then
-              echo "Testing ./test-xml-$j $j/data*.xml # from `basename $i`:"
+              echo "Testing $TEST_PATH/test-xml-$j $j/data*.xml # from `basename $i`:"
 	  fi
-        eval "./test-xml-$j $FILES 2>/dev/null"
+        eval "$TEST_PATH/test-xml-$j $FILES 2>/dev/null"
         if [ $? != 0 ] ; then
           EXIT_VALUE=1
         fi

--- a/src/gnc-module/test/test-dynload.c
+++ b/src/gnc-module/test/test-dynload.c
@@ -40,9 +40,15 @@ guile_main(void *closure, int argc, char ** argv)
     gchar *logdomain = "gnc.module";
     gchar *modpath;
     guint loglevel = G_LOG_LEVEL_WARNING;
+    const char *libdir = g_getenv("LIBDIR");
     TestErrorStruct check = { loglevel, logdomain, msg };
     g_log_set_handler (logdomain, loglevel,
                        (GLogFunc)test_checked_handler, &check);
+
+    if (libdir == NULL)
+    {
+        libdir = "../.libs";
+    }
 
     g_test_message("  test-dynload.c: testing dynamic linking of libgnc-module ...");
 #ifdef G_OS_WIN32
@@ -53,9 +59,16 @@ guile_main(void *closure, int argc, char ** argv)
  * that means that g_module_build_path (), which uses ".so", doesn't
  * build the right path name.
  */
-    modpath = g_build_filename ("..", ".libs", "libgnc-module.dylib", NULL);
+    if (libdir == NULL)
+    {
+        modpath = g_build_filename ("..", ".libs", "libgnc-module.dylib", NULL);
+    }
+    else
+    {
+        modpath = g_build_filename (libdir, "libgnc-module.dylib", NULL);
+    }
 #else /* Regular Unix */
-    modpath = g_module_build_path ("../.libs", "gnc-module");
+    modpath = g_module_build_path (libdir, "gnc-module");
 #endif
     gmodule = g_module_open(modpath, 0);
 


### PR DESCRIPTION
  * src/backend/xml/test/test-real-data.sh.in: Assumes test executables live in same directory as test. Add TEST_PATH variable, set to "." by default and overridden in CMakeLists.txt.

  * src/gnc-module/test/test-dynload.c: Assumes that libraries are at ../.libs. Added support for LIBDIR to allow override.

* app-utils/test/test-scm-query-string.c: Not a CMake issue, but test is skipped when compiling with clang due to issues with guile 1.8. Since we run with guile 2.x except in Windows, don't skip when using guile 2.x

