### PR TITLE
report: fix default colors incorrectly shown as transparent

### DIFF
--- a/gnucash/report/report-system/doc/report-html.txt
+++ b/gnucash/report/report-system/doc/report-html.txt
@@ -363,7 +363,7 @@ We have three different kinds of style control information available:
             (gnc:make-color-option
               (_ "Style Sheet Options")
 	      (_ "Background Color") "a" (_ "Background color for reports.")
-	      (list #xff #xff #xff 0)
+	      (list #xff #xff #xff #xff)
 	      255 #f))
           options))
 

--- a/gnucash/report/standard-reports/price-scatter.scm
+++ b/gnucash/report/standard-reports/price-scatter.scm
@@ -118,7 +118,7 @@
       gnc:pagename-display optname-markercolor
       "b"
       (N_ "Color of the marker.")
-      (list #xb2 #x22 #x22 0)
+      (list #xb2 #x22 #x22 #xff)
       255 #f))
 
     (gnc:options-set-default-section options gnc:pagename-general)

--- a/gnucash/report/stylesheets/stylesheet-easy.scm
+++ b/gnucash/report/stylesheets/stylesheet-easy.scm
@@ -101,28 +101,28 @@
      (gnc:make-color-option
       (N_ "Colors")
       (N_ "Background Color") "a" (N_ "General background color for report.")
-      (list #xff #xff #xff 0)
+      (list #xff #xff #xff #xff)
       255 #f))      
 
     (opt-register
      (gnc:make-color-option
       (N_ "Colors")
       (N_ "Text Color") "b" (N_ "Normal body text color.")
-      (list #x00 #x00 #x00 0)
+      (list #x00 #x00 #x00 #xff)
       255 #f))      
 
     (opt-register
      (gnc:make-color-option
       (N_ "Colors")
       (N_ "Link Color") "c" (N_ "Link text color.")
-      (list #xb2 #x22 #x22 0)
+      (list #xb2 #x22 #x22 #xff)
       255 #f))
 
     (opt-register
      (gnc:make-color-option
       (N_ "Colors")
       (N_ "Table Cell Color") "c" (N_ "Default background for table cells.")
-      (list #xff #xff #xff 0)
+      (list #xff #xff #xff #xff)
       255 #f))      
 
     (opt-register
@@ -130,7 +130,7 @@
       (N_ "Colors")
       (N_ "Alternate Table Cell Color") "d"
       (N_ "Default alternate background for table cells.")
-      (list #xff #xff #xff 0)
+      (list #xff #xff #xff #xff)
       255 #f))
 
     (opt-register
@@ -138,7 +138,7 @@
       (N_ "Colors")
       (N_ "Subheading/Subtotal Cell Color") "e"
       (N_ "Default color for subtotal rows.")
-      (list #xee #xe8 #xaa 0)
+      (list #xee #xe8 #xaa #xff)
       255 #f))
 
     (opt-register
@@ -146,7 +146,7 @@
       (N_ "Colors")
       (N_ "Sub-subheading/total Cell Color") "f"
       (N_ "Color for subsubtotals.")
-      (list #xfa #xfa #xd2 0)
+      (list #xfa #xfa #xd2 #xff)
       255 #f))
 
     (opt-register
@@ -154,7 +154,7 @@
       (N_ "Colors")
       (N_ "Grand Total Cell Color") "g"
       (N_ "Color for grand totals.")
-      (list #xff #xff #x00 0)
+      (list #xff #xff #x00 #xff)
       255 #f))
 
     (opt-register 

--- a/gnucash/report/stylesheets/stylesheet-fancy.scm
+++ b/gnucash/report/stylesheets/stylesheet-fancy.scm
@@ -95,28 +95,28 @@
      (gnc:make-color-option
       (N_ "Colors")
       (N_ "Background Color") "a" (N_ "General background color for report.")
-      (list #xff #xff #xff 0)
+      (list #xff #xff #xff #xff)
       255 #f))      
 
     (opt-register
      (gnc:make-color-option
       (N_ "Colors")
       (N_ "Text Color") "b" (N_ "Normal body text color.")
-      (list #x00 #x00 #x00 0)
+      (list #x00 #x00 #x00 #xff)
       255 #f))      
 
     (opt-register
      (gnc:make-color-option
       (N_ "Colors")
       (N_ "Link Color") "c" (N_ "Link text color.")
-      (list #xb2 #x22 #x22 0)
+      (list #xb2 #x22 #x22 #xff)
       255 #f))
 
     (opt-register
      (gnc:make-color-option
       (N_ "Colors")
       (N_ "Table Cell Color") "c" (N_ "Default background for table cells.")
-      (list #xff #xff #xff 0)
+      (list #xff #xff #xff #xff)
       255 #f))      
 
     (opt-register
@@ -124,7 +124,7 @@
       (N_ "Colors")
       (N_ "Alternate Table Cell Color") "d"
       (N_ "Default alternate background for table cells.")
-      (list #xff #xff #xff 0)
+      (list #xff #xff #xff #xff)
       255 #f))
 
     (opt-register
@@ -132,7 +132,7 @@
       (N_ "Colors")
       (N_ "Subheading/Subtotal Cell Color") "e"
       (N_ "Default color for subtotal rows.")
-      (list #xee #xe8 #xaa 0)
+      (list #xee #xe8 #xaa #xff)
       255 #f))
 
     (opt-register
@@ -140,7 +140,7 @@
       (N_ "Colors")
       (N_ "Sub-subheading/total Cell Color") "f"
       (N_ "Color for subsubtotals.")
-      (list #xfa #xfa #xd2 0)
+      (list #xfa #xfa #xd2 #xff)
       255 #f))
 
     (opt-register
@@ -148,7 +148,7 @@
       (N_ "Colors")
       (N_ "Grand Total Cell Color") "g"
       (N_ "Color for grand totals.")
-      (list #xff #xff #x00 0)
+      (list #xff #xff #x00 #xff)
       255 #f))
 
     (opt-register 

--- a/gnucash/report/stylesheets/stylesheet-footer.scm
+++ b/gnucash/report/stylesheets/stylesheet-footer.scm
@@ -114,28 +114,28 @@
      (gnc:make-color-option
       (N_ "Colors")
       (N_ "Background Color") "a" (N_ "General background color for report.")
-      (list #xff #xff #xff 0)
+      (list #xff #xff #xff #xff)
       255 #f))      
 
     (opt-register
      (gnc:make-color-option
       (N_ "Colors")
       (N_ "Text Color") "b" (N_ "Normal body text color.")
-      (list #x00 #x00 #x00 0)
+      (list #x00 #x00 #x00 #xff)
       255 #f))      
 
     (opt-register
      (gnc:make-color-option
       (N_ "Colors")
       (N_ "Link Color") "c" (N_ "Link text color.")
-      (list #xb2 #x22 #x22 0)
+      (list #xb2 #x22 #x22 #xff)
       255 #f))
 
     (opt-register
      (gnc:make-color-option
       (N_ "Colors")
       (N_ "Table Cell Color") "c" (N_ "Default background for table cells.")
-      (list #xff #xff #xff 0)
+      (list #xff #xff #xff #xff)
       255 #f))      
 
     (opt-register
@@ -143,7 +143,7 @@
       (N_ "Colors")
       (N_ "Alternate Table Cell Color") "d"
       (N_ "Default alternate background for table cells.")
-      (list #xff #xff #xff 0)
+      (list #xff #xff #xff #xff)
       255 #f))
 
     (opt-register
@@ -151,7 +151,7 @@
       (N_ "Colors")
       (N_ "Subheading/Subtotal Cell Color") "e"
       (N_ "Default color for subtotal rows.")
-      (list #xee #xe8 #xaa 0)
+      (list #xee #xe8 #xaa #xff)
       255 #f))
 
     (opt-register
@@ -159,7 +159,7 @@
       (N_ "Colors")
       (N_ "Sub-subheading/total Cell Color") "f"
       (N_ "Color for subsubtotals.")
-      (list #xfa #xfa #xd2 0)
+      (list #xfa #xfa #xd2 #xff)
       255 #f))
 
     (opt-register
@@ -167,7 +167,7 @@
       (N_ "Colors")
       (N_ "Grand Total Cell Color") "g"
       (N_ "Color for grand totals.")
-      (list #xff #xff #x00 0)
+      (list #xff #xff #x00 #xff)
       255 #f))
 
     (opt-register 

--- a/gnucash/report/stylesheets/stylesheet-head-or-tail.scm
+++ b/gnucash/report/stylesheets/stylesheet-head-or-tail.scm
@@ -170,28 +170,28 @@
      (gnc:make-color-option
       (N_ "Colors")
       (N_ "Background Color") "a" (N_ "General background color for report.")
-      (list #xff #xff #xff 0)
+      (list #xff #xff #xff #xff)
       255 #f))
 
     (opt-register
      (gnc:make-color-option
       (N_ "Colors")
       (N_ "Text Color") "b" (N_ "Normal body text color.")
-      (list #x00 #x00 #x00 0)
+      (list #x00 #x00 #x00 #xff)
       255 #f))
 
     (opt-register
      (gnc:make-color-option
       (N_ "Colors")
       (N_ "Link Color") "c" (N_ "Link text color.")
-      (list #xb2 #x22 #x22 0)
+      (list #xb2 #x22 #x22 #xff)
       255 #f))
 
     (opt-register
      (gnc:make-color-option
       (N_ "Colors")
       (N_ "Table Cell Color") "c" (N_ "Default background for table cells.")
-      (list #xff #xff #xff 0)
+      (list #xff #xff #xff #xff)
       255 #f))
 
     (opt-register
@@ -199,7 +199,7 @@
       (N_ "Colors")
       (N_ "Alternate Table Cell Color") "d"
       (N_ "Default alternate background for table cells.")
-      (list #xff #xff #xff 0)
+      (list #xff #xff #xff #xff)
       255 #f))
 
     (opt-register
@@ -207,7 +207,7 @@
       (N_ "Colors")
       (N_ "Subheading/Subtotal Cell Color") "e"
       (N_ "Default color for subtotal rows.")
-      (list #xee #xe8 #xaa 0)
+      (list #xee #xe8 #xaa #xff)
       255 #f))
 
     (opt-register
@@ -215,7 +215,7 @@
       (N_ "Colors")
       (N_ "Sub-subheading/total Cell Color") "f"
       (N_ "Color for subsubtotals.")
-      (list #xfa #xfa #xd2 0)
+      (list #xfa #xfa #xd2 #xff)
       255 #f))
 
     (opt-register
@@ -223,7 +223,7 @@
       (N_ "Colors")
       (N_ "Grand Total Cell Color") "g"
       (N_ "Color for grand totals.")
-      (list #xff #xff #x00 0)
+      (list #xff #xff #x00 #xff)
       255 #f))
 
     (opt-register

--- a/gnucash/report/stylesheets/stylesheet-plain.scm
+++ b/gnucash/report/stylesheets/stylesheet-plain.scm
@@ -46,7 +46,7 @@
           (gnc:make-color-option
            (N_ "General")
            (N_ "Background Color") "a" (N_ "Background color for reports.")
-           (list #xff #xff #xff 0)
+           (list #xff #xff #xff #xff)
            255 #f))
          (opt-register
           (gnc:make-pixmap-option
@@ -62,7 +62,7 @@
           (gnc:make-color-option
            (N_ "Colors")
            (N_ "Alternate Table Cell Color") "a" (N_ "Background color for alternate lines.")
-           (list #xff #xff #xff 0)
+           (list #xff #xff #xff #xff)
            255 #f))
          (opt-register
           (gnc:make-number-range-option

--- a/gnucash/report/utility-reports/hello-world.scm
+++ b/gnucash/report/utility-reports/hello-world.scm
@@ -159,14 +159,14 @@
      (gnc:make-color-option
       (N_ "Hello, World!") (N_ "Background Color")
       "f" (N_ "This is a color option.")
-      (list #xf6 #xff #xdb 0)
+      (list #xf6 #xff #xdb #xff)
       255
       #f))
     (add-option
      (gnc:make-color-option
       (N_ "Hello, World!") (N_ "Text Color")
       "f" (N_ "This is a color option.")
-      (list #x00 #x00 #x00 0)
+      (list #x00 #x00 #x00 #xff)
       255
       #f))
     


### PR DESCRIPTION
In all the scheme files that create a color option with "gnc:make-color-option" the default colors are being passed as a list of rgba values. For example, white color is given as: (list #xff #xff #xff 0)
Where the last value 0 is meant as transparency 0, i.e., fully opaque.

However, gtk uses a different convention. From the docs for GdkRGBA: "alpha: The opacity of the color from 0.0 for completely translucent to 1.0 for opaque"
Because of this disagreement, gui color buttons display a transparent checkerboard pattern instead of the intended default color.

In this commit I convert from the gnucash convention to the gtk convention when setting or getting
colors. Another way to fix this would be to change the gnucash alpha convention to match the gtk convention, changing all the default color alpha values from 0 to #xff. I don't know which solution would be more preferable.

There aren't many users of the color-option, only the example report "hello-world.scm", the standard report "price-scatter.scm", and some "stylesheets-*.scm" files appear to use it. 