### PR TITLE
fix reconcile dialog always showing ending balance of zero

### DIFF
--- a/libgnucash/engine/Account.c
+++ b/libgnucash/engine/Account.c
@@ -4444,14 +4444,15 @@ xaccAccountGetReconcilePostponeBalance (const Account *acc,
     g_return_val_if_fail(GNC_IS_ACCOUNT(acc), FALSE);
     qof_instance_get_kvp (QOF_INSTANCE(acc),
                           "reconcile-info/postpone/balance", &v);
-    if (G_VALUE_HOLDS_INT64 (&v))
+    if (G_VALUE_HOLDS_INT64 (&v)) {
         bal = *(gnc_numeric*)g_value_get_boxed (&v);
 
-    if (bal.denom)
-    {
-        if (balance)
-            *balance = bal;
-        return TRUE;
+        if (bal.denom)
+        {
+            if (balance)
+                *balance = bal;
+            return TRUE;
+        }
     }
     return FALSE;
 }


### PR DESCRIPTION
The reconcile account dialog always displays a value of 0.00 as the
Ending Balance, regardless of account and statement date.
This is caused by function xaccAccountGetReconcilePostponeBalance
returning the wrong value, returning TRUE when it should return FALSE,
and setting balance to the default {0,1}.

The code uses bal.denom!=0 as an indicator that a valid balance was
received in variable v. However, bal is initialized to {0,1}
making the test always true even when we didn't receive a valid
value in variable v.
Thus, this function returns TRUE with *balance={0,1} when no valid
balance was found in "reconcile-info/postpone/balance".

This patch fixes the function to return FALSE if v doesn't hold
a valid value or if bal.denom is set to 0.