### PR TITLE
Scheme future

### DIFF
--- a/gnucash/report/standard-reports/income-gst-statement.scm
+++ b/gnucash/report/standard-reports/income-gst-statement.scm
@@ -63,10 +63,10 @@ accounts must be of type ASSET for taxes paid on expenses, and type LIABILITY fo
   ;; split -> bool
   ;;
   ;; additional split filter - returns #t if split must be included
-  ;; we need to exclude Closing, Link and Payment transactions
+  ;; we need to exclude Link and Payment transactions
   (let ((trans (xaccSplitGetParent split)))
-    (and (member (xaccTransGetTxnType trans) (list TXN-TYPE-NONE TXN-TYPE-INVOICE))
-         (not (xaccTransGetIsClosingTxn trans)))))
+    (memv (xaccTransGetTxnType trans) (list TXN-TYPE-NONE TXN-TYPE-INVOICE))
+    ))
 
 (define (gst-statement-options-generator)
 
@@ -115,6 +115,9 @@ for taxes paid on expenses, and type LIABILITY for taxes collected on sales.")
   (gnc:option-make-internal! options gnc:pagename-accounts "Filter Type")
   (gnc:option-make-internal! options gnc:pagename-accounts "Filter By...")
   (gnc:option-make-internal! options gnc:pagename-general "Show original currency amount")
+  ;; Disallow closing transactions
+  (gnc:option-set-value (gnc:lookup-option options gnc:pagename-filter "Closing Transactions") #f)
+  (gnc:option-make-internal! options gnc:pagename-filter "Closing Transactions")
   ;; Disable display options not being used anymore
   (gnc:option-make-internal! options gnc:pagename-display "Shares")
   (gnc:option-make-internal! options gnc:pagename-display "Price")

--- a/gnucash/report/standard-reports/transaction.scm
+++ b/gnucash/report/standard-reports/transaction.scm
@@ -242,8 +242,10 @@ in the Options panel."))
 (define (time64-quarter t64) (+ (* 10 (gnc:date-get-year (gnc-localtime t64)))  (gnc:date-get-quarter (gnc-localtime t64))))
 (define (time64-month t64)   (+ (* 100 (gnc:date-get-year (gnc-localtime t64))) (gnc:date-get-month (gnc-localtime t64))))
 (define (time64-week t64)    (gnc:date-get-week (gnc-localtime t64)))
+(define (time64-weekday t64) (gnc:time64-get-week-day t64))
 (define (time64-day t64)     (+ (* 500 (gnc:date-get-year (gnc-localtime t64))) (gnc:date-get-year-day (gnc-localtime t64))))
 (define (time64->daily-string t) (qof-print-date t))
+(define (time64->weekday-string t) (gnc:date-get-weekday-string (gnc-localtime t)))
 (define (split->time64 s) (xaccTransGetDate (xaccSplitGetParent s)))
 
 (define date-subtotal-list
@@ -261,6 +263,12 @@ in the Options panel."))
                 (cons 'text (_ "None"))
                 (cons 'tip (_ "None."))
                 (cons 'renderer-fn #f)))
+
+   (cons 'weekday (list
+                   (cons 'split-sortvalue (lambda (s) (time64-weekday (split->time64 s))))
+                   (cons 'text (_ "Weekday"))
+                   (cons 'tip (_ "Weekday."))
+                   (cons 'renderer-fn (lambda (s) (time64->weekday-string (split->time64 s))))))
 
    (cons 'daily (list
                   (cons 'split-sortvalue (lambda (s) (time64-day (split->time64 s))))
@@ -1791,6 +1799,7 @@ tags within description, notes or memo. ")
                 ((quarterly) (lambda (s) (time64-quarter (date s))))
                 ((weekly)    (lambda (s) (time64-week (date s))))
                 ((daily)     (lambda (s) (time64-day (date s))))
+                ((weekday)   (lambda (s) (time64-weekday (date s))))
                 ((none)      (lambda (s) (date s)))))
             (case key
               ((account-name) (lambda (s) (gnc-account-get-full-name (xaccSplitGetAccount s))))

--- a/libgnucash/app-utils/app-utils.scm
+++ b/libgnucash/app-utils/app-utils.scm
@@ -201,6 +201,7 @@
 (export gnc:date-get-quarter-year-string)
 (export gnc:date-get-month-string)
 (export gnc:date-get-month-year-string)
+(export gnc:date-get-weekday-string)
 (export gnc:date-get-week-year-string)
 (export gnc:leap-year?)
 (export gnc:days-in-year)

--- a/libgnucash/app-utils/date-utilities.scm
+++ b/libgnucash/app-utils/date-utilities.scm
@@ -85,6 +85,9 @@
 (define (gnc:date-get-month-year-string datevec)
   (gnc-locale-to-utf8 (strftime "%B %Y" datevec)))
 
+(define (gnc:date-get-weekday-string datevec)
+  (gnc-locale-to-utf8 (strftime "%A" datevec)))
+
 (define (gnc:date-get-week-year-string datevec)
   (let* ((beginweekt64 (* (gnc:time64-get-week
                             (gnc-mktime datevec))


### PR DESCRIPTION
PR opened for discussion - not for merging please. 

1. ~TR had 1 last time64 conversion, missed out on #259 (fixes report crashing if common-currency = #t)~

2. ~options.scm - allow interchange Num & Num/Action reading - will avoid some report crashes.~
 ~Display / Num & Num/Action are similar enough that I think they can be interchanged~

3. ~option.scm - make-internal! and unregister-option - option modification functions~
 ~3(a) income-gst-statement.scm uses them to modify and defer to the TR~

4. ~(infobox) -> can probably be renamed into (gnc:options->html) for inclusion in options.scm moved to (gnc:render-changed-options) in options.scm~

5. TR New Sortkey: weekday, e.g. which weekday generates most income?
    TR New default: exclude Closing txns - this is probably desirable.

6. ~TR - Subtotal Summary Grid - long-requested feature, which can be provided for free by the TR. I prefered to add here instead of augmenting other reports which I don't 100% understand.~

7. ~net-barchart.scm and net-linechart.scm merging - is this desirable? Unfortunately the API for linecharts and barcharts as defined in html-linechart.scm and html-barchart.scm are similar but named differently, which leads to net-charts.scm looking stilted with (if linechart?) clauses throughout. Perhaps html-linechart and html-barchart could be combined one day...~ --> moved to another branch based from master