### PR TITLE
Bug 792800 - Advanced Portfolio Report tries to divide by zero balance and aborts

### DIFF
--- a/gnucash/report/business-reports/easy-invoice.scm
+++ b/gnucash/report/business-reports/easy-invoice.scm
@@ -139,19 +139,7 @@
 
 (define (monetary-or-percent numeric currency entry-type)
   (if (gnc:entry-type-percent-p entry-type)
-      (let ((table (gnc:make-html-table)))
-	(gnc:html-table-set-style!
-	 table "table"
-	 'attribute (list "border" 0)
-	 'attribute (list "cellspacing" 1)
-	 'attribute (list "cellpadding" 0))
-	(gnc:html-table-append-row!
-	 table
-	 (list numeric (_ "%")))
-	(set-last-row-style!
-	 table "td"
-	 'attribute (list "valign" "top"))
-	table)
+      (string-append (gnc:default-html-gnc-numeric-renderer numeric #f) " " (_ "%"))
       (gnc:make-gnc-monetary currency numeric)))
 
 (define (add-entry-row table currency entry column-vector row-style cust-doc? credit-note?)

--- a/gnucash/report/business-reports/invoice.scm
+++ b/gnucash/report/business-reports/invoice.scm
@@ -134,19 +134,7 @@
 
 (define (monetary-or-percent numeric currency entry-type)
   (if (gnc:entry-type-percent-p entry-type)
-      (let ((table (gnc:make-html-table)))
-	(gnc:html-table-set-style!
-	 table "table"
-	 'attribute (list "border" 0)
-	 'attribute (list "cellspacing" 1)
-	 'attribute (list "cellpadding" 0))
-	(gnc:html-table-append-row!
-	 table
-	 (list numeric (_ "%")))
-	(set-last-row-style!
-	 table "td"
-	 'attribute (list "valign" "top"))
-	table)
+      (string-append (gnc:default-html-gnc-numeric-renderer numeric #f) " " (_ "%"))
       (gnc:make-gnc-monetary currency numeric)))
 
 (define (add-entry-row table currency entry column-vector row-style cust-doc? credit-note?)


### PR DESCRIPTION
This fixes a div/0 error identified in bug 792800. It is thought to be related to negative-stock-balance situation rather than high-precision security error. From #321.