### PR TITLE
Consistently capitalise budget in en-GB menu items

### DIFF
--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -5412,7 +5412,7 @@ msgstr "Create a new budget"
 
 #: ../src/gnome/gnc-plugin-budget.c:65
 msgid "Open Budget"
-msgstr "Open budget"
+msgstr "Open Budget"
 
 #: ../src/gnome/gnc-plugin-budget.c:66
 msgid "Open an existing Budget"


### PR DESCRIPTION
For the last few months, I've had a minor frustration over the fact the menu items in my en-GB variant of Gnucash's "Actions" > "Budget" are:

- New Budget
- Open budget
- Copy Budget

So this pull request makes all instances of 'Budget' capitalised.