### PR TITLE
Unstable prepare srfi64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,6 +323,17 @@ IF (NOT GUILE_EXECUTABLE)
   MESSAGE (SEND_ERROR "The guile executable was not found, but is required. Please set GUILE_EXECUTABLE.")
 ENDIF (NOT GUILE_EXECUTABLE)
 
+# Test that guile has SRFI-64. This is required for some unit tests.
+execute_process (COMMAND ${GUILE_EXECUTABLE} -c "(use-modules (srfi srfi-64))"
+  RESULT_VARIABLE GNC_SRFI64_RESULT
+  ERROR_QUIET
+)
+
+if (GNC_SRFI64_RESULT EQUAL 0)
+  message (STATUS "Using guile SRFI-64")
+  set (HAVE_SRFI64 TRUE)
+endif ()
+
 # ############################################################
 IF (WITH_AQBANKING)
   GNC_PKG_CHECK_MODULES (GWENHYWFAR REQUIRED gwenhywfar)

--- a/gnucash/report/report-system/html-document.scm
+++ b/gnucash/report/report-system/html-document.scm
@@ -157,6 +157,7 @@
                 ;;./share/gnucash/scm/gnucash/report/taxinvoice.eguile.scm:<html>
                 ;;./share/gnucash/scm/gnucash/report/balsheet-eg.eguile.scm:<html>
 
+                (push "<html>\n")
                 (push "<head>\n")
                 (push "<meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\" />\n")
                 (if css?

--- a/gnucash/report/standard-reports/test/CMakeLists.txt
+++ b/gnucash/report/standard-reports/test/CMakeLists.txt
@@ -6,6 +6,9 @@ SET(scm_test_standard_reports_SOURCES
   test-standard-net-linechart.scm
 )
 
+set(scm_test_with_srfi64_SOURCES
+)
+
 SET(scm_test_report_SUPPORT
   test-generic-category-report.scm
   test-generic-net-barchart.scm
@@ -23,6 +26,11 @@ set(GUILE_DEPENDS
   scm-standard-reports
   scm-report-stylesheets
   )
+
+if (HAVE_SRFI64)
+  gnc_add_scheme_tests("${scm_test_with_srfi64_SOURCES}")
+endif (HAVE_SRFI64)
+
 GNC_ADD_SCHEME_TESTS("${scm_test_standard_reports_SOURCES}")
 
 GNC_ADD_SCHEME_TARGETS(scm-test-standard-support
@@ -41,4 +49,5 @@ GNC_ADD_SCHEME_TARGETS(scm-test-standard-reports
 add_dependencies(check scm-test-standard-reports)
 
 SET_DIST_LIST(test_standard_reports_DIST CMakeLists.txt 
+  ${scm_test_with_srfi64_SOURCES}
   ${scm_test_standard_reports_SOURCES} ${scm_test_report_SUPPORT})

--- a/gnucash/report/standard-reports/transaction.scm
+++ b/gnucash/report/standard-reports/transaction.scm
@@ -1095,7 +1095,7 @@ tags within description, notes or memo. ")
                                 str
                                 (if (column-uses? 'common-currency)
                                     (string-append
-                                     "<br>"
+                                     "<br />"
                                      (gnc-commodity-get-mnemonic
                                       (opt-val gnc:pagename-general optname-currency)))
                                     ""))))

--- a/gnucash/report/standard-reports/transaction.scm
+++ b/gnucash/report/standard-reports/transaction.scm
@@ -987,7 +987,7 @@ tags within description, notes or memo. ")
                                (lambda (split transaction-row?)
                                  (gnc:make-html-table-cell/markup
                                   "date-cell"
-                                  (if (eq? (xaccSplitGetReconcile split) #\y)
+                                  (if (eqv? (xaccSplitGetReconcile split) #\y)
                                       (qof-print-date (xaccSplitGetDateReconciled split))
                                       "")))))
 

--- a/libgnucash/app-utils/options.scm
+++ b/libgnucash/app-utils/options.scm
@@ -2056,8 +2056,8 @@
             (set! row-contents (cons return-string row-contents)))))
     (gnc:options-for-each disp-option-if-changed options)
     (string-append (string-join (reverse row-contents)
-                                (if plaintext? "\n" "<br>"))
-                   (if plaintext? "\n\n" "<br><br>"))))
+                                (if plaintext? "\n" "<br />"))
+                   (if plaintext? "\n\n" "<br /><br />"))))
 
 (define (gnc:send-options db_handle options)
   (gnc:options-for-each


### PR DESCRIPTION
A few commits, mainly to prepare for srfi-64 and sxpath-based tests which will need well-formed XML renders.
1. Change html break tag from `<br>` to `<br />`
2. Opening `<html>` tag was mistakenly deleted two years ago.
3. Test for SRFI-64 and enable testing group. This group will be run on systems containing guile-2.0.10 onwards, such as travis-ci arch.

And a minor amendment to TR according to guile guide.

After this, TR-unittest #270 can progress.