### PR TITLE
Link test_import_pending_matches as C++

### DIFF
--- a/gnucash/import-export/test/Makefile.am
+++ b/gnucash/import-export/test/Makefile.am
@@ -61,6 +61,14 @@ noinst_PROGRAMS = $(TEST_PROGS) $(check_PROGRAMS)
 
 test_import_pending_matches_SOURCES = test-import-pending-matches.c
 
+#
+# Force automake to treat test-import-pending-matches as a C++ program.
+#
+# dummy.cpp, intentionally, does not actually exist.  See:
+#     https://www.gnu.org/software/automake/manual/html_node/Libtool-Convenience-Libraries.html
+#
+nodist_EXTRA_test_import_pending_matches_SOURCES = dummy.cpp
+
 test_import_pending_matches_LDADD = \
   ${top_builddir}/libgnucash/engine/libgncmod-engine.la \
   ../libgncmod-generic-import.la \


### PR DESCRIPTION
This fixes the problem that was discussed in http://gnucash.1415818.n4.nabble.com/building-master-tc4691183.html#a4691186.