### PR TITLE
Updated info and migrated to the latest AppStream specs

### DIFF
--- a/gnucash/gnome/gnucash.appdata.xml.in
+++ b/gnucash/gnome/gnucash.appdata.xml.in
@@ -1,34 +1,48 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<application>
- <id type="desktop">org.gnucash.Gnucash</id>
- <licence>CC0</licence>
- <description>
-  <_p>
-   GnuCash is a program for personal and small-business financial-accounting.
-  </_p>
-  <_p>
-   Designed to be easy to use, yet powerful and flexible, GnuCash allows you
-   to track bank accounts, stocks, income and expenses. As quick
-   and intuitive to use as a checkbook register, it is based on professional
-   accounting principles like double-entry accounting to ensure balanced books
-   and accurate reports. 
-  </_p>
-  <_p>With GnuCash you can (but are not limited to):</_p>
-  <ul>
-   <_li>Keep track of your day to day personal income and expenses</_li>
-   <_li>Manage your stock, bond and mutual fund accounts with ease</_li>
-   <_li>Keep your small business' accounting up to date</_li>
-   <_li>Create accurate reports and graphs from your financial data</_li>
-   <_li>Set up scheduled transactions to avoid repeated data entry</_li>
-   <_li>QIF/OFX/HBCI Import, Transaction Matching</_li>
-   <_li>Perform financial calculations, such as a loan repayment</_li>
-  </ul>
- </description>
- <screenshots>
-  <screenshot type="default" width="1049" height="590">http://www.gnucash.org/images/features/feature_accounts_lg.png</screenshot>
-  <screenshot width="1049" height="590">http://www.gnucash.org/images/features/feature_register_lg.png</screenshot>
-  <screenshot width="1049" height="590">http://www.gnucash.org/images/features/feature_bar_chart_lg.png</screenshot>
- </screenshots>
- <url type="homepage">http://www.gnucash.org/</url>
- <updatecontact>gnucash-devel@gnucash.org</updatecontact>
-</application>
+<component>
+  <id type="desktop">org.gnucash.Gnucash</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0+</project_license>
+  <name>GnuCash</name>
+  <summary>Manage your finances, accounts, and investments</summary>
+  <description>
+    <_p>
+      GnuCash is a program for personal and small-business financial-accounting.
+    </_p>
+    <_p>
+      Designed to be easy to use, yet powerful and flexible, GnuCash allows you to track bank accounts, stocks, income and expenses. As quick and intuitive to use as a checkbook register, it is based on professional accounting principles like double-entry
+      accounting to ensure balanced books and accurate reports.
+    </_p>
+    <_p>With GnuCash you can (but are not limited to):</_p>
+    <ul>
+      <_li>Keep track of your day to day personal income and expenses</_li>
+      <_li>Manage your stock, bond and mutual fund accounts with ease</_li>
+      <_li>Keep your small business' accounting up to date</_li>
+      <_li>Create accurate reports and graphs from your financial data</_li>
+      <_li>Set up scheduled transactions to avoid repeated data entry</_li>
+      <_li>QIF/OFX/HBCI Import, Transaction Matching</_li>
+      <_li>Perform financial calculations, such as a loan repayment</_li>
+    </ul>
+  </description>
+  <categories>
+    <category>Finance</category>
+  </categories>
+  <screenshots>
+    <screenshot type="default">
+      <image type="source" width="1049" height="590">https://www.gnucash.org/images/features/feature_accounts_lg.png</image>
+    </screenshot>
+    <screenshot>
+      <image type="source" width="1049" height="590">https://www.gnucash.org/images/features/feature_register_lg.png</image>
+    </screenshot>
+    <screenshot>
+      <image type="source" width="1049" height="590">https://www.gnucash.org/images/features/feature_bar_chart_lg.png</image>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">https://www.gnucash.org</url>
+  <url type="bugtracker">https://bugzilla.gnome.org</url>
+  <url type="faq">https://wiki.gnucash.org/wiki/FAQ</url>
+  <url type="help">https://gnucash.org/docs.phtml</url>
+  <url type="donation">https://gnucash.org/donate.phtml</url>
+  <url type="translate">https://wiki.gnucash.org/wiki/Translation</url>
+  <update_contact>gnucash-devel@gnucash.org</update_contact>
+</component>


### PR DESCRIPTION
+ Specified metadata license
+ Added required nametag
+ Added required project license
+ Added required summary
+ Changed urls to https
+ Fixed screenshot tags
+ Added category
+ Added url for bugtracker, faq, help, donation and translate

I have not removed the current underscore prefixes as you may want to migrate from the deprecated intltool to modern gettext before doing so. Relevant information:
- https://blogs.gnome.org/mclasen/2016/07/21/using-modern-gettext/
- https://wiki.gnome.org/MigratingFromIntltoolToGettext