### PR TITLE
bugzilla 793898 and ongoing scheme progress

### DIFF
--- a/gnucash/report/standard-reports/daily-reports.scm
+++ b/gnucash/report/standard-reports/daily-reports.scm
@@ -2,7 +2,6 @@
 ;; daily-reports.scm: reports based on the day of the week
 ;;
 ;; Copyright (C) 2003, Andy Wingo <wingo at pobox dot com>
-;; Christopher Lam upgrade to time64 (2017)
 ;;
 ;; based on account-piecharts.scm by Robert Merkel (rgmerk@mira.net)
 ;; and Christian Stimming <stimming@tu-harburg.de> with

--- a/gnucash/report/standard-reports/sx-summary.scm
+++ b/gnucash/report/standard-reports/sx-summary.scm
@@ -5,7 +5,6 @@
 ;; Copyright 2004 David Montenegro <sunrise2000@comcast.net>
 ;; Copyright 2001 Christian Stimming <stimming@tu-harburg.de>
 ;; Copyright 2000-2001 Bill Gribble <grib@gnumatic.com>
-;; Copyright 2017 Christopher Lam upgrade to time64
 ;;    
 ;; This program is free software; you can redistribute it and/or    
 ;; modify it under the terms of the GNU General Public License as   

--- a/gnucash/report/standard-reports/transaction.scm
+++ b/gnucash/report/standard-reports/transaction.scm
@@ -1823,11 +1823,12 @@ tags within description, notes or memo. ")
 
               ;; error condition: no splits found
               (begin
+
                 (gnc:html-document-add-object!
                  document
-                 (gnc:make-html-text
-                  (gnc:html-markup-h2 NO-MATCHING-TRANS-HEADER)
-                  (gnc:html-markup-p NO-MATCHING-TRANS-TEXT)))
+                 (gnc:html-make-generic-warning
+                  report-title (gnc:report-id report-obj)
+                  NO-MATCHING-TRANS-HEADER NO-MATCHING-TRANS-TEXT))
 
                 (if (member 'no-match infobox-display)
                     (gnc:html-document-add-object!

--- a/gnucash/report/standard-reports/transaction.scm
+++ b/gnucash/report/standard-reports/transaction.scm
@@ -1744,19 +1744,17 @@ tags within description, notes or memo. ")
         ;; error condition: no accounts specified or obtained after filtering
         (begin
 
-            ;; error condition: no accounts specified
-            (begin
+          (gnc:html-document-add-object!
+           document
+           (gnc:html-make-no-account-warning
+            report-title (gnc:report-id report-obj)))
 
+          ;; if an empty-report-message is passed by a derived report to
+          ;; the renderer, display it here.
+          (if empty-report-message
               (gnc:html-document-add-object!
                document
-               (gnc:html-make-no-account-warning report-title (gnc:report-id report-obj)))
-
-              ;; if an empty-report-message is passed by a derived report to
-              ;; the renderer, display it here.
-              (if empty-report-message
-                  (gnc:html-document-add-object!
-                   document
-                   empty-report-message)))
+               empty-report-message))
 
           (if (member 'no-match infobox-display)
               (gnc:html-document-add-object!

--- a/libgnucash/app-utils/date-utilities.scm
+++ b/libgnucash/app-utils/date-utilities.scm
@@ -91,19 +91,7 @@
                           604800))
          (begin-string (qof-print-date (+ beginweekt64 345600)))
          (end-string (qof-print-date (+ beginweekt64 864000))))
-    (format #f (_ "~s to ~s") begin-string end-string)))
-    
-;  (let ((begin-string (qof-print-date
-;                       (+ (* (gnc:date-get-week
-;                              (gnc:time64-start-day-time
-;                               (gnc-mktime datevec)))
-;                             604800) 345600)))
-;        (end-string (qof-print-date
-;                     (+ (* (gnc:date-get-week
-;                            (gnc:time64-start-day-time
-;                             (gnc-mktime datevec)))
-;                           604800) 864000))))
-;    (format #f (_ "~s to ~s") begin-string end-string)))
+    (format #f (_ "~a to ~a") begin-string end-string)))
 
 ;; is leap year?
 (define (gnc:leap-year? year)

--- a/libgnucash/app-utils/options.scm
+++ b/libgnucash/app-utils/options.scm
@@ -2056,8 +2056,8 @@
             (set! row-contents (cons return-string row-contents)))))
     (gnc:options-for-each disp-option-if-changed options)
     (string-append (string-join (reverse row-contents)
-                                (if plaintext? "\n" "<br />"))
-                   (if plaintext? "\n\n" "<br /><br />"))))
+                                (if plaintext? "\n" "<br />\n"))
+                   (if plaintext? "\n\n" "<br />\n<br />\n"))))
 
 (define (gnc:send-options db_handle options)
   (gnc:options-for-each


### PR DESCRIPTION
No user-visible changes at all, except that TR may have to be recreated/resaved.

- TR multichoice -> symbols instead of lists. This may break saved-reports/reports across sessions. Best merge this in unstable
- Fixes unintended copyright statements.
- Clean up `<br/>` tag to include `\n` in HTML.
- Homogenize TR blank-report messages
