### PR TITLE
Adjustment of Account Hierarchy Templates.

### DIFF
--- a/accounts/ru/acctchrt_auto.gnucash-xea
+++ b/accounts/ru/acctchrt_auto.gnucash-xea
@@ -1,14 +1,46 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<gnc-account-example>
-    <gnc-act:title>
-      Автомобиль
-    </gnc-act:title>
-    <gnc-act:short-description>
-      Расходы на автомобиль
-    </gnc-act:short-description>
-    <gnc-act:long-description>
-      Счета для учёта расходов связанных с автомобилем.
-    </gnc-act:long-description>
+<gnc-account-example 
+  xmlns="http://www.gnucash.org/XML/"
+  xmlns:act="http://www.gnucash.org/XML/act"
+  xmlns:addr="http://www.gnucash.org/XML/addr"
+  xmlns:bgt="http://www.gnucash.org/XML/bgt"
+  xmlns:billterm="http://www.gnucash.org/XML/billterm"
+  xmlns:book="http://www.gnucash.org/XML/book"
+  xmlns:bt-days="http://www.gnucash.org/XML/bt-days"
+  xmlns:bt-prox="http://www.gnucash.org/XML/bt-prox"
+  xmlns:cd="http://www.gnucash.org/XML/cd"
+  xmlns:cmdty="http://www.gnucash.org/XML/cmdty"
+  xmlns:cust="http://www.gnucash.org/XML/cust"
+  xmlns:employee="http://www.gnucash.org/XML/employee"
+  xmlns:entry="http://www.gnucash.org/XML/entry"
+  xmlns:fs="http://www.gnucash.org/XML/fs"
+  xmlns:gnc="http://www.gnucash.org/XML/gnc"
+  xmlns:gnc-act="http://www.gnucash.org/XML/gnc-act"
+  xmlns:invoice="http://www.gnucash.org/XML/invoice"
+  xmlns:job="http://www.gnucash.org/XML/job"
+  xmlns:lot="http://www.gnucash.org/XML/lot"
+  xmlns:order="http://www.gnucash.org/XML/order"
+  xmlns:owner="http://www.gnucash.org/XML/owner"
+  xmlns:price="http://www.gnucash.org/XML/price"
+  xmlns:recurrence="http://www.gnucash.org/XML/recurrence"
+  xmlns:slot="http://www.gnucash.org/XML/slot"
+  xmlns:split="http://www.gnucash.org/XML/split"
+  xmlns:sx="http://www.gnucash.org/XML/sx"
+  xmlns:taxtable="http://www.gnucash.org/XML/taxtable"
+  xmlns:trn="http://www.gnucash.org/XML/trn"
+  xmlns:ts="http://www.gnucash.org/XML/ts"
+  xmlns:tte="http://www.gnucash.org/XML/tte"
+  xmlns:vendor="http://www.gnucash.org/XML/vendor">
+
+<gnc-act:title>
+  Автомобиль
+</gnc-act:title>
+<gnc-act:short-description>
+  Расходы на автомобиль
+</gnc-act:short-description>
+<gnc-act:long-description>
+  Счета для учёта расходов связанных с автомобилем.
+</gnc-act:long-description>
 
 <gnc:account version="2.0.0">
   <act:name>Головной счет</act:name>
@@ -60,6 +92,12 @@
   </act:commodity>
   <act:description>Расходы на автомобиль</act:description>
   <act:parent type="new">9d0482216d51316b84927898529861f0</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>  
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Сборы</act:name>

--- a/accounts/ru/acctchrt_autoloan.gnucash-xea
+++ b/accounts/ru/acctchrt_autoloan.gnucash-xea
@@ -1,14 +1,46 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<gnc-account-example>
-    <gnc-act:title>
-      Кредит на автомобиль
-    </gnc-act:title>
-    <gnc-act:short-description>
-      Кредит на автомобиль
-    </gnc-act:short-description>
-    <gnc-act:long-description>
-      Счета для учёта расходов связанных с оплатой кредита на автомобиль.
-    </gnc-act:long-description>
+<gnc-account-example 
+  xmlns="http://www.gnucash.org/XML/"
+  xmlns:act="http://www.gnucash.org/XML/act"
+  xmlns:addr="http://www.gnucash.org/XML/addr"
+  xmlns:bgt="http://www.gnucash.org/XML/bgt"
+  xmlns:billterm="http://www.gnucash.org/XML/billterm"
+  xmlns:book="http://www.gnucash.org/XML/book"
+  xmlns:bt-days="http://www.gnucash.org/XML/bt-days"
+  xmlns:bt-prox="http://www.gnucash.org/XML/bt-prox"
+  xmlns:cd="http://www.gnucash.org/XML/cd"
+  xmlns:cmdty="http://www.gnucash.org/XML/cmdty"
+  xmlns:cust="http://www.gnucash.org/XML/cust"
+  xmlns:employee="http://www.gnucash.org/XML/employee"
+  xmlns:entry="http://www.gnucash.org/XML/entry"
+  xmlns:fs="http://www.gnucash.org/XML/fs"
+  xmlns:gnc="http://www.gnucash.org/XML/gnc"
+  xmlns:gnc-act="http://www.gnucash.org/XML/gnc-act"
+  xmlns:invoice="http://www.gnucash.org/XML/invoice"
+  xmlns:job="http://www.gnucash.org/XML/job"
+  xmlns:lot="http://www.gnucash.org/XML/lot"
+  xmlns:order="http://www.gnucash.org/XML/order"
+  xmlns:owner="http://www.gnucash.org/XML/owner"
+  xmlns:price="http://www.gnucash.org/XML/price"
+  xmlns:recurrence="http://www.gnucash.org/XML/recurrence"
+  xmlns:slot="http://www.gnucash.org/XML/slot"
+  xmlns:split="http://www.gnucash.org/XML/split"
+  xmlns:sx="http://www.gnucash.org/XML/sx"
+  xmlns:taxtable="http://www.gnucash.org/XML/taxtable"
+  xmlns:trn="http://www.gnucash.org/XML/trn"
+  xmlns:ts="http://www.gnucash.org/XML/ts"
+  xmlns:tte="http://www.gnucash.org/XML/tte"
+  xmlns:vendor="http://www.gnucash.org/XML/vendor">
+
+<gnc-act:title>
+  Кредит на автомобиль
+</gnc-act:title>
+<gnc-act:short-description>
+  Кредит на автомобиль
+</gnc-act:short-description>
+<gnc-act:long-description>
+  Счета для учёта расходов связанных с оплатой кредита на автомобиль.
+</gnc-act:long-description>
 
 <gnc:account version="2.0.0">
   <act:name>Головной счет</act:name>

--- a/accounts/ru/acctchrt_common.gnucash-xea
+++ b/accounts/ru/acctchrt_common.gnucash-xea
@@ -1,15 +1,47 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<gnc-account-example>
-    <gnc-act:title>
-      Общие счета
-    </gnc-act:title>
-    <gnc-act:short-description>
-      Базовый набор наиболее используемых счетов
-    </gnc-act:short-description>
-    <gnc-act:long-description>
-      Наиболее часто используемые счета (чеки, депозиты, наличные, кредитные карты, доходы, общие расходы).
-    </gnc-act:long-description>
-    <gnc-act:start-selected>1</gnc-act:start-selected>
+<gnc-account-example 
+  xmlns="http://www.gnucash.org/XML/"
+  xmlns:act="http://www.gnucash.org/XML/act"
+  xmlns:addr="http://www.gnucash.org/XML/addr"
+  xmlns:bgt="http://www.gnucash.org/XML/bgt"
+  xmlns:billterm="http://www.gnucash.org/XML/billterm"
+  xmlns:book="http://www.gnucash.org/XML/book"
+  xmlns:bt-days="http://www.gnucash.org/XML/bt-days"
+  xmlns:bt-prox="http://www.gnucash.org/XML/bt-prox"
+  xmlns:cd="http://www.gnucash.org/XML/cd"
+  xmlns:cmdty="http://www.gnucash.org/XML/cmdty"
+  xmlns:cust="http://www.gnucash.org/XML/cust"
+  xmlns:employee="http://www.gnucash.org/XML/employee"
+  xmlns:entry="http://www.gnucash.org/XML/entry"
+  xmlns:fs="http://www.gnucash.org/XML/fs"
+  xmlns:gnc="http://www.gnucash.org/XML/gnc"
+  xmlns:gnc-act="http://www.gnucash.org/XML/gnc-act"
+  xmlns:invoice="http://www.gnucash.org/XML/invoice"
+  xmlns:job="http://www.gnucash.org/XML/job"
+  xmlns:lot="http://www.gnucash.org/XML/lot"
+  xmlns:order="http://www.gnucash.org/XML/order"
+  xmlns:owner="http://www.gnucash.org/XML/owner"
+  xmlns:price="http://www.gnucash.org/XML/price"
+  xmlns:recurrence="http://www.gnucash.org/XML/recurrence"
+  xmlns:slot="http://www.gnucash.org/XML/slot"
+  xmlns:split="http://www.gnucash.org/XML/split"
+  xmlns:sx="http://www.gnucash.org/XML/sx"
+  xmlns:taxtable="http://www.gnucash.org/XML/taxtable"
+  xmlns:trn="http://www.gnucash.org/XML/trn"
+  xmlns:ts="http://www.gnucash.org/XML/ts"
+  xmlns:tte="http://www.gnucash.org/XML/tte"
+  xmlns:vendor="http://www.gnucash.org/XML/vendor">
+
+<gnc-act:title>
+  Общие счета
+</gnc-act:title>
+<gnc-act:short-description>
+  Базовый набор наиболее используемых счетов
+</gnc-act:short-description>
+<gnc-act:long-description>
+  Наиболее часто используемые счета (чеки, депозиты, наличные, кредитные карты, доходы, общие расходы).
+</gnc-act:long-description>
+<gnc-act:start-selected>1</gnc-act:start-selected>
 
 <gnc:account version="2.0.0">
   <act:name>Головной счет</act:name>
@@ -139,6 +171,12 @@
   </act:commodity>
   <act:description>Премия</act:description>
   <act:parent type="new">a7ab23dd2d41616042034d5a012a0850</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Заработная плата</act:name>
@@ -183,6 +221,12 @@
   </act:commodity>
   <act:description>Процентный доход</act:description>
   <act:parent type="new">a7ab23dd2d41616042034d5a012a0850</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Чековые проценты</act:name>
@@ -416,6 +460,12 @@
   </act:commodity>
   <act:description>Развлечения</act:description>
   <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Музыка и кино</act:name>
@@ -493,6 +543,12 @@
   </act:commodity>
   <act:description>Страхование</act:description>
   <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>  
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Медицинское страхование</act:name>
@@ -715,6 +771,12 @@
   </act:commodity>
   <act:description>Коммунальные услуги</act:description>
   <act:parent type="new">19931e1ab10d980a9209aecab4665a54</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>  
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Электричество</act:name>

--- a/accounts/ru/acctchrt_homeloan.gnucash-xea
+++ b/accounts/ru/acctchrt_homeloan.gnucash-xea
@@ -1,14 +1,46 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<gnc-account-example>
-    <gnc-act:title>
-      Кредит на недвижимость
-    </gnc-act:title>
-    <gnc-act:short-description>
-      Кредит на недвижимость
-    </gnc-act:short-description>
-    <gnc-act:long-description>
-      Счета для учёта расходов связанных с оплатой кредита на недвижимость.
-    </gnc-act:long-description>
+<gnc-account-example 
+  xmlns="http://www.gnucash.org/XML/"
+  xmlns:act="http://www.gnucash.org/XML/act"
+  xmlns:addr="http://www.gnucash.org/XML/addr"
+  xmlns:bgt="http://www.gnucash.org/XML/bgt"
+  xmlns:billterm="http://www.gnucash.org/XML/billterm"
+  xmlns:book="http://www.gnucash.org/XML/book"
+  xmlns:bt-days="http://www.gnucash.org/XML/bt-days"
+  xmlns:bt-prox="http://www.gnucash.org/XML/bt-prox"
+  xmlns:cd="http://www.gnucash.org/XML/cd"
+  xmlns:cmdty="http://www.gnucash.org/XML/cmdty"
+  xmlns:cust="http://www.gnucash.org/XML/cust"
+  xmlns:employee="http://www.gnucash.org/XML/employee"
+  xmlns:entry="http://www.gnucash.org/XML/entry"
+  xmlns:fs="http://www.gnucash.org/XML/fs"
+  xmlns:gnc="http://www.gnucash.org/XML/gnc"
+  xmlns:gnc-act="http://www.gnucash.org/XML/gnc-act"
+  xmlns:invoice="http://www.gnucash.org/XML/invoice"
+  xmlns:job="http://www.gnucash.org/XML/job"
+  xmlns:lot="http://www.gnucash.org/XML/lot"
+  xmlns:order="http://www.gnucash.org/XML/order"
+  xmlns:owner="http://www.gnucash.org/XML/owner"
+  xmlns:price="http://www.gnucash.org/XML/price"
+  xmlns:recurrence="http://www.gnucash.org/XML/recurrence"
+  xmlns:slot="http://www.gnucash.org/XML/slot"
+  xmlns:split="http://www.gnucash.org/XML/split"
+  xmlns:sx="http://www.gnucash.org/XML/sx"
+  xmlns:taxtable="http://www.gnucash.org/XML/taxtable"
+  xmlns:trn="http://www.gnucash.org/XML/trn"
+  xmlns:ts="http://www.gnucash.org/XML/ts"
+  xmlns:tte="http://www.gnucash.org/XML/tte"
+  xmlns:vendor="http://www.gnucash.org/XML/vendor">
+
+<gnc-act:title>
+  Кредит на недвижимость
+</gnc-act:title>
+<gnc-act:short-description>
+  Кредит на недвижимость
+</gnc-act:short-description>
+<gnc-act:long-description>
+  Счета для учёта расходов связанных с оплатой кредита на недвижимость.
+</gnc-act:long-description>
 
 <gnc:account version="2.0.0">
   <act:name>Root Account</act:name>

--- a/accounts/ru/acctchrt_homeown.gnucash-xea
+++ b/accounts/ru/acctchrt_homeown.gnucash-xea
@@ -1,14 +1,46 @@
 <?xml version="1.0" encoding="UTF-8"?>
-    <gnc-account-example>
-    <gnc-act:title>
-      Дом/Квартира
-    </gnc-act:title>
-    <gnc-act:short-description>
-      Расходы связанные с домовладением
-    </gnc-act:short-description>
-    <gnc-act:long-description>
-      Счета для учёта расходов связанных с владением квартирой или домом (страховка, налоги и ремонт).
-    </gnc-act:long-description>
+<gnc-account-example 
+  xmlns="http://www.gnucash.org/XML/"
+  xmlns:act="http://www.gnucash.org/XML/act"
+  xmlns:addr="http://www.gnucash.org/XML/addr"
+  xmlns:bgt="http://www.gnucash.org/XML/bgt"
+  xmlns:billterm="http://www.gnucash.org/XML/billterm"
+  xmlns:book="http://www.gnucash.org/XML/book"
+  xmlns:bt-days="http://www.gnucash.org/XML/bt-days"
+  xmlns:bt-prox="http://www.gnucash.org/XML/bt-prox"
+  xmlns:cd="http://www.gnucash.org/XML/cd"
+  xmlns:cmdty="http://www.gnucash.org/XML/cmdty"
+  xmlns:cust="http://www.gnucash.org/XML/cust"
+  xmlns:employee="http://www.gnucash.org/XML/employee"
+  xmlns:entry="http://www.gnucash.org/XML/entry"
+  xmlns:fs="http://www.gnucash.org/XML/fs"
+  xmlns:gnc="http://www.gnucash.org/XML/gnc"
+  xmlns:gnc-act="http://www.gnucash.org/XML/gnc-act"
+  xmlns:invoice="http://www.gnucash.org/XML/invoice"
+  xmlns:job="http://www.gnucash.org/XML/job"
+  xmlns:lot="http://www.gnucash.org/XML/lot"
+  xmlns:order="http://www.gnucash.org/XML/order"
+  xmlns:owner="http://www.gnucash.org/XML/owner"
+  xmlns:price="http://www.gnucash.org/XML/price"
+  xmlns:recurrence="http://www.gnucash.org/XML/recurrence"
+  xmlns:slot="http://www.gnucash.org/XML/slot"
+  xmlns:split="http://www.gnucash.org/XML/split"
+  xmlns:sx="http://www.gnucash.org/XML/sx"
+  xmlns:taxtable="http://www.gnucash.org/XML/taxtable"
+  xmlns:trn="http://www.gnucash.org/XML/trn"
+  xmlns:ts="http://www.gnucash.org/XML/ts"
+  xmlns:tte="http://www.gnucash.org/XML/tte"
+  xmlns:vendor="http://www.gnucash.org/XML/vendor">
+
+<gnc-act:title>
+  Дом/Квартира
+</gnc-act:title>
+<gnc-act:short-description>
+  Расходы связанные с домовладением
+</gnc-act:short-description>
+<gnc-act:long-description>
+  Счета для учёта расходов связанных с владением квартирой или домом (страховка, налоги и ремонт).
+</gnc-act:long-description>
 
 <gnc:account version="2.0.0">
   <act:name>Root Account</act:name>
@@ -43,6 +75,12 @@
   </act:commodity>
   <act:description>Страхование</act:description>
   <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>  
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Страхование имущества</act:name>
@@ -65,6 +103,12 @@
   </act:commodity>
   <act:description>Налоги</act:description>
   <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>  
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Налог на имущество</act:name>

--- a/accounts/ru/acctchrt_kids.gnucash-xea
+++ b/accounts/ru/acctchrt_kids.gnucash-xea
@@ -1,14 +1,46 @@
-<?xml version="1.0" encoding="utf-8"?>
-<gnc-account-example>
-    <gnc-act:title>
-      Дети
-    </gnc-act:title>
-    <gnc-act:short-description>
-      Расходы на детей
-    </gnc-act:short-description>
-    <gnc-act:long-description>
-      Счета для учёта расходов связанных с детьми.
-    </gnc-act:long-description>
+<?xml version="1.0" encoding="UTF-8"?>
+<gnc-account-example 
+  xmlns="http://www.gnucash.org/XML/"
+  xmlns:act="http://www.gnucash.org/XML/act"
+  xmlns:addr="http://www.gnucash.org/XML/addr"
+  xmlns:bgt="http://www.gnucash.org/XML/bgt"
+  xmlns:billterm="http://www.gnucash.org/XML/billterm"
+  xmlns:book="http://www.gnucash.org/XML/book"
+  xmlns:bt-days="http://www.gnucash.org/XML/bt-days"
+  xmlns:bt-prox="http://www.gnucash.org/XML/bt-prox"
+  xmlns:cd="http://www.gnucash.org/XML/cd"
+  xmlns:cmdty="http://www.gnucash.org/XML/cmdty"
+  xmlns:cust="http://www.gnucash.org/XML/cust"
+  xmlns:employee="http://www.gnucash.org/XML/employee"
+  xmlns:entry="http://www.gnucash.org/XML/entry"
+  xmlns:fs="http://www.gnucash.org/XML/fs"
+  xmlns:gnc="http://www.gnucash.org/XML/gnc"
+  xmlns:gnc-act="http://www.gnucash.org/XML/gnc-act"
+  xmlns:invoice="http://www.gnucash.org/XML/invoice"
+  xmlns:job="http://www.gnucash.org/XML/job"
+  xmlns:lot="http://www.gnucash.org/XML/lot"
+  xmlns:order="http://www.gnucash.org/XML/order"
+  xmlns:owner="http://www.gnucash.org/XML/owner"
+  xmlns:price="http://www.gnucash.org/XML/price"
+  xmlns:recurrence="http://www.gnucash.org/XML/recurrence"
+  xmlns:slot="http://www.gnucash.org/XML/slot"
+  xmlns:split="http://www.gnucash.org/XML/split"
+  xmlns:sx="http://www.gnucash.org/XML/sx"
+  xmlns:taxtable="http://www.gnucash.org/XML/taxtable"
+  xmlns:trn="http://www.gnucash.org/XML/trn"
+  xmlns:ts="http://www.gnucash.org/XML/ts"
+  xmlns:tte="http://www.gnucash.org/XML/tte"
+  xmlns:vendor="http://www.gnucash.org/XML/vendor">
+
+<gnc-act:title>
+  Дети
+</gnc-act:title>
+<gnc-act:short-description>
+  Расходы на детей
+</gnc-act:short-description>
+<gnc-act:long-description>
+  Счета для учёта расходов связанных с детьми.
+</gnc-act:long-description>
 
 <gnc:account version="2.0.0">
   <act:name>Root Account</act:name>

--- a/accounts/ru/acctchrt_otherloan.gnucash-xea
+++ b/accounts/ru/acctchrt_otherloan.gnucash-xea
@@ -1,14 +1,46 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<gnc-account-example>
-    <gnc-act:title>
-      Другие кредиты
-    </gnc-act:title>
-    <gnc-act:short-description>
-      Различные кредиты и связанные с ними платежи
-    </gnc-act:short-description>
-    <gnc-act:long-description>
-      Счета для различных кредитов и связанных с ними платежей.
-    </gnc-act:long-description>
+<gnc-account-example 
+  xmlns="http://www.gnucash.org/XML/"
+  xmlns:act="http://www.gnucash.org/XML/act"
+  xmlns:addr="http://www.gnucash.org/XML/addr"
+  xmlns:bgt="http://www.gnucash.org/XML/bgt"
+  xmlns:billterm="http://www.gnucash.org/XML/billterm"
+  xmlns:book="http://www.gnucash.org/XML/book"
+  xmlns:bt-days="http://www.gnucash.org/XML/bt-days"
+  xmlns:bt-prox="http://www.gnucash.org/XML/bt-prox"
+  xmlns:cd="http://www.gnucash.org/XML/cd"
+  xmlns:cmdty="http://www.gnucash.org/XML/cmdty"
+  xmlns:cust="http://www.gnucash.org/XML/cust"
+  xmlns:employee="http://www.gnucash.org/XML/employee"
+  xmlns:entry="http://www.gnucash.org/XML/entry"
+  xmlns:fs="http://www.gnucash.org/XML/fs"
+  xmlns:gnc="http://www.gnucash.org/XML/gnc"
+  xmlns:gnc-act="http://www.gnucash.org/XML/gnc-act"
+  xmlns:invoice="http://www.gnucash.org/XML/invoice"
+  xmlns:job="http://www.gnucash.org/XML/job"
+  xmlns:lot="http://www.gnucash.org/XML/lot"
+  xmlns:order="http://www.gnucash.org/XML/order"
+  xmlns:owner="http://www.gnucash.org/XML/owner"
+  xmlns:price="http://www.gnucash.org/XML/price"
+  xmlns:recurrence="http://www.gnucash.org/XML/recurrence"
+  xmlns:slot="http://www.gnucash.org/XML/slot"
+  xmlns:split="http://www.gnucash.org/XML/split"
+  xmlns:sx="http://www.gnucash.org/XML/sx"
+  xmlns:taxtable="http://www.gnucash.org/XML/taxtable"
+  xmlns:trn="http://www.gnucash.org/XML/trn"
+  xmlns:ts="http://www.gnucash.org/XML/ts"
+  xmlns:tte="http://www.gnucash.org/XML/tte"
+  xmlns:vendor="http://www.gnucash.org/XML/vendor">
+
+<gnc-act:title>
+  Другие кредиты
+</gnc-act:title>
+<gnc-act:short-description>
+  Различные кредиты и связанные с ними платежи
+</gnc-act:short-description>
+<gnc-act:long-description>
+  Счета для различных кредитов и связанных с ними платежей.
+</gnc-act:long-description>
 
 <gnc:account version="2.0.0">
   <act:name>Root Account</act:name>

--- a/accounts/ru/acctchrt_renter.gnucash-xea
+++ b/accounts/ru/acctchrt_renter.gnucash-xea
@@ -1,14 +1,46 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<gnc-account-example>
-    <gnc-act:title>
-      Аренда
-    </gnc-act:title>
-    <gnc-act:short-description>
-      Расходы связанные с арендой недвижимости
-    </gnc-act:short-description>
-    <gnc-act:long-description>
-      Счета для учёта расходов связанных с арендой дома или квартиры.
-    </gnc-act:long-description>
+<gnc-account-example 
+  xmlns="http://www.gnucash.org/XML/"
+  xmlns:act="http://www.gnucash.org/XML/act"
+  xmlns:addr="http://www.gnucash.org/XML/addr"
+  xmlns:bgt="http://www.gnucash.org/XML/bgt"
+  xmlns:billterm="http://www.gnucash.org/XML/billterm"
+  xmlns:book="http://www.gnucash.org/XML/book"
+  xmlns:bt-days="http://www.gnucash.org/XML/bt-days"
+  xmlns:bt-prox="http://www.gnucash.org/XML/bt-prox"
+  xmlns:cd="http://www.gnucash.org/XML/cd"
+  xmlns:cmdty="http://www.gnucash.org/XML/cmdty"
+  xmlns:cust="http://www.gnucash.org/XML/cust"
+  xmlns:employee="http://www.gnucash.org/XML/employee"
+  xmlns:entry="http://www.gnucash.org/XML/entry"
+  xmlns:fs="http://www.gnucash.org/XML/fs"
+  xmlns:gnc="http://www.gnucash.org/XML/gnc"
+  xmlns:gnc-act="http://www.gnucash.org/XML/gnc-act"
+  xmlns:invoice="http://www.gnucash.org/XML/invoice"
+  xmlns:job="http://www.gnucash.org/XML/job"
+  xmlns:lot="http://www.gnucash.org/XML/lot"
+  xmlns:order="http://www.gnucash.org/XML/order"
+  xmlns:owner="http://www.gnucash.org/XML/owner"
+  xmlns:price="http://www.gnucash.org/XML/price"
+  xmlns:recurrence="http://www.gnucash.org/XML/recurrence"
+  xmlns:slot="http://www.gnucash.org/XML/slot"
+  xmlns:split="http://www.gnucash.org/XML/split"
+  xmlns:sx="http://www.gnucash.org/XML/sx"
+  xmlns:taxtable="http://www.gnucash.org/XML/taxtable"
+  xmlns:trn="http://www.gnucash.org/XML/trn"
+  xmlns:ts="http://www.gnucash.org/XML/ts"
+  xmlns:tte="http://www.gnucash.org/XML/tte"
+  xmlns:vendor="http://www.gnucash.org/XML/vendor">
+
+<gnc-act:title>
+  Аренда
+</gnc-act:title>
+<gnc-act:short-description>
+  Расходы связанные с арендой недвижимости
+</gnc-act:short-description>
+<gnc-act:long-description>
+  Счета для учёта расходов связанных с арендой дома или квартиры.
+</gnc-act:long-description>
 
 <gnc:account version="2.0.0">
   <act:name>Root Account</act:name>


### PR DESCRIPTION
Adjustment of Account Hierarchy Templates.
(mentioned in PR #293 on GitHub)

1) Added namespace section (header)
2) Added missing placeholder

After adjustment, I checked it with **xmllint** => no errors.
`for i in *-xea; do xmllint --noout $i; done` 


Two questions:
* I use two versions of GnuCash: de and ru. I have seen that in the German version the most files haven't definition of namespace section. Should I adjust the "de"-templates? How about "C"-templates? 
* There are three comments at the end of each hierarchy template file. Do they have any meaning? Can they be removed?
`< !-- Local variables: -->`
`< !-- mode: xml        -->`
`< !-- End:             -->`