### PR TITLE
Bug794360 error when deleting accounts with subaccounts

### DIFF
--- a/gnucash/gnome/dialog-price-edit-db.c
+++ b/gnucash/gnome/dialog-price-edit-db.c
@@ -387,6 +387,7 @@ gnc_prices_dialog_remove_old_clicked (GtkWidget *widget, gpointer data)
 {
     PricesDialog *pdb_dialog = data;
     GtkBuilder *builder;
+    GtkTreeModel *model;
     GtkWidget *date, *label, *box;
     GtkWidget *button;
     GtkTreeSelection *selection;
@@ -459,6 +460,11 @@ gnc_prices_dialog_remove_old_clicked (GtkWidget *widget, gpointer data)
             PriceRemoveSourceFlags source = PRICE_REMOVE_SOURCE_FQ;
             PriceRemoveKeepOptions keep = PRICE_REMOVE_KEEP_NONE;
 
+            // disconnect the model to the price treeview
+            model = gtk_tree_view_get_model (GTK_TREE_VIEW(pdb_dialog->price_tree));
+            g_object_ref (G_OBJECT(model));
+            gtk_tree_view_set_model (GTK_TREE_VIEW(pdb_dialog->price_tree), NULL);
+
             DEBUG("deleting prices");
             last_ts.tv_sec = gnc_date_edit_get_date (GNC_DATE_EDIT (date));
             last_ts.tv_nsec = 0;
@@ -498,6 +504,9 @@ gnc_prices_dialog_remove_old_clicked (GtkWidget *widget, gpointer data)
                 gnc_pricedb_remove_old_prices (pdb_dialog->price_db, comm_list, &fiscal_end_date, tmp_ts,
                                                pdb_dialog->remove_source, PRICE_REMOVE_KEEP_LAST_MONTHLY);
             }
+            // reconnect the model to the price treeview
+            gtk_tree_view_set_model (GTK_TREE_VIEW(pdb_dialog->price_tree), model);
+            g_object_unref(G_OBJECT(model));
         }
         g_list_free (comm_list);
     }

--- a/gnucash/gnome/gnc-plugin-page-account-tree.c
+++ b/gnucash/gnome/gnc-plugin-page-account-tree.c
@@ -82,6 +82,8 @@ static QofLogModule log_module = GNC_MOD_GUI;
 #define DELETE_DIALOG_TRANS_MAS    "trans_mas"
 #define DELETE_DIALOG_SA_MAS       "sa_mas"
 #define DELETE_DIALOG_SA_TRANS_MAS "sa_trans_mas"
+#define DELETE_DIALOG_SA_TRANS     "sa_trans"
+#define DELETE_DIALOG_SA_SPLITS    "sa_has_split"
 #define DELETE_DIALOG_OK_BUTTON    "deletebutton"
 
 enum
@@ -1286,8 +1288,36 @@ gppat_populate_trans_mas_list(GtkToggleButton *sa_mrb,
 void
 gppat_set_insensitive_iff_rb_active(GtkWidget *widget, GtkToggleButton *b)
 {
+    GtkWidget *dialog = gtk_widget_get_toplevel(widget);
+    GtkWidget *subaccount_trans = g_object_get_data(G_OBJECT(dialog), DELETE_DIALOG_SA_TRANS);
+    GtkWidget *sa_mas = g_object_get_data(G_OBJECT(dialog), DELETE_DIALOG_SA_MAS);
+    gboolean have_splits = GPOINTER_TO_INT (g_object_get_data(G_OBJECT(dialog), DELETE_DIALOG_SA_SPLITS));
+
     gtk_widget_set_sensitive(widget, !gtk_toggle_button_get_active(b));
-    set_ok_sensitivity(gtk_widget_get_toplevel(widget));
+
+    // If we have subaccount splits & delete subaccounts, enable subaccount_trans
+    if ((have_splits) && !gtk_widget_is_sensitive(sa_mas))
+        gtk_widget_set_sensitive(subaccount_trans, TRUE);
+    else
+        gtk_widget_set_sensitive(subaccount_trans, FALSE);
+
+    set_ok_sensitivity(dialog);
+}
+
+static GtkWidget *
+gppat_setup_account_selector (GtkBuilder *builder, GtkWidget *dialog,
+                              const gchar *hbox, const gchar *sel_name)
+{
+    GtkWidget *selector = gnc_account_sel_new();
+    GtkWidget *box = GTK_WIDGET(gtk_builder_get_object (builder, hbox));
+
+    gtk_box_pack_start (GTK_BOX(box), selector, TRUE, TRUE, 0);
+    g_object_set_data(G_OBJECT(dialog), sel_name, selector);
+
+    gppat_populate_gas_list(dialog, GNC_ACCOUNT_SEL(selector), TRUE);
+    gtk_widget_show_all(box);
+
+    return selector;
 }
 
 static void
@@ -1332,7 +1362,7 @@ gnc_plugin_page_account_tree_cmd_delete_account (GtkAction *action, GncPluginPag
     splits = xaccAccountGetSplitList(account);
 
     /*
-     * If the account has transactions or child accounts then conduct a
+     * If the account has transactions or child accounts then present a
      * dialog to allow the user to specify what should be done with them.
      */
     if ((NULL != splits) || (gnc_account_n_children(account) > 0))
@@ -1340,7 +1370,6 @@ gnc_plugin_page_account_tree_cmd_delete_account (GtkAction *action, GncPluginPag
         GList *filter = NULL;
         GtkBuilder *builder = NULL;
         GtkWidget *dialog = NULL;
-        GtkWidget *box = NULL;
         GtkWidget *widget = NULL;
         gchar *title = NULL;
 
@@ -1366,78 +1395,70 @@ gnc_plugin_page_account_tree_cmd_delete_account (GtkAction *action, GncPluginPag
         g_object_set_data(G_OBJECT(dialog), DELETE_DIALOG_FILTER, filter);
         g_object_set_data(G_OBJECT(dialog), DELETE_DIALOG_ACCOUNT, account);
 
-        /*
-         * Adjust the dialog based on whether the account has
-         * transactions.
-         */
+        // Add the account selectors and enable sections as appropiate
+        // setup transactions selector
+        trans_mas = gppat_setup_account_selector (builder, dialog, "trans_mas_hbox", DELETE_DIALOG_TRANS_MAS);
+
+        // Does the selected account have splits
         if (splits)
         {
             delete_helper_t delete_res2 = { FALSE, FALSE };
 
-            trans_mas = gnc_account_sel_new();
-            box = GTK_WIDGET(gtk_builder_get_object (builder, "trans_mas_hbox"));
-            gtk_box_pack_start (GTK_BOX(box), trans_mas, TRUE, TRUE, 0);
-            g_object_set_data(G_OBJECT(dialog), DELETE_DIALOG_TRANS_MAS, trans_mas);
-            gppat_populate_gas_list(dialog, GNC_ACCOUNT_SEL(trans_mas), FALSE);
-
             delete_account_helper(account, &delete_res2);
             if (delete_res2.has_ro_splits)
             {
-                gtk_widget_destroy(GTK_WIDGET(gtk_builder_get_object (builder, "trans_rw")));
+                gtk_widget_hide(GTK_WIDGET(gtk_builder_get_object (builder, "trans_rw")));
                 widget = GTK_WIDGET(gtk_builder_get_object (builder, "trans_drb"));
                 gtk_widget_set_sensitive(widget, FALSE);
             }
             else
-            {
-                gtk_widget_destroy(GTK_WIDGET(gtk_builder_get_object (builder, "trans_ro")));
-            }
+                gtk_widget_hide(GTK_WIDGET(gtk_builder_get_object (builder, "trans_ro")));
         }
         else
         {
-            gtk_widget_destroy(GTK_WIDGET(gtk_builder_get_object (builder, "transactions")));
+            gtk_widget_set_sensitive (GTK_WIDGET(gtk_builder_get_object (builder, "transactions")), FALSE);
+            gtk_widget_hide(GTK_WIDGET(gtk_builder_get_object (builder, "trans_ro")));
         }
 
-        /*
-         * Adjust the dialog based on whether the account has children.
-         */
+        // setup subaccount account selector
+        sa_mas = gppat_setup_account_selector (builder, dialog, "sa_mas_hbox", DELETE_DIALOG_SA_MAS);
+
+        // setup subaccount transaction selector
+        sa_trans_mas = gppat_setup_account_selector (builder, dialog, "sa_trans_mas_hbox", DELETE_DIALOG_SA_TRANS_MAS);
+        g_object_set_data(G_OBJECT(dialog), DELETE_DIALOG_SA_TRANS,
+                          GTK_WIDGET(gtk_builder_get_object (builder, "subaccount_trans")));
+
+        // Does the selected account have sub accounts
         if (gnc_account_n_children(account) > 0)
         {
-            /*
-             * Check for RO txns in descendants
-             */
+            // Check for RO txns in descendants
             gnc_account_foreach_descendant_until(account, delete_account_helper,
                                                  &delete_res);
-            if (delete_res.has_ro_splits)
+            if (delete_res.has_splits)
             {
-                gtk_widget_destroy(GTK_WIDGET(gtk_builder_get_object (builder, "sa_trans_rw")));
-                widget = GTK_WIDGET(gtk_builder_get_object (builder, "sa_trans_drb"));
-                gtk_widget_set_sensitive(widget, FALSE);
-            }
-            else if (delete_res.has_splits)
-            {
-                gtk_widget_destroy(GTK_WIDGET(gtk_builder_get_object (builder, "sa_trans_ro")));
+                if (delete_res.has_ro_splits)
+                {
+                    gtk_widget_hide(GTK_WIDGET(gtk_builder_get_object (builder, "sa_trans_rw")));
+                    widget = GTK_WIDGET(gtk_builder_get_object (builder, "sa_trans_drb"));
+                    gtk_widget_set_sensitive(widget, FALSE);
+                }
+                else
+                    gtk_widget_hide(GTK_WIDGET(gtk_builder_get_object (builder, "sa_trans_ro")));
+
+                g_object_set_data(G_OBJECT(dialog), DELETE_DIALOG_SA_SPLITS, GINT_TO_POINTER(1));
             }
             else
             {
-                gtk_widget_destroy(GTK_WIDGET(gtk_builder_get_object (builder, "subaccount_trans")));
+                g_object_set_data(G_OBJECT(dialog), DELETE_DIALOG_SA_SPLITS, GINT_TO_POINTER(0));
+                gtk_widget_set_sensitive (GTK_WIDGET(gtk_builder_get_object (builder, "subaccount_trans")), FALSE);
+                gtk_widget_hide(GTK_WIDGET(gtk_builder_get_object (builder, "sa_trans_ro")));
             }
-
-            sa_mas = gnc_account_sel_new();
-            box = GTK_WIDGET(gtk_builder_get_object (builder, "sa_mas_hbox"));
-            gtk_box_pack_start (GTK_BOX(box), sa_mas, TRUE, TRUE, 0);
-            g_object_set_data(G_OBJECT(dialog), DELETE_DIALOG_SA_MAS, sa_mas);
-            gppat_populate_gas_list(dialog, GNC_ACCOUNT_SEL(sa_mas), TRUE);
-
-            sa_trans_mas = gnc_account_sel_new();
-            box = GTK_WIDGET(gtk_builder_get_object (builder, "sa_trans_mas_hbox"));
-            gtk_box_pack_start (GTK_BOX(box), sa_trans_mas, TRUE, TRUE, 0);
-            g_object_set_data(G_OBJECT(dialog), DELETE_DIALOG_SA_TRANS_MAS, sa_trans_mas);
-            gppat_populate_gas_list(dialog, GNC_ACCOUNT_SEL(sa_trans_mas), TRUE);
         }
         else
         {
-            gtk_widget_destroy(GTK_WIDGET(gtk_builder_get_object (builder, "subaccounts")));
-            gtk_widget_destroy(GTK_WIDGET(gtk_builder_get_object (builder, "subaccount_trans")));
+            gtk_widget_set_sensitive(GTK_WIDGET(gtk_builder_get_object (builder, "subaccounts")), FALSE);
+            gtk_widget_set_sensitive(GTK_WIDGET(gtk_builder_get_object (builder, "subaccount_trans")), FALSE);
+            gtk_widget_hide(GTK_WIDGET(gtk_builder_get_object (builder, "sa_trans_ro")));
         }
 
         /* default to cancel */
@@ -1450,7 +1471,6 @@ gnc_plugin_page_account_tree_cmd_delete_account (GtkAction *action, GncPluginPag
          * Note that one effect of the modal dialog is preventing
          * the account selectors from being repopulated.
          */
-        gtk_widget_show_all(dialog);
         response = gtk_dialog_run(GTK_DIALOG(dialog));
         if (GTK_RESPONSE_ACCEPT != response)
         {

--- a/gnucash/gnome/gnc-split-reg.c
+++ b/gnucash/gnome/gnc-split-reg.c
@@ -786,7 +786,7 @@ gnc_split_reg_reverse_trans_cb (GtkWidget *w, gpointer data)
 
 
 static gboolean
-is_trans_readonly_and_warn (const Transaction *trans)
+is_trans_readonly_and_warn (GtkWindow *parent, const Transaction *trans)
 {
     GtkWidget *dialog;
     const gchar *reason;
@@ -798,7 +798,7 @@ is_trans_readonly_and_warn (const Transaction *trans)
 
     if (xaccTransIsReadonlyByPostedDate (trans))
     {
-        dialog = gtk_message_dialog_new(NULL,
+        dialog = gtk_message_dialog_new(parent,
                                         0,
                                         GTK_MESSAGE_ERROR,
                                         GTK_BUTTONS_OK,
@@ -814,7 +814,7 @@ is_trans_readonly_and_warn (const Transaction *trans)
     reason = xaccTransGetReadOnly (trans);
     if (reason)
     {
-        dialog = gtk_message_dialog_new(NULL,
+        dialog = gtk_message_dialog_new(parent,
                                         0,
                                         GTK_MESSAGE_ERROR,
                                         GTK_BUTTONS_OK,
@@ -848,7 +848,7 @@ gsr_default_reinit_handler( GNCSplitReg *gsr, gpointer data )
     reg = gnc_ledger_display_get_split_register( gsr->ledger );
 
     trans = gnc_split_register_get_current_trans (reg);
-    if (is_trans_readonly_and_warn(trans))
+    if (is_trans_readonly_and_warn(GTK_WINDOW(gsr->window), trans))
         return;
     dialog = gtk_message_dialog_new(GTK_WINDOW(gsr->window),
                                     GTK_DIALOG_DESTROY_WITH_PARENT,
@@ -1056,7 +1056,7 @@ gsr_default_associate_handler (GNCSplitReg *gsr, gboolean uri_is_file)
     if (cursor_class == CURSOR_CLASS_NONE)
         return;
 
-    if (is_trans_readonly_and_warn (trans))
+    if (is_trans_readonly_and_warn (GTK_WINDOW(gsr->window), trans))
         return;
 
     // get the existing uri
@@ -1183,7 +1183,7 @@ gsr_default_delete_handler( GNCSplitReg *gsr, gpointer data )
     if (cursor_class == CURSOR_CLASS_NONE)
         return;
 
-    if (is_trans_readonly_and_warn(trans))
+    if (is_trans_readonly_and_warn(GTK_WINDOW(gsr->window), trans))
         return;
 
     /* On a split cursor, just delete the one split. */

--- a/gnucash/gtkbuilder/dialog-account.glade
+++ b/gnucash/gtkbuilder/dialog-account.glade
@@ -195,7 +195,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
-                <property name="position">1</property>
+                <property name="position">2</property>
               </packing>
             </child>
             <child>
@@ -302,7 +302,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
-                <property name="position">2</property>
+                <property name="position">1</property>
               </packing>
             </child>
             <child>

--- a/gnucash/register/ledger-core/gnc-ledger-display.c
+++ b/gnucash/register/ledger-core/gnc-ledger-display.c
@@ -594,6 +594,7 @@ close_handler (gpointer user_data)
         return;
 
     gnc_unregister_gui_component (ld->component_id);
+    ld->component_id = NO_COMPONENT;
 
     if (ld->destroy)
         ld->destroy (ld);

--- a/gnucash/register/ledger-core/split-register-model.c
+++ b/gnucash/register/ledger-core/split-register-model.c
@@ -1957,7 +1957,7 @@ gnc_split_register_get_security_io_flags (VirtualLocation virt_loc,
 }
 
 static gboolean
-xaccTransWarnReadOnly (const Transaction *trans)
+xaccTransWarnReadOnly (GtkWidget *parent, const Transaction *trans)
 {
     GtkWidget *dialog;
     const gchar *reason;
@@ -1970,7 +1970,7 @@ xaccTransWarnReadOnly (const Transaction *trans)
     reason = xaccTransGetReadOnly (trans);
     if (reason)
     {
-        dialog = gtk_message_dialog_new(NULL,
+        dialog = gtk_message_dialog_new(GTK_WINDOW(parent),
                                         0,
                                         GTK_MESSAGE_ERROR,
                                         GTK_BUTTONS_OK,
@@ -2007,7 +2007,7 @@ gnc_split_register_confirm (VirtualLocation virt_loc, gpointer user_data)
         return TRUE;
 
     trans = xaccSplitGetParent (split);
-    if (xaccTransWarnReadOnly(trans))
+    if (xaccTransWarnReadOnly(gnc_split_register_get_parent(reg), trans))
         return FALSE;
 
     if (!xaccTransHasReconciledSplits (trans))

--- a/libgnucash/app-utils/gnc-component-manager.c
+++ b/libgnucash/app-utils/gnc-component-manager.c
@@ -690,6 +690,8 @@ gnc_gui_refresh_internal (gboolean force)
 #endif
 
     list = find_component_ids_by_class (NULL);
+    // reverse the list so class GncPluginPageRegister is before register-single
+    list = g_list_reverse (list);
 
     for (node = list; node; node = node->next)
     {


### PR DESCRIPTION
Test for valid widgets before trying to get there sensitivity. Also if the register was open when the account is deleted an invalid component_id error is logged so check for it being valid before using.