### PR TITLE
TR: catch invalid regex instead of report crashing.

### DIFF
--- a/gnucash/report/report-system/html-fonts.scm
+++ b/gnucash/report/report-system/html-fonts.scm
@@ -68,7 +68,7 @@
 		))))
 	(set! font-family font-name)
 	(set! result (string-append
-		"font-family: " font-family "; "
+		"font-family: " font-family ", Sans-Serif; "
 		"font-size: " font-size "pt; "
 		(if font-style (string-append "font-style: " font-style "; ") "")
 		(if font-weight (string-append "font-weight: " font-weight "; ") "")))

--- a/gnucash/report/standard-reports/income-gst-statement.scm
+++ b/gnucash/report/standard-reports/income-gst-statement.scm
@@ -43,14 +43,15 @@
  authorities. From <i>Edit report options</i> above, choose your Business Income and Business Expense accounts.
  Each transaction may contain, in addition to the accounts payable/receivable or bank accounts,
  a split to a tax account, e.g. Income:Sales -$1000, Liability:GST on Sales -$100, Asset:Bank $1100.")
-   "<br><br>"
+   "<br/><br/>"
    (_ "These tax accounts can either be populated using the standard register, or from Business Invoices and Bills
  which will require Business > Sales Tax Tables to be set up correctly. Please see the documentation.")
-   "<br><br>"
+   "<br/><br/>"
    (_ "From the Report Options, you will need to select the accounts which will \
 hold the GST/VAT taxes collected or paid. These accounts must contain splits which document the \
 monies which are wholly sent or claimed from tax authorities during periodic GST/VAT returns. These \
-accounts must be of type ASSET for taxes paid on expenses, and type LIABILITY for taxes collected on sales.")))
+accounts must be of type ASSET for taxes paid on expenses, and type LIABILITY for taxes collected on sales.")
+   "<br/><br/>"))
 
 (define (income-gst-statement-renderer rpt)
   (trep-renderer rpt

--- a/gnucash/report/standard-reports/income-gst-statement.scm
+++ b/gnucash/report/standard-reports/income-gst-statement.scm
@@ -216,7 +216,7 @@ for taxes paid on expenses, and type LIABILITY for taxes collected on sales.")
                        (lambda (a) ""))))
      (if (opt-val gnc:pagename-display (N_ "Individual tax columns"))
          (map (lambda (acc) (vector (xaccAccountGetName acc)
-                                    (account-adder acc)
+                                    (account-adder-neg acc)
                                     #t #t #f
                                     (lambda (a) "")))
               accounts-tax-collected)


### PR DESCRIPTION
The main fix here is an exception catcher for invalid-regex for account/transaction matcher. There are also a few other IMHO harmless refinements. Please cherry-pick if this is preferred.