### PR TITLE
Fix permanent storage of vendor details.

### DIFF
--- a/libgnucash/engine/gncVendor.c
+++ b/libgnucash/engine/gncVendor.c
@@ -376,7 +376,7 @@ gnc_vendor_class_init (GncVendorClass *klass)
      g_param_spec_object ("terms",
                           "Terms",
                           "The billing terms used by this vendor.",
-                          GNC_TYPE_COMMODITY,
+                          GNC_TYPE_BILLTERM,
                           G_PARAM_READWRITE));
 
     g_object_class_install_property
@@ -385,7 +385,7 @@ gnc_vendor_class_init (GncVendorClass *klass)
      g_param_spec_object ("tax-table",
                           "Tax table",
                           "The tax table which applies to this vendor.",
-                          GNC_TYPE_COMMODITY,
+                          GNC_TYPE_TAXTABLE,
                           G_PARAM_READWRITE));
 
     g_object_class_install_property


### PR DESCRIPTION
Since the data types did not match for the billterms and taxtable,
those references/guids were not saved to the database.

Similar to the PR before, but for the maint branch here.