### PR TITLE
Fix Segmentation fault when going to File->New

### DIFF
--- a/gnucash/gnome/gnc-plugin-account-tree.c
+++ b/gnucash/gnome/gnc-plugin-account-tree.c
@@ -142,6 +142,7 @@ gnc_plugin_account_tree_main_window_page_changed (GncMainWindow *window,
 
         // The page changed signal is emitted multiple times so we need
         // to use an idle_add to change the focus to the tree view
+        g_idle_remove_by_data (GNC_PLUGIN_PAGE_ACCOUNT_TREE (plugin_page));
         g_idle_add ((GSourceFunc)gnc_plugin_page_account_tree_focus,
                       GNC_PLUGIN_PAGE_ACCOUNT_TREE (plugin_page));
     }

--- a/gnucash/gnome/gnc-plugin-budget.c
+++ b/gnucash/gnome/gnc-plugin-budget.c
@@ -143,6 +143,7 @@ gnc_plugin_budget_main_window_page_changed (GncMainWindow *window,
 
         // The page changed signal is emitted multiple times so we need
         // to use an idle_add to change the focus to the tree view
+        g_idle_remove_by_data (GNC_PLUGIN_PAGE_BUDGET (plugin_page));
         g_idle_add ((GSourceFunc)gnc_plugin_page_budget_focus,
                       GNC_PLUGIN_PAGE_BUDGET (plugin_page));
     }

--- a/gnucash/gnome/gnc-plugin-page-account-tree.c
+++ b/gnucash/gnome/gnc-plugin-page-account-tree.c
@@ -776,6 +776,9 @@ gnc_plugin_page_account_tree_destroy_widget (GncPluginPage *plugin_page)
     // Destroy the filter override hash table
     g_hash_table_destroy(priv->fd.filter_override);
 
+    // Remove the page focus idle function if present
+    g_idle_remove_by_data (GNC_PLUGIN_PAGE_ACCOUNT_TREE (plugin_page));
+
     if (priv->widget)
     {
         g_object_unref(G_OBJECT(priv->widget));

--- a/gnucash/gnome/gnc-plugin-page-budget.c
+++ b/gnucash/gnome/gnc-plugin-page-budget.c
@@ -474,6 +474,9 @@ gnc_plugin_page_budget_destroy_widget (GncPluginPage *plugin_page)
     ENTER("page %p", plugin_page);
     priv = GNC_PLUGIN_PAGE_BUDGET_GET_PRIVATE(plugin_page);
 
+    // Remove the page focus idle function if present
+    g_idle_remove_by_data (GNC_PLUGIN_PAGE_BUDGET (plugin_page));
+
     if (priv->budget_view)
     {
         if (priv->delete_budget)

--- a/gnucash/gnome/gnc-plugin-page-invoice.c
+++ b/gnucash/gnome/gnc-plugin-page-invoice.c
@@ -452,7 +452,7 @@ gnc_plugin_page_invoice_focus (InvoiceWindow *iw)
 
     if (!GNUCASH_IS_REGISTER(regWidget))
         return FALSE;
-    
+
     sheet = gnucash_register_get_sheet (GNUCASH_REGISTER(regWidget));
 
     // Test for the sheet being read only
@@ -495,6 +495,7 @@ gnc_plugin_page_invoice_main_window_page_changed (GncMainWindow *window,
 
         // The page changed signal is emitted multiple times so we need
         // to use an idle_add to change the focus to the sheet
+        g_idle_remove_by_data (priv->iw);
         g_idle_add ((GSourceFunc)gnc_plugin_page_invoice_focus, priv->iw);
     }
 }
@@ -582,6 +583,9 @@ gnc_plugin_page_invoice_destroy_widget (GncPluginPage *plugin_page)
                                  GNC_PREF_SUMMARYBAR_POSITION_BOTTOM,
                                  gnc_plugin_page_invoice_summarybar_position_changed,
                                  page);
+
+    // Remove the page focus idle function if present
+    g_idle_remove_by_data (priv->iw);
 
     if (priv->widget == NULL)
     {

--- a/gnucash/gnome/gnc-plugin-page-owner-tree.c
+++ b/gnucash/gnome/gnc-plugin-page-owner-tree.c
@@ -425,6 +425,7 @@ gnc_plugin_page_owner_main_window_page_changed (GncMainWindow *window,
 
         // The page changed signal is emitted multiple times so we need
         // to use an idle_add to change the focus to the tree view
+        g_idle_remove_by_data (GTK_TREE_VIEW (priv->tree_view));
         g_idle_add ((GSourceFunc)gnc_plugin_page_owner_focus,
                       GTK_TREE_VIEW (priv->tree_view));
     }
@@ -731,6 +732,9 @@ gnc_plugin_page_owner_tree_destroy_widget (GncPluginPage *plugin_page)
     ENTER("page %p", plugin_page);
     page = GNC_PLUGIN_PAGE_OWNER_TREE (plugin_page);
     priv = GNC_PLUGIN_PAGE_OWNER_TREE_GET_PRIVATE(page);
+
+    // Remove the page focus idle function if present
+    g_idle_remove_by_data (GTK_TREE_VIEW (priv->tree_view));
 
     if (priv->widget)
     {

--- a/gnucash/gnome/gnc-plugin-page-register.c
+++ b/gnucash/gnome/gnc-plugin-page-register.c
@@ -1262,6 +1262,10 @@ gnc_plugin_page_register_destroy_widget (GncPluginPage *plugin_page)
                                  GNC_PREF_SUMMARYBAR_POSITION_BOTTOM,
                                  gnc_plugin_page_register_summarybar_position_changed,
                                  page);
+
+    // Remove the page focus idle function if present
+    g_idle_remove_by_data (GNC_PLUGIN_PAGE_REGISTER (plugin_page));
+
     if (priv->widget == NULL)
         return;
 

--- a/gnucash/gnome/gnc-plugin-page-sx-list.c
+++ b/gnucash/gnome/gnc-plugin-page-sx-list.c
@@ -246,6 +246,7 @@ gnc_plugin_page_sx_list_main_window_page_changed (GncMainWindow *window,
 
         // The page changed signal is emitted multiple times so we need
         // to use an idle_add to change the focus to the tree view
+        g_idle_remove_by_data (GTK_TREE_VIEW (priv->tree_view));
         g_idle_add ((GSourceFunc)gnc_plugin_page_sx_list_focus,
                       GTK_TREE_VIEW (priv->tree_view));
     }
@@ -542,6 +543,9 @@ gnc_plugin_page_sx_list_destroy_widget (GncPluginPage *plugin_page)
 
     page = GNC_PLUGIN_PAGE_SX_LIST (plugin_page);
     priv = GNC_PLUGIN_PAGE_SX_LIST_GET_PRIVATE(page);
+
+    // Remove the page focus idle function if present
+    g_idle_remove_by_data (GTK_TREE_VIEW (priv->tree_view));
 
     if (priv->widget)
     {

--- a/gnucash/gnome/gnc-plugin-register.c
+++ b/gnucash/gnome/gnc-plugin-register.c
@@ -161,6 +161,7 @@ gnc_plugin_register_main_window_page_changed(GncMainWindow *window,
 
         // The page changed signal is emitted multiple times so we need
         // to use an idle_add to change the focus to the register
+        g_idle_remove_by_data (GNC_PLUGIN_PAGE_REGISTER (plugin_page));
         g_idle_add ((GSourceFunc)gnc_plugin_page_register_focus,
                       GNC_PLUGIN_PAGE_REGISTER (plugin_page));
     }

--- a/gnucash/report/report-gnome/gnc-plugin-page-report.c
+++ b/gnucash/report/report-gnome/gnc-plugin-page-report.c
@@ -296,6 +296,7 @@ gnc_plugin_page_report_main_window_page_changed (GncMainWindow *window,
 
         // The page changed signal is emitted multiple times so we need
         // to use an idle_add to change the focus to the webkit widget
+        g_idle_remove_by_data (widget);
         g_idle_add ((GSourceFunc)gnc_plugin_page_report_focus, widget);
     }
 }
@@ -797,11 +798,17 @@ static void
 gnc_plugin_page_report_destroy_widget(GncPluginPage *plugin_page)
 {
     GncPluginPageReportPrivate *priv;
+    GtkWidget *widget;
 
     // FIXME: cleanup other resources.
 
     PINFO("destroy widget");
     priv = GNC_PLUGIN_PAGE_REPORT_GET_PRIVATE(plugin_page);
+
+    widget = gnc_html_get_widget(priv->html);
+
+    // Remove the page focus idle function if present
+    g_idle_remove_by_data (widget);
 
     if (priv->component_manager_id)
     {


### PR DESCRIPTION
When selecting the File->New with existing register pages open a crash
can happen as the register pages get closed forcing a page-changed
signal to queue the page focus function when there is no page. Add a
call to remove the page focus function in the ..destroy_widget function.

Also with the addition of g_idle_remove before the add when page-changed
is emitted the page focus function only gets run once.