### PR TITLE
Eradicate gncInvoiceDateExists

### DIFF
--- a/gnucash/report/business-reports/job-report.scm
+++ b/gnucash/report/business-reports/job-report.scm
@@ -191,10 +191,9 @@
 	(addto! row-contents (qof-print-date date)))
     (if (date-due-col column-vector)
 	(addto! row-contents 
-		(if (and due-date
-			 (gncInvoiceDateExists due-date))
-		    (qof-print-date due-date)
-		    "")))
+                (if due-date
+                    (qof-print-date due-date)
+                    "")))
     (if (num-col column-vector)
 	(addto! row-contents num))
     (if (type-col column-vector)
@@ -264,8 +263,9 @@
 	  (set! printed? (add-balance-row table column-vector txn odd-row? printed? start-date total))
 	  
 	  ; Now print out the invoice row
-	  (if (not (null? invoice))
-	      (set! due-date (gncInvoiceGetDateDue invoice)))
+          (if (and (not (null? invoice))
+                   (gncInvoiceIsPosted invoice))
+              (set! due-date (gncInvoiceGetDateDue invoice)))
 
 	  (let ((row (make-row column-vector date due-date (gnc-get-num-action txn split)
 			       type-str (xaccSplitGetMemo split)

--- a/gnucash/report/business-reports/owner-report.scm
+++ b/gnucash/report/business-reports/owner-report.scm
@@ -290,8 +290,7 @@
         (addto! row-contents (qof-print-date date)))
     (if (date-due-col column-vector)
         (addto! row-contents 
-         (if (and due-date
-                  (gncInvoiceDateExists due-date))
+         (if due-date
              (qof-print-date due-date)
              "")))
     (if (num-col column-vector)
@@ -382,7 +381,8 @@
       ; Now print out the invoice row
       (if (not (null? invoice))
         (begin
-          (set! due-date (gncInvoiceGetDateDue invoice))
+          (set! due-date (and (gncInvoiceIsPosted invoice)
+                              (gncInvoiceGetDateDue invoice)))
           (set! sale (gncInvoiceGetTotalSubtotal invoice))
           (set! tax (gncInvoiceGetTotalTax invoice))))
 

--- a/gnucash/report/business-reports/taxinvoice.eguile.scm
+++ b/gnucash/report/business-reports/taxinvoice.eguile.scm
@@ -36,6 +36,7 @@
            (invoiceid    (gncInvoiceGetID         opt-invoice))
            (credit-note? (gncInvoiceGetIsCreditNote opt-invoice))
            (book         (gncInvoiceGetBook       opt-invoice))
+           (isposted     (gncInvoiceIsPosted      opt-invoice))
            (postdate     (gncInvoiceGetDatePosted opt-invoice))
            (duedate      (gncInvoiceGetDateDue    opt-invoice))
            (billingid    (gncInvoiceGetBillingID  opt-invoice))
@@ -246,7 +247,7 @@
         <td align="right" class="invnum"><big><strong><?scm:d invoiceid ?></strong></big></td>
       </tr>
       <?scm )) ?>
-      <?scm (if (not (gncInvoiceDateExists postdate)) (begin ?>
+      <?scm (if (not isposted) (begin ?>
         <tr>
            <td colspan="2" align="right"><?scm:d (_ "Invoice in progress...") ?></td>
         </tr>

--- a/libgnucash/engine/gncInvoice.c
+++ b/libgnucash/engine/gncInvoice.c
@@ -1856,14 +1856,6 @@ gncInvoiceApplyPayment (const GncInvoice *invoice, Transaction *txn,
     gncOwnerAutoApplyPaymentsWithLots (owner, selected_lots);
 }
 
-static gboolean gncInvoiceDateExists (time64 date)
-{
-/* Going forward we want to use INT64_MAX to indicate "no date", but for
- * backward compatibility we need to treat 0 as no date as well.
- */
-    return (date != INT64_MAX && date !=0);
-}
-
 gboolean gncInvoiceIsPosted (const GncInvoice *invoice)
 {
     if (!invoice) return FALSE;

--- a/libgnucash/engine/gncInvoice.c
+++ b/libgnucash/engine/gncInvoice.c
@@ -1856,7 +1856,7 @@ gncInvoiceApplyPayment (const GncInvoice *invoice, Transaction *txn,
     gncOwnerAutoApplyPaymentsWithLots (owner, selected_lots);
 }
 
-gboolean gncInvoiceDateExists (time64 date)
+static gboolean gncInvoiceDateExists (time64 date)
 {
 /* Going forward we want to use INT64_MAX to indicate "no date", but for
  * backward compatibility we need to treat 0 as no date as well.

--- a/libgnucash/engine/gncInvoice.h
+++ b/libgnucash/engine/gncInvoice.h
@@ -275,7 +275,6 @@ static inline GncInvoice * gncInvoiceLookup (const QofBook *book, const GncGUID 
 void gncInvoiceBeginEdit (GncInvoice *invoice);
 void gncInvoiceCommitEdit (GncInvoice *invoice);
 int gncInvoiceCompare (const GncInvoice *a, const GncInvoice *b);
-gboolean gncInvoiceDateExists (time64 date);
 gboolean gncInvoiceIsPosted (const GncInvoice *invoice);
 gboolean gncInvoiceIsPaid (const GncInvoice *invoice);
 


### PR DESCRIPTION
This commit replaces gncInvoiceDateExists calls to gncInvoiceIsPosted. I think it's a reasonable assumption that all posted invoices will have posted-date.