### PR TITLE
Fix permanent storage of vendor details.

### DIFF
--- a/src/backend/sql/gnc-bill-term-sql.c
+++ b/src/backend/sql/gnc-bill-term-sql.c
@@ -198,7 +198,7 @@ load_single_billterm( GncSqlBackend* be, GncSqlRow* row,
 
         s->billterm = pBillTerm;
         s->have_guid = FALSE;
-        gnc_sql_load_object( be, row, GNC_ID_TAXTABLE, s, billterm_parent_col_table );
+        gnc_sql_load_object( be, row, GNC_ID_BILLTERM, s, billterm_parent_col_table );
         if ( s->have_guid )
         {
             *l_billterms_needing_parents = g_list_prepend( *l_billterms_needing_parents, s );

--- a/src/engine/gncVendor.c
+++ b/src/engine/gncVendor.c
@@ -350,7 +350,7 @@ gnc_vendor_class_init (GncVendorClass *klass)
      g_param_spec_object ("terms",
                           "Terms",
                           "The billing terms used by this vendor.",
-                          GNC_TYPE_COMMODITY,
+                          GNC_TYPE_BILLTERM,
                           G_PARAM_READWRITE));
 
     g_object_class_install_property
@@ -359,7 +359,7 @@ gnc_vendor_class_init (GncVendorClass *klass)
      g_param_spec_object ("tax-table",
                           "Tax table",
                           "The tax table which applies to this vendor.",
-                          GNC_TYPE_COMMODITY,
+                          GNC_TYPE_TAXTABLE,
                           G_PARAM_READWRITE));
 
     g_object_class_install_property


### PR DESCRIPTION
Since the data types did not match for the billterms and taxtable,
those references/guids were not saved to the database.
Also, while at it, fix another copy'n'paste error in sql backend.