### PR TITLE
tests: Skip tests for dates on 32-bit platforms which cannot be representated

### DIFF
--- a/libgnucash/engine/test/gtest-gnc-timezone.cpp
+++ b/libgnucash/engine/test/gtest-gnc-timezone.cpp
@@ -154,6 +154,14 @@ TEST(gnc_timezone_constructors, test_IANA_Perth_tz)
         }
         else if (year < 1916)
 #else
+        if (year < 1902)
+        {
+            // Earliest timestamp which can be represented on a 32-bit
+            // system is "1901-12-13 20:45:52" -- so skip tests until we
+            // reach a year >1901 to be safe
+            continue;
+        }
+
         if (year < 1916)
 #endif
         {
@@ -216,6 +224,14 @@ TEST(gnc_timezone_constructors, test_IANA_Minsk_tz)
         }
         else if (year < 1924)
 #else
+        if (year < 1902)
+        {
+            // Earliest timestamp which can be represented on a 32-bit
+            // system is "1901-12-13 20:45:52" -- so skip tests until we
+            // reach a year >1901 to be safe
+            continue;
+        }
+
         if (year < 1924)
 #endif
         {


### PR DESCRIPTION
Tests "test_IANA_Perth_tz" and "test_IANA_Minsk_tz" are failing on 32-bit
platforms because the earliest timestamp which can be representated on a
32-bit platform is "1901-12-13 20:45:52" but the test ranges start before
that date.

To be safe, this commit will add code to skip tests before year 1902 on
32-bit platforms.

Bug: https://bugs.gentoo.org/647596