### PR TITLE
Fixed null pointer dereferencing during first transaction retrieval

### DIFF
--- a/gnucash/import-export/aqb/gnc-ab-kvp.c
+++ b/gnucash/import-export/aqb/gnc-ab-kvp.c
@@ -99,9 +99,17 @@ Timespec
 gnc_ab_get_account_trans_retrieval(const Account *a)
 {
     Timespec *t = NULL;
+    Timespec never;
+    never.tv_nsec = 0;
+    never.tv_sec = 0;
+    
     qof_instance_get (QOF_INSTANCE (a),
 		      "ab-trans-retrieval", &t,
 		      NULL);
+    if (!t)
+    {
+      return never;
+    }
     return *t;
 }
 


### PR DESCRIPTION
This fixes the issue that the first attempt to import transactions into a newly created account synchronized via HBCI crashes Gnucash because there is no date of last retrieval available for that account.