### PR TITLE
Fix import-export compile on windows

### DIFF
--- a/src/import-export/test/Makefile.am
+++ b/src/import-export/test/Makefile.am
@@ -68,8 +68,8 @@ test_import_pending_matches_LDADD = \
   ${top_builddir}/src/libqof/qof/libgnc-qof.la \
   ${top_builddir}/src/engine/libgncmod-engine.la \
   ../libgncmod-generic-import.la \
-  ${top_builddir}/src/test-core/libtest-core.la \
   ${top_builddir}/src/engine/test-core/libgncmod-test-engine.la \
+  ${top_builddir}/src/test-core/libtest-core.la \
   ${GLIB_LIBS}
 
 test_import_pending_matches_CFLAGS = $(AM_CPPFLAGS)


### PR DESCRIPTION
libgncmod-test-engine.la uses some functions defined in libtest-core.la, so libtest-core.la should be put after libgncmod-test-engine.la