### PR TITLE
BUGFIX: invoice posted-date is no longer 0 for unposted invoices

### DIFF
--- a/gnucash/report/business-reports/easy-invoice.scm
+++ b/gnucash/report/business-reports/easy-invoice.scm
@@ -776,12 +776,11 @@
           (add-html! document "</tr></table>")
         )
 
-        ; add the date
-        (let ((date-table #f)
-              (post-date (gncInvoiceGetDatePosted invoice))
-              (due-date (gncInvoiceGetDateDue invoice)))
-          (if (not (zero? post-date))
-            (begin
+        ;; add the date
+        (if (gncInvoiceIsPosted invoice)
+            (let ((date-table #f)
+                  (post-date (gncInvoiceGetDatePosted invoice))
+                  (due-date (gncInvoiceGetDateDue invoice)))
               (set! date-table (make-date-table))
               (make-date-row! date-table (_ "Date") post-date date-format)
               (if (opt-val "Display" "Due Date")
@@ -790,7 +789,7 @@
             (add-html! document
 		       (string-append "<font color='red'>"
 				      (_ "INVOICE NOT POSTED")
-				      "</font>"))))
+				      "</font>")))
 
         (make-break! document)
 

--- a/gnucash/report/business-reports/fancy-invoice.scm
+++ b/gnucash/report/business-reports/fancy-invoice.scm
@@ -857,19 +857,17 @@
 	   'attribute (list "cellpadding" 0)
 	   'attribute (list "width" "100%"))
 
-	  (set! date-object (let ((date-table #f)
-		(post-date (gncInvoiceGetDatePosted invoice))
-		(due-date (gncInvoiceGetDateDue invoice)))
-
-	    (if (not (zero? post-date))
-		(begin
+          (set! date-object
+            (if (gncInvoiceIsPosted invoice)
+                (let ((date-table #f)
+                      (post-date (gncInvoiceGetDatePosted invoice))
+                      (due-date (gncInvoiceGetDateDue invoice)))
 		  (set! date-table (make-date-table))
-		  ;; oli-custom - moved invoice number here
 		  (gnc:html-table-append-row!
                   ;; Translators: %s below is "Invoice" or "Bill" or even the
                   ;; custom title from the options. The next column contains
                   ;; the number of the document.
-		   date-table (list (sprintf #f (_ "%s&nbsp;#") title) (gncInvoiceGetID invoice)))
+                  date-table (list (sprintf #f (_ "%s&nbsp;#") title) (gncInvoiceGetID invoice)))
                   ;; Translators: The first %s below is "Invoice" or
                   ;; "Bill" or even the custom title from the
                   ;; options. This string sucks for i18n, but I don't
@@ -879,10 +877,8 @@
 		  (make-date-row! date-table (_ "Due&nbsp;Date") due-date date-format)
 		  date-table)
 		(gnc:make-html-text
-		  ;; oli-custom - FIXME: I have a feeling I broke a
-          ;; translation by not using string-expand for &nbsp;
-		  (string-append title "<br>"
-            (_ "Invoice in progress..."))))))
+                 (string-append title "<br>"
+                                (_ "Invoice in progress...")))))
 
 	  (gnc:html-table-append-row!
 	  	helper-table

--- a/gnucash/report/business-reports/invoice.scm
+++ b/gnucash/report/business-reports/invoice.scm
@@ -708,22 +708,18 @@
 	   document
 	   (make-myname-table book date-format))
 
-	  (let ((date-table #f)
-		(post-date (gncInvoiceGetDatePosted invoice))
-		(due-date (gncInvoiceGetDateDue invoice)))
-
-	    (if (not (zero? post-date))
-		(begin
-		  (set! date-table (make-date-table))
-		  (make-date-row! date-table (string-append title " " (_ "Date")) post-date date-format)
-		  (make-date-row! date-table (_ "Due Date") due-date date-format)
-		  (gnc:html-document-add-object! document date-table))
-		(gnc:html-document-add-object!
-		 document
-		 (gnc:make-html-text
-		  (_ "Invoice in progress...")))))
-      
-    
+          (if (gncInvoiceIsPosted invoice)
+              (let ((date-table #f)
+                    (post-date (gncInvoiceGetDatePosted invoice))
+                    (due-date (gncInvoiceGetDateDue invoice)))
+                (set! date-table (make-date-table))
+                (make-date-row! date-table (string-append title " " (_ "Date")) post-date date-format)
+                (make-date-row! date-table (_ "Due Date") due-date date-format)
+                (gnc:html-document-add-object! document date-table))
+              (gnc:html-document-add-object!
+               document
+               (gnc:make-html-text
+                (_ "Invoice in progress..."))))
 
 	  (make-break! document)
 	  (make-break! document)

--- a/gnucash/report/business-reports/job-report.scm
+++ b/gnucash/report/business-reports/job-report.scm
@@ -193,7 +193,7 @@
     (if (date-due-col column-vector)
 	(addto! row-contents 
 		(if (and due-date
-			 (not (zero? due-date)))
+			 (gncInvoiceDateExists due-date))
 		    (qof-print-date due-date)
 		    "")))
     (if (num-col column-vector)

--- a/gnucash/report/business-reports/owner-report.scm
+++ b/gnucash/report/business-reports/owner-report.scm
@@ -291,7 +291,7 @@
     (if (date-due-col column-vector)
         (addto! row-contents 
          (if (and due-date
-              (not (zero? due-date)))
+                  (gncInvoiceDateExists due-date))
              (qof-print-date due-date)
              "")))
     (if (num-col column-vector)

--- a/gnucash/report/business-reports/taxinvoice.eguile.scm
+++ b/gnucash/report/business-reports/taxinvoice.eguile.scm
@@ -246,7 +246,7 @@
         <td align="right" class="invnum"><big><strong><?scm:d invoiceid ?></strong></big></td>
       </tr>
       <?scm )) ?>
-      <?scm (if (zero? postdate) (begin ?>
+      <?scm (if (not (gncInvoiceDateExists postdate)) (begin ?>
         <tr>
            <td colspan="2" align="right"><?scm:d (_ "Invoice in progress...") ?></td>
         </tr>

--- a/libgnucash/engine/gncInvoice.c
+++ b/libgnucash/engine/gncInvoice.c
@@ -1856,7 +1856,7 @@ gncInvoiceApplyPayment (const GncInvoice *invoice, Transaction *txn,
     gncOwnerAutoApplyPaymentsWithLots (owner, selected_lots);
 }
 
-static gboolean gncInvoiceDateExists (time64 date)
+gboolean gncInvoiceDateExists (time64 date)
 {
     return date != INT64_MAX;
 }

--- a/libgnucash/engine/gncInvoice.h
+++ b/libgnucash/engine/gncInvoice.h
@@ -275,6 +275,7 @@ static inline GncInvoice * gncInvoiceLookup (const QofBook *book, const GncGUID 
 void gncInvoiceBeginEdit (GncInvoice *invoice);
 void gncInvoiceCommitEdit (GncInvoice *invoice);
 int gncInvoiceCompare (const GncInvoice *a, const GncInvoice *b);
+gboolean gncInvoiceDateExists (time64 date);
 gboolean gncInvoiceIsPosted (const GncInvoice *invoice);
 gboolean gncInvoiceIsPaid (const GncInvoice *invoice);
 


### PR DESCRIPTION
This commit fixes business reports caused by 91f4b190394df6
whereby the posted-date for unposted invoice was changed
from 0 to MAXINT. Now we need to use (gncInvoiceIsPosted)
or (gncInvoiceDateExists) instead.