### PR TITLE
Fix report colors

### DIFF
--- a/gnucash/report/report-system/html-barchart.scm
+++ b/gnucash/report/report-system/html-barchart.scm
@@ -353,8 +353,10 @@
                       (gnc:html-barchart-row-labels barchart)))
          (col-labels (catenate-escaped-strings 
                       (gnc:html-barchart-col-labels barchart)))
-         (col-colors (catenate-escaped-strings 
-                      (gnc:html-barchart-col-colors barchart)))
+         ;; convert color list to string with valid js array of strings, example: "\"blue\", \"red\""
+         (colors-str (string-join (map (lambda (color)
+					 (string-append "\"" color "\""))
+				       (gnc:html-barchart-col-colors barchart)) ", "))
          (series-data-start (lambda (series-index)
                          (push "var d")
                          (push series-index)
@@ -476,6 +478,7 @@
                        showTooltip: false,
                        zoom: true,
                    },
+                   seriesColors: false,
                 };\n")
 
             (push "  options.stackSeries = ")
@@ -506,6 +509,13 @@
                 (push y-label)
                 (push "\";\n")))
             (push "  options.axes.xaxis.ticks = all_ticks;\n")
+            (if (not (equal? colors-str ""))
+                (begin            ; example: options.seriesColors= ["blue", "red"];
+                  (push "options.seriesColors = [")
+                  (push colors-str)
+                  (push "];\n")
+                  )
+                )
 
 
             (push "$.jqplot.config.enablePlugins = true;\n")

--- a/gnucash/report/report-system/html-linechart.scm
+++ b/gnucash/report/report-system/html-linechart.scm
@@ -388,8 +388,10 @@
                       (gnc:html-linechart-row-labels linechart)))
          (col-labels (catenate-escaped-strings
                       (gnc:html-linechart-col-labels linechart)))
-         (col-colors (catenate-escaped-strings
-                      (gnc:html-linechart-col-colors linechart)))
+         ;; convert color list to string with valid js array of strings, example: "\"blue\", \"red\""
+         (colors-str (string-join (map (lambda (color)
+                                         (string-append "\"" color "\""))
+                                       (gnc:html-linechart-col-colors linechart)) ", "))
          (line-width (gnc:html-linechart-line-width linechart))
          (series-data-start (lambda (series-index)
                          (push "var d")
@@ -501,7 +503,8 @@
                    cursor: {
                        show: true,
                        zoom: true
-                   }
+                   },
+                   seriesColors: false,
                 };\n")
 
             (push "  options.stackSeries = ")
@@ -546,6 +549,13 @@
                 (push "  options.axes.yaxis.label = \"")
                 (push y-label)
                 (push "\";\n")))
+	    (if (not (equal? colors-str ""))
+                (begin            ; example: options.seriesColors= ["blue", "red"];
+                  (push "options.seriesColors = [")
+                  (push colors-str)
+                  (push "];\n")
+                  )
+                )
 
             ;; adjust the date string format to the one given by the preferences
             (push "  options.axes.xaxis.tickOptions.formatString = '")

--- a/gnucash/report/report-system/html-piechart.scm
+++ b/gnucash/report/report-system/html-piechart.scm
@@ -200,6 +200,10 @@
            (gnc:html-piechart-button-3-legend-urls piechart)))
          (data 
           (ensure-positive-numbers (gnc:html-piechart-data piechart)))
+         ;; convert color list to string with valid js array of strings, example: "\"blue\", \"red\""
+         (colors-str (string-join (map (lambda (color)
+                                         (string-append "\"" color "\""))
+                                       (gnc:html-piechart-colors piechart)) ", "))
          ; Use a unique chart-id for each chart. This prevents chart
          ; clashed on multi-column reports
          (chart-id (string-append "chart-" (number->string (random 999999)))))
@@ -247,6 +251,7 @@
                          show: false },
                     cursor: {
                          showTooltip: false },
+                    seriesColors: false,
                    };\n")
 
             (if title
@@ -259,6 +264,13 @@
                 (push "  options.title += \" (")
                 (push (jqplot-escape-string subtitle))
                 (push ")\";\n")))
+            (if (not (equal? colors-str ""))
+                (begin            ; example: options.seriesColors= ["blue", "red"];
+                  (push "options.seriesColors = [")
+                  (push colors-str)
+                  (push "];\n")
+                  )
+                )
 
             (push "$.jqplot.config.enablePlugins = true;\n")
             (push "$(document).ready(function() {


### PR DESCRIPTION
Many of the standard reports specify colors to use in their charts. However, these colors are ignored in the chart rendering code.

These commits modify the rendering code of all 3 types of charts (bar, pie and line) to fix this issue. This is done by adding the jqplot option "seriesColors"  to pass the requested bar/pie/line colors to jqplot. If no colors are requested, we let jqplot use default colors by setting "seriesColors: false".