### PR TITLE
Account fullname filter for transaction.scm

### DIFF
--- a/src/report/standard-reports/transaction.scm
+++ b/src/report/standard-reports/transaction.scm
@@ -33,6 +33,7 @@
 
 (use-modules (gnucash main)) ;; FIXME: delete after we finish modularizing.
 (use-modules (srfi srfi-1))
+(use-modules (srfi srfi-13))
 (use-modules (gnucash gnc-module))
 (use-modules (gnucash gettext))
 
@@ -649,6 +650,14 @@
     (lambda ()
       '())
     #f #t))
+
+  (gnc:register-trep-option
+     (gnc:make-string-option
+   gnc:pagename-accounts (N_ "Account Substring")
+    "a5" (N_ "Match only above accounts whose fullname contains substring e.g. ':Travel' will \
+match Expenses:Travel:Holiday and Expenses:Business:Travel. Can be left blank, which will \
+disable the substring filter. This filter is case sensitive.")
+    ""))
 
   (gnc:register-trep-option
    (gnc:make-account-list-option
@@ -1437,6 +1446,7 @@ Credit Card, and Income accounts.")))))
   (gnc:report-starting reportname)
   (let ((document (gnc:make-html-document))
 	(c_account_1 (opt-val gnc:pagename-accounts "Accounts"))
+	(c_account_substring (opt-val gnc:pagename-accounts (N_ "Account Substring")))
 	(c_account_2 (opt-val gnc:pagename-accounts "Filter By..."))
 	(filter-mode (opt-val gnc:pagename-accounts "Filter Type"))
         (begindate (gnc:timepair-start-day-time
@@ -1458,6 +1468,11 @@ Credit Card, and Income accounts.")))))
 
     ;;(gnc:warn "accts in trep-renderer:" c_account_1)
     ;;(gnc:warn "Report Account names:" (get-other-account-names c_account_1))
+
+    (set! c_account_1
+      (filter (lambda (acc)
+                 (string-contains (gnc-account-get-full-name acc) c_account_substring))
+              c_account_1))
 
     (if (not (or (null? c_account_1) (and-map not c_account_1)))
         (begin


### PR DESCRIPTION
This small change will introduce an account full-name filter. Only accounts whose fullname containing substring will be selected e.g. ":Travel" will match Expenses:Travel:Holiday and Expenses:Business:Travel. This can be left blank, which will mimic previous behavior. This will ease accounts selection tremendously. This filter is case sensitive. For Gnucash 2.8 or later.