### PR TITLE
Allow creation of prices in Python bindings

### DIFF
--- a/bindings/python/gnucash_core.py
+++ b/bindings/python/gnucash_core.py
@@ -356,7 +356,7 @@ class GncPrice(GnuCashCoreClass):
 
       See also http://code.gnucash.org/docs/head/group__Price.html
     '''
-    pass
+    _new_instance = 'gnc_price_create'
 GncPrice.add_methods_with_prefix('gnc_price_')
 
 


### PR DESCRIPTION
Using the function gnc_price_create and book as a parameter, it is possible to create the new GncPrice object. This will remove the necessity of cloning the prices from existing ones in Python scripts.