### PR TITLE
Bug 796081 Tax Schedule Report - An error occurred while running the report

### DIFF
--- a/gnucash/report/locale-specific/us/taxtxf.scm
+++ b/gnucash/report/locale-specific/us/taxtxf.scm
@@ -973,7 +973,7 @@
                                              (list (gnc:make-html-table-cell/markup
                                                     "text-cell-center"
                                                   (strftime "%Y-%b-%d" (gnc-localtime
-                                                            (car trans-date)))))
+                                                            trans-date))))
                                              (list (gnc:make-html-table-cell/markup
                                                     "number-cell-bot"
                                                     (xaccPrintAmount


### PR DESCRIPTION
Missed out from timepair->time64 conversion.