### PR TITLE
BUGFIX: numeric->number in commodity-utilities.scm 

### DIFF
--- a/gnucash/report/report-system/commodity-utilities.scm
+++ b/gnucash/report/report-system/commodity-utilities.scm
@@ -531,8 +531,8 @@
 
 (define (create-commodity-list inner-comm outer-comm value-amount share-amount)
   (let ((pair (list inner-comm
-                    (cons (gnc:make-numeric-collector)
-                          (gnc:make-numeric-collector)))))
+                    (cons (gnc:make-number-collector)
+                          (gnc:make-number-collector)))))
     ((caadr pair) 'add value-amount)
     ((cdadr pair) 'add share-amount)
     (set comm-list (list outer-comm (list pair)))))


### PR DESCRIPTION
I think this patches correctly for now.
Addendum to e0300d3 - was crashing reports.
And 45f61a3 had couple bugs.
value/share swapped
no need to define comm-list in create-commodity-list