### PR TITLE
 Clean Up for Account Hierarchy Templates: "de_DE" (german)

### DIFF
--- a/accounts/de_DE/acctchrt_auto.gnucash-xea
+++ b/accounts/de_DE/acctchrt_auto.gnucash-xea
@@ -1,14 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
-<gnc-account-example>
-    <gnc-act:title>
-      Autobesitz
-    </gnc-act:title>
-    <gnc-act:short-description>
-      Ausgaben von Autobesitzern
-    </gnc-act:short-description>
-    <gnc-act:long-description>
-      Diese Auswahl erstellt Konten, die Ausgaben für ein Auto repräsentieren.
-  </gnc-act:long-description>    
+<gnc-account-example 
+  xmlns="http://www.gnucash.org/XML/"
+  xmlns:act="http://www.gnucash.org/XML/act"
+  xmlns:addr="http://www.gnucash.org/XML/addr"
+  xmlns:bgt="http://www.gnucash.org/XML/bgt"
+  xmlns:billterm="http://www.gnucash.org/XML/billterm"
+  xmlns:book="http://www.gnucash.org/XML/book"
+  xmlns:bt-days="http://www.gnucash.org/XML/bt-days"
+  xmlns:bt-prox="http://www.gnucash.org/XML/bt-prox"
+  xmlns:cd="http://www.gnucash.org/XML/cd"
+  xmlns:cmdty="http://www.gnucash.org/XML/cmdty"
+  xmlns:cust="http://www.gnucash.org/XML/cust"
+  xmlns:employee="http://www.gnucash.org/XML/employee"
+  xmlns:entry="http://www.gnucash.org/XML/entry"
+  xmlns:fs="http://www.gnucash.org/XML/fs"
+  xmlns:gnc="http://www.gnucash.org/XML/gnc"
+  xmlns:gnc-act="http://www.gnucash.org/XML/gnc-act"
+  xmlns:invoice="http://www.gnucash.org/XML/invoice"
+  xmlns:job="http://www.gnucash.org/XML/job"
+  xmlns:lot="http://www.gnucash.org/XML/lot"
+  xmlns:order="http://www.gnucash.org/XML/order"
+  xmlns:owner="http://www.gnucash.org/XML/owner"
+  xmlns:price="http://www.gnucash.org/XML/price"
+  xmlns:recurrence="http://www.gnucash.org/XML/recurrence"
+  xmlns:slot="http://www.gnucash.org/XML/slot"
+  xmlns:split="http://www.gnucash.org/XML/split"
+  xmlns:sx="http://www.gnucash.org/XML/sx"
+  xmlns:taxtable="http://www.gnucash.org/XML/taxtable"
+  xmlns:trn="http://www.gnucash.org/XML/trn"
+  xmlns:ts="http://www.gnucash.org/XML/ts"
+  xmlns:tte="http://www.gnucash.org/XML/tte"
+  xmlns:vendor="http://www.gnucash.org/XML/vendor">
+
+<gnc-act:title>
+  Autobesitz
+</gnc-act:title>
+<gnc-act:short-description>
+  Ausgaben von Autobesitzern
+</gnc-act:short-description>
+<gnc-act:long-description>
+  Diese Auswahl erstellt Konten, die Ausgaben für ein Auto repräsentieren.
+</gnc-act:long-description>
+
 <gnc:account version="2.0.0">
   <act:name>Root Account</act:name>
   <act:id type="new">1972cce2e2364f95b2b0bc014502661d</act:id>
@@ -166,8 +199,5 @@
   <act:description>KFZ Versicherungen</act:description>
   <act:parent type="new">8fc4ba994d32d90d7a9a9112ee37f3f6</act:parent>
 </gnc:account>
-</gnc-account-example>
 
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->
+</gnc-account-example>

--- a/accounts/de_DE/acctchrt_autoloan.gnucash-xea
+++ b/accounts/de_DE/acctchrt_autoloan.gnucash-xea
@@ -1,14 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
-<gnc-account-example>
-    <gnc-act:title>
-      Kredit Auto
-    </gnc-act:title>
-    <gnc-act:short-description>
-      Kredit für Autokauf
-    </gnc-act:short-description>
-    <gnc-act:long-description>
-      Falls Sie einen Kredit zum Autokauf besitzen, können Sie mit dieser Auswahl die passenden Konten bekommen.
-  </gnc-act:long-description>
+<gnc-account-example 
+  xmlns="http://www.gnucash.org/XML/"
+  xmlns:act="http://www.gnucash.org/XML/act"
+  xmlns:addr="http://www.gnucash.org/XML/addr"
+  xmlns:bgt="http://www.gnucash.org/XML/bgt"
+  xmlns:billterm="http://www.gnucash.org/XML/billterm"
+  xmlns:book="http://www.gnucash.org/XML/book"
+  xmlns:bt-days="http://www.gnucash.org/XML/bt-days"
+  xmlns:bt-prox="http://www.gnucash.org/XML/bt-prox"
+  xmlns:cd="http://www.gnucash.org/XML/cd"
+  xmlns:cmdty="http://www.gnucash.org/XML/cmdty"
+  xmlns:cust="http://www.gnucash.org/XML/cust"
+  xmlns:employee="http://www.gnucash.org/XML/employee"
+  xmlns:entry="http://www.gnucash.org/XML/entry"
+  xmlns:fs="http://www.gnucash.org/XML/fs"
+  xmlns:gnc="http://www.gnucash.org/XML/gnc"
+  xmlns:gnc-act="http://www.gnucash.org/XML/gnc-act"
+  xmlns:invoice="http://www.gnucash.org/XML/invoice"
+  xmlns:job="http://www.gnucash.org/XML/job"
+  xmlns:lot="http://www.gnucash.org/XML/lot"
+  xmlns:order="http://www.gnucash.org/XML/order"
+  xmlns:owner="http://www.gnucash.org/XML/owner"
+  xmlns:price="http://www.gnucash.org/XML/price"
+  xmlns:recurrence="http://www.gnucash.org/XML/recurrence"
+  xmlns:slot="http://www.gnucash.org/XML/slot"
+  xmlns:split="http://www.gnucash.org/XML/split"
+  xmlns:sx="http://www.gnucash.org/XML/sx"
+  xmlns:taxtable="http://www.gnucash.org/XML/taxtable"
+  xmlns:trn="http://www.gnucash.org/XML/trn"
+  xmlns:ts="http://www.gnucash.org/XML/ts"
+  xmlns:tte="http://www.gnucash.org/XML/tte"
+  xmlns:vendor="http://www.gnucash.org/XML/vendor">
+
+<gnc-act:title>
+  Kredit Auto
+</gnc-act:title>
+<gnc-act:short-description>
+  Kredit für Autokauf
+</gnc-act:short-description>
+<gnc-act:long-description>
+  Falls Sie einen Kredit zum Autokauf besitzen, können Sie mit dieser Auswahl die passenden Konten bekommen.
+</gnc-act:long-description>
+
 <gnc:account version="2.0.0">
   <act:name>Root Account</act:name>
   <act:id type="new">1972cce2e2364f95b2b0bc014502661d</act:id>
@@ -122,8 +155,5 @@
   <act:description>Kreditzinsen für Autokauf</act:description>
   <act:parent type="new">8fc4ba994d32d90d7a9a9112ee37f3f6</act:parent>
 </gnc:account>
-</gnc-account-example>
 
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->
+</gnc-account-example>

--- a/accounts/de_DE/acctchrt_brokerage.gnucash-xea
+++ b/accounts/de_DE/acctchrt_brokerage.gnucash-xea
@@ -1,14 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
-<gnc-account-example>
-    <gnc-act:title>
-      Aktienhandel
-    </gnc-act:title>
-    <gnc-act:short-description>
-      Konten zum Handel mit Aktien und Fonds
-    </gnc-act:short-description>
-    <gnc-act:long-description>
-      Mit dieser Auswahl werden Konten zum Handel mit Aktien und Aktienfonds erstellt.
-  </gnc-act:long-description>    
+<gnc-account-example 
+  xmlns="http://www.gnucash.org/XML/"
+  xmlns:act="http://www.gnucash.org/XML/act"
+  xmlns:addr="http://www.gnucash.org/XML/addr"
+  xmlns:bgt="http://www.gnucash.org/XML/bgt"
+  xmlns:billterm="http://www.gnucash.org/XML/billterm"
+  xmlns:book="http://www.gnucash.org/XML/book"
+  xmlns:bt-days="http://www.gnucash.org/XML/bt-days"
+  xmlns:bt-prox="http://www.gnucash.org/XML/bt-prox"
+  xmlns:cd="http://www.gnucash.org/XML/cd"
+  xmlns:cmdty="http://www.gnucash.org/XML/cmdty"
+  xmlns:cust="http://www.gnucash.org/XML/cust"
+  xmlns:employee="http://www.gnucash.org/XML/employee"
+  xmlns:entry="http://www.gnucash.org/XML/entry"
+  xmlns:fs="http://www.gnucash.org/XML/fs"
+  xmlns:gnc="http://www.gnucash.org/XML/gnc"
+  xmlns:gnc-act="http://www.gnucash.org/XML/gnc-act"
+  xmlns:invoice="http://www.gnucash.org/XML/invoice"
+  xmlns:job="http://www.gnucash.org/XML/job"
+  xmlns:lot="http://www.gnucash.org/XML/lot"
+  xmlns:order="http://www.gnucash.org/XML/order"
+  xmlns:owner="http://www.gnucash.org/XML/owner"
+  xmlns:price="http://www.gnucash.org/XML/price"
+  xmlns:recurrence="http://www.gnucash.org/XML/recurrence"
+  xmlns:slot="http://www.gnucash.org/XML/slot"
+  xmlns:split="http://www.gnucash.org/XML/split"
+  xmlns:sx="http://www.gnucash.org/XML/sx"
+  xmlns:taxtable="http://www.gnucash.org/XML/taxtable"
+  xmlns:trn="http://www.gnucash.org/XML/trn"
+  xmlns:ts="http://www.gnucash.org/XML/ts"
+  xmlns:tte="http://www.gnucash.org/XML/tte"
+  xmlns:vendor="http://www.gnucash.org/XML/vendor">
+
+<gnc-act:title>
+  Aktienhandel
+</gnc-act:title>
+<gnc-act:short-description>
+  Konten zum Handel mit Aktien und Fonds
+</gnc-act:short-description>
+<gnc-act:long-description>
+  Mit dieser Auswahl werden Konten zum Handel mit Aktien und Aktienfonds erstellt.
+</gnc-act:long-description>
+
 <gnc:account version="2.0.0">
   <act:name>Root Account</act:name>
   <act:id type="new">1972cce2e2364f95b2b0bc014502661d</act:id>
@@ -172,8 +205,5 @@
   <act:description>Komissionen im Aktienhandel</act:description>
   <act:parent type="new">18ca785b6fcd2895427459c233a47c57</act:parent>
 </gnc:account>
-</gnc-account-example>
 
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->
+</gnc-account-example>

--- a/accounts/de_DE/acctchrt_common.gnucash-xea
+++ b/accounts/de_DE/acctchrt_common.gnucash-xea
@@ -1,15 +1,48 @@
 <?xml version="1.0" encoding="utf-8"?>
-<gnc-account-example>
-    <gnc-act:title>
-      Allgemeine Konten
-    </gnc-act:title>
-    <gnc-act:short-description>
-      Grundlegende Kontenstruktur
-    </gnc-act:short-description>
-    <gnc-act:long-description>
-    Die meisten Anwender benötigen diese grundlegende Kontenstruktur. Sie finden hier die allgemein üblichen Konten wie Giro-, Sparkonto, Bargeld, Kreditkarte, Erträge und verschiedene Ausgaben. Wenn Sie aber einen SKR verwenden wollen, brauchen Sie sie nicht.
-  </gnc-act:long-description>
-  <gnc-act:start-selected>1</gnc-act:start-selected>
+<gnc-account-example 
+  xmlns="http://www.gnucash.org/XML/"
+  xmlns:act="http://www.gnucash.org/XML/act"
+  xmlns:addr="http://www.gnucash.org/XML/addr"
+  xmlns:bgt="http://www.gnucash.org/XML/bgt"
+  xmlns:billterm="http://www.gnucash.org/XML/billterm"
+  xmlns:book="http://www.gnucash.org/XML/book"
+  xmlns:bt-days="http://www.gnucash.org/XML/bt-days"
+  xmlns:bt-prox="http://www.gnucash.org/XML/bt-prox"
+  xmlns:cd="http://www.gnucash.org/XML/cd"
+  xmlns:cmdty="http://www.gnucash.org/XML/cmdty"
+  xmlns:cust="http://www.gnucash.org/XML/cust"
+  xmlns:employee="http://www.gnucash.org/XML/employee"
+  xmlns:entry="http://www.gnucash.org/XML/entry"
+  xmlns:fs="http://www.gnucash.org/XML/fs"
+  xmlns:gnc="http://www.gnucash.org/XML/gnc"
+  xmlns:gnc-act="http://www.gnucash.org/XML/gnc-act"
+  xmlns:invoice="http://www.gnucash.org/XML/invoice"
+  xmlns:job="http://www.gnucash.org/XML/job"
+  xmlns:lot="http://www.gnucash.org/XML/lot"
+  xmlns:order="http://www.gnucash.org/XML/order"
+  xmlns:owner="http://www.gnucash.org/XML/owner"
+  xmlns:price="http://www.gnucash.org/XML/price"
+  xmlns:recurrence="http://www.gnucash.org/XML/recurrence"
+  xmlns:slot="http://www.gnucash.org/XML/slot"
+  xmlns:split="http://www.gnucash.org/XML/split"
+  xmlns:sx="http://www.gnucash.org/XML/sx"
+  xmlns:taxtable="http://www.gnucash.org/XML/taxtable"
+  xmlns:trn="http://www.gnucash.org/XML/trn"
+  xmlns:ts="http://www.gnucash.org/XML/ts"
+  xmlns:tte="http://www.gnucash.org/XML/tte"
+  xmlns:vendor="http://www.gnucash.org/XML/vendor">
+
+<gnc-act:title>
+  Allgemeine Konten
+</gnc-act:title>
+<gnc-act:short-description>
+  Grundlegende Kontenstruktur
+</gnc-act:short-description>
+<gnc-act:long-description>
+  Die meisten Anwender benötigen diese grundlegende Kontenstruktur. Sie finden hier die allgemein üblichen Konten wie Giro-, Sparkonto, Bargeld, Kreditkarte, Erträge und verschiedene Ausgaben. Wenn Sie aber einen SKR verwenden wollen, brauchen Sie sie nicht.
+</gnc-act:long-description>
+<gnc-act:start-selected>1</gnc-act:start-selected>
+
 <gnc:account version="2.0.0">
   <act:name>Root Account</act:name>
   <act:id type="new">1972cce2e2364f95b2b0bc014502661d</act:id>
@@ -811,8 +844,5 @@
   <act:description>Anfangsbestand</act:description>
   <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
 </gnc:account>
-</gnc-account-example>
 
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->
+</gnc-account-example>

--- a/accounts/de_DE/acctchrt_full.gnucash-xea
+++ b/accounts/de_DE/acctchrt_full.gnucash-xea
@@ -1,14 +1,48 @@
 <?xml version="1.0" encoding="utf-8"?>
-<gnc-account-example>
-    <gnc-act:title>
-      Alle Konten
-    </gnc-act:title>
-    <gnc-act:short-description>
-      Alle vorgeschlagenen Konten
-    </gnc-act:short-description>
-    <gnc-act:long-description>
-      Dies ist die komplette Liste aller vorgeschlagenen Konten.
-  </gnc-act:long-description>
+<gnc-account-example 
+  xmlns="http://www.gnucash.org/XML/"
+  xmlns:act="http://www.gnucash.org/XML/act"
+  xmlns:addr="http://www.gnucash.org/XML/addr"
+  xmlns:bgt="http://www.gnucash.org/XML/bgt"
+  xmlns:billterm="http://www.gnucash.org/XML/billterm"
+  xmlns:book="http://www.gnucash.org/XML/book"
+  xmlns:bt-days="http://www.gnucash.org/XML/bt-days"
+  xmlns:bt-prox="http://www.gnucash.org/XML/bt-prox"
+  xmlns:cd="http://www.gnucash.org/XML/cd"
+  xmlns:cmdty="http://www.gnucash.org/XML/cmdty"
+  xmlns:cust="http://www.gnucash.org/XML/cust"
+  xmlns:employee="http://www.gnucash.org/XML/employee"
+  xmlns:entry="http://www.gnucash.org/XML/entry"
+  xmlns:fs="http://www.gnucash.org/XML/fs"
+  xmlns:gnc="http://www.gnucash.org/XML/gnc"
+  xmlns:gnc-act="http://www.gnucash.org/XML/gnc-act"
+  xmlns:invoice="http://www.gnucash.org/XML/invoice"
+  xmlns:job="http://www.gnucash.org/XML/job"
+  xmlns:lot="http://www.gnucash.org/XML/lot"
+  xmlns:order="http://www.gnucash.org/XML/order"
+  xmlns:owner="http://www.gnucash.org/XML/owner"
+  xmlns:price="http://www.gnucash.org/XML/price"
+  xmlns:recurrence="http://www.gnucash.org/XML/recurrence"
+  xmlns:slot="http://www.gnucash.org/XML/slot"
+  xmlns:split="http://www.gnucash.org/XML/split"
+  xmlns:sx="http://www.gnucash.org/XML/sx"
+  xmlns:taxtable="http://www.gnucash.org/XML/taxtable"
+  xmlns:trn="http://www.gnucash.org/XML/trn"
+  xmlns:ts="http://www.gnucash.org/XML/ts"
+  xmlns:tte="http://www.gnucash.org/XML/tte"
+  xmlns:vendor="http://www.gnucash.org/XML/vendor">
+
+<gnc-act:title>
+  Alle Konten
+</gnc-act:title>
+<gnc-act:short-description>
+  Alle vorgeschlagenen Konten
+</gnc-act:short-description>
+<gnc-act:long-description>
+  Dies ist die komplette Liste aller vorgeschlagenen Konten.
+</gnc-act:long-description>
+<gnc-act:exclude-from-select-all>1</gnc-act:exclude-from-select-all>
+
 <gnc:account version="2.0.0">
   <act:name>Root Account</act:name>
   <act:id type="new">1972cce2e2364f95b2b0bc014502661d</act:id>
@@ -1159,8 +1193,5 @@
   <act:description>Anfangsbestand</act:description>
   <act:parent type="new">320d3cf62b418db6281c3cd8ec2e95c7</act:parent>
 </gnc:account>
-</gnc-account-example>
 
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->
+</gnc-account-example>

--- a/accounts/de_DE/acctchrt_houseown.gnucash-xea
+++ b/accounts/de_DE/acctchrt_houseown.gnucash-xea
@@ -1,14 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
-<gnc-account-example>
-    <gnc-act:title>
-      Hausbesitz
-    </gnc-act:title>
-    <gnc-act:short-description>
-      Konten für Hausbesitzer/innen
-    </gnc-act:short-description>
-    <gnc-act:long-description>
-      Konten für Hausbesitzer/innen
-  </gnc-act:long-description>
+<gnc-account-example 
+  xmlns="http://www.gnucash.org/XML/"
+  xmlns:act="http://www.gnucash.org/XML/act"
+  xmlns:addr="http://www.gnucash.org/XML/addr"
+  xmlns:bgt="http://www.gnucash.org/XML/bgt"
+  xmlns:billterm="http://www.gnucash.org/XML/billterm"
+  xmlns:book="http://www.gnucash.org/XML/book"
+  xmlns:bt-days="http://www.gnucash.org/XML/bt-days"
+  xmlns:bt-prox="http://www.gnucash.org/XML/bt-prox"
+  xmlns:cd="http://www.gnucash.org/XML/cd"
+  xmlns:cmdty="http://www.gnucash.org/XML/cmdty"
+  xmlns:cust="http://www.gnucash.org/XML/cust"
+  xmlns:employee="http://www.gnucash.org/XML/employee"
+  xmlns:entry="http://www.gnucash.org/XML/entry"
+  xmlns:fs="http://www.gnucash.org/XML/fs"
+  xmlns:gnc="http://www.gnucash.org/XML/gnc"
+  xmlns:gnc-act="http://www.gnucash.org/XML/gnc-act"
+  xmlns:invoice="http://www.gnucash.org/XML/invoice"
+  xmlns:job="http://www.gnucash.org/XML/job"
+  xmlns:lot="http://www.gnucash.org/XML/lot"
+  xmlns:order="http://www.gnucash.org/XML/order"
+  xmlns:owner="http://www.gnucash.org/XML/owner"
+  xmlns:price="http://www.gnucash.org/XML/price"
+  xmlns:recurrence="http://www.gnucash.org/XML/recurrence"
+  xmlns:slot="http://www.gnucash.org/XML/slot"
+  xmlns:split="http://www.gnucash.org/XML/split"
+  xmlns:sx="http://www.gnucash.org/XML/sx"
+  xmlns:taxtable="http://www.gnucash.org/XML/taxtable"
+  xmlns:trn="http://www.gnucash.org/XML/trn"
+  xmlns:ts="http://www.gnucash.org/XML/ts"
+  xmlns:tte="http://www.gnucash.org/XML/tte"
+  xmlns:vendor="http://www.gnucash.org/XML/vendor">
+
+<gnc-act:title>
+  Hausbesitz
+</gnc-act:title>
+<gnc-act:short-description>
+  Konten für Hausbesitzer/innen
+</gnc-act:short-description>
+<gnc-act:long-description>
+  Konten für Hausbesitzer/innen
+</gnc-act:long-description>
+
 <gnc:account version="2.0.0">
   <act:name>Root Account</act:name>
   <act:id type="new">1972cce2e2364f95b2b0bc014502661d</act:id>
@@ -200,8 +233,5 @@
   <act:description>Reparaturen</act:description>
   <act:parent type="new">b413c76bf6939070b97f7fed1c4fd367</act:parent>
 </gnc:account>
-</gnc-account-example>
 
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->
+</gnc-account-example>

--- a/accounts/de_DE/acctchrt_investment.gnucash-xea
+++ b/accounts/de_DE/acctchrt_investment.gnucash-xea
@@ -1,14 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
-<gnc-account-example>
-    <gnc-act:title>
-      Geldanlagen
-    </gnc-act:title>
-    <gnc-act:short-description>
-      Konten für Geldanlagen
-    </gnc-act:short-description>
-    <gnc-act:long-description>
-      Konten für Investitionen in Geldanlagen: Bausparvertrag, Lebensversicherung, Festgeld, Investmentfonds.
-  </gnc-act:long-description>    
+<gnc-account-example 
+  xmlns="http://www.gnucash.org/XML/"
+  xmlns:act="http://www.gnucash.org/XML/act"
+  xmlns:addr="http://www.gnucash.org/XML/addr"
+  xmlns:bgt="http://www.gnucash.org/XML/bgt"
+  xmlns:billterm="http://www.gnucash.org/XML/billterm"
+  xmlns:book="http://www.gnucash.org/XML/book"
+  xmlns:bt-days="http://www.gnucash.org/XML/bt-days"
+  xmlns:bt-prox="http://www.gnucash.org/XML/bt-prox"
+  xmlns:cd="http://www.gnucash.org/XML/cd"
+  xmlns:cmdty="http://www.gnucash.org/XML/cmdty"
+  xmlns:cust="http://www.gnucash.org/XML/cust"
+  xmlns:employee="http://www.gnucash.org/XML/employee"
+  xmlns:entry="http://www.gnucash.org/XML/entry"
+  xmlns:fs="http://www.gnucash.org/XML/fs"
+  xmlns:gnc="http://www.gnucash.org/XML/gnc"
+  xmlns:gnc-act="http://www.gnucash.org/XML/gnc-act"
+  xmlns:invoice="http://www.gnucash.org/XML/invoice"
+  xmlns:job="http://www.gnucash.org/XML/job"
+  xmlns:lot="http://www.gnucash.org/XML/lot"
+  xmlns:order="http://www.gnucash.org/XML/order"
+  xmlns:owner="http://www.gnucash.org/XML/owner"
+  xmlns:price="http://www.gnucash.org/XML/price"
+  xmlns:recurrence="http://www.gnucash.org/XML/recurrence"
+  xmlns:slot="http://www.gnucash.org/XML/slot"
+  xmlns:split="http://www.gnucash.org/XML/split"
+  xmlns:sx="http://www.gnucash.org/XML/sx"
+  xmlns:taxtable="http://www.gnucash.org/XML/taxtable"
+  xmlns:trn="http://www.gnucash.org/XML/trn"
+  xmlns:ts="http://www.gnucash.org/XML/ts"
+  xmlns:tte="http://www.gnucash.org/XML/tte"
+  xmlns:vendor="http://www.gnucash.org/XML/vendor">
+
+<gnc-act:title>
+  Geldanlagen
+</gnc-act:title>
+<gnc-act:short-description>
+  Konten für Geldanlagen
+</gnc-act:short-description>
+<gnc-act:long-description>
+  Konten für Investitionen in Geldanlagen: Bausparvertrag, Lebensversicherung, Festgeld, Investmentfonds.
+</gnc-act:long-description>
+
 <gnc:account version="2.0.0">
   <act:name>Root Account</act:name>
   <act:id type="new">1972cce2e2364f95b2b0bc014502661d</act:id>
@@ -205,8 +238,5 @@
   <act:description>Lebensversicherung</act:description>
   <act:parent type="new">b0dbf43ea99f54e0a9f94a535b10941b</act:parent>
 </gnc:account>
-</gnc-account-example>
 
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->
+</gnc-account-example>

--- a/accounts/de_DE/acctchrt_kids.gnucash-xea
+++ b/accounts/de_DE/acctchrt_kids.gnucash-xea
@@ -1,14 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
-<gnc-account-example>
-    <gnc-act:title>
-      Kinder
-    </gnc-act:title>
-    <gnc-act:short-description>
-      Konten im Zusammenhang mit Kindern
-    </gnc-act:short-description>
-    <gnc-act:long-description>
-      Kindergeld, Kindergarten
-  </gnc-act:long-description>    
+<gnc-account-example 
+  xmlns="http://www.gnucash.org/XML/"
+  xmlns:act="http://www.gnucash.org/XML/act"
+  xmlns:addr="http://www.gnucash.org/XML/addr"
+  xmlns:bgt="http://www.gnucash.org/XML/bgt"
+  xmlns:billterm="http://www.gnucash.org/XML/billterm"
+  xmlns:book="http://www.gnucash.org/XML/book"
+  xmlns:bt-days="http://www.gnucash.org/XML/bt-days"
+  xmlns:bt-prox="http://www.gnucash.org/XML/bt-prox"
+  xmlns:cd="http://www.gnucash.org/XML/cd"
+  xmlns:cmdty="http://www.gnucash.org/XML/cmdty"
+  xmlns:cust="http://www.gnucash.org/XML/cust"
+  xmlns:employee="http://www.gnucash.org/XML/employee"
+  xmlns:entry="http://www.gnucash.org/XML/entry"
+  xmlns:fs="http://www.gnucash.org/XML/fs"
+  xmlns:gnc="http://www.gnucash.org/XML/gnc"
+  xmlns:gnc-act="http://www.gnucash.org/XML/gnc-act"
+  xmlns:invoice="http://www.gnucash.org/XML/invoice"
+  xmlns:job="http://www.gnucash.org/XML/job"
+  xmlns:lot="http://www.gnucash.org/XML/lot"
+  xmlns:order="http://www.gnucash.org/XML/order"
+  xmlns:owner="http://www.gnucash.org/XML/owner"
+  xmlns:price="http://www.gnucash.org/XML/price"
+  xmlns:recurrence="http://www.gnucash.org/XML/recurrence"
+  xmlns:slot="http://www.gnucash.org/XML/slot"
+  xmlns:split="http://www.gnucash.org/XML/split"
+  xmlns:sx="http://www.gnucash.org/XML/sx"
+  xmlns:taxtable="http://www.gnucash.org/XML/taxtable"
+  xmlns:trn="http://www.gnucash.org/XML/trn"
+  xmlns:ts="http://www.gnucash.org/XML/ts"
+  xmlns:tte="http://www.gnucash.org/XML/tte"
+  xmlns:vendor="http://www.gnucash.org/XML/vendor">
+
+<gnc-act:title>
+  Kinder
+</gnc-act:title>
+<gnc-act:short-description>
+  Konten im Zusammenhang mit Kindern
+</gnc-act:short-description>
+<gnc-act:long-description>
+  Kindergeld, Kindergarten
+</gnc-act:long-description>
+
 <gnc:account version="2.0.0">
   <act:name>Root Account</act:name>
   <act:id type="new">1972cce2e2364f95b2b0bc014502661d</act:id>
@@ -88,8 +121,5 @@
   <act:description>Kindergarten</act:description>
   <act:parent type="new">bc39f4d37eb75353f4f971e80b9d2818</act:parent>
 </gnc:account>
-</gnc-account-example>
 
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->
+</gnc-account-example>

--- a/accounts/de_DE/acctchrt_otherasset.gnucash-xea
+++ b/accounts/de_DE/acctchrt_otherasset.gnucash-xea
@@ -1,14 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
-<gnc-account-example>
-    <gnc-act:title>
-      Sonstige Sachanlage
-    </gnc-act:title>
-    <gnc-act:short-description>
-      Sonstige Sachanlagen
-    </gnc-act:short-description>
-    <gnc-act:long-description>
-      Sonstige Sachanlagen
-  </gnc-act:long-description>    
+<gnc-account-example 
+  xmlns="http://www.gnucash.org/XML/"
+  xmlns:act="http://www.gnucash.org/XML/act"
+  xmlns:addr="http://www.gnucash.org/XML/addr"
+  xmlns:bgt="http://www.gnucash.org/XML/bgt"
+  xmlns:billterm="http://www.gnucash.org/XML/billterm"
+  xmlns:book="http://www.gnucash.org/XML/book"
+  xmlns:bt-days="http://www.gnucash.org/XML/bt-days"
+  xmlns:bt-prox="http://www.gnucash.org/XML/bt-prox"
+  xmlns:cd="http://www.gnucash.org/XML/cd"
+  xmlns:cmdty="http://www.gnucash.org/XML/cmdty"
+  xmlns:cust="http://www.gnucash.org/XML/cust"
+  xmlns:employee="http://www.gnucash.org/XML/employee"
+  xmlns:entry="http://www.gnucash.org/XML/entry"
+  xmlns:fs="http://www.gnucash.org/XML/fs"
+  xmlns:gnc="http://www.gnucash.org/XML/gnc"
+  xmlns:gnc-act="http://www.gnucash.org/XML/gnc-act"
+  xmlns:invoice="http://www.gnucash.org/XML/invoice"
+  xmlns:job="http://www.gnucash.org/XML/job"
+  xmlns:lot="http://www.gnucash.org/XML/lot"
+  xmlns:order="http://www.gnucash.org/XML/order"
+  xmlns:owner="http://www.gnucash.org/XML/owner"
+  xmlns:price="http://www.gnucash.org/XML/price"
+  xmlns:recurrence="http://www.gnucash.org/XML/recurrence"
+  xmlns:slot="http://www.gnucash.org/XML/slot"
+  xmlns:split="http://www.gnucash.org/XML/split"
+  xmlns:sx="http://www.gnucash.org/XML/sx"
+  xmlns:taxtable="http://www.gnucash.org/XML/taxtable"
+  xmlns:trn="http://www.gnucash.org/XML/trn"
+  xmlns:ts="http://www.gnucash.org/XML/ts"
+  xmlns:tte="http://www.gnucash.org/XML/tte"
+  xmlns:vendor="http://www.gnucash.org/XML/vendor">
+
+<gnc-act:title>
+  Sonstige Sachanlage
+</gnc-act:title>
+<gnc-act:short-description>
+  Sonstige Sachanlagen
+</gnc-act:short-description>
+<gnc-act:long-description>
+  Sonstige Sachanlagen
+</gnc-act:long-description>
+
 <gnc:account version="2.0.0">
   <act:name>Root Account</act:name>
   <act:id type="new">1972cce2e2364f95b2b0bc014502661d</act:id>
@@ -60,8 +93,5 @@
   <act:description>Sonstige Sachanlagen</act:description>
   <act:parent type="new">f7b3424631deed453984e6f5c5569669</act:parent>
 </gnc:account>
-</gnc-account-example>
 
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->
+</gnc-account-example>

--- a/accounts/de_DE/acctchrt_otherloan.gnucash-xea
+++ b/accounts/de_DE/acctchrt_otherloan.gnucash-xea
@@ -1,14 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
-<gnc-account-example>
-    <gnc-act:title>
-      Sonstiger Kredit
-    </gnc-act:title>
-    <gnc-act:short-description>
-      Sonstige Kredite
-    </gnc-act:short-description>
-    <gnc-act:long-description>
-      Weitere Kredite
-  </gnc-act:long-description>
+<gnc-account-example 
+  xmlns="http://www.gnucash.org/XML/"
+  xmlns:act="http://www.gnucash.org/XML/act"
+  xmlns:addr="http://www.gnucash.org/XML/addr"
+  xmlns:bgt="http://www.gnucash.org/XML/bgt"
+  xmlns:billterm="http://www.gnucash.org/XML/billterm"
+  xmlns:book="http://www.gnucash.org/XML/book"
+  xmlns:bt-days="http://www.gnucash.org/XML/bt-days"
+  xmlns:bt-prox="http://www.gnucash.org/XML/bt-prox"
+  xmlns:cd="http://www.gnucash.org/XML/cd"
+  xmlns:cmdty="http://www.gnucash.org/XML/cmdty"
+  xmlns:cust="http://www.gnucash.org/XML/cust"
+  xmlns:employee="http://www.gnucash.org/XML/employee"
+  xmlns:entry="http://www.gnucash.org/XML/entry"
+  xmlns:fs="http://www.gnucash.org/XML/fs"
+  xmlns:gnc="http://www.gnucash.org/XML/gnc"
+  xmlns:gnc-act="http://www.gnucash.org/XML/gnc-act"
+  xmlns:invoice="http://www.gnucash.org/XML/invoice"
+  xmlns:job="http://www.gnucash.org/XML/job"
+  xmlns:lot="http://www.gnucash.org/XML/lot"
+  xmlns:order="http://www.gnucash.org/XML/order"
+  xmlns:owner="http://www.gnucash.org/XML/owner"
+  xmlns:price="http://www.gnucash.org/XML/price"
+  xmlns:recurrence="http://www.gnucash.org/XML/recurrence"
+  xmlns:slot="http://www.gnucash.org/XML/slot"
+  xmlns:split="http://www.gnucash.org/XML/split"
+  xmlns:sx="http://www.gnucash.org/XML/sx"
+  xmlns:taxtable="http://www.gnucash.org/XML/taxtable"
+  xmlns:trn="http://www.gnucash.org/XML/trn"
+  xmlns:ts="http://www.gnucash.org/XML/ts"
+  xmlns:tte="http://www.gnucash.org/XML/tte"
+  xmlns:vendor="http://www.gnucash.org/XML/vendor">
+
+<gnc-act:title>
+  Sonstiger Kredit
+</gnc-act:title>
+<gnc-act:short-description>
+  Sonstige Kredite
+</gnc-act:short-description>
+<gnc-act:long-description>
+  Weitere Kredite
+</gnc-act:long-description>
+
 <gnc:account version="2.0.0">
   <act:name>Root Account</act:name>
   <act:id type="new">1972cce2e2364f95b2b0bc014502661d</act:id>
@@ -60,8 +93,5 @@
   <act:description>Sonstige Kredite</act:description>
   <act:parent type="new">13df44e66790069c74d563946aa0394e</act:parent>
 </gnc:account>
-</gnc-account-example>
 
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->
+</gnc-account-example>

--- a/accounts/de_DE/acctchrt_skr03.gnucash-xea
+++ b/accounts/de_DE/acctchrt_skr03.gnucash-xea
@@ -31,6 +31,7 @@
   xmlns:tte="http://www.gnucash.org/XML/tte"
   xmlns:entry="http://www.gnucash.org/XML/entry"
   xmlns:vendor="http://www.gnucash.org/XML/vendor">
+
   <gnc-act:title>
     Kontenrahmen SKR03
   </gnc-act:title>
@@ -41,6 +42,7 @@
     Beta Version des Kontenrahmes SKR03 zum Erweitern und Umstrukturieren. Der Kontenrahmen sollte den eigenen Bedürfnissen angepasst werden was Struktur und Kontenbezeichnungen angeht. WICHTIG!: Die Privatkonten fließen nicht in die Berechnung des Berichtes Bilanz, sind jedoch im Bericht Bilanz aufgeführt. Die im Bericht Bilanz aufgeführte Passiva "Gewinnrücklagen" gibt den Saldo der GuV aus. Die Anlage dieses Kontenrahmens wurde von der Firma LiHAS - Linuxhaus Stuttgart - unterstützt.
   </gnc-act:long-description>
   <gnc-act:exclude-from-select-all>1</gnc-act:exclude-from-select-all>
+
   <gnc:account version="2.0.0">
     <act:name>Root Account</act:name>
     <act:id type="new">1972cce2e2364f95b2b0bc014502661d</act:id>
@@ -1398,8 +1400,5 @@
     <act:code>1890</act:code>
     <act:parent type="new">b9ae1b059749ea81c757a9adad39db1b</act:parent>
   </gnc:account>
-</gnc-account-example>
 
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->
+</gnc-account-example>

--- a/accounts/de_DE/acctchrt_skr04.gnucash-xea
+++ b/accounts/de_DE/acctchrt_skr04.gnucash-xea
@@ -31,6 +31,7 @@
   xmlns:tte="http://www.gnucash.org/XML/tte"
   xmlns:entry="http://www.gnucash.org/XML/entry"
   xmlns:vendor="http://www.gnucash.org/XML/vendor">
+
   <gnc-act:title>
     Kontenrahmen SKR04
   </gnc-act:title>
@@ -41,6 +42,7 @@
     BETA-Version eines Kontenrahmes SKR04 für 2005.  Mehr Informationen unter http://wiki.gnucash.org/wiki/De/SKR04
   </gnc-act:long-description>
   <gnc-act:exclude-from-select-all>1</gnc-act:exclude-from-select-all>
+
   <gnc:account version="2.0.0">
     <act:name>Root Account</act:name>
     <act:id type="new">1972cce2e2364f95b2b0bc014502661d</act:id>
@@ -26072,8 +26074,5 @@
     </act:slots>
     <act:parent type="new">e57d948c9a884e179bd090118b9212f8</act:parent>
   </gnc:account>
-</gnc-account-example>
 
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->
+</gnc-account-example>

--- a/accounts/de_DE/acctchrt_skr49.gnucash-xea
+++ b/accounts/de_DE/acctchrt_skr49.gnucash-xea
@@ -31,6 +31,7 @@
   xmlns:ts="http://www.gnucash.org/XML/ts"
   xmlns:tte="http://www.gnucash.org/XML/tte"
   xmlns:vendor="http://www.gnucash.org/XML/vendor">
+
 <gnc-act:title>
   Kontenrahmen SKR49
 </gnc-act:title>
@@ -48,6 +49,7 @@
   Formalia für GnuCash-Vorlagen: Frank H. Ellenberger 2009
 </gnc-act:long-description>
 <gnc-act:exclude-from-select-all>1</gnc-act:exclude-from-select-all>
+
 <gnc:account version="2.0.0">
   <act:name>Root Account</act:name>
   <act:id type="new">e24772da4864456b196be5a6301c6756</act:id>
@@ -16893,8 +16895,5 @@
   <act:description>Umgebuchte Ausgaben bisheriger Zweckbetriebe </act:description>
   <act:parent type="new">8268da381a30e25c7c483162066858d4</act:parent>
 </gnc:account>
-</gnc-account-example>
 
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->
+</gnc-account-example>

--- a/accounts/de_DE/acctchrt_studium.gnucash-xea
+++ b/accounts/de_DE/acctchrt_studium.gnucash-xea
@@ -1,14 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
-<gnc-account-example>
-    <gnc-act:title>
-      Studium
-    </gnc-act:title>
-    <gnc-act:short-description>
-      Konten für Studentinnen und Studenten
-    </gnc-act:short-description>
-    <gnc-act:long-description>
-      BAFöG, Studiengebühren
-  </gnc-act:long-description>
+<gnc-account-example 
+  xmlns="http://www.gnucash.org/XML/"
+  xmlns:act="http://www.gnucash.org/XML/act"
+  xmlns:addr="http://www.gnucash.org/XML/addr"
+  xmlns:bgt="http://www.gnucash.org/XML/bgt"
+  xmlns:billterm="http://www.gnucash.org/XML/billterm"
+  xmlns:book="http://www.gnucash.org/XML/book"
+  xmlns:bt-days="http://www.gnucash.org/XML/bt-days"
+  xmlns:bt-prox="http://www.gnucash.org/XML/bt-prox"
+  xmlns:cd="http://www.gnucash.org/XML/cd"
+  xmlns:cmdty="http://www.gnucash.org/XML/cmdty"
+  xmlns:cust="http://www.gnucash.org/XML/cust"
+  xmlns:employee="http://www.gnucash.org/XML/employee"
+  xmlns:entry="http://www.gnucash.org/XML/entry"
+  xmlns:fs="http://www.gnucash.org/XML/fs"
+  xmlns:gnc="http://www.gnucash.org/XML/gnc"
+  xmlns:gnc-act="http://www.gnucash.org/XML/gnc-act"
+  xmlns:invoice="http://www.gnucash.org/XML/invoice"
+  xmlns:job="http://www.gnucash.org/XML/job"
+  xmlns:lot="http://www.gnucash.org/XML/lot"
+  xmlns:order="http://www.gnucash.org/XML/order"
+  xmlns:owner="http://www.gnucash.org/XML/owner"
+  xmlns:price="http://www.gnucash.org/XML/price"
+  xmlns:recurrence="http://www.gnucash.org/XML/recurrence"
+  xmlns:slot="http://www.gnucash.org/XML/slot"
+  xmlns:split="http://www.gnucash.org/XML/split"
+  xmlns:sx="http://www.gnucash.org/XML/sx"
+  xmlns:taxtable="http://www.gnucash.org/XML/taxtable"
+  xmlns:trn="http://www.gnucash.org/XML/trn"
+  xmlns:ts="http://www.gnucash.org/XML/ts"
+  xmlns:tte="http://www.gnucash.org/XML/tte"
+  xmlns:vendor="http://www.gnucash.org/XML/vendor">
+
+<gnc-act:title>
+  Studium
+</gnc-act:title>
+<gnc-act:short-description>
+  Konten für Studentinnen und Studenten
+</gnc-act:short-description>
+<gnc-act:long-description>
+  BAFöG, Studiengebühren
+</gnc-act:long-description>
+
 <gnc:account version="2.0.0">
   <act:name>Root Account</act:name>
   <act:id type="new">1972cce2e2364f95b2b0bc014502661d</act:id>
@@ -133,8 +166,5 @@
   <act:description>Studiengebühren</act:description>
   <act:parent type="new">5416a78a11e81e963990cd6a398e5022</act:parent>
 </gnc:account>
-</gnc-account-example>
 
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->
+</gnc-account-example>

--- a/accounts/de_DE/acctchrt_wohnungsw.gnucash-xea
+++ b/accounts/de_DE/acctchrt_wohnungsw.gnucash-xea
@@ -31,6 +31,7 @@
   xmlns:tte="http://www.gnucash.org/XML/tte"
   xmlns:entry="http://www.gnucash.org/XML/entry"
   xmlns:vendor="http://www.gnucash.org/XML/vendor">
+
   <gnc-act:title>
     Kontenrahmen für Wohnungswirtschaft
   </gnc-act:title>
@@ -41,12 +42,13 @@
     BETA-Version eines allgemeinen Kontenrahmes für Wohnungswirtschaft, bearbeitet von Christoph Franzen. Fehlermeldungen an ChristophFranzen@gmx.net .
   </gnc-act:long-description>
   <gnc-act:exclude-from-select-all>1</gnc-act:exclude-from-select-all>
-  <gnc:account version="2.0.0">
-    <act:name>Root Account</act:name>
-    <act:id type="new">1972cce2e2364f95b2b0bc014502661d</act:id>
-    <act:type>ROOT</act:type>
-    <act:commodity-scu>0</act:commodity-scu>
-  </gnc:account>
+
+<gnc:account version="2.0.0">
+  <act:name>Root Account</act:name>
+  <act:id type="new">1972cce2e2364f95b2b0bc014502661d</act:id>
+  <act:type>ROOT</act:type>
+  <act:commodity-scu>0</act:commodity-scu>
+</gnc:account>
 <gnc:account version="2.0.0">
   <act:name>0 Anlagevermögen</act:name>
   <act:id type="new">5dfd1f9eb05cbb673ebfe7cb3a9fdda9</act:id>
@@ -9612,8 +9614,5 @@
   </act:slots>
   <act:parent type="new">6d7edd606e6f0aa8e56c5694161e64c7</act:parent>
 </gnc:account>
-</gnc-account-example>
 
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->
+</gnc-account-example>


### PR DESCRIPTION
 Clean Up for Account Hierarchy Templates: "de_DE" (german):

* Add XML namespaces
  The parser in GC 2.6 makes no use of it, but future versions might change.
  Defining the namespace has the benefit, you can check the syntax of template files with `xmllint`:
  `for i in *-xea; do xmllint --noout $i; done`

 * Remove emacs-comments at the end of files:
  `<! -- Local variables: -->`
  `<! -- mode: xml -->`
  `<! -- End: -->`

 * Add `<gnc-act:exclude-from-select-all>1</gnc-act:exclude-from-select-all>` for `acctchrt_full.gnucash-xea`
   This template should not be selected if the user clicks the button "Select All",
   because it consists of all other non-business templates, which would be selected with "Select All".
   BTW: This template is currently not active.

If these changes are not ok, please just cancel this PR. Thanks in advance!
For more Info see PRs #293, #300 and #303.