### PR TITLE
FreeBSD does not have the daylight global. so I just check tm_is_dst

### DIFF
--- a/src/import-export/ofx/gnc-ofx-import.c
+++ b/src/import-export/ofx/gnc-ofx-import.c
@@ -336,10 +336,23 @@ fix_ofx_bug_39 (time64 t)
 {
 #if HAVE_OFX_BUG_39
     struct tm stm;
-    gnc_localtime_r(&t, &stm);
+
 #ifdef __FreeBSD__
+    time64 now;
+    /*
+     * FreeBSD has it's own libc implementation which differs from glibc. In particular:
+     * There is no daylight global
+     * tzname members are set to the string "   " (three spaces) when not explicitly populated
+     *
+     * To check that the current timezone does not observe DST I check if tzname[1] starts with a space.
+     */
+    now = gnc_time (NULL);
+    gnc_localtime_r(&now, &stm);
+    tzset();
+
     if (tzname[1][0] != ' ' && !stm.tm_isdst)
 #else
+    gnc_localtime_r(&t, &stm);
     if (daylight && !stm.tm_isdst)
 #endif
       t += 3600;

--- a/src/import-export/ofx/gnc-ofx-import.c
+++ b/src/import-export/ofx/gnc-ofx-import.c
@@ -337,7 +337,11 @@ fix_ofx_bug_39 (time64 t)
 #if HAVE_OFX_BUG_39
     struct tm stm;
     gnc_localtime_r(&t, &stm);
+#ifdef __FreeBSD__
+    if (tzname[1][0] != ' ' && !stm.tm_isdst)
+#else
     if (daylight && !stm.tm_isdst)
+#endif
       t += 3600;
 #endif
     return t;


### PR DESCRIPTION
NOTE: I'm the maintainer of the FreeBSD port here:

http://www.freshports.org/finance/gnucash

And I'm going to update the port including this modification. I'd like to upstream it or have suggestions for a better fix.

Thanks in advance.