### PR TITLE
Gtk3 update5

### DIFF
--- a/gnucash/gnome-utils/dialog-account.c
+++ b/gnucash/gnome-utils/dialog-account.c
@@ -669,7 +669,7 @@ verify_children_compatible (AccountWindow *aw)
     gnc_label_set_alignment (label, 0.0, 0.0);
 
     /* make label large */
-    gnc_widget_set_style_context (GTK_WIDGET(label), "primary_label_size");
+    gnc_widget_set_style_context (GTK_WIDGET(label), "emphasize-label");
 
     gtk_box_pack_start (GTK_BOX (vbox), label, FALSE, FALSE, 0);
 

--- a/gnucash/gnome-utils/dialog-utils.c
+++ b/gnucash/gnome-utils/dialog-utils.c
@@ -69,7 +69,7 @@ gnc_set_label_color(GtkWidget *label, gnc_numeric value)
     deficit = gnc_numeric_negative_p (value);
 
     if (deficit)
-        gnc_widget_set_style_context (GTK_WIDGET(label), "negative-color");
+        gnc_widget_set_style_context (GTK_WIDGET(label), "negative-numbers");
     else
         gnc_widget_set_style_context (GTK_WIDGET(label), "default-color");
 }

--- a/gnucash/gnome-utils/dialog-utils.c
+++ b/gnucash/gnome-utils/dialog-utils.c
@@ -69,9 +69,9 @@ gnc_set_label_color(GtkWidget *label, gnc_numeric value)
     deficit = gnc_numeric_negative_p (value);
 
     if (deficit)
-        gnc_widget_set_style_context (GTK_WIDGET(label), "css_red_color");
+        gnc_widget_set_style_context (GTK_WIDGET(label), "negative-color");
     else
-        gnc_widget_set_style_context (GTK_WIDGET(label), "css_default_color");
+        gnc_widget_set_style_context (GTK_WIDGET(label), "default-color");
 }
 
 

--- a/gnucash/gnome-utils/dialog-utils.c
+++ b/gnucash/gnome-utils/dialog-utils.c
@@ -293,6 +293,38 @@ gnc_widget_set_style_context (GtkWidget *widget, const char *gnc_class)
     gtk_style_context_add_class (context, gnc_class);
 }
 
+/********************************************************************\
+ * Draw an arrow on a Widget so it can be altered with css          *
+ *                                                                  *
+ * Args:     widget - widget to add arrow to in the draw callback   *
+ *               cr - cairo context for the draw callback           *
+ *        direction - 0 for up, 1 for down                          *
+ * Returns:  TRUE, stop other handlers being invoked for the event  *
+\********************************************************************/
+gboolean
+gnc_draw_arrow_cb (GtkWidget *widget, cairo_t *cr, gpointer direction)
+{
+    GtkStyleContext *context = gtk_widget_get_style_context (widget);
+    gint width = gtk_widget_get_allocated_width (widget);
+    gint height = gtk_widget_get_allocated_height (widget);
+    gint size;
+
+    gtk_render_background (context, cr, 0, 0, width, height);
+    gtk_style_context_add_class (context, GTK_STYLE_CLASS_ARROW);
+
+    size = MIN(width / 2, height / 2);
+
+    if (GPOINTER_TO_INT(direction) == 0)
+        gtk_render_arrow (context, cr, 0,
+                         (width - size)/2, (height - size)/2, size);
+    else
+        gtk_render_arrow (context, cr, G_PI,
+                         (width - size)/2, (height - size)/2, size);
+
+    return TRUE;
+}
+
+
 gboolean
 gnc_handle_date_accelerator (GdkEventKey *event,
                              struct tm *tm,

--- a/gnucash/gnome-utils/dialog-utils.h
+++ b/gnucash/gnome-utils/dialog-utils.h
@@ -88,6 +88,16 @@ GtkTreeViewGridLines gnc_tree_view_get_grid_lines_pref (void);
 \********************************************************************/
 void gnc_widget_set_style_context (GtkWidget *widget, const char *gnc_class);
 
+/********************************************************************\
+ * Draw an arrow on a Widget so it can be altered with css          *
+ *                                                                  *
+ * Args:     widget - widget to add arrow to in the draw callback   *
+ *               cr - cairo context for the draw callback           *
+ *        direction - 0 for up, 1 for down                          *
+ * Returns:  TRUE, stop other handlers being invoked for the event  *
+\********************************************************************/
+gboolean gnc_draw_arrow_cb (GtkWidget *widget, cairo_t *cr, gpointer direction);
+
 gboolean gnc_handle_date_accelerator (GdkEventKey *event,
                                       struct tm *tm,
                                       const char *date_str);

--- a/gnucash/gnome-utils/gnc-cell-renderer-popup-entry.c
+++ b/gnucash/gnome-utils/gnc-cell-renderer-popup-entry.c
@@ -111,6 +111,9 @@ gnc_popup_entry_init (GncPopupEntry *widget)
     arrow = gtk_image_new_from_icon_name ("go-down", GTK_ICON_SIZE_BUTTON);
     gtk_widget_show (arrow);
 
+    g_signal_connect (G_OBJECT (arrow), "draw",
+                      G_CALLBACK (gnc_draw_arrow_cb), GINT_TO_POINTER(1));
+
     gtk_container_add (GTK_CONTAINER (widget->button), arrow);
 
     gtk_box_pack_start (GTK_BOX (widget->hbox), widget->entry, TRUE, TRUE, 0);

--- a/gnucash/gnome-utils/gnc-combott.c
+++ b/gnucash/gnome-utils/gnc-combott.c
@@ -229,6 +229,9 @@ gctt_init (GncCombott *combott)
 
     arrow = gtk_image_new_from_icon_name ("go-down", GTK_ICON_SIZE_BUTTON);
 
+    g_signal_connect (G_OBJECT (arrow), "draw",
+                      G_CALLBACK (gnc_draw_arrow_cb), GINT_TO_POINTER(1));
+
 #if GTK_CHECK_VERSION(3,12,0)
     gtk_widget_set_margin_start (GTK_WIDGET(arrow), 5);
 #else

--- a/gnucash/gnome-utils/gnc-date-edit.c
+++ b/gnucash/gnome-utils/gnc-date-edit.c
@@ -929,6 +929,9 @@ create_children (GNCDateEdit *gde)
     /* Graphic for the popup button. */
     arrow = gtk_image_new_from_icon_name ("go-down", GTK_ICON_SIZE_BUTTON);
 
+    g_signal_connect (G_OBJECT (arrow), "draw",
+                      G_CALLBACK (gnc_draw_arrow_cb), GINT_TO_POINTER(1));
+
     gtk_box_pack_start (GTK_BOX (hbox), arrow, TRUE, FALSE, 0);
     gtk_widget_show (GTK_WIDGET(arrow));
 

--- a/gnucash/gnome-utils/gnc-dense-cal.c
+++ b/gnucash/gnome-utils/gnc-dense-cal.c
@@ -1030,7 +1030,15 @@ gnc_dense_cal_draw_to_buffer(GncDenseCal *dcal)
                 center_y = (y1 + y2 ) / 2;
                 radius = MIN((x2 - x1), (y2 - y1)) * .75;
 
-                gtk_render_background (stylectxt, cr, center_x - radius - 2, center_y - radius, (radius * 2) + 4, radius * 2);
+                // try to compensate for row height being odd or even
+                if (((y2 -y1) % 2) == 0)
+                    gtk_render_background (stylectxt, cr,
+                                           center_x - radius - 2, center_y - radius - 1,
+                                            (radius * 2) + 4, radius * 2);
+                else
+                    gtk_render_background (stylectxt, cr,
+                                           center_x - radius - 2, center_y - radius,
+                                            (radius * 2) + 4, (radius * 2) + 1);
             }
         }
         gtk_style_context_restore (stylectxt);

--- a/gnucash/gnome-utils/gnc-dense-cal.c
+++ b/gnucash/gnome-utils/gnc-dense-cal.c
@@ -25,6 +25,7 @@
 #include "gnc-dense-cal.h"
 #include "gnc-dense-cal-model.h"
 #include "gnc-engine.h"
+#include "gnc-gtk-utils.h"
 #include <glib.h>
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
@@ -923,21 +924,6 @@ gnc_style_context_get_border_color (GtkStyleContext *context,
     gdk_rgba_free (c);
 }
 
-static gboolean
-is_color_light (GdkRGBA *color)
-{
-    gboolean is_light = FALSE;
-
-    // Counting the perceptive luminance - human eye favors green color...
-    double a = (0.299 * color->red + 0.587 * color->green + 0.114 * color->blue);
-
-    if (a > 0.5)
-        is_light = TRUE;
-
-    return is_light;
-}
-
-static void
 gnc_dense_cal_draw_to_buffer(GncDenseCal *dcal)
 {
     GtkWidget *widget;
@@ -980,7 +966,7 @@ gnc_dense_cal_draw_to_buffer(GncDenseCal *dcal)
 
          gtk_style_context_get_color (stylectxt, GTK_STATE_FLAG_NORMAL, &color);
 
-          if (is_color_light (&color))
+          if (gnc_is_dark_theme (&color))
               class_extension = "-dark";
 
           primary_color_class = g_strconcat ("primary", class_extension, NULL);

--- a/gnucash/gnome-utils/gnc-dense-cal.c
+++ b/gnucash/gnome-utils/gnc-dense-cal.c
@@ -889,41 +889,6 @@ gnc_dense_cal_draw(GtkWidget *widget, cairo_t *cr, gpointer user_data)
 #define LOG_AND_RESET(timer, msg) do { g_debug("%s: %f", msg, g_timer_elapsed(timer, NULL) * 1000.); g_timer_reset(timer); } while (0);
 
 static void
-gnc_style_context_get_background_color (GtkStyleContext *context,
-                                        GtkStateFlags    state,
-                                        GdkRGBA         *color)
-{
-    GdkRGBA *c;
-
-    g_return_if_fail (color != NULL);
-    g_return_if_fail (GTK_IS_STYLE_CONTEXT (context));
-
-    gtk_style_context_get (context,
-                           state,
-                           GTK_STYLE_PROPERTY_BACKGROUND_COLOR, &c,
-                           NULL);
-    *color = *c;
-    gdk_rgba_free (c);
-}
-
-static void
-gnc_style_context_get_border_color (GtkStyleContext *context,
-                                    GtkStateFlags    state,
-                                    GdkRGBA         *color)
-{
-    GdkRGBA *c;
-
-    g_return_if_fail (color != NULL);
-    g_return_if_fail (GTK_IS_STYLE_CONTEXT (context));
-
-    gtk_style_context_get (context,
-                           state,
-                           GTK_STYLE_PROPERTY_BORDER_COLOR, &c,
-                           NULL);
-    *color = *c;
-    gdk_rgba_free (c);
-}
-
 gnc_dense_cal_draw_to_buffer(GncDenseCal *dcal)
 {
     GtkWidget *widget;

--- a/gnucash/gnome-utils/gnc-dense-cal.c
+++ b/gnucash/gnome-utils/gnc-dense-cal.c
@@ -262,7 +262,6 @@ static void
 gnc_dense_cal_init(GncDenseCal *dcal)
 {
     GtkStyleContext *context = gtk_widget_get_style_context (GTK_WIDGET(dcal));
-    gboolean colorAllocSuccess[MAX_COLORS];
 
     gtk_orientable_set_orientation (GTK_ORIENTABLE(dcal), GTK_ORIENTATION_VERTICAL);
 

--- a/gnucash/gnome-utils/gnc-dense-cal.c
+++ b/gnucash/gnome-utils/gnc-dense-cal.c
@@ -419,8 +419,8 @@ gnc_dense_cal_init(GncDenseCal *dcal)
     dcal->topPadding = 2;
 
     {
-	GDate now;
-	g_date_clear (&now, 1);
+    GDate now;
+    g_date_clear (&now, 1);
         gnc_gdate_set_today (&now);
         _gnc_dense_cal_set_month(dcal, g_date_get_month(&now), FALSE);
         _gnc_dense_cal_set_year(dcal, g_date_get_year(&now), FALSE);
@@ -1341,7 +1341,7 @@ gnc_dense_cal_motion_notify(GtkWidget *widget,
         GdkWindow *win = gdk_screen_get_root_window (gtk_widget_get_screen (widget));
         GdkMonitor *mon = gdk_display_get_monitor_at_window (gtk_widget_get_display (widget), win);
         GdkRectangle monitor_size;
-                
+
         gdk_monitor_get_geometry (mon, &monitor_size);
 
         screen_width = monitor_size.width;
@@ -1355,7 +1355,7 @@ gnc_dense_cal_motion_notify(GtkWidget *widget,
 
         gtk_widget_get_allocation(GTK_WIDGET(dcal->transPopup), &alloc);
 
-        gtk_widget_show_all(GTK_WIDGET(dcal->transPopup));      
+        gtk_widget_show_all(GTK_WIDGET(dcal->transPopup));
 
         if (event->x_root + 5 + alloc.width > screen_width)
             win_xpos = event->x_root - 2 - alloc.width;

--- a/gnucash/gnome-utils/gnc-dense-cal.c
+++ b/gnucash/gnome-utils/gnc-dense-cal.c
@@ -924,17 +924,17 @@ gnc_style_context_get_border_color (GtkStyleContext *context,
 }
 
 static gboolean
-is_color_dark (GdkRGBA *color)
+is_color_light (GdkRGBA *color)
 {
-    gboolean is_dark = FALSE;
+    gboolean is_light = FALSE;
 
     // Counting the perceptive luminance - human eye favors green color...
     double a = (0.299 * color->red + 0.587 * color->green + 0.114 * color->blue);
 
     if (a > 0.5)
-        is_dark = TRUE;
+        is_light = TRUE;
 
-    return is_dark;
+    return is_light;
 }
 
 static void
@@ -949,7 +949,7 @@ gnc_dense_cal_draw_to_buffer(GncDenseCal *dcal)
     PangoLayout *layout;
     GTimer *timer;
     cairo_t *cr;
-    const gchar *primary_color_class, *secondary_color_class, *marker_color_class;
+    gchar *primary_color_class, *secondary_color_class, *marker_color_class;
 
     timer = g_timer_new();
     g_debug("drawing");
@@ -976,16 +976,16 @@ gnc_dense_cal_draw_to_buffer(GncDenseCal *dcal)
     /* get the colors */
     {
          GdkRGBA color;
-         gchar *color_extension = NULL;
+         gchar *class_extension = NULL;
 
          gtk_style_context_get_color (stylectxt, GTK_STATE_FLAG_NORMAL, &color);
 
-          if (is_color_dark (&color))
-              color_extension = "-dark";
+          if (is_color_light (&color))
+              class_extension = "-dark";
 
-          primary_color_class = g_strconcat ("primary", color_extension, NULL);
-          secondary_color_class = g_strconcat ("secondary", color_extension, NULL);
-          marker_color_class = g_strconcat ("markers", color_extension, NULL);
+          primary_color_class = g_strconcat ("primary", class_extension, NULL);
+          secondary_color_class = g_strconcat ("secondary", class_extension, NULL);
+          marker_color_class = g_strconcat ("markers", class_extension, NULL);
     }
 
 
@@ -1231,6 +1231,10 @@ gnc_dense_cal_draw_to_buffer(GncDenseCal *dcal)
                                alloc.height);
 
     LOG_AND_RESET(timer, "queue draw");
+
+    g_free (primary_color_class);
+    g_free (secondary_color_class);
+    g_free (marker_color_class);
 
     g_object_unref(layout);
     cairo_destroy (cr);

--- a/gnucash/gnome-utils/gnc-dense-cal.h
+++ b/gnucash/gnome-utils/gnc-dense-cal.h
@@ -44,13 +44,6 @@ typedef struct _gdc_month_coords
     gint x, y;
 } gdc_month_coords;
 
-enum GDC_COLORS
-{
-    MONTH_THIS = 0,
-    MONTH_THAT,
-    MAX_COLORS
-};
-
 struct _GncDenseCal
 {
     GtkBox widget;
@@ -83,8 +76,6 @@ struct _GncDenseCal
     gint topPadding;
 
     gdc_month_coords monthPositions[12];
-
-    GdkRGBA weekColors[MAX_COLORS];
 
     guint label_width;
     guint label_height;

--- a/gnucash/gnome-utils/gnc-gnome-utils.c
+++ b/gnucash/gnome-utils/gnc-gnome-utils.c
@@ -172,7 +172,7 @@ gnc_configure_date_completion (void)
 void
 gnc_add_css_file (void)
 {
-    GtkCssProvider *provider_user, *provider_app;
+    GtkCssProvider *provider_user, *provider_app, *provider_fallback;
     GdkDisplay *display;
     GdkScreen *screen;
     const gchar *var;
@@ -182,13 +182,20 @@ gnc_add_css_file (void)
 
     provider_user = gtk_css_provider_new ();
     provider_app = gtk_css_provider_new ();
+    provider_fallback = gtk_css_provider_new ();
     display = gdk_display_get_default ();
     screen = gdk_display_get_default_screen (display);
+
+    gtk_style_context_add_provider_for_screen (screen, GTK_STYLE_PROVIDER (provider_fallback), GTK_STYLE_PROVIDER_PRIORITY_THEME - 50);
     gtk_style_context_add_provider_for_screen (screen, GTK_STYLE_PROVIDER (provider_app), GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
     gtk_style_context_add_provider_for_screen (screen, GTK_STYLE_PROVIDER (provider_user), GTK_STYLE_PROVIDER_PRIORITY_USER);
 
     if (pkgdatadir)
     {
+        str = g_build_filename (pkgdatadir, "ui", "gnucash-fallback.css", (char *)NULL);
+        gtk_css_provider_load_from_path (provider_fallback, str, &error);
+        g_free (str);
+ 
         str = g_build_filename (pkgdatadir, "ui", "gnucash.css", (char *)NULL);
         gtk_css_provider_load_from_path (provider_app, str, &error);
         g_free (str);
@@ -204,6 +211,7 @@ gnc_add_css_file (void)
     }
     g_object_unref (provider_user);
     g_object_unref (provider_app);
+    g_object_unref (provider_fallback);
 }
 
 #ifdef MAC_INTEGRATION

--- a/gnucash/gnome-utils/gnc-gnome-utils.c
+++ b/gnucash/gnome-utils/gnc-gnome-utils.c
@@ -186,7 +186,7 @@ gnc_add_css_file (void)
     display = gdk_display_get_default ();
     screen = gdk_display_get_default_screen (display);
 
-    gtk_style_context_add_provider_for_screen (screen, GTK_STYLE_PROVIDER (provider_fallback), GTK_STYLE_PROVIDER_PRIORITY_THEME - 50);
+    gtk_style_context_add_provider_for_screen (screen, GTK_STYLE_PROVIDER (provider_fallback), GTK_STYLE_PROVIDER_PRIORITY_FALLBACK);
     gtk_style_context_add_provider_for_screen (screen, GTK_STYLE_PROVIDER (provider_app), GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
     gtk_style_context_add_provider_for_screen (screen, GTK_STYLE_PROVIDER (provider_user), GTK_STYLE_PROVIDER_PRIORITY_USER);
 
@@ -195,7 +195,7 @@ gnc_add_css_file (void)
         str = g_build_filename (pkgdatadir, "ui", "gnucash-fallback.css", (char *)NULL);
         gtk_css_provider_load_from_path (provider_fallback, str, &error);
         g_free (str);
- 
+
         str = g_build_filename (pkgdatadir, "ui", "gnucash.css", (char *)NULL);
         gtk_css_provider_load_from_path (provider_app, str, &error);
         g_free (str);

--- a/gnucash/gnome-utils/gnc-gtk-utils.c
+++ b/gnucash/gnome-utils/gnc-gtk-utils.c
@@ -223,3 +223,22 @@ gnc_cbwe_require_list_item (GtkComboBox *cbwe)
 
     g_object_set_data(G_OBJECT(cbwe), CHANGED_ID, GINT_TO_POINTER(id));
 }
+
+/** Test to see if fg_color is a light one which should be a foreground
+ *  one and hence would be on a dark background
+ *
+ *  @param fg_color The foreground color to test.
+ */
+gboolean
+gnc_is_dark_theme (GdkRGBA *fg_color)
+{
+    gboolean is_dark = FALSE;
+
+    // Counting the perceptive luminance - human eye favors green color...
+    double lightness = (0.299 * fg_color->red + 0.587 * fg_color->green + 0.114 * fg_color->blue);
+
+    if (lightness > 0.5)
+        is_dark = TRUE;
+
+    return is_dark;
+}

--- a/gnucash/gnome-utils/gnc-gtk-utils.c
+++ b/gnucash/gnome-utils/gnc-gtk-utils.c
@@ -242,3 +242,55 @@ gnc_is_dark_theme (GdkRGBA *fg_color)
 
     return is_dark;
 }
+
+/** Wrapper to get the background color of a widget for a given state
+ *
+ *  @param context Style context of widget.
+ *
+ *  @param state The stateflag of the widget.
+ *
+ *  @param color The returned background color of the widget.
+ */
+void
+gnc_style_context_get_background_color (GtkStyleContext *context,
+                                        GtkStateFlags    state,
+                                        GdkRGBA         *color)
+{
+    GdkRGBA *c;
+
+    g_return_if_fail (color != NULL);
+    g_return_if_fail (GTK_IS_STYLE_CONTEXT (context));
+
+    gtk_style_context_get (context,
+                           state,
+                           GTK_STYLE_PROPERTY_BACKGROUND_COLOR, &c,
+                           NULL);
+    *color = *c;
+    gdk_rgba_free (c);
+}
+
+/** Wrapper to get the border color of a widget for a given state
+ *
+ *  @param context Style context of widget.
+ *
+ *  @param state The stateflag of the widget.
+ *
+ *  @param color The returned border color of the widget.
+ */
+void
+gnc_style_context_get_border_color (GtkStyleContext *context,
+                                    GtkStateFlags    state,
+                                    GdkRGBA         *color)
+{
+    GdkRGBA *c;
+
+    g_return_if_fail (color != NULL);
+    g_return_if_fail (GTK_IS_STYLE_CONTEXT (context));
+
+    gtk_style_context_get (context,
+                           state,
+                           GTK_STYLE_PROPERTY_BORDER_COLOR, &c,
+                           NULL);
+    *color = *c;
+    gdk_rgba_free (c);
+}

--- a/gnucash/gnome-utils/gnc-gtk-utils.h
+++ b/gnucash/gnome-utils/gnc-gtk-utils.h
@@ -45,6 +45,7 @@ void gnc_cbwe_set_by_string(GtkComboBox *cbwe, const gchar *text);
 void gnc_cbwe_add_completion (GtkComboBox *cbwe);
 void gnc_cbwe_require_list_item (GtkComboBox *cbwe);
 
+gboolean gnc_is_dark_theme (GdkRGBA *fg_color);
 /** @} */
 
 #endif /* GNC_GTK_UTILS_H */

--- a/gnucash/gnome-utils/gnc-gtk-utils.h
+++ b/gnucash/gnome-utils/gnc-gtk-utils.h
@@ -46,6 +46,13 @@ void gnc_cbwe_add_completion (GtkComboBox *cbwe);
 void gnc_cbwe_require_list_item (GtkComboBox *cbwe);
 
 gboolean gnc_is_dark_theme (GdkRGBA *fg_color);
+void gnc_style_context_get_background_color (GtkStyleContext *context,
+                                             GtkStateFlags    state,
+                                             GdkRGBA         *color);
+void gnc_style_context_get_border_color (GtkStyleContext *context,
+                                         GtkStateFlags    state,
+                                         GdkRGBA         *color);
+
 /** @} */
 
 #endif /* GNC_GTK_UTILS_H */

--- a/gnucash/gnome-utils/gnc-tree-model-account.c
+++ b/gnucash/gnome-utils/gnc-tree-model-account.c
@@ -106,6 +106,17 @@ typedef struct GncTreeModelAccountPrivate
 /************************************************************/
 /*           Account Tree Model - Misc Functions            */
 /************************************************************/
+static gchar*
+get_negative_color (void)
+{
+    GdkRGBA color;
+    GtkWidget *label = gtk_label_new ("Color");
+    GtkStyleContext *context = gtk_widget_get_style_context (GTK_WIDGET(label));
+    gtk_style_context_add_class (context, "negative-color");
+    gtk_style_context_get_color (context, GTK_STATE_FLAG_NORMAL, &color);
+
+    return gdk_rgba_to_string (&color);;
+}
 
 /** Tell the GncTreeModelAccount code to update the color that it will
  *  use for negative numbers.  This function will iterate over all
@@ -124,7 +135,7 @@ gnc_tree_model_account_update_color (gpointer gsettings, gchar *key, gpointer us
     model = user_data;
     priv = GNC_TREE_MODEL_ACCOUNT_GET_PRIVATE(model);
     use_red = gnc_prefs_get_bool (GNC_PREFS_GROUP_GENERAL, GNC_PREF_NEGATIVE_IN_RED);
-    priv->negative_color = use_red ? "red" : NULL;
+    priv->negative_color = use_red ? get_negative_color () : NULL;
 }
 /************************************************************/
 /*               g_object required functions                */
@@ -205,7 +216,7 @@ gnc_tree_model_account_init (GncTreeModelAccount *model)
     priv = GNC_TREE_MODEL_ACCOUNT_GET_PRIVATE(model);
     priv->book = NULL;
     priv->root = NULL;
-    priv->negative_color = red ? "red" : NULL;
+    priv->negative_color = red ? get_negative_color () : NULL;
 
     gnc_prefs_register_cb(GNC_PREFS_GROUP_GENERAL, GNC_PREF_NEGATIVE_IN_RED,
                           gnc_tree_model_account_update_color,

--- a/gnucash/gnome-utils/gnc-tree-model-account.c
+++ b/gnucash/gnome-utils/gnc-tree-model-account.c
@@ -115,7 +115,7 @@ get_negative_color (void)
     gtk_style_context_add_class (context, "negative-numbers");
     gtk_style_context_get_color (context, GTK_STATE_FLAG_NORMAL, &color);
 
-    return gdk_rgba_to_string (&color);;
+    return gdk_rgba_to_string (&color);
 }
 
 /** Tell the GncTreeModelAccount code to update the color that it will

--- a/gnucash/gnome-utils/gnc-tree-model-account.c
+++ b/gnucash/gnome-utils/gnc-tree-model-account.c
@@ -112,7 +112,7 @@ get_negative_color (void)
     GdkRGBA color;
     GtkWidget *label = gtk_label_new ("Color");
     GtkStyleContext *context = gtk_widget_get_style_context (GTK_WIDGET(label));
-    gtk_style_context_add_class (context, "negative-color");
+    gtk_style_context_add_class (context, "negative-numbers");
     gtk_style_context_get_color (context, GTK_STATE_FLAG_NORMAL, &color);
 
     return gdk_rgba_to_string (&color);;

--- a/gnucash/gnome-utils/gnc-tree-view-split-reg.c
+++ b/gnucash/gnome-utils/gnc-tree-view-split-reg.c
@@ -1017,7 +1017,7 @@ gnc_tree_view_split_reg_new_with_model (GncTreeModelSplitReg *model)
     view->help_text = g_strdup ("Help Text");
 
     /* Set the grid lines to be solid */
-    gnc_widget_set_style_context (GTK_WIDGET(view), "treeview_grid_lines");
+    gnc_widget_set_style_context (GTK_WIDGET(view), "register2_grid_lines");
 
     /* TreeView Grid lines */
     if (view->priv->use_horizontal_lines)

--- a/gnucash/gnome-utils/gnc-tree-view.c
+++ b/gnucash/gnome-utils/gnc-tree-view.c
@@ -247,9 +247,6 @@ gnc_tree_view_init (GncTreeView *view, GncTreeViewClass *klass)
     priv->sort_column_changed_cb_id = 0;
     priv->size_allocate_cb_id = 0;
 
-    /* Ask gtk to help the user keep track of rows. */
-    g_object_set(view, "rules-hint", TRUE, NULL);
-
     // Set the style context for this page so it can be easily manipulated with css
     gnc_widget_set_style_context (GTK_WIDGET(view), "GncTreeView");
 

--- a/gnucash/gnome-utils/gnc-tree-view.c
+++ b/gnucash/gnome-utils/gnc-tree-view.c
@@ -273,9 +273,12 @@ gnc_tree_view_init (GncTreeView *view, GncTreeViewClass *klass)
     /* Create the last column which contains the column selection
      * widget.  gnc_tree_view_add_text_column will do most of the
      * work. */
-    icon = gtk_image_new_from_icon_name ("go-down",
-                                    GTK_ICON_SIZE_SMALL_TOOLBAR);
+    icon = gtk_image_new_from_icon_name ("go-down", GTK_ICON_SIZE_SMALL_TOOLBAR);
     gtk_widget_show(icon);
+
+    g_signal_connect (G_OBJECT (icon), "draw",
+                      G_CALLBACK (gnc_draw_arrow_cb), GINT_TO_POINTER(1));
+
     gtk_widget_get_preferred_size(icon, &requisition, NULL);
     column = gnc_tree_view_add_text_column (view, NULL, NULL, NULL, NULL,
                                             -1, -1, NULL);

--- a/gnucash/gnome-utils/ui/CMakeLists.txt
+++ b/gnucash/gnome-utils/ui/CMakeLists.txt
@@ -16,6 +16,7 @@ SET(gnome_utils_ui_DIST_local
         Makefile.am
         osx_accel_map
         gnucash.css
+        gnucash-fallback.css
         )
 
 SET_DIST_LIST(gnome_utils_ui_DIST ${gnome_utils_ui_DIST_local})

--- a/gnucash/gnome-utils/ui/Makefile.am
+++ b/gnucash/gnome-utils/ui/Makefile.am
@@ -4,6 +4,7 @@ ui_DATA = \
 	gnc-windows-menu-ui.xml \
 	gnc-windows-menu-ui-quartz.xml \
 	osx_accel_map \
-	gnucash.css
+	gnucash.css \
+	gnucash-fallback.css
 
 EXTRA_DIST = $(ui_DATA) CMakeLists.txt

--- a/gnucash/gnome-utils/ui/gnucash-fallback.css
+++ b/gnucash/gnome-utils/ui/gnucash-fallback.css
@@ -2,3 +2,16 @@
    directly by name as these are not brought in when loaded, only
    the widget type can be configured unless they are named in code */
 
+
+/* These are the defaults used in the dense-cal */
+*.primary {
+  background-color: lavender;
+}
+
+*.secondary {
+  background-color: SlateGray1;
+}
+
+*.markers {
+  background-color: yellow;
+}

--- a/gnucash/gnome-utils/ui/gnucash-fallback.css
+++ b/gnucash/gnome-utils/ui/gnucash-fallback.css
@@ -1,5 +1,5 @@
 /* Note: Widgets obtained from Glade files will not be addressable
-   directly by name as these are not brought in when loaded, only
+   unless they have been named or have style classes added. Only 
    the widget type can be configured unless they are named in code */
 
 

--- a/gnucash/gnome-utils/ui/gnucash-fallback.css
+++ b/gnucash/gnome-utils/ui/gnucash-fallback.css
@@ -30,6 +30,13 @@
   border-color: black;
 }
 
+/* Make Label bold and larger */
+.emphasize-label {
+  font-size: large;
+  font-weight: bold;
+}
+
+/* The Dense Calendar defaults */
 *.primary {
   background-color: lavender;
 }

--- a/gnucash/gnome-utils/ui/gnucash-fallback.css
+++ b/gnucash/gnome-utils/ui/gnucash-fallback.css
@@ -37,14 +37,31 @@
 }
 
 /* The Dense Calendar defaults */
+@define-color primary_bg_color lavender;
+@define-color secondary_bg_color SlateGray1;
+@define-color marker_bg_color yellow;
+
 *.primary {
-  background-color: lavender;
+   background-color: @primary_bg_color;
+}
+
+*.primary-dark {
+  background-color: shade (@primary_bg_color, 0.7);
 }
 
 *.secondary {
-  background-color: SlateGray1;
+  background-color: @secondary_bg_color;
+}
+
+*.secondary-dark {
+  background-color: shade (@secondary_bg_color, 0.7);
 }
 
 *.markers {
-  background-color: yellow;
+  background-color: @marker_bg_color;
 }
+
+*.markers-dark {
+  background-color: shade (@marker_bg_color, 0.8);
+}
+

--- a/gnucash/gnome-utils/ui/gnucash-fallback.css
+++ b/gnucash/gnome-utils/ui/gnucash-fallback.css
@@ -7,7 +7,7 @@
   color: currentColor;
 }
 
-.negative-color {
+.negative-numbers {
   color: rgb(75%, 0%, 0%);
 }
 

--- a/gnucash/gnome-utils/ui/gnucash-fallback.css
+++ b/gnucash/gnome-utils/ui/gnucash-fallback.css
@@ -2,8 +2,16 @@
    directly by name as these are not brought in when loaded, only
    the widget type can be configured unless they are named in code */
 
+/* negative value label colors # dialog-utils.c */
+.default-color {
+  color: currentColor;
+}
 
-/* These are the defaults used in the dense-cal */
+.negative-color {
+  color: rgb(75%, 0%, 0%);
+}
+
+/* These are the defaults used in # gnc-dense-cal.c */
 *.primary {
   background-color: lavender;
 }

--- a/gnucash/gnome-utils/ui/gnucash-fallback.css
+++ b/gnucash/gnome-utils/ui/gnucash-fallback.css
@@ -30,7 +30,7 @@
   border-color: black;
 }
 
-/* Make Label bold and larger */
+/* Make label more important */
 .emphasize-label {
   font-size: large;
   font-weight: bold;

--- a/gnucash/gnome-utils/ui/gnucash-fallback.css
+++ b/gnucash/gnome-utils/ui/gnucash-fallback.css
@@ -1,0 +1,4 @@
+/* Note: Widgets obtained from Glade files will not be addressable
+   directly by name as these are not brought in when loaded, only
+   the widget type can be configured unless they are named in code */
+

--- a/gnucash/gnome-utils/ui/gnucash-fallback.css
+++ b/gnucash/gnome-utils/ui/gnucash-fallback.css
@@ -25,7 +25,11 @@
   color: rgb(75%, 0%, 0%);
 }
 
-/* These are the defaults used in # gnc-dense-cal.c */
+/* Register2 grid lines color */
+.register2_grid_lines {
+  border-color: black;
+}
+
 *.primary {
   background-color: lavender;
 }

--- a/gnucash/gnome-utils/ui/gnucash-fallback.css
+++ b/gnucash/gnome-utils/ui/gnucash-fallback.css
@@ -2,7 +2,21 @@
    directly by name as these are not brought in when loaded, only
    the widget type can be configured unless they are named in code */
 
-/* negative value label colors # dialog-utils.c */
+
+/* Import Matcher, amount of intervention required */
+.intervention-required {
+  background-color: brown1;
+}
+
+.intervention-probably-required {
+  background-color: gold;
+}
+
+.intervention-not-required {
+  background-color: DarkSeaGreen1;
+}
+
+/* Negative value label colors */
 .default-color {
   color: currentColor;
 }

--- a/gnucash/gnome-utils/ui/gnucash-fallback.css
+++ b/gnucash/gnome-utils/ui/gnucash-fallback.css
@@ -4,16 +4,32 @@
 
 
 /* Import Matcher, amount of intervention required */
+@define-color intervention-required_bg_color brown1;
+@define-color intervention-probably-required_bg_color gold;
+@define-color intervention-not-required_bg_color DarkSeaGreen1;
+
 .intervention-required {
-  background-color: brown1;
+  background-color: @intervention-required_bg_color;
 }
 
 .intervention-probably-required {
-  background-color: gold;
+  background-color: @intervention-probably-required_bg_color;
 }
 
 .intervention-not-required {
-  background-color: DarkSeaGreen1;
+  background-color: @intervention-not-required_bg_color;
+}
+
+.intervention-required-dark {
+  background-color: shade (@intervention-required_bg_color, 0.7);
+}
+
+.intervention-probably-required-dark {
+  background-color: shade (@intervention-probably-required_bg_color, 0.8);
+}
+
+.intervention-not-required-dark {
+  background-color: shade (@intervention-not-required_bg_color, 0.3);
 }
 
 /* Negative value label colors */

--- a/gnucash/gnome-utils/ui/gnucash.css
+++ b/gnucash/gnome-utils/ui/gnucash.css
@@ -2,11 +2,6 @@
    directly by name as these are not brought in when loaded, only
    the widget type can be configured unless they are named in code */
 
-/* Set the grid lines to be solid # gnc-tree-view-split-reg.c */
-.treeview_grid_lines {
-  border-color: black;
-}
-
 /* Increase label size # dialog-account.c */
 .primary_label_size {
   font-size: large;

--- a/gnucash/gnome-utils/ui/gnucash.css
+++ b/gnucash/gnome-utils/ui/gnucash.css
@@ -2,9 +2,3 @@
    directly by name as these are not brought in when loaded, only
    the widget type can be configured unless they are named in code */
 
-/* Increase label size # dialog-account.c */
-.primary_label_size {
-  font-size: large;
-  font-weight: bold;
-}
-

--- a/gnucash/gnome-utils/ui/gnucash.css
+++ b/gnucash/gnome-utils/ui/gnucash.css
@@ -2,19 +2,6 @@
    directly by name as these are not brought in when loaded, only
    the widget type can be configured unless they are named in code */
 
-/* Import Matcher # import-main-matcher.*/
-.color_back_red {
-  background-color: brown1;
-}
-
-.color_back_yellow {
-  background-color: gold;
-}
-
-.color_back_green {
-  background-color: DarkSeaGreen1;
-}
-
 /* Set the grid lines to be solid # gnc-tree-view-split-reg.c */
 .treeview_grid_lines {
   border-color: black;

--- a/gnucash/gnome-utils/ui/gnucash.css
+++ b/gnucash/gnome-utils/ui/gnucash.css
@@ -1,4 +1,4 @@
 /* Note: Widgets obtained from Glade files will not be addressable
-   directly by name as these are not brought in when loaded, only
+   unless they have been named or have style classes added. Only 
    the widget type can be configured unless they are named in code */
 

--- a/gnucash/gnome-utils/ui/gnucash.css
+++ b/gnucash/gnome-utils/ui/gnucash.css
@@ -15,15 +15,6 @@
   background-color: DarkSeaGreen1;
 }
 
-/* label colors # dialog-utils.c */
-.css_default_color {
-  color: currentColor;
-}
-
-.css_red_color {
-  color: rgb(75%, 0%, 0%);
-}
-
 /* Set the grid lines to be solid # gnc-tree-view-split-reg.c */
 .treeview_grid_lines {
   border-color: black;

--- a/gnucash/gnome-utils/window-main-summarybar.c
+++ b/gnucash/gnome-utils/window-main-summarybar.c
@@ -453,7 +453,7 @@ get_negative_color (void)
     gchar *color_str;
     GtkWidget *label = gtk_label_new ("Color");
     GtkStyleContext *context = gtk_widget_get_style_context (GTK_WIDGET(label));
-    gtk_style_context_add_class (context, "negative-color");
+    gtk_style_context_add_class (context, "negative-numbers");
     gtk_style_context_get_color (context, GTK_STATE_FLAG_NORMAL, &color);
     rgba = gdk_rgba_copy (&color);
 

--- a/gnucash/gnome-utils/window-main-summarybar.c
+++ b/gnucash/gnome-utils/window-main-summarybar.c
@@ -47,6 +47,8 @@ typedef struct
     int           component_id;
     int           cnxn_id;
     gboolean      combo_popped;
+    gboolean      show_negative_color;
+    gchar        *negative_color;
 } GNCMainSummary;
 
 #define WINDOW_SUMMARYBAR_CM_CLASS "summary-bar"
@@ -327,6 +329,8 @@ enum
     COLUMN_ASSETS_VALUE,
     COLUMN_PROFITS,
     COLUMN_PROFITS_VALUE,
+    COLUMN_ASSETS_NEG,
+    COLUMN_PROFITS_NEG,
     N_COLUMNS
 };
 
@@ -417,8 +421,10 @@ gnc_main_window_summary_refresh (GNCMainSummary * summary)
                                COLUMN_MNEMONIC_TYPE, total_mode_label,
                                COLUMN_ASSETS,        _("Net Assets:"),
                                COLUMN_ASSETS_VALUE,  asset_amount_string,
+                               COLUMN_ASSETS_NEG,    gnc_numeric_negative_p(currency_accum->assets),
                                COLUMN_PROFITS,       _("Profits:"),
                                COLUMN_PROFITS_VALUE, profit_amount_string,
+                               COLUMN_PROFITS_NEG,   gnc_numeric_negative_p(currency_accum->profits),
                                -1);
             g_free(total_mode_label);
         }
@@ -439,12 +445,48 @@ gnc_main_window_summary_refresh (GNCMainSummary * summary)
     g_list_free(currency_list);
 }
 
+static gchar*
+get_negative_color (void)
+{
+    GdkRGBA color;
+    GdkRGBA *rgba;
+    gchar *color_str;
+    GtkWidget *label = gtk_label_new ("Color");
+    GtkStyleContext *context = gtk_widget_get_style_context (GTK_WIDGET(label));
+    gtk_style_context_add_class (context, "negative-color");
+    gtk_style_context_get_color (context, GTK_STATE_FLAG_NORMAL, &color);
+    rgba = gdk_rgba_copy (&color);
+
+    color_str = g_strdup_printf ("#%02X%02X%02X",
+                              (int)(0.5 + CLAMP (rgba->red, 0., 1.) * 255.),
+                              (int)(0.5 + CLAMP (rgba->green, 0., 1.) * 255.),
+                              (int)(0.5 + CLAMP (rgba->blue, 0., 1.) * 255.));
+    gdk_rgba_free (rgba);
+    return color_str;
+}
+
+static void
+summarybar_update_color (gpointer gsettings, gchar *key, gpointer user_data)
+{
+    GNCMainSummary *summary = user_data;
+
+    summary->negative_color = get_negative_color();
+    summary->show_negative_color = gnc_prefs_get_bool (GNC_PREFS_GROUP_GENERAL, GNC_PREF_NEGATIVE_IN_RED);
+
+    gnc_main_window_summary_refresh (summary);
+}
+
 static void
 gnc_main_window_summary_destroy_cb(GNCMainSummary *summary, gpointer data)
 {
     gnc_prefs_remove_cb_by_id (GNC_PREFS_GROUP, summary->cnxn_id);
     gnc_unregister_gui_component(summary->component_id);
-    g_free(summary);
+
+    gnc_prefs_remove_cb_by_func(GNC_PREFS_GROUP_GENERAL, GNC_PREF_NEGATIVE_IN_RED,
+                                summarybar_update_color, summary);
+
+    g_free (summary->negative_color);
+    g_free (summary);
 }
 
 static void
@@ -461,12 +503,57 @@ prefs_changed_cb (gpointer prefs, gchar *pref, gpointer user_data)
     gnc_main_window_summary_refresh(summary);
 }
 
+static gchar*
+check_string_for_markup (gchar *string)
+{
+    gchar **strings;
+    gchar *ret_string = g_strdup (string);
+
+    if (g_strrstr (ret_string, "&") != NULL)
+    {
+        strings = g_strsplit (ret_string, "&", -1);
+        g_free (ret_string);
+        ret_string = g_strjoinv ("&amp;", strings);
+        g_strfreev (strings);
+    }
+    if (g_strrstr (ret_string, "<") != NULL)
+    {
+        strings = g_strsplit (ret_string, "<", -1);
+        g_free (ret_string);
+        ret_string = g_strjoinv ("&lt;", strings);
+        g_strfreev (strings);
+    }
+    if (g_strrstr (ret_string, ">") != NULL)
+    {
+        strings = g_strsplit (ret_string, ">", -1);
+        g_free (ret_string);
+        ret_string = g_strjoinv ("&gt;", strings);
+        g_strfreev (strings);
+    }
+    if (g_strrstr (ret_string, "\"") != NULL)
+    {
+        strings = g_strsplit (ret_string, "\"", -1);
+        g_free (ret_string);
+        ret_string = g_strjoinv ("&quot;", strings);
+        g_strfreev (strings);
+    }
+    if (g_strrstr (ret_string, "'") != NULL)
+    {
+        strings = g_strsplit (ret_string, "'", -1);
+        g_free (ret_string);
+        ret_string = g_strjoinv ("&apos;", strings);
+        g_strfreev (strings);
+    }
+    return ret_string;
+}
+
 static void
 cdf (GtkCellLayout *cell_layout, GtkCellRenderer *cell, GtkTreeModel *tree_model, GtkTreeIter *iter,
                           gpointer user_data)
 {
     GNCMainSummary * summary = user_data;
     gchar *type, *assets, *assets_val, *profits, *profits_val;
+    gboolean assets_neg, profits_neg;
     gint viewcol;
 
     viewcol = GPOINTER_TO_INT (g_object_get_data (G_OBJECT (cell), "view_column"));
@@ -481,23 +568,37 @@ cdf (GtkCellLayout *cell_layout, GtkCellRenderer *cell, GtkTreeModel *tree_model
                             COLUMN_ASSETS, &assets,
                             COLUMN_ASSETS_VALUE, &assets_val,
                             COLUMN_PROFITS, &profits,
-                            COLUMN_PROFITS_VALUE, &profits_val, -1);
+                            COLUMN_PROFITS_VALUE, &profits_val,
+                            COLUMN_ASSETS_NEG, &assets_neg,
+                            COLUMN_PROFITS_NEG, &profits_neg, -1);
 
     if (viewcol == 0)
         g_object_set (cell, "text", type, NULL);
 
     if (viewcol == 2)
     {
-        gchar *a_string = g_strconcat (assets, " ", assets_val, NULL);
-        g_object_set (cell, "text", a_string, NULL);
+        gchar *a_string, *checked_string = check_string_for_markup (assets_val);
+        if ((summary->show_negative_color == TRUE) && (assets_neg == TRUE))
+            a_string = g_strconcat (assets, " <span foreground='", summary->negative_color, "'>", checked_string, "</span>", NULL);
+        else
+            a_string = g_strconcat (assets, " ", checked_string, NULL);
+
+        g_object_set (cell, "markup", a_string, NULL);
         g_free (a_string);
+        g_free (checked_string);
     }
 
     if (viewcol == 4)
     {
-        gchar *p_string = g_strconcat (profits, " ", profits_val, NULL);
-        g_object_set (cell, "text", p_string, NULL);
+        gchar *p_string, *checked_string = check_string_for_markup (profits_val);
+        if ((summary->show_negative_color == TRUE) && (profits_neg == TRUE))
+            p_string = g_strconcat (profits, " <span foreground='", summary->negative_color, "'>", checked_string, "</span>", NULL);
+        else
+            p_string = g_strconcat (profits, " ", checked_string, NULL);
+
+        g_object_set (cell, "markup", p_string, NULL);
         g_free (p_string);
+        g_free (checked_string);
     }
 
     g_free (type);
@@ -529,16 +630,23 @@ gnc_main_window_summary_new (void)
                                             G_TYPE_STRING,
                                             G_TYPE_STRING,
                                             G_TYPE_STRING,
-                                            G_TYPE_STRING);
+                                            G_TYPE_STRING,
+                                            G_TYPE_BOOLEAN,
+                                            G_TYPE_BOOLEAN);
 
     retval->hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
     gtk_box_set_homogeneous (GTK_BOX (retval->hbox), FALSE);
 
     // Set the style context for this widget so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(retval->hbox), "GncSummaryBar");
+    gnc_widget_set_style_context (GTK_WIDGET(retval->hbox), "summary-bar");
 
     retval->totals_combo = gtk_combo_box_new_with_model (GTK_TREE_MODEL (retval->datamodel));
     g_object_unref (retval->datamodel);
+
+    retval->negative_color = get_negative_color();
+    retval->show_negative_color = gnc_prefs_get_bool (GNC_PREFS_GROUP_GENERAL, GNC_PREF_NEGATIVE_IN_RED);
+    gnc_prefs_register_cb (GNC_PREFS_GROUP_GENERAL, GNC_PREF_NEGATIVE_IN_RED,
+                          summarybar_update_color, retval);
 
     retval->component_id = gnc_register_gui_component (WINDOW_SUMMARYBAR_CM_CLASS,
                            summarybar_refresh_handler,
@@ -553,7 +661,7 @@ gnc_main_window_summary_new (void)
 
     retval->combo_popped = FALSE;
 
-    for (i = 0; i <= N_COLUMNS; i += 2)
+    for (i = 0; i <= N_COLUMNS - 2; i += 2)
     {
         textRenderer = GTK_CELL_RENDERER(gtk_cell_renderer_text_new());
 

--- a/gnucash/import-export/dialog-import.glade
+++ b/gnucash/import-export/dialog-import.glade
@@ -1004,7 +1004,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkEventBox" id="red">
+              <object class="GtkEventBox" id="intervention_required_box">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <child>
@@ -1021,7 +1021,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkEventBox" id="yellow">
+              <object class="GtkEventBox" id="intervention_probably_required_box">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <child>
@@ -1038,7 +1038,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkEventBox" id="green">
+              <object class="GtkEventBox" id="intervention_not_required_box">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <child>

--- a/gnucash/import-export/import-main-matcher.c
+++ b/gnucash/import-export/import-main-matcher.c
@@ -43,6 +43,7 @@
 #include "gnc-ui.h"
 #include "gnc-ui-util.h"
 #include "gnc-engine.h"
+#include "gnc-gtk-utils.h"
 #include "import-settings.h"
 #include "import-match-picker.h"
 #include "import-backend.h"
@@ -511,19 +512,7 @@ gnc_gen_trans_init_view (GNCImportMainMatcher *info,
                      G_CALLBACK(gnc_gen_trans_row_changed_cb), info);
 }
 
-static gboolean
-is_color_light (GdkRGBA *color)
-{
-    gboolean is_light = FALSE;
 
-    // Counting the perceptive luminance - human eye favors green color...
-    double a = (0.299 * color->red + 0.587 * color->green + 0.114 * color->blue);
-
-    if (a > 0.5)
-        is_light = TRUE;
-
-    return is_light;
-}
 
 GNCImportMainMatcher *gnc_gen_trans_list_new (GtkWidget *parent,
         const gchar* heading,
@@ -547,7 +536,7 @@ GNCImportMainMatcher *gnc_gen_trans_list_new (GtkWidget *parent,
 
     stylectxt = gtk_widget_get_style_context (GTK_WIDGET(parent));
     gtk_style_context_get_color (stylectxt, GTK_STATE_FLAG_NORMAL, &color);
-    info->dark_theme = is_color_light (&color);
+    info->dark_theme = gnc_is_dark_theme (&color);
 
     /* Initialize the GtkDialog. */
     builder = gtk_builder_new();
@@ -616,7 +605,7 @@ GNCImportMainMatcher * gnc_gen_trans_assist_new (GtkWidget *parent,
 
     stylectxt = gtk_widget_get_style_context (GTK_WIDGET(parent));
     gtk_style_context_get_color (stylectxt, GTK_STATE_FLAG_NORMAL, &color);
-    info->dark_theme = is_color_light (&color);
+    info->dark_theme = gnc_is_dark_theme (&color);
 
     /* load the interface */
     builder = gtk_builder_new();

--- a/gnucash/import-export/import-main-matcher.c
+++ b/gnucash/import-export/import-main-matcher.c
@@ -82,9 +82,9 @@ enum downloaded_cols
     NUM_DOWNLOADED_COLS
 };
 
-#define COLOR_RED_CLASS    "intervention-required"
-#define COLOR_YELLOW_CLASS "intervention-probably-required"
-#define COLOR_GREEN_CLASS  "intervention-not-required"
+#define CSS_INT_REQUIRED_CLASS      "intervention-required"
+#define CSS_INT_PROB_REQUIRED_CLASS "intervention-probably-required"
+#define CSS_INT_NOT_REQUIRED_CLASS  "intervention-not-required"
 
 static QofLogModule log_module = GNC_MOD_IMPORT;
 
@@ -214,14 +214,14 @@ on_matcher_help_clicked (GtkButton *button, gpointer user_data)
     gnc_builder_add_from_file (builder, "dialog-import.glade", "textbuffer5");
     gnc_builder_add_from_file (builder, "dialog-import.glade", "matcher_help_dialog");
 
-    box = GTK_WIDGET(gtk_builder_get_object (builder, "red"));
-    gnc_widget_set_style_context (GTK_WIDGET(box), COLOR_RED_CLASS);
+    box = GTK_WIDGET(gtk_builder_get_object (builder, "intervention_required_box"));
+    gnc_widget_set_style_context (GTK_WIDGET(box), CSS_INT_REQUIRED_CLASS);
 
-    box = GTK_WIDGET(gtk_builder_get_object (builder, "yellow"));
-    gnc_widget_set_style_context (GTK_WIDGET(box), COLOR_YELLOW_CLASS);
+    box = GTK_WIDGET(gtk_builder_get_object (builder, "intervention_probably_required_box"));
+    gnc_widget_set_style_context (GTK_WIDGET(box), CSS_INT_PROB_REQUIRED_CLASS);
 
-    box = GTK_WIDGET(gtk_builder_get_object (builder, "green"));
-    gnc_widget_set_style_context (GTK_WIDGET(box), COLOR_GREEN_CLASS);
+    box = GTK_WIDGET(gtk_builder_get_object (builder, "intervention_not_required_box"));
+    gnc_widget_set_style_context (GTK_WIDGET(box), CSS_INT_NOT_REQUIRED_CLASS);
 
     help_dialog = GTK_WIDGET(gtk_builder_get_object (builder, "matcher_help_dialog"));
     gtk_window_set_transient_for(GTK_WINDOW(help_dialog),
@@ -726,7 +726,7 @@ refresh_model_row (GNCImportMainMatcher *gui,
         if (gnc_import_TransInfo_is_balanced(info) == TRUE)
         {
             ro_text = _("New, already balanced");
-            color = get_required_color (COLOR_GREEN_CLASS);
+            color = get_required_color (CSS_INT_NOT_REQUIRED_CLASS);
         }
         else
         {
@@ -742,7 +742,7 @@ refresh_model_row (GNCImportMainMatcher *gui,
                    TRUE) ));
             if (gnc_import_TransInfo_get_destacc (info) != NULL)
             {
-                color = get_required_color (COLOR_GREEN_CLASS);
+                color = get_required_color (CSS_INT_NOT_REQUIRED_CLASS);
                 tmp = gnc_account_get_full_name
                       (gnc_import_TransInfo_get_destacc (info));
                 if (gnc_import_TransInfo_get_destacc_selected_manually(info)
@@ -767,7 +767,7 @@ refresh_model_row (GNCImportMainMatcher *gui,
             }
             else
             {
-                color = get_required_color (COLOR_YELLOW_CLASS);
+                color = get_required_color (CSS_INT_PROB_REQUIRED_CLASS);
                 text =
                     /* Translators: %s is the amount to be transferred. */
                     g_strdup_printf(_("New, UNBALANCED (need acct to transfer %s)!"),
@@ -779,7 +779,7 @@ refresh_model_row (GNCImportMainMatcher *gui,
     case GNCImport_CLEAR:
         if (gnc_import_TransInfo_get_selected_match(info))
         {
-            color = get_required_color (COLOR_GREEN_CLASS);
+            color = get_required_color (CSS_INT_NOT_REQUIRED_CLASS);
             if (gnc_import_TransInfo_get_match_selected_manually(info) == TRUE)
             {
                 ro_text = _("Reconcile (manual) match");
@@ -791,14 +791,14 @@ refresh_model_row (GNCImportMainMatcher *gui,
         }
         else
         {
-            color = get_required_color (COLOR_RED_CLASS);
+            color = get_required_color (CSS_INT_REQUIRED_CLASS);
             ro_text = _("Match missing!");
         }
         break;
     case GNCImport_UPDATE:
         if (gnc_import_TransInfo_get_selected_match(info))
         {
-            color = get_required_color (COLOR_GREEN_CLASS);
+            color = get_required_color (CSS_INT_NOT_REQUIRED_CLASS);
             if (gnc_import_TransInfo_get_match_selected_manually(info) == TRUE)
             {
                 ro_text = _("Update and reconcile (manual) match");
@@ -810,12 +810,12 @@ refresh_model_row (GNCImportMainMatcher *gui,
         }
         else
         {
-            color = get_required_color (COLOR_RED_CLASS);
+            color = get_required_color (CSS_INT_REQUIRED_CLASS);
             ro_text = _("Match missing!");
         }
         break;
     case GNCImport_SKIP:
-        color = get_required_color (COLOR_RED_CLASS);
+        color = get_required_color (CSS_INT_REQUIRED_CLASS);
         ro_text = _("Do not import (no action selected)");
         break;
     default:

--- a/gnucash/import-export/import-main-matcher.c
+++ b/gnucash/import-export/import-main-matcher.c
@@ -215,13 +215,13 @@ on_matcher_help_clicked (GtkButton *button, gpointer user_data)
     gnc_builder_add_from_file (builder, "dialog-import.glade", "matcher_help_dialog");
 
     box = GTK_WIDGET(gtk_builder_get_object (builder, "red"));
-    gnc_widget_set_style_context (GTK_WIDGET(box), "intervention-required");
+    gnc_widget_set_style_context (GTK_WIDGET(box), COLOR_RED_CLASS);
 
     box = GTK_WIDGET(gtk_builder_get_object (builder, "yellow"));
-    gnc_widget_set_style_context (GTK_WIDGET(box), "intervention-probably-required");
+    gnc_widget_set_style_context (GTK_WIDGET(box), COLOR_YELLOW_CLASS);
 
     box = GTK_WIDGET(gtk_builder_get_object (builder, "green"));
-    gnc_widget_set_style_context (GTK_WIDGET(box), "intervention-not-required");
+    gnc_widget_set_style_context (GTK_WIDGET(box), COLOR_GREEN_CLASS);
 
     help_dialog = GTK_WIDGET(gtk_builder_get_object (builder, "matcher_help_dialog"));
     gtk_window_set_transient_for(GTK_WINDOW(help_dialog),

--- a/gnucash/import-export/import-main-matcher.c
+++ b/gnucash/import-export/import-main-matcher.c
@@ -671,24 +671,6 @@ gboolean gnc_gen_trans_list_run (GNCImportMainMatcher *info)
     return result;
 }
 
-static void
-gnc_style_context_get_background_color (GtkStyleContext *context,
-                                        GtkStateFlags    state,
-                                        GdkRGBA         *color)
-{
-    GdkRGBA *c;
-
-    g_return_if_fail (color != NULL);
-    g_return_if_fail (GTK_IS_STYLE_CONTEXT (context));
-
-    gtk_style_context_get (context,
-                           state,
-                           GTK_STYLE_PROPERTY_BACKGROUND_COLOR, &c,
-                           NULL);
-    *color = *c;
-    gdk_rgba_free (c);
-}
-
 static gchar*
 get_required_color (const gchar *class_name)
 {

--- a/gnucash/import-export/import-main-matcher.c
+++ b/gnucash/import-export/import-main-matcher.c
@@ -398,10 +398,6 @@ add_text_column(GtkTreeView *view, const gchar *title, int col_num)
     GtkTreeViewColumn *column;
 
     renderer = gtk_cell_renderer_text_new();
-    g_object_set(G_OBJECT(renderer),
-                 "foreground", "black",
-                 "foreground-set", TRUE,
-                 NULL);
     column = gtk_tree_view_column_new_with_attributes
              (title, renderer,
               "text", col_num,
@@ -481,10 +477,6 @@ gnc_gen_trans_init_view (GNCImportMainMatcher *info,
              "cell-background", DOWNLOADED_COL_COLOR,
              NULL);
     renderer = gtk_cell_renderer_text_new();
-    g_object_set(G_OBJECT(renderer),
-                 "foreground", "black",
-                 "foreground-set", TRUE,
-                 NULL);
     gtk_tree_view_column_pack_start(column, renderer, TRUE);
     gtk_tree_view_column_set_attributes(column, renderer,
                                         "text", DOWNLOADED_COL_ACTION_INFO,

--- a/gnucash/register/register-gnome/gnucash-item-edit.c
+++ b/gnucash/register/register-gnome/gnucash-item-edit.c
@@ -167,7 +167,7 @@ gnc_item_edit_init (GncItemEdit *item_edit)
 
     item_edit->popup_toggle.ebox = NULL;
     item_edit->popup_toggle.tbutton = NULL;
-    item_edit->popup_toggle.direction = TRUE;
+    item_edit->popup_toggle.arrow_down = TRUE;
     item_edit->popup_toggle.signals_connected = FALSE;
 
     item_edit->popup_item = NULL;
@@ -347,7 +347,7 @@ draw_arrow_cb (GtkWidget *widget, cairo_t *cr, gpointer data)
 
     size = MIN(width / 2, height / 2);
 
-    if (item_edit->popup_toggle.direction == 0)
+    if (item_edit->popup_toggle.arrow_down == 0)
         gtk_render_arrow (context, cr, 0,
                          (width - size)/2, (height - size)/2, size);
     else
@@ -685,7 +685,7 @@ gnc_item_edit_show_popup (GncItemEdit *item_edit)
     }
 
     // set the popup arrow direction up
-    item_edit->popup_toggle.direction = FALSE;
+    item_edit->popup_toggle.arrow_down = FALSE;
 
     if (item_edit->popup_set_focus)
         item_edit->popup_set_focus (item_edit->popup_item,
@@ -731,7 +731,7 @@ gnc_item_edit_hide_popup (GncItemEdit *item_edit)
     gtk_container_remove (GTK_CONTAINER(item_edit->sheet), item_edit->popup_item);
 
     // set the popup arrow direction down
-    item_edit->popup_toggle.direction = TRUE;
+    item_edit->popup_toggle.arrow_down = TRUE;
 
     gtk_toggle_button_set_active
     (GTK_TOGGLE_BUTTON(item_edit->popup_toggle.tbutton), FALSE);

--- a/gnucash/register/register-gnome/gnucash-item-edit.h
+++ b/gnucash/register/register-gnome/gnucash-item-edit.h
@@ -61,8 +61,7 @@ struct _PopupToggle
 {
     GtkWidget *ebox;
     GtkWidget *tbutton;
-    GtkWidget *arrow_up;
-    GtkWidget *arrow_down;
+    gboolean   direction;
     gboolean signals_connected;
 };
 

--- a/gnucash/register/register-gnome/gnucash-item-edit.h
+++ b/gnucash/register/register-gnome/gnucash-item-edit.h
@@ -61,7 +61,7 @@ struct _PopupToggle
 {
     GtkWidget *ebox;
     GtkWidget *tbutton;
-    gboolean   direction;
+    gboolean   arrow_down;
     gboolean signals_connected;
 };
 

--- a/gnucash/register/register-gnome/gnucash-sheet.c
+++ b/gnucash/register/register-gnome/gnucash-sheet.c
@@ -37,6 +37,7 @@
 #include "gnucash-sheetP.h"
 
 #include "dialog-utils.h"
+#include "gnc-gtk-utils.h"
 #include "gnc-prefs.h"
 #include "gnucash-color.h"
 #include "gnucash-cursor.h"
@@ -2329,25 +2330,6 @@ gnucash_sheet_realize_entry (GnucashSheet *sheet, GtkWidget *entry)
  * cells drawn on the canvas.  This code should all go away whenever
  * the register is rewritten.
  */
-
-static void
-gnc_style_context_get_background_color (GtkStyleContext *context,
-                                        GtkStateFlags    state,
-                                        GdkRGBA         *color)
-{
-    GdkRGBA *c;
-
-    g_return_if_fail (color != NULL);
-    g_return_if_fail (GTK_IS_STYLE_CONTEXT (context));
-
-    gtk_style_context_get (context,
-                           state,
-                           GTK_STYLE_PROPERTY_BACKGROUND_COLOR, &c,
-                           NULL);
-    *color = *c;
-    gdk_rgba_free (c);
-}
-
 
 /** Map a cell type to a gtkrc specified color. */
 GdkRGBA *


### PR DESCRIPTION
Highlights...
Add a fall back css file that has a lower priority than themes.
Change the way the dense calendar is drawn, now theme-able and can look more like the default calendar, below is some css that hopefully should give you an idea, the only thing I was not sure about was the default names...
Changed the up/down arrow to be drawn based on theme which brings it more inline with the rest of the look.
Bob

calendar {
  color:yellow;
  background-color: lightgrey;
}

calendar.header {
 background-color: lightgreen;
}

calendar.highlight { color: red;
  background-color: pink;
}

calendar:indeterminate { color: alpha(currentColor,0.2); }

calendar:selected { 
  color: white;
  background-color: grey;
  border-radius: 10px;
}


.calendar {
  border-color: white;
}

.calendar.header {
 background-color: lightgreen;
}

.calendar:selected { 
  color: white;
  background-color: grey;
  border-radius: 10px;
}

.calendar.primary {
  background-color: darksalmon;
}

.calendar.secondary {
  background-color: darkseagreen;
}

.calendar.markers {
  background-color: indianred;
}

#dense-cal-popup treeview {
  background-color: lightcoral;
}