### PR TITLE
bug 793278 fix for maint

### DIFF
--- a/src/report/report-system/report-collectors.scm
+++ b/src/report/report-system/report-collectors.scm
@@ -94,7 +94,8 @@
 	 (slotset (make-slotset (lambda (split)
 				  (let* ((date (split->date split))
 					 (interval-index (binary-search-lt (lambda (pair date)
-									     (gnc:timepair-le (car pair) date))
+									     (or (not (car pair))
+                                                                                 (gnc:timepair-le (car pair) date)))
 									   (cons date 0)
 									   date-vector))
 					 (interval (vector-ref date-vector interval-index)))
@@ -155,7 +156,7 @@
     (list min-date max-date datepairs)))
 
 (define (category-report-dates-accumulate dates)
-  (let* ((min-date (decdate (car (list-min-max dates gnc:timepair-lt)) DayDelta))
+  (let* ((min-date #f)
 	 (max-date (cdr (list-min-max dates gnc:timepair-lt)))
 	 (datepairs (reverse! (cdr (fold (lambda (next acc)
 					   (let ((prev (car acc))


### PR DESCRIPTION
This is caused by commit 766e74096 - min-date was
erroneously thought to mean 'min date of date-list'
but actually meant 'negative infinity date'. This
commit changes date comparison logic to always
return #t when comparing
(gnc:timepair-le min-date date) for
the first date interval.

Test case also created. The test is derived from the
equivalent test in unstable.

I believe this fixes maint. I think merging onto unstable
will lead to conflicts, both to report-collectors.scm
and to the unit test. When resolving the conflict,
unstable must take priority.

This is the maint equivalent to #276 