### PR TITLE
add gnc_get_current_session to swig interface

### DIFF
--- a/src/app-utils/app-utils.i
+++ b/src/app-utils/app-utils.i
@@ -66,6 +66,7 @@ typedef int GNCOptionDBHandle;
 void gnc_prefs_init();
 
 QofBook * gnc_get_current_book (void);
+QofSession * gnc_get_current_session (void);
 const gchar * gnc_get_current_book_tax_name (void);
 const gchar * gnc_get_current_book_tax_type (void);
 Account * gnc_get_current_root_account (void);


### PR DESCRIPTION
to allow to retrieve the path of a book from a report in guile via (qof-session-get-url (gnc-get-current-session))