### PR TITLE
Allow to export the last commit's date

### DIFF
--- a/util/gnc-vcs-info
+++ b/util/gnc-vcs-info
@@ -2,9 +2,11 @@
 #
 # Usage:
 #   gnc-vcs-info -r <srcdir>
+#   gnc-vcs-info -d <srcdir>
 #   gnc-vcs-info -t <srcdir>
 #
 # With -r prints the revision number to stdout and exits 0 on success
+# With -d prints the commit date to stdout and exits 0 on success
 # With -t prints the vcs type that was detected to stdout and exits 0
 #         on success.
 #
@@ -17,6 +19,7 @@
 
 # Default string to return if not invoked properly
 usage="Usage: $0 -r <srcdir>
+       $0 -d <srcdir>
        $0 -t <srcdir>"
 
 # Print an error message and then exit
@@ -49,6 +52,9 @@ then
 elif [ "$1" = "-r" ]
 then
   request="revision"
+elif [ "$1" = "-d" ]
+then
+  request="date"
 else
   my_die "$usage"
 fi
@@ -108,6 +114,11 @@ then
   # to the PATH in Windows results in a build failure).
   # So for platform independence, use GIT_CMD for all
   [ -n "$GIT_CMD" ] || GIT_CMD=git
+  if [ "$request" = "date" ]
+  then
+    exec "$GIT_CMD" --git-dir "${real_gitdir}" log -1 --format=%ct
+    exit 0
+  fi
   githead=`"$GIT_CMD" --git-dir "${real_gitdir}" log -1 --pretty=format:"%h" HEAD 2>/dev/null`  # short hash only
   if test $? = 0 ; then
     /bin/echo -n $githead


### PR DESCRIPTION
for use in release tarballs
to give users a hint on how old their software is.

Partial implementation of an idea discussed in PR #180