### PR TITLE
CMake: Don't try to install COPYING file that does not exist.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -490,7 +490,6 @@ SET(gnucash_DOCS
     ChangeLog.2012
     ChangeLog.2013
     ChangeLog.2014
-    COPYING
     DOCUMENTERS
     HACKING
     LICENSE


### PR DESCRIPTION
This should fix the nightly build of master on Windows.