### PR TITLE
fix syntax of example qif file

### DIFF
--- a/gnucash/import-export/qif-imp/file-format.txt
+++ b/gnucash/import-export/qif-imp/file-format.txt
@@ -392,6 +392,8 @@ Investment Transactions
 !Account
 NAssets:Investments:Mutual Fund
 TInvst
+^
+!Type:Invst
 D10/30/2006
 Q0.9
 T500
@@ -400,6 +402,7 @@ NBuyX
 L[Assets:Investments:Mutual Fund:Cash]
 YFOO
 ^
+!Type:Invst
 D11/28/2006
 Q0.897
 T100


### PR DESCRIPTION
Attempting to import the given example .qif file results in an error about an unrecognized credit limit format. It appears that this is caused by a lack of transaction breaks between the !Account header and the individual transactions. Adding the breaks as in this pull request appears to fix the example; I can successfully import this .qif file into GnuCash, and the transaction appears correct.