### PR TITLE
Allow HTMLHELP_DIR to be specified on cmake command line

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ SET(GNC_DBD_DIR ${CMAKE_PREFIX_PATH}/lib/dbd CACHE PATH "specify location of lib
 SET(PKGLIBDIR ${CMAKE_INSTALL_PREFIX}/lib/gnucash)
 SET(TEST_MYSQL_URL "" CACHE STRING "MySQL database URL for testing")
 SET(TEST_PGSQL_URL "" CACHE STRING "PgSQL database URL for testing")
+SET(HTMLHELP_DIR ${CMAKE_PREFIX_PATH}/hh CACHE PATH "Specify location of Win32 HTMLHELP library")
 
 IF(GNC_BUILD_AS_INSTALL)
   SET(DATADIR_BUILD    ${CMAKE_BINARY_DIR}/${DATADIRNAME})
@@ -205,10 +206,8 @@ FIND_PATH (REGEX_INCLUDE_PATH NAMES regex.h
 		  PATHS /usr/include /opt/gnome/include)
 FIND_LIBRARY (REGEX_LIBRARY NAMES regex)
 IF (WIN32)
-  FIND_PATH (HTMLHELP_INCLUDE_PATH NAMES htmlhelp.h
-             PATHS /usr/include
-             HINTS ${CMAKE_PREFIX_PATH}/hh/include)
-  FIND_LIBRARY (HTMLHELP_LIBRARY htmlhelp HINTS ${CMAKE_PREFIX_PATH}/hh/lib)
+  FIND_PATH (HTMLHELP_INCLUDE_PATH NAMES htmlhelp.h HINTS ${HTMLHELP_DIR}/include)
+  FIND_LIBRARY (HTMLHELP_LIBRARY htmlhelp HINTS ${HTMLHELP_DIR}/lib)
 ENDIF (WIN32)
 
 # ############################################################


### PR DESCRIPTION
Needs PR 9 from gnucash-on-windows also.