### PR TITLE
Prices Import and delete old ones 

### DIFF
--- a/src/engine/gnc-pricedb.c
+++ b/src/engine/gnc-pricedb.c
@@ -28,6 +28,7 @@
 #include <string.h>
 #include "gnc-pricedb-p.h"
 #include <qofinstance-p.h>
+#include "Recurrence.h"
 
 /* This static indicates the debugging module that this .o belongs to.  */
 static QofLogModule log_module = GNC_MOD_PRICE;
@@ -1274,6 +1275,10 @@ gnc_pricedb_remove_price(GNCPriceDB *db, GNCPrice *p)
            qof_instance_get_destroying(p));
 
     gnc_price_ref(p);
+
+    DEBUG("Remove Date is %s, Commodity is %s, Source is %s", gnc_print_date (gnc_price_get_time (p)),
+           gnc_commodity_get_fullname (gnc_price_get_commodity (p)), gnc_price_get_source_string (p));
+
     rc = remove_price (db, p, TRUE);
     gnc_pricedb_begin_edit(db);
     qof_instance_set_dirty(&db->inst);
@@ -1293,8 +1298,9 @@ typedef struct
 {
     GNCPriceDB *db;
     Timespec cutoff;
+    gboolean delete_fq;
     gboolean delete_user;
-    gboolean delete_last;
+    gboolean delete_all;
     GSList *list;
 } remove_info;
 
@@ -1308,12 +1314,18 @@ check_one_price_date (GNCPrice *price, gpointer user_data)
     ENTER("price %p (%s), data %p", price,
           gnc_commodity_get_mnemonic(gnc_price_get_commodity(price)),
           user_data);
-    if (!data->delete_user)
+
+    if (!data->delete_all)
     {
         source = gnc_price_get_source (price);
-        if (source != PRICE_SOURCE_FQ)
+        
+        if ((source == PRICE_SOURCE_FQ) && data->delete_fq)
+            PINFO ("Delete Quote Source");
+        else if ((source == PRICE_SOURCE_USER_PRICE) && data->delete_user)
+            PINFO ("Delete User Source");
+        else
         {
-            LEAVE("Not an automatic quote");
+            LEAVE("Not a matching source");
             return TRUE;
         }
     }
@@ -1344,10 +1356,6 @@ pricedb_remove_foreach_pricelist (gpointer key,
 
     ENTER("key %p, value %p, data %p", key, val, user_data);
 
-    /* The most recent price is the first in the list */
-    if (!data->delete_last)
-        node = g_list_next(node);
-
     /* now check each item in the list */
     g_list_foreach(node, (GFunc)check_one_price_date, data);
 
@@ -1355,57 +1363,144 @@ pricedb_remove_foreach_pricelist (gpointer key,
 }
 
 static void
-pricedb_remove_foreach_currencies_hash (gpointer key,
-                                        gpointer val,
-                                        gpointer user_data)
+free_data (gpointer data)
 {
-    GHashTable *currencies_hash = (GHashTable *) val;
-
-    ENTER("key %p, value %p, data %p", key, val, user_data);
-    g_hash_table_foreach(currencies_hash,
-                         pricedb_remove_foreach_pricelist, user_data);
-    LEAVE(" ");
+    g_free (data);
 }
 
+GHashTable *
+gnc_pricedb_get_remove_dates (Timespec first, Timespec cutoff, gboolean leave_month)
+{
+    GHashTable* hash_dates = g_hash_table_new_full (g_str_hash, g_str_equal, free_data, NULL);
+    Recurrence *r;
+    int nperiods = 0;
+    GDate period_begin, period_end, date_old, date_now;
+
+    GDateWeekday selected_day_of_week = G_DATE_FRIDAY;
+    GDate day_of_week_date;
+
+    period_begin = timespec_to_gdate (first);
+    period_end = timespec_to_gdate (cutoff);
+
+    day_of_week_date = period_begin;
+
+    r = g_new (Recurrence, 1);
+
+    DEBUG("Period Begin date is %d/%d/%d and End date is %d/%d/%d", g_date_get_day (&period_begin),
+           g_date_get_month (&period_begin), g_date_get_year (&period_begin), g_date_get_day (&period_end),
+           g_date_get_month (&period_end), g_date_get_year (&period_end));
+
+    g_date_set_day (&day_of_week_date, 1); // set date to 1st of month
+
+    while (g_date_get_weekday (&day_of_week_date) != selected_day_of_week)
+        g_date_subtract_days (&day_of_week_date, 1); // go back till we find last Friday of month
+
+    if (leave_month)
+        recurrenceSet (r, 1, PERIOD_LAST_WEEKDAY, &day_of_week_date, WEEKEND_ADJ_NONE); // Month set begin on last friday of month
+    else
+        recurrenceSet (r, 1, PERIOD_WEEK, &day_of_week_date, WEEKEND_ADJ_NONE); // Week set to begin on Friday of week
+
+    date_now = date_old = day_of_week_date;
+
+    while (g_date_compare (&period_end, &date_now ) > 0)
+    {
+        gchar *date_str;
+        
+        nperiods ++;
+        recurrenceNextInstance (r, &date_old, &date_now);
+        date_str = g_strdup_printf ("%d/%d/%d", g_date_get_day (&date_old), g_date_get_month (&date_old), g_date_get_year (&date_old));
+
+        DEBUG("Date Old string for hash table insert is %s", date_str);
+
+        g_hash_table_insert (hash_dates, date_str, "Keep");
+
+        date_old = date_now;
+    }
+    g_free (r);
+
+    return hash_dates;
+}
 
 gboolean
-gnc_pricedb_remove_old_prices(GNCPriceDB *db,
-                              Timespec cutoff,
-                              gboolean delete_user,
-                              gboolean delete_last)
+gnc_pricedb_remove_old_prices (GNCPriceDB *db, GList *comm_list,
+                              Timespec first, Timespec cutoff,
+                              gchar const *source,
+                              gchar const *leave)
 {
+    GHashTable *hash_dates = NULL;
     remove_info data;
     GSList *item;
+    GList  *node;
+
+    gboolean leave_none = FALSE;
+    gboolean leave_month = FALSE;
+    gboolean leave_week = FALSE;
 
     data.db = db;
     data.cutoff = cutoff;
-    data.delete_user = delete_user;
-    data.delete_last = delete_last;
     data.list = NULL;
+    data.delete_fq = FALSE;
+    data.delete_user = FALSE;
+    data.delete_all = FALSE;
 
-    ENTER("db %p, delet_user %d, delete_last %d", db, delete_user, delete_last);
+    ENTER("Remove Prices for Source %s, leaving %s", source, leave);
+
+    // setup the options
+    if (g_strcmp0 (source, "all") == 0)
+        data.delete_all = TRUE;
+    else
     {
-        gchar buf[40];
-        gnc_timespec_to_iso8601_buff(cutoff, buf);
-        DEBUG("checking date %s", buf);
+        data.delete_fq = g_str_has_prefix (source,"fq");
+        data.delete_user = g_str_has_suffix (source,"user");
     }
 
-    /* Traverse the database once building up an external list of prices
-     * to be deleted */
-    g_hash_table_foreach(db->commodity_hash,
-                         pricedb_remove_foreach_currencies_hash,
-                         &data);
+    if (g_strcmp0 (leave, "month") == 0)
+        leave_month = TRUE;
+    else if (g_strcmp0 (leave, "week") == 0)
+        leave_week = TRUE;
+    else
+        leave_none = TRUE;
+
+    // Walk the list of commodities
+    for (node = g_list_first (comm_list); node; node = g_list_next (node))
+    {
+        GHashTable *currencies_hash = g_hash_table_lookup (db->commodity_hash, node->data);
+        g_hash_table_foreach (currencies_hash, pricedb_remove_foreach_pricelist, &data);
+    }
 
     if (data.list == NULL)
+    {
+        LEAVE("Empty price list");
         return FALSE;
+    }
+    DEBUG("Number of Prices in list is %d", g_slist_length (data.list));
+
+    if (leave_none != TRUE)
+        hash_dates = gnc_pricedb_get_remove_dates (first, cutoff, leave_month);
+
+    DEBUG("There are %d keys in the hash_dates", g_hash_table_size (hash_dates));
 
     /* Now run this external list deleting prices */
     for (item = data.list; item; item = g_slist_next(item))
     {
-        gnc_pricedb_remove_price(db, item->data);
-    }
+        GDate price_date = timespec_to_gdate (gnc_price_get_time (item->data));
+        gboolean found = FALSE;
+        gchar *date_str; 
 
-    g_slist_free(data.list);
+        if (g_hash_table_size (hash_dates) != 0)
+        {
+            date_str = g_strdup_printf ("%d/%d/%d", g_date_get_day(&price_date), g_date_get_month(&price_date), g_date_get_year(&price_date));
+            found = g_hash_table_contains (hash_dates, date_str);
+
+            DEBUG("Looking for date string in hash_dates %s, found is %d", date_str, found);
+            g_free (date_str);
+        }
+        if (!found)
+            gnc_pricedb_remove_price (db, item->data);
+    }
+    g_hash_table_unref (hash_dates);
+    g_slist_free (data.list);
+
     LEAVE(" ");
     return TRUE;
 }

--- a/src/engine/gnc-pricedb.c
+++ b/src/engine/gnc-pricedb.c
@@ -1368,7 +1368,7 @@ free_data (gpointer data)
     g_free (data);
 }
 
-GHashTable *
+static GHashTable *
 gnc_pricedb_get_remove_dates (Timespec first, Timespec cutoff, gboolean leave_month)
 {
     GHashTable* hash_dates = g_hash_table_new_full (g_str_hash, g_str_equal, free_data, NULL);

--- a/src/engine/gnc-pricedb.h
+++ b/src/engine/gnc-pricedb.h
@@ -372,15 +372,16 @@ gboolean     gnc_pricedb_remove_price(GNCPriceDB *db, GNCPrice *p);
 
 /** @brief Remove and unref prices older than a certain time.
  * @param db The pricedb
+ * @param comm_list A list of commodities
+ * @param first The oldest price time in the pricedb 
  * @param cutoff The time before which prices should be deleted.
- * @param delete_user Whether user-created (i.e. not Finance::Quote) prices
- * should be deleted.
- * @param delete_last Whether a price should be deleted if it's the only
- * remaining price for its commodity.
+ * @param source Whether Finance::Quote, user or all prices should be deleted.
+ * @param leave Whether monthly, weekly or no prices should be left.
  */
-gboolean     gnc_pricedb_remove_old_prices(GNCPriceDB *db, Timespec cutoff,
-                                           const gboolean delete_user,
-                                           gboolean delete_last);
+gboolean     gnc_pricedb_remove_old_prices(GNCPriceDB *db, GList *comm_list,
+                                           Timespec first, Timespec cutoff,
+                                           gchar const *source,
+                                           gchar const *leave);
 
 /** @brief Find the most recent price between the two commodities.
  *

--- a/src/gnome/gtkbuilder/dialog-price.glade
+++ b/src/gnome/gtkbuilder/dialog-price.glade
@@ -1,31 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <requires lib="gtk+" version="2.16"/>
-  <object class="GtkDialog" id="Deletion Date">
-    <property name="visible">True</property>
+  <!-- interface-naming-policy toplevel-contextual -->
+  <object class="GtkDialog" id="Prices Dialog">
     <property name="can_focus">False</property>
     <property name="border_width">6</property>
-    <property name="resizable">False</property>
-    <property name="type_hint">dialog</property>
+    <property name="title" translatable="yes">Price Database</property>
+    <property name="default_width">400</property>
+    <property name="default_height">400</property>
+    <property name="type_hint">normal</property>
+    <signal name="destroy" handler="gnc_prices_dialog_window_destroy_cb" swapped="no"/>
+    <signal name="close" handler="gnc_prices_dialog_close_cb" after="yes" swapped="no"/>
+    <signal name="response" handler="gnc_prices_dialog_response" swapped="no"/>
     <child internal-child="vbox">
-      <object class="GtkBox" id="dialog-vbox19">
+      <object class="GtkVBox" id="dialog-vbox3">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="spacing">6</property>
+        <property name="spacing">2</property>
         <child internal-child="action_area">
-          <object class="GtkButtonBox" id="dialog-action_area19">
+          <object class="GtkHButtonBox" id="dialog-action_area3">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
-              <object class="GtkButton" id="cancel_button">
-                <property name="label">gtk-cancel</property>
-                <property name="use_action_appearance">False</property>
+              <object class="GtkButton" id="close_button">
+                <property name="label">gtk-close</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
               </object>
               <packing>
@@ -34,135 +37,245 @@
                 <property name="position">0</property>
               </packing>
             </child>
-            <child>
-              <object class="GtkButton" id="ok_button">
-                <property name="label">gtk-ok</property>
-                <property name="use_action_appearance">False</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="can_default">True</property>
-                <property name="receives_default">False</property>
-                <property name="use_action_appearance">False</property>
-                <property name="use_stock">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
           </object>
           <packing>
             <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="pack_type">end</property>
+            <property name="fill">False</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
-          <object class="GtkTable" id="table2">
+          <object class="GtkHBox" id="hbox118">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="n_rows">5</property>
-            <property name="n_columns">2</property>
-            <property name="column_spacing">12</property>
-            <property name="row_spacing">6</property>
             <child>
-              <object class="GtkLabel" id="label8477429">
+              <object class="GtkScrolledWindow" id="price_list_window">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Delete all stock prices before the date below based upon the following criteria:</property>
-                <property name="wrap">True</property>
-              </object>
-              <packing>
-                <property name="right_attach">2</property>
-                <property name="x_options">GTK_FILL</property>
-                <property name="y_options"/>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkCheckButton" id="delete_manual">
-                <property name="label" translatable="yes">Delete _manually entered prices</property>
-                <property name="use_action_appearance">False</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="tooltip_text" translatable="yes">If activated, delete manually entered stock prices dated earlier than the specified date. Otherwise only stock prices added by Finance::Quote will be deleted.</property>
-                <property name="use_action_appearance">False</property>
-                <property name="use_underline">True</property>
-                <property name="draw_indicator">True</property>
-              </object>
-              <packing>
-                <property name="right_attach">2</property>
-                <property name="top_attach">3</property>
-                <property name="bottom_attach">4</property>
-                <property name="x_options">GTK_FILL</property>
-                <property name="y_options"/>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkCheckButton" id="delete_last">
-                <property name="label" translatable="yes">Delete _last price for a stock</property>
-                <property name="use_action_appearance">False</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="tooltip_text" translatable="yes">If activated, delete all prices before the specified date. Otherwise the last stock price dated before the date will be kept and all earlier quotes deleted.</property>
-                <property name="use_action_appearance">False</property>
-                <property name="use_underline">True</property>
-                <property name="draw_indicator">True</property>
-              </object>
-              <packing>
-                <property name="right_attach">2</property>
-                <property name="top_attach">4</property>
-                <property name="bottom_attach">5</property>
-                <property name="x_options">GTK_FILL</property>
-                <property name="y_options"/>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="label8477431">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="xalign">0</property>
-              </object>
-              <packing>
-                <property name="right_attach">2</property>
-                <property name="top_attach">1</property>
-                <property name="bottom_attach">2</property>
-                <property name="x_options">GTK_FILL</property>
-                <property name="y_options"/>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="date_label">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="xalign">0</property>
-                <property name="label" translatable="yes">_Date:</property>
-                <property name="use_underline">True</property>
-              </object>
-              <packing>
-                <property name="top_attach">2</property>
-                <property name="bottom_attach">3</property>
-                <property name="x_options"/>
-                <property name="y_options"/>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkHBox" id="date_hbox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="border_width">3</property>
+                <property name="shadow_type">in</property>
                 <child>
                   <placeholder/>
                 </child>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
-                <property name="top_attach">2</property>
-                <property name="bottom_attach">3</property>
-                <property name="y_options">GTK_FILL</property>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkVButtonBox" id="vbuttonbox5">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="border_width">5</property>
+                <property name="layout_style">spread</property>
+                <child>
+                  <object class="GtkButton" id="add_button">
+                    <property name="label">gtk-add</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="can_default">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">Add a new price.</property>
+                    <property name="use_stock">True</property>
+                    <signal name="clicked" handler="gnc_prices_dialog_add_clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="remove_button">
+                    <property name="label">gtk-remove</property>
+                    <property name="visible">True</property>
+                    <property name="sensitive">False</property>
+                    <property name="can_focus">True</property>
+                    <property name="can_default">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">Remove the current price.</property>
+                    <property name="use_stock">True</property>
+                    <signal name="clicked" handler="gnc_prices_dialog_remove_clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="edit_button">
+                    <property name="visible">True</property>
+                    <property name="sensitive">False</property>
+                    <property name="can_focus">True</property>
+                    <property name="can_default">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">Edit the current price.</property>
+                    <signal name="clicked" handler="gnc_prices_dialog_edit_clicked" swapped="no"/>
+                    <child>
+                      <object class="GtkAlignment" id="alignment5">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="xscale">0</property>
+                        <property name="yscale">0</property>
+                        <child>
+                          <object class="GtkHBox" id="hbox115">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="spacing">2</property>
+                            <child>
+                              <object class="GtkImage" id="image5">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="stock">gtk-properties</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="label8477426">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">_Edit</property>
+                                <property name="use_underline">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="remove_old_button">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="can_default">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">Remove prices older than a user-entered date.</property>
+                    <signal name="clicked" handler="gnc_prices_dialog_remove_old_clicked" swapped="no"/>
+                    <child>
+                      <object class="GtkAlignment" id="alignment6">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="xscale">0</property>
+                        <property name="yscale">0</property>
+                        <child>
+                          <object class="GtkHBox" id="hbox116">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="spacing">2</property>
+                            <child>
+                              <object class="GtkImage" id="image6">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="stock">gtk-remove</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="label8477427">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Remove _Old</property>
+                                <property name="use_underline">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="get_quotes_button">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="can_default">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">Get new online quotes for stock accounts.</property>
+                    <signal name="clicked" handler="gnc_prices_dialog_get_quotes_clicked" swapped="no"/>
+                    <child>
+                      <object class="GtkAlignment" id="alignment7">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="xscale">0</property>
+                        <property name="yscale">0</property>
+                        <child>
+                          <object class="GtkHBox" id="hbox117">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="spacing">2</property>
+                            <child>
+                              <object class="GtkImage" id="image7">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="stock">gtk-execute</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="label8477428">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Get _Quotes</property>
+                                <property name="use_underline">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">4</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
               </packing>
             </child>
           </object>
@@ -175,9 +288,53 @@
       </object>
     </child>
     <action-widgets>
-      <action-widget response="-6">cancel_button</action-widget>
-      <action-widget response="-5">ok_button</action-widget>
+      <action-widget response="-7">close_button</action-widget>
     </action-widgets>
+  </object>
+  <object class="GtkListStore" id="liststore1">
+    <columns>
+      <!-- column-name item -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">Bid</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Ask</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Last</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Net Asset Value</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Unknown</col>
+      </row>
+    </data>
+  </object>
+  <object class="GtkListStore" id="liststore2">
+    <columns>
+      <!-- column-name item -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">Dummy commodity Line</col>
+      </row>
+    </data>
+  </object>
+  <object class="GtkListStore" id="liststore3">
+    <columns>
+      <!-- column-name item -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">Dummy namespace Line</col>
+      </row>
+    </data>
   </object>
   <object class="GtkDialog" id="Price Dialog">
     <property name="can_focus">False</property>
@@ -187,24 +344,22 @@
     <property name="type_hint">dialog</property>
     <signal name="response" handler="pedit_dialog_response_cb" swapped="no"/>
     <child internal-child="vbox">
-      <object class="GtkBox" id="dialog-vbox18">
+      <object class="GtkVBox" id="dialog-vbox2">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="spacing">6</property>
+        <property name="spacing">2</property>
         <child internal-child="action_area">
-          <object class="GtkButtonBox" id="dialog-action_area18">
+          <object class="GtkHButtonBox" id="dialog-action_area2">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="pd_cancel_button">
                 <property name="label">gtk-cancel</property>
-                <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
               </object>
               <packing>
@@ -216,11 +371,9 @@
             <child>
               <object class="GtkButton" id="pd_apply_button">
                 <property name="label">gtk-apply</property>
-                <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
               </object>
               <packing>
@@ -232,13 +385,11 @@
             <child>
               <object class="GtkButton" id="pd_ok_button">
                 <property name="label">gtk-ok</property>
-                <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="has_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
               </object>
               <packing>
@@ -249,9 +400,8 @@
             </child>
           </object>
           <packing>
-            <property name="expand">False</property>
+            <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="pack_type">end</property>
             <property name="position">0</property>
           </packing>
         </child>
@@ -416,6 +566,8 @@
                 <property name="editable">False</property>
                 <property name="primary_icon_activatable">False</property>
                 <property name="secondary_icon_activatable">False</property>
+                <property name="primary_icon_sensitive">True</property>
+                <property name="secondary_icon_sensitive">True</property>
                 <signal name="changed" handler="pedit_data_changed_cb" swapped="no"/>
               </object>
               <packing>
@@ -474,12 +626,6 @@
                 <property name="has_entry">True</property>
                 <property name="entry_text_column">0</property>
                 <signal name="changed" handler="pedit_commodity_ns_changed_cb" swapped="no"/>
-                <child internal-child="entry">
-                  <object class="GtkEntry" id="combobox-entry3">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                  </object>
-                </child>
               </object>
               <packing>
                 <property name="left_attach">1</property>
@@ -494,12 +640,6 @@
                 <property name="has_entry">True</property>
                 <property name="entry_text_column">0</property>
                 <signal name="changed" handler="pedit_commodity_changed_cb" swapped="no"/>
-                <child internal-child="entry">
-                  <object class="GtkEntry" id="combobox-entry2">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                  </object>
-                </child>
               </object>
               <packing>
                 <property name="left_attach">1</property>
@@ -523,35 +663,41 @@
       <action-widget response="-5">pd_ok_button</action-widget>
     </action-widgets>
   </object>
-  <object class="GtkDialog" id="Prices Dialog">
+  <object class="GtkListStore" id="liststore4">
+    <columns>
+      <!-- column-name full_name -->
+      <column type="gchararray"/>
+      <!-- column-name commodity -->
+      <column type="gpointer"/>
+      <!-- column-name first_date -->
+      <column type="gchararray"/>
+      <!-- column-name number -->
+      <column type="gchararray"/>
+    </columns>
+  </object>
+  <object class="GtkDialog" id="Deletion Date">
+    <property name="visible">True</property>
     <property name="can_focus">False</property>
     <property name="border_width">6</property>
-    <property name="title" translatable="yes">Price Database</property>
     <property name="default_width">400</property>
-    <property name="default_height">400</property>
-    <property name="type_hint">normal</property>
-    <signal name="destroy" handler="gnc_prices_dialog_window_destroy_cb" swapped="no"/>
-    <signal name="close" handler="gnc_prices_dialog_close_cb" after="yes" swapped="no"/>
-    <signal name="response" handler="gnc_prices_dialog_response" swapped="no"/>
+    <property name="type_hint">dialog</property>
     <child internal-child="vbox">
-      <object class="GtkBox" id="vbox121">
+      <object class="GtkVBox" id="dialog-vbox2">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="spacing">6</property>
+        <property name="spacing">2</property>
         <child internal-child="action_area">
-          <object class="GtkButtonBox" id="hbuttonbox4">
+          <object class="GtkHButtonBox" id="dialog-action_area2">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
-              <object class="GtkButton" id="close_button">
-                <property name="label">gtk-close</property>
-                <property name="use_action_appearance">False</property>
+              <object class="GtkButton" id="cancel_button">
+                <property name="label">gtk-cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
               </object>
               <packing>
@@ -560,52 +706,76 @@
                 <property name="position">0</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkButton" id="ok_button">
+                <property name="label">gtk-ok</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="can_default">True</property>
+                <property name="receives_default">False</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="pack_type">end</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
-          <object class="GtkHBox" id="hbox118">
+          <object class="GtkTable" id="table2">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="n_rows">9</property>
+            <property name="n_columns">2</property>
+            <property name="column_spacing">12</property>
+            <property name="row_spacing">10</property>
             <child>
-              <object class="GtkScrolledWindow" id="price_list_window">
+              <object class="GtkLabel" id="label8477429">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="border_width">3</property>
-                <property name="shadow_type">in</property>
-                <child>
-                  <placeholder/>
-                </child>
+                <property name="label" translatable="yes">Delete prices that meet the following criteria:</property>
+                <property name="wrap">True</property>
               </object>
               <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
+                <property name="right_attach">2</property>
+                <property name="top_attach">1</property>
+                <property name="bottom_attach">2</property>
+                <property name="x_options">GTK_FILL</property>
+                <property name="y_options"/>
               </packing>
             </child>
             <child>
-              <object class="GtkVButtonBox" id="vbuttonbox5">
+              <object class="GtkLabel" id="label8477431">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="border_width">5</property>
-                <property name="layout_style">spread</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="right_attach">2</property>
+                <property name="top_attach">1</property>
+                <property name="bottom_attach">2</property>
+                <property name="x_options">GTK_FILL</property>
+                <property name="y_options"/>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkHBox" id="date_hbox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
                 <child>
-                  <object class="GtkButton" id="add_button">
-                    <property name="label">gtk-add</property>
-                    <property name="use_action_appearance">False</property>
+                  <object class="GtkLabel" id="date_label">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="can_default">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Add a new price.</property>
-                    <property name="use_action_appearance">False</property>
-                    <property name="use_stock">True</property>
-                    <signal name="clicked" handler="gnc_prices_dialog_add_clicked" swapped="no"/>
+                    <property name="can_focus">False</property>
+                    <property name="xalign">0</property>
+                    <property name="label" translatable="yes">Before _Date:</property>
+                    <property name="use_underline">True</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -614,202 +784,257 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkButton" id="remove_button">
-                    <property name="label">gtk-remove</property>
-                    <property name="use_action_appearance">False</property>
+                  <placeholder/>
+                </child>
+              </object>
+              <packing>
+                <property name="right_attach">2</property>
+                <property name="top_attach">3</property>
+                <property name="bottom_attach">4</property>
+                <property name="x_options">GTK_EXPAND</property>
+                <property name="y_options"/>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkHBox" id="hbox1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkLabel" id="label1">
                     <property name="visible">True</property>
-                    <property name="sensitive">False</property>
-                    <property name="can_focus">True</property>
-                    <property name="can_default">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Remove the current price.</property>
-                    <property name="use_action_appearance">False</property>
-                    <property name="use_stock">True</property>
-                    <signal name="clicked" handler="gnc_prices_dialog_remove_clicked" swapped="no"/>
+                    <property name="can_focus">False</property>
+                    <property name="xalign">0</property>
+                    <property name="label" translatable="yes">Source:</property>
                   </object>
                   <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="checkbutton_fq">
+                    <property name="label" translatable="yes">FQ Prices</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">If activated, prices added by Finance::Quote will be included.</property>
+                    <property name="active">True</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
                     <property name="position">1</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkButton" id="edit_button">
-                    <property name="use_action_appearance">False</property>
+                  <object class="GtkCheckButton" id="checkbutton_user">
+                    <property name="label" translatable="yes">User Prices</property>
                     <property name="visible">True</property>
-                    <property name="sensitive">False</property>
                     <property name="can_focus">True</property>
-                    <property name="can_default">True</property>
                     <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Edit the current price.</property>
-                    <property name="use_action_appearance">False</property>
-                    <signal name="clicked" handler="gnc_prices_dialog_edit_clicked" swapped="no"/>
-                    <child>
-                      <object class="GtkAlignment" id="alignment5">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="xscale">0</property>
-                        <property name="yscale">0</property>
-                        <child>
-                          <object class="GtkHBox" id="hbox115">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="spacing">2</property>
-                            <child>
-                              <object class="GtkImage" id="image5">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="stock">gtk-properties</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="label8477426">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">_Edit</property>
-                                <property name="use_underline">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
+                    <property name="tooltip_text" translatable="yes">If activated, prices added by the user will be included.</property>
+                    <property name="draw_indicator">True</property>
                   </object>
                   <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
                     <property name="position">2</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkButton" id="remove_old_button">
-                    <property name="use_action_appearance">False</property>
+                  <object class="GtkCheckButton" id="checkbutton_all">
+                    <property name="label" translatable="yes">All Prices</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
-                    <property name="can_default">True</property>
                     <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Remove prices older than a user-entered date.</property>
-                    <property name="use_action_appearance">False</property>
-                    <signal name="clicked" handler="gnc_prices_dialog_remove_old_clicked" swapped="no"/>
-                    <child>
-                      <object class="GtkAlignment" id="alignment6">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="xscale">0</property>
-                        <property name="yscale">0</property>
-                        <child>
-                          <object class="GtkHBox" id="hbox116">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="spacing">2</property>
-                            <child>
-                              <object class="GtkImage" id="image6">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="stock">gtk-remove</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="label8477427">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Remove _Old</property>
-                                <property name="use_underline">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
+                    <property name="tooltip_text" translatable="yes">If activated, all prices will be included.</property>
+                    <property name="draw_indicator">True</property>
                   </object>
                   <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
                     <property name="position">3</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkButton" id="get_quotes_button">
-                    <property name="use_action_appearance">False</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="can_default">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Get new online quotes for stock accounts.</property>
-                    <property name="use_action_appearance">False</property>
-                    <signal name="clicked" handler="gnc_prices_dialog_get_quotes_clicked" swapped="no"/>
-                    <child>
-                      <object class="GtkAlignment" id="alignment7">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="xscale">0</property>
-                        <property name="yscale">0</property>
-                        <child>
-                          <object class="GtkHBox" id="hbox117">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="spacing">2</property>
-                            <child>
-                              <object class="GtkImage" id="image7">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="stock">gtk-execute</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="label8477428">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Get _Quotes</property>
-                                <property name="use_underline">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">4</property>
                   </packing>
                 </child>
               </object>
               <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
+                <property name="right_attach">2</property>
+                <property name="top_attach">2</property>
+                <property name="bottom_attach">3</property>
+                <property name="y_options">GTK_FILL</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label2">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Remove Old Prices</property>
+                <attributes>
+                  <attribute name="underline" value="True"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="right_attach">2</property>
+                <property name="y_options">GTK_FILL</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkHBox" id="hbox2">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkLabel" id="label4">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="xalign">0</property>
+                    <property name="label" translatable="yes">Leaving:</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkRadioButton" id="radiobutton_none">
+                    <property name="label" translatable="yes">None</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">Remove all prices before date.</property>
+                    <property name="active">True</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkRadioButton" id="radiobutton_month">
+                    <property name="label" translatable="yes">One a Month</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">Leave a price on the last Friday of the month if present before date.</property>
+                    <property name="draw_indicator">True</property>
+                    <property name="group">radiobutton_none</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkRadioButton" id="radiobutton_week">
+                    <property name="label" translatable="yes">One a Week</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">Leave a price on the Friday of each week if present before date.</property>
+                    <property name="draw_indicator">True</property>
+                    <property name="group">radiobutton_none</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="right_attach">2</property>
+                <property name="top_attach">7</property>
+                <property name="bottom_attach">8</property>
+                <property name="y_options">GTK_FILL</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkHBox" id="hbox3">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkScrolledWindow" id="scrolledwindow1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="hscrollbar_policy">automatic</property>
+                    <property name="vscrollbar_policy">automatic</property>
+                    <child>
+                      <object class="GtkTreeView" id="commodty_treeview">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="model">liststore4</property>
+                        <child>
+                          <object class="GtkTreeViewColumn" id="name_column">
+                            <property name="title" translatable="yes">Commodity Fullname</property>
+                            <child>
+                              <object class="GtkCellRendererText" id="name_cellr"/>
+                              <attributes>
+                                <attribute name="text">0</attribute>
+                              </attributes>
+                            </child>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkTreeViewColumn" id="date_column">
+                            <property name="title" translatable="yes">First Date</property>
+                            <child>
+                              <object class="GtkCellRendererText" id="date_cellr"/>
+                              <attributes>
+                                <attribute name="text">2</attribute>
+                              </attributes>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="right_attach">2</property>
+                <property name="top_attach">5</property>
+                <property name="bottom_attach">7</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label3">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="xalign">0</property>
+                <property name="yalign">0</property>
+                <property name="ypad">2</property>
+                <property name="label" translatable="yes">From these Commodities:</property>
+              </object>
+              <packing>
+                <property name="right_attach">2</property>
+                <property name="top_attach">4</property>
+                <property name="bottom_attach">5</property>
+                <property name="y_options">GTK_FILL</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label5">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Caution: If you select to leave prices and there are none on a Friday you may end up with no prices before selected date.</property>
+                <property name="justify">fill</property>
+                <property name="wrap">True</property>
+              </object>
+              <packing>
+                <property name="right_attach">2</property>
+                <property name="top_attach">8</property>
+                <property name="bottom_attach">9</property>
+                <property name="y_options">GTK_FILL</property>
               </packing>
             </child>
           </object>
@@ -822,52 +1047,8 @@
       </object>
     </child>
     <action-widgets>
-      <action-widget response="-7">close_button</action-widget>
+      <action-widget response="-6">cancel_button</action-widget>
+      <action-widget response="-5">ok_button</action-widget>
     </action-widgets>
-  </object>
-  <object class="GtkListStore" id="liststore1">
-    <columns>
-      <!-- column-name item -->
-      <column type="gchararray"/>
-    </columns>
-    <data>
-      <row>
-        <col id="0" translatable="yes">Bid</col>
-      </row>
-      <row>
-        <col id="0" translatable="yes">Ask</col>
-      </row>
-      <row>
-        <col id="0" translatable="yes">Last</col>
-      </row>
-      <row>
-        <col id="0" translatable="yes">Net Asset Value</col>
-      </row>
-      <row>
-        <col id="0" translatable="yes">Unknown</col>
-      </row>
-    </data>
-  </object>
-  <object class="GtkListStore" id="liststore2">
-    <columns>
-      <!-- column-name item -->
-      <column type="gchararray"/>
-    </columns>
-    <data>
-      <row>
-        <col id="0" translatable="yes">Dummy commodity Line</col>
-      </row>
-    </data>
-  </object>
-  <object class="GtkListStore" id="liststore3">
-    <columns>
-      <!-- column-name item -->
-      <column type="gchararray"/>
-    </columns>
-    <data>
-      <row>
-        <col id="0" translatable="yes">Dummy namespace Line</col>
-      </row>
-    </data>
   </object>
 </interface>

--- a/src/import-export/csv-imp/CMakeLists.txt
+++ b/src/import-export/csv-imp/CMakeLists.txt
@@ -4,10 +4,12 @@ ADD_SUBDIRECTORY(test)
 SET(csv_import_SOURCES
   gncmod-csv-import.c
   assistant-csv-account-import.c
+  assistant-csv-fixed-price-import.c
   assistant-csv-fixed-trans-import.c
   assistant-csv-trans-import.c
   gnc-plugin-csv-import.c
   csv-account-import.c
+  csv-fixed-price-import.c
   csv-fixed-trans-import.c
   gnc-csv-account-map.c
   gnc-csv-model.c
@@ -21,10 +23,12 @@ SET_SOURCE_FILES_PROPERTIES (${csv_import_SOURCES} PROPERTIES OBJECT_DEPENDS ${C
 
 SET(csv_import_noinst_HEADERS
   assistant-csv-account-import.h
+  assistant-csv-fixed-price-import.h
   assistant-csv-fixed-trans-import.h
   assistant-csv-trans-import.h
   gnc-plugin-csv-import.h
   csv-account-import.h
+  csv-fixed-price-import.h
   csv-fixed-trans-import.h
   gnc-csv-account-map.h
   gnc-csv-model.h
@@ -53,7 +57,7 @@ INSTALL(TARGETS gncmod-csv-import
 # No headers to install
 
 SET(csv_import_GLADE assistant-csv-account-import.glade assistant-csv-fixed-trans-import.glade
-      assistant-csv-trans-import.glade)
+      assistant-csv-fixed-price-import.glade assistant-csv-trans-import.glade)
 
 INSTALL(FILES ${csv_import_GLADE} DESTINATION share/gnucash/gtkbuilder)
 

--- a/src/import-export/csv-imp/Makefile.am
+++ b/src/import-export/csv-imp/Makefile.am
@@ -5,10 +5,12 @@ pkglib_LTLIBRARIES=libgncmod-csv-import.la
 libgncmod_csv_import_la_SOURCES = \
   gncmod-csv-import.c \
   assistant-csv-account-import.c \
+  assistant-csv-fixed-price-import.c \
   assistant-csv-fixed-trans-import.c \
   assistant-csv-trans-import.c \
   gnc-plugin-csv-import.c \
   csv-account-import.c \
+  csv-fixed-price-import.c \
   csv-fixed-trans-import.c \
   gnc-csv-account-map.c \
   gnc-csv-model.c \
@@ -17,10 +19,12 @@ libgncmod_csv_import_la_SOURCES = \
 
 noinst_HEADERS = \
   assistant-csv-account-import.h \
+  assistant-csv-fixed-price-import.h \
   assistant-csv-fixed-trans-import.h \
   assistant-csv-trans-import.h \
   gnc-plugin-csv-import.h \
   csv-account-import.h \
+  csv-fixed-price-import.h \
   csv-fixed-trans-import.h \
   gnc-csv-account-map.h \
   gnc-csv-model.h \
@@ -65,6 +69,7 @@ ui_DATA = \
 gtkbuilderdir = ${GNC_GTKBUILDER_DIR}
 gtkbuilder_DATA = \
 	assistant-csv-account-import.glade \
+        assistant-csv-fixed-price-import.glade \
         assistant-csv-fixed-trans-import.glade \
 	assistant-csv-trans-import.glade
 

--- a/src/import-export/csv-imp/assistant-csv-fixed-price-import.c
+++ b/src/import-export/csv-imp/assistant-csv-fixed-price-import.c
@@ -1,0 +1,757 @@
+/*******************************************************************\
+ * assistant-csv-fixed-price-import.c -- An assistant for importing *
+ *                                       set format price file.     *
+ *                                                                  *
+ * Copyright (C) 2016 Robert Fewell                                 *
+ *                                                                  *
+ * This program is free software; you can redistribute it and/or    *
+ * modify it under the terms of the GNU General Public License as   *
+ * published by the Free Software Foundation; either version 2 of   *
+ * the License, or (at your option) any later version.              *
+ *                                                                  *
+ * This program is distributed in the hope that it will be useful,  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    *
+ * GNU General Public License for more details.                     *
+ *                                                                  *
+ * You should have received a copy of the GNU General Public License*
+ * along with this program; if not, contact:                        *
+ *                                                                  *
+ * Free Software Foundation           Voice:  +1-617-542-5942       *
+ * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652       *
+ * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
+\********************************************************************/
+/** @file assistant-csv-fixed-price-import.c
+    @brief CSV Import Assistant
+    @author Copyright (c) 2016 Robert Fewell
+*/
+#include "config.h"
+
+#include <gtk/gtk.h>
+#include <glib/gi18n.h>
+
+#include "dialog-utils.h"
+#include "gnc-ui.h"
+#include "gnc-uri-utils.h"
+#include "gnc-ui-util.h"
+
+#include "gnc-component-manager.h"
+
+#include "assistant-csv-fixed-price-import.h"
+#include "csv-fixed-price-import.h"
+#include "gnc-csv-model.h"
+
+#define GNC_PREFS_GROUP "dialogs.import.csv"
+#define ASSISTANT_CSV_FIXED_PRICE_IMPORT_CM_CLASS "assistant-csv-fixed-price-import"
+
+/* This static indicates the debugging module that this .o belongs to. */
+static QofLogModule log_module = GNC_MOD_ASSISTANT;
+
+/*************************************************************************/
+
+void csv_fixed_price_import_assistant_prepare (GtkAssistant *assistant, GtkWidget *page, gpointer user_data);
+void csv_fixed_price_import_assistant_finish (GtkAssistant *gtkassistant, gpointer user_data);
+void csv_fixed_price_import_assistant_cancel (GtkAssistant *gtkassistant, gpointer user_data);
+void csv_fixed_price_import_assistant_close (GtkAssistant *gtkassistant, gpointer user_data);
+
+void csv_fixed_price_import_start_page_prepare (GtkAssistant *gtkassistant, gpointer user_data);
+void csv_fixed_price_import_file_page_prepare (GtkAssistant *assistant, gpointer user_data);
+void csv_fixed_price_import_view_page_prepare (GtkAssistant *gtkassistant, gpointer user_data);
+void csv_fixed_price_import_finish_page_prepare (GtkAssistant *assistant, gpointer user_data);
+void csv_fixed_price_import_summary_page_prepare (GtkAssistant *assistant, gpointer user_data);
+
+void csv_fixed_price_import_sep_cb (GtkWidget *radio, gpointer user_data );
+void csv_fixed_price_import_hrows_cb (GtkWidget *spin, gpointer user_data );
+
+void csv_fixed_price_import_file_chooser_confirm_cb (GtkWidget *button, CsvPriceImportInfo *info);
+
+static gchar *gnc_input_dialog (GtkWidget *parent, const gchar *title, const gchar *msg, const gchar *default_input);
+
+static const gchar *finish_tree_string = N_(
+            "The prices will be imported from the file '%s' when you click 'Apply'.\n\n"
+            "This operation is not reversable, so make sure you have a working backup.\n\n"
+            "You can verify your selections by clicking on 'Back' or 'Cancel' to Abort Import.\n");
+
+/* Escape '_' in string */
+static gchar *mnemonic_escape (const gchar *source);
+static gchar *mnemonic_escape (const gchar *source)
+{
+    const guchar *p;
+    gchar *dest;
+    gchar *q;
+
+    g_return_val_if_fail (source != NULL, NULL);
+
+    p = (guchar *) source;
+    q = dest = g_malloc (strlen (source) * 2 + 1);
+
+    while (*p)
+    {
+        switch (*p)
+        {
+        case '_':
+            *q++ = '_';
+            *q++ = '_';
+            break;
+        default:
+            *q++ = *p;
+            break;
+        }
+        p++;
+    }
+    *q = 0;
+    return dest;
+}
+
+static
+void create_regex (GString *regex_str, const gchar *sep)
+{
+    if (!sep) return;
+
+    g_string_printf (regex_str,
+            "\\G(?<p_comm1>\"(?:[^\"]|\"\")*\"|[^%s]*)%s"
+            "(?<p_date>\"(?:[^\"]|\"\")*\"|[^%s]*)%s"
+            "(?<p_amount>\"(?:[^\"]|\"\")*\"|[^%s]*)%s"
+            "(?<p_comm2>\"(?:[^\"]|\"\")*\"|[^%s[:cntrl:]]*)(?:\\R*)",
+            sep, sep, sep, sep, sep, sep, sep);
+}
+
+/*************************************************************************/
+
+/**************************************************
+ * csv_fixed_price_import_file_chooser_confirm_cb
+ *
+ * call back for ok button in file chooser widget
+ **************************************************/
+void
+csv_fixed_price_import_file_chooser_confirm_cb (GtkWidget *button, CsvPriceImportInfo *info)
+{
+    GtkAssistant *assistant = GTK_ASSISTANT(info->window);
+    gint num = gtk_assistant_get_current_page (assistant);
+    GtkWidget *page = gtk_assistant_get_nth_page (assistant, num);
+
+    gchar *file_name;
+    csv_fixed_price_import_result res;
+
+    gtk_assistant_set_page_complete (assistant, page, FALSE);
+
+    file_name = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER(info->file_chooser));
+
+    if (file_name)
+    {
+        gchar *filepath = gnc_uri_get_path (file_name);
+        gchar *filedir = g_path_get_dirname (filepath);
+        info->starting_dir = g_strdup (filedir);
+        g_free (filedir);
+        g_free (filepath);
+
+        info->file_name = g_strdup (file_name);
+
+        // generate preview
+        gtk_list_store_clear (info->store);
+        res = csv_fixed_price_import_read_file (info->file_name, info->regexp->str, info->store, 1 );
+        if (res == RESULT_OPEN_FAILED)
+            gnc_error_dialog (info->window, _("The input file can not be opened."));
+        else if (res == RESULT_OK)
+            gtk_assistant_set_page_complete (assistant, page, TRUE);
+        else if (res == MATCH_FOUND)
+            gtk_assistant_set_page_complete (assistant, page, TRUE);
+    }
+    g_free (file_name);
+
+    DEBUG("file_name selected is %s", info->file_name);
+    DEBUG("starting directory is %s", info->starting_dir);
+
+    /* Step to next page if page is complete */
+    if(gtk_assistant_get_page_complete (assistant, page))
+        gtk_assistant_set_current_page (assistant, num + 1);
+
+}
+
+
+/*******************************************************
+ * csv_fxed_price_import_hrows_cb
+ *
+ * call back for the start row / number of header rows
+ *******************************************************/
+void csv_fixed_price_import_hrows_cb (GtkWidget *spin, gpointer user_data)
+{
+    CsvPriceImportInfo *info = user_data;
+
+    GtkTreeIter iter;
+    gboolean valid;
+    int num_rows;
+
+    /* Get number of rows for header */
+    info->header_rows = gtk_spin_button_get_value_as_int (GTK_SPIN_BUTTON(spin));
+
+    /* Get number of rows displayed */
+    num_rows = gtk_tree_model_iter_n_children (GTK_TREE_MODEL(info->store), NULL);
+
+    /* Modify background color for header rows */
+    if (info->header_rows == 0)
+    {
+        valid = gtk_tree_model_iter_nth_child (GTK_TREE_MODEL(info->store), &iter, NULL, 0 );
+        if (valid)
+            gtk_list_store_set (info->store, &iter, PRICE_ROW_COLOR, NULL, -1);
+    }
+    else
+    {
+        if (info->header_rows - 1 < num_rows)
+        {
+            valid = gtk_tree_model_iter_nth_child (GTK_TREE_MODEL(info->store), &iter, NULL, info->header_rows - 1 );
+            if (valid)
+                gtk_list_store_set (info->store, &iter, PRICE_ROW_COLOR, "pink", -1);
+            valid = gtk_tree_model_iter_next (GTK_TREE_MODEL(info->store), &iter);
+            if (valid)
+                gtk_list_store_set (info->store, &iter, PRICE_ROW_COLOR, NULL, -1);
+        }
+    }
+}
+
+
+/*******************************************************
+ * csv_fixed_price_import_sep_cb
+ *
+ * call back for type of separartor required
+ *******************************************************/
+void csv_fixed_price_import_sep_cb (GtkWidget *radio, gpointer user_data)
+{
+    CsvPriceImportInfo *info = user_data;
+    const gchar *name;
+    gchar *temp;
+    gchar *sep = NULL;
+
+    if (!gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON(radio)))
+    {
+        LEAVE("1st callback of pair. Defer to 2nd callback.");
+        return;
+    }
+
+    name = gtk_buildable_get_name (GTK_BUILDABLE(radio));
+    if (g_strcmp0 (name, "radio_semi") == 0)
+        sep = ";";
+    else if (g_strcmp0 (name, "radio_colon") == 0)
+        sep = ":";
+    else
+        sep = ","; /* Use as default as well */
+
+    create_regex (info->regexp, sep);
+
+    if (g_strcmp0 (name, "radio_custom") == 0)
+    {
+        temp = gnc_input_dialog (0, _("Adjust regular expression used for import"), _("This regular expression is used to parse the import file. Modify according to your needs.\n"), info->regexp->str);
+        if (temp)
+        {
+            g_string_assign (info->regexp, temp);
+            g_free (temp);
+        }
+    }
+
+    /* Generate preview */
+    gtk_list_store_clear (info->store);
+
+    gtk_tree_view_columns_autosize (GTK_TREE_VIEW(info->tree_view));
+
+    gtk_tree_view_set_grid_lines (GTK_TREE_VIEW(info->tree_view), GTK_TREE_VIEW_GRID_LINES_BOTH);
+
+    if (csv_fixed_price_import_read_file (info->file_name, info->regexp->str, info->store, 11) == MATCH_FOUND)
+        gtk_widget_set_sensitive (info->header_row_spin, TRUE);
+    else
+        gtk_widget_set_sensitive (info->header_row_spin, FALSE);
+
+    /* Reset Header spin to 0 */
+    gtk_spin_button_set_value (GTK_SPIN_BUTTON(info->header_row_spin), 0);
+    csv_fixed_price_import_hrows_cb (info->header_row_spin, info);
+}
+
+/*******************************************************
+ * csv_fixed_price_import_over_write_cb
+ *
+ * call back for the over wite check button
+ *******************************************************/
+void csv_fixed_price_import_over_write_cb (GtkWidget *check, gpointer user_data)
+{
+    CsvPriceImportInfo *info = user_data;
+
+    if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON(check)))
+        info->over_write = TRUE;
+    else
+        info->over_write = FALSE;
+}
+
+/*******************************************************
+ * date_format_selected
+ *
+ * Event handler for selecting a new date format.
+ *******************************************************/
+static void date_format_selected (GtkComboBoxText* format_selector, CsvPriceImportInfo *info)
+{
+    info->date_format = gtk_combo_box_get_active (GTK_COMBO_BOX(format_selector));
+}
+
+
+/*******************************************************
+ * currency_format_selected
+ *
+ * Event handler for selecting a new currency format.
+ *******************************************************/
+static void currency_format_selected (GtkComboBoxText* currency_selector, CsvPriceImportInfo *info)
+{
+    info->currency_format = gtk_combo_box_get_active (GTK_COMBO_BOX(currency_selector));
+}
+
+
+/*******************************************************
+ * load_settings
+ *
+ * load the default settings for the assistant
+ *******************************************************/
+static void
+load_settings (CsvPriceImportInfo *info)
+{
+    info->header_rows = 0;
+    info->error = "";
+    info->starting_dir = NULL;
+    info->file_name = NULL;
+    info->date_format = 0;
+    info->currency_format = 0;
+    info->over_write = FALSE;
+
+    /* The default directory for the user to select files. */
+    info->starting_dir = gnc_get_default_directory (GNC_PREFS_GROUP);
+}
+
+
+/* =============================================================== */
+
+
+/********************************************************************\
+ * gnc_input_dialog                                                 *
+ *   simple convenience dialog to get a single value from the user  *
+ *   user may choose between "Ok" and "Cancel"                      *
+ *                                                                  *
+ * NOTE: This function does not return until the dialog is closed   *
+ *                                                                  *
+ * Args:   parent  - the parent window or NULL                      *
+ *         title   - the title of the dialog                        *
+ *         msg     - the message to display                         *
+ *         default_input - will be displayed as default input       *
+ * Return: the input (text) the user entered, if pressed "Ok"       *
+ *         NULL, if pressed "Cancel"                                *
+\********************************************************************/
+static gchar *
+gnc_input_dialog (GtkWidget *parent, const gchar *title, const gchar *msg, const gchar *default_input)
+{
+    GtkWidget *dialog, *label, *content_area;
+    gint result;
+    GtkWidget *view;
+    GtkTextBuffer *buffer;
+    gchar *user_input;
+    GtkTextIter start, end;
+
+    /* Create the widgets */
+    dialog = gtk_dialog_new_with_buttons (title, GTK_WINDOW(parent),
+                                          GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
+                                          GTK_STOCK_OK, GTK_RESPONSE_ACCEPT,
+                                          GTK_STOCK_CANCEL, GTK_RESPONSE_REJECT,
+                                          NULL);
+
+    content_area = gtk_dialog_get_content_area (GTK_DIALOG(dialog));
+
+    // add a label
+    label = gtk_label_new (msg);
+    gtk_container_add (GTK_CONTAINER(content_area), label);
+
+    // add a textview
+    view = gtk_text_view_new ();
+    gtk_text_view_set_wrap_mode (GTK_TEXT_VIEW(view), GTK_WRAP_WORD_CHAR);
+    buffer = gtk_text_view_get_buffer (GTK_TEXT_VIEW(view));
+    gtk_text_buffer_set_text (buffer, default_input, -1);
+    gtk_container_add (GTK_CONTAINER(content_area), view);
+
+    // run the dialog
+    gtk_widget_show_all (dialog);
+    result = gtk_dialog_run (GTK_DIALOG(dialog));
+
+    if (result == GTK_RESPONSE_REJECT)
+        user_input = 0;
+    else
+    {
+        gtk_text_buffer_get_start_iter (buffer, &start);
+        gtk_text_buffer_get_end_iter (buffer, &end);
+        user_input = gtk_text_buffer_get_text (buffer,
+                                               &start, &end, FALSE);
+    }
+
+    gtk_widget_destroy (dialog);
+
+    return user_input;
+}
+
+
+/* =============================================================== */
+
+
+/*******************************************************
+ * Assistant page prepare functions
+ *******************************************************/
+void
+csv_fixed_price_import_start_page_prepare (GtkAssistant *assistant,
+        gpointer user_data)
+{
+    gint num = gtk_assistant_get_current_page (assistant);
+    GtkWidget *page = gtk_assistant_get_nth_page (assistant, num);
+
+    /* Enable the Assistant Buttons */
+    gtk_assistant_set_page_complete (assistant, page, TRUE);
+}
+
+
+void
+csv_fixed_price_import_file_page_prepare (GtkAssistant *assistant,
+                                        gpointer user_data)
+{
+    CsvPriceImportInfo *info = user_data;
+    gint num = gtk_assistant_get_current_page (assistant);
+    GtkWidget *page = gtk_assistant_get_nth_page (assistant, num);
+
+    /* Set the default directory */
+    if (info->starting_dir)
+        gtk_file_chooser_set_current_folder (GTK_FILE_CHOOSER(info->file_chooser), info->starting_dir);
+
+    /* Reset Header spin to 0 */
+    info->header_rows = 0;
+    gtk_spin_button_set_value (GTK_SPIN_BUTTON(info->header_row_spin), 0);
+
+    /* Disable the Forward Assistant Button */
+    gtk_assistant_set_page_complete (assistant, page, FALSE);
+}
+
+
+void
+csv_fixed_price_import_view_page_prepare (GtkAssistant *assistant,
+        gpointer user_data)
+{
+    CsvPriceImportInfo *info = user_data;
+
+    gtk_list_store_clear (info->store);
+
+    if (csv_fixed_price_import_read_file (info->file_name, info->regexp->str, info->store, 11 ) == MATCH_FOUND)
+    {
+        /* Reset Header spin to 0 */
+        if (info->header_rows != 0)
+            gtk_spin_button_set_value (GTK_SPIN_BUTTON(info->header_row_spin), 0);
+        csv_fixed_price_import_hrows_cb (info->header_row_spin, info);
+        gtk_widget_set_sensitive (info->header_row_spin, TRUE);
+    }
+    else
+        gtk_widget_set_sensitive (info->header_row_spin, FALSE);
+}
+
+
+void
+csv_fixed_price_import_finish_page_prepare (GtkAssistant *assistant,
+        gpointer user_data)
+{
+    CsvPriceImportInfo *info = user_data;
+    gint num = gtk_assistant_get_current_page (assistant);
+    GtkWidget *page = gtk_assistant_get_nth_page (assistant, num);
+    gchar *text;
+    gboolean test_ok = FALSE;
+
+    /* Set Finish page text */
+    if (csv_fixed_price_test_one_line (info))
+    {
+        text = g_strdup_printf (gettext (finish_tree_string), info->file_name);
+        test_ok = TRUE;
+    }
+    else
+        text = g_strdup (_("Date or Number format is incorrect, press 'back' to correct"));
+
+    gtk_label_set_text (GTK_LABEL(info->finish_label), text);
+    g_free (text);
+
+    /* Save the Window size and directory */
+    gnc_set_default_directory (GNC_PREFS_GROUP, info->starting_dir);
+
+    /* Enable the Assistant Buttons */
+    gtk_assistant_set_page_complete (assistant, page, test_ok);
+}
+
+
+void
+csv_fixed_price_import_summary_page_prepare (GtkAssistant *assistant,
+        gpointer user_data)
+{
+    CsvPriceImportInfo *info = user_data;
+    gchar *text, *errtext, *mtext;
+
+    if (g_strcmp0 (info->error, "") != 0)
+    {
+        GtkTextBuffer *buffer;
+
+        buffer = gtk_text_view_get_buffer (GTK_TEXT_VIEW(info->summary_error_view));
+        text = g_strdup_printf (gettext ("Import completed but with warnings!\n\nThe number of Prices added was %u and "
+                                        "%u were duplicates.\n\nSee below for warnings..."), info->num_new, info->num_duplicates);
+        errtext = g_strdup_printf ("%s", info->error);
+        gtk_text_buffer_set_text (buffer, errtext, -1);
+        g_free (errtext);
+        g_free (info->error);
+    }
+    else
+        text = g_strdup_printf (gettext ("Import completed successfully!\n\nThe number of Prices added was %u and "
+                                        "%u were duplicates.\n"), info->num_new, info->num_duplicates);
+
+    mtext = g_strdup_printf ("<span size=\"medium\"><b>%s</b></span>", text);
+    gtk_label_set_markup (GTK_LABEL(info->summary_label), mtext);
+
+    g_free (text);
+    g_free (mtext);
+}
+
+
+void
+csv_fixed_price_import_assistant_prepare (GtkAssistant *assistant, GtkWidget *page,
+                              gpointer user_data)
+{
+    gint currentpage = gtk_assistant_get_current_page (assistant);
+
+    switch (currentpage)
+    {
+    case 0:
+        /* Current page is Import Start page */
+        csv_fixed_price_import_start_page_prepare (assistant, user_data);
+        break;
+    case 1:
+        /* Current page is File select page */
+        csv_fixed_price_import_file_page_prepare (assistant, user_data);
+        break;
+    case 2:
+        /* Current page is Inmport View page */
+        csv_fixed_price_import_view_page_prepare (assistant, user_data);
+        break;
+    case 3:
+        /* Current page is Finish page */
+        csv_fixed_price_import_finish_page_prepare (assistant, user_data);
+        break;
+    case 4:
+        /* Current page is Summary page */
+        csv_fixed_price_import_summary_page_prepare (assistant, user_data);
+        break;
+    }
+}
+
+
+/*******************************************************
+ * Assistant call back functions
+ *******************************************************/
+static void
+csv_fixed_price_import_assistant_destroy_cb (GtkObject *object, gpointer user_data)
+{
+    CsvPriceImportInfo *info = user_data;
+    gnc_unregister_gui_component_by_data (ASSISTANT_CSV_FIXED_PRICE_IMPORT_CM_CLASS, info);
+    g_free (info);
+}
+
+void
+csv_fixed_price_import_assistant_cancel (GtkAssistant *assistant, gpointer user_data)
+{
+    CsvPriceImportInfo *info = user_data;
+    gnc_close_gui_component_by_data (ASSISTANT_CSV_FIXED_PRICE_IMPORT_CM_CLASS, info);
+}
+
+void
+csv_fixed_price_import_assistant_close (GtkAssistant *assistant, gpointer user_data)
+{
+    CsvPriceImportInfo *info = user_data;
+    gnc_close_gui_component_by_data (ASSISTANT_CSV_FIXED_PRICE_IMPORT_CM_CLASS, info);
+}
+
+void
+csv_fixed_price_import_assistant_finish (GtkAssistant *assistant, gpointer user_data)
+{
+    CsvPriceImportInfo *info = user_data;
+
+    gtk_list_store_clear (info->store);
+    csv_fixed_price_import_read_file (info->file_name, info->regexp->str, info->store, 0 );
+    csv_fixed_price_import (info);
+}
+
+static void
+csv_fixed_price_import_close_handler (gpointer user_data)
+{
+    CsvPriceImportInfo *info = user_data;
+
+    g_free (info->starting_dir);
+    g_free (info->file_name);
+    g_string_free (info->regexp, TRUE);
+
+    gnc_save_window_size (GNC_PREFS_GROUP, GTK_WINDOW(info->window));
+    gtk_widget_destroy (info->window);
+}
+
+/*******************************************************
+ * Create the Assistant
+ *******************************************************/
+static GtkWidget *
+csv_fixed_price_import_assistant_create (CsvPriceImportInfo *info)
+{
+    GtkBuilder *builder;
+    GtkWidget *window;
+    GtkWidget *box, *h_box;
+    GtkWidget *button;
+    GtkCellRenderer *renderer;
+    GtkTreeViewColumn *column;
+    gchar *mnemonic_desc = NULL;
+    gint i;
+    GtkContainer *date_format_container, *currency_format_container;
+
+    builder = gtk_builder_new();
+    gnc_builder_add_from_file (builder, "assistant-csv-fixed-price-import.glade", "num_hrows_adj");
+    gnc_builder_add_from_file (builder, "assistant-csv-fixed-price-import.glade", "CSV Fixed Price Import Assistant");
+    window = GTK_WIDGET(gtk_builder_get_object (builder, "CSV Fixed Price Import Assistant"));
+    info->window = window;
+
+    /* Load default settings */
+    load_settings (info);
+
+    /* Enable buttons on all page. */
+    gtk_assistant_set_page_complete (GTK_ASSISTANT(window),
+                                     GTK_WIDGET(gtk_builder_get_object(builder, "start_page")),
+                                     TRUE);
+    gtk_assistant_set_page_complete (GTK_ASSISTANT(window),
+                                     GTK_WIDGET(gtk_builder_get_object(builder, "file_page")),
+                                     FALSE);
+    gtk_assistant_set_page_complete (GTK_ASSISTANT(window),
+                                     GTK_WIDGET(gtk_builder_get_object(builder, "import_view_page")),
+                                     TRUE);
+    gtk_assistant_set_page_complete (GTK_ASSISTANT(window),
+                                     GTK_WIDGET(gtk_builder_get_object(builder, "finish_page")),
+                                     FALSE);
+    gtk_assistant_set_page_complete (GTK_ASSISTANT(window),
+                                     GTK_WIDGET(gtk_builder_get_object(builder, "summary_page")),
+                                     TRUE);
+
+    /* Start Page */
+
+    /* File chooser Page */
+    info->file_chooser = gtk_file_chooser_widget_new (GTK_FILE_CHOOSER_ACTION_OPEN);
+    g_signal_connect (G_OBJECT(info->file_chooser), "file-activated",
+                      G_CALLBACK(csv_fixed_price_import_file_chooser_confirm_cb), info);
+    button = gtk_button_new_from_stock (GTK_STOCK_OK);
+    gtk_widget_set_size_request (button, 100, -1);
+    gtk_widget_show (button);
+    h_box = gtk_hbox_new (TRUE, 0);
+    gtk_box_pack_start (GTK_BOX(h_box), button, FALSE, FALSE, 0);
+    gtk_file_chooser_set_extra_widget (GTK_FILE_CHOOSER(info->file_chooser), h_box);
+    g_signal_connect (G_OBJECT(button), "clicked",
+                      G_CALLBACK(csv_fixed_price_import_file_chooser_confirm_cb), info);
+
+    box = GTK_WIDGET(gtk_builder_get_object(builder, "file_page"));
+    gtk_box_pack_start (GTK_BOX(box), info->file_chooser, TRUE, TRUE, 6);
+    gtk_widget_show (info->file_chooser);
+
+    /* Preview Page */
+    info->header_row_spin = GTK_WIDGET(gtk_builder_get_object (builder, "num_hrows"));
+    info->tree_view = GTK_WIDGET(gtk_builder_get_object (builder, "treeview"));
+
+    /* Add in the date format combo box and hook it up to an event handler. */
+    info->date_format_combo = GTK_COMBO_BOX_TEXT(gtk_combo_box_text_new());
+    for (i = 0; i < num_date_formats; i++)
+    {
+        gtk_combo_box_text_append_text (info->date_format_combo, _(date_format_user[i]));
+    }
+    gtk_combo_box_set_active (GTK_COMBO_BOX(info->date_format_combo), 0);
+    g_signal_connect (G_OBJECT(info->date_format_combo), "changed",
+                      G_CALLBACK(date_format_selected), (gpointer)info);
+
+    /* Add it to the assistant. */
+    date_format_container = GTK_CONTAINER(gtk_builder_get_object (builder, "date_format_container"));
+    gtk_container_add (date_format_container, GTK_WIDGET(info->date_format_combo));
+    gtk_widget_show_all (GTK_WIDGET(date_format_container));
+
+    /* Add in the currency format combo box and hook it up to an event handler. */
+    info->currency_format_combo = GTK_COMBO_BOX_TEXT(gtk_combo_box_text_new());
+    for (i = 0; i < num_currency_formats; i++)
+    {
+        gtk_combo_box_text_append_text (info->currency_format_combo, _(currency_format_user[i]));
+    }
+    /* Default will the locale */
+    gtk_combo_box_set_active (GTK_COMBO_BOX(info->currency_format_combo), 0);
+    g_signal_connect (G_OBJECT(info->currency_format_combo), "changed",
+                      G_CALLBACK(currency_format_selected), (gpointer)info);
+
+    /* Add it to the assistant. */
+    currency_format_container = GTK_CONTAINER(gtk_builder_get_object (builder, "currency_format_container"));
+    gtk_container_add (currency_format_container, GTK_WIDGET(info->currency_format_combo));
+    gtk_widget_show_all (GTK_WIDGET(currency_format_container));
+
+    /* Comma Separated file default */
+    info->regexp = g_string_new ("");
+    create_regex (info->regexp, ",");
+
+    /* create model and bind to view */
+    info->store = gtk_list_store_new (PRICE_N_COLUMNS,
+                                      G_TYPE_STRING, G_TYPE_STRING, G_TYPE_STRING, G_TYPE_STRING, G_TYPE_STRING);
+
+    gtk_tree_view_set_model (GTK_TREE_VIEW(info->tree_view), GTK_TREE_MODEL(info->store));
+
+#define CREATE_COLUMN(description,column_id) \
+  renderer = gtk_cell_renderer_text_new (); \
+  mnemonic_desc = mnemonic_escape (_(description)); \
+  column = gtk_tree_view_column_new_with_attributes (mnemonic_desc, renderer, "text", column_id, NULL); \
+  gtk_tree_view_column_add_attribute (column, renderer, "background", PRICE_ROW_COLOR); \
+  gtk_tree_view_column_set_resizable (column, TRUE); \
+  gtk_tree_view_append_column (GTK_TREE_VIEW(info->tree_view), column); \
+  g_free (mnemonic_desc);
+    CREATE_COLUMN ("Symbol", PRICE_COMM1);
+    CREATE_COLUMN ("Date", PRICE_IMPORT_DATE);
+    CREATE_COLUMN ("Amount", PRICE_IMPORT_AMOUNT);
+    CREATE_COLUMN ("Symbol To", PRICE_COMM2);
+
+    // Enable Horizontal and vertical grid lines
+    gtk_tree_view_set_grid_lines (GTK_TREE_VIEW(info->tree_view), GTK_TREE_VIEW_GRID_LINES_BOTH);
+
+    /* Finish Page */
+    info->finish_label = GTK_WIDGET(gtk_builder_get_object (builder, "finish_label"));
+
+    /* Summary Page */
+    info->summary_label = GTK_WIDGET(gtk_builder_get_object (builder, "summary_label"));
+    info->summary_error_view = GTK_WIDGET(gtk_builder_get_object (builder, "summary_error_view"));
+
+    g_signal_connect (G_OBJECT(window), "destroy",
+                      G_CALLBACK(csv_fixed_price_import_assistant_destroy_cb), info);
+
+    gnc_restore_window_size (GNC_PREFS_GROUP, GTK_WINDOW(info->window));
+
+    gtk_builder_connect_signals (builder, info);
+    g_object_unref (G_OBJECT(builder));
+    return window;
+}
+
+
+/********************************************************************\
+ * gnc_file_csv_account_import                                      *
+ * opens up a assistant to import accounts.                         *
+ *                                                                  *
+ * Args:   import_type                                              *
+ * Return: nothing                                                  *
+\********************************************************************/
+void
+gnc_file_csv_fixed_price_import(void)
+{
+    CsvPriceImportInfo *info;
+
+    info = g_new0 (CsvPriceImportInfo, 1);
+
+    csv_fixed_price_import_assistant_create (info);
+
+    gnc_register_gui_component (ASSISTANT_CSV_FIXED_PRICE_IMPORT_CM_CLASS,
+                                NULL, csv_fixed_price_import_close_handler,
+                                info);
+
+    gtk_widget_show_all (info->window);
+
+    gnc_window_adjust_for_screen (GTK_WINDOW(info->window));
+}

--- a/src/import-export/csv-imp/assistant-csv-fixed-price-import.glade
+++ b/src/import-export/csv-imp/assistant-csv-fixed-price-import.glade
@@ -1,0 +1,471 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk+" version="2.16"/>
+  <!-- interface-naming-policy project-wide -->
+  <object class="GtkAdjustment" id="num_hrows_adj">
+    <property name="upper">100</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
+  <object class="GtkAssistant" id="CSV Fixed Price Import Assistant">
+    <property name="can_focus">False</property>
+    <property name="border_width">12</property>
+    <property name="title" translatable="yes">CSV Fixed Price Import Assistant</property>
+    <property name="default_width">400</property>
+    <property name="default_height">500</property>
+    <signal name="close" handler="csv_fixed_price_import_assistant_close" swapped="no"/>
+    <signal name="apply" handler="csv_fixed_price_import_assistant_finish" swapped="no"/>
+    <signal name="prepare" handler="csv_fixed_price_import_assistant_prepare" swapped="no"/>
+    <signal name="cancel" handler="csv_fixed_price_import_assistant_cancel" swapped="no"/>
+    <child>
+      <object class="GtkVBox" id="start_page">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="border_width">12</property>
+        <child>
+          <object class="GtkLabel" id="start_label">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">
+This assistant will help you import Prices from a CSV file in a fixed format.
+
+The file must be in the required format, that is, 'Security Symbol', 'Date', 'Amount', 'Security Symbol To' with a valid separater.
+There is an option to over write existing prices for that day if required.
+
+Examples are "RR.L","21/11/2016",5.345,"GBP" and "USD","2016-11-21",1.56,"GBP"
+
+
+This operation is not reversable, so make sure you have a working backup.
+
+Click on 'Forward' to proceed or 'Cancel' to Abort Import.
+</property>
+            <property name="justify">center</property>
+            <property name="wrap">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="page_type">intro</property>
+        <property name="title" translatable="yes">Fixed Format Price Import Assistant</property>
+        <property name="complete">True</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkVBox" id="file_page">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="border_width">12</property>
+        <child>
+          <object class="GtkLabel" id="label4">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">
+Enter file name and location for the Import...
+</property>
+            <property name="wrap">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="title" translatable="yes">Choose File to Import</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkVBox" id="import_view_page">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="border_width">12</property>
+        <child>
+          <object class="GtkHBox" id="hbox1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="spacing">15</property>
+            <child>
+              <object class="GtkFrame" id="frame1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label_xalign">0</property>
+                <property name="shadow_type">none</property>
+                <child>
+                  <object class="GtkAlignment" id="date_format_container">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="left_padding">12</property>
+                  </object>
+                </child>
+                <child type="label">
+                  <object class="GtkLabel" id="label1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Date Format</property>
+                    <property name="use_markup">True</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFrame" id="frame2">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label_xalign">0</property>
+                <property name="shadow_type">none</property>
+                <child>
+                  <object class="GtkAlignment" id="currency_format_container">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="left_padding">12</property>
+                  </object>
+                </child>
+                <child type="label">
+                  <object class="GtkLabel" id="label3">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Currency Format</property>
+                    <property name="use_markup">True</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFrame" id="frame3">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label_xalign">0</property>
+                <property name="shadow_type">none</property>
+                <child>
+                  <object class="GtkAlignment" id="alignment1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="left_padding">12</property>
+                    <child>
+                      <object class="GtkHBox" id="hbox3">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkSpinButton" id="num_hrows">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="editable">False</property>
+                            <property name="invisible_char">●</property>
+                            <property name="invisible_char_set">True</property>
+                            <property name="primary_icon_activatable">False</property>
+                            <property name="secondary_icon_activatable">False</property>
+                            <property name="primary_icon_sensitive">True</property>
+                            <property name="secondary_icon_sensitive">True</property>
+                            <property name="adjustment">num_hrows_adj</property>
+                            <signal name="value-changed" handler="csv_fixed_price_import_hrows_cb" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child type="label">
+                  <object class="GtkLabel" id="label5">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Header Rows</property>
+                    <property name="use_markup">True</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFrame" id="frame4">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label_xalign">0</property>
+                <property name="shadow_type">none</property>
+                <child>
+                  <object class="GtkAlignment" id="alignment4">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="left_padding">12</property>
+                    <child>
+                      <object class="GtkHBox" id="hbox2">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkCheckButton" id="over-write">
+                            <property name="label" translatable="yes">Over Write</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="draw_indicator">True</property>
+                            <signal name="toggled" handler="csv_fixed_price_import_over_write_cb" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+                <child type="label">
+                  <object class="GtkLabel" id="label2">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Existing Entries</property>
+                    <property name="use_markup">True</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkFrame" id="separator_frame">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label_xalign">0</property>
+            <property name="shadow_type">in</property>
+            <child>
+              <object class="GtkTable" id="table4">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="border_width">12</property>
+                <property name="n_rows">2</property>
+                <property name="n_columns">3</property>
+                <child>
+                  <object class="GtkRadioButton" id="radio_comma">
+                    <property name="label" translatable="yes">Comma Separated</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="active">True</property>
+                    <property name="draw_indicator">True</property>
+                    <signal name="toggled" handler="csv_fixed_price_import_sep_cb" swapped="no"/>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkRadioButton" id="radio_semi">
+                    <property name="label" translatable="yes">Semicolon Separated</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="draw_indicator">True</property>
+                    <property name="group">radio_comma</property>
+                    <signal name="toggled" handler="csv_fixed_price_import_sep_cb" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="right_attach">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkRadioButton" id="radio_custom">
+                    <property name="label" translatable="yes">Custom regular Expression</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="draw_indicator">True</property>
+                    <property name="group">radio_comma</property>
+                    <signal name="toggled" handler="csv_fixed_price_import_sep_cb" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="top_attach">1</property>
+                    <property name="bottom_attach">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkRadioButton" id="radio_colon">
+                    <property name="label" translatable="yes">Colon Separated</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="draw_indicator">True</property>
+                    <property name="group">radio_comma</property>
+                    <signal name="toggled" handler="csv_fixed_price_import_sep_cb" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="left_attach">2</property>
+                    <property name="right_attach">3</property>
+                  </packing>
+                </child>
+              </object>
+            </child>
+            <child type="label">
+              <object class="GtkLabel" id="label6">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Select Separator Type</property>
+                <property name="use_markup">True</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="padding">7</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkFrame" id="preview_frame">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label_xalign">0</property>
+            <property name="shadow_type">in</property>
+            <child>
+              <object class="GtkScrolledWindow" id="scroll_window">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="border_width">6</property>
+                <property name="hscrollbar_policy">automatic</property>
+                <property name="vscrollbar_policy">automatic</property>
+                <child>
+                  <object class="GtkTreeView" id="treeview">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child type="label">
+              <object class="GtkLabel" id="label8">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Preview</property>
+                <property name="use_markup">True</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="title" translatable="yes">Import Price Preview, first 10 rows only</property>
+        <property name="complete">True</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkVBox" id="finish_page">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <child>
+          <object class="GtkAlignment" id="alignment2">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <child>
+              <object class="GtkLabel" id="finish_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Press Apply to add Prices.
+Cancel to abort.</property>
+                <property name="justify">center</property>
+                <property name="wrap">True</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="page_type">confirm</property>
+        <property name="title" translatable="yes">Import Prices Now</property>
+        <property name="complete">True</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkVBox" id="summary_page">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="border_width">12</property>
+        <child>
+          <object class="GtkLabel" id="summary_label">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">label</property>
+            <property name="use_markup">True</property>
+            <property name="justify">center</property>
+            <property name="wrap">True</property>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkScrolledWindow" id="summary_error_scrolledwindow">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="border_width">1</property>
+            <property name="hscrollbar_policy">automatic</property>
+            <property name="vscrollbar_policy">automatic</property>
+            <property name="shadow_type">etched-in</property>
+            <child>
+              <object class="GtkTextView" id="summary_error_view">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="left_margin">2</property>
+                <property name="right_margin">2</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="page_type">summary</property>
+        <property name="title" translatable="yes">Import Summary</property>
+        <property name="complete">True</property>
+      </packing>
+    </child>
+  </object>
+</interface>

--- a/src/import-export/csv-imp/assistant-csv-fixed-price-import.h
+++ b/src/import-export/csv-imp/assistant-csv-fixed-price-import.h
@@ -1,0 +1,70 @@
+/*******************************************************************\
+ * assistant-csv-fixed-price-import.h -- An assistant for importing *
+ *                                       set format price file.     *
+ *                                                                  *
+ * Copyright (C) 2016 Robert Fewell                                 *
+ *                                                                  *
+ * This program is free software; you can redistribute it and/or    *
+ * modify it under the terms of the GNU General Public License as   *
+ * published by the Free Software Foundation; either version 2 of   *
+ * the License, or (at your option) any later version.              *
+ *                                                                  *
+ * This program is distributed in the hope that it will be useful,  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    *
+ * GNU General Public License for more details.                     *
+ *                                                                  *
+ * You should have received a copy of the GNU General Public License*
+ * along with this program; if not, contact:                        *
+ *                                                                  *
+ * Free Software Foundation           Voice:  +1-617-542-5942       *
+ * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652       *
+ * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
+\********************************************************************/
+/** @file assistant-csv-fixed-price-import.h
+    @brief CSV Price Import Assistant
+    @author Copyright (c) 2016 Robert Fewell
+*/
+#ifndef GNC_ASSISTANT_CSV_FIXED_PRICE_IMPORT_H
+#define GNC_ASSISTANT_CSV_FIXED_PRICE_IMPORT_H
+
+// Account tree model
+enum fixed_price_import_model_columns
+{
+   PRICE_COMM1, PRICE_IMPORT_DATE, PRICE_IMPORT_AMOUNT, PRICE_COMM2, PRICE_ROW_COLOR, PRICE_N_COLUMNS
+};
+
+typedef struct
+{
+    GtkWidget       *window;
+    GtkWidget       *assistant;
+
+    GtkWidget       *file_chooser;           /**< The File Chooser widget on File page */
+    GtkWidget       *tree_view;              /**< The Preview Treeview */
+    GtkListStore    *store;                  /**< The Liststore of imported data */
+    GString         *regexp;                 /**< The Regular expression string */
+    GtkWidget       *header_row_spin;        /**< The Number of header rows widget */
+    GtkComboBoxText *date_format_combo;      /**< The Combo Text widget for selecting the date format */
+    GtkComboBoxText *currency_format_combo;  /**< The Combo Text widget for selecting the currency format */
+    GtkWidget       *finish_label;           /**< The Label widget on the Finish page */
+    GtkWidget       *summary_label;          /**< The Label widget on the Summary page */
+    GtkWidget       *summary_error_view;     /**< The Text view widget on the Summary page */
+
+    gchar           *starting_dir;           /**< The starting directory where import file is */
+    gchar           *file_name;              /**< The File name to import */
+    gchar           *error;                  /**< The Error Text */
+
+    gboolean         over_write;             /**< Whether to over write existing entries */
+    gint             header_rows;            /**< The Number of header rows, usually defaults to 1 */
+    gint             num_new;                /**< The Number of new prices imported */
+    gint             num_duplicates;         /**< The Number of duplicate prices not imported */
+    gint             date_format;            /**< The format of the text in the date columns from date_format_internal. */
+    gint             currency_format;        /**< The currency format, 0 for locale, 1 for comma dec and 2 for period */
+} CsvPriceImportInfo;
+
+
+/** The gnc_file_csv_fixed_price_import() will let the user import
+ *  prices from a delimited fixed format file.
+ */
+void gnc_file_csv_fixed_price_import (void);
+#endif

--- a/src/import-export/csv-imp/csv-fixed-price-import.c
+++ b/src/import-export/csv-imp/csv-fixed-price-import.c
@@ -1,0 +1,489 @@
+/*******************************************************************\
+ * csv-fixed-price-import.c -- Price importing from file            *
+ *                                                                  *
+ * Copyright (C) 2016 Robert Fewell                                 *
+ *                                                                  *
+ *                                                                  *
+ * This program is free software; you can redistribute it and/or    *
+ * modify it under the terms of the GNU General Public License as   *
+ * published by the Free Software Foundation; either version 2 of   *
+ * the License, or (at your option) any later version.              *
+ *                                                                  *
+ * This program is distributed in the hope that it will be useful,  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    *
+ * GNU General Public License for more details.                     *
+ *                                                                  *
+ * You should have received a copy of the GNU General Public License*
+ * along with this program; if not, contact:                        *
+ *                                                                  *
+ * Free Software Foundation           Voice:  +1-617-542-5942       *
+ * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652       *
+ * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
+\********************************************************************/
+
+#include "config.h"
+
+#include <glib.h>
+#include <glib/gi18n.h>
+#include <glib/gstdio.h>
+
+#include "gnc-ui-util.h"
+#include <regex.h>
+#include "gnc-commodity.h"
+#include "gnc-pricedb.h"
+#include "gnc-component-manager.h"
+#include "csv-fixed-price-import.h"
+#include "gnc-gdate-utils.h"
+#include "gnc-csv-model.h"
+
+/* This static indicates the debugging module that this .o belongs to.  */
+static QofLogModule log_module = GNC_MOD_ASSISTANT;
+
+/* This helper function takes a regexp match and fills the model */
+static void
+fill_model_with_match(GMatchInfo *match_info,
+                      const gchar *match_name,
+                      GtkListStore *store,
+                      GtkTreeIter *iterptr,
+                      gint column)
+{
+    gchar *temp;
+
+    if (!match_info || !match_name)
+        return;
+
+    temp = g_match_info_fetch_named (match_info, match_name);
+    if (temp)
+    {
+        g_strstrip (temp);
+        if (g_str_has_prefix (temp, "\""))
+        {
+            if (strlen (temp) >= 2)
+            {
+                gchar *toptail = g_strndup (temp + 1, strlen (temp)-2);
+                gchar **parts = g_strsplit (toptail, "\"\"", -1);
+                temp = g_strjoinv ("\"", parts);
+                g_strfreev (parts);
+                g_free (toptail);
+            }
+        }
+        gtk_list_store_set (store, iterptr, column, temp, -1);
+        g_free (temp);
+     }
+}
+
+
+/*******************************************************
+ * csv_fixed_price_import_read_file
+ *
+ * Parse the file for a correctly formatted file
+ *******************************************************/
+csv_fixed_price_import_result
+csv_fixed_price_import_read_file (const gchar *filename, const gchar *parser_regexp,
+                                  GtkListStore *store, guint max_rows)
+{
+    gchar      *locale_cont, *contents;
+    GMatchInfo *match_info = NULL;
+    GRegex     *regexpat = NULL;
+    GError     *err;
+    gint       row = 0;
+    gboolean   match_found = FALSE;
+
+    // model
+    GtkTreeIter iter;
+
+    if (!g_file_get_contents (filename, &locale_cont, NULL, NULL))
+        return RESULT_OPEN_FAILED;
+
+    contents = g_locale_to_utf8 (locale_cont, -1, NULL, NULL, NULL);
+    g_free (locale_cont);
+
+    // compile the regular expression and check for errors
+    err = NULL;
+    regexpat =
+        g_regex_new (parser_regexp, G_REGEX_OPTIMIZE, 0, &err);
+    if (err != NULL)
+    {
+        GtkWidget *dialog;
+        gchar *errmsg;
+
+        errmsg = g_strdup_printf (_("Error in regular expression '%s':\n%s"),
+                                  parser_regexp, err->message);
+        g_error_free (err);
+
+        dialog = gtk_message_dialog_new (NULL,
+                                         GTK_DIALOG_MODAL,
+                                         GTK_MESSAGE_ERROR,
+                                         GTK_BUTTONS_OK, "%s", errmsg);
+        gtk_dialog_run (GTK_DIALOG (dialog));
+        gtk_widget_destroy (dialog);
+        g_free (errmsg);
+        g_free (contents);
+
+        return RESULT_ERROR_IN_REGEXP;
+    }
+
+    g_regex_match (regexpat, contents, 0, &match_info);
+    while (g_match_info_matches (match_info))
+    {
+        match_found = TRUE;
+        // fill in the values
+        gtk_list_store_append (store, &iter);
+        fill_model_with_match (match_info, "p_comm1", store, &iter, PRICE_COMM1);
+        fill_model_with_match (match_info, "p_date", store, &iter, PRICE_IMPORT_DATE);
+        fill_model_with_match (match_info, "p_amount", store, &iter, PRICE_IMPORT_AMOUNT);
+        fill_model_with_match (match_info, "p_comm2", store, &iter, PRICE_COMM2);
+        gtk_list_store_set (store, &iter, PRICE_ROW_COLOR, NULL, -1);
+
+        row++;
+        if (row == max_rows)
+            break;
+        g_match_info_next (match_info, &err);
+    }
+
+    g_match_info_free (match_info);
+    g_regex_unref (regexpat);
+    g_free (contents);
+
+    if (err != NULL)
+    {
+        g_printerr ("Error while matching: %s\n", err->message);
+        g_error_free (err);
+    }
+
+    if (match_found == TRUE)
+        return MATCH_FOUND;
+    else
+        return RESULT_OK;
+}
+
+
+/*******************************************************
+ * save_error_text
+ *
+ * Add error text to existing errors
+ *******************************************************/
+static void
+save_error_text (CsvPriceImportInfo *info, gint row, gchar *etext)
+{
+    gchar *current_error_text;
+    gchar *text;
+
+    current_error_text = g_strdup (info->error);
+
+    if (g_strcmp0 (info->error, "") != 0)
+        g_free (info->error);
+
+    text = g_strdup_printf (gettext("Row %u, %s\n"), row + 1, etext);
+    info->error = g_strconcat (current_error_text, text, NULL);
+    g_free (text);
+    g_free (current_error_text);
+}
+
+
+/*******************************************************
+ * parse_number_string
+ *
+ * Parse the number string and return a gnc_number
+ *******************************************************/
+static gboolean
+parse_number_string (CsvPriceImportInfo *info, const gchar *num_string, gnc_numeric *ret_num)
+{
+    char       *endptr, *str_num;
+    gboolean    valid = FALSE;
+    gchar      *result = NULL;
+    gnc_numeric num;
+
+    str_num = g_strdup (num_string);
+
+    /* Currency format */
+    switch (info->currency_format)
+    {
+        case 0:
+            /* Currency locale */
+            valid = xaccParseAmount (str_num, TRUE, &num, &endptr);
+            break;
+        case 1:
+            /* Currency decimal period */
+            valid = xaccParseAmountExtended (str_num, TRUE, '-', '.', ',', "\003\003", "$+", &num, &endptr);
+            break;
+        case 2:
+            /* Currency decimal comma */
+            valid = xaccParseAmountExtended (str_num, TRUE, '-', ',', '.', "\003\003", "$+", &num, &endptr);
+            break;
+    }
+    *ret_num = num;
+    g_free (str_num);
+
+    return valid;
+}
+
+
+/*******************************************************
+ * csv_fixed_price_test_one_line
+ *
+ * Test a line for valid date and valid number
+ *******************************************************/
+gboolean
+csv_fixed_price_test_one_line (CsvPriceImportInfo *info)
+{
+    gboolean     valid;
+    GtkTreeIter  iter;
+    gchar       *date, *amount_num;
+    gnc_numeric  amount;
+    gint         row;
+    gboolean     date_ok = FALSE;
+    gboolean     num_ok = FALSE;
+
+    row = info->header_rows;
+    valid = gtk_tree_model_iter_nth_child (GTK_TREE_MODEL(info->store), &iter, NULL, row);
+
+    gtk_tree_model_get (GTK_TREE_MODEL (info->store), &iter,
+                        PRICE_IMPORT_DATE, &date,
+                        PRICE_IMPORT_AMOUNT, &amount_num, -1);
+
+    if (parse_date (date, info->date_format) != -1) // invalid date
+        date_ok = TRUE;
+
+    if (g_strcmp0 (amount_num, "") != 0) // test for valid number
+    {
+        if (parse_number_string (info, amount_num, &amount))
+            num_ok = TRUE;
+    }
+    /* free resources */
+    g_free (date);
+    g_free (amount_num);
+
+    if ((date_ok == TRUE) && (num_ok == TRUE))
+       return TRUE;
+    else
+       return FALSE;
+}
+
+/*******************************************************
+ * get_price_commodity
+ *
+ * Find a commodity by Symbol/mnemonic
+ *******************************************************/
+static gnc_commodity *
+get_price_commodity (const char *symbol)
+{
+    const gnc_commodity_table *commodity_table = gnc_get_current_commodities ();
+    GList         *namespaces;
+    gnc_commodity *retval = NULL;
+    gnc_commodity *tmp_commodity = NULL;
+    char  *tmp_namespace = NULL;
+    GList *commodity_list = NULL;
+    GList *namespace_list = gnc_commodity_table_get_namespaces (commodity_table);
+
+    namespace_list = g_list_first (namespace_list);
+    while (namespace_list != NULL && retval == NULL)
+    {
+        tmp_namespace = namespace_list->data;
+        DEBUG("Looking at namespace %s", tmp_namespace);
+        commodity_list = gnc_commodity_table_get_commodities (commodity_table, tmp_namespace);
+        commodity_list  = g_list_first (commodity_list);
+        while (commodity_list != NULL && retval == NULL)
+        {
+            const char* tmp_mnemonic = NULL;
+            tmp_commodity = commodity_list->data;
+            DEBUG("Looking at commodity %s", gnc_commodity_get_fullname (tmp_commodity));
+            tmp_mnemonic = gnc_commodity_get_mnemonic (tmp_commodity);
+            if (g_strcmp0 (tmp_mnemonic, symbol) == 0)
+            {
+                retval = tmp_commodity;
+                DEBUG("Commodity %s%s", gnc_commodity_get_fullname (retval), " matches.");
+            }
+            commodity_list = g_list_next (commodity_list);
+        }
+        namespace_list = g_list_next (namespace_list);
+    }
+    g_list_free (commodity_list);
+    g_list_free (namespace_list);
+
+    return retval;
+}
+
+
+/*******************************************************
+ * csv_fixed_price_import
+ *
+ * Parse the liststore for price updates
+ *******************************************************/
+void
+csv_fixed_price_import (CsvPriceImportInfo *info)
+{
+    QofBook       *book = gnc_get_current_book();
+    gboolean       valid;
+    GtkTreeIter    iter;
+    gchar         *p_comm1, *p_date, *p_amount, *p_comm2;
+    gchar         *last_p_comm1 = NULL;
+    gchar         *last_p_comm2 = NULL;
+    int            row;
+    gnc_numeric    amount;
+    gnc_commodity *commodity1 = NULL;
+    gnc_commodity *commodity2 = NULL;
+    gboolean commodity1_is_currency = FALSE;
+
+    ENTER("");
+
+    info->num_new = 0;
+    info->num_duplicates = 0;
+
+    /* Move to the first valid entry in store */
+    row = info->header_rows;
+    valid = gtk_tree_model_iter_nth_child (GTK_TREE_MODEL(info->store), &iter, NULL, row );
+    while (valid)
+    {
+        gboolean price_error = FALSE;
+
+        /* Walk through the list, reading each row */
+        gtk_tree_model_get (GTK_TREE_MODEL (info->store), &iter,
+                            PRICE_COMM1, &p_comm1,
+                            PRICE_IMPORT_DATE, &p_date,
+                            PRICE_IMPORT_AMOUNT, &p_amount,
+                            PRICE_COMM2, &p_comm2, -1);
+
+        DEBUG("Row is %u and Symbol from is %s, Symbol to is %s", row, p_comm1, p_comm2);
+g_print("Row is %u and Symbol from is %s, Symbol to is %s\n", row, p_comm1, p_comm2);
+
+        if (g_strcmp0 (p_comm1, last_p_comm1) != 0)
+        {
+            g_free (last_p_comm1);
+            commodity1 = get_price_commodity (p_comm1); // find commodity for symbol from
+            if (commodity1 == NULL)
+            {
+                save_error_text (info, row, _("Can not find First Commodity."));
+                price_error = TRUE;
+            }
+            else
+                commodity1_is_currency = gnc_commodity_is_currency (commodity1);
+
+            last_p_comm1 = g_strdup (p_comm1);
+        }
+
+        if (g_strcmp0 (p_comm2, last_p_comm2) != 0)
+        {
+            g_free (last_p_comm2);
+            commodity2 = get_price_commodity (p_comm2); // find commodity for symbol to
+            if (commodity2 == NULL)
+            {
+                save_error_text (info, row, _("Can not find Second Commodity."));
+                price_error = TRUE;
+            }
+            else
+            {
+                if ((commodity1_is_currency == FALSE) && (gnc_commodity_is_currency (commodity2) == FALSE))
+                {
+                    save_error_text (info, row, _("Second Commodity is not a Currency when first is not."));
+                    price_error = TRUE;
+                }
+            }
+            last_p_comm2 = g_strdup (p_comm2);
+        }
+
+        if (parse_date (p_date, info->date_format) == -1) // invalid date
+        {
+            save_error_text (info, row, _("Date is invalid."));
+            price_error = TRUE;
+        }
+
+        // Lets get some numbers
+        if ((parse_number_string (info, p_amount, &amount) == FALSE) &&
+            (gnc_numeric_positive_p (amount) == FALSE)) // invalid amount
+        {
+            save_error_text (info, row, _("Numeric Amount is invalid."));
+            price_error = TRUE;
+        }
+
+        // Start to Create a new Price 
+        if (price_error == FALSE)
+        {
+            GNCPriceDB *pdb = gnc_pricedb_get_db (book);
+            GNCPrice *price, *old_price = NULL;
+            Timespec date;
+            gboolean rev = FALSE;
+
+            DEBUG("Create new price");
+
+            timespecFromTime64 (&date, parse_date (p_date, info->date_format));
+            date.tv_nsec = 0;
+
+            if (commodity1_is_currency == TRUE)
+            {
+                // Check for currency in reverse direction.
+                GNCPrice *rev_price = gnc_pricedb_lookup_day (pdb, commodity2, commodity1, date);
+                if (rev_price != NULL)
+                    rev = TRUE;
+                gnc_price_unref (rev_price);
+
+                // Check for price less than 1, reverse if so.
+                if (gnc_numeric_compare (amount, gnc_numeric_create (1, 1)) != 1)
+                    rev = TRUE;
+                DEBUG("Commodity one is a Currency, amount is %s, rev is %d", gnc_num_dbg_to_string (amount), rev);
+            }
+
+            // Should the commodities be reversed
+            if (rev)
+                old_price = gnc_pricedb_lookup_day (pdb, commodity2, commodity1, date);
+            else
+                old_price = gnc_pricedb_lookup_day (pdb, commodity1, commodity2, date);
+
+            // Should old price be over writen
+            if ((old_price != NULL) && (info->over_write == TRUE))
+            {
+                DEBUG("Over write");
+                gnc_pricedb_remove_price (pdb, old_price);
+                old_price = NULL;
+            }
+
+            // Create the new price
+            if (old_price == NULL)
+            {
+                price = gnc_price_create (book);
+                gnc_price_begin_edit (price);
+                if(rev)
+                {
+                    gnc_price_set_commodity (price, commodity2);
+                    gnc_price_set_currency (price, commodity1);
+                    amount = gnc_numeric_convert (gnc_numeric_invert (amount),
+                                                  CURRENCY_DENOM, GNC_HOW_RND_ROUND_HALF_UP);
+                    gnc_price_set_value (price, amount);
+                }
+                else
+                {
+                    gnc_price_set_commodity (price, commodity1);
+                    gnc_price_set_currency (price, commodity2);
+                    gnc_price_set_value (price, amount);
+                }
+                gnc_price_set_time (price, date);
+                gnc_price_set_source (price, PRICE_SOURCE_USER_PRICE);
+                gnc_price_set_typestr (price, PRICE_TYPE_LAST);
+                gnc_price_commit_edit (price);
+
+                if (!gnc_pricedb_add_price (pdb, price))
+                    save_error_text (info, row, _("Error adding Price to database."));
+
+                gnc_price_unref (price);
+                info->num_new++;
+            }
+            else
+                info->num_duplicates++;
+
+            gnc_price_unref (old_price);
+        }
+        valid = gtk_tree_model_iter_next (GTK_TREE_MODEL (info->store), &iter);
+        row++;
+
+        /* free resources */
+        g_free (p_comm1);
+        g_free (p_date);
+        g_free (p_amount);
+        g_free (p_comm2);
+    }
+    g_free (last_p_comm1);
+    g_free (last_p_comm2);
+
+    LEAVE("");
+}

--- a/src/import-export/csv-imp/csv-fixed-price-import.h
+++ b/src/import-export/csv-imp/csv-fixed-price-import.h
@@ -1,0 +1,52 @@
+/*******************************************************************\
+ * csv-fixed-price-import.h -- Price importing from file            *
+ *                                                                  *
+ * Copyright (C) 2016 Robert Fewell                                 *
+ *                                                                  *
+ * Based on code from bi_import written by Sebastian Held  and      *
+ * Mike Evans.                                                      *
+ *                                                                  *
+ * This program is free software; you can redistribute it and/or    *
+ * modify it under the terms of the GNU General Public License as   *
+ * published by the Free Software Foundation; either version 2 of   *
+ * the License, or (at your option) any later version.              *
+ *                                                                  *
+ * This program is distributed in the hope that it will be useful,  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    *
+ * GNU General Public License for more details.                     *
+ *                                                                  *
+ * You should have received a copy of the GNU General Public License*
+ * along with this program; if not, contact:                        *
+ *                                                                  *
+ * Free Software Foundation           Voice:  +1-617-542-5942       *
+ * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652       *
+ * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
+\********************************************************************/
+
+#ifndef CSV_FIXED_PRICE_IMPORT_H
+#define CSV_FIXED_PRICE_IMPORT_H
+
+#include <glib.h>
+#include <gtk/gtk.h>
+
+#include "assistant-csv-fixed-price-import.h"
+
+enum _csv_fixed_price_import_result
+{
+    RESULT_OK,
+    RESULT_OPEN_FAILED,
+    RESULT_ERROR_IN_REGEXP,
+    MATCH_FOUND,
+};
+typedef enum _csv_fixed_price_import_result csv_fixed_price_import_result;
+
+csv_fixed_price_import_result
+csv_fixed_price_import_read_file (const gchar *filename, const gchar *parser_regexp, GtkListStore *store, guint max_rows );
+
+gboolean csv_fixed_price_test_one_line (CsvPriceImportInfo *info);
+
+void csv_fixed_price_import (CsvPriceImportInfo *info);
+
+#endif /* CSV_FIXED_PRICE_IMPORT_H */
+

--- a/src/import-export/csv-imp/gnc-plugin-csv-import-ui.xml
+++ b/src/import-export/csv-imp/gnc-plugin-csv-import-ui.xml
@@ -6,6 +6,7 @@
       	   <menuitem name="FileCsvImportAccounts" action="CsvImportAccountAction"/>
       	   <menuitem name="FileCsvImportTrans" action="CsvImportTransAction"/>
       	   <menuitem name="FileCsvImportFixedTrans" action="CsvImportFixedTransAction"/>
+      	   <menuitem name="FileCsvImportPrice" action="CsvImportPriceAction"/>
       	</placeholder>
       </menu>
     </menu>

--- a/src/import-export/csv-imp/gnc-plugin-csv-import.c
+++ b/src/import-export/csv-imp/gnc-plugin-csv-import.c
@@ -31,6 +31,7 @@
 #include "assistant-csv-account-import.h"
 #include "assistant-csv-fixed-trans-import.h"
 #include "assistant-csv-trans-import.h"
+#include "assistant-csv-fixed-price-import.h"
 
 static void gnc_plugin_csv_import_class_init (GncPluginCsvImportClass *klass);
 static void gnc_plugin_csv_import_init (GncPluginCsvImport *plugin);
@@ -40,6 +41,7 @@ static void gnc_plugin_csv_import_finalize (GObject *object);
 static void gnc_plugin_csv_import_tree_cmd (GtkAction *action, GncMainWindowActionData *data);
 static void gnc_plugin_csv_import_trans_cmd (GtkAction *action, GncMainWindowActionData *data);
 static void gnc_plugin_csv_import_fixed_trans_cmd (GtkAction *action, GncMainWindowActionData *data);
+static void gnc_plugin_csv_import_price_cmd (GtkAction *action, GncMainWindowActionData *data);
 
 #define PLUGIN_ACTIONS_NAME "gnc-plugin-csv-import-actions"
 #define PLUGIN_UI_FILENAME  "gnc-plugin-csv-import-ui.xml"
@@ -60,6 +62,11 @@ static GtkActionEntry gnc_plugin_actions [] =
         "CsvImportFixedTransAction", GTK_STOCK_CONVERT, N_("Import Transactions in a _Fixed Format CSV file..."), NULL,
         N_("Import Transactions in a Fixed Format CSV file"),
         G_CALLBACK (gnc_plugin_csv_import_fixed_trans_cmd)
+    },
+    {
+        "CsvImportPriceAction", GTK_STOCK_CONVERT, N_("Import _Prices in a Fixed Format CSV file..."), NULL,
+        N_("Import Prices in a Fixed Format CSV file"),
+        G_CALLBACK (gnc_plugin_csv_import_price_cmd)
     },
 };
 static guint gnc_plugin_n_actions = G_N_ELEMENTS (gnc_plugin_actions);
@@ -170,6 +177,14 @@ gnc_plugin_csv_import_fixed_trans_cmd (GtkAction *action,
 {
     gnc_file_csv_fixed_trans_import ();
 }
+
+static void
+gnc_plugin_csv_import_price_cmd (GtkAction *action,
+                                 GncMainWindowActionData *data)
+{
+    gnc_file_csv_fixed_price_import ();
+}
+
 
 /************************************************************
  *                    Plugin Bootstrapping                   *


### PR DESCRIPTION
This pull request adds the ability to import prices from a fixed format csv file. It all seems to work OK so was looking for any suggestions / changes. I will refactor some functions to a util file as they are repeated in other fixed format import files. There is a known problem with the date format selector affecting all import options that I will raise on the list.

Also I have changed the options for deleting old prices to make it more flexible and this is where travis is failing. Any suggestions / changes are always welcome and I will change the unit tests if these changes are OK.