### PR TITLE
Export compiled GSchema when using CPack

### DIFF
--- a/common/cmake_modules/GncAddGSchemaTargets.cmake
+++ b/common/cmake_modules/GncAddGSchemaTargets.cmake
@@ -33,6 +33,6 @@ macro(add_gschema_targets _gschema_INPUTS)
 
   set(gschema_depends ${local_depends} CACHE INTERNAL "gschemas.compiled dependencies")
 
-  INSTALL(FILES ${_gschema_OUTPUTS} DESTINATION share/glib-2.0/schemas)
+  INSTALL(FILES ${_gschema_OUTPUTS} DESTINATION ${CMAKE_INSTALL_DATADIR}/glib-2.0/schemas)
 
 endmacro()

--- a/gnucash/CMakeLists.txt
+++ b/gnucash/CMakeLists.txt
@@ -29,7 +29,7 @@ ADD_SUBDIRECTORY (python)
 ADD_SUBDIRECTORY (register)
 ADD_SUBDIRECTORY (report)
 ADD_SUBDIRECTORY (ui)
-ADD_SUBDIRECTORY (gschemas)
+ADD_SUBDIRECTORY (gschemas) # required to be after all other uses of "add_gschema_targets" (ie. import-export)
 
 ADD_DEFINITIONS (-DHAVE_CONFIG_H)
 

--- a/gnucash/gschemas/CMakeLists.txt
+++ b/gnucash/gschemas/CMakeLists.txt
@@ -35,10 +35,7 @@ add_custom_command(
 
 add_custom_target(compiled-schemas ALL DEPENDS ${SCHEMADIR_BUILD}/gschemas.compiled)
 
-
-install(CODE "execute_process(
-    COMMAND ${SHELL} -c \"echo Compiling gschema files in $DESTDIR${CMAKE_INSTALL_FULL_DATADIR}/glib-2.0/schemas ;
-                          ${GLIB_COMPILE_SCHEMAS} $DESTDIR${CMAKE_INSTALL_FULL_DATADIR}/glib-2.0/schemas\")")
+INSTALL(FILES ${SCHEMADIR_BUILD}/gschemas.compiled DESTINATION ${CMAKE_INSTALL_DATADIR}/glib-2.0/schemas)
 
 SET(gschemas_DIST_local "")
 FOREACH(file ${gschema_SOURCES})


### PR DESCRIPTION
This uses the already generated compiled GSchema file, from the
"compiled-schemas" target, for installation. Previously the compiler was
rerun at install time.