### PR TITLE
Make the notebook pages the primary focus

### DIFF
--- a/gnucash/gnome-utils/gnc-main-window.c
+++ b/gnucash/gnome-utils/gnc-main-window.c
@@ -3539,6 +3539,18 @@ gnc_main_window_window_menu (GncMainWindow *window)
 #endif
 };
 
+/* This is used to prevent the tab having focus */
+static gboolean
+gnc_main_window_page_focus_in (GtkWidget *widget, GdkEvent  *event,
+                               gpointer user_data)
+{
+    GncMainWindow *window = user_data;
+    GncPluginPage *page = gnc_main_window_get_current_page (window);
+
+    g_signal_emit (window, main_window_signals[PAGE_CHANGED], 0, page);
+    return FALSE;
+}
+
 static void
 gnc_main_window_setup_window (GncMainWindow *window)
 {
@@ -3579,6 +3591,8 @@ gnc_main_window_setup_window (GncMainWindow *window)
                       G_CALLBACK (gnc_main_window_switch_page), window);
     g_signal_connect (G_OBJECT (priv->notebook), "page-reordered",
                       G_CALLBACK (gnc_main_window_page_reordered), window);
+    g_signal_connect (G_OBJECT (priv->notebook), "focus-in-event",
+                      G_CALLBACK (gnc_main_window_page_focus_in), window);
     gtk_box_pack_start (GTK_BOX (main_vbox), priv->notebook,
                         TRUE, TRUE, 0);
 

--- a/gnucash/gnome/dialog-invoice.c
+++ b/gnucash/gnome/dialog-invoice.c
@@ -237,6 +237,14 @@ gnc_invoice_get_register(InvoiceWindow *iw)
     return NULL;
 }
 
+GtkWidget *
+gnc_invoice_get_notes(InvoiceWindow *iw)
+{
+    if (iw)
+        return (GtkWidget *)iw->notes_text;
+    return NULL;
+}
+
 /*******************************************************************************/
 /* FUNCTIONS FOR UNPOSTING */
 

--- a/gnucash/gnome/dialog-invoice.h
+++ b/gnucash/gnome/dialog-invoice.h
@@ -86,6 +86,7 @@ void gnc_invoice_save_page (InvoiceWindow *iw, GKeyFile *key_file, const gchar *
 GtkWidget * gnc_invoice_create_page (InvoiceWindow *iw, gpointer page);
 
 GtkWidget *gnc_invoice_get_register(InvoiceWindow *iw);
+GtkWidget *gnc_invoice_get_notes(InvoiceWindow *iw);
 
 /* definitions for CB functions */
 void gnc_invoice_window_destroy_cb (GtkWidget *widget, gpointer data);

--- a/gnucash/gnome/gnc-budget-view.c
+++ b/gnucash/gnome/gnc-budget-view.c
@@ -290,6 +290,17 @@ gnc_budget_view_get_account_from_path(GncBudgetView* view, GtkTreePath* path)
     return gnc_tree_view_account_get_account_from_path(GNC_TREE_VIEW_ACCOUNT(priv->tree_view), path);
 }
 
+GtkWidget*
+gnc_budget_view_get_account_tree_view (GncBudgetView* view)
+{
+    GncBudgetViewPrivate *priv;
+    
+    g_return_val_if_fail(GNC_IS_BUDGET_VIEW(view), NULL);
+        
+    priv =  GNC_BUDGET_VIEW_GET_PRIVATE(view);
+    return GTK_WIDGET(priv->fd->tree_view);
+}
+
 GList*
 gnc_budget_view_get_selected_accounts(GncBudgetView* view)
 {

--- a/gnucash/gnome/gnc-budget-view.h
+++ b/gnucash/gnome/gnc-budget-view.h
@@ -68,6 +68,7 @@ gboolean gnc_budget_view_restore(GncBudgetView* view, GKeyFile *key_file, const 
 GtkTreeSelection* gnc_budget_view_get_selection(GncBudgetView* view);
 Account* gnc_budget_view_get_account_from_path(GncBudgetView* view, GtkTreePath* path);
 GList* gnc_budget_view_get_selected_accounts(GncBudgetView* view);
+GtkWidget *gnc_budget_view_get_account_tree_view (GncBudgetView* view);
 
 G_END_DECLS
 

--- a/gnucash/gnome/gnc-plugin-account-tree.c
+++ b/gnucash/gnome/gnc-plugin-account-tree.c
@@ -44,6 +44,8 @@
 static void gnc_plugin_account_tree_class_init (GncPluginAccountTreeClass *klass);
 static void gnc_plugin_account_tree_init (GncPluginAccountTree *plugin);
 static void gnc_plugin_account_tree_finalize (GObject *object);
+static void gnc_plugin_account_tree_add_to_window (GncPlugin *plugin,
+                                                   GncMainWindow *window, GQuark type);
 
 /* Command callbacks */
 static void gnc_plugin_account_tree_cmd_new_account_tree (GtkAction *action, GncMainWindowActionData *data);
@@ -125,6 +127,27 @@ gnc_plugin_account_tree_new (void)
 }
 
 
+static void
+gnc_plugin_account_tree_main_window_page_changed (GncMainWindow *window,
+        GncPluginPage *plugin_page, gpointer user_data)
+{
+    // We continue only if the plugin_page is a valid
+    if (!plugin_page || !GNC_IS_PLUGIN_PAGE(plugin_page))
+        return;
+
+    if (gnc_main_window_get_current_page (window) == plugin_page)
+    {
+        if (!GNC_IS_PLUGIN_PAGE_ACCOUNT_TREE(plugin_page))
+            return;
+
+        // The page changed signal is emitted multiple times so we need
+        // to use an idle_add to change the focus to the tree view
+        g_idle_add ((GSourceFunc)gnc_plugin_page_account_tree_focus,
+                      GNC_PLUGIN_PAGE_ACCOUNT_TREE (plugin_page));
+    }
+}
+
+
 /** Initialize the class for a new account tree plugin.  This will set
  *  up any function pointers that override functions in the parent
  *  class, and also configure the private data storage for this
@@ -144,6 +167,9 @@ gnc_plugin_account_tree_class_init (GncPluginAccountTreeClass *klass)
 
     /* plugin info */
     plugin_class->plugin_name  = GNC_PLUGIN_ACCOUNT_TREE_NAME;
+
+    /* function overrides */
+    plugin_class->add_to_window = gnc_plugin_account_tree_add_to_window;
 
     /* widget addition/removal */
     plugin_class->actions_name = PLUGIN_ACTIONS_NAME;
@@ -182,6 +208,20 @@ gnc_plugin_account_tree_finalize (GObject *object)
     G_OBJECT_CLASS (parent_class)->finalize (object);
 }
 
+
+/**
+ * Called when this plugin is added to a main window.  Connect a few callbacks
+ * here to track page changes.
+ *
+ */
+static void gnc_plugin_account_tree_add_to_window (GncPlugin *plugin,
+        GncMainWindow *mainwindow,
+        GQuark type)
+{
+    g_signal_connect(mainwindow, "page_changed",
+                     G_CALLBACK(gnc_plugin_account_tree_main_window_page_changed),
+                     plugin);
+}
 /************************************************************
  *                    Command Callbacks                     *
  ************************************************************/

--- a/gnucash/gnome/gnc-plugin-budget.c
+++ b/gnucash/gnome/gnc-plugin-budget.c
@@ -97,13 +97,13 @@ gnc_plugin_budget_get_type (void)
         static const GTypeInfo our_info =
         {
             sizeof (GncPluginBudgetClass),
-            NULL,		/* base_init */
-            NULL,		/* base_finalize */
+            NULL,       /* base_init */
+            NULL,       /* base_finalize */
             (GClassInitFunc) gnc_plugin_budget_class_init,
-            NULL,		/* class_finalize */
-            NULL,		/* class_data */
+            NULL,       /* class_finalize */
+            NULL,       /* class_data */
             sizeof (GncPluginBudget),
-            0,		/* n_preallocs */
+            0,          /* n_preallocs */
             (GInstanceInitFunc) gnc_plugin_budget_init
         };
 

--- a/gnucash/gnome/gnc-plugin-budget.c
+++ b/gnucash/gnome/gnc-plugin-budget.c
@@ -44,6 +44,8 @@ static QofLogModule log_module = GNC_MOD_GUI;
 static void gnc_plugin_budget_class_init (GncPluginBudgetClass *klass);
 static void gnc_plugin_budget_init (GncPluginBudget *plugin);
 static void gnc_plugin_budget_finalize (GObject *object);
+static void gnc_plugin_budget_add_to_window (GncPlugin *plugin,
+                                             GncMainWindow *window, GQuark type);
 
 /* Command Callbacks */
 static void gnc_plugin_budget_cmd_new_budget (GtkAction *action,
@@ -127,6 +129,26 @@ GncPlugin * gnc_plugin_budget_new (void)
 }
 
 static void
+gnc_plugin_budget_main_window_page_changed (GncMainWindow *window,
+        GncPluginPage *plugin_page, gpointer user_data)
+{
+    // We continue only if the plugin_page is a valid
+    if (!plugin_page || !GNC_IS_PLUGIN_PAGE(plugin_page))
+        return;
+
+    if (gnc_main_window_get_current_page (window) == plugin_page)
+    {
+        if (!GNC_IS_PLUGIN_PAGE_BUDGET(plugin_page))
+            return;
+
+        // The page changed signal is emitted multiple times so we need
+        // to use an idle_add to change the focus to the tree view
+        g_idle_add ((GSourceFunc)gnc_plugin_page_budget_focus,
+                      GNC_PLUGIN_PAGE_BUDGET (plugin_page));
+    }
+}
+
+static void
 gnc_plugin_budget_class_init (GncPluginBudgetClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS (klass);
@@ -135,6 +157,9 @@ gnc_plugin_budget_class_init (GncPluginBudgetClass *klass)
     ENTER (" ");
     parent_class = g_type_class_peek_parent (klass);
     object_class->finalize = gnc_plugin_budget_finalize;
+
+    /* function overrides */
+    plugin_class->add_to_window = gnc_plugin_budget_add_to_window;
 
     plugin_class->plugin_name  = GNC_PLUGIN_BUDGET_NAME;
     plugin_class->actions_name = PLUGIN_ACTIONS_NAME;
@@ -160,6 +185,20 @@ gnc_plugin_budget_finalize(GObject *object)
     (parent_class->finalize)(object);
     LEAVE(" ");
 
+}
+
+/**
+ * Called when this plugin is added to a main window.  Connect a few callbacks
+ * here to track page changes.
+ *
+ */
+static void gnc_plugin_budget_add_to_window (GncPlugin *plugin,
+        GncMainWindow *mainwindow,
+        GQuark type)
+{
+    g_signal_connect(mainwindow, "page_changed",
+                     G_CALLBACK(gnc_plugin_budget_main_window_page_changed),
+                     plugin);
 }
 
 /************************************************************

--- a/gnucash/gnome/gnc-plugin-business.c
+++ b/gnucash/gnome/gnc-plugin-business.c
@@ -354,13 +354,13 @@ gnc_plugin_business_get_type (void)
         static const GTypeInfo our_info =
         {
             sizeof (GncPluginBusinessClass),
-            NULL,		/* base_init */
-            NULL,		/* base_finalize */
+            NULL,       /* base_init */
+            NULL,       /* base_finalize */
             (GClassInitFunc) gnc_plugin_business_class_init,
-            NULL,		/* class_finalize */
-            NULL,		/* class_data */
+            NULL,       /* class_finalize */
+            NULL,       /* class_data */
             sizeof (GncPluginBusiness),
-            0,		/* n_preallocs */
+            0,          /* n_preallocs */
             (GInstanceInitFunc) gnc_plugin_business_init
         };
 
@@ -953,17 +953,17 @@ static void
 gnc_plugin_business_cmd_test_init_data (GtkAction *action,
                                         GncMainWindowActionData *data)
 {
-    QofBook *book		= gnc_get_current_book();
-    GncCustomer *customer	= gncCustomerCreate(book);
-    GncAddress *address	= gncCustomerGetAddr(customer);
-    GncInvoice *invoice	= gncInvoiceCreate(book);
-    GncOwner *owner		= gncOwnerNew();
-    GncJob *job		= gncJobCreate(book);
-    Account *root		= gnc_book_get_root_account(book);
-    Account *inc_acct	= xaccMallocAccount(book);
-    Account *bank_acct	= xaccMallocAccount(book);
-    Account *tax_acct	= xaccMallocAccount(book);
-    Account *ar_acct	= xaccMallocAccount(book);
+    QofBook *book       = gnc_get_current_book();
+    GncCustomer *customer   = gncCustomerCreate(book);
+    GncAddress *address = gncCustomerGetAddr(customer);
+    GncInvoice *invoice = gncInvoiceCreate(book);
+    GncOwner *owner     = gncOwnerNew();
+    GncJob *job         = gncJobCreate(book);
+    Account *root       = gnc_book_get_root_account(book);
+    Account *inc_acct   = xaccMallocAccount(book);
+    Account *bank_acct  = xaccMallocAccount(book);
+    Account *tax_acct   = xaccMallocAccount(book);
+    Account *ar_acct    = xaccMallocAccount(book);
     Timespec now;
 
     // Create Customer

--- a/gnucash/gnome/gnc-plugin-page-account-tree.c
+++ b/gnucash/gnome/gnc-plugin-page-account-tree.c
@@ -587,6 +587,19 @@ gnc_plugin_page_account_tree_get_current_account (GncPluginPageAccountTree *page
     return account;
 }
 
+gboolean
+gnc_plugin_page_account_tree_focus (GncPluginPageAccountTree *page)
+{
+    if (GNC_IS_PLUGIN_PAGE_ACCOUNT_TREE(page))
+    {
+        GncPluginPageAccountTreePrivate *priv = GNC_PLUGIN_PAGE_ACCOUNT_TREE_GET_PRIVATE(page);
+        GtkTreeView *view = GTK_TREE_VIEW(priv->tree_view);
+
+        if (!gtk_widget_is_focus (GTK_WIDGET(view)))
+            gtk_widget_grab_focus (GTK_WIDGET(view));
+    }
+    return FALSE;
+}
 
 /* Virtual Functions */
 

--- a/gnucash/gnome/gnc-plugin-page-account-tree.h
+++ b/gnucash/gnome/gnc-plugin-page-account-tree.h
@@ -95,6 +95,15 @@ GncPluginPage *gnc_plugin_page_account_tree_new  (void);
 Account * gnc_plugin_page_account_tree_get_current_account (GncPluginPageAccountTree *page);
 
 
+/** Given a pointer to an account tree plugin page, set the focus to
+ *  the GtkTreeView. This is used in a g_idle_add so return FALSE.
+ *
+ *  @param page The "account tree" page.
+ * 
+ *  @return FALSE;
+ */
+gboolean gnc_plugin_page_account_tree_focus (GncPluginPageAccountTree *page);
+
 /** Given a pointer to an account, the account tree will open
  *  and the account will be selected (if any).
  *

--- a/gnucash/gnome/gnc-plugin-page-budget.c
+++ b/gnucash/gnome/gnc-plugin-page-budget.c
@@ -368,6 +368,22 @@ gnc_plugin_page_budget_close_cb (gpointer user_data)
 }
 
 
+gboolean
+gnc_plugin_page_budget_focus (GncPluginPageBudget *page)
+{
+    if (GNC_IS_PLUGIN_PAGE_BUDGET(page))
+    {
+        GncPluginPageBudgetPrivate *priv = GNC_PLUGIN_PAGE_BUDGET_GET_PRIVATE(page);
+        GncBudgetView *budget_view = priv->budget_view;
+        GtkWidget *account_view = gnc_budget_view_get_account_tree_view (budget_view);
+
+        if (!gtk_widget_is_focus (GTK_WIDGET(account_view)))
+            gtk_widget_grab_focus (GTK_WIDGET(account_view));
+    }
+    return FALSE;
+}
+
+
 static void
 gnc_plugin_page_budget_refresh_cb(GHashTable *changes, gpointer user_data)
 {

--- a/gnucash/gnome/gnc-plugin-page-budget.c
+++ b/gnucash/gnome/gnc-plugin-page-budget.c
@@ -175,10 +175,10 @@ static const gchar *actions_requiring_account[] =
 /** Short labels for use on the toolbar buttons. */
 static action_toolbar_labels toolbar_labels[] =
 {
-    { "OpenAccountAction", 	    N_("Open") },
-    { "DeleteBudgetAction", 	    N_("Delete") },
-    { "OptionsBudgetAction", 	    N_("Options") },
-    { "EstimateBudgetAction", 	    N_("Estimate") },
+    { "OpenAccountAction",          N_("Open") },
+    { "DeleteBudgetAction",         N_("Delete") },
+    { "OptionsBudgetAction",        N_("Options") },
+    { "EstimateBudgetAction",       N_("Estimate") },
     { NULL, NULL },
 };
 

--- a/gnucash/gnome/gnc-plugin-page-budget.h
+++ b/gnucash/gnome/gnc-plugin-page-budget.h
@@ -70,6 +70,16 @@ GncPluginPage *gnc_plugin_page_budget_new  (GncBudget *budget);
 
 void gnc_budget_gui_delete_budget(GncBudget *budget);
 
+/** Given a pointer to a budget plugin page, set the focus to
+ *  the Account GtkTreeView. This is used in a g_idle_add so
+ *  return FALSE.
+ *
+ *  @param page The "budget" page.
+ *
+ *  @return FALSE
+ */
+gboolean gnc_plugin_page_budget_focus (GncPluginPageBudget *page);
+
 G_END_DECLS
 
 #endif /* __GNC_PLUGIN_PAGE_BUDGET_H */

--- a/gnucash/gnome/gnc-plugin-page-register.c
+++ b/gnucash/gnome/gnc-plugin-page-register.c
@@ -393,8 +393,8 @@ static GtkActionEntry gnc_plugin_page_register_actions [] =
     },
     {
         "ScrubAllAction", NULL,
-		/* Translators: The following 2 are Scrub actions in register view */
-		N_("_All transactions"), NULL, NULL,
+        /* Translators: The following 2 are Scrub actions in register view */
+        N_("_All transactions"), NULL, NULL,
         G_CALLBACK (gnc_plugin_page_register_cmd_scrub_all)
     },
     {
@@ -488,11 +488,11 @@ static const gchar *view_style_actions[] =
 /** Short labels for use on the toolbar buttons. */
 static action_toolbar_labels toolbar_labels[] =
 {
-    { "ActionsTransferAction", 	            N_("Transfer") },
-    { "RecordTransactionAction", 	        N_("Enter") },
-    { "CancelTransactionAction", 	        N_("Cancel") },
-    { "DeleteTransactionAction", 	        N_("Delete") },
-	{ "DuplicateTransactionAction",         N_("Duplicate") },
+    { "ActionsTransferAction",              N_("Transfer") },
+    { "RecordTransactionAction",            N_("Enter") },
+    { "CancelTransactionAction",            N_("Cancel") },
+    { "DeleteTransactionAction",            N_("Delete") },
+    { "DuplicateTransactionAction",         N_("Duplicate") },
     { "SplitTransactionAction",             N_("Split") },
     { "ScheduleTransactionAction",          N_("Schedule") },
     { "BlankTransactionAction",             N_("Blank") },
@@ -1323,10 +1323,10 @@ static const gchar *style_names[] =
 #define KEY_REGISTER_STYLE      "RegisterStyle"
 #define KEY_DOUBLE_LINE         "DoubleLineMode"
 
-#define LABEL_ACCOUNT		"Account"
-#define LABEL_SUBACCOUNT	"SubAccount"
-#define LABEL_GL		"GL"
-#define LABEL_SEARCH		"Search"
+#define LABEL_ACCOUNT       "Account"
+#define LABEL_SUBACCOUNT    "SubAccount"
+#define LABEL_GL            "GL"
+#define LABEL_SEARCH        "Search"
 
 
 /** Save enough information about this register page that it can be
@@ -2219,10 +2219,10 @@ gnc_plugin_page_register_filter_dmy2time (char *date_string)
     struct tm when;
 
     PINFO("Date string is %s", date_string);
-    memset (&when, 0, sizeof (when));
+        memset (&when, 0, sizeof (when));
 
     sscanf (date_string, "%d-%d-%d", &when.tm_mday,
-	    &when.tm_mon, &when.tm_year);
+        &when.tm_mon, &when.tm_year);
 
     when.tm_mon -= 1;
     when.tm_year -= 1900;
@@ -4162,7 +4162,7 @@ gnc_plugin_page_register_event_handler (QofInstance *entity,
     GtkWidget *window;
     gchar *label, *color;
 
-    g_return_if_fail(page);	/* Required */
+    g_return_if_fail(page); /* Required */
     if (!GNC_IS_TRANS(entity) && !GNC_IS_ACCOUNT(entity))
         return;
 

--- a/gnucash/gnome/gnc-plugin-page-register.c
+++ b/gnucash/gnome/gnc-plugin-page-register.c
@@ -836,6 +836,18 @@ gnc_plugin_page_register_get_current_txn (GncPluginPageRegister *page)
     return gnc_split_register_get_current_trans(reg);
 }
 
+gboolean
+gnc_plugin_page_register_focus (GncPluginPageRegister *page)
+{
+    if (GNC_IS_PLUGIN_PAGE_REGISTER(page))
+    {
+        GncPluginPageRegisterPrivate *priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
+        GNCSplitReg *gsr = gnc_plugin_page_register_get_gsr(GNC_PLUGIN_PAGE(page));
+        gnc_split_reg_focus_on_sheet (gsr);
+    }
+    return FALSE;
+}
+
 /* This is the list of actions which are switched inactive in a read-only book. */
 static const char* readonly_inactive_actions[] =
 {

--- a/gnucash/gnome/gnc-plugin-page-register.h
+++ b/gnucash/gnome/gnc-plugin-page-register.h
@@ -163,6 +163,16 @@ gnc_plugin_page_register_get_account (GncPluginPageRegister *page);
 Transaction *
 gnc_plugin_page_register_get_current_txn (GncPluginPageRegister *page);
 
+/** Given a pointer to a register plugin page, set the focus to
+ *  the sheet. This is used in a g_idle_add so return FALSE.
+ *
+ *  @param page The "register" page.
+ *
+ *  @return FALSE
+ */
+gboolean
+gnc_plugin_page_register_focus (GncPluginPageRegister *page);
+
 G_END_DECLS
 /** @} */
 /** @} */

--- a/gnucash/gnome/gnc-plugin-page-sx-list.c
+++ b/gnucash/gnome/gnc-plugin-page-sx-list.c
@@ -200,10 +200,10 @@ gnc_plugin_page_sx_list_new (void)
     GncPluginPageSxList *plugin_page;
     const GList *object = gnc_gobject_tracking_get_list (GNC_PLUGIN_PAGE_SX_LIST_NAME);
     if (object && GNC_IS_PLUGIN_PAGE_SX_LIST (object->data))
-	plugin_page = GNC_PLUGIN_PAGE_SX_LIST (object->data);
+        plugin_page = GNC_PLUGIN_PAGE_SX_LIST (object->data);
     else
     {
-	plugin_page = g_object_new (GNC_TYPE_PLUGIN_PAGE_SX_LIST, NULL);
+        plugin_page = g_object_new (GNC_TYPE_PLUGIN_PAGE_SX_LIST, NULL);
     }
     return GNC_PLUGIN_PAGE(plugin_page);
 }

--- a/gnucash/gnome/gnc-plugin-page-sx-list.c
+++ b/gnucash/gnome/gnc-plugin-page-sx-list.c
@@ -209,6 +209,49 @@ gnc_plugin_page_sx_list_new (void)
 }
 
 
+static gboolean
+gnc_plugin_page_sx_list_focus (GtkTreeView *tree_view)
+{
+    if (GTK_IS_TREE_VIEW(tree_view))
+    {
+        if (!gtk_widget_is_focus (GTK_WIDGET(tree_view)))
+            gtk_widget_grab_focus (GTK_WIDGET(tree_view));
+    }
+    return FALSE;
+}
+
+
+/**
+ * Whenever the current page is changed, if a schedule editor page is
+ * the current page, set focus on the treeview.
+ */
+static void
+gnc_plugin_page_sx_list_main_window_page_changed (GncMainWindow *window,
+        GncPluginPage *plugin_page, gpointer user_data)
+{
+    // We continue only if the plugin_page is a valid
+    if (!plugin_page || !GNC_IS_PLUGIN_PAGE(plugin_page))
+        return;
+
+    if (gnc_main_window_get_current_page (window) == plugin_page)
+    {
+        GncPluginPageSxList *page;
+        GncPluginPageSxListPrivate *priv;
+
+        if (!GNC_IS_PLUGIN_PAGE_SX_LIST(plugin_page))
+            return;
+
+        page = GNC_PLUGIN_PAGE_SX_LIST(plugin_page);
+        priv = GNC_PLUGIN_PAGE_SX_LIST_GET_PRIVATE(page);
+
+        // The page changed signal is emitted multiple times so we need
+        // to use an idle_add to change the focus to the tree view
+        g_idle_add ((GSourceFunc)gnc_plugin_page_sx_list_focus,
+                      GTK_TREE_VIEW (priv->tree_view));
+    }
+}
+
+
 static void
 gnc_plugin_page_sx_list_class_init (GncPluginPageSxListClass *klass)
 {
@@ -355,6 +398,7 @@ gnc_plugin_page_sx_list_create_widget (GncPluginPage *plugin_page)
 {
     GncPluginPageSxList *page;
     GncPluginPageSxListPrivate *priv;
+    GncMainWindow  *window;
     GtkWidget *widget;
     GtkWidget *vbox;
     GtkWidget *label;
@@ -480,6 +524,11 @@ gnc_plugin_page_sx_list_create_widget (GncPluginPage *plugin_page)
                              page);
     gnc_gui_component_set_session (priv->gnc_component_id,
                                    gnc_get_current_session());
+
+    window = GNC_MAIN_WINDOW(GNC_PLUGIN_PAGE(plugin_page)->window);
+    g_signal_connect(window, "page_changed",
+                     G_CALLBACK(gnc_plugin_page_sx_list_main_window_page_changed),
+                     plugin_page);
 
     return priv->widget;
 }

--- a/gnucash/gnome/gnc-plugin-register.c
+++ b/gnucash/gnome/gnc-plugin-register.c
@@ -147,6 +147,26 @@ gnc_plugin_register_new (void)
 }
 
 static void
+gnc_plugin_register_main_window_page_changed(GncMainWindow *window,
+        GncPluginPage *plugin_page, gpointer user_data)
+{
+    // We continue only if the plugin_page is a valid
+    if (!plugin_page || !GNC_IS_PLUGIN_PAGE(plugin_page))
+        return;
+
+    if (gnc_main_window_get_current_page (window) == plugin_page)
+    {
+        if (!GNC_IS_PLUGIN_PAGE_REGISTER(plugin_page))
+            return;
+
+        // The page changed signal is emitted multiple times so we need
+        // to use an idle_add to change the focus to the register
+        g_idle_add ((GSourceFunc)gnc_plugin_page_register_focus,
+                      GNC_PLUGIN_PAGE_REGISTER (plugin_page));
+    }
+}
+
+static void
 gnc_plugin_register_class_init (GncPluginRegisterClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS (klass);
@@ -211,6 +231,10 @@ gnc_plugin_register_add_to_window (GncPlugin *plugin,
 {
     gnc_prefs_register_cb (GNC_PREFS_GROUP_GENERAL_REGISTER, NULL,
                            gnc_plugin_register_pref_changed, window);
+
+    g_signal_connect(window, "page_changed",
+                     G_CALLBACK(gnc_plugin_register_main_window_page_changed),
+                     plugin);
 }
 
 

--- a/gnucash/gnome/gnc-split-reg.c
+++ b/gnucash/gnome/gnc-split-reg.c
@@ -1520,6 +1520,17 @@ gnc_split_reg_jump_to_blank (GNCSplitReg *gsr)
 }
 
 void
+gnc_split_reg_focus_on_sheet (GNCSplitReg *gsr)
+{
+    GnucashRegister *reg = gsr->reg;
+    GnucashSheet *sheet = gnucash_register_get_sheet (reg);
+
+    // Make sure the sheet is the focus
+    if (!gtk_widget_has_focus(GTK_WIDGET (sheet)))
+        gtk_widget_grab_focus (GTK_WIDGET (sheet));
+}
+
+void
 gnc_split_reg_balancing_entry(GNCSplitReg *gsr, Account *account,
                               time64 statement_date, gnc_numeric balancing_amount)
 {

--- a/gnucash/gnome/gnc-split-reg.c
+++ b/gnucash/gnome/gnc-split-reg.c
@@ -181,13 +181,13 @@ gnc_split_reg_get_type( void )
         GTypeInfo type_info =
         {
             sizeof(GNCSplitRegClass),      /* class_size */
-            NULL,   			/* base_init */
-            NULL,				/* base_finalize */
+            NULL,               /* base_init */
+            NULL,               /* base_finalize */
             (GClassInitFunc)gnc_split_reg_class_init,
-            NULL,				/* class_finalize */
-            NULL,				/* class_data */
-            sizeof(GNCSplitReg),		/* */
-            0,				/* n_preallocs */
+            NULL,               /* class_finalize */
+            NULL,               /* class_data */
+            sizeof(GNCSplitReg),        /* */
+            0,                  /* n_preallocs */
             (GInstanceInitFunc)gnc_split_reg_init,
         };
 
@@ -928,7 +928,7 @@ gsr_default_associate_handler_file (GNCSplitReg *gsr, Transaction *trans, gboole
 
         const gchar *uri = xaccTransGetAssociation (trans);
 
-        if (valid_path_head && g_str_has_prefix (uri,"file:/") && !g_str_has_prefix (uri,"file://")) 
+        if (valid_path_head && g_str_has_prefix (uri,"file:/") && !g_str_has_prefix (uri,"file://"))
         {
             const gchar *part = uri + strlen ("file:");
             new_uri = g_strconcat (path_head, part, NULL);
@@ -952,7 +952,7 @@ gsr_default_associate_handler_file (GNCSplitReg *gsr, Transaction *trans, gboole
 
     if (response == GTK_RESPONSE_ACCEPT)
     {
-	gchar *dialog_uri = gtk_file_chooser_get_uri (GTK_FILE_CHOOSER (dialog));
+        gchar *dialog_uri = gtk_file_chooser_get_uri (GTK_FILE_CHOOSER (dialog));
 
         PINFO("Dialog File URI: %s\n", dialog_uri);
 
@@ -1337,37 +1337,35 @@ gnc_split_reg_duplicate_trans_cb(GtkWidget *w, gpointer data)
 void
 gsr_default_schedule_handler( GNCSplitReg *gsr, gpointer data )
 {
+    GncGUID *fromSXId = NULL;
+    SchedXaction *theSX = NULL;
+    GList *sxElts;
     SplitRegister *reg = gnc_ledger_display_get_split_register( gsr->ledger );
     Transaction *pending_trans = gnc_split_register_get_current_trans (reg);
 
     /* If the transaction has a sched-xact KVP frame, then go to the editor
      * for the existing SX; otherwise, do the sx-from-trans dialog. */
+
+    qof_instance_get (QOF_INSTANCE (pending_trans),
+              "from-sched-xaction", &fromSXId,
+              NULL);
+
+    /* Get the correct SX */
+    for ( sxElts = gnc_book_get_schedxactions (gnc_get_current_book())->sx_list;
+          (!theSX) && sxElts;
+          sxElts = sxElts->next )
     {
-	GncGUID *fromSXId = NULL;
-	SchedXaction *theSX = NULL;
-	GList *sxElts;
-	qof_instance_get (QOF_INSTANCE (pending_trans),
-			  "from-sched-xaction", &fromSXId,
-			  NULL);
-
-	/* Get the correct SX */
-	for ( sxElts = gnc_book_get_schedxactions (gnc_get_current_book())->sx_list;
-	      (!theSX) && sxElts;
-	      sxElts = sxElts->next )
-	{
-	    SchedXaction *sx = (SchedXaction*)sxElts->data;
-	    theSX =
-		((guid_equal (xaccSchedXactionGetGUID (sx), fromSXId))
-		 ? sx : NULL);
-	}
-
-	if ( theSX )
-	{
-	    gnc_ui_scheduled_xaction_editor_dialog_create(theSX, FALSE);
-	    return;
-	}
+        SchedXaction *sx = (SchedXaction*)sxElts->data;
+        theSX =
+        ((guid_equal (xaccSchedXactionGetGUID (sx), fromSXId))
+         ? sx : NULL);
     }
 
+    if ( theSX )
+    {
+        gnc_ui_scheduled_xaction_editor_dialog_create(theSX, FALSE);
+        return;
+    }
     gnc_sx_create_from_trans(pending_trans);
 }
 

--- a/gnucash/gnome/gnc-split-reg.h
+++ b/gnucash/gnome/gnc-split-reg.h
@@ -233,6 +233,11 @@ void gnc_split_reg_jump_to_blank (GNCSplitReg *gsr);
 void gnc_split_reg_jump_to_split(GNCSplitReg *gsr, Split *split);
 void gnc_split_reg_jump_to_split_amount(GNCSplitReg *gsr, Split *split);
 
+/**
+ * Set the focus of the register to the sheet
+ **/
+void gnc_split_reg_focus_on_sheet (GNCSplitReg *gsr);
+
 /*
  * Create a transaction entry with given amount and date. One account is
  * specified, the other is undefined i.e. it defaults to orphan account.

--- a/gnucash/html/gnc-html-webkit2.c
+++ b/gnucash/html/gnc-html-webkit2.c
@@ -92,21 +92,21 @@ static char error_404_body[] = N_("The specified URL could not be loaded.");
 #define GNC_PREF_RPT_DFLT_ZOOM "default-zoom"
 
 static gboolean webkit_decide_policy_cb (WebKitWebView* web_view,
-					 WebKitPolicyDecision *decision,
-					 WebKitPolicyDecisionType decision_type,
-					 gpointer user_data);
+                     WebKitPolicyDecision *decision,
+                     WebKitPolicyDecisionType decision_type,
+                     gpointer user_data);
 static void webkit_mouse_target_cb (WebKitWebView* web_view,
-				    WebKitHitTestResult *hit,
-				    guint modifiers, gpointer data);
+                     WebKitHitTestResult *hit,
+                     guint modifiers, gpointer data);
 #if WEBKIT_MINOR_VERSION >= 8
 static gboolean webkit_notification_cb (WebKitWebView *web_view,
-					WebKitNotification *note,
-					gpointer user_data);
+                     WebKitNotification *note,
+                     gpointer user_data);
 #endif
 static gboolean webkit_load_failed_cb (WebKitWebView *web_view,
-				       WebKitLoadEvent event,
-				       gchar *uri, GError *error,
-				       gpointer user_data);
+                     WebKitLoadEvent event,
+                     gchar *uri, GError *error,
+                     gpointer user_data);
 static void webkit_resource_load_started_cb (WebKitWebView *web_view,
                                              WebKitWebResource *resource,
                                              WebKitURIRequest *request,
@@ -134,14 +134,14 @@ gnc_html_webkit_webview_new (void)
      GValue val = G_VALUE_INIT;
      GtkStateFlags state = gtk_style_context_get_state (style);
      gtk_style_context_get_property (style, GTK_STYLE_PROPERTY_FONT,
-				     state, &val);
+                     state, &val);
 
      if (G_VALUE_HOLDS_BOXED (&val))
      {
-	  const PangoFontDescription *font =
-	       (const PangoFontDescription*)g_value_get_boxed (&val);
-	  default_font_family = pango_font_description_get_family (font);
-	  g_value_unset (&val);
+      const PangoFontDescription *font =
+           (const PangoFontDescription*)g_value_get_boxed (&val);
+      default_font_family = pango_font_description_get_family (font);
+      g_value_unset (&val);
      }
 /* Set default webkit settings */
      webkit_settings = webkit_web_view_get_settings (WEBKIT_WEB_VIEW (view));
@@ -162,9 +162,8 @@ gnc_html_webkit_webview_new (void)
                    NULL);
      if (default_font_family != NULL)
      {
-	  g_object_set (G_OBJECT (webkit_settings),
-			"default-font-family", default_font_family,
-			NULL);
+          g_object_set (G_OBJECT (webkit_settings),
+              "default-font-family", default_font_family, NULL);
      }
      return view;
 }
@@ -186,7 +185,7 @@ gnc_html_webkit_init( GncHtmlWebkit* self )
 
      /* Scale everything up */
      zoom = gnc_prefs_get_float (GNC_PREFS_GROUP_GENERAL_REPORT,
-				 GNC_PREF_RPT_DFLT_ZOOM);
+                 GNC_PREF_RPT_DFLT_ZOOM);
      webkit_web_view_set_zoom_level (priv->web_view, zoom);
 
 
@@ -297,8 +296,8 @@ extract_base_name(URLType type, const gchar* path)
 {
      gchar       machine_rexp[] = "^(//[^/]*)/*(/.*)?$";
      gchar       path_rexp[] = "^/*(.*)/+([^/]*)$";
-     regex_t    compiled_m, compiled_p;
-     regmatch_t match[4];
+     regex_t     compiled_m, compiled_p;
+     regmatch_t  match[4];
      gchar       * machine = NULL, * location = NULL, * base = NULL;
      gchar       * basename = NULL;
 
@@ -330,7 +329,6 @@ extract_base_name(URLType type, const gchar* path)
                                          match[2].rm_eo - match[2].rm_so);
                }
           }
-
      }
      else
      {
@@ -533,7 +531,7 @@ load_to_stream( GncHtmlWebkit* self, URLType type,
                          g_strdup_printf( error_404_format,
                                           _(error_404_title), _(error_404_body) );
                     webkit_web_view_load_html (priv->web_view, fdata,
-					       BASE_URI_NAME);
+                           BASE_URI_NAME);
                }
 
                g_free( fdata );
@@ -546,7 +544,6 @@ load_to_stream( GncHtmlWebkit* self, URLType type,
                     }
                     /* No action required: Webkit jumps to the anchor on its own. */
                }
-
                return;
           }
      }
@@ -580,7 +577,6 @@ load_to_stream( GncHtmlWebkit* self, URLType type,
                {
                     gnc_build_url( type, location, label );
                }
-
           }
           else
           {
@@ -593,26 +589,25 @@ load_to_stream( GncHtmlWebkit* self, URLType type,
                webkit_web_view_load_html (priv->web_view, fdata, BASE_URI_NAME);
                g_free( fdata );
           }
-
      }
      while ( FALSE );
 }
 #ifdef WEBKIT2_4
 static gboolean
 perform_navigation_policy (WebKitWebView *web_view,
-			   WebKitNavigationPolicyDecision *decision,
-			   GncHtml *self)
+               WebKitNavigationPolicyDecision *decision,
+               GncHtml *self)
 {
      WebKitURIRequest *req = NULL;
      const gchar* uri; // Can't init it here.
      gchar *scheme = NULL, *location = NULL, *label = NULL;
      WebKitNavigationAction *action =
-	  webkit_navigation_policy_decision_get_navigation_action (decision);
+      webkit_navigation_policy_decision_get_navigation_action (decision);
      if (webkit_navigation_action_get_navigation_type (action) !=
-	 WEBKIT_NAVIGATION_TYPE_LINK_CLICKED)
+         WEBKIT_NAVIGATION_TYPE_LINK_CLICKED)
      {
-	  webkit_policy_decision_use ((WebKitPolicyDecision*)decision);
-	  return TRUE;
+          webkit_policy_decision_use ((WebKitPolicyDecision*)decision);
+          return TRUE;
      }
      req = webkit_navigation_action_get_request (action);
      uri = webkit_uri_request_get_uri (req);
@@ -631,20 +626,20 @@ perform_navigation_policy (WebKitWebView *web_view,
 
 static gboolean
 webkit_decide_policy_cb (WebKitWebView *web_view,
-			 WebKitPolicyDecision *decision,
-			 WebKitPolicyDecisionType decision_type,
-			 gpointer user_data)
+             WebKitPolicyDecision *decision,
+             WebKitPolicyDecisionType decision_type,
+             gpointer user_data)
 {
 /* This turns out to be the signal to intercept for handling a link-click. */
 #ifdef WEBKIT2_4
      if (decision_type != WEBKIT_POLICY_DECISION_TYPE_NAVIGATION_ACTION)
      {
-	  webkit_policy_decision_use (decision);
-	  return TRUE;
+          webkit_policy_decision_use (decision);
+          return TRUE;
      }
      return perform_navigation_policy (
-	  web_view, (WebKitNavigationPolicyDecision*) decision,
-	  GNC_HTML (user_data));
+      web_view, (WebKitNavigationPolicyDecision*) decision,
+      GNC_HTML (user_data));
 #else
      webkit_policy_decision_use (decision);
      return TRUE;
@@ -653,14 +648,14 @@ webkit_decide_policy_cb (WebKitWebView *web_view,
 
 static void
 webkit_mouse_target_cb (WebKitWebView *web_view, WebKitHitTestResult *hit,
-			guint modifiers, gpointer user_data)
+            guint modifiers, gpointer user_data)
 {
      GncHtmlWebkitPrivate* priv;
      GncHtmlWebkit *self = (GncHtmlWebkit*)user_data;
      gchar *uri;
 
      if (!webkit_hit_test_result_context_is_link (hit))
-	  return;
+         return;
 
      priv = GNC_HTML_WEBKIT_GET_PRIVATE (self);
      uri = g_strdup (webkit_hit_test_result_get_link_uri (hit));
@@ -669,13 +664,13 @@ webkit_mouse_target_cb (WebKitWebView *web_view, WebKitHitTestResult *hit,
      if (priv->base.flyover_cb)
      {
           (priv->base.flyover_cb) (GNC_HTML (self), uri,
-				   priv->base.flyover_cb_data);
+                   priv->base.flyover_cb_data);
      }
 }
 #if WEBKIT_MINOR_VERSION >= 8
 static gboolean
 webkit_notification_cb (WebKitWebView* web_view, WebKitNotification *note,
-			gpointer user_data)
+            gpointer user_data)
 {
      GtkWindow *top = NULL;
      GtkWidget *dialog = NULL;
@@ -963,7 +958,6 @@ impl_webkit_show_url( GncHtml* self, URLType type,
 
           }
           while ( FALSE );
-
      }
      else
      {
@@ -1056,7 +1050,7 @@ impl_webkit_copy_to_clipboard( GncHtml* self )
 
      priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
      webkit_web_view_execute_editing_command (priv->web_view,
-					      WEBKIT_EDITING_COMMAND_COPY);
+                          WEBKIT_EDITING_COMMAND_COPY);
 }
 
 /**************************************************************

--- a/gnucash/register/register-gnome/gnucash-register.c
+++ b/gnucash/register/register-gnome/gnucash-register.c
@@ -272,10 +272,6 @@ gnucash_register_sheet_resize (GnucashRegister *reg)
     if (!reg->hscrollbar_visible)
         gtk_widget_queue_resize (GTK_WIDGET (reg->sheet));
 
-    // Make sure the sheet is the focus
-    if (!gtk_widget_has_focus(GTK_WIDGET (reg->sheet)))
-        gtk_widget_grab_focus (GTK_WIDGET (reg->sheet));
-
     return FALSE;
 }
 

--- a/gnucash/register/register-gnome/gnucash-sheet.c
+++ b/gnucash/register/register-gnome/gnucash-sheet.c
@@ -746,6 +746,14 @@ gnucash_sheet_redraw_block (GnucashSheet *sheet, VirtualCellLocation vcell_loc)
     gtk_widget_queue_draw_area (GTK_WIDGET(sheet), x, y, w + 1, h + 1);
 }
 
+gboolean
+gnucash_sheet_is_read_only (GnucashSheet *sheet)
+{
+    g_return_val_if_fail (sheet != NULL, TRUE);
+    g_return_val_if_fail (GNUCASH_IS_SHEET(sheet), TRUE);
+    return gnc_table_model_read_only (sheet->table->model);
+}
+
 static void
 gnucash_sheet_finalize (GObject *object)
 {

--- a/gnucash/register/register-gnome/gnucash-sheet.h
+++ b/gnucash/register/register-gnome/gnucash-sheet.h
@@ -110,5 +110,7 @@ void gnucash_sheet_set_text_bounds (GnucashSheet *sheet, GdkRectangle *rect,
 gint gnucash_sheet_get_text_offset (GnucashSheet *sheet, const VirtualLocation virt_loc,
                                     gint rect_width, gint logical_width);
 
+gboolean gnucash_sheet_is_read_only (GnucashSheet *sheet);
+
 /** @} */
 #endif


### PR DESCRIPTION
The main focus of these changes make the notebook page contents the primary focus so that you can use the keyboard straight away. Also stepping through the pages with ctrl+alt+pg_up/pg_down works consistently.

All seems to work as expected.
Bob