### PR TITLE
fix compilation with guile-2.0.12

### DIFF
--- a/src/engine/test/Makefile.am
+++ b/src/engine/test/Makefile.am
@@ -64,18 +64,21 @@ GNC_TEST_DEPS = \
   --gnc-module-dir ${top_builddir}/src/engine \
   --gnc-module-dir ${top_builddir}/src/engine/test \
   --gnc-module-dir ${top_builddir}/src/app-utils \
+  --gnc-module-dir ${top_builddir}/src/engine/test \
   --guile-load-dir ${top_builddir}/src/gnc-module \
   --guile-load-dir ${top_builddir}/src/engine \
   --guile-load-dir ${top_builddir}/src/app-utils \
   --guile-load-dir ${top_builddir}/src/core-utils \
   --guile-load-dir ${top_builddir}/src/scm \
+  --guile-load-dir ${top_builddir}/src/engine/test \
   --library-dir    ${top_builddir}/src/libqof/qof \
   --library-dir    ${top_builddir}/src/core-utils \
   --library-dir    ${top_builddir}/src/gnc-module \
   --library-dir    ${top_builddir}/src/engine \
   --library-dir    ${top_builddir}/src/app-utils \
   --library-dir    ${top_builddir}/src/backend/xml \
-  --library-dir    ${top_builddir}/src/backend/sql
+  --library-dir    ${top_builddir}/src/backend/sql \
+  --library-dir    ${top_builddir}/src/engine/test
 
 $(SCM_TESTS): %: $(srcdir)/%.scm Makefile .scm-links
 	echo '${GUILE} --debug -l $(srcdir)/$*.scm -c "(exit (run-test))"' > $@

--- a/src/engine/test/Makefile.am
+++ b/src/engine/test/Makefile.am
@@ -64,7 +64,6 @@ GNC_TEST_DEPS = \
   --gnc-module-dir ${top_builddir}/src/engine \
   --gnc-module-dir ${top_builddir}/src/engine/test \
   --gnc-module-dir ${top_builddir}/src/app-utils \
-  --gnc-module-dir ${top_builddir}/src/engine/test \
   --guile-load-dir ${top_builddir}/src/gnc-module \
   --guile-load-dir ${top_builddir}/src/engine \
   --guile-load-dir ${top_builddir}/src/app-utils \

--- a/src/report/business-reports/Makefile.am
+++ b/src/report/business-reports/Makefile.am
@@ -51,6 +51,7 @@ GUILE_COMPILE_ENV = \
   --gnc-module-dir ${top_builddir}/src/html \
   --gnc-module-dir ${top_builddir}/src/report/report-system \
   --gnc-module-dir ${top_builddir}/src/report/standard-reports \
+  --gnc-module-dir ${top_builddir}/src/report/business-reports \
   --guile-load-dir ${top_builddir}/src/app-utils \
   --guile-load-dir ${top_builddir}/src/core-utils \
   --guile-load-dir ${top_builddir}/src/engine \
@@ -58,6 +59,7 @@ GUILE_COMPILE_ENV = \
   --guile-load-dir ${top_builddir}/src/gnome-utils \
   --guile-load-dir ${top_builddir}/src/report/report-system \
   --guile-load-dir ${top_builddir}/src/report/standard-reports \
+  --guile-load-dir ${top_builddir}/src/report/business-reports \
   --guile-load-dir ${top_builddir}/src/scm \
   --library-dir    ${top_builddir}/src/engine \
   --library-dir    ${top_builddir}/src/libqof/qof \
@@ -68,7 +70,8 @@ GUILE_COMPILE_ENV = \
   --library-dir    ${top_builddir}/src/backend/sql \
   --library-dir    ${top_builddir}/src/html \
   --library-dir    ${top_builddir}/src/gnc-module \
-  --library-dir    ${top_builddir}/src/report/report-system
+  --library-dir    ${top_builddir}/src/report/report-system \
+  --library-dir    ${top_builddir}/src/report/business-reports
 
 
 %.go : %.scm .scm-links $(pkglib_LTLIBRARIES)

--- a/src/report/locale-specific/us/Makefile.am
+++ b/src/report/locale-specific/us/Makefile.am
@@ -58,6 +58,7 @@ GUILE_COMPILE_ENV = \
   --gnc-module-dir ${top_builddir}/src/gnome-utils \
   --gnc-module-dir ${top_builddir}/src/html \
   --gnc-module-dir ${top_builddir}/src/report/report-system \
+  --gnc-module-dir ${top_builddir}/src/report/locale-specific/us \
   --gnc-module-dir ${top_builddir}/src/tax/us \
   --guile-load-dir ${top_builddir}/src/app-utils \
   --guile-load-dir ${top_builddir}/src/core-utils \
@@ -65,6 +66,7 @@ GUILE_COMPILE_ENV = \
   --guile-load-dir ${top_builddir}/src/gnc-module \
   --guile-load-dir ${top_builddir}/src/gnome-utils \
   --guile-load-dir ${top_builddir}/src/report/report-system \
+  --guile-load-dir ${top_builddir}/src/report/locale-specific/us \
   --guile-load-dir ${top_builddir}/src/scm \
   --guile-load-dir ${top_builddir}/src/tax/us \
   --library-dir    ${top_builddir}/src/engine \
@@ -76,7 +78,8 @@ GUILE_COMPILE_ENV = \
   --library-dir    ${top_builddir}/src/backend/xml \
   --library-dir    ${top_builddir}/src/backend/sql \
   --library-dir    ${top_builddir}/src/html \
-  --library-dir    ${top_builddir}/src/report/report-system
+  --library-dir    ${top_builddir}/src/report/report-system \
+  --library-dir    ${top_builddir}/src/report/locale-specific/us
 
 %.go : %.scm .scm-links $(pkglib_LTLIBRARIES)
 	GNC_UNINSTALLED=yes \

--- a/src/report/report-system/Makefile.am
+++ b/src/report/report-system/Makefile.am
@@ -119,6 +119,7 @@ GUILE_COMPILE_ENV = \
   --guile-load-dir ${top_builddir}/src/gnc-module \
   --guile-load-dir ${top_builddir}/src/gnome-utils \
   --guile-load-dir ${top_builddir}/src/scm \
+  --guile-load-dir ${top_builddir}/src/report/report-system \
   --library-dir    ${top_builddir}/src/libqof/qof \
   --library-dir    ${top_builddir}/src/engine \
   --library-dir    ${top_builddir}/src/app-utils \

--- a/src/report/standard-reports/Makefile.am
+++ b/src/report/standard-reports/Makefile.am
@@ -81,12 +81,14 @@ GUILE_COMPILE_ENV = \
   --gnc-module-dir ${top_builddir}/src/gnome-utils \
   --gnc-module-dir ${top_builddir}/src/html \
   --gnc-module-dir ${top_builddir}/src/report/report-system \
+  --gnc-module-dir ${top_builddir}/src/report/standard-reports \
   --guile-load-dir ${top_builddir}/src/app-utils \
   --guile-load-dir ${top_builddir}/src/core-utils \
   --guile-load-dir ${top_builddir}/src/engine \
   --guile-load-dir ${top_builddir}/src/gnc-module \
   --guile-load-dir ${top_builddir}/src/gnome-utils \
   --guile-load-dir ${top_builddir}/src/report/report-system \
+  --guile-load-dir ${top_builddir}/src/report/standard-reports \
   --guile-load-dir ${top_builddir}/src/scm \
   --library-dir    ${top_builddir}/src/libqof/qof \
   --library-dir    ${top_builddir}/src/engine \
@@ -97,7 +99,8 @@ GUILE_COMPILE_ENV = \
   --library-dir    ${top_builddir}/src/backend/xml \
   --library-dir    ${top_builddir}/src/backend/sql \
   --library-dir    ${top_builddir}/src/html \
-  --library-dir    ${top_builddir}/src/report/report-system
+  --library-dir    ${top_builddir}/src/report/report-system \
+  --library-dir    ${top_builddir}/src/report/standard-reports
 
 %.go : %.scm .scm-links $(pkglib_LTLIBRARIES)
 	GNC_UNINSTALLED=yes \

--- a/src/report/stylesheets/Makefile.am
+++ b/src/report/stylesheets/Makefile.am
@@ -68,12 +68,14 @@ GUILE_COMPILE_ENV = \
   --gnc-module-dir ${top_builddir}/src/html \
   --gnc-module-dir ${top_builddir}/src/gnome-utils \
   --gnc-module-dir ${top_builddir}/src/report/report-system \
+  --gnc-module-dir ${top_builddir}/src/report/stylesheets \
   --guile-load-dir ${top_builddir}/src/app-utils \
   --guile-load-dir ${top_builddir}/src/core-utils \
   --guile-load-dir ${top_builddir}/src/engine \
   --guile-load-dir ${top_builddir}/src/gnc-module \
   --guile-load-dir ${top_builddir}/src/gnome-utils \
   --guile-load-dir ${top_builddir}/src/report/report-system \
+  --guile-load-dir ${top_builddir}/src/report/stylesheets \
   --guile-load-dir ${top_builddir}/src/scm \
   --library-dir    ${top_builddir}/src/libqof/qof \
   --library-dir    ${top_builddir}/src/engine \
@@ -84,7 +86,8 @@ GUILE_COMPILE_ENV = \
   --library-dir    ${top_builddir}/src/backend/xml \
   --library-dir    ${top_builddir}/src/backend/sql \
   --library-dir    ${top_builddir}/src/html \
-  --library-dir    ${top_builddir}/src/report/report-system
+  --library-dir    ${top_builddir}/src/report/report-system \
+  --library-dir    ${top_builddir}/src/report/stylesheets
 
 %.go : %.scm .scm-links $(pkglib_LTLIBRARIES)
 	GNC_UNINSTALLED=yes \

--- a/src/report/utility-reports/Makefile.am
+++ b/src/report/utility-reports/Makefile.am
@@ -53,12 +53,14 @@ GUILE_COMPILE_ENV = \
   --gnc-module-dir ${top_builddir}/src/gnome-utils \
   --gnc-module-dir ${top_builddir}/src/html \
   --gnc-module-dir ${top_builddir}/src/report/report-system \
+  --gnc-module-dir ${top_builddir}/src/report/utility-reports \
   --guile-load-dir ${top_builddir}/src/app-utils \
   --guile-load-dir ${top_builddir}/src/core-utils \
   --guile-load-dir ${top_builddir}/src/engine \
   --guile-load-dir ${top_builddir}/src/gnc-module \
   --guile-load-dir ${top_builddir}/src/gnome-utils \
   --guile-load-dir ${top_builddir}/src/report/report-system \
+  --guile-load-dir ${top_builddir}/src/report/utility-reports \
   --guile-load-dir ${top_builddir}/src/scm \
   --library-dir    ${top_builddir}/src/engine \
   --library-dir    ${top_builddir}/src/libqof/qof \
@@ -69,7 +71,8 @@ GUILE_COMPILE_ENV = \
   --library-dir    ${top_builddir}/src/backend/xml \
   --library-dir    ${top_builddir}/src/backend/sql \
   --library-dir    ${top_builddir}/src/html \
-  --library-dir    ${top_builddir}/src/report/report-system
+  --library-dir    ${top_builddir}/src/report/report-system \
+  --library-dir    ${top_builddir}/src/report/utility-reports
 
 %.go : %.scm .scm-links $(pkglib_LTLIBRARIES)
 	GNC_UNINSTALLED=yes \


### PR DESCRIPTION
This version of guile needs some extra paths added to GUILE_COMPILE_ENV and GNC_TEST_DEPS.

Tested with the following configure options, on Gentoo ~amd64:

./configure --prefix=/usr --build=x86_64-pc-linux-gnu --host=x86_64-pc-linux-gnu --mandir=/usr/share/man --infodir=/usr/share/info --datadir=/usr/share --sysconfdir=/etc --localstatedir=/var/lib --disable-dependency-tracking --disable-silent-rules --docdir=/usr/share/doc/gnucash-2.6.13-r1 --htmldir=/usr/share/doc/gnucash-2.6.13-r1/html --libdir=/usr/lib64 --disable-schemas-compile --enable-compile-warnings=minimum --disable-debug --disable-password-storage --enable-ofx --disable-aqbanking --enable-python --with-guile=2.0 --disable-doxygen --disable-gtkmm --enable-locale-specific-tax --disable-error-on-warning --enable-dbi
