### PR TITLE
Value "price" allowed in attr cd:type for element book (RELAX NG file)

### DIFF
--- a/src/doc/xml/gnucash-v2.rnc
+++ b/src/doc/xml/gnucash-v2.rnc
@@ -86,6 +86,7 @@ Book = element gnc:book {
   element gnc:count-data { attribute cd:type { "transaction" }, xsd:int }?,
   element gnc:count-data { attribute cd:type { "schedxaction" }, xsd:int }?,
   element gnc:count-data { attribute cd:type { "budget" }, xsd:int }?,
+  element gnc:count-data { attribute cd:type { "price" }, xsd:int }?,
 
 # plugins (those with a get_count slot)
 


### PR DESCRIPTION
"price" is a legal value, as per code in [1]. Added value to RELAX NG
file to pass validation of modern gnucash files.

[1] https://github.com/Gnucash/gnucash/blob/51e29e7836af814868f51161cb3263465a5e951f/src/backend/xml/io-gncxml-v2.c#L1037

51e29e7836af814868f51161cb3263465a5e951f = current HEAD of branch maint