### PR TITLE
WITH_PYTHON uses backwards compatible print().

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -240,6 +240,7 @@ Volodymyr M. Lisivka  Ukrainian translation
 Phil Longstaff  fixes for pricedb
 Duarte Loreto  message and documentation Portuguese translations
 Raffael Luthiger  Swiss German translation
+Idigo Luwum  for python build fix
 Lionel Elie Mamane  Patches for gcc2.95 macro compatibility
 Kjartan Maraas  Norwegian translations
 Heath Martin  gnome patches, major register work, x86_64 support

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -457,7 +457,7 @@ IF (WITH_PYTHON)
 
   # Determine where to install the python libraries.
   EXECUTE_PROCESS(
-    COMMAND ${PYTHON_EXECUTABLE} -c "from distutils import sysconfig; print sysconfig.get_python_lib(prefix='${CMAKE_INSTALL_PREFIX}', plat_specific=True)"
+    COMMAND ${PYTHON_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_python_lib(prefix='${CMAKE_INSTALL_PREFIX}', plat_specific=True))"
     RESULT_VARIABLE PYTHON_SYSCONFIG_RESULT
     OUTPUT_VARIABLE PYTHON_SYSCONFIG_OUTPUT
     ERROR_VARIABLE PYTHON_SYSCONFIG_ERROR


### PR DESCRIPTION
# Issue
If  `python3` is aliased or installed as `python` you will receive the following error.
```
CMake Error at CMakeLists.txt:468 (MESSAGE):
  Could not determine Python site-package directory:
    File "<string>", line 1
      from distutils import sysconfig; print sysconfig.get_python_lib(prefix='/usr', plat_specific=True)
                                                     ^
  SyntaxError: invalid syntax

```
# Proposed Solution
Use the print function with parenthesis for compatibility between versions 2 and 3.
