### PR TITLE
Flat Bayes Import Map KVP

### DIFF
--- a/common/test-core/test-stuff.h
+++ b/common/test-core/test-stuff.h
@@ -57,7 +57,9 @@ Otherwise, only failures are printed out.
 #include <glib.h>
 #include <stdlib.h>
 
-
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* Privately used to indicate a test result. You may use these if you
  * wish, but it's easier to use the do_test macro above.
@@ -150,5 +152,8 @@ gint64 get_random_gint64(void);
 double get_random_double(void);
 const char* get_random_string_in_array(const char* str_list[]);
 
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
 
 #endif /* TEST_STUFF_H */

--- a/common/test-core/unittest-support.h
+++ b/common/test-core/unittest-support.h
@@ -179,6 +179,14 @@ GSList *test_log_set_fatal_handler (GSList *list, TestErrorStruct *error,
 void test_free_log_handler (gpointer item);
 
 /**
+ * Check that the user_data error message is a substring of the
+ * actual error otherwise assert.  Displays the error (and asserts
+ * if G_LOG_FLAG_FATAL is TRUE) if NULL is passed as user_data,
+ * but a NULL or 0 value member matches anything.
+ */
+gboolean test_checked_substring_handler (const char *log_domain, GLogLevelFlags log_level,
+                                         const gchar *msg, gpointer user_data);
+/**
  * Check the user_data against the actual error and assert on any
  * differences.  Displays the error (and asserts if G_LOG_FLAG_FATAL
  * is TRUE) if NULL is passed as user_data, but a NULL or 0 value
@@ -212,6 +220,18 @@ gboolean test_null_handler (const char *log_domain, GLogLevelFlags log_level,
  */
 void test_add_error (TestErrorStruct *error);
 void test_clear_error_list (void);
+
+/**
+ * Checks received errors against the list created by
+ * test_add_error. Rather than checking for an exact match, this function
+ * checks using a substring match. If the list is empty or nothing
+ * matches, passes control on to test_checked_substring_handler, giving
+ * the opportunity for an additional check that's not in the list
+ * (set user_data to NULL if you want test_checked_handler to
+ * immediately print the error).
+ */
+gboolean test_list_substring_handler (const char *log_domain, GLogLevelFlags log_level,
+                      const gchar *msg, gpointer user_data);
 
 /**
  * Checks received errors against the list created by

--- a/gnucash/gnome-utils/gnc-file.c
+++ b/gnucash/gnome-utils/gnc-file.c
@@ -1040,6 +1040,7 @@ RESTART:
     // Convert imap mappings from account full name to guid strings
     qof_event_suspend();
     gnc_account_imap_convert_bayes (gnc_get_current_book());
+    gnc_account_imap_convert_flat (gnc_get_current_book());
     qof_event_resume();
 
     return TRUE;

--- a/libgnucash/backend/sql/gnc-account-sql.cpp
+++ b/libgnucash/backend/sql/gnc-account-sql.cpp
@@ -34,7 +34,6 @@ extern "C"
 
 #include "qof.h"
 #include "Account.h"
-#include "AccountP.h"
 #include "gnc-commodity.h"
 
 #if defined( S_SPLINT_S )
@@ -46,6 +45,7 @@ extern "C"
 #include <vector>
 #include <algorithm>
 
+#include "Account.hpp"
 #include "gnc-sql-connection.hpp"
 #include "gnc-sql-backend.hpp"
 #include "gnc-sql-object-backend.hpp"

--- a/libgnucash/backend/xml/gnc-account-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-account-xml-v2.cpp
@@ -29,10 +29,10 @@ extern "C"
 #include <glib.h>
 #include <stdlib.h>
 #include <string.h>
-#include <AccountP.h>
 #include <Account.h>
 }
 
+#include "Account.hpp"
 #include "gnc-xml-helper.h"
 #include "sixtp.h"
 #include "sixtp-utils.h"

--- a/libgnucash/backend/xml/gnc-commodity-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-commodity-xml-v2.cpp
@@ -27,10 +27,10 @@ extern "C"
 
 #include <glib.h>
 #include <string.h>
-#include "AccountP.h"
 #include "Account.h"
 }
 
+#include "Account.hpp"
 #include "gnc-xml-helper.h"
 #include "sixtp.h"
 #include "sixtp-utils.h"

--- a/libgnucash/backend/xml/gnc-transaction-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-transaction-xml-v2.cpp
@@ -27,12 +27,13 @@ extern "C"
 
 #include <glib.h>
 #include <string.h>
-#include "AccountP.h"
 #include "Transaction.h"
 #include "TransactionP.h"
 #include "gnc-lot.h"
 #include "gnc-lot-p.h"
 }
+
+#include "Account.hpp"
 #include "gnc-xml-helper.h"
 
 #include "sixtp.h"

--- a/libgnucash/backend/xml/io-gncxml-v1.cpp
+++ b/libgnucash/backend/xml/io-gncxml-v1.cpp
@@ -36,7 +36,6 @@ extern "C"
 
 #include <gnc-xml-helper.h>
 #include <Account.h>
-#include <AccountP.h>
 #include <Query.h>
 #include <Scrub.h>
 #include <Transaction.h>
@@ -46,6 +45,7 @@ extern "C"
 #include <gnc-pricedb-p.h>
 }
 
+#include "Account.hpp"
 #include "io-gncxml.h"
 #include "sixtp.h"
 #include "sixtp-dom-parsers.h"

--- a/libgnucash/backend/xml/sixtp-dom-generators.cpp
+++ b/libgnucash/backend/xml/sixtp-dom-generators.cpp
@@ -334,7 +334,7 @@ add_kvp_value_node (xmlNodePtr node, const gchar* tag, KvpValue* val)
         auto frame = val->get<KvpFrame*> ();
         if (!frame)
             break;
-        frame->for_each_slot (add_kvp_slot, static_cast<void*> (val_node));
+        frame->for_each_slot_temp (&add_kvp_slot, val_node);
         break;
     }
     default:
@@ -366,6 +366,6 @@ qof_instance_slots_to_dom_tree (const char* tag, const QofInstance* inst)
         return nullptr;
 
     ret = xmlNewNode (nullptr, BAD_CAST tag);
-    frame->for_each_slot (add_kvp_slot, static_cast<void*> (ret));
+    frame->for_each_slot_temp (&add_kvp_slot, ret);
     return ret;
 }

--- a/libgnucash/backend/xml/test/test-date-converting.cpp
+++ b/libgnucash/backend/xml/test/test-date-converting.cpp
@@ -21,7 +21,6 @@ extern "C"
 {
 #include "config.h"
 
-#include "test-stuff.h"
 #include "test-engine-stuff.h"
 
 #include <stdlib.h>
@@ -30,6 +29,7 @@ extern "C"
 #include "test-file-stuff.h"
 #include "sixtp-utils.h"
 #include "sixtp-dom-generators.h"
+#include "test-stuff.h"
 
 #define GNC_V2_STRING "gnc-v2"
 const gchar* gnc_v2_xml_version_string = GNC_V2_STRING;

--- a/libgnucash/backend/xml/test/test-dom-converters1.cpp
+++ b/libgnucash/backend/xml/test/test-dom-converters1.cpp
@@ -30,7 +30,6 @@ extern "C"
 
 #include <glib.h>
 
-#include "test-stuff.h"
 #include "test-engine-stuff.h"
 #include "cashobjects.h"
 #include "gnc-engine.h"
@@ -44,6 +43,7 @@ extern "C"
 #include "sixtp-utils.h"
 #include "sixtp-dom-parsers.h"
 #include "sixtp-dom-generators.h"
+#include "test-stuff.h"
 
 #define GNC_V2_STRING "gnc-v2"
 const gchar* gnc_v2_xml_version_string = GNC_V2_STRING;

--- a/libgnucash/backend/xml/test/test-load-example-account.cpp
+++ b/libgnucash/backend/xml/test/test-load-example-account.cpp
@@ -34,7 +34,6 @@ extern "C"
 
 #include "gnc-module.h"
 #include "gnc-engine.h"
-#include "test-stuff.h"
 #include "test-engine-stuff.h"
 }
 
@@ -43,6 +42,7 @@ extern "C"
 #include "io-gncxml-v2.h"
 
 #include "io-example-account.h"
+#include "test-stuff.h"
 
 static const gchar* da_ending = ".gnucash-xea";
 

--- a/libgnucash/backend/xml/test/test-load-xml2.cpp
+++ b/libgnucash/backend/xml/test/test-load-xml2.cpp
@@ -45,7 +45,6 @@ extern "C"
 #include <gnc-engine.h>
 #include <gnc-prefs.h>
 
-#include <test-stuff.h>
 #include <unittest-support.h>
 #include <test-engine-stuff.h>
 }
@@ -53,6 +52,7 @@ extern "C"
 #include "../gnc-backend-xml.h"
 #include "../io-gncxml-v2.h"
 #include "test-file-stuff.h"
+#include <test-stuff.h>
 
 #define GNC_LIB_NAME "gncmod-backend-xml"
 #define GNC_LIB_REL_PATH "xml"

--- a/libgnucash/backend/xml/test/test-save-in-lang.cpp
+++ b/libgnucash/backend/xml/test/test-save-in-lang.cpp
@@ -30,7 +30,6 @@ extern "C"
 #include <stdlib.h>
 #include <string.h>
 
-#include "test-stuff.h"
 #include "test-engine-stuff.h"
 
 #include "gnc-engine.h"
@@ -39,6 +38,7 @@ extern "C"
 
 #include "test-file-stuff.h"
 #include "io-gncxml-v2.h"
+#include "test-stuff.h"
 
 const char* possible_envs[] =
 {

--- a/libgnucash/backend/xml/test/test-string-converters.cpp
+++ b/libgnucash/backend/xml/test/test-string-converters.cpp
@@ -24,13 +24,13 @@ extern "C"
 #include <stdlib.h>
 #include "gnc-engine.h"
 
-#include "test-stuff.h"
 #include "test-engine-stuff.h"
 }
 
 #include "test-file-stuff.h"
 #include "sixtp-dom-parsers.h"
 #include "sixtp-dom-generators.h"
+#include "test-stuff.h"
 
 
 #define GNC_V2_STRING "gnc-v2"

--- a/libgnucash/backend/xml/test/test-xml-account.cpp
+++ b/libgnucash/backend/xml/test/test-xml-account.cpp
@@ -32,7 +32,6 @@ extern "C"
 #include <gnc-engine.h>
 #include <cashobjects.h>
 
-#include <test-stuff.h>
 #include <test-engine-stuff.h>
 #include <unittest-support.h>
 
@@ -45,6 +44,7 @@ extern "C"
 #include "../sixtp-parsers.h"
 #include "../sixtp-dom-parsers.h"
 #include "test-file-stuff.h"
+#include <test-stuff.h>
 
 static QofBook* sixbook;
 

--- a/libgnucash/backend/xml/test/test-xml-commodity.cpp
+++ b/libgnucash/backend/xml/test/test-xml-commodity.cpp
@@ -28,7 +28,6 @@ extern "C"
 
 #include "gnc-module.h"
 #include "qof.h"
-#include "test-stuff.h"
 #include "test-engine-stuff.h"
 
 #include "Account.h"
@@ -41,6 +40,7 @@ extern "C"
 #include "sixtp-dom-parsers.h"
 #include "io-gncxml-gen.h"
 #include "test-file-stuff.h"
+#include "test-stuff.h"
 
 static QofBook* book;
 

--- a/libgnucash/backend/xml/test/test-xml-pricedb.cpp
+++ b/libgnucash/backend/xml/test/test-xml-pricedb.cpp
@@ -34,7 +34,6 @@ extern "C"
 #include "gnc-engine.h"
 #include "gnc-pricedb.h"
 
-#include "test-stuff.h"
 #include "test-engine-stuff.h"
 }
 
@@ -45,6 +44,7 @@ extern "C"
 #include "sixtp-dom-parsers.h"
 #include "io-gncxml-v2.h"
 #include "test-file-stuff.h"
+#include "test-stuff.h"
 
 static QofSession* session;
 static int iter;

--- a/libgnucash/backend/xml/test/test-xml-transaction.cpp
+++ b/libgnucash/backend/xml/test/test-xml-transaction.cpp
@@ -38,7 +38,6 @@ extern "C"
 #include <cashobjects.h>
 #include <TransLog.h>
 
-#include <test-stuff.h>
 #include <test-engine-stuff.h>
 #include <unittest-support.h>
 
@@ -53,7 +52,7 @@ extern "C"
 #include "../sixtp-dom-parsers.h"
 #include "../io-gncxml-gen.h"
 #include "test-file-stuff.h"
-
+#include <test-stuff.h>
 static QofBook* book;
 
 extern gboolean gnc_transaction_xml_v2_testing;

--- a/libgnucash/backend/xml/test/test-xml-transaction.cpp
+++ b/libgnucash/backend/xml/test/test-xml-transaction.cpp
@@ -41,11 +41,11 @@ extern "C"
 #include <test-engine-stuff.h>
 #include <unittest-support.h>
 
-#include <AccountP.h>
 #include <Transaction.h>
 #include <TransactionP.h>
 }
 
+#include "Account.hpp"
 #include "../gnc-xml-helper.h"
 #include "../gnc-xml.h"
 #include "../sixtp-parsers.h"

--- a/libgnucash/backend/xml/test/test-xml2-is-file.cpp
+++ b/libgnucash/backend/xml/test/test-xml2-is-file.cpp
@@ -23,12 +23,12 @@ extern "C"
 #include <stdlib.h>
 #include <string.h>
 
-#include "test-stuff.h"
 #include "test-engine-stuff.h"
 }
 
 #include "io-gncxml-v2.h"
 #include "test-file-stuff.h"
+#include "test-stuff.h"
 
 #define FILENAME "Money95bank_fr.gml2"
 

--- a/libgnucash/core-utils/gnc-glib-utils.h
+++ b/libgnucash/core-utils/gnc-glib-utils.h
@@ -39,6 +39,10 @@
 
 #include <glib.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** @name Character Sets
  @{
 */
@@ -185,6 +189,10 @@ void gnc_scm_log_debug(const gchar *msg);
 void gnc_gpid_kill(GPid pid);
 
 /** @} */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* GNC_GLIB_UTILS_H */
 /** @} */

--- a/libgnucash/engine/Account.cpp
+++ b/libgnucash/engine/Account.cpp
@@ -31,7 +31,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "AccountP.h"
+#include "Account.hpp"
 #include "Split.h"
 #include "Transaction.h"
 #include "TransactionP.h"

--- a/libgnucash/engine/Account.cpp
+++ b/libgnucash/engine/Account.cpp
@@ -41,6 +41,7 @@
 #include "gnc-pricedb.h"
 #include "qofinstance-p.h"
 #include "gnc-features.h"
+#include "guid.hpp"
 
 static QofLogModule log_module = GNC_MOD_ACCOUNT;
 
@@ -5178,48 +5179,6 @@ gnc_account_imap_delete_account (GncImportMatchMap *imap,
 --------------------------------------------------------------------------*/
 
 
-struct account_token_count
-{
-    char* account_guid;
-    gint64 token_count; /**< occurrences of a given token for this account_guid */
-};
-
-/** total_count and the token_count for a given account let us calculate the
- * probability of a given account with any single token
- */
-struct token_accounts_info
-{
-    GList *accounts; /**< array of struct account_token_count */
-    gint64 total_count;
-};
-
-/** gpointer is a pointer to a struct token_accounts_info
- * \note Can always assume that keys are unique, reduces code in this function
- */
-static void
-buildTokenInfo(const char *key, const GValue *value, gpointer data)
-{
-    struct token_accounts_info *tokenInfo = (struct token_accounts_info*)data;
-    struct account_token_count* this_account;
-
-    //  PINFO("buildTokenInfo: account '%s', token_count: '%" G_GINT64_FORMAT "'", (char*)key,
-    //                  g_value_get_int64(value));
-
-    /* add the count to the total_count */
-    tokenInfo->total_count += g_value_get_int64(value);
-
-    /* allocate a new structure for this account and it's token count */
-    this_account = (struct account_token_count*)
-                   g_new0(struct account_token_count, 1);
-
-    /* fill in the account guid and number of tokens found for this account guid */
-    this_account->account_guid = (char*)key;
-    this_account->token_count = g_value_get_int64(value);
-
-    /* append onto the glist a pointer to the new account_token_count structure */
-    tokenInfo->accounts = g_list_prepend(tokenInfo->accounts, this_account);
-}
-
 /** intermediate values used to calculate the bayes probability of a given account
   where p(AB) = (a*b)/[a*b + (1-a)(1-b)], product is (a*b),
   product_difference is (1-a) * (1-b)
@@ -5230,70 +5189,114 @@ struct account_probability
     double product_difference; /* product of (1-probabilities) */
 };
 
-/** convert a hash table of account names and (struct account_probability*)
-  into a hash table of 100000x the percentage match value, ie. 10% would be
-  0.10 * 100000 = 10000
+struct account_token_count
+{
+    std::string account_guid;
+    int64_t token_count; /** occurrences of a given token for this account_guid */
+};
+
+/** total_count and the token_count for a given account let us calculate the
+ * probability of a given account with any single token
  */
-#define PROBABILITY_FACTOR 100000
-static void
-buildProbabilities(gpointer key, gpointer value, gpointer data)
+struct token_accounts_info
 {
-    GHashTable *final_probabilities = (GHashTable*)data;
-    struct account_probability *account_p = (struct account_probability*)value;
-
-    /* P(AB) = A*B / [A*B + (1-A)*(1-B)]
-     * NOTE: so we only keep track of a running product(A*B*C...)
-     * and product difference ((1-A)(1-B)...)
-     */
-    gint32 probability =
-        (account_p->product /
-         (account_p->product + account_p->product_difference))
-        * PROBABILITY_FACTOR;
-
-    PINFO("P('%s') = '%d'", (char*)key, probability);
-
-    g_hash_table_insert(final_probabilities, key, GINT_TO_POINTER(probability));
-}
-
-/** Frees an array of the same time that buildProperties built */
-static void
-freeProbabilities(gpointer key, gpointer value, gpointer data)
-{
-    /* free up the struct account_probability that was allocated
-     * in gnc_account_find_account_bayes()
-     */
-    g_free(value);
-}
+    std::vector<account_token_count> accounts;
+    int64_t total_count;
+};
 
 /** holds an account guid and its corresponding integer probability
   the integer probability is some factor of 10
  */
 struct account_info
 {
-    char* account_guid;
-    gint32 probability;
+    std::string account_guid;
+    int32_t probability;
 };
 
-/** Find the highest probability and the corresponding account guid
-    store in data, a (struct account_info*)
-    NOTE: this is a g_hash_table_foreach() function for a hash table of entries
-    key is a  pointer to the account guid, value is a gint32, 100000x
-    the probability for this account
-*/
 static void
-highestProbability(gpointer key, gpointer value, gpointer data)
+build_token_info(char const * key, KvpValue * value, token_accounts_info & tokenInfo)
 {
-    struct account_info *account_i = (struct account_info*)data;
-
-    /* if the current probability is greater than the stored, store the current */
-    if (GPOINTER_TO_INT(value) > account_i->probability)
-    {
-        /* Save the new highest probability and the assoaciated account guid */
-        account_i->probability = GPOINTER_TO_INT(value);
-        account_i->account_guid = static_cast <char*> (key);
-    }
+    tokenInfo.total_count += value->get<int64_t>();
+    account_token_count this_account;
+    std::string account_guid {key};
+    /*By convention, the key ends with the account GUID.*/
+    this_account.account_guid = account_guid.substr(account_guid.size() - GUID_ENCODING_LENGTH);
+    this_account.token_count = value->get<int64_t>();
+    tokenInfo.accounts.push_back(this_account);
 }
 
+/** We scale the probability values by PROBABILITY_FACTOR.
+  ie. with PROBABILITY_FACTOR of 100000, 10% would be
+  0.10 * 100000 = 10000 */
+#define PROBABILITY_FACTOR 100000
+
+static std::vector<std::pair<std::string, int32_t>>
+build_probabilities(std::vector<std::pair<std::string, account_probability>> const & first_pass)
+{
+    std::vector<std::pair<std::string, int32_t>> ret;
+    for (auto const & first_pass_prob : first_pass)
+    {
+        auto const & account_probability = first_pass_prob.second;
+        /* P(AB) = A*B / [A*B + (1-A)*(1-B)]
+         * NOTE: so we only keep track of a running product(A*B*C...)
+         * and product difference ((1-A)(1-B)...)
+         */
+        int32_t probability = (account_probability.product /
+                (account_probability.product + account_probability.product_difference)) * PROBABILITY_FACTOR;
+        ret.push_back({first_pass_prob.first, probability});
+    }
+    return ret;
+}
+
+static account_info
+highest_probability(std::vector<std::pair<std::string, int32_t>> const & probabilities)
+{
+    account_info ret {"", std::numeric_limits<int32_t>::min()};
+    for (auto const & prob : probabilities)
+        if (prob.second > ret.probability)
+            ret = account_info{prob.first, prob.second};
+    return ret;
+}
+
+static std::vector<std::pair<std::string, account_probability>>
+get_first_pass_probabilities(GncImportMatchMap * imap, GList * tokens)
+{
+    std::vector<std::pair<std::string, account_probability>> ret;
+    /* find the probability for each account that contains any of the tokens
+     * in the input tokens list. */
+    for (auto current_token = tokens; current_token; current_token = current_token->next)
+    {
+        auto translated_token = std::string{static_cast<char const *>(current_token->data)};
+        std::replace(translated_token.begin(), translated_token.end(), '/', '-');
+        token_accounts_info tokenInfo{};
+        auto path = std::string{IMAP_FRAME_BAYES "-"} + translated_token;
+        qof_instance_foreach_slot_prefix (QOF_INSTANCE (imap->acc), path, &build_token_info, tokenInfo);
+        for (auto const & current_account_token : tokenInfo.accounts)
+        {
+            auto item = std::find_if(ret.begin(), ret.end(), [&current_account_token]
+                (std::pair<std::string, account_probability> const & a) {
+                    return current_account_token.account_guid == a.first;
+                });
+            if (item != ret.end())
+            {/* This account is already in the map */
+                item->second.product = ((double)current_account_token.token_count /
+                                      (double)tokenInfo.total_count) * item->second.product;
+                item->second.product_difference = ((double)1 - ((double)current_account_token.token_count /
+                                              (double)tokenInfo.total_count)) * item->second.product_difference;
+            }
+            else
+            {
+                /* add a new entry */
+                account_probability new_probability;
+                new_probability.product = ((double)current_account_token.token_count /
+                                      (double)tokenInfo.total_count);
+                new_probability.product_difference = 1 - (new_probability.product);
+                ret.push_back({current_account_token.account_guid, std::move(new_probability)});
+            }
+        } /* for all accounts in tokenInfo */
+    }
+    return ret;
+}
 
 #define threshold (.90 * PROBABILITY_FACTOR) /* 90% */
 
@@ -5301,173 +5304,28 @@ highestProbability(gpointer key, gpointer value, gpointer data)
 Account*
 gnc_account_imap_find_account_bayes (GncImportMatchMap *imap, GList *tokens)
 {
-    struct token_accounts_info tokenInfo; /**< holds the accounts and total
-                                           * token count for a single token */
-    GList *current_token;                 /**< pointer to the current
-                                           * token from the input GList
-                                           * tokens */
-    GList *current_account_token;         /**< pointer to the struct
-                                           * account_token_count */
-    struct account_token_count *account_c; /**< an account name and the number
-                                            * of times a token has appeared
-                                            * for the account */
-    struct account_probability *account_p; /**< intermediate storage of values
-                                            * to compute the bayes probability
-                                            * of an account */
-    GHashTable *running_probabilities = g_hash_table_new(g_str_hash,
-                                                         g_str_equal);
-    GHashTable *final_probabilities = g_hash_table_new(g_str_hash,
-                                                       g_str_equal);
-    struct account_info account_i;
-
-    ENTER(" ");
-
-    /* check to see if the imap is NULL */
     if (!imap)
-    {
-        PINFO("imap is null, returning null");
-        LEAVE(" ");
-        return NULL;
+        return nullptr;
+    auto first_pass = get_first_pass_probabilities(imap, tokens);
+    if (!first_pass.size())
+        return nullptr;
+    auto final_probabilities = build_probabilities(first_pass);
+    if (!final_probabilities.size())
+        return nullptr;
+    auto best = highest_probability(final_probabilities);
+    if (best.account_guid == "")
+        return nullptr;
+    if (best.probability < threshold)
+        return nullptr;
+    gnc::GUID guid;
+    try {
+        guid = gnc::GUID::from_string(best.account_guid);
+    } catch (gnc::guid_syntax_exception) {
+        return nullptr;
     }
-
-    /* find the probability for each account that contains any of the tokens
-     * in the input tokens list
-     */
-    for (current_token = tokens; current_token;
-         current_token = current_token->next)
-    {
-        char* path = g_strdup_printf (IMAP_FRAME_BAYES "/%s",
-                                            (char*)current_token->data);
-        /* zero out the token_accounts_info structure */
-        memset(&tokenInfo, 0, sizeof(struct token_accounts_info));
-
-        PINFO("token: '%s'", (char*)current_token->data);
-
-        /* process the accounts for this token, adding the account if it
-         * doesn't already exist or adding to the existing accounts token
-         * count if it does
-         */
-        qof_instance_foreach_slot(QOF_INSTANCE (imap->acc), path,
-                                  buildTokenInfo, &tokenInfo);
-        g_free (path);
-        /* for each account we have just found, see if the account
-         * already exists in the list of account probabilities, if not
-         * add it
-         */
-        for (current_account_token = tokenInfo.accounts; current_account_token;
-                current_account_token = current_account_token->next)
-        {
-            /* get the account name and corresponding token count */
-            account_c = (struct account_token_count*)current_account_token->data;
-
-            PINFO("account_c->account_guid('%s'), "
-                  "account_c->token_count('%" G_GINT64_FORMAT
-                  "')/total_count('%" G_GINT64_FORMAT "')",
-                  account_c->account_guid, account_c->token_count,
-                  tokenInfo.total_count);
-
-            account_p = static_cast <account_probability*> (
-                    g_hash_table_lookup(running_probabilities, account_c->account_guid));
-
-            /* if the account exists in the list then continue
-             * the running probablities
-             */
-            if (account_p)
-            {
-                account_p->product = (((double)account_c->token_count /
-                                      (double)tokenInfo.total_count)
-                                      * account_p->product);
-                account_p->product_difference =
-                    ((double)1 - ((double)account_c->token_count /
-                                  (double)tokenInfo.total_count))
-                    * account_p->product_difference;
-                PINFO("product == %f, product_difference == %f",
-                      account_p->product, account_p->product_difference);
-            }
-            else
-            {
-                /* add a new entry */
-                PINFO("adding a new entry for this account");
-                account_p = (struct account_probability*)
-                            g_new0(struct account_probability, 1);
-
-                /* set the product and product difference values */
-                account_p->product = ((double)account_c->token_count /
-                                      (double)tokenInfo.total_count);
-                account_p->product_difference =
-                    (double)1 - ((double)account_c->token_count /
-                                 (double)tokenInfo.total_count);
-
-                PINFO("product == %f, product_difference == %f",
-                      account_p->product, account_p->product_difference);
-
-                /* add the account guid and (struct account_probability*)
-                 * to the hash table */
-                g_hash_table_insert(running_probabilities,
-                                    account_c->account_guid, account_p);
-            }
-        } /* for all accounts in tokenInfo */
-
-        /* free the data in tokenInfo */
-        for (current_account_token = tokenInfo.accounts; current_account_token;
-                current_account_token = current_account_token->next)
-        {
-            /* free up each struct account_token_count we allocated */
-            g_free((struct account_token_count*)current_account_token->data);
-        }
-
-        g_list_free(tokenInfo.accounts); /* free the accounts GList */
-    }
-
-    /* build a hash table of account names and their final probabilities
-     * from each entry in the running_probabilties hash table
-     */
-    g_hash_table_foreach(running_probabilities, buildProbabilities,
-                         final_probabilities);
-
-    /* find the highest probabilty and the corresponding account */
-    memset(&account_i, 0, sizeof(struct account_info));
-    g_hash_table_foreach(final_probabilities, highestProbability, &account_i);
-
-    /* free each element of the running_probabilities hash */
-    g_hash_table_foreach(running_probabilities, freeProbabilities, NULL);
-
-    /* free the hash tables */
-    g_hash_table_destroy(running_probabilities);
-    g_hash_table_destroy(final_probabilities);
-
-    PINFO("highest P('%s') = '%d'",
-          account_i.account_guid ? account_i.account_guid : "(null)",
-          account_i.probability);
-
-    /* has this probability met our threshold? */
-    if (account_i.probability >= threshold)
-    {
-        GncGUID *guid;
-        Account *account = NULL;
-
-        PINFO("Probability has met threshold");
-
-        guid = g_new (GncGUID, 1);
-
-        if (string_to_guid (account_i.account_guid, guid))
-            account = xaccAccountLookup (guid, imap->book);
-
-        g_free (guid);
-
-        if (account != NULL)
-            LEAVE("Return account is '%s'", xaccAccountGetName (account));
-        else
-            LEAVE("Return NULL, account for Guid '%s' can not be found", account_i.account_guid);
-
-        return account;
-    }
-    PINFO("Probability has not met threshold");
-    LEAVE("Return NULL");
-
-    return NULL; /* we didn't meet our threshold, return NULL for an account */
+    auto account = xaccAccountLookup (reinterpret_cast<GncGUID*>(&guid), imap->book);
+    return account;
 }
-
 
 static void
 change_imap_entry (GncImportMatchMap *imap, gchar *kvp_path, int64_t token_count)
@@ -5550,13 +5408,13 @@ gnc_account_imap_add_account_bayes (GncImportMatchMap *imap,
 
         PINFO("adding token '%s'", (char*)current_token->data);
 
-        kvp_path = g_strdup_printf (IMAP_FRAME_BAYES "/%s/%s",
-                                    (char*)current_token->data,
+        std::string translated_token {static_cast<char*>(current_token->data)};
+        std::replace(translated_token.begin(), translated_token.end(), '/', '-');
+        kvp_path = g_strdup_printf (IMAP_FRAME_BAYES "-%s-%s",
+                                    translated_token.c_str(),
                                     guid_string);
-
         /* change the imap entry for the account */
         change_imap_entry (imap, kvp_path, token_count);
-
         g_free (kvp_path);
     }
 
@@ -5572,13 +5430,15 @@ gnc_account_imap_add_account_bayes (GncImportMatchMap *imap,
 /*******************************************************************************/
 
 static void
-build_bayes_layer_two (const char *key, const GValue *value, gpointer user_data)
+build_non_bayes (const char *key, const GValue *value, gpointer user_data)
 {
+    if (!G_VALUE_HOLDS_BOXED (value))
+        return;
+
     QofBook     *book;
-    Account     *map_account = NULL;
-    GncGUID     *guid;
+    GncGUID     *guid = NULL;
     gchar       *kvp_path;
-    gchar       *count;
+    gchar       *guid_string = NULL;
 
     struct imap_info *imapInfo_node;
 
@@ -5587,134 +5447,94 @@ build_bayes_layer_two (const char *key, const GValue *value, gpointer user_data)
     // Get the book
     book = qof_instance_get_book (imapInfo->source_account);
 
-    if (G_VALUE_HOLDS_INT64 (value))
-    {
-        PINFO("build_bayes_layer_two: account '%s', token_count: '%" G_GINT64_FORMAT "'",
-                                  (char*)key, g_value_get_int64(value));
+    guid = (GncGUID*)g_value_get_boxed (value);
+    guid_string = guid_to_string (guid);
 
-        count = g_strdup_printf ("%" G_GINT64_FORMAT, g_value_get_int64 (value));
-    }
-    else
-        count = g_strdup ("0");
+    PINFO("build_non_bayes: account '%s', match account guid: '%s'",
+                            (char*)key, guid_string);
 
     kvp_path = g_strconcat (imapInfo->category_head, "/", key, NULL);
 
-    PINFO("build_bayes_layer_two: kvp_path is '%s'", kvp_path);
-
-    guid = g_new (GncGUID, 1);
-
-    if (string_to_guid (key, guid))
-        map_account = xaccAccountLookup (guid, book);
-
-    g_free (guid);
+    PINFO("build_non_bayes: kvp_path is '%s'", kvp_path);
 
     imapInfo_node = static_cast <imap_info*> (g_malloc(sizeof(*imapInfo_node)));
 
     imapInfo_node->source_account = imapInfo->source_account;
-    imapInfo_node->map_account    = map_account;
+    imapInfo_node->map_account    = xaccAccountLookup (guid, book);
     imapInfo_node->full_category  = g_strdup (kvp_path);
-    imapInfo_node->match_string   = g_strdup (imapInfo->match_string);
+    imapInfo_node->match_string   = g_strdup (key);
     imapInfo_node->category_head  = g_strdup (imapInfo->category_head);
-    imapInfo_node->count          = g_strdup (count);
+    imapInfo_node->count          = g_strdup (" ");
 
     imapInfo->list = g_list_append (imapInfo->list, imapInfo_node);
 
+    g_free (kvp_path);
+    g_free (guid_string);
+}
+
+static void
+build_bayes_layer_two (const char *key, KvpValue * val, imap_info imapInfo)
+{
+    QofBook     *book;
+    Account     *map_account = NULL;
+    GncGUID     *guid;
+    gchar       *kvp_path;
+    gchar       *count;
+    struct imap_info *imapInfo_node;
+    // Get the book
+    book = qof_instance_get_book (imapInfo.source_account);
+    if (val->get_type() == KvpValue::Type::INT64)
+    {
+        PINFO("build_bayes_layer_two: account '%s', token_count: '%" G_GINT64_FORMAT "'",
+                                  key, val->get<int64_t>());
+        count = g_strdup_printf ("%" G_GINT64_FORMAT, val->get<int64_t>());
+    }
+    else
+        count = g_strdup ("0");
+    kvp_path = g_strconcat (imapInfo.category_head, "/", key, NULL);
+    PINFO("build_bayes_layer_two: kvp_path is '%s'", kvp_path);
+    guid = g_new (GncGUID, 1);
+    if (string_to_guid (key, guid))
+        map_account = xaccAccountLookup (guid, book);
+    g_free (guid);
+    imapInfo_node = static_cast <imap_info*> (g_malloc(sizeof(*imapInfo_node)));
+    imapInfo_node->source_account = imapInfo.source_account;
+    imapInfo_node->map_account    = map_account;
+    imapInfo_node->full_category  = g_strdup (kvp_path);
+    imapInfo_node->match_string   = g_strdup (imapInfo.match_string);
+    imapInfo_node->category_head  = g_strdup (imapInfo.category_head);
+    imapInfo_node->count          = g_strdup (count);
+    imapInfo.list = g_list_append (imapInfo.list, imapInfo_node);
     g_free (kvp_path);
     g_free (count);
 }
 
 static void
-build_bayes (const char *key, const GValue *value, gpointer user_data)
+build_bayes (const char *key, KvpValue * value, imap_info & imapInfo)
 {
-    gchar *kvp_path;
-    struct imap_info *imapInfo = (struct imap_info*)user_data;
-    struct imap_info  imapInfol2;
-
+    struct imap_info imapInfol2;
     PINFO("build_bayes: match string '%s'", (char*)key);
 
-    if (G_VALUE_HOLDS (value, G_TYPE_STRING) && g_value_get_string (value) == NULL)
-    {
-        kvp_path = g_strdup_printf (IMAP_FRAME_BAYES "/%s", key);
-
-        if (qof_instance_has_slot (QOF_INSTANCE(imapInfo->source_account), kvp_path))
-        {
-            PINFO("build_bayes: kvp_path is '%s', key '%s'", kvp_path, key);
-
-            imapInfol2.source_account = imapInfo->source_account;
-            imapInfol2.match_string   = g_strdup (key);
-            imapInfol2.category_head  = g_strdup (kvp_path);
-            imapInfol2.list           = imapInfo->list;
-
-            qof_instance_foreach_slot (QOF_INSTANCE(imapInfo->source_account), kvp_path,
-                                       build_bayes_layer_two, &imapInfol2);
-
-            imapInfo->list = imapInfol2.list;
-            g_free (imapInfol2.match_string);
-            g_free (imapInfol2.category_head);
-        }
-        g_free (kvp_path);
-    }
+    std::string prefix {g_strdup_printf (IMAP_FRAME_BAYES "-%s", key)};
+    PINFO("build_bayes: prefix is '%s', key '%s'", prefix.c_str(), key);
+    imapInfol2.source_account = imapInfo.source_account;
+    imapInfol2.match_string   = g_strdup (key);
+    imapInfol2.category_head  = g_strdup (prefix.c_str());
+    imapInfol2.list           = imapInfo.list;
+    qof_instance_foreach_slot_prefix (QOF_INSTANCE(imapInfo.source_account), prefix,
+                               build_bayes_layer_two, imapInfol2);
+    imapInfo.list = imapInfol2.list;
+    g_free (imapInfol2.match_string);
+    g_free (imapInfol2.category_head);
 }
-
-
-static void
-build_non_bayes (const char *key, const GValue *value, gpointer user_data)
-{
-    if (G_VALUE_HOLDS_BOXED (value))
-    {
-        QofBook     *book;
-        GncGUID     *guid = NULL;
-        gchar       *kvp_path;
-        gchar       *guid_string = NULL;
-
-        struct imap_info *imapInfo_node;
-
-        struct imap_info *imapInfo = (struct imap_info*)user_data;
-
-        // Get the book
-        book = qof_instance_get_book (imapInfo->source_account);
-
-        guid = (GncGUID*)g_value_get_boxed (value);
-        guid_string = guid_to_string (guid);
-
-        PINFO("build_non_bayes: account '%s', match account guid: '%s'",
-                                (char*)key, guid_string);
-
-        kvp_path = g_strconcat (imapInfo->category_head, "/", key, NULL);
-
-        PINFO("build_non_bayes: kvp_path is '%s'", kvp_path);
-
-        imapInfo_node = static_cast <imap_info*> (g_malloc(sizeof(*imapInfo_node)));
-
-        imapInfo_node->source_account = imapInfo->source_account;
-        imapInfo_node->map_account    = xaccAccountLookup (guid, book);
-        imapInfo_node->full_category  = g_strdup (kvp_path);
-        imapInfo_node->match_string   = g_strdup (key);
-        imapInfo_node->category_head  = g_strdup (imapInfo->category_head);
-        imapInfo_node->count          = g_strdup (" ");
-
-        imapInfo->list = g_list_append (imapInfo->list, imapInfo_node);
-
-        g_free (kvp_path);
-        g_free (guid_string);
-    }
-}
-
 
 GList *
 gnc_account_imap_get_info_bayes (Account *acc)
 {
-    GList *list = NULL;
-
-    GncImapInfo imapInfo;
-
-    imapInfo.source_account = acc;
-    imapInfo.list = list;
-
-    if (qof_instance_has_slot (QOF_INSTANCE(acc), IMAP_FRAME_BAYES))
-        qof_instance_foreach_slot (QOF_INSTANCE(acc), IMAP_FRAME_BAYES,
-                                   build_bayes, &imapInfo);
-
+    /* A dummy object which is used to hold the specified account, and the list
+     * of data about which we care. */
+    GncImapInfo imapInfo {acc, nullptr};
+    qof_instance_foreach_slot_prefix (QOF_INSTANCE (acc), IMAP_FRAME_BAYES, &build_bayes, imapInfo);
     return imapInfo.list;
 }
 
@@ -5771,18 +5591,14 @@ void
 gnc_account_delete_map_entry (Account *acc, char *full_category, gboolean empty)
 {
     gchar *kvp_path = g_strdup (full_category);
-
     if ((acc != NULL) && qof_instance_has_slot (QOF_INSTANCE(acc), kvp_path))
     {
         xaccAccountBeginEdit (acc);
-
         if (empty)
             qof_instance_slot_delete_if_empty (QOF_INSTANCE(acc), kvp_path);
         else
             qof_instance_slot_delete (QOF_INSTANCE(acc), kvp_path);
-
         PINFO("Account is '%s', path is '%s'", xaccAccountGetName (acc), kvp_path);
-
         qof_instance_set_dirty (QOF_INSTANCE(acc));
         xaccAccountCommitEdit (acc);
     }
@@ -5793,11 +5609,12 @@ gnc_account_delete_map_entry (Account *acc, char *full_category, gboolean empty)
 /*******************************************************************************/
 
 static gchar *
-look_for_old_separator_descendants (Account *root, gchar *full_name, const gchar *separator)
+look_for_old_separator_descendants (Account *root, gchar const *full_name, const gchar *separator)
 {
     GList *top_accounts, *ptr;
     gint   found_len = 0;
     gchar  found_sep;
+    gchar * new_name = nullptr;
 
     top_accounts = gnc_account_get_descendants (root);
 
@@ -5825,16 +5642,20 @@ look_for_old_separator_descendants (Account *root, gchar *full_name, const gchar
         }
     }
     g_list_free (top_accounts); // Free the List
+    new_name = g_strdup (full_name);
 
     if (found_len > 1)
-        full_name = g_strdelimit (full_name, &found_sep, *separator);
+        g_strdelimit (new_name, &found_sep, *separator);
 
-    PINFO("Return full_name is '%s'", full_name);
+    PINFO("Return full_name is '%s'", new_name);
 
-    return full_name;
+    return new_name;
 }
 
-
+/**
+ * Converts an imap entry from one based on account name to one based
+ * on account GUID.
+ */
 static void
 convert_imap_entry (GncImapInfo *imapInfo, Account *map_account)
 {
@@ -5902,7 +5723,9 @@ look_for_old_mapping (GncImapInfo *imapInfo)
     // do we have a valid account, if not, look for old separator
     if (map_account == NULL)
     {
-        full_name = look_for_old_separator_descendants (root, full_name, sep);
+        gchar * temp_name = look_for_old_separator_descendants (root, full_name, sep);
+        g_free(full_name);
+        full_name = temp_name;
         map_account = gnc_account_lookup_by_full_name (root, full_name); // lets try again
     }
 
@@ -5913,84 +5736,150 @@ look_for_old_mapping (GncImapInfo *imapInfo)
     return map_account;
 }
 
-static void
-convert_imap_account (Account *acc)
+static std::vector<std::pair<std::string, KvpValue*>>
+get_new_guid_imap (Account * acc)
 {
-    GList *imap_list, *node;
-    gchar *acc_name = NULL;
+    auto frame = qof_instance_get_slots (QOF_INSTANCE (acc));
+    auto slot = frame->get_slot(IMAP_FRAME_BAYES);
+    if (!slot)
+        return {};
+    std::string const imap_frame_str {IMAP_FRAME_BAYES};
+    std::vector<std::pair<std::string, KvpValue*>> ret;
+    auto root = gnc_account_get_root (acc);
+    auto imap_frame = slot->get<KvpFrame*>();
+    imap_frame->for_each_slot_temp ([&ret, root, &imap_frame_str] (char const * token, KvpValue* val) {
+        auto token_frame = val->get<KvpFrame*>();
+        token_frame->for_each_slot_temp ([&ret, root, &imap_frame_str, token] (char const * account_name, KvpValue* val) {
+            auto map_account = gnc_account_lookup_by_full_name (root, account_name);
+            if (!map_account)
+            {
+                auto temp_account_name = look_for_old_separator_descendants (root, account_name, gnc_get_account_separator_string());
+                map_account = gnc_account_lookup_by_full_name (root, temp_account_name);
+                g_free (temp_account_name);
+            }
+            auto temp_guid = gnc::GUID{*xaccAccountGetGUID (map_account)};
+            auto guid_str = temp_guid.to_string();
+            ret.push_back({imap_frame_str + "-" + token + "-" + guid_str, val});
+        });
+    });
+    return ret;
+}
 
-    acc_name = gnc_account_get_full_name (acc);
-    PINFO("Source Acc '%s'", acc_name);
+static void
+convert_imap_account_bayes_to_guid (Account *acc)
+{
+    auto frame = qof_instance_get_slots (QOF_INSTANCE (acc));
+    if (!frame->get_keys().size())
+        return;
+    auto new_imap = get_new_guid_imap(acc);
+    xaccAccountBeginEdit(acc);
+    frame->set(IMAP_FRAME_BAYES, nullptr);
+    std::for_each(new_imap.begin(), new_imap.end(), [&frame] (std::pair<std::string, KvpValue*> const & entry) {
+        frame->set(entry.first.c_str(), entry.second);
+    });
+    qof_instance_set_dirty (QOF_INSTANCE (acc));
+    xaccAccountCommitEdit(acc);
+}
 
-    imap_list = gnc_account_imap_get_info_bayes (acc);
+char const * run_once_key_to_guid {"changed-bayesian-to-guid"};
+char const * run_once_key_to_flat {"changed-bayesian-to-flat"};
 
-    if (g_list_length (imap_list) > 0) // we have mappings
+static void
+imap_convert_bayes_to_guid (QofBook * book)
+{
+    auto root = gnc_book_get_root_account (book);
+    auto accts = gnc_account_get_descendants_sorted (root);
+    for (auto ptr = accts; ptr; ptr = g_list_next (ptr))
     {
-        PINFO("List length is %d", g_list_length (imap_list));
-        xaccAccountBeginEdit(acc);
-        for (node = imap_list;  node; node = g_list_next (node))
-        {
-            Account *map_account = NULL;
-            GncImapInfo *imapInfo = static_cast <GncImapInfo *> (node->data);
-
-            // Lets start doing stuff
-            map_account = look_for_old_mapping (imapInfo);
-
-            if (map_account != NULL) // we have an account, try and update it
-                convert_imap_entry (imapInfo, map_account);
-            // Free the members and structure
-            g_free (imapInfo->category_head);
-            g_free (imapInfo->full_category);
-            g_free (imapInfo->match_string);
-            g_free (imapInfo->count);
-            g_free (imapInfo);
-        }
-        xaccAccountCommitEdit(acc);
+        Account *acc = static_cast <Account*> (ptr->data);
+        convert_imap_account_bayes_to_guid (acc);
     }
-    g_free (acc_name);
-    g_list_free (imap_list); // Free the List
+    g_list_free (accts);
+}
+
+static std::vector<std::pair<std::string, KvpValue*>>
+get_new_flat_imap (Account * acc)
+{
+    auto frame = qof_instance_get_slots (QOF_INSTANCE (acc));
+    auto slot = frame->get_slot(IMAP_FRAME_BAYES);
+    if (!slot)
+        return {};
+    std::string const imap_frame_str {IMAP_FRAME_BAYES};
+    std::vector<std::pair<std::string, KvpValue*>> ret;
+    auto root = gnc_account_get_root (acc);
+    auto imap_frame = slot->get<KvpFrame*>();
+    imap_frame->for_each_slot_temp ([&ret, &imap_frame_str] (char const * token, KvpValue* val) {
+        auto token_frame = val->get<KvpFrame*>();
+        token_frame->for_each_slot_temp ([&ret, &imap_frame_str, token] (char const * account_guid, KvpValue* val) {
+            ret.push_back({imap_frame_str + "-" + token + "-" + account_guid, val});
+        });
+    });
+    return ret;
+}
+
+static void
+convert_imap_account_bayes_to_flat (Account * acc)
+{
+    auto flat_imap = get_new_flat_imap (acc);
+    if (!flat_imap.size())
+        return;
+    auto frame = qof_instance_get_slots (QOF_INSTANCE (acc));
+    xaccAccountBeginEdit(acc);
+    frame->set(IMAP_FRAME_BAYES, nullptr);
+    std::for_each(flat_imap.begin(), flat_imap.end(), [&frame] (std::pair<std::string, KvpValue*> const & entry) {
+        frame->set(entry.first.c_str(), entry.second);
+    });
+    qof_instance_set_dirty (QOF_INSTANCE (acc));
+    xaccAccountCommitEdit(acc);
+}
+
+static void
+imap_convert_bayes_to_flat (QofBook * book)
+{
+    auto root = gnc_book_get_root_account (book);
+    auto accts = gnc_account_get_descendants_sorted (root);
+    for (auto ptr = accts; ptr; ptr = g_list_next (ptr))
+    {
+        Account *acc = static_cast <Account*> (ptr->data);
+        convert_imap_account_bayes_to_flat (acc);
+    }
+    g_list_free (accts);
+}
+
+static bool
+run_once_key_set (char const * key, QofBook * book)
+{
+    GValue value G_VALUE_INIT;
+    qof_instance_get_kvp (QOF_INSTANCE(book), key, &value);
+    return G_VALUE_HOLDS_STRING(&value) && strcmp(g_value_get_string(&value), "true");
+}
+
+static void
+set_run_once_key (char const * key, QofBook * book)
+{
+    GValue value G_VALUE_INIT;
+    g_value_init(&value, G_TYPE_BOOLEAN);
+    g_value_set_boolean(&value, TRUE);
+    qof_instance_set_kvp(QOF_INSTANCE (book), key, &value);
+}
+
+void
+gnc_account_imap_convert_flat (QofBook *book)
+{
+    if (run_once_key_set(run_once_key_to_flat, book))
+        return;
+    imap_convert_bayes_to_flat (book);
+    set_run_once_key(run_once_key_to_flat, book);
 }
 
 void
 gnc_account_imap_convert_bayes (QofBook *book)
 {
-    Account      *root;
-    GList        *accts, *ptr;
-    gboolean      run_once = FALSE;
-    GValue        value_s = G_VALUE_INIT;
-
-    // get the run-once value
-    qof_instance_get_kvp (QOF_INSTANCE (book), "changed-bayesian-to-guid", &value_s);
-
-    if (G_VALUE_HOLDS_STRING (&value_s) && (strcmp(g_value_get_string (&value_s), "true") == 0))
-        run_once = TRUE;
-
-    if (run_once == FALSE)
-    {
-        GValue value_b = G_VALUE_INIT;
-
-        /* Get list of Accounts */
-        root = gnc_book_get_root_account (book);
-        accts = gnc_account_get_descendants_sorted (root);
-
-        /* Go through list of accounts */
-        for (ptr = accts; ptr; ptr = g_list_next (ptr))
-        {
-            Account *acc = static_cast <Account*> (ptr->data);
-
-            convert_imap_account (acc);
-        }
-        g_list_free (accts);
-
-        g_value_init (&value_b, G_TYPE_BOOLEAN);
-
-        g_value_set_boolean (&value_b, TRUE);
-
-        // set the run-once value
-        qof_instance_set_kvp (QOF_INSTANCE (book), "changed-bayesian-to-guid", &value_b);
-    }
+    if (run_once_key_set(run_once_key_to_guid, book))
+        return;
+    imap_convert_bayes_to_guid(book);
+    set_run_once_key(run_once_key_to_guid, book);
 }
-
 
 /* ================================================================ */
 /* QofObject function implementation and registration */

--- a/libgnucash/engine/Account.cpp
+++ b/libgnucash/engine/Account.cpp
@@ -171,7 +171,7 @@ gchar *gnc_account_name_violations_errmsg (const gchar *separator, GList* invali
     for ( node = invalid_account_names;  node; node = g_list_next(node))
     {
         if ( !account_list )
-            account_list = node->data;
+            account_list = static_cast<gchar *>(node->data);
         else
         {
             gchar *tmp_list = NULL;
@@ -251,9 +251,9 @@ gnc_account_init(Account* acc)
     priv->parent   = NULL;
     priv->children = NULL;
 
-    priv->accountName = CACHE_INSERT("");
-    priv->accountCode = CACHE_INSERT("");
-    priv->description = CACHE_INSERT("");
+    priv->accountName = static_cast<char*>(qof_string_cache_insert(""));
+    priv->accountCode = static_cast<char*>(qof_string_cache_insert(""));
+    priv->description = static_cast<char*>(qof_string_cache_insert(""));
 
     priv->type = ACCT_TYPE_NONE;
 
@@ -473,10 +473,10 @@ gnc_account_set_property (GObject         *object,
         break;
     case PROP_TYPE:
         // NEED TO BE CONVERTED TO A G_TYPE_ENUM
-        xaccAccountSetType(account, g_value_get_int(value));
+        xaccAccountSetType(account, static_cast<GNCAccountType>(g_value_get_int(value)));
         break;
     case PROP_COMMODITY:
-        xaccAccountSetCommodity(account, g_value_get_object(value));
+        xaccAccountSetCommodity(account, static_cast<gnc_commodity*>(g_value_get_object(value)));
         break;
     case PROP_COMMODITY_SCU:
         xaccAccountSetCommoditySCU(account, g_value_get_int(value));
@@ -491,19 +491,19 @@ gnc_account_set_property (GObject         *object,
         gnc_account_set_balance_dirty(account);
         break;
     case PROP_START_BALANCE:
-        number = g_value_get_boxed(value);
+        number = static_cast<gnc_numeric*>(g_value_get_boxed(value));
         gnc_account_set_start_balance(account, *number);
         break;
     case PROP_START_CLEARED_BALANCE:
-        number = g_value_get_boxed(value);
+        number = static_cast<gnc_numeric*>(g_value_get_boxed(value));
         gnc_account_set_start_cleared_balance(account, *number);
         break;
     case PROP_START_RECONCILED_BALANCE:
-        number = g_value_get_boxed(value);
+        number = static_cast<gnc_numeric*>(g_value_get_boxed(value));
         gnc_account_set_start_reconciled_balance(account, *number);
         break;
     case PROP_POLICY:
-        gnc_account_set_policy(account, g_value_get_pointer(value));
+        gnc_account_set_policy(account, static_cast<GNCPolicy*>(g_value_get_pointer(value)));
         break;
     case PROP_MARK:
         xaccAccountSetMark(account, g_value_get_int(value));
@@ -595,7 +595,7 @@ gnc_account_class_init (AccountClass *klass)
                           "repeated. but no two accounts that share "
                           "a parent may have the same name.",
                           NULL,
-                          G_PARAM_READWRITE));
+                          static_cast<GParamFlags>(G_PARAM_READWRITE)));
 
     g_object_class_install_property
     (gobject_class,
@@ -606,7 +606,7 @@ gnc_account_class_init (AccountClass *klass)
                           "all its parent account names to indicate "
                           "a unique account.",
                           NULL,
-                          G_PARAM_READABLE));
+                          static_cast<GParamFlags>(G_PARAM_READABLE)));
 
     g_object_class_install_property
     (gobject_class,
@@ -618,7 +618,7 @@ gnc_account_class_init (AccountClass *klass)
                           "be reporting code that is a synonym for "
                           "the accountName.",
                           NULL,
-                          G_PARAM_READWRITE));
+                          static_cast<GParamFlags>(G_PARAM_READWRITE)));
 
     g_object_class_install_property
     (gobject_class,
@@ -630,7 +630,7 @@ gnc_account_class_init (AccountClass *klass)
                           "to be a longer, 1-5 sentence description of "
                           "what this account is all about.",
                           NULL,
-                          G_PARAM_READWRITE));
+                          static_cast<GParamFlags>(G_PARAM_READWRITE)));
 
     g_object_class_install_property
     (gobject_class,
@@ -641,7 +641,7 @@ gnc_account_class_init (AccountClass *klass)
                           "by the user. It is intended to highlight the "
                           "account based on the users wishes.",
                           NULL,
-                          G_PARAM_READWRITE));
+                          static_cast<GParamFlags>(G_PARAM_READWRITE)));
 
     g_object_class_install_property
     (gobject_class,
@@ -652,7 +652,7 @@ gnc_account_class_init (AccountClass *klass)
                           "for the user to attach any other text that "
                           "they would like to associate with the account.",
                           NULL,
-                          G_PARAM_READWRITE));
+                          static_cast<GParamFlags>(G_PARAM_READWRITE)));
 
     g_object_class_install_property
     (gobject_class,
@@ -665,7 +665,7 @@ gnc_account_class_init (AccountClass *klass)
                        ACCT_TYPE_NONE,
                        NUM_ACCOUNT_TYPES - 1,
                        ACCT_TYPE_BANK,
-                       G_PARAM_READWRITE));
+                       static_cast<GParamFlags>(G_PARAM_READWRITE)));
 
     g_object_class_install_property
     (gobject_class,
@@ -676,7 +676,7 @@ gnc_account_class_init (AccountClass *klass)
                           "'stuff' stored  in this account, whether "
                           "it is USD, gold, stock, etc.",
                           GNC_TYPE_COMMODITY,
-                          G_PARAM_READWRITE));
+                          static_cast<GParamFlags>(G_PARAM_READWRITE)));
 
     g_object_class_install_property
     (gobject_class,
@@ -691,7 +691,7 @@ gnc_account_class_init (AccountClass *klass)
                        0,
                        G_MAXINT32,
                        1000000,
-                       G_PARAM_READWRITE));
+                       static_cast<GParamFlags>(G_PARAM_READWRITE)));
 
     g_object_class_install_property
     (gobject_class,
@@ -704,7 +704,7 @@ gnc_account_class_init (AccountClass *klass)
                            "mismatched values in older versions of "
                            "GnuCash.",
                            FALSE,
-                           G_PARAM_READWRITE));
+                           static_cast<GParamFlags>(G_PARAM_READWRITE)));
 
     g_object_class_install_property
     (gobject_class,
@@ -719,7 +719,7 @@ gnc_account_class_init (AccountClass *klass)
                           "affect the sort order of the account. Note: "
                           "This value can only be set to TRUE.",
                           FALSE,
-                          G_PARAM_READWRITE));
+                          static_cast<GParamFlags>(G_PARAM_READWRITE)));
 
     g_object_class_install_property
     (gobject_class,
@@ -733,7 +733,7 @@ gnc_account_class_init (AccountClass *klass)
                           "the engine to say a split has been modified. "
                           "Note: This value can only be set to TRUE.",
                           FALSE,
-                          G_PARAM_READWRITE));
+                          static_cast<GParamFlags>(G_PARAM_READWRITE)));
 
     g_object_class_install_property
     (gobject_class,
@@ -749,7 +749,7 @@ gnc_account_class_init (AccountClass *klass)
                         "the 'starting balance' will represent the "
                         "summation of the splits up to that date.",
                         GNC_TYPE_NUMERIC,
-                        G_PARAM_READWRITE));
+                        static_cast<GParamFlags>(G_PARAM_READWRITE)));
 
     g_object_class_install_property
     (gobject_class,
@@ -766,7 +766,7 @@ gnc_account_class_init (AccountClass *klass)
                         "balance' will represent the summation of the "
                         "splits up to that date.",
                         GNC_TYPE_NUMERIC,
-                        G_PARAM_READWRITE));
+                        static_cast<GParamFlags>(G_PARAM_READWRITE)));
 
     g_object_class_install_property
     (gobject_class,
@@ -783,7 +783,7 @@ gnc_account_class_init (AccountClass *klass)
                         "balance' will represent the summation of the "
                         "splits up to that date.",
                         GNC_TYPE_NUMERIC,
-                        G_PARAM_READWRITE));
+                        static_cast<GParamFlags>(G_PARAM_READWRITE)));
 
     g_object_class_install_property
     (gobject_class,
@@ -818,7 +818,7 @@ gnc_account_class_init (AccountClass *klass)
                         "the starting balance and all reconciled splits "
                         "in the account.",
                         GNC_TYPE_NUMERIC,
-                        G_PARAM_READABLE));
+                        static_cast<GParamFlags>(G_PARAM_READABLE)));
 
     g_object_class_install_property
     (gobject_class,
@@ -826,7 +826,7 @@ gnc_account_class_init (AccountClass *klass)
      g_param_spec_pointer ("policy",
                            "Policy",
                            "The account lots policy.",
-                           G_PARAM_READWRITE));
+                           static_cast<GParamFlags>(G_PARAM_READWRITE)));
 
     g_object_class_install_property
     (gobject_class,
@@ -837,7 +837,7 @@ gnc_account_class_init (AccountClass *klass)
                        0,
                        G_MAXINT16,
                        0,
-                       G_PARAM_READWRITE));
+                       static_cast<GParamFlags>(G_PARAM_READWRITE)));
 
     g_object_class_install_property
     (gobject_class,
@@ -847,7 +847,7 @@ gnc_account_class_init (AccountClass *klass)
                            "Whether the account maps to an entry on an "
                            "income tax document.",
                            FALSE,
-                           G_PARAM_READWRITE));
+                           static_cast<GParamFlags>(G_PARAM_READWRITE)));
 
     g_object_class_install_property
     (gobject_class,
@@ -859,7 +859,7 @@ gnc_account_class_init (AccountClass *klass)
                           "United States it is used to transfer totals "
                           "into tax preparation software.",
                           NULL,
-                          G_PARAM_READWRITE));
+                          static_cast<GParamFlags>(G_PARAM_READWRITE)));
 
     g_object_class_install_property
     (gobject_class,
@@ -868,7 +868,7 @@ gnc_account_class_init (AccountClass *klass)
                           "Tax Source",
                           "This specifies where exported name comes from.",
                           NULL,
-                          G_PARAM_READWRITE));
+                          static_cast<GParamFlags>(G_PARAM_READWRITE)));
 
     g_object_class_install_property
     (gobject_class,
@@ -880,7 +880,7 @@ gnc_account_class_init (AccountClass *klass)
                          (gint64)1,
                          G_MAXINT64,
                          (gint64)1,
-                         G_PARAM_READWRITE));
+                         static_cast<GParamFlags>(G_PARAM_READWRITE)));
 
     g_object_class_install_property
     (gobject_class,
@@ -890,7 +890,7 @@ gnc_account_class_init (AccountClass *klass)
                            "Whether the account should be hidden in the  "
                            "account tree.",
                            FALSE,
-                           G_PARAM_READWRITE));
+                           static_cast<GParamFlags>(G_PARAM_READWRITE)));
 
     g_object_class_install_property
     (gobject_class,
@@ -900,7 +900,7 @@ gnc_account_class_init (AccountClass *klass)
                            "Whether the account is a placeholder account which does not "
                            "allow transactions to be created, edited or deleted.",
                            FALSE,
-                           G_PARAM_READWRITE));
+                           static_cast<GParamFlags>(G_PARAM_READWRITE)));
 
     g_object_class_install_property
     (gobject_class,
@@ -910,7 +910,7 @@ gnc_account_class_init (AccountClass *klass)
                           "The account filter is a value saved to allow "
                           "filters to be recalled.",
                           NULL,
-                          G_PARAM_READWRITE));
+                          static_cast<GParamFlags>(G_PARAM_READWRITE)));
 
     g_object_class_install_property
     (gobject_class,
@@ -920,7 +920,7 @@ gnc_account_class_init (AccountClass *klass)
                           "The account sort order is a value saved to allow "
                           "the sort order to be recalled.",
                           NULL,
-                          G_PARAM_READWRITE));
+                          static_cast<GParamFlags>(G_PARAM_READWRITE)));
 
     g_object_class_install_property
     (gobject_class,
@@ -929,7 +929,7 @@ gnc_account_class_init (AccountClass *klass)
                           "Account Sort Reversed",
                           "Parameter to store whether the sort order is reversed or not.",
                           FALSE,
-                          G_PARAM_READWRITE));
+                          static_cast<GParamFlags>(G_PARAM_READWRITE)));
 
     g_object_class_install_property
     (gobject_class,
@@ -940,7 +940,7 @@ gnc_account_class_init (AccountClass *klass)
                          (gint64)1,
                          G_MAXINT64,
                          (gint64)1,
-                         G_PARAM_READWRITE));
+                         static_cast<GParamFlags>(G_PARAM_READWRITE)));
 
     g_object_class_install_property
     (gobject_class,
@@ -950,7 +950,7 @@ gnc_account_class_init (AccountClass *klass)
                           "The online account which corresponds to this "
                           "account for OFX import",
                           NULL,
-                          G_PARAM_READWRITE));
+                          static_cast<GParamFlags>(G_PARAM_READWRITE)));
 
      g_object_class_install_property(
        gobject_class,
@@ -959,7 +959,7 @@ gnc_account_class_init (AccountClass *klass)
                            "Associated income account",
                            "Used by the OFX importer.",
                            GNC_TYPE_GUID,
-                           G_PARAM_READWRITE));
+                           static_cast<GParamFlags>(G_PARAM_READWRITE)));
 
     g_object_class_install_property
     (gobject_class,
@@ -969,7 +969,7 @@ gnc_account_class_init (AccountClass *klass)
                           "The AqBanking account which corresponds to this "
                           "account for AQBanking import",
                           NULL,
-                          G_PARAM_READWRITE));
+                          static_cast<GParamFlags>(G_PARAM_READWRITE)));
     g_object_class_install_property
     (gobject_class,
      PROP_AB_BANK_CODE,
@@ -978,7 +978,7 @@ gnc_account_class_init (AccountClass *klass)
                           "The online account which corresponds to this "
                           "account for AQBanking import",
                           NULL,
-                          G_PARAM_READWRITE));
+                          static_cast<GParamFlags>(G_PARAM_READWRITE)));
 
     g_object_class_install_property
     (gobject_class,
@@ -989,7 +989,7 @@ gnc_account_class_init (AccountClass *klass)
                          (gint64)1,
                          G_MAXINT64,
                          (gint64)1,
-                         G_PARAM_READWRITE));
+                         static_cast<GParamFlags>(G_PARAM_READWRITE)));
 
     g_object_class_install_property
     (gobject_class,
@@ -999,7 +999,7 @@ gnc_account_class_init (AccountClass *klass)
                         "The time of the last transaction retrieval for this "
                         "account.",
                         GNC_TYPE_TIMESPEC,
-                        G_PARAM_READWRITE));
+                        static_cast<GParamFlags>(G_PARAM_READWRITE)));
 
 }
 
@@ -1028,7 +1028,7 @@ static Account *
 gnc_coll_get_root_account (QofCollection *col)
 {
     if (!col) return NULL;
-    return qof_collection_get_data (col);
+    return static_cast<Account*>(qof_collection_get_data (col));
 }
 
 static void
@@ -1101,7 +1101,7 @@ xaccMallocAccount (QofBook *book)
 
     g_return_val_if_fail (book, NULL);
 
-    acc = g_object_new (GNC_TYPE_ACCOUNT, NULL);
+    acc = static_cast<Account*>(g_object_new (GNC_TYPE_ACCOUNT, NULL));
     xaccInitAccount (acc, book);
     qof_event_gen (&acc->inst, QOF_EVENT_CREATE, NULL);
 
@@ -1118,7 +1118,7 @@ gnc_account_create_root (QofBook *book)
     rpriv = GET_PRIVATE(root);
     xaccAccountBeginEdit(root);
     rpriv->type = ACCT_TYPE_ROOT;
-    CACHE_REPLACE(rpriv->accountName, "Root Account");
+    qof_string_cache_replace((void const **)(&rpriv->accountName), "Root Account");
     mark_account (root);
     xaccAccountCommitEdit(root);
     gnc_book_set_root_account(book, root);
@@ -1135,7 +1135,7 @@ xaccCloneAccount(const Account *from, QofBook *book)
     g_return_val_if_fail(QOF_IS_BOOK(book), NULL);
 
     ENTER (" ");
-    ret = g_object_new (GNC_TYPE_ACCOUNT, NULL);
+    ret = static_cast<Account*>(g_object_new (GNC_TYPE_ACCOUNT, NULL));
     g_return_val_if_fail (ret, NULL);
 
     from_priv = GET_PRIVATE(from);
@@ -1147,9 +1147,9 @@ xaccCloneAccount(const Account *from, QofBook *book)
      * Also let caller issue the generate_event (EVENT_CREATE) */
     priv->type = from_priv->type;
 
-    priv->accountName = CACHE_INSERT(from_priv->accountName);
-    priv->accountCode = CACHE_INSERT(from_priv->accountCode);
-    priv->description = CACHE_INSERT(from_priv->description);
+    priv->accountName = static_cast<char*>(qof_string_cache_insert(from_priv->accountName));
+    priv->accountCode = static_cast<char*>(qof_string_cache_insert(from_priv->accountCode));
+    priv->description = static_cast<char*>(qof_string_cache_insert(from_priv->description));
 
     qof_instance_copy_kvp (QOF_INSTANCE (ret), QOF_INSTANCE (from));
 
@@ -1229,7 +1229,7 @@ xaccFreeAccount (Account *acc)
 
         for (lp = priv->lots; lp; lp = lp->next)
         {
-            GNCLot *lot = lp->data;
+            GNCLot *lot = static_cast<GNCLot*>(lp->data);
             gnc_lot_destroy (lot);
         }
         g_list_free (priv->lots);
@@ -1261,15 +1261,16 @@ xaccFreeAccount (Account *acc)
 */
     }
 
-    CACHE_REPLACE(priv->accountName, NULL);
-    CACHE_REPLACE(priv->accountCode, NULL);
-    CACHE_REPLACE(priv->description, NULL);
+    qof_string_cache_remove(priv->accountName);
+    qof_string_cache_remove(priv->accountCode);
+    qof_string_cache_remove(priv->description);
+    priv->accountName = priv->accountCode = priv->description = nullptr;
 
     /* zero out values, just in case stray
      * pointers are pointing here. */
 
-    priv->parent = NULL;
-    priv->children = NULL;
+    priv->parent = nullptr;
+    priv->children = nullptr;
 
     priv->balance  = gnc_numeric_zero();
     priv->cleared_balance = gnc_numeric_zero();
@@ -1327,7 +1328,7 @@ destroy_pending_splits_for_account(QofInstance *ent, gpointer acc)
     Split *split;
 
     if (xaccTransIsOpen(trans))
-        while ((split = xaccTransFindSplitByAccount(trans, acc)))
+        while ((split = xaccTransFindSplitByAccount(trans, static_cast<Account*>(acc))))
             xaccSplitDestroy(split);
 }
 
@@ -1365,7 +1366,7 @@ xaccAccountCommitEdit (Account *acc)
             slist = g_list_copy(priv->splits);
             for (lp = slist; lp; lp = lp->next)
             {
-                Split *s = lp->data;
+                Split *s = static_cast<Split *>(lp->data);
                 xaccSplitDestroy (s);
             }
             g_list_free(slist);
@@ -1392,7 +1393,7 @@ xaccAccountCommitEdit (Account *acc)
             /* the lots should be empty by now */
             for (lp = priv->lots; lp; lp = lp->next)
             {
-                GNCLot *lot = lp->data;
+                GNCLot *lot = static_cast<GNCLot*>(lp->data);
                 gnc_lot_destroy (lot);
             }
         }
@@ -1455,7 +1456,7 @@ xaccAcctChildrenEqual(const GList *na,
 
     while (na)
     {
-        Account *aa = na->data;
+        Account *aa = static_cast<Account*>(na->data);
         Account *ab;
         GList *node = g_list_find_custom ((GList*)nb, aa,
                                           (GCompareFunc)compare_account_by_name);
@@ -1465,7 +1466,7 @@ xaccAcctChildrenEqual(const GList *na,
             PINFO ("Unable to find matching child account.");
             return FALSE;
         }
-        ab = node->data;
+        ab = static_cast<Account*>(node->data);
         if (!xaccAccountEqual(aa, ab, check_guids))
         {
             char sa[GUID_ENCODING_LENGTH + 1];
@@ -1883,7 +1884,7 @@ xaccClearMarkDown (Account *acc, short val)
     priv->mark = val;
     for (node = priv->children; node; node = node->next)
     {
-        xaccClearMarkDown(node->data, val);
+        xaccClearMarkDown(static_cast<Account*>(node->data), val);
     }
 }
 
@@ -2254,7 +2255,7 @@ xaccAccountSetName (Account *acc, const char *str)
         return;
 
     xaccAccountBeginEdit(acc);
-    CACHE_REPLACE(priv->accountName, str);
+    qof_string_cache_replace((void const **)(&priv->accountName), str);
     mark_account (acc);
     xaccAccountCommitEdit(acc);
 }
@@ -2273,7 +2274,7 @@ xaccAccountSetCode (Account *acc, const char *str)
         return;
 
     xaccAccountBeginEdit(acc);
-    CACHE_REPLACE(priv->accountCode, str ? str : "");
+    qof_string_cache_replace((void const **)(&priv->accountCode), str ? str : "");
     mark_account (acc);
     xaccAccountCommitEdit(acc);
 }
@@ -2292,7 +2293,7 @@ xaccAccountSetDescription (Account *acc, const char *str)
         return;
 
     xaccAccountBeginEdit(acc);
-    CACHE_REPLACE(priv->description, str ? str : "");
+    qof_string_cache_replace((void const **)(&priv->description), str ? str : "");
     mark_account (acc);
     xaccAccountCommitEdit(acc);
 }
@@ -2691,7 +2692,7 @@ Account *
 gnc_account_nth_child (const Account *parent, gint num)
 {
     g_return_val_if_fail(GNC_IS_ACCOUNT(parent), NULL);
-    return g_list_nth_data(GET_PRIVATE(parent)->children, num);
+    return static_cast<Account*>(g_list_nth_data(GET_PRIVATE(parent)->children, num));
 }
 
 gint
@@ -2706,7 +2707,7 @@ gnc_account_n_descendants (const Account *account)
     priv = GET_PRIVATE(account);
     for (node = priv->children; node; node = g_list_next(node))
     {
-        count += gnc_account_n_descendants(node->data) + 1;
+        count += gnc_account_n_descendants(static_cast<Account*>(node->data)) + 1;
     }
     return count;
 }
@@ -2745,7 +2746,7 @@ gnc_account_get_tree_depth (const Account *account)
 
     for (node = priv->children; node; node = g_list_next(node))
     {
-        child_depth = gnc_account_get_tree_depth(node->data);
+        child_depth = gnc_account_get_tree_depth(static_cast<Account const *>(node->data));
         depth = MAX(depth, child_depth);
     }
     return depth + 1;
@@ -2768,7 +2769,7 @@ gnc_account_get_descendants (const Account *account)
     {
         descendants = g_list_append(descendants, child->data);
         descendants = g_list_concat(descendants,
-                                    gnc_account_get_descendants(child->data));
+                gnc_account_get_descendants(static_cast<Account const *>(child->data)));
     }
     return descendants;
 }
@@ -2793,7 +2794,7 @@ gnc_account_get_descendants_sorted (const Account *account)
     {
         descendants = g_list_append(descendants, child->data);
         descendants = g_list_concat(descendants,
-                                    gnc_account_get_descendants_sorted(child->data));
+                gnc_account_get_descendants_sorted(static_cast<Account const *>(child->data)));
     }
     g_list_free(children);
     return descendants;
@@ -2813,7 +2814,7 @@ gnc_account_lookup_by_name (const Account *parent, const char * name)
     ppriv = GET_PRIVATE(parent);
     for (node = ppriv->children; node; node = node->next)
     {
-        child = node->data;
+        child = static_cast<Account*>(node->data);
         cpriv = GET_PRIVATE(child);
         if (g_strcmp0(cpriv->accountName, name) == 0)
             return child;
@@ -2823,7 +2824,7 @@ gnc_account_lookup_by_name (const Account *parent, const char * name)
      * Recursively search each of the child accounts next */
     for (node = ppriv->children; node; node = node->next)
     {
-        child = node->data;
+        child = static_cast<Account*>(node->data);
         result = gnc_account_lookup_by_name (child, name);
         if (result)
             return result;
@@ -2846,7 +2847,7 @@ gnc_account_lookup_by_code (const Account *parent, const char * code)
     ppriv = GET_PRIVATE(parent);
     for (node = ppriv->children; node; node = node->next)
     {
-        child = node->data;
+        child = static_cast<Account*>(node->data);
         cpriv = GET_PRIVATE(child);
         if (g_strcmp0(cpriv->accountCode, code) == 0)
             return child;
@@ -2856,7 +2857,7 @@ gnc_account_lookup_by_code (const Account *parent, const char * code)
      * Recursively search each of the child accounts next */
     for (node = ppriv->children; node; node = node->next)
     {
-        child = node->data;
+        child = static_cast<Account*>(node->data);
         result = gnc_account_lookup_by_code (child, code);
         if (result)
             return result;
@@ -2884,7 +2885,7 @@ gnc_account_lookup_by_full_name_helper (const Account *parent,
     ppriv = GET_PRIVATE(parent);
     for (node = ppriv->children; node; node = node->next)
     {
-        Account *account = node->data;
+        Account *account = static_cast<Account*>(node->data);
 
         priv = GET_PRIVATE(account);
         if (g_strcmp0(priv->accountName, names[0]) == 0)
@@ -2950,7 +2951,7 @@ gnc_account_foreach_child (const Account *acc,
     priv = GET_PRIVATE(acc);
     for (node = priv->children; node; node = node->next)
     {
-        thunk (node->data, user_data);
+        thunk (static_cast<Account*>(node->data), user_data);
     }
 }
 
@@ -2969,7 +2970,7 @@ gnc_account_foreach_descendant (const Account *acc,
     priv = GET_PRIVATE(acc);
     for (node = priv->children; node; node = node->next)
     {
-        child = node->data;
+        child = static_cast<Account*>(node->data);
         thunk(child, user_data);
         gnc_account_foreach_descendant(child, thunk, user_data);
     }
@@ -2991,7 +2992,7 @@ gnc_account_foreach_descendant_until (const Account *acc,
     priv = GET_PRIVATE(acc);
     for (node = priv->children; node; node = node->next)
     {
-        child = node->data;
+        child = static_cast<Account*>(node->data);
         result = thunk(child, user_data);
         if (result)
             return(result);
@@ -3040,7 +3041,6 @@ gnc_account_get_full_name(const Account *account)
     AccountPrivate *priv;
     const Account *a;
     char *fullname;
-    gchar **names;
     int level;
 
     /* So much for hardening the API. Too many callers to this function don't
@@ -3067,7 +3067,7 @@ gnc_account_get_full_name(const Account *account)
 
     /* Get all the pointers in the right order. The root node "entry"
      * becomes the terminating NULL pointer for the array of strings. */
-    names = g_malloc(level * sizeof(gchar *));
+    gchar* names[level*sizeof(gchar*)];
     names[--level] = NULL;
     for (a = account; level > 0; a = priv->parent)
     {
@@ -3077,7 +3077,6 @@ gnc_account_get_full_name(const Account *account)
 
     /* Build the full name */
     fullname =  g_strjoinv(account_separator, names);
-    g_free(names);
 
     return fullname;
 }
@@ -3267,7 +3266,7 @@ xaccAccountGetProjectedMinimumBalance (const Account *acc)
     today = gnc_time64_get_today_end();
     for (node = g_list_last(priv->splits); node; node = node->prev)
     {
-        Split *split = node->data;
+        Split *split = static_cast<Split*>(node->data);
 
         if (!seen_a_transaction)
         {
@@ -3383,7 +3382,7 @@ xaccAccountGetPresentBalance (const Account *acc)
     today = gnc_time64_get_today_end();
     for (node = g_list_last(priv->splits); node; node = node->prev)
     {
-        Split *split = node->data;
+        Split *split = static_cast<Split*>(node->data);
 
         if (xaccTransGetDate (xaccSplitGetParent (split)) <= today)
             return xaccSplitGetBalance (split);
@@ -3517,7 +3516,7 @@ typedef struct
 static void
 xaccAccountBalanceHelper (Account *acc, gpointer data)
 {
-    CurrencyBalance *cb = data;
+    CurrencyBalance *cb = static_cast<CurrencyBalance*>(data);
     gnc_numeric balance;
 
     if (!cb->fn || !cb->currency)
@@ -3531,7 +3530,7 @@ xaccAccountBalanceHelper (Account *acc, gpointer data)
 static void
 xaccAccountBalanceAsOfDateHelper (Account *acc, gpointer data)
 {
-    CurrencyBalance *cb = data;
+    CurrencyBalance *cb = static_cast<CurrencyBalance*>(data);
     gnc_numeric balance;
 
     g_return_if_fail (cb->asOfDateFn && cb->currency);
@@ -3768,7 +3767,7 @@ xaccAccountFindOpenLots (const Account *acc,
     priv = GET_PRIVATE(acc);
     for (lot_list = priv->lots; lot_list; lot_list = lot_list->next)
     {
-        GNCLot *lot = lot_list->data;
+        GNCLot *lot = static_cast<GNCLot*>(lot_list->data);
 
         /* If this lot is closed, then ignore it */
         if (gnc_lot_is_closed (lot))
@@ -4109,7 +4108,7 @@ xaccAccountStringToEnum(const char* str)
 /********************************************************************\
 \********************************************************************/
 
-static char *
+static char const *
 account_type_name[NUM_ACCOUNT_TYPES] =
 {
     N_("Bank"),
@@ -4760,7 +4759,7 @@ finder_help_function(const Account *acc, const char *description,
     priv = GET_PRIVATE(acc);
     for (slp = g_list_last(priv->splits); slp; slp = slp->prev)
     {
-        Split *lsplit = slp->data;
+        Split *lsplit = static_cast<Split*>(slp->data);
         Transaction *ltrans = xaccSplitGetParent(lsplit);
 
         if (g_strcmp0 (description, xaccTransGetDescription (ltrans)) == 0)
@@ -4818,7 +4817,7 @@ gnc_account_join_children (Account *to_parent, Account *from_parent)
     ENTER (" ");
     children = g_list_copy(from_priv->children);
     for (node = children; node; node = g_list_next(node))
-        gnc_account_append_child(to_parent, node->data);
+        gnc_account_append_child(to_parent, static_cast <Account*> (node->data));
     g_list_free(children);
     LEAVE (" ");
 }
@@ -4836,12 +4835,12 @@ gnc_account_merge_children (Account *parent)
     ppriv = GET_PRIVATE(parent);
     for (node_a = ppriv->children; node_a; node_a = node_a->next)
     {
-        Account *acc_a = node_a->data;
+        Account *acc_a = static_cast <Account*> (node_a->data);
 
         priv_a = GET_PRIVATE(acc_a);
         for (node_b = node_a->next; node_b; node_b = g_list_next(node_b))
         {
-            Account *acc_b = node_b->data;
+            Account *acc_b = static_cast <Account*> (node_b->data);
 
             priv_b = GET_PRIVATE(acc_b);
             if (0 != null_strcmp(priv_a->accountName, priv_b->accountName))
@@ -4878,7 +4877,7 @@ gnc_account_merge_children (Account *parent)
 
             /* consolidate transactions */
             while (priv_b->splits)
-                xaccSplitSetAccount (priv_b->splits->data, acc_a);
+                xaccSplitSetAccount (static_cast <Split*> (priv_b->splits->data), acc_a);
 
             /* move back one before removal. next iteration around the loop
              * will get the node after node_b */
@@ -4903,7 +4902,7 @@ xaccSplitsBeginStagedTransactionTraversals (GList *splits)
 
     for (lp = splits; lp; lp = lp->next)
     {
-        Split *s = lp->data;
+        Split *s = static_cast <Split*> (lp->data);
         Transaction *trans = s->parent;
 
         if (trans)
@@ -4984,7 +4983,7 @@ xaccAccountStagedTransactionTraversal (const Account *acc,
          * a thunk removes splits from this account. */
         next = g_list_next(split_p);
 
-        s = split_p->data;
+        s = static_cast <Split*> (split_p->data);
         trans = s->parent;
         if (trans && (trans->marker < stage))
         {
@@ -5018,15 +5017,15 @@ gnc_account_tree_staged_transaction_traversal (const Account *acc,
     priv = GET_PRIVATE(acc);
     for (acc_p = priv->children; acc_p; acc_p = g_list_next(acc_p))
     {
-        retval = gnc_account_tree_staged_transaction_traversal(acc_p->data, stage,
-                 thunk, cb_data);
+        retval = gnc_account_tree_staged_transaction_traversal(static_cast <Account*> (acc_p->data),
+                stage, thunk, cb_data);
         if (retval) return retval;
     }
 
     /* Now this account */
     for (split_p = priv->splits; split_p; split_p = g_list_next(split_p))
     {
-        s = split_p->data;
+        s = static_cast <Split*> (split_p->data);
         trans = s->parent;
         if (trans && (trans->marker < stage))
         {
@@ -5291,7 +5290,7 @@ highestProbability(gpointer key, gpointer value, gpointer data)
     {
         /* Save the new highest probability and the assoaciated account guid */
         account_i->probability = GPOINTER_TO_INT(value);
-        account_i->account_guid = key;
+        account_i->account_guid = static_cast <char*> (key);
     }
 }
 
@@ -5367,8 +5366,8 @@ gnc_account_imap_find_account_bayes (GncImportMatchMap *imap, GList *tokens)
                   account_c->account_guid, account_c->token_count,
                   tokenInfo.total_count);
 
-            account_p = g_hash_table_lookup(running_probabilities,
-                                            account_c->account_guid);
+            account_p = static_cast <account_probability*> (
+                    g_hash_table_lookup(running_probabilities, account_c->account_guid));
 
             /* if the account exists in the list then continue
              * the running probablities
@@ -5609,7 +5608,7 @@ build_bayes_layer_two (const char *key, const GValue *value, gpointer user_data)
 
     g_free (guid);
 
-    imapInfo_node = g_malloc(sizeof(*imapInfo_node));
+    imapInfo_node = static_cast <imap_info*> (g_malloc(sizeof(*imapInfo_node)));
 
     imapInfo_node->source_account = imapInfo->source_account;
     imapInfo_node->map_account    = map_account;
@@ -5685,7 +5684,7 @@ build_non_bayes (const char *key, const GValue *value, gpointer user_data)
 
         PINFO("build_non_bayes: kvp_path is '%s'", kvp_path);
 
-        imapInfo_node = g_malloc(sizeof(*imapInfo_node));
+        imapInfo_node = static_cast <imap_info*> (g_malloc(sizeof(*imapInfo_node)));
 
         imapInfo_node->source_account = imapInfo->source_account;
         imapInfo_node->map_account    = xaccAccountLookup (guid, book);
@@ -5807,7 +5806,7 @@ look_for_old_separator_descendants (Account *root, gchar *full_name, const gchar
     /* Go through list of top level accounts */
     for (ptr = top_accounts; ptr; ptr = g_list_next (ptr))
     {
-        const gchar *name = xaccAccountGetName (ptr->data);
+        const gchar *name = xaccAccountGetName (static_cast <Account const *> (ptr->data));
 
         // we are looking for the longest top level account that matches
         if (g_str_has_prefix (full_name, name))
@@ -5932,7 +5931,7 @@ convert_imap_account (Account *acc)
         for (node = imap_list;  node; node = g_list_next (node))
         {
             Account *map_account = NULL;
-            GncImapInfo *imapInfo = node->data;
+            GncImapInfo *imapInfo = static_cast <GncImapInfo *> (node->data);
 
             // Lets start doing stuff
             map_account = look_for_old_mapping (imapInfo);
@@ -5977,7 +5976,7 @@ gnc_account_imap_convert_bayes (QofBook *book)
         /* Go through list of accounts */
         for (ptr = accts; ptr; ptr = g_list_next (ptr))
         {
-            Account *acc = ptr->data;
+            Account *acc = static_cast <Account*> (ptr->data);
 
             convert_imap_account (acc);
         }
@@ -6017,7 +6016,7 @@ static QofObject account_object_def =
     DI(.interface_version = ) QOF_OBJECT_VERSION,
     DI(.e_type            = ) GNC_ID_ACCOUNT,
     DI(.type_label        = ) "Account",
-    DI(.create            = ) (gpointer)xaccMallocAccount,
+    DI(.create            = ) (void*(*)(QofBook*)) xaccMallocAccount,
     DI(.book_begin        = ) NULL,
     DI(.book_end          = ) gnc_account_book_end,
     DI(.is_dirty          = ) qof_collection_is_dirty,

--- a/libgnucash/engine/Account.h
+++ b/libgnucash/engine/Account.h
@@ -48,6 +48,9 @@
 #include "gnc-engine.h"
 #include "policy.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 typedef gnc_numeric (*xaccGetBalanceFn)( const Account *account );
 
 typedef gnc_numeric (*xaccGetBalanceInCurrencyFn) (
@@ -1516,6 +1519,10 @@ const char * dxaccAccountGetQuoteTZ (const Account *account);
 /** This is the type-override when you want to match all accounts.  Used
  * in the gnome-search parameter list.  Be careful when you use this. */
 #define ACCOUNT_MATCH_ALL_TYPE	"account-match-all"
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* XACC_ACCOUNT_H */
 /** @} */

--- a/libgnucash/engine/Account.h
+++ b/libgnucash/engine/Account.h
@@ -1454,6 +1454,10 @@ void gnc_account_delete_map_entry (Account *acc, char *full_category, gboolean e
  */
 void gnc_account_imap_convert_bayes (QofBook *book);
 
+/** Change the bayes imap entries from a nested representation to a flat representation.
+ */
+void gnc_account_imap_convert_flat (QofBook *);
+
 /** @} */
 
 

--- a/libgnucash/engine/Account.h
+++ b/libgnucash/engine/Account.h
@@ -1494,6 +1494,17 @@ void dxaccAccountSetQuoteTZ (Account *account, const char *tz);
 const char * dxaccAccountGetQuoteTZ (const Account *account);
 /** @} */
 
+/**
+ * Register Accounts with the engine
+ *
+ * NOTE: This function originates from AccountP.h.
+ * A header file private to libgnucash/engine. This has been
+ * moved to Account.h to aid the transition to c++.
+ *
+ * The intention is likely to move this to a private method on Account.
+ * Therefore this method should not be used outside of libgnucash/engine.
+ */
+gboolean xaccAccountRegister (void);
 
 /** @name Account parameter names
  @{

--- a/libgnucash/engine/Account.hpp
+++ b/libgnucash/engine/Account.hpp
@@ -136,8 +136,6 @@ struct account_s
  * call this on an existing account! */
 void xaccAccountSetGUID (Account *account, const GncGUID *guid);
 
-/* Register Accounts with the engine */
-gboolean xaccAccountRegister (void);
 
 /* Structure for accessing static functions for testing */
 typedef struct

--- a/libgnucash/engine/AccountP.h
+++ b/libgnucash/engine/AccountP.h
@@ -41,6 +41,10 @@
 
 #include "Account.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define GNC_ID_ROOT_ACCOUNT        "RootAccount"
 
 /** STRUCTS *********************************************************/
@@ -149,5 +153,8 @@ typedef struct
 
 AccountTestFunctions* _utest_account_fill_functions(void);
 
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* XACC_ACCOUNT_P_H */

--- a/libgnucash/engine/CMakeLists.txt
+++ b/libgnucash/engine/CMakeLists.txt
@@ -136,7 +136,7 @@ ADD_CUSTOM_COMMAND (
 ADD_CUSTOM_TARGET(iso-4217-c DEPENDS ${ISO_4217_C})
 
 SET (engine_SOURCES
-  Account.c
+  Account.cpp
   Recurrence.c
   Query.c
   SchedXaction.c

--- a/libgnucash/engine/CMakeLists.txt
+++ b/libgnucash/engine/CMakeLists.txt
@@ -4,7 +4,7 @@ ADD_SUBDIRECTORY(test-core)
 ADD_SUBDIRECTORY(test)
 
 SET(engine_noinst_HEADERS
-  AccountP.h
+  Account.hpp
   ScrubP.h
   SplitP.h
   SX-book.h

--- a/libgnucash/engine/Makefile.am
+++ b/libgnucash/engine/Makefile.am
@@ -17,7 +17,7 @@ AM_CPPFLAGS = \
 
 
 libgncmod_engine_la_SOURCES = \
-  Account.c \
+  Account.cpp \
   Recurrence.c \
   Query.c \
   SchedXaction.c \

--- a/libgnucash/engine/Makefile.am
+++ b/libgnucash/engine/Makefile.am
@@ -187,7 +187,7 @@ gncinclude_HEADERS = \
   qof-string-cache.h
 
 noinst_HEADERS = \
-  AccountP.h \
+  Account.hpp \
   ScrubP.h \
   SplitP.h \
   SX-book.h \

--- a/libgnucash/engine/Scrub.c
+++ b/libgnucash/engine/Scrub.c
@@ -44,7 +44,6 @@
 #include <string.h>
 
 #include "Account.h"
-#include "AccountP.h"
 #include "Scrub.h"
 #include "ScrubP.h"
 #include "Transaction.h"

--- a/libgnucash/engine/Scrub2.c
+++ b/libgnucash/engine/Scrub2.c
@@ -36,7 +36,6 @@
 
 #include "qof.h"
 #include "Account.h"
-#include "AccountP.h"
 #include "Transaction.h"
 #include "TransactionP.h"
 #include "Scrub2.h"

--- a/libgnucash/engine/Scrub3.c
+++ b/libgnucash/engine/Scrub3.c
@@ -39,7 +39,6 @@
 #include "gnc-lot.h"
 #include "policy-p.h"
 #include "Account.h"
-#include "AccountP.h"
 #include "Scrub2.h"
 #include "Scrub3.h"
 #include "Transaction.h"

--- a/libgnucash/engine/Split.c
+++ b/libgnucash/engine/Split.c
@@ -46,7 +46,7 @@
 #include "qof.h"
 #include "qofbook.h"
 #include "Split.h"
-#include "AccountP.h"
+#include "Account.h"
 #include "Scrub.h"
 #include "TransactionP.h"
 #include "TransLog.h"

--- a/libgnucash/engine/Split.h
+++ b/libgnucash/engine/Split.h
@@ -41,6 +41,10 @@ typedef struct _SplitClass SplitClass;
 #include "gnc-commodity.h"
 #include "gnc-engine.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* --- type macros --- */
 #define GNC_TYPE_SPLIT            (gnc_split_get_type ())
 #define GNC_SPLIT(o)              \
@@ -549,6 +553,10 @@ gnc_numeric xaccSplitVoidFormerValue(const Split *split);
 #define xaccSplitGetGUID(X)      qof_entity_get_guid(QOF_INSTANCE(X))
 /** \deprecated */
 #define xaccSplitReturnGUID(X) (X ? *(qof_entity_get_guid(QOF_INSTANCE(X))) : *(guid_null()))
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* XACC_SPLIT_H */
 /** @} */

--- a/libgnucash/engine/Transaction.c
+++ b/libgnucash/engine/Transaction.c
@@ -51,7 +51,7 @@ struct timeval
 # include <unistd.h>
 #endif
 
-#include "AccountP.h"
+#include "Account.h"
 #include "Scrub.h"
 #include "Scrub3.h"
 #include "TransactionP.h"
@@ -253,7 +253,7 @@ void gen_event_trans (Transaction *trans)
         Account *account = s->acc;
         GNCLot *lot = s->lot;
         if (account)
-            qof_event_gen (&account->inst, GNC_EVENT_ITEM_CHANGED, s);
+            qof_event_gen (QOF_INSTANCE(account), GNC_EVENT_ITEM_CHANGED, s);
 
         if (lot)
         {

--- a/libgnucash/engine/Transaction.h
+++ b/libgnucash/engine/Transaction.h
@@ -94,6 +94,10 @@ typedef struct _TransactionClass TransactionClass;
 #include "gnc-engine.h"
 #include "Split.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* --- type macros --- */
 #define GNC_TYPE_TRANSACTION            (gnc_transaction_get_type ())
 #define GNC_TRANSACTION(o)              \
@@ -770,6 +774,10 @@ void xaccTransDump (const Transaction *trans, const char *tag);
 #define xaccTransGetGUID(X)      qof_entity_get_guid(QOF_INSTANCE(X))
 /** \deprecated */
 #define xaccTransReturnGUID(X) (X ? *(qof_entity_get_guid(QOF_INSTANCE(X))) : *(guid_null()))
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* XACC_TRANSACTION_H */
 /** @} */

--- a/libgnucash/engine/cap-gains.c
+++ b/libgnucash/engine/cap-gains.c
@@ -58,7 +58,7 @@ ToDo:
 #include <glib.h>
 #include <glib/gi18n.h>
 
-#include "AccountP.h"
+#include "Account.h"
 #include "Scrub2.h"
 #include "Scrub3.h"
 #include "Transaction.h"

--- a/libgnucash/engine/cashobjects.c
+++ b/libgnucash/engine/cashobjects.c
@@ -29,7 +29,7 @@
 #include "config.h"
 #include "cashobjects.h"
 #include "gnc-engine.h"
-#include "AccountP.h"
+#include "Account.h"
 #include "TransactionP.h"
 #include "SchedXaction.h"
 #include "SX-book-p.h"

--- a/libgnucash/engine/gnc-aqbanking-templates.cpp
+++ b/libgnucash/engine/gnc-aqbanking-templates.cpp
@@ -30,9 +30,9 @@
 extern "C"
 {
 #include "gnc-aqbanking-templates.h"
-#include "qofinstance-p.h"
 }
 
+#include "qofinstance-p.h"
 #include "kvp-frame.hpp"
 #include "gnc-rational.hpp"
 

--- a/libgnucash/engine/gnc-commodity.h
+++ b/libgnucash/engine/gnc-commodity.h
@@ -53,6 +53,10 @@ typedef struct _GncCommodityNamespaceClass gnc_commodity_namespaceClass;
 #include <glib/gi18n.h>
 #include "gnc-engine.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* --- type macros --- */
 #define GNC_TYPE_COMMODITY            (gnc_commodity_get_type ())
 #define GNC_COMMODITY(o)              \
@@ -1055,6 +1059,10 @@ void gnc_monetary_list_free(MonetaryList *list);
 /** @} */
 
 /** @} */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* GNC_COMMODITY_H */
 /** @} */

--- a/libgnucash/engine/gnc-engine.c
+++ b/libgnucash/engine/gnc-engine.c
@@ -27,7 +27,7 @@
 #include "gnc-engine.h"
 #include "qof.h"
 #include "cashobjects.h"
-#include "AccountP.h"
+#include "Account.h"
 #include "SX-book-p.h"
 #include "gnc-budget.h"
 #include "TransactionP.h"

--- a/libgnucash/engine/gnc-engine.h
+++ b/libgnucash/engine/gnc-engine.h
@@ -39,6 +39,10 @@
 #include <glib.h>
 #include "qof.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** \name QofLogModule identifiers */
 // @{
 #define GNC_MOD_ROOT      "gnc"
@@ -257,6 +261,9 @@ void gnc_engine_signal_commit_error( QofBackendError errcode );
 #define GNC_OWNER_GUID    "owner-guid"
 #define GNC_SX_ID         "sched-xaction"
 
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif
 /** @} */

--- a/libgnucash/engine/gnc-engine.h
+++ b/libgnucash/engine/gnc-engine.h
@@ -130,7 +130,7 @@ extern "C" {
 
 /** @brief Account in Gnucash.
  * This is the typename for an account. The actual structure is
- * defined in the private header AccountP.h, but no one outside the
+ * defined in the header Account.hpp, but no one outside the
  * engine should include that file. Instead, access that data only
  * through the functions in Account.h .*/
 typedef struct account_s             Account;

--- a/libgnucash/engine/gnc-features.h
+++ b/libgnucash/engine/gnc-features.h
@@ -38,6 +38,10 @@
 
 #include "qof.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** @name Defined features
 @{
  */
@@ -63,6 +67,10 @@ gchar *gnc_features_test_unknown (QofBook *book);
  * this book.
  */
 void gnc_features_set_used (QofBook *book, const gchar *feature);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* GNC_FEATURES_H */
 /** @} */

--- a/libgnucash/engine/gnc-lot.c
+++ b/libgnucash/engine/gnc-lot.c
@@ -46,7 +46,6 @@
 #include <qofinstance-p.h>
 
 #include "Account.h"
-#include "AccountP.h"
 #include "gnc-lot.h"
 #include "gnc-lot-p.h"
 #include "cap-gains.h"

--- a/libgnucash/engine/gnc-lot.h
+++ b/libgnucash/engine/gnc-lot.h
@@ -65,6 +65,10 @@
 #include "gnc-engine.h"
 /*#include "gnc-lot-p.h"*/
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct
 {
     QofInstanceClass parent_class;
@@ -174,6 +178,11 @@ GNCLot * gnc_lot_make_default (Account * acc);
 #define LOT_BALANCE     "balance"
 #define LOT_TITLE       "lot-title"
 #define LOT_NOTES       "notes"
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #endif /* GNC_LOT_H */
 /** @} */
 /** @} */

--- a/libgnucash/engine/gnc-pricedb.h
+++ b/libgnucash/engine/gnc-pricedb.h
@@ -31,6 +31,10 @@ typedef struct _GncPriceDBClass GNCPriceDBClass;
 #include "gnc-commodity.h"
 #include "gnc-engine.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* --- type macros --- */
 #define GNC_TYPE_PRICE            (gnc_price_get_type ())
 #define GNC_PRICE(o)              \
@@ -661,6 +665,10 @@ void gnc_pricedb_print_contents(GNCPriceDB *db, FILE *f);
 /**@}*/
 
 /** @} */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* GNC_PRICEDB_H */
 /** @} */

--- a/libgnucash/engine/guid.cpp
+++ b/libgnucash/engine/guid.cpp
@@ -356,6 +356,21 @@ GUID::from_string (std::string const & str)
     }
 }
 
+bool
+GUID::is_valid_guid (std::string const & str)
+{
+    try
+    {
+        static boost::uuids::string_generator strgen;
+        auto a = strgen (str);
+        return true;
+    }
+    catch (...)
+    {
+        return false;
+    }
+}
+
 guid_syntax_exception::guid_syntax_exception () noexcept
     : invalid_argument {"Invalid syntax for guid."}
 {

--- a/libgnucash/engine/guid.hpp
+++ b/libgnucash/engine/guid.hpp
@@ -50,6 +50,7 @@ struct GUID
     static GUID create_random () noexcept;
     static GUID const & null_guid () noexcept;
     static GUID from_string (std::string const &);
+    static bool is_valid_guid (std::string const &);
     std::string to_string () const noexcept;
     auto begin () const noexcept -> decltype (implementation.begin ());
     auto end () const noexcept -> decltype (implementation.end ());

--- a/libgnucash/engine/kvp-frame.cpp
+++ b/libgnucash/engine/kvp-frame.cpp
@@ -214,20 +214,6 @@ KvpFrameImpl::get_keys() const noexcept
     return ret;
 }
 
-void
-KvpFrameImpl::for_each_slot(void (*proc)(const char *key, KvpValue *value,
-                                         void * data),
-                            void *data) const noexcept
-{
-    if (!proc) return;
-    std::for_each (m_valuemap.begin(), m_valuemap.end(),
-        [proc,data](const KvpFrameImpl::map_type::value_type & a)
-        {
-            proc (a.first, a.second, data);
-        }
-    );
-}
-
 KvpValueImpl *
 KvpFrameImpl::get_slot(const char * key) const noexcept
 {

--- a/libgnucash/engine/kvp-frame.cpp
+++ b/libgnucash/engine/kvp-frame.cpp
@@ -181,23 +181,30 @@ KvpFrameImpl::set_path(Path path, KvpValue* value) noexcept
 std::string
 KvpFrameImpl::to_string() const noexcept
 {
-    std::ostringstream ret;
-    ret << "{\n";
+    return to_string("");
+}
 
+std::string
+KvpFrameImpl::to_string(std::string const & prefix) const noexcept
+{
+    if (!m_valuemap.size())
+        return prefix;
+    std::ostringstream ret;
     std::for_each(m_valuemap.begin(), m_valuemap.end(),
-        [this,&ret](const map_type::value_type &a)
+        [this,&ret,&prefix](const map_type::value_type &a)
         {
-            ret << "    ";
+            std::string new_prefix {prefix};
             if (a.first)
-                ret << a.first;
-            ret << " => ";
+            {
+                new_prefix += a.first;
+                new_prefix += "/";
+            }
             if (a.second)
-                ret << a.second->to_string();
-            ret << ",\n";
+                ret << a.second->to_string(new_prefix) << "\n";
+            else
+                ret << new_prefix << "(null)\n";
         }
     );
-
-    ret << "}\n";
     return ret.str();
 }
 

--- a/libgnucash/engine/kvp-frame.cpp
+++ b/libgnucash/engine/kvp-frame.cpp
@@ -472,4 +472,39 @@ gnc_value_list_get_type (void)
     return type;
 }
 
-/* ========================== END OF FILE ======================= */
+std::map<std::string, KvpValue*>
+KvpFrame::get_values_with_prefix(std::string const & prefix)
+{
+    std::map<std::string, KvpValue*> ret;
+    auto all_values = get_all_values();
+    std::for_each (all_values.begin(), all_values.end(), [&ret, &prefix] (std::map<std::string, KvpValue*>::value_type const & entry) {
+        if (std::mismatch(prefix.begin(), prefix.end(), entry.first.begin()).first == prefix.end())
+            ret[entry.first] = entry.second;
+    });;
+    return ret;
+}
+
+void
+KvpFrame::add_all_values (std::map<std::string, KvpValue*> & m, std::string const & prefix)
+{
+    std::for_each (m_valuemap.begin(), m_valuemap.end(), [&m, &prefix] (map_type::value_type const & entry) {
+        std::string new_key;
+        if (prefix.size())
+            new_key = prefix + delim + entry.first;
+        else
+            new_key = entry.first;
+        if (entry.second->get_type() == KvpValue::Type::FRAME)
+            entry.second->get<KvpFrame*>()->add_all_values(m, new_key);
+        else
+            m[new_key] = entry.second;
+    });
+}
+
+std::map<std::string, KvpValue*>
+KvpFrame::get_all_values (void)
+{
+    std::map<std::string, KvpValue*> ret;
+    add_all_values(ret, "");
+    return ret;
+}
+

--- a/libgnucash/engine/kvp-frame.hpp
+++ b/libgnucash/engine/kvp-frame.hpp
@@ -188,6 +188,12 @@ struct KvpFrameImpl
      */
     std::string to_string() const noexcept;
     /**
+     * Make a string representation of the frame with the specified string
+     * prefixed to every item in the frame.
+     * @return A std::string representing all the children of the frame.
+     */
+    std::string to_string(std::string const & prefix) const noexcept;
+    /**
      * Report the keys in the immediate frame. Be sensible about using this, it
      * isn't a very efficient way to iterate.
      * @return std::vector of keys as std::strings.

--- a/libgnucash/engine/kvp-frame.hpp
+++ b/libgnucash/engine/kvp-frame.hpp
@@ -204,11 +204,15 @@ struct KvpFrameImpl
      * @return The value at the key or nullptr.
      */
     KvpValue* get_slot(Path keys) const noexcept;
-    /** Convenience wrapper for std::for_each, which should be preferred.
+
+    void for_each_slot(void (*)(char const *key, KvpValue*, void*data), void*data) const noexcept;
+
+    /** The function should be of the form:
+     * <anything> func (char const *, KvpValue *, data_type &);
+     * Do not pass nullptr for the function.
      */
-    void for_each_slot(void (*proc)(const char *key, KvpValue *value,
-                                    void * data),
-                       void *data) const noexcept;
+    template <typename func_type, typename data_type>
+    void for_each_slot_temp (func_type const &, data_type &) const noexcept;
 
     /** Test for emptiness
      * @return true if the frame contains nothing.
@@ -219,6 +223,18 @@ struct KvpFrameImpl
     private:
     map_type m_valuemap;
 };
+
+template <typename func_type, typename data_type>
+void KvpFrame::for_each_slot_temp(func_type const & func, data_type & data) const noexcept
+{
+    std::for_each (m_valuemap.begin(), m_valuemap.end(),
+        [&func,&data](const KvpFrameImpl::map_type::value_type & a)
+        {
+            func (a.first, a.second, data);
+        }
+    );
+}
+
 
 int compare (const KvpFrameImpl &, const KvpFrameImpl &) noexcept;
 int compare (const KvpFrameImpl *, const KvpFrameImpl *) noexcept;

--- a/libgnucash/engine/kvp-frame.hpp
+++ b/libgnucash/engine/kvp-frame.hpp
@@ -93,6 +93,8 @@
 #include <string>
 #include <vector>
 #include <cstring>
+#include <algorithm>
+#include <iostream>
 using Path = std::vector<std::string>;
 
 /** Implements KvpFrame.
@@ -192,7 +194,7 @@ struct KvpFrameImpl
      * prefixed to every item in the frame.
      * @return A std::string representing all the children of the frame.
      */
-    std::string to_string(std::string const & prefix) const noexcept;
+    std::string to_string(std::string const &) const noexcept;
     /**
      * Report the keys in the immediate frame. Be sensible about using this, it
      * isn't a very efficient way to iterate.
@@ -211,14 +213,33 @@ struct KvpFrameImpl
      */
     KvpValue* get_slot(Path keys) const noexcept;
 
-    void for_each_slot(void (*)(char const *key, KvpValue*, void*data), void*data) const noexcept;
+    void for_each_slot(void (*proc)(const char *key, KvpValue *, void *data), void* data) const noexcept;
 
     /** The function should be of the form:
      * <anything> func (char const *, KvpValue *, data_type &);
-     * Do not pass nullptr for the function.
+     * Do not pass nullptr as the function.
      */
     template <typename func_type, typename data_type>
-    void for_each_slot_temp (func_type const &, data_type &) const noexcept;
+    void for_each_slot_temp(func_type const &, data_type &) const noexcept;
+
+    template <typename func_type>
+    void for_each_slot_temp(func_type const &) const noexcept;
+
+    /**
+     * Like for_each_slot, but doesn't traverse nested values. This will only loop
+     * over root-level values whose keys match the specified prefix.
+     */
+    template <typename func_type, typename data_type>
+    void for_each_slot_prefix(std::string const & prefix, func_type const &, data_type &) const noexcept;
+
+    template <typename func_type>
+    void for_each_slot_prefix(std::string const & prefix, func_type const &) const noexcept;
+
+    std::map<std::string, KvpValue*>
+    get_all_values(void);
+
+    std::map<std::string, KvpValue*>
+    get_values_with_prefix(std::string const &);
 
     /** Test for emptiness
      * @return true if the frame contains nothing.
@@ -228,7 +249,54 @@ struct KvpFrameImpl
 
     private:
     map_type m_valuemap;
+
+    void add_all_values (std::map<std::string, KvpValue*> &, std::string const &);
 };
+
+template<typename func_type>
+void KvpFrame::for_each_slot_prefix(std::string const & prefix,
+        func_type const & func) const noexcept
+{
+    std::for_each (m_valuemap.begin(), m_valuemap.end(),
+        [&prefix,&func](const KvpFrameImpl::map_type::value_type & a)
+        {
+            std::string temp_key {a.first};
+            if (temp_key.size() < prefix.size())
+                return;
+            /* Testing for prefix matching */
+            if (std::mismatch(prefix.begin(), prefix.end(), temp_key.begin()).first == prefix.end())
+                func (a.first, a.second);
+        }
+    );
+}
+
+template<typename func_type, typename data_type>
+void KvpFrame::for_each_slot_prefix(std::string const & prefix,
+        func_type const & func, data_type & data) const noexcept
+{
+    std::for_each (m_valuemap.begin(), m_valuemap.end(),
+        [&prefix,&func,&data](const KvpFrameImpl::map_type::value_type & a)
+        {
+            std::string temp_key {a.first};
+            if (temp_key.size() < prefix.size())
+                return;
+            /* Testing for prefix matching */
+            if (std::mismatch(prefix.begin(), prefix.end(), temp_key.begin()).first == prefix.end())
+                func (a.first, a.second, data);
+        }
+    );
+}
+
+template <typename func_type>
+void KvpFrame::for_each_slot_temp(func_type const & func) const noexcept
+{
+    std::for_each (m_valuemap.begin(), m_valuemap.end(),
+        [&func](const KvpFrameImpl::map_type::value_type & a)
+        {
+            func (a.first, a.second);
+        }
+    );
+}
 
 template <typename func_type, typename data_type>
 void KvpFrame::for_each_slot_temp(func_type const & func, data_type & data) const noexcept
@@ -240,7 +308,6 @@ void KvpFrame::for_each_slot_temp(func_type const & func, data_type & data) cons
         }
     );
 }
-
 
 int compare (const KvpFrameImpl &, const KvpFrameImpl &) noexcept;
 int compare (const KvpFrameImpl *, const KvpFrameImpl *) noexcept;

--- a/libgnucash/engine/kvp-value.hpp
+++ b/libgnucash/engine/kvp-value.hpp
@@ -138,6 +138,7 @@ struct KvpValueImpl
     KvpValueImpl::Type get_type() const noexcept;
 
     std::string to_string() const noexcept;
+    std::string to_string(std::string const & prefix) const noexcept;
 
     template <typename T>
     T get() const noexcept;

--- a/libgnucash/engine/policy.h
+++ b/libgnucash/engine/policy.h
@@ -37,6 +37,10 @@
 #ifndef XACC_POLICY_H
 #define XACC_POLICY_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct gncpolicy_s GNCPolicy;
 
 /** Valid Policy List
@@ -82,6 +86,10 @@ GNCPolicy *xaccGetFIFOPolicy (void);
  *     selected, this will always be book currency).
  */
 GNCPolicy *xaccGetLIFOPolicy (void);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* XACC_POLICY_H */
 /** @} */

--- a/libgnucash/engine/qof-backend.hpp
+++ b/libgnucash/engine/qof-backend.hpp
@@ -45,12 +45,12 @@ extern "C"
 {
 #include "qofbackend.h"
 #include "qofbook.h"
-#include "qofinstance-p.h"
 #include "qofquery.h"
 #include "qofsession.h"
 #include <gmodule.h>
 }
 
+#include "qofinstance-p.h"
 #include <string>
 #include <algorithm>
 #include <vector>

--- a/libgnucash/engine/qof-string-cache.cpp
+++ b/libgnucash/engine/qof-string-cache.cpp
@@ -132,4 +132,11 @@ qof_string_cache_insert(gconstpointer key)
     return NULL;
 }
 
+void
+qof_string_cache_replace(gconstpointer * dst, gconstpointer src)
+{
+    gpointer tmp {qof_string_cache_insert(src)};
+    qof_string_cache_remove(&dst);
+    *dst = tmp;
+}
 /* ************************ END OF FILE ***************************** */

--- a/libgnucash/engine/qof-string-cache.h
+++ b/libgnucash/engine/qof-string-cache.h
@@ -86,6 +86,10 @@ void qof_string_cache_remove(gconstpointer key);
 */
 gpointer qof_string_cache_insert(gconstpointer key);
 
+/** Same as CACHE_REPLACE below, but safe to call from C++.
+ */
+void qof_string_cache_replace(gconstpointer * dst, gconstpointer src);
+
 #define CACHE_INSERT(str) qof_string_cache_insert((gconstpointer)(str))
 #define CACHE_REMOVE(str) qof_string_cache_remove((str))
 

--- a/libgnucash/engine/qofbook.cpp
+++ b/libgnucash/engine/qofbook.cpp
@@ -1118,7 +1118,7 @@ static void commit_err (G_GNUC_UNUSED QofInstance *inst, QofBackendError errcode
 
 #define GNC_FEATURES "features"
 static void
-add_feature_to_hash (const gchar *key, KvpValue *value, gpointer user_data)
+add_feature_to_hash (const gchar *key, KvpValue *value, GHashTable * user_data)
 {
     gchar *descr = g_strdup(value->get<const char*>());
     g_hash_table_insert (*(GHashTable**)user_data, (gchar*)key, descr);
@@ -1134,8 +1134,8 @@ qof_book_get_features (QofBook *book)
     auto slot = frame->get_slot(GNC_FEATURES);
     if (slot != nullptr)
     {
-	frame = slot->get<KvpFrame*>();
-	frame->for_each_slot(&add_feature_to_hash, &features);
+        frame = slot->get<KvpFrame*>();
+        frame->for_each_slot_temp(&add_feature_to_hash, features);
     }
     return features;
 }

--- a/libgnucash/engine/qofinstance-p.h
+++ b/libgnucash/engine/qofinstance-p.h
@@ -160,6 +160,10 @@ void qof_instance_foreach_slot (const QofInstance *inst, const char *path,
 #ifdef __cplusplus
 } /* extern "C" */
 
+/** Returns all keys that match the given prefix and their corresponding values.*/
+std::map<std::string, KvpValue*>
+qof_instance_get_slots_prefix (QofInstance const *, std::string const & prefix);
+
 /* Don't pass nullptr as the function */
 template<typename func_type, typename data_type>
 void qof_instance_foreach_slot_temp (QofInstance const * inst, std::string const & path,
@@ -171,6 +175,18 @@ void qof_instance_foreach_slot_temp (QofInstance const * inst, std::string const
     auto frame = slot->get<KvpFrame*>();
     frame->for_each_slot(func, data);
 }
+
+/**
+ * Similar to qof_instance_foreach_slot, but we don't traverse the depth of the key value frame,
+ * we only check the root level for keys that match the specified prefix.
+ */
+template<typename func_type, typename data_type>
+void qof_instance_foreach_slot_prefix(QofInstance const * inst, std::string const & path_prefix,
+        func_type const & func, data_type & data)
+{
+    inst->kvp_data->for_each_slot_prefix(path_prefix, func, data);
+}
+
 #endif
 
 #endif /* QOF_INSTANCE_P_H */

--- a/libgnucash/engine/qofinstance-p.h
+++ b/libgnucash/engine/qofinstance-p.h
@@ -33,6 +33,8 @@
 #include "qofinstance.h"
 
 #ifdef __cplusplus
+#include "kvp-frame.hpp"
+#include <string>
 extern "C"
 {
 #endif
@@ -156,8 +158,19 @@ void qof_instance_foreach_slot (const QofInstance *inst, const char *path,
                                 void(*proc)(const char*, const GValue*, void*),
                                 void* data);
 #ifdef __cplusplus
+} /* extern "C" */
+
+/* Don't pass nullptr as the function */
+template<typename func_type, typename data_type>
+void qof_instance_foreach_slot_temp (QofInstance const * inst, std::string const & path,
+        func_type const & func, data_type & data)
+{
+    auto slot = inst->kvp_data->get_slot(path.c_str());
+    if (slot == nullptr || slot->get_type() != KvpValue::Type::FRAME)
+        return;
+    auto frame = slot->get<KvpFrame*>();
+    frame->for_each_slot(func, data);
 }
 #endif
-
 
 #endif /* QOF_INSTANCE_P_H */

--- a/libgnucash/engine/qofinstance.cpp
+++ b/libgnucash/engine/qofinstance.cpp
@@ -1278,10 +1278,9 @@ struct wrap_param
 };
 }
 static void
-wrap_gvalue_function (const char* key, KvpValue *val, gpointer data)
+wrap_gvalue_function (const char* key, KvpValue *val, wrap_param & param)
 {
     GValue *gv;
-    auto param = static_cast<wrap_param*>(data);
     if (val->get_type() != KvpValue::Type::FRAME)
         gv = gvalue_from_kvp_value(val);
     else
@@ -1290,7 +1289,7 @@ wrap_gvalue_function (const char* key, KvpValue *val, gpointer data)
         g_value_init (gv, G_TYPE_STRING);
         g_value_set_string (gv, nullptr);
     }
-    param->proc(key, gv, param->user_data);
+    param.proc(key, gv, param.user_data);
     g_slice_free (GValue, gv);
 }
 
@@ -1304,7 +1303,7 @@ qof_instance_foreach_slot (const QofInstance *inst, const char* path,
         return;
     auto frame = slot->get<KvpFrame*>();
     wrap_param new_data {proc, data};
-    frame->for_each_slot(wrap_gvalue_function, &new_data);
+    frame->for_each_slot_temp(&wrap_gvalue_function, new_data);
 }
 
 /* ========================== END OF FILE ======================= */

--- a/libgnucash/engine/qofsession.cpp
+++ b/libgnucash/engine/qofsession.cpp
@@ -50,12 +50,12 @@ extern "C"
 
 #include <glib.h>
 #include "qof.h"
-#include "qofbook-p.h"
 #include "qofobject-p.h"
 
 static QofLogModule log_module = QOF_MOD_SESSION;
 } //extern 'C'
 
+#include "qofbook-p.h"
 #include "qof-backend.hpp"
 #include "qofsession.hpp"
 #include "gnc-backend-prov.hpp"

--- a/libgnucash/engine/test-core/test-engine-stuff.cpp
+++ b/libgnucash/engine/test-core/test-engine-stuff.cpp
@@ -55,7 +55,6 @@ extern "C"
 #include <string.h>
 #include <sys/stat.h>
 #include <qof.h>
-#include <qofinstance-p.h>
 
 #include "Account.h"
 #include "AccountP.h"
@@ -71,6 +70,7 @@ extern "C"
 #include "test-stuff.h"
 #include "test-engine-strings.h"
 }
+#include <qofinstance-p.h>
 
 static gboolean glist_strings_only = FALSE;
 

--- a/libgnucash/engine/test-core/test-engine-stuff.cpp
+++ b/libgnucash/engine/test-core/test-engine-stuff.cpp
@@ -57,7 +57,6 @@ extern "C"
 #include <qof.h>
 
 #include "Account.h"
-#include "AccountP.h"
 #include "gnc-engine.h"
 #include "gnc-session.h"
 #include "Transaction.h"
@@ -70,6 +69,8 @@ extern "C"
 #include "test-stuff.h"
 #include "test-engine-strings.h"
 }
+
+#include "Account.hpp"
 #include <qofinstance-p.h>
 
 static gboolean glist_strings_only = FALSE;

--- a/libgnucash/engine/test/gtest-import-map.cpp
+++ b/libgnucash/engine/test/gtest-import-map.cpp
@@ -25,9 +25,9 @@ extern "C"
 #include <config.h>
 #include "../Account.h"
 #include <qof.h>
-#include <qofinstance-p.h>
 }
 
+#include <qofinstance-p.h>
 #include <kvp-frame.hpp>
 #include <gtest/gtest.h>
 

--- a/libgnucash/engine/test/gtest-import-map.cpp
+++ b/libgnucash/engine/test/gtest-import-map.cpp
@@ -30,6 +30,7 @@ extern "C"
 #include <qofinstance-p.h>
 #include <kvp-frame.hpp>
 #include <gtest/gtest.h>
+#include <string>
 
 class ImapTest : public testing::Test
 {
@@ -67,7 +68,11 @@ protected:
         gnc_account_append_child(t_expense_account, t_expense_account2);
     }
     void TearDown() {
-        qof_book_destroy (gnc_account_get_book (t_bank_account));
+        auto root = gnc_account_get_root (t_bank_account);
+        auto book = gnc_account_get_book (root);
+        xaccAccountBeginEdit (root);
+        xaccAccountDestroy (root);
+        qof_book_destroy (book);
     }
     Account *t_bank_account {};
     Account *t_sav_account {};
@@ -110,18 +115,16 @@ protected:
 TEST_F(ImapPlainTest, FindAccount)
 {
     auto root = qof_instance_get_slots(QOF_INSTANCE(t_bank_account));
-    auto acc1_val = new KvpValue(const_cast<GncGUID*>(xaccAccountGetGUID(t_expense_account1)));
-    auto acc2_val = new KvpValue(const_cast<GncGUID*>(xaccAccountGetGUID(t_expense_account2)));
+    auto acc1_val = new KvpValue(guid_copy(xaccAccountGetGUID(t_expense_account1)));
+    auto acc2_val = new KvpValue(guid_copy(xaccAccountGetGUID(t_expense_account2)));
     root->set_path({IMAP_FRAME, "foo", "bar"}, acc1_val);
     root->set_path({IMAP_FRAME, "baz", "waldo"}, acc2_val);
-    root->set_path({IMAP_FRAME, "pepper"}, acc1_val);
-    root->set_path({IMAP_FRAME, "salt"}, acc2_val);
+    root->set_path({IMAP_FRAME, "pepper"}, new KvpValue{*acc1_val});
+    root->set_path({IMAP_FRAME, "salt"}, new KvpValue{*acc2_val});
 
     EXPECT_EQ(t_expense_account1, gnc_account_imap_find_account(t_imap, "foo", "bar"));
-    EXPECT_EQ(t_expense_account2,
-              gnc_account_imap_find_account(t_imap, "baz", "waldo"));
-    EXPECT_EQ(t_expense_account1,
-              gnc_account_imap_find_account(t_imap, NULL, "pepper"));
+    EXPECT_EQ(t_expense_account2, gnc_account_imap_find_account(t_imap, "baz", "waldo"));
+    EXPECT_EQ(t_expense_account1, gnc_account_imap_find_account(t_imap, NULL, "pepper"));
     EXPECT_EQ(t_expense_account2, gnc_account_imap_find_account(t_imap, NULL, "salt"));
     EXPECT_EQ(nullptr, gnc_account_imap_find_account(t_imap, "salt", NULL));
 }
@@ -251,12 +254,12 @@ TEST_F(ImapBayesTest, FindAccountBayes)
     auto acct2_guid = guid_to_string (xaccAccountGetGUID(t_expense_account2));
     auto value = new KvpValue(INT64_C(42));
 
-    root->set_path({IMAP_FRAME_BAYES, foo, acct1_guid}, value);
-    root->set_path({IMAP_FRAME_BAYES, bar, acct1_guid}, value);
-    root->set_path({IMAP_FRAME_BAYES, baz, acct2_guid}, value);
-    root->set_path({IMAP_FRAME_BAYES, waldo, acct2_guid}, value);
-    root->set_path({IMAP_FRAME_BAYES, pepper, acct1_guid}, value);
-    root->set_path({IMAP_FRAME_BAYES, salt, acct2_guid}, value);
+    root->set_path((std::string{IMAP_FRAME_BAYES} + "-" + foo + "-" + acct1_guid).c_str(), value);
+    root->set_path((std::string{IMAP_FRAME_BAYES} + "-" + bar + "-" + acct1_guid).c_str(), new KvpValue{*value});
+    root->set_path((std::string{IMAP_FRAME_BAYES} + "-" + baz + "-" + acct2_guid).c_str(), new KvpValue{*value});
+    root->set_path((std::string{IMAP_FRAME_BAYES} + "-" + waldo + "-" + acct2_guid).c_str(), new KvpValue{*value});
+    root->set_path((std::string{IMAP_FRAME_BAYES} + "-" + pepper + "-" + acct1_guid).c_str(), new KvpValue{*value});
+    root->set_path((std::string{IMAP_FRAME_BAYES} + "-" + salt + "-" + acct2_guid).c_str(), new KvpValue{*value});
 
     auto account = gnc_account_imap_find_account_bayes(t_imap, t_list1);
     EXPECT_EQ(t_expense_account1, account);
@@ -289,29 +292,29 @@ TEST_F(ImapBayesTest, AddAccountBayes)
     auto root = qof_instance_get_slots(QOF_INSTANCE(t_bank_account));
     auto acct1_guid = guid_to_string (xaccAccountGetGUID(t_expense_account1));
     auto acct2_guid = guid_to_string (xaccAccountGetGUID(t_expense_account2));
-    auto value = root->get_slot({IMAP_FRAME_BAYES, "foo", "bar"});
+    auto value = root->get_slot((std::string{IMAP_FRAME_BAYES} + "-foo-bar").c_str());
     auto check_account = [this](KvpValue* v) {
         return (v->get<const char*>(), this->t_imap->book); };
-    value = root->get_slot({IMAP_FRAME_BAYES, foo, acct1_guid});
+    value = root->get_slot((std::string{IMAP_FRAME_BAYES} + "-" + foo + "-" + acct1_guid).c_str());
     EXPECT_EQ(1, value->get<int64_t>());
-    value = root->get_slot({IMAP_FRAME_BAYES, bar, acct1_guid});
+    value = root->get_slot((std::string{IMAP_FRAME_BAYES} + "-" + bar + "-" + acct1_guid).c_str());
     EXPECT_EQ(1, value->get<int64_t>());
-    value = root->get_slot({IMAP_FRAME_BAYES, baz, acct2_guid});
+    value = root->get_slot((std::string{IMAP_FRAME_BAYES} + "-" + baz + "-" + acct2_guid).c_str());
     EXPECT_EQ(1, value->get<int64_t>());
-    value = root->get_slot({IMAP_FRAME_BAYES, waldo, acct2_guid});
+    value = root->get_slot((std::string{IMAP_FRAME_BAYES} + "-" + waldo + "-" + acct2_guid).c_str());
     EXPECT_EQ(1, value->get<int64_t>());
-    value = root->get_slot({IMAP_FRAME_BAYES, pepper, acct1_guid});
+    value = root->get_slot((std::string{IMAP_FRAME_BAYES} + "-" + pepper + "-" + acct1_guid).c_str());
     EXPECT_EQ(1, value->get<int64_t>());
-    value = root->get_slot({IMAP_FRAME_BAYES, salt, acct2_guid});
+    value = root->get_slot((std::string{IMAP_FRAME_BAYES} + "-" + salt + "-" + acct2_guid).c_str());
     EXPECT_EQ(1, value->get<int64_t>());
-    value = root->get_slot({IMAP_FRAME_BAYES, baz, acct1_guid});
+    value = root->get_slot((std::string{IMAP_FRAME_BAYES} + "-" + baz + "-" + acct1_guid).c_str());
     EXPECT_EQ(nullptr, value);
 
     qof_instance_increase_editlevel(QOF_INSTANCE(t_bank_account));
     gnc_account_imap_add_account_bayes(t_imap, t_list2, t_expense_account2);
     qof_instance_mark_clean(QOF_INSTANCE(t_bank_account));
     qof_instance_reset_editlevel(QOF_INSTANCE(t_bank_account));
-    value = root->get_slot({IMAP_FRAME_BAYES, baz, acct2_guid});
+    value = root->get_slot((std::string{IMAP_FRAME_BAYES} + "-" + baz + "-" + acct2_guid).c_str());
     EXPECT_EQ(2, value->get<int64_t>());
 }
 
@@ -336,22 +339,22 @@ TEST_F(ImapBayesTest, ConvertAccountBayes)
     auto val3 = new KvpValue(static_cast<int64_t>(2));
 
     // Test for existing entries, all will be 1
-    auto value = root->get_slot({IMAP_FRAME_BAYES, foo, acct1_guid});
+    auto value = root->get_slot((std::string{IMAP_FRAME_BAYES} + "-" + foo + "-" + acct1_guid).c_str());
     EXPECT_EQ(1, value->get<int64_t>());
-    value = root->get_slot({IMAP_FRAME_BAYES, bar, acct1_guid});
+    value = root->get_slot((std::string{IMAP_FRAME_BAYES} + "-" + bar + "-" + acct1_guid).c_str());
     EXPECT_EQ(1, value->get<int64_t>());
-    value = root->get_slot({IMAP_FRAME_BAYES, baz, acct2_guid});
+    value = root->get_slot((std::string{IMAP_FRAME_BAYES} + "-" + baz + "-" + acct2_guid).c_str());
     EXPECT_EQ(1, value->get<int64_t>());
-    value = root->get_slot({IMAP_FRAME_BAYES, waldo, acct2_guid});
+    value = root->get_slot((std::string{IMAP_FRAME_BAYES} + "-" + waldo + "-" + acct2_guid).c_str());
     EXPECT_EQ(1, value->get<int64_t>());
 
     // Set up some old entries
-    root->set_path({IMAP_FRAME_BAYES, pepper, "Asset-Bank"}, val1);
-    root->set_path({IMAP_FRAME_BAYES, salt, "Asset-Bank#Bank"}, val1);
-    root->set_path({IMAP_FRAME_BAYES, salt, "Asset>Bank#Bank"}, val2);
-    root->set_path({IMAP_FRAME_BAYES, pork, "Expense#Food"}, val2);
-    root->set_path({IMAP_FRAME_BAYES, sausage, "Expense#Drink"}, val3);
-    root->set_path({IMAP_FRAME_BAYES, foo, "Expense#Food"}, val2);
+    root->set_path((std::string{IMAP_FRAME_BAYES} + "/" + pepper + "/" + "Asset-Bank").c_str(), val1);
+    root->set_path((std::string{IMAP_FRAME_BAYES} + "/" + salt + "/" + "Asset-Bank#Bank").c_str(), new KvpValue{*val1});
+    root->set_path((std::string{IMAP_FRAME_BAYES} + "/" + salt + "/" + "Asset>Bank#Bank").c_str(), val2);
+    root->set_path((std::string{IMAP_FRAME_BAYES} + "/" + pork + "/" + "Expense#Food").c_str(), new KvpValue{*val2});
+    root->set_path((std::string{IMAP_FRAME_BAYES} + "/" + sausage + "/" + "Expense#Drink").c_str(), val3);
+    root->set_path((std::string{IMAP_FRAME_BAYES} + "/" + foo + "/" + "Expense#Food").c_str(), new KvpValue{*val2});
 
     EXPECT_EQ(1, qof_instance_get_editlevel(QOF_INSTANCE(t_bank_account)));
     EXPECT_TRUE(qof_instance_get_dirty_flag(QOF_INSTANCE(t_bank_account)));
@@ -361,24 +364,24 @@ TEST_F(ImapBayesTest, ConvertAccountBayes)
     gnc_account_imap_convert_bayes (t_imap->book);
 
     // convert from 'Asset-Bank' to 'Asset-Bank' guid
-    value = root->get_slot({IMAP_FRAME_BAYES, pepper, acct3_guid});
+    value = root->get_slot((std::string{IMAP_FRAME_BAYES} + "-" + pepper + "-" + acct3_guid).c_str());
     EXPECT_EQ(10, value->get<int64_t>());
 
     // convert from 'Asset-Bank#Bank' to 'Sav Bank' guid
-    value = root->get_slot({IMAP_FRAME_BAYES, salt, acct4_guid});
+    value = root->get_slot((std::string{IMAP_FRAME_BAYES} + "-" + salt + "-" + acct4_guid).c_str());
     EXPECT_EQ(10, value->get<int64_t>());
 
     // convert from 'Expense#Food' to 'Food' guid
-    value = root->get_slot({IMAP_FRAME_BAYES, pork, acct1_guid});
+    value = root->get_slot((std::string{IMAP_FRAME_BAYES} + "-" + pork + "-" + acct1_guid).c_str());
     EXPECT_EQ(5, value->get<int64_t>());
 
     // convert from 'Expense#Drink' to 'Drink' guid
-    value = root->get_slot({IMAP_FRAME_BAYES, sausage, acct2_guid});
+    value = root->get_slot((std::string{IMAP_FRAME_BAYES} + "-" + sausage + "-" + acct2_guid).c_str());
     EXPECT_EQ(2, value->get<int64_t>());
 
     // convert from 'Expense#Food' to 'Food' guid but add to original value
-    value = root->get_slot({IMAP_FRAME_BAYES, foo, acct1_guid});
-    EXPECT_EQ(6, value->get<int64_t>());
+    value = root->get_slot((std::string{IMAP_FRAME_BAYES} + "-" + foo + "-" + acct1_guid).c_str());
+    EXPECT_EQ(5, value->get<int64_t>());
 
     // Check for run once flag
     auto vals = book->get_slot("changed-bayesian-to-guid");
@@ -388,4 +391,53 @@ TEST_F(ImapBayesTest, ConvertAccountBayes)
     EXPECT_TRUE(qof_instance_get_dirty_flag(QOF_INSTANCE(t_bank_account)));
 }
 
+TEST_F (ImapBayesTest, convert_map_flat)
+{
+    // prevent the embedded beginedit/committedit from doing anything
+    qof_instance_increase_editlevel(QOF_INSTANCE(t_bank_account));
+    qof_instance_mark_clean(QOF_INSTANCE(t_bank_account));
+    //gnc_account_imap_add_account_bayes(t_imap, t_list1, t_expense_account1); //Food
+    //gnc_account_imap_add_account_bayes(t_imap, t_list2, t_expense_account2); //Drink
+    auto root = qof_instance_get_slots(QOF_INSTANCE(t_bank_account));
+    auto acct1_guid = guid_to_string (xaccAccountGetGUID(t_expense_account1)); //Food
+    auto acct2_guid = guid_to_string (xaccAccountGetGUID(t_expense_account2)); //Drink
+    auto acct3_guid = guid_to_string (xaccAccountGetGUID(t_asset_account2)); //Asset-Bank
+    auto acct4_guid = guid_to_string (xaccAccountGetGUID(t_sav_account)); //Sav Bank
+    auto val1 = new KvpValue(static_cast<int64_t>(10));
+    auto val2 = new KvpValue(static_cast<int64_t>(5));
+    auto val3 = new KvpValue(static_cast<int64_t>(2));
+    // Set up some old entries
+    root->set_path((std::string{IMAP_FRAME_BAYES} + "/" + pepper + "/" + acct1_guid).c_str(), val1);
+    root->set_path((std::string{IMAP_FRAME_BAYES} + "/" + salt + "/" + acct2_guid).c_str(), new KvpValue{*val1});
+    root->set_path((std::string{IMAP_FRAME_BAYES} + "/" + foo + "/" + acct3_guid).c_str(), val2);
+    root->set_path((std::string{IMAP_FRAME_BAYES} + "/" + pork + "/" + acct4_guid).c_str(), val3);
+    EXPECT_EQ(1, qof_instance_get_editlevel(QOF_INSTANCE(t_bank_account)));
+    qof_instance_mark_clean(QOF_INSTANCE(t_bank_account));
+    gnc_account_imap_convert_flat (t_imap->book);
+    auto value = root->get_slot((std::string{IMAP_FRAME_BAYES} + "-" + pepper + "-" + acct1_guid).c_str());
+    EXPECT_EQ(10, value->get<int64_t>());
+    value = root->get_slot((std::string{IMAP_FRAME_BAYES} + "-" + salt + "-" + acct2_guid).c_str());
+    EXPECT_EQ(10, value->get<int64_t>());
+    value = root->get_slot((std::string{IMAP_FRAME_BAYES} + "-" + foo + "-" + acct3_guid).c_str());
+    EXPECT_EQ(5, value->get<int64_t>());
+    value = root->get_slot((std::string{IMAP_FRAME_BAYES} + "-" + pork + "-" + acct4_guid).c_str());
+    EXPECT_EQ(2, value->get<int64_t>());
+    auto book = qof_instance_get_slots(QOF_INSTANCE(t_imap->book));
+    auto vals = book->get_slot("changed-bayesian-to-flat");
+    EXPECT_STREQ("true", vals->get<const char*>());
+    EXPECT_EQ(1, qof_instance_get_editlevel(QOF_INSTANCE(t_bank_account)));
+    EXPECT_TRUE(qof_instance_get_dirty_flag(QOF_INSTANCE(t_bank_account)));
+}
 
+/* Tests the import map's handling of KVP delimiters */
+TEST_F (ImapBayesTest, import_map_with_delimiters)
+{
+    GList * tokens {nullptr};
+    tokens = g_list_prepend(tokens, const_cast<char*>("one/two/three"));
+    gnc_account_imap_add_account_bayes(t_imap, tokens, t_expense_account1);
+    gnc_account_imap_add_account_bayes(t_imap, tokens, t_expense_account1);
+    gnc_account_imap_add_account_bayes(t_imap, tokens, t_expense_account1);
+
+    auto account = gnc_account_imap_find_account_bayes (t_imap, tokens);
+    EXPECT_EQ (account, t_expense_account1);
+}

--- a/libgnucash/engine/test/test-account-object.cpp
+++ b/libgnucash/engine/test/test-account-object.cpp
@@ -32,10 +32,10 @@ extern "C"
 #include "qof.h"
 #include "Account.h"
 #include "cashobjects.h"
-#include "test-stuff.h"
 #include "test-engine-stuff.h"
-#include <qofinstance-p.h>
 }
+#include <qofinstance-p.h>
+#include "test-stuff.h"
 
 static void
 run_test (void)

--- a/libgnucash/engine/test/test-split-vs-account.cpp
+++ b/libgnucash/engine/test/test-split-vs-account.cpp
@@ -27,13 +27,14 @@ extern "C"
 #include <glib.h>
 #include "qof.h"
 #include "cashobjects.h"
-#include "AccountP.h"
 #include "TransLog.h"
 #include "gnc-engine.h"
 #include "test-engine-stuff.h"
 #include "test-stuff.h"
 #include "Transaction.h"
 }
+
+#include "Account.hpp"
 
 static void
 run_test (void)

--- a/libgnucash/engine/test/utest-Account.cpp
+++ b/libgnucash/engine/test/utest-Account.cpp
@@ -27,7 +27,6 @@ extern "C"
 #include <unittest-support.h>
 #include <gnc-event.h>
 #include <gnc-date.h>
-#include <qofinstance-p.h>
 /* Add specific headers for this class */
 #include "../Account.h"
 #include "../AccountP.h"
@@ -42,6 +41,7 @@ static const gchar *suitename = "/engine/Account";
 void test_suite_account (void);
 }
 
+#include <qofinstance-p.h>
 #include <kvp-frame.hpp>
 
 typedef struct

--- a/libgnucash/engine/test/utest-Account.cpp
+++ b/libgnucash/engine/test/utest-Account.cpp
@@ -29,7 +29,6 @@ extern "C"
 #include <gnc-date.h>
 /* Add specific headers for this class */
 #include "../Account.h"
-#include "../AccountP.h"
 #include "../Split.h"
 #include "../Transaction.h"
 #include "../gnc-lot.h"
@@ -41,6 +40,7 @@ static const gchar *suitename = "/engine/Account";
 void test_suite_account (void);
 }
 
+#include "../Account.hpp"
 #include <qofinstance-p.h>
 #include <kvp-frame.hpp>
 

--- a/libgnucash/engine/test/utest-Account.cpp
+++ b/libgnucash/engine/test/utest-Account.cpp
@@ -467,13 +467,7 @@ test_gnc_account_list_name_violations (Fixture *fixture, gconstpointer pData)
 {
     auto log_level = static_cast<GLogLevelFlags>(G_LOG_LEVEL_CRITICAL | G_LOG_FLAG_FATAL);
     auto log_domain = "gnc.engine";
-#ifdef USE_CLANG_FUNC_SIG
-#define _func "GList *gnc_account_list_name_violations(QofBook *, const gchar *)"
-#else
-#define _func "gnc_account_list_name_violations"
-#endif
-    auto msg = _func ": assertion 'separator != NULL' failed";
-#undef _func
+    auto msg = ": assertion 'separator != NULL' failed";
     auto check = test_error_struct_new(log_domain, log_level, msg);
     GList *results, *res_iter;
     auto sep = ":";
@@ -482,7 +476,7 @@ test_gnc_account_list_name_violations (Fixture *fixture, gconstpointer pData)
      * affect the test_log_fatal_handler
      */
     GLogFunc oldlogger = g_log_set_default_handler ((GLogFunc)test_null_handler, check);
-    g_test_log_set_fatal_handler ((GTestLogFatalFunc)test_checked_handler, check);
+    g_test_log_set_fatal_handler ((GTestLogFatalFunc)test_checked_substring_handler, check);
     g_assert (gnc_account_list_name_violations (NULL, NULL) == NULL);
     g_assert_cmpint (check->hits, ==, 1);
     g_assert (gnc_account_list_name_violations (book, NULL) == NULL);
@@ -753,19 +747,13 @@ test_xaccCloneAccount (Fixture *fixture, gconstpointer pData)
     Account *clone;
     QofBook *book = gnc_account_get_book (fixture->acct);
     auto loglevel = static_cast<GLogLevelFlags>(G_LOG_LEVEL_CRITICAL | G_LOG_FLAG_FATAL);
-#ifdef USE_CLANG_FUNC_SIG
-#define _func "Account *xaccCloneAccount(const Account *, QofBook *)"
-#else
-#define _func "xaccCloneAccount"
-#endif
-    auto msg1 = _func ": assertion 'GNC_IS_ACCOUNT(from)' failed";
-    auto msg2 = _func ": assertion 'QOF_IS_BOOK(book)' failed";
-#undef _func
+    auto msg1 = ": assertion 'GNC_IS_ACCOUNT(from)' failed";
+    auto msg2 = ": assertion 'QOF_IS_BOOK(book)' failed";
     auto check = test_error_struct_new("gnc.engine", loglevel, msg1);
     AccountPrivate *acct_p, *clone_p;
     auto oldlogger = g_log_set_default_handler ((GLogFunc)test_null_handler,
                                                 check);
-    g_test_log_set_fatal_handler ((GTestLogFatalFunc)test_checked_handler, check);
+    g_test_log_set_fatal_handler ((GTestLogFatalFunc)test_checked_substring_handler, check);
     clone = xaccCloneAccount (NULL, book);
     g_assert (clone == NULL);
     g_assert_cmpint (check->hits, ==, 1);
@@ -1089,14 +1077,8 @@ test_gnc_account_insert_remove_split (Fixture *fixture, gconstpointer pData)
     Split *split3 = xaccMallocSplit (book);
     TestSignal sig1, sig2, sig3;
     AccountPrivate *priv = fixture->func->get_private (fixture->acct);
-#ifdef USE_CLANG_FUNC_SIG
-#define _func "gboolean gnc_account_insert_split(Account *, Split *)"
-#else
-#define _func "gnc_account_insert_split"
-#endif
-    auto msg1 = _func ": assertion 'GNC_IS_ACCOUNT(acc)' failed";
-    auto msg2 = _func ": assertion 'GNC_IS_SPLIT(s)' failed";
-#undef _func
+    auto msg1 = ": assertion 'GNC_IS_ACCOUNT(acc)' failed";
+    auto msg2 = ": assertion 'GNC_IS_SPLIT(s)' failed";
     auto loglevel = static_cast<GLogLevelFlags>(G_LOG_LEVEL_CRITICAL | G_LOG_FLAG_FATAL);
 //    auto log_domain = "gnc.engine";
     auto check1 = test_error_struct_new("gnc.engine", loglevel, msg1);
@@ -1110,7 +1092,7 @@ test_gnc_account_insert_remove_split (Fixture *fixture, gconstpointer pData)
     test_add_error (check2);
     logger = g_log_set_handler ("gnc.engine", loglevel,
                                 (GLogFunc)test_null_handler, check3);
-    g_test_log_set_fatal_handler ((GTestLogFatalFunc)test_list_handler, NULL);
+    g_test_log_set_fatal_handler ((GTestLogFatalFunc)test_list_substring_handler, NULL);
 
     /* Check that the call fails with invalid account and split (throws) */
     g_assert (!gnc_account_insert_split (NULL, split1));

--- a/libgnucash/engine/test/utest-Split.cpp
+++ b/libgnucash/engine/test/utest-Split.cpp
@@ -35,7 +35,6 @@ extern "C"
 #include <TransactionP.h>
 #include <gnc-lot.h>
 #include <gnc-event.h>
-#include <qofinstance-p.h>
 
 #if defined(__clang__) && (__clang_major__ == 5 || (__clang_major__ == 3 && __clang_minor__ < 5))
 #define USE_CLANG_FUNC_SIG 1
@@ -45,6 +44,7 @@ static const gchar *suitename = "/engine/Split";
 void test_suite_split ( void );
 }
 
+#include <qofinstance-p.h>
 #include <kvp-frame.hpp>
 
 typedef struct

--- a/libgnucash/engine/test/utest-Split.cpp
+++ b/libgnucash/engine/test/utest-Split.cpp
@@ -738,7 +738,7 @@ test_xaccSplitDetermineGainStatus (Fixture *fixture, gconstpointer pData)
     g_assert (fixture->split->gains_split == NULL);
     g_assert_cmpint (fixture->split->gains, ==, GAINS_STATUS_A_VDIRTY | GAINS_STATUS_DATE_DIRTY);
 
-    fixture->split->inst.kvp_data->set("gains-source", new KvpValue(const_cast<GncGUID*>(guid_copy(g_guid))));
+    fixture->split->inst.kvp_data->set("gains-source", new KvpValue(guid_copy(g_guid)));
     g_assert (fixture->split->gains_split == NULL);
     fixture->split->gains = GAINS_STATUS_UNKNOWN;
     xaccSplitDetermineGainStatus (fixture->split);

--- a/libgnucash/engine/test/utest-Transaction.cpp
+++ b/libgnucash/engine/test/utest-Transaction.cpp
@@ -885,7 +885,7 @@ test_xaccTransEqual (Fixture *fixture, gconstpointer pData)
     xaccTransCommitEdit (clone);
     g_free (cleanup->msg);
     g_free (check->msg);
-    check->msg = g_strdup ("[xaccTransEqual] kvp frames differ:\n{\n    notes => KVP_VALUE_STRING(Salt pork sausage),\n    qux => KVP_VALUE_FRAME({\n    quux => KVP_VALUE_FRAME({\n    corge => KVP_VALUE_DOUBLE(654.321),\n}\n),\n}\n),\n}\n\n\nvs\n\n{\n    notes => KVP_VALUE_STRING(Salt pork sausage),\n    qux => KVP_VALUE_FRAME({\n    quux => KVP_VALUE_FRAME({\n    corge => KVP_VALUE_DOUBLE(123.456),\n}\n),\n}\n),\n}\n");
+    check->msg = g_strdup ("[xaccTransEqual] kvp frames differ:\nnotes/Salt pork sausage (char *)\nqux/quux/corge/654.321 (double)\n\n\n\n\nvs\n\nnotes/Salt pork sausage (char *)\nqux/quux/corge/123.456 (double)\n\n\n");
 
     g_assert (!xaccTransEqual (clone, txn0, TRUE, FALSE, TRUE, TRUE));
 

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -607,7 +607,7 @@ libgnucash/core-utils/gnc-locale-utils.c
 libgnucash/core-utils/gnc-path.c
 libgnucash/core-utils/gnc-prefs.c
 libgnucash/doc/doxygen_main_page.c
-libgnucash/engine/Account.c
+libgnucash/engine/Account.cpp
 libgnucash/engine/business-core.scm
 libgnucash/engine/cap-gains.c
 libgnucash/engine/cashobjects.c


### PR DESCRIPTION
This also required compiling `Account.c` as `Account.cpp`. There were a number of changes to `kvp-frame` (and exposed by `qofinstance`) to support flat KVP structures. This allows callers to search KVP by prefix. Each commit passes make check and has somewhat detailed comments.