### PR TITLE
Update the Unit tests for import-map

### DIFF
--- a/src/engine/test/gtest-import-map.cpp
+++ b/src/engine/test/gtest-import-map.cpp
@@ -221,16 +221,16 @@ protected:
 TEST_F(ImapBayesTest, FindAccountBayes)
 {
     auto root = qof_instance_get_slots(QOF_INSTANCE(t_bank_account));
-    auto acct1_name = gnc_account_get_full_name(t_expense_account1);
-    auto acct2_name = gnc_account_get_full_name(t_expense_account2);
+    auto acct1_guid = guid_to_string (xaccAccountGetGUID(t_expense_account1));
+    auto acct2_guid = guid_to_string (xaccAccountGetGUID(t_expense_account2));
     auto value = new KvpValue(INT64_C(42));
 
-    root->set_path({IMAP_FRAME_BAYES, foo, acct1_name}, value);
-    root->set_path({IMAP_FRAME_BAYES, bar, acct1_name}, value);
-    root->set_path({IMAP_FRAME_BAYES, baz, acct2_name}, value);
-    root->set_path({IMAP_FRAME_BAYES, waldo, acct2_name}, value);
-    root->set_path({IMAP_FRAME_BAYES, pepper, acct1_name}, value);
-    root->set_path({IMAP_FRAME_BAYES, salt, acct2_name}, value);
+    root->set_path({IMAP_FRAME_BAYES, foo, acct1_guid}, value);
+    root->set_path({IMAP_FRAME_BAYES, bar, acct1_guid}, value);
+    root->set_path({IMAP_FRAME_BAYES, baz, acct2_guid}, value);
+    root->set_path({IMAP_FRAME_BAYES, waldo, acct2_guid}, value);
+    root->set_path({IMAP_FRAME_BAYES, pepper, acct1_guid}, value);
+    root->set_path({IMAP_FRAME_BAYES, salt, acct2_guid}, value);
 
     auto account = gnc_account_imap_find_account_bayes(t_imap, t_list1);
     EXPECT_EQ(t_expense_account1, account);
@@ -261,30 +261,30 @@ TEST_F(ImapBayesTest, AddAccountBayes)
     qof_instance_reset_editlevel(QOF_INSTANCE(t_bank_account));
 
     auto root = qof_instance_get_slots(QOF_INSTANCE(t_bank_account));
-    auto acct1_name = gnc_account_get_full_name(t_expense_account1);
-    auto acct2_name = gnc_account_get_full_name(t_expense_account2);
+    auto acct1_guid = guid_to_string (xaccAccountGetGUID(t_expense_account1));
+    auto acct2_guid = guid_to_string (xaccAccountGetGUID(t_expense_account2));
     auto value = root->get_slot({IMAP_FRAME_BAYES, "foo", "bar"});
     auto check_account = [this](KvpValue* v) {
         return (v->get<const char*>(), this->t_imap->book); };
-    value = root->get_slot({IMAP_FRAME_BAYES, foo, acct1_name});
+    value = root->get_slot({IMAP_FRAME_BAYES, foo, acct1_guid});
     EXPECT_EQ(1, value->get<int64_t>());
-    value = root->get_slot({IMAP_FRAME_BAYES, bar, acct1_name});
+    value = root->get_slot({IMAP_FRAME_BAYES, bar, acct1_guid});
     EXPECT_EQ(1, value->get<int64_t>());
-    value = root->get_slot({IMAP_FRAME_BAYES, baz, acct2_name});
+    value = root->get_slot({IMAP_FRAME_BAYES, baz, acct2_guid});
     EXPECT_EQ(1, value->get<int64_t>());
-    value = root->get_slot({IMAP_FRAME_BAYES, waldo, acct2_name});
+    value = root->get_slot({IMAP_FRAME_BAYES, waldo, acct2_guid});
     EXPECT_EQ(1, value->get<int64_t>());
-    value = root->get_slot({IMAP_FRAME_BAYES, pepper, acct1_name});
+    value = root->get_slot({IMAP_FRAME_BAYES, pepper, acct1_guid});
     EXPECT_EQ(1, value->get<int64_t>());
-    value = root->get_slot({IMAP_FRAME_BAYES, salt, acct2_name});
+    value = root->get_slot({IMAP_FRAME_BAYES, salt, acct2_guid});
     EXPECT_EQ(1, value->get<int64_t>());
-    value = root->get_slot({IMAP_FRAME_BAYES, baz, acct1_name});
+    value = root->get_slot({IMAP_FRAME_BAYES, baz, acct1_guid});
     EXPECT_EQ(nullptr, value);
 
     qof_instance_increase_editlevel(QOF_INSTANCE(t_bank_account));
     gnc_account_imap_add_account_bayes(t_imap, t_list2, t_expense_account2);
     qof_instance_mark_clean(QOF_INSTANCE(t_bank_account));
     qof_instance_reset_editlevel(QOF_INSTANCE(t_bank_account));
-    value = root->get_slot({IMAP_FRAME_BAYES, baz, acct2_name});
+    value = root->get_slot({IMAP_FRAME_BAYES, baz, acct2_guid});
     EXPECT_EQ(2, value->get<int64_t>());
 }

--- a/src/engine/test/gtest-import-map.cpp
+++ b/src/engine/test/gtest-import-map.cpp
@@ -37,20 +37,46 @@ protected:
     void SetUp() {
         QofBook *book = qof_book_new();
         Account *root = gnc_account_create_root(book);
+
+        t_asset_account1 = xaccMallocAccount(book);
+        xaccAccountSetName(t_asset_account1, "Asset");
+        gnc_account_append_child(root, t_asset_account1);
+
         t_bank_account = xaccMallocAccount(book);
+        xaccAccountSetName(t_bank_account, "Bank");
+        gnc_account_append_child(t_asset_account1, t_bank_account);
+
+        t_asset_account2 = xaccMallocAccount(book);
+        xaccAccountSetName(t_asset_account2, "Asset-Bank");
+        gnc_account_append_child(root, t_asset_account2);
+
+        t_sav_account = xaccMallocAccount(book);
+        xaccAccountSetName(t_sav_account, "Bank");
+        gnc_account_append_child(t_asset_account2, t_sav_account);
+
+        t_expense_account = xaccMallocAccount(book);
+        xaccAccountSetName(t_expense_account, "Expense");
+        gnc_account_append_child(root, t_expense_account);
+
         t_expense_account1 = xaccMallocAccount(book);
         xaccAccountSetName(t_expense_account1, "Food");
-        gnc_account_append_child(root, t_expense_account1);
+        gnc_account_append_child(t_expense_account, t_expense_account1);
+
         t_expense_account2 = xaccMallocAccount(book);
         xaccAccountSetName(t_expense_account2, "Drink");
-        gnc_account_append_child(root, t_expense_account2);
+        gnc_account_append_child(t_expense_account, t_expense_account2);
     }
     void TearDown() {
         qof_book_destroy (gnc_account_get_book (t_bank_account));
     }
     Account *t_bank_account {};
+    Account *t_sav_account {};
     Account *t_expense_account1 {};
     Account *t_expense_account2 {};
+
+    Account *t_asset_account1 {};
+    Account *t_asset_account2 {};
+    Account *t_expense_account {};
 };
 
 TEST_F(ImapTest, CreateImap) {
@@ -288,3 +314,78 @@ TEST_F(ImapBayesTest, AddAccountBayes)
     value = root->get_slot({IMAP_FRAME_BAYES, baz, acct2_guid});
     EXPECT_EQ(2, value->get<int64_t>());
 }
+
+
+TEST_F(ImapBayesTest, ConvertAccountBayes)
+{
+    // prevent the embedded beginedit/commitedit from doing anything
+    qof_instance_increase_editlevel(QOF_INSTANCE(t_bank_account));
+    qof_instance_mark_clean(QOF_INSTANCE(t_bank_account));
+    gnc_account_imap_add_account_bayes(t_imap, t_list1, t_expense_account1); //Food
+    gnc_account_imap_add_account_bayes(t_imap, t_list2, t_expense_account2); //Drink
+
+    auto root = qof_instance_get_slots(QOF_INSTANCE(t_bank_account));
+    auto book = qof_instance_get_slots(QOF_INSTANCE(t_imap->book));
+    auto acct1_guid = guid_to_string (xaccAccountGetGUID(t_expense_account1)); //Food
+    auto acct2_guid = guid_to_string (xaccAccountGetGUID(t_expense_account2)); //Drink
+    auto acct3_guid = guid_to_string (xaccAccountGetGUID(t_asset_account2)); //Asset-Bank
+    auto acct4_guid = guid_to_string (xaccAccountGetGUID(t_sav_account)); //Sav Bank
+
+    auto val1 = new KvpValue(static_cast<int64_t>(10));
+    auto val2 = new KvpValue(static_cast<int64_t>(5));
+    auto val3 = new KvpValue(static_cast<int64_t>(2));
+
+    // Test for existing entries, all will be 1
+    auto value = root->get_slot({IMAP_FRAME_BAYES, foo, acct1_guid});
+    EXPECT_EQ(1, value->get<int64_t>());
+    value = root->get_slot({IMAP_FRAME_BAYES, bar, acct1_guid});
+    EXPECT_EQ(1, value->get<int64_t>());
+    value = root->get_slot({IMAP_FRAME_BAYES, baz, acct2_guid});
+    EXPECT_EQ(1, value->get<int64_t>());
+    value = root->get_slot({IMAP_FRAME_BAYES, waldo, acct2_guid});
+    EXPECT_EQ(1, value->get<int64_t>());
+
+    // Set up some old entries
+    root->set_path({IMAP_FRAME_BAYES, pepper, "Asset-Bank"}, val1);
+    root->set_path({IMAP_FRAME_BAYES, salt, "Asset-Bank#Bank"}, val1);
+    root->set_path({IMAP_FRAME_BAYES, salt, "Asset>Bank#Bank"}, val2);
+    root->set_path({IMAP_FRAME_BAYES, pork, "Expense#Food"}, val2);
+    root->set_path({IMAP_FRAME_BAYES, sausage, "Expense#Drink"}, val3);
+    root->set_path({IMAP_FRAME_BAYES, foo, "Expense#Food"}, val2);
+
+    EXPECT_EQ(1, qof_instance_get_editlevel(QOF_INSTANCE(t_bank_account)));
+    EXPECT_TRUE(qof_instance_get_dirty_flag(QOF_INSTANCE(t_bank_account)));
+    qof_instance_mark_clean(QOF_INSTANCE(t_bank_account));
+
+    // Start Convert
+    gnc_account_imap_convert_bayes (t_imap->book);
+
+    // convert from 'Asset-Bank' to 'Asset-Bank' guid
+    value = root->get_slot({IMAP_FRAME_BAYES, pepper, acct3_guid});
+    EXPECT_EQ(10, value->get<int64_t>());
+
+    // convert from 'Asset-Bank#Bank' to 'Sav Bank' guid
+    value = root->get_slot({IMAP_FRAME_BAYES, salt, acct4_guid});
+    EXPECT_EQ(10, value->get<int64_t>());
+
+    // convert from 'Expense#Food' to 'Food' guid
+    value = root->get_slot({IMAP_FRAME_BAYES, pork, acct1_guid});
+    EXPECT_EQ(5, value->get<int64_t>());
+
+    // convert from 'Expense#Drink' to 'Drink' guid
+    value = root->get_slot({IMAP_FRAME_BAYES, sausage, acct2_guid});
+    EXPECT_EQ(2, value->get<int64_t>());
+
+    // convert from 'Expense#Food' to 'Food' guid but add to original value
+    value = root->get_slot({IMAP_FRAME_BAYES, foo, acct1_guid});
+    EXPECT_EQ(6, value->get<int64_t>());
+
+    // Check for run once flag
+    auto vals = book->get_slot("changed-bayesian-to-guid");
+    EXPECT_STREQ("true", vals->get<const char*>());
+
+    EXPECT_EQ(1, qof_instance_get_editlevel(QOF_INSTANCE(t_bank_account)));
+    EXPECT_TRUE(qof_instance_get_dirty_flag(QOF_INSTANCE(t_bank_account)));
+}
+
+


### PR DESCRIPTION
Updated the existing Bayesian import tests to reflect change to using the account guid to store mappings and also added a test for the conversion of existing entries.