### PR TITLE
bugfix incorrect min-date handling

### DIFF
--- a/src/report/report-system/report-collectors.scm
+++ b/src/report/report-system/report-collectors.scm
@@ -155,7 +155,7 @@
     (list min-date max-date datepairs)))
 
 (define (category-report-dates-accumulate dates)
-  (let* ((min-date (gnc:secs->timepair 0))
+  (let* ((min-date (decdate (car (list-min-max dates gnc:timepair-lt)) DayDelta))
 	 (max-date (cdr (list-min-max dates gnc:timepair-lt)))
 	 (datepairs (reverse! (cdr (fold (lambda (next acc)
 					   (let ((prev (car acc))


### PR DESCRIPTION
This bugfix affects net-linechart and net-barchart - assumes the min-date for dates must be 0. Net worth bar & line charts with dates earlier than 01-01-1970 were incorrect. I'll fix in time64-ftw as well.