### PR TITLE
Change Baysian matching accounts to be saved by Guid

### DIFF
--- a/src/core-utils/gnc-features.c
+++ b/src/core-utils/gnc-features.c
@@ -45,6 +45,7 @@ static gncFeature known_features[] =
     { GNC_FEATURE_NUM_FIELD_SOURCE, "User specifies source of 'num' field'; either transaction number or split action (requires at least GnuCash 2.5.0)" },
     { GNC_FEATURE_KVP_EXTRA_DATA, "Extra data for addresses, jobs or invoice entries (requires at least GnuCash 2.6.4)" },
     { GNC_FEATURE_BOOK_CURRENCY, "User specifies a 'book-currency'; costs of other currencies/commodities tracked in terms of book-currency (requires at least GnuCash 2.7.0)" },
+    { GNC_FEATURE_CHANGE_BAYESIAN, "Change the way Bayesian data is saved to use the Account Guid (requires at least GnuCash 2.7.0)" },
     { NULL },
 };
 

--- a/src/core-utils/gnc-features.h
+++ b/src/core-utils/gnc-features.h
@@ -45,6 +45,7 @@
 #define GNC_FEATURE_NUM_FIELD_SOURCE "Number Field Source"
 #define GNC_FEATURE_KVP_EXTRA_DATA "Extra data in addresses, jobs or invoice entries"
 #define GNC_FEATURE_BOOK_CURRENCY "Use a Book-Currency"
+#define GNC_FEATURE_CHANGE_BAYESIAN "Change the way Bayesian data is saved to use Guid"
 
 /** @} */
 

--- a/src/engine/Account.c
+++ b/src/engine/Account.c
@@ -5829,7 +5829,7 @@ change_imap_entry (Account *root, gpointer user_data)
         // check for existing guid entry
         if (qof_instance_has_slot (QOF_INSTANCE(imapInfo->source_account), kvp_path))
         {
-            int64_t  existing_count = 1;
+            int64_t  existing_count = 0;
 
             // get the count value
             qof_instance_get_kvp (QOF_INSTANCE (imapInfo->source_account), kvp_path, &value);
@@ -5837,9 +5837,7 @@ change_imap_entry (Account *root, gpointer user_data)
             if (G_VALUE_HOLDS_INT64 (&value))
                 existing_count = g_value_get_int64 (&value);
 
-            // if existing_count is greater, use that one
-            if (existing_count > count)
-                count = existing_count;
+            count = count + existing_count;
         }
         g_value_set_int64 (&value, count);
 

--- a/src/engine/Account.c
+++ b/src/engine/Account.c
@@ -40,6 +40,7 @@
 #include "gnc-lot.h"
 #include "gnc-pricedb.h"
 #include "qofinstance-p.h"
+#include "gnc-features.h"
 
 static QofLogModule log_module = GNC_MOD_ACCOUNT;
 
@@ -5922,7 +5923,11 @@ gnc_account_imap_convert_bayes (QofBook *book)
 
         // set the run-once value
         qof_instance_set_kvp (QOF_INSTANCE (book), "changed-bayesian-to-guid", &value_b);
-        qof_instance_set_dirty (QOF_INSTANCE (book));
+
+        /* Set a feature flag in the book for the change to use guid.
+         * This will prevent older GnuCash versions that don't support this feature
+         * from opening this file. */
+        gnc_features_set_used (book, GNC_FEATURE_CHANGE_BAYESIAN);
     }
 }
 

--- a/src/engine/Account.c
+++ b/src/engine/Account.c
@@ -5639,7 +5639,7 @@ gnc_account_imap_get_info_bayes (Account *acc)
 {
     GList *list = NULL;
 
-    struct imap_info imapInfo;
+    GncImapInfo imapInfo;
 
     imapInfo.source_account = acc;
     imapInfo.list = list;
@@ -5658,7 +5658,7 @@ gnc_account_imap_get_info (Account *acc, const char *category)
     GList *list = NULL;
     gchar *category_head = NULL;
 
-    struct imap_info imapInfo;
+    GncImapInfo imapInfo;
 
     imapInfo.source_account = acc;
     imapInfo.list = list;
@@ -5770,13 +5770,11 @@ look_for_old_separator_descendants (Account *root, gchar *full_name, const gchar
 }
 
 static void
-change_imap_entry (Account *root, gpointer user_data)
+change_imap_entry (Account *root, GncImapInfo *imapInfo)
 {
     Account       *map_account = NULL;
     const gchar   *sep = gnc_get_account_separator_string ();
     gchar         *full_name;
-
-    struct imap_info *imapInfo = (struct imap_info*)user_data;
 
     PINFO("Category Head is '%s', Full Category is '%s'", imapInfo->category_head, imapInfo->full_category);
 
@@ -5870,7 +5868,7 @@ get_account_imap_info (Account *root, Account *acc)
 
         for (node = imap_list;  node; node = g_list_next (node))
         {
-            struct imap_info *imapInfo = node->data;
+            GncImapInfo *imapInfo = node->data;
 
             // Lets start doing stuff
             change_imap_entry (root, imapInfo);

--- a/src/engine/Account.c
+++ b/src/engine/Account.c
@@ -5886,6 +5886,7 @@ gnc_account_imap_convert_bayes (QofBook *book)
 
         get_account_imap_info (root, acc);
     }
+    g_list_free (accts);
 }
 
 

--- a/src/engine/Account.c
+++ b/src/engine/Account.c
@@ -5755,7 +5755,6 @@ static gchar *
 look_for_old_separator_descendants (Account *root, gchar *full_name, const gchar *separator)
 {
     GList *top_accounts, *ptr;
-    gchar *converted_name = g_strdup (full_name);
     gint   found_len = 0;
     gchar  found_sep;
 
@@ -5769,30 +5768,29 @@ look_for_old_separator_descendants (Account *root, gchar *full_name, const gchar
         const gchar *name = xaccAccountGetName (ptr->data);
 
         // we are looking for the longest top level account that matches
-        if (g_str_has_prefix (converted_name, name))
+        if (g_str_has_prefix (full_name, name))
         {
             gint name_len = strlen (name);
-            const gchar old_sep = converted_name[name_len];
+            const gchar old_sep = full_name[name_len];
 
             if (!g_ascii_isalnum (old_sep)) // test for non alpha numeric
             {
                 if (name_len > found_len)
                 {
-                    found_sep = converted_name[name_len];
+                    found_sep = full_name[name_len];
                     found_len = name_len;
                 }
             }
         }
     }
     g_list_free (top_accounts); // Free the List
-    g_free (full_name);
 
     if (found_len > 1)
-        converted_name = g_strdelimit (converted_name, &found_sep, *separator);
+        full_name = g_strdelimit (full_name, &found_sep, *separator);
 
-    PINFO("Return full_name is '%s'", converted_name);
+    PINFO("Return full_name is '%s'", full_name);
 
-    return converted_name;
+    return full_name;
 }
 
 

--- a/src/engine/Account.c
+++ b/src/engine/Account.c
@@ -5849,7 +5849,7 @@ look_for_old_mapping (GncImapInfo *imapInfo)
 
     // do we have a map_account all ready, implying a guid string
     if (imapInfo->map_account != NULL)
-        return map_account;
+        return NULL;
 
     root = gnc_account_get_root (imapInfo->source_account);
 

--- a/src/engine/Account.c
+++ b/src/engine/Account.c
@@ -5874,19 +5874,40 @@ gnc_account_imap_convert_bayes (QofBook *book)
 {
     Account      *root;
     GList        *accts, *ptr;
+    gboolean      run_once = FALSE;
+    GValue        value_s = G_VALUE_INIT;
 
-    /* Get list of Accounts */
-    root = gnc_book_get_root_account (book);
-    accts = gnc_account_get_descendants_sorted (root);
+    // get the run-once value
+    qof_instance_get_kvp (QOF_INSTANCE (book), "changed-bayesian-to-guid", &value_s);
 
-    /* Go through list of accounts */
-    for (ptr = accts; ptr; ptr = g_list_next (ptr))
+    if (G_VALUE_HOLDS_STRING (&value_s) && (strcmp(g_value_get_string (&value_s), "true") == 0))
+        run_once = TRUE;
+
+    if (run_once == FALSE)
     {
-        Account *acc = ptr->data;
+        GValue value_b = G_VALUE_INIT;
 
-        get_account_imap_info (root, acc);
+        /* Get list of Accounts */
+        root = gnc_book_get_root_account (book);
+        accts = gnc_account_get_descendants_sorted (root);
+
+        /* Go through list of accounts */
+        for (ptr = accts; ptr; ptr = g_list_next (ptr))
+        {
+            Account *acc = ptr->data;
+
+            get_account_imap_info (root, acc);
+        }
+        g_list_free (accts);
+
+        g_value_init (&value_b, G_TYPE_BOOLEAN);
+
+        g_value_set_boolean (&value_b, TRUE);
+
+        // set the run-once value
+        qof_instance_set_kvp (QOF_INSTANCE (book), "changed-bayesian-to-guid", &value_b);
+        qof_instance_set_dirty (QOF_INSTANCE (book));
     }
-    g_list_free (accts);
 }
 
 

--- a/src/engine/Account.c
+++ b/src/engine/Account.c
@@ -5803,10 +5803,27 @@ change_imap_entry (Account *root, gpointer user_data)
         kvp_path = g_strdup (imapInfo->full_category);
         gnc_account_delete_map_entry (imapInfo->source_account, kvp_path, FALSE);
 
+        // create path based on guid
+        kvp_path = g_strdup_printf ("/%s/%s", imapInfo->category_head, guid_string);
+
+        // check for existing guid entry
+        if (qof_instance_has_slot (QOF_INSTANCE(imapInfo->source_account), kvp_path))
+        {
+            int64_t  existing_count = 1;
+
+            // get the count value
+            qof_instance_get_kvp (QOF_INSTANCE (imapInfo->source_account), kvp_path, &value);
+
+            if (G_VALUE_HOLDS_INT64 (&value))
+                existing_count = g_value_get_int64 (&value);
+
+            // if existing_count is greater, use that one
+            if (existing_count > count)
+                count = existing_count;
+        }
         g_value_set_int64 (&value, count);
 
-        // Add new entry based on guid
-        kvp_path = g_strdup_printf ("/%s/%s", imapInfo->category_head, guid_string);
+        // Add or Update the entry based on guid
         qof_instance_set_kvp (QOF_INSTANCE (imapInfo->source_account), kvp_path, &value);
 
         qof_instance_set_dirty (QOF_INSTANCE (imapInfo->source_account));

--- a/src/engine/Account.c
+++ b/src/engine/Account.c
@@ -5723,6 +5723,154 @@ gnc_account_delete_map_entry (Account *acc, char *full_category, gboolean empty)
     g_free (full_category);
 }
 
+/*******************************************************************************/
+
+static gchar *
+look_for_old_separator (Account *root, gchar *full_name, const gchar *separator)
+{
+    GList *top_accounts, *ptr;
+    gchar *converted_name = g_strdup (full_name);
+
+    top_accounts = gnc_account_get_descendants (root);
+
+    PINFO("Incoming full_name is '%s'", full_name);
+
+    /* Go through list of top level accounts */
+    for (ptr = top_accounts; ptr; ptr = g_list_next (ptr))
+    {
+        const gchar *name = xaccAccountGetName (ptr->data);
+
+        if (g_str_has_prefix (converted_name, name))
+        {
+            const gchar old_sep = converted_name[strlen (name)];
+
+            if (!g_ascii_isalnum (old_sep)) // test for non alpha numeric
+                converted_name = g_strdelimit (converted_name, &old_sep, *separator);
+
+            break;
+        }
+    }
+    g_list_free (top_accounts); // Free the List
+    g_free (full_name);
+
+    PINFO("Return full_name is '%s'", converted_name);
+
+    return converted_name;
+}
+
+static void
+change_imap_entry (Account *root, gpointer user_data)
+{
+    Account       *map_account = NULL;
+    const gchar   *sep = gnc_get_account_separator_string ();
+    gchar         *full_name;
+
+    struct imap_info *imapInfo = (struct imap_info*)user_data;
+
+    PINFO("Category Head is '%s', Full Category is '%s'", imapInfo->category_head, imapInfo->full_category);
+
+    full_name = g_strdup (imapInfo->full_category + strlen (imapInfo->category_head) + 1);
+
+    if (g_strstr_len (full_name, -1, sep) == NULL) // does full_name contain a different account separator
+        full_name = look_for_old_separator (root, full_name, sep);
+
+    PINFO("full name is '%s'", full_name);
+
+    map_account = gnc_account_lookup_by_full_name (root, full_name);
+
+    if (map_account != NULL)
+    {
+        gchar   *guid_string;
+        gchar   *kvp_path;
+        int64_t  count = 1;
+
+        GValue value = G_VALUE_INIT;
+
+        xaccAccountBeginEdit (imapInfo->source_account);
+
+        guid_string = guid_to_string (xaccAccountGetGUID (map_account));
+
+        PINFO("Map Account is '%s',GUID is '%s', Count is %s", xaccAccountGetName (map_account),
+               guid_string, imapInfo->count);
+
+        // save converting string, get the count value
+        qof_instance_get_kvp (QOF_INSTANCE (imapInfo->source_account), imapInfo->full_category, &value);
+
+        if (G_VALUE_HOLDS_INT64 (&value))
+            count = g_value_get_int64 (&value);
+
+        // Delete the old entry based on full account name
+        kvp_path = g_strdup (imapInfo->full_category);
+        gnc_account_delete_map_entry (imapInfo->source_account, kvp_path, FALSE);
+
+        g_value_set_int64 (&value, count);
+
+        // Add new entry based on guid
+        kvp_path = g_strdup_printf ("/%s/%s", imapInfo->category_head, guid_string);
+        qof_instance_set_kvp (QOF_INSTANCE (imapInfo->source_account), kvp_path, &value);
+
+        qof_instance_set_dirty (QOF_INSTANCE (imapInfo->source_account));
+        xaccAccountCommitEdit (imapInfo->source_account);
+
+        g_free (kvp_path);
+        g_free (guid_string);
+    }
+    g_free (full_name);
+}
+
+static void
+get_account_imap_info (Account *root, Account *acc)
+{
+    GList *imap_list, *node;
+    gchar *acc_name = NULL;
+
+    acc_name = gnc_account_get_full_name (acc);
+    PINFO("Source Acc '%s'", acc_name);
+
+    imap_list = gnc_account_imap_get_info_bayes (acc);
+
+    if (g_list_length (imap_list) > 0)
+    {
+        PINFO("List length is %d", g_list_length (imap_list));
+
+        for (node = imap_list;  node; node = g_list_next (node))
+        {
+            struct imap_info *imapInfo = node->data;
+
+            // Lets start doing stuff
+            change_imap_entry (root, imapInfo);
+
+            // Free the members and structure
+            g_free (imapInfo->category_head);
+            g_free (imapInfo->full_category);
+            g_free (imapInfo->match_string);
+            g_free (imapInfo->count);
+            g_free (imapInfo);
+        }
+    }
+    g_free (acc_name);
+    g_list_free (imap_list); // Free the List
+}
+
+void
+gnc_account_imap_convert_bayes (QofBook *book)
+{
+    Account      *root;
+    GList        *accts, *ptr;
+
+    /* Get list of Accounts */
+    root = gnc_book_get_root_account (book);
+    accts = gnc_account_get_descendants_sorted (root);
+
+    /* Go through list of accounts */
+    for (ptr = accts; ptr; ptr = g_list_next (ptr))
+    {
+        Account *acc = ptr->data;
+
+        get_account_imap_info (root, acc);
+    }
+}
+
 
 /* ================================================================ */
 /* QofObject function implementation and registration */

--- a/src/engine/Account.c
+++ b/src/engine/Account.c
@@ -5427,6 +5427,45 @@ gnc_account_imap_find_account_bayes (GncImportMatchMap *imap, GList *tokens)
 }
 
 
+static void
+change_imap_entry (GncImportMatchMap *imap, gchar *kvp_path, int64_t token_count)
+{
+    GValue value = G_VALUE_INIT;
+
+    PINFO("Source Account is '%s', kvp_path is '%s', Count is '%" G_GINT64_FORMAT "'",
+           xaccAccountGetName (imap->acc), kvp_path, token_count);
+
+    // check for existing guid entry
+    if (qof_instance_has_slot (QOF_INSTANCE(imap->acc), kvp_path))
+    {
+        int64_t  existing_token_count = 0;
+
+        // get the existing_token_count value
+        qof_instance_get_kvp (QOF_INSTANCE (imap->acc), kvp_path, &value);
+
+        if (G_VALUE_HOLDS_INT64 (&value))
+            existing_token_count = g_value_get_int64 (&value);
+
+        PINFO("found existing value of '%" G_GINT64_FORMAT "'", existing_token_count);
+
+        token_count = token_count + existing_token_count;
+    }
+
+    if (!G_IS_VALUE (&value))
+        g_value_init (&value, G_TYPE_INT64);
+
+    g_value_set_int64 (&value, token_count);
+
+    // Add or Update the entry based on guid
+    qof_instance_set_kvp (QOF_INSTANCE (imap->acc), kvp_path, &value);
+
+    /* Set a feature flag in the book for the change to use guid.
+     * This will prevent older GnuCash versions that don't support this feature
+     * from opening this file. */
+    gnc_features_set_used (imap->book, GNC_FEATURE_CHANGE_BAYESIAN);
+}
+
+
 /** Updates the imap for a given account using a list of tokens */
 void
 gnc_account_imap_add_account_bayes (GncImportMatchMap *imap,
@@ -5465,8 +5504,8 @@ gnc_account_imap_add_account_bayes (GncImportMatchMap *imap,
         if (!current_token->data || (*((char*)current_token->data) == '\0'))
             continue;
 
-        /* start off with no tokens for this account */
-        token_count = 0;
+        /* start off with one token for this account */
+        token_count = 1;
 
         PINFO("adding token '%s'", (char*)current_token->data);
 
@@ -5474,23 +5513,9 @@ gnc_account_imap_add_account_bayes (GncImportMatchMap *imap,
                                     (char*)current_token->data,
                                     guid_string);
 
-        qof_instance_get_kvp (QOF_INSTANCE (imap->acc), kvp_path, &value);
-        /* if the token/account is already in the tree, read the current
-         * value from the tree and use this for the basis of the value we
-         * are putting back
-         */
-        if (G_VALUE_HOLDS_INT64 (&value))
-        {
-            int64_t count = g_value_get_int64 (&value);
-            PINFO("found existing value of '%" G_GINT64_FORMAT "'", count);
+        /* change the imap entry for the account */
+        change_imap_entry (imap, kvp_path, token_count);
 
-            token_count += count;
-        }
-        token_count++;
-        if (!G_IS_VALUE (&value))
-            g_value_init (&value, G_TYPE_INT64);
-        g_value_set_int64 (&value, token_count);
-        qof_instance_set_kvp (QOF_INSTANCE (imap->acc), kvp_path, &value);
         g_free (kvp_path);
     }
 
@@ -5770,8 +5795,53 @@ look_for_old_separator_descendants (Account *root, gchar *full_name, const gchar
     return converted_name;
 }
 
+
 static void
-change_imap_entry (Account *root, GncImapInfo *imapInfo)
+update_imap_entry (Account *map_account, GncImapInfo *imapInfo)
+{
+    GncImportMatchMap *imap;
+    gchar   *guid_string;
+    gchar   *kvp_path;
+    int64_t  token_count = 1;
+
+    GValue value = G_VALUE_INIT;
+
+    // Create an ImportMatchMap object
+    imap = gnc_account_imap_create_imap (imapInfo->source_account);
+
+    xaccAccountBeginEdit (imapInfo->source_account);
+
+    guid_string = guid_to_string (xaccAccountGetGUID (map_account));
+
+    PINFO("Map Account is '%s', GUID is '%s', Count is %s", xaccAccountGetName (map_account),
+               guid_string, imapInfo->count);
+
+    // save converting string, get the count value
+    qof_instance_get_kvp (QOF_INSTANCE (imapInfo->source_account), imapInfo->full_category, &value);
+
+    if (G_VALUE_HOLDS_INT64 (&value))
+        token_count = g_value_get_int64 (&value);
+
+    // Delete the old entry based on full account name
+    kvp_path = g_strdup (imapInfo->full_category);
+    gnc_account_delete_map_entry (imapInfo->source_account, kvp_path, FALSE);
+
+    // create path based on guid
+    kvp_path = g_strdup_printf ("/%s/%s", imapInfo->category_head, guid_string);
+
+    // change the imap entry of source_account
+    change_imap_entry (imap, kvp_path, token_count);
+
+    qof_instance_set_dirty (QOF_INSTANCE (imapInfo->source_account));
+    xaccAccountCommitEdit (imapInfo->source_account);
+
+    g_free (kvp_path);
+    g_free (guid_string);
+}
+
+
+static void
+convert_imap_entry (Account *root, GncImapInfo *imapInfo)
 {
     Account       *map_account = NULL;
     const gchar   *sep = gnc_get_account_separator_string ();
@@ -5797,58 +5867,9 @@ change_imap_entry (Account *root, GncImapInfo *imapInfo)
 
     PINFO("Full account name is '%s'", full_name);
 
-    if (map_account != NULL) // we have an account, try and convert
-    {
-        gchar   *guid_string;
-        gchar   *kvp_path;
-        int64_t  count = 1;
+    if (map_account != NULL) // we have an account, try and update it
+        update_imap_entry (map_account, imapInfo);
 
-        GValue value = G_VALUE_INIT;
-
-        xaccAccountBeginEdit (imapInfo->source_account);
-
-        guid_string = guid_to_string (xaccAccountGetGUID (map_account));
-
-        PINFO("Map Account is '%s',GUID is '%s', Count is %s", xaccAccountGetName (map_account),
-               guid_string, imapInfo->count);
-
-        // save converting string, get the count value
-        qof_instance_get_kvp (QOF_INSTANCE (imapInfo->source_account), imapInfo->full_category, &value);
-
-        if (G_VALUE_HOLDS_INT64 (&value))
-            count = g_value_get_int64 (&value);
-
-        // Delete the old entry based on full account name
-        kvp_path = g_strdup (imapInfo->full_category);
-        gnc_account_delete_map_entry (imapInfo->source_account, kvp_path, FALSE);
-
-        // create path based on guid
-        kvp_path = g_strdup_printf ("/%s/%s", imapInfo->category_head, guid_string);
-
-        // check for existing guid entry
-        if (qof_instance_has_slot (QOF_INSTANCE(imapInfo->source_account), kvp_path))
-        {
-            int64_t  existing_count = 0;
-
-            // get the count value
-            qof_instance_get_kvp (QOF_INSTANCE (imapInfo->source_account), kvp_path, &value);
-
-            if (G_VALUE_HOLDS_INT64 (&value))
-                existing_count = g_value_get_int64 (&value);
-
-            count = count + existing_count;
-        }
-        g_value_set_int64 (&value, count);
-
-        // Add or Update the entry based on guid
-        qof_instance_set_kvp (QOF_INSTANCE (imapInfo->source_account), kvp_path, &value);
-
-        qof_instance_set_dirty (QOF_INSTANCE (imapInfo->source_account));
-        xaccAccountCommitEdit (imapInfo->source_account);
-
-        g_free (kvp_path);
-        g_free (guid_string);
-    }
     g_free (full_name);
 }
 
@@ -5863,7 +5884,7 @@ get_account_imap_info (Account *root, Account *acc)
 
     imap_list = gnc_account_imap_get_info_bayes (acc);
 
-    if (g_list_length (imap_list) > 0)
+    if (g_list_length (imap_list) > 0) // we have mappings
     {
         PINFO("List length is %d", g_list_length (imap_list));
 
@@ -5872,7 +5893,7 @@ get_account_imap_info (Account *root, Account *acc)
             GncImapInfo *imapInfo = node->data;
 
             // Lets start doing stuff
-            change_imap_entry (root, imapInfo);
+            convert_imap_entry (root, imapInfo);
 
             // Free the members and structure
             g_free (imapInfo->category_head);
@@ -5923,11 +5944,6 @@ gnc_account_imap_convert_bayes (QofBook *book)
 
         // set the run-once value
         qof_instance_set_kvp (QOF_INSTANCE (book), "changed-bayesian-to-guid", &value_b);
-
-        /* Set a feature flag in the book for the change to use guid.
-         * This will prevent older GnuCash versions that don't support this feature
-         * from opening this file. */
-        gnc_features_set_used (book, GNC_FEATURE_CHANGE_BAYESIAN);
     }
 }
 

--- a/src/engine/Account.h
+++ b/src/engine/Account.h
@@ -1437,6 +1437,11 @@ gchar *gnc_account_get_map_entry (Account *acc, const char *full_category);
  */
 void gnc_account_delete_map_entry (Account *acc, char *full_category, gboolean empty);
 
+/** Search for Bayesian entries with mappings based on full account name and change
+ *  them to be based on the account guid
+ */
+void gnc_account_imap_convert_bayes (QofBook *book);
+
 /** @} */
 
 

--- a/src/engine/Account.h
+++ b/src/engine/Account.h
@@ -1406,7 +1406,7 @@ Account* gnc_account_imap_find_account_bayes (GncImportMatchMap *imap, GList* to
 void gnc_account_imap_add_account_bayes (GncImportMatchMap *imap, GList* tokens,
                                          Account *acc);
 
-struct imap_info
+typedef struct imap_info
 {
     Account        *source_account;
     Account        *map_account;
@@ -1415,7 +1415,7 @@ struct imap_info
     char           *full_category;
     char           *match_string;
     char           *count;
-};
+}GncImapInfo;
 
 /** Returns a GList of structure imap_info of all Bayesian mappings for
  *  required Account

--- a/src/gnome-utils/gnc-file.c
+++ b/src/gnome-utils/gnc-file.c
@@ -1002,6 +1002,11 @@ RESTART:
         g_free ( message );
     }
 
+    // Convert imap mappings from account full name to guid strings
+    qof_event_suspend();
+    gnc_account_imap_convert_bayes (gnc_get_current_book());
+    qof_event_resume();
+
     return TRUE;
 }
 

--- a/src/gnome/dialog-imap-editor.c
+++ b/src/gnome/dialog-imap-editor.c
@@ -400,12 +400,10 @@ show_count_column (ImapDialog *imap_dialog, gboolean show)
 }
 
 static void
-add_to_store (GtkTreeModel *model, GtkTreeIter *iter, const gchar *text, gpointer user_data)
+add_to_store (GtkTreeModel *model, GtkTreeIter *iter, const gchar *text, GncImapInfo *imapInfo)
 {
     gchar       *fullname = NULL;
     gchar       *map_fullname = NULL;
-
-    struct imap_info *imapInfo = (struct imap_info*)user_data;
 
     fullname = gnc_account_get_full_name (imapInfo->source_account);
 
@@ -455,7 +453,7 @@ get_imap_info (Account *acc, const gchar *category, GtkTreeModel *model, const g
 
         for (node = imap_list;  node; node = g_list_next (node))
         {
-            struct imap_info *imapInfo = node->data;
+            GncImapInfo *imapInfo = node->data;
 
             // First add a child entry and pass iter to add_to_store
             gtk_tree_store_append (GTK_TREE_STORE(model), &child, &toplevel);
@@ -533,7 +531,7 @@ get_account_info_online (GList *accts, GtkTreeModel *model)
     GList       *ptr;
     GtkTreeIter  toplevel;
 
-    struct imap_info imapInfo;
+    GncImapInfo imapInfo;
 
     /* Go through list of accounts */
     for (ptr = accts; ptr; ptr = g_list_next (ptr))


### PR DESCRIPTION
This pull request changes the way Bayesian matched accounts are saved in KVP, instead of using the account full name as part of the path it uses the account Guid.
As part of this there is a function to change all existing entries to that of Guids which is run when a file is opened. I have also added a KVP entry to the book so I can test for this and allow the conversion to be run once.
Not sure if this is correct but seems to work.