### PR TITLE
Cache a couple of split register preferences

### DIFF
--- a/gnucash/register/ledger-core/split-register-control.c
+++ b/gnucash/register/ledger-core/split-register-control.c
@@ -1019,7 +1019,8 @@ gnc_split_register_auto_completion (SplitRegister *reg,
         /* auto-complete the account name */
         cell = gnc_table_layout_get_cell (reg->table->layout, XFRM_CELL);
 
-        account_name = gnc_get_account_name_for_register (xaccSplitGetAccount (auto_split));
+        account_name = gnc_get_account_name_for_split_register (xaccSplitGetAccount (auto_split),
+                           reg->show_leaf_accounts);
         gnc_combo_cell_set_value ((ComboCell *) cell, account_name);
         g_free(account_name);
 

--- a/gnucash/register/ledger-core/split-register-model.c
+++ b/gnucash/register/ledger-core/split-register-model.c
@@ -573,7 +573,6 @@ gnc_split_register_get_cell_color_internal (VirtualLocation virt_loc,
     const char *cursor_name;
     VirtualCell *vcell;
     gboolean is_current;
-    gboolean double_alternate_virt;
     guint32 colorbase = 0;
 
      /* a bit of enum arithmetic */
@@ -617,11 +616,9 @@ gnc_split_register_get_cell_color_internal (VirtualLocation virt_loc,
             g_strcmp0 (cursor_name, CURSOR_DOUBLE_LEDGER) == 0 ||
             g_strcmp0 (cursor_name, CURSOR_DOUBLE_LEDGER_NUM_ACTN) == 0)
     {
-        double_alternate_virt = gnc_prefs_get_bool (GNC_PREFS_GROUP_GENERAL_REGISTER,
-                                                    GNC_PREF_ALT_COLOR_BY_TRANS);
         if (is_current)
         {
-            if (double_alternate_virt)
+            if (reg->double_alt_color)
                 return vcell->start_primary_color ?
                         (colorbase + COLOR_PRIMARY_ACTIVE) :
                         (colorbase + COLOR_SECONDARY_ACTIVE);
@@ -631,7 +628,7 @@ gnc_split_register_get_cell_color_internal (VirtualLocation virt_loc,
                     (colorbase + COLOR_SECONDARY_ACTIVE);
         }
 
-        if (double_alternate_virt)
+        if (reg->double_alt_color)
             return vcell->start_primary_color ?
                     (colorbase + COLOR_PRIMARY) :
                     (colorbase + COLOR_SECONDARY);
@@ -1383,7 +1380,8 @@ gnc_split_register_get_xfrm_entry (VirtualLocation virt_loc,
 
     g_free (name);
 
-    name = gnc_get_account_name_for_register (xaccSplitGetAccount (split));
+    name = gnc_get_account_name_for_split_register (xaccSplitGetAccount (split),
+               reg->show_leaf_accounts);
 
     return name;
 }
@@ -1424,7 +1422,8 @@ gnc_split_register_get_mxfrm_entry (VirtualLocation virt_loc,
     g_free (name);
 
     if (s)
-        name = gnc_get_account_name_for_register (xaccSplitGetAccount (s));
+        name = gnc_get_account_name_for_split_register (xaccSplitGetAccount (s),
+                   reg->show_leaf_accounts);
     else
     {
         /* For multi-split transactions and stock splits,
@@ -2164,8 +2163,8 @@ gnc_template_register_get_xfrm_entry (VirtualLocation virt_loc,
               "sx-account", &guid,
               NULL);
     account = xaccAccountLookup (guid, gnc_get_current_book ());
-    name = account ? gnc_get_account_name_for_register (account) : NULL;
-
+    name = account ? gnc_get_account_name_for_split_register (account,
+                         reg->show_leaf_accounts) : NULL;
     return name;
 }
 

--- a/gnucash/register/ledger-core/split-register.h
+++ b/gnucash/register/ledger-core/split-register.h
@@ -249,6 +249,9 @@ struct split_register
     gboolean use_tran_num_for_num_field;  /**< whether to use transaction number
                                                 or split action for number
                                                 field in register */
+    gboolean show_leaf_accounts; /**< whether to show full account names */
+    gboolean double_alt_color;   /**< whether transaction use alternate colors */
+
     gboolean is_template;
     gboolean do_auto_complete; /**< whether to use auto-completion */
 

--- a/libgnucash/app-utils/gnc-ui-util.c
+++ b/libgnucash/app-utils/gnc-ui-util.c
@@ -412,16 +412,22 @@ gnc_get_current_commodities (void)
 }
 
 gchar *
+gnc_get_account_name_for_split_register(const Account *account, gboolean show_leaf_accounts)
+{
+    if (show_leaf_accounts)
+        return g_strdup (xaccAccountGetName (account));
+    else
+        return gnc_account_get_full_name (account);
+}
+
+gchar *
 gnc_get_account_name_for_register(const Account *account)
 {
     gboolean show_leaf_accounts;
     show_leaf_accounts = gnc_prefs_get_bool(GNC_PREFS_GROUP_GENERAL_REGISTER,
                                             GNC_PREF_SHOW_LEAF_ACCT_NAMES);
 
-    if (show_leaf_accounts)
-        return g_strdup (xaccAccountGetName (account));
-    else
-        return gnc_account_get_full_name (account);
+    return gnc_get_account_name_for_split_register(account, show_leaf_accounts);
 }
 
 Account *

--- a/libgnucash/app-utils/gnc-ui-util.h
+++ b/libgnucash/app-utils/gnc-ui-util.h
@@ -140,6 +140,17 @@ gchar *gnc_get_account_name_for_register(const Account *account);
 Account *gnc_account_lookup_for_register(const Account *base_account, const
         gchar *name);
 
+/**
+ * Get either the full name of the account or the simple name, depending on the
+ * show_leaf_accounts.
+ *
+ * @param account The account to retrieve the name for.
+ * @param show_leaf_accounts Whether the full name will be returned.
+ * @return A newly allocated string.
+*/
+gchar *gnc_get_account_name_for_split_register(const Account *account,
+        gboolean show_leaf_accounts);
+
 /*
  * This is a wrapper routine around an xaccGetBalanceInCurrency
  * function that handles additional needs of the gui.


### PR DESCRIPTION
Two preferences were being used heavily in the drawing of the register especially when it is obscured so it makes sense for them to be saved in the split_register structure so they can be easily be referenced.