### PR TITLE
Fix swig wrapper for gncTaxTableGetTaxTables

### DIFF
--- a/src/engine/business-core.i
+++ b/src/engine/business-core.i
@@ -74,6 +74,7 @@ static GncEmployee * gncEmployeeLookupFlip(GncGUID g, QofBook *b)
 
 GLIST_HELPER_INOUT(GncInvoiceList, SWIGTYPE_p__gncInvoice);
 GLIST_HELPER_INOUT(EntryList, SWIGTYPE_p__gncEntry);
+GLIST_HELPER_INOUT(GncTaxTableGetTables, SWIGTYPE_p__gncTaxTable);
 GLIST_HELPER_INOUT(GncTaxTableEntryList, SWIGTYPE_p__gncTaxTableEntry);
 GLIST_HELPER_INOUT(OwnerList, SWIGTYPE_p__gncOwner);
 

--- a/src/engine/gncTaxTable.c
+++ b/src/engine/gncTaxTable.c
@@ -676,7 +676,7 @@ GncTaxTable *gncTaxTableLookupByName (QofBook *book, const char *name)
     return NULL;
 }
 
-GList * gncTaxTableGetTables (QofBook *book)
+GncTaxTableList * gncTaxTableGetTables (QofBook *book)
 {
     struct _book_info *bi;
     if (!book) return NULL;

--- a/src/engine/gncTaxTable.h
+++ b/src/engine/gncTaxTable.h
@@ -152,7 +152,8 @@ static inline GncTaxTable *gncTaxTableLookup (const QofBook* book, const GncGUID
 
 GncTaxTable *gncTaxTableLookupByName (QofBook *book, const char *name);
 
-GList * gncTaxTableGetTables (QofBook *book);
+typedef GList GncTaxTableList;
+GncTaxTableList  * gncTaxTableGetTables (QofBook *book);
 
 const char *gncTaxTableGetName (const GncTaxTable *table);
 GncTaxTable *gncTaxTableGetParent (const GncTaxTable *table);


### PR DESCRIPTION
Bug: (gncTaxTableGetTables (gnc-get-current-book)) currently returns a #\<swig-pointer GncInvoiceList\>
Fix: It should return a list of #\<swig-pointer GncTaxTable\> entries.

This patches gncTaxTableGetTables to return a GncTaxTableList, according to formula in old commit https://github.com/Gnucash/gnucash/commit/8221aada49ec01ad91f6d3a69aefd473ef6608f1 from https://bugzilla.gnome.org/show_bug.cgi?id=573645

I don't have a dev environment and cannot really test above. But I'll still document this (partial?) fix.