### PR TITLE
Use transaction texts if they are available

### DIFF
--- a/src/import-export/aqb/dialog-ab.glade
+++ b/src/import-export/aqb/dialog-ab.glade
@@ -853,6 +853,25 @@
           </packing>
         </child>
         <child>
+          <object class="GtkCheckButton" id="pref/dialogs.import.hbci/use-ns-transaction-text">
+            <property name="label" translatable="yes">Use Non-SWIFT _transaction text</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="use_action_appearance">False</property>
+            <property name="use_underline">True</property>
+            <property name="draw_indicator">True</property>
+          </object>
+          <packing>
+            <property name="right_attach">4</property>
+            <property name="top_attach">3</property>
+            <property name="bottom_attach">4</property>
+            <property name="x_options">GTK_FILL</property>
+            <property name="y_options"></property>
+            <property name="x_padding">12</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkCheckButton" id="checkbutton3">
             <property name="label" translatable="yes">_Verbose debug messages</property>
             <property name="visible">True</property>
@@ -864,8 +883,8 @@
           </object>
           <packing>
             <property name="right_attach">4</property>
-            <property name="top_attach">3</property>
-            <property name="bottom_attach">4</property>
+            <property name="top_attach">4</property>
+            <property name="bottom_attach">5</property>
             <property name="x_options">GTK_FILL</property>
             <property name="y_options"></property>
             <property name="x_padding">12</property>

--- a/src/import-export/aqb/gnc-ab-utils.c
+++ b/src/import-export/aqb/gnc-ab-utils.c
@@ -319,7 +319,7 @@ join_ab_strings_cb(const gchar *str, gpointer user_data)
 
     if (!str || !*str)
         return NULL;
-
+ 
     tmp = g_strdup(str);
     g_strstrip(tmp);
     gnc_utf8_strip_invalid(tmp);
@@ -369,7 +369,8 @@ gnc_ab_get_purpose(const AB_TRANSACTION *ab_trans)
 
     g_return_val_if_fail(ab_trans, g_strdup(""));
 
-    if (gnc_prefs_get_bool(GNC_PREFS_GROUP_AQBANKING, GNC_PREF_USE_TRANSACTION_TXT)) {
+    if (gnc_prefs_get_bool(GNC_PREFS_GROUP_AQBANKING, GNC_PREF_USE_TRANSACTION_TXT)) 
+    {
         /* According to AqBanking, some of the non-swift lines have a special
          * meaning. Some banks place valuable text into the transaction text,
          * hence we put this text in front of the purpose. */

--- a/src/import-export/aqb/gnc-ab-utils.c
+++ b/src/import-export/aqb/gnc-ab-utils.c
@@ -364,9 +364,17 @@ gchar *
 gnc_ab_get_purpose(const AB_TRANSACTION *ab_trans)
 {
     const GWEN_STRINGLIST *ab_purpose;
+    const char *ab_transactionText = NULL;
     gchar *gnc_description = NULL;
 
     g_return_val_if_fail(ab_trans, g_strdup(""));
+
+    /* According to AqBanking, some of the non-swift lines have a special
+     * meaning. Some banks place valuable text into the transaction text,
+     * hence we put this text in front of the purpose. */
+    ab_transactionText = AB_Transaction_GetTransactionText(ab_trans);
+    if (ab_transactionText)
+        gnc_description = g_strdup(ab_transactionText);
 
     ab_purpose = AB_Transaction_GetPurpose(ab_trans);
     if (ab_purpose)

--- a/src/import-export/aqb/gnc-ab-utils.c
+++ b/src/import-export/aqb/gnc-ab-utils.c
@@ -369,12 +369,14 @@ gnc_ab_get_purpose(const AB_TRANSACTION *ab_trans)
 
     g_return_val_if_fail(ab_trans, g_strdup(""));
 
-    /* According to AqBanking, some of the non-swift lines have a special
-     * meaning. Some banks place valuable text into the transaction text,
-     * hence we put this text in front of the purpose. */
-    ab_transactionText = AB_Transaction_GetTransactionText(ab_trans);
-    if (ab_transactionText)
-        gnc_description = g_strdup(ab_transactionText);
+    if (gnc_prefs_get_bool(GNC_PREFS_GROUP_AQBANKING, GNC_PREF_USE_TRANSACTION_TXT)) {
+        /* According to AqBanking, some of the non-swift lines have a special
+         * meaning. Some banks place valuable text into the transaction text,
+         * hence we put this text in front of the purpose. */
+        ab_transactionText = AB_Transaction_GetTransactionText(ab_trans);
+        if (ab_transactionText)
+            gnc_description = g_strdup(ab_transactionText);
+    }
 
     ab_purpose = AB_Transaction_GetPurpose(ab_trans);
     if (ab_purpose)

--- a/src/import-export/aqb/gnc-ab-utils.h
+++ b/src/import-export/aqb/gnc-ab-utils.h
@@ -70,11 +70,12 @@ G_BEGIN_DECLS
 # define AQBANKING_VERSION_4_EXACTLY
 #endif
 
-#define GNC_PREFS_GROUP_AQBANKING "dialogs.import.hbci"
-#define GNC_PREF_FORMAT_SWIFT940  "format-swift-mt940"
-#define GNC_PREF_FORMAT_SWIFT942  "format-swift-mt942"
-#define GNC_PREF_FORMAT_DTAUS     "format-dtaus"
-#define GNC_PREF_VERBOSE_DEBUG    "verbose-debug"
+#define GNC_PREFS_GROUP_AQBANKING       "dialogs.import.hbci"
+#define GNC_PREF_FORMAT_SWIFT940        "format-swift-mt940"
+#define GNC_PREF_FORMAT_SWIFT942        "format-swift-mt942"
+#define GNC_PREF_FORMAT_DTAUS           "format-dtaus"
+#define GNC_PREF_USE_TRANSACTION_TXT    "use-ns-transaction-text"
+#define GNC_PREF_VERBOSE_DEBUG          "verbose-debug"
 
 typedef struct _GncABImExContextImport GncABImExContextImport;
 

--- a/src/import-export/aqb/gschemas/org.gnucash.dialogs.import.hbci.gschema.xml.in.in
+++ b/src/import-export/aqb/gschemas/org.gnucash.dialogs.import.hbci.gschema.xml.in.in
@@ -20,6 +20,11 @@
       <summary>Remember the PIN in memory</summary>
       <description>If active, the PIN for HBCI/AqBanking actions will be remembered in memory during a session. Otherwise it will have to be entered again each time during a session when it is needed.</description>
     </key>
+    <key name="use-ns-transaction-text" type="b">
+      <default>true</default>
+      <summary>Put the transaction text in front of the purpose of a transaction.</summary>
+      <description>Some banks place part of transaction description as "transaction text" in the MT940 file. Normally GNUcash ignores this text. However by activating this option, the transaction text is used for the transaction description too.</description>
+    </key>
     <key name="verbose-debug" type="b">
       <default>false</default>
       <summary>Verbose HBCI debug messages</summary>


### PR DESCRIPTION
While importing a transaction list in mt940 format, I found that not all information supplied by the bank has been used to create a proper transaction description. Finally I found that the purpose supplied by aqbanking does not contain the whole non-swift-section (:NS:) as lines with a number >14 are treated specailly. The one of interest for me (line 17) is treated as transaction text.

This pull request add some additional logic to the aqbanking adapter of GNUcash that uses transaction text if available as a description and adds the purpose as a note. In case there is no transaction text, the purpose is used for the description.

As the transaction text contains vital information, I also changed the gnc_ab_description_to_gnc such that it concatenates transaction text and purpose, separated by ";" to give a complete overview.

I'd be happy if this change would find it's way into one of the next maintenance releases. However being new to this project I'm pretty sure I did not comply with all the rules and concepts. So feel free to review and comment on these changes. 

Attached you'll find some examples of the different SWIFT transactions created by my bank (of course with fake data :-) ). Just rename [Examples.mt940.txt](https://github.com/Gnucash/gnucash/files/860663/Examples.mt940.txt) to Examples.mt940 and import it into GNUcash.
