### PR TITLE
Bug 776396 - Foreign currency reports, amounts are not aligned correctly

### DIFF
--- a/src/report/report-system/html-acct-table.scm
+++ b/src/report/report-system/html-acct-table.scm
@@ -1162,6 +1162,7 @@
 	   )
 	  )
 	 )))
+    (gnc:html-table-set-style! table "table" 'attribute(list "style" "width:100%; max-width:20em") 'attribute (list "cellpadding" "0"))
     table)
   )
 


### PR DESCRIPTION
Bug 776396 - Foreign currency reports, amounts are not aligned correctly

This commit will improve the styling of the table element used
for foreign currencies in the Balance sheet report so they
end up aligned with the other currencies.

Follow up on feedback on:

- https://github.com/Gnucash/gnucash/pull/147
- https://bugzilla.gnome.org/show_bug.cgi?id=776396