### PR TITLE
Item edit cell padding and code reduction of cell colours

### DIFF
--- a/gnucash/gnucash-310.css
+++ b/gnucash/gnucash-310.css
@@ -27,7 +27,7 @@
   padding: 2px 2px 2px 2px; /* all work with different values, around the text blue area */
 }
 
-.cursor .button {
+.cursor .toggle-button {
   margin: 1px 1px 1px 1px; /* does not work, not used, here for completeness */
 }
 

--- a/gnucash/gnucash-310.css
+++ b/gnucash/gnucash-310.css
@@ -21,13 +21,14 @@
   color: mix (currentColor, grey, 0.2);
 }
 
-/* Register Cursor padding settings, make sure entry matches sheet.h */
-cursor entry {
-  padding: 2px 5px 2px 5px;
+/* Register Cursor settings, top, right, bottom, left */
+.cursor .entry {
+  margin: 2px 5px 2px 5px;  /* this only works by doing it in code, yellow area */
+  padding: 2px 2px 2px 2px; /* all work with different values, around the text blue area */
 }
 
-cursor button {
-  padding: 1px 1px 1px 1px;
+.cursor .button {
+  margin: 1px 1px 1px 1px; /* does not work, not used, here for completeness */
 }
 
 /* Register defaults */
@@ -37,7 +38,7 @@ cursor button {
 @define-color register_split_bg_color #EDE7D3;
 @define-color register_cursor_bg_color #FFEF98;
 
-.register-header {
+*.register-header {
   background-color: @register_header_bg_color;
 }
 

--- a/gnucash/gnucash-320.css
+++ b/gnucash/gnucash-320.css
@@ -12,13 +12,14 @@
   color: @negative-numbers;
 }
 
-/* Register Cursor padding settings, make sure entry matches sheet.h */
+/* Register Cursor settings, top, right, bottom, left */
 cursor entry {
-  padding: 2px 5px 2px 5px;
+  margin: 2px 5px 2px 5px;
+  padding: 0px 2px 0px 2px;
 }
 
 cursor button {
-  padding: 1px 1px 1px 1px;
+  margin: 1px 1px 1px 1px;
 }
 
 /* Register defaults */
@@ -28,7 +29,7 @@ cursor button {
 @define-color register_split_bg_color #EDE7D3;
 @define-color register_cursor_bg_color #FFEF98;
 
-.register-header {
+*.register-header {
   background-color: @register_header_bg_color;
 }
 

--- a/gnucash/gnucash-320.css
+++ b/gnucash/gnucash-320.css
@@ -18,7 +18,7 @@ cursor entry {
   padding: 0px 2px 0px 2px;
 }
 
-cursor button {
+cursor toggle-button {
   margin: 1px 1px 1px 1px;
 }
 

--- a/gnucash/register/ledger-core/gncEntryLedgerModel.c
+++ b/gnucash/register/ledger-core/gncEntryLedgerModel.c
@@ -915,65 +915,57 @@ static CellIOFlags get_qty_io_flags (VirtualLocation virt_loc, gpointer user_dat
     return flags;
 }
 
-/* GET BG_COLORS */
+/* GET COLORS */
 
 static guint32
-gnc_entry_ledger_get_color_internal (VirtualLocation virt_loc,
-                                     GncEntryLedger *ledger,
-                                     gboolean foreground)
+gnc_entry_ledger_get_cell_color_internal (VirtualLocation virt_loc,
+                                          GncEntryLedger *ledger)
 {
     VirtualCell *vcell;
     gboolean is_current;
-    guint32 colorbase = 0; /* By default return background colors */
+    guint32 colorbase = 0;
 
-    if (foreground)
-        colorbase = COLOR_UNKNOWN_FG; /* a bit of enum arithmetic */
+    /* a bit of enum arithmetic */
+
+    // There are negative numbers
 
     if (!ledger)
-        return (colorbase + COLOR_UNKNOWN_BG);
+        return (colorbase + COLOR_UNDEFINED);
 
     if (gnc_table_virtual_location_in_header (ledger->table, virt_loc))
-        return (colorbase + COLOR_HEADER_BG);
+        return (colorbase + COLOR_HEADER);
 
     vcell = gnc_table_get_virtual_cell (ledger->table, virt_loc.vcell_loc);
     if (!vcell || !vcell->cellblock)
-        return (colorbase + COLOR_UNKNOWN_BG);
+        return (colorbase + COLOR_UNDEFINED);
 
     if ((virt_loc.phys_col_offset < vcell->cellblock->start_col) ||
             (virt_loc.phys_col_offset > vcell->cellblock->stop_col))
-        return (colorbase + COLOR_UNKNOWN_BG);
+        return (colorbase + COLOR_UNDEFINED);
 
     is_current = virt_cell_loc_equal (ledger->table->current_cursor_loc.vcell_loc,
                                       virt_loc.vcell_loc);
 
     if (is_current)
         return vcell->start_primary_color ?
-                (colorbase + COLOR_PRIMARY_BG_ACTIVE) :
-                (colorbase + COLOR_SECONDARY_BG_ACTIVE);
+                (colorbase + COLOR_PRIMARY_ACTIVE) :
+                (colorbase + COLOR_SECONDARY_ACTIVE);
 
     return vcell->start_primary_color ?
-            (colorbase + COLOR_PRIMARY_BG) : (colorbase + COLOR_SECONDARY_BG);
+            (colorbase + COLOR_PRIMARY) : (colorbase + COLOR_SECONDARY);
 
 }
 
 static guint32
-gnc_entry_ledger_get_fg_color (VirtualLocation virt_loc,
-                               gpointer user_data)
-{
-    GncEntryLedger *ledger = user_data;
-    return gnc_entry_ledger_get_color_internal (virt_loc, ledger, TRUE);
-}
-
-static guint32
-gnc_entry_ledger_get_bg_color (VirtualLocation virt_loc,
-                               gboolean *hatching, gpointer user_data)
+gnc_entry_ledger_get_cell_color (VirtualLocation virt_loc,
+                                 gboolean *hatching, gpointer user_data)
 {
     GncEntryLedger *ledger = user_data;
 
     if (hatching)
         *hatching = FALSE;
 
-    return gnc_entry_ledger_get_color_internal (virt_loc, ledger, FALSE);
+    return gnc_entry_ledger_get_cell_color_internal (virt_loc, ledger);
 }
 
 /* SAVE CELLS */
@@ -1225,11 +1217,8 @@ static void gnc_entry_ledger_model_new_handlers (TableModel *model,
     };
     unsigned int i;
 
-    gnc_table_model_set_default_fg_color_handler
-    (model, gnc_entry_ledger_get_fg_color);
-
-    gnc_table_model_set_default_bg_color_handler
-    (model, gnc_entry_ledger_get_bg_color);
+    // Set the cell color handler
+    gnc_table_model_set_default_cell_color_handler (model, gnc_entry_ledger_get_cell_color);
 
     for (i = 0; i < (sizeof(models) / sizeof(*models)); i++)
     {

--- a/gnucash/register/register-core/table-allgui.c
+++ b/gnucash/register/register-core/table-allgui.c
@@ -345,68 +345,29 @@ gnc_table_get_label (Table *table, VirtualLocation virt_loc)
     return label;
 }
 
-static guint32
-gnc_table_get_fg_color_internal (Table *table, VirtualLocation virt_loc)
-{
-    TableGetFGColorHandler fg_color_handler;
-    const char *handler_name;
-
-    if (!table || !table->model)
-        return COLOR_UNKNOWN_FG;
-
-    handler_name = gnc_table_get_cell_name (table, virt_loc);
-
-    fg_color_handler = gnc_table_model_get_fg_color_handler (table->model,
-                       handler_name);
-    if (!fg_color_handler)
-    {
-        TableGetBGColorHandler bg_color_handler =
-            gnc_table_model_get_bg_color_handler (table->model, handler_name);
-
-        guint32 bg_color =
-            bg_color_handler (virt_loc, NULL, table->model->handler_user_data);
-        return bg_color + COLOR_UNKNOWN_FG;
-    }
-
-    return fg_color_handler (virt_loc, table->model->handler_user_data);
-}
-
 guint32
-gnc_table_get_fg_color (Table *table, VirtualLocation virt_loc)
-{
-    return gnc_table_get_fg_color_internal (table, virt_loc);
-}
-
-static guint32
-gnc_table_get_bg_color_internal (Table *table, VirtualLocation virt_loc,
+gnc_table_get_color (Table *table, VirtualLocation virt_loc,
                                  gboolean *hatching)
 {
-    TableGetBGColorHandler bg_color_handler;
+    TableGetCellColorHandler color_handler;
     const char *handler_name;
 
     if (hatching)
         *hatching = FALSE;
 
     if (!table || !table->model)
-        return COLOR_UNKNOWN_BG;
+        return COLOR_UNDEFINED;
 
     handler_name = gnc_table_get_cell_name (table, virt_loc);
 
-    bg_color_handler = gnc_table_model_get_bg_color_handler (table->model,
-            handler_name);
+    color_handler = gnc_table_model_get_cell_color_handler (table->model,
+                                                            handler_name);
 
-    if (!bg_color_handler)
-        return COLOR_UNKNOWN_BG;
+    if (!color_handler)
+        return COLOR_UNDEFINED;
 
-    return bg_color_handler (virt_loc, hatching,
-                             table->model->handler_user_data);
-}
-
-guint32
-gnc_table_get_bg_color (Table *table, VirtualLocation virt_loc,
-                        gboolean *hatching)
-{
-    return gnc_table_get_bg_color_internal (table, virt_loc, hatching);
+    return color_handler (virt_loc, hatching,
+                          table->model->handler_user_data);
 }
 
 void

--- a/gnucash/register/register-core/table-allgui.h
+++ b/gnucash/register/register-core/table-allgui.h
@@ -179,34 +179,18 @@ struct table
 };
 
 /** Color definitions used for table elements */
-typedef enum
-{
-    /* Colors used for background drawing */
-    COLOR_UNKNOWN_BG,          // 0
-    COLOR_HEADER_BG,           // 1
-    COLOR_PRIMARY_BG,          // 2
-    COLOR_PRIMARY_BG_ACTIVE,   // 3
-    COLOR_SECONDARY_BG,        // 4
-    COLOR_SECONDARY_BG_ACTIVE, // 5
-    COLOR_SPLIT_BG,            // 6
-    COLOR_SPLIT_BG_ACTIVE,     // 7
-
-    /* Colors used for foreground drawing (text etc)
-     * ATTENTION: the background and foreground lists should have
-     *            the same types (the same amount of entries) !
-     *            The code relies on this ! */
-    COLOR_UNKNOWN_FG,          // 8
-    COLOR_HEADER_FG,           // 9
-    COLOR_PRIMARY_FG,          // 10
-    COLOR_PRIMARY_FG_ACTIVE,   // 11
-    COLOR_SECONDARY_FG,        // 12
-    COLOR_SECONDARY_FG_ACTIVE, // 13
-    COLOR_SPLIT_FG,            // 14
-    COLOR_SPLIT_FG_ACTIVE,     // 15
-
-    /* Other colors */
-    COLOR_NEGATIVE,            // 16 Color to use for negative numbers
+typedef enum {
+    COLOR_UNDEFINED = 0,      // 0
+    COLOR_HEADER,             // 1
+    COLOR_PRIMARY,            // 2
+    COLOR_PRIMARY_ACTIVE,     // 3
+    COLOR_SECONDARY,          // 4
+    COLOR_SECONDARY_ACTIVE,   // 5
+    COLOR_SPLIT,              // 6
+    COLOR_SPLIT_ACTIVE,       // 7
+    COLOR_NEGATIVE = 16,      // 16
 } RegisterColor;
+
 
 /** Set the default gui handlers used by new tables. */
 void gnc_table_set_default_gui_handlers (TableGUIHandlers *gui_handlers);
@@ -258,9 +242,7 @@ const char *   gnc_table_get_label (Table *table, VirtualLocation virt_loc);
 
 CellIOFlags    gnc_table_get_io_flags (Table *table, VirtualLocation virt_loc);
 
-guint32        gnc_table_get_fg_color (Table *table, VirtualLocation virt_loc);
-
-guint32        gnc_table_get_bg_color (Table *table, VirtualLocation virt_loc,
+guint32        gnc_table_get_color (Table *table, VirtualLocation virt_loc,
                                        gboolean *hatching);
 
 void           gnc_table_get_borders (Table *table, VirtualLocation virt_loc,

--- a/gnucash/register/register-core/table-model.c
+++ b/gnucash/register/register-core/table-model.c
@@ -134,8 +134,7 @@ gnc_table_model_new (void)
     model->label_handlers = gnc_table_model_handler_hash_new ();
     model->help_handlers = gnc_table_model_handler_hash_new ();
     model->io_flags_handlers = gnc_table_model_handler_hash_new ();
-    model->fg_color_handlers = gnc_table_model_handler_hash_new ();
-    model->bg_color_handlers = gnc_table_model_handler_hash_new ();
+    model->cell_color_handlers = gnc_table_model_handler_hash_new ();
     model->cell_border_handlers = gnc_table_model_handler_hash_new ();
     model->confirm_handlers = gnc_table_model_handler_hash_new ();
     model->save_handlers = gnc_table_model_handler_hash_new ();
@@ -165,11 +164,8 @@ gnc_table_model_destroy (TableModel *model)
     gnc_table_model_handler_hash_destroy (model->io_flags_handlers);
     model->io_flags_handlers = NULL;
 
-    gnc_table_model_handler_hash_destroy (model->fg_color_handlers);
-    model->fg_color_handlers = NULL;
-
-    gnc_table_model_handler_hash_destroy (model->bg_color_handlers);
-    model->bg_color_handlers = NULL;
+    gnc_table_model_handler_hash_destroy (model->cell_color_handlers);
+    model->cell_color_handlers = NULL;
 
     gnc_table_model_handler_hash_destroy (model->cell_border_handlers);
     model->cell_border_handlers = NULL;
@@ -334,75 +330,39 @@ gnc_table_model_get_io_flags_handler (TableModel *model,
 }
 
 void
-gnc_table_model_set_fg_color_handler
+gnc_table_model_set_cell_color_handler
 (TableModel *model,
- TableGetFGColorHandler fg_color_handler,
+ TableGetCellColorHandler color_handler,
  const char * cell_name)
 {
     g_return_if_fail (model != NULL);
     g_return_if_fail (cell_name != NULL);
 
-    gnc_table_model_handler_hash_insert (model->fg_color_handlers,
+    gnc_table_model_handler_hash_insert (model->cell_color_handlers,
                                          cell_name,
-                                         fg_color_handler);
+                                         color_handler);
 }
 
 void
-gnc_table_model_set_default_fg_color_handler
+gnc_table_model_set_default_cell_color_handler
 (TableModel *model,
- TableGetFGColorHandler fg_color_handler)
+ TableGetCellColorHandler color_handler)
 {
     g_return_if_fail (model != NULL);
 
-    gnc_table_model_handler_hash_insert (model->fg_color_handlers,
+    gnc_table_model_handler_hash_insert (model->cell_color_handlers,
                                          DEFAULT_HANDLER,
-                                         fg_color_handler);
+                                         color_handler);
 }
 
-TableGetFGColorHandler
-gnc_table_model_get_fg_color_handler (TableModel *model,
-                                      const char * cell_name)
+TableGetCellColorHandler
+gnc_table_model_get_cell_color_handler (TableModel *model,
+                                   const char * cell_name)
 {
     g_return_val_if_fail (model != NULL, NULL);
 
-    return gnc_table_model_handler_hash_lookup (model->fg_color_handlers,
-            cell_name);
-}
-
-void
-gnc_table_model_set_bg_color_handler
-(TableModel *model,
- TableGetBGColorHandler bg_color_handler,
- const char * cell_name)
-{
-    g_return_if_fail (model != NULL);
-    g_return_if_fail (cell_name != NULL);
-
-    gnc_table_model_handler_hash_insert (model->bg_color_handlers,
-                                         cell_name,
-                                         bg_color_handler);
-}
-
-void
-gnc_table_model_set_default_bg_color_handler
-(TableModel *model,
- TableGetBGColorHandler bg_color_handler)
-{
-    g_return_if_fail (model != NULL);
-
-    gnc_table_model_handler_hash_insert (model->bg_color_handlers,
-                                         DEFAULT_HANDLER,
-                                         bg_color_handler);
-}
-
-TableGetBGColorHandler
-gnc_table_model_get_bg_color_handler (TableModel *model,
-                                      const char * cell_name)
-{
-    g_return_val_if_fail (model != NULL, NULL);
-
-    return gnc_table_model_handler_hash_lookup (model->bg_color_handlers,
-            cell_name);
+    return gnc_table_model_handler_hash_lookup (model->cell_color_handlers,
+                                                cell_name);
 }
 
 void

--- a/gnucash/register/register-core/table-model.h
+++ b/gnucash/register/register-core/table-model.h
@@ -76,10 +76,7 @@ typedef char * (*TableGetHelpHandler) (VirtualLocation virt_loc,
 typedef CellIOFlags (*TableGetCellIOFlagsHandler) (VirtualLocation virt_loc,
         gpointer user_data);
 
-typedef guint32 (*TableGetFGColorHandler) (VirtualLocation virt_loc,
-        gpointer user_data);
-
-typedef guint32 (*TableGetBGColorHandler) (VirtualLocation virt_loc,
+typedef guint32 (*TableGetCellColorHandler) (VirtualLocation virt_loc,
         gboolean *hatching,
         gpointer user_data);
 
@@ -107,8 +104,7 @@ typedef struct
     GHashTable *label_handlers;
     GHashTable *help_handlers;
     GHashTable *io_flags_handlers;
-    GHashTable *fg_color_handlers;
-    GHashTable *bg_color_handlers;
+    GHashTable *cell_color_handlers;
     GHashTable *cell_border_handlers;
     GHashTable *confirm_handlers;
 
@@ -189,25 +185,14 @@ TableGetCellIOFlagsHandler gnc_table_model_get_io_flags_handler
 (TableModel *model,
  const char * cell_name);
 
-void gnc_table_model_set_fg_color_handler
+void gnc_table_model_set_cell_color_handler
 (TableModel *model,
- TableGetFGColorHandler io_flags_handler,
+ TableGetCellColorHandler io_flags_handler,
  const char * cell_name);
-void gnc_table_model_set_default_fg_color_handler
+ void gnc_table_model_set_default_cell_color_handler
 (TableModel *model,
- TableGetFGColorHandler io_flags_handler);
-TableGetFGColorHandler gnc_table_model_get_fg_color_handler
-(TableModel *model,
- const char * cell_name);
-
-void gnc_table_model_set_bg_color_handler
-(TableModel *model,
- TableGetBGColorHandler io_flags_handler,
- const char * cell_name);
-void gnc_table_model_set_default_bg_color_handler
-(TableModel *model,
- TableGetBGColorHandler io_flags_handler);
-TableGetBGColorHandler gnc_table_model_get_bg_color_handler
+ TableGetCellColorHandler io_flags_handler);
+TableGetCellColorHandler gnc_table_model_get_cell_color_handler
 (TableModel *model,
  const char * cell_name);
 

--- a/gnucash/register/register-gnome/gnucash-header.c
+++ b/gnucash/register/register-gnome/gnucash-header.c
@@ -69,6 +69,7 @@ static void
 gnc_header_draw_offscreen (GncHeader *header)
 {
     SheetBlockStyle *style = header->style;
+    GncItemEdit *item_edit = GNC_ITEM_EDIT(header->sheet->item_editor);
     Table *table = header->sheet->table;
     VirtualLocation virt_loc;
     VirtualCell *vcell;
@@ -125,7 +126,7 @@ gnc_header_draw_offscreen (GncHeader *header)
     for (i = 0; i < style->nrows; i++)
     {
         int col_offset = 0;
-        int h = 0, j;
+        int height = 0, j;
         virt_loc.phys_row_offset = i;
 
         /* TODO: This routine is duplicated in several places.
@@ -139,26 +140,29 @@ gnc_header_draw_offscreen (GncHeader *header)
             double text_x, text_y, text_w, text_h;
             BasicCell *cell;
             const char *text;
-            int w;
+            int width;
             PangoLayout *layout;
+            PangoRectangle logical_rect;
+            GdkRectangle rect;
+            int x_offset;
 
             virt_loc.phys_col_offset = j;
 
             cd = gnucash_style_get_cell_dimensions (style, i, j);
-            h = cd->pixel_height;
+            height = cd->pixel_height;
             if (header->in_resize && (j == header->resize_col))
-                w = header->resize_col_width;
+                width = header->resize_col_width;
             else
-                w = cd->pixel_width;
+                width = cd->pixel_width;
 
             cell = gnc_cellblock_get_cell (cb, i, j);
             if (!cell || !cell->cell_name)
             {
-                col_offset += w;
+                col_offset += width;
                 continue;
             }
 
-            cairo_rectangle (cr, col_offset - 0.5, row_offset + 0.5, w, h);
+            cairo_rectangle (cr, col_offset - 0.5, row_offset + 0.5, width, height);
             cairo_set_line_width (cr, 1.0);
             cairo_stroke (cr);
 
@@ -169,38 +173,28 @@ gnc_header_draw_offscreen (GncHeader *header)
                 text = "";
 
             layout = gtk_widget_create_pango_layout (GTK_WIDGET (header->sheet), text);
-            switch (gnc_table_get_align (table, virt_loc))
-            {
-            default:
-            case CELL_ALIGN_LEFT:
-                pango_layout_set_alignment (layout, PANGO_ALIGN_LEFT);
-                break;
 
-            case CELL_ALIGN_RIGHT:
-                pango_layout_set_alignment (layout, PANGO_ALIGN_RIGHT);
-                break;
+            pango_layout_get_pixel_extents (layout, NULL, &logical_rect);
 
-            case CELL_ALIGN_CENTER:
-                pango_layout_set_alignment (layout, PANGO_ALIGN_CENTER);
-                break;
-            }
+            gnucash_sheet_set_text_bounds (header->sheet, &rect,
+                                           col_offset, row_offset, width, height);
 
-            text_x = col_offset + CELL_HPADDING;
-            text_y = row_offset + 1;
-            text_w = MAX (0, w - (2 * CELL_HPADDING));
-            text_h = h - 2;
             cairo_save (cr);
-            cairo_rectangle (cr, text_x, text_y, text_w, text_h);
+            cairo_rectangle (cr, rect.x, rect.y, rect.width, rect.height);
             cairo_clip (cr);
 
-            gtk_render_layout (stylectxt, cr, text_x, text_y, layout);
+            x_offset = gnucash_sheet_get_text_offset (header->sheet, virt_loc,
+                                                      rect.width, logical_rect.width);
+
+            gtk_render_layout (stylectxt, cr, rect.x + x_offset,
+                               rect.y + gnc_item_edit_get_padding_border (item_edit, top), layout);
 
             cairo_restore (cr);
             g_object_unref (layout);
 
-            col_offset += w;
+            col_offset += width;
         }
-        row_offset += h;
+        row_offset += height;
     }
     gtk_style_context_restore (stylectxt);
 

--- a/gnucash/register/register-gnome/gnucash-header.c
+++ b/gnucash/register/register-gnome/gnucash-header.c
@@ -88,8 +88,8 @@ gnc_header_draw_offscreen (GncHeader *header)
 
     gtk_style_context_save (stylectxt);
 
-    // Get the background color type and apply the css class
-    color_type = gnc_table_get_bg_color (table, virt_loc, NULL);
+    // Get the color type and apply the css class
+    color_type = gnc_table_get_color (table, virt_loc, NULL);
     gnucash_get_style_classes (header->sheet, stylectxt, color_type);
 
     if (header->surface)

--- a/gnucash/register/register-gnome/gnucash-item-edit.c
+++ b/gnucash/register/register-gnome/gnucash-item-edit.c
@@ -138,7 +138,8 @@ gnc_item_edit_tb_class_init (GncItemEditTbClass *gnc_item_edit_tb_class)
     GtkWidgetClass *widget_class;
 
 #if GTK_CHECK_VERSION(3,20,0)
-    gtk_widget_class_set_css_name (GTK_WIDGET_CLASS(gnc_item_edit_tb_class), "button");
+//    gtk_widget_class_set_css_name (GTK_WIDGET_CLASS(gnc_item_edit_tb_class), "button");
+    gtk_widget_class_set_css_name (GTK_WIDGET_CLASS(gnc_item_edit_tb_class), "toggle-button");
 #endif
 
     gnc_item_edit_tb_parent_class = g_type_class_peek_parent (gnc_item_edit_tb_class);
@@ -200,7 +201,8 @@ gnc_item_edit_tb_new (GnucashSheet *sheet)
                            NULL);
 
     // This sets a style class for when Gtk+ version is less than 3.20
-    gnc_widget_set_css_name (GTK_WIDGET(item_edit_tb), "button");
+//    gnc_widget_set_css_name (GTK_WIDGET(item_edit_tb), "button");
+    gnc_widget_set_css_name (GTK_WIDGET(item_edit_tb), "toggle-button");
 
     context = gtk_widget_get_style_context (GTK_WIDGET(item_edit_tb));
     gtk_style_context_add_class (context, GTK_STYLE_CLASS_BUTTON);
@@ -568,6 +570,9 @@ draw_arrow_cb (GtkWidget *widget, cairo_t *cr, gpointer data)
     gint size;
 
     gtk_render_background (context, cr, 0, 0, width, height);
+
+    gtk_style_context_add_class (context, GTK_STYLE_CLASS_FRAME);
+    gtk_render_frame (context, cr, 1, 1, width - 2, height - 2);
 
     gtk_style_context_add_class (context, GTK_STYLE_CLASS_ARROW);
 

--- a/gnucash/register/register-gnome/gnucash-item-edit.c
+++ b/gnucash/register/register-gnome/gnucash-item-edit.c
@@ -487,11 +487,8 @@ draw_background_cb (GtkWidget *widget, cairo_t *cr, gpointer user_data)
 
     gtk_style_context_save (stylectxt);
 
-    // Get the background and foreground color types and apply the css class
-    color_type = gnc_table_get_bg_color (item_edit->sheet->table, item_edit->virt_loc, NULL);
-    gnucash_get_style_classes (item_edit->sheet, stylectxt, color_type);
-
-    color_type = gnc_table_get_fg_color (item_edit->sheet->table, item_edit->virt_loc);
+    // Get the color type and apply the css class
+    color_type = gnc_table_get_color (item_edit->sheet->table, item_edit->virt_loc, NULL);
     gnucash_get_style_classes (item_edit->sheet, stylectxt, color_type);
 
     gtk_render_background (stylectxt, cr, 0, 1, width, height - 2);

--- a/gnucash/register/register-gnome/gnucash-item-edit.c
+++ b/gnucash/register/register-gnome/gnucash-item-edit.c
@@ -94,14 +94,6 @@ gnc_item_edit_get_pixel_coords (GncItemEdit *item_edit,
     *y += yd;
 }
 
-
-int
-gnc_item_edit_get_toggle_offset (int row_height)
-{
-    /* sync with gnc_item_edit_update */
-    return row_height - (2 * (CELL_VPADDING + 1)) + 3;
-}
-
 static gboolean
 gnc_item_edit_update (GncItemEdit *item_edit)
 {

--- a/gnucash/register/register-gnome/gnucash-item-edit.c
+++ b/gnucash/register/register-gnome/gnucash-item-edit.c
@@ -58,6 +58,155 @@ enum
 
 static GtkBoxClass *gnc_item_edit_parent_class;
 
+static GtkToggleButtonClass *gnc_item_edit_tb_parent_class;
+
+static void
+gnc_item_edit_tb_init (GncItemEditTb *item_edit_tb)
+{
+    item_edit_tb->sheet = NULL;
+}
+
+static void
+gnc_item_edit_tb_get_property (GObject *object,
+                               guint param_id,
+                               GValue *value,
+                               GParamSpec *pspec)
+{
+    GncItemEditTb *item_edit_tb = GNC_ITEM_EDIT_TB (object);
+
+    switch (param_id)
+    {
+    case PROP_SHEET:
+        g_value_take_object (value, item_edit_tb->sheet);
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, param_id, pspec);
+        break;
+    }
+}
+
+static void
+gnc_item_edit_tb_set_property (GObject *object,
+                               guint param_id,
+                               const GValue *value,
+                               GParamSpec *pspec)
+{
+    GncItemEditTb *item_edit_tb = GNC_ITEM_EDIT_TB (object);
+
+    switch (param_id)
+    {
+    case PROP_SHEET:
+        item_edit_tb->sheet = GNUCASH_SHEET (g_value_get_object (value));
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, param_id, pspec);
+        break;
+    }
+}
+
+static void
+gnc_item_edit_tb_get_preferred_width (GtkWidget *widget,
+                                   gint *minimal_width,
+                                   gint *natural_width)
+{
+    GncItemEditTb *tb = GNC_ITEM_EDIT_TB (widget);
+    GncItemEdit *item_edit = GNC_ITEM_EDIT(tb->sheet->item_editor);
+    gint x, y, w, h, width = 0;
+    gnc_item_edit_get_pixel_coords (GNC_ITEM_EDIT (item_edit), &x, &y, &w, &h);
+    width = ((h - 2)*2)/3;
+    if (width < 20) // minimum size for a button
+        width = 20;
+    *minimal_width = *natural_width = width;
+}
+
+static void
+gnc_item_edit_tb_get_preferred_height (GtkWidget *widget,
+                                    gint *minimal_width,
+                                    gint *natural_width)
+{
+    GncItemEditTb *tb = GNC_ITEM_EDIT_TB (widget);
+    GncItemEdit *item_edit = GNC_ITEM_EDIT(tb->sheet->item_editor);
+    gint x, y, w, h;
+    gnc_item_edit_get_pixel_coords (GNC_ITEM_EDIT (item_edit), &x, &y, &w, &h);
+    *minimal_width = *natural_width = (h - 2);
+}
+
+static void
+gnc_item_edit_tb_class_init (GncItemEditTbClass *gnc_item_edit_tb_class)
+{
+    GObjectClass  *object_class;
+    GtkWidgetClass *widget_class;
+
+#if GTK_CHECK_VERSION(3,20,0)
+    gtk_widget_class_set_css_name (GTK_WIDGET_CLASS(gnc_item_edit_tb_class), "button");
+#endif
+
+    gnc_item_edit_tb_parent_class = g_type_class_peek_parent (gnc_item_edit_tb_class);
+
+    object_class = G_OBJECT_CLASS (gnc_item_edit_tb_class);
+    widget_class = GTK_WIDGET_CLASS (gnc_item_edit_tb_class);
+
+    object_class->get_property = gnc_item_edit_tb_get_property;
+    object_class->set_property = gnc_item_edit_tb_set_property;
+
+    g_object_class_install_property (object_class,
+                                     PROP_SHEET,
+                                     g_param_spec_object ("sheet",
+                                             "Sheet Value",
+                                             "Sheet Value",
+                                             GNUCASH_TYPE_SHEET,
+                                             G_PARAM_READWRITE));
+
+    /* GtkWidget method overrides */
+    widget_class->get_preferred_width = gnc_item_edit_tb_get_preferred_width;
+    widget_class->get_preferred_height = gnc_item_edit_tb_get_preferred_height;
+}
+
+GType
+gnc_item_edit_tb_get_type (void)
+{
+    static GType gnc_item_edit_tb_type = 0;
+
+    if (!gnc_item_edit_tb_type)
+    {
+        static const GTypeInfo gnc_item_edit_tb_info =
+        {
+            sizeof (GncItemEditTbClass),
+            NULL,
+            NULL,
+            (GClassInitFunc) gnc_item_edit_tb_class_init,
+            NULL,
+            NULL,
+            sizeof (GncItemEditTb),
+            0, /* n_preallocs */
+            (GInstanceInitFunc) gnc_item_edit_tb_init,
+            NULL,
+        };
+        gnc_item_edit_tb_type =
+            g_type_register_static(GTK_TYPE_TOGGLE_BUTTON,
+                                   "GncItemEditTb",
+                                   &gnc_item_edit_tb_info, 0);
+    }
+    return gnc_item_edit_tb_type;
+}
+
+GtkWidget *
+gnc_item_edit_tb_new (GnucashSheet *sheet)
+{
+    GtkStyleContext *context;
+    GncItemEditTb *item_edit_tb =
+            g_object_new (GNC_TYPE_ITEM_EDIT_TB,
+                          "sheet", sheet,
+                           NULL);
+
+    // This sets a style class for when Gtk+ version is less than 3.20
+    gnc_widget_set_css_name (GTK_WIDGET(item_edit_tb), "button");
+
+    context = gtk_widget_get_style_context (GTK_WIDGET(item_edit_tb));
+    gtk_style_context_add_class (context, GTK_STYLE_CLASS_BUTTON);
+
+    return GTK_WIDGET(item_edit_tb);
+}
 
 /*
  * Returns the coordinates for the editor bounding box
@@ -722,7 +871,7 @@ gnc_item_edit_new (GnucashSheet *sheet)
     /* Create the popup button
        It will only be displayed when the cell being edited provides
        a popup item (like a calendar or account list) */
-    item_edit->popup_toggle.tbutton = gtk_toggle_button_new();
+    item_edit->popup_toggle.tbutton = gnc_item_edit_tb_new (sheet);
     gtk_toggle_button_set_mode (GTK_TOGGLE_BUTTON (item_edit->popup_toggle.tbutton), FALSE);
 
     /* Wrap the popup button in an event box to give it its own gdkwindow.

--- a/gnucash/register/register-gnome/gnucash-item-edit.c
+++ b/gnucash/register/register-gnome/gnucash-item-edit.c
@@ -742,6 +742,25 @@ gnc_item_edit_new (GnucashSheet *sheet)
     return GTK_WIDGET(item_edit);
 }
 
+static void
+check_popup_height_is_true (GtkWidget    *widget,
+                            GdkRectangle *allocation,
+                            gpointer user_data)
+{
+    GncItemEdit *item_edit = GNC_ITEM_EDIT(user_data);
+    GnucashSheet *sheet = item_edit->sheet;
+
+    // if a larger font is specified in css for the sheet, the popup returned height value
+    // on first pop does not reflect the true height but the minimum height so just to be
+    // sure check this value against the allocated one.
+    if (allocation->height != item_edit->popup_returned_height)
+    {
+        gtk_container_remove (GTK_CONTAINER(item_edit->sheet), item_edit->popup_item);
+
+        g_idle_add_full (G_PRIORITY_HIGH_IDLE,
+                        (GSourceFunc) gnc_item_edit_update, item_edit, NULL);
+    }
+}
 
 void
 gnc_item_edit_show_popup (GncItemEdit *item_edit)
@@ -809,6 +828,11 @@ gnc_item_edit_show_popup (GncItemEdit *item_edit)
 
     if (!gtk_widget_get_parent (item_edit->popup_item))
         gtk_layout_put (GTK_LAYOUT(sheet), item_edit->popup_item, popup_x, popup_y);
+
+    // Lets check popup height is the true height
+    item_edit->popup_returned_height = popup_h;
+    g_signal_connect_after (item_edit->popup_item, "size-allocate",
+                            G_CALLBACK(check_popup_height_is_true), item_edit);
 
     gtk_widget_set_size_request (item_edit->popup_item, popup_w - 1, popup_h);
 

--- a/gnucash/register/register-gnome/gnucash-item-edit.h
+++ b/gnucash/register/register-gnome/gnucash-item-edit.h
@@ -133,8 +133,6 @@ void gnc_item_edit_set_popup (GncItemEdit    *item_edit,
 void gnc_item_edit_show_popup (GncItemEdit *item_edit);
 void gnc_item_edit_hide_popup (GncItemEdit *item_edit);
 
-int gnc_item_edit_get_toggle_offset (int row_height);
-
 void gnc_item_edit_cut_clipboard (GncItemEdit *item_edit);
 void gnc_item_edit_copy_clipboard (GncItemEdit *item_edit);
 void gnc_item_edit_paste_clipboard (GncItemEdit *item_edit);

--- a/gnucash/register/register-gnome/gnucash-item-edit.h
+++ b/gnucash/register/register-gnome/gnucash-item-edit.h
@@ -37,6 +37,10 @@
 #define GNC_ITEM_EDIT_CLASS(k)    (G_TYPE_CHECK_CLASS_CAST ((k), GNC_TYPE_ITEM_EDIT, GncItemEditClass))
 #define GNC_IS_ITEM_EDIT(o)       (G_TYPE_CHECK_INSTANCE_TYPE((o), GNC_TYPE_ITEM_EDIT))
 
+#define GNC_TYPE_ITEM_EDIT_TB        (gnc_item_edit_tb_get_type ())
+#define GNC_ITEM_EDIT_TB(o)          (G_TYPE_CHECK_INSTANCE_CAST((o), GNC_TYPE_ITEM_EDIT_TB, GncItemEditTb))
+#define GNC_ITEM_EDIT_TB_CLASS(k)    (G_TYPE_CHECK_CLASS_CAST ((k), GNC_TYPE_ITEM_EDIT_TB, GncItemEditTbClass))
+#define GNC_IS_ITEM_EDIT_TB(o)       (G_TYPE_CHECK_INSTANCE_TYPE((o), GNC_TYPE_ITEM_EDIT_TB))
 
 typedef int (*PopupGetHeight) (GtkWidget *item,
                                int space_available,
@@ -102,6 +106,19 @@ typedef struct
     GtkBoxClass parent_class;
 } GncItemEditClass;
 
+typedef struct
+{
+    GtkToggleButton tb;
+    GnucashSheet *sheet;
+} GncItemEditTb;
+
+typedef struct
+{
+    GtkToggleButtonClass parent_class;
+
+    void (* toggled) (GncItemEditTb *item_edit_tb);
+} GncItemEditTbClass;
+
 typedef enum
 {
     left,
@@ -144,6 +161,9 @@ void gnc_item_edit_focus_out (GncItemEdit *item_edit);
 
 gint gnc_item_edit_get_margin (GncItemEdit *item_edit, Sides side);
 gint gnc_item_edit_get_padding_border (GncItemEdit *item_edit, Sides side);
+
+GType gnc_item_edit_tb_get_type (void);
+GtkWidget *gnc_item_edit_tb_new (GnucashSheet *sheet);
 
 /** @} */
 #endif /* GNUCASH_ITEM_EDIT_H */

--- a/gnucash/register/register-gnome/gnucash-item-edit.h
+++ b/gnucash/register/register-gnome/gnucash-item-edit.h
@@ -85,6 +85,7 @@ typedef struct
     PopupPostShow    popup_post_show;
     PopupGetWidth    popup_get_width;
     gpointer         popup_user_data;
+    gint             popup_returned_height;
 
     GtkBorder        padding;
     GtkBorder        margin;

--- a/gnucash/register/register-gnome/gnucash-item-edit.h
+++ b/gnucash/register/register-gnome/gnucash-item-edit.h
@@ -86,6 +86,10 @@ typedef struct
     PopupGetWidth    popup_get_width;
     gpointer         popup_user_data;
 
+    GtkBorder        padding;
+    GtkBorder        margin;
+    GtkBorder        border;
+
     /* Where are we */
     VirtualLocation virt_loc;
 
@@ -97,6 +101,15 @@ typedef struct
     GtkBoxClass parent_class;
 } GncItemEditClass;
 
+typedef enum
+{
+    left,
+    right,
+    top,
+    bottom,
+    left_right,
+    top_bottom,
+} Sides;
 
 GType gnc_item_edit_get_type (void);
 
@@ -129,6 +142,9 @@ void gnc_item_edit_paste_clipboard (GncItemEdit *item_edit);
 gboolean gnc_item_edit_get_has_selection (GncItemEdit *item_edit);
 void gnc_item_edit_focus_in (GncItemEdit *item_edit);
 void gnc_item_edit_focus_out (GncItemEdit *item_edit);
+
+gint gnc_item_edit_get_margin (GncItemEdit *item_edit, Sides side);
+gint gnc_item_edit_get_padding_border (GncItemEdit *item_edit, Sides side);
 
 /** @} */
 #endif /* GNUCASH_ITEM_EDIT_H */

--- a/gnucash/register/register-gnome/gnucash-sheet-private.c
+++ b/gnucash/register/register-gnome/gnucash-sheet-private.c
@@ -381,6 +381,7 @@ draw_cell (GnucashSheet *sheet,
            cairo_t *cr,
            int x, int y, int width, int height)
 {
+    GncItemEdit *item_edit = GNC_ITEM_EDIT(sheet->item_editor);
     Table *table = sheet->table;
     PhysicalCellBorders borders;
     const char *text;
@@ -524,39 +525,19 @@ draw_cell (GnucashSheet *sheet,
         goto exit;
     }
 
-    pango_layout_get_pixel_extents(layout,
-                                   NULL,
-                                   &logical_rect);
+    pango_layout_get_pixel_extents (layout, NULL, &logical_rect);
 
-    rect.x      = x + CELL_HPADDING;
-    rect.y      = y + CELL_VPADDING;
-    rect.width  = MAX (0, width - (2 * CELL_HPADDING));
-    rect.height = height - 2;
+    gnucash_sheet_set_text_bounds (sheet, &rect, x, y, width, height);
 
     cairo_save (cr);
     cairo_rectangle (cr, rect.x, rect.y, rect.width, rect.height);
     cairo_clip (cr);
 
-    switch (gnc_table_get_align (table, virt_loc))
-    {
-    default:
-    case CELL_ALIGN_LEFT:
-        x_offset = 0;
-        break;
+    x_offset = gnucash_sheet_get_text_offset (sheet, virt_loc,
+                                              rect.width, logical_rect.width);
 
-    case CELL_ALIGN_RIGHT:
-        x_offset = width - 2 * CELL_HPADDING - logical_rect.width - 3;
-        break;
-
-    case CELL_ALIGN_CENTER:
-        if (logical_rect.width > width - 2 * CELL_HPADDING)
-            x_offset = 0;
-        else
-            x_offset = (width - 2 * CELL_HPADDING -
-                        logical_rect.width) / 2;
-        break;
-    }
-    gtk_render_layout (stylectxt, cr, rect.x + x_offset + 1, rect.y, layout);
+    gtk_render_layout (stylectxt, cr, rect.x + x_offset,
+                       rect.y + gnc_item_edit_get_padding_border (item_edit, top), layout);
 
     cairo_restore (cr);
 

--- a/gnucash/register/register-gnome/gnucash-sheet-private.c
+++ b/gnucash/register/register-gnome/gnucash-sheet-private.c
@@ -418,7 +418,10 @@ draw_cell (GnucashSheet *sheet,
     gtk_render_background (stylectxt, cr, x, y, width, height);
 
     gdk_rgba_parse (&color, "black");
-    gnc_style_context_get_background_color (stylectxt, GTK_STATE_FLAG_NORMAL, &color);
+    if (gtk_style_context_get_state (stylectxt) == GTK_STATE_FLAG_INSENSITIVE)
+        gnc_style_context_get_background_color (stylectxt, GTK_STATE_FLAG_INSENSITIVE, &color);
+    else
+        gnc_style_context_get_background_color (stylectxt, GTK_STATE_FLAG_NORMAL, &color);
     bg_color = &color;
 
     get_cell_borders (sheet, virt_loc, &borders);

--- a/gnucash/register/register-gnome/gnucash-sheet-private.c
+++ b/gnucash/register/register-gnome/gnucash-sheet-private.c
@@ -682,7 +682,7 @@ gnucash_sheet_draw_cursor (GnucashCursor *cursor, cairo_t *cr)
     cairo_stroke (cr);
 
     // make the bottom line thicker
-    cairo_move_to (cr, cursor->x - x + 0.5, cursor->y - y + cursor->h - 1.5);
+    cairo_move_to (cr, cursor->x - x + 0.5, cursor->y - y + cursor->h - 3.5);
     cairo_rel_line_to (cr, cursor->w, 0);
     cairo_set_line_width (cr, 1.0);
     cairo_stroke (cr);

--- a/gnucash/register/register-gnome/gnucash-sheet-private.c
+++ b/gnucash/register/register-gnome/gnucash-sheet-private.c
@@ -399,11 +399,8 @@ draw_cell (GnucashSheet *sheet,
 
     gtk_style_context_save (stylectxt);
 
-    // Get the background and foreground color types and apply the css class
-    color_type = gnc_table_get_bg_color (table, virt_loc, &hatching);
-    gnucash_get_style_classes (sheet, stylectxt, color_type);
-
-    color_type = gnc_table_get_fg_color (table, virt_loc);
+    // Get the color type and apply the css class
+    color_type = gnc_table_get_color (table, virt_loc, &hatching);
     gnucash_get_style_classes (sheet, stylectxt, color_type);
 
     // Are we in a read-only row? Then make the background color somewhat more grey.

--- a/gnucash/register/register-gnome/gnucash-sheet.c
+++ b/gnucash/register/register-gnome/gnucash-sheet.c
@@ -2428,52 +2428,46 @@ gnucash_sheet_table_load (GnucashSheet *sheet, gboolean do_scroll)
 
 /*************************************************************/
 
-/** Map a cell type to a css style class. */
+/** Map a cell color type to a css style class. */
 void
 gnucash_get_style_classes (GnucashSheet *sheet, GtkStyleContext *stylectxt,
                            RegisterColor field_type)
 {
     gchar *full_class, *style_class = NULL;
 
+    if (field_type >= COLOR_NEGATIVE) // Require a Negative fg color
+    {
+        gtk_style_context_add_class (stylectxt, "negative-numbers");
+        field_type -= COLOR_NEGATIVE;
+    }
+
     switch (field_type)
     {
     default:
-    case COLOR_UNKNOWN_BG:
-    case COLOR_UNKNOWN_FG:
+    case COLOR_UNDEFINED:
         gtk_style_context_add_class (stylectxt, GTK_STYLE_CLASS_BACKGROUND);
         return;
 
-    case COLOR_NEGATIVE:
-        gtk_style_context_add_class (stylectxt, "negative-numbers");
-        return;
-
-    case COLOR_HEADER_BG:
-    case COLOR_HEADER_FG:
+    case COLOR_HEADER:
         style_class = "header";
         break;
 
-    case COLOR_PRIMARY_BG:
-    case COLOR_PRIMARY_FG:
+    case COLOR_PRIMARY:
         style_class = "primary";
         break;
 
-    case COLOR_PRIMARY_BG_ACTIVE:
-    case COLOR_PRIMARY_FG_ACTIVE:
-    case COLOR_SECONDARY_BG_ACTIVE:
-    case COLOR_SECONDARY_FG_ACTIVE:
-    case COLOR_SPLIT_BG_ACTIVE:
-    case COLOR_SPLIT_FG_ACTIVE:
+    case COLOR_PRIMARY_ACTIVE:
+    case COLOR_SECONDARY_ACTIVE:
+    case COLOR_SPLIT_ACTIVE:
         gtk_style_context_set_state (stylectxt, GTK_STATE_FLAG_SELECTED);
         style_class = "cursor";
         break;
 
-    case COLOR_SECONDARY_BG:
-    case COLOR_SECONDARY_FG:
+    case COLOR_SECONDARY:
         style_class = "secondary";
         break;
 
-    case COLOR_SPLIT_BG:
-    case COLOR_SPLIT_FG:
+    case COLOR_SPLIT:
         style_class = "split";
         break;
     }

--- a/gnucash/register/register-gnome/gnucash-sheet.h
+++ b/gnucash/register/register-gnome/gnucash-sheet.h
@@ -33,10 +33,6 @@
  * @brief Public declarations of GnucashSheet class.
  */
 
-#define CELL_VPADDING 2
-#define CELL_HPADDING 5
-
-
 #define GNUCASH_TYPE_SHEET     (gnucash_sheet_get_type ())
 #define GNUCASH_SHEET(obj)     (G_TYPE_CHECK_INSTANCE_CAST((obj), GNUCASH_TYPE_SHEET, GnucashSheet))
 #define GNUCASH_SHEET_CLASS(k) (G_TYPE_CHECK_CLASS_CAST ((k), GNUCASH_TYPE_SHEET))

--- a/gnucash/register/register-gnome/gnucash-sheet.h
+++ b/gnucash/register/register-gnome/gnucash-sheet.h
@@ -108,5 +108,11 @@ void gnucash_sheet_set_window (GnucashSheet *sheet, GtkWidget *window);
 void gnucash_get_style_classes (GnucashSheet *sheet, GtkStyleContext *stylectxt,
                                 RegisterColor field_type);
 
+void gnucash_sheet_set_text_bounds (GnucashSheet *sheet, GdkRectangle *rect,
+                                    gint x, gint y, gint width, gint height);
+
+gint gnucash_sheet_get_text_offset (GnucashSheet *sheet, const VirtualLocation virt_loc,
+                                    gint rect_width, gint logical_width);
+
 /** @} */
 #endif

--- a/gnucash/register/register-gnome/gnucash-style.c
+++ b/gnucash/register/register-gnome/gnucash-style.c
@@ -215,9 +215,10 @@ set_dimensions_pass_one (GnucashSheet *sheet, CellBlock *cursor,
             if (cd->pixel_width > 0)
                 continue;
 
+            // This is used on new account popup cells to get the default
+            // width of text plus toggle button.
             if (cell && cell->is_popup)
-                width += gnc_item_edit_get_toggle_offset
-                         (cd->pixel_height);
+                width += cd->pixel_height; // toggle button is square, use cell height
 
             cd->pixel_width = MAX (cd->pixel_width, width);
         }

--- a/gnucash/register/register-gnome/gnucash-style.c
+++ b/gnucash/register/register-gnome/gnucash-style.c
@@ -169,6 +169,7 @@ set_dimensions_pass_one (GnucashSheet *sheet, CellBlock *cursor,
     int row, col;
     gint max_height = -1;
     PangoLayout *layout;
+    GncItemEdit *item_edit = GNC_ITEM_EDIT(sheet->item_editor);
 
     /* g_return_if_fail (font != NULL); */
 
@@ -196,13 +197,17 @@ set_dimensions_pass_one (GnucashSheet *sheet, CellBlock *cursor,
                 layout = gtk_widget_create_pango_layout (GTK_WIDGET (sheet), text);
                 pango_layout_get_pixel_size (layout, &width, &cd->pixel_height);
                 g_object_unref (layout);
-                width += 2 * CELL_HPADDING;
-                cd->pixel_height += 2 * CELL_VPADDING;
+                width += gnc_item_edit_get_margin (item_edit, left_right) +
+                         gnc_item_edit_get_padding_border (item_edit, left_right);
+
+                cd->pixel_height += gnc_item_edit_get_margin (item_edit, top_bottom) +
+                                    gnc_item_edit_get_padding_border (item_edit, top_bottom);
             }
             else
             {
                 width = 0;
-                cd->pixel_height = (2 * CELL_VPADDING);
+                cd->pixel_height = gnc_item_edit_get_margin (item_edit, top_bottom) +
+                                   gnc_item_edit_get_padding_border (item_edit, top_bottom);
             }
 
             max_height = MAX(max_height, cd->pixel_height);
@@ -239,6 +244,7 @@ static void
 set_dimensions_pass_two (GnucashSheet *sheet, int default_width)
 {
     SheetBlockStyle *style;
+    GncItemEdit *item_edit = GNC_ITEM_EDIT(sheet->item_editor);
     BlockDimensions *dimensions;
     CellDimensions *cd;
     GTable *cd_table;
@@ -315,7 +321,8 @@ set_dimensions_pass_two (GnucashSheet *sheet, int default_width)
                 pango_layout_get_pixel_size (layout, &sample_width, NULL);
                 g_object_unref (layout);
                 /*sample_width = gdk_string_width (font, text);*/
-                sample_width += 2 * CELL_HPADDING;
+                sample_width += gnc_item_edit_get_margin (item_edit, left_right) +
+                                gnc_item_edit_get_padding_border (item_edit, left_right);
             }
             else
                 sample_width = 0;


### PR DESCRIPTION
The first lot of commits get the cell margin, border and padding from the CSS values. Previously the border would take up 1px when not specified and the padding default was 2px. This is still the case but with margin so there should be 3px top and bottom which should be enough space for the double line so I have moved it back up and does not interfere with the cell. Also the cell alignment is now a common set of functions which fixes a header alignment issue. I have cast a new toggle button so that the button width can be controlled which leads in to commit 'Change the look...', with these changes the button is removed and replaced with the arrow and possible frame, this could be adjusted if it was a way to go. The latter commits were the code reduction for the cell colours.
Bob

To test here is some CSS...

/* Register sheet font setting */
sheet {
  font: 18px arial, sans-serif;
}

sheet calendar {
  font: 12px arial, sans-serif;
}

/* Register Cursor settings, top, right, bottom, left */
cursor entry {
  margin: 10px 5px 10px 5px;
  padding: 2px 2px 2px 2px;
  border-width: 2px 2px 2px 2px;
  border-color: blue red blue green;
  background-color: #4dd2ff;
}

cursor button {
  margin: 1px 1px 1px 1px;
}

/* Test */
cursor toggle-button {
  margin: 1px 1px 1px 1px;
  background-color: pink;
}
