### PR TITLE
Modify KRW fraction of ISO4217 currency settings

### DIFF
--- a/src/engine/iso-4217-currencies.xml
+++ b/src/engine/iso-4217-currencies.xml
@@ -1452,8 +1452,8 @@
   partname="chon"
   namespace="ISO4217"
   exchange-code="410"
-  parts-per-unit="1"
-  smallest-fraction="100"
+  parts-per-unit="100"
+  smallest-fraction="1"
   local-symbol="₩"
 />
 <!-- "KWD" - "Kuwaiti Dinar"


### PR DESCRIPTION
Chon(=Jeon), the smaller part of KRW, is no longer used in Korea.
Leaving it as it is causes annoying .00 attached after every value.

(FYI, JPY is the same, but it is already marked as having 1 smallest fraction, not 100. 
Someone must have updated it before)

Reference:
- https://en.wikipedia.org/wiki/ISO_4217 :
Number of digits after decimal separator is 0 for KRW
- https://en.wikipedia.org/wiki/South_Korean_won :
“The jeon is no longer used for everyday transactions”