### PR TITLE
Bug 795064 - Enable subtotal-only if sortkeys are dates

### DIFF
--- a/gnucash/report/standard-reports/transaction.scm
+++ b/gnucash/report/standard-reports/transaction.scm
@@ -630,7 +630,9 @@ tags within description, notes or memo. ")
         (gnc-option-db-set-option-selectable-by-name
          options pagename-sorting optname-show-subtotals-only
          (or (and prime-sortkey-subtotal-enabled prime-sortkey-subtotal-true)
-             (and sec-sortkey-subtotal-enabled sec-sortkey-subtotal-true)))
+             (and sec-sortkey-subtotal-enabled sec-sortkey-subtotal-true)
+             prime-date-sortingtype-enabled
+             sec-date-sortingtype-enabled))
 
         (gnc-option-db-set-option-selectable-by-name
          options pagename-sorting optname-show-informal-headers


### PR DESCRIPTION
This will allow 'show subtotals only' if sortkeys are date-types. This allows, for example, prime-sortkey=date, yearly. sec-sortkey=date, monthly.

This can still produce invalid combinations eg both sortkeys = date and subtotals = none means this option is invalid. But I figure the user will need to make some effort to produce this combination.