### PR TITLE
Add constructor to create GncDate from string and predefined date format

### DIFF
--- a/src/bin/Makefile.am
+++ b/src/bin/Makefile.am
@@ -16,6 +16,7 @@ AM_CPPFLAGS = -I${top_builddir} ${GLIB_CFLAGS} ${GNOME_CFLAGS} ${GTK_CFLAGS} \
   -I${top_srcdir}/src/engine \
   -I${top_srcdir}/src/gnome \
   -I${top_builddir}/src \
+  -I${top_builddir}/src/core-utils \
   -I${top_srcdir}/src/gnc-module \
   -I${top_srcdir}/src/libqof/qof \
   -I${top_srcdir}/src/report/report-system \

--- a/src/engine/test/test-date.cpp
+++ b/src/engine/test/test-date.cpp
@@ -99,8 +99,10 @@ check_conversion (const char * str, Timespec expected_ts)
             || (g_date_get_year(&d1) != year))
     {
         fprintf (stderr,
-                 "\nmis-converted \"%s\" to GDate\n",
-                 str);
+                 "\nmis-converted \"%s\" to GDate. "
+                 "Got d1(Y-M-D) = %i-%i-%i, d2(Y-M-D) = %i-%i-%i\n",
+                 str, year, month, day,
+                 g_date_get_year(&d2), g_date_get_month(&d2), g_date_get_day(&d2));
         failure ("misconverted timespec");
         return FALSE;
     }

--- a/src/engine/test/utest-gnc-pricedb.c
+++ b/src/engine/test/utest-gnc-pricedb.c
@@ -968,6 +968,11 @@ gnc_pricedb_lookup_day(GNCPriceDB *db,// C: 4 in 2 SCM: 2 in 1 Local: 1:0:0
 static void
 test_gnc_pricedb_lookup_day (PriceDBFixture *fixture, gconstpointer pData)
 {
+    gchar *msg1 = "[gnc_dmy2timespec_internal()] Date computation error from Y-M-D 12-11-18: Year is out of valid range: 1400..10000";
+    gint loglevel = G_LOG_LEVEL_CRITICAL | G_LOG_FLAG_FATAL;
+    gchar *logdomain = "qof.engine";
+    TestErrorStruct check = {loglevel, logdomain, msg1, 0};
+    GLogFunc hdlr = g_log_set_default_handler ((GLogFunc)test_null_handler, &check);
     Timespec t = gnc_dmy2timespec(17, 11, 2012);
     GNCPrice *price = gnc_pricedb_lookup_day(fixture->pricedb,
                                              fixture->com->usd,
@@ -978,11 +983,13 @@ test_gnc_pricedb_lookup_day (PriceDBFixture *fixture, gconstpointer pData)
                                    fixture->com->usd,
                                    fixture->com->gbp, t);
     g_assert_cmpstr(GET_COM_NAME(price), ==, "GBP");
+    g_test_log_set_fatal_handler ((GTestLogFatalFunc)test_checked_handler, &check);
     t = gnc_dmy2timespec(18, 11, 12);
     price = gnc_pricedb_lookup_day(fixture->pricedb,
                                    fixture->com->usd,
                                    fixture->com->gbp, t);
     g_assert(price == NULL);
+    g_log_set_default_handler (hdlr, 0);
 }
 
 // Not Used

--- a/src/gnome-utils/Makefile.am
+++ b/src/gnome-utils/Makefile.am
@@ -12,6 +12,7 @@ AM_CPPFLAGS = \
   -I${top_srcdir}/src/app-utils \
   -I${top_srcdir}/src \
   -I${top_builddir}/src \
+  -I${top_builddir}/src/core-utils \
   -I${top_srcdir}/lib/libc \
   -I${top_srcdir}/src/libqof/qof \
   ${GLIB_CFLAGS} \

--- a/src/import-export/csv-imp/assistant-csv-trans-import.cpp
+++ b/src/import-export/csv-imp/assistant-csv-trans-import.cpp
@@ -793,7 +793,6 @@ CsvImpTransAssist::preview_settings_delete ()
 void
 CsvImpTransAssist::preview_settings_save ()
 {
-    auto title = _("Save the Import Settings.");
     auto new_name = tx_imp->settings_name();
 
     /* Check if the entry text matches an already existing preset */
@@ -889,7 +888,6 @@ void CsvImpTransAssist::preview_multi_split (bool multi)
  * separator checkbuttons or the custom separator entry) is
  * changed.
  * @param widget The widget that was changed
- * @param info The data that is being configured
  */
 void CsvImpTransAssist::preview_update_separators (GtkWidget* widget)
 {
@@ -952,8 +950,6 @@ void CsvImpTransAssist::preview_update_separators (GtkWidget* widget)
 
 /** Event handler for clicking one of the format type radio
  * buttons. This occurs if the format (Fixed-Width or CSV) is changed.
- * @param csv_button The "Separated" radio button
- * @param info The display of the data being imported
  */
 void CsvImpTransAssist::preview_update_file_format ()
 {
@@ -1007,7 +1003,6 @@ void CsvImpTransAssist::preview_update_account ()
 /** Event handler for a new encoding. This is called when the user
  * selects a new encoding; the data is reparsed and shown to the
  * user.
- * @param selector The widget the user uses to select a new encoding
  * @param encoding The encoding that the user selected
  */
 void
@@ -1080,10 +1075,7 @@ enum PreviewDataTableCols {
  * user selects a new column type, that column's text must be changed
  * to the selection, and any other columns containing that selection
  * must be changed to "None" because we don't allow duplicates.
- * @param renderer The renderer of the column the user changed
- * @param path There is only 1 row in info->ctreeview, so this is always 0.
- * @param new_text The text the user selected
- * @param info The display of the data being imported
+ * @param cbox The combo box the user just clicked to make a change
  */
 void CsvImpTransAssist::preview_update_col_type (GtkComboBox* cbox)
 {
@@ -1470,12 +1462,12 @@ void CsvImpTransAssist::preview_refresh_table ()
         GtkTreeIter iter;
         gtk_list_store_append (store, &iter);
         preview_row_fill_state_cells (store, &iter,
-                std::get<1>(parse_line), std::get<4>(parse_line));
+                std::get<PL_ERROR>(parse_line), std::get<PL_SKIP>(parse_line));
 
         /* Fill the data cells. */
-        for (auto cell_str_it = std::get<0>(parse_line).cbegin(); cell_str_it != std::get<0>(parse_line).cend(); cell_str_it++)
+        for (auto cell_str_it = std::get<PL_INPUT>(parse_line).cbegin(); cell_str_it != std::get<PL_INPUT>(parse_line).cend(); cell_str_it++)
         {
-            uint32_t pos = PREV_N_FIXED_COLS + cell_str_it - std::get<0>(parse_line).cbegin();
+            uint32_t pos = PREV_N_FIXED_COLS + cell_str_it - std::get<PL_INPUT>(parse_line).cbegin();
             gtk_list_store_set (store, &iter, pos, cell_str_it->c_str(), -1);
         }
     }

--- a/src/import-export/csv-imp/gnc-csv-trans-settings.cpp
+++ b/src/import-export/csv-imp/gnc-csv-trans-settings.cpp
@@ -245,7 +245,7 @@ CsvTransSettings::load (void)
     if (key_char && *key_char != '\0')
         m_encoding = key_char;
     else
-        "UTF-8";
+        m_encoding = "UTF-8";
     m_load_error |= handle_load_error (&key_error, group);
     if (key_char)
         g_free (key_char);

--- a/src/import-export/csv-imp/gnc-csv-trans-settings.hpp
+++ b/src/import-export/csv-imp/gnc-csv-trans-settings.hpp
@@ -75,9 +75,6 @@ void remove (void);
  *  The internally generated presets are read-only. The others
  *  can be saved to the state file or deleted.
  *
- *  @param group The group name where the settings are stored in the
- *  key file.
- *
  *  @return true if there was a problem.
  */
 bool read_only (void);
@@ -89,8 +86,8 @@ std::string   m_encoding;                     // File encoding
 bool          m_multi_split;                  // Assume multiple lines per transaction
 int           m_date_format;                  // Date Active id
 int           m_currency_format;              // Currency Active id
-uint32_t          m_skip_start_lines;             // Number of header rows to skip
-uint32_t          m_skip_end_lines;               // Number of footer rows to skip
+uint32_t      m_skip_start_lines;             // Number of header rows to skip
+uint32_t      m_skip_end_lines;               // Number of footer rows to skip
 bool          m_skip_alt_lines;               // Skip alternate rows
 std::string   m_separators;                   // Separators for csv format
 

--- a/src/import-export/csv-imp/gnc-tx-import.hpp
+++ b/src/import-export/csv-imp/gnc-tx-import.hpp
@@ -68,16 +68,23 @@ extern const gchar* currency_format_user[];
 extern const int num_date_formats;
 extern const gchar* date_format_user[];
 
-/** Tuple to hold
+/** An enum describing the columns found in a parse_line_t. Currently these are:
  *  - a tokenized line of input
  *  - an optional error string
  *  - a struct to hold user selected properties for a transaction
- *  - a struct to hold user selected properties for one or two splits in the above transaction */
-#define PL_INPUT    0
-#define PL_ERROR    1
-#define PL_PRETRANS 2
-#define PL_PRESPLIT 3
-#define PL_SKIP     4
+ *  - a struct to hold user selected properties for one or two splits in the above transaction
+ *  - a boolean to mark the line as skipped by error and/or user or not */
+enum parse_line_cols {
+    PL_INPUT,
+    PL_ERROR,
+    PL_PRETRANS,
+    PL_PRESPLIT,
+    PL_SKIP
+};
+
+/** Tuple to hold all internal state for one parsed line. The contents of each
+ * colummn is described by the parse_line_cols enum. This enum should be used
+ * with std::get to access the columns. */
 using parse_line_t = std::tuple<StrVec,
                                 std::string,
                                 std::shared_ptr<GncPreTrans>,

--- a/src/import-export/csv-imp/gnc-tx-import.hpp
+++ b/src/import-export/csv-imp/gnc-tx-import.hpp
@@ -73,6 +73,11 @@ extern const gchar* date_format_user[];
  *  - an optional error string
  *  - a struct to hold user selected properties for a transaction
  *  - a struct to hold user selected properties for one or two splits in the above transaction */
+#define PL_INPUT    0
+#define PL_ERROR    1
+#define PL_PRETRANS 2
+#define PL_PRESPLIT 3
+#define PL_SKIP     4
 using parse_line_t = std::tuple<StrVec,
                                 std::string,
                                 std::shared_ptr<GncPreTrans>,

--- a/src/libqof/qof/gnc-datetime.cpp
+++ b/src/libqof/qof/gnc-datetime.cpp
@@ -223,7 +223,7 @@ GncDateTimeImpl::GncDateTimeImpl(const GncDateImpl& date, DayPart part) :
     using TD = boost::posix_time::time_duration;
     static const TD start(0, 0, 0);
     static const TD neutral(10, 59, 0);
-    static const TD end(23,59, 0);
+    static const TD end(23,59, 59);
     TD time_of_day;
     switch (part)
     {

--- a/src/libqof/qof/gnc-datetime.hpp
+++ b/src/libqof/qof/gnc-datetime.hpp
@@ -28,6 +28,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <vector>
 
 typedef struct
 {
@@ -152,11 +153,28 @@ private:
     std::unique_ptr<GncDateTimeImpl> m_impl;
 };
 
+class GncDateFormat
+{
+public:
+    GncDateFormat (const char* fmt, const char* re) :
+    m_fmt(fmt), m_re(re) {}
+    const std::string m_fmt;
+private:
+    const std::string m_re;
+
+    friend class GncDateImpl;
+};
+
+
 class GncDate
 {
-    public:/** Construct a GncDate representing the current day.
-        */
-        GncDate();;
+    public:
+        /** A vector with all the date formats supported by the string constructor
+         */
+        static const std::vector<GncDateFormat> c_formats;
+        /** Construct a GncDate representing the current day.
+         */
+        GncDate();
         /** Construct a GncDate representing the given year, month, and day in
          * the proleptic Gregorian calendar.
          *
@@ -171,6 +189,23 @@ class GncDate
          * of the constrained range.
          */
         GncDate(int year, int month, int day);
+        /** Construct a GncDate by parsing a string assumed to be in the format
+         * passed in.
+         *
+         * The currently recognized formats are d-m-y, m-d-y, y-m-d, m-d, d-m.
+         * Note while the format descriptions use "-" as separator any of
+         * "-" (hyphen), "/" (slash), "'" (single quote), " " (space) or
+         * "." will be accepted.
+         *
+         * @param str The string to be interpreted.
+         * @param fmt The expected date format of the string passed in.
+         * @exception std::invalid_argument if
+         * - the string couldn't be parsed using the provided format
+         * - any of the date components is outside of its limit
+         *   (like month being 13, or day being 31 in February)
+         * - fmt doesn't specify a year, yet a year was found in the string
+         */
+        GncDate(const std::string str, const std::string fmt);
         GncDate(std::unique_ptr<GncDateImpl> impl);
         GncDate(GncDate&&);
         ~GncDate();

--- a/src/libqof/qof/gnc-datetime.hpp
+++ b/src/libqof/qof/gnc-datetime.hpp
@@ -153,23 +153,61 @@ private:
     std::unique_ptr<GncDateTimeImpl> m_impl;
 };
 
+/** GnuCash DateFormat class
+ *
+ * A helper class to represent a date format understood
+ * by the GncDate string/format constructor. Consumers
+ * of this header file are not supposed to create
+ * objects of this class themselves. Instead they
+ * can get a list of the understood formats from the
+ * GncDate::c_formats class variable and work with those.
+ */
+
 class GncDateFormat
 {
 public:
+    /** Construct a GncDateFormat with a given format and corresponding
+     * regular expression. This should only be used internally by the
+     * GncDate implementation. Consumers should never construct a GncDateFormat
+     * themselves!
+     */
     GncDateFormat (const char* fmt, const char* re) :
     m_fmt(fmt), m_re(re) {}
+    /** A string representing the format. */
     const std::string m_fmt;
 private:
+    /** Regular expression associated with the format string. This is to and
+     * only be used internally by the gnc-datetime code.
+     */
     const std::string m_re;
 
     friend class GncDateImpl;
 };
 
+/** GnuCash Date class
+ *
+ * The represented date is limited to the period
+ * between 1400 and 9999 CE.
+ */
 
 class GncDate
 {
     public:
-        /** A vector with all the date formats supported by the string constructor
+        /** A vector with all the date formats supported by the string constructor.
+         * The currently supported formats are:
+         * "y-m-d" (including yyyymmdd)
+         * "d-m-y" (including ddmmyyyy)
+         * "m-d-y" (including mmddyyyy)
+         * "d-m"   (including ddmm)
+         * "m-d"   (including mmdd)
+         *
+         * Notes:
+         * - while the format names are using a "-" as separator, the
+         * regexes will accept any of "-/.' " and will also work for dates
+         * without separators.
+         * - the format strings are marked for translation so it is possible
+         * to use a localized version of a format string using gettext. Example:
+         * gettext(GncDate::c_formats[0])
          */
         static const std::vector<GncDateFormat> c_formats;
         /** Construct a GncDate representing the current day.

--- a/src/libqof/qof/test/CMakeLists.txt
+++ b/src/libqof/qof/test/CMakeLists.txt
@@ -129,8 +129,11 @@ IF (NOT WIN32)
 
   SET(test_gnc_datetime_SOURCES
     ${MODULEPATH}/gnc-datetime.cpp
+    ${MODULEPATH}/gnc-timezone.cpp
+    ${MODULEPATH}/gnc-date.cpp
+    ${MODULEPATH}/qoflog.cpp
     gtest-gnc-datetime.cpp
     ${GTEST_SRC})
   GNC_ADD_TEST(test-gnc-datetime "${test_gnc_datetime_SOURCES}"
-    gtest_qof_INCLUDES gtest_old_qof_LIBS)
+    gtest_qof_INCLUDES gtest_qof_LIBS)
 ENDIF()

--- a/src/libqof/qof/test/CMakeLists.txt
+++ b/src/libqof/qof/test/CMakeLists.txt
@@ -50,9 +50,18 @@ IF (NOT WIN32)
   GNC_ADD_TEST(test-qof "${test_qof_SOURCES}" TEST_QOF_INCLUDE_DIRS TEST_QOF_LIBS)
   TARGET_COMPILE_DEFINITIONS(test-qof PRIVATE TESTPROG=test_qof)
   SET(MODULEPATH ${CMAKE_SOURCE_DIR}/src/libqof/qof)
-  SET(gtest_qof_LIBS gnc-qof ${GLIB2_LDFLAGS} ${Boost_LIBRARIES} ${GTEST_LIB})
+  SET(gtest_old_qof_LIBS gnc-qof ${GLIB2_LDFLAGS} ${Boost_LIBRARIES} ${GTEST_LIB})
+  SET(gtest_qof_LIBS
+    ${GLIB2_LDFLAGS}
+    ${GOBJECT_LDFLAGS}
+    ${GMODULE_LDFLAGS}
+    ${GTHREAD_LDFLAGS}
+    ${Boost_LIBRARIES}
+    ${GTEST_LIB})
   SET(gtest_qof_INCLUDES
     ${MODULEPATH}
+    ${CMAKE_BINARY_DIR}/src # for config.h
+    ${CMAKE_SOURCE_DIR}/src # for platform.h
     ${GLIB2_INCLUDE_DIRS}
     ${GTEST_INCLUDE_DIR})
 
@@ -61,7 +70,7 @@ IF (NOT WIN32)
     test-gnc-guid.cpp
     ${GTEST_SRC})
   GNC_ADD_TEST(test-gnc-guid "${test_gnc_guid_SOURCES}"
-    gtest_qof_INCLUDES gtest_qof_LIBS)
+    gtest_qof_INCLUDES gtest_old_qof_LIBS)
 
   SET(test_kvp_value_SOURCES
     ${MODULEPATH}/kvp-value.cpp
@@ -69,14 +78,14 @@ IF (NOT WIN32)
     test-kvp-frame.cpp
     ${GTEST_SRC})
   GNC_ADD_TEST(test-kvp-value "${test_kvp_value_SOURCES}"
-    gtest_qof_INCLUDES gtest_qof_LIBS)
+    gtest_qof_INCLUDES gtest_old_qof_LIBS)
 
   SET(test_qofsession_SOURCES
     ${MODULEPATH}/qofsession.cpp
     test-qofsession.cpp
     ${GTEST_SRC})
   GNC_ADD_TEST(test-qofsession "${test_qofsession_SOURCES}"
-    gtest_qof_INCLUDES gtest_qof_LIBS)
+    gtest_qof_INCLUDES gtest_old_qof_LIBS)
 
   SET(test_gnc_int128_SOURCES
     ${MODULEPATH}/gnc-int128.cpp
@@ -87,13 +96,25 @@ IF (NOT WIN32)
 
   SET(test_gnc_rational_SOURCES
     ${MODULEPATH}/gnc-rational.cpp
+    ${MODULEPATH}/gnc-numeric.cpp
+    ${MODULEPATH}/gnc-int128.cpp
+    ${MODULEPATH}/gnc-datetime.cpp
+    ${MODULEPATH}/gnc-timezone.cpp
+    ${MODULEPATH}/gnc-date.cpp
+    ${MODULEPATH}/qoflog.cpp
     gtest-gnc-rational.cpp
     ${GTEST_SRC})
   GNC_ADD_TEST(test-gnc-rational "${test_gnc_rational_SOURCES}"
     gtest_qof_INCLUDES gtest_qof_LIBS)
 
   SET(test_gnc_numeric_SOURCES
+    ${MODULEPATH}/gnc-rational.cpp
+    ${MODULEPATH}/gnc-int128.cpp
     ${MODULEPATH}/gnc-numeric.cpp
+    ${MODULEPATH}/gnc-datetime.cpp
+    ${MODULEPATH}/gnc-timezone.cpp
+    ${MODULEPATH}/gnc-date.cpp
+    ${MODULEPATH}/qoflog.cpp
     gtest-gnc-numeric.cpp
     ${GTEST_SRC})
   GNC_ADD_TEST(test-gnc-numeric "${test_gnc_numeric_SOURCES}"
@@ -104,12 +125,12 @@ IF (NOT WIN32)
     gtest-gnc-timezone.cpp
     ${GTEST_SRC})
   GNC_ADD_TEST(test-gnc-timezone "${test_gnc_timezone_SOURCES}"
-    gtest_qof_INCLUDES gtest_qof_LIBS)
+    gtest_qof_INCLUDES gtest_old_qof_LIBS)
 
   SET(test_gnc_datetime_SOURCES
     ${MODULEPATH}/gnc-datetime.cpp
     gtest-gnc-datetime.cpp
     ${GTEST_SRC})
   GNC_ADD_TEST(test-gnc-datetime "${test_gnc_datetime_SOURCES}"
-    gtest_qof_INCLUDES gtest_qof_LIBS)
+    gtest_qof_INCLUDES gtest_old_qof_LIBS)
 ENDIF()

--- a/src/libqof/qof/test/Makefile.am
+++ b/src/libqof/qof/test/Makefile.am
@@ -212,6 +212,8 @@ check_PROGRAMS += test-gnc-timezone
 test_gnc_datetime_SOURCES = \
         $(top_srcdir)/$(MODULEPATH)/gnc-datetime.cpp \
         $(top_srcdir)/$(MODULEPATH)/gnc-timezone.cpp \
+        $(top_srcdir)/$(MODULEPATH)/gnc-date.cpp \
+        $(top_srcdir)/${MODULEPATH}/qoflog.cpp \
         gtest-gnc-datetime.cpp
 test_gnc_datetime_CPPFLAGS =\
         -I$(GTEST_HEADERS) \
@@ -221,10 +223,9 @@ test_gnc_datetime_CPPFLAGS =\
         $(BOOST_CPPFLAGS)
 
 test_gnc_datetime_LDADD = \
-        -lboost_date_time \
-        ${top_builddir}/${MODULEPATH}/libgnc-qof.la \
         $(GLIB_LIBS) \
-        $(GTEST_LIBS)
+        $(GTEST_LIBS) \
+        ${BOOST_LDFLAGS} -lboost_regex -lboost_date_time
 if !GOOGLE_TEST_LIBS
 nodist_test_gnc_datetime_SOURCES = \
         $(GTEST_SRC)/src/gtest_main.cc

--- a/src/libqof/qof/test/gtest-gnc-datetime.cpp
+++ b/src/libqof/qof/test/gtest-gnc-datetime.cpp
@@ -236,7 +236,7 @@ TEST(gnc_datetime_constructors, test_gncdate_end_constructor)
     const ymd aymd = { 2046, 11, 06 };
     GncDateTime atime(GncDate(aymd.year, aymd.month, aymd.day), DayPart::end);
     //Skipping timezone information as this can't be controlled.
-    EXPECT_EQ(atime.format("%d-%m-%Y %H:%M:%S"), "06-11-2046 23:59:00");
+    EXPECT_EQ(atime.format("%d-%m-%Y %H:%M:%S"), "06-11-2046 23:59:59");
 }
 
 TEST(gnc_datetime_constructors, test_gncdate_neutral_constructor)


### PR DESCRIPTION
Primary use case is for parsing dates from external sources (importers).
Current implementation causes the test to abort in a segfault. I don't see any reason for that unfortunately. It seems to happen in boost:regex' memory housekeeping at the end of the test run. Running under gdb results in the following bt:
```
Program received signal SIGSEGV, Segmentation fault.
malloc_consolidate (av=av@entry=0x7ffff5b4bae0 <main_arena>) at malloc.c:4204
4204              nextsize = chunksize(nextchunk);
Missing separate debuginfos, use: dnf debuginfo-install gtest-1.7.0-8.fc25.x86_64
(gdb) bt
#0  0x00007ffff580bfbb in malloc_consolidate (av=av@entry=0x7ffff5b4bae0 <main_arena>) at malloc.c:4204
#1  0x00007ffff580db20 in _int_free (av=0x7ffff5b4bae0 <main_arena>, p=0x6f25a0, have_lock=0) at malloc.c:4110
#2  0x00007ffff58112bc in __GI___libc_free (mem=<optimized out>) at malloc.c:2982
#3  0x00007ffff724f6db in boost::re_detail_106000::mem_block_cache::~mem_block_cache() (this=0x7ffff74a9160 <boost::re_detail_106000::block_cache>, __in_chrg=<optimized out>) at boost/regex/v4/mem_block_cache.hpp:53
#4  0x00007ffff57c578a in __cxa_finalize (d=0x7ffff74a2d60) at cxa_finalize.c:56
#5  0x00007ffff71f04f3 in __do_global_dtors_aux () at /lib64/libboost_regex.so.1.60.0
#6  0x00007fffffffd840 in  ()
#7  0x00007ffff7de818a in _dl_fini () at dl-fini.c:235
```