### PR TITLE
Remove the emacs comments at the end of files

### DIFF
--- a/data/accounts/C/acctchrt_brokerage.gnucash-xea
+++ b/data/accounts/C/acctchrt_brokerage.gnucash-xea
@@ -214,7 +214,3 @@
   <act:parent type="new">6de23244232785031501171abcc1d4aa</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/C/acctchrt_carloan.gnucash-xea
+++ b/data/accounts/C/acctchrt_carloan.gnucash-xea
@@ -131,8 +131,3 @@
   <act:parent type="new">9e8495e80ebfb762089be917dff7ab72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/C/acctchrt_cdmoneymkt.gnucash-xea
+++ b/data/accounts/C/acctchrt_cdmoneymkt.gnucash-xea
@@ -153,7 +153,3 @@
   <act:parent type="new">fd131cae797d1fb83c2e2bf57254eca5</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/C/acctchrt_checkbook.gnucash-xea
+++ b/data/accounts/C/acctchrt_checkbook.gnucash-xea
@@ -149,8 +149,3 @@
   <act:parent type="new">b8b72887da1adf889f171923d23efbdd</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/C/acctchrt_childcare.gnucash-xea
+++ b/data/accounts/C/acctchrt_childcare.gnucash-xea
@@ -75,7 +75,3 @@
   <act:parent type="new">ee8238ee2c2ce590160761df09b99b72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/C/acctchrt_eduloan.gnucash-xea
+++ b/data/accounts/C/acctchrt_eduloan.gnucash-xea
@@ -131,7 +131,3 @@
   <act:parent type="new">1cfcd30ea97b954ffb550ab87d561033</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/C/acctchrt_fixedassets.gnucash-xea
+++ b/data/accounts/C/acctchrt_fixedassets.gnucash-xea
@@ -114,7 +114,3 @@
   <act:parent type="new">9b171f77000bf68dd1ebbaf58336656d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/C/acctchrt_homeloan.gnucash-xea
+++ b/data/accounts/C/acctchrt_homeloan.gnucash-xea
@@ -131,7 +131,3 @@
   <act:parent type="new">3dc58d8a51b5deaa22e0c65d81e90346</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/C/acctchrt_homeown.gnucash-xea
+++ b/data/accounts/C/acctchrt_homeown.gnucash-xea
@@ -119,7 +119,3 @@
   <act:parent type="new">a931b8ffe2917ff9a069333623da96ca</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/C/acctchrt_otherloan.gnucash-xea
+++ b/data/accounts/C/acctchrt_otherloan.gnucash-xea
@@ -131,7 +131,3 @@
   <act:parent type="new">4a02c14e992ea79076837c164aa6fc8d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/C/acctchrt_renter.gnucash-xea
+++ b/data/accounts/C/acctchrt_renter.gnucash-xea
@@ -97,7 +97,3 @@
   <act:parent type="new">9a2b4520f113372f4e576f5b6dc129c6</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/C/acctchrt_retiremt.gnucash-xea
+++ b/data/accounts/C/acctchrt_retiremt.gnucash-xea
@@ -146,7 +146,3 @@
   <act:parent type="new">4173f3047238f4b5595b11d6161b2f48</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/C/acctchrt_spouseinc.gnucash-xea
+++ b/data/accounts/C/acctchrt_spouseinc.gnucash-xea
@@ -158,7 +158,3 @@
   <act:parent type="new">3cd0ca7d6b0e5f44e4cde2851c3ff387</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/C/acctchrt_spouseretire.gnucash-xea
+++ b/data/accounts/C/acctchrt_spouseretire.gnucash-xea
@@ -146,7 +146,3 @@
   <act:parent type="new">4426b41837adc284f96b291c31022844</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ca/acctchrt_brokerage.gnucash-xea
+++ b/data/accounts/ca/acctchrt_brokerage.gnucash-xea
@@ -190,7 +190,3 @@
   <act:parent type="new">6de23244232785031501171abcc1d4aa</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ca/acctchrt_carloan.gnucash-xea
+++ b/data/accounts/ca/acctchrt_carloan.gnucash-xea
@@ -113,8 +113,3 @@
   <act:parent type="new">9e8495e80ebfb762089be917dff7ab72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ca/acctchrt_cdmoneymkt.gnucash-xea
+++ b/data/accounts/ca/acctchrt_cdmoneymkt.gnucash-xea
@@ -135,7 +135,3 @@
   <act:parent type="new">fd131cae797d1fb83c2e2bf57254eca5</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ca/acctchrt_childcare.gnucash-xea
+++ b/data/accounts/ca/acctchrt_childcare.gnucash-xea
@@ -69,7 +69,3 @@
   <act:parent type="new">ee8238ee2c2ce590160761df09b99b72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ca/acctchrt_common.gnucash-xea
+++ b/data/accounts/ca/acctchrt_common.gnucash-xea
@@ -753,7 +753,3 @@
   <act:parent type="new">3ab6a6d97b216c11333e48aa2b749a91</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ca/acctchrt_currency.gnucash-xea
+++ b/data/accounts/ca/acctchrt_currency.gnucash-xea
@@ -82,7 +82,3 @@
   <act:parent type="new">d9c796b35784533aee4309e28a3cbfc5</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ca/acctchrt_eduloan.gnucash-xea
+++ b/data/accounts/ca/acctchrt_eduloan.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">1cfcd30ea97b954ffb550ab87d561033</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ca/acctchrt_fixedassets.gnucash-xea
+++ b/data/accounts/ca/acctchrt_fixedassets.gnucash-xea
@@ -102,7 +102,3 @@
   <act:parent type="new">9b171f77000bf68dd1ebbaf58336656d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ca/acctchrt_homeloan.gnucash-xea
+++ b/data/accounts/ca/acctchrt_homeloan.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">3dc58d8a51b5deaa22e0c65d81e90346</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ca/acctchrt_homeown.gnucash-xea
+++ b/data/accounts/ca/acctchrt_homeown.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">a931b8ffe2917ff9a069333623da96ca</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ca/acctchrt_otherloan.gnucash-xea
+++ b/data/accounts/ca/acctchrt_otherloan.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">4a02c14e992ea79076837c164aa6fc8d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ca/acctchrt_renter.gnucash-xea
+++ b/data/accounts/ca/acctchrt_renter.gnucash-xea
@@ -91,7 +91,3 @@
   <act:parent type="new">9a2b4520f113372f4e576f5b6dc129c6</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ca/acctchrt_retiremt.gnucash-xea
+++ b/data/accounts/ca/acctchrt_retiremt.gnucash-xea
@@ -130,7 +130,3 @@
   <act:parent type="new">4173f3047238f4b5595b11d6161b2f48</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ca/acctchrt_spouseinc.gnucash-xea
+++ b/data/accounts/ca/acctchrt_spouseinc.gnucash-xea
@@ -146,7 +146,3 @@
   <act:parent type="new">3cd0ca7d6b0e5f44e4cde2851c3ff387</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ca/acctchrt_spouseretire.gnucash-xea
+++ b/data/accounts/ca/acctchrt_spouseretire.gnucash-xea
@@ -130,7 +130,3 @@
   <act:parent type="new">4426b41837adc284f96b291c31022844</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/cs/acctchrt_brokerage.gnucash-xea
+++ b/data/accounts/cs/acctchrt_brokerage.gnucash-xea
@@ -190,7 +190,3 @@
   <act:parent type="new">6de23244232785031501171abcc1d4aa</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/cs/acctchrt_carloan.gnucash-xea
+++ b/data/accounts/cs/acctchrt_carloan.gnucash-xea
@@ -113,8 +113,3 @@
   <act:parent type="new">9e8495e80ebfb762089be917dff7ab72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/cs/acctchrt_cdmoneymkt.gnucash-xea
+++ b/data/accounts/cs/acctchrt_cdmoneymkt.gnucash-xea
@@ -135,7 +135,3 @@
   <act:parent type="new">fd131cae797d1fb83c2e2bf57254eca5</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/cs/acctchrt_childcare.gnucash-xea
+++ b/data/accounts/cs/acctchrt_childcare.gnucash-xea
@@ -69,7 +69,3 @@
   <act:parent type="new">ee8238ee2c2ce590160761df09b99b72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/cs/acctchrt_common.gnucash-xea
+++ b/data/accounts/cs/acctchrt_common.gnucash-xea
@@ -752,7 +752,3 @@
   <act:parent type="new">3ab6a6d97b216c11333e48aa2b749a91</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/cs/acctchrt_currency.gnucash-xea
+++ b/data/accounts/cs/acctchrt_currency.gnucash-xea
@@ -82,7 +82,3 @@
   <act:parent type="new">d9c796b35784533aee4309e28a3cbfc5</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/cs/acctchrt_eduloan.gnucash-xea
+++ b/data/accounts/cs/acctchrt_eduloan.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">1cfcd30ea97b954ffb550ab87d561033</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/cs/acctchrt_fixedassets.gnucash-xea
+++ b/data/accounts/cs/acctchrt_fixedassets.gnucash-xea
@@ -102,7 +102,3 @@
   <act:parent type="new">9b171f77000bf68dd1ebbaf58336656d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/cs/acctchrt_homeloan.gnucash-xea
+++ b/data/accounts/cs/acctchrt_homeloan.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">3dc58d8a51b5deaa22e0c65d81e90346</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/cs/acctchrt_homeown.gnucash-xea
+++ b/data/accounts/cs/acctchrt_homeown.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">a931b8ffe2917ff9a069333623da96ca</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/cs/acctchrt_otherloan.gnucash-xea
+++ b/data/accounts/cs/acctchrt_otherloan.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">4a02c14e992ea79076837c164aa6fc8d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/cs/acctchrt_renter.gnucash-xea
+++ b/data/accounts/cs/acctchrt_renter.gnucash-xea
@@ -91,7 +91,3 @@
   <act:parent type="new">9a2b4520f113372f4e576f5b6dc129c6</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/cs/acctchrt_retiremt.gnucash-xea
+++ b/data/accounts/cs/acctchrt_retiremt.gnucash-xea
@@ -130,7 +130,3 @@
   <act:parent type="new">4173f3047238f4b5595b11d6161b2f48</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/cs/acctchrt_spouseinc.gnucash-xea
+++ b/data/accounts/cs/acctchrt_spouseinc.gnucash-xea
@@ -146,7 +146,3 @@
   <act:parent type="new">3cd0ca7d6b0e5f44e4cde2851c3ff387</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/cs/acctchrt_spouseretire.gnucash-xea
+++ b/data/accounts/cs/acctchrt_spouseretire.gnucash-xea
@@ -130,7 +130,3 @@
   <act:parent type="new">4426b41837adc284f96b291c31022844</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/da/acctchrt_car.gnucash-xea
+++ b/data/accounts/da/acctchrt_car.gnucash-xea
@@ -135,7 +135,3 @@
   <act:parent type="new">5bda5ff833bc395dc1b00f95c66ce555</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/da/acctchrt_common.gnucash-xea
+++ b/data/accounts/da/acctchrt_common.gnucash-xea
@@ -686,7 +686,3 @@
   <act:parent type="new">3ab6a6d97b216c11333e48aa2b749a91</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/da/acctchrt_homeloan.gnucash-xea
+++ b/data/accounts/da/acctchrt_homeloan.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">3dc58d8a51b5deaa22e0c65d81e90346</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/da/acctchrt_homeown.gnucash-xea
+++ b/data/accounts/da/acctchrt_homeown.gnucash-xea
@@ -124,7 +124,3 @@
   <act:parent type="new">a931b8ffe2917ff9a069333623da96ca</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/de_AT/acctchrt_autoloan.gnucash-xea
+++ b/data/accounts/de_AT/acctchrt_autoloan.gnucash-xea
@@ -154,7 +154,3 @@
   <act:parent type="new">8fc4ba994d32d90d7a9a9112ee37f3f6</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/de_AT/acctchrt_business.gnucash-xea
+++ b/data/accounts/de_AT/acctchrt_business.gnucash-xea
@@ -966,7 +966,3 @@
   <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/de_AT/acctchrt_common.gnucash-xea
+++ b/data/accounts/de_AT/acctchrt_common.gnucash-xea
@@ -966,7 +966,3 @@
   <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/de_AT/acctchrt_houseown.gnucash-xea
+++ b/data/accounts/de_AT/acctchrt_houseown.gnucash-xea
@@ -232,7 +232,3 @@
   <act:parent type="new">b413c76bf6939070b97f7fed1c4fd367</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/de_CH/acctchrt_brokerage.gnucash-xea
+++ b/data/accounts/de_CH/acctchrt_brokerage.gnucash-xea
@@ -168,7 +168,3 @@
   <act:parent type="new">18ca785b6fcd2895427459c233a47c57</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/de_CH/acctchrt_chkmu.gnucash-xea
+++ b/data/accounts/de_CH/acctchrt_chkmu.gnucash-xea
@@ -9251,7 +9251,3 @@
   <act:parent type="new">7cf6f12e6b6fbbc4dd29b9e66463ddca</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/de_CH/acctchrt_common.gnucash-xea
+++ b/data/accounts/de_CH/acctchrt_common.gnucash-xea
@@ -741,7 +741,3 @@
   <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/de_CH/acctchrt_kids.gnucash-xea
+++ b/data/accounts/de_CH/acctchrt_kids.gnucash-xea
@@ -102,7 +102,3 @@
   <act:parent type="new">bc39f4d37eb75353f4f971e80b9d2818</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/de_CH/acctchrt_otherasset.gnucash-xea
+++ b/data/accounts/de_CH/acctchrt_otherasset.gnucash-xea
@@ -80,7 +80,3 @@
   <act:parent type="new">f7b3424631deed453984e6f5c5569669</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/de_CH/acctchrt_otherloan.gnucash-xea
+++ b/data/accounts/de_CH/acctchrt_otherloan.gnucash-xea
@@ -80,7 +80,3 @@
   <act:parent type="new">13df44e66790069c74d563946aa0394e</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/de_DE/acctchrt_auto.gnucash-xea
+++ b/data/accounts/de_DE/acctchrt_auto.gnucash-xea
@@ -198,7 +198,3 @@
   <act:parent type="new">8fc4ba994d32d90d7a9a9112ee37f3f6</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/de_DE/acctchrt_brokerage.gnucash-xea
+++ b/data/accounts/de_DE/acctchrt_brokerage.gnucash-xea
@@ -204,7 +204,3 @@
   <act:parent type="new">18ca785b6fcd2895427459c233a47c57</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/de_DE/acctchrt_investment.gnucash-xea
+++ b/data/accounts/de_DE/acctchrt_investment.gnucash-xea
@@ -237,7 +237,3 @@
   <act:parent type="new">b0dbf43ea99f54e0a9f94a535b10941b</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/de_DE/acctchrt_kids.gnucash-xea
+++ b/data/accounts/de_DE/acctchrt_kids.gnucash-xea
@@ -120,7 +120,3 @@
   <act:parent type="new">bc39f4d37eb75353f4f971e80b9d2818</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/el_GR/acctchrt_brokerage.gnucash-xea
+++ b/data/accounts/el_GR/acctchrt_brokerage.gnucash-xea
@@ -214,7 +214,3 @@
   <act:parent type="new">6de23244232785031501171abcc1d4aa</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/el_GR/acctchrt_carloan.gnucash-xea
+++ b/data/accounts/el_GR/acctchrt_carloan.gnucash-xea
@@ -131,8 +131,3 @@
   <act:parent type="new">9e8495e80ebfb762089be917dff7ab72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/el_GR/acctchrt_common.gnucash-xea
+++ b/data/accounts/el_GR/acctchrt_common.gnucash-xea
@@ -788,7 +788,3 @@
   <act:parent type="new">3ab6a6d97b216c11333e48aa2b749a91</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/en_GB/acctchrt_business.gnucash-xea
+++ b/data/accounts/en_GB/acctchrt_business.gnucash-xea
@@ -1438,7 +1438,3 @@
   <act:parent type="new">87e02e757b32b3059652cfe09fe9ae00</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/en_GB/acctchrt_common.gnucash-xea
+++ b/data/accounts/en_GB/acctchrt_common.gnucash-xea
@@ -777,7 +777,3 @@
   <act:parent type="new">3ab6a6d97b216c11333e48aa2b749a91</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/en_GB/acctchrt_full.gnucash-xea
+++ b/data/accounts/en_GB/acctchrt_full.gnucash-xea
@@ -1389,7 +1389,3 @@
   <act:parent type="new">68d4074f91295062c0b773b4ae8de6bd</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/en_IN/acctchrt_gstindia.gnucash-xea
+++ b/data/accounts/en_IN/acctchrt_gstindia.gnucash-xea
@@ -1163,7 +1163,3 @@
   <act:parent type="new">599b08659324698f0177ce3dbb513e5f</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/es_ES/acctchrt_brokerage.gnucash-xea
+++ b/data/accounts/es_ES/acctchrt_brokerage.gnucash-xea
@@ -192,7 +192,3 @@
   <act:parent type="new">6de23244232785031501171abcc1d4aa</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/es_ES/acctchrt_carloan.gnucash-xea
+++ b/data/accounts/es_ES/acctchrt_carloan.gnucash-xea
@@ -115,8 +115,3 @@
   <act:parent type="new">9e8495e80ebfb762089be917dff7ab72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/es_ES/acctchrt_cdmoneymkt.gnucash-xea
+++ b/data/accounts/es_ES/acctchrt_cdmoneymkt.gnucash-xea
@@ -137,7 +137,3 @@
   <act:parent type="new">fd131cae797d1fb83c2e2bf57254eca5</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/es_ES/acctchrt_childcare.gnucash-xea
+++ b/data/accounts/es_ES/acctchrt_childcare.gnucash-xea
@@ -70,7 +70,3 @@
   <act:parent type="new">ee8238ee2c2ce590160761df09b99b72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/es_ES/acctchrt_common.gnucash-xea
+++ b/data/accounts/es_ES/acctchrt_common.gnucash-xea
@@ -755,7 +755,3 @@
   <act:parent type="new">3ab6a6d97b216c11333e48aa2b749a91</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/es_ES/acctchrt_currency.gnucash-xea
+++ b/data/accounts/es_ES/acctchrt_currency.gnucash-xea
@@ -84,7 +84,3 @@
   <act:parent type="new">d9c796b35784533aee4309e28a3cbfc5</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/es_ES/acctchrt_eduloan.gnucash-xea
+++ b/data/accounts/es_ES/acctchrt_eduloan.gnucash-xea
@@ -115,7 +115,3 @@
   <act:parent type="new">1cfcd30ea97b954ffb550ab87d561033</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/es_ES/acctchrt_fixedassets.gnucash-xea
+++ b/data/accounts/es_ES/acctchrt_fixedassets.gnucash-xea
@@ -103,7 +103,3 @@
   <act:parent type="new">9b171f77000bf68dd1ebbaf58336656d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/es_ES/acctchrt_homeloan.gnucash-xea
+++ b/data/accounts/es_ES/acctchrt_homeloan.gnucash-xea
@@ -114,7 +114,3 @@
   <act:parent type="new">3dc58d8a51b5deaa22e0c65d81e90346</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/es_ES/acctchrt_homeown.gnucash-xea
+++ b/data/accounts/es_ES/acctchrt_homeown.gnucash-xea
@@ -115,7 +115,3 @@
   <act:parent type="new">a931b8ffe2917ff9a069333623da96ca</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/es_ES/acctchrt_otherloan.gnucash-xea
+++ b/data/accounts/es_ES/acctchrt_otherloan.gnucash-xea
@@ -115,7 +115,3 @@
   <act:parent type="new">4a02c14e992ea79076837c164aa6fc8d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/es_ES/acctchrt_renter.gnucash-xea
+++ b/data/accounts/es_ES/acctchrt_renter.gnucash-xea
@@ -92,7 +92,3 @@
   <act:parent type="new">9a2b4520f113372f4e576f5b6dc129c6</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/es_ES/acctchrt_retiremt.gnucash-xea
+++ b/data/accounts/es_ES/acctchrt_retiremt.gnucash-xea
@@ -132,7 +132,3 @@
   <act:parent type="new">4173f3047238f4b5595b11d6161b2f48</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/es_ES/acctchrt_spouseinc.gnucash-xea
+++ b/data/accounts/es_ES/acctchrt_spouseinc.gnucash-xea
@@ -147,7 +147,3 @@
   <act:parent type="new">3cd0ca7d6b0e5f44e4cde2851c3ff387</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/es_ES/acctchrt_spouseretire.gnucash-xea
+++ b/data/accounts/es_ES/acctchrt_spouseretire.gnucash-xea
@@ -132,7 +132,3 @@
   <act:parent type="new">4426b41837adc284f96b291c31022844</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/es_MX/acctchrt_brokerage.gnucash-xea
+++ b/data/accounts/es_MX/acctchrt_brokerage.gnucash-xea
@@ -192,7 +192,3 @@
   <act:parent type="new">6de23244232785031501171abcc1d4aa</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/es_MX/acctchrt_carloan.gnucash-xea
+++ b/data/accounts/es_MX/acctchrt_carloan.gnucash-xea
@@ -115,8 +115,3 @@
   <act:parent type="new">9e8495e80ebfb762089be917dff7ab72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/es_MX/acctchrt_cdmoneymkt.gnucash-xea
+++ b/data/accounts/es_MX/acctchrt_cdmoneymkt.gnucash-xea
@@ -137,7 +137,3 @@
   <act:parent type="new">fd131cae797d1fb83c2e2bf57254eca5</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/es_MX/acctchrt_childcare.gnucash-xea
+++ b/data/accounts/es_MX/acctchrt_childcare.gnucash-xea
@@ -70,7 +70,3 @@
   <act:parent type="new">ee8238ee2c2ce590160761df09b99b72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/es_MX/acctchrt_common.gnucash-xea
+++ b/data/accounts/es_MX/acctchrt_common.gnucash-xea
@@ -832,7 +832,3 @@
   <act:parent type="new">3ab6a6d97b216c11333e48aa2b749a91</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/es_MX/acctchrt_currency.gnucash-xea
+++ b/data/accounts/es_MX/acctchrt_currency.gnucash-xea
@@ -84,7 +84,3 @@
   <act:parent type="new">d9c796b35784533aee4309e28a3cbfc5</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/es_MX/acctchrt_eduloan.gnucash-xea
+++ b/data/accounts/es_MX/acctchrt_eduloan.gnucash-xea
@@ -115,7 +115,3 @@
   <act:parent type="new">1cfcd30ea97b954ffb550ab87d561033</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/es_MX/acctchrt_fixedassets.gnucash-xea
+++ b/data/accounts/es_MX/acctchrt_fixedassets.gnucash-xea
@@ -103,7 +103,3 @@
   <act:parent type="new">9b171f77000bf68dd1ebbaf58336656d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/es_MX/acctchrt_homeloan.gnucash-xea
+++ b/data/accounts/es_MX/acctchrt_homeloan.gnucash-xea
@@ -114,7 +114,3 @@
   <act:parent type="new">3dc58d8a51b5deaa22e0c65d81e90346</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/es_MX/acctchrt_homeown.gnucash-xea
+++ b/data/accounts/es_MX/acctchrt_homeown.gnucash-xea
@@ -115,7 +115,3 @@
   <act:parent type="new">a931b8ffe2917ff9a069333623da96ca</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/es_MX/acctchrt_otherloan.gnucash-xea
+++ b/data/accounts/es_MX/acctchrt_otherloan.gnucash-xea
@@ -115,7 +115,3 @@
   <act:parent type="new">4a02c14e992ea79076837c164aa6fc8d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/es_MX/acctchrt_renter.gnucash-xea
+++ b/data/accounts/es_MX/acctchrt_renter.gnucash-xea
@@ -92,7 +92,3 @@
   <act:parent type="new">9a2b4520f113372f4e576f5b6dc129c6</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/es_MX/acctchrt_retiremt.gnucash-xea
+++ b/data/accounts/es_MX/acctchrt_retiremt.gnucash-xea
@@ -132,7 +132,3 @@
   <act:parent type="new">4173f3047238f4b5595b11d6161b2f48</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/es_MX/acctchrt_spouseinc.gnucash-xea
+++ b/data/accounts/es_MX/acctchrt_spouseinc.gnucash-xea
@@ -147,7 +147,3 @@
   <act:parent type="new">3cd0ca7d6b0e5f44e4cde2851c3ff387</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/es_MX/acctchrt_spouseretire.gnucash-xea
+++ b/data/accounts/es_MX/acctchrt_spouseretire.gnucash-xea
@@ -132,7 +132,3 @@
   <act:parent type="new">4426b41837adc284f96b291c31022844</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fi_FI/acctchrt_common.gnucash-xea
+++ b/data/accounts/fi_FI/acctchrt_common.gnucash-xea
@@ -701,7 +701,3 @@
   <act:parent type="new">3ab6a6d97b216c11333e48aa2b749a91</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fi_FI/acctchrt_ry.gnucash-xea
+++ b/data/accounts/fi_FI/acctchrt_ry.gnucash-xea
@@ -400,7 +400,3 @@
     </gnc:account>
 
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fi_FI/acctchrt_sbr-xbrl.gnucash-xea
+++ b/data/accounts/fi_FI/acctchrt_sbr-xbrl.gnucash-xea
@@ -2708,7 +2708,3 @@
         <act:parent type="guid">91ca36e058bbbb5deae199ca187e701e</act:parent>
     </gnc:account>
 </gnc-account-example>
-
-        <!-- Local variables: -->
-        <!-- mode: xml        -->
-        <!-- End:             -->

--- a/data/accounts/fr_CA/acctchrt_actifsfixes.gnucash-xea
+++ b/data/accounts/fr_CA/acctchrt_actifsfixes.gnucash-xea
@@ -119,7 +119,3 @@
 		  <act:parent type="new">c888710a53770a065aceae44d8abd0dd</act:parent>
 	  </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_CA/acctchrt_automobile.gnucash-xea
+++ b/data/accounts/fr_CA/acctchrt_automobile.gnucash-xea
@@ -287,8 +287,3 @@
 	  <act:parent type="new">93afcfa6113ca99a60ed52fff880904c</act:parent>
   </gnc:account>
 </gnc-account-example>
-
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_CA/acctchrt_basecommune.gnucash-xea
+++ b/data/accounts/fr_CA/acctchrt_basecommune.gnucash-xea
@@ -773,7 +773,3 @@
 			<act:parent type="new">7715b898a1079feb67f582f438c62177</act:parent>
 		</gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_CA/acctchrt_cdmarchemon.gnucash-xea
+++ b/data/accounts/fr_CA/acctchrt_cdmarchemon.gnucash-xea
@@ -167,7 +167,3 @@
 	  <act:parent type="new">59057b71a3fd0057b2e5c2d23277ad96</act:parent>
   </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_CA/acctchrt_chequier.gnucash-xea
+++ b/data/accounts/fr_CA/acctchrt_chequier.gnucash-xea
@@ -149,8 +149,3 @@
 		    <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
 	    </gnc:account>
 </gnc-account-example>
-
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_CA/acctchrt_conjointretraite.gnucash-xea
+++ b/data/accounts/fr_CA/acctchrt_conjointretraite.gnucash-xea
@@ -143,7 +143,3 @@
 		    <act:parent type="new">3b7fc349a666e9d43b12f7a7bad07a76</act:parent>
 	    </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_CA/acctchrt_conjointrev.gnucash-xea
+++ b/data/accounts/fr_CA/acctchrt_conjointrev.gnucash-xea
@@ -233,7 +233,3 @@
 	  <act:parent type="new">b39178d39ea997115b592f0b8a488dee</act:parent>
   </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_CA/acctchrt_courtage.gnucash-xea
+++ b/data/accounts/fr_CA/acctchrt_courtage.gnucash-xea
@@ -233,7 +233,3 @@
 	<act:parent type="new">e5e6414e2da9abb0d11a675a1244e380</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_CA/acctchrt_etudeemprunt.gnucash-xea
+++ b/data/accounts/fr_CA/acctchrt_etudeemprunt.gnucash-xea
@@ -143,7 +143,3 @@
 	  <act:parent type="new">6622783b69e9ca8105125c778c7b621f</act:parent>
   </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_CA/acctchrt_garderie.gnucash-xea
+++ b/data/accounts/fr_CA/acctchrt_garderie.gnucash-xea
@@ -77,7 +77,3 @@
 	  <act:parent type="new">5882be9c31d58cc589c53f94d86f82da</act:parent>
   </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_CA/acctchrt_locataire.gnucash-xea
+++ b/data/accounts/fr_CA/acctchrt_locataire.gnucash-xea
@@ -107,7 +107,3 @@
 	  <act:parent type="new">5882be9c31d58cc589c53f94d86f82da</act:parent>
   </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_CA/acctchrt_proprietaire.gnucash-xea
+++ b/data/accounts/fr_CA/acctchrt_proprietaire.gnucash-xea
@@ -263,7 +263,3 @@
 		  <act:parent type="new">80e04606e5258beb9d50e264d5a40d85</act:parent>
 	  </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_CA/acctchrt_retraite.gnucash-xea
+++ b/data/accounts/fr_CA/acctchrt_retraite.gnucash-xea
@@ -143,7 +143,3 @@
 			  <act:parent type="new">4da3426bfefc086f7922e263e8de98f7</act:parent>
 		  </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_CA/acctchrt_revenus.gnucash-xea
+++ b/data/accounts/fr_CA/acctchrt_revenus.gnucash-xea
@@ -233,7 +233,3 @@
 			<act:parent type="new">43e6d2ed9633b94707da60146f3559c4</act:parent>
 		</gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_CH/acctchrt_brokerage.gnucash-xea
+++ b/data/accounts/fr_CH/acctchrt_brokerage.gnucash-xea
@@ -191,7 +191,3 @@
   <act:parent type="new">6de23244232785031501171abcc1d4aa</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_CH/acctchrt_business.gnucash-xea
+++ b/data/accounts/fr_CH/acctchrt_business.gnucash-xea
@@ -1402,7 +1402,3 @@ Les utilisateurs gérant une entreprise sélectionneront ceci au lieu des autres
   <act:parent type="new">87e02e757b32b3059652cfe09fe9ae00</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_CH/acctchrt_carloan.gnucash-xea
+++ b/data/accounts/fr_CH/acctchrt_carloan.gnucash-xea
@@ -113,8 +113,3 @@
   <act:parent type="new">3dc58d8a51b5deaa22e0c65d81e90346</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_CH/acctchrt_cdmoneymkt.gnucash-xea
+++ b/data/accounts/fr_CH/acctchrt_cdmoneymkt.gnucash-xea
@@ -135,7 +135,3 @@
   <act:parent type="new">c47361e40d9478ec11758097e64d693c</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_CH/acctchrt_childcare.gnucash-xea
+++ b/data/accounts/fr_CH/acctchrt_childcare.gnucash-xea
@@ -69,7 +69,3 @@
   <act:parent type="new">ee8238ee2c2ce590160761df09b99b72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_CH/acctchrt_common.gnucash-xea
+++ b/data/accounts/fr_CH/acctchrt_common.gnucash-xea
@@ -752,7 +752,3 @@
   <act:parent type="new">3ab6a6d97b216c11333e48aa2b749a91</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_CH/acctchrt_currency.gnucash-xea
+++ b/data/accounts/fr_CH/acctchrt_currency.gnucash-xea
@@ -82,7 +82,3 @@
   <act:parent type="new">d9c796b35784533aee4309e28a3cbfc5</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_CH/acctchrt_eduloan.gnucash-xea
+++ b/data/accounts/fr_CH/acctchrt_eduloan.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">1cfcd30ea97b954ffb550ab87d561033</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_CH/acctchrt_fixedassets.gnucash-xea
+++ b/data/accounts/fr_CH/acctchrt_fixedassets.gnucash-xea
@@ -102,7 +102,3 @@
   <act:parent type="new">9b171f77000bf68dd1ebbaf58336656d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_CH/acctchrt_homeloan.gnucash-xea
+++ b/data/accounts/fr_CH/acctchrt_homeloan.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">3dc58d8a51b5deaa22e0c65d81e90346</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_CH/acctchrt_homeown.gnucash-xea
+++ b/data/accounts/fr_CH/acctchrt_homeown.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">a931b8ffe2917ff9a069333623da96ca</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_CH/acctchrt_otherloan.gnucash-xea
+++ b/data/accounts/fr_CH/acctchrt_otherloan.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">4a02c14e992ea79076837c164aa6fc8d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_CH/acctchrt_renter.gnucash-xea
+++ b/data/accounts/fr_CH/acctchrt_renter.gnucash-xea
@@ -91,7 +91,3 @@
   <act:parent type="new">9a2b4520f113372f4e576f5b6dc129c6</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_CH/acctchrt_retiremt.gnucash-xea
+++ b/data/accounts/fr_CH/acctchrt_retiremt.gnucash-xea
@@ -130,7 +130,3 @@
   <act:parent type="new">4173f3047238f4b5595b11d6161b2f48</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_CH/acctchrt_spouseinc.gnucash-xea
+++ b/data/accounts/fr_CH/acctchrt_spouseinc.gnucash-xea
@@ -146,7 +146,3 @@
   <act:parent type="new">3cd0ca7d6b0e5f44e4cde2851c3ff387</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_CH/acctchrt_spouseretire.gnucash-xea
+++ b/data/accounts/fr_CH/acctchrt_spouseretire.gnucash-xea
@@ -130,7 +130,3 @@
   <act:parent type="new">4426b41837adc284f96b291c31022844</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_FR/acctchrt_brokerage.gnucash-xea
+++ b/data/accounts/fr_FR/acctchrt_brokerage.gnucash-xea
@@ -191,7 +191,3 @@
   <act:parent type="new">6de23244232785031501171abcc1d4aa</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_FR/acctchrt_business.gnucash-xea
+++ b/data/accounts/fr_FR/acctchrt_business.gnucash-xea
@@ -1402,7 +1402,3 @@ Les utilisateurs gérant une entreprise sélectionneront ceci au lieu des autres
   <act:parent type="new">87e02e757b32b3059652cfe09fe9ae00</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_FR/acctchrt_carloan.gnucash-xea
+++ b/data/accounts/fr_FR/acctchrt_carloan.gnucash-xea
@@ -113,8 +113,3 @@
   <act:parent type="new">3dc58d8a51b5deaa22e0c65d81e90346</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_FR/acctchrt_cdmoneymkt.gnucash-xea
+++ b/data/accounts/fr_FR/acctchrt_cdmoneymkt.gnucash-xea
@@ -135,7 +135,3 @@
   <act:parent type="new">c47361e40d9478ec11758097e64d693c</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_FR/acctchrt_childcare.gnucash-xea
+++ b/data/accounts/fr_FR/acctchrt_childcare.gnucash-xea
@@ -69,7 +69,3 @@
   <act:parent type="new">ee8238ee2c2ce590160761df09b99b72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_FR/acctchrt_common.gnucash-xea
+++ b/data/accounts/fr_FR/acctchrt_common.gnucash-xea
@@ -752,7 +752,3 @@
   <act:parent type="new">3ab6a6d97b216c11333e48aa2b749a91</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_FR/acctchrt_currency.gnucash-xea
+++ b/data/accounts/fr_FR/acctchrt_currency.gnucash-xea
@@ -82,7 +82,3 @@
   <act:parent type="new">d9c796b35784533aee4309e28a3cbfc5</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_FR/acctchrt_eduloan.gnucash-xea
+++ b/data/accounts/fr_FR/acctchrt_eduloan.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">1cfcd30ea97b954ffb550ab87d561033</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_FR/acctchrt_fixedassets.gnucash-xea
+++ b/data/accounts/fr_FR/acctchrt_fixedassets.gnucash-xea
@@ -102,7 +102,3 @@
   <act:parent type="new">9b171f77000bf68dd1ebbaf58336656d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_FR/acctchrt_homeloan.gnucash-xea
+++ b/data/accounts/fr_FR/acctchrt_homeloan.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">3dc58d8a51b5deaa22e0c65d81e90346</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_FR/acctchrt_homeown.gnucash-xea
+++ b/data/accounts/fr_FR/acctchrt_homeown.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">a931b8ffe2917ff9a069333623da96ca</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_FR/acctchrt_otherloan.gnucash-xea
+++ b/data/accounts/fr_FR/acctchrt_otherloan.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">4a02c14e992ea79076837c164aa6fc8d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_FR/acctchrt_renter.gnucash-xea
+++ b/data/accounts/fr_FR/acctchrt_renter.gnucash-xea
@@ -91,7 +91,3 @@
   <act:parent type="new">9a2b4520f113372f4e576f5b6dc129c6</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_FR/acctchrt_retiremt.gnucash-xea
+++ b/data/accounts/fr_FR/acctchrt_retiremt.gnucash-xea
@@ -130,7 +130,3 @@
   <act:parent type="new">4173f3047238f4b5595b11d6161b2f48</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_FR/acctchrt_spouseinc.gnucash-xea
+++ b/data/accounts/fr_FR/acctchrt_spouseinc.gnucash-xea
@@ -146,7 +146,3 @@
   <act:parent type="new">3cd0ca7d6b0e5f44e4cde2851c3ff387</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/fr_FR/acctchrt_spouseretire.gnucash-xea
+++ b/data/accounts/fr_FR/acctchrt_spouseretire.gnucash-xea
@@ -130,7 +130,3 @@
   <act:parent type="new">4426b41837adc284f96b291c31022844</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/hu_HU/acctchrt_brokerage.gnucash-xea
+++ b/data/accounts/hu_HU/acctchrt_brokerage.gnucash-xea
@@ -179,7 +179,3 @@
   <act:parent type="new">6de23244232785031501171abcc1d4aa</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/hu_HU/acctchrt_business.gnucash-xea
+++ b/data/accounts/hu_HU/acctchrt_business.gnucash-xea
@@ -1402,7 +1402,3 @@
   <act:parent type="new">87e02e757b32b3059652cfe09fe9ae00</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/hu_HU/acctchrt_carloan.gnucash-xea
+++ b/data/accounts/hu_HU/acctchrt_carloan.gnucash-xea
@@ -113,8 +113,3 @@
   <act:parent type="new">9e8495e80ebfb762089be917dff7ab72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/hu_HU/acctchrt_cdmoneymkt.gnucash-xea
+++ b/data/accounts/hu_HU/acctchrt_cdmoneymkt.gnucash-xea
@@ -135,7 +135,3 @@
   <act:parent type="new">fd131cae797d1fb83c2e2bf57254eca5</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/hu_HU/acctchrt_checkbook.gnucash-xea
+++ b/data/accounts/hu_HU/acctchrt_checkbook.gnucash-xea
@@ -141,8 +141,3 @@
   <act:parent type="new">b8b72887da1adf889f171923d23efbdd</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/hu_HU/acctchrt_childcare.gnucash-xea
+++ b/data/accounts/hu_HU/acctchrt_childcare.gnucash-xea
@@ -69,7 +69,3 @@
   <act:parent type="new">ee8238ee2c2ce590160761df09b99b72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/hu_HU/acctchrt_common.gnucash-xea
+++ b/data/accounts/hu_HU/acctchrt_common.gnucash-xea
@@ -730,7 +730,3 @@
   <act:parent type="new">3ab6a6d97b216c11333e48aa2b749a91</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/hu_HU/acctchrt_eduloan.gnucash-xea
+++ b/data/accounts/hu_HU/acctchrt_eduloan.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">1cfcd30ea97b954ffb550ab87d561033</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/hu_HU/acctchrt_fixedassets.gnucash-xea
+++ b/data/accounts/hu_HU/acctchrt_fixedassets.gnucash-xea
@@ -102,7 +102,3 @@
   <act:parent type="new">9b171f77000bf68dd1ebbaf58336656d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/hu_HU/acctchrt_homeloan.gnucash-xea
+++ b/data/accounts/hu_HU/acctchrt_homeloan.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">3dc58d8a51b5deaa22e0c65d81e90346</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/hu_HU/acctchrt_homeown.gnucash-xea
+++ b/data/accounts/hu_HU/acctchrt_homeown.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">a931b8ffe2917ff9a069333623da96ca</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/hu_HU/acctchrt_otherloan.gnucash-xea
+++ b/data/accounts/hu_HU/acctchrt_otherloan.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">4a02c14e992ea79076837c164aa6fc8d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/hu_HU/acctchrt_renter.gnucash-xea
+++ b/data/accounts/hu_HU/acctchrt_renter.gnucash-xea
@@ -91,7 +91,3 @@
   <act:parent type="new">9a2b4520f113372f4e576f5b6dc129c6</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/hu_HU/acctchrt_retiremt.gnucash-xea
+++ b/data/accounts/hu_HU/acctchrt_retiremt.gnucash-xea
@@ -130,7 +130,3 @@
   <act:parent type="new">4173f3047238f4b5595b11d6161b2f48</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/hu_HU/acctchrt_spouseinc.gnucash-xea
+++ b/data/accounts/hu_HU/acctchrt_spouseinc.gnucash-xea
@@ -135,7 +135,3 @@
   <act:parent type="new">3cd0ca7d6b0e5f44e4cde2851c3ff387</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/hu_HU/acctchrt_spouseretire.gnucash-xea
+++ b/data/accounts/hu_HU/acctchrt_spouseretire.gnucash-xea
@@ -130,7 +130,3 @@
   <act:parent type="new">4426b41837adc284f96b291c31022844</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/it/acctchrt_brokerage.gnucash-xea
+++ b/data/accounts/it/acctchrt_brokerage.gnucash-xea
@@ -198,7 +198,3 @@
   <act:parent type="new">6de23244232785031501171abcc1d4aa</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/it/acctchrt_carloan.gnucash-xea
+++ b/data/accounts/it/acctchrt_carloan.gnucash-xea
@@ -118,8 +118,3 @@
   <act:parent type="new">9e8495e80ebfb762089be917dff7ab72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/it/acctchrt_checkbook.gnucash-xea
+++ b/data/accounts/it/acctchrt_checkbook.gnucash-xea
@@ -146,8 +146,3 @@
   <act:parent type="new">b8b72887da1adf889f171923d23efbdd</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/it/acctchrt_childcare.gnucash-xea
+++ b/data/accounts/it/acctchrt_childcare.gnucash-xea
@@ -74,7 +74,3 @@
   <act:parent type="new">ee8238ee2c2ce590160761df09b99b72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/it/acctchrt_common.gnucash-xea
+++ b/data/accounts/it/acctchrt_common.gnucash-xea
@@ -749,7 +749,3 @@
   <act:parent type="new">3ab6a6d97b216c11333e48aa2b749a91</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/it/acctchrt_fixedassets.gnucash-xea
+++ b/data/accounts/it/acctchrt_fixedassets.gnucash-xea
@@ -107,7 +107,3 @@
   <act:parent type="new">9b171f77000bf68dd1ebbaf58336656d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/it/acctchrt_homeloan.gnucash-xea
+++ b/data/accounts/it/acctchrt_homeloan.gnucash-xea
@@ -118,7 +118,3 @@
   <act:parent type="new">3dc58d8a51b5deaa22e0c65d81e90346</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/it/acctchrt_homeown.gnucash-xea
+++ b/data/accounts/it/acctchrt_homeown.gnucash-xea
@@ -118,7 +118,3 @@
   <act:parent type="new">a931b8ffe2917ff9a069333623da96ca</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/it/acctchrt_otherloan.gnucash-xea
+++ b/data/accounts/it/acctchrt_otherloan.gnucash-xea
@@ -118,7 +118,3 @@
   <act:parent type="new">4a02c14e992ea79076837c164aa6fc8d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/it/acctchrt_renter.gnucash-xea
+++ b/data/accounts/it/acctchrt_renter.gnucash-xea
@@ -74,7 +74,3 @@
   <act:parent type="new">9a2b4520f113372f4e576f5b6dc129c6</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/it/acctchrt_retiremt.gnucash-xea
+++ b/data/accounts/it/acctchrt_retiremt.gnucash-xea
@@ -129,7 +129,3 @@
   <act:parent type="new">4173f3047238f4b5595b11d6161b2f48</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/it/acctchrt_spouseinc.gnucash-xea
+++ b/data/accounts/it/acctchrt_spouseinc.gnucash-xea
@@ -154,7 +154,3 @@
   <act:parent type="new">3cd0ca7d6b0e5f44e4cde2851c3ff387</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/it/acctchrt_spouseretire.gnucash-xea
+++ b/data/accounts/it/acctchrt_spouseretire.gnucash-xea
@@ -132,7 +132,3 @@
   <act:parent type="new">4426b41837adc284f96b291c31022844</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ja/acctchrt_brokerage.gnucash-xea
+++ b/data/accounts/ja/acctchrt_brokerage.gnucash-xea
@@ -214,7 +214,3 @@
   <act:parent type="new">6de23244232785031501171abcc1d4aa</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ja/acctchrt_business.gnucash-xea
+++ b/data/accounts/ja/acctchrt_business.gnucash-xea
@@ -1438,7 +1438,3 @@
   <act:parent type="new">87e02e757b32b3059652cfe09fe9ae00</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ja/acctchrt_carloan.gnucash-xea
+++ b/data/accounts/ja/acctchrt_carloan.gnucash-xea
@@ -131,8 +131,3 @@
   <act:parent type="new">9e8495e80ebfb762089be917dff7ab72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ja/acctchrt_cdmoneymkt.gnucash-xea
+++ b/data/accounts/ja/acctchrt_cdmoneymkt.gnucash-xea
@@ -153,7 +153,3 @@
   <act:parent type="new">fd131cae797d1fb83c2e2bf57254eca5</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ja/acctchrt_checkbook.gnucash-xea
+++ b/data/accounts/ja/acctchrt_checkbook.gnucash-xea
@@ -149,8 +149,3 @@
   <act:parent type="new">b8b72887da1adf889f171923d23efbdd</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ja/acctchrt_childcare.gnucash-xea
+++ b/data/accounts/ja/acctchrt_childcare.gnucash-xea
@@ -75,7 +75,3 @@
   <act:parent type="new">ee8238ee2c2ce590160761df09b99b72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ja/acctchrt_common.gnucash-xea
+++ b/data/accounts/ja/acctchrt_common.gnucash-xea
@@ -777,7 +777,3 @@
   <act:parent type="new">3ab6a6d97b216c11333e48aa2b749a91</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ja/acctchrt_eduloan.gnucash-xea
+++ b/data/accounts/ja/acctchrt_eduloan.gnucash-xea
@@ -131,7 +131,3 @@
   <act:parent type="new">1cfcd30ea97b954ffb550ab87d561033</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ja/acctchrt_fixedassets.gnucash-xea
+++ b/data/accounts/ja/acctchrt_fixedassets.gnucash-xea
@@ -114,7 +114,3 @@
   <act:parent type="new">9b171f77000bf68dd1ebbaf58336656d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ja/acctchrt_full.gnucash-xea
+++ b/data/accounts/ja/acctchrt_full.gnucash-xea
@@ -1394,7 +1394,3 @@
   <act:parent type="new">68d4074f91295062c0b773b4ae8de6bd</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ja/acctchrt_homeloan.gnucash-xea
+++ b/data/accounts/ja/acctchrt_homeloan.gnucash-xea
@@ -131,7 +131,3 @@
   <act:parent type="new">3dc58d8a51b5deaa22e0c65d81e90346</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ja/acctchrt_homeown.gnucash-xea
+++ b/data/accounts/ja/acctchrt_homeown.gnucash-xea
@@ -119,7 +119,3 @@
   <act:parent type="new">a931b8ffe2917ff9a069333623da96ca</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ja/acctchrt_otherloan.gnucash-xea
+++ b/data/accounts/ja/acctchrt_otherloan.gnucash-xea
@@ -131,7 +131,3 @@
   <act:parent type="new">4a02c14e992ea79076837c164aa6fc8d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ja/acctchrt_renter.gnucash-xea
+++ b/data/accounts/ja/acctchrt_renter.gnucash-xea
@@ -97,7 +97,3 @@
   <act:parent type="new">9a2b4520f113372f4e576f5b6dc129c6</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ja/acctchrt_retiremt.gnucash-xea
+++ b/data/accounts/ja/acctchrt_retiremt.gnucash-xea
@@ -146,7 +146,3 @@
   <act:parent type="new">4173f3047238f4b5595b11d6161b2f48</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ja/acctchrt_spouseinc.gnucash-xea
+++ b/data/accounts/ja/acctchrt_spouseinc.gnucash-xea
@@ -158,7 +158,3 @@
   <act:parent type="new">3cd0ca7d6b0e5f44e4cde2851c3ff387</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ja/acctchrt_spouseretire.gnucash-xea
+++ b/data/accounts/ja/acctchrt_spouseretire.gnucash-xea
@@ -146,7 +146,3 @@
   <act:parent type="new">4426b41837adc284f96b291c31022844</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ko/acctchrt_brokerage.gnucash-xea
+++ b/data/accounts/ko/acctchrt_brokerage.gnucash-xea
@@ -214,7 +214,3 @@
   <act:parent type="new">6de23244232785031501171abcc1d4aa</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ko/acctchrt_business.gnucash-xea
+++ b/data/accounts/ko/acctchrt_business.gnucash-xea
@@ -1438,7 +1438,3 @@
   <act:parent type="new">87e02e757b32b3059652cfe09fe9ae00</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ko/acctchrt_carloan.gnucash-xea
+++ b/data/accounts/ko/acctchrt_carloan.gnucash-xea
@@ -131,8 +131,3 @@
   <act:parent type="new">9e8495e80ebfb762089be917dff7ab72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ko/acctchrt_cdmoneymkt.gnucash-xea
+++ b/data/accounts/ko/acctchrt_cdmoneymkt.gnucash-xea
@@ -153,7 +153,3 @@
   <act:parent type="new">fd131cae797d1fb83c2e2bf57254eca5</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ko/acctchrt_checkbook.gnucash-xea
+++ b/data/accounts/ko/acctchrt_checkbook.gnucash-xea
@@ -149,8 +149,3 @@
   <act:parent type="new">b8b72887da1adf889f171923d23efbdd</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ko/acctchrt_childcare.gnucash-xea
+++ b/data/accounts/ko/acctchrt_childcare.gnucash-xea
@@ -75,7 +75,3 @@
   <act:parent type="new">ee8238ee2c2ce590160761df09b99b72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ko/acctchrt_common.gnucash-xea
+++ b/data/accounts/ko/acctchrt_common.gnucash-xea
@@ -777,7 +777,3 @@
   <act:parent type="new">3ab6a6d97b216c11333e48aa2b749a91</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ko/acctchrt_eduloan.gnucash-xea
+++ b/data/accounts/ko/acctchrt_eduloan.gnucash-xea
@@ -131,7 +131,3 @@
   <act:parent type="new">1cfcd30ea97b954ffb550ab87d561033</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ko/acctchrt_fixedassets.gnucash-xea
+++ b/data/accounts/ko/acctchrt_fixedassets.gnucash-xea
@@ -114,7 +114,3 @@
   <act:parent type="new">9b171f77000bf68dd1ebbaf58336656d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ko/acctchrt_homeloan.gnucash-xea
+++ b/data/accounts/ko/acctchrt_homeloan.gnucash-xea
@@ -131,7 +131,3 @@
   <act:parent type="new">3dc58d8a51b5deaa22e0c65d81e90346</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ko/acctchrt_homeown.gnucash-xea
+++ b/data/accounts/ko/acctchrt_homeown.gnucash-xea
@@ -119,7 +119,3 @@
   <act:parent type="new">a931b8ffe2917ff9a069333623da96ca</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ko/acctchrt_otherloan.gnucash-xea
+++ b/data/accounts/ko/acctchrt_otherloan.gnucash-xea
@@ -131,7 +131,3 @@
   <act:parent type="new">4a02c14e992ea79076837c164aa6fc8d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ko/acctchrt_renter.gnucash-xea
+++ b/data/accounts/ko/acctchrt_renter.gnucash-xea
@@ -97,7 +97,3 @@
   <act:parent type="new">9a2b4520f113372f4e576f5b6dc129c6</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ko/acctchrt_retiremt.gnucash-xea
+++ b/data/accounts/ko/acctchrt_retiremt.gnucash-xea
@@ -146,7 +146,3 @@
   <act:parent type="new">4173f3047238f4b5595b11d6161b2f48</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ko/acctchrt_spouseinc.gnucash-xea
+++ b/data/accounts/ko/acctchrt_spouseinc.gnucash-xea
@@ -158,7 +158,3 @@
   <act:parent type="new">3cd0ca7d6b0e5f44e4cde2851c3ff387</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/ko/acctchrt_spouseretire.gnucash-xea
+++ b/data/accounts/ko/acctchrt_spouseretire.gnucash-xea
@@ -146,7 +146,3 @@
   <act:parent type="new">4426b41837adc284f96b291c31022844</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/lt/acctchrt_business.gnucash-xea
+++ b/data/accounts/lt/acctchrt_business.gnucash-xea
@@ -1135,7 +1135,3 @@
   <act:parent type="new">87e02e757b32b3059652cfe09fe9ae00</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/lv/acctchrt_brokerage.gnucash-xea
+++ b/data/accounts/lv/acctchrt_brokerage.gnucash-xea
@@ -192,7 +192,3 @@
   <act:parent type="new">6de23244232785031501171abcc1d4aa</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/lv/acctchrt_business.gnucash-xea
+++ b/data/accounts/lv/acctchrt_business.gnucash-xea
@@ -1548,7 +1548,3 @@
   <act:parent type="new">f1d190ad7b90d92a692014bbf7e281a2</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/lv/acctchrt_carloan.gnucash-xea
+++ b/data/accounts/lv/acctchrt_carloan.gnucash-xea
@@ -131,8 +131,3 @@
   <act:parent type="new">9e8495e80ebfb762089be917dff7ab72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/lv/acctchrt_cdmoneymkt.gnucash-xea
+++ b/data/accounts/lv/acctchrt_cdmoneymkt.gnucash-xea
@@ -153,7 +153,3 @@
   <act:parent type="new">fd131cae797d1fb83c2e2bf57254eca5</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/lv/acctchrt_checkbook.gnucash-xea
+++ b/data/accounts/lv/acctchrt_checkbook.gnucash-xea
@@ -131,8 +131,3 @@
   <act:parent type="new">b8b72887da1adf889f171923d23efbdd</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/lv/acctchrt_childcare.gnucash-xea
+++ b/data/accounts/lv/acctchrt_childcare.gnucash-xea
@@ -108,7 +108,3 @@
   <act:parent type="new">8999739a6bfc46088a3ea5ec45e5f8a4</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/lv/acctchrt_common.gnucash-xea
+++ b/data/accounts/lv/acctchrt_common.gnucash-xea
@@ -738,7 +738,3 @@
   <act:parent type="new">3ab6a6d97b216c11333e48aa2b749a91</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/lv/acctchrt_eduloan.gnucash-xea
+++ b/data/accounts/lv/acctchrt_eduloan.gnucash-xea
@@ -131,7 +131,3 @@
   <act:parent type="new">1cfcd30ea97b954ffb550ab87d561033</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/lv/acctchrt_fixedassets.gnucash-xea
+++ b/data/accounts/lv/acctchrt_fixedassets.gnucash-xea
@@ -114,7 +114,3 @@
   <act:parent type="new">9b171f77000bf68dd1ebbaf58336656d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/lv/acctchrt_full.gnucash-xea
+++ b/data/accounts/lv/acctchrt_full.gnucash-xea
@@ -1356,7 +1356,3 @@
   <act:parent type="new">68d4074f91295062c0b773b4ae8de6bd</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/lv/acctchrt_homeloan.gnucash-xea
+++ b/data/accounts/lv/acctchrt_homeloan.gnucash-xea
@@ -131,7 +131,3 @@
   <act:parent type="new">3dc58d8a51b5deaa22e0c65d81e90346</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/lv/acctchrt_homeown.gnucash-xea
+++ b/data/accounts/lv/acctchrt_homeown.gnucash-xea
@@ -119,7 +119,3 @@
   <act:parent type="new">a931b8ffe2917ff9a069333623da96ca</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/lv/acctchrt_otherloan.gnucash-xea
+++ b/data/accounts/lv/acctchrt_otherloan.gnucash-xea
@@ -131,7 +131,3 @@
   <act:parent type="new">4a02c14e992ea79076837c164aa6fc8d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/lv/acctchrt_renter.gnucash-xea
+++ b/data/accounts/lv/acctchrt_renter.gnucash-xea
@@ -75,7 +75,3 @@
   <act:parent type="new">9a2b4520f113372f4e576f5b6dc129c6</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/lv/acctchrt_retiremt.gnucash-xea
+++ b/data/accounts/lv/acctchrt_retiremt.gnucash-xea
@@ -135,7 +135,3 @@
   <act:parent type="new">4173f3047238f4b5595b11d6161b2f48</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/lv/acctchrt_spouseinc.gnucash-xea
+++ b/data/accounts/lv/acctchrt_spouseinc.gnucash-xea
@@ -147,7 +147,3 @@
   <act:parent type="new">3cd0ca7d6b0e5f44e4cde2851c3ff387</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/lv/acctchrt_spouseretire.gnucash-xea
+++ b/data/accounts/lv/acctchrt_spouseretire.gnucash-xea
@@ -135,7 +135,3 @@
   <act:parent type="new">4426b41837adc284f96b291c31022844</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/nb/acctchrt_brokerage.gnucash-xea
+++ b/data/accounts/nb/acctchrt_brokerage.gnucash-xea
@@ -190,7 +190,3 @@
   <act:parent type="new">6de23244232785031501171abcc1d4aa</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/nb/acctchrt_business.gnucash-xea
+++ b/data/accounts/nb/acctchrt_business.gnucash-xea
@@ -1402,7 +1402,3 @@
   <act:parent type="new">87e02e757b32b3059652cfe09fe9ae00</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/nb/acctchrt_carloan.gnucash-xea
+++ b/data/accounts/nb/acctchrt_carloan.gnucash-xea
@@ -113,8 +113,3 @@
   <act:parent type="new">9e8495e80ebfb762089be917dff7ab72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/nb/acctchrt_cdmoneymkt.gnucash-xea
+++ b/data/accounts/nb/acctchrt_cdmoneymkt.gnucash-xea
@@ -135,7 +135,3 @@
   <act:parent type="new">fd131cae797d1fb83c2e2bf57254eca5</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/nb/acctchrt_checkbook.gnucash-xea
+++ b/data/accounts/nb/acctchrt_checkbook.gnucash-xea
@@ -141,8 +141,3 @@
   <act:parent type="new">b8b72887da1adf889f171923d23efbdd</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/nb/acctchrt_childcare.gnucash-xea
+++ b/data/accounts/nb/acctchrt_childcare.gnucash-xea
@@ -69,7 +69,3 @@
   <act:parent type="new">ee8238ee2c2ce590160761df09b99b72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/nb/acctchrt_common.gnucash-xea
+++ b/data/accounts/nb/acctchrt_common.gnucash-xea
@@ -741,7 +741,3 @@
   <act:parent type="new">3ab6a6d97b216c11333e48aa2b749a91</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/nb/acctchrt_eduloan.gnucash-xea
+++ b/data/accounts/nb/acctchrt_eduloan.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">1cfcd30ea97b954ffb550ab87d561033</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/nb/acctchrt_fixedassets.gnucash-xea
+++ b/data/accounts/nb/acctchrt_fixedassets.gnucash-xea
@@ -102,7 +102,3 @@
   <act:parent type="new">9b171f77000bf68dd1ebbaf58336656d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/nb/acctchrt_full.gnucash-xea
+++ b/data/accounts/nb/acctchrt_full.gnucash-xea
@@ -1321,7 +1321,3 @@
   <act:parent type="new">68d4074f91295062c0b773b4ae8de6bd</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/nb/acctchrt_homeloan.gnucash-xea
+++ b/data/accounts/nb/acctchrt_homeloan.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">3dc58d8a51b5deaa22e0c65d81e90346</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/nb/acctchrt_homeown.gnucash-xea
+++ b/data/accounts/nb/acctchrt_homeown.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">a931b8ffe2917ff9a069333623da96ca</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/nb/acctchrt_otherloan.gnucash-xea
+++ b/data/accounts/nb/acctchrt_otherloan.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">4a02c14e992ea79076837c164aa6fc8d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/nb/acctchrt_renter.gnucash-xea
+++ b/data/accounts/nb/acctchrt_renter.gnucash-xea
@@ -91,7 +91,3 @@
   <act:parent type="new">9a2b4520f113372f4e576f5b6dc129c6</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/nb/acctchrt_retiremt.gnucash-xea
+++ b/data/accounts/nb/acctchrt_retiremt.gnucash-xea
@@ -130,7 +130,3 @@
   <act:parent type="new">4173f3047238f4b5595b11d6161b2f48</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/nb/acctchrt_spouseinc.gnucash-xea
+++ b/data/accounts/nb/acctchrt_spouseinc.gnucash-xea
@@ -146,7 +146,3 @@
   <act:parent type="new">3cd0ca7d6b0e5f44e4cde2851c3ff387</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/nb/acctchrt_spouseretire.gnucash-xea
+++ b/data/accounts/nb/acctchrt_spouseretire.gnucash-xea
@@ -130,7 +130,3 @@
   <act:parent type="new">4426b41837adc284f96b291c31022844</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/nl/acctchrt_checkbook.gnucash-xea
+++ b/data/accounts/nl/acctchrt_checkbook.gnucash-xea
@@ -149,8 +149,3 @@
   <act:parent type="new">b8b72887da1adf889f171923d23efbdd</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/nl/acctchrt_full.gnucash-xea
+++ b/data/accounts/nl/acctchrt_full.gnucash-xea
@@ -1389,7 +1389,3 @@
   <act:parent type="new">68d4074f91295062c0b773b4ae8de6bd</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pl/acctchrt_brokerage.gnucash-xea
+++ b/data/accounts/pl/acctchrt_brokerage.gnucash-xea
@@ -214,7 +214,3 @@
   <act:parent type="new">6de23244232785031501171abcc1d4aa</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pl/acctchrt_business.gnucash-xea
+++ b/data/accounts/pl/acctchrt_business.gnucash-xea
@@ -1438,7 +1438,3 @@
   <act:parent type="new">87e02e757b32b3059652cfe09fe9ae00</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pl/acctchrt_carloan.gnucash-xea
+++ b/data/accounts/pl/acctchrt_carloan.gnucash-xea
@@ -131,8 +131,3 @@
   <act:parent type="new">9e8495e80ebfb762089be917dff7ab72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pl/acctchrt_cdmoneymkt.gnucash-xea
+++ b/data/accounts/pl/acctchrt_cdmoneymkt.gnucash-xea
@@ -153,7 +153,3 @@
   <act:parent type="new">fd131cae797d1fb83c2e2bf57254eca5</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pl/acctchrt_checkbook.gnucash-xea
+++ b/data/accounts/pl/acctchrt_checkbook.gnucash-xea
@@ -149,8 +149,3 @@
   <act:parent type="new">b8b72887da1adf889f171923d23efbdd</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pl/acctchrt_childcare.gnucash-xea
+++ b/data/accounts/pl/acctchrt_childcare.gnucash-xea
@@ -75,7 +75,3 @@
   <act:parent type="new">ee8238ee2c2ce590160761df09b99b72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pl/acctchrt_common.gnucash-xea
+++ b/data/accounts/pl/acctchrt_common.gnucash-xea
@@ -777,7 +777,3 @@
   <act:parent type="new">3ab6a6d97b216c11333e48aa2b749a91</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pl/acctchrt_eduloan.gnucash-xea
+++ b/data/accounts/pl/acctchrt_eduloan.gnucash-xea
@@ -131,7 +131,3 @@
   <act:parent type="new">1cfcd30ea97b954ffb550ab87d561033</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pl/acctchrt_fixedassets.gnucash-xea
+++ b/data/accounts/pl/acctchrt_fixedassets.gnucash-xea
@@ -114,7 +114,3 @@
   <act:parent type="new">9b171f77000bf68dd1ebbaf58336656d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pl/acctchrt_full.gnucash-xea
+++ b/data/accounts/pl/acctchrt_full.gnucash-xea
@@ -1389,7 +1389,3 @@
   <act:parent type="new">68d4074f91295062c0b773b4ae8de6bd</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pl/acctchrt_homeloan.gnucash-xea
+++ b/data/accounts/pl/acctchrt_homeloan.gnucash-xea
@@ -131,7 +131,3 @@
   <act:parent type="new">3dc58d8a51b5deaa22e0c65d81e90346</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pl/acctchrt_homeown.gnucash-xea
+++ b/data/accounts/pl/acctchrt_homeown.gnucash-xea
@@ -119,7 +119,3 @@
   <act:parent type="new">a931b8ffe2917ff9a069333623da96ca</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pl/acctchrt_otherloan.gnucash-xea
+++ b/data/accounts/pl/acctchrt_otherloan.gnucash-xea
@@ -131,7 +131,3 @@
   <act:parent type="new">4a02c14e992ea79076837c164aa6fc8d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pl/acctchrt_renter.gnucash-xea
+++ b/data/accounts/pl/acctchrt_renter.gnucash-xea
@@ -97,7 +97,3 @@
   <act:parent type="new">9a2b4520f113372f4e576f5b6dc129c6</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pl/acctchrt_retiremt.gnucash-xea
+++ b/data/accounts/pl/acctchrt_retiremt.gnucash-xea
@@ -146,7 +146,3 @@
   <act:parent type="new">4173f3047238f4b5595b11d6161b2f48</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pl/acctchrt_spouseinc.gnucash-xea
+++ b/data/accounts/pl/acctchrt_spouseinc.gnucash-xea
@@ -158,7 +158,3 @@
   <act:parent type="new">3cd0ca7d6b0e5f44e4cde2851c3ff387</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pl/acctchrt_spouseretire.gnucash-xea
+++ b/data/accounts/pl/acctchrt_spouseretire.gnucash-xea
@@ -146,7 +146,3 @@
   <act:parent type="new">4426b41837adc284f96b291c31022844</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pt_BR/acctchrt_brokerage.gnucash-xea
+++ b/data/accounts/pt_BR/acctchrt_brokerage.gnucash-xea
@@ -191,7 +191,3 @@
   <act:parent type="new">6de23244232785031501171abcc1d4aa</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pt_BR/acctchrt_carloan.gnucash-xea
+++ b/data/accounts/pt_BR/acctchrt_carloan.gnucash-xea
@@ -113,8 +113,3 @@
   <act:parent type="new">9e8495e80ebfb762089be917dff7ab72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pt_BR/acctchrt_cdmoneymkt.gnucash-xea
+++ b/data/accounts/pt_BR/acctchrt_cdmoneymkt.gnucash-xea
@@ -135,7 +135,3 @@
   <act:parent type="new">fd131cae797d1fb83c2e2bf57254eca5</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pt_BR/acctchrt_childcare.gnucash-xea
+++ b/data/accounts/pt_BR/acctchrt_childcare.gnucash-xea
@@ -69,7 +69,3 @@
   <act:parent type="new">ee8238ee2c2ce590160761df09b99b72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pt_BR/acctchrt_common.gnucash-xea
+++ b/data/accounts/pt_BR/acctchrt_common.gnucash-xea
@@ -730,7 +730,3 @@
   <act:parent type="new">3ab6a6d97b216c11333e48aa2b749a91</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pt_BR/acctchrt_currency.gnucash-xea
+++ b/data/accounts/pt_BR/acctchrt_currency.gnucash-xea
@@ -82,7 +82,3 @@
   <act:parent type="new">d9c796b35784533aee4309e28a3cbfc5</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pt_BR/acctchrt_eduloan.gnucash-xea
+++ b/data/accounts/pt_BR/acctchrt_eduloan.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">1cfcd30ea97b954ffb550ab87d561033</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pt_BR/acctchrt_fixedassets.gnucash-xea
+++ b/data/accounts/pt_BR/acctchrt_fixedassets.gnucash-xea
@@ -102,7 +102,3 @@
   <act:parent type="new">9b171f77000bf68dd1ebbaf58336656d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pt_BR/acctchrt_homeloan.gnucash-xea
+++ b/data/accounts/pt_BR/acctchrt_homeloan.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">3dc58d8a51b5deaa22e0c65d81e90346</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pt_BR/acctchrt_homeown.gnucash-xea
+++ b/data/accounts/pt_BR/acctchrt_homeown.gnucash-xea
@@ -102,7 +102,3 @@
   <act:parent type="new">84732f5fdd27b6463d75bf958e3a4b06</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pt_BR/acctchrt_otherloan.gnucash-xea
+++ b/data/accounts/pt_BR/acctchrt_otherloan.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">4a02c14e992ea79076837c164aa6fc8d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pt_BR/acctchrt_renter.gnucash-xea
+++ b/data/accounts/pt_BR/acctchrt_renter.gnucash-xea
@@ -80,7 +80,3 @@
   <act:parent type="new">9a2b4520f113372f4e576f5b6dc129c6</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pt_BR/acctchrt_retiremt.gnucash-xea
+++ b/data/accounts/pt_BR/acctchrt_retiremt.gnucash-xea
@@ -130,7 +130,3 @@
   <act:parent type="new">4173f3047238f4b5595b11d6161b2f48</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pt_BR/acctchrt_spouseinc.gnucash-xea
+++ b/data/accounts/pt_BR/acctchrt_spouseinc.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">3cd0ca7d6b0e5f44e4cde2851c3ff387</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pt_BR/acctchrt_spouseretire.gnucash-xea
+++ b/data/accounts/pt_BR/acctchrt_spouseretire.gnucash-xea
@@ -130,7 +130,3 @@
   <act:parent type="new">4426b41837adc284f96b291c31022844</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pt_PT/acctchrt_brokerage.gnucash-xea
+++ b/data/accounts/pt_PT/acctchrt_brokerage.gnucash-xea
@@ -191,7 +191,3 @@
   <act:parent type="new">6de23244232785031501171abcc1d4aa</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pt_PT/acctchrt_carloan.gnucash-xea
+++ b/data/accounts/pt_PT/acctchrt_carloan.gnucash-xea
@@ -113,8 +113,3 @@
   <act:parent type="new">9e8495e80ebfb762089be917dff7ab72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pt_PT/acctchrt_cdmoneymkt.gnucash-xea
+++ b/data/accounts/pt_PT/acctchrt_cdmoneymkt.gnucash-xea
@@ -135,7 +135,3 @@
   <act:parent type="new">fd131cae797d1fb83c2e2bf57254eca5</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pt_PT/acctchrt_childcare.gnucash-xea
+++ b/data/accounts/pt_PT/acctchrt_childcare.gnucash-xea
@@ -69,7 +69,3 @@
   <act:parent type="new">ee8238ee2c2ce590160761df09b99b72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pt_PT/acctchrt_common.gnucash-xea
+++ b/data/accounts/pt_PT/acctchrt_common.gnucash-xea
@@ -741,7 +741,3 @@
   <act:parent type="new">3ab6a6d97b216c11333e48aa2b749a91</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pt_PT/acctchrt_eduloan.gnucash-xea
+++ b/data/accounts/pt_PT/acctchrt_eduloan.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">1cfcd30ea97b954ffb550ab87d561033</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pt_PT/acctchrt_fixedassets.gnucash-xea
+++ b/data/accounts/pt_PT/acctchrt_fixedassets.gnucash-xea
@@ -102,7 +102,3 @@
   <act:parent type="new">9b171f77000bf68dd1ebbaf58336656d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pt_PT/acctchrt_homeloan.gnucash-xea
+++ b/data/accounts/pt_PT/acctchrt_homeloan.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">3dc58d8a51b5deaa22e0c65d81e90346</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pt_PT/acctchrt_homeown.gnucash-xea
+++ b/data/accounts/pt_PT/acctchrt_homeown.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">a931b8ffe2917ff9a069333623da96ca</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pt_PT/acctchrt_otherloan.gnucash-xea
+++ b/data/accounts/pt_PT/acctchrt_otherloan.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">4a02c14e992ea79076837c164aa6fc8d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pt_PT/acctchrt_renter.gnucash-xea
+++ b/data/accounts/pt_PT/acctchrt_renter.gnucash-xea
@@ -91,7 +91,3 @@
   <act:parent type="new">9a2b4520f113372f4e576f5b6dc129c6</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pt_PT/acctchrt_retiremt.gnucash-xea
+++ b/data/accounts/pt_PT/acctchrt_retiremt.gnucash-xea
@@ -130,7 +130,3 @@
   <act:parent type="new">4173f3047238f4b5595b11d6161b2f48</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pt_PT/acctchrt_spouseinc.gnucash-xea
+++ b/data/accounts/pt_PT/acctchrt_spouseinc.gnucash-xea
@@ -146,7 +146,3 @@
   <act:parent type="new">3cd0ca7d6b0e5f44e4cde2851c3ff387</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/pt_PT/acctchrt_spouseretire.gnucash-xea
+++ b/data/accounts/pt_PT/acctchrt_spouseretire.gnucash-xea
@@ -130,7 +130,3 @@
   <act:parent type="new">4426b41837adc284f96b291c31022844</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/sk/acctchrt_brokerage.gnucash-xea
+++ b/data/accounts/sk/acctchrt_brokerage.gnucash-xea
@@ -190,7 +190,3 @@
   <act:parent type="new">6de23244232785031501171abcc1d4aa</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/sk/acctchrt_carloan.gnucash-xea
+++ b/data/accounts/sk/acctchrt_carloan.gnucash-xea
@@ -113,8 +113,3 @@
   <act:parent type="new">9e8495e80ebfb762089be917dff7ab72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/sk/acctchrt_cdmoneymkt.gnucash-xea
+++ b/data/accounts/sk/acctchrt_cdmoneymkt.gnucash-xea
@@ -135,7 +135,3 @@
   <act:parent type="new">fd131cae797d1fb83c2e2bf57254eca5</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/sk/acctchrt_childcare.gnucash-xea
+++ b/data/accounts/sk/acctchrt_childcare.gnucash-xea
@@ -69,7 +69,3 @@
   <act:parent type="new">ee8238ee2c2ce590160761df09b99b72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/sk/acctchrt_common.gnucash-xea
+++ b/data/accounts/sk/acctchrt_common.gnucash-xea
@@ -752,7 +752,3 @@
   <act:parent type="new">3ab6a6d97b216c11333e48aa2b749a91</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/sk/acctchrt_currency.gnucash-xea
+++ b/data/accounts/sk/acctchrt_currency.gnucash-xea
@@ -82,7 +82,3 @@
   <act:parent type="new">d9c796b35784533aee4309e28a3cbfc5</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/sk/acctchrt_eduloan.gnucash-xea
+++ b/data/accounts/sk/acctchrt_eduloan.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">1cfcd30ea97b954ffb550ab87d561033</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/sk/acctchrt_fixedassets.gnucash-xea
+++ b/data/accounts/sk/acctchrt_fixedassets.gnucash-xea
@@ -102,7 +102,3 @@
   <act:parent type="new">9b171f77000bf68dd1ebbaf58336656d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/sk/acctchrt_homeloan.gnucash-xea
+++ b/data/accounts/sk/acctchrt_homeloan.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">3dc58d8a51b5deaa22e0c65d81e90346</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/sk/acctchrt_homeown.gnucash-xea
+++ b/data/accounts/sk/acctchrt_homeown.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">a931b8ffe2917ff9a069333623da96ca</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/sk/acctchrt_otherloan.gnucash-xea
+++ b/data/accounts/sk/acctchrt_otherloan.gnucash-xea
@@ -113,7 +113,3 @@
   <act:parent type="new">4a02c14e992ea79076837c164aa6fc8d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/sk/acctchrt_renter.gnucash-xea
+++ b/data/accounts/sk/acctchrt_renter.gnucash-xea
@@ -91,7 +91,3 @@
   <act:parent type="new">9a2b4520f113372f4e576f5b6dc129c6</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/sk/acctchrt_retiremt.gnucash-xea
+++ b/data/accounts/sk/acctchrt_retiremt.gnucash-xea
@@ -130,7 +130,3 @@
   <act:parent type="new">4173f3047238f4b5595b11d6161b2f48</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/sk/acctchrt_spouseinc.gnucash-xea
+++ b/data/accounts/sk/acctchrt_spouseinc.gnucash-xea
@@ -146,7 +146,3 @@
   <act:parent type="new">3cd0ca7d6b0e5f44e4cde2851c3ff387</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/sk/acctchrt_spouseretire.gnucash-xea
+++ b/data/accounts/sk/acctchrt_spouseretire.gnucash-xea
@@ -130,7 +130,3 @@
   <act:parent type="new">4426b41837adc284f96b291c31022844</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/sv_AX/acctchrt_common.gnucash-xea
+++ b/data/accounts/sv_AX/acctchrt_common.gnucash-xea
@@ -738,6 +738,3 @@
         <act:parent type="new">3ab6a6d97b216c11333e48aa2b749a91</act:parent>
     </gnc:account>
 </gnc-account-example>
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/sv_AX/acctchrt_rf.gnucash-xea
+++ b/data/accounts/sv_AX/acctchrt_rf.gnucash-xea
@@ -367,6 +367,3 @@
     </gnc:account>
 
 </gnc-account-example>
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/sv_AX/acctchrt_sbr-xbrl.gnucash-xea
+++ b/data/accounts/sv_AX/acctchrt_sbr-xbrl.gnucash-xea
@@ -2708,7 +2708,3 @@
         <act:parent type="guid">91ca36e058bbbb5deae199ca187e701e</act:parent>
     </gnc:account>
 </gnc-account-example>
-
-        <!-- Local variables: -->
-        <!-- mode: xml        -->
-        <!-- End:             -->

--- a/data/accounts/sv_FI/acctchrt_common.gnucash-xea
+++ b/data/accounts/sv_FI/acctchrt_common.gnucash-xea
@@ -738,6 +738,3 @@
         <act:parent type="new">3ab6a6d97b216c11333e48aa2b749a91</act:parent>
     </gnc:account>
 </gnc-account-example>
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/sv_FI/acctchrt_rf.gnucash-xea
+++ b/data/accounts/sv_FI/acctchrt_rf.gnucash-xea
@@ -367,6 +367,3 @@
     </gnc:account>
 
 </gnc-account-example>
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/sv_FI/acctchrt_sbr-xbrl.gnucash-xea
+++ b/data/accounts/sv_FI/acctchrt_sbr-xbrl.gnucash-xea
@@ -2708,7 +2708,3 @@
         <act:parent type="guid">91ca36e058bbbb5deae199ca187e701e</act:parent>
     </gnc:account>
 </gnc-account-example>
-
-        <!-- Local variables: -->
-        <!-- mode: xml        -->
-        <!-- End:             -->

--- a/data/accounts/sv_SE/acctchrt_common.gnucash-xea
+++ b/data/accounts/sv_SE/acctchrt_common.gnucash-xea
@@ -738,6 +738,3 @@
         <act:parent type="new">3ab6a6d97b216c11333e48aa2b749a91</act:parent>
     </gnc:account>
 </gnc-account-example>
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/tr_TR/acctchrt_TEKDUZ.gnucash-xea
+++ b/data/accounts/tr_TR/acctchrt_TEKDUZ.gnucash-xea
@@ -6261,7 +6261,3 @@
   <act:parent type="new">68ed78ebc81c897e31897325861d6ae7</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/tr_TR/acctchrt_brokerage.gnucash-xea
+++ b/data/accounts/tr_TR/acctchrt_brokerage.gnucash-xea
@@ -214,7 +214,3 @@
   <act:parent type="new">6de23244232785031501171abcc1d4aa</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/tr_TR/acctchrt_carloan.gnucash-xea
+++ b/data/accounts/tr_TR/acctchrt_carloan.gnucash-xea
@@ -131,8 +131,3 @@
   <act:parent type="new">9e8495e80ebfb762089be917dff7ab72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/tr_TR/acctchrt_cdmoneymkt.gnucash-xea
+++ b/data/accounts/tr_TR/acctchrt_cdmoneymkt.gnucash-xea
@@ -135,7 +135,3 @@
   <act:parent type="new">fd131cae797d1fb83c2e2bf57254eca5</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/tr_TR/acctchrt_checkbook.gnucash-xea
+++ b/data/accounts/tr_TR/acctchrt_checkbook.gnucash-xea
@@ -149,8 +149,3 @@
   <act:parent type="new">b8b72887da1adf889f171923d23efbdd</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/tr_TR/acctchrt_common.gnucash-xea
+++ b/data/accounts/tr_TR/acctchrt_common.gnucash-xea
@@ -777,7 +777,3 @@
   <act:parent type="new">3ab6a6d97b216c11333e48aa2b749a91</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/tr_TR/acctchrt_fixedassets.gnucash-xea
+++ b/data/accounts/tr_TR/acctchrt_fixedassets.gnucash-xea
@@ -114,7 +114,3 @@
   <act:parent type="new">9b171f77000bf68dd1ebbaf58336656d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/tr_TR/acctchrt_homeloan.gnucash-xea
+++ b/data/accounts/tr_TR/acctchrt_homeloan.gnucash-xea
@@ -131,7 +131,3 @@
   <act:parent type="new">3dc58d8a51b5deaa22e0c65d81e90346</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/zh_CN/acctchrt_brokerage.gnucash-xea
+++ b/data/accounts/zh_CN/acctchrt_brokerage.gnucash-xea
@@ -214,7 +214,3 @@
   <act:parent type="new">6de23244232785031501171abcc1d4aa</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/zh_CN/acctchrt_business.gnucash-xea
+++ b/data/accounts/zh_CN/acctchrt_business.gnucash-xea
@@ -1438,7 +1438,3 @@
   <act:parent type="new">87e02e757b32b3059652cfe09fe9ae00</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/zh_CN/acctchrt_carloan.gnucash-xea
+++ b/data/accounts/zh_CN/acctchrt_carloan.gnucash-xea
@@ -131,8 +131,3 @@
   <act:parent type="new">9e8495e80ebfb762089be917dff7ab72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/zh_CN/acctchrt_cdmoneymkt.gnucash-xea
+++ b/data/accounts/zh_CN/acctchrt_cdmoneymkt.gnucash-xea
@@ -153,7 +153,3 @@
   <act:parent type="new">fd131cae797d1fb83c2e2bf57254eca5</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/zh_CN/acctchrt_checkbook.gnucash-xea
+++ b/data/accounts/zh_CN/acctchrt_checkbook.gnucash-xea
@@ -149,8 +149,3 @@
   <act:parent type="new">b8b72887da1adf889f171923d23efbdd</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/zh_CN/acctchrt_childcare.gnucash-xea
+++ b/data/accounts/zh_CN/acctchrt_childcare.gnucash-xea
@@ -75,7 +75,3 @@
   <act:parent type="new">ee8238ee2c2ce590160761df09b99b72</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/zh_CN/acctchrt_common.gnucash-xea
+++ b/data/accounts/zh_CN/acctchrt_common.gnucash-xea
@@ -777,7 +777,3 @@
   <act:parent type="new">3ab6a6d97b216c11333e48aa2b749a91</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/zh_CN/acctchrt_eduloan.gnucash-xea
+++ b/data/accounts/zh_CN/acctchrt_eduloan.gnucash-xea
@@ -131,7 +131,3 @@
   <act:parent type="new">1cfcd30ea97b954ffb550ab87d561033</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/zh_CN/acctchrt_fixedassets.gnucash-xea
+++ b/data/accounts/zh_CN/acctchrt_fixedassets.gnucash-xea
@@ -114,7 +114,3 @@
   <act:parent type="new">9b171f77000bf68dd1ebbaf58336656d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/zh_CN/acctchrt_full.gnucash-xea
+++ b/data/accounts/zh_CN/acctchrt_full.gnucash-xea
@@ -1389,7 +1389,3 @@
   <act:parent type="new">68d4074f91295062c0b773b4ae8de6bd</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/zh_CN/acctchrt_homeloan.gnucash-xea
+++ b/data/accounts/zh_CN/acctchrt_homeloan.gnucash-xea
@@ -131,7 +131,3 @@
   <act:parent type="new">3dc58d8a51b5deaa22e0c65d81e90346</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/zh_CN/acctchrt_homeown.gnucash-xea
+++ b/data/accounts/zh_CN/acctchrt_homeown.gnucash-xea
@@ -119,7 +119,3 @@
   <act:parent type="new">a931b8ffe2917ff9a069333623da96ca</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/zh_CN/acctchrt_otherloan.gnucash-xea
+++ b/data/accounts/zh_CN/acctchrt_otherloan.gnucash-xea
@@ -131,7 +131,3 @@
   <act:parent type="new">4a02c14e992ea79076837c164aa6fc8d</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/zh_CN/acctchrt_renter.gnucash-xea
+++ b/data/accounts/zh_CN/acctchrt_renter.gnucash-xea
@@ -97,7 +97,3 @@
   <act:parent type="new">9a2b4520f113372f4e576f5b6dc129c6</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/zh_CN/acctchrt_retiremt.gnucash-xea
+++ b/data/accounts/zh_CN/acctchrt_retiremt.gnucash-xea
@@ -146,7 +146,3 @@
   <act:parent type="new">4173f3047238f4b5595b11d6161b2f48</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/zh_CN/acctchrt_spouseinc.gnucash-xea
+++ b/data/accounts/zh_CN/acctchrt_spouseinc.gnucash-xea
@@ -158,7 +158,3 @@
   <act:parent type="new">3cd0ca7d6b0e5f44e4cde2851c3ff387</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/zh_CN/acctchrt_spouseretire.gnucash-xea
+++ b/data/accounts/zh_CN/acctchrt_spouseretire.gnucash-xea
@@ -146,7 +146,3 @@
   <act:parent type="new">4426b41837adc284f96b291c31022844</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/zh_HK/acctchrt_business.gnucash-xea
+++ b/data/accounts/zh_HK/acctchrt_business.gnucash-xea
@@ -1438,7 +1438,3 @@
   <act:parent type="new">87e02e757b32b3059652cfe09fe9ae00</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->

--- a/data/accounts/zh_TW/acctchrt_business.gnucash-xea
+++ b/data/accounts/zh_TW/acctchrt_business.gnucash-xea
@@ -1438,7 +1438,3 @@
   <act:parent type="new">87e02e757b32b3059652cfe09fe9ae00</act:parent>
 </gnc:account>
 </gnc-account-example>
-
-<!-- Local variables: -->
-<!-- mode: xml        -->
-<!-- End:             -->


### PR DESCRIPTION
Remove the emacs comments at the end of files (for all Account Hierarchy Templates):

```
C, ca, cs, da, de_AT, de_CH, de_DE, el_GR, en_GB, en_IN, es_ES,
es_MX, fi_FI, fr_CA, fr_CH, fr_FR, hu_HU, it, ja, ko,
lt, lv, nb, nl, pl, pt_BR, pt_PT, sk, sv_AX, sv_FI,
sv_SE, tr_TR, zh_CN, zh_HK, zh_TW
```
For more info see PR #311 and #303

