### PR TITLE
Add tooltips to the register

### DIFF
--- a/gnucash/register/ledger-core/split-register-model.c
+++ b/gnucash/register/ledger-core/split-register-model.c
@@ -497,6 +497,17 @@ gnc_split_register_get_fcredit_label (VirtualLocation virt_loc,
     return _("Credit Formula");
 }
 
+
+static char *
+gnc_split_register_get_default_tooltip (VirtualLocation virt_loc,
+                                     gpointer user_data)
+{
+    SplitRegister *reg = user_data;
+    const char *tooltip = gnc_table_get_entry(reg->table, virt_loc);
+
+    return g_strdup (tooltip);
+}
+
 static gnc_numeric
 get_trans_total_amount (SplitRegister *reg, Transaction *trans)
 {
@@ -2343,6 +2354,7 @@ gnc_split_register_model_new (void)
 
     model = gnc_table_model_new ();
 
+    // entry handlers
     gnc_table_model_set_entry_handler (model,
                                        gnc_split_register_get_date_entry,
                                        DATE_CELL);
@@ -2443,7 +2455,7 @@ gnc_split_register_model_new (void)
                                        gnc_split_register_get_rbaln_entry,
                                        RBALN_CELL);
 
-
+    // label handlers
     gnc_table_model_set_label_handler (model,
                                        gnc_split_register_get_date_label,
                                        DATE_CELL);
@@ -2548,7 +2560,13 @@ gnc_split_register_model_new (void)
                                        gnc_split_register_get_tbalance_label,
                                        RBALN_CELL);
 
+    // tooltip handlers
+//    gnc_table_model_set_default_tooltip_handler(
+//        model, gnc_split_register_get_default_tooltip);
 
+
+
+    // help handlers
     gnc_table_model_set_default_help_handler(
         model, gnc_split_register_get_default_help);
 
@@ -2612,7 +2630,7 @@ gnc_split_register_model_new (void)
                                       gnc_split_register_get_fdebt_help,
                                       FDEBT_CELL);
 
-
+    // io flag handlers
     gnc_table_model_set_io_flags_handler(
         model, gnc_split_register_get_standard_io_flags, DATE_CELL);
 

--- a/gnucash/register/register-core/table-allgui.c
+++ b/gnucash/register/register-core/table-allgui.c
@@ -297,6 +297,25 @@ gnc_table_get_entry (Table *table, VirtualLocation virt_loc)
     return entry;
 }
 
+char *
+gnc_table_get_tooltip (Table *table, VirtualLocation virt_loc)
+{
+    TableGetTooltipHandler tooltip_handler;
+    BasicCell *cell;
+
+    cell = gnc_table_get_cell (table, virt_loc);
+    if (!cell || !cell->cell_name)
+        return NULL;
+
+    tooltip_handler = gnc_table_model_get_tooltip_handler (table->model,
+                         cell->cell_name);
+
+    if (!tooltip_handler)
+        return NULL;
+
+    return  tooltip_handler (virt_loc, table->model->handler_user_data);
+}
+
 CellIOFlags
 gnc_table_get_io_flags (Table *table, VirtualLocation virt_loc)
 {

--- a/gnucash/register/register-core/table-allgui.h
+++ b/gnucash/register/register-core/table-allgui.h
@@ -238,6 +238,8 @@ VirtualCell *  gnc_table_get_virtual_cell (Table *table,
 
 const char *   gnc_table_get_entry (Table *table, VirtualLocation virt_loc);
 
+char *         gnc_table_get_tooltip (Table *table, VirtualLocation virt_loc);
+
 const char *   gnc_table_get_label (Table *table, VirtualLocation virt_loc);
 
 CellIOFlags    gnc_table_get_io_flags (Table *table, VirtualLocation virt_loc);

--- a/gnucash/register/register-core/table-model.c
+++ b/gnucash/register/register-core/table-model.c
@@ -133,6 +133,7 @@ gnc_table_model_new (void)
     model->entry_handlers = gnc_table_model_handler_hash_new ();
     model->label_handlers = gnc_table_model_handler_hash_new ();
     model->help_handlers = gnc_table_model_handler_hash_new ();
+    model->tooltip_handlers = gnc_table_model_handler_hash_new ();
     model->io_flags_handlers = gnc_table_model_handler_hash_new ();
     model->cell_color_handlers = gnc_table_model_handler_hash_new ();
     model->cell_border_handlers = gnc_table_model_handler_hash_new ();
@@ -157,6 +158,9 @@ gnc_table_model_destroy (TableModel *model)
 
     gnc_table_model_handler_hash_destroy (model->label_handlers);
     model->label_handlers = NULL;
+
+    gnc_table_model_handler_hash_destroy (model->tooltip_handlers);
+    model->tooltip_handlers = NULL;
 
     gnc_table_model_handler_hash_destroy (model->help_handlers);
     model->help_handlers = NULL;
@@ -258,6 +262,39 @@ gnc_table_model_get_label_handler (TableModel *model, const char * cell_name)
     g_return_val_if_fail (model != NULL, NULL);
 
     return gnc_table_model_handler_hash_lookup (model->label_handlers,
+            cell_name);
+}
+
+void
+gnc_table_model_set_tooltip_handler (TableModel *model,
+                                   TableGetTooltipHandler tooltip_handler,
+                                   const char * cell_name)
+{
+    g_return_if_fail (model != NULL);
+    g_return_if_fail (cell_name != NULL);
+
+    gnc_table_model_handler_hash_insert (model->tooltip_handlers,
+                                         cell_name,
+                                         tooltip_handler);
+}
+
+void
+gnc_table_model_set_default_tooltip_handler
+(TableModel *model, TableGetTooltipHandler tooltip_handler)
+{
+    g_return_if_fail (model != NULL);
+
+    gnc_table_model_handler_hash_insert (model->tooltip_handlers,
+                                         DEFAULT_HANDLER,
+                                         tooltip_handler);
+}
+
+TableGetTooltipHandler
+gnc_table_model_get_tooltip_handler (TableModel *model, const char * cell_name)
+{
+    g_return_val_if_fail (model != NULL, NULL);
+
+    return gnc_table_model_handler_hash_lookup (model->tooltip_handlers,
             cell_name);
 }
 

--- a/gnucash/register/register-core/table-model.h
+++ b/gnucash/register/register-core/table-model.h
@@ -41,7 +41,7 @@ typedef enum
     XACC_CELL_ALLOW_SHADOW     = 1 << 1,
     XACC_CELL_ALLOW_ALL        = XACC_CELL_ALLOW_INPUT | XACC_CELL_ALLOW_SHADOW,
     XACC_CELL_ALLOW_EXACT_ONLY = 1 << 2,
-    XACC_CELL_ALLOW_ENTER	     = 1 << 3,
+    XACC_CELL_ALLOW_ENTER      = 1 << 3,
     XACC_CELL_ALLOW_READ_ONLY  = XACC_CELL_ALLOW_SHADOW | XACC_CELL_ALLOW_ENTER
 } CellIOFlags;
 
@@ -73,6 +73,9 @@ typedef const char * (*TableGetLabelHandler) (VirtualLocation virt_loc,
 typedef char * (*TableGetHelpHandler) (VirtualLocation virt_loc,
                                        gpointer user_data);
 
+typedef char * (*TableGetTooltipHandler) (VirtualLocation virt_loc,
+        gpointer user_data);
+
 typedef CellIOFlags (*TableGetCellIOFlagsHandler) (VirtualLocation virt_loc,
         gpointer user_data);
 
@@ -103,6 +106,7 @@ typedef struct
     GHashTable *entry_handlers;
     GHashTable *label_handlers;
     GHashTable *help_handlers;
+    GHashTable *tooltip_handlers;
     GHashTable *io_flags_handlers;
     GHashTable *cell_color_handlers;
     GHashTable *cell_border_handlers;
@@ -171,6 +175,17 @@ void gnc_table_model_set_default_help_handler
 (TableModel *model,
  TableGetHelpHandler help_handler);
 TableGetHelpHandler gnc_table_model_get_help_handler
+(TableModel *model,
+ const char * cell_name);
+
+void gnc_table_model_set_tooltip_handler
+(TableModel *model,
+ TableGetTooltipHandler tooltip_handler,
+ const char * cell_name);
+void gnc_table_model_set_default_tooltip_handler
+(TableModel *model,
+ TableGetTooltipHandler tooltip_handler);
+TableGetTooltipHandler gnc_table_model_get_tooltip_handler
 (TableModel *model,
  const char * cell_name);
 

--- a/gnucash/register/register-gnome/gnucash-sheet.c
+++ b/gnucash/register/register-gnome/gnucash-sheet.c
@@ -2620,6 +2620,66 @@ gnucash_sheet_get_type (void)
     return gnucash_sheet_type;
 }
 
+
+static gboolean
+gnucash_sheet_tooltip (GtkWidget  *widget, gint x, gint y,
+               gboolean    keyboard_mode, GtkTooltip *tooltip,
+               gpointer    user_data)
+{
+    GnucashSheet *sheet = GNUCASH_SHEET (widget);
+    GnucashCursor *cursor = sheet->cursor;
+    Table *table = sheet->table;
+    VirtualLocation virt_loc;
+    gchar *tooltip_text;
+    gint cx, cy, cw, ch;
+    GdkRectangle rect;
+    SheetBlock *block;
+    gint bx, by;
+    gint hscroll_val, vscroll_val;
+
+    if (keyboard_mode)
+        return FALSE;
+
+    // get the scroll window values
+    hscroll_val = (gint) gtk_adjustment_get_value (sheet->hadj);
+    vscroll_val = (gint) gtk_adjustment_get_value (sheet->vadj);
+
+    if (!gnucash_sheet_find_loc_by_pixel (sheet, x + hscroll_val, y + vscroll_val, &virt_loc))
+        return FALSE;
+
+    tooltip_text = gnc_table_get_tooltip (table, virt_loc);
+
+    // if tooltip_text empty, clear tooltip and return FALSE
+    if ((tooltip_text == NULL) || (g_strcmp0 (tooltip_text,"") == 0))
+    {
+        gtk_tooltip_set_text (tooltip, NULL);
+        return FALSE;
+    }
+
+    block = gnucash_sheet_get_block (sheet, virt_loc.vcell_loc);
+    if (block == NULL)
+        return FALSE;
+
+    bx = block->origin_x;
+    by = block->origin_y;
+
+    // get the cell location and dimensions
+    gnucash_sheet_style_get_cell_pixel_rel_coords (cursor->style,
+            virt_loc.phys_row_offset, virt_loc.phys_col_offset,
+            &cx, &cy, &cw, &ch);
+
+     rect.x = cx + bx - hscroll_val;
+     rect.y = cy + by - vscroll_val;
+     rect.width = cw;
+     rect.height = ch;
+
+     gtk_tooltip_set_tip_area (tooltip, &rect);
+     gtk_tooltip_set_text (tooltip, tooltip_text);
+     g_free (tooltip_text);
+     return TRUE;
+}
+
+
 GtkWidget *
 gnucash_sheet_new (Table *table)
 {
@@ -2639,6 +2699,11 @@ gnucash_sheet_new (Table *table)
     sheet->dimensions_hash_table = g_hash_table_new_full (g_int_hash,
                                    g_int_equal,
                                    g_free, NULL);
+
+    /* add tooltips to sheet */
+    gtk_widget_set_has_tooltip (GTK_WIDGET(sheet), TRUE);
+    g_signal_connect(G_OBJECT(sheet), "query-tooltip",
+                     G_CALLBACK(gnucash_sheet_tooltip), NULL);
 
     gnucash_sheet_refresh_from_prefs(sheet);
 


### PR DESCRIPTION
First up, not sure if this should be against maint or master but can be changed if required.
The first patch adds the ability to create register tooltips based on cell type.
The second adds a couple of tooltips, one is based on the recn cell, this shows the reconciled date and the void reason if the transaction is voided. The other is based on the associate cell and shows the uri associated to a transaction if present. The reason for tooltips was I was thinking about a wide register layout and this would allow me to remove the void reason cell.

This could be extended to tooltips for the header but not sure if that would be required.

The last patch is for Bug 796545, not sure whether this covers the problem but maybe a start to see what is possible. There was another bug which mentions a tooltip for the date cell but I am unsure about that.