### PR TITLE
Toggle "Account Name" should effect "Use Full Account Name" in Options.

### DIFF
--- a/src/report/standard-reports/transaction.scm
+++ b/src/report/standard-reports/transaction.scm
@@ -951,11 +951,11 @@
         (list (N_ "Num")                      "b"  (N_ "Display the check number?") #t))
     (list (N_ "Description")                  "c"  (N_ "Display the description?") #t)
     (list (N_ "Notes")                        "d2" (N_ "Display the notes if the memo is unavailable?") #t)
-    (list (N_ "Account Name")                 "e"  (N_ "Display the account name?") #f)
+;    (list (N_ "Account Name")                 "e"  (N_ "Display the account name?") #f)
     (list (N_ "Use Full Account Name")        "f"  (N_ "Display the full account name?") #t)
     (list (N_ "Account Code")                 "g"  (N_ "Display the account code?") #f)
-    (list (N_ "Other Account Name")           "h"  (N_ "Display the other account name?\
- (if this is a split transaction, this parameter is guessed).") #f)
+;    (list (N_ "Other Account Name")           "h"  (N_ "Display the other account name?\
+; (if this is a split transaction, this parameter is guessed).") #f)
     (list (N_ "Use Full Other Account Name")  "i"  (N_ "Display the full account name?") #t)
     (list (N_ "Other Account Code")           "j"  (N_ "Display the other account code?") #f)
     (list (N_ "Shares")                       "k"  (N_ "Display the number of shares?") #f)
@@ -982,6 +982,30 @@
 		 gnc:pagename-display
 		 (N_ "Notes")
 		 x))))
+
+  ;; Ditto for Account Name #t -> Use Full Account Name is selectable
+  (gnc:register-trep-option
+   (gnc:make-complex-boolean-option
+    gnc:pagename-display (N_ "Account Name")
+    "e"  (N_ "Display the account name?") #t
+    #f
+    (lambda (x) (gnc-option-db-set-option-selectable-by-name
+                 gnc:*transaction-report-options*
+                 gnc:pagename-display
+                 (N_ "Use Full Account Name")
+                 x))))
+
+  ;; Ditto for Other Account Name #t -> Use Full Other Account Name is selectable
+  (gnc:register-trep-option
+   (gnc:make-complex-boolean-option
+    gnc:pagename-display (N_ "Other Account Name")
+    "h"  (N_ "Display the other account name? (if this is a split transaction, this parameter is guessed).") #f
+    #f
+    (lambda (x) (gnc-option-db-set-option-selectable-by-name
+                 gnc:*transaction-report-options*
+                 gnc:pagename-display
+                 (N_ "Use Full Other Account Name")
+                 x))))
 
   (gnc:register-trep-option
    (gnc:make-multichoice-option


### PR DESCRIPTION
From https://bugzilla.gnome.org/show_bug.cgi?id=776263

Currently, setting "Use Account Name" / "Other Account Name" to #f would disable the Account column, rendering the "Use Full Account Name" option useless. This setting ensures the user understands that toggling (Other) Account Name effects the next option.

No effect is anticipated upon backwards compatibility, saved-reports, or report content. This purely enhances UI of report options.