### PR TITLE
PR for partial fix for bug 660027

### DIFF
--- a/src/report/report-system/html-document.scm
+++ b/src/report/report-system/html-document.scm
@@ -286,7 +286,7 @@
                       (attr (gnc:warn "non-string attribute" attr)))))
              (build-first-tag
               (lambda (tag)
-                (push "\n<") (push tag)
+                (push "<") (push tag)
                 (if attr (hash-fold add-attribute #f attr))
                 (if extra-attrib (for-each addextraatt extra-attrib))
                 (if (not end-tag?)
@@ -336,7 +336,7 @@
             (let ((addtag (lambda (t)
                             (push "</")
                             (push tag)
-                            (push ">"))))
+                            (push ">\n"))))
               (cond
                ((string? tag)
                 (addtag tag))

--- a/src/report/report-system/html-document.scm
+++ b/src/report/report-system/html-document.scm
@@ -168,7 +168,7 @@
                 (let ((title (gnc:html-document-title doc)))
                   (if title 
                       (push (list "</title>" title "<title>\n"))))
-                (push "</head>\n")
+                (push "</head>")
                 
                 ;; this lovely little number just makes sure that <body>
                 ;; attributes like bgcolor get included 
@@ -336,7 +336,7 @@
             (let ((addtag (lambda (t)
                             (push "</")
                             (push tag)
-                            (push ">\n"))))
+                            (push ">"))))
               (cond
                ((string? tag)
                 (addtag tag))

--- a/src/report/report-system/html-document.scm
+++ b/src/report/report-system/html-document.scm
@@ -395,7 +395,7 @@
                (lambda (obj doc)
                  (gnc:html-document-render-data doc obj))
                ;; if the object is #f, make it a placeholder
-               (if obj obj "&nbsp;&nbsp;&nbsp;")))        
+               (if obj obj " ")))        
         (cond 
          ((gnc:html-text? obj)
           (set! o (gnc:make-html-object-internal 

--- a/src/report/report-system/html-fonts.scm
+++ b/src/report/report-system/html-fonts.scm
@@ -159,6 +159,7 @@
                 "a { " account-link-font-info " }\n"
                 "body, p, table, tr, td { text-align: left; vertical-align: top; " text-cell-font-info " }\n"
                 "tr.alternate-row { background: " alternate-row-color " }\n"
+                "tr { page-break-inside: avoid !important;}\n"
                 "th.column-heading-left { text-align: left; " number-header-font-info " }\n"
                 "th.column-heading-center { text-align: center; " number-header-font-info " }\n"
                 "th.column-heading-right { text-align: right; " number-header-font-info " }\n"

--- a/src/report/report-system/html-table.scm
+++ b/src/report/report-system/html-table.scm
@@ -702,7 +702,7 @@
        #f)
      #f (gnc:html-table-col-styles table))
     
-	(push (gnc:html-document-markup-start doc "tbody" #t))
+    (push (gnc:html-document-markup-start doc "tbody" #t))
     ;; now iterate over the rows 
     (let ((rownum 0) (colnum 0))
       (for-each 
@@ -752,7 +752,7 @@
            (set! colnum 0)
            (set! rownum (+ 1 rownum))))
        (reverse (gnc:html-table-data table))))
-	(push (gnc:html-document-markup-end doc "tbody"))
+    (push (gnc:html-document-markup-end doc "tbody"))
     
     ;; write the table end tag and pop the table style
     (push (gnc:html-document-markup-end doc "table"))

--- a/src/report/report-system/html-table.scm
+++ b/src/report/report-system/html-table.scm
@@ -668,6 +668,7 @@
              #f (gnc:html-table-col-styles table))
             
             ;; render the headers 
+            (push (gnc:html-document-markup-start doc "thead" #t))
             (push (gnc:html-document-markup-start doc "tr" #t))
             (for-each 
              (lambda (hdr) 
@@ -685,6 +686,7 @@
                                    colnum))))
              ch)
             (push (gnc:html-document-markup-end doc "tr"))
+            (push (gnc:html-document-markup-end doc "thead"))
 
             ;; pop the col header style 
             (gnc:html-document-pop-style doc))))
@@ -700,6 +702,7 @@
        #f)
      #f (gnc:html-table-col-styles table))
     
+	(push (gnc:html-document-markup-start doc "tbody" #t))
     ;; now iterate over the rows 
     (let ((rownum 0) (colnum 0))
       (for-each 
@@ -749,6 +752,7 @@
            (set! colnum 0)
            (set! rownum (+ 1 rownum))))
        (reverse (gnc:html-table-data table))))
+	(push (gnc:html-document-markup-end doc "tbody"))
     
     ;; write the table end tag and pop the table style
     (push (gnc:html-document-markup-end doc "table"))


### PR DESCRIPTION
This will partially fix bug 660027 when the report is HTML Exported, and the resultant file is opened and printed from a modern browser. I can confirm the table headers will then be repeated in every page... perhaps one day webkit will be upgraded!