### PR TITLE
Session refactor

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -868,7 +868,9 @@ if test x$enable_google_test != xno; then
    AC_CHECK_LIB([gtest_main], [main],
       [AC_CHECK_FILES([/usr/src/gmock/gmock-all.cc
 		       /usr/include/gtest/gtest.h
-		       /usr/include/gmock/gmock.h],
+		       /usr/include/gmock/gmock.h
+               /usr/src/gmock/src/gmock-all.cc
+               /usr/src/gtest/src/gtest-all.cc],
       	[ac_cv_gtest_system_install=yes] [ac_cv_have_gtest_libs=yes],
 	[ac_cv_gtest_system_install=no])],
       [AC_CHECK_FILES([/usr/src/gtest/src/gtest-all.cc

--- a/src/app-utils/gnc-state.c
+++ b/src/app-utils/gnc-state.c
@@ -84,9 +84,9 @@ gnc_state_set_base (const QofSession *session)
     state_file_name = NULL;
     state_file_name_pre_241 = NULL;
 
-    uri = qof_session_get_url(session);
+    uri = qof_session_get_url (session);
     ENTER("session %p (%s)", session, uri ? uri : "(null)");
-    if (!uri)
+    if (!strlen (uri))
     {
         LEAVE("no uri, nothing to do");
         return;
@@ -228,7 +228,7 @@ void gnc_state_save (const QofSession *session)
 {
     GError *error = NULL;
 
-    if (!qof_session_get_url(session))
+    if (!strlen (qof_session_get_url(session)))
     {
         DEBUG("No file associated with session - skip state saving");
         return;

--- a/src/backend/dbi/test/test-backend-dbi-basic.cpp
+++ b/src/backend/dbi/test/test-backend-dbi-basic.cpp
@@ -51,7 +51,6 @@ extern "C"
 #include "gncInvoice.h"
     /* For version_control */
 #include <gnc-prefs.h>
-#include <qofsession-p.h>
 }
 /* For test_conn_index_functions */
 #include "test-dbi-stuff.h"

--- a/src/backend/dbi/test/test-dbi-stuff.cpp
+++ b/src/backend/dbi/test/test-dbi-stuff.cpp
@@ -26,7 +26,6 @@ extern "C"
 {
 #include <config.h>
 #include <qof.h>
-#include <qofsession-p.h>
 #include <cashobjects.h>
 #include <test-dbi-stuff.h>
 #include <unittest-support.h>

--- a/src/gnome-utils/gnc-file.c
+++ b/src/gnome-utils/gnc-file.c
@@ -492,7 +492,7 @@ gnc_add_history (QofSession * session)
     if (!session) return;
 
     url = qof_session_get_url ( session );
-    if ( !url )
+    if ( !strlen (url) )
         return;
 
     if ( gnc_uri_is_file_uri ( url ) )
@@ -1188,7 +1188,7 @@ gnc_file_do_export(const char * filename)
      * file. If so, prevent the export from happening to avoid killing this file */
     current_session = gnc_get_current_session ();
     oldfile = qof_session_get_url(current_session);
-    if (oldfile && (strcmp(oldfile, newfile) == 0))
+    if (strlen (oldfile) && (strcmp(oldfile, newfile) == 0))
     {
         g_free (newfile);
         show_session_error (ERR_FILEIO_WRITE_ERROR, filename,
@@ -1271,7 +1271,7 @@ gnc_file_save (void)
     /* If we don't have a filename/path to save to get one. */
     session = gnc_get_current_session ();
 
-    if (!qof_session_get_url(session))
+    if (!strlen (qof_session_get_url (session)))
     {
         gnc_file_save_as ();
         return;
@@ -1420,7 +1420,7 @@ gnc_file_do_save_as (const char* filename)
      * file. If so, then just do a simple save, instead of a full save as */
     session = gnc_get_current_session ();
     oldfile = qof_session_get_url(session);
-    if (oldfile && (strcmp(oldfile, newfile) == 0))
+    if (strlen (oldfile) && (strcmp(oldfile, newfile) == 0))
     {
         g_free (newfile);
         gnc_file_save ();
@@ -1578,7 +1578,7 @@ gnc_file_revert (void)
 
     session = gnc_get_current_session();
     fileurl = qof_session_get_url(session);
-    if (fileurl == NULL)
+    if (!strlen (fileurl))
         fileurl = _("<unknown>");
     if ((tmp = strrchr(fileurl, '/')) != NULL)
         filename = tmp + 1;

--- a/src/gnome-utils/gnc-main-window.c
+++ b/src/gnome-utils/gnc-main-window.c
@@ -1216,7 +1216,7 @@ gnc_main_window_prompt_for_save (GtkWidget *window)
     session = gnc_get_current_session();
     book = qof_session_get_book(session);
     filename = qof_session_get_url(session);
-    if (filename == NULL)
+    if (!strlen (filename))
         filename = _("<unknown>");
     if ((tmp = strrchr(filename, '/')) != NULL)
         filename = tmp + 1;
@@ -1626,7 +1626,7 @@ static gchar *generate_statusbar_lastmodified_message()
         book_id = qof_session_get_url (gnc_get_current_session ());
     }
 
-    if (!book_id)
+    if (!strlen (book_id))
         return NULL;
     else
     {

--- a/src/libqof/qof/Makefile.am
+++ b/src/libqof/qof/Makefile.am
@@ -77,6 +77,7 @@ qofinclude_HEADERS = \
    qofquery.h        \
    qofquerycore.h    \
    qofsession.h      \
+   qofsession.hpp    \
    qof-string-cache.h  \
    qofutil.h         \
    qof-gobject.h
@@ -89,8 +90,7 @@ noinst_HEADERS = \
    gnc-int128.hpp  \
    qofobject-p.h  \
    qofquery-p.h  \
-   qofquerycore-p.h \
-   qofsession-p.h
+   qofquerycore-p.h
 
 if OS_WIN32
 libgnc_qof_la_SOURCES += qof-win32.cpp

--- a/src/libqof/qof/gnc-backend-prov.hpp
+++ b/src/libqof/qof/gnc-backend-prov.hpp
@@ -78,4 +78,6 @@ using QofBackendProvider_ptr = std::unique_ptr<QofBackendProvider>;
  */
 void qof_backend_register_provider (QofBackendProvider_ptr&&);
 
+void qof_backend_unregister_all_providers ();
+
 #endif // __GNC_BACKEND_PROV_HPP__

--- a/src/libqof/qof/qofbook.h
+++ b/src/libqof/qof/qofbook.h
@@ -56,6 +56,7 @@ typedef struct KvpValueImpl KvpValue;
 
 #include "qofid.h"
 #include "qofinstance.h"
+#include "qofbackend.h"
 
 /* --- type macros --- */
 #define QOF_TYPE_BOOK            (qof_book_get_type ())

--- a/src/libqof/qof/qofsession.h
+++ b/src/libqof/qof/qofsession.h
@@ -112,7 +112,7 @@ extern "C"
 
 /* PROTOTYPES ******************************************************/
 
-typedef struct _QofSession    QofSession;
+typedef struct QofSessionImpl QofSession;
 
 QofSession * qof_session_new (void);
 void         qof_session_destroy (QofSession *session);
@@ -156,7 +156,6 @@ void qof_session_begin (QofSession *session, const char * book_id,
                         gboolean ignore_lock, gboolean create,
                         gboolean force);
 
-
 /**
  * The qof_session_load() method causes the QofBook to be made ready to
  *    to use with this URL/datastore.   When the URL points at a file,
@@ -195,7 +194,6 @@ const char * qof_session_get_error_message(const QofSession *session);
 QofBackendError qof_session_pop_error (QofSession *session);
 /** @} */
 
-
 /** Returns the QofBook of this session. */
 QofBook * qof_session_get_book (const QofSession *session);
 
@@ -223,6 +221,11 @@ const char * qof_session_get_url (const QofSession *session);
  */
 /* gboolean qof_session_not_saved(const QofSession *session); <- unimplemented */
 gboolean qof_session_save_in_progress(const QofSession *session);
+
+/**
+ * Returns the qof session's backend.
+ */
+QofBackend * qof_session_get_backend(const QofSession *session);
 
 /** The qof_session_save() method will commit all changes that have been
  *    made to the session. For the file backend, this is nothing

--- a/src/libqof/qof/test/Makefile.am
+++ b/src/libqof/qof/test/Makefile.am
@@ -14,7 +14,7 @@ test_qof_SOURCES = \
 	test-qofbook.c \
 	test-qofinstance.cpp \
 	test-qofobject.c \
-	test-qofsession.cpp \
+	test-qofsession-old.cpp \
 	test-qof-string-cache.c \
 	test-gnc-guid.cpp \
 	${top_srcdir}/src/test-core/unittest-support.c
@@ -55,6 +55,28 @@ test_kvp_value_CPPFLAGS = \
     $(BOOST_CPPFLAGS)
 
 check_PROGRAMS += test-kvp-value
+
+test_qofsession_SOURCES = \
+	$(top_srcdir)/$(MODULEPATH)/qofsession.cpp \
+	test-qofsession.cpp
+test_qofsession_LDADD = \
+	$(top_builddir)/$(MODULEPATH)/libgnc-qof.la \
+	$(GLIB_LIBS) \
+	$(GTEST_LIBS) \
+	$(BOOST_LDFLAGS)
+
+if !GOOGLE_TEST_LIBS
+nodist_test_qofsession_SOURCES = \
+	${GTEST_SRC}/src/gtest_main.cc
+endif
+
+test_qofsession_CPPFLAGS = \
+	-I$(GTEST_HEADERS) \
+	-I$(top_srcdir)/$(MODULEPATH) \
+	$(GLIB_CFLAGS) \
+	$(BOOST_CPPFLAGS)
+
+check_PROGRAMS += test-qofsession
 
 test_gnc_int128_SOURCES = \
         $(top_srcdir)/${MODULEPATH}/gnc-int128.cpp \

--- a/src/libqof/qof/test/test-qofsession-old.cpp
+++ b/src/libqof/qof/test/test-qofsession-old.cpp
@@ -1,0 +1,861 @@
+/********************************************************************
+ * test_qofsession.c: GLib g_test test suite for qofsession.        *
+ * Copyright 2011 John Ralls <jralls@ceridwen.us>                   *
+ *                                                                  *
+ * This program is free software; you can redistribute it and/or    *
+ * modify it under the terms of the GNU General Public License as   *
+ * published by the Free Software Foundation; either version 2 of   *
+ * the License, or (at your option) any later version.              *
+ *                                                                  *
+ * This program is distributed in the hope that it will be useful,  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    *
+ * GNU General Public License for more details.                     *
+ *                                                                  *
+ * You should have received a copy of the GNU General Public License*
+ * along with this program; if not, contact:                        *
+ *                                                                  *
+ * Free Software Foundation           Voice:  +1-617-542-5942       *
+ * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652       *
+ * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
+\********************************************************************/
+
+extern "C"
+{
+#include "config.h"
+#include <glib.h>
+#include <unittest-support.h>
+}
+
+#include "../qof.h"
+#include "../qofbackend-p.h"
+#include "../qofsession.h"
+#include "../qofclass-p.h"
+#include "../gnc-backend-prov.hpp"
+#include <vector>
+
+static const gchar *suitename = "/qof/qofsession";
+extern "C" void test_suite_qofsession ( void );
+
+extern void (*p_qof_session_load_backend) (QofSession *, const char * access_method);
+extern void (*p_qof_session_clear_error) (QofSession *);
+extern void (*p_qof_session_destroy_backend) (QofSession *);
+extern void (*p_qof_session_set_book_id) (QofSession *, const char * book_id);
+
+void init_static_qofsession_pointers (void);
+
+using ProviderVec =  std::vector<QofBackendProvider_ptr>;
+extern ProviderVec& get_providers (void);
+extern bool get_providers_initialized (void);
+
+typedef struct
+{
+    QofSession *session;
+} Fixture;
+
+static void
+safe_sync( QofBackend *be, QofBook *book )
+{
+    qof_backend_set_error( be, ERR_BACKEND_DATA_CORRUPT );
+    qof_backend_set_message( be, "Just Kidding!" );
+}
+
+static void
+percentage_fn ( const char* message, double percent )
+{
+    g_print( "%s %f complete", message, percent );
+}
+
+static void
+setup( Fixture *fixture, gconstpointer pData )
+{
+    fixture->session = qof_session_new();
+    init_static_qofsession_pointers ();
+    g_assert (p_qof_session_clear_error && p_qof_session_destroy_backend && p_qof_session_load_backend);
+}
+
+static void
+teardown( Fixture *fixture, gconstpointer pData )
+{
+    qof_session_destroy( fixture->session );
+    p_qof_session_clear_error = NULL;
+    p_qof_session_destroy_backend = NULL;
+    p_qof_session_load_backend = NULL;
+}
+
+static void
+test_qof_session_new_destroy (void)
+{
+    QofSession *session = NULL;
+    QofBook *book = NULL;
+
+    g_test_message ("Test session initialization");
+    session = qof_session_new ();
+    g_assert (session);
+    g_assert (qof_session_get_book (session));
+    book = (QofBook*) qof_session_get_book (session);
+    g_assert (book);
+    g_assert (QOF_IS_BOOK (book));
+    g_assert (!strlen (qof_session_get_url (session)));
+    g_assert (!qof_session_get_backend (session));
+    g_assert (!qof_session_save_in_progress (session));
+    g_assert_cmpint (qof_session_get_error (session), == , ERR_BACKEND_NO_ERR);
+
+    g_test_message ("Test session destroy");
+    qof_session_destroy (session);
+    /* all data structures of session get deallocated so we can't really test this place
+     * instead qof_session_destroy_backend and qof_session_end are tested
+     */
+}
+
+static void
+test_session_safe_save( Fixture *fixture, gconstpointer pData )
+{
+    qof_book_set_backend (qof_session_get_book (fixture->session), g_new0 (QofBackend, 1));
+    qof_book_get_backend (qof_session_get_book (fixture->session))->safe_sync = safe_sync;
+    qof_session_safe_save( fixture->session, percentage_fn );
+    g_assert_cmpint( ERR_BACKEND_DATA_CORRUPT, == ,
+                     qof_session_get_error( fixture->session ));
+    g_assert (!strlen (qof_session_get_url (fixture->session)));
+}
+
+static struct
+{
+    QofBackend *be;
+    bool data_compatible;
+    bool check_data_type_called;
+    bool backend_new_called;
+} load_backend_struct;
+
+struct QofMockLoadBackendProvider : public QofBackendProvider
+{
+    QofMockLoadBackendProvider(const char *name, const char* type) :
+        QofBackendProvider{name, type} {}
+    QofBackend* create_backend(void);
+    bool type_check(const char* type);
+};
+
+bool
+QofMockLoadBackendProvider::type_check (const char* book_id)
+{
+    g_assert (book_id);
+    g_assert_cmpstr (book_id, ==, "my book");
+    load_backend_struct.check_data_type_called = true;
+    return load_backend_struct.data_compatible;
+}
+
+QofBackend*
+QofMockLoadBackendProvider::create_backend (void)
+{
+    QofBackend *be = NULL;
+
+    be = g_new0 (QofBackend, 1);
+    g_assert (be);
+    load_backend_struct.be = be;
+    load_backend_struct.backend_new_called = TRUE;
+    return be;
+}
+
+static void
+test_qof_session_load_backend (Fixture *fixture, gconstpointer pData)
+{
+    QofBook *book = NULL;
+
+    /* init */
+
+    g_test_message ("Test when no provider is registered");
+    g_assert (!get_providers_initialized ());
+    g_assert (get_providers ().empty());
+    p_qof_session_load_backend (fixture->session, "file");
+    g_assert (!get_providers_initialized ());
+    g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_NO_HANDLER);
+    p_qof_session_clear_error (fixture->session);
+
+    g_test_message ("Test with provider registered but access method not supported");
+    auto prov = QofBackendProvider_ptr(new QofMockLoadBackendProvider("Mock Backend", "unsupported"));
+    qof_backend_register_provider (std::move(prov));
+    g_assert (!get_providers().empty());
+    g_assert_cmpint (get_providers().size(), == , 1);
+    p_qof_session_load_backend (fixture->session, "file");
+    g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_NO_HANDLER);
+    p_qof_session_clear_error (fixture->session);
+
+    g_test_message ("Test with access method supported but type incompatible");
+    prov = QofBackendProvider_ptr(new QofMockLoadBackendProvider("Mock Backend",
+                                                                 "file"));
+    qof_backend_register_provider (std::move(prov));
+    load_backend_struct.data_compatible = FALSE;
+    load_backend_struct.check_data_type_called = FALSE;
+    p_qof_session_set_book_id (fixture->session, "my book");
+    p_qof_session_load_backend (fixture->session, "file");
+    g_assert (load_backend_struct.check_data_type_called);
+    g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_NO_HANDLER);
+    p_qof_session_clear_error (fixture->session);
+
+
+    g_test_message ("Test with type compatible backend_new set");
+    load_backend_struct.be = NULL;
+    load_backend_struct.data_compatible = TRUE;
+    load_backend_struct.check_data_type_called = FALSE;
+    load_backend_struct.backend_new_called = FALSE;
+    g_assert (qof_book_get_backend (qof_session_get_book (fixture->session)) == NULL);
+    book = qof_session_get_book (fixture->session);
+    g_assert (book);
+    g_assert (qof_book_get_backend (book) == NULL);
+    p_qof_session_load_backend (fixture->session, "file");
+    g_assert (load_backend_struct.check_data_type_called);
+    g_assert (load_backend_struct.backend_new_called);
+    g_assert (load_backend_struct.be);
+    g_assert (load_backend_struct.be == qof_book_get_backend (qof_session_get_book (fixture->session)));
+    g_assert (qof_book_get_backend (book) == load_backend_struct.be);
+    g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_NO_ERR);
+
+    qof_backend_unregister_all_providers ();
+    g_assert_cmpint (get_providers().size(), == , 0);
+}
+
+static struct
+{
+    QofBackend *be;
+    QofBook *oldbook;
+    gboolean error;
+    gboolean load_called;
+} load_session_struct;
+
+static void
+mock_load (QofBackend *be, QofBook *book, QofBackendLoadType type)
+{
+    g_assert (be);
+    g_assert (book);
+    g_assert (be == load_session_struct.be);
+    g_assert (book != load_session_struct.oldbook);
+    g_assert (qof_book_get_backend (book) == be);
+    if (load_session_struct.error)
+        qof_backend_set_error (be, ERR_BACKEND_DATA_CORRUPT); /* just any valid error */
+    load_session_struct.load_called = TRUE;
+}
+
+static void
+test_qof_session_load (Fixture *fixture, gconstpointer pData)
+{
+    /* Method initializes a new book and loads data into it
+     * if load fails old books are restored
+     */
+    QofBackend *be = NULL;
+    QofBook *newbook = NULL;
+
+    /* init */
+    p_qof_session_set_book_id (fixture->session, "my book");
+    be = g_new0 (QofBackend, 1);
+    g_assert (be);
+    qof_book_set_backend (qof_session_get_book (fixture->session), be);
+    be->load = mock_load;
+
+    g_test_message ("Test when no error is produced");
+    g_assert (be->percentage == NULL);
+    load_session_struct.be = be;
+    load_session_struct.oldbook = qof_session_get_book (fixture->session);
+    g_assert (qof_session_get_book (fixture->session));
+    load_session_struct.error = FALSE;
+    load_session_struct.load_called = FALSE;
+    qof_session_load (fixture->session, percentage_fn);
+    newbook = qof_session_get_book (fixture->session);
+    g_assert (newbook);
+    g_assert (load_session_struct.oldbook != newbook);
+    g_assert (qof_session_get_book (fixture->session));
+    g_assert (load_session_struct.load_called);
+
+    g_test_message ("Test when no is produced");
+    load_session_struct.oldbook = qof_session_get_book (fixture->session);
+    g_assert (qof_session_get_book (fixture->session));
+    load_session_struct.error = TRUE;
+    load_session_struct.load_called = FALSE;
+    qof_session_load (fixture->session, percentage_fn);
+    newbook = qof_session_get_book (fixture->session);
+    g_assert (newbook);
+    g_assert (load_session_struct.oldbook == newbook);
+    g_assert (qof_session_get_book (fixture->session));
+    g_assert (load_session_struct.load_called);
+}
+
+static struct
+{
+    QofBackend *be;
+    QofSession *session;
+    const char *book_id;
+    gboolean backend_new_called;
+    gboolean session_begin_called;
+    gboolean produce_error;
+} session_begin_struct;
+
+static void
+mock_session_begin (QofBackend *be, QofSession *session, const char *book_id,
+                    gboolean ignore_lock, gboolean create, gboolean force)
+{
+    g_assert (be);
+    g_assert (be == session_begin_struct.be);
+    g_assert (session);
+    g_assert (session == session_begin_struct.session);
+    g_assert (book_id);
+    g_assert_cmpstr (book_id, == , session_begin_struct.book_id);
+    g_assert (ignore_lock);
+    g_assert (!create);
+    g_assert (force);
+    if (session_begin_struct.produce_error)
+    {
+        qof_backend_set_error (be, ERR_BACKEND_DATA_CORRUPT);
+        qof_backend_set_message (be, "push any error");
+    }
+    session_begin_struct.session_begin_called = TRUE;
+}
+struct QofMockSessBackendProvider : public QofBackendProvider
+{
+    QofMockSessBackendProvider(const char *name, const char* type) :
+        QofBackendProvider{name, type} {}
+    QofBackend* create_backend(void);
+    bool type_check(const char* type);
+};
+
+bool
+QofMockSessBackendProvider::type_check (const char* book_id)
+{
+    g_assert (book_id);
+    return true;
+}
+
+QofBackend*
+QofMockSessBackendProvider::create_backend (void)
+{
+    QofBackend *be = NULL;
+
+    be = g_new0 (QofBackend, 1);
+    g_assert (be);
+    be->session_begin = mock_session_begin;
+    session_begin_struct.be = be;
+    session_begin_struct.backend_new_called = TRUE;
+    return be;
+}
+
+static void
+test_qof_session_begin (Fixture *fixture, gconstpointer pData)
+{
+    gboolean ignore_lock, create, force;
+    QofBackend *be = NULL;
+
+    /* setup */
+    ignore_lock = TRUE;
+    create = FALSE;
+    force = TRUE;
+
+    be = g_new0 (QofBackend, 1);
+    g_assert (be);
+    g_assert_cmpint (get_providers().size(), == , 0);
+
+    /* run tests */
+    g_test_message ("Test when book_id is set backend is not changed");
+    qof_book_set_backend (qof_session_get_book (fixture->session), be);
+    p_qof_session_set_book_id (fixture->session, "my book");
+    qof_session_begin (fixture->session, "my book", ignore_lock, create, force);
+    g_assert (qof_book_get_backend (qof_session_get_book (fixture->session)) == be);
+
+    g_test_message ("Test when session book_id is not set and book_id passed is null backend is not changed");
+    p_qof_session_set_book_id (fixture->session, NULL);
+    qof_session_begin (fixture->session, NULL, ignore_lock, create, force);
+    g_assert (qof_book_get_backend (qof_session_get_book (fixture->session)) == be);
+
+    g_test_message ("Test default access_method parsing");
+    /* routine will destroy old backend
+     * parse access_method as 'file' and try to find backend
+     * as there is no backend registered error will be raised
+     */
+    qof_session_begin (fixture->session, "default_should_be_file", ignore_lock, create, force);
+    g_assert (qof_book_get_backend (qof_session_get_book (fixture->session)) == NULL);
+    g_assert (!strlen (qof_session_get_url (fixture->session)));
+    g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_NO_HANDLER);
+
+    g_test_message ("Test access_method parsing");
+    qof_session_begin (fixture->session, "postgres://localhost:8080", ignore_lock, create, force);
+    g_assert (qof_book_get_backend (qof_session_get_book (fixture->session)) == NULL);
+    g_assert (!strlen (qof_session_get_url (fixture->session)));
+    g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_NO_HANDLER);
+
+    g_test_message ("Test with valid backend returned and session begin set; error is produced");
+    session_begin_struct.session = fixture->session;
+    session_begin_struct.book_id = "postgres://localhost:8080";
+    session_begin_struct.backend_new_called = FALSE;
+    session_begin_struct.session_begin_called = FALSE;
+    session_begin_struct.produce_error = TRUE;
+    auto prov = QofBackendProvider_ptr(new QofMockSessBackendProvider("Mock Backend",
+                                                                  "postgres"));
+    qof_backend_register_provider (std::move(prov));
+
+    qof_session_begin (fixture->session, "postgres://localhost:8080", ignore_lock, create, force);
+    g_assert (qof_book_get_backend (qof_session_get_book (fixture->session)));
+    g_assert (session_begin_struct.be == qof_book_get_backend (qof_session_get_book (fixture->session)));
+    g_assert (session_begin_struct.backend_new_called == TRUE);
+    g_assert (session_begin_struct.session_begin_called == TRUE);
+    g_assert (!strlen (qof_session_get_url (fixture->session)));
+    g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_DATA_CORRUPT);
+    g_assert_cmpstr (qof_session_get_error_message (fixture->session), == , "push any error");
+
+    g_test_message ("Test normal session_begin execution");
+    session_begin_struct.backend_new_called = FALSE;
+    session_begin_struct.session_begin_called = FALSE;
+    session_begin_struct.produce_error = FALSE;
+    qof_session_begin (fixture->session, "postgres://localhost:8080", ignore_lock, create, force);
+    g_assert (qof_book_get_backend (qof_session_get_book (fixture->session)));
+    g_assert (session_begin_struct.be == qof_book_get_backend (qof_session_get_book (fixture->session)));
+    g_assert (session_begin_struct.backend_new_called == TRUE);
+    g_assert (session_begin_struct.session_begin_called == TRUE);
+    g_assert (strlen (qof_session_get_url (fixture->session)));
+    g_assert_cmpstr (qof_session_get_url (fixture->session), == , "postgres://localhost:8080");
+    g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_NO_ERR);
+
+    qof_backend_unregister_all_providers ();
+}
+
+static struct
+{
+    QofBackend *be;
+    QofBook *book;
+    QofSession *session;
+    const char *book_id;
+    gboolean sync_called;
+    gboolean backend_new_called;
+    gboolean session_begin_called;
+} session_save_struct;
+
+static void
+mock_sync (QofBackend *be, QofBook *book)
+{
+    g_assert (be);
+    g_assert (book);
+    g_assert (be == session_save_struct.be);
+    g_assert (book == session_save_struct.book);
+    session_save_struct.sync_called = TRUE;
+}
+
+static void
+test_qof_session_save (Fixture *fixture, gconstpointer pData)
+{
+    QofBook *book = NULL;
+    QofBackend *be = NULL;
+    QofBackendProvider *prov = NULL;
+
+    g_test_message ("Test when backend not set");
+    g_assert (qof_book_get_backend (qof_session_get_book (fixture->session)) == NULL);
+    book = qof_session_get_book (fixture->session);
+    g_assert (book);
+    g_assert_cmpint (qof_session_get_error (fixture->session), !=, ERR_BACKEND_NO_HANDLER);
+    g_assert (!qof_session_save_in_progress (fixture->session));
+    qof_session_save (fixture->session, NULL);
+    g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_NO_HANDLER);
+    g_assert (!qof_session_save_in_progress (fixture->session));
+
+    g_test_message ("Test when backend set; imitate error");
+    be = g_new0 (QofBackend, 1);
+    g_assert (be);
+    be->sync = mock_sync;
+    qof_book_set_backend (qof_session_get_book (fixture->session), be);
+    g_assert (!qof_session_save_in_progress (fixture->session));
+    session_save_struct.sync_called = FALSE;
+    session_save_struct.be = be;
+    session_save_struct.book = book;
+    qof_backend_set_error (be, ERR_BACKEND_DATA_CORRUPT);
+    qof_backend_set_message (be, "push any error");
+    qof_session_save (fixture->session, percentage_fn);
+    g_assert (qof_book_get_backend (book) == be);
+    g_assert (be->percentage == percentage_fn);
+    g_assert (session_save_struct.sync_called);
+    g_assert (!qof_session_save_in_progress (fixture->session));
+    g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_DATA_CORRUPT);
+    g_assert_cmpstr (qof_session_get_error_message (fixture->session), == , "");
+
+    g_test_message ("Test when backend set; successful save");
+    g_assert (!qof_session_save_in_progress (fixture->session));
+    session_save_struct.sync_called = FALSE;
+    qof_session_save (fixture->session, percentage_fn);
+    g_assert (qof_book_get_backend (book) == be);
+    g_assert (be->percentage == percentage_fn);
+    g_assert (session_save_struct.sync_called);
+    g_assert (!qof_session_save_in_progress (fixture->session));
+    g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_NO_ERR);
+
+    /* change backend testing
+     * code probably should be moved to separate routine or some existing code can be reused
+     * for example: qof_session_load_backend
+     */
+
+    qof_backend_unregister_all_providers ();
+    g_free (prov);
+}
+
+static struct
+{
+    QofBackend *be;
+    gboolean called;
+} destroy_backend_struct;
+
+static void
+mock_destroy_backend (QofBackend *be)
+{
+    g_assert (be);
+    g_assert (destroy_backend_struct.be == be);
+    destroy_backend_struct.called = TRUE;
+}
+
+static void
+test_qof_session_destroy_backend (Fixture *fixture, gconstpointer pData)
+{
+    QofBackend *be = NULL;
+
+    g_test_message ("Test with destroy backend callback not set");
+    be = g_new0 (QofBackend, 1);
+    g_assert (be);
+    qof_book_set_backend (qof_session_get_book (fixture->session), be);
+    p_qof_session_destroy_backend (fixture->session);
+    g_assert (!qof_book_get_backend (qof_session_get_book (fixture->session)));
+
+    g_test_message ("Test with destroy backend callback set");
+    be = g_new0 (QofBackend, 1);
+    g_assert (be);
+    be->destroy_backend = mock_destroy_backend;
+    qof_book_set_backend (qof_session_get_book (fixture->session), be);
+    destroy_backend_struct.called = FALSE;
+    destroy_backend_struct.be = be;
+    p_qof_session_destroy_backend (fixture->session);
+    g_assert (!qof_book_get_backend (qof_session_get_book (fixture->session)));
+    g_assert (destroy_backend_struct.called);
+}
+
+static struct
+{
+    QofBackend *be;
+    gboolean called;
+} session_end_struct;
+
+static void
+mock_session_end (QofBackend *be)
+{
+    g_assert (be);
+    g_assert (session_end_struct.be == be);
+    session_end_struct.called = TRUE;
+}
+
+static void
+test_qof_session_end (Fixture *fixture, gconstpointer pData)
+{
+    QofBackend *be = NULL;
+
+    g_test_message ("Test backend is closed, errors cleared and book_id removed");
+    be = g_new0 (QofBackend, 1);
+    g_assert (be);
+    be->session_end = mock_session_end;
+    be->last_err = ERR_BACKEND_DATA_CORRUPT;
+    be->error_msg = g_strdup("push any error");
+    qof_book_set_backend (qof_session_get_book (fixture->session), be);
+    p_qof_session_set_book_id (fixture->session, "my book");
+    session_end_struct.called = FALSE;
+    session_end_struct.be = be;
+    qof_session_end (fixture->session);
+    g_assert (session_end_struct.called);
+    g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_NO_ERR);
+    g_assert (!strlen (qof_session_get_url (fixture->session)));
+}
+
+static struct
+{
+    QofBackend *be;
+    QofBook *book;
+    gboolean called;
+} session_export_struct;
+
+static void
+mock_export (QofBackend *be, QofBook *book)
+{
+    g_assert (be);
+    g_assert (session_export_struct.be == be);
+    g_assert (book);
+    g_assert (session_export_struct.book == book);
+    session_export_struct.called = TRUE;
+}
+
+static void
+test_qof_session_export (Fixture *fixture, gconstpointer pData)
+{
+    QofSession *real_session = NULL;
+    QofBook *tmp_book = NULL, *real_book = NULL;
+    QofBackend *be = NULL;
+
+    real_session = qof_session_new ();
+    g_assert (real_session);
+
+    g_test_message ("Test null checks");
+    g_assert (!qof_session_export (NULL, real_session, percentage_fn));
+    g_assert (!qof_session_export (fixture->session, NULL, percentage_fn));
+
+    g_test_message ("Test with backend not set");
+    tmp_book = qof_session_get_book (fixture->session);
+    g_assert (tmp_book);
+    be = qof_book_get_backend (tmp_book);
+    g_assert (!be);
+    g_assert (!qof_session_export (fixture->session, real_session, percentage_fn));
+
+    g_test_message ("Test with backend set");
+    be = g_new0 (QofBackend, 1);
+    g_assert (be);
+    qof_book_set_backend (qof_session_get_book (fixture->session), be);
+    qof_book_set_backend (tmp_book, be);
+    g_assert (!be->percentage);
+    g_assert (qof_session_export (fixture->session, real_session, percentage_fn));
+    g_assert (be->percentage == percentage_fn);
+
+    g_test_message ("Test with backend export function set and error is produced");
+    be->export_fn = mock_export;
+    qof_backend_set_error (be, ERR_BACKEND_DATA_CORRUPT);
+    qof_backend_set_message (be, "push any error");
+    session_export_struct.called = FALSE;
+    real_book = qof_session_get_book (real_session);
+    g_assert (real_book);
+    session_export_struct.be = be;
+    session_export_struct.book = real_book;
+    g_assert (!qof_session_export (fixture->session, real_session, percentage_fn));
+    g_assert (session_export_struct.called);
+
+    g_test_message ("Test with backend export function set and no error produced");
+    p_qof_session_clear_error (fixture->session);
+    session_export_struct.called = FALSE;
+    g_assert (qof_session_export (fixture->session, real_session, percentage_fn));
+    g_assert (session_export_struct.called);
+
+    qof_session_destroy (real_session);
+}
+
+static void
+test_qof_session_swap_data (Fixture *fixture, gconstpointer pData)
+{
+    QofSession *session2 = NULL;
+    QofBackend *be1 = NULL, *be2 = NULL;
+    QofBook *book1 = NULL, *book2 = NULL;
+
+    /* init */
+    g_assert (fixture->session);
+    session2 = qof_session_new ();
+    g_assert (session2);
+    g_assert (fixture->session != session2);
+    be1 = g_new0 (QofBackend, 1);
+    g_assert (be1);
+    be2 = g_new0 (QofBackend, 1);
+    g_assert (be2);
+    qof_book_set_backend (qof_session_get_book (fixture->session), be1);
+    qof_book_set_backend (qof_session_get_book (session2), be2);
+    book1 = qof_session_get_book (fixture->session);
+    book2 = qof_session_get_book (session2);
+    g_assert (book1);
+    g_assert (book2);
+    qof_book_set_backend (book1, qof_book_get_backend (qof_session_get_book (fixture->session)));
+    qof_book_set_backend (book2, qof_book_get_backend (qof_session_get_book (session2)));
+
+
+    g_test_message ("Test book lists are swapped and backend for each book is swapped");
+    qof_session_swap_data (fixture->session, session2);
+    g_assert (qof_session_get_book (fixture->session) == book2);
+    g_assert (qof_session_get_book (session2) == book1);
+
+    qof_session_destroy (session2);
+}
+
+static struct
+{
+    QofBackend *be;
+    gboolean called;
+} events_struct;
+
+static gboolean
+mock_events_fn (QofBackend *be)
+{
+    g_assert (be);
+    g_assert (be == events_struct.be);
+    events_struct.called = TRUE;
+    return TRUE;
+}
+
+static void
+test_qof_session_events (Fixture *fixture, gconstpointer pData)
+{
+    QofBackend *be = NULL;
+
+    g_test_message ("Test pending events null checks");
+    g_assert (!qof_session_events_pending (NULL));
+    g_assert (!qof_book_get_backend (qof_session_get_book (fixture->session)));
+    g_assert (!qof_session_events_pending (fixture->session));
+    be = g_new0 (QofBackend, 1);
+    g_assert (be);
+    be->events_pending = NULL;
+    qof_book_set_backend (qof_session_get_book (fixture->session), be);
+    g_assert (!qof_session_events_pending (fixture->session));
+
+    g_test_message ("Test pending events callback");
+    be->events_pending = mock_events_fn;
+    events_struct.called = FALSE;
+    events_struct.be = be;
+    g_assert (qof_session_events_pending (fixture->session));
+    g_assert (events_struct.called);
+
+    g_test_message ("Test process events null checks");
+    g_assert (!qof_session_process_events (NULL));
+    qof_book_set_backend (qof_session_get_book (fixture->session), NULL);
+    g_assert (!qof_session_process_events (fixture->session));
+    be->process_events = NULL;
+    qof_book_set_backend (qof_session_get_book (fixture->session), be);
+    g_assert (!qof_session_process_events (fixture->session));
+
+    g_test_message ("Test process events callback");
+    be->process_events = mock_events_fn;
+    events_struct.called = FALSE;
+    events_struct.be = be;
+    g_assert (qof_session_process_events (fixture->session));
+    g_assert (events_struct.called);
+}
+
+static struct
+{
+    QofBackend *be;
+    QofBook *book;
+    gboolean called;
+} data_load_struct;
+
+static void
+mock_all_data_load (QofBackend *be, QofBook *book, QofBackendLoadType type)
+{
+    g_assert (be);
+    g_assert (book);
+    g_assert (be == data_load_struct.be);
+    g_assert (book == data_load_struct.book);
+    g_assert_cmpint (type, == , LOAD_TYPE_LOAD_ALL);
+    qof_backend_set_error (be, ERR_BACKEND_DATA_CORRUPT);
+    data_load_struct.called = TRUE;
+}
+
+static void
+test_qof_session_data_loaded (Fixture *fixture, gconstpointer pData)
+{
+    QofBackend *be = NULL;
+
+    be = g_new0 (QofBackend, 1);
+    g_assert (be);
+    be->load = mock_all_data_load;
+    qof_book_set_backend (qof_session_get_book (fixture->session), be);
+
+    g_test_message ("Test load callback and artificial error");
+    data_load_struct.be = be;
+    data_load_struct.book = qof_session_get_book (fixture->session);
+    data_load_struct.called = FALSE;
+    qof_session_ensure_all_data_loaded (fixture->session);
+    g_assert (data_load_struct.called);
+    g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_DATA_CORRUPT);
+    g_assert_cmpstr (qof_session_get_error_message (fixture->session), == , "");
+}
+
+static void
+test_qof_session_get_book (Fixture *fixture, gconstpointer pData)
+{
+    QofBook *book = NULL;
+
+    g_test_message ("Test null check");
+    g_assert (!qof_session_get_book (NULL));
+
+    g_test_message ("Test open book is returned");
+    g_assert (qof_session_get_book (fixture->session));
+    book = qof_session_get_book (fixture->session);
+    g_assert (book);
+    g_assert_cmpuint (book->book_open, == , 'y');
+
+    g_test_message ("Test when book is closed null returned");
+    qof_book_mark_closed (book);
+    g_assert (!qof_session_get_book (fixture->session));
+
+}
+
+static void
+test_qof_session_get_error (Fixture *fixture, gconstpointer pData)
+{
+    QofBackend *be = NULL;
+
+    g_test_message ("Test if session is null");
+    g_assert_cmpint (qof_session_get_error (NULL), == , ERR_BACKEND_NO_BACKEND);
+
+    g_test_message ("Test for backend error");
+    be = g_new0 (QofBackend, 1);
+    g_assert (be);
+    qof_backend_set_error (be, ERR_BACKEND_CANT_CONNECT);
+    qof_book_set_backend (qof_session_get_book (fixture->session), be);
+    g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_CANT_CONNECT);
+}
+
+static void
+test_qof_session_clear_error (Fixture *fixture, gconstpointer pData)
+{
+    QofBackend *be = NULL;
+
+    be = g_new0 (QofBackend, 1);
+    g_assert (be);
+
+    g_test_message ("Test session and backend errors are cleared");
+    be->last_err = ERR_BACKEND_NO_SUCH_DB;
+    be->error_msg = g_strdup ("push any error");
+    qof_book_set_backend (qof_session_get_book (fixture->session), be);
+    qof_backend_set_error (be, ERR_BACKEND_CANT_CONNECT);
+    p_qof_session_clear_error (fixture->session);
+    g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_NO_ERR);
+    g_assert_cmpstr (qof_session_get_error_message (fixture->session), == , "");
+    g_assert (!strlen (qof_session_get_error_message (fixture->session)));
+    g_assert_cmpint (qof_backend_get_error (be), == , ERR_BACKEND_NO_ERR);
+}
+
+static struct
+{
+    QofSession *session;
+    gpointer data1;
+    gpointer data2;
+    gpointer data3;
+    guint call_count;
+} hooks_struct;
+
+static void
+mock_hook_fn (gpointer data, gpointer user_data)
+{
+    QofSession *session;
+
+    g_assert (data);
+    g_assert (user_data);
+    session = (QofSession*) data;
+    g_assert (session == hooks_struct.session);
+    if (hooks_struct.call_count == 0)
+        g_assert (hooks_struct.data1 == user_data);
+    if (hooks_struct.call_count == 1)
+        g_assert (hooks_struct.data2 == user_data);
+    if (hooks_struct.call_count == 2)
+        g_assert (hooks_struct.data3 == user_data);
+    hooks_struct.call_count++;
+}
+
+void
+test_suite_qofsession ( void )
+{
+    GNC_TEST_ADD_FUNC (suitename, "qof session new and destroy", test_qof_session_new_destroy);
+    GNC_TEST_ADD (suitename, "qof session safe save", Fixture, NULL, setup, test_session_safe_save, teardown);
+    GNC_TEST_ADD (suitename, "qof session load backend", Fixture, NULL, setup, test_qof_session_load_backend, teardown);
+    GNC_TEST_ADD (suitename, "qof session load", Fixture, NULL, setup, test_qof_session_load, teardown);
+    GNC_TEST_ADD (suitename, "qof session begin", Fixture, NULL, setup, test_qof_session_begin, teardown);
+    GNC_TEST_ADD (suitename, "qof session save", Fixture, NULL, setup, test_qof_session_save, teardown);
+    GNC_TEST_ADD (suitename, "qof session destroy backend", Fixture, NULL, setup, test_qof_session_destroy_backend, teardown);
+    GNC_TEST_ADD (suitename, "qof session end", Fixture, NULL, setup, test_qof_session_end, teardown);
+    GNC_TEST_ADD (suitename, "qof session export", Fixture, NULL, setup, test_qof_session_export, teardown);
+    GNC_TEST_ADD (suitename, "qof session swap data", Fixture, NULL, setup, test_qof_session_swap_data, teardown);
+    GNC_TEST_ADD (suitename, "qof session events", Fixture, NULL, setup, test_qof_session_events, teardown);
+    GNC_TEST_ADD (suitename, "qof session data loaded", Fixture, NULL, setup, test_qof_session_data_loaded, teardown);
+    GNC_TEST_ADD (suitename, "qof session get book", Fixture, NULL, setup, test_qof_session_get_book, teardown);
+    GNC_TEST_ADD (suitename, "qof session get error", Fixture, NULL, setup, test_qof_session_get_error, teardown);
+    GNC_TEST_ADD (suitename, "qof session clear error", Fixture, NULL, setup, test_qof_session_clear_error, teardown);
+}

--- a/src/libqof/qof/test/test-qofsession.cpp
+++ b/src/libqof/qof/test/test-qofsession.cpp
@@ -1,6 +1,6 @@
 /********************************************************************
- * test_qofsession.c: GLib g_test test suite for qofsession.        *
- * Copyright 2011 John Ralls <jralls@ceridwen.us>                   *
+ * test-qofsession.cpp: A Google Test suite for Qof Session.        *
+ * Copyright 2016 Aaron Laws                                        *
  *                                                                  *
  * This program is free software; you can redistribute it and/or    *
  * modify it under the terms of the GNU General Public License as   *
@@ -13,864 +13,217 @@
  * GNU General Public License for more details.                     *
  *                                                                  *
  * You should have received a copy of the GNU General Public License*
- * along with this program; if not, contact:                        *
+ * along with this program; if not, you can retrieve it from        *
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.html            *
+ * or contact:                                                      *
  *                                                                  *
  * Free Software Foundation           Voice:  +1-617-542-5942       *
  * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652       *
  * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
-\********************************************************************/
+ ********************************************************************/
 
-extern "C"
-{
-#include "config.h"
-#include <glib.h>
-#include <unittest-support.h>
-}
-
-#include "../qof.h"
-#include "../qofbackend-p.h"
-#include "../qofsession-p.h"
-#include "../qofclass-p.h"
+#include <gtest/gtest.h>
+#include <qofsession.hpp>
+#include "qofbackend-p.h"
+#include <cstdlib>
 #include "../gnc-backend-prov.hpp"
-#include <vector>
 
-static const gchar *suitename = "/qof/qofsession";
-extern "C" void test_suite_qofsession ( void );
-
-extern void (*p_qof_session_load_backend) (QofSession * session, const char * access_method);
-extern void (*p_qof_session_clear_error) (QofSession * session);
-extern void (*p_qof_session_destroy_backend) (QofSession * session);
-
-void init_static_qofsession_pointers (void);
-
-using ProviderVec =  std::vector<QofBackendProvider_ptr>;
-extern ProviderVec& get_providers (void);
-extern bool get_providers_initialized (void);
-extern void unregister_all_providers (void);
-
-typedef struct
+static QofBook * exported_book {nullptr};
+static bool safe_sync_called {false};
+static bool sync_called {false};
+static bool load_error {true};
+static bool hook_called {false};
+static bool data_loaded {false};
+void example_hook (QofSession & session)
 {
-    QofSession *session;
-} Fixture;
-
-static void
-safe_sync( QofBackend *be, QofBook *book )
-{
-    qof_backend_set_error( be, ERR_BACKEND_DATA_CORRUPT );
-    qof_backend_set_message( be, "Just Kidding!" );
+    hook_called = true;
 }
 
-static void
-percentage_fn ( const char* message, double percent )
+void test_load (QofBackend * be, QofBook *, QofBackendLoadType)
 {
-    g_print( "%s %f complete", message, percent );
+    if (load_error) be->last_err = ERR_BACKEND_NO_BACKEND;
+    data_loaded = true;
 }
 
-static void
-setup( Fixture *fixture, gconstpointer pData )
+void test_safe_sync (QofBackend *, QofBook *)
 {
-    fixture->session = qof_session_new();
-    init_static_qofsession_pointers ();
-    g_assert (p_qof_session_clear_error && p_qof_session_destroy_backend && p_qof_session_load_backend);
+    safe_sync_called = true;
 }
 
-static void
-teardown( Fixture *fixture, gconstpointer pData )
+void test_sync (QofBackend *, QofBook *)
 {
-    qof_session_destroy( fixture->session );
-    p_qof_session_clear_error = NULL;
-    p_qof_session_destroy_backend = NULL;
-    p_qof_session_load_backend = NULL;
+    sync_called = true;
 }
 
-static void
-test_qof_session_new_destroy (void)
+void test_export_fn (QofBackend *, QofBook * book)
 {
-    QofSession *session = NULL;
-    QofBook *book = NULL;
-
-    g_test_message ("Test session initialization");
-    session = qof_session_new ();
-    g_assert (session);
-    g_assert_cmpstr (session->entity.e_type, == , QOF_ID_SESSION);
-    g_assert (session->book);
-    book = (QofBook*) session->book;
-    g_assert (book);
-    g_assert (QOF_IS_BOOK (book));
-    g_assert (!session->book_id);
-    g_assert (!session->backend);
-    g_assert_cmpint (session->lock, == , 1);
-    g_assert_cmpint (qof_session_get_error (session), == , ERR_BACKEND_NO_ERR);
-
-    g_test_message ("Test session destroy");
-    qof_session_destroy (session);
-    /* all data structures of session get deallocated so we can't really test this place
-     * instead qof_session_destroy_backend and qof_session_end are tested
-     */
+    exported_book = book;
 }
 
-static void
-test_session_safe_save( Fixture *fixture, gconstpointer pData )
+QofBackend * test_backend_factory ()
 {
-    fixture->session->backend = g_new0 (QofBackend, 1);
-    fixture->session->backend->safe_sync = safe_sync;
-    qof_session_safe_save( fixture->session, percentage_fn );
-    g_assert_cmpint( ERR_BACKEND_DATA_CORRUPT, == ,
-                     qof_session_get_error( fixture->session ));
-    g_assert( NULL == qof_session_get_url( fixture->session ));
+    QofBackend * ret = (QofBackend*) std::malloc (sizeof (QofBackend));
+    ret->session_begin = nullptr;
+    ret->session_end = nullptr;
+    ret->destroy_backend = nullptr;
+    ret->load = &test_load;
+    ret->sync = &test_sync;
+    ret->safe_sync = &test_safe_sync;
+    ret->export_fn = &test_export_fn;
+    ret->error_msg = nullptr;
+    ret->fullpath = nullptr;
+    ret->last_err = ERR_BACKEND_NO_ERR;
+    ret->begin = nullptr;
+    ret->commit = nullptr;
+    ret->rollback = nullptr;
+    ret->compile_query = nullptr;
+    ret->free_query = nullptr;
+    ret->run_query = nullptr;
+    ret->events_pending = nullptr;
+    ret->process_events = nullptr;
+    ret->percentage = nullptr;
+    ret->config_count = 0;
+    ret->price_lookup = nullptr;
+    return ret;
 }
 
-static struct
+struct MockProvider : public QofBackendProvider
 {
-    QofBackend *be;
-    bool data_compatible;
-    bool check_data_type_called;
-    bool backend_new_called;
-} load_backend_struct;
-
-struct QofMockLoadBackendProvider : public QofBackendProvider
-{
-    QofMockLoadBackendProvider(const char *name, const char* type) :
-        QofBackendProvider{name, type} {}
-    QofBackend* create_backend(void);
-    bool type_check(const char* type);
+    MockProvider (char const * name, char const * access_method)
+        : QofBackendProvider {name, access_method} {}
+    QofBackend * create_backend (void) {return test_backend_factory ();}
+    bool type_check (char const * type) {return true;}
 };
 
-bool
-QofMockLoadBackendProvider::type_check (const char* book_id)
+QofBackendProvider_ptr get_provider ()
 {
-    g_assert (book_id);
-    g_assert_cmpstr (book_id, ==, "my book");
-    load_backend_struct.check_data_type_called = true;
-    return load_backend_struct.data_compatible;
+    return QofBackendProvider_ptr {new MockProvider {"Mock Backend", "file"}};
 }
 
-QofBackend*
-QofMockLoadBackendProvider::create_backend (void)
+TEST (QofSessionTest, swap_books)
 {
-    QofBackend *be = NULL;
-
-    be = g_new0 (QofBackend, 1);
-    g_assert (be);
-    load_backend_struct.be = be;
-    load_backend_struct.backend_new_called = TRUE;
-    return be;
+    qof_backend_register_provider (get_provider ());
+    QofSession s1;
+    s1.begin ("book1", false, false, false);
+    QofSession s2;
+    s2.begin ("book2", false, false, false);
+    QofBook * b1 {s1.get_book ()};
+    QofBook * b2 {s2.get_book ()};
+    ASSERT_NE (b1, b2);
+    s1.swap_books (s2);
+    EXPECT_EQ (s1.get_book (), b2);
+    EXPECT_EQ (s2.get_book (), b1);
+    qof_backend_unregister_all_providers ();
 }
 
-static void
-test_qof_session_load_backend (Fixture *fixture, gconstpointer pData)
+TEST (QofSessionTest, ensure_all_data_loaded)
 {
-    QofBook *book = NULL;
-
-    /* init */
-
-    g_test_message ("Test when no provider is registered");
-    g_assert (!get_providers_initialized ());
-    g_assert (get_providers ().empty());
-    p_qof_session_load_backend (fixture->session, "file");
-    g_assert (!get_providers_initialized ());
-    g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_NO_HANDLER);
-    g_assert_cmpstr (qof_session_get_error_message (fixture->session), == , "Failed to load 'file' using access_method");
-    p_qof_session_clear_error (fixture->session);
-
-    g_test_message ("Test with provider registered but access method not supported");
-    auto prov = QofBackendProvider_ptr(new QofMockLoadBackendProvider("Mock Backend", "unsupported"));
-    qof_backend_register_provider (std::move(prov));
-    g_assert (!get_providers().empty());
-    g_assert_cmpint (get_providers().size(), == , 1);
-    p_qof_session_load_backend (fixture->session, "file");
-    g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_NO_HANDLER);
-    g_assert_cmpstr (qof_session_get_error_message (fixture->session), == , "Failed to load 'file' using access_method");
-    p_qof_session_clear_error (fixture->session);
-
-    g_test_message ("Test with access method supported but type incompatible");
-    prov = QofBackendProvider_ptr(new QofMockLoadBackendProvider("Mock Backend",
-                                                                 "file"));
-    qof_backend_register_provider (std::move(prov));
-    load_backend_struct.data_compatible = FALSE;
-    load_backend_struct.check_data_type_called = FALSE;
-    fixture->session->book_id = g_strdup ("my book");
-    p_qof_session_load_backend (fixture->session, "file");
-    g_assert (load_backend_struct.check_data_type_called);
-    g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_NO_HANDLER);
-    g_assert_cmpstr (qof_session_get_error_message (fixture->session), == , "Failed to load 'file' using access_method");
-    p_qof_session_clear_error (fixture->session);
-
-
-    g_test_message ("Test with type compatible backend_new set");
-    load_backend_struct.be = NULL;
-    load_backend_struct.data_compatible = TRUE;
-    load_backend_struct.check_data_type_called = FALSE;
-    load_backend_struct.backend_new_called = FALSE;
-    g_assert (fixture->session->backend == NULL);
-    book = qof_session_get_book (fixture->session);
-    g_assert (book);
-    g_assert (qof_book_get_backend (book) == NULL);
-    p_qof_session_load_backend (fixture->session, "file");
-    g_assert (load_backend_struct.check_data_type_called);
-    g_assert (load_backend_struct.backend_new_called);
-    g_assert (load_backend_struct.be);
-    g_assert (load_backend_struct.be == fixture->session->backend);
-    g_assert (qof_book_get_backend (book) == load_backend_struct.be);
-    g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_NO_ERR);
-
-    unregister_all_providers ();
-    g_assert_cmpint (get_providers().size(), == , 0);
+    qof_backend_register_provider (get_provider ());
+    QofSession s;
+    s.begin ("book1", false, false, false);
+    data_loaded = false;
+    s.ensure_all_data_loaded ();
+    EXPECT_EQ (data_loaded, true);
+    qof_backend_unregister_all_providers ();
 }
 
-static struct
+TEST (QofSessionTest, get_error)
 {
-    QofBackend *be;
-    QofBook *oldbook;
-    gboolean error;
-    gboolean load_called;
-} load_session_struct;
-
-static void
-mock_load (QofBackend *be, QofBook *book, QofBackendLoadType type)
-{
-    g_assert (be);
-    g_assert (book);
-    g_assert (be == load_session_struct.be);
-    g_assert (book != load_session_struct.oldbook);
-    g_assert (qof_book_get_backend (book) == be);
-    if (load_session_struct.error)
-        qof_backend_set_error (be, ERR_BACKEND_DATA_CORRUPT); /* just any valid error */
-    load_session_struct.load_called = TRUE;
+    qof_backend_register_provider (get_provider ());
+    QofSession s;
+    s.begin ("book1", false, false, false);
+    s.ensure_all_data_loaded ();
+    EXPECT_NE (s.get_error (), ERR_BACKEND_NO_ERR);
+    //get_error should not clear the error.
+    EXPECT_NE (s.get_error (), ERR_BACKEND_NO_ERR);
+    qof_backend_unregister_all_providers ();
 }
 
-static void
-test_qof_session_load (Fixture *fixture, gconstpointer pData)
+TEST (QofSessionTest, pop_error)
 {
-    /* Method initializes a new book and loads data into it
-     * if load fails old books are restored
-     */
-    QofBackend *be = NULL;
-    QofBook *newbook = NULL;
-
-    /* init */
-    fixture->session->book_id = g_strdup ("my book");
-    be = g_new0 (QofBackend, 1);
-    g_assert (be);
-    fixture->session->backend = be;
-    be->load = mock_load;
-
-    g_test_message ("Test when no error is produced");
-    g_assert (be->percentage == NULL);
-    load_session_struct.be = be;
-    load_session_struct.oldbook = qof_session_get_book (fixture->session);
-    g_assert (fixture->session->book);
-    load_session_struct.error = FALSE;
-    load_session_struct.load_called = FALSE;
-    qof_session_load (fixture->session, percentage_fn);
-    newbook = qof_session_get_book (fixture->session);
-    g_assert (newbook);
-    g_assert (load_session_struct.oldbook != newbook);
-    g_assert (fixture->session->book);
-    g_assert (load_session_struct.load_called);
-
-    g_test_message ("Test when no is produced");
-    load_session_struct.oldbook = qof_session_get_book (fixture->session);
-    g_assert (fixture->session->book);
-    load_session_struct.error = TRUE;
-    load_session_struct.load_called = FALSE;
-    qof_session_load (fixture->session, percentage_fn);
-    newbook = qof_session_get_book (fixture->session);
-    g_assert (newbook);
-    g_assert (load_session_struct.oldbook == newbook);
-    g_assert (fixture->session->book);
-    g_assert (load_session_struct.load_called);
+    qof_backend_register_provider (get_provider ());
+    QofSession s;
+    s.begin ("book1", false, false, false);
+    //We run the test first, and make sure there is an error condition.
+    s.ensure_all_data_loaded ();
+    EXPECT_NE (s.pop_error (), ERR_BACKEND_NO_ERR);
+    EXPECT_EQ (s.get_error (), ERR_BACKEND_NO_ERR);
+    qof_backend_unregister_all_providers ();
 }
 
-static struct
+TEST (QofSessionTest, clear_error)
 {
-    QofBackend *be;
-    QofSession *session;
-    const char *book_id;
-    gboolean backend_new_called;
-    gboolean session_begin_called;
-    gboolean produce_error;
-} session_begin_struct;
-
-static void
-mock_session_begin (QofBackend *be, QofSession *session, const char *book_id,
-                    gboolean ignore_lock, gboolean create, gboolean force)
-{
-    g_assert (be);
-    g_assert (be == session_begin_struct.be);
-    g_assert (session);
-    g_assert (session == session_begin_struct.session);
-    g_assert (book_id);
-    g_assert_cmpstr (book_id, == , session_begin_struct.book_id);
-    g_assert (ignore_lock);
-    g_assert (!create);
-    g_assert (force);
-    if (session_begin_struct.produce_error)
-    {
-        qof_backend_set_error (be, ERR_BACKEND_DATA_CORRUPT);
-        qof_backend_set_message (be, "push any error");
-    }
-    session_begin_struct.session_begin_called = TRUE;
-}
-struct QofMockSessBackendProvider : public QofBackendProvider
-{
-    QofMockSessBackendProvider(const char *name, const char* type) :
-        QofBackendProvider{name, type} {}
-    QofBackend* create_backend(void);
-    bool type_check(const char* type);
-};
-
-bool
-QofMockSessBackendProvider::type_check (const char* book_id)
-{
-    g_assert (book_id);
-    return true;
+    qof_backend_register_provider (get_provider ());
+    QofSession s;
+    s.begin ("book1", false, false, false);
+    //We run the test first, and make sure there is an error condition.
+    s.ensure_all_data_loaded ();
+    EXPECT_NE (s.get_error (), ERR_BACKEND_NO_ERR);
+    //Now we run it, and clear_error to make sure the error is actually cleared.
+    s.ensure_all_data_loaded ();
+    s.clear_error ();
+    EXPECT_EQ (s.get_error (), ERR_BACKEND_NO_ERR);
+    qof_backend_unregister_all_providers ();
 }
 
-QofBackend*
-QofMockSessBackendProvider::create_backend (void)
+TEST (QofSessionTest, load)
 {
-    QofBackend *be = NULL;
+    // We register a provider that gives a backend that
+    // throws an error on load.
+    // This error during load should cause the qof session to
+    // "roll back" the book load.
+    qof_backend_register_provider (get_provider ());
+    QofSession s;
+    s.begin ("book1", false, false, false);
+    auto book = s.get_book ();
+    s.load (nullptr);
+    EXPECT_EQ (book, s.get_book ());
 
-    be = g_new0 (QofBackend, 1);
-    g_assert (be);
-    be->session_begin = mock_session_begin;
-    session_begin_struct.be = be;
-    session_begin_struct.backend_new_called = TRUE;
-    return be;
+    // Now we'll do the load without returning an error from the backend,
+    // and ensure that the book changed to a new book.
+    load_error = false;
+    s.load (nullptr);
+    EXPECT_NE (book, s.get_book ());
+    // I'll put load_error back just to be tidy.
+    load_error = true;
+    qof_backend_unregister_all_providers ();
 }
 
-static void
-test_qof_session_begin (Fixture *fixture, gconstpointer pData)
+TEST (QofSessionTest, save)
 {
-    gboolean ignore_lock, create, force;
-    QofBackend *be = NULL;
-
-    /* setup */
-    ignore_lock = TRUE;
-    create = FALSE;
-    force = TRUE;
-
-    be = g_new0 (QofBackend, 1);
-    g_assert (be);
-    g_assert_cmpint (get_providers().size(), == , 0);
-
-    /* run tests */
-    g_test_message ("Test when book_id is set backend is not changed");
-    fixture->session->backend = be;
-    fixture->session->book_id = g_strdup ("my book");
-    qof_session_begin (fixture->session, "my book", ignore_lock, create, force);
-    g_assert (fixture->session->backend == be);
-
-    g_test_message ("Test when session book_id is not set and book_id passed is null backend is not changed");
-    g_free (fixture->session->book_id);
-    fixture->session->book_id = NULL;
-    qof_session_begin (fixture->session, NULL, ignore_lock, create, force);
-    g_assert (fixture->session->backend == be);
-
-    g_test_message ("Test default access_method parsing");
-    /* routine will destroy old backend
-     * parse access_method as 'file' and try to find backend
-     * as there is no backend registered error will be raised
-     */
-    qof_session_begin (fixture->session, "default_should_be_file", ignore_lock, create, force);
-    g_assert (fixture->session->backend == NULL);
-    g_assert (fixture->session->book_id == NULL);
-    g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_NO_HANDLER);
-    g_assert_cmpstr (qof_session_get_error_message (fixture->session), == , "Failed to load 'file' using access_method");
-
-    g_test_message ("Test access_method parsing");
-    qof_session_begin (fixture->session, "postgres://localhost:8080", ignore_lock, create, force);
-    g_assert (fixture->session->backend == NULL);
-    g_assert (fixture->session->book_id == NULL);
-    g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_NO_HANDLER);
-    g_assert_cmpstr (qof_session_get_error_message (fixture->session), == , "Failed to load 'postgres' using access_method");
-
-    g_test_message ("Test with valid backend returned and session begin set; error is produced");
-    session_begin_struct.session = fixture->session;
-    session_begin_struct.book_id = "postgres://localhost:8080";
-    session_begin_struct.backend_new_called = FALSE;
-    session_begin_struct.session_begin_called = FALSE;
-    session_begin_struct.produce_error = TRUE;
-    auto prov = QofBackendProvider_ptr(new QofMockSessBackendProvider("Mock Backend",
-                                                                  "postgres"));
-    qof_backend_register_provider (std::move(prov));
-
-    qof_session_begin (fixture->session, "postgres://localhost:8080", ignore_lock, create, force);
-    g_assert (fixture->session->backend);
-    g_assert (session_begin_struct.be == fixture->session->backend);
-    g_assert (session_begin_struct.backend_new_called == TRUE);
-    g_assert (session_begin_struct.session_begin_called == TRUE);
-    g_assert (fixture->session->book_id == NULL);
-    g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_DATA_CORRUPT);
-    g_assert_cmpstr (qof_session_get_error_message (fixture->session), == , "push any error");
-
-    g_test_message ("Test normal session_begin execution");
-    session_begin_struct.backend_new_called = FALSE;
-    session_begin_struct.session_begin_called = FALSE;
-    session_begin_struct.produce_error = FALSE;
-    qof_session_begin (fixture->session, "postgres://localhost:8080", ignore_lock, create, force);
-    g_assert (fixture->session->backend);
-    g_assert (session_begin_struct.be == fixture->session->backend);
-    g_assert (session_begin_struct.backend_new_called == TRUE);
-    g_assert (session_begin_struct.session_begin_called == TRUE);
-    g_assert (fixture->session->book_id);
-    g_assert_cmpstr (fixture->session->book_id, == , "postgres://localhost:8080");
-    g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_NO_ERR);
-
-    unregister_all_providers ();
+    qof_backend_register_provider (get_provider ());
+    QofSession s;
+    s.begin ("book1", false, false, false);
+    s.save (nullptr);
+    EXPECT_EQ (sync_called, true);
+    qof_backend_unregister_all_providers ();
+    sync_called = false;
 }
 
-static struct
+TEST (QofSessionTest, safe_save)
 {
-    QofBackend *be;
-    QofBook *book;
-    QofSession *session;
-    const char *book_id;
-    gboolean sync_called;
-    gboolean backend_new_called;
-    gboolean session_begin_called;
-} session_save_struct;
-
-static void
-mock_sync (QofBackend *be, QofBook *book)
-{
-    g_assert (be);
-    g_assert (book);
-    g_assert (be == session_save_struct.be);
-    g_assert (book == session_save_struct.book);
-    session_save_struct.sync_called = TRUE;
+    qof_backend_register_provider (get_provider ());
+    QofSession s;
+    s.begin ("book1", false, false, false);
+    s.safe_save (nullptr);
+    EXPECT_EQ (safe_sync_called, true);
+    qof_backend_unregister_all_providers ();
+    safe_sync_called = false;
 }
 
-static void
-test_qof_session_save (Fixture *fixture, gconstpointer pData)
+TEST (QofSessionTest, export_session)
 {
-    QofBook *book = NULL;
-    QofBackend *be = NULL;
-    QofBackendProvider *prov = NULL;
+    qof_backend_register_provider (get_provider ());
+    QofSession s1;
+    s1.begin ("book1", false, false, false);
+    QofSession s2;
+    s2.begin ("book2", false, false, false);
+    QofBook * b1 = s1.get_book ();
+    QofBook * b2 = s2.get_book ();
+    b1->backend = s1.get_backend ();
+    b2->backend = s2.get_backend ();
+    s2.export_session (s1, nullptr);
+    EXPECT_EQ (exported_book, b1);
 
-    g_test_message ("Test when backend not set");
-    g_assert (fixture->session->backend == NULL);
-    book = qof_session_get_book (fixture->session);
-    g_assert (book);
-    qof_session_push_error (fixture->session, ERR_BACKEND_DATA_CORRUPT, "push any error");
-    g_assert_cmpint (fixture->session->lock, == , 1);
-    qof_session_save (fixture->session, NULL);
-    g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_NO_HANDLER);
-    g_assert_cmpstr (qof_session_get_error_message (fixture->session), == , "failed to load backend");
-    g_assert_cmpint (fixture->session->lock, == , 1);
-
-    g_test_message ("Test when backend set; imitate error");
-    be = g_new0 (QofBackend, 1);
-    g_assert (be);
-    be->sync = mock_sync;
-    fixture->session->backend = be;
-    g_assert_cmpint (fixture->session->lock, == , 1);
-    session_save_struct.sync_called = FALSE;
-    session_save_struct.be = be;
-    session_save_struct.book = book;
-    qof_backend_set_error (be, ERR_BACKEND_DATA_CORRUPT);
-    qof_backend_set_message (be, "push any error");
-    qof_session_save (fixture->session, percentage_fn);
-    g_assert (qof_book_get_backend (book) == be);
-    g_assert (be->percentage == percentage_fn);
-    g_assert (session_save_struct.sync_called);
-    g_assert_cmpint (fixture->session->lock, == , 1);
-    g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_DATA_CORRUPT);
-    g_assert_cmpstr (qof_session_get_error_message (fixture->session), == , "");
-
-    g_test_message ("Test when backend set; successful save");
-    g_assert_cmpint (fixture->session->lock, == , 1);
-    session_save_struct.sync_called = FALSE;
-    qof_session_save (fixture->session, percentage_fn);
-    g_assert (qof_book_get_backend (book) == be);
-    g_assert (be->percentage == percentage_fn);
-    g_assert (session_save_struct.sync_called);
-    g_assert_cmpint (fixture->session->lock, == , 1);
-    g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_NO_ERR);
-
-    /* change backend testing
-     * code probably should be moved to separate routine or some existing code can be reused
-     * for example: qof_session_load_backend
-     */
-
-    unregister_all_providers ();
-    g_free (prov);
-}
-
-static struct
-{
-    QofBackend *be;
-    gboolean called;
-} destroy_backend_struct;
-
-static void
-mock_destroy_backend (QofBackend *be)
-{
-    g_assert (be);
-    g_assert (destroy_backend_struct.be == be);
-    destroy_backend_struct.called = TRUE;
-}
-
-static void
-test_qof_session_destroy_backend (Fixture *fixture, gconstpointer pData)
-{
-    QofBackend *be = NULL;
-
-    g_test_message ("Test with destroy backend callback not set");
-    be = g_new0 (QofBackend, 1);
-    g_assert (be);
-    fixture->session->backend = be;
-    p_qof_session_destroy_backend (fixture->session);
-    g_assert (!fixture->session->backend);
-
-    g_test_message ("Test with destroy backend callback set");
-    be = g_new0 (QofBackend, 1);
-    g_assert (be);
-    be->destroy_backend = mock_destroy_backend;
-    fixture->session->backend = be;
-    destroy_backend_struct.called = FALSE;
-    destroy_backend_struct.be = be;
-    p_qof_session_destroy_backend (fixture->session);
-    g_assert (!fixture->session->backend);
-    g_assert (destroy_backend_struct.called);
-}
-
-static struct
-{
-    QofBackend *be;
-    gboolean called;
-} session_end_struct;
-
-static void
-mock_session_end (QofBackend *be)
-{
-    g_assert (be);
-    g_assert (session_end_struct.be == be);
-    session_end_struct.called = TRUE;
-}
-
-static void
-test_qof_session_end (Fixture *fixture, gconstpointer pData)
-{
-    QofBackend *be = NULL;
-
-    g_test_message ("Test backend is closed, errors cleared and book_id removed");
-    be = g_new0 (QofBackend, 1);
-    g_assert (be);
-    be->session_end = mock_session_end;
-    fixture->session->backend = be;
-    qof_session_push_error (fixture->session, ERR_BACKEND_DATA_CORRUPT, "push any error");
-    fixture->session->book_id = g_strdup ("my book");
-    session_end_struct.called = FALSE;
-    session_end_struct.be = be;
-    qof_session_end (fixture->session);
-    g_assert (session_end_struct.called);
-    g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_NO_ERR);
-    g_assert (!fixture->session->book_id);
-}
-
-static struct
-{
-    QofBackend *be;
-    QofBook *book;
-    gboolean called;
-} session_export_struct;
-
-static void
-mock_export (QofBackend *be, QofBook *book)
-{
-    g_assert (be);
-    g_assert (session_export_struct.be == be);
-    g_assert (book);
-    g_assert (session_export_struct.book == book);
-    session_export_struct.called = TRUE;
-}
-
-static void
-test_qof_session_export (Fixture *fixture, gconstpointer pData)
-{
-    QofSession *real_session = NULL;
-    QofBook *tmp_book = NULL, *real_book = NULL;
-    QofBackend *be = NULL;
-
-    real_session = qof_session_new ();
-    g_assert (real_session);
-
-    g_test_message ("Test null checks");
-    g_assert (!qof_session_export (NULL, real_session, percentage_fn));
-    g_assert (!qof_session_export (fixture->session, NULL, percentage_fn));
-
-    g_test_message ("Test with backend not set");
-    tmp_book = qof_session_get_book (fixture->session);
-    g_assert (tmp_book);
-    be = qof_book_get_backend (tmp_book);
-    g_assert (!be);
-    g_assert (!qof_session_export (fixture->session, real_session, percentage_fn));
-
-    g_test_message ("Test with backend set");
-    be = g_new0 (QofBackend, 1);
-    g_assert (be);
-    fixture->session->backend = be;
-    qof_book_set_backend (tmp_book, be);
-    g_assert (!be->percentage);
-    g_assert (qof_session_export (fixture->session, real_session, percentage_fn));
-    g_assert (be->percentage == percentage_fn);
-
-    g_test_message ("Test with backend export function set and error is produced");
-    be->export_fn = mock_export;
-    qof_backend_set_error (be, ERR_BACKEND_DATA_CORRUPT);
-    qof_backend_set_message (be, "push any error");
-    session_export_struct.called = FALSE;
-    real_book = qof_session_get_book (real_session);
-    g_assert (real_book);
-    session_export_struct.be = be;
-    session_export_struct.book = real_book;
-    g_assert (!qof_session_export (fixture->session, real_session, percentage_fn));
-    g_assert (session_export_struct.called);
-
-    g_test_message ("Test with backend export function set and no error produced");
-    p_qof_session_clear_error (fixture->session);
-    session_export_struct.called = FALSE;
-    g_assert (qof_session_export (fixture->session, real_session, percentage_fn));
-    g_assert (session_export_struct.called);
-
-    qof_session_destroy (real_session);
-}
-
-static void
-test_qof_session_swap_data (Fixture *fixture, gconstpointer pData)
-{
-    QofSession *session2 = NULL;
-    QofBackend *be1 = NULL, *be2 = NULL;
-    QofBook *book1 = NULL, *book2 = NULL;
-
-    /* init */
-    g_assert (fixture->session);
-    session2 = qof_session_new ();
-    g_assert (session2);
-    g_assert (fixture->session != session2);
-    be1 = g_new0 (QofBackend, 1);
-    g_assert (be1);
-    be2 = g_new0 (QofBackend, 1);
-    g_assert (be2);
-    fixture->session->backend = be1;
-    session2->backend = be2;
-    book1 = fixture->session->book;
-    book2 = session2->book;
-    g_assert (book1);
-    g_assert (book2);
-    qof_book_set_backend (book1, fixture->session->backend);
-    qof_book_set_backend (book2, session2->backend);
-
-
-    g_test_message ("Test book lists are swapped and backend for each book is swapped");
-    qof_session_swap_data (fixture->session, session2);
-    g_assert (fixture->session->book == book2);
-    g_assert (session2->book == book1);
-
-    qof_session_destroy (session2);
-}
-
-static struct
-{
-    QofBackend *be;
-    gboolean called;
-} events_struct;
-
-static gboolean
-mock_events_fn (QofBackend *be)
-{
-    g_assert (be);
-    g_assert (be == events_struct.be);
-    events_struct.called = TRUE;
-    return TRUE;
-}
-
-static void
-test_qof_session_events (Fixture *fixture, gconstpointer pData)
-{
-    QofBackend *be = NULL;
-
-    g_test_message ("Test pending events null checks");
-    g_assert (!qof_session_events_pending (NULL));
-    g_assert (!fixture->session->backend);
-    g_assert (!qof_session_events_pending (fixture->session));
-    be = g_new0 (QofBackend, 1);
-    g_assert (be);
-    be->events_pending = NULL;
-    fixture->session->backend = be;
-    g_assert (!qof_session_events_pending (fixture->session));
-
-    g_test_message ("Test pending events callback");
-    be->events_pending = mock_events_fn;
-    events_struct.called = FALSE;
-    events_struct.be = be;
-    g_assert (qof_session_events_pending (fixture->session));
-    g_assert (events_struct.called);
-
-    g_test_message ("Test process events null checks");
-    g_assert (!qof_session_process_events (NULL));
-    fixture->session->backend = NULL;
-    g_assert (!qof_session_process_events (fixture->session));
-    be->process_events = NULL;
-    fixture->session->backend = be;
-    g_assert (!qof_session_process_events (fixture->session));
-
-    g_test_message ("Test process events callback");
-    be->process_events = mock_events_fn;
-    events_struct.called = FALSE;
-    events_struct.be = be;
-    g_assert (qof_session_process_events (fixture->session));
-    g_assert (events_struct.called);
-}
-
-static struct
-{
-    QofBackend *be;
-    QofBook *book;
-    gboolean called;
-} data_load_struct;
-
-static void
-mock_all_data_load (QofBackend *be, QofBook *book, QofBackendLoadType type)
-{
-    g_assert (be);
-    g_assert (book);
-    g_assert (be == data_load_struct.be);
-    g_assert (book == data_load_struct.book);
-    g_assert_cmpint (type, == , LOAD_TYPE_LOAD_ALL);
-    qof_backend_set_error (be, ERR_BACKEND_DATA_CORRUPT);
-    data_load_struct.called = TRUE;
-}
-
-static void
-test_qof_session_data_loaded (Fixture *fixture, gconstpointer pData)
-{
-    QofBackend *be = NULL;
-
-    be = g_new0 (QofBackend, 1);
-    g_assert (be);
-    be->load = mock_all_data_load;
-    fixture->session->backend = be;
-
-    g_test_message ("Test load callback and artificial error");
-    data_load_struct.be = be;
-    data_load_struct.book = qof_session_get_book (fixture->session);
-    data_load_struct.called = FALSE;
-    qof_session_ensure_all_data_loaded (fixture->session);
-    g_assert (data_load_struct.called);
-    g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_DATA_CORRUPT);
-    g_assert_cmpstr (qof_session_get_error_message (fixture->session), == , "");
-}
-
-static void
-test_qof_session_get_book (Fixture *fixture, gconstpointer pData)
-{
-    QofBook *book = NULL;
-
-    g_test_message ("Test null check");
-    g_assert (!qof_session_get_book (NULL));
-
-    g_test_message ("Test open book is returned");
-    g_assert (fixture->session->book);
-    book = qof_session_get_book (fixture->session);
-    g_assert (book);
-    g_assert_cmpuint (book->book_open, == , 'y');
-
-    g_test_message ("Test when book is closed null returned");
-    qof_book_mark_closed (book);
-    g_assert (!qof_session_get_book (fixture->session));
-
-}
-
-static void
-test_qof_session_get_error (Fixture *fixture, gconstpointer pData)
-{
-    QofBackend *be = NULL;
-
-    g_test_message ("Test if session is null");
-    g_assert_cmpint (qof_session_get_error (NULL), == , ERR_BACKEND_NO_BACKEND);
-
-    g_test_message ("Test when there is a local error");
-    fixture->session->last_err = ERR_BACKEND_DATA_CORRUPT; /* just any error */
-    g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_DATA_CORRUPT);
-
-    g_test_message ("Test if session backend is null");
-    g_assert (!fixture->session->backend);
-    fixture->session->last_err = ERR_BACKEND_NO_ERR;
-    g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_NO_ERR);
-
-    g_test_message ("Test for backend error");
-    be = g_new0 (QofBackend, 1);
-    g_assert (be);
-    qof_backend_set_error (be, ERR_BACKEND_CANT_CONNECT);
-    fixture->session->backend = be;
-    g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_CANT_CONNECT);
-}
-
-static void
-test_qof_session_clear_error (Fixture *fixture, gconstpointer pData)
-{
-    QofBackend *be = NULL;
-
-    be = g_new0 (QofBackend, 1);
-    g_assert (be);
-
-    g_test_message ("Test session and backend errors are cleared");
-    qof_session_push_error (fixture->session, ERR_BACKEND_NO_SUCH_DB, "push any error");
-    fixture->session->backend = be;
-    qof_backend_set_error (be, ERR_BACKEND_CANT_CONNECT);
-    p_qof_session_clear_error (fixture->session);
-    g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_NO_ERR);
-    g_assert_cmpstr (qof_session_get_error_message (fixture->session), == , "");
-    g_assert (!fixture->session->error_message);
-    g_assert_cmpint (qof_backend_get_error (be), == , ERR_BACKEND_NO_ERR);
-}
-
-static struct
-{
-    QofSession *session;
-    gpointer data1;
-    gpointer data2;
-    gpointer data3;
-    guint call_count;
-} hooks_struct;
-
-static void
-mock_hook_fn (gpointer data, gpointer user_data)
-{
-    QofSession *session;
-
-    g_assert (data);
-    g_assert (user_data);
-    session = (QofSession*) data;
-    g_assert (session == hooks_struct.session);
-    if (hooks_struct.call_count == 0)
-        g_assert (hooks_struct.data1 == user_data);
-    if (hooks_struct.call_count == 1)
-        g_assert (hooks_struct.data2 == user_data);
-    if (hooks_struct.call_count == 2)
-        g_assert (hooks_struct.data3 == user_data);
-    hooks_struct.call_count++;
-}
-
-void
-test_suite_qofsession ( void )
-{
-    GNC_TEST_ADD_FUNC (suitename, "qof session new and destroy", test_qof_session_new_destroy);
-    GNC_TEST_ADD (suitename, "qof session safe save", Fixture, NULL, setup, test_session_safe_save, teardown);
-    GNC_TEST_ADD (suitename, "qof session load backend", Fixture, NULL, setup, test_qof_session_load_backend, teardown);
-    GNC_TEST_ADD (suitename, "qof session load", Fixture, NULL, setup, test_qof_session_load, teardown);
-    GNC_TEST_ADD (suitename, "qof session begin", Fixture, NULL, setup, test_qof_session_begin, teardown);
-    GNC_TEST_ADD (suitename, "qof session save", Fixture, NULL, setup, test_qof_session_save, teardown);
-    GNC_TEST_ADD (suitename, "qof session destroy backend", Fixture, NULL, setup, test_qof_session_destroy_backend, teardown);
-    GNC_TEST_ADD (suitename, "qof session end", Fixture, NULL, setup, test_qof_session_end, teardown);
-    GNC_TEST_ADD (suitename, "qof session export", Fixture, NULL, setup, test_qof_session_export, teardown);
-    GNC_TEST_ADD (suitename, "qof session swap data", Fixture, NULL, setup, test_qof_session_swap_data, teardown);
-    GNC_TEST_ADD (suitename, "qof session events", Fixture, NULL, setup, test_qof_session_events, teardown);
-    GNC_TEST_ADD (suitename, "qof session data loaded", Fixture, NULL, setup, test_qof_session_data_loaded, teardown);
-    GNC_TEST_ADD (suitename, "qof session get book", Fixture, NULL, setup, test_qof_session_get_book, teardown);
-    GNC_TEST_ADD (suitename, "qof session get error", Fixture, NULL, setup, test_qof_session_get_error, teardown);
-    GNC_TEST_ADD (suitename, "qof session clear error", Fixture, NULL, setup, test_qof_session_clear_error, teardown);
+    qof_backend_unregister_all_providers ();
 }


### PR DESCRIPTION
I hope this is right. This is the same changeset I had proposed in bugzilla, but it's expressed as a series of commits rather than squashed in a patch.

As a reprise of that bugzilla (https://bugzilla.gnome.org/show_bug.cgi?id=748669), this does not have the RAII behaviour of acquiring the backend and book upon session construction, although this is desired eventually. Also, access_method remains without becoming an enum. Both of these concessions are due to the tight coupling with src/engine which should be overcome soon with further work.