### PR TITLE
Bug 776396 - Foreign currency reports, amounts are not aligned correctly 

### DIFF
--- a/src/report/report-system/html-acct-table.scm
+++ b/src/report/report-system/html-acct-table.scm
@@ -1163,7 +1163,7 @@
 	  )
 	 )))
     ;;below line as fix to Bug 776396 - make sure the commidity aligns the same as the rest of the currency (on the right)
-    (gnc:html-table-set-style! table "table" 'attribute(list "style" "width:100%; max-width:20em"))
+    (gnc:html-table-set-style! table "table" 'attribute(list "style" "width:100%; max-width:20em") 'attribute (list "cellpadding" "0"))
     ;;end fix
     table)
   )


### PR DESCRIPTION
https://bugzilla.gnome.org/show_bug.cgi?id=776396

Fixes the bug with the css change proposed in the bugzilla report.