### PR TITLE
Add vertical-align:top to default text fields.

### DIFF
--- a/src/report/report-system/html-fonts.scm
+++ b/src/report/report-system/html-fonts.scm
@@ -157,7 +157,7 @@
             (string-append
                 "h3 { " title-font-info " }\n"
                 "a { " account-link-font-info " }\n"
-                "body, p, table, tr, td { text-align: left; " text-cell-font-info " }\n"
+                "body, p, table, tr, td { text-align: left; vertical-align: top; " text-cell-font-info " }\n"
                 "tr.alternate-row { background: " alternate-row-color " }\n"
                 "th.column-heading-left { text-align: left; " number-header-font-info " }\n"
                 "th.column-heading-center { text-align: center; " number-header-font-info " }\n"


### PR DESCRIPTION
Add vertical-align top.

Previously, text fields would have vertical-align:default = centre. This means long transaction descriptions would cause all other fields to be vertically centred. This amendment will ensure the transactional report text are aligned from the top.

Cosmetic change only.