### PR TITLE
Fix income statement when trading accounts not used

### DIFF
--- a/src/report/standard-reports/income-statement.scm
+++ b/src/report/standard-reports/income-statement.scm
@@ -647,14 +647,16 @@
 		  (if standard-order?
 		      (list
 		       (gnc:make-html-table-cell inc-table)
-		       (if (not (null? trading-accounts))
+		       (if (null? trading-accounts)
+			   (gnc:html-make-empty-cell)
 		           (gnc:make-html-table-cell tra-table))
 		       (gnc:make-html-table-cell exp-table)
 		       )
 		      (list
 		       (gnc:make-html-table-cell exp-table)
 		       (gnc:make-html-table-cell inc-table)
-		       (if (not (null? trading-accounts))
+		       (if (null? trading-accounts)
+			   (gnc:html-make-empty-cell)
 		           (gnc:make-html-table-cell tra-table))
 		       )
 		      )


### PR DESCRIPTION
Fix cosmetic bug
http://gnucash.1415818.n4.nabble.com/unknown-column-in-Income-Statement-Profit-amp-Loss-td4680661.html#a4692940

Insert an empty-cell instead of #unspecified, which is the result of (if predicate? result-if-true) where predicate? is #false