### PR TITLE
report: fix negative colors in barcharts

### DIFF
--- a/gnucash/report/report-system/html-barchart.scm
+++ b/gnucash/report/report-system/html-barchart.scm
@@ -514,6 +514,9 @@
                   (push "options.seriesColors = [")
                   (push colors-str)
                   (push "];\n")
+                  (push "options.negativeSeriesColors = [")
+                  (push colors-str)
+                  (push "];\n")
                   )
                 )
 


### PR DESCRIPTION
Bar colors specified by a report only apply to positive bars in the plot. Negative bars still have the default colors, which are slightly darker shades of the default positive colors.

This commit forces negative bars to have the same colors as positive bars.