### PR TITLE
FIX: fix segmentation fault when loading libgnc-module

### DIFF
--- a/libgnucash/gnc-module/gnc-module.scm
+++ b/libgnucash/gnc-module/gnc-module.scm
@@ -30,7 +30,7 @@
 ;; Guile 2 needs to find the symbols from the extension at compile time already
 (eval-when
       (compile load eval expand)
-      (load-extension "libgnc-module" "scm_init_sw_gnc_module_module"))
+      (load-extension "libgnc-module.so" "scm_init_sw_gnc_module_module"))
 
 (use-modules (sw_gnc_module))
 


### PR DESCRIPTION
Without this change, compiling gnucash from a git repository crashed.

At "[ 30%] Generating ../../lib64/gnucash/scm/ccache/2.2/gnucash/gnc-module.go" a Segmentation fault occurs.

This problem starts to occur with commit "6ffb77de2   Merge branch Rob Gowin's 'bye_bye_autotools' into unstable".

I had this problem for guile-2.2.3 and guile-2.2.0.

I am using an Arch Linux system with the following software:

pacman -Q glib2 gtk3 guile libxml2 libxslt boost swig webkit2gtk gtest
glib2 2.56.0+7+g66948ae23-1
gtk3 3.22.29+60+ge42d8598ca-1
guile 2.2.3-1
libxml2 2.9.8-2
libxslt 1.1.32+3+g32c88216-1
boost 1.66.0-2
swig 3.0.12-1    (also tried 2.0.12)
webkit2gtk 2.20.0-2
gtest 1.8.0-1

I tried to narrow down the source of the segfault by creating a minimal example. At some point the segfault could be removed by either renaming gnc-module in CMakeLists.txt to gncmodule (or gnc-modul) or by removing ${GLIB2_LDFLAGS} from the linked libraries.
I attached the repository to this request ([trial.zip](https://github.com/Gnucash/gnucash/files/1887559/trial.zip)). The interesting commits are tagged "segfault", "linkremove" and "namechange". Just run "./new.sh; ./test.sh" to cause the error or see that no error occurs.


I guess this is some weird name clash and apperently it can prevented by providing the full filename of the lib (libgnc-module.so).

For me this fixes the problem. However, I have not tried the fix on other operating systems.