### PR TITLE
timepair->time64 scheme & some API changes in C

### DIFF
--- a/gnucash/gnome-utils/window-main-summarybar.c
+++ b/gnucash/gnome-utils/window-main-summarybar.c
@@ -142,8 +142,6 @@ gnc_ui_accounts_recurse (Account *parent, GList **currency_list,
     GNCCurrencyAcc *non_curr_accum = NULL;
     GList *children, *node;
     gboolean non_currency = FALSE;
-    Timespec end_timespec;
-    Timespec start_timespec;
 
     if (parent == NULL) return;
 
@@ -190,12 +188,11 @@ gnc_ui_accounts_recurse (Account *parent, GList **currency_list,
         case ACCT_TYPE_PAYABLE:
         case ACCT_TYPE_RECEIVABLE:
             end_amount = xaccAccountGetBalanceAsOfDate(account, options.end_date);
-            timespecFromTime64(&end_timespec, options.end_date);
             end_amount_default_currency =
                 gnc_pricedb_convert_balance_nearest_price (pricedb, end_amount,
                                                            account_currency,
                                                            to_curr,
-                                                           end_timespec);
+                                                           options.end_date);
 
             if (!non_currency || options.non_currency)
             {
@@ -226,20 +223,18 @@ gnc_ui_accounts_recurse (Account *parent, GList **currency_list,
         case ACCT_TYPE_INCOME:
         case ACCT_TYPE_EXPENSE:
             start_amount = xaccAccountGetBalanceAsOfDate(account, options.start_date);
-            timespecFromTime64(&start_timespec, options.start_date);
             start_amount_default_currency =
                 gnc_pricedb_convert_balance_nearest_price (pricedb,
                                                            start_amount,
                                                            account_currency,
                                                            to_curr,
-                                                           start_timespec);
+                                                           options.start_date);
             end_amount = xaccAccountGetBalanceAsOfDate(account, options.end_date);
-            timespecFromTime64(&end_timespec, options.end_date);
             end_amount_default_currency =
                 gnc_pricedb_convert_balance_nearest_price (pricedb, end_amount,
                                                            account_currency,
                                                            to_curr,
-                                                           end_timespec);
+                                                           options.end_date);
 
             if (!non_currency || options.non_currency)
             {

--- a/gnucash/report/standard-reports/transaction.scm
+++ b/gnucash/report/standard-reports/transaction.scm
@@ -1071,7 +1071,7 @@ tags within description, notes or memo. ")
           ((damount (lambda (s) (if (gnc:split-voided? s)
                                     (xaccSplitVoidFormerAmount s)
                                     (xaccSplitGetAmount s))))
-           (trans-date (lambda (s) (gnc-transaction-get-date-posted (xaccSplitGetParent s))))
+           (trans-date (lambda (s) (xaccTransGetDate (xaccSplitGetParent s))))
            (currency (lambda (s) (xaccAccountGetCommodity (xaccSplitGetAccount s))))
            (report-currency (lambda (s) (if (column-uses? 'common-currency)
                                             (opt-val gnc:pagename-general optname-currency)
@@ -1087,7 +1087,6 @@ tags within description, notes or memo. ")
                                      (gnc-commodity-get-mnemonic
                                       (opt-val gnc:pagename-general optname-currency)))
                                     ""))))
-           (time64CanonicalDayTime (lambda (t64)  (gnc-tm-set-day-middle (gnc-localtime t64))))
            (convert (lambda (s num)
                       (gnc:exchange-by-pricedb-nearest
                        (gnc:make-gnc-monetary (currency s) num)
@@ -1095,7 +1094,7 @@ tags within description, notes or memo. ")
                        ;; Use midday as the transaction time so it matches a price
                        ;; on the same day.  Otherwise it uses midnight which will
                        ;; likely match a price on the previous day
-                       (timespecCanonicalDayTime (trans-date s)))))
+                       (time64CanonicalDayTime (trans-date s)))))
            (split-value (lambda (s) (convert s (damount s)))) ; used for correct debit/credit
            (amount (lambda (s) (split-value s)))
            (debit-amount (lambda (s) (and (positive? (gnc:gnc-monetary-amount (split-value s)))

--- a/libgnucash/engine/Account.cpp
+++ b/libgnucash/engine/Account.cpp
@@ -3424,7 +3424,6 @@ xaccAccountConvertBalanceToCurrencyAsOfDate(const Account *acc, /* for book */
 {
     QofBook *book;
     GNCPriceDB *pdb;
-    Timespec ts;
 
     if (gnc_numeric_zero_p (balance) ||
             gnc_commodity_equiv (balance_currency, new_currency))
@@ -3433,11 +3432,8 @@ xaccAccountConvertBalanceToCurrencyAsOfDate(const Account *acc, /* for book */
     book = gnc_account_get_book (acc);
     pdb = gnc_pricedb_get_db (book);
 
-    ts.tv_sec = date;
-    ts.tv_nsec = 0;
-
     balance = gnc_pricedb_convert_balance_nearest_price(
-                  pdb, balance, balance_currency, new_currency, ts);
+                  pdb, balance, balance_currency, new_currency, date);
 
     return balance;
 }

--- a/libgnucash/engine/gnc-pricedb.c
+++ b/libgnucash/engine/gnc-pricedb.c
@@ -2676,9 +2676,12 @@ gnc_pricedb_convert_balance_nearest_price(GNCPriceDB *pdb,
         gnc_numeric balance,
         const gnc_commodity *balance_currency,
         const gnc_commodity *new_currency,
-        Timespec t)
+        time64 t64)
 {
+    Timespec t;
     gnc_numeric new_value;
+
+    t.tv_sec = t64;
 
     if (gnc_numeric_zero_p (balance) ||
         gnc_commodity_equiv (balance_currency, new_currency))

--- a/libgnucash/engine/gnc-pricedb.h
+++ b/libgnucash/engine/gnc-pricedb.h
@@ -604,7 +604,7 @@ gnc_pricedb_convert_balance_nearest_price(GNCPriceDB *pdb,
                                           gnc_numeric balance,
                                           const gnc_commodity *balance_currency,
                                           const gnc_commodity *new_currency,
-                                          Timespec t);
+                                          time64 t64);
 
 typedef gboolean (*GncPriceForeachFunc)(GNCPrice *p, gpointer user_data);
 


### PR DESCRIPTION
Follow on from #256 time64 changes manually verified
Context: https://code.gnucash.org/logs/2018/01/08.html#T06:25:15