### PR TITLE
Small XML related fixes removing ambiguity improving uniformity

### DIFF
--- a/data/accounts/ca/acctchrt_common.gnucash-xea
+++ b/data/accounts/ca/acctchrt_common.gnucash-xea
@@ -698,7 +698,7 @@
   <act:parent type="new">57635fa5f71dee8ffc207c277250e773</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
-  <act:name>Recollida de brossa</act:name>i
+  <act:name>Recollida de brossa</act:name>
   <act:id type="new">2d0315d7b2f8f11a8a8b32d805bca6eb</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>

--- a/data/accounts/en_GB/uk-vat.gnucash-xea
+++ b/data/accounts/en_GB/uk-vat.gnucash-xea
@@ -40,13 +40,13 @@
   <gnc-act:long-description>
     A basic set of accounts for tracking VAT in the UK.
   </gnc-act:long-description>
+  <gnc-act:start-selected>0</gnc-act:start-selected>
   <gnc:account version="2.0.0">
   <act:name>Root Account</act:name>
   <act:id type="new">1972cce2e2364f95b2b0bc014502661d</act:id>
   <act:type>ROOT</act:type>
   <act:commodity-scu>0</act:commodity-scu>
 </gnc:account>
-  <gnc-act:start-selected>0</gnc-act:start-selected>
 <gnc:account version="2.0.0">
   <act:name>Bank Accounts</act:name>
   <act:id type="new">48a242bf9a2d8c947cb41d96493d91da</act:id>

--- a/data/accounts/ja/acctchrt_full.gnucash-xea
+++ b/data/accounts/ja/acctchrt_full.gnucash-xea
@@ -266,7 +266,7 @@
     <cmdty:id>USD</cmdty:id>
   </act:commodity>
   <act:description>個人年金</act:description>
-  <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:parent type="new">0efa7e60042a8d5e4f07a2e6f76bb66d</act:parent>
   <act:slots>
     <slot>
       <slot:key>placeholder</slot:key>
@@ -277,7 +277,6 @@
       <slot:value type="string">確定拠出年金、退職金、IRA、401(k)など</slot:value>
     </slot>
   </act:slots>
-  <act:parent type="new">0efa7e60042a8d5e4f07a2e6f76bb66d</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>債券</act:name>
@@ -332,7 +331,7 @@
     <cmdty:id>USD</cmdty:id>
   </act:commodity>
   <act:description>配偶者個人年金</act:description>
-  <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:parent type="new">0efa7e60042a8d5e4f07a2e6f76bb66d</act:parent>
   <act:slots>
     <slot>
       <slot:key>notes</slot:key>
@@ -343,7 +342,6 @@
       <slot:value type="string">true</slot:value>
     </slot>
   </act:slots>
-  <act:parent type="new">0efa7e60042a8d5e4f07a2e6f76bb66d</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>債券</act:name>


### PR DESCRIPTION
acctchrt_common:
there is a gratituous "i"

acctchrt_full (ja):
the Retirement and Spouse's retirement accounts have two parents
(Investment as well as ROOT), removed ROOT.

uk-vat:
the root account was pasted a line too high 7y ago. all other files have
the header block continuous