### PR TITLE
use correct pointer (gnc_numeric**) with qof_instance_get

### DIFF
--- a/libgnucash/app-utils/gnc-sx-instance-model.c
+++ b/libgnucash/app-utils/gnc-sx-instance-model.c
@@ -78,7 +78,7 @@ scrub_sx_split_numeric (Split* split, const char *debcred)
     const char *numeric = is_credit ?
         "sx-credit-numeric" : "sx-debit-numeric";
     char *formval;
-    gnc_numeric numval;
+    gnc_numeric *numval = NULL;
     GHashTable *parser_vars = g_hash_table_new (g_str_hash, g_str_equal);
     char *error_loc;
     gnc_numeric amount = gnc_numeric_zero ();
@@ -93,7 +93,7 @@ scrub_sx_split_numeric (Split* split, const char *debcred)
     if (!parse_result || g_hash_table_size (parser_vars) != 0)
         amount = gnc_numeric_zero ();
     g_hash_table_unref (parser_vars);
-    if (gnc_numeric_eq (amount, numval))
+    if (gnc_numeric_eq (amount, *numval))
         return FALSE;
     qof_instance_set (QOF_INSTANCE (split),
 		  numeric, &amount,


### PR DESCRIPTION
Function `qof_instance_get` needs a `gnc_numeric**` instead of a `gnc_numeric*` to work correctly.
The proper usage of function `qof_instance_get` with a `gnc_numeric` is shown in function:
```
split-register-model.c:gnc_template_register_get_debcred_entry
```

This bug had an interesting side effect. It was causing the session to be marked as dirty on startup: the Save button is active and an asterisk (*) appears in the window title.
One of the last steps when reading the user data file is to replay any scheduled transaction. This bug produced wrong values for `"sx-debit-numeric"` and `"sx-credit-numeric"` which forced the transaction
to be modified marking the whole session as dirty.