### PR TITLE
Export gnc_get_current_session to guile bindings

### DIFF
--- a/src/app-utils/app-utils.i
+++ b/src/app-utils/app-utils.i
@@ -66,6 +66,7 @@ typedef int GNCOptionDBHandle;
 void gnc_prefs_init();
 
 QofBook * gnc_get_current_book (void);
+QofSession * gnc_get_current_session (void);
 const gchar * gnc_get_current_book_tax_name (void);
 const gchar * gnc_get_current_book_tax_type (void);
 Account * gnc_get_current_root_account (void);


### PR DESCRIPTION
this allows to retrieve the name of a book in a report by using (qof-session-get-url (gnc-get-current-session))