### PR TITLE
Adjust catch syntax to avoid GCC8 warnings.

### DIFF
--- a/libgnucash/backend/sql/gnc-address-sql.cpp
+++ b/libgnucash/backend/sql/gnc-address-sql.cpp
@@ -98,7 +98,7 @@ GncSqlColumnTableEntryImpl<CT_ADDRESS>::load (const GncSqlBackend* sql_be,
             set_parameter (addr, val.c_str(), sub_setter,
                            subtable_row->m_gobj_param_name);
         }
-        catch (std::invalid_argument)
+        catch (std::invalid_argument&)
         {
             return;
         }

--- a/libgnucash/backend/sql/gnc-owner-sql.cpp
+++ b/libgnucash/backend/sql/gnc-owner-sql.cpp
@@ -73,7 +73,7 @@ GncSqlColumnTableEntryImpl<CT_OWNERREF>::load (const GncSqlBackend* sql_be,
         if (string_to_guid (val.c_str(), &guid))
             pGuid = &guid;
     }
-    catch (std::invalid_argument)
+    catch (std::invalid_argument&)
     {
         return;
     }

--- a/libgnucash/backend/sql/gnc-slots-sql.cpp
+++ b/libgnucash/backend/sql/gnc-slots-sql.cpp
@@ -703,7 +703,7 @@ gnc_sql_slots_delete (GncSqlBackend* sql_be, const GncGUID* guid)
                 if (string_to_guid (val.c_str(), &child_guid))
                     gnc_sql_slots_delete (sql_be, &child_guid);
             }
-            catch (std::invalid_argument)
+            catch (std::invalid_argument&)
             {
                 continue;
             }

--- a/libgnucash/backend/sql/gnc-sql-column-table-entry.cpp
+++ b/libgnucash/backend/sql/gnc-sql-column-table-entry.cpp
@@ -130,7 +130,7 @@ GncSqlColumnTableEntryImpl<CT_STRING>::load (const GncSqlBackend* sql_be,
         auto s = row.get_string_at_col (m_col_name);
         set_parameter(pObject, s.c_str(), get_setter(obj_name), m_gobj_param_name);
     }
-    catch (std::invalid_argument) {}
+    catch (std::invalid_argument&) {}
 }
 
 template<> void
@@ -279,19 +279,19 @@ GncSqlColumnTableEntryImpl<CT_DOUBLE>::load (const GncSqlBackend* sql_be,
     {
         val = static_cast<double>(row.get_int_at_col(m_col_name));
     }
-    catch (std::invalid_argument)
+    catch (std::invalid_argument&)
     {
         try
         {
             val = static_cast<double>(row.get_float_at_col(m_col_name));
         }
-        catch (std::invalid_argument)
+        catch (std::invalid_argument&)
         {
             try
             {
                 val = row.get_double_at_col(m_col_name);
             }
-            catch (std::invalid_argument)
+            catch (std::invalid_argument&)
             {
                 val = 0.0;
             }
@@ -336,7 +336,7 @@ GncSqlColumnTableEntryImpl<CT_GUID>::load (const GncSqlBackend* sql_be,
     {
         str = row.get_string_at_col(m_col_name);
     }
-    catch (std::invalid_argument)
+    catch (std::invalid_argument&)
     {
         return;
     }
@@ -391,7 +391,7 @@ GncSqlColumnTableEntryImpl<CT_TIMESPEC>::load (const GncSqlBackend* sql_be,
         auto val = row.get_time64_at_col(m_col_name);
         timespecFromTime64 (&ts, val);
     }
-    catch (std::invalid_argument)
+    catch (std::invalid_argument&)
     {
         try
         {
@@ -399,7 +399,7 @@ GncSqlColumnTableEntryImpl<CT_TIMESPEC>::load (const GncSqlBackend* sql_be,
             GncDateTime time(val);
             ts.tv_sec = static_cast<time64>(time);
         }
-        catch (std::invalid_argument)
+        catch (std::invalid_argument&)
         {
             return;
         }
@@ -471,7 +471,7 @@ GncSqlColumnTableEntryImpl<CT_TIME64>::load (const GncSqlBackend* sql_be,
     {
         t = row.get_time64_at_col (m_col_name);
     }
-    catch (std::invalid_argument)
+    catch (std::invalid_argument&)
     {
         try
         {
@@ -479,7 +479,7 @@ GncSqlColumnTableEntryImpl<CT_TIME64>::load (const GncSqlBackend* sql_be,
             GncDateTime time(val);
             t = static_cast<time64>(time);
         }
-        catch (std::invalid_argument)
+        catch (std::invalid_argument&)
         {
             return;
         }
@@ -543,7 +543,7 @@ GncSqlColumnTableEntryImpl<CT_GDATE>::load (const GncSqlBackend* sql_be,
                        tm->tm_year + 1900);
         free(tm);
     }
-    catch (std::invalid_argument)
+    catch (std::invalid_argument&)
     {
         try
         {
@@ -557,7 +557,7 @@ GncSqlColumnTableEntryImpl<CT_GDATE>::load (const GncSqlBackend* sql_be,
                 g_date_set_dmy(&date, day, month, year);
 
         }
-        catch (std::invalid_argument)
+        catch (std::invalid_argument&)
         {
             return;
         }
@@ -622,7 +622,7 @@ GncSqlColumnTableEntryImpl<CT_NUMERIC>::load (const GncSqlBackend* sql_be,
         n = gnc_numeric_create (num, denom);
         g_free (buf);
     }
-    catch (std::invalid_argument)
+    catch (std::invalid_argument&)
     {
         return;
     }

--- a/libgnucash/backend/sql/gnc-sql-column-table-entry.hpp
+++ b/libgnucash/backend/sql/gnc-sql-column-table-entry.hpp
@@ -199,7 +199,7 @@ public:
                                        m_gobj_param_name);
                 }
             }
-            catch (std::invalid_argument) {}
+            catch (std::invalid_argument&) {}
         }
 
 

--- a/libgnucash/backend/sql/gnc-transaction-sql.cpp
+++ b/libgnucash/backend/sql/gnc-transaction-sql.cpp
@@ -1326,7 +1326,7 @@ GncSqlColumnTableEntryImpl<CT_TXREF>::load (const GncSqlBackend* sql_be,
         if (tx != nullptr)
             set_parameter (pObject, tx, get_setter(obj_name), m_gobj_param_name);
     }
-    catch (std::invalid_argument) {}
+    catch (std::invalid_argument&) {}
 }
 
 template<> void

--- a/libgnucash/engine/Account.cpp
+++ b/libgnucash/engine/Account.cpp
@@ -5442,7 +5442,7 @@ gnc_account_imap_find_account_bayes (GncImportMatchMap *imap, GList *tokens)
     gnc::GUID guid;
     try {
         guid = gnc::GUID::from_string(best.account_guid);
-    } catch (gnc::guid_syntax_exception) {
+    } catch (gnc::guid_syntax_exception&) {
         return nullptr;
     }
     auto account = xaccAccountLookup (reinterpret_cast<GncGUID*>(&guid), imap->book);

--- a/libgnucash/engine/gnc-date.cpp
+++ b/libgnucash/engine/gnc-date.cpp
@@ -120,7 +120,7 @@ gnc_localtime_r (const time64 *secs, struct tm* time)
         *time = static_cast<struct tm>(GncDateTime(*secs));
         return time;
     }
-    catch(std::invalid_argument)
+    catch(std::invalid_argument&)
     {
         return NULL;
     }
@@ -194,7 +194,7 @@ gnc_gmtime (const time64 *secs)
         *time = gncdt.utc_tm();
         return time;
     }
-    catch(std::invalid_argument)
+    catch(std::invalid_argument&)
     {
         return NULL;
     }
@@ -211,7 +211,7 @@ gnc_mktime (struct tm* time)
         *time = static_cast<struct tm>(gncdt);
         return static_cast<time64>(gncdt);
     }
-    catch(std::invalid_argument)
+    catch(std::invalid_argument&)
     {
         return 0;
     }
@@ -232,7 +232,7 @@ gnc_timegm (struct tm* time)
 #endif
         return static_cast<time64>(gncdt) - gncdt.offset();
     }
-    catch(std::invalid_argument)
+    catch(std::invalid_argument&)
     {
         return 0;
     }

--- a/libgnucash/engine/gnc-datetime.cpp
+++ b/libgnucash/engine/gnc-datetime.cpp
@@ -149,7 +149,7 @@ LDT_from_unix_local(const time64 time)
         auto tz = tzp.get(temp.date().year());
         return LDT(temp, tz);
     }
-    catch(boost::gregorian::bad_year)
+    catch(boost::gregorian::bad_year&)
     {
         throw(std::invalid_argument("Time value is outside the supported year range."));
     }
@@ -167,15 +167,15 @@ LDT_from_struct_tm(const struct tm tm)
         LDT ldt(tdate, tdur, tz, LDTBase::EXCEPTION_ON_ERROR);
         return ldt;
     }
-    catch(boost::gregorian::bad_year)
+    catch(boost::gregorian::bad_year&)
     {
         throw(std::invalid_argument("Time value is outside the supported year range."));
     }
-    catch(boost::local_time::time_label_invalid)
+    catch(boost::local_time::time_label_invalid&)
     {
         throw(std::invalid_argument("Struct tm does not resolve to a valid time."));
     }
-    catch(boost::local_time::ambiguous_result)
+    catch(boost::local_time::ambiguous_result&)
     {
         throw(std::invalid_argument("Struct tm can resolve to more than one time."));
     }
@@ -256,7 +256,7 @@ GncDateTimeImpl::GncDateTimeImpl(const GncDateImpl& date, DayPart part) :
                 m_time -= hours(offset.hours() - 11);
         }
     }
-    catch(boost::gregorian::bad_year)
+    catch(boost::gregorian::bad_year&)
     {
         throw(std::invalid_argument("Time value is outside the supported year range."));
     }
@@ -298,7 +298,7 @@ GncDateTimeImpl::GncDateTimeImpl(std::string str) :
         m_time = LDT(pdt.date(), pdt.time_of_day(), tzptr,
                          LDTBase::NOT_DATE_TIME_ON_ERROR);
     }
-    catch(boost::gregorian::bad_year)
+    catch(boost::gregorian::bad_year&)
     {
         throw(std::invalid_argument("The date string was outside of the supported year range."));
     }

--- a/libgnucash/engine/gnc-rational.cpp
+++ b/libgnucash/engine/gnc-rational.cpp
@@ -69,7 +69,7 @@ GncRational::operator gnc_numeric () const noexcept
     {
         return {static_cast<int64_t>(m_num), static_cast<int64_t>(m_den)};
     }
-    catch (std::overflow_error)
+    catch (std::overflow_error&)
     {
         return gnc_numeric_error (GNC_ERROR_OVERFLOW);
     }


### PR DESCRIPTION
Building with gcc-8 yields a plethora of:

error: catching polymorphic type ‘class std::invalid_argument’ by value [-Werror=catch-value=]

warnings (promoted to errors with -Werror).
