### PR TITLE
correct typo in horizontal

### DIFF
--- a/gnucash/gnome/gschemas/org.gnucash.gschema.xml.in.in
+++ b/gnucash/gnome/gschemas/org.gnucash.gschema.xml.in.in
@@ -173,7 +173,7 @@
     <key name="grid-lines-horizontal" type="b">
       <default>false</default>
       <summary>Show Horizontal Grid Lines</summary>
-      <description>If active, horzontal grid lines will be shown on table displays. Otherwise no horizontal grid lines will be shown.</description>
+      <description>If active, horizontal grid lines will be shown on table displays. Otherwise no horizontal grid lines will be shown.</description>
     </key>
     <key name="grid-lines-vertical" type="b">
       <default>false</default>

--- a/gnucash/register/register-gnome/gnucash-register.c
+++ b/gnucash/register/register-gnome/gnucash-register.c
@@ -267,7 +267,7 @@ gnucash_register_goto_next_matching_row (GnucashRegister *reg,
 static gboolean
 gnucash_register_sheet_resize (GnucashRegister *reg)
 {
-    // Sometimes the space left by the horzontal scrollbar does
+    // Sometimes the space left by the horizontal scrollbar does
     // not get filled on load, this makes sure it does
     if (!reg->hscrollbar_visible)
         gtk_widget_queue_resize (GTK_WIDGET (reg->sheet));


### PR DESCRIPTION
Correct two times 'horzontal' to 'horizontal' in the source code