### PR TITLE
Prices remove old prices

### DIFF
--- a/src/engine/gnc-pricedb.c
+++ b/src/engine/gnc-pricedb.c
@@ -1372,7 +1372,7 @@ static void
 gnc_pricedb_get_remove_dates (GHashTable* hash_dates, GDate period_begin, GDate period_end, PriceRemoveOptions leave)
 {
     Recurrence *r;
-    GDate recurrance_date_old, recurrance_date_next;
+    GDate recurrence_date_old, recurrence_date_next;
 
     GDateWeekday selected_day_of_week = G_DATE_FRIDAY;
     GDate day_of_week_date;
@@ -1395,20 +1395,20 @@ gnc_pricedb_get_remove_dates (GHashTable* hash_dates, GDate period_begin, GDate 
     else
         recurrenceSet (r, 1, PERIOD_WEEK, &day_of_week_date, WEEKEND_ADJ_NONE); // Week set to begin on Friday of week
 
-    recurrance_date_next = recurrance_date_old = day_of_week_date;
+    recurrence_date_next = recurrence_date_old = day_of_week_date;
 
-    while (g_date_compare (&period_end, &recurrance_date_next) > 0)
+    while (g_date_compare (&period_end, &recurrence_date_next) > 0)
     {
         gchar *date_str;
         
-        recurrenceNextInstance (r, &recurrance_date_old, &recurrance_date_next);
-        date_str = g_strdup_printf ("%d/%d/%d", g_date_get_day (&recurrance_date_old),
-                   g_date_get_month (&recurrance_date_old), g_date_get_year (&recurrance_date_old));
+        recurrenceNextInstance (r, &recurrence_date_old, &recurrence_date_next);
+        date_str = g_strdup_printf ("%d/%d/%d", g_date_get_day (&recurrence_date_old),
+                   g_date_get_month (&recurrence_date_old), g_date_get_year (&recurrence_date_old));
 
-        DEBUG("Recurrance date old string for hash table insert is %s", date_str);
+        DEBUG("Recurrence date old string for hash table insert is %s", date_str);
 
         g_hash_table_insert (hash_dates, date_str, "Keep"); // date_str freed by hashtable
-        recurrance_date_old = recurrance_date_next;
+        recurrence_date_old = recurrence_date_next;
     }
     g_free (r);
 }

--- a/src/engine/gnc-pricedb.c
+++ b/src/engine/gnc-pricedb.c
@@ -29,6 +29,7 @@
 #include "gnc-pricedb-p.h"
 #include <qofinstance-p.h>
 #include "Recurrence.h"
+#include "gnc-gdate-utils.h"
 
 /* This static indicates the debugging module that this .o belongs to.  */
 static QofLogModule log_module = GNC_MOD_PRICE;
@@ -1461,8 +1462,260 @@ gnc_pricedb_remove_old_prices_keep_friday (GNCPriceDB *db, Timespec first, Times
 }
 
 
+static gint
+compare_prices_by_commodity_date (gconstpointer a, gconstpointer b)
+{
+    Timespec time_a;
+    Timespec time_b;
+    gnc_commodity *comma;
+    gnc_commodity *commb;
+    gnc_commodity *curra;
+    gnc_commodity *currb;
+    gint result;
+
+    if (!a && !b) return 0;
+    /* nothing is always less than something */
+    if (!a) return -1;
+
+    comma = gnc_price_get_commodity ((GNCPrice *) a);
+    commb = gnc_price_get_commodity ((GNCPrice *) b);
+
+    if (!gnc_commodity_equal(comma, commb))
+        return gnc_commodity_compare(comma, commb);
+
+    curra = gnc_price_get_currency ((GNCPrice *) a);
+    currb = gnc_price_get_currency ((GNCPrice *) b);
+
+    if (!gnc_commodity_equal(curra, currb))
+        return gnc_commodity_compare(curra, currb);
+
+    time_a = gnc_price_get_time((GNCPrice *) a);
+    time_b = gnc_price_get_time((GNCPrice *) b);
+
+    result = -timespec_cmp(&time_a, &time_b);
+    if (result) return result;
+
+    /* For a stable sort */
+    return guid_compare (gnc_price_get_guid((GNCPrice *) a),
+                         gnc_price_get_guid((GNCPrice *) b));
+}
+
+static gboolean
+price_commodity_and_currency_equal (GNCPrice *a, GNCPrice *b)
+{
+    gboolean ret_comm = FALSE;
+    gboolean ret_curr = FALSE;
+
+    if (gnc_commodity_equal (gnc_price_get_commodity(a), gnc_price_get_commodity (b)))
+        ret_comm = TRUE;
+
+    if (gnc_commodity_equal (gnc_price_get_currency(a), gnc_price_get_currency (b)))
+        ret_curr = TRUE;
+
+    return (ret_comm && ret_curr);
+}
+
+static void
+gnc_pricedb_remove_old_prices_pinfo (GNCPrice *price, gboolean keep_message)
+{
+    GDate price_date = timespec_to_gdate (gnc_price_get_time (price));
+    char date_buf[MAX_DATE_LENGTH+1];
+
+    if (g_date_valid (&price_date))
+    {
+        qof_print_gdate (date_buf, MAX_DATE_LENGTH, &price_date);
+
+        if (keep_message)
+        {
+            PINFO("#### Keep price with date %s, commodity is %s, currency is %s", date_buf,
+                     gnc_commodity_get_printname(gnc_price_get_commodity(price)),
+                     gnc_commodity_get_printname(gnc_price_get_currency(price)));
+        }
+        else
+            PINFO("## Remove price with date %s", date_buf);
+    }
+    else
+        PINFO("Keep price date is invalid");
+}
+
+static GNCPrice*
+save_cloned_price (GNCPrice *price, GNCPrice *clone_price)
+{
+    QofBook *book = qof_instance_get_book (QOF_INSTANCE(clone_price));
+    GNCPrice *cloned_price;
+
+    if (price)
+        gnc_price_unref (price);
+
+    cloned_price = gnc_price_clone (clone_price, book);
+
+    gnc_pricedb_remove_old_prices_pinfo (clone_price, TRUE);
+
+    return cloned_price;
+}
+
+static gint
+roundUp (gint numToRound, gint multiple)
+{
+    gint remainder;
+
+    if (multiple == 0)
+        return numToRound;
+
+    remainder = numToRound % multiple;
+    if (remainder == 0)
+        return numToRound;
+
+    return numToRound + multiple - remainder;
+}
+
+static gint
+get_fiscal_quarter (GDate *date, GDateMonth fiscal_start)
+{
+    GDateMonth month = g_date_get_month (date);
+
+    gint q = ((roundUp (22 - fiscal_start + month, 3)/3) % 4) + 1;
+
+    PINFO("Return fiscal quarter is %d", q);
+    return q;
+}
+
+static void
+gnc_pricedb_remove_old_prices_keep_last (GNCPriceDB *db, GDate *fiscal_end_date,
+                                         remove_info data, PriceRemoveKeepOptions keep)
+{
+    GSList *item;
+    gboolean save_first_price = FALSE;
+    GNCPrice *saved_price = NULL;
+    GDateMonth fiscal_month_end = g_date_get_month (fiscal_end_date);
+    GDateMonth fiscal_month_start;
+    GDate *tmp_date = g_date_new_dmy (g_date_get_day (fiscal_end_date),
+                                      g_date_get_month (fiscal_end_date),
+                                      g_date_get_year (fiscal_end_date));
+
+    // get the fiscal start month
+    g_date_subtract_months (tmp_date, 12);
+    fiscal_month_start = g_date_get_month (tmp_date) + 1;
+    g_date_free (tmp_date);
+
+    // sort the list by commodity / currency / date
+    data.list = g_slist_sort (data.list, compare_prices_by_commodity_date);
+
+    /* Now run this external list deleting prices */
+    for (item = data.list; item; item = g_slist_next(item))
+    {
+        save_first_price = !price_commodity_and_currency_equal (item->data, saved_price); // Not Equal
+
+        if (save_first_price == TRUE)
+        {
+            saved_price = save_cloned_price (saved_price, item->data);
+            save_first_price = FALSE;
+            continue;
+        }
+
+        // Keep last price in fiscal year
+        if (keep == PRICE_REMOVE_KEEP_LAST_PERIOD && save_first_price == FALSE)
+        {
+            GDate saved_price_date = timespec_to_gdate (gnc_price_get_time (saved_price));
+            GDate *saved_fiscal_end = g_date_new_dmy (g_date_get_day (&saved_price_date),
+                                                      g_date_get_month (&saved_price_date),
+                                                      g_date_get_year (&saved_price_date));
+            GDateMonth saved_fiscal_year;
+
+            GDate next_price_date = timespec_to_gdate (gnc_price_get_time (item->data));
+            GDate *next_fiscal_end = g_date_new_dmy (g_date_get_day (&next_price_date),
+                                                     g_date_get_month (&next_price_date),
+                                                     g_date_get_year (&next_price_date));
+            GDateMonth next_fiscal_year;
+
+            gnc_gdate_set_fiscal_year_end (saved_fiscal_end, fiscal_end_date);
+            gnc_gdate_set_fiscal_year_end (next_fiscal_end, fiscal_end_date);
+
+            saved_fiscal_year = g_date_get_year (saved_fiscal_end);
+            next_fiscal_year = g_date_get_year (next_fiscal_end);
+
+            PINFO("Keep last price in fiscal year");
+
+            if (saved_fiscal_year == next_fiscal_year)
+            {
+                gnc_pricedb_remove_old_prices_pinfo (item->data, FALSE);
+                gnc_pricedb_remove_price (db, item->data);
+            }
+            else
+                saved_price = save_cloned_price (saved_price, item->data);
+
+            g_date_free (saved_fiscal_end);
+            g_date_free (next_fiscal_end);
+        }
+
+        // Keep last price in fiscal quarter
+        if (keep == PRICE_REMOVE_KEEP_LAST_QUARTERLY && save_first_price == FALSE)
+        {
+            GDate saved_price_date = timespec_to_gdate (gnc_price_get_time (saved_price));
+            gint  saved_price_q = get_fiscal_quarter (&saved_price_date, fiscal_month_start);
+
+            GDate next_price_date = timespec_to_gdate (gnc_price_get_time (item->data));
+            gint  next_price_q = get_fiscal_quarter (&next_price_date, fiscal_month_start);
+
+            PINFO("Keep last price in fiscal quarter");
+
+            if (saved_price_q == next_price_q)
+            {
+                gnc_pricedb_remove_old_prices_pinfo (item->data, FALSE);
+                gnc_pricedb_remove_price (db, item->data);
+            }
+            else
+                saved_price = save_cloned_price (saved_price, item->data);
+        }
+
+        // Keep last price of every month
+        if (keep == PRICE_REMOVE_KEEP_LAST_MONTHLY && save_first_price == FALSE)
+        {
+            GDate saved_price_date = timespec_to_gdate (gnc_price_get_time (saved_price));
+            GDateMonth saved_price_month = g_date_get_month (&saved_price_date);
+
+            GDate next_price_date = timespec_to_gdate (gnc_price_get_time (item->data));
+            GDateMonth next_price_month = g_date_get_month (&next_price_date);
+
+            PINFO("Keep last price of every month");
+
+            if (next_price_month == saved_price_month)
+            {
+                gnc_pricedb_remove_old_prices_pinfo (item->data, FALSE);
+                gnc_pricedb_remove_price (db, item->data);
+            }
+            else
+                saved_price = save_cloned_price (saved_price, item->data);
+        }
+
+        // Keep last price of every week
+        if (keep == PRICE_REMOVE_KEEP_LAST_WEEKLY && save_first_price == FALSE)
+        {
+            GDate saved_price_date = timespec_to_gdate (gnc_price_get_time (saved_price));
+            gint saved_week_of_year = g_date_get_iso8601_week_of_year (&saved_price_date);
+
+            GDate next_price_date = timespec_to_gdate (gnc_price_get_time (item->data));
+            gint next_price_week_of_year = g_date_get_iso8601_week_of_year (&next_price_date);
+
+            PINFO("Keep last price of every week");
+
+            if (next_price_week_of_year == saved_week_of_year)
+            {
+                gnc_pricedb_remove_old_prices_pinfo (item->data, FALSE);
+                gnc_pricedb_remove_price (db, item->data);
+            }
+            else
+                saved_price = save_cloned_price (saved_price, item->data);
+        }
+    }
+    if (saved_price)
+        gnc_price_unref (saved_price);
+}
+
+
 gboolean
 gnc_pricedb_remove_old_prices (GNCPriceDB *db, GList *comm_list,
+                              GDate *fiscal_end_date,
                               Timespec first, Timespec cutoff,
                               PriceRemoveSourceFlags source,
                               PriceRemoveKeepOptions keep)
@@ -1501,11 +1754,19 @@ gnc_pricedb_remove_old_prices (GNCPriceDB *db, GList *comm_list,
         LEAVE("Empty price list");
         return FALSE;
     }
-    DEBUG("Number of Prices in list is %d", g_slist_length (data.list));
+    DEBUG("Number of Prices in list is %d, Cutoff date is %s", g_slist_length (data.list), gnc_print_date (cutoff));
 
     // decide on what remove procedure to use
     if (keep > PRICE_REMOVE_KEEP_LAST)
-        PINFO("keep last function");
+    {
+        // Check for a valid fiscal end of year date
+        if (!g_date_valid (fiscal_end_date))
+        {
+            GDateYear year_now = g_date_get_year (gnc_g_date_new_today ());
+            g_date_set_dmy (fiscal_end_date, 31, 12, year_now);
+        }
+        gnc_pricedb_remove_old_prices_keep_last (db, fiscal_end_date, data, keep);
+    }
     else
         gnc_pricedb_remove_old_prices_keep_friday (db, first, cutoff, data, keep);
 

--- a/src/engine/gnc-pricedb.c
+++ b/src/engine/gnc-pricedb.c
@@ -1369,7 +1369,7 @@ free_data (gpointer data)
 }
 
 static void
-gnc_pricedb_get_remove_dates (GHashTable* hash_dates, GDate period_begin, GDate period_end, PriceRemoveOptions leave)
+gnc_pricedb_remove_get_keep_dates (GHashTable* hash_dates, GDate period_begin, GDate period_end, PriceRemoveOptions leave)
 {
     Recurrence *r;
     GDate recurrence_date_old, recurrence_date_next;
@@ -1465,11 +1465,11 @@ gnc_pricedb_remove_old_prices (GNCPriceDB *db, GList *comm_list,
             GDate temp_begin_date = period_end;
             g_date_subtract_months (&temp_end_date, 6);
             g_date_subtract_months (&temp_begin_date, 12);
-            gnc_pricedb_get_remove_dates (hash_dates, temp_begin_date, temp_end_date, PRICE_REMOVE_WEEKLY);
-            gnc_pricedb_get_remove_dates (hash_dates, period_begin, temp_begin_date, PRICE_REMOVE_MONTHLY);
+            gnc_pricedb_remove_get_keep_dates (hash_dates, temp_begin_date, temp_end_date, PRICE_REMOVE_WEEKLY);
+            gnc_pricedb_remove_get_keep_dates (hash_dates, period_begin, temp_begin_date, PRICE_REMOVE_MONTHLY);
         }
         else
-            gnc_pricedb_get_remove_dates (hash_dates, period_begin, period_end, leave);
+            gnc_pricedb_remove_get_keep_dates (hash_dates, period_begin, period_end, leave);
 
         DEBUG("There are %d keys in hash_dates", g_hash_table_size (hash_dates));
     }

--- a/src/engine/gnc-pricedb.h
+++ b/src/engine/gnc-pricedb.h
@@ -397,6 +397,7 @@ typedef enum
 /** @brief Remove and unref prices older than a certain time.
  * @param db The pricedb
  * @param comm_list A list of commodities
+ * @param fiscal_end_date the end date of the current accounting period
  * @param first The oldest price time in the pricedb 
  * @param cutoff The time before which prices should be deleted.
  * @param source Whether Finance::Quote, user or all prices should be deleted.
@@ -404,6 +405,7 @@ typedef enum
  * @return True if there were prices to process, False if not.
  */
 gboolean     gnc_pricedb_remove_old_prices(GNCPriceDB *db, GList *comm_list,
+                                           GDate *fiscal_end_date,
                                            Timespec first, Timespec cutoff,
                                            PriceRemoveSourceFlags source,
                                            PriceRemoveKeepOptions keep);

--- a/src/engine/gnc-pricedb.h
+++ b/src/engine/gnc-pricedb.h
@@ -372,17 +372,29 @@ gboolean     gnc_pricedb_add_price(GNCPriceDB *db, GNCPrice *p);
  */
 gboolean     gnc_pricedb_remove_price(GNCPriceDB *db, GNCPrice *p);
 
+typedef enum
+{
+    PRICE_REMOVE_DEFAULT, // default option value
+    PRICE_REMOVE_USER,    // only user prices
+    PRICE_REMOVE_ALL,     // all prices
+    PRICE_REMOVE_WEEKLY,  // leave one every week on a friday
+    PRICE_REMOVE_MONTHLY, // leave one every last friday of month
+    PRICE_REMOVE_SCALED,  // leave one every week then one a month
+} PriceRemoveOptions;
+
 /** @brief Remove and unref prices older than a certain time.
  * @param db The pricedb
+ * @param comm_list A list of commodities
+ * @param first The oldest price time in the pricedb 
  * @param cutoff The time before which prices should be deleted.
- * @param delete_user Whether user-created (i.e. not Finance::Quote) prices
- * should be deleted.
- * @param delete_last Whether a price should be deleted if it's the only
- * remaining price for its commodity.
+ * @param source Whether Finance::Quote, user or all prices should be deleted.
+ * @param leave Whether scaled, monthly, weekly or no prices should be left.
+ * @return True if there were prices to process, False if not.
  */
-gboolean     gnc_pricedb_remove_old_prices(GNCPriceDB *db, Timespec cutoff,
-                                           const gboolean delete_user,
-                                           gboolean delete_last);
+gboolean     gnc_pricedb_remove_old_prices(GNCPriceDB *db, GList *comm_list,
+                                           Timespec first, Timespec cutoff,
+                                           PriceRemoveOptions source,
+                                           PriceRemoveOptions leave);
 
 /** @brief Find the most recent price between the two commodities.
  *

--- a/src/engine/gnc-pricedb.h
+++ b/src/engine/gnc-pricedb.h
@@ -374,13 +374,18 @@ gboolean     gnc_pricedb_remove_price(GNCPriceDB *db, GNCPrice *p);
 
 typedef enum
 {
-    PRICE_REMOVE_DEFAULT, // default option value
-    PRICE_REMOVE_USER,    // only user prices
-    PRICE_REMOVE_ALL,     // all prices
-    PRICE_REMOVE_WEEKLY,  // leave one every week on a friday
-    PRICE_REMOVE_MONTHLY, // leave one every last friday of month
-    PRICE_REMOVE_SCALED,  // leave one every week then one a month
-} PriceRemoveOptions;
+    PRICE_REMOVE_SOURCE_DEFAULT, // default option value
+    PRICE_REMOVE_SOURCE_USER,    // only user prices
+    PRICE_REMOVE_SOURCE_ALL,     // all prices
+} PriceRemoveSourceOptions;
+
+typedef enum
+{
+    PRICE_REMOVE_KEEP_DEFAULT, // default option value
+    PRICE_REMOVE_KEEP_WEEKLY,  // leave one every week on a friday
+    PRICE_REMOVE_KEEP_MONTHLY, // leave one every last friday of month
+    PRICE_REMOVE_KEEP_SCALED,  // leave one every week then one a month
+} PriceRemoveKeepOptions;
 
 /** @brief Remove and unref prices older than a certain time.
  * @param db The pricedb
@@ -388,13 +393,13 @@ typedef enum
  * @param first The oldest price time in the pricedb 
  * @param cutoff The time before which prices should be deleted.
  * @param source Whether Finance::Quote, user or all prices should be deleted.
- * @param leave Whether scaled, monthly, weekly or no prices should be left.
+ * @param keep Whether scaled, monthly, weekly or no prices should be left.
  * @return True if there were prices to process, False if not.
  */
 gboolean     gnc_pricedb_remove_old_prices(GNCPriceDB *db, GList *comm_list,
                                            Timespec first, Timespec cutoff,
-                                           PriceRemoveOptions source,
-                                           PriceRemoveOptions leave);
+                                           PriceRemoveSourceOptions source,
+                                           PriceRemoveKeepOptions keep);
 
 /** @brief Find the most recent price between the two commodities.
  *

--- a/src/engine/gnc-pricedb.h
+++ b/src/engine/gnc-pricedb.h
@@ -382,31 +382,25 @@ typedef enum
 
 typedef enum
 {
-    PRICE_REMOVE_KEEP_DEFAULT, // default option value, keep none
-    PRICE_REMOVE_KEEP_WEEKLY,  // leave one every week on a friday
-    PRICE_REMOVE_KEEP_MONTHLY, // leave one every last friday of month
-    PRICE_REMOVE_KEEP_SCALED,  // leave one every week then one a month
-    PRICE_REMOVE_KEEP_LAST = PRICE_REMOVE_KEEP_SCALED,
-
+    PRICE_REMOVE_KEEP_NONE,           // keep none
     PRICE_REMOVE_KEEP_LAST_WEEKLY,    // leave last one of every week
     PRICE_REMOVE_KEEP_LAST_MONTHLY,   // leave last one of every month
     PRICE_REMOVE_KEEP_LAST_QUARTERLY, // leave last one of every quarter
     PRICE_REMOVE_KEEP_LAST_PERIOD,    // leave last one of every annual period
+    PRICE_REMOVE_KEEP_SCALED,         // leave one every week then one a month
 } PriceRemoveKeepOptions;
 
 /** @brief Remove and unref prices older than a certain time.
  * @param db The pricedb
  * @param comm_list A list of commodities
  * @param fiscal_end_date the end date of the current accounting period
- * @param first The oldest price time in the pricedb 
  * @param cutoff The time before which prices should be deleted.
  * @param source Whether Finance::Quote, user or all prices should be deleted.
  * @param keep Whether scaled, monthly, weekly or no prices should be left.
  * @return True if there were prices to process, False if not.
  */
 gboolean     gnc_pricedb_remove_old_prices(GNCPriceDB *db, GList *comm_list,
-                                           GDate *fiscal_end_date,
-                                           Timespec first, Timespec cutoff,
+                                           GDate *fiscal_end_date, Timespec cutoff,
                                            PriceRemoveSourceFlags source,
                                            PriceRemoveKeepOptions keep);
 

--- a/src/engine/gnc-pricedb.h
+++ b/src/engine/gnc-pricedb.h
@@ -374,17 +374,24 @@ gboolean     gnc_pricedb_remove_price(GNCPriceDB *db, GNCPrice *p);
 
 typedef enum
 {
-    PRICE_REMOVE_SOURCE_DEFAULT, // default option value
-    PRICE_REMOVE_SOURCE_USER,    // only user prices
-    PRICE_REMOVE_SOURCE_ALL,     // all prices
-} PriceRemoveSourceOptions;
+    PRICE_REMOVE_SOURCE_FQ = 1,   // this flag is set when added by F:Q checked
+    PRICE_REMOVE_SOURCE_USER = 2, // this flag is set when added by the user checked
+    PRICE_REMOVE_SOURCE_APP = 4,  // this flag is set when added by the app checked
+    PRICE_REMOVE_SOURCE_COMM = 8, // this flag is set when we have commodities selected
+} PriceRemoveSourceFlags;
 
 typedef enum
 {
-    PRICE_REMOVE_KEEP_DEFAULT, // default option value
+    PRICE_REMOVE_KEEP_DEFAULT, // default option value, keep none
     PRICE_REMOVE_KEEP_WEEKLY,  // leave one every week on a friday
     PRICE_REMOVE_KEEP_MONTHLY, // leave one every last friday of month
     PRICE_REMOVE_KEEP_SCALED,  // leave one every week then one a month
+    PRICE_REMOVE_KEEP_LAST = PRICE_REMOVE_KEEP_SCALED,
+
+    PRICE_REMOVE_KEEP_LAST_WEEKLY,    // leave last one of every week
+    PRICE_REMOVE_KEEP_LAST_MONTHLY,   // leave last one of every month
+    PRICE_REMOVE_KEEP_LAST_QUARTERLY, // leave last one of every quarter
+    PRICE_REMOVE_KEEP_LAST_PERIOD,    // leave last one of every annual period
 } PriceRemoveKeepOptions;
 
 /** @brief Remove and unref prices older than a certain time.
@@ -398,7 +405,7 @@ typedef enum
  */
 gboolean     gnc_pricedb_remove_old_prices(GNCPriceDB *db, GList *comm_list,
                                            Timespec first, Timespec cutoff,
-                                           PriceRemoveSourceOptions source,
+                                           PriceRemoveSourceFlags source,
                                            PriceRemoveKeepOptions keep);
 
 /** @brief Find the most recent price between the two commodities.

--- a/src/engine/test/utest-gnc-pricedb.c
+++ b/src/engine/test/utest-gnc-pricedb.c
@@ -759,8 +759,8 @@ static void test_gnc_pricedb_remove_old_prices (PriceDBFixture *fixture, gconstp
 
     g_assert (gnc_pricedb_remove_old_prices(fixture->pricedb, comm_list,
                                            t_old, t_cut,
-                                           PRICE_REMOVE_DEFAULT, // source is FQ
-                                           PRICE_REMOVE_DEFAULT)); // leave none
+                                           PRICE_REMOVE_SOURCE_DEFAULT, // source is FQ
+                                           PRICE_REMOVE_KEEP_DEFAULT)); // keep none
 
     g_assert_cmpint (gnc_pricedb_num_prices(fixture->pricedb, c->gbp), ==, 12);
     g_assert_cmpint (gnc_pricedb_num_prices(fixture->pricedb, c->usd), ==, 9);
@@ -769,23 +769,23 @@ static void test_gnc_pricedb_remove_old_prices (PriceDBFixture *fixture, gconstp
 
     g_assert (gnc_pricedb_remove_old_prices(fixture->pricedb, comm_list,
                                            t_old, t_cut,
-                                           PRICE_REMOVE_USER, // source is USER
-                                           PRICE_REMOVE_DEFAULT)); // leave none
+                                           PRICE_REMOVE_SOURCE_USER, // source is USER
+                                           PRICE_REMOVE_KEEP_DEFAULT)); // keep none
 
     g_assert_cmpint (gnc_pricedb_get_num_prices(fixture->pricedb), ==, 28);
 
     // there should be no prices before cutoff, returns false
     g_assert (!gnc_pricedb_remove_old_prices(fixture->pricedb, comm_list,
                                            t_old, t_cut,
-                                           PRICE_REMOVE_ALL, // source is ALL
-                                           PRICE_REMOVE_DEFAULT)); // leave none
+                                           PRICE_REMOVE_SOURCE_ALL, // source is ALL
+                                           PRICE_REMOVE_KEEP_DEFAULT)); // keep none
 
     g_assert_cmpint (gnc_pricedb_get_num_prices(fixture->pricedb), ==, 28);
 
     g_assert (gnc_pricedb_remove_old_prices(fixture->pricedb, comm_list,
                                            t_old, t_cut2,
-                                           PRICE_REMOVE_DEFAULT, // source is FQ
-                                           PRICE_REMOVE_SCALED)); // leave scaled
+                                           PRICE_REMOVE_SOURCE_DEFAULT, // source is FQ
+                                           PRICE_REMOVE_KEEP_SCALED)); // keep scaled
 
     g_assert_cmpint (gnc_pricedb_get_num_prices(fixture->pricedb), ==, 16);
 

--- a/src/gnome/dialog-price-edit-db.c
+++ b/src/gnome/dialog-price-edit-db.c
@@ -32,6 +32,7 @@
 #include <time.h>
 
 #include "dialog-utils.h"
+#include "gnc-accounting-period.h"
 #include "gnc-amount-edit.h"
 #include "gnc-commodity-edit.h"
 #include "gnc-general-select.h"
@@ -376,6 +377,20 @@ selection_changed_cb (GtkTreeSelection *selection, gpointer data)
         change_source_flag (PRICE_REMOVE_SOURCE_COMM, FALSE, pdb_dialog);
 }
 
+static GDate
+get_fiscal_end_date (void)
+{
+    Timespec ts_end;
+    GDate f_end;
+
+    timespecFromTime64 (&ts_end, gnc_accounting_period_fiscal_end());
+    f_end = timespec_to_gdate (ts_end);
+
+    PINFO("Fiscal end date is %s", qof_print_date (gnc_accounting_period_fiscal_end()));
+
+    return f_end;
+}
+
 void
 gnc_prices_dialog_remove_old_clicked (GtkWidget *widget, gpointer data)
 {
@@ -450,6 +465,7 @@ gnc_prices_dialog_remove_old_clicked (GtkWidget *widget, gpointer data)
         if ((g_list_length (comm_list) != 0) && (gnc_verify_dialog (pdb_dialog->remove_dialog, FALSE, fmt, NULL)))
         {
             Timespec last_ts;
+            GDate fiscal_end_date = get_fiscal_end_date ();
             PriceRemoveSourceFlags source = PRICE_REMOVE_SOURCE_FQ; 
             PriceRemoveKeepOptions keep = PRICE_REMOVE_KEEP_DEFAULT;
 
@@ -479,7 +495,7 @@ gnc_prices_dialog_remove_old_clicked (GtkWidget *widget, gpointer data)
             if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button)))
                 keep = PRICE_REMOVE_KEEP_LAST_PERIOD;
 
-            gnc_pricedb_remove_old_prices (pdb_dialog->price_db, comm_list,
+            gnc_pricedb_remove_old_prices (pdb_dialog->price_db, comm_list, &fiscal_end_date,
                                            first_ts, last_ts, pdb_dialog->remove_source, keep);
         }
         g_list_free (comm_list);

--- a/src/gnome/dialog-price-edit-db.c
+++ b/src/gnome/dialog-price-edit-db.c
@@ -175,13 +175,12 @@ gnc_prices_dialog_remove_clicked (GtkWidget *widget, gpointer data)
     }
 
     length = g_list_length(price_list);
-    if (length > 1)
+    if (length > 0)
     {
         gchar *message;
 
         message = g_strdup_printf
-                  (/* Translators: %d is the number of prices. This
-	  is a ngettext(3) message. */
+                  (/* Translators: %d is the number of prices. This is a ngettext(3) message. */
                       ngettext("Are you sure you want to delete the selected price?",
                                "Are you sure you want to delete the %d selected prices?",
                                length),
@@ -215,18 +214,116 @@ gnc_prices_dialog_remove_clicked (GtkWidget *widget, gpointer data)
     LEAVE(" ");
 }
 
+ 
+/** Enumeration for the price delete list-store */
+enum GncPriceColumn {PRICED_FULL_NAME, PRICED_COMM, PRICED_DATE, PRICED_COUNT};
+
+static Timespec
+gnc_prices_dialog_load_view (GtkTreeView *view, GNCPriceDB *pdb)
+{
+    GtkTreeModel *model = gtk_tree_view_get_model (view);
+    const gnc_commodity_table *commodity_table = gnc_get_current_commodities ();
+    GList *namespace_list = gnc_commodity_table_get_namespaces (commodity_table);
+    gnc_commodity *tmp_commodity = NULL;
+    char  *tmp_namespace = NULL;
+    GList *commodity_list = NULL;
+    GtkTreeIter iter;
+
+    Timespec oldest_ts = timespec_now ();
+    oldest_ts.tv_nsec = 0;
+
+    namespace_list = g_list_first (namespace_list);
+    while (namespace_list != NULL)
+    {
+        tmp_namespace = namespace_list->data;
+        DEBUG("Looking at namespace %s", tmp_namespace);
+        commodity_list = gnc_commodity_table_get_commodities (commodity_table, tmp_namespace);
+        commodity_list  = g_list_first (commodity_list);
+        while (commodity_list != NULL)
+        {
+            gint num = 0;
+            tmp_commodity = commodity_list->data;
+            num = gnc_pricedb_num_prices (pdb, tmp_commodity);
+            DEBUG("Looking at commodity %s, Number of prices %d", gnc_commodity_get_fullname (tmp_commodity), num);
+
+            if (num > 0)
+            {
+                PriceList *list = gnc_pricedb_get_prices (pdb, tmp_commodity, NULL);
+                GList *node = g_list_last (list);
+                GNCPrice *price = (GNCPrice*)node->data;
+                Timespec price_ts = gnc_price_get_time (price);
+                const gchar *name_str = gnc_commodity_get_printname (tmp_commodity);
+                gchar *date_str, *num_str;
+
+                if (timespec_cmp(&oldest_ts, &price_ts) >= 0)
+                    oldest_ts.tv_sec = price_ts.tv_sec;
+
+                date_str = g_strdup (gnc_print_date (price_ts));
+                num_str = g_strdup_printf ("%d", num);
+
+                gtk_list_store_append (GTK_LIST_STORE(model), &iter);
+
+                gtk_list_store_set (GTK_LIST_STORE(model), &iter, PRICED_FULL_NAME, name_str,
+                                    PRICED_COMM, tmp_commodity, PRICED_DATE, date_str, PRICED_COUNT, num_str, -1);
+
+                g_free (date_str);
+                g_free (num_str);
+                gnc_price_unref (price);
+            }
+            commodity_list = g_list_next (commodity_list);
+        }
+        namespace_list = g_list_next (namespace_list);
+    }
+    g_list_free (commodity_list);
+    g_list_free (namespace_list);
+
+    return oldest_ts;
+}
+
+
+static GList *
+gnc_prices_dialog_get_commodity (GtkTreeView *view)
+{
+    GtkTreeModel     *model = gtk_tree_view_get_model (GTK_TREE_VIEW(view));
+    GtkTreeSelection *selection = gtk_tree_view_get_selection (GTK_TREE_VIEW(view));
+    GList            *list = gtk_tree_selection_get_selected_rows (selection, &model);
+    GList            *row;
+    GList            *comm_list = NULL;
+    GtkTreeIter       iter;
+    gnc_commodity    *comm;
+
+    // Walk the list
+    for (row = g_list_first (list); row; row = g_list_next (row))
+    {
+        if (gtk_tree_model_get_iter (model, &iter, row->data))
+        {
+            gtk_tree_model_get (model, &iter, PRICED_COMM, &comm, -1);
+            comm_list = g_list_append (comm_list, comm);
+        }
+    }
+    g_list_foreach (list, (GFunc) gtk_tree_path_free, NULL);
+    g_list_free (list);
+
+    return comm_list;
+}
+
 
 void
 gnc_prices_dialog_remove_old_clicked (GtkWidget *widget, gpointer data)
 {
     PricesDialog *pdb_dialog = data;
     GtkBuilder *builder;
-    GtkWidget *dialog, *button, *date, *label, *box;
+    GtkWidget *dialog, *date, *label, *box;
+    GtkWidget *button, *button1, *button2, *button3;
+    GtkTreeView *view;
+    GtkTreeViewColumn *tree_column;
+    GtkCellRenderer   *cr;
+    Timespec first_ts;
     gint result;
-    gboolean delete_user, delete_last;
 
     ENTER(" ");
     builder = gtk_builder_new();
+    gnc_builder_add_from_file (builder, "dialog-price.glade", "liststore4");
     gnc_builder_add_from_file (builder, "dialog-price.glade", "Deletion Date");
 
     dialog = GTK_WIDGET(gtk_builder_get_object (builder, "Deletion Date"));
@@ -240,6 +337,27 @@ gnc_prices_dialog_remove_old_clicked (GtkWidget *widget, gpointer data)
     label = GTK_WIDGET(gtk_builder_get_object (builder, "date_label"));
     gnc_date_make_mnemonic_target (GNC_DATE_EDIT(date), label);
 
+    // Setup the commodity view
+    view = GTK_TREE_VIEW(gtk_builder_get_object (builder, "commodty_treeview"));
+    gtk_tree_view_set_rules_hint (view, TRUE);
+    gtk_tree_selection_set_mode (gtk_tree_view_get_selection (view), GTK_SELECTION_MULTIPLE);
+
+    // Add Entries column this way as align does not seem to work from builder
+    tree_column = gtk_tree_view_column_new();
+    gtk_tree_view_column_set_title (tree_column, _("Entries"));
+    gtk_tree_view_append_column (GTK_TREE_VIEW(view), tree_column);
+    gtk_tree_view_column_set_alignment (tree_column, 0.5);
+    gtk_tree_view_column_set_expand (tree_column, TRUE);
+    cr = gtk_cell_renderer_text_new();
+    gtk_tree_view_column_pack_start (tree_column, cr, TRUE);
+    // set 'xalign' property of the cell renderer
+    gtk_tree_view_column_set_attributes (tree_column, cr, "text", PRICED_COUNT, NULL);
+    gtk_cell_renderer_set_alignment (cr, 0.5, 0.5);
+
+    // Load the view and get the earliest date
+    first_ts = gnc_prices_dialog_load_view (view, pdb_dialog->price_db);
+    gtk_tree_selection_select_all (gtk_tree_view_get_selection (view));
+
     gtk_builder_connect_signals_full (builder, gnc_builder_connect_full_func, pdb_dialog);
 
     gtk_window_set_transient_for (GTK_WINDOW (dialog), GTK_WINDOW (pdb_dialog->dialog));
@@ -247,22 +365,47 @@ gnc_prices_dialog_remove_old_clicked (GtkWidget *widget, gpointer data)
     result = gtk_dialog_run (GTK_DIALOG (dialog));
     if (result == GTK_RESPONSE_OK)
     {
-        Timespec ts;
+        const char *fmt = _("Are you sure you want to delete these prices ?");
+        GList *comm_list = gnc_prices_dialog_get_commodity (view);
 
-        DEBUG("deleting prices");
-        ts.tv_sec = gnc_date_edit_get_date (GNC_DATE_EDIT (date));
-        ts.tv_nsec = 0;
+        // Are you sure you want to delete the entries and we have commodities
+        if ((g_list_length (comm_list) != 0) && (gnc_verify_dialog (dialog, FALSE, fmt, NULL)))
+        {
+            Timespec last_ts;
+            PriceRemoveOptions source = PRICE_REMOVE_DEFAULT; 
+            PriceRemoveOptions leave = PRICE_REMOVE_DEFAULT;
+            gboolean user, all;
 
-        button = GTK_WIDGET(gtk_builder_get_object (builder, "delete_manual"));
-        delete_user = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button));
-        button = GTK_WIDGET(gtk_builder_get_object (builder, "delete_last"));
-        delete_last = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button));
+            DEBUG("deleting prices");
+            last_ts.tv_sec = gnc_date_edit_get_date (GNC_DATE_EDIT (date));
+            last_ts.tv_nsec = 0;
 
-        gnc_pricedb_remove_old_prices(pdb_dialog->price_db, ts,
-                                      delete_user, delete_last);
+            // Get the buttons
+            button = GTK_WIDGET(gtk_builder_get_object (builder, "checkbutton_all"));
+            all = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button));
+            button = GTK_WIDGET(gtk_builder_get_object (builder, "checkbutton_user"));
+            user = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button));
+            if (user)
+                source = PRICE_REMOVE_USER;
+            if (all)
+                source = PRICE_REMOVE_ALL;
+
+            button1 = GTK_WIDGET(gtk_builder_get_object (builder, "radiobutton_month"));
+            button2 = GTK_WIDGET(gtk_builder_get_object (builder, "radiobutton_week"));
+            button3 = GTK_WIDGET(gtk_builder_get_object (builder, "radiobutton_scaled"));
+            if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button1)))
+                leave = PRICE_REMOVE_MONTHLY;
+            if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button2)))
+                leave = PRICE_REMOVE_WEEKLY;
+            if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button3)))
+                leave = PRICE_REMOVE_SCALED;
+
+            gnc_pricedb_remove_old_prices (pdb_dialog->price_db, comm_list,
+                                           first_ts, last_ts, source, leave);
+        }
+        g_list_free (comm_list);
     }
-
-    gtk_widget_destroy(dialog);
+    gtk_widget_destroy (dialog);
     LEAVE(" ");
 }
 

--- a/src/gnome/dialog-price-edit-db.c
+++ b/src/gnome/dialog-price-edit-db.c
@@ -372,8 +372,8 @@ gnc_prices_dialog_remove_old_clicked (GtkWidget *widget, gpointer data)
         if ((g_list_length (comm_list) != 0) && (gnc_verify_dialog (dialog, FALSE, fmt, NULL)))
         {
             Timespec last_ts;
-            PriceRemoveOptions source = PRICE_REMOVE_DEFAULT; 
-            PriceRemoveOptions leave = PRICE_REMOVE_DEFAULT;
+            PriceRemoveSourceOptions source = PRICE_REMOVE_SOURCE_DEFAULT; 
+            PriceRemoveKeepOptions keep = PRICE_REMOVE_KEEP_DEFAULT;
             gboolean user, all;
 
             DEBUG("deleting prices");
@@ -386,22 +386,22 @@ gnc_prices_dialog_remove_old_clicked (GtkWidget *widget, gpointer data)
             button = GTK_WIDGET(gtk_builder_get_object (builder, "checkbutton_user"));
             user = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button));
             if (user)
-                source = PRICE_REMOVE_USER;
+                source = PRICE_REMOVE_SOURCE_USER;
             if (all)
-                source = PRICE_REMOVE_ALL;
+                source = PRICE_REMOVE_SOURCE_ALL;
 
             button1 = GTK_WIDGET(gtk_builder_get_object (builder, "radiobutton_month"));
             button2 = GTK_WIDGET(gtk_builder_get_object (builder, "radiobutton_week"));
             button3 = GTK_WIDGET(gtk_builder_get_object (builder, "radiobutton_scaled"));
             if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button1)))
-                leave = PRICE_REMOVE_MONTHLY;
+                keep = PRICE_REMOVE_KEEP_MONTHLY;
             if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button2)))
-                leave = PRICE_REMOVE_WEEKLY;
+                keep = PRICE_REMOVE_KEEP_WEEKLY;
             if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button3)))
-                leave = PRICE_REMOVE_SCALED;
+                keep = PRICE_REMOVE_KEEP_SCALED;
 
             gnc_pricedb_remove_old_prices (pdb_dialog->price_db, comm_list,
-                                           first_ts, last_ts, source, leave);
+                                           first_ts, last_ts, source, keep);
         }
         g_list_free (comm_list);
     }

--- a/src/gnome/gtkbuilder/dialog-price.glade
+++ b/src/gnome/gtkbuilder/dialog-price.glade
@@ -679,6 +679,7 @@
     <property name="visible">True</property>
     <property name="can_focus">False</property>
     <property name="border_width">6</property>
+    <property name="title" translatable="yes">Remove Old Prices</property>
     <property name="default_width">400</property>
     <property name="type_hint">dialog</property>
     <child internal-child="vbox">
@@ -732,7 +733,7 @@
           <object class="GtkTable" id="table2">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="n_rows">9</property>
+            <property name="n_rows">11</property>
             <property name="n_columns">2</property>
             <property name="column_spacing">12</property>
             <property name="row_spacing">10</property>
@@ -740,149 +741,20 @@
               <object class="GtkLabel" id="label8477429">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="xalign">0</property>
                 <property name="label" translatable="yes">Delete prices that meet the following criteria:</property>
                 <property name="wrap">True</property>
               </object>
               <packing>
                 <property name="right_attach">2</property>
-                <property name="top_attach">1</property>
-                <property name="bottom_attach">2</property>
                 <property name="x_options">GTK_FILL</property>
                 <property name="y_options"/>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="label8477431">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="xalign">0</property>
-              </object>
-              <packing>
-                <property name="right_attach">2</property>
-                <property name="top_attach">1</property>
-                <property name="bottom_attach">2</property>
-                <property name="x_options">GTK_FILL</property>
-                <property name="y_options"/>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkHBox" id="date_hbox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <child>
-                  <object class="GtkLabel" id="date_label">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Before _Date:</property>
-                    <property name="use_underline">True</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <placeholder/>
-                </child>
-              </object>
-              <packing>
-                <property name="right_attach">2</property>
-                <property name="top_attach">3</property>
-                <property name="bottom_attach">4</property>
-                <property name="x_options">GTK_EXPAND</property>
-                <property name="y_options"/>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkHBox" id="hbox1">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <child>
-                  <object class="GtkLabel" id="label1">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Source:</property>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkCheckButton" id="checkbutton_user">
-                    <property name="label" translatable="yes">Include manually _entered prices</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">If activated, only include manually entered stock prices. Otherwise only stock prices added by Finance::Quote will be included.</property>
-                    <property name="use_underline">True</property>
-                    <property name="draw_indicator">True</property>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkCheckButton" id="checkbutton_all">
-                    <property name="label" translatable="yes">_All Prices</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">If activated, all prices will be included.</property>
-                    <property name="use_underline">True</property>
-                    <property name="draw_indicator">True</property>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">2</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="right_attach">2</property>
-                <property name="top_attach">2</property>
-                <property name="bottom_attach">3</property>
-                <property name="y_options">GTK_FILL</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="label2">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Remove Old Prices</property>
-                <attributes>
-                  <attribute name="underline" value="True"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="right_attach">2</property>
-                <property name="y_options">GTK_FILL</property>
               </packing>
             </child>
             <child>
               <object class="GtkHBox" id="hbox2">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <child>
-                  <object class="GtkLabel" id="label4">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Keeping:</property>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
                 <child>
                   <object class="GtkRadioButton" id="radiobutton_none">
                     <property name="label" translatable="yes">_None</property>
@@ -895,14 +767,14 @@
                     <property name="draw_indicator">True</property>
                   </object>
                   <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="radiobutton_week">
-                    <property name="label" translatable="yes">One a _Week</property>
+                    <property name="label" translatable="yes">One per _Week</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
@@ -912,14 +784,14 @@
                     <property name="group">radiobutton_none</property>
                   </object>
                   <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">2</property>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">1</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="radiobutton_month">
-                    <property name="label" translatable="yes">One a _Month</property>
+                    <property name="label" translatable="yes">One per _Month</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
@@ -929,9 +801,9 @@
                     <property name="group">radiobutton_none</property>
                   </object>
                   <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">3</property>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">2</property>
                   </packing>
                 </child>
                 <child>
@@ -946,9 +818,9 @@
                     <property name="group">radiobutton_none</property>
                   </object>
                   <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">4</property>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">3</property>
                   </packing>
                 </child>
               </object>
@@ -957,6 +829,7 @@
                 <property name="top_attach">7</property>
                 <property name="bottom_attach">8</property>
                 <property name="y_options">GTK_FILL</property>
+                <property name="x_padding">10</property>
               </packing>
             </child>
             <child>
@@ -1008,8 +881,8 @@
               </object>
               <packing>
                 <property name="right_attach">2</property>
-                <property name="top_attach">5</property>
-                <property name="bottom_attach">7</property>
+                <property name="top_attach">4</property>
+                <property name="bottom_attach">6</property>
               </packing>
             </child>
             <child>
@@ -1023,8 +896,8 @@
               </object>
               <packing>
                 <property name="right_attach">2</property>
-                <property name="top_attach">4</property>
-                <property name="bottom_attach">5</property>
+                <property name="top_attach">3</property>
+                <property name="bottom_attach">4</property>
                 <property name="y_options">GTK_FILL</property>
               </packing>
             </child>
@@ -1032,15 +905,266 @@
               <object class="GtkLabel" id="label5">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Caution: If you select to Keep prices and there are none on a Friday you may end up with no prices before the selected date.</property>
+                <property name="xalign">0</property>
+                <property name="label" translatable="yes">Caution: If you select to keep prices and there are none on a Friday you may end up with no prices before the selected date.</property>
                 <property name="justify">fill</property>
                 <property name="wrap">True</property>
               </object>
               <packing>
                 <property name="right_attach">2</property>
+                <property name="top_attach">10</property>
+                <property name="bottom_attach">11</property>
+                <property name="y_options">GTK_FILL</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label2">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="xalign">0</property>
+                <property name="label" translatable="yes">Keeping a price on Friday (if available):</property>
+              </object>
+              <packing>
+                <property name="right_attach">2</property>
+                <property name="top_attach">6</property>
+                <property name="bottom_attach">7</property>
+                <property name="y_options"/>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="xalign">0</property>
+                <property name="yalign">0</property>
+                <property name="label" translatable="yes">Source:</property>
+              </object>
+              <packing>
+                <property name="top_attach">1</property>
+                <property name="bottom_attach">2</property>
+                <property name="x_options">GTK_FILL</property>
+                <property name="y_options">GTK_FILL</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkVBox" id="vbox1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkCheckButton" id="checkbutton_fq">
+                    <property name="label" translatable="yes">Include _Fetched online prices</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">If activated, prices added by Finance::Quote will be included.</property>
+                    <property name="use_underline">True</property>
+                    <property name="active">True</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="checkbutton_user">
+                    <property name="label" translatable="yes">Include manually _Entered prices</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">If activated, include manually entered prices.</property>
+                    <property name="use_underline">True</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkHBox" id="hbox4">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkCheckButton" id="checkbutton_app">
+                        <property name="label" translatable="yes">_Added by the application</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="tooltip_text" translatable="yes">If activated, include application added prices.
+
+These prices were added so that there's always a "nearest in time" price for every multi-commodity transaction so that 
+the Accounts page and reports are able to correctly report values so removing them may make this less reliable.</property>
+                        <property name="use_underline">True</property>
+                        <property name="image_position">right</property>
+                        <property name="draw_indicator">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkImage" id="image_source">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">1</property>
+                        <property name="stock">gtk-dialog-warning</property>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="right_attach">2</property>
+                <property name="top_attach">1</property>
+                <property name="bottom_attach">2</property>
+                <property name="y_options"/>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="date_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="xalign">0</property>
+                <property name="label" translatable="yes">Before _Date:</property>
+                <property name="use_underline">True</property>
+              </object>
+              <packing>
+                <property name="top_attach">2</property>
+                <property name="bottom_attach">3</property>
+                <property name="x_options">GTK_FILL</property>
+                <property name="y_options">GTK_FILL</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkHBox" id="date_hbox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <placeholder/>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="right_attach">2</property>
+                <property name="top_attach">2</property>
+                <property name="bottom_attach">3</property>
+                <property name="y_options"/>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkHBox" id="hbox1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkRadioButton" id="radiobutton_last_week">
+                    <property name="label" translatable="yes">Last of Wee_k</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">Keep the last price of each week if present before date.</property>
+                    <property name="use_underline">True</property>
+                    <property name="active">True</property>
+                    <property name="draw_indicator">True</property>
+                    <property name="group">radiobutton_none</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkRadioButton" id="radiobutton_last_month">
+                    <property name="label" translatable="yes">Last of M_onth</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">Keep the last price of each month if present before date.</property>
+                    <property name="use_underline">True</property>
+                    <property name="active">True</property>
+                    <property name="draw_indicator">True</property>
+                    <property name="group">radiobutton_none</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkRadioButton" id="radiobutton_last_quarter">
+                    <property name="label" translatable="yes">Last of _Quarter</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">Keep the last price of each quarter if present before date.</property>
+                    <property name="use_underline">True</property>
+                    <property name="active">True</property>
+                    <property name="draw_indicator">True</property>
+                    <property name="group">radiobutton_none</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkRadioButton" id="radiobutton_last_period">
+                    <property name="label" translatable="yes">Last of _Period</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">Keep the last price of each period if present before date.</property>
+                    <property name="use_underline">True</property>
+                    <property name="active">True</property>
+                    <property name="draw_indicator">True</property>
+                    <property name="group">radiobutton_none</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="right_attach">2</property>
+                <property name="top_attach">9</property>
+                <property name="bottom_attach">10</property>
+                <property name="y_options"/>
+                <property name="x_padding">10</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label4">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="xalign">0</property>
+                <property name="label" translatable="yes">or the last available price for the option:</property>
+              </object>
+              <packing>
+                <property name="right_attach">2</property>
                 <property name="top_attach">8</property>
                 <property name="bottom_attach">9</property>
-                <property name="y_options">GTK_FILL</property>
+                <property name="y_options"/>
               </packing>
             </child>
           </object>

--- a/src/gnome/gtkbuilder/dialog-price.glade
+++ b/src/gnome/gtkbuilder/dialog-price.glade
@@ -875,7 +875,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Leaving:</property>
+                    <property name="label" translatable="yes">Keeping:</property>
                   </object>
                   <packing>
                     <property name="expand">True</property>
@@ -906,7 +906,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Leave a price on the Friday of each week if present before date.</property>
+                    <property name="tooltip_text" translatable="yes">Keep a price on the Friday of each week if present before date.</property>
                     <property name="use_underline">True</property>
                     <property name="draw_indicator">True</property>
                     <property name="group">radiobutton_none</property>
@@ -923,7 +923,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Leave a price on the last Friday of the month if present before date.</property>
+                    <property name="tooltip_text" translatable="yes">Keep a price on the last Friday of the month if present before date.</property>
                     <property name="use_underline">True</property>
                     <property name="draw_indicator">True</property>
                     <property name="group">radiobutton_none</property>
@@ -1032,7 +1032,7 @@
               <object class="GtkLabel" id="label5">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Caution: If you select to leave prices and there are none on a Friday you may end up with no prices before the selected date.</property>
+                <property name="label" translatable="yes">Caution: If you select to Keep prices and there are none on a Friday you may end up with no prices before the selected date.</property>
                 <property name="justify">fill</property>
                 <property name="wrap">True</property>
               </object>

--- a/src/gnome/gtkbuilder/dialog-price.glade
+++ b/src/gnome/gtkbuilder/dialog-price.glade
@@ -1,31 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <requires lib="gtk+" version="2.16"/>
-  <object class="GtkDialog" id="Deletion Date">
-    <property name="visible">True</property>
+  <requires lib="gtk+" version="2.24"/>
+  <!-- interface-naming-policy toplevel-contextual -->
+  <object class="GtkDialog" id="Prices Dialog">
     <property name="can_focus">False</property>
     <property name="border_width">6</property>
-    <property name="resizable">False</property>
-    <property name="type_hint">dialog</property>
+    <property name="title" translatable="yes">Price Database</property>
+    <property name="default_width">400</property>
+    <property name="default_height">400</property>
+    <property name="type_hint">normal</property>
+    <signal name="destroy" handler="gnc_prices_dialog_window_destroy_cb" swapped="no"/>
+    <signal name="close" handler="gnc_prices_dialog_close_cb" after="yes" swapped="no"/>
+    <signal name="response" handler="gnc_prices_dialog_response" swapped="no"/>
     <child internal-child="vbox">
-      <object class="GtkBox" id="dialog-vbox19">
+      <object class="GtkVBox" id="dialog-vbox3">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="spacing">6</property>
+        <property name="spacing">2</property>
         <child internal-child="action_area">
-          <object class="GtkButtonBox" id="dialog-action_area19">
+          <object class="GtkHButtonBox" id="dialog-action_area3">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
-              <object class="GtkButton" id="cancel_button">
-                <property name="label">gtk-cancel</property>
-                <property name="use_action_appearance">False</property>
+              <object class="GtkButton" id="close_button">
+                <property name="label">gtk-close</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
               </object>
               <packing>
@@ -34,135 +37,245 @@
                 <property name="position">0</property>
               </packing>
             </child>
-            <child>
-              <object class="GtkButton" id="ok_button">
-                <property name="label">gtk-ok</property>
-                <property name="use_action_appearance">False</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="can_default">True</property>
-                <property name="receives_default">False</property>
-                <property name="use_action_appearance">False</property>
-                <property name="use_stock">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
           </object>
           <packing>
             <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="pack_type">end</property>
+            <property name="fill">False</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
-          <object class="GtkTable" id="table2">
+          <object class="GtkHBox" id="hbox118">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="n_rows">5</property>
-            <property name="n_columns">2</property>
-            <property name="column_spacing">12</property>
-            <property name="row_spacing">6</property>
             <child>
-              <object class="GtkLabel" id="label8477429">
+              <object class="GtkScrolledWindow" id="price_list_window">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Delete all stock prices before the date below based upon the following criteria:</property>
-                <property name="wrap">True</property>
-              </object>
-              <packing>
-                <property name="right_attach">2</property>
-                <property name="x_options">GTK_FILL</property>
-                <property name="y_options"/>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkCheckButton" id="delete_manual">
-                <property name="label" translatable="yes">Delete _manually entered prices</property>
-                <property name="use_action_appearance">False</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="tooltip_text" translatable="yes">If activated, delete manually entered stock prices dated earlier than the specified date. Otherwise only stock prices added by Finance::Quote will be deleted.</property>
-                <property name="use_action_appearance">False</property>
-                <property name="use_underline">True</property>
-                <property name="draw_indicator">True</property>
-              </object>
-              <packing>
-                <property name="right_attach">2</property>
-                <property name="top_attach">3</property>
-                <property name="bottom_attach">4</property>
-                <property name="x_options">GTK_FILL</property>
-                <property name="y_options"/>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkCheckButton" id="delete_last">
-                <property name="label" translatable="yes">Delete _last price for a stock</property>
-                <property name="use_action_appearance">False</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="tooltip_text" translatable="yes">If activated, delete all prices before the specified date. Otherwise the last stock price dated before the date will be kept and all earlier quotes deleted.</property>
-                <property name="use_action_appearance">False</property>
-                <property name="use_underline">True</property>
-                <property name="draw_indicator">True</property>
-              </object>
-              <packing>
-                <property name="right_attach">2</property>
-                <property name="top_attach">4</property>
-                <property name="bottom_attach">5</property>
-                <property name="x_options">GTK_FILL</property>
-                <property name="y_options"/>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="label8477431">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="xalign">0</property>
-              </object>
-              <packing>
-                <property name="right_attach">2</property>
-                <property name="top_attach">1</property>
-                <property name="bottom_attach">2</property>
-                <property name="x_options">GTK_FILL</property>
-                <property name="y_options"/>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="date_label">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="xalign">0</property>
-                <property name="label" translatable="yes">_Date:</property>
-                <property name="use_underline">True</property>
-              </object>
-              <packing>
-                <property name="top_attach">2</property>
-                <property name="bottom_attach">3</property>
-                <property name="x_options"/>
-                <property name="y_options"/>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkHBox" id="date_hbox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="border_width">3</property>
+                <property name="shadow_type">in</property>
                 <child>
                   <placeholder/>
                 </child>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
-                <property name="top_attach">2</property>
-                <property name="bottom_attach">3</property>
-                <property name="y_options">GTK_FILL</property>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkVButtonBox" id="vbuttonbox5">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="border_width">5</property>
+                <property name="layout_style">spread</property>
+                <child>
+                  <object class="GtkButton" id="add_button">
+                    <property name="label">gtk-add</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="can_default">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">Add a new price.</property>
+                    <property name="use_stock">True</property>
+                    <signal name="clicked" handler="gnc_prices_dialog_add_clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="remove_button">
+                    <property name="label">gtk-remove</property>
+                    <property name="visible">True</property>
+                    <property name="sensitive">False</property>
+                    <property name="can_focus">True</property>
+                    <property name="can_default">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">Remove the current price.</property>
+                    <property name="use_stock">True</property>
+                    <signal name="clicked" handler="gnc_prices_dialog_remove_clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="edit_button">
+                    <property name="visible">True</property>
+                    <property name="sensitive">False</property>
+                    <property name="can_focus">True</property>
+                    <property name="can_default">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">Edit the current price.</property>
+                    <signal name="clicked" handler="gnc_prices_dialog_edit_clicked" swapped="no"/>
+                    <child>
+                      <object class="GtkAlignment" id="alignment5">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="xscale">0</property>
+                        <property name="yscale">0</property>
+                        <child>
+                          <object class="GtkHBox" id="hbox115">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="spacing">2</property>
+                            <child>
+                              <object class="GtkImage" id="image5">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="stock">gtk-properties</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="label8477426">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">_Edit</property>
+                                <property name="use_underline">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="remove_old_button">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="can_default">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">Remove prices older than a user-entered date.</property>
+                    <signal name="clicked" handler="gnc_prices_dialog_remove_old_clicked" swapped="no"/>
+                    <child>
+                      <object class="GtkAlignment" id="alignment6">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="xscale">0</property>
+                        <property name="yscale">0</property>
+                        <child>
+                          <object class="GtkHBox" id="hbox116">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="spacing">2</property>
+                            <child>
+                              <object class="GtkImage" id="image6">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="stock">gtk-remove</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="label8477427">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Remove _Old</property>
+                                <property name="use_underline">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="get_quotes_button">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="can_default">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">Get new online quotes for stock accounts.</property>
+                    <signal name="clicked" handler="gnc_prices_dialog_get_quotes_clicked" swapped="no"/>
+                    <child>
+                      <object class="GtkAlignment" id="alignment7">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="xscale">0</property>
+                        <property name="yscale">0</property>
+                        <child>
+                          <object class="GtkHBox" id="hbox117">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="spacing">2</property>
+                            <child>
+                              <object class="GtkImage" id="image7">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="stock">gtk-execute</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="label8477428">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Get _Quotes</property>
+                                <property name="use_underline">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">4</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
               </packing>
             </child>
           </object>
@@ -175,9 +288,53 @@
       </object>
     </child>
     <action-widgets>
-      <action-widget response="-6">cancel_button</action-widget>
-      <action-widget response="-5">ok_button</action-widget>
+      <action-widget response="-7">close_button</action-widget>
     </action-widgets>
+  </object>
+  <object class="GtkListStore" id="liststore1">
+    <columns>
+      <!-- column-name item -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">Bid</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Ask</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Last</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Net Asset Value</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Unknown</col>
+      </row>
+    </data>
+  </object>
+  <object class="GtkListStore" id="liststore2">
+    <columns>
+      <!-- column-name item -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">Dummy commodity Line</col>
+      </row>
+    </data>
+  </object>
+  <object class="GtkListStore" id="liststore3">
+    <columns>
+      <!-- column-name item -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">Dummy namespace Line</col>
+      </row>
+    </data>
   </object>
   <object class="GtkDialog" id="Price Dialog">
     <property name="can_focus">False</property>
@@ -187,24 +344,22 @@
     <property name="type_hint">dialog</property>
     <signal name="response" handler="pedit_dialog_response_cb" swapped="no"/>
     <child internal-child="vbox">
-      <object class="GtkBox" id="dialog-vbox18">
+      <object class="GtkVBox" id="dialog-vbox2">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="spacing">6</property>
+        <property name="spacing">2</property>
         <child internal-child="action_area">
-          <object class="GtkButtonBox" id="dialog-action_area18">
+          <object class="GtkHButtonBox" id="dialog-action_area2">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="pd_cancel_button">
                 <property name="label">gtk-cancel</property>
-                <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
               </object>
               <packing>
@@ -216,11 +371,9 @@
             <child>
               <object class="GtkButton" id="pd_apply_button">
                 <property name="label">gtk-apply</property>
-                <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
               </object>
               <packing>
@@ -232,13 +385,11 @@
             <child>
               <object class="GtkButton" id="pd_ok_button">
                 <property name="label">gtk-ok</property>
-                <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="has_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
               </object>
               <packing>
@@ -249,9 +400,8 @@
             </child>
           </object>
           <packing>
-            <property name="expand">False</property>
+            <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="pack_type">end</property>
             <property name="position">0</property>
           </packing>
         </child>
@@ -416,6 +566,8 @@
                 <property name="editable">False</property>
                 <property name="primary_icon_activatable">False</property>
                 <property name="secondary_icon_activatable">False</property>
+                <property name="primary_icon_sensitive">True</property>
+                <property name="secondary_icon_sensitive">True</property>
                 <signal name="changed" handler="pedit_data_changed_cb" swapped="no"/>
               </object>
               <packing>
@@ -474,12 +626,6 @@
                 <property name="has_entry">True</property>
                 <property name="entry_text_column">0</property>
                 <signal name="changed" handler="pedit_commodity_ns_changed_cb" swapped="no"/>
-                <child internal-child="entry">
-                  <object class="GtkEntry" id="combobox-entry3">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                  </object>
-                </child>
               </object>
               <packing>
                 <property name="left_attach">1</property>
@@ -494,12 +640,6 @@
                 <property name="has_entry">True</property>
                 <property name="entry_text_column">0</property>
                 <signal name="changed" handler="pedit_commodity_changed_cb" swapped="no"/>
-                <child internal-child="entry">
-                  <object class="GtkEntry" id="combobox-entry2">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                  </object>
-                </child>
               </object>
               <packing>
                 <property name="left_attach">1</property>
@@ -523,35 +663,41 @@
       <action-widget response="-5">pd_ok_button</action-widget>
     </action-widgets>
   </object>
-  <object class="GtkDialog" id="Prices Dialog">
+  <object class="GtkListStore" id="liststore4">
+    <columns>
+      <!-- column-name full_name -->
+      <column type="gchararray"/>
+      <!-- column-name commodity -->
+      <column type="gpointer"/>
+      <!-- column-name first_date -->
+      <column type="gchararray"/>
+      <!-- column-name number -->
+      <column type="gchararray"/>
+    </columns>
+  </object>
+  <object class="GtkDialog" id="Deletion Date">
+    <property name="visible">True</property>
     <property name="can_focus">False</property>
     <property name="border_width">6</property>
-    <property name="title" translatable="yes">Price Database</property>
     <property name="default_width">400</property>
-    <property name="default_height">400</property>
-    <property name="type_hint">normal</property>
-    <signal name="destroy" handler="gnc_prices_dialog_window_destroy_cb" swapped="no"/>
-    <signal name="close" handler="gnc_prices_dialog_close_cb" after="yes" swapped="no"/>
-    <signal name="response" handler="gnc_prices_dialog_response" swapped="no"/>
+    <property name="type_hint">dialog</property>
     <child internal-child="vbox">
-      <object class="GtkBox" id="vbox121">
+      <object class="GtkVBox" id="dialog-vbox2">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="spacing">6</property>
+        <property name="spacing">2</property>
         <child internal-child="action_area">
-          <object class="GtkButtonBox" id="hbuttonbox4">
+          <object class="GtkHButtonBox" id="dialog-action_area2">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
-              <object class="GtkButton" id="close_button">
-                <property name="label">gtk-close</property>
-                <property name="use_action_appearance">False</property>
+              <object class="GtkButton" id="cancel_button">
+                <property name="label">gtk-cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_action_appearance">False</property>
                 <property name="use_stock">True</property>
               </object>
               <packing>
@@ -560,52 +706,76 @@
                 <property name="position">0</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkButton" id="ok_button">
+                <property name="label">gtk-ok</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="can_default">True</property>
+                <property name="receives_default">False</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="pack_type">end</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
-          <object class="GtkHBox" id="hbox118">
+          <object class="GtkTable" id="table2">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="n_rows">9</property>
+            <property name="n_columns">2</property>
+            <property name="column_spacing">12</property>
+            <property name="row_spacing">10</property>
             <child>
-              <object class="GtkScrolledWindow" id="price_list_window">
+              <object class="GtkLabel" id="label8477429">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="border_width">3</property>
-                <property name="shadow_type">in</property>
-                <child>
-                  <placeholder/>
-                </child>
+                <property name="label" translatable="yes">Delete prices that meet the following criteria:</property>
+                <property name="wrap">True</property>
               </object>
               <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
+                <property name="right_attach">2</property>
+                <property name="top_attach">1</property>
+                <property name="bottom_attach">2</property>
+                <property name="x_options">GTK_FILL</property>
+                <property name="y_options"/>
               </packing>
             </child>
             <child>
-              <object class="GtkVButtonBox" id="vbuttonbox5">
+              <object class="GtkLabel" id="label8477431">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="border_width">5</property>
-                <property name="layout_style">spread</property>
+                <property name="xalign">0</property>
+              </object>
+              <packing>
+                <property name="right_attach">2</property>
+                <property name="top_attach">1</property>
+                <property name="bottom_attach">2</property>
+                <property name="x_options">GTK_FILL</property>
+                <property name="y_options"/>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkHBox" id="date_hbox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
                 <child>
-                  <object class="GtkButton" id="add_button">
-                    <property name="label">gtk-add</property>
-                    <property name="use_action_appearance">False</property>
+                  <object class="GtkLabel" id="date_label">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="can_default">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Add a new price.</property>
-                    <property name="use_action_appearance">False</property>
-                    <property name="use_stock">True</property>
-                    <signal name="clicked" handler="gnc_prices_dialog_add_clicked" swapped="no"/>
+                    <property name="can_focus">False</property>
+                    <property name="xalign">0</property>
+                    <property name="label" translatable="yes">Before _Date:</property>
+                    <property name="use_underline">True</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -614,202 +784,263 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkButton" id="remove_button">
-                    <property name="label">gtk-remove</property>
-                    <property name="use_action_appearance">False</property>
+                  <placeholder/>
+                </child>
+              </object>
+              <packing>
+                <property name="right_attach">2</property>
+                <property name="top_attach">3</property>
+                <property name="bottom_attach">4</property>
+                <property name="x_options">GTK_EXPAND</property>
+                <property name="y_options"/>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkHBox" id="hbox1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkLabel" id="label1">
                     <property name="visible">True</property>
-                    <property name="sensitive">False</property>
-                    <property name="can_focus">True</property>
-                    <property name="can_default">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Remove the current price.</property>
-                    <property name="use_action_appearance">False</property>
-                    <property name="use_stock">True</property>
-                    <signal name="clicked" handler="gnc_prices_dialog_remove_clicked" swapped="no"/>
+                    <property name="can_focus">False</property>
+                    <property name="xalign">0</property>
+                    <property name="label" translatable="yes">Source:</property>
                   </object>
                   <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="checkbutton_user">
+                    <property name="label" translatable="yes">Include manually _entered prices</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">If activated, only include manually entered stock prices. Otherwise only stock prices added by Finance::Quote will be included.</property>
+                    <property name="use_underline">True</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
                     <property name="position">1</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkButton" id="edit_button">
-                    <property name="use_action_appearance">False</property>
+                  <object class="GtkCheckButton" id="checkbutton_all">
+                    <property name="label" translatable="yes">_All Prices</property>
                     <property name="visible">True</property>
-                    <property name="sensitive">False</property>
                     <property name="can_focus">True</property>
-                    <property name="can_default">True</property>
                     <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Edit the current price.</property>
-                    <property name="use_action_appearance">False</property>
-                    <signal name="clicked" handler="gnc_prices_dialog_edit_clicked" swapped="no"/>
-                    <child>
-                      <object class="GtkAlignment" id="alignment5">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="xscale">0</property>
-                        <property name="yscale">0</property>
-                        <child>
-                          <object class="GtkHBox" id="hbox115">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="spacing">2</property>
-                            <child>
-                              <object class="GtkImage" id="image5">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="stock">gtk-properties</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="label8477426">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">_Edit</property>
-                                <property name="use_underline">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
+                    <property name="tooltip_text" translatable="yes">If activated, all prices will be included.</property>
+                    <property name="use_underline">True</property>
+                    <property name="draw_indicator">True</property>
                   </object>
                   <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="right_attach">2</property>
+                <property name="top_attach">2</property>
+                <property name="bottom_attach">3</property>
+                <property name="y_options">GTK_FILL</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label2">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Remove Old Prices</property>
+                <attributes>
+                  <attribute name="underline" value="True"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="right_attach">2</property>
+                <property name="y_options">GTK_FILL</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkHBox" id="hbox2">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkLabel" id="label4">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="xalign">0</property>
+                    <property name="label" translatable="yes">Leaving:</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkRadioButton" id="radiobutton_none">
+                    <property name="label" translatable="yes">_None</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">Remove all prices before date.</property>
+                    <property name="use_underline">True</property>
+                    <property name="active">True</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkRadioButton" id="radiobutton_week">
+                    <property name="label" translatable="yes">One a _Week</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">Leave a price on the Friday of each week if present before date.</property>
+                    <property name="use_underline">True</property>
+                    <property name="draw_indicator">True</property>
+                    <property name="group">radiobutton_none</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
                     <property name="position">2</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkButton" id="remove_old_button">
-                    <property name="use_action_appearance">False</property>
+                  <object class="GtkRadioButton" id="radiobutton_month">
+                    <property name="label" translatable="yes">One a _Month</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
-                    <property name="can_default">True</property>
                     <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Remove prices older than a user-entered date.</property>
-                    <property name="use_action_appearance">False</property>
-                    <signal name="clicked" handler="gnc_prices_dialog_remove_old_clicked" swapped="no"/>
-                    <child>
-                      <object class="GtkAlignment" id="alignment6">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="xscale">0</property>
-                        <property name="yscale">0</property>
-                        <child>
-                          <object class="GtkHBox" id="hbox116">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="spacing">2</property>
-                            <child>
-                              <object class="GtkImage" id="image6">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="stock">gtk-remove</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="label8477427">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Remove _Old</property>
-                                <property name="use_underline">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
+                    <property name="tooltip_text" translatable="yes">Leave a price on the last Friday of the month if present before date.</property>
+                    <property name="use_underline">True</property>
+                    <property name="draw_indicator">True</property>
+                    <property name="group">radiobutton_none</property>
                   </object>
                   <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
                     <property name="position">3</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkButton" id="get_quotes_button">
-                    <property name="use_action_appearance">False</property>
+                  <object class="GtkRadioButton" id="radiobutton_scaled">
+                    <property name="label" translatable="yes">_Scaled</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
-                    <property name="can_default">True</property>
                     <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Get new online quotes for stock accounts.</property>
-                    <property name="use_action_appearance">False</property>
-                    <signal name="clicked" handler="gnc_prices_dialog_get_quotes_clicked" swapped="no"/>
-                    <child>
-                      <object class="GtkAlignment" id="alignment7">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="xscale">0</property>
-                        <property name="yscale">0</property>
-                        <child>
-                          <object class="GtkHBox" id="hbox117">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="spacing">2</property>
-                            <child>
-                              <object class="GtkImage" id="image7">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="stock">gtk-execute</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="label8477428">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Get _Quotes</property>
-                                <property name="use_underline">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
+                    <property name="tooltip_text" translatable="yes">With the scaled option, prices are removed relative to the date selected. 'One a month' is used for dates older than a year and 'One a week' is used for dates older than six months to a year.</property>
+                    <property name="use_underline">True</property>
+                    <property name="draw_indicator">True</property>
+                    <property name="group">radiobutton_none</property>
                   </object>
                   <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
                     <property name="position">4</property>
                   </packing>
                 </child>
               </object>
               <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
+                <property name="right_attach">2</property>
+                <property name="top_attach">7</property>
+                <property name="bottom_attach">8</property>
+                <property name="y_options">GTK_FILL</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkHBox" id="hbox3">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkScrolledWindow" id="scrolledwindow1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="hscrollbar_policy">automatic</property>
+                    <property name="vscrollbar_policy">automatic</property>
+                    <child>
+                      <object class="GtkTreeView" id="commodty_treeview">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="model">liststore4</property>
+                        <child>
+                          <object class="GtkTreeViewColumn" id="name_column">
+                            <property name="title" translatable="yes">Commodity</property>
+                            <child>
+                              <object class="GtkCellRendererText" id="name_cellr"/>
+                              <attributes>
+                                <attribute name="text">0</attribute>
+                              </attributes>
+                            </child>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkTreeViewColumn" id="date_column">
+                            <property name="title" translatable="yes">First Date</property>
+                            <child>
+                              <object class="GtkCellRendererText" id="date_cellr"/>
+                              <attributes>
+                                <attribute name="text">2</attribute>
+                              </attributes>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="right_attach">2</property>
+                <property name="top_attach">5</property>
+                <property name="bottom_attach">7</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label3">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="xalign">0</property>
+                <property name="yalign">0</property>
+                <property name="ypad">2</property>
+                <property name="label" translatable="yes">From these Commodities:</property>
+              </object>
+              <packing>
+                <property name="right_attach">2</property>
+                <property name="top_attach">4</property>
+                <property name="bottom_attach">5</property>
+                <property name="y_options">GTK_FILL</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="label5">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Caution: If you select to leave prices and there are none on a Friday you may end up with no prices before the selected date.</property>
+                <property name="justify">fill</property>
+                <property name="wrap">True</property>
+              </object>
+              <packing>
+                <property name="right_attach">2</property>
+                <property name="top_attach">8</property>
+                <property name="bottom_attach">9</property>
+                <property name="y_options">GTK_FILL</property>
               </packing>
             </child>
           </object>
@@ -822,52 +1053,8 @@
       </object>
     </child>
     <action-widgets>
-      <action-widget response="-7">close_button</action-widget>
+      <action-widget response="-6">cancel_button</action-widget>
+      <action-widget response="-5">ok_button</action-widget>
     </action-widgets>
-  </object>
-  <object class="GtkListStore" id="liststore1">
-    <columns>
-      <!-- column-name item -->
-      <column type="gchararray"/>
-    </columns>
-    <data>
-      <row>
-        <col id="0" translatable="yes">Bid</col>
-      </row>
-      <row>
-        <col id="0" translatable="yes">Ask</col>
-      </row>
-      <row>
-        <col id="0" translatable="yes">Last</col>
-      </row>
-      <row>
-        <col id="0" translatable="yes">Net Asset Value</col>
-      </row>
-      <row>
-        <col id="0" translatable="yes">Unknown</col>
-      </row>
-    </data>
-  </object>
-  <object class="GtkListStore" id="liststore2">
-    <columns>
-      <!-- column-name item -->
-      <column type="gchararray"/>
-    </columns>
-    <data>
-      <row>
-        <col id="0" translatable="yes">Dummy commodity Line</col>
-      </row>
-    </data>
-  </object>
-  <object class="GtkListStore" id="liststore3">
-    <columns>
-      <!-- column-name item -->
-      <column type="gchararray"/>
-    </columns>
-    <data>
-      <row>
-        <col id="0" translatable="yes">Dummy namespace Line</col>
-      </row>
-    </data>
   </object>
 </interface>

--- a/src/gnome/gtkbuilder/dialog-price.glade
+++ b/src/gnome/gtkbuilder/dialog-price.glade
@@ -733,7 +733,7 @@
           <object class="GtkTable" id="table2">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="n_rows">11</property>
+            <property name="n_rows">9</property>
             <property name="n_columns">2</property>
             <property name="column_spacing">12</property>
             <property name="row_spacing">10</property>
@@ -765,6 +765,7 @@
                     <property name="use_underline">True</property>
                     <property name="active">True</property>
                     <property name="draw_indicator">True</property>
+                    <property name="group">radiobutton_last_week</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -773,15 +774,15 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkRadioButton" id="radiobutton_week">
-                    <property name="label" translatable="yes">One per _Week</property>
+                  <object class="GtkRadioButton" id="radiobutton_last_week">
+                    <property name="label" translatable="yes">Last of _Week</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Keep a price on the Friday of each week if present before date.</property>
+                    <property name="tooltip_text" translatable="yes">Keep the last price of each week if present before date.</property>
                     <property name="use_underline">True</property>
+                    <property name="active">True</property>
                     <property name="draw_indicator">True</property>
-                    <property name="group">radiobutton_none</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -790,20 +791,54 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkRadioButton" id="radiobutton_month">
-                    <property name="label" translatable="yes">One per _Month</property>
+                  <object class="GtkRadioButton" id="radiobutton_last_month">
+                    <property name="label" translatable="yes">Last of _Month</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Keep a price on the last Friday of the month if present before date.</property>
+                    <property name="tooltip_text" translatable="yes">Keep the last price of each month if present before date.</property>
                     <property name="use_underline">True</property>
                     <property name="draw_indicator">True</property>
-                    <property name="group">radiobutton_none</property>
+                    <property name="group">radiobutton_last_week</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">False</property>
                     <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkRadioButton" id="radiobutton_last_quarter">
+                    <property name="label" translatable="yes">Last of _Quarter</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">Keep the last price of each fiscal quarter if present before date. This fiscal quarters are derived from the accounting period end date.</property>
+                    <property name="use_underline">True</property>
+                    <property name="draw_indicator">True</property>
+                    <property name="group">radiobutton_last_week</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkRadioButton" id="radiobutton_last_period">
+                    <property name="label" translatable="yes">Last of _Period</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">Keep the last price of each fiscal period if present before date. The fiscal period is derived from the accounting period end date.</property>
+                    <property name="use_underline">True</property>
+                    <property name="draw_indicator">True</property>
+                    <property name="group">radiobutton_last_week</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">4</property>
                   </packing>
                 </child>
                 <child>
@@ -815,12 +850,12 @@
                     <property name="tooltip_text" translatable="yes">With the scaled option, prices are removed relative to the date selected. 'One a month' is used for dates older than a year and 'One a week' is used for dates older than six months to a year.</property>
                     <property name="use_underline">True</property>
                     <property name="draw_indicator">True</property>
-                    <property name="group">radiobutton_none</property>
+                    <property name="group">radiobutton_last_week</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">False</property>
-                    <property name="position">3</property>
+                    <property name="position">5</property>
                   </packing>
                 </child>
               </object>
@@ -902,27 +937,11 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="label5">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="xalign">0</property>
-                <property name="label" translatable="yes">Caution: If you select to keep prices and there are none on a Friday you may end up with no prices before the selected date.</property>
-                <property name="justify">fill</property>
-                <property name="wrap">True</property>
-              </object>
-              <packing>
-                <property name="right_attach">2</property>
-                <property name="top_attach">10</property>
-                <property name="bottom_attach">11</property>
-                <property name="y_options">GTK_FILL</property>
-              </packing>
-            </child>
-            <child>
               <object class="GtkLabel" id="label2">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="xalign">0</property>
-                <property name="label" translatable="yes">Keeping a price on Friday (if available):</property>
+                <property name="label" translatable="yes">Keeping the last available price for option:</property>
               </object>
               <packing>
                 <property name="right_attach">2</property>
@@ -1073,98 +1092,21 @@ the Accounts page and reports are able to correctly report values so removing th
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <child>
-                  <object class="GtkRadioButton" id="radiobutton_last_week">
-                    <property name="label" translatable="yes">Last of Wee_k</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Keep the last price of each week if present before date.</property>
-                    <property name="use_underline">True</property>
-                    <property name="active">True</property>
-                    <property name="draw_indicator">True</property>
-                    <property name="group">radiobutton_none</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
+                  <placeholder/>
                 </child>
                 <child>
-                  <object class="GtkRadioButton" id="radiobutton_last_month">
-                    <property name="label" translatable="yes">Last of M_onth</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Keep the last price of each month if present before date.</property>
-                    <property name="use_underline">True</property>
-                    <property name="active">True</property>
-                    <property name="draw_indicator">True</property>
-                    <property name="group">radiobutton_none</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">1</property>
-                  </packing>
+                  <placeholder/>
                 </child>
                 <child>
-                  <object class="GtkRadioButton" id="radiobutton_last_quarter">
-                    <property name="label" translatable="yes">Last of _Quarter</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Keep the last price of each quarter if present before date.</property>
-                    <property name="use_underline">True</property>
-                    <property name="active">True</property>
-                    <property name="draw_indicator">True</property>
-                    <property name="group">radiobutton_none</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">2</property>
-                  </packing>
+                  <placeholder/>
                 </child>
-                <child>
-                  <object class="GtkRadioButton" id="radiobutton_last_period">
-                    <property name="label" translatable="yes">Last of _Period</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Keep the last price of each period if present before date.</property>
-                    <property name="use_underline">True</property>
-                    <property name="active">True</property>
-                    <property name="draw_indicator">True</property>
-                    <property name="group">radiobutton_none</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">3</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="right_attach">2</property>
-                <property name="top_attach">9</property>
-                <property name="bottom_attach">10</property>
-                <property name="y_options"/>
-                <property name="x_padding">10</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="label4">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="xalign">0</property>
-                <property name="label" translatable="yes">or the last available price for the option:</property>
               </object>
               <packing>
                 <property name="right_attach">2</property>
                 <property name="top_attach">8</property>
                 <property name="bottom_attach">9</property>
                 <property name="y_options"/>
+                <property name="x_padding">10</property>
               </packing>
             </child>
           </object>


### PR DESCRIPTION
This request changes the way old prices can be removed. There is now an option to specify which commodities to remove prices from as well as options to leave a weekly Friday price, the last Friday of a monthly and a scaled option.

Bob