### PR TITLE
membuf changes in gnc-dense-cal.c for gcc7 warnings

### DIFF
--- a/src/gnome-utils/gnc-dense-cal.c
+++ b/src/gnome-utils/gnc-dense-cal.c
@@ -1128,7 +1128,7 @@ gnc_dense_cal_draw_to_buffer(GncDenseCal *dcal)
     {
         GDate d, eoc;
         gint doc;
-        gchar dayNumBuf[3];
+        gchar dayNumBuf[4];
         gint numW, numH;
         gint x1, y1, x2, y2, w, h;
 
@@ -1138,8 +1138,8 @@ gnc_dense_cal_draw_to_buffer(GncDenseCal *dcal)
         for (doc = 0; g_date_get_julian(&d) < g_date_get_julian(&eoc); g_date_add_days(&d, 1), doc++)
         {
             doc_coords(dcal, doc, &x1, &y1, &x2, &y2);
-            memset(dayNumBuf, 0, 3);
-            snprintf(dayNumBuf, 3, "%d", g_date_get_day(&d));
+            memset(dayNumBuf, 0, 4);
+            snprintf(dayNumBuf, 4, "%d", g_date_get_day(&d));
             pango_layout_set_text(layout, dayNumBuf, -1);
             pango_layout_get_pixel_size(layout, &numW, &numH);
             w = (x2 - x1) + 1;


### PR DESCRIPTION
This PR fixes a gcc 7 warning for this [change](https://gcc.gnu.org/gcc-7/changes.html):

The -Wformat-truncation=*level* option detects certain and likely output truncation in calls to the snprintf family of formatted output functions. -Wformat-truncation=1 is included in -Wall and enabled without optimization but works best with -O2 and higher.