### PR TITLE
Bug 773436, use columnnames when adding data to: gnclock, numtest, versions

### DIFF
--- a/src/backend/dbi/gnc-backend-dbi.cpp
+++ b/src/backend/dbi/gnc-backend-dbi.cpp
@@ -741,7 +741,7 @@ gnc_dbi_lock_database (QofBackend* qbe, gboolean ignore_lock)
         memset (hostname, 0, sizeof (hostname));
         gethostname (hostname, GNC_HOST_NAME_MAX);
         result = dbi_conn_queryf (dcon,
-                                  "INSERT INTO %s VALUES ('%s', '%d')",
+                                  "INSERT INTO %s (Hostname, PID) VALUES ('%s', '%d')",
                                   lock_table, hostname, (int)GETPID ());
         if (!result)
         {
@@ -3230,7 +3230,7 @@ conn_test_dbi_library (dbi_conn conn)
     }
     dbi_result_free (result);
     g_ascii_dtostr (doublestr, sizeof (doublestr), testdouble);
-    querystr = g_strdup_printf ("INSERT INTO numtest VALUES (%" G_GINT64_FORMAT
+    querystr = g_strdup_printf ("INSERT INTO numtest (test_int, test_unsigned, test_double) VALUES (%" G_GINT64_FORMAT
                                 ", %" G_GUINT64_FORMAT ", %s)",
                                 testlonglong, testulonglong, doublestr);
     result = dbi_conn_query (conn, querystr);

--- a/src/backend/sql/gnc-backend-sql.cpp
+++ b/src/backend/sql/gnc-backend-sql.cpp
@@ -3403,7 +3403,8 @@ gnc_sql_set_table_version (GncSqlBackend* be, const gchar* table_name,
     {
         if (cur_version == 0)
         {
-            sql = g_strdup_printf ("INSERT INTO %s VALUES('%s',%d)", VERSION_TABLE_NAME,
+            sql = g_strdup_printf ("INSERT INTO %s (%s, %s) VALUES('%s',%d)", VERSION_TABLE_NAME,
+                                   TABLE_COL_NAME, VERSION_COL_NAME,
                                    table_name, version);
         }
         else


### PR DESCRIPTION
If you add a field to a table, for example a timestamp to gnclock, the program can no longer load the data.

`ALTER TABLE gnclock ADD ts TIMESTAMP NOT NULL DEFALUT CURRENT_TIMESTAMP;`

If all insert-queries specify what columns they inserting the data to, the queries will still work with a newer version of the database.

So if a future version of gnucash need an extra column, it will not lock out the older version of gnucash, likewise if some external tool, want an extra column in a table, gnucash will still work.