### PR TITLE
BUGFIX: Added parent window as argument

### DIFF
--- a/gnucash/gnome/gnc-plugin-basic-commands.c
+++ b/gnucash/gnome/gnc-plugin-basic-commands.c
@@ -528,7 +528,7 @@ gnc_main_window_cmd_file_export_accounts (GtkAction *action, GncMainWindowAction
 #ifdef HAVE_DBI_DBI_H
     gnc_ui_file_access_for_export (GTK_WINDOW (data->window));
 #else
-    gnc_file_export ();
+    gnc_file_export (GTK_WINDOW (data->window));
 #endif
     gnc_window_set_progressbar_window (NULL);
 }


### PR DESCRIPTION
gnc_file_export expects the parent window as an argument. Without this
fix a compilation error is caused when --disable-dbi is used during
configuration.