### PR TITLE
Some scheme progress

### DIFF
--- a/gnucash/report/business-reports/CMakeLists.txt
+++ b/gnucash/report/business-reports/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory (test)
 
 set (business_reports_SCHEME
   aging.scm

--- a/gnucash/report/business-reports/customer-summary.scm
+++ b/gnucash/report/business-reports/customer-summary.scm
@@ -97,8 +97,10 @@
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-macro (addto! alist element)
-  `(set! ,alist (cons ,element ,alist)))
+(define-syntax addto!
+  (syntax-rules ()
+    ((addto! alist element)
+     (set! alist (cons element alist)))))
 
 (define (set-last-row-style! table tag . rest)
   (let ((arg-list 

--- a/gnucash/report/business-reports/customer-summary.scm
+++ b/gnucash/report/business-reports/customer-summary.scm
@@ -97,13 +97,6 @@
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define (set-last-row-style! table tag . rest)
-  (let ((arg-list 
-         (cons table 
-               (cons (- (gnc:html-table-num-rows table) 1)
-                     (cons tag rest)))))
-    (apply gnc:html-table-set-row-style! arg-list)))
-
 (define (date-col columns-used)
   (vector-ref columns-used 0))
 (define (num-col columns-used)
@@ -591,7 +584,7 @@
     (gnc:html-table-append-row!
      table
      (list "<br>"))
-    (set-last-row-style!
+    (gnc:html-table-set-last-row-style!
      table "td"
      'attribute (list "valign" "top"))
     table))
@@ -609,7 +602,7 @@
      table "table"
      'attribute (list "border" 0)
      'attribute (list "cellpadding" 0))
-    (set-last-row-style!
+    (gnc:html-table-set-last-row-style!
      table "td"
      'attribute (list "valign" "top"))
     table))

--- a/gnucash/report/business-reports/customer-summary.scm
+++ b/gnucash/report/business-reports/customer-summary.scm
@@ -97,11 +97,6 @@
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define-syntax addto!
-  (syntax-rules ()
-    ((addto! alist element)
-     (set! alist (cons element alist)))))
-
 (define (set-last-row-style! table tag . rest)
   (let ((arg-list 
          (cons table 

--- a/gnucash/report/business-reports/easy-invoice.scm
+++ b/gnucash/report/business-reports/easy-invoice.scm
@@ -33,15 +33,11 @@
 (use-modules (srfi srfi-1))
 (use-modules (gnucash gnc-module))
 (use-modules (gnucash gettext))
+(use-modules (gnucash utilities))
 
 (gnc:module-load "gnucash/report/report-system" 0)
 (use-modules (gnucash report standard-reports))
 (use-modules (gnucash report business-reports))
-
-(define-syntax addto!
-  (syntax-rules ()
-    ((addto! alist element)
-     (set! alist (cons element alist)))))
 
 (define (set-last-row-style! table tag . rest)
   (let ((arg-list

--- a/gnucash/report/business-reports/easy-invoice.scm
+++ b/gnucash/report/business-reports/easy-invoice.scm
@@ -38,8 +38,10 @@
 (use-modules (gnucash report standard-reports))
 (use-modules (gnucash report business-reports))
 
-(define-macro (addto! alist element)
-  `(set! ,alist (cons ,element ,alist)))
+(define-syntax addto!
+  (syntax-rules ()
+    ((addto! alist element)
+     (set! alist (cons element alist)))))
 
 (define (set-last-row-style! table tag . rest)
   (let ((arg-list

--- a/gnucash/report/business-reports/easy-invoice.scm
+++ b/gnucash/report/business-reports/easy-invoice.scm
@@ -39,13 +39,6 @@
 (use-modules (gnucash report standard-reports))
 (use-modules (gnucash report business-reports))
 
-(define (set-last-row-style! table tag . rest)
-  (let ((arg-list
-         (cons table
-               (cons (- (gnc:html-table-num-rows table) 1)
-                     (cons tag rest)))))
-    (apply gnc:html-table-set-row-style! arg-list)))
-
 (define (date-col columns-used)
   (vector-ref columns-used 0))
 (define (description-col columns-used)
@@ -585,7 +578,7 @@
 	       ;; This string is supposed to be an abbrev. for "Reference"?
 	       (string-append (_ "REF") ":&nbsp;" reference))))))
      orders)
-    (set-last-row-style!
+    (gnc:html-table-set-last-row-style!
      table "td"
      'attribute (list "valign" "top"))
     table))
@@ -605,7 +598,7 @@
      table "table"
      'attribute (list "border" 0)
      'attribute (list "cellpadding" 0))
-    (set-last-row-style!
+    (gnc:html-table-set-last-row-style!
      table "td"
      'attribute (list "valign" "top"))
     table))

--- a/gnucash/report/business-reports/fancy-invoice.scm
+++ b/gnucash/report/business-reports/fancy-invoice.scm
@@ -57,13 +57,6 @@
 (use-modules (gnucash report standard-reports))
 (use-modules (gnucash report business-reports))
 
-(define (set-last-row-style! table tag . rest)
-  (let ((arg-list
-         (cons table
-               (cons (- (gnc:html-table-num-rows table) 1)
-                     (cons tag rest)))))
-    (apply gnc:html-table-set-row-style! arg-list)))
-
 (define (date-col columns-used)
   (vector-ref columns-used 0))
 (define (description-col columns-used)
@@ -646,7 +639,7 @@
 	      (list
 	       (string-append (_ "REF") ":&nbsp;" reference))))))
      orders)
-    (set-last-row-style!
+    (gnc:html-table-set-last-row-style!
      table "td"
      'attribute (list "valign" "top"))
     table))
@@ -671,7 +664,7 @@
      table "table"
      'attribute (list "border" 0)
      'attribute (list "cellpadding" 0))
-    (set-last-row-style!
+    (gnc:html-table-set-last-row-style!
      table "td"
      'attribute (list "valign" "top"))
     table))

--- a/gnucash/report/business-reports/fancy-invoice.scm
+++ b/gnucash/report/business-reports/fancy-invoice.scm
@@ -51,15 +51,11 @@
 (use-modules (srfi srfi-1))
 (use-modules (gnucash gnc-module))
 (use-modules (gnucash gettext))
+(use-modules (gnucash utilities))
 
 (gnc:module-load "gnucash/report/report-system" 0)
 (use-modules (gnucash report standard-reports))
 (use-modules (gnucash report business-reports))
-
-(define-syntax addto!
-  (syntax-rules ()
-    ((addto! alist element)
-     (set! alist (cons element alist)))))
 
 (define (set-last-row-style! table tag . rest)
   (let ((arg-list

--- a/gnucash/report/business-reports/fancy-invoice.scm
+++ b/gnucash/report/business-reports/fancy-invoice.scm
@@ -56,8 +56,10 @@
 (use-modules (gnucash report standard-reports))
 (use-modules (gnucash report business-reports))
 
-(define-macro (addto! alist element)
-  `(set! ,alist (cons ,element ,alist)))
+(define-syntax addto!
+  (syntax-rules ()
+    ((addto! alist element)
+     (set! alist (cons element alist)))))
 
 (define (set-last-row-style! table tag . rest)
   (let ((arg-list

--- a/gnucash/report/business-reports/invoice.scm
+++ b/gnucash/report/business-reports/invoice.scm
@@ -27,15 +27,11 @@
 (use-modules (srfi srfi-1))
 (use-modules (gnucash gnc-module))
 (use-modules (gnucash gettext))
+(use-modules (gnucash utilities))
 
 (gnc:module-load "gnucash/report/report-system" 0)
 (use-modules (gnucash report standard-reports))
 (use-modules (gnucash report business-reports))
-
-(define-syntax addto!
-  (syntax-rules ()
-    ((addto! alist element)
-     (set! alist (cons element alist)))))
 
 (define (set-last-row-style! table tag . rest)
   (let ((arg-list

--- a/gnucash/report/business-reports/invoice.scm
+++ b/gnucash/report/business-reports/invoice.scm
@@ -32,8 +32,10 @@
 (use-modules (gnucash report standard-reports))
 (use-modules (gnucash report business-reports))
 
-(define-macro (addto! alist element)
-  `(set! ,alist (cons ,element ,alist)))
+(define-syntax addto!
+  (syntax-rules ()
+    ((addto! alist element)
+     (set! alist (cons element alist)))))
 
 (define (set-last-row-style! table tag . rest)
   (let ((arg-list

--- a/gnucash/report/business-reports/invoice.scm
+++ b/gnucash/report/business-reports/invoice.scm
@@ -33,13 +33,6 @@
 (use-modules (gnucash report standard-reports))
 (use-modules (gnucash report business-reports))
 
-(define (set-last-row-style! table tag . rest)
-  (let ((arg-list
-         (cons table
-               (cons (- (gnc:html-table-num-rows table) 1)
-                     (cons tag rest)))))
-    (apply gnc:html-table-set-row-style! arg-list)))
-
 (define (date-col columns-used)
   (vector-ref columns-used 0))
 (define (description-col columns-used)
@@ -561,7 +554,7 @@
 	      (list
 	       (string-append (_ "REF") ":&nbsp;" reference))))))
      orders)
-    (set-last-row-style!
+    (gnc:html-table-set-last-row-style!
      table "td"
      'attribute (list "valign" "top"))
     table))
@@ -582,7 +575,7 @@
      table "table"
      'attribute (list "border" 0)
      'attribute (list "cellpadding" 0))
-    (set-last-row-style!
+    (gnc:html-table-set-last-row-style!
      table "td"
      'attribute (list "valign" "top"))
     table))

--- a/gnucash/report/business-reports/job-report.scm
+++ b/gnucash/report/business-reports/job-report.scm
@@ -46,11 +46,6 @@
 (define desc-header (N_ "Description"))
 (define amount-header (N_ "Amount"))
 
-(define-syntax addto!
-  (syntax-rules ()
-    ((addto! alist element)
-     (set! alist (cons element alist)))))
-
 (define (set-last-row-style! table tag . rest)
   (let ((arg-list 
          (cons table 

--- a/gnucash/report/business-reports/job-report.scm
+++ b/gnucash/report/business-reports/job-report.scm
@@ -46,13 +46,6 @@
 (define desc-header (N_ "Description"))
 (define amount-header (N_ "Amount"))
 
-(define (set-last-row-style! table tag . rest)
-  (let ((arg-list 
-         (cons table 
-               (cons (- (gnc:html-table-num-rows table) 1)
-                     (cons tag rest)))))
-    (apply gnc:html-table-set-row-style! arg-list)))
-
 (define (date-col columns-used)
   (vector-ref columns-used 0))
 (define (date-due-col columns-used)
@@ -479,7 +472,7 @@
     (gnc:html-table-append-row!
      table
      (list "<br/>"))
-    (set-last-row-style!
+    (gnc:html-table-set-last-row-style!
      table "td"
      'attribute (list "valign" "top"))
     table))
@@ -497,7 +490,7 @@
      table "table"
      'attribute (list "border" 0)
      'attribute (list "cellpadding" 0))
-    (set-last-row-style!
+    (gnc:html-table-set-last-row-style!
      table "td"
      'attribute (list "valign" "top"))
     table))

--- a/gnucash/report/business-reports/job-report.scm
+++ b/gnucash/report/business-reports/job-report.scm
@@ -46,8 +46,10 @@
 (define desc-header (N_ "Description"))
 (define amount-header (N_ "Amount"))
 
-(define-macro (addto! alist element)
-  `(set! ,alist (cons ,element ,alist)))
+(define-syntax addto!
+  (syntax-rules ()
+    ((addto! alist element)
+     (set! alist (cons element alist)))))
 
 (define (set-last-row-style! table tag . rest)
   (let ((arg-list 

--- a/gnucash/report/business-reports/owner-report.scm
+++ b/gnucash/report/business-reports/owner-report.scm
@@ -117,13 +117,6 @@
         (else
           (_ "Vendor")))) 
 
-(define (set-last-row-style! table tag . rest)
-  (let ((arg-list 
-         (cons table 
-               (cons (- (gnc:html-table-num-rows table) 1)
-                     (cons tag rest)))))
-    (apply gnc:html-table-set-row-style! arg-list)))
-
 (define (date-col columns-used)
   (vector-ref columns-used 0))
 (define (date-due-col columns-used)
@@ -689,7 +682,7 @@
     (gnc:html-table-append-row!
      table
      (list "<br>"))
-    (set-last-row-style!
+    (gnc:html-table-set-last-row-style!
      table "td"
      'attribute (list "valign" "top"))
     table))
@@ -707,7 +700,7 @@
      table "table"
      'attribute (list "border" 0)
      'attribute (list "cellpadding" 0))
-    (set-last-row-style!
+    (gnc:html-table-set-last-row-style!
      table "td"
      'attribute (list "valign" "top"))
     table))

--- a/gnucash/report/business-reports/owner-report.scm
+++ b/gnucash/report/business-reports/owner-report.scm
@@ -117,8 +117,10 @@
         (else
           (_ "Vendor")))) 
 
-(define-macro (addto! alist element)
-  `(set! ,alist (cons ,element ,alist)))
+(define-syntax addto!
+  (syntax-rules ()
+    ((addto! alist element)
+     (set! alist (cons element alist)))))
 
 (define (set-last-row-style! table tag . rest)
   (let ((arg-list 

--- a/gnucash/report/business-reports/owner-report.scm
+++ b/gnucash/report/business-reports/owner-report.scm
@@ -117,11 +117,6 @@
         (else
           (_ "Vendor")))) 
 
-(define-syntax addto!
-  (syntax-rules ()
-    ((addto! alist element)
-     (set! alist (cons element alist)))))
-
 (define (set-last-row-style! table tag . rest)
   (let ((arg-list 
          (cons table 

--- a/gnucash/report/business-reports/test/CMakeLists.txt
+++ b/gnucash/report/business-reports/test/CMakeLists.txt
@@ -1,0 +1,31 @@
+
+set(scm_test_business_reports_with_srfi64_SOURCES
+)
+
+set(GUILE_DEPENDS
+  scm-gnc-module
+  scm-app-utils
+  scm-engine
+  scm-test-engine
+  scm-gettext
+  scm-scm
+  scm-test-report-system
+  scm-report-stylesheets
+  )
+
+if (HAVE_SRFI64)
+  gnc_add_scheme_tests("${scm_test_business_reports_with_srfi64_SOURCES}")
+endif (HAVE_SRFI64)
+
+gnc_add_scheme_targets(scm-test-business-reports
+  "${scm_test_business_reports_SOURCES}"
+  gnucash/report/business-reports/test
+  "scm-test-business-support"
+  FALSE
+)
+
+add_dependencies(check scm-test-business-reports)
+
+set_dist_list(test_business_reports_DIST CMakeLists.txt
+  ${scm_test_business_reports_with_srfi64_SOURCES}
+  )

--- a/gnucash/report/report-system/html-table.scm
+++ b/gnucash/report/report-system/html-table.scm
@@ -756,3 +756,10 @@
     (push (gnc:html-document-markup-end doc "table"))
     (gnc:html-document-pop-style doc)
     retval))
+
+(define (gnc:html-table-set-last-row-style! table tag . rest)
+  (let ((arg-list
+         (cons table
+               (cons (- (gnc:html-table-num-rows table) 1)
+                     (cons tag rest)))))
+    (apply gnc:html-table-set-row-style! arg-list)))

--- a/gnucash/report/report-system/html-utilities.scm
+++ b/gnucash/report/report-system/html-utilities.scm
@@ -818,6 +818,65 @@
        "")
       (_ "Edit report options")))))
 
+(define* (gnc:render-options-changed options #:optional plaintext?)
+  ;; options -> html-object or string, depending on plaintext?.  This
+  ;; summarises options that were changed by the user. Set plaintext?
+  ;; to #t for unit-tests only.
+  (define (disp d)
+    ;; option-value -> string.  The option is passed to various
+    ;; scm->string converters; ultimately a generic stringify
+    ;; function handles symbol/string/other types.
+    (define (try proc)
+      ;; Try proc with d as a parameter, catching 'wrong-type-arg
+      ;; exceptions to return #f to the or evaluator.
+      (catch 'wrong-type-arg
+        (lambda () (proc d))
+        (const #f)))
+    (or (and (boolean? d) (if d (_ "Enabled") (_ "Disabled")))
+        (and (null? d) "null")
+        (and (list? d) (string-join (map disp d) ", "))
+        (and (pair? d) (format #f "~a . ~a"
+                               (car d)
+                               (if (eq? (car d) 'absolute)
+                                   (qof-print-date (cdr d))
+                                   (disp (cdr d)))))
+        (try gnc-commodity-get-mnemonic)
+        (try xaccAccountGetName)
+        (try gnc-budget-get-name)
+        (format #f "~a" d)))
+  (let ((render-list '()))
+    (define (add-option-if-changed option)
+      (let* ((section (gnc:option-section option))
+             (name (gnc:option-name option))
+             (default-value (gnc:option-default-value option))
+             (value (gnc:option-value option))
+             (retval (cons (format #f "~a / ~a" section name)
+                           (disp value))))
+        (if (not (or (equal? default-value value)
+                     (char=? (string-ref section 0) #\_)))
+            (set! render-list (cons retval render-list)))))
+    (gnc:options-for-each add-option-if-changed options)
+    (if plaintext?
+        (string-append
+         (string-join
+          (map (lambda (item)
+                 (format #f "~a: ~a\n" (car item) (cdr item)))
+               render-list)
+          "")
+         "\n")
+        (apply
+         gnc:make-html-text
+         (apply
+          append
+          (map
+           (lambda (item)
+             (list
+              (gnc:html-markup-b (car item))
+              ": "
+              (cdr item)
+              (gnc:html-markup-br)))
+           render-list))))))
+
 (define (gnc:html-make-generic-warning
          report-title-string report-id
          warning-title-string warning-string)
@@ -877,3 +936,5 @@
             ((#\>) "&gt;")
             (else c))))
        str))))
+
+

--- a/gnucash/report/report-system/html-utilities.scm
+++ b/gnucash/report/report-system/html-utilities.scm
@@ -22,6 +22,8 @@
 ;; Boston, MA  02110-1301,  USA       gnu@gnu.org
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(use-modules (gnucash utilities))
+
 ;; returns a list with n #f (empty cell) values 
 (define (gnc:html-make-empty-cell) #f)
 (define (gnc:html-make-empty-cells n)
@@ -854,7 +856,7 @@
                            (disp value))))
         (if (not (or (equal? default-value value)
                      (char=? (string-ref section 0) #\_)))
-            (set! render-list (cons retval render-list)))))
+            (addto! render-list retval))))
     (gnc:options-for-each add-option-if-changed options)
     (if plaintext?
         (string-append

--- a/gnucash/report/report-system/html-utilities.scm
+++ b/gnucash/report/report-system/html-utilities.scm
@@ -818,7 +818,7 @@
        "")
       (_ "Edit report options")))))
 
-(define* (gnc:render-options-changed options #:optional plaintext?)
+(define* (gnc:html-render-options-changed options #:optional plaintext?)
   ;; options -> html-object or string, depending on plaintext?.  This
   ;; summarises options that were changed by the user. Set plaintext?
   ;; to #t for unit-tests only.

--- a/gnucash/report/report-system/report-system.scm
+++ b/gnucash/report/report-system/report-system.scm
@@ -601,6 +601,7 @@
 (export gnc:html-table-set-col-headers-style!)
 (export gnc:html-table-row-headers-style)
 (export gnc:html-table-set-row-headers-style!)
+(export gnc:html-table-set-last-row-style!)
 (export gnc:html-table-set-style!)
 (export gnc:html-table-set-col-style!)
 (export gnc:html-table-set-row-style!)

--- a/gnucash/report/report-system/report-system.scm
+++ b/gnucash/report/report-system/report-system.scm
@@ -112,6 +112,7 @@
 (export gnc:html-build-acct-table)
 (export gnc:first-html-build-acct-table)
 (export gnc:html-make-exchangerates)
+(export gnc:render-options-changed)
 (export gnc:html-make-generic-warning)
 (export gnc:html-make-no-account-warning)
 (export gnc:html-make-generic-budget-warning)

--- a/gnucash/report/report-system/report-system.scm
+++ b/gnucash/report/report-system/report-system.scm
@@ -112,7 +112,7 @@
 (export gnc:html-build-acct-table)
 (export gnc:first-html-build-acct-table)
 (export gnc:html-make-exchangerates)
-(export gnc:render-options-changed)
+(export gnc:html-render-options-changed)
 (export gnc:html-make-generic-warning)
 (export gnc:html-make-no-account-warning)
 (export gnc:html-make-generic-budget-warning)

--- a/gnucash/report/report-system/test/test-extras.scm
+++ b/gnucash/report/report-system/test/test-extras.scm
@@ -26,19 +26,12 @@
 
 (export pattern-streamer)
 
-(export create-option-set)
-(export option-set-setter)
-(export option-set-getter)
-
 (export tbl-column-count)
 (export tbl-row-count)
 (export tbl-ref)
 (export tbl-ref->number)
 
 (export gnc:options->sxml)
-;;
-;; Random report test related syntax and the like
-;;
 
 ;;
 ;; Table parsing
@@ -90,73 +83,6 @@
 
 (define (tbl-ref->number tbl row-index column-index)
   (string->number (car (tbl-ref tbl row-index column-index))))
-
-;;
-;; Test sinks
-;;
-
-(define (make-test-sink) (list 'sink 0 '()))
-
-(define (test-sink-count sink)
-  (second sink))
-
-(define (test-sink-count! sink value)
-  (set-car! (cdr sink) value))
-
-(define (test-sink-messages sink)
-  (third sink))
-
-(define (test-sink-messages! sink messages)
-  (set-car! (cdr (cdr sink)) messages))
-
-(define (test-sink-check sink message flag)
-  (test-sink-count! sink (+ (test-sink-count sink) 1))
-  (if flag #t
-      (test-sink-messages! sink (cons message (test-sink-messages sink)))))
-
-(define (test-sink-report sink)
-  (format #t "Completed ~a tests ~a\n"
-	  (test-sink-count sink)
-	  (if (null? (test-sink-messages sink)) "PASS" "FAIL"))
-  (if (null? (test-sink-messages sink)) #t
-      (begin (for-each (lambda (delayed-message)
-			 (delayed-format-render #t delayed-message))
-		       (test-sink-messages sink))
-	     #f)))
-
-(define (delayed-format . x) x)
-
-(define (delayed-format-render stream msg)
-  (apply format stream msg))
-
-;;
-;; options
-;;
-
-
-(define (create-option-set)
-  (make-hash-table) )
-
-(define (option-set-setter option-set)
-  (lambda (category name value)
-    (hash-set! option-set (list category name) value)))
-
-(define (option-set-getter option-set)
-  (lambda (category name)
-    (hash-ref option-set (list category name))))
-
-;;
-;;
-;;
-
-(define (report-show-options stream expense-options)
-  (gnc:options-for-each (lambda (option)
-			  (format stream "Option: ~a.~a Value ~a\n"
-				  (gnc:option-section option)
-				  (gnc:option-name option)
-				  (gnc:option-value option)))
-			expense-options))
-
 
 (define (gnc:options->sxml options test-title uuid prefix)
   ;; options object -> sxml tree

--- a/gnucash/report/report-system/test/test-extras.scm
+++ b/gnucash/report/report-system/test/test-extras.scm
@@ -21,6 +21,8 @@
 
 (use-modules (gnucash gnc-module))
 (use-modules (gnucash engine test test-extras))
+(use-modules (gnucash report report-system))
+(use-modules (sxml simple))
 
 (export pattern-streamer)
 
@@ -33,6 +35,7 @@
 (export tbl-ref)
 (export tbl-ref->number)
 
+(export gnc:options->sxml)
 ;;
 ;; Random report test related syntax and the like
 ;;
@@ -154,3 +157,38 @@
 				  (gnc:option-value option)))
 			expense-options))
 
+
+(define (gnc:options->sxml options test-title uuid prefix)
+  ;; options object -> sxml tree
+  ;; test-title: str describing tests e.g. "test-trep"
+  ;; uuid - str to locate report uuid
+  ;; prefix - str describing each unit test e.g. "test disable filter"
+  ;;
+  ;; This function abstracts the report renderer. It also catches XML
+  ;; parsing errors, dumping the options changed.
+  ;;
+  ;; It also dumps the render into /tmp/XX-YY.html where XX is the
+  ;; test prefix and YY is the test title.
+
+  (let* ((template (gnc:find-report-template uuid))
+         (constructor (record-constructor <report>))
+         (report (constructor uuid "bar" options #t #t #f #f ""))
+         (renderer (gnc:report-template-renderer template))
+         (document (renderer report))
+         (sanitize-char (lambda (c)
+                          (if (char-alphabetic? c) c #\-)))
+         (fileprefix (string-map sanitize-char prefix))
+         (filename (string-map sanitize-char test-title)))
+    (gnc:html-document-set-style-sheet! document (gnc:report-stylesheet report))
+    (if test-title
+        (gnc:html-document-set-title! document test-title))
+    (let* ((filename (format #f "/tmp/~a-~a.html" fileprefix filename))
+           (render (gnc:html-document-render document))
+           (outfile (open-file filename "w")))
+      (display render outfile)
+      (close-output-port outfile)
+      (catch 'parser-error
+        (lambda () (xml->sxml render))
+        (lambda (k . args)
+          (test-assert k #f)            ; XML parse error doesn't cause a crash but logs as a failure
+          (format #t "see render output at ~a\n~a" filename (gnc:html-render-options-changed options #t)))))))

--- a/gnucash/report/report-system/test/test-html-utilities-srfi64.scm
+++ b/gnucash/report/report-system/test/test-html-utilities-srfi64.scm
@@ -6,37 +6,11 @@
 (use-modules (gnucash engine test test-extras))
 (use-modules (gnucash report report-system test test-extras))
 (use-modules (gnucash report report-system))
+(use-modules (gnucash engine test srfi64-extras))
 (use-modules (srfi srfi-64))
 
-(define (test-runner)
-  (let ((runner (test-runner-null))
-        (num-passed 0)
-        (num-failed 0))
-    (test-runner-on-test-end! runner
-      (lambda (runner)
-        (format #t "[~a] line:~a, test: ~a\n"
-                (test-result-ref runner 'result-kind)
-                (test-result-ref runner 'source-line)
-                (test-runner-test-name runner))
-        (case (test-result-kind runner)
-          ((pass xpass) (set! num-passed (1+ num-passed)))
-          ((fail xfail)
-           (if (test-result-ref runner 'expected-value)
-               (format #t "~a\n -> expected: ~s\n -> obtained: ~s\n"
-                       (string-join (test-runner-group-path runner) "/")
-                       (test-result-ref runner 'expected-value)
-                       (test-result-ref runner 'actual-value)))
-           (set! num-failed (1+ num-failed)))
-          (else #t))))
-    (test-runner-on-final! runner
-      (lambda (runner)
-        (format #t "Source:~a\npass = ~a, fail = ~a\n"
-                (test-result-ref runner 'source-file) num-passed num-failed)
-        (zero? num-failed)))
-    runner))
-
 (define (run-test)
-  (test-runner-factory test-runner)
+  (test-runner-factory gnc:test-runner)
   (test-begin "test-html-utilities-srfi64.scm")
   (test-gnc:html-string-sanitize)
   (test-end "test-html-utilities-srfi64.scm"))

--- a/gnucash/report/report-system/test/test-test-extras.scm
+++ b/gnucash/report/report-system/test/test-test-extras.scm
@@ -24,10 +24,7 @@
 (use-modules (ice-9 streams))
 
 (define (run-test)
-  (and (logging-and #t)
-       (logging-and)
-       (not (logging-and #t #f))
-       (test-pattern-streamer)
+  (and (test-pattern-streamer)
        (test-create-account-structure)))
 
 (define (test-pattern-streamer)

--- a/gnucash/report/standard-reports/income-gst-statement.scm
+++ b/gnucash/report/standard-reports/income-gst-statement.scm
@@ -38,20 +38,23 @@
 (define reportname (N_ "Income & GST Statement"))
 (define pagename-sorting (N_ "Sorting"))
 (define TAX-SETUP-DESC
-  (string-append
+  (gnc:make-html-text
    (_ "This report is useful to calculate periodic business tax payable/receivable from
  authorities. From <i>Edit report options</i> above, choose your Business Income and Business Expense accounts.
  Each transaction may contain, in addition to the accounts payable/receivable or bank accounts,
  a split to a tax account, e.g. Income:Sales -$1000, Liability:GST on Sales -$100, Asset:Bank $1100.")
-   "<br/><br/>"
+   (gnc:html-markup-br)
+   (gnc:html-markup-br)
    (_ "These tax accounts can either be populated using the standard register, or from Business Invoices and Bills
  which will require Business > Sales Tax Tables to be set up correctly. Please see the documentation.")
-   "<br/><br/>"
+   (gnc:html-markup-br)
+   (gnc:html-markup-br)
    (_ "From the Report Options, you will need to select the accounts which will \
 hold the GST/VAT taxes collected or paid. These accounts must contain splits which document the \
 monies which are wholly sent or claimed from tax authorities during periodic GST/VAT returns. These \
 accounts must be of type ASSET for taxes paid on expenses, and type LIABILITY for taxes collected on sales.")
-   "<br/><br/>"))
+   (gnc:html-markup-br)
+   (gnc:html-markup-br)))
 
 (define (income-gst-statement-renderer rpt)
   (trep-renderer rpt

--- a/gnucash/report/standard-reports/income-gst-statement.scm
+++ b/gnucash/report/standard-reports/income-gst-statement.scm
@@ -66,10 +66,10 @@ accounts must be of type ASSET for taxes paid on expenses, and type LIABILITY fo
   ;; split -> bool
   ;;
   ;; additional split filter - returns #t if split must be included
-  ;; we need to exclude Closing, Link and Payment transactions
+  ;; we need to exclude Link and Payment transactions
   (let ((trans (xaccSplitGetParent split)))
-    (and (member (xaccTransGetTxnType trans) (list TXN-TYPE-NONE TXN-TYPE-INVOICE))
-         (not (xaccTransGetIsClosingTxn trans)))))
+    (memv (xaccTransGetTxnType trans) (list TXN-TYPE-NONE TXN-TYPE-INVOICE))
+    ))
 
 (define (gst-statement-options-generator)
 
@@ -118,6 +118,9 @@ for taxes paid on expenses, and type LIABILITY for taxes collected on sales.")
   (gnc:option-make-internal! options gnc:pagename-accounts "Filter Type")
   (gnc:option-make-internal! options gnc:pagename-accounts "Filter By...")
   (gnc:option-make-internal! options gnc:pagename-general "Show original currency amount")
+  ;; Disallow closing transactions
+  (gnc:option-set-value (gnc:lookup-option options gnc:pagename-filter "Closing Transactions") 'exclude-closing)
+  (gnc:option-make-internal! options gnc:pagename-filter "Closing Transactions")
   ;; Disable display options not being used anymore
   (gnc:option-make-internal! options gnc:pagename-display "Shares")
   (gnc:option-make-internal! options gnc:pagename-display "Price")

--- a/gnucash/report/standard-reports/register.scm
+++ b/gnucash/report/standard-reports/register.scm
@@ -29,13 +29,6 @@
 
 (gnc:module-load "gnucash/report/report-system" 0)
 
-(define (set-last-row-style! table tag . rest)
-  (let ((arg-list 
-         (cons table 
-               (cons (- (gnc:html-table-num-rows table) 1)
-                     (cons tag rest)))))
-    (apply gnc:html-table-set-row-style! arg-list)))
-
 (define (date-col columns-used)
   (vector-ref columns-used 0))
 (define (num-col columns-used)
@@ -790,7 +783,7 @@
      (list
       (string-append (_ "Client") ":&nbsp;")
       (string-expand address #\newline "<br>")))
-    (set-last-row-style!
+    (gnc:html-table-set-last-row-style!
      table "td"
      'attribute (list "valign" "top"))
     table))
@@ -810,7 +803,7 @@
        (string-expand (qof-print-date (current-time))
                       #\space "&nbsp;"))
       (make-client-table address)))
-    (set-last-row-style!
+    (gnc:html-table-set-last-row-style!
      table "td"
      'attribute (list "valign" "top"))
     table))

--- a/gnucash/report/standard-reports/register.scm
+++ b/gnucash/report/standard-reports/register.scm
@@ -29,8 +29,10 @@
 
 (gnc:module-load "gnucash/report/report-system" 0)
 
-(define-macro (addto! alist element)
-  `(set! ,alist (cons ,element ,alist)))
+(define-syntax addto!
+  (syntax-rules ()
+    ((addto! alist element)
+     (set! alist (cons element alist)))))
 
 (define (set-last-row-style! table tag . rest)
   (let ((arg-list 

--- a/gnucash/report/standard-reports/register.scm
+++ b/gnucash/report/standard-reports/register.scm
@@ -29,11 +29,6 @@
 
 (gnc:module-load "gnucash/report/report-system" 0)
 
-(define-syntax addto!
-  (syntax-rules ()
-    ((addto! alist element)
-     (set! alist (cons element alist)))))
-
 (define (set-last-row-style! table tag . rest)
   (let ((arg-list 
          (cons table 

--- a/gnucash/report/standard-reports/test/test-cashflow-barchart.scm
+++ b/gnucash/report/standard-reports/test/test-cashflow-barchart.scm
@@ -39,9 +39,9 @@
 (setlocale LC_ALL "C")
 
 (define (run-test)
-  (logging-and (test-in-txn)
-               (test-out-txn)
-               (test-null-txn)))
+  (and (test-in-txn)
+       (test-out-txn)
+       (test-null-txn)))
 
 
 (define (set-option report page tag value)

--- a/gnucash/report/standard-reports/test/test-generic-net-barchart.scm
+++ b/gnucash/report/standard-reports/test/test-generic-net-barchart.scm
@@ -40,7 +40,7 @@
 (define constructor (record-constructor <report>))
 
 (define (run-net-asset-income-test asset-report-uuid income-report-uuid)
-  (logging-and  (two-txn-test asset-report-uuid)
+  (and          (two-txn-test asset-report-uuid)
 		(two-txn-test-2 asset-report-uuid)
 		(two-txn-test-income income-report-uuid)
 

--- a/gnucash/report/standard-reports/test/test-generic-net-linechart.scm
+++ b/gnucash/report/standard-reports/test/test-generic-net-linechart.scm
@@ -40,7 +40,7 @@
 (define constructor (record-constructor <report>))
 
 (define (run-net-asset-test asset-report-uuid)
-  (logging-and  (two-txn-test asset-report-uuid)
+  (and          (two-txn-test asset-report-uuid)
 		(two-txn-test-2 asset-report-uuid)
 
 		(null-test asset-report-uuid)

--- a/gnucash/report/standard-reports/test/test-transaction.scm
+++ b/gnucash/report/standard-reports/test/test-transaction.scm
@@ -91,24 +91,7 @@
   ;; It also catches XML parsing errors, dumping the options changed.
   ;;
   ;; It also dumps the render into /tmp/test-trep-XX.html where XX is the test title
-  (let* ((template (gnc:find-report-template trep-uuid))
-         (report (constructor trep-uuid "bar" options #t #t #f #f ""))
-         (renderer (gnc:report-template-renderer template))
-         (document (renderer report))
-         (filename (string-map (lambda (c) (if (char-alphabetic? c) c #\-)) test-title)))
-    (gnc:html-document-set-style-sheet! document (gnc:report-stylesheet report))
-    (if test-title
-        (gnc:html-document-set-title! document test-title))
-    (let* ((filename (format #f "/tmp/test-trep-~a.html" filename))
-           (render (gnc:html-document-render document))
-           (outfile (open-file filename "w")))
-      (display render outfile)
-      (close-output-port outfile)
-      (catch 'parser-error
-        (lambda () (xml->sxml render))
-        (lambda (k . args)
-          (test-assert k #f)            ; XML parse error doesn't cause a crash but logs as a failure
-          (format #t "see render output at ~a\n~a" filename (gnc:html-render-options-changed options #t)))))))
+  (gnc:options->sxml options test-title trep-uuid "test-trep"))
 
 (define (get-row-col sxml row col)
   ;; sxml, row & col (numbers or #f) -> list-of-string
@@ -134,8 +117,6 @@
 ;;
 ;; END CANDIDATES
 ;;
-
-(define constructor (record-constructor <report>))
 
 (define (set-option! options section name value)
   (let ((option (gnc:lookup-option options section name)))

--- a/gnucash/report/standard-reports/test/test-transaction.scm
+++ b/gnucash/report/standard-reports/test/test-transaction.scm
@@ -6,6 +6,7 @@
 (use-modules (gnucash report report-system))
 (use-modules (gnucash report report-system test test-extras))
 (use-modules (srfi srfi-64))
+(use-modules (gnucash engine test srfi64-extras))
 (use-modules (sxml simple))
 (use-modules (sxml xpath))
 (use-modules (system vm coverage))
@@ -42,33 +43,6 @@
 ;; Explicitly set locale to make the report output predictable
 (setlocale LC_ALL "C")
 
-(define (test-runner)
-  (let ((runner (test-runner-null))
-        (num-passed 0)
-        (num-failed 0))
-    (test-runner-on-test-end! runner
-      (lambda (runner)
-        (format #t "[~a] line:~a, test: ~a\n"
-                (test-result-ref runner 'result-kind)
-                (test-result-ref runner 'source-line)
-                (test-runner-test-name runner))
-        (case (test-result-kind runner)
-          ((pass xpass) (set! num-passed (1+ num-passed)))
-          ((fail xfail)
-           (if (test-result-ref runner 'expected-value)
-               (format #t "~a\n -> expected: ~s\n -> obtained: ~s\n"
-                       (string-join (test-runner-group-path runner) "/")
-                       (test-result-ref runner 'expected-value)
-                       (test-result-ref runner 'actual-value)))
-           (set! num-failed (1+ num-failed)))
-          (else #t))))
-    (test-runner-on-final! runner
-      (lambda (runner)
-        (format #t "Source:~a\npass = ~a, fail = ~a\n"
-                (test-result-ref runner 'source-file) num-passed num-failed)
-        (zero? num-failed)))
-    runner))
-
 (define (run-test)
   (if #f
       (coverage-test)
@@ -86,7 +60,7 @@
         (close port)))))
 
 (define (run-test-proper)
-  (test-runner-factory test-runner)
+  (test-runner-factory gnc:test-runner)
   (test-begin "transaction.scm")
   (null-test)
   (trep-tests)

--- a/gnucash/report/standard-reports/test/test-transaction.scm
+++ b/gnucash/report/standard-reports/test/test-transaction.scm
@@ -725,6 +725,12 @@
           '("Expenses" "Expenses" "Income" "Income" "Liabilities")
           (get-row-col sxml #f 6)))
 
+      (set-option! options "Sorting" "Primary Key" 'notes)
+      (let* ((sxml (options->sxml options "sorting=trans-notes")))
+        (test-equal "sort by transaction notes"
+          '("memo-3" "memo-2" "memo-1" "notes3")
+          (get-row-col sxml #f 4)))
+
       (set-option! options "Sorting" "Primary Key" 'amount)
       (let* ((sxml (options->sxml options "sorting=amount")))
         (test-equal "sort by amount"

--- a/gnucash/report/standard-reports/test/test-transaction.scm
+++ b/gnucash/report/standard-reports/test/test-transaction.scm
@@ -134,7 +134,7 @@
         (lambda () (xml->sxml render))
         (lambda (k . args)
           (test-assert k #f)            ; XML parse error doesn't cause a crash but logs as a failure
-          (format #t "see render output at ~a\n~a" filename (gnc:render-options-changed options #t)))))))
+          (format #t "see render output at ~a\n~a" filename (gnc:html-render-options-changed options #t)))))))
 
 (define (get-row-col sxml row col)
   ;; sxml, row & col (numbers or #f) -> list-of-string

--- a/gnucash/report/standard-reports/test/test-transaction.scm
+++ b/gnucash/report/standard-reports/test/test-transaction.scm
@@ -348,7 +348,7 @@
       (set-option! options "Sorting" "Secondary Subtotal for Date Key" 'monthly)
       (let ((sxml (options->sxml options "test basic column headers, and original currency")))
         (test-equal "default headers, indented, includes common-currency"
-          '(" " " " "Date" "Num" "Description" "Memo/Notes" "Account" "Amount" "USD" "Amount")
+          '(" " " " "Date" "Num" "Description" "Memo/Notes" "Account" "Amount (USD)" "Amount")
           (get-row-col sxml 0 #f))
         (test-equal "grand total present, no blank cells, and is $2,280 in both common-currency and original-currency"
           '("Grand Total" "$2,280.00" "$2,280.00")
@@ -584,7 +584,7 @@
       (let* ((sxml (options->sxml options "single column, with original currency headers")))
         (test-equal "single amount column, with original currency headers"
           (list "Date" "Num" "Description" "Memo/Notes" "Account"
-                "Amount" "USD" "Amount")
+                "Amount (USD)" "Amount")
           (get-row-col sxml 0 #f)))
 
       (set-option! options "Display" "Amount" 'double)
@@ -601,7 +601,7 @@
         ;; output here too.
         (test-equal "dual amount headers"
           (list "Date" "Num" "Description" "Memo/Notes" "Account" "Transfer from/to"
-                "Debit" "USD" "Credit" "USD" "Debit" "Credit")
+                "Debit (USD)" "Credit (USD)" "Debit" "Credit")
           (get-row-col sxml 0 #f))
         (test-equal "Account Name and Code displayed"
           (list "01-GBP Root.Asset.GBP Bank")
@@ -663,7 +663,7 @@
       (let* ((sxml (options->sxml options "dual columns")))
         (test-equal "dual amount column, with original currency headers"
           (list "Date" "Num" "Description" "Memo/Notes" "Account"
-                "Debit" "USD" "Credit" "USD" "Debit" "Credit")
+                "Debit (USD)" "Credit (USD)" "Debit" "Credit")
           (get-row-col sxml 0 #f))
         (test-equal "dual amount column, grand totals available"
           (list "Grand Total" " " " " " " " " "$2,280.00" "$2,280.00")

--- a/gnucash/report/standard-reports/test/test-transaction.scm
+++ b/gnucash/report/standard-reports/test/test-transaction.scm
@@ -767,10 +767,10 @@
       (set-option! options "Sorting" "Show Account Description" #t)
       (let* ((sxml (options->sxml options "sorting=date")))
         (test-equal "expense acc friendly headers"
-          '("\n" "Expenses" "Expense" "Rebate")
+          '("\n" "Expenses" "\n" "Expense" "\n" "Rebate")
           (get-row-col sxml 47 #f))
         (test-equal "income acc friendly headers"
-          '("\n" "Income" "Charge" "Income")
+          '("\n" "Income" "\n" "Charge" "\n" "Income")
           (get-row-col sxml 69 #f)))
 
       (set-option! options "Accounts" "Accounts" (list bank))

--- a/gnucash/report/standard-reports/transaction.scm
+++ b/gnucash/report/standard-reports/transaction.scm
@@ -1113,10 +1113,11 @@ tags within description, notes or memo. ")
                                     "number-cell"
                                     (gnc:make-gnc-monetary currency price-decimal)))))))))
 
-        (if (and (null? left-cols-list)
-                 (or (opt-val gnc:pagename-display "Totals")
-                     (primary-get-info 'renderer-fn)
-                     (secondary-get-info 'renderer-fn)))
+        (if (or (column-uses? 'subtotals-only)
+                (and (null? left-cols-list)
+                     (or (opt-val gnc:pagename-display "Totals")
+                         (primary-get-info 'renderer-fn)
+                         (secondary-get-info 'renderer-fn))))
             (list (vector "" (lambda (s t) #f)))
             left-cols-list)))
 

--- a/gnucash/report/standard-reports/transaction.scm
+++ b/gnucash/report/standard-reports/transaction.scm
@@ -17,6 +17,7 @@
 ;; - add support for indenting for better grouping
 ;; - add defaults suitable for a reconciliation report
 ;; - add subtotal summary grid
+;; - by default, exclude closing transactions from the report
 ;;
 ;; This program is free software; you can redistribute it and/or    
 ;; modify it under the terms of the GNU General Public License as   
@@ -100,6 +101,7 @@
 (define optname-transaction-matcher-regex (N_ "Use regular expressions for transaction filter"))
 (define optname-reconcile-status (N_ "Reconcile Status"))
 (define optname-void-transactions (N_ "Void Transactions"))
+(define optname-closing-transactions (N_ "Closing transactions"))
 
 ;;Styles
 (define def:grand-total-style "grand-total")
@@ -326,6 +328,23 @@ in the Options panel."))
    (cons 'both (list
                 (cons 'text (_ "Both"))
                 (cons 'tip (_ "Show both (and include void transactions in totals)."))))))
+
+(define show-closing-list
+  (list
+   (cons 'exclude-closing (list
+                           (cons 'text (_ "Exclude closing transactions"))
+                           (cons 'tip (_ "Exclude closing transactions from report."))
+                           (cons 'closing-match #f)))
+
+   (cons 'include-both (list
+                        (cons 'text (_ "Show both closing and regular transactions"))
+                        (cons 'tip (_ "Show both (and include closing transactions in totals)."))
+                        (cons 'closing-match 'both)))
+
+   (cons 'closing-only (list
+                        (cons 'text (_ "Show closing transactions only"))
+                        (cons 'tip (_ "Show only closing transactions."))
+                        (cons 'closing-match #t)))))
 
 (define reconcile-status-list
   ;; 'filter-types must be either #f (i.e. disable reconcile filter)
@@ -556,6 +575,16 @@ tags within description, notes or memo. ")
     "k" (N_ "How to handle void transactions.")
     'non-void-only
     (keylist->vectorlist show-void-list)))
+
+  (gnc:register-trep-option
+   (gnc:make-multichoice-option
+    pagename-filter optname-closing-transactions
+    "l" (_ "By default most users should not include closing \
+transactions in a transaction report. Closing transactions are \
+transfers from INCOME and EXPENSE accounts to equity, and must usually \
+be excluded from periodic reporting.")
+    'exclude-closing
+    (keylist->vectorlist show-closing-list)))
 
   ;; Accounts options
 
@@ -1784,6 +1813,9 @@ tags within description, notes or memo. ")
          (secondary-order (opt-val pagename-sorting optname-sec-sortorder))
          (secondary-date-subtotal (opt-val pagename-sorting optname-sec-date-subtotal))
          (void-status (opt-val pagename-filter optname-void-transactions))
+         (closing-match (keylist-get-info show-closing-list
+                                          (opt-val pagename-filter optname-closing-transactions)
+                                          'closing-match))
          (splits '())
          (custom-sort? (or (and (member primary-key DATE-SORTING-TYPES)   ; this will remain
                                 (not (eq? primary-date-subtotal 'none)))  ; until qof-query
@@ -1863,6 +1895,8 @@ tags within description, notes or memo. ")
             (else #f))
           (if reconcile-status-filter
               (xaccQueryAddClearedMatch query reconcile-status-filter QOF-QUERY-AND))
+          (if (boolean? closing-match)
+              (xaccQueryAddClosingTransMatch query closing-match QOF-QUERY-AND))
           (if (not custom-sort?)
               (begin
                 (qof-query-set-sort-order query

--- a/gnucash/report/standard-reports/transaction.scm
+++ b/gnucash/report/standard-reports/transaction.scm
@@ -196,10 +196,10 @@ in the Options panel."))
                                    (cons 'renderer-fn #f)))
 
         (cons 'description   (list (cons 'sortkey (list SPLIT-TRANS TRANS-DESCRIPTION))
-                                   (cons 'split-sortvalue #f)
+                                   (cons 'split-sortvalue (lambda (s) (xaccTransGetDescription (xaccSplitGetParent s))))
                                    (cons 'text (_ "Description"))
                                    (cons 'tip (_ "Sort by description."))
-                                   (cons 'renderer-fn #f)))
+                                   (cons 'renderer-fn (lambda (s) (xaccTransGetDescription (xaccSplitGetParent s))))))
 
         (if (and (gnc-current-session-exist)
                  (qof-book-use-split-action-for-num-field (gnc-get-current-book)))

--- a/gnucash/report/standard-reports/transaction.scm
+++ b/gnucash/report/standard-reports/transaction.scm
@@ -222,10 +222,10 @@ in the Options panel."))
                                    (cons 'renderer-fn #f)))
 
         (cons 'memo          (list (cons 'sortkey (list SPLIT-MEMO))
-                                   (cons 'split-sortvalue #f)
+                                   (cons 'split-sortvalue (lambda (s) (xaccSplitGetMemo s)))
                                    (cons 'text (_ "Memo"))
                                    (cons 'tip (_ "Sort by memo."))
-                                   (cons 'renderer-fn #f)))
+                                   (cons 'renderer-fn (lambda (s) (xaccSplitGetMemo s)))))
 
         (cons 'notes         (list (cons 'sortkey #f)
                                    (cons 'split-sortvalue (lambda (s) (xaccTransGetNotes (xaccSplitGetParent s))))

--- a/gnucash/report/standard-reports/transaction.scm
+++ b/gnucash/report/standard-reports/transaction.scm
@@ -49,8 +49,10 @@
 
 (gnc:module-load "gnucash/report/report-system" 0)
 
-(define-macro (addto! alist element)
-  `(set! ,alist (cons ,element ,alist)))
+(define-syntax addto!
+  (syntax-rules ()
+    ((addto! alist element)
+     (set! alist (cons element alist)))))
 
 ;; Define the strings here to avoid typos and make changes easier.
 (define reportname (N_ "Transaction Report"))

--- a/gnucash/report/standard-reports/transaction.scm
+++ b/gnucash/report/standard-reports/transaction.scm
@@ -118,8 +118,6 @@ in the Options panel."))
 (define ACCOUNT-SORTING-TYPES (list 'account-name 'corresponding-acc-name
                                     'account-code 'corresponding-acc-code))
 
-(define CUSTOM-SORTING (list 'reconciled-status))
-
 (define SORTKEY-INFORMAL-HEADERS (list 'account-name 'account-code))
 
 (define sortkey-list
@@ -399,6 +397,16 @@ Credit Card, and Income accounts."))
   ;; this returns whether sortkey *can* be subtotalled/grouped.
   ;; it checks whether a renderer-fn is defined.
   (keylist-get-info sortkey-list sortkey 'renderer-fn))
+
+(define (CUSTOM-SORTING? sortkey)
+  ;; sortkey -> bool
+  ;;
+  ;; this returns which sortkeys which *must* use the custom sorter.
+  ;; it filters whereby a split-sortvalue is defined (i.e. the splits
+  ;; can be compared according to their 'sortvalue) but the QofQuery
+  ;; sortkey is not defined (i.e. their 'sortkey is #f).
+  (and (keylist-get-info sortkey-list sortkey 'split-sortvalue)
+       (not (keylist-get-info sortkey-list sortkey 'sortkey))))
 
 ;;
 ;; Set defaults for reconcilation report
@@ -1773,8 +1781,8 @@ tags within description, notes or memo. ")
                                 (not (eq? primary-date-subtotal 'none)))  ; until qof-query
                            (and (member secondary-key DATE-SORTING-TYPES) ; is upgraded
                                 (not (eq? secondary-date-subtotal 'none)))
-                           (or (member primary-key CUSTOM-SORTING)
-                               (member secondary-key CUSTOM-SORTING))))
+                           (or (CUSTOM-SORTING? primary-key)
+                               (CUSTOM-SORTING? secondary-key))))
          (infobox-display (opt-val gnc:pagename-general optname-infobox-display))
          (query (qof-query-create-for-splits)))
 

--- a/gnucash/report/standard-reports/transaction.scm
+++ b/gnucash/report/standard-reports/transaction.scm
@@ -147,13 +147,13 @@ in the Options panel."))
                                   (cons 'renderer-fn (lambda (a) (xaccSplitGetAccount a)))))
 
         (cons 'date         (list (cons 'sortkey (list SPLIT-TRANS TRANS-DATE-POSTED))
-                                  (cons 'split-sortvalue #f)
+                                  (cons 'split-sortvalue (lambda (s) (xaccTransGetDate (xaccSplitGetParent s))))
                                   (cons 'text (_ "Date"))
                                   (cons 'tip (_ "Sort by date."))
                                   (cons 'renderer-fn #f)))
 
         (cons 'reconciled-date (list (cons 'sortkey (list SPLIT-DATE-RECONCILED))
-                                     (cons 'split-sortvalue #f)
+                                     (cons 'split-sortvalue (lambda (s) (xaccSplitGetDateReconciled s)))
                                      (cons 'text (_ "Reconciled Date"))
                                      (cons 'tip (_ "Sort by the Reconciled Date."))
                                      (cons 'renderer-fn #f)))
@@ -190,7 +190,7 @@ in the Options panel."))
                                             (cons 'renderer-fn (lambda (a) (xaccSplitGetAccount (xaccSplitGetOtherSplit a))))))
 
         (cons 'amount        (list (cons 'sortkey (list SPLIT-VALUE))
-                                   (cons 'split-sortvalue #f)
+                                   (cons 'split-sortvalue (lambda (a) (gnc-numeric-to-scm (xaccSplitGetValue a))))
                                    (cons 'text (_ "Amount"))
                                    (cons 'tip (_ "Sort by amount."))
                                    (cons 'renderer-fn #f)))
@@ -204,19 +204,19 @@ in the Options panel."))
         (if (and (gnc-current-session-exist)
                  (qof-book-use-split-action-for-num-field (gnc-get-current-book)))
             (cons 'number    (list (cons 'sortkey (list SPLIT-ACTION))
-                                   (cons 'split-sortvalue #f)
+                                   (cons 'split-sortvalue (lambda (a) (xaccSplitGetAction a)))
                                    (cons 'text (_ "Number/Action"))
                                    (cons 'tip (_ "Sort by check number/action."))
                                    (cons 'renderer-fn #f)))
 
             (cons 'number    (list (cons 'sortkey (list SPLIT-TRANS TRANS-NUM))
-                                   (cons 'split-sortvalue #f)
+                                   (cons 'split-sortvalue (lambda (a) (xaccTransGetNum (xaccSplitGetParent a))))
                                    (cons 'text (_ "Number"))
                                    (cons 'tip (_ "Sort by check/transaction number."))
                                    (cons 'renderer-fn #f))))
 
         (cons 't-number      (list (cons 'sortkey (list SPLIT-TRANS TRANS-NUM))
-                                   (cons 'split-sortvalue #f)
+                                   (cons 'split-sortvalue (lambda (a) (xaccTransGetNum (xaccSplitGetParent a))))
                                    (cons 'text (_ "Transaction Number"))
                                    (cons 'tip (_ "Sort by transaction number."))
                                    (cons 'renderer-fn #f)))
@@ -253,36 +253,42 @@ in the Options panel."))
   (list
    (cons 'none (list
                 (cons 'split-sortvalue #f)
+                (cons 'date-sortvalue #f)
                 (cons 'text (_ "None"))
                 (cons 'tip (_ "None."))
                 (cons 'renderer-fn #f)))
 
    (cons 'daily (list
                   (cons 'split-sortvalue (lambda (s) (time64-day (split->time64 s))))
+                  (cons 'date-sortvalue time64-day)
                   (cons 'text (_ "Daily"))
                   (cons 'tip (_ "Daily."))
                   (cons 'renderer-fn (lambda (s) (time64->daily-string (split->time64 s))))))
 
    (cons 'weekly (list
                   (cons 'split-sortvalue (lambda (s) (time64-week (split->time64 s))))
+                  (cons 'date-sortvalue time64-week)
                   (cons 'text (_ "Weekly"))
                   (cons 'tip (_ "Weekly."))
                   (cons 'renderer-fn (lambda (s) (gnc:date-get-week-year-string (gnc-localtime (split->time64 s)))))))
 
    (cons 'monthly (list
                    (cons 'split-sortvalue (lambda (s) (time64-month (split->time64 s))))
+                   (cons 'date-sortvalue time64-month)
                    (cons 'text (_ "Monthly"))
                    (cons 'tip (_ "Monthly."))
                    (cons 'renderer-fn (lambda (s) (gnc:date-get-month-year-string (gnc-localtime (split->time64 s)))))))
 
    (cons 'quarterly (list
                      (cons 'split-sortvalue (lambda (s) (time64-quarter (split->time64 s))))
+                     (cons 'date-sortvalue time64-quarter)
                      (cons 'text (_ "Quarterly"))
                      (cons 'tip (_ "Quarterly."))
                      (cons 'renderer-fn (lambda (s) (gnc:date-get-quarter-year-string (gnc-localtime (split->time64 s)))))))
 
    (cons 'yearly (list
                   (cons 'split-sortvalue (lambda (s) (time64-year (split->time64 s))))
+                  (cons 'date-sortvalue time64-year)
                   (cons 'text (_ "Yearly"))
                   (cons 'tip (_ "Yearly."))
                   (cons 'renderer-fn (lambda (s) (gnc:date-get-year-string (gnc-localtime (split->time64 s)))))))))
@@ -1426,7 +1432,7 @@ tags within description, notes or memo. ")
           (render-date date-subtotal-key split))
          ((member sortkey ACCOUNT-SORTING-TYPES)
           (render-account sortkey split anchor?))
-         ((eq? sortkey 'reconciled-status)
+         (else
           (render-generic sortkey split)))))
 
     (define (render-grand-total)
@@ -1786,41 +1792,25 @@ tags within description, notes or memo. ")
          (infobox-display (opt-val gnc:pagename-general optname-infobox-display))
          (query (qof-query-create-for-splits)))
 
-    (define (generic-less? X Y key date-subtotal ascend?)
-      (define comparator-function
-        (if (member key DATE-SORTING-TYPES)
-            (let ((date (lambda (s)
-                          (case key
-                            ((date) (xaccTransGetDate (xaccSplitGetParent s)))
-                            ((reconciled-date) (xaccSplitGetDateReconciled s))))))
-              (case date-subtotal
-                ((yearly)    (lambda (s) (time64-year (date s))))
-                ((monthly)   (lambda (s) (time64-month (date s))))
-                ((quarterly) (lambda (s) (time64-quarter (date s))))
-                ((weekly)    (lambda (s) (time64-week (date s))))
-                ((daily)     (lambda (s) (time64-day (date s))))
-                ((none)      (lambda (s) (date s)))))
-            (case key
-              ((account-name) (lambda (s) (gnc-account-get-full-name (xaccSplitGetAccount s))))
-              ((account-code) (lambda (s) (xaccAccountGetCode (xaccSplitGetAccount s))))
-              ((corresponding-acc-name) (lambda (s) (xaccSplitGetCorrAccountFullName s)))
-              ((corresponding-acc-code) (lambda (s) (xaccSplitGetCorrAccountCode s)))
-              ((reconciled-status) (lambda (s) (length (memq (xaccSplitGetReconcile s)
-                                                             '(#\n #\c #\y #\f #\v)))))
-              ((amount) (lambda (s) (gnc-numeric-to-scm (xaccSplitGetValue s))))
-              ((description) (lambda (s) (xaccTransGetDescription (xaccSplitGetParent s))))
-              ((number) (lambda (s)
-                          (if BOOK-SPLIT-ACTION
-                              (xaccSplitGetAction s)
-                              (xaccTransGetNum (xaccSplitGetParent s)))))
-              ((t-number) (lambda (s) (xaccTransGetNum (xaccSplitGetParent s))))
-              ((register-order) (lambda (s) #f))
-              ((memo) (lambda (s) (xaccSplitGetMemo s)))
-              ((none) (lambda (s) #f)))))
-      (cond
-       ((string? (comparator-function X)) ((if ascend? string<? string>?) (comparator-function X) (comparator-function Y)))
-       ((comparator-function X)           ((if ascend? < >)               (comparator-function X) (comparator-function Y)))
-       (else                              #f)))
+    (define (generic-less? split-X split-Y sortkey date-subtotal-key ascend?)
+      ;; compare splits X and Y, whereby
+      ;; sortkey and date-subtotal-key specify the options used
+      ;; ascend? specifies whether ascending or descending
+      (let* ((comparator-function
+              (if (memq sortkey DATE-SORTING-TYPES)
+                  (let ((date (keylist-get-info sortkey-list sortkey 'split-sortvalue))
+                        (date-comparator (keylist-get-info date-subtotal-list date-subtotal-key 'date-sortvalue)))
+                    (lambda (s)
+                      (and date-comparator
+                           (date-comparator (date s)))))
+                  (or (keylist-get-info sortkey-list sortkey 'split-sortvalue)
+                      (lambda (s) #f))))
+             (value-of-X (comparator-function split-X))
+             (value-of-Y (comparator-function split-Y))
+             (op (if (string? value-of-X)
+                     (if ascend? string<? string>?)
+                     (if ascend? < >))))
+        (and value-of-X (op value-of-X value-of-Y))))
 
     (define (primary-comparator? X Y)
       (generic-less? X Y primary-key
@@ -1835,7 +1825,6 @@ tags within description, notes or memo. ")
     ;; This will, by default, sort the split list by ascending posted-date.
     (define (date-comparator? X Y)
       (generic-less? X Y 'date 'none #t))
-
 
     (if (or (or (null? c_account_1) (and-map not c_account_1))
             (eq? account-matcher-regexp 'invalid-regex)

--- a/gnucash/report/standard-reports/transaction.scm
+++ b/gnucash/report/standard-reports/transaction.scm
@@ -115,14 +115,9 @@ in the Options panel."))
 
 (define DATE-SORTING-TYPES (list 'date 'reconciled-date))
 
-;; The option-values of the sorting key multichoice option, for
-;; which a subtotal should be enabled.
-(define SUBTOTAL-ENABLED (list 'account-name 'corresponding-acc-name
-                               'account-code 'corresponding-acc-code
-                               'reconciled-status))
-
 (define ACCOUNT-SORTING-TYPES (list 'account-name 'corresponding-acc-name
                                     'account-code 'corresponding-acc-code))
+
 (define CUSTOM-SORTING (list 'reconciled-status))
 
 (define SORTKEY-INFORMAL-HEADERS (list 'account-name 'account-code))
@@ -388,7 +383,6 @@ Credit Card, and Income accounts."))
                                   ACCT-TYPE-EQUITY ACCT-TYPE-CREDIT
                                   ACCT-TYPE-INCOME))))))
 
-
 (define (keylist-get-info keylist key info)
   (cdr (assq info (cdr (assq key keylist)))))
 
@@ -401,6 +395,10 @@ Credit Card, and Income accounts."))
       (keylist-get-info keylist (car item) 'tip)))
    keylist))
 
+(define (SUBTOTAL-ENABLED? sortkey)
+  ;; this returns whether sortkey *can* be subtotalled/grouped.
+  ;; it checks whether a renderer-fn is defined.
+  (keylist-get-info sortkey-list sortkey 'renderer-fn))
 
 ;;
 ;; Set defaults for reconcilation report
@@ -587,10 +585,10 @@ tags within description, notes or memo. ")
 
     (define (apply-selectable-by-name-sorting-options)
       (let* ((prime-sortkey-enabled (not (eq? prime-sortkey 'none)))
-             (prime-sortkey-subtotal-enabled (member prime-sortkey SUBTOTAL-ENABLED))
+             (prime-sortkey-subtotal-enabled (SUBTOTAL-ENABLED? prime-sortkey))
              (prime-date-sortingtype-enabled (member prime-sortkey DATE-SORTING-TYPES))
              (sec-sortkey-enabled (not (eq? sec-sortkey 'none)))
-             (sec-sortkey-subtotal-enabled (member sec-sortkey SUBTOTAL-ENABLED))
+             (sec-sortkey-subtotal-enabled (SUBTOTAL-ENABLED? sec-sortkey))
              (sec-date-sortingtype-enabled (member sec-sortkey DATE-SORTING-TYPES)))
 
         (gnc-option-db-set-option-selectable-by-name
@@ -964,17 +962,17 @@ tags within description, notes or memo. ")
     (let ((sortkey (opt-val pagename-sorting optname-prime-sortkey)))
       (if (member sortkey DATE-SORTING-TYPES)
           (keylist-get-info date-subtotal-list (opt-val pagename-sorting optname-prime-date-subtotal) info)
-          (and (member sortkey SUBTOTAL-ENABLED)
-               (and (opt-val pagename-sorting optname-prime-subtotal)
-                    (keylist-get-info sortkey-list sortkey info))))))
+          (and (SUBTOTAL-ENABLED? sortkey)
+               (opt-val pagename-sorting optname-prime-subtotal)
+               (keylist-get-info sortkey-list sortkey info)))))
 
   (define (secondary-get-info info)
     (let ((sortkey (opt-val pagename-sorting optname-sec-sortkey)))
       (if (member sortkey DATE-SORTING-TYPES)
           (keylist-get-info date-subtotal-list (opt-val pagename-sorting optname-sec-date-subtotal) info)
-          (and (member sortkey SUBTOTAL-ENABLED)
-               (and (opt-val pagename-sorting optname-sec-subtotal)
-                    (keylist-get-info sortkey-list sortkey info))))))
+          (and (SUBTOTAL-ENABLED? sortkey)
+               (opt-val pagename-sorting optname-sec-subtotal)
+               (keylist-get-info sortkey-list sortkey info)))))
 
   (let* ((work-to-do (length splits))
          (work-done 0)

--- a/gnucash/report/standard-reports/transaction.scm
+++ b/gnucash/report/standard-reports/transaction.scm
@@ -1276,11 +1276,10 @@ tags within description, notes or memo. ")
                                         1 (+ right-indent width-left-columns) data)))
               (for-each (lambda (cell)
                           (addto! row-contents
-                                  (gnc:make-html-table-cell
-                                   "<b>"
-                                   ((vector-ref cell 5)
-                                    ((keylist-get-info sortkey-list sortkey 'renderer-fn) split))
-                                   "</b>")))
+                                  (gnc:make-html-text
+                                   (gnc:html-markup-b
+                                    ((vector-ref cell 5)
+                                     ((keylist-get-info sortkey-list sortkey 'renderer-fn) split))))))
                         calculated-cells))
             (addto! row-contents (gnc:make-html-table-cell/size
                                   1 (+ right-indent width-left-columns width-right-columns) data)))

--- a/gnucash/report/standard-reports/transaction.scm
+++ b/gnucash/report/standard-reports/transaction.scm
@@ -1850,7 +1850,7 @@ tags within description, notes or memo. ")
           (if (memq infobox-display '(always no-match))
               (gnc:html-document-add-object!
                document
-               (gnc:render-options-changed options))))
+               (gnc:html-render-options-changed options))))
 
         (begin
 
@@ -1924,7 +1924,7 @@ tags within description, notes or memo. ")
                 (if (memq infobox-display '(always no-match))
                     (gnc:html-document-add-object!
                      document
-                     (gnc:render-options-changed options))))
+                     (gnc:html-render-options-changed options))))
 
               (let-values (((table grid) (make-split-table splits options custom-calculated-cells)))
 
@@ -1953,7 +1953,7 @@ tags within description, notes or memo. ")
                 (if (eq? infobox-display 'always)
                     (gnc:html-document-add-object!
                      document
-                     (gnc:render-options-changed options)))
+                     (gnc:html-render-options-changed options)))
 
                 (gnc:html-document-add-object! document table)))))
 

--- a/gnucash/report/standard-reports/transaction.scm
+++ b/gnucash/report/standard-reports/transaction.scm
@@ -227,6 +227,12 @@ in the Options panel."))
                                    (cons 'tip (_ "Sort by memo."))
                                    (cons 'renderer-fn #f)))
 
+        (cons 'notes         (list (cons 'sortkey #f)
+                                   (cons 'split-sortvalue (lambda (s) (xaccTransGetNotes (xaccSplitGetParent s))))
+                                   (cons 'text (_ "Notes"))
+                                   (cons 'tip (_ "Sort by transaction notes."))
+                                   (cons 'renderer-fn (lambda (s) (xaccTransGetNotes (xaccSplitGetParent s))))))
+
         (cons 'none          (list (cons 'sortkey '())
                                    (cons 'split-sortvalue #f)
                                    (cons 'text (_ "None"))

--- a/gnucash/report/standard-reports/transaction.scm
+++ b/gnucash/report/standard-reports/transaction.scm
@@ -1129,48 +1129,42 @@ tags within description, notes or memo. ")
 
     (define default-calculated-cells
       (letrec
-          ((damount (lambda (s) (if (gnc:split-voided? s)
-                                    (xaccSplitVoidFormerAmount s)
-                                    (xaccSplitGetAmount s))))
-           (trans-date (lambda (s) (xaccTransGetDate (xaccSplitGetParent s))))
-           (currency (lambda (s) (xaccAccountGetCommodity (xaccSplitGetAccount s))))
-           (report-currency (lambda (s) (if (column-uses? 'common-currency)
-                                            (opt-val gnc:pagename-general optname-currency)
-                                            (currency s))))
+          ((split-amount (lambda (s) (if (gnc:split-voided? s)
+                                         (xaccSplitVoidFormerAmount s)
+                                         (xaccSplitGetAmount s))))
+           (split-currency (lambda (s) (xaccAccountGetCommodity (xaccSplitGetAccount s))))
+           (row-currency (lambda (s) (if (column-uses? 'common-currency)
+                                         (opt-val gnc:pagename-general optname-currency)
+                                         (split-currency s))))
            (friendly-debit (lambda (a) (gnc:get-debit-string (xaccAccountGetType a))))
            (friendly-credit (lambda (a) (gnc:get-credit-string (xaccAccountGetType a))))
            (header-commodity (lambda (str)
                                (string-append
                                 str
                                 (if (column-uses? 'common-currency)
-                                    (string-append
-                                     "<br />"
-                                     (gnc-commodity-get-mnemonic
-                                      (opt-val gnc:pagename-general optname-currency)))
+                                    (format #f " (~a)"
+                                            (gnc-commodity-get-mnemonic
+                                             (opt-val gnc:pagename-general optname-currency)))
                                     ""))))
-           (convert (lambda (s num)
-                      (gnc:exchange-by-pricedb-nearest
-                       (gnc:make-gnc-monetary (currency s) num)
-                       (report-currency s)
-                       ;; Use midday as the transaction time so it matches a price
-                       ;; on the same day.  Otherwise it uses midnight which will
-                       ;; likely match a price on the previous day
-                       (time64CanonicalDayTime (trans-date s)))))
-           (split-value (lambda (s) (convert s (damount s)))) ; used for correct debit/credit
-           (amount (lambda (s) (split-value s)))
-           (debit-amount (lambda (s) (and (positive? (gnc:gnc-monetary-amount (split-value s)))
-                                          (split-value s))))
-           (credit-amount (lambda (s) (if (positive? (gnc:gnc-monetary-amount (split-value s)))
-                                          #f
-                                          (gnc:monetary-neg (split-value s)))))
-           (original-amount (lambda (s) (gnc:make-gnc-monetary (currency s) (damount s))))
-           (original-debit-amount (lambda (s) (if (positive? (damount s))
-                                                  (original-amount s)
-                                                  #f)))
-           (original-credit-amount (lambda (s) (if (positive? (damount s))
-                                                   #f
-                                                   (gnc:monetary-neg (original-amount s)))))
-           (running-balance (lambda (s) (gnc:make-gnc-monetary (currency s) (xaccSplitGetBalance s)))))
+           ;; For conversion to row-currency. Use midday as the
+           ;; transaction time so it matches a price on the same day.
+           ;; Otherwise it uses midnight which will likely match a
+           ;; price on the previous day
+           (converted-amount (lambda (s) (gnc:exchange-by-pricedb-nearest
+                                          (gnc:make-gnc-monetary (split-currency s) (split-amount s))
+                                          (row-currency s)
+                                          (time64CanonicalDayTime
+                                           (xaccTransGetDate (xaccSplitGetParent s))))))
+           (converted-debit-amount (lambda (s) (and (positive? (split-amount s))
+                                                    (converted-amount s))))
+           (converted-credit-amount (lambda (s) (and (not (positive? (split-amount s)))
+                                                     (gnc:monetary-neg (converted-amount s)))))
+           (original-amount (lambda (s) (gnc:make-gnc-monetary (split-currency s) (split-amount s))))
+           (original-debit-amount (lambda (s) (and (positive? (split-amount s))
+                                                   (original-amount s))))
+           (original-credit-amount (lambda (s) (and (not (positive? (split-amount s)))
+                                                    (gnc:monetary-neg (original-amount s)))))
+           (running-balance (lambda (s) (gnc:make-gnc-monetary (split-currency s) (xaccSplitGetBalance s)))))
         (append
          ;; each column will be a vector
          ;; (vector heading
@@ -1180,17 +1174,19 @@ tags within description, notes or memo. ")
          ;;         start-dual-column?                           ;; #t for the debit side of a dual column (i.e. debit/credit)
          ;;                                                      ;; which means the next column must be the credit side
          ;;         friendly-heading-fn                          ;; (friendly-heading-fn account) to retrieve friendly name for account debit/credit
+
          (if (column-uses? 'amount-single)
              (list (vector (header-commodity (_ "Amount"))
-                           amount #t #t #f
+                           converted-amount #t #t #f
                            (lambda (a) "")))
              '())
+
          (if (column-uses? 'amount-double)
              (list (vector (header-commodity (_ "Debit"))
-                           debit-amount #f #t #t
+                           converted-debit-amount #f #t #t
                            friendly-debit)
                    (vector (header-commodity (_ "Credit"))
-                           credit-amount #f #t #f
+                           converted-credit-amount #f #t #f
                            friendly-credit))
              '())
 

--- a/gnucash/report/standard-reports/transaction.scm
+++ b/gnucash/report/standard-reports/transaction.scm
@@ -40,7 +40,7 @@
 
 (define-module (gnucash report standard-reports transaction))
 
-(use-modules (gnucash utilities)) 
+(use-modules (gnucash utilities))
 (use-modules (srfi srfi-1))
 (use-modules (srfi srfi-11))
 (use-modules (srfi srfi-13))
@@ -49,11 +49,6 @@
 (use-modules (gnucash gettext))
 
 (gnc:module-load "gnucash/report/report-system" 0)
-
-(define-syntax addto!
-  (syntax-rules ()
-    ((addto! alist element)
-     (set! alist (cons element alist)))))
 
 ;; Define the strings here to avoid typos and make changes easier.
 (define reportname (N_ "Transaction Report"))

--- a/libgnucash/app-utils/app-utils.scm
+++ b/libgnucash/app-utils/app-utils.scm
@@ -101,7 +101,6 @@
 (export gnc:make-radiobutton-option)
 (export gnc:make-radiobutton-callback-option)
 (export gnc:make-list-option)
-(export gnc:render-options-changed)
 (export gnc:options-make-end-date!)
 (export gnc:options-make-date-interval!)
 (export gnc:option-make-internal!)

--- a/libgnucash/app-utils/test/CMakeLists.txt
+++ b/libgnucash/app-utils/test/CMakeLists.txt
@@ -43,6 +43,9 @@ set(GUILE_DEPENDS
 set(test_app_utils_scheme_SOURCES
   test-c-interface.scm
   test-load-app-utils-module.scm
+)
+
+set (test_app_utils_scheme_SRFI64_SOURCES
   test-date-utilities.scm
 )
 
@@ -61,6 +64,11 @@ gnc_add_scheme_targets(scm-test-c-interface
 )
 
 gnc_add_scheme_tests("${test_app_utils_scheme_SOURCES}")
+
+if (HAVE_SRFI64)
+  gnc_add_scheme_tests("${test_app_utils_scheme_SRFI64_SOURCES}")
+endif ()
+
 # Doesn't work yet:
 gnc_add_test_with_guile(test-app-utils "${test_app_utils_SOURCES}" APP_UTILS_TEST_INCLUDE_DIRS APP_UTILS_TEST_LIBS)
 

--- a/libgnucash/app-utils/test/test-date-utilities.scm
+++ b/libgnucash/app-utils/test/test-date-utilities.scm
@@ -1,10 +1,15 @@
 (use-modules (gnucash gnc-module))
 (gnc:module-begin-syntax (gnc:module-load "gnucash/app-utils" 0))
 (use-modules (gnucash engine test test-extras))
+(use-modules (srfi srfi-64))
+(use-modules (gnucash engine test srfi64-extras))
 
 (define (run-test)
-  (and (test test-weeknum-calculator)
-       (test test-date-get-quarter-string)))
+  (test-runner-factory gnc:test-runner)
+  (test-begin "test-date-utilities.scm")
+  (test-weeknum-calculator)
+  (test-date-get-quarter-string)
+  (test-end "test-date-utilities.scm"))
 
 (define (create-datevec l)
   (let ((now (gnc-localtime (current-time))))
@@ -12,8 +17,8 @@
     (set-tm:min now (list-ref l 4))
     (set-tm:hour now (list-ref l 3))
     (set-tm:mday now (list-ref l 2))
-    (set-tm:mon now (list-ref l 1))
-    (set-tm:year now (list-ref l 0))
+    (set-tm:mon now (1- (list-ref l 1)))
+    (set-tm:year now (- (list-ref l 0) 1900))
     (set-tm:isdst now -1)
     now))
 
@@ -28,28 +33,39 @@
             (gnc:date-to-week (create-time64 d2)))))
 
 (define (test-weeknum-calculator)
-  (and (weeknums-equal? (cons '(1970 1 1 0 0 0)
-                              '(1970 1 1 23 59 59)))
-       (weeknums-equal? (cons '(1969 12 31 0 0 0)
-                              '(1969 12 31 23 59 59)))
-       (weeknums-equal? (cons '(1969 12 31 0 0 0)
-                              '(1970 1 1 0 0 1)))
-       (weeknums-equal? (cons '(2001 1 1 0 0 0)
-                              '(2001 1 1 23 59 59)))
-       (not (weeknums-equal? (cons '(1970 1 1 0 0 0)
-                                   '(1970 1 10 0 0 1))))
-       (not (weeknums-equal? (cons '(1969 12 28 0 0 1)
-                                   '(1970 1 5 0 0 1))))
-       ))
+  (test-assert "weeknums 1/1/70early = 1/1/70late"
+    (weeknums-equal? (cons '(1970 1 1 0 0 0)
+                           '(1970 1 1 23 59 59))))
+
+  (test-assert "weeknums 31/12/69early = 31/12/69late"
+    (weeknums-equal? (cons '(1969 12 31 0 0 0)
+                           '(1969 12 31 23 59 59))))
+
+  (test-assert "weeknums 31/12/69 = 1/1/70"
+    (weeknums-equal? (cons '(1969 12 31 0 0 0)
+                           '(1970 1 1 0 0 1))))
+
+  (test-assert "weeknums 1/1/01early = 01/01/01 late"
+    (weeknums-equal? (cons '(2001 1 1 0 0 0)
+                           '(2001 1 1 23 59 59))))
+
+  (test-assert "weeknums 1/1/70 != 10/1/70"
+    (not (weeknums-equal? (cons '(1970 1 1 0 0 0)
+                                '(1970 1 10 0 0 1)))))
+
+  (test-assert "weeknum 28/12/69 != 5/1/70"
+    (not (weeknums-equal? (cons '(1969 12 28 0 0 1)
+                                '(1970 1 5 0 0 1))))))
 
 (define (test-date-get-quarter-string)
-  (and (or (string=? "Q1" (gnc:date-get-quarter-string (create-datevec '(2001 2 14 11 42 23))))
-           (begin (format #t "Expected Q1, got ~a~%" (gnc:date-get-quarter-string (creaete-datevec '(2001 2 14 11 42 23))))
-                  #f))
-       (or (string=? "Q2" (gnc:date-get-quarter-string (create-datevec '(2013 4 23 18 11 49))))
-           (begin (format #t "Expected Q1, got ~a~%" (gnc:date-get-quarter-string (create-datevec '(2001 2 14 11 42 23))))
-                  #f))
-       (or (string=? "Q3" (gnc:date-get-quarter-string (create-datevec '(1997 9 11 08 14 21))))
-           (begin (format #t "Expected Q1, got ~a~%" (gnc:date-get-quarter-string (create-datevec '(2001 2 14 11 42 23)))))
-           #f)))
-       
+  (test-equal "14/02/2001 = Q1"
+    "Q1"
+    (gnc:date-get-quarter-string (create-datevec '(2001 2 14 11 42 23))))
+
+  (test-equal "23/04/2013 = Q2"
+    "Q2"
+    (gnc:date-get-quarter-string (create-datevec '(2013 4 23 18 11 49))))
+
+  (test-equal "11/09/1997 = Q3"
+    "Q3"
+    (gnc:date-get-quarter-string (create-datevec '(1997 9 11 08 14 21)))))

--- a/libgnucash/engine/test/CMakeLists.txt
+++ b/libgnucash/engine/test/CMakeLists.txt
@@ -233,6 +233,20 @@ gnc_add_scheme_targets(scm-test-engine-extras
   FALSE
   )
 
+if (HAVE_SRFI64)
+  gnc_add_scheme_targets (scm-srfi64-extras
+    "srfi64-extras.scm"
+    "gnucash/engine/test/"
+    "${GUILE_DEPENDS}"
+    FALSE
+    )
+
+  set(srfi64_extras_SCHEME_DIST
+    srfi64-extras.scm
+    )
+
+endif (HAVE_SRFI64)
+
 gnc_add_scheme_targets(scm-test-engine
   "${engine_test_SCHEME}"
   ""
@@ -311,4 +325,5 @@ set(test_engine_EXTRA_DIST
 )
 
 set_dist_list(test_engine_DIST CMakeLists.txt
+        ${srfi64_extras_SCHEME_DIST}
         ${test_engine_SOURCES_DIST} ${test_engine_SCHEME_DIST} ${test_engine_EXTRA_DIST})

--- a/libgnucash/engine/test/srfi64-extras.scm
+++ b/libgnucash/engine/test/srfi64-extras.scm
@@ -1,0 +1,49 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation; either version 2 of
+;; the License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program; if not, contact:
+;;
+;; Free Software Foundation           Voice:  +1-617-542-5942
+;; 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652
+;; Boston, MA  02110-1301,  USA       gnu@gnu.org
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define-module (gnucash engine test srfi64-extras))
+(use-modules (srfi srfi-64))
+
+(export gnc:test-runner)
+(define (gnc:test-runner)
+  (let ((runner (test-runner-null))
+        (num-passed 0)
+        (num-failed 0))
+    (test-runner-on-test-end! runner
+      (lambda (runner)
+        (format #t "[~a] line:~a, test: ~a\n"
+                (test-result-ref runner 'result-kind)
+                (test-result-ref runner 'source-line)
+                (test-runner-test-name runner))
+        (case (test-result-kind runner)
+          ((pass xpass) (set! num-passed (1+ num-passed)))
+          ((fail xfail)
+           (if (test-result-ref runner 'expected-value)
+               (format #t "~a\n -> expected: ~s\n -> obtained: ~s\n"
+                       (string-join (test-runner-group-path runner) "/")
+                       (test-result-ref runner 'expected-value)
+                       (test-result-ref runner 'actual-value)))
+           (set! num-failed (1+ num-failed)))
+          (else #t))))
+    (test-runner-on-final! runner
+      (lambda (runner)
+        (format #t "Source:~a\npass = ~a, fail = ~a\n"
+                (test-result-ref runner 'source-file) num-passed num-failed)
+        (zero? num-failed)))
+    runner))

--- a/libgnucash/engine/test/test-extras.scm
+++ b/libgnucash/engine/test/test-extras.scm
@@ -29,13 +29,6 @@
 
 (export logging-and)
 (export test)
-(export make-test-sink)
-(export env-test-sink)
-(export test-sink-report)
-(export test-sink-check)
-
-(export delayed-format)
-(export delayed-format-render)
 
 (export with-account)
 (export with-transaction)
@@ -113,7 +106,7 @@
 (define (create-test-env)
   (list (cons 'random (seed->random-state (random 1000)))
 	(cons 'counter (make-counter))
-	(cons 'sink (make-test-sink))))
+        ))
 
 (define (env-random-amount env n)
   (/ (env-random env n) 1))
@@ -129,9 +122,6 @@
 
 (define (env-select-price-source env)
   'pricedb-nearest)
-
-(define (env-test-sink env)
-  (assoc-ref env 'sink))
 
 (define (env-any-date env) (gnc:get-today))
 
@@ -324,69 +314,5 @@
 					    (list "Other")
 					    (list "Expenses"
 						  (list (cons 'type ACCT-TYPE-EXPENSE))))))
-;;
-;; Test sinks
-;;
 
-(define (make-test-sink) (list 'sink 0 '()))
-
-(define (test-sink-count sink)
-  (second sink))
-
-(define (test-sink-count! sink value)
-  (set-car! (cdr sink) value))
-
-(define (test-sink-messages sink)
-  (third sink))
-
-(define (test-sink-messages! sink messages)
-  (set-car! (cdr (cdr sink)) messages))
-
-(define (test-sink-check sink message flag)
-  (test-sink-count! sink (+ (test-sink-count sink) 1))
-  (if flag #t
-      (test-sink-messages! sink (cons message (test-sink-messages sink)))))
-
-(define (test-sink-report sink)
-  (format #t "Completed ~a tests ~a\n"
-	  (test-sink-count sink)
-	  (if (null? (test-sink-messages sink)) "PASS" "FAIL"))
-  (if (null? (test-sink-messages sink)) #t
-      (begin (for-each (lambda (delayed-message)
-			 (delayed-format-render #t delayed-message))
-		       (test-sink-messages sink))
-	     #f)))
-
-(define (delayed-format . x) x)
-
-(define (delayed-format-render stream msg)
-  (apply format stream msg))
-
-;;
-;; options
-;;
-
-
-(define (create-option-set)
-  (make-hash-table) )
-
-(define (option-set-setter option-set)
-  (lambda (category name value)
-    (hash-set! option-set (list category name) value)))
-
-(define (option-set-getter option-set)
-  (lambda (category name)
-    (hash-ref option-set (list category name))))
-
-;;
-;;
-;;
-
-(define (report-show-options stream expense-options)
-  (gnc:options-for-each (lambda (option)
-			  (format stream "Option: ~a.~a Value ~a\n"
-				  (gnc:option-section option)
-				  (gnc:option-name option)
-				  (gnc:option-value option)))
-			expense-options))
 

--- a/libgnucash/engine/test/test-extras.scm
+++ b/libgnucash/engine/test/test-extras.scm
@@ -27,7 +27,6 @@
 (use-modules (sw_app_utils))
 (use-modules (sw_engine))
 
-(export logging-and)
 (export test)
 
 (export with-account)
@@ -55,15 +54,6 @@
 ;; Random test related syntax and the like
 ;;
 
-;; logging-and is mostly for debugging tests
-(define-macro (logging-and . args)
-  (cons 'and (map (lambda (arg)
-		    (list 'begin
-			  (list 'format #t "Test: ~a\n" (list 'quote arg))
-			  arg))
-		  args)))
-
-;; ..and 'test' gives nicer output
 (define (test the-test)
   (format #t "(Running ~a " the-test)
   (let ((result (the-test)))

--- a/libgnucash/engine/test/test-test-extras.scm
+++ b/libgnucash/engine/test/test-test-extras.scm
@@ -26,10 +26,7 @@
 (use-modules (sw_engine))
 
 (define (run-test)
-  (and (logging-and #t)
-       (logging-and)
-       (not (logging-and #t #f))
-       (test-create-account-structure)))
+  (and (test-create-account-structure)))
 
 (define (test-create-account-structure)
   (let ((env (create-test-env)))

--- a/libgnucash/scm/utilities.scm
+++ b/libgnucash/scm/utilities.scm
@@ -42,6 +42,7 @@
 (export gnc:error)
 (export gnc:msg)
 (export gnc:debug)
+(export addto!)
 
 ;; Do this stuff very early -- but other than that, don't add any
 ;; executable code until the end of the file if you can help it.
@@ -71,6 +72,10 @@
 (define (gnc:debug . items)
   (gnc-scm-log-debug (strify items)))
 
+(define-syntax addto!
+  (syntax-rules ()
+    ((addto! alist element)
+     (set! alist (cons element alist)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;  gnc:substring-replace


### PR DESCRIPTION
### A few harmless refinements
1. `(define-macro)` is apparently frowned upon nowadays; use `(define-syntax)` instead.
2. TR sortkey capabilities were listed manually; change to dynamically check according to their attributes.
3. TR: enable subtotal/grouping of Desc/Notes/Memo.
4. test-transaction.scm modified to change "out-NN.html" output in /tmp to "test-trep-TESTNAME.html"
5. TR/GSTR: begin string sanitizing project

### User-visible changes TR

1. Description/Notes/Memo can be grouped and subtotalled. The original TR did not allow grouping for these sortkeys, and there is no reason we should disallow grouping on these freetext fields which can allow arbitrary personal coding.
2. Common-currency amount/debit/credit changed from 2-line `Amount + commodity` to 1-line `Amount (commodity)` - this is due to the table-col-headers cannot receive gnc:make-html-text objects.
3. If subtotal-only was selected, the left-columns (date, desc etc) were still rendered. Cosmetic bugfix.
4. Add Filter/Closing transactions, and enable it by default? I think it's a good thing.