### PR TITLE
Add missing export (gnc:date-get-week)

### DIFF
--- a/src/app-utils/app-utils.scm
+++ b/src/app-utils/app-utils.scm
@@ -175,6 +175,7 @@
 (export gnc:date-get-month-day)
 (export gnc:date-get-month)
 (export gnc:date-get-week-day)
+(export gnc:date-get-week)
 (export gnc:date-get-year-day)
 (export gnc:timepair-get-year)
 (export gnc:timepair-get-quarter)


### PR DESCRIPTION
Hit this bug during development. meanwhile I'm using (gnc:timepair-get-week) instead