### PR TITLE
Fix dense calendar on Windows

### DIFF
--- a/gnucash/gnome-utils/gnc-dense-cal.c
+++ b/gnucash/gnome-utils/gnc-dense-cal.c
@@ -1292,11 +1292,11 @@ gnc_dense_cal_button_press(GtkWidget *widget,
         // trick with a bit of flicker.
         gtk_window_move(GTK_WINDOW(dcal->transPopup), evt->x_root + 5, evt->y_root + 5);
 
-        gtk_widget_get_allocation(GTK_WIDGET(dcal->transPopup), &alloc);
-
         populate_hover_window(dcal);
         gtk_widget_queue_resize(GTK_WIDGET(dcal->transPopup));
         gtk_widget_show_all(GTK_WIDGET(dcal->transPopup));
+
+        gtk_widget_get_allocation(GTK_WIDGET(dcal->transPopup), &alloc);
 
         if (evt->x_root + 5 + alloc.width > dcal->screen_width)
             win_xpos = evt->x_root - 2 - alloc.width;

--- a/gnucash/gnome-utils/gnc-dense-cal.c
+++ b/gnucash/gnome-utils/gnc-dense-cal.c
@@ -1234,6 +1234,17 @@ populate_hover_window(GncDenseCal *dcal, gint doc)
             gtk_list_store_set(model, &iter, 0, (gdcmd->name ? gdcmd->name : _("(unnamed)")), 1, gdcmd->info, -1);
         }
 
+        // if there are no rows, add one
+        if (gtk_tree_model_iter_n_children (GTK_TREE_MODEL(model), NULL) == 0)
+        {
+            GtkTreeIter iter;
+            gtk_list_store_insert(model, &iter, -1);
+        }
+
+        // make sure all pending events are processed
+        while(gtk_events_pending())
+            gtk_main_iteration();
+
         g_date_free(date);
     }
 }

--- a/gnucash/gnome-utils/gnc-dense-cal.c
+++ b/gnucash/gnome-utils/gnc-dense-cal.c
@@ -338,6 +338,11 @@ gnc_dense_cal_init(GncDenseCal *dcal)
         gtk_widget_set_name (GTK_WIDGET(dcal->transPopup), "dense-cal-popup");
 
         l = gtk_label_new(_("Date: "));
+#if GTK_CHECK_VERSION(3,12,0)
+        gtk_widget_set_margin_start (l, 5);
+#else
+        gtk_widget_set_margin_left (l, 5);
+#endif
         gtk_container_add(GTK_CONTAINER(hbox), l);
         l = gtk_label_new("YY/MM/DD");
         g_object_set_data(G_OBJECT(dcal->transPopup), "dateLabel", l);

--- a/gnucash/gnome-utils/gnc-dense-cal.c
+++ b/gnucash/gnome-utils/gnc-dense-cal.c
@@ -1311,7 +1311,7 @@ gnc_dense_cal_button_press(GtkWidget *widget,
         dcal->doc = -1;
         gtk_widget_hide(GTK_WIDGET(dcal->transPopup));
     }
-    return FALSE;
+    return TRUE;
 }
 
 static gint

--- a/gnucash/gnome-utils/gnc-dense-cal.c
+++ b/gnucash/gnome-utils/gnc-dense-cal.c
@@ -1256,26 +1256,24 @@ gnc_dense_cal_button_press(GtkWidget *widget,
 #if GTK_CHECK_VERSION(3,22,0)
     GdkWindow *win = gdk_screen_get_root_window (gtk_widget_get_screen (widget));
     GdkMonitor *mon = gdk_display_get_monitor_at_window (gtk_widget_get_display (widget), win);
-    GdkRectangle monitor_size;
+    GdkRectangle work_area_size;
 #else
     GdkScreen *screen = gdk_screen_get_default ();
 #endif
     GtkAllocation alloc;
     gint doc;
-    gint screen_width;
-    gint screen_height;
     GncDenseCal *dcal = GNC_DENSE_CAL(widget);
     gint win_xpos = evt->x_root + 5;
     gint win_ypos = evt->y_root + 5;
 
 #if GTK_CHECK_VERSION(3,22,0)
-    gdk_monitor_get_geometry (mon, &monitor_size);
+    gdk_monitor_get_workarea (mon, &work_area_size);
 
-    screen_width = monitor_size.width;
-    screen_height = monitor_size.height;
+    dcal->screen_width = work_area_size.width;
+    dcal->screen_height = work_area_size.height;
 #else
-    screen_width = gdk_screen_get_width (screen);
-    screen_height = gdk_screen_get_height (screen);
+    dcal->screen_width = gdk_screen_get_width (screen);
+    dcal->screen_height = gdk_screen_get_height (screen);
 #endif
 
     doc = wheres_this(dcal, evt->x, evt->y);
@@ -1296,10 +1294,10 @@ gnc_dense_cal_button_press(GtkWidget *widget,
         gtk_widget_queue_resize(GTK_WIDGET(dcal->transPopup));
         gtk_widget_show_all(GTK_WIDGET(dcal->transPopup));
 
-        if (evt->x_root + 5 + alloc.width > screen_width)
+        if (evt->x_root + 5 + alloc.width > dcal->screen_width)
             win_xpos = evt->x_root - 2 - alloc.width;
 
-        if (evt->y_root + 5 + alloc.height > screen_height)
+        if (evt->y_root + 5 + alloc.height > dcal->screen_height)
             win_ypos = evt->y_root - 2 - alloc.height;
 
         gtk_window_move(GTK_WINDOW(dcal->transPopup), win_xpos, win_ypos);
@@ -1313,12 +1311,9 @@ static gint
 gnc_dense_cal_motion_notify(GtkWidget *widget,
                             GdkEventMotion *event)
 {
-    GdkScreen *screen = gdk_screen_get_default ();
     GncDenseCal *dcal;
     GtkAllocation alloc;
     gint doc;
-    gint screen_width;
-    gint screen_height;
     int unused;
     GdkModifierType unused2;
     gint win_xpos = event->x_root + 5;
@@ -1345,30 +1340,14 @@ gnc_dense_cal_motion_notify(GtkWidget *widget,
     doc = wheres_this(dcal, event->x, event->y);
     if (doc >= 0)
     {
-#if GTK_CHECK_VERSION(3,22,0)
-        GdkWindow *win = gdk_screen_get_root_window (gtk_widget_get_screen (widget));
-        GdkMonitor *mon = gdk_display_get_monitor_at_window (gtk_widget_get_display (widget), win);
-        GdkRectangle monitor_size;
-
-        gdk_monitor_get_geometry (mon, &monitor_size);
-
-        screen_width = monitor_size.width;
-        screen_height = monitor_size.height;
-#else
-        screen_width = gdk_screen_get_width (screen);
-        screen_height = gdk_screen_get_height (screen);
-#endif
-        populate_hover_window(dcal, doc);
-        gtk_widget_queue_resize(GTK_WIDGET(dcal->transPopup));
-
         gtk_widget_get_allocation(GTK_WIDGET(dcal->transPopup), &alloc);
 
         gtk_widget_show_all(GTK_WIDGET(dcal->transPopup));
 
-        if (event->x_root + 5 + alloc.width > screen_width)
+        if (event->x_root + 5 + alloc.width > dcal->screen_width)
             win_xpos = event->x_root - 2 - alloc.width;
 
-        if (event->y_root + 5 + alloc.height > screen_height)
+        if (event->y_root + 5 + alloc.height > dcal->screen_height)
             win_ypos = event->y_root - 2 - alloc.height;
 
         gtk_window_move(GTK_WINDOW(dcal->transPopup), win_xpos, win_ypos);

--- a/gnucash/gnome-utils/gnc-dense-cal.h
+++ b/gnucash/gnome-utils/gnc-dense-cal.h
@@ -59,6 +59,7 @@ struct _GncDenseCal
     GtkWindow *transPopup;
     gint screen_width;
     gint screen_height;
+    gint doc;
 
     gint min_x_scale;
     gint min_y_scale;

--- a/gnucash/gnome-utils/gnc-dense-cal.h
+++ b/gnucash/gnome-utils/gnc-dense-cal.h
@@ -57,6 +57,8 @@ struct _GncDenseCal
 
     gboolean showPopup;
     GtkWindow *transPopup;
+    gint screen_width;
+    gint screen_height;
 
     gint min_x_scale;
     gint min_y_scale;


### PR DESCRIPTION
This PR fixes Gnucash crashing when in Windows you click on a date that does not have any scheduled transactions marked. It seems to stem from the treeview being empty and not being displayed so if there are no entries I add a blank. There are also a couple of changes to help improve when the popup is displayed.
Bob