### PR TITLE
Add COMPILE_SCHEMA to allow disabling gschema compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,9 @@ OPTION (ALLOW_OLD_GETTEXT "allow to configure build with a gettext version older
 
 # These are also settable from the command line in a similar way.
 
+# Use gsettings-desktop-schema for a better integration with GNOME
+SET(COMPILE_SCHEMA ON CACHE BOOL "Compile the GSettings schema")
+
 SET(GNUCASH_BUILD_ID "" CACHE STRING "Overrides the GnuCash build identification (Build ID) which defaults to a description of the vcs commit from which gnucash is built. Distributions may want to insert a package management based version number instead")
 # GENERATE_SWIG_WRAPPERS - Controls whether to generate the swig wrappers for guile and python. If not set the wrappers will only be generated when building from a git worktree, commented out here, but will be evaluated later on in this file
 

--- a/gnucash/gschemas/CMakeLists.txt
+++ b/gnucash/gschemas/CMakeLists.txt
@@ -22,23 +22,25 @@ SET(gschema_SOURCES
 add_gschema_targets("${gschema_SOURCES}")
 
 # Handle gschemas.compiled
-set(CMAKE_COMMAND_TMP "")
-if (${CMAKE_VERSION} VERSION_GREATER 3.1)
-    set(CMAKE_COMMAND_TMP ${CMAKE_COMMAND} -E env)
-endif()
+if (COMPILE_SCHEMA)
+    set(CMAKE_COMMAND_TMP "")
+    if (${CMAKE_VERSION} VERSION_GREATER 3.1)
+        set(CMAKE_COMMAND_TMP ${CMAKE_COMMAND} -E env)
+    endif()
 
-add_custom_command(
-    OUTPUT ${SCHEMADIR_BUILD}/gschemas.compiled
-    COMMAND ${CMAKE_COMMAND_TMP} ${GLIB_COMPILE_SCHEMAS} ${SCHEMADIR_BUILD}
-    DEPENDS ${gschema_depends}
-)
+    add_custom_command(
+        OUTPUT ${SCHEMADIR_BUILD}/gschemas.compiled
+        COMMAND ${CMAKE_COMMAND_TMP} ${GLIB_COMPILE_SCHEMAS} ${SCHEMADIR_BUILD}
+        DEPENDS ${gschema_depends}
+    )
 
-add_custom_target(compiled-schemas ALL DEPENDS ${SCHEMADIR_BUILD}/gschemas.compiled)
+    add_custom_target(compiled-schemas ALL DEPENDS ${SCHEMADIR_BUILD}/gschemas.compiled)
 
 
-install(CODE "execute_process(
-    COMMAND ${SHELL} -c \"echo Compiling gschema files in $DESTDIR${CMAKE_INSTALL_FULL_DATADIR}/glib-2.0/schemas ;
-                          ${GLIB_COMPILE_SCHEMAS} $DESTDIR${CMAKE_INSTALL_FULL_DATADIR}/glib-2.0/schemas\")")
+    install(CODE "execute_process(
+        COMMAND ${SHELL} -c \"echo Compiling gschema files in $DESTDIR${CMAKE_INSTALL_FULL_DATADIR}/glib-2.0/schemas ;
+                              ${GLIB_COMPILE_SCHEMAS} $DESTDIR${CMAKE_INSTALL_FULL_DATADIR}/glib-2.0/schemas\")")
+endif ()
 
 SET(gschemas_DIST_local "")
 FOREACH(file ${gschema_SOURCES})


### PR DESCRIPTION
Adding the COMPILE_SCHEMA option allows a choice to compile the gschema or not, defaulting to 'ON'. This is useful for distributions that choose to not compile the gschema when producing packages for some good reasons.