### PR TITLE
Budget balance sheet, Liabilities section, negated sign

### DIFF
--- a/src/report/standard-reports/budget-balance-sheet.scm
+++ b/src/report/standard-reports/budget-balance-sheet.scm
@@ -522,7 +522,7 @@
             (get-assoc-account-balances-budget
               budget
               liability-accounts
-              get-budget-account-budget-balance))
+              get-budget-account-budget-balance-negated))
 
           (set! liability-get-balance-fn
             (lambda (account start-date end-date)
@@ -566,7 +566,7 @@
 
           ;; Budgeted liabilities are liability repayments (negative liabilities).
           (set! liability-repayments
-            (get-assoc-account-balances-total-negated liability-account-budget-balances))
+            (gnc:get-assoc-account-balances-total liability-account-budget-balances))
 
           ;; New liabilities are then negated liability repayments.
           (set! new-liabilities

--- a/src/report/standard-reports/budget-balance-sheet.scm
+++ b/src/report/standard-reports/budget-balance-sheet.scm
@@ -566,7 +566,7 @@
 
           ;; Budgeted liabilities are liability repayments (negative liabilities).
           (set! liability-repayments
-            (gnc:get-assoc-account-balances-total liability-account-budget-balances))
+            (get-assoc-account-balances-total-negated liability-account-budget-balances))
 
           ;; New liabilities are then negated liability repayments.
           (set! new-liabilities


### PR DESCRIPTION
The Budget Balance Sheet report currently shows the budgeted liabilities with the wrong sign, for example it shows that liabilities _increase_ when you budget a liability repayment.
My understanding is that liabilities are budgeted with a negated sign. Positive amount means new liabilities, negative amount means liability repayment. 
This PR fixes the report for me.