### PR TITLE
Fix crash while saving scheduled transaction template

### DIFF
--- a/src/register/ledger-core/split-register-model-save.c
+++ b/src/register/ledger-core/split-register-model-save.c
@@ -715,7 +715,7 @@ save_cell (SplitRegister *reg, Split* split, const char *cell_name)
         new_amount = gnc_numeric_zero ();
     g_hash_table_unref (parser_vars);
     qof_instance_set (QOF_INSTANCE (split),
-		  numeric, new_amount,
+		  numeric, &new_amount,
 		  formula, value,
 		  NULL);
 }


### PR DESCRIPTION
Currently Gnucash crashed when you try to save scheduled transactions. This fixes the issue.