### PR TITLE
Bug 776396 Further Fix

### DIFF
--- a/src/report/report-system/html-acct-table.scm
+++ b/src/report/report-system/html-acct-table.scm
@@ -1156,6 +1156,7 @@
 	   ;; add the account balance in the respective commodity
 	   (gnc:make-html-table-cell/markup
 	    "number-cell" bal)
+	   "&nbsp;"
 	   ;; add the account balance in the report commodity
 	   (gnc:make-html-table-cell/markup
 	    "number-cell" (exchange-fn bal report-commodity))


### PR DESCRIPTION
This commit will further improve the styling of the table element used for foreign 
currencies in reports with stocks or foreign currencies. Adds non-breaking space 
between foreign currency/stock and report currency.