### PR TITLE
Enable CMake build in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,29 @@ compiler:
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get build-dep -qq gnucash
-  - sudo apt-get install -qq swig xsltproc libdbd-sqlite3
+  - sudo apt-get install -qq swig xsltproc libdbd-sqlite3 cmake3 texinfo ninja-build
   - sudo apt-get --reinstall install -qq language-pack-en language-pack-fr
-script: ./autogen.sh && ./configure && make && make check
+script: |
+  # The -e here says that if any line below fails, the whole script fails
+  set -ev
+
+  # First, do the cmake build using the default Makefile generator
+  mkdir /tmp/gnucash-build-cmake-make
+  cd /tmp/gnucash-build-cmake-make
+  cmake $TRAVIS_BUILD_DIR
+  make -j 4
+  make check
+
+  # Next, do cmake again, using the Ninja generator this time
+  mkdir /tmp/gnucash-build-cmake-ninja
+  cd /tmp/gnucash-build-cmake-ninja
+  cmake -G Ninja $TRAVIS_BUILD_DIR
+  ninja
+  ninja check
+
+  # Finally, do the autotools build
+  cd $TRAVIS_BUILD_DIR
+  ./autogen.sh
+  ./configure
+  make
+  make check


### PR DESCRIPTION
This PR has the Travis build system do CMake builds (Makefile and Ninja) in addition to the autotools build.

We did not need a PPA for cmake, as Trusty provides a cmake3 package. 

Also, I did not move the script part to a separate file, as I figured out that using 'set -e' will allow us to put one command per line in the 'script:' section and have a failing line fail the whole build.

