### PR TITLE
Fix taxinvoice for bill entries with taxes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,4 @@ install:
   - sudo apt-get --reinstall install -qq language-pack-en language-pack-fr
   - git clone https://github.com/google/googletest -b release-1.8.0 ~/gtest
 script: ./autogen.sh && ./configure GTEST_ROOT=~/gtest/googletest GMOCK_ROOT=~/gtest/googlemock && make && TZ="America/Los_Angeles" make check
+after_failure: "cat src/engine/test/test-import-map.log"

--- a/src/report/business-reports/taxinvoice.eguile.scm
+++ b/src/report/business-reports/taxinvoice.eguile.scm
@@ -82,18 +82,30 @@
                          (< (car (gnc-transaction-get-date-posted t1))
                             (car (gnc-transaction-get-date-posted t2))))))))
 
+
+      ;; Is this an invoice or something else
+      (if (not (null? opt-invoice))
+          (begin
+            (set! owner (gncInvoiceGetOwner  opt-invoice))
+            (let ((type (gncInvoiceGetType  opt-invoice)))
+              (cond
+               ((eqv? type GNC-INVOICE-CUST-INVOICE)
+                (set! cust-doc? #t))
+               
+               ))))
+      
       ; pre-scan invoice entries to look for discounts and taxes
       (for entry in entries do
           (let ((action    (gncEntryGetAction entry))
                 (qty       (gncEntryGetDocQuantity entry credit-note?))
                 (discount  (gncEntryGetInvDiscount entry))
-                (taxable?   (gncEntryGetInvTaxable entry))
-                (taxtable  (gncEntryGetInvTaxTable entry)))
+                (taxable?  (if cust-doc? (gncEntryGetInvTaxable entry) (gncEntryGetBillTaxable entry)))
+                (taxtable  (if cust-doc? (gncEntryGetInvTaxTable entry) (gncEntryGetBillTaxTable entry))))
             (if (not (string=? action ""))
               (set! units? #t))
             (if (not (= (gnc-numeric-to-double qty) 1.0))
               (set! qty? #t))
-            (if (not (gnc-numeric-zero-p discount)) (set! discount? #t))
+            (if (not (or cust-doc? (gnc-numeric-zero-p discount))) (set! discount? #t))
             ;(if taxable - no, this flag is redundant
             (if taxable? ; Also check if the taxable flag is set
               (if  (not (eq? taxtable '()))
@@ -106,16 +118,6 @@
             (if (not (equal? t txn))
               (set! payments? #t))))
 
-  ;; Is this an invoice or something else
-  (if (not (null? opt-invoice))
-    (begin
-      (set! owner (gncInvoiceGetOwner  opt-invoice))
-      (let ((type (gncInvoiceGetType  opt-invoice)))
-        (cond
-          ((eqv? type GNC-INVOICE-CUST-INVOICE)
-           (set! cust-doc? #t))
-
-  ))))
 
 ?>
 
@@ -332,11 +334,11 @@
                   (rval      (gncEntryGetDocValue entry #t cust-doc? credit-note?))
                   (rdiscval  (gncEntryGetDocDiscountValue entry #t cust-doc? credit-note?))
                   (rtaxval   (gncEntryGetDocTaxValue entry #t cust-doc? credit-note?))
-                  (disc  (if cust-doc? (gncEntryGetInvDiscount entry)))
+                  (disc      (if cust-doc? (gncEntryGetInvDiscount entry)))
                   (disctype  (gncEntryGetInvDiscountType entry))
                   (acc       (if cust-doc? (gncEntryGetInvAccount entry)(gncEntryGetBillAccount entry)))
                   (taxable   (if cust-doc? (gncEntryGetInvTaxable entry)(gncEntryGetBillTaxable entry)))
-                  (taxtable  (if cust-doc? (gncEntryGetInvTaxTable entry)(gncEntryGetBillTaxable entry))))
+                  (taxtable  (if cust-doc? (gncEntryGetInvTaxTable entry)(gncEntryGetBillTaxTable entry))))
               (inv-total 'add currency rval)
               (inv-total 'add currency rtaxval)
               (tax-total 'add currency rtaxval)

--- a/src/report/business-reports/taxinvoice.eguile.scm
+++ b/src/report/business-reports/taxinvoice.eguile.scm
@@ -105,7 +105,8 @@
               (set! units? #t))
             (if (not (= (gnc-numeric-to-double qty) 1.0))
               (set! qty? #t))
-            (if (not (or cust-doc? (gnc-numeric-zero-p discount))) (set! discount? #t))
+            (if cust-doc? ; Only invoices have discounts
+                (if (not (gnc-numeric-zero-p discount)) (set! discount? #t)))
             ;(if taxable - no, this flag is redundant
             (if taxable? ; Also check if the taxable flag is set
               (if  (not (eq? taxtable '()))


### PR DESCRIPTION
For bills taxinvoice was throwing an exception when there were taxes on bill entries.
It also did scan the invoice members instead of the bill members to determine if there were taxes and discounts.

This should merge without problem with my previous change on taxinvoice.eguile.scm. I tested that too.