### PR TITLE
Charge back net value of bill entries in invoices

### DIFF
--- a/src/engine/gncInvoice.c
+++ b/src/engine/gncInvoice.c
@@ -1460,7 +1460,11 @@ Transaction * gncInvoicePostToAccount (GncInvoice *invoice, Account *acc,
 
             /* If this is a bill, and the entry came from an invoice originally, copy the price */
             if (gncEntryGetBillable (entry))
-                gncEntrySetInvPrice (entry, gncEntryGetBillPrice (entry));
+            {
+                /* We need to set the net price since it may be another tax rate for invoices than bills */
+                gncEntrySetInvPrice (entry, gncEntryGetPrice (entry, FALSE, TRUE));
+                gncEntrySetInvTaxIncluded (entry, FALSE);
+            }
         }
         gncEntryCommitEdit (entry);
 


### PR DESCRIPTION
When charging entries from bills we need to exclude taxes since the tax
rate of the invoice might be different than that of the bill.

This fixes Bug 776380 - Gross value of bills charged back instead of
net value (https://bugzilla.gnome.org/show_bug.cgi?id=776380)