### PR TITLE
ENH: display infobox when no accounts matched

### DIFF
--- a/gnucash/report/standard-reports/transaction.scm
+++ b/gnucash/report/standard-reports/transaction.scm
@@ -1811,7 +1811,7 @@ tags within description, notes or memo. ")
                 (gnc:html-markup-h2 NO-MATCHING-ACCT-HEADER)
                 (gnc:html-markup-p NO-MATCHING-ACCT-TEXT)))
 
-              (if (member 'nomatch infobox-display)
+              (if (member 'no-match infobox-display)
                   (gnc:html-document-add-object!
                    document
                    (infobox)))))


### PR DESCRIPTION
Bugfix infobox display when no accounts were matched. Good catch @gjanssens 