### PR TITLE
Various gwenywfar fixes

### DIFF
--- a/borrowed/gwengui-gtk3/w_combobox.c
+++ b/borrowed/gwengui-gtk3/w_combobox.c
@@ -258,10 +258,13 @@ int Gtk3Gui_WComboBox_Setup(GWEN_WIDGET *w) {
   /* create widget */
   store=gtk_list_store_new(1, G_TYPE_STRING);
   if (flags & GWEN_WIDGET_FLAGS_READONLY)
-    g=gtk_combo_box_new_with_model_and_entry(GTK_TREE_MODEL(store));
+    g=gtk_combo_box_new_with_model(GTK_TREE_MODEL(store));
   else
+  {
     /* TODO: why the heck does *this* combo box have two columns in the list?? */
     g=gtk_combo_box_new_with_model_and_entry(GTK_TREE_MODEL(store));
+    gtk_combo_box_set_entry_text_column (GTK_COMBO_BOX(g), 0);
+  }
   g_object_unref(store);
 
   cr=gtk_cell_renderer_text_new();

--- a/borrowed/gwengui-gtk3/w_groupbox.c
+++ b/borrowed/gwengui-gtk3/w_groupbox.c
@@ -36,6 +36,10 @@ int Gtk3Gui_WGroupBox_SetIntProperty(GWEN_WIDGET *w,
     /* just ignore these for now */
     return 0;
 
+  case GWEN_DialogProperty_Visibility:
+    gtk_widget_set_visible (GTK_WIDGET(g), (value==0)?FALSE:TRUE);
+    return 0;
+
   default:
     break;
   }
@@ -71,6 +75,9 @@ int Gtk3Gui_WGroupBox_GetIntProperty(GWEN_WIDGET *w,
   case GWEN_DialogProperty_Height:
     /* just ignore these for now */
     return 0;
+
+  case  GWEN_DialogProperty_Visibility:
+    return (gtk_widget_get_visible(GTK_WIDGET(g))==TRUE)?1:0;
 
   default:
     break;

--- a/borrowed/gwengui-gtk3/w_lineedit.c
+++ b/borrowed/gwengui-gtk3/w_lineedit.c
@@ -97,7 +97,8 @@ int Gtk3Gui_WLineEdit_SetCharProperty(GWEN_WIDGET *w,
 
   switch(prop) {
   case GWEN_DialogProperty_Value:
-    gtk_entry_set_text(GTK_ENTRY(g), value);
+    if (value && *value)
+        gtk_entry_set_text(GTK_ENTRY(g), value);
     return 0;
   default:
     break;

--- a/borrowed/gwengui-gtk3/w_textbrowser.c
+++ b/borrowed/gwengui-gtk3/w_textbrowser.c
@@ -203,6 +203,7 @@ static int Gtk3Gui_WTextBrowser_Setup(GWEN_WIDGET *w) {
   /* create widget */
   gs=gtk_scrolled_window_new(NULL, NULL);
   g=gtk_text_view_new();
+  gtk_container_add(GTK_CONTAINER(gs), GTK_WIDGET(g));
 
   if (s && *s) {
     GWEN_BUFFER *tbuf;

--- a/gnucash/import-export/aqb/gnc-ab-utils.c
+++ b/gnucash/import-export/aqb/gnc-ab-utils.c
@@ -60,9 +60,9 @@ static AB_BANKING *gnc_AB_BANKING = NULL;
 static gint gnc_AB_BANKING_refcount = 0;
 
 static gpointer join_ab_strings_cb(const gchar *str, gpointer user_data);
-static Account *gnc_ab_accinfo_to_gnc_acc(
+static Account *gnc_ab_accinfo_to_gnc_acc(GtkWidget *parent,
     AB_IMEXPORTER_ACCOUNTINFO *account_info);
-static Account *gnc_ab_txn_to_gnc_acc(
+static Account *gnc_ab_txn_to_gnc_acc(GtkWidget *parent,
     const AB_TRANSACTION *transaction);
 static const AB_TRANSACTION *txn_transaction_cb(
     const AB_TRANSACTION *element, gpointer user_data);
@@ -590,11 +590,12 @@ gnc_ab_trans_to_gnc(const AB_TRANSACTION *ab_trans, Account *gnc_acc)
  * Call gnc_import_select_account() on the online id constructed using
  * the information in @a acc_info.
  *
+ * @param parent Parent Widget
  * @param acc_info AB_IMEXPORTER_ACCOUNTINFO
  * @return A GnuCash account, or NULL otherwise
  */
 static Account *
-gnc_ab_accinfo_to_gnc_acc(AB_IMEXPORTER_ACCOUNTINFO *acc_info)
+gnc_ab_accinfo_to_gnc_acc(GtkWidget *parent, AB_IMEXPORTER_ACCOUNTINFO *acc_info)
 {
     const gchar *bankcode, *accountnumber;
     gchar *online_id;
@@ -608,7 +609,7 @@ gnc_ab_accinfo_to_gnc_acc(AB_IMEXPORTER_ACCOUNTINFO *acc_info)
                             accountnumber ? accountnumber : "",
                             (gchar*)NULL);
     gnc_acc = gnc_import_select_account(
-                  NULL, online_id, 1, AB_ImExporterAccountInfo_GetAccountName(acc_info),
+                  parent, online_id, 1, AB_ImExporterAccountInfo_GetAccountName(acc_info),
                   NULL, ACCT_TYPE_NONE, NULL, NULL);
     if (!gnc_acc)
     {
@@ -625,11 +626,12 @@ gnc_ab_accinfo_to_gnc_acc(AB_IMEXPORTER_ACCOUNTINFO *acc_info)
  * Call gnc_import_select_account() on the online id constructed using
  * the local information in @a transaction.
  *
+ * @param parent Parent Widget
  * @param transaction AB_TRANSACTION
  * @return A GnuCash account, or NULL otherwise
  */
 static Account *
-gnc_ab_txn_to_gnc_acc(const AB_TRANSACTION *transaction)
+gnc_ab_txn_to_gnc_acc(GtkWidget *parent, const AB_TRANSACTION *transaction)
 {
     const gchar *bankcode, *accountnumber;
     gchar *online_id;
@@ -648,7 +650,7 @@ gnc_ab_txn_to_gnc_acc(const AB_TRANSACTION *transaction)
                             accountnumber ? accountnumber : "",
                             (gchar*)NULL);
     gnc_acc = gnc_import_select_account(
-                  NULL, online_id, 1, AB_Transaction_GetLocalName(transaction),
+                  parent, online_id, 1, AB_Transaction_GetLocalName(transaction),
                   NULL, ACCT_TYPE_NONE, NULL, NULL);
     if (!gnc_acc)
     {
@@ -671,7 +673,7 @@ txn_transaction_cb(const AB_TRANSACTION *element, gpointer user_data)
     g_return_val_if_fail(element && data, NULL);
 
     /* Create a GnuCash transaction from ab_trans */
-    txnacc = gnc_ab_txn_to_gnc_acc(element);
+    txnacc = gnc_ab_txn_to_gnc_acc(GTK_WIDGET(data->parent), element);
     gnc_trans = gnc_ab_trans_to_gnc(element, txnacc ? txnacc : data->gnc_acc);
 
     if (data->execute_txns && data->ab_acc)
@@ -824,7 +826,7 @@ txn_accountinfo_cb(AB_IMEXPORTER_ACCOUNTINFO *element, gpointer user_data)
     }
 
     /* Lookup the corresponding gnucash account */
-    gnc_acc = gnc_ab_accinfo_to_gnc_acc(element);
+    gnc_acc = gnc_ab_accinfo_to_gnc_acc(GTK_WIDGET(data->parent), element);
     if (!gnc_acc) return NULL;
     data->gnc_acc = gnc_acc;
 
@@ -928,7 +930,7 @@ bal_accountinfo_cb(AB_IMEXPORTER_ACCOUNTINFO *element, gpointer user_data)
     }
 
     /* Lookup the corresponding gnucash account */
-    gnc_acc = gnc_ab_accinfo_to_gnc_acc(element);
+    gnc_acc = gnc_ab_accinfo_to_gnc_acc(GTK_WIDGET (data->parent), element);
     if (!gnc_acc) return NULL;
     data->gnc_acc = gnc_acc;
 

--- a/gnucash/import-export/aqb/gnc-file-aqb-import.c
+++ b/gnucash/import-export/aqb/gnc-file-aqb-import.c
@@ -236,7 +236,7 @@ gnc_file_aqbanking_import(GtkWindow *parent,
     ieci = gnc_ab_import_context(context, AWAIT_TRANSACTIONS,
                                  execute_transactions,
                                  execute_transactions ? api : NULL,
-                                 NULL);
+                                 GTK_WIDGET(parent));
 
     if (execute_transactions)
     {


### PR DESCRIPTION
The first and fourth commits were errors migrating from the gtk2 Gui to the gtk3 version.
The second and third errors I observed while trying to fix the first one which I think are correct.
The last commit fixes a couple of transient parent warnings when doing a MT940 file import.

I do not use the Aqbanking stuff but was able to create a user and account via the wizard, a strange thing when setting the currency for a account is that there are two 'Pound Sterling' options but was unable to set it to either, maybe because it was the default currency, others worked OK.

If the first four fixes are accepted then the gwenywdar library would need to patched on Windows along with the Aqbanking compile fix.

Bob