### PR TITLE
Remove the emacs comments at the end of files

### DIFF
--- a/accounts/ru/acctchrt_auto.gnucash-xea
+++ b/accounts/ru/acctchrt_auto.gnucash-xea
@@ -178,7 +178,3 @@
 </gnc:account>
 
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/accounts/ru/acctchrt_autoloan.gnucash-xea
+++ b/accounts/ru/acctchrt_autoloan.gnucash-xea
@@ -140,7 +140,3 @@
 </gnc:account>
 
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/accounts/ru/acctchrt_common.gnucash-xea
+++ b/accounts/ru/acctchrt_common.gnucash-xea
@@ -846,7 +846,3 @@
 </gnc:account>
 
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/accounts/ru/acctchrt_homeloan.gnucash-xea
+++ b/accounts/ru/acctchrt_homeloan.gnucash-xea
@@ -140,7 +140,3 @@
 </gnc:account>
 
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/accounts/ru/acctchrt_homeown.gnucash-xea
+++ b/accounts/ru/acctchrt_homeown.gnucash-xea
@@ -134,7 +134,3 @@
 </gnc:account>
 
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/accounts/ru/acctchrt_kids.gnucash-xea
+++ b/accounts/ru/acctchrt_kids.gnucash-xea
@@ -151,7 +151,3 @@
 </gnc:account>
 
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/accounts/ru/acctchrt_otherloan.gnucash-xea
+++ b/accounts/ru/acctchrt_otherloan.gnucash-xea
@@ -140,7 +140,3 @@
 </gnc:account>
 
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/accounts/ru/acctchrt_renter.gnucash-xea
+++ b/accounts/ru/acctchrt_renter.gnucash-xea
@@ -95,7 +95,3 @@
 </gnc:account>
 
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->


### PR DESCRIPTION
Remove the emacs comments at the end of files:
`<! -- Local variables: -->`
`<! -- mode: xml        -->`
`<! -- End:             -->`

This comments are to help emacs recognize that the files are xml
since they don't have 'xml' as an extension (see PR #300).