### PR TITLE
Fix broken german account template 'Kontenrahmen für Wohnungswirtschaft'.

### DIFF
--- a/accounts/de_DE/acctchrt_wohnungsw.gnucash-xea
+++ b/accounts/de_DE/acctchrt_wohnungsw.gnucash-xea
@@ -64,6 +64,7 @@
       <slot:value type="string">true</slot:value>
     </slot>
   </act:slots>
+  <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>00 Grundstücke mit Wohnbauten</act:name>


### PR DESCRIPTION
The root node was not used as parent in any other account.

This issue has been detected on updateing account templates
into kmymoney sources.