### PR TITLE
Find account

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -206,6 +206,7 @@ src/gnome/assistant-loan.c
 src/gnome/assistant-stock-split.c
 src/gnome/dialog-commodities.c
 src/gnome/dialog-fincalc.c
+src/gnome/dialog-find-account.c
 src/gnome/dialog-find-transactions2.c
 src/gnome/dialog-find-transactions.c
 src/gnome/dialog-imap-editor.c
@@ -249,6 +250,7 @@ src/gnome/gtkbuilder/assistant-loan.glade
 src/gnome/gtkbuilder/assistant-stock-split.glade
 src/gnome/gtkbuilder/dialog-commodities.glade
 src/gnome/gtkbuilder/dialog-fincalc.glade
+src/gnome/gtkbuilder/dialog-find-account.glade
 src/gnome/gtkbuilder/dialog-imap-editor.glade
 src/gnome/gtkbuilder/dialog-lot-viewer.glade
 src/gnome/gtkbuilder/dialog-new-user.glade

--- a/src/business/business-gnome/gnc-plugin-page-invoice.c
+++ b/src/business/business-gnome/gnc-plugin-page-invoice.c
@@ -104,7 +104,7 @@ static GtkActionEntry gnc_plugin_page_invoice_actions [] =
         G_CALLBACK (gnc_plugin_page_invoice_cmd_new_account)
     },
     {
-        "FilePrintAction", GTK_STOCK_PRINT, N_("Print Invoice"), "<control>p",
+        "FilePrintAction", GTK_STOCK_PRINT, N_("Print Invoice"), "<primary>p",
         N_("Make a printable invoice"),
         G_CALLBACK (gnc_plugin_page_invoice_cmd_print)
     },

--- a/src/business/business-gnome/gnc-plugin-page-owner-tree.c
+++ b/src/business/business-gnome/gnc-plugin-page-owner-tree.c
@@ -138,17 +138,17 @@ static GtkActionEntry gnc_plugin_page_owner_tree_actions [] =
 
     /* Edit menu */
     {
-        "OTEditVendorAction", GNC_STOCK_EDIT_ACCOUNT, N_("E_dit Vendor"), "<control>e",
+        "OTEditVendorAction", GNC_STOCK_EDIT_ACCOUNT, N_("E_dit Vendor"), "<primary>e",
         N_("Edit the selected vendor"),
         G_CALLBACK (gnc_plugin_page_owner_tree_cmd_edit_owner)
     },
     {
-        "OTEditCustomerAction", GNC_STOCK_EDIT_ACCOUNT, N_("E_dit Customer"), "<control>e",
+        "OTEditCustomerAction", GNC_STOCK_EDIT_ACCOUNT, N_("E_dit Customer"), "<primary>e",
         N_("Edit the selected customer"),
         G_CALLBACK (gnc_plugin_page_owner_tree_cmd_edit_owner)
     },
     {
-        "OTEditEmployeeAction", GNC_STOCK_EDIT_ACCOUNT, N_("E_dit Employee"), "<control>e",
+        "OTEditEmployeeAction", GNC_STOCK_EDIT_ACCOUNT, N_("E_dit Employee"), "<primary>e",
         N_("Edit the selected employee"),
         G_CALLBACK (gnc_plugin_page_owner_tree_cmd_edit_owner)
     },

--- a/src/gnome-utils/gnc-main-window.c
+++ b/src/gnome-utils/gnc-main-window.c
@@ -272,14 +272,14 @@ static GtkActionEntry gnc_menu_actions [] =
     { "FileImportAction", NULL, N_("_Import"), NULL, NULL, NULL },
     { "FileExportAction", NULL, N_("_Export"), NULL, NULL, NULL },
     {
-        "FilePrintAction", GTK_STOCK_PRINT, N_("_Print..."), "<control>p",
+        "FilePrintAction", GTK_STOCK_PRINT, N_("_Print..."), "<primary>p",
         N_("Print the currently active page"), NULL
     },
 #ifndef GTK_STOCK_PAGE_SETUP
 #    define GTK_STOCK_PAGE_SETUP NULL
 #endif
     {
-        "FilePageSetupAction", GTK_STOCK_PAGE_SETUP, N_("Pa_ge Setup..."), "<control><shift>p",
+        "FilePageSetupAction", GTK_STOCK_PAGE_SETUP, N_("Pa_ge Setup..."), "<primary><shift>p",
         N_("Specify the page size and orientation for printing"),
         G_CALLBACK (gnc_main_window_cmd_page_setup)
     },
@@ -333,7 +333,7 @@ static GtkActionEntry gnc_menu_actions [] =
         N_("Select the account types that should be displayed."), NULL
     },
     {
-        "ViewRefreshAction", GTK_STOCK_REFRESH, N_("_Refresh"), "<control>r",
+        "ViewRefreshAction", GTK_STOCK_REFRESH, N_("_Refresh"), "<primary>r",
         N_("Refresh this window"),
         G_CALLBACK (gnc_main_window_cmd_view_refresh)
     },

--- a/src/gnome-utils/gnc-tree-view-account.c
+++ b/src/gnome-utils/gnc-tree-view-account.c
@@ -1911,6 +1911,17 @@ gnc_plugin_page_account_tree_filter_accounts (Account *account,
 
     ENTER("account %p:%s", account, xaccAccountGetName(account));
 
+    if (g_hash_table_size (fd->filter_override) > 0)
+    {
+        Account *test_acc = NULL;
+        test_acc = g_hash_table_lookup (fd->filter_override, account);
+        if (test_acc != NULL)
+        {
+            LEAVE(" filter: override");
+            return TRUE;
+        }
+    }
+
     if (!fd->show_hidden && xaccAccountIsHidden (account))
     {
         LEAVE(" hide: hidden");

--- a/src/gnome-utils/gnc-tree-view-account.h
+++ b/src/gnome-utils/gnc-tree-view-account.h
@@ -78,6 +78,7 @@ typedef	struct
     GtkWidget           *dialog;
     GtkTreeModel        *model;
     GncTreeViewAccount  *tree_view;
+    GHashTable          *filter_override;
     guint32              visible_types;
     guint32              original_visible_types;
     gboolean             show_hidden;

--- a/src/gnome/CMakeLists.txt
+++ b/src/gnome/CMakeLists.txt
@@ -9,6 +9,7 @@ SET (gnc_gnome_noinst_HEADERS
   assistant-loan.h
   assistant-stock-split.h
   dialog-fincalc.h
+  dialog-find-account.h
   dialog-find-transactions.h
   dialog-find-transactions2.h
   dialog-imap-editor.h
@@ -56,6 +57,7 @@ SET (gnc_gnome_SOURCES
   assistant-stock-split.c
   dialog-commodities.c
   dialog-fincalc.c
+  dialog-find-account.c
   dialog-find-transactions.c
   dialog-find-transactions2.c
   dialog-imap-editor.c

--- a/src/gnome/Makefile.am
+++ b/src/gnome/Makefile.am
@@ -30,6 +30,7 @@ libgnc_gnome_la_SOURCES = \
   assistant-stock-split.c \
   dialog-commodities.c \
   dialog-fincalc.c \
+  dialog-find-account.c \
   dialog-find-transactions.c \
   dialog-find-transactions2.c \
   dialog-imap-editor.c \
@@ -83,6 +84,7 @@ noinst_HEADERS = \
   assistant-loan.h \
   assistant-stock-split.h \
   dialog-fincalc.h \
+  dialog-find-account.h \
   dialog-find-transactions.h \
   dialog-find-transactions2.h \
   dialog-imap-editor.h \

--- a/src/gnome/dialog-find-account.c
+++ b/src/gnome/dialog-find-account.c
@@ -45,6 +45,7 @@ enum GncFindAccountColumn {ACC_FULL_NAME, ACCOUNT, PLACE_HOLDER, HIDDEN};
 typedef struct
 {
     GtkWidget    *dialog;
+    GtkWidget    *parent;
     QofSession   *session;
     Account      *account;
     GtkWidget    *view;
@@ -98,12 +99,8 @@ static void
 jump_to_account (FindAccountDialog *facc_dialog, Account *jump_account)
 {
     if (jump_account != NULL)
-    {
-        if (xaccAccountGetHidden (jump_account))
-            gnc_ui_edit_account_window (jump_account);
-        else
-            gnc_plugin_page_account_tree_open (jump_account);
-    }
+        gnc_plugin_page_account_tree_open (jump_account, GTK_WINDOW(facc_dialog->parent));
+
     if (facc_dialog->jump_close == TRUE)
         gnc_find_account_dialog_close_cb (GTK_DIALOG(facc_dialog->dialog), facc_dialog);
 }
@@ -272,7 +269,12 @@ gnc_find_account_dialog_create (GtkWidget *parent, FindAccountDialog *facc_dialo
 
     /* parent */
     if (parent != NULL)
+    {
+        facc_dialog->parent = parent;
         gtk_window_set_transient_for (GTK_WINDOW(dialog), GTK_WINDOW(parent));
+    }
+    else
+        facc_dialog->parent = NULL;
 
     /* Connect the radio buttons...*/
     facc_dialog->radio_root = GTK_WIDGET(gtk_builder_get_object (builder, "radio-root"));

--- a/src/gnome/dialog-find-account.c
+++ b/src/gnome/dialog-find-account.c
@@ -1,0 +1,420 @@
+/********************************************************************\
+ * dialog-find-account.c -- Find Account dialog                     *
+ * Copyright (C) 2016 Robert Fewell                                 *
+ *                                                                  *
+ * This program is free software; you can redistribute it and/or    *
+ * modify it under the terms of the GNU General Public License as   *
+ * published by the Free Software Foundation; either version 2 of   *
+ * the License, or (at your option) any later version.              *
+ *                                                                  *
+ * This program is distributed in the hope that it will be useful,  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    *
+ * GNU General Public License for more details.                     *
+ *                                                                  *
+ * You should have received a copy of the GNU General Public License*
+ * along with this program; if not, contact:                        *
+ *                                                                  *
+ * Free Software Foundation           Voice:  +1-617-542-5942       *
+ * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652       *
+ * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
+\********************************************************************/
+
+#include "config.h"
+
+#include <gtk/gtk.h>
+#include <glib/gi18n.h>
+
+#include "dialog-find-account.h"
+
+#include "dialog-utils.h"
+#include "gnc-component-manager.h"
+#include "gnc-session.h"
+
+#include "gnc-ui-util.h"
+#include "Account.h"
+#include "gnc-plugin-page-account-tree.h"
+#include "dialog-account.h"
+
+#define DIALOG_FIND_ACCOUNT_CM_CLASS    "dialog-find-account"
+#define GNC_PREFS_GROUP                 "dialogs.find-account"
+
+/** Enumeration for the tree-store */
+enum GncFindAccountColumn {ACC_FULL_NAME, ACCOUNT, PLACE_HOLDER, HIDDEN};
+
+typedef struct
+{
+    GtkWidget    *dialog;
+    QofSession   *session;
+    Account      *account;
+    GtkWidget    *view;
+
+    GtkWidget    *radio_root;
+    GtkWidget    *radio_subroot;
+
+    GtkWidget    *filter_button;
+    GtkWidget    *filter_text_entry;
+    GtkWidget    *sub_label;
+
+    gboolean      jump_close;
+
+}FindAccountDialog;
+
+/* This static indicates the debugging module that this .o belongs to.  */
+static QofLogModule log_module = GNC_MOD_GUI;
+
+void gnc_find_account_dialog_window_destroy_cb (GtkWidget *object, gpointer user_data);
+void gnc_find_account_dialog_close_cb (GtkDialog *dialog, gpointer user_data);
+void gnc_find_account_dialog_response_cb (GtkDialog *dialog, gint response_id, gpointer user_data);
+
+void
+gnc_find_account_dialog_window_destroy_cb (GtkWidget *object, gpointer user_data)
+{
+    FindAccountDialog *facc_dialog = user_data;
+
+    ENTER(" ");
+    gnc_unregister_gui_component_by_data (DIALOG_FIND_ACCOUNT_CM_CLASS, facc_dialog);
+
+    if (facc_dialog->dialog)
+    {
+        gtk_widget_destroy (facc_dialog->dialog);
+        facc_dialog->dialog = NULL;
+    }
+    g_free (facc_dialog);
+    LEAVE(" ");
+}
+
+void
+gnc_find_account_dialog_close_cb (GtkDialog *dialog, gpointer user_data)
+{
+    FindAccountDialog *facc_dialog = user_data;
+
+    ENTER(" ");
+    gnc_close_gui_component_by_data (DIALOG_FIND_ACCOUNT_CM_CLASS, facc_dialog);
+    LEAVE(" ");
+}
+
+static void
+jump_to_account (FindAccountDialog *facc_dialog, Account *jump_account)
+{
+    if (jump_account != NULL)
+    {
+        if (xaccAccountGetHidden (jump_account))
+            gnc_ui_edit_account_window (jump_account);
+        else
+            gnc_plugin_page_account_tree_open (jump_account);
+    }
+    if (facc_dialog->jump_close == TRUE)
+        gnc_find_account_dialog_close_cb (GTK_DIALOG(facc_dialog->dialog), facc_dialog);
+}
+
+static void
+gnc_find_account_dialog_jump_set (FindAccountDialog *facc_dialog)
+{
+    if (facc_dialog->jump_close == TRUE)
+        facc_dialog->jump_close = FALSE;
+    else
+        facc_dialog->jump_close = TRUE;
+}
+
+static void
+gnc_find_account_dialog_jump_to (FindAccountDialog *facc_dialog)
+{
+    Account          *jump_account = NULL;
+    GtkTreeModel     *model;
+    GtkTreeIter       iter;
+    GtkTreeSelection *selection;
+
+    model = gtk_tree_view_get_model (GTK_TREE_VIEW(facc_dialog->view));
+    selection = gtk_tree_view_get_selection (GTK_TREE_VIEW(facc_dialog->view));
+
+    if (gtk_tree_selection_get_selected (selection, &model, &iter))
+        gtk_tree_model_get (model, &iter, ACCOUNT, &jump_account,  -1);
+
+    jump_to_account (facc_dialog, jump_account);
+}
+
+static void
+row_double_clicked (GtkTreeView *treeview, GtkTreePath *path,
+                    GtkTreeViewColumn *col, FindAccountDialog *facc_dialog)
+{
+    Account      *jump_account = NULL;
+    GtkTreeModel *model;
+    GtkTreeIter   iter;
+
+    model = gtk_tree_view_get_model (treeview);
+
+    if (gtk_tree_model_get_iter (model, &iter, path))
+       gtk_tree_model_get (model, &iter, ACCOUNT, &jump_account, -1);
+
+    jump_to_account (facc_dialog, jump_account);
+}
+
+void
+gnc_find_account_dialog_response_cb (GtkDialog *dialog, gint response_id, gpointer user_data)
+{
+    FindAccountDialog *facc_dialog = user_data;
+
+    switch (response_id)
+    {
+    case GTK_RESPONSE_APPLY:
+        gnc_find_account_dialog_jump_to (facc_dialog);
+        return;
+
+    case GTK_RESPONSE_YES:
+        gnc_find_account_dialog_jump_set (facc_dialog);
+        return;
+
+    case GTK_RESPONSE_CLOSE:
+    default:
+        gnc_close_gui_component_by_data (DIALOG_FIND_ACCOUNT_CM_CLASS, facc_dialog);
+        return;
+    }
+}
+
+static void
+fill_model (FindAccountDialog *facc_dialog, Account *account)
+{
+    GtkTreeModel *model;
+    GtkTreeIter   iter;
+    gchar        *fullname = gnc_account_get_full_name (account);
+
+    PINFO("Add to Store: Account '%s'", fullname);
+
+    model = gtk_tree_view_get_model (GTK_TREE_VIEW(facc_dialog->view));
+
+    gtk_list_store_append (GTK_LIST_STORE(model), &iter);
+
+    gtk_list_store_set (GTK_LIST_STORE(model), &iter,
+                        ACC_FULL_NAME, fullname, ACCOUNT, account,
+                        PLACE_HOLDER, xaccAccountGetPlaceholder (account),
+                        HIDDEN, xaccAccountGetHidden (account), -1);
+    g_free (fullname);
+}
+
+static void
+get_account_info (FindAccountDialog *facc_dialog)
+{
+    Account      *root;
+    GList        *accts;
+    GList        *ptr;
+    gchar        *filter_text;
+    gboolean      radio_root;
+
+    /* Get the state of the root radio button */
+    radio_root = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON(facc_dialog->radio_root));
+
+     /* Get list of Accounts */
+    if ((facc_dialog->account == NULL) || (radio_root == TRUE))
+        root = gnc_book_get_root_account (gnc_get_current_book());
+    else
+        root = facc_dialog->account;
+
+    accts = gnc_account_get_descendants_sorted (root);
+
+    filter_text = g_ascii_strdown (gtk_entry_get_text (GTK_ENTRY(facc_dialog->filter_text_entry)), -1);
+
+    /* Go through list of accounts */
+    for (ptr = accts; ptr; ptr = g_list_next (ptr))
+    {
+        Account *acc = ptr->data;
+        gchar   *full_name = gnc_account_get_full_name (acc);
+        gchar   *match_string = g_ascii_strdown (full_name, -1);
+
+        if ((g_strcmp0 (filter_text, "") == 0) || (g_strrstr (match_string, filter_text) != NULL))
+            fill_model (facc_dialog, acc);
+
+        g_free (match_string);
+        g_free (full_name);
+    }
+    g_free (filter_text);
+    g_list_free (accts);
+
+    gtk_tree_view_columns_autosize (GTK_TREE_VIEW(facc_dialog->view));
+}
+
+static void
+filter_button_cb (GtkButton *button, FindAccountDialog *facc_dialog)
+{
+    GtkTreeModel *model;
+    const gchar  *filter_text = gtk_entry_get_text (GTK_ENTRY(facc_dialog->filter_text_entry));
+
+    model = gtk_tree_view_get_model (GTK_TREE_VIEW(facc_dialog->view));
+
+    // Clear the list store
+    gtk_list_store_clear (GTK_LIST_STORE(model));
+
+    get_account_info (facc_dialog);
+
+    // Clear the filter
+    gtk_entry_set_text (GTK_ENTRY(facc_dialog->filter_text_entry), "");
+}
+
+static void
+gnc_find_account_dialog_create (GtkWidget *parent, FindAccountDialog *facc_dialog)
+{
+    GtkWidget         *dialog;
+    GtkBuilder        *builder;
+    GtkTreeSelection  *selection;
+
+    GtkTreeViewColumn *tree_column;
+    GtkCellRenderer   *cr;
+
+    ENTER(" ");
+    builder = gtk_builder_new();
+    gnc_builder_add_from_file (builder, "dialog-find-account.glade", "list-store");
+    gnc_builder_add_from_file (builder, "dialog-find-account.glade", "Find Account Dialog");
+
+    dialog = GTK_WIDGET(gtk_builder_get_object (builder, "Find Account Dialog"));
+    facc_dialog->dialog = dialog;
+
+    facc_dialog->session = gnc_get_current_session();
+
+    /* parent */
+    if (parent != NULL)
+        gtk_window_set_transient_for (GTK_WINDOW(dialog), GTK_WINDOW(parent));
+
+    /* Connect the radio buttons...*/
+    facc_dialog->radio_root = GTK_WIDGET(gtk_builder_get_object (builder, "radio-root"));
+    facc_dialog->radio_subroot = GTK_WIDGET(gtk_builder_get_object (builder, "radio-subroot"));
+
+    facc_dialog->filter_text_entry = GTK_WIDGET(gtk_builder_get_object (builder, "filter-text-entry"));
+    facc_dialog->sub_label = GTK_WIDGET(gtk_builder_get_object (builder, "sub-label"));
+    facc_dialog->filter_button = GTK_WIDGET(gtk_builder_get_object (builder, "filter-button"));
+    g_signal_connect (facc_dialog->filter_button, "clicked",
+                      G_CALLBACK(filter_button_cb), (gpointer)facc_dialog);
+
+    facc_dialog->view = GTK_WIDGET(gtk_builder_get_object (builder, "treeview"));
+    g_signal_connect (facc_dialog->view, "row-activated",
+                     G_CALLBACK(row_double_clicked), (gpointer)facc_dialog);
+
+    /* Enable alternative line colors */
+    gtk_tree_view_set_rules_hint (GTK_TREE_VIEW(facc_dialog->view), TRUE);
+
+    /* default to 'close' button */
+    gtk_dialog_set_default_response (GTK_DIALOG(dialog), GTK_RESPONSE_CLOSE);
+
+    selection = gtk_tree_view_get_selection (GTK_TREE_VIEW(facc_dialog->view));
+    gtk_tree_selection_set_mode (selection, GTK_SELECTION_SINGLE);
+
+    /* Need to add toggle renderers here to get the xalign to work. */
+    tree_column = gtk_tree_view_column_new();
+    gtk_tree_view_column_set_title (tree_column, _("Place Holder"));
+    gtk_tree_view_append_column (GTK_TREE_VIEW(facc_dialog->view), tree_column);
+    gtk_tree_view_column_set_alignment (tree_column, 0.5);
+    cr = gtk_cell_renderer_toggle_new();
+    gtk_tree_view_column_pack_start (tree_column, cr, TRUE);
+    // connect 'active' and set 'xalign' property of the cell renderer
+    gtk_tree_view_column_set_attributes (tree_column, cr, "active", PLACE_HOLDER, NULL);
+    gtk_cell_renderer_set_alignment (cr, 0.5, 0.5);
+
+    tree_column = gtk_tree_view_column_new();
+    gtk_tree_view_column_set_title (tree_column, _("Hidden"));
+    gtk_tree_view_append_column (GTK_TREE_VIEW(facc_dialog->view), tree_column);
+    gtk_tree_view_column_set_alignment (tree_column, 0.5);
+    cr = gtk_cell_renderer_toggle_new();
+    gtk_tree_view_column_pack_start (tree_column, cr, TRUE);
+    // connect 'active' and set 'xalign' property of the cell renderer
+    gtk_tree_view_column_set_attributes (tree_column, cr, "active", HIDDEN, NULL);
+    gtk_cell_renderer_set_alignment (cr, 0.5, 0.5);
+
+    gtk_builder_connect_signals_full (builder, gnc_builder_connect_full_func, facc_dialog);
+
+    g_object_unref (G_OBJECT(builder));
+
+    gnc_restore_window_size (GNC_PREFS_GROUP, GTK_WINDOW(facc_dialog->dialog));
+
+    if (facc_dialog->account != NULL)
+    {
+        const gchar *sub_label_start = _("Search from ");
+        gchar *sub_full_name = gnc_account_get_full_name (facc_dialog->account);
+        gchar *sub_label;
+
+        sub_label = g_strconcat (sub_label_start, sub_full_name, NULL);
+        gtk_button_set_label (GTK_BUTTON(facc_dialog->radio_subroot), sub_label);
+        g_free (sub_full_name);
+        g_free (sub_label);
+
+        gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON(facc_dialog->radio_subroot), TRUE);
+    }
+    else
+        gtk_widget_set_sensitive (GTK_WIDGET(facc_dialog->radio_subroot), FALSE);
+
+    // Set the filter to Wildcard
+    gtk_entry_set_text (GTK_ENTRY(facc_dialog->filter_text_entry), "");
+
+    get_account_info (facc_dialog);
+
+    LEAVE(" ");
+}
+
+static void
+close_handler (gpointer user_data)
+{
+    FindAccountDialog *facc_dialog = user_data;
+
+    ENTER(" ");
+    gnc_save_window_size (GNC_PREFS_GROUP, GTK_WINDOW(facc_dialog->dialog));
+    gtk_widget_destroy (GTK_WIDGET(facc_dialog->dialog));
+    LEAVE(" ");
+}
+
+static void
+refresh_handler (GHashTable *changes, gpointer user_data)
+{
+    ENTER(" ");
+    LEAVE(" ");
+}
+
+static gboolean
+show_handler (const char *klass, gint component_id,
+              gpointer user_data, gpointer iter_data)
+{
+    FindAccountDialog *facc_dialog = user_data;
+
+    ENTER(" ");
+    if (!facc_dialog)
+    {
+        LEAVE("No data strucure");
+        return(FALSE);
+    }
+    gtk_window_present (GTK_WINDOW(facc_dialog->dialog));
+    LEAVE(" ");
+    return(TRUE);
+}
+
+/********************************************************************\
+ * gnc_find_account_dialog                                          *
+ * opens a window allowing for searches on account names            *
+ *                                                                  *
+ * Args:   parent  - the parent of the window to be created         *
+ * Return: nothing                                                  *
+\********************************************************************/
+void
+gnc_find_account_dialog (GtkWidget *parent, Account *account)
+{
+    FindAccountDialog *facc_dialog;
+    gint component_id;
+
+    ENTER(" ");
+    if (gnc_forall_gui_components (DIALOG_FIND_ACCOUNT_CM_CLASS, show_handler, NULL))
+    {
+        LEAVE("Existing dialog raised");
+        return;
+    }
+    facc_dialog = g_new0 (FindAccountDialog, 1);
+
+    facc_dialog->account = account;
+    facc_dialog->jump_close = TRUE;
+
+    gnc_find_account_dialog_create (parent, facc_dialog);
+
+    component_id = gnc_register_gui_component (DIALOG_FIND_ACCOUNT_CM_CLASS,
+                   refresh_handler, close_handler,
+                   facc_dialog);
+
+    gnc_gui_component_set_session (component_id, facc_dialog->session);
+
+    gtk_widget_show (facc_dialog->dialog);
+    LEAVE(" ");
+}

--- a/src/gnome/dialog-find-account.c
+++ b/src/gnome/dialog-find-account.c
@@ -50,6 +50,7 @@ typedef struct
     Account      *account;
     GtkWidget    *view;
 
+    GtkWidget    *radio_hbox;
     GtkWidget    *radio_root;
     GtkWidget    *radio_subroot;
 
@@ -286,6 +287,7 @@ gnc_find_account_dialog_create (GtkWidget *parent, FindAccountDialog *facc_dialo
 
     facc_dialog->filter_text_entry = GTK_WIDGET(gtk_builder_get_object (builder, "filter-text-entry"));
     facc_dialog->sub_label = GTK_WIDGET(gtk_builder_get_object (builder, "sub-label"));
+    facc_dialog->radio_hbox = GTK_WIDGET(gtk_builder_get_object (builder, "hbox-radio"));
     facc_dialog->filter_button = GTK_WIDGET(gtk_builder_get_object (builder, "filter-button"));
     g_signal_connect (facc_dialog->filter_button, "clicked",
                       G_CALLBACK(filter_button_cb), (gpointer)facc_dialog);
@@ -366,9 +368,10 @@ gnc_find_account_dialog_create (GtkWidget *parent, FindAccountDialog *facc_dialo
         g_free (sub_label);
 
         gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON(facc_dialog->radio_subroot), TRUE);
+        gtk_widget_show_all (facc_dialog->radio_hbox);
     }
     else
-        gtk_widget_set_sensitive (GTK_WIDGET(facc_dialog->radio_subroot), FALSE);
+        gtk_widget_hide_all (facc_dialog->radio_hbox);
 
     // Set the filter to Wildcard
     gtk_entry_set_text (GTK_ENTRY(facc_dialog->filter_text_entry), "");

--- a/src/gnome/dialog-find-account.c
+++ b/src/gnome/dialog-find-account.c
@@ -38,7 +38,6 @@
 
 #define DIALOG_FIND_ACCOUNT_CM_CLASS    "dialog-find-account"
 #define GNC_PREFS_GROUP                 "dialogs.find-account"
-#define ICON_TICK                       "emblem-default"
 
 /** Enumeration for the tree-store */
 enum GncFindAccountColumn {ACC_FULL_NAME, ACCOUNT, PLACE_HOLDER, HIDDEN, NOT_USED, BAL_ZERO};
@@ -187,10 +186,10 @@ fill_model (FindAccountDialog *facc_dialog, Account *account)
 
     gtk_list_store_set (GTK_LIST_STORE(model), &iter,
                         ACC_FULL_NAME, fullname, ACCOUNT, account,
-                        PLACE_HOLDER, (xaccAccountGetPlaceholder (account) == TRUE ? ICON_TICK : NULL),
-                        HIDDEN, (xaccAccountGetHidden (account) == TRUE ? ICON_TICK : NULL),
-                        NOT_USED, (splits == 0 ? ICON_TICK : NULL),
-                        BAL_ZERO, (gnc_numeric_zero_p (total) == TRUE ? ICON_TICK : NULL), -1);
+                        PLACE_HOLDER, (xaccAccountGetPlaceholder (account) == TRUE ? GTK_STOCK_YES : NULL),
+                        HIDDEN, (xaccAccountGetHidden (account) == TRUE ? GTK_STOCK_YES : NULL),
+                        NOT_USED, (splits == 0 ? GTK_STOCK_YES : NULL),
+                        BAL_ZERO, (gnc_numeric_zero_p (total) == TRUE ? GTK_STOCK_YES : NULL), -1);
     g_free (fullname);
 }
 
@@ -313,7 +312,7 @@ gnc_find_account_dialog_create (GtkWidget *parent, FindAccountDialog *facc_dialo
     cr = gtk_cell_renderer_pixbuf_new();
     gtk_tree_view_column_pack_start (tree_column, cr, TRUE);
     // connect 'active' and set 'xalign' property of the cell renderer
-    gtk_tree_view_column_set_attributes (tree_column, cr, "icon-name", PLACE_HOLDER, NULL);
+    gtk_tree_view_column_set_attributes (tree_column, cr, "stock-id", PLACE_HOLDER, NULL);
     gtk_cell_renderer_set_alignment (cr, 0.5, 0.5);
 
     tree_column = gtk_tree_view_column_new();
@@ -324,7 +323,7 @@ gnc_find_account_dialog_create (GtkWidget *parent, FindAccountDialog *facc_dialo
     cr = gtk_cell_renderer_pixbuf_new();
     gtk_tree_view_column_pack_start (tree_column, cr, TRUE);
     // connect 'active' and set 'xalign' property of the cell renderer
-    gtk_tree_view_column_set_attributes (tree_column, cr, "icon-name", HIDDEN, NULL);
+    gtk_tree_view_column_set_attributes (tree_column, cr, "stock-id", HIDDEN, NULL);
     gtk_cell_renderer_set_alignment (cr, 0.5, 0.5);
 
     tree_column = gtk_tree_view_column_new();
@@ -335,7 +334,7 @@ gnc_find_account_dialog_create (GtkWidget *parent, FindAccountDialog *facc_dialo
     cr = gtk_cell_renderer_pixbuf_new();
     gtk_tree_view_column_pack_start (tree_column, cr, TRUE);
     // connect 'active' and set 'xalign' property of the cell renderer
-    gtk_tree_view_column_set_attributes (tree_column, cr, "icon-name", NOT_USED, NULL);
+    gtk_tree_view_column_set_attributes (tree_column, cr, "stock-id", NOT_USED, NULL);
     gtk_cell_renderer_set_alignment (cr, 0.5, 0.5);
 
     tree_column = gtk_tree_view_column_new();
@@ -346,7 +345,7 @@ gnc_find_account_dialog_create (GtkWidget *parent, FindAccountDialog *facc_dialo
     cr = gtk_cell_renderer_pixbuf_new();
     gtk_tree_view_column_pack_start (tree_column, cr, TRUE);
     // connect 'active' and set 'xalign' property of the cell renderer
-    gtk_tree_view_column_set_attributes (tree_column, cr, "icon-name", BAL_ZERO, NULL);
+    gtk_tree_view_column_set_attributes (tree_column, cr, "stock-id", BAL_ZERO, NULL);
     gtk_cell_renderer_set_alignment (cr, 0.5, 0.5);
 
     gtk_builder_connect_signals_full (builder, gnc_builder_connect_full_func, facc_dialog);

--- a/src/gnome/dialog-find-account.c
+++ b/src/gnome/dialog-find-account.c
@@ -38,6 +38,7 @@
 
 #define DIALOG_FIND_ACCOUNT_CM_CLASS    "dialog-find-account"
 #define GNC_PREFS_GROUP                 "dialogs.find-account"
+#define ICON_TICK                       "emblem-default"
 
 /** Enumeration for the tree-store */
 enum GncFindAccountColumn {ACC_FULL_NAME, ACCOUNT, PLACE_HOLDER, HIDDEN, NOT_USED, BAL_ZERO};
@@ -186,10 +187,10 @@ fill_model (FindAccountDialog *facc_dialog, Account *account)
 
     gtk_list_store_set (GTK_LIST_STORE(model), &iter,
                         ACC_FULL_NAME, fullname, ACCOUNT, account,
-                        PLACE_HOLDER, xaccAccountGetPlaceholder (account),
-                        HIDDEN, xaccAccountGetHidden (account),
-                        NOT_USED, (splits == 0 ? TRUE : FALSE),
-                        BAL_ZERO, gnc_numeric_zero_p(total), -1);
+                        PLACE_HOLDER, (xaccAccountGetPlaceholder (account) == TRUE ? ICON_TICK : NULL),
+                        HIDDEN, (xaccAccountGetHidden (account) == TRUE ? ICON_TICK : NULL),
+                        NOT_USED, (splits == 0 ? ICON_TICK : NULL),
+                        BAL_ZERO, (gnc_numeric_zero_p (total) == TRUE ? ICON_TICK : NULL), -1);
     g_free (fullname);
 }
 
@@ -303,16 +304,16 @@ gnc_find_account_dialog_create (GtkWidget *parent, FindAccountDialog *facc_dialo
     selection = gtk_tree_view_get_selection (GTK_TREE_VIEW(facc_dialog->view));
     gtk_tree_selection_set_mode (selection, GTK_SELECTION_SINGLE);
 
-    /* Need to add toggle renderers here to get the xalign to work. */
+    /* Need to add pixbuf renderers here to get the xalign to work. */
     tree_column = gtk_tree_view_column_new();
     gtk_tree_view_column_set_title (tree_column, _("Place Holder"));
     gtk_tree_view_append_column (GTK_TREE_VIEW(facc_dialog->view), tree_column);
     gtk_tree_view_column_set_alignment (tree_column, 0.5);
     gtk_tree_view_column_set_expand (tree_column, TRUE);
-    cr = gtk_cell_renderer_toggle_new();
+    cr = gtk_cell_renderer_pixbuf_new();
     gtk_tree_view_column_pack_start (tree_column, cr, TRUE);
     // connect 'active' and set 'xalign' property of the cell renderer
-    gtk_tree_view_column_set_attributes (tree_column, cr, "active", PLACE_HOLDER, NULL);
+    gtk_tree_view_column_set_attributes (tree_column, cr, "icon-name", PLACE_HOLDER, NULL);
     gtk_cell_renderer_set_alignment (cr, 0.5, 0.5);
 
     tree_column = gtk_tree_view_column_new();
@@ -320,10 +321,10 @@ gnc_find_account_dialog_create (GtkWidget *parent, FindAccountDialog *facc_dialo
     gtk_tree_view_append_column (GTK_TREE_VIEW(facc_dialog->view), tree_column);
     gtk_tree_view_column_set_alignment (tree_column, 0.5);
     gtk_tree_view_column_set_expand (tree_column, TRUE);
-    cr = gtk_cell_renderer_toggle_new();
+    cr = gtk_cell_renderer_pixbuf_new();
     gtk_tree_view_column_pack_start (tree_column, cr, TRUE);
     // connect 'active' and set 'xalign' property of the cell renderer
-    gtk_tree_view_column_set_attributes (tree_column, cr, "active", HIDDEN, NULL);
+    gtk_tree_view_column_set_attributes (tree_column, cr, "icon-name", HIDDEN, NULL);
     gtk_cell_renderer_set_alignment (cr, 0.5, 0.5);
 
     tree_column = gtk_tree_view_column_new();
@@ -331,10 +332,10 @@ gnc_find_account_dialog_create (GtkWidget *parent, FindAccountDialog *facc_dialo
     gtk_tree_view_append_column (GTK_TREE_VIEW(facc_dialog->view), tree_column);
     gtk_tree_view_column_set_alignment (tree_column, 0.5);
     gtk_tree_view_column_set_expand (tree_column, TRUE);
-    cr = gtk_cell_renderer_toggle_new();
+    cr = gtk_cell_renderer_pixbuf_new();
     gtk_tree_view_column_pack_start (tree_column, cr, TRUE);
     // connect 'active' and set 'xalign' property of the cell renderer
-    gtk_tree_view_column_set_attributes (tree_column, cr, "active", NOT_USED, NULL);
+    gtk_tree_view_column_set_attributes (tree_column, cr, "icon-name", NOT_USED, NULL);
     gtk_cell_renderer_set_alignment (cr, 0.5, 0.5);
 
     tree_column = gtk_tree_view_column_new();
@@ -342,10 +343,10 @@ gnc_find_account_dialog_create (GtkWidget *parent, FindAccountDialog *facc_dialo
     gtk_tree_view_append_column (GTK_TREE_VIEW(facc_dialog->view), tree_column);
     gtk_tree_view_column_set_alignment (tree_column, 0.5);
     gtk_tree_view_column_set_expand (tree_column, TRUE);
-    cr = gtk_cell_renderer_toggle_new();
+    cr = gtk_cell_renderer_pixbuf_new();
     gtk_tree_view_column_pack_start (tree_column, cr, TRUE);
     // connect 'active' and set 'xalign' property of the cell renderer
-    gtk_tree_view_column_set_attributes (tree_column, cr, "active", BAL_ZERO, NULL);
+    gtk_tree_view_column_set_attributes (tree_column, cr, "icon-name", BAL_ZERO, NULL);
     gtk_cell_renderer_set_alignment (cr, 0.5, 0.5);
 
     gtk_builder_connect_signals_full (builder, gnc_builder_connect_full_func, facc_dialog);

--- a/src/gnome/dialog-find-account.h
+++ b/src/gnome/dialog-find-account.h
@@ -1,0 +1,30 @@
+/********************************************************************\
+ * dialog-find-account.h -- Find Account dialog                     *
+ * Copyright (C) 2016 Robert Fewell                                 *
+ *                                                                  *
+ * This program is free software; you can redistribute it and/or    *
+ * modify it under the terms of the GNU General Public License as   *
+ * published by the Free Software Foundation; either version 2 of   *
+ * the License, or (at your option) any later version.              *
+ *                                                                  *
+ * This program is distributed in the hope that it will be useful,  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    *
+ * GNU General Public License for more details.                     *
+ *                                                                  *
+ * You should have received a copy of the GNU General Public License*
+ * along with this program; if not, contact:                        *
+ *                                                                  *
+ * Free Software Foundation           Voice:  +1-617-542-5942       *
+ * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652       *
+ * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
+\********************************************************************/
+
+#ifndef DIALOG_FIND_ACCOUNT_H
+#define DIALOG_FIND_ACCOUNT_H
+
+#include "Account.h"
+
+void gnc_find_account_dialog (GtkWidget *parent, Account *account);
+
+#endif

--- a/src/gnome/gnc-plugin-account-tree.c
+++ b/src/gnome/gnc-plugin-account-tree.c
@@ -61,11 +61,6 @@ static GtkActionEntry gnc_plugin_actions [] =
         N_("Open a new Account Tree page"),
         G_CALLBACK (gnc_plugin_account_tree_cmd_new_account_tree)
     },
-    {
-        "ViewFindAccountAction", GTK_STOCK_FIND, N_("F_ind Account"), "<control>i",
-        N_("Find an account"),
-        G_CALLBACK (gnc_plugin_account_tree_cmd_find_account)
-    },
 };
 /** The number of actions provided by this plugin. */
 static guint gnc_plugin_n_actions = G_N_ELEMENTS (gnc_plugin_actions);
@@ -202,15 +197,6 @@ gnc_plugin_account_tree_cmd_new_account_tree (GtkAction *action,
 
     page = gnc_plugin_page_account_tree_new ();
     gnc_main_window_open_page (data->window, page);
-}
-
-static void
-gnc_plugin_account_tree_cmd_find_account (GtkAction *action,
-        GncMainWindowActionData *data)
-{
-    g_return_if_fail (data != NULL);
-
-    gnc_find_account_dialog (GTK_WIDGET(data->window), NULL);
 }
 
 /** @} */

--- a/src/gnome/gnc-plugin-account-tree.c
+++ b/src/gnome/gnc-plugin-account-tree.c
@@ -39,6 +39,7 @@
 
 #include "gnc-plugin-account-tree.h"
 #include "gnc-plugin-page-account-tree.h"
+#include "dialog-find-account.h"
 
 static void gnc_plugin_account_tree_class_init (GncPluginAccountTreeClass *klass);
 static void gnc_plugin_account_tree_init (GncPluginAccountTree *plugin);
@@ -46,7 +47,7 @@ static void gnc_plugin_account_tree_finalize (GObject *object);
 
 /* Command callbacks */
 static void gnc_plugin_account_tree_cmd_new_account_tree (GtkAction *action, GncMainWindowActionData *data);
-
+static void gnc_plugin_account_tree_cmd_find_account (GtkAction *action, GncMainWindowActionData *data);
 
 #define PLUGIN_ACTIONS_NAME "gnc-plugin-account-tree-actions"
 #define PLUGIN_UI_FILENAME  "gnc-plugin-account-tree-ui.xml"
@@ -59,6 +60,11 @@ static GtkActionEntry gnc_plugin_actions [] =
         "ViewAccountTreeAction", NULL, N_("New Accounts _Page"), NULL,
         N_("Open a new Account Tree page"),
         G_CALLBACK (gnc_plugin_account_tree_cmd_new_account_tree)
+    },
+    {
+        "ViewFindAccountAction", GTK_STOCK_FIND, N_("F_ind Account"), "<control>i",
+        N_("Find an account"),
+        G_CALLBACK (gnc_plugin_account_tree_cmd_find_account)
     },
 };
 /** The number of actions provided by this plugin. */
@@ -196,6 +202,15 @@ gnc_plugin_account_tree_cmd_new_account_tree (GtkAction *action,
 
     page = gnc_plugin_page_account_tree_new ();
     gnc_main_window_open_page (data->window, page);
+}
+
+static void
+gnc_plugin_account_tree_cmd_find_account (GtkAction *action,
+        GncMainWindowActionData *data)
+{
+    g_return_if_fail (data != NULL);
+
+    gnc_find_account_dialog (GTK_WIDGET(data->window), NULL);
 }
 
 /** @} */

--- a/src/gnome/gnc-plugin-basic-commands.c
+++ b/src/gnome/gnc-plugin-basic-commands.c
@@ -108,22 +108,22 @@ static GtkActionEntry gnc_plugin_actions [] =
     /* File menu */
 
     {
-        "FileNewAction", GTK_STOCK_NEW, N_("New _File"), "<control>n",
+        "FileNewAction", GTK_STOCK_NEW, N_("New _File"), "<primary>n",
         N_("Create a new file"),
         G_CALLBACK (gnc_main_window_cmd_file_new)
     },
     {
-        "FileOpenAction", GTK_STOCK_OPEN, N_("_Open..."), "<control>o",
+        "FileOpenAction", GTK_STOCK_OPEN, N_("_Open..."), "<primary>o",
         N_("Open an existing GnuCash file"),
         G_CALLBACK (gnc_main_window_cmd_file_open)
     },
     {
-        "FileSaveAction", GTK_STOCK_SAVE, N_("_Save"), "<control>s",
+        "FileSaveAction", GTK_STOCK_SAVE, N_("_Save"), "<primary>s",
         N_("Save the current file"),
         G_CALLBACK (gnc_main_window_cmd_file_save)
     },
     {
-        "FileSaveAsAction", GTK_STOCK_SAVE_AS, N_("Save _As..."), "<shift><control>s",
+        "FileSaveAsAction", GTK_STOCK_SAVE_AS, N_("Save _As..."), "<shift><primary>s",
         N_("Save this file with a different name"),
         G_CALLBACK (gnc_main_window_cmd_file_save_as)
     },
@@ -142,7 +142,7 @@ static GtkActionEntry gnc_plugin_actions [] =
     /* Edit menu */
 
     {
-        "EditFindTransactionsAction", GTK_STOCK_FIND, N_("_Find..."), "<control>f",
+        "EditFindTransactionsAction", GTK_STOCK_FIND, N_("_Find..."), "<primary>f",
         N_("Find transactions with a search"),
         G_CALLBACK (gnc_main_window_cmd_tools_find_transactions)
     },

--- a/src/gnome/gnc-plugin-page-account-tree.c
+++ b/src/gnome/gnc-plugin-page-account-tree.c
@@ -214,7 +214,7 @@ static GtkActionEntry gnc_plugin_page_account_tree_actions [] =
 
     /* Edit menu */
     {
-        "EditEditAccountAction", GNC_STOCK_EDIT_ACCOUNT, N_("Edit _Account"), "<control>e",
+        "EditEditAccountAction", GNC_STOCK_EDIT_ACCOUNT, N_("Edit _Account"), "<primary>e",
         N_("Edit the selected account"),
         G_CALLBACK (gnc_plugin_page_account_tree_cmd_edit_account)
     },
@@ -224,12 +224,12 @@ static GtkActionEntry gnc_plugin_page_account_tree_actions [] =
         G_CALLBACK (gnc_plugin_page_account_tree_cmd_delete_account)
     },
     {
-        "EditFindAccountAction", GTK_STOCK_FIND, N_("F_ind Account"), "<control>i",
+        "EditFindAccountAction", GTK_STOCK_FIND, N_("F_ind Account"), "<primary>i",
         N_("Find an account"),
         G_CALLBACK (gnc_plugin_page_account_tree_cmd_find_account)
     },
     {
-        "EditFindAccountPopupAction", GTK_STOCK_FIND, N_("F_ind Account"), "<control>i",
+        "EditFindAccountPopupAction", GTK_STOCK_FIND, N_("F_ind Account"), "<primary>i",
         N_("Find an account"),
         G_CALLBACK (gnc_plugin_page_account_tree_cmd_find_account_popup)
     },
@@ -257,7 +257,7 @@ static GtkActionEntry gnc_plugin_page_account_tree_actions [] =
         G_CALLBACK (gnc_plugin_page_account_tree_cmd_autoclear)
     },
     {
-        "ActionsTransferAction", NULL, N_("_Transfer..."), "<control>t",
+        "ActionsTransferAction", NULL, N_("_Transfer..."), "<primary>t",
         N_("Transfer funds from one account to another"),
         G_CALLBACK (gnc_plugin_page_account_tree_cmd_transfer)
     },

--- a/src/gnome/gnc-plugin-page-account-tree.c
+++ b/src/gnome/gnc-plugin-page-account-tree.c
@@ -138,6 +138,7 @@ static void gnc_plugin_page_account_tree_cmd_open_account (GtkAction *action, Gn
 static void gnc_plugin_page_account_tree_cmd_open_subaccounts (GtkAction *action, GncPluginPageAccountTree *page);
 static void gnc_plugin_page_account_tree_cmd_edit_account (GtkAction *action, GncPluginPageAccountTree *page);
 static void gnc_plugin_page_account_tree_cmd_find_account (GtkAction *action, GncPluginPageAccountTree *page);
+static void gnc_plugin_page_account_tree_cmd_find_account_popup (GtkAction *action, GncPluginPageAccountTree *page);
 static void gnc_plugin_page_account_tree_cmd_delete_account (GtkAction *action, GncPluginPageAccountTree *page);
 static void gnc_plugin_page_account_tree_cmd_renumber_accounts (GtkAction *action, GncPluginPageAccountTree *page);
 static void gnc_plugin_page_account_tree_cmd_view_filter_by (GtkAction *action, GncPluginPageAccountTree *plugin_page);
@@ -223,6 +224,16 @@ static GtkActionEntry gnc_plugin_page_account_tree_actions [] =
         G_CALLBACK (gnc_plugin_page_account_tree_cmd_delete_account)
     },
     {
+        "EditFindAccountAction", GTK_STOCK_FIND, N_("F_ind Account"), "<control>i",
+        N_("Find an account"),
+        G_CALLBACK (gnc_plugin_page_account_tree_cmd_find_account)
+    },
+    {
+        "EditFindAccountPopupAction", GTK_STOCK_FIND, N_("F_ind Account"), "<control>i",
+        N_("Find an account"),
+        G_CALLBACK (gnc_plugin_page_account_tree_cmd_find_account_popup)
+    },
+    {
         "EditRenumberSubaccountsAction", NULL, N_("_Renumber Subaccounts..."), NULL,
         N_("Renumber the children of the selected account"),
         G_CALLBACK (gnc_plugin_page_account_tree_cmd_renumber_accounts)
@@ -232,11 +243,6 @@ static GtkActionEntry gnc_plugin_page_account_tree_actions [] =
     {
         "ViewFilterByAction", NULL, N_("_Filter By..."), NULL, NULL,
         G_CALLBACK (gnc_plugin_page_account_tree_cmd_view_filter_by)
-    },
-    {
-        "FindAccountAction", GTK_STOCK_FIND, N_("F_ind Account"), "<control>i",
-        N_("Find an account"),
-        G_CALLBACK (gnc_plugin_page_account_tree_cmd_find_account)
     },
 
     /* Actions menu */
@@ -1095,13 +1101,25 @@ gnc_plugin_page_account_tree_cmd_edit_account (GtkAction *action, GncPluginPageA
 static void
 gnc_plugin_page_account_tree_cmd_find_account (GtkAction *action, GncPluginPageAccountTree *page)
 {
-    Account *account;
+    GtkWidget *window;
+
+    ENTER("action %p, page %p", action, page);
+
+    window = gnc_plugin_page_get_window(GNC_PLUGIN_PAGE(page));
+
+    gnc_find_account_dialog (window, NULL);
+    LEAVE(" ");
+}
+
+static void
+gnc_plugin_page_account_tree_cmd_find_account_popup (GtkAction *action, GncPluginPageAccountTree *page)
+{
+    Account *account = NULL;
     GtkWidget *window;
 
     ENTER("action %p, page %p", action, page);
 
     account = gnc_plugin_page_account_tree_get_current_account (page);
-    g_return_if_fail (account != NULL);
 
     window = gnc_plugin_page_get_window(GNC_PLUGIN_PAGE(page));
 

--- a/src/gnome/gnc-plugin-page-account-tree.c
+++ b/src/gnome/gnc-plugin-page-account-tree.c
@@ -68,6 +68,7 @@
 #include "window-autoclear.h"
 #include "window-main-summarybar.h"
 #include "dialog-object-references.h"
+#include "dialog-find-account.h"
 
 /* This static indicates the debugging module that this .o belongs to.  */
 static QofLogModule log_module = GNC_MOD_GUI;
@@ -136,6 +137,7 @@ static void gnc_plugin_page_account_tree_cmd_file_new_hierarchy (GtkAction *acti
 static void gnc_plugin_page_account_tree_cmd_open_account (GtkAction *action, GncPluginPageAccountTree *page);
 static void gnc_plugin_page_account_tree_cmd_open_subaccounts (GtkAction *action, GncPluginPageAccountTree *page);
 static void gnc_plugin_page_account_tree_cmd_edit_account (GtkAction *action, GncPluginPageAccountTree *page);
+static void gnc_plugin_page_account_tree_cmd_find_account (GtkAction *action, GncPluginPageAccountTree *page);
 static void gnc_plugin_page_account_tree_cmd_delete_account (GtkAction *action, GncPluginPageAccountTree *page);
 static void gnc_plugin_page_account_tree_cmd_renumber_accounts (GtkAction *action, GncPluginPageAccountTree *page);
 static void gnc_plugin_page_account_tree_cmd_view_filter_by (GtkAction *action, GncPluginPageAccountTree *plugin_page);
@@ -230,6 +232,11 @@ static GtkActionEntry gnc_plugin_page_account_tree_actions [] =
     {
         "ViewFilterByAction", NULL, N_("_Filter By..."), NULL, NULL,
         G_CALLBACK (gnc_plugin_page_account_tree_cmd_view_filter_by)
+    },
+    {
+        "FindAccountAction", GTK_STOCK_FIND, N_("F_ind Account"), "<control>i",
+        N_("Find an account"),
+        G_CALLBACK (gnc_plugin_page_account_tree_cmd_find_account)
     },
 
     /* Actions menu */
@@ -493,6 +500,34 @@ gnc_plugin_page_account_tree_finalize (GObject *object)
 
     G_OBJECT_CLASS (parent_class)->finalize (object);
     LEAVE(" ");
+}
+
+void
+gnc_plugin_page_account_tree_open (Account *account)
+{
+    GncPluginPageAccountTreePrivate *priv;
+    GncPluginPageAccountTree *page;
+    GncPluginPage *plugin_page;
+    const GList *page_list;
+    GtkWidget   *window;
+
+    /* Find Accounts page */
+    page_list = gnc_gobject_tracking_get_list(GNC_PLUGIN_PAGE_ACCOUNT_TREE_NAME);
+
+    if (g_list_length ((GList*)page_list) != 0)
+        plugin_page = GNC_PLUGIN_PAGE(page_list->data);
+    else
+        plugin_page = gnc_plugin_page_account_tree_new ();
+
+    window = plugin_page->window;
+
+    gnc_main_window_open_page (GNC_MAIN_WINDOW(window), plugin_page);
+
+    page = GNC_PLUGIN_PAGE_ACCOUNT_TREE (plugin_page);
+    priv = GNC_PLUGIN_PAGE_ACCOUNT_TREE_GET_PRIVATE(page);
+
+    if (account != NULL)
+        gnc_tree_view_account_set_selected_account (GNC_TREE_VIEW_ACCOUNT(priv->tree_view), account);
 }
 
 Account *
@@ -1009,7 +1044,6 @@ gnc_plugin_page_account_tree_cmd_open2_subaccounts (GtkAction *action,
 }
 /*################## Added for Reg2 #################*/
 
-
 static void
 gnc_plugin_page_account_tree_cmd_edit_account (GtkAction *action, GncPluginPageAccountTree *page)
 {
@@ -1021,6 +1055,23 @@ gnc_plugin_page_account_tree_cmd_edit_account (GtkAction *action, GncPluginPageA
     g_return_if_fail (account != NULL);
 
     gnc_ui_edit_account_window (account);
+    LEAVE(" ");
+}
+
+static void
+gnc_plugin_page_account_tree_cmd_find_account (GtkAction *action, GncPluginPageAccountTree *page)
+{
+    Account *account;
+    GtkWidget *window;
+
+    ENTER("action %p, page %p", action, page);
+
+    account = gnc_plugin_page_account_tree_get_current_account (page);
+    g_return_if_fail (account != NULL);
+
+    window = gnc_plugin_page_get_window(GNC_PLUGIN_PAGE(page));
+
+    gnc_find_account_dialog (window, account);
     LEAVE(" ");
 }
 

--- a/src/gnome/gnc-plugin-page-account-tree.c
+++ b/src/gnome/gnc-plugin-page-account-tree.c
@@ -542,7 +542,20 @@ gnc_plugin_page_account_tree_open (Account *account, GtkWindow *win)
 
     if (account != NULL)
     {
+        Account *root_account = gnc_get_current_root_account ();
+        Account *parent_account = NULL;
+        Account *temp_account = account;
+
         g_hash_table_insert (priv->fd.filter_override, account, account);
+
+        // make sure we overide all the parent accounts to root
+        while (parent_account != root_account)
+        {
+            parent_account = gnc_account_get_parent (temp_account);
+
+            g_hash_table_insert (priv->fd.filter_override, parent_account, parent_account);
+            temp_account = parent_account;
+        }
         gnc_tree_view_account_refilter (GNC_TREE_VIEW_ACCOUNT(priv->tree_view));
         gnc_tree_view_account_set_selected_account (GNC_TREE_VIEW_ACCOUNT(priv->tree_view), account);
     }

--- a/src/gnome/gnc-plugin-page-account-tree.h
+++ b/src/gnome/gnc-plugin-page-account-tree.h
@@ -99,8 +99,10 @@ Account * gnc_plugin_page_account_tree_get_current_account (GncPluginPageAccount
  *  and the account will be selected (if any).
  *
  *  @param account The "account" to be selected.
+ *
+ *  @param win The "window" where the account tree is to be selected.
  */
-void gnc_plugin_page_account_tree_open (Account *account);
+void gnc_plugin_page_account_tree_open (Account *account, GtkWindow *win);
 
 G_END_DECLS
 

--- a/src/gnome/gnc-plugin-page-account-tree.h
+++ b/src/gnome/gnc-plugin-page-account-tree.h
@@ -1,5 +1,5 @@
 /*
- * gnc-plugin_page-account-tree.h --
+ * gnc-plugin-page-account-tree.h --
  *
  * Copyright (C) 2003 Jan Arne Petersen <jpetersen@uni-bonn.de>
  * Copyright (C) 2003 David Hampton <hampton@employees.org>
@@ -93,6 +93,14 @@ GncPluginPage *gnc_plugin_page_account_tree_new  (void);
  *  selected.
  */
 Account * gnc_plugin_page_account_tree_get_current_account (GncPluginPageAccountTree *page);
+
+
+/** Given a pointer to an account, the account tree will open
+ *  and the account will be selected (if any).
+ *
+ *  @param account The "account" to be selected.
+ */
+void gnc_plugin_page_account_tree_open (Account *account);
 
 G_END_DECLS
 

--- a/src/gnome/gnc-plugin-page-register.c
+++ b/src/gnome/gnc-plugin-page-register.c
@@ -50,6 +50,7 @@
 #include "gnc-plugin-page-report.h"
 
 #include "dialog-account.h"
+#include "dialog-find-account.h"
 #include "dialog-find-transactions.h"
 #include "dialog-print-check.h"
 #include "dialog-transfer.h"
@@ -141,6 +142,7 @@ static void gnc_plugin_page_register_cmd_cut (GtkAction *action, GncPluginPageRe
 static void gnc_plugin_page_register_cmd_copy (GtkAction *action, GncPluginPageRegister *plugin_page);
 static void gnc_plugin_page_register_cmd_paste (GtkAction *action, GncPluginPageRegister *plugin_page);
 static void gnc_plugin_page_register_cmd_edit_account (GtkAction *action, GncPluginPageRegister *plugin_page);
+static void gnc_plugin_page_register_cmd_find_account (GtkAction *action, GncPluginPageRegister *plugin_page);
 static void gnc_plugin_page_register_cmd_find_transactions (GtkAction *action, GncPluginPageRegister *plugin_page);
 static void gnc_plugin_page_register_cmd_cut_transaction (GtkAction *action, GncPluginPageRegister *plugin_page);
 static void gnc_plugin_page_register_cmd_copy_transaction (GtkAction *action, GncPluginPageRegister *plugin_page);
@@ -248,6 +250,11 @@ static GtkActionEntry gnc_plugin_page_register_actions [] =
         "EditEditAccountAction", GNC_STOCK_EDIT_ACCOUNT, N_("Edit _Account"), "<control>e",
         N_("Edit the selected account"),
         G_CALLBACK (gnc_plugin_page_register_cmd_edit_account)
+    },
+    {
+        "EditFindAccountAction", GTK_STOCK_FIND, N_("F_ind Account"), "<control>i",
+        N_("Find an account"),
+        G_CALLBACK (gnc_plugin_page_register_cmd_find_account)
     },
     {
         "EditFindTransactionsAction", GTK_STOCK_FIND, N_("_Find..."), "<control>f",
@@ -2923,6 +2930,21 @@ gnc_plugin_page_register_cmd_edit_account (GtkAction *action,
         gnc_ui_edit_account_window (account);
     LEAVE(" ");
 }
+
+
+static void
+gnc_plugin_page_register_cmd_find_account (GtkAction *action,
+        GncPluginPageRegister *page)
+{
+    GtkWidget *window;
+
+    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
+
+    window = gnc_plugin_page_get_window (GNC_PLUGIN_PAGE(page));
+
+    gnc_find_account_dialog (window, NULL);
+}
+
 
 
 static void

--- a/src/gnome/gnc-plugin-page-register.c
+++ b/src/gnome/gnc-plugin-page-register.c
@@ -225,7 +225,7 @@ static GtkActionEntry gnc_plugin_page_register_actions [] =
     /* File menu */
 
     {
-        "FilePrintAction", GTK_STOCK_PRINT, N_("_Print Checks..."), "<control>p", NULL,
+        "FilePrintAction", GTK_STOCK_PRINT, N_("_Print Checks..."), "<primary>p", NULL,
         G_CALLBACK (gnc_plugin_page_register_cmd_print_check)
     },
 
@@ -247,17 +247,17 @@ static GtkActionEntry gnc_plugin_page_register_actions [] =
         G_CALLBACK (gnc_plugin_page_register_cmd_paste)
     },
     {
-        "EditEditAccountAction", GNC_STOCK_EDIT_ACCOUNT, N_("Edit _Account"), "<control>e",
+        "EditEditAccountAction", GNC_STOCK_EDIT_ACCOUNT, N_("Edit _Account"), "<primary>e",
         N_("Edit the selected account"),
         G_CALLBACK (gnc_plugin_page_register_cmd_edit_account)
     },
     {
-        "EditFindAccountAction", GTK_STOCK_FIND, N_("F_ind Account"), "<control>i",
+        "EditFindAccountAction", GTK_STOCK_FIND, N_("F_ind Account"), "<primary>i",
         N_("Find an account"),
         G_CALLBACK (gnc_plugin_page_register_cmd_find_account)
     },
     {
-        "EditFindTransactionsAction", GTK_STOCK_FIND, N_("_Find..."), "<control>f",
+        "EditFindTransactionsAction", GTK_STOCK_FIND, N_("_Find..."), "<primary>f",
         N_("Find transactions with a search"),
         G_CALLBACK (gnc_plugin_page_register_cmd_find_transactions)
     },
@@ -346,7 +346,7 @@ static GtkActionEntry gnc_plugin_page_register_actions [] =
     /* Actions menu */
 
     {
-        "ActionsTransferAction", GNC_STOCK_TRANSFER, N_("_Transfer..."), "<control>t",
+        "ActionsTransferAction", GNC_STOCK_TRANSFER, N_("_Transfer..."), "<primary>t",
         N_("Transfer funds from one account to another"),
         G_CALLBACK (gnc_plugin_page_register_cmd_transfer)
     },
@@ -371,7 +371,7 @@ static GtkActionEntry gnc_plugin_page_register_actions [] =
         G_CALLBACK (gnc_plugin_page_register_cmd_lots)
     },
     {
-        "BlankTransactionAction", GTK_STOCK_GOTO_BOTTOM, N_("_Blank Transaction"), "<control>Page_Down",
+        "BlankTransactionAction", GTK_STOCK_GOTO_BOTTOM, N_("_Blank Transaction"), "<primary>Page_Down",
         N_("Move to the blank transaction at the bottom of the register"),
         G_CALLBACK (gnc_plugin_page_register_cmd_blank_transaction)
     },

--- a/src/gnome/gnc-plugin-page-register2.c
+++ b/src/gnome/gnc-plugin-page-register2.c
@@ -218,7 +218,7 @@ static GtkActionEntry gnc_plugin_page_register2_actions [] =
     /* File menu */
 
     {
-        "FilePrintAction", GTK_STOCK_PRINT, N_("_Print Checks..."), "<control>p", NULL,
+        "FilePrintAction", GTK_STOCK_PRINT, N_("_Print Checks..."), "<primary>p", NULL,
         G_CALLBACK (gnc_plugin_page_register2_cmd_print_check)
     },
 
@@ -240,17 +240,17 @@ static GtkActionEntry gnc_plugin_page_register2_actions [] =
         G_CALLBACK (gnc_plugin_page_register2_cmd_paste)
     },
     {
-        "EditEditAccountAction", GNC_STOCK_EDIT_ACCOUNT, N_("Edit _Account"), "<control>e",
+        "EditEditAccountAction", GNC_STOCK_EDIT_ACCOUNT, N_("Edit _Account"), "<primary>e",
         N_("Edit the selected account"),
         G_CALLBACK (gnc_plugin_page_register2_cmd_edit_account)
     },
     {
-        "EditFindAccountAction", GTK_STOCK_FIND, N_("F_ind Account"), "<control>i",
+        "EditFindAccountAction", GTK_STOCK_FIND, N_("F_ind Account"), "<primary>i",
         N_("Find an account"),
         G_CALLBACK (gnc_plugin_page_register2_cmd_find_account)
     },
     {
-        "EditFindTransactionsAction", GTK_STOCK_FIND, N_("_Find..."), "<control>f",
+        "EditFindTransactionsAction", GTK_STOCK_FIND, N_("_Find..."), "<primary>f",
         N_("Find transactions with a search"),
         G_CALLBACK (gnc_plugin_page_register2_cmd_find_transactions)
     },
@@ -327,7 +327,7 @@ static GtkActionEntry gnc_plugin_page_register2_actions [] =
         G_CALLBACK (gnc_plugin_page_register2_cmd_view_filter_by)
     },
     {
-        "ViewRefreshAction", GTK_STOCK_REFRESH, N_("_Refresh"), "<control>r",
+        "ViewRefreshAction", GTK_STOCK_REFRESH, N_("_Refresh"), "<primary>r",
         N_("Refresh this window"),
         G_CALLBACK (gnc_plugin_page_register2_cmd_reload)
     },
@@ -335,7 +335,7 @@ static GtkActionEntry gnc_plugin_page_register2_actions [] =
     /* Actions menu */
 
     {
-        "ActionsTransferAction", GNC_STOCK_TRANSFER, N_("_Transfer..."), "<control>t",
+        "ActionsTransferAction", GNC_STOCK_TRANSFER, N_("_Transfer..."), "<primary>t",
         N_("Transfer funds from one account to another"),
         G_CALLBACK (gnc_plugin_page_register2_cmd_transfer)
     },
@@ -360,7 +360,7 @@ static GtkActionEntry gnc_plugin_page_register2_actions [] =
         G_CALLBACK (gnc_plugin_page_register2_cmd_lots)
     },
     {
-        "BlankTransactionAction", GTK_STOCK_GOTO_BOTTOM, N_("_Blank Transaction"), "<control>Page_Down",
+        "BlankTransactionAction", GTK_STOCK_GOTO_BOTTOM, N_("_Blank Transaction"), "<primary>Page_Down",
         N_("Move to the blank transaction at the bottom of the register"),
         G_CALLBACK (gnc_plugin_page_register2_cmd_blank_transaction)
     },

--- a/src/gnome/gnc-plugin-page-register2.c
+++ b/src/gnome/gnc-plugin-page-register2.c
@@ -55,6 +55,7 @@
 #include "gnc-tree-control-split-reg.h"
 
 #include "dialog-account.h"
+#include "dialog-find-account.h"
 #include "dialog-find-transactions2.h"
 #include "dialog-print-check.h"
 #include "dialog-transfer.h"
@@ -137,6 +138,7 @@ static void gnc_plugin_page_register2_cmd_cut (GtkAction *action, GncPluginPageR
 static void gnc_plugin_page_register2_cmd_copy (GtkAction *action, GncPluginPageRegister2 *plugin_page);
 static void gnc_plugin_page_register2_cmd_paste (GtkAction *action, GncPluginPageRegister2 *plugin_page);
 static void gnc_plugin_page_register2_cmd_edit_account (GtkAction *action, GncPluginPageRegister2 *plugin_page);
+static void gnc_plugin_page_register2_cmd_find_account (GtkAction *action, GncPluginPageRegister2 *plugin_page);
 static void gnc_plugin_page_register2_cmd_find_transactions (GtkAction *action, GncPluginPageRegister2 *plugin_page);
 static void gnc_plugin_page_register2_cmd_cut_transaction (GtkAction *action, GncPluginPageRegister2 *plugin_page);
 static void gnc_plugin_page_register2_cmd_copy_transaction (GtkAction *action, GncPluginPageRegister2 *plugin_page);
@@ -241,6 +243,11 @@ static GtkActionEntry gnc_plugin_page_register2_actions [] =
         "EditEditAccountAction", GNC_STOCK_EDIT_ACCOUNT, N_("Edit _Account"), "<control>e",
         N_("Edit the selected account"),
         G_CALLBACK (gnc_plugin_page_register2_cmd_edit_account)
+    },
+    {
+        "EditFindAccountAction", GTK_STOCK_FIND, N_("F_ind Account"), "<control>i",
+        N_("Find an account"),
+        G_CALLBACK (gnc_plugin_page_register2_cmd_find_account)
     },
     {
         "EditFindTransactionsAction", GTK_STOCK_FIND, N_("_Find..."), "<control>f",
@@ -2773,6 +2780,19 @@ gnc_plugin_page_register2_cmd_edit_account (GtkAction *action,
     if (account)
         gnc_ui_edit_account_window (account);
     LEAVE(" ");
+}
+
+static void
+gnc_plugin_page_register2_cmd_find_account (GtkAction *action,
+        GncPluginPageRegister2 *page)
+{
+    GtkWidget *window;
+
+    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER2(page));
+
+    window = gnc_plugin_page_get_window (GNC_PLUGIN_PAGE(page));
+
+    gnc_find_account_dialog (window, NULL);
 }
 
 static void

--- a/src/gnome/gschemas/org.gnucash.dialogs.gschema.xml.in.in
+++ b/src/gnome/gschemas/org.gnucash.dialogs.gschema.xml.in.in
@@ -9,6 +9,7 @@
     <child name="tax-info" schema="org.gnucash.dialogs.tax-info"/>
     <child name="fincalc" schema="org.gnucash.dialogs.fincalc"/>
     <child name="find" schema="org.gnucash.dialogs.find"/>
+    <child name="find-account" schema="org.gnucash.dialogs.find-account"/>
     <child name="export-accounts" schema="org.gnucash.dialogs.export-accounts"/>
     <child name="log-replay" schema="org.gnucash.dialogs.log-replay"/>
     <child name="open-save" schema="org.gnucash.dialogs.open-save"/>
@@ -33,6 +34,16 @@
   </schema>
 
   <schema id="org.gnucash.dialogs.imap-editor" path="/org/gnucash/dialogs/imap-editor/">
+    <key type="(iiii)" name="last-geometry">
+      <default>(-1,-1,-1,-1)</default>
+      <summary>Last window position and size</summary>
+      <description>This setting describes the size and position of the window when it was last closed.
+        The numbers are the X and Y coordinates of the top left corner of the window
+        followed by the width and height of the window.</description>
+    </key>
+  </schema>
+
+  <schema id="org.gnucash.dialogs.find-account" path="/org/gnucash/dialogs/find-account/">
     <key type="(iiii)" name="last-geometry">
       <default>(-1,-1,-1,-1)</default>
       <summary>Last window position and size</summary>

--- a/src/gnome/gtkbuilder/Makefile.am
+++ b/src/gnome/gtkbuilder/Makefile.am
@@ -7,6 +7,7 @@ gtkbuilder_DATA = \
 	dialog-commodities.glade \
 	dialog-imap-editor.glade \
 	dialog-fincalc.glade \
+	dialog-find-account.glade \
 	dialog-lot-viewer.glade \
 	dialog-new-user.glade \
 	dialog-price.glade \

--- a/src/gnome/gtkbuilder/dialog-find-account.glade
+++ b/src/gnome/gtkbuilder/dialog-find-account.glade
@@ -101,7 +101,7 @@
           </packing>
         </child>
         <child>
-          <object class="GtkHBox" id="hbox1">
+          <object class="GtkHBox" id="hbox-radio">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="border_width">5</property>

--- a/src/gnome/gtkbuilder/dialog-find-account.glade
+++ b/src/gnome/gtkbuilder/dialog-find-account.glade
@@ -9,13 +9,13 @@
       <!-- column-name account -->
       <column type="gpointer"/>
       <!-- column-name place_holder -->
-      <column type="gboolean"/>
+      <column type="gchararray"/>
       <!-- column-name hidden -->
-      <column type="gboolean"/>
+      <column type="gchararray"/>
       <!-- column-name not_used -->
-      <column type="gboolean"/>
+      <column type="gchararray"/>
       <!-- column-name bal_zero -->
-      <column type="gboolean"/>
+      <column type="gchararray"/>
     </columns>
   </object>
   <object class="GtkDialog" id="Find Account Dialog">

--- a/src/gnome/gtkbuilder/dialog-find-account.glade
+++ b/src/gnome/gtkbuilder/dialog-find-account.glade
@@ -1,0 +1,279 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk+" version="2.16"/>
+  <!-- interface-naming-policy toplevel-contextual -->
+  <object class="GtkListStore" id="list-store">
+    <columns>
+      <!-- column-name account_full_name -->
+      <column type="gchararray"/>
+      <!-- column-name account -->
+      <column type="gpointer"/>
+      <!-- column-name place_holder -->
+      <column type="gboolean"/>
+      <!-- column-name hidden -->
+      <column type="gboolean"/>
+    </columns>
+  </object>
+  <object class="GtkDialog" id="Find Account Dialog">
+    <property name="can_focus">False</property>
+    <property name="border_width">6</property>
+    <property name="title" translatable="yes">Find Account Dialog</property>
+    <property name="default_width">600</property>
+    <property name="default_height">400</property>
+    <property name="type_hint">dialog</property>
+    <signal name="destroy" handler="gnc_find_account_dialog_window_destroy_cb" swapped="no"/>
+    <signal name="response" handler="gnc_find_account_dialog_response_cb" swapped="no"/>
+    <child internal-child="vbox">
+      <object class="GtkVBox" id="dialog-vbox2">
+        <property name="can_focus">False</property>
+        <child>
+          <object class="GtkLabel" id="label1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="ypad">10</property>
+            <property name="label" translatable="yes">Search the Account List</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child internal-child="action_area">
+          <object class="GtkHButtonBox" id="dialog-action_area1">
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkCheckButton" id="check_button">
+                <property name="label" translatable="yes">Close on Jump</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="active">True</property>
+                <property name="draw_indicator">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="jumpto_button">
+                <property name="label">gtk-jump-to</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="close_button">
+                <property name="label">gtk-close</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="can_default">True</property>
+                <property name="has_default">True</property>
+                <property name="receives_default">False</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="pack_type">end</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkHBox" id="hbox1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="border_width">5</property>
+            <property name="homogeneous">True</property>
+            <child>
+              <object class="GtkRadioButton" id="radio-root">
+                <property name="label" translatable="yes">Search from Root</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="active">True</property>
+                <property name="draw_indicator">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkRadioButton" id="radio-subroot">
+                <property name="label" translatable="yes">Search from Sub Account</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="active">True</property>
+                <property name="draw_indicator">True</property>
+                <property name="group">radio-root</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkScrolledWindow" id="scrolledwindow2">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="hscrollbar_policy">automatic</property>
+            <property name="vscrollbar_policy">automatic</property>
+            <child>
+              <object class="GtkTreeView" id="treeview">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="model">list-store</property>
+                <child>
+                  <object class="GtkTreeViewColumn" id="account_full_name">
+                    <property name="resizable">True</property>
+                    <property name="title" translatable="yes">Account Full Name</property>
+                    <child>
+                      <object class="GtkCellRendererText" id="cellrenderertext1"/>
+                      <attributes>
+                        <attribute name="text">0</attribute>
+                      </attributes>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="filter-label">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="ypad">5</property>
+            <property name="label" translatable="yes">Case insensative filtering is available on 'Account Full Name'.</property>
+            <property name="justify">center</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">4</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkHBox" id="hbox2">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <child>
+              <object class="GtkLabel" id="label3">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkEntry" id="filter-text-entry">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="invisible_char">●</property>
+                <property name="invisible_char_set">True</property>
+                <property name="primary_icon_activatable">False</property>
+                <property name="secondary_icon_activatable">False</property>
+                <property name="primary_icon_sensitive">True</property>
+                <property name="secondary_icon_sensitive">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="filter-button">
+                <property name="label" translatable="yes">_Filter</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_underline">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label4">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">5</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="label2">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="ypad">5</property>
+            <property name="label" translatable="yes">Select a row and then press 'jump to' to jump to account in the Account Tree,
+if account is hidden then the Account Editor will open.</property>
+            <property name="justify">center</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">6</property>
+          </packing>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="-8">check_button</action-widget>
+      <action-widget response="-10">jumpto_button</action-widget>
+      <action-widget response="-6">close_button</action-widget>
+    </action-widgets>
+  </object>
+</interface>

--- a/src/gnome/gtkbuilder/dialog-find-account.glade
+++ b/src/gnome/gtkbuilder/dialog-find-account.glade
@@ -177,7 +177,7 @@
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="ypad">5</property>
-            <property name="label" translatable="yes">Case insensative filtering is available on 'Account Full Name'.</property>
+            <property name="label" translatable="yes">Case insensative searching is available on 'Account Full Name'.</property>
             <property name="justify">center</property>
           </object>
           <packing>
@@ -220,7 +220,7 @@
             </child>
             <child>
               <object class="GtkButton" id="filter-button">
-                <property name="label" translatable="yes">_Filter</property>
+                <property name="label" translatable="yes">_Search</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
@@ -256,7 +256,7 @@
             <property name="can_focus">False</property>
             <property name="ypad">5</property>
             <property name="label" translatable="yes">Select a row and then press 'jump to' to jump to account in the Account Tree,
-if account is hidden then the Account Editor will open.</property>
+if account should not be shown, this will be temporarily overridden.</property>
             <property name="justify">center</property>
           </object>
           <packing>

--- a/src/gnome/gtkbuilder/dialog-find-account.glade
+++ b/src/gnome/gtkbuilder/dialog-find-account.glade
@@ -12,6 +12,10 @@
       <column type="gboolean"/>
       <!-- column-name hidden -->
       <column type="gboolean"/>
+      <!-- column-name not_used -->
+      <column type="gboolean"/>
+      <!-- column-name bal_zero -->
+      <column type="gboolean"/>
     </columns>
   </object>
   <object class="GtkDialog" id="Find Account Dialog">

--- a/src/gnome/ui/gnc-plugin-account-tree-ui.xml
+++ b/src/gnome/ui/gnc-plugin-account-tree-ui.xml
@@ -3,6 +3,7 @@
     <menu name="View" action="ViewAction">
       <placeholder name="ViewMiddlePlaceholder">
         <menuitem name="ViewAccountTree" action="ViewAccountTreeAction"/>
+        <menuitem name="ViewFindAccount" action="ViewFindAccountAction"/>
       </placeholder>
     </menu>
   </menubar>

--- a/src/gnome/ui/gnc-plugin-account-tree-ui.xml
+++ b/src/gnome/ui/gnc-plugin-account-tree-ui.xml
@@ -3,7 +3,6 @@
     <menu name="View" action="ViewAction">
       <placeholder name="ViewMiddlePlaceholder">
         <menuitem name="ViewAccountTree" action="ViewAccountTreeAction"/>
-        <menuitem name="ViewFindAccount" action="ViewFindAccountAction"/>
       </placeholder>
     </menu>
   </menubar>

--- a/src/gnome/ui/gnc-plugin-page-account-tree-ui.xml
+++ b/src/gnome/ui/gnc-plugin-page-account-tree-ui.xml
@@ -44,6 +44,7 @@
       <menuitem name="AccountOpenAccount" action="FileOpenAccountAction"/>
       <menuitem name="AccountOpenSubaccounts" action="FileOpenSubaccountsAction"/>
       <menuitem name="AccountEditAccount" action="EditEditAccountAction"/>
+      <menuitem name="AccountFindAccount" action="FindAccountAction"/>
       <separator name="AccountSep1"/>
       <menuitem name="AccountReconcile" action="ActionsReconcileAction"/>
       <menuitem name="AccountAutoClear" action="ActionsAutoClearAction"/>

--- a/src/gnome/ui/gnc-plugin-page-account-tree-ui.xml
+++ b/src/gnome/ui/gnc-plugin-page-account-tree-ui.xml
@@ -4,6 +4,7 @@
       <placeholder name="EditSelectedPlaceholder">
         <menuitem name="EditEditAccount" action="EditEditAccountAction"/>
 	<menuitem name="EditDeleteAccount" action="EditDeleteAccountAction"/>
+        <menuitem name="EditAccountFindAccount" action="EditFindAccountAction"/>
 	<menuitem name="EditRenumberSubaccounts" action="EditRenumberSubaccountsAction"/>
         <separator name="EditSep2"/>
         <menuitem name="FileOpenAccount" action="FileOpenAccountAction"/>
@@ -44,7 +45,7 @@
       <menuitem name="AccountOpenAccount" action="FileOpenAccountAction"/>
       <menuitem name="AccountOpenSubaccounts" action="FileOpenSubaccountsAction"/>
       <menuitem name="AccountEditAccount" action="EditEditAccountAction"/>
-      <menuitem name="AccountFindAccount" action="FindAccountAction"/>
+      <menuitem name="AccountFindAccountPopup" action="EditFindAccountPopupAction"/>
       <separator name="AccountSep1"/>
       <menuitem name="AccountReconcile" action="ActionsReconcileAction"/>
       <menuitem name="AccountAutoClear" action="ActionsAutoClearAction"/>

--- a/src/gnome/ui/gnc-plugin-page-account-tree2-ui.xml
+++ b/src/gnome/ui/gnc-plugin-page-account-tree2-ui.xml
@@ -4,6 +4,7 @@
       <placeholder name="EditSelectedPlaceholder">
         <menuitem name="EditEditAccount" action="EditEditAccountAction"/>
 	<menuitem name="EditDeleteAccount" action="EditDeleteAccountAction"/>
+        <menuitem name="EditAccountFindAccount" action="EditFindAccountAction"/>
 	<menuitem name="EditRenumberSubaccounts" action="EditRenumberSubaccountsAction"/>
         <separator name="EditSep2"/>
         <menuitem name="FileOpenAccount2" action="FileOpenAccount2Action"/>
@@ -48,6 +49,7 @@
       <menuitem name="AccountOpenSubaccounts2" action="FileOpenSubaccounts2Action"/>
       <menuitem name="AccountOpenSubaccounts" action="FileOpenSubaccountsAction"/>
       <menuitem name="AccountEditAccount" action="EditEditAccountAction"/>
+      <menuitem name="AccountFindAccountPopup" action="EditFindAccountPopupAction"/>
       <separator name="AccountSep1"/>
       <menuitem name="AccountReconcile" action="ActionsReconcileAction"/>
       <menuitem name="AccountAutoClear" action="ActionsAutoClearAction"/>

--- a/src/gnome/ui/gnc-plugin-page-register-ui.xml
+++ b/src/gnome/ui/gnc-plugin-page-register-ui.xml
@@ -3,6 +3,7 @@
     <menu name="Edit" action="EditAction">
       <placeholder name="EditAllSelectedPlaceholder">
         <menuitem name="EditEditAccount"        action="EditEditAccountAction"/>
+        <menuitem name="EditFindAccount"        action="EditFindAccountAction"/>
       </placeholder>
     </menu>
 

--- a/src/gnome/ui/gnc-plugin-page-register2-ui.xml
+++ b/src/gnome/ui/gnc-plugin-page-register2-ui.xml
@@ -3,6 +3,7 @@
     <menu name="Edit" action="EditAction">
       <placeholder name="EditAllSelectedPlaceholder">
         <menuitem name="EditEditAccount"        action="EditEditAccountAction"/>
+        <menuitem name="EditFindAccount"        action="EditFindAccountAction"/>
       </placeholder>
     </menu>
 

--- a/src/gnome/window-reconcile.c
+++ b/src/gnome/window-reconcile.c
@@ -2193,12 +2193,12 @@ static GtkActionEntry recnWindow_actions [] =
         G_CALLBACK (gnc_ui_reconcile_window_change_cb)
     },
     {
-        "RecnFinishAction", GTK_STOCK_YES, N_("_Finish"), "<control>w",
+        "RecnFinishAction", GTK_STOCK_YES, N_("_Finish"), "<primary>w",
         N_("Finish the reconciliation of this account"),
         G_CALLBACK(recnFinishCB)
     },
     {
-        "RecnPostponeAction", GTK_STOCK_GO_BACK, N_("_Postpone"), "<control>p",
+        "RecnPostponeAction", GTK_STOCK_GO_BACK, N_("_Postpone"), "<primary>p",
         N_("Postpone the reconciliation of this account"),
         G_CALLBACK(recnPostponeCB)
     },
@@ -2235,27 +2235,27 @@ static GtkActionEntry recnWindow_actions [] =
     /* Transaction menu */
 
     {
-        "TransBalanceAction", GTK_STOCK_NEW, N_("_Balance"), "<control>b",
+        "TransBalanceAction", GTK_STOCK_NEW, N_("_Balance"), "<primary>b",
         N_("Add a new balancing entry to the account"),
         G_CALLBACK(gnc_ui_reconcile_window_balance_cb)
     },
     {
-        "TransEditAction", GTK_STOCK_PROPERTIES, N_("_Edit"),  "<control>e",
+        "TransEditAction", GTK_STOCK_PROPERTIES, N_("_Edit"),  "<primary>e",
         N_("Edit the current transaction"),
         G_CALLBACK(gnc_ui_reconcile_window_edit_cb)
     },
     {
-        "TransDeleteAction", GTK_STOCK_DELETE, N_("_Delete"),  "<control>d",
+        "TransDeleteAction", GTK_STOCK_DELETE, N_("_Delete"),  "<primary>d",
         N_("Delete the selected transaction"),
         G_CALLBACK(gnc_ui_reconcile_window_delete_cb)
     },
     {
-        "TransRecAction", GTK_STOCK_APPLY, N_("_Reconcile Selection"), "<control>r",
+        "TransRecAction", GTK_STOCK_APPLY, N_("_Reconcile Selection"), "<primary>r",
         N_("Reconcile the selected transactions"),
         G_CALLBACK(gnc_ui_reconcile_window_rec_cb)
     },
     {
-        "TransUnRecAction", GTK_STOCK_CLEAR, N_("_Unreconcile Selection"), "<control>u",
+        "TransUnRecAction", GTK_STOCK_CLEAR, N_("_Unreconcile Selection"), "<primary>u",
         N_("Unreconcile the selected transactions"),
         G_CALLBACK(gnc_ui_reconcile_window_unrec_cb)
     },

--- a/src/gnome/window-reconcile2.c
+++ b/src/gnome/window-reconcile2.c
@@ -2153,12 +2153,12 @@ static GtkActionEntry recnWindow2_actions [] =
         G_CALLBACK (gnc_ui_reconcile_window_change_cb)
     },
     {
-        "RecnFinishAction", GTK_STOCK_YES, N_("_Finish"), "<control>w",
+        "RecnFinishAction", GTK_STOCK_YES, N_("_Finish"), "<primary>w",
         N_("Finish the reconciliation of this account"),
         G_CALLBACK(recnFinishCB)
     },
     {
-        "RecnPostponeAction", GTK_STOCK_GO_BACK, N_("_Postpone"), "<control>p",
+        "RecnPostponeAction", GTK_STOCK_GO_BACK, N_("_Postpone"), "<primary>p",
         N_("Postpone the reconciliation of this account"),
         G_CALLBACK(recnPostponeCB)
     },
@@ -2195,27 +2195,27 @@ static GtkActionEntry recnWindow2_actions [] =
     /* Transaction menu */
 
     {
-        "TransBalanceAction", GTK_STOCK_NEW, N_("_Balance"), "<control>b",
+        "TransBalanceAction", GTK_STOCK_NEW, N_("_Balance"), "<primary>b",
         N_("Add a new balancing entry to the account"),
         G_CALLBACK(gnc_ui_reconcile_window_balance_cb)
     },
     {
-        "TransEditAction", GTK_STOCK_PROPERTIES, N_("_Edit"),  "<control>e",
+        "TransEditAction", GTK_STOCK_PROPERTIES, N_("_Edit"),  "<primary>e",
         N_("Edit the current transaction"),
         G_CALLBACK(gnc_ui_reconcile_window_edit_cb)
     },
     {
-        "TransDeleteAction", GTK_STOCK_DELETE, N_("_Delete"),  "<control>d",
+        "TransDeleteAction", GTK_STOCK_DELETE, N_("_Delete"),  "<primary>d",
         N_("Delete the selected transaction"),
         G_CALLBACK(gnc_ui_reconcile_window_delete_cb)
     },
     {
-        "TransRecAction", GTK_STOCK_APPLY, N_("_Reconcile Selection"), "<control>r",
+        "TransRecAction", GTK_STOCK_APPLY, N_("_Reconcile Selection"), "<primary>r",
         N_("Reconcile the selected transactions"),
         G_CALLBACK(gnc_ui_reconcile_window_rec_cb)
     },
     {
-        "TransUnRecAction", GTK_STOCK_CLEAR, N_("_Unreconcile Selection"), "<control>u",
+        "TransUnRecAction", GTK_STOCK_CLEAR, N_("_Unreconcile Selection"), "<primary>u",
         N_("Unreconcile the selected transactions"),
         G_CALLBACK(gnc_ui_reconcile_window_unrec_cb)
     },

--- a/src/report/report-gnome/gnc-plugin-page-report.c
+++ b/src/report/report-gnome/gnc-plugin-page-report.c
@@ -1006,7 +1006,7 @@ gnc_plugin_page_report_destroy(GncPluginPageReportPrivate * priv)
 static GtkActionEntry report_actions[] =
 {
     {
-        "FilePrintAction", GTK_STOCK_PRINT, N_("_Print Report..."), "<control>p",
+        "FilePrintAction", GTK_STOCK_PRINT, N_("_Print Report..."), "<primary>p",
         N_("Print the current report"),
         G_CALLBACK(gnc_plugin_page_report_print_cb)
     },
@@ -1031,18 +1031,18 @@ static GtkActionEntry report_actions[] =
         NULL
     },
     {
-        "ViewRefreshAction", GTK_STOCK_REFRESH, N_("_Refresh"), "<control>r",
+        "ViewRefreshAction", GTK_STOCK_REFRESH, N_("_Refresh"), "<primary>r",
         N_("Refresh this window"),
         G_CALLBACK (gnc_plugin_page_report_reload_cb)
     },
     {
-        "ReportSaveAction", GTK_STOCK_SAVE, N_("Save _Report Configuration"), "<control><alt>s",
+        "ReportSaveAction", GTK_STOCK_SAVE, N_("Save _Report Configuration"), "<primary><alt>s",
         N_("Update the current report's saved configuration. "
         "The report will be saved in the file ~/.gnucash/saved-reports-2.4. "),
         G_CALLBACK(gnc_plugin_page_report_save_cb)
     },
     {
-        "ReportSaveAsAction", GTK_STOCK_SAVE_AS, N_("Save Report Configuration As..."), "<control><alt><shift>s",
+        "ReportSaveAsAction", GTK_STOCK_SAVE_AS, N_("Save Report Configuration As..."), "<primary><alt><shift>s",
         N_("Add the current report's configuration to the `Saved Report Configurations' menu. "
         "The report will be saved in the file ~/.gnucash/saved-reports-2.4. "),
         G_CALLBACK(gnc_plugin_page_report_save_as_cb)


### PR DESCRIPTION
The first patch fixes the hidden and Tax options on Accounts as they are not being read correctly. I have used the same procedure that was used for the place holder value.

The second patch adds the option to search for an account, once found, you can select it and it will be opened  in the account tree or if it is hidden the account edit dialogue will pop up. The menu option placement may need adjusting but I think it is OK. This was recently mentioned on the lists and thought it was an interesting idea.