### PR TITLE
Eradicate gtkhtml in .scm

### DIFF
--- a/gnucash/report/business-reports/balsheet-eg.eguile.scm
+++ b/gnucash/report/business-reports/balsheet-eg.eguile.scm
@@ -153,9 +153,6 @@
 
 </head>
 <body>
-<?scm (if (not css?) (begin ?>
-  <table border="0" cellpadding="16"><tr><td> <!-- hack for GTKHTML -->
-<?scm )) ?>
 <h3><?scm:d coyname ?></h3>
 <h2><?scm:d reportname ?> <?scm:d (qof-print-date opt-date) ?></h2>
 
@@ -313,10 +310,6 @@
 
 <br clear="both">
 <p><?scm:d opt-extra-notes ?>
-
-<?scm (if (not css?) (begin ?>
-  </table> <!-- hack for GTKHTML -->
-<?scm )) ?>
 
 </body>
 </html>

--- a/gnucash/report/business-reports/balsheet-eg.scm
+++ b/gnucash/report/business-reports/balsheet-eg.scm
@@ -433,8 +433,6 @@
          ;; XXX I haven't found a way to get the book for which the report was opened here
          (coyname (or (gnc:company-info (gnc-get-current-book) gnc:*company-name*) ""))
 
-         (css? (gnc-html-engine-supports-css))
-
          (html #f))
 
     ;; end of all the lets.  time for some real code
@@ -458,8 +456,7 @@
 
     (define (foreignstyle item)
       ;; apply styling for amount in foreign currency
-      (if css?
-        (string-append "<span class=\"foreign\">" item "</span>"))
+        (string-append "<span class=\"foreign\">" item "</span>")
         (string-append "<small><i>" item "</i></small>"))
 
     ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -671,13 +668,7 @@
     (set! html (eguile-file-to-string opt-template-file (the-environment)))
     (gnc:debug "balsheet-eg.scm - generated html:") (gnc:debug html)
     (gnc:report-finished)
-    (if css? ; return report as document or html, depending on version
-      html
-      (let ((document (gnc:make-html-document)))
-        (gnc:html-document-add-object! document html)
-        document))
-
-    ))
+    html))
 
 (gnc:define-report
   'version 1

--- a/gnucash/report/business-reports/receipt.scm
+++ b/gnucash/report/business-reports/receipt.scm
@@ -240,22 +240,14 @@
          (opt-amount-due-heading    (opt-value headingpage2 optname-amount-due))
          (opt-payment-recd-heading  (opt-value headingpage2 optname-payment-recd))
          (opt-extra-notes           (opt-value notespage    optname-extra-notes))
-         (css? #t) ;(and (defined? 'gnc-html-engine-supports-css) (gnc-html-engine-supports-css)))
-         (html #f))
-
-    (set! html (eguile-file-to-string
+         (css? #t)
+         (html (eguile-file-to-string
                  opt-template-file
-                 (the-environment)))
+                 (the-environment))))
 
-    (gnc:debug "receipt.scm: css? is " css?)
-    (gnc:debug "receipt.scm: defined is " (defined? 'gnc-html-engine-supports-css))
     (gnc:debug "receipt.scm - generated html:") (gnc:debug html)
 
-    (if css? ; return report as document or html, depending on version
-      html
-      (let ((document (gnc:make-html-document)))
-        (gnc:html-document-add-object! document html)
-        document))))
+    html))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Define the report

--- a/gnucash/report/business-reports/taxinvoice.scm
+++ b/gnucash/report/business-reports/taxinvoice.scm
@@ -306,22 +306,14 @@
          (opt-jobname-text          (opt-value headingpage2 optname-jobname-text))
          (opt-extra-css             (opt-value notespage    optname-extra-css)) 
          (opt-extra-notes           (opt-value notespage    optname-extra-notes)) 
-         (css? #t) ;(and (defined? 'gnc-html-engine-supports-css) (gnc-html-engine-supports-css)))
-         (html #f))
-
-    (set! html (eguile-file-to-string 
+         (css? #t)
+         (html (eguile-file-to-string
                  opt-template-file
-                 (the-environment)))
+                 (the-environment))))
 
-    (gnc:debug "taxinvoice.scm: css? is " css?)
-    (gnc:debug "taxinvoice.scm: defined is " (defined? 'gnc-html-engine-supports-css))
     (gnc:debug "taxinvoice.scm - generated html:") (gnc:debug html)
 
-    (if css? ; return report as document or html, depending on version 
-      html 
-      (let ((document (gnc:make-html-document)))
-        (gnc:html-document-add-object! document html)
-        document))))
+    html))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Define the report

--- a/gnucash/report/locale-specific/us/taxtxf.scm
+++ b/gnucash/report/locale-specific/us/taxtxf.scm
@@ -104,7 +104,7 @@
 
 (use-modules (gnucash core-utils)) ; for gnc:version
 
-(gnc:module-load "gnucash/html" 0)   ; added for 'gnc-html-engine-supports-css'
+(gnc:module-load "gnucash/html" 0)
 (gnc:module-load "gnucash/tax/us" 0)
 (gnc:module-load "gnucash/report/report-system" 0)
 
@@ -262,13 +262,7 @@
            (list 'conv-to-report-date (N_ "Nearest report date") (N_ "Use nearest to report date.")))
     )))
 
-  (if (gnc-html-engine-supports-css)
-      #t
-      (gnc:register-tax-option
-       (gnc:make-simple-boolean-option
-        gnc:pagename-display (N_ "Shade alternate transactions")
-        "n" (N_ "Shade background of alternate transactions, if more than one displayed.") #f))
-  )
+  #t
 
   (gnc:options-set-default-section options gnc:pagename-general)
 
@@ -2063,10 +2057,7 @@
                                      "Do not print Action:Memo data")
                                     (get-option gnc:pagename-display
                                      "Do not print T-Num:Memo data")))
-         (shade-alternate-transactions? (if (gnc-html-engine-supports-css)
-                                            #t
-                                            (get-option gnc:pagename-display
-                                               "Shade alternate transactions")))
+         (shade-alternate-transactions? #t)
          (currency-conversion-date (get-option gnc:pagename-display
                                  "Currency conversion date"))
          (user-sel-accnts (get-option gnc:pagename-accounts
@@ -3058,7 +3049,7 @@
               #f) ;;end of if
           #f) ;;end of if
           (begin  ; else do tax report
-             (if (gnc-html-engine-supports-css)
+             (if #t                     ;does gcn-html-engine-support-css? #t!
                  (begin ;; this is for webkit
                   (gnc:html-document-set-style!
                    doc "header-just-top"
@@ -3101,65 +3092,6 @@
                    'tag "td"
                    'attribute (list "class" "number-cell neg")
                    'attribute (list "valign" "bottom"))
-                 )
-                 (begin ;; this is for gtkhtml
-                  (gnc:html-document-set-style!
-                   doc "header-just-top"
-                   'tag "th"
-                   'attribute (list "align" "left")
-                   'attribute (list "valign" "top"))
-
-                  (gnc:html-document-set-style!
-                   doc "header-just-bot"
-                   'tag "th"
-                   'attribute (list "align" "left")
-                   'attribute (list "valign" "bottom"))
-
-                  (gnc:html-document-set-style!
-                   doc "column-heading-center"
-                   'tag "th"
-                   'attribute (list "align" "center")
-                   'attribute (list "valign" "bottom"))
-
-                  (gnc:html-document-set-style!
-                   doc "tran-detail"
-                   'tag "tr"
-                   'attribute (list "valign" "top"))
-
-                  (gnc:html-document-set-style!
-                   doc "tran-detail-shade"
-                   'tag "tr"
-                   'attribute (list "valign" "top")
-                   'attribute (list "bgcolor" "grey"))
-
-                  (gnc:html-document-set-style!
-                   doc "column-heading-right"
-                   'tag "th"
-                   'attribute (list "align" "right"))
-
-                  (gnc:html-document-set-style!
-                   doc "text-cell-center"
-                   'tag "td"
-                   'attribute (list "align" "center"))
-
-                  (gnc:html-document-set-style!
-                   doc "number-cell-bot"
-                   'tag "td"
-                   'attribute (list "align" "right")
-                   'attribute (list "nowrap" "nowrap")
-                   'attribute (list "valign" "bottom"))
-
-                  (gnc:html-document-set-style!
-                   doc "number-cell-bot-neg"
-                   'tag "td"
-                   'attribute (list "align" "right")
-                   'attribute (list "nowrap" "nowrap")
-                   'attribute (list "valign" "bottom"))
-
-                  (gnc:html-document-set-style!
-                   doc "date-cell"
-                   'tag "td"
-                   'attribute (list "nowrap" "nowrap"))
                  ))
 
              (gnc:html-document-set-style!
@@ -3469,10 +3401,7 @@
                              ;; currency conversion date
                              "&nbsp; &nbsp; &nbsp; ~a <br/>"
                              ;; alternate transaction shading
-                             (if (gnc-html-engine-supports-css)
-                                 ""
-                                 "&nbsp; &nbsp; &nbsp; ~a <br/>"
-                             ))
+                             "")
                              (if (not (null? user-sel-accnts))
                                  "Subset of accounts"
                                  "No accounts (none = all accounts)")
@@ -3501,11 +3430,6 @@
                                          'conv-to-tran-date)
                                  "PriceDB lookups nearest to transaction date"
                                  "PriceDB lookups nearest to report end date")
-                             (if (not (gnc-html-engine-supports-css))
-                                 (if shade-alternate-transactions?
-                                     "Shade alternate transactions"
-                                     "Do not shade alternate transactions")
-                             )
                           )
                         ))))
 

--- a/gnucash/report/report-system/html-document.scm
+++ b/gnucash/report/report-system/html-document.scm
@@ -140,7 +140,6 @@
                (push (lambda (l) (set! retval (cons l retval))))
                (objs (gnc:html-document-objects doc))
                (work-to-do (length objs))
-               (css? (gnc-html-engine-supports-css))
                (work-done 0)
                (title (gnc:html-document-title doc)))
           ;; compile the doc style
@@ -160,9 +159,8 @@
                 (push "<html>\n")
                 (push "<head>\n")
                 (push "<meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\" />\n")
-                (if css?
-                  (if style-text
-                    (push (list "</style>" style-text "<style type=\"text/css\">\n"))))
+                (if style-text
+                    (push (list "</style>" style-text "<style type=\"text/css\">\n")))
                 (let ((title (gnc:html-document-title doc)))
                   (if title
                       (push (list "</title>" title "<title>\n"))))

--- a/gnucash/report/stylesheets/stylesheet-easy.scm
+++ b/gnucash/report/stylesheets/stylesheet-easy.scm
@@ -33,7 +33,7 @@
 (use-modules (gnucash gnc-module))
 (use-modules (gnucash gettext))
 
-(gnc:module-load "gnucash/html" 0)   ; added for 'gnc-html-engine-supports-css'
+(gnc:module-load "gnucash/html" 0)
 (gnc:module-load "gnucash/report/report-system" 0)
 
 (define (easy-options)
@@ -227,143 +227,70 @@
 ;;;;
 ;;;;
 ;;;;
-    (if (gnc-html-engine-supports-css)
-        (begin ;; this is for webkit
-          (gnc:html-document-set-style!
-             ssdoc "column-heading-left"
-             'tag "th"
-             'attribute (list "class" "column-heading-left"))
+    (gnc:html-document-set-style!
+     ssdoc "column-heading-left"
+     'tag "th"
+     'attribute (list "class" "column-heading-left"))
 
-          (gnc:html-document-set-style!
-             ssdoc "column-heading-center"
-             'tag "th"
-             'attribute (list "class" "column-heading-center"))
+    (gnc:html-document-set-style!
+     ssdoc "column-heading-center"
+     'tag "th"
+     'attribute (list "class" "column-heading-center"))
 
-          (gnc:html-document-set-style!
-             ssdoc "column-heading-right"
-             'tag "th"
-             'attribute (list "class" "column-heading-right"))
+    (gnc:html-document-set-style!
+     ssdoc "column-heading-right"
+     'tag "th"
+     'attribute (list "class" "column-heading-right"))
 
-          (gnc:html-document-set-style!
-             ssdoc "date-cell"
-             'tag "td"
-             'attribute (list "class" "date-cell"))
+    (gnc:html-document-set-style!
+     ssdoc "date-cell"
+     'tag "td"
+     'attribute (list "class" "date-cell"))
 
-          (gnc:html-document-set-style!
-             ssdoc "anchor-cell"
-             'tag "td"
-             'attribute (list "class" "anchor-cell"))
+    (gnc:html-document-set-style!
+     ssdoc "anchor-cell"
+     'tag "td"
+     'attribute (list "class" "anchor-cell"))
 
-          (gnc:html-document-set-style!
-             ssdoc "number-cell"
-             'tag "td"
-             'attribute (list "class" "number-cell"))
+    (gnc:html-document-set-style!
+     ssdoc "number-cell"
+     'tag "td"
+     'attribute (list "class" "number-cell"))
 
-          (gnc:html-document-set-style!
-             ssdoc "number-cell-neg"
-             'tag "td"
-             'attribute (list "class" "number-cell neg"))
+    (gnc:html-document-set-style!
+     ssdoc "number-cell-neg"
+     'tag "td"
+     'attribute (list "class" "number-cell neg"))
 
-          (gnc:html-document-set-style!
-             ssdoc "number-header"
-             'tag "th"
-             'attribute (list "class" "number-header"))
+    (gnc:html-document-set-style!
+     ssdoc "number-header"
+     'tag "th"
+     'attribute (list "class" "number-header"))
 
-          (gnc:html-document-set-style!
-             ssdoc "text-cell"
-             'tag "td"
-             'attribute (list "class" "text-cell"))
+    (gnc:html-document-set-style!
+     ssdoc "text-cell"
+     'tag "td"
+     'attribute (list "class" "text-cell"))
 
-          (gnc:html-document-set-style!
-             ssdoc "total-number-cell"
-             'tag '("td")
-             'attribute (list "class" "total-number-cell"))
+    (gnc:html-document-set-style!
+     ssdoc "total-number-cell"
+     'tag '("td")
+     'attribute (list "class" "total-number-cell"))
 
-          (gnc:html-document-set-style!
-             ssdoc "total-number-cell-neg"
-             'tag '("td")
-             'attribute (list "class" "total-number-cell neg"))
+    (gnc:html-document-set-style!
+     ssdoc "total-number-cell-neg"
+     'tag '("td")
+     'attribute (list "class" "total-number-cell neg"))
 
-          (gnc:html-document-set-style!
-             ssdoc "total-label-cell"
-             'tag '("td")
-             'attribute (list "class" "total-label-cell"))
+    (gnc:html-document-set-style!
+     ssdoc "total-label-cell"
+     'tag '("td")
+     'attribute (list "class" "total-label-cell"))
 
-          (gnc:html-document-set-style!
-             ssdoc "centered-label-cell"
-             'tag '("td")
-             'attribute (list "class" "centered-label-cell"))
-        )
-        (begin ;; this is for gtkhtml
-          (gnc:html-document-set-style!
-             ssdoc "column-heading-left"
-             'tag "th"
-             'attribute (list "align" "left"))
-
-          (gnc:html-document-set-style!
-             ssdoc "column-heading-center"
-             'tag "th"
-             'attribute (list "align" "center"))
-
-          (gnc:html-document-set-style!
-             ssdoc "column-heading-right"
-             'tag "th"
-             'attribute (list "align" "right"))
-
-          (gnc:html-document-set-style!
-             ssdoc "date-cell"
-             'tag "td"
-             'attribute (list "nowrap" "nowrap"))
-
-          (gnc:html-document-set-style!
-             ssdoc "anchor-cell"
-             'tag "td"
-             'attribute (list "align" "left")
-             'attribute (list "nowrap"))
-
-          (gnc:html-document-set-style!
-             ssdoc "number-cell"
-             'tag "td"
-             'attribute (list "align" "right")
-             'attribute (list "nowrap"))
-
-          (gnc:html-document-set-style!
-             ssdoc "number-cell-neg"
-             'tag "td"
-             'attribute (list "align" "right")
-             'attribute (list "nowrap"))
-
-          (gnc:html-document-set-style!
-             ssdoc "number-header"
-             'tag "th"
-             'attribute (list "align" "right"))
-
-          (gnc:html-document-set-style!
-             ssdoc "text-cell"
-             'tag "td"
-             'attribute (list "align" "left"))
-
-          (gnc:html-document-set-style!
-             ssdoc "total-number-cell"
-             'tag '("td")
-             'attribute (list "align" "right"))
-
-          (gnc:html-document-set-style!
-             ssdoc "total-number-cell-neg"
-             'tag '("td")
-             'attribute (list "align" "right"))
-
-          (gnc:html-document-set-style!
-             ssdoc "total-label-cell"
-             'tag '("td")
-             'attribute (list "align" "left"))
-
-          (gnc:html-document-set-style!
-             ssdoc "centered-label-cell"
-             'tag '("td")
-             'attribute (list "align" "center"))
-        )
-    )
+    (gnc:html-document-set-style!
+     ssdoc "centered-label-cell"
+     'tag '("td")
+     'attribute (list "class" "centered-label-cell"))
 
     (if (and bgpixmap
 	     (not (string=? bgpixmap "")))

--- a/gnucash/report/stylesheets/stylesheet-fancy.scm
+++ b/gnucash/report/stylesheets/stylesheet-fancy.scm
@@ -27,7 +27,7 @@
 (use-modules (gnucash gnc-module))
 (use-modules (gnucash gettext))
 
-(gnc:module-load "gnucash/html" 0)   ; added for 'gnc-html-engine-supports-css'
+(gnc:module-load "gnucash/html" 0)
 (gnc:module-load "gnucash/report/report-system" 0)
 
 (define (fancy-options)
@@ -222,143 +222,70 @@
 ;;;;
 ;;;;
 ;;;;
-    (if (gnc-html-engine-supports-css)
-        (begin ;; this is for webkit
-          (gnc:html-document-set-style!
-             ssdoc "column-heading-left"
-             'tag "th"
-             'attribute (list "class" "column-heading-left"))
+    (gnc:html-document-set-style!
+     ssdoc "column-heading-left"
+     'tag "th"
+     'attribute (list "class" "column-heading-left"))
 
-          (gnc:html-document-set-style!
-             ssdoc "column-heading-center"
-             'tag "th"
-             'attribute (list "class" "column-heading-center"))
+    (gnc:html-document-set-style!
+     ssdoc "column-heading-center"
+     'tag "th"
+     'attribute (list "class" "column-heading-center"))
 
-          (gnc:html-document-set-style!
-             ssdoc "column-heading-right"
-             'tag "th"
-             'attribute (list "class" "column-heading-right"))
+    (gnc:html-document-set-style!
+     ssdoc "column-heading-right"
+     'tag "th"
+     'attribute (list "class" "column-heading-right"))
 
-          (gnc:html-document-set-style!
-             ssdoc "date-cell"
-             'tag "td"
-             'attribute (list "class" "date-cell"))
+    (gnc:html-document-set-style!
+     ssdoc "date-cell"
+     'tag "td"
+     'attribute (list "class" "date-cell"))
 
-          (gnc:html-document-set-style!
-             ssdoc "anchor-cell"
-             'tag "td"
-             'attribute (list "class" "anchor-cell"))
+    (gnc:html-document-set-style!
+     ssdoc "anchor-cell"
+     'tag "td"
+     'attribute (list "class" "anchor-cell"))
 
-          (gnc:html-document-set-style!
-             ssdoc "number-cell"
-             'tag "td"
-             'attribute (list "class" "number-cell"))
+    (gnc:html-document-set-style!
+     ssdoc "number-cell"
+     'tag "td"
+     'attribute (list "class" "number-cell"))
 
-          (gnc:html-document-set-style!
-             ssdoc "number-cell-neg"
-             'tag "td"
-             'attribute (list "class" "number-cell neg"))
+    (gnc:html-document-set-style!
+     ssdoc "number-cell-neg"
+     'tag "td"
+     'attribute (list "class" "number-cell neg"))
 
-          (gnc:html-document-set-style!
-             ssdoc "number-header"
-             'tag "th"
-             'attribute (list "class" "number-header"))
+    (gnc:html-document-set-style!
+     ssdoc "number-header"
+     'tag "th"
+     'attribute (list "class" "number-header"))
 
-          (gnc:html-document-set-style!
-             ssdoc "text-cell"
-             'tag "td"
-             'attribute (list "class" "text-cell"))
+    (gnc:html-document-set-style!
+     ssdoc "text-cell"
+     'tag "td"
+     'attribute (list "class" "text-cell"))
 
-          (gnc:html-document-set-style!
-             ssdoc "total-number-cell"
-             'tag '("td")
-             'attribute (list "class" "total-number-cell"))
+    (gnc:html-document-set-style!
+     ssdoc "total-number-cell"
+     'tag '("td")
+     'attribute (list "class" "total-number-cell"))
 
-          (gnc:html-document-set-style!
-             ssdoc "total-number-cell-neg"
-             'tag '("td")
-             'attribute (list "class" "total-number-cell neg"))
+    (gnc:html-document-set-style!
+     ssdoc "total-number-cell-neg"
+     'tag '("td")
+     'attribute (list "class" "total-number-cell neg"))
 
-          (gnc:html-document-set-style!
-             ssdoc "total-label-cell"
-             'tag '("td")
-             'attribute (list "class" "total-label-cell"))
+    (gnc:html-document-set-style!
+     ssdoc "total-label-cell"
+     'tag '("td")
+     'attribute (list "class" "total-label-cell"))
 
-          (gnc:html-document-set-style!
-             ssdoc "centered-label-cell"
-             'tag '("td")
-             'attribute (list "class" "centered-label-cell"))
-        )
-        (begin ;; this is for gtkhtml
-          (gnc:html-document-set-style!
-             ssdoc "column-heading-left"
-             'tag "th"
-             'attribute (list "align" "left"))
-
-          (gnc:html-document-set-style!
-             ssdoc "column-heading-center"
-             'tag "th"
-             'attribute (list "align" "center"))
-
-          (gnc:html-document-set-style!
-             ssdoc "column-heading-right"
-             'tag "th"
-             'attribute (list "align" "right"))
-
-          (gnc:html-document-set-style!
-             ssdoc "date-cell"
-             'tag "td"
-             'attribute (list "nowrap" "nowrap"))
-
-          (gnc:html-document-set-style!
-             ssdoc "anchor-cell"
-             'tag "td"
-             'attribute (list "align" "left")
-             'attribute (list "nowrap"))
-
-          (gnc:html-document-set-style!
-             ssdoc "number-cell"
-             'tag "td"
-             'attribute (list "align" "right")
-             'attribute (list "nowrap"))
-
-          (gnc:html-document-set-style!
-             ssdoc "number-cell-neg"
-             'tag "td"
-             'attribute (list "align" "right")
-             'attribute (list "nowrap"))
-
-          (gnc:html-document-set-style!
-             ssdoc "number-header"
-             'tag "th"
-             'attribute (list "align" "right"))
-
-          (gnc:html-document-set-style!
-             ssdoc "text-cell"
-             'tag "td"
-             'attribute (list "align" "left"))
-
-          (gnc:html-document-set-style!
-             ssdoc "total-number-cell"
-             'tag '("td")
-             'attribute (list "align" "right"))
-
-          (gnc:html-document-set-style!
-             ssdoc "total-number-cell-neg"
-             'tag '("td")
-             'attribute (list "align" "right"))
-
-          (gnc:html-document-set-style!
-             ssdoc "total-label-cell"
-             'tag '("td")
-             'attribute (list "align" "left"))
-
-          (gnc:html-document-set-style!
-             ssdoc "centered-label-cell"
-             'tag '("td")
-             'attribute (list "align" "center"))
-        )
-    )
+    (gnc:html-document-set-style!
+     ssdoc "centered-label-cell"
+     'tag '("td")
+     'attribute (list "class" "centered-label-cell"))
 
     (if (and bgpixmap
 	     (not (string=? bgpixmap "")))

--- a/gnucash/report/stylesheets/stylesheet-footer.scm
+++ b/gnucash/report/stylesheets/stylesheet-footer.scm
@@ -38,7 +38,7 @@
 (use-modules (gnucash gnc-module))
 (use-modules (gnucash gettext))
 
-(gnc:module-load "gnucash/html" 0)   ; added for 'gnc-html-engine-supports-css'
+(gnc:module-load "gnucash/html" 0)
 (gnc:module-load "gnucash/report/report-system" 0)
 
 (define (footer-options)
@@ -241,143 +241,70 @@
 ;;;;
 ;;;;
 ;;;;
-    (if (gnc-html-engine-supports-css)
-        (begin ;; this is for webkit
-          (gnc:html-document-set-style!
-             ssdoc "column-heading-left"
-             'tag "th"
-             'attribute (list "class" "column-heading-left"))
+    (gnc:html-document-set-style!
+     ssdoc "column-heading-left"
+     'tag "th"
+     'attribute (list "class" "column-heading-left"))
 
-          (gnc:html-document-set-style!
-             ssdoc "column-heading-center"
-             'tag "th"
-             'attribute (list "class" "column-heading-center"))
+    (gnc:html-document-set-style!
+     ssdoc "column-heading-center"
+     'tag "th"
+     'attribute (list "class" "column-heading-center"))
 
-          (gnc:html-document-set-style!
-             ssdoc "column-heading-right"
-             'tag "th"
-             'attribute (list "class" "column-heading-right"))
+    (gnc:html-document-set-style!
+     ssdoc "column-heading-right"
+     'tag "th"
+     'attribute (list "class" "column-heading-right"))
 
-          (gnc:html-document-set-style!
-             ssdoc "date-cell"
-             'tag "td"
-             'attribute (list "class" "date-cell"))
+    (gnc:html-document-set-style!
+     ssdoc "date-cell"
+     'tag "td"
+     'attribute (list "class" "date-cell"))
 
-          (gnc:html-document-set-style!
-             ssdoc "anchor-cell"
-             'tag "td"
-             'attribute (list "class" "anchor-cell"))
+    (gnc:html-document-set-style!
+     ssdoc "anchor-cell"
+     'tag "td"
+     'attribute (list "class" "anchor-cell"))
 
-          (gnc:html-document-set-style!
-             ssdoc "number-cell"
-             'tag "td"
-             'attribute (list "class" "number-cell"))
+    (gnc:html-document-set-style!
+     ssdoc "number-cell"
+     'tag "td"
+     'attribute (list "class" "number-cell"))
 
-          (gnc:html-document-set-style!
-             ssdoc "number-cell-neg"
-             'tag "td"
-             'attribute (list "class" "number-cell neg"))
+    (gnc:html-document-set-style!
+     ssdoc "number-cell-neg"
+     'tag "td"
+     'attribute (list "class" "number-cell neg"))
 
-          (gnc:html-document-set-style!
-             ssdoc "number-header"
-             'tag "th"
-             'attribute (list "class" "number-header"))
+    (gnc:html-document-set-style!
+     ssdoc "number-header"
+     'tag "th"
+     'attribute (list "class" "number-header"))
 
-          (gnc:html-document-set-style!
-             ssdoc "text-cell"
-             'tag "td"
-             'attribute (list "class" "text-cell"))
+    (gnc:html-document-set-style!
+     ssdoc "text-cell"
+     'tag "td"
+     'attribute (list "class" "text-cell"))
 
-          (gnc:html-document-set-style!
-             ssdoc "total-number-cell"
-             'tag '("td")
-             'attribute (list "class" "total-number-cell"))
+    (gnc:html-document-set-style!
+     ssdoc "total-number-cell"
+     'tag '("td")
+     'attribute (list "class" "total-number-cell"))
 
-          (gnc:html-document-set-style!
-             ssdoc "total-number-cell-neg"
-             'tag '("td")
-             'attribute (list "class" "total-number-cell neg"))
+    (gnc:html-document-set-style!
+     ssdoc "total-number-cell-neg"
+     'tag '("td")
+     'attribute (list "class" "total-number-cell neg"))
 
-          (gnc:html-document-set-style!
-             ssdoc "total-label-cell"
-             'tag '("td")
-             'attribute (list "class" "total-label-cell"))
+    (gnc:html-document-set-style!
+     ssdoc "total-label-cell"
+     'tag '("td")
+     'attribute (list "class" "total-label-cell"))
 
-          (gnc:html-document-set-style!
-             ssdoc "centered-label-cell"
-             'tag '("td")
-             'attribute (list "class" "centered-label-cell"))
-        )
-        (begin ;; this is for gtkhtml
-          (gnc:html-document-set-style!
-             ssdoc "column-heading-left"
-             'tag "th"
-             'attribute (list "align" "left"))
-
-          (gnc:html-document-set-style!
-             ssdoc "column-heading-center"
-             'tag "th"
-             'attribute (list "align" "center"))
-
-          (gnc:html-document-set-style!
-             ssdoc "column-heading-right"
-             'tag "th"
-             'attribute (list "align" "right"))
-
-          (gnc:html-document-set-style!
-             ssdoc "date-cell"
-             'tag "td"
-             'attribute (list "nowrap" "nowrap"))
-
-          (gnc:html-document-set-style!
-             ssdoc "anchor-cell"
-             'tag "td"
-             'attribute (list "align" "left")
-             'attribute (list "nowrap"))
-
-          (gnc:html-document-set-style!
-             ssdoc "number-cell"
-             'tag "td"
-             'attribute (list "align" "right")
-             'attribute (list "nowrap"))
-
-          (gnc:html-document-set-style!
-             ssdoc "number-cell-neg"
-             'tag "td"
-             'attribute (list "align" "right")
-             'attribute (list "nowrap"))
-
-          (gnc:html-document-set-style!
-             ssdoc "number-header"
-             'tag "th"
-             'attribute (list "align" "right"))
-
-          (gnc:html-document-set-style!
-             ssdoc "text-cell"
-             'tag "td"
-             'attribute (list "align" "left"))
-
-          (gnc:html-document-set-style!
-             ssdoc "total-number-cell"
-             'tag '("td")
-             'attribute (list "align" "right"))
-
-          (gnc:html-document-set-style!
-             ssdoc "total-number-cell-neg"
-             'tag '("td")
-             'attribute (list "align" "right"))
-
-          (gnc:html-document-set-style!
-             ssdoc "total-label-cell"
-             'tag '("td")
-             'attribute (list "align" "left"))
-
-          (gnc:html-document-set-style!
-             ssdoc "centered-label-cell"
-             'tag '("td")
-             'attribute (list "align" "center"))
-        )
-    )
+    (gnc:html-document-set-style!
+     ssdoc "centered-label-cell"
+     'tag '("td")
+     'attribute (list "class" "centered-label-cell"))
 
     (if (and bgpixmap
 	     (not (string=? bgpixmap "")))

--- a/gnucash/report/stylesheets/stylesheet-head-or-tail.scm
+++ b/gnucash/report/stylesheets/stylesheet-head-or-tail.scm
@@ -40,7 +40,7 @@
 (use-modules (gnucash core-utils)) ; for gnc:version
 (use-modules (gnucash gettext))
 
-(gnc:module-load "gnucash/html" 0)   ; added for 'gnc-html-engine-supports-css'
+(gnc:module-load "gnucash/html" 0)
 (gnc:module-load "gnucash/report/report-system" 0)
 
 (define (head-or-tail-options)
@@ -306,143 +306,70 @@
 ;;;;
 ;;;;
 ;;;;
-    (if (gnc-html-engine-supports-css)
-        (begin ;; this is for webkit
-          (gnc:html-document-set-style!
-             ssdoc "column-heading-left"
-             'tag "th"
-             'attribute (list "class" "column-heading-left"))
+    (gnc:html-document-set-style!
+     ssdoc "column-heading-left"
+     'tag "th"
+     'attribute (list "class" "column-heading-left"))
 
-          (gnc:html-document-set-style!
-             ssdoc "column-heading-center"
-             'tag "th"
-             'attribute (list "class" "column-heading-center"))
+    (gnc:html-document-set-style!
+     ssdoc "column-heading-center"
+     'tag "th"
+     'attribute (list "class" "column-heading-center"))
 
-          (gnc:html-document-set-style!
-             ssdoc "column-heading-right"
-             'tag "th"
-             'attribute (list "class" "column-heading-right"))
+    (gnc:html-document-set-style!
+     ssdoc "column-heading-right"
+     'tag "th"
+     'attribute (list "class" "column-heading-right"))
 
-          (gnc:html-document-set-style!
-             ssdoc "date-cell"
-             'tag "td"
-             'attribute (list "class" "date-cell"))
+    (gnc:html-document-set-style!
+     ssdoc "date-cell"
+     'tag "td"
+     'attribute (list "class" "date-cell"))
 
-          (gnc:html-document-set-style!
-             ssdoc "anchor-cell"
-             'tag "td"
-             'attribute (list "class" "anchor-cell"))
+    (gnc:html-document-set-style!
+     ssdoc "anchor-cell"
+     'tag "td"
+     'attribute (list "class" "anchor-cell"))
 
-          (gnc:html-document-set-style!
-             ssdoc "number-cell"
-             'tag "td"
-             'attribute (list "class" "number-cell"))
+    (gnc:html-document-set-style!
+     ssdoc "number-cell"
+     'tag "td"
+     'attribute (list "class" "number-cell"))
 
-          (gnc:html-document-set-style!
-             ssdoc "number-cell-neg"
-             'tag "td"
-             'attribute (list "class" "number-cell neg"))
+    (gnc:html-document-set-style!
+     ssdoc "number-cell-neg"
+     'tag "td"
+     'attribute (list "class" "number-cell neg"))
 
-          (gnc:html-document-set-style!
-             ssdoc "number-header"
-             'tag "th"
-             'attribute (list "class" "number-header"))
+    (gnc:html-document-set-style!
+     ssdoc "number-header"
+     'tag "th"
+     'attribute (list "class" "number-header"))
 
-          (gnc:html-document-set-style!
-             ssdoc "text-cell"
-             'tag "td"
-             'attribute (list "class" "text-cell"))
+    (gnc:html-document-set-style!
+     ssdoc "text-cell"
+     'tag "td"
+     'attribute (list "class" "text-cell"))
 
-          (gnc:html-document-set-style!
-             ssdoc "total-number-cell"
-             'tag '("td")
-             'attribute (list "class" "total-number-cell"))
+    (gnc:html-document-set-style!
+     ssdoc "total-number-cell"
+     'tag '("td")
+     'attribute (list "class" "total-number-cell"))
 
-          (gnc:html-document-set-style!
-             ssdoc "total-number-cell-neg"
-             'tag '("td")
-             'attribute (list "class" "total-number-cell neg"))
+    (gnc:html-document-set-style!
+     ssdoc "total-number-cell-neg"
+     'tag '("td")
+     'attribute (list "class" "total-number-cell neg"))
 
-          (gnc:html-document-set-style!
-             ssdoc "total-label-cell"
-             'tag '("td")
-             'attribute (list "class" "total-label-cell"))
+    (gnc:html-document-set-style!
+     ssdoc "total-label-cell"
+     'tag '("td")
+     'attribute (list "class" "total-label-cell"))
 
-          (gnc:html-document-set-style!
-             ssdoc "centered-label-cell"
-             'tag '("td")
-             'attribute (list "class" "centered-label-cell"))
-        )
-        (begin ;; this is for gtkhtml
-          (gnc:html-document-set-style!
-             ssdoc "column-heading-left"
-             'tag "th"
-             'attribute (list "align" "left"))
-
-          (gnc:html-document-set-style!
-             ssdoc "column-heading-center"
-             'tag "th"
-             'attribute (list "align" "center"))
-
-          (gnc:html-document-set-style!
-             ssdoc "column-heading-right"
-             'tag "th"
-             'attribute (list "align" "right"))
-
-          (gnc:html-document-set-style!
-             ssdoc "date-cell"
-             'tag "td"
-             'attribute (list "nowrap" "nowrap"))
-
-          (gnc:html-document-set-style!
-             ssdoc "anchor-cell"
-             'tag "td"
-             'attribute (list "align" "left")
-             'attribute (list "nowrap"))
-
-          (gnc:html-document-set-style!
-             ssdoc "number-cell"
-             'tag "td"
-             'attribute (list "align" "right")
-             'attribute (list "nowrap"))
-
-          (gnc:html-document-set-style!
-             ssdoc "number-cell-neg"
-             'tag "td"
-             'attribute (list "align" "right")
-             'attribute (list "nowrap"))
-
-          (gnc:html-document-set-style!
-             ssdoc "number-header"
-             'tag "th"
-             'attribute (list "align" "right"))
-
-          (gnc:html-document-set-style!
-             ssdoc "text-cell"
-             'tag "td"
-             'attribute (list "align" "left"))
-
-          (gnc:html-document-set-style!
-             ssdoc "total-number-cell"
-             'tag '("td")
-             'attribute (list "align" "right"))
-
-          (gnc:html-document-set-style!
-             ssdoc "total-number-cell-neg"
-             'tag '("td")
-             'attribute (list "align" "right"))
-
-          (gnc:html-document-set-style!
-             ssdoc "total-label-cell"
-             'tag '("td")
-             'attribute (list "align" "left"))
-
-          (gnc:html-document-set-style!
-             ssdoc "centered-label-cell"
-             'tag '("td")
-             'attribute (list "align" "center"))
-        )
-    )
+    (gnc:html-document-set-style!
+     ssdoc "centered-label-cell"
+     'tag '("td")
+     'attribute (list "class" "centered-label-cell"))
 
     (if (and bgpixmap
 	     (not (string=? bgpixmap "")))

--- a/gnucash/report/stylesheets/stylesheet-plain.scm
+++ b/gnucash/report/stylesheets/stylesheet-plain.scm
@@ -31,7 +31,7 @@
 (use-modules (srfi srfi-13))
 (use-modules (srfi srfi-14))
 
-(gnc:module-load "gnucash/html" 0)   ; added for 'gnc-html-engine-supports-css'
+(gnc:module-load "gnucash/html" 0)
 (gnc:module-load "gnucash/report/report-system" 0)
 
 ;; plain style sheet
@@ -123,143 +123,70 @@
        'attribute (list "cellspacing" spacing)
        'attribute (list "cellpadding" padding))
 
-    (if (gnc-html-engine-supports-css)
-        (begin ;; this is for webkit
-          (gnc:html-document-set-style!
-             ssdoc "column-heading-left"
-             'tag "th"
-             'attribute (list "class" "column-heading-left"))
+    (gnc:html-document-set-style!
+     ssdoc "column-heading-left"
+     'tag "th"
+     'attribute (list "class" "column-heading-left"))
 
-          (gnc:html-document-set-style!
-             ssdoc "column-heading-center"
-             'tag "th"
-             'attribute (list "class" "column-heading-center"))
+    (gnc:html-document-set-style!
+     ssdoc "column-heading-center"
+     'tag "th"
+     'attribute (list "class" "column-heading-center"))
 
-          (gnc:html-document-set-style!
-             ssdoc "column-heading-right"
-             'tag "th"
-             'attribute (list "class" "column-heading-right"))
+    (gnc:html-document-set-style!
+     ssdoc "column-heading-right"
+     'tag "th"
+     'attribute (list "class" "column-heading-right"))
 
-          (gnc:html-document-set-style!
-             ssdoc "date-cell"
-             'tag "td"
-             'attribute (list "class" "date-cell"))
+    (gnc:html-document-set-style!
+     ssdoc "date-cell"
+     'tag "td"
+     'attribute (list "class" "date-cell"))
 
-          (gnc:html-document-set-style!
-             ssdoc "anchor-cell"
-             'tag "td"
-             'attribute (list "class" "anchor-cell"))
+    (gnc:html-document-set-style!
+     ssdoc "anchor-cell"
+     'tag "td"
+     'attribute (list "class" "anchor-cell"))
 
-          (gnc:html-document-set-style!
-             ssdoc "number-cell"
-             'tag "td"
-             'attribute (list "class" "number-cell"))
+    (gnc:html-document-set-style!
+     ssdoc "number-cell"
+     'tag "td"
+     'attribute (list "class" "number-cell"))
 
-          (gnc:html-document-set-style!
-             ssdoc "number-cell-neg"
-             'tag "td"
-             'attribute (list "class" "number-cell neg"))
+    (gnc:html-document-set-style!
+     ssdoc "number-cell-neg"
+     'tag "td"
+     'attribute (list "class" "number-cell neg"))
 
-          (gnc:html-document-set-style!
-             ssdoc "number-header"
-             'tag "th"
-             'attribute (list "class" "number-header"))
+    (gnc:html-document-set-style!
+     ssdoc "number-header"
+     'tag "th"
+     'attribute (list "class" "number-header"))
 
-          (gnc:html-document-set-style!
-             ssdoc "text-cell"
-             'tag "td"
-             'attribute (list "class" "text-cell"))
+    (gnc:html-document-set-style!
+     ssdoc "text-cell"
+     'tag "td"
+     'attribute (list "class" "text-cell"))
 
-          (gnc:html-document-set-style!
-             ssdoc "total-number-cell"
-             'tag "td"
-             'attribute (list "class" "total-number-cell"))
+    (gnc:html-document-set-style!
+     ssdoc "total-number-cell"
+     'tag "td"
+     'attribute (list "class" "total-number-cell"))
 
-          (gnc:html-document-set-style!
-             ssdoc "total-number-cell-neg"
-             'tag "td"
-             'attribute (list "class" "total-number-cell neg"))
+    (gnc:html-document-set-style!
+     ssdoc "total-number-cell-neg"
+     'tag "td"
+     'attribute (list "class" "total-number-cell neg"))
 
-          (gnc:html-document-set-style!
-             ssdoc "total-label-cell"
-             'tag "td"
-             'attribute (list "class" "total-label-cell"))
+    (gnc:html-document-set-style!
+     ssdoc "total-label-cell"
+     'tag "td"
+     'attribute (list "class" "total-label-cell"))
 
-          (gnc:html-document-set-style!
-             ssdoc "centered-label-cell"
-             'tag "td"
-             'attribute (list "class" "centered-label-cell"))
-        )
-        (begin ;; this is for gtkhtml
-          (gnc:html-document-set-style!
-             ssdoc "column-heading-left"
-             'tag "th"
-             'attribute (list "align" "left"))
-
-          (gnc:html-document-set-style!
-             ssdoc "column-heading-center"
-             'tag "th"
-             'attribute (list "align" "center"))
-
-          (gnc:html-document-set-style!
-             ssdoc "column-heading-right"
-             'tag "th"
-             'attribute (list "align" "right"))
-
-          (gnc:html-document-set-style!
-             ssdoc "date-cell"
-             'tag "td"
-             'attribute (list "nowrap" "nowrap"))
-
-          (gnc:html-document-set-style!
-             ssdoc "anchor-cell"
-             'tag "td"
-             'attribute (list "align" "left")
-             'attribute (list "nowrap"))
-
-          (gnc:html-document-set-style!
-             ssdoc "number-cell"
-             'tag "td"
-             'attribute (list "align" "right")
-             'attribute (list "nowrap"))
-
-          (gnc:html-document-set-style!
-             ssdoc "number-cell-neg"
-             'tag "td"
-             'attribute (list "align" "right")
-             'attribute (list "nowrap"))
-
-          (gnc:html-document-set-style!
-             ssdoc "number-header"
-             'tag "th"
-             'attribute (list "align" "right"))
-
-          (gnc:html-document-set-style!
-             ssdoc "text-cell"
-             'tag "td"
-             'attribute (list "align" "left"))
-
-          (gnc:html-document-set-style!
-             ssdoc "total-number-cell"
-             'tag "td"
-             'attribute (list "align" "right"))
-
-          (gnc:html-document-set-style!
-             ssdoc "total-number-cell-neg"
-             'tag "td"
-             'attribute (list "align" "right"))
-
-          (gnc:html-document-set-style!
-             ssdoc "total-label-cell"
-             'tag "td"
-             'attribute (list "align" "left"))
-
-          (gnc:html-document-set-style!
-             ssdoc "centered-label-cell"
-             'tag "td"
-             'attribute (list "align" "center"))
-        )
-    )
+    (gnc:html-document-set-style!
+     ssdoc "centered-label-cell"
+     'tag "td"
+     'attribute (list "class" "centered-label-cell"))
 
     (gnc:html-document-set-style!
        ssdoc "normal-row"


### PR DESCRIPTION
This commit does away with anything gtkhtml related. Pulled out from another PR because it's different enough.
Also POTFILES.in is always regenerated during CMake - it means during development it was always annoyingly being scanned for changes. Deleting from repo means it is not tracked as directed by .gitignore in project root.