### PR TITLE
Reconciliation report amendments for 796614

### DIFF
--- a/gnucash/report/standard-reports/test/test-transaction.scm
+++ b/gnucash/report/standard-reports/test/test-transaction.scm
@@ -901,13 +901,13 @@
       (set-option! options "General" "End Date" (cons 'absolute (gnc-dmy2time64 31 03 1970)))
       (let ((sxml (options->sxml options "filter reconcile date")))
         (test-equal "test reconciled amounts = $8"
-          (list "Total For Reconciled" "-$8.00")
+          (list "Total For Reconciled" "$8.00")
           (get-row-col sxml 3 #f))
         (test-equal "test cleared amounts = $29"
           (list "Total For Cleared" "$29.00")
           (get-row-col sxml 6 #f))
-        (test-equal "test unreconciled amounts = -$31"
-          (list "Total For Unreconciled" "-$31.00")
+        (test-equal "test unreconciled amounts = $31"
+          (list "Total For Unreconciled" "$31.00")
           (get-row-col sxml 11 #f))
         sxml)
       )))

--- a/gnucash/report/standard-reports/transaction.scm
+++ b/gnucash/report/standard-reports/transaction.scm
@@ -2041,6 +2041,11 @@ be excluded from periodic reporting.")
                             (qof-print-date begindate)
                             (qof-print-date enddate)))))
 
+                (if (eq? infobox-display 'always)
+                    (gnc:html-document-add-object!
+                     document
+                     (gnc:html-render-options-changed options)))
+
                 (if (and (opt-val gnc:pagename-display optname-grid)
                          (if (memq primary-key DATE-SORTING-TYPES)
                              (keylist-get-info date-subtotal-list primary-date-subtotal 'renderer-fn)
@@ -2054,11 +2059,6 @@ be excluded from periodic reporting.")
                            (list-of-cols (stable-sort! (delete 'col-total (grid-cols grid)) generic<?)))
                       (gnc:html-document-add-object!
                        document (grid->html-table grid list-of-rows list-of-cols))))
-
-                (if (eq? infobox-display 'always)
-                    (gnc:html-document-add-object!
-                     document
-                     (gnc:html-render-options-changed options)))
 
                 (gnc:html-document-add-object! document table)))))
 

--- a/gnucash/report/standard-reports/transaction.scm
+++ b/gnucash/report/standard-reports/transaction.scm
@@ -1977,12 +1977,6 @@ be excluded from periodic reporting.")
 
           (qof-query-destroy query)
 
-          (if custom-sort?
-              (begin
-                (set! splits (stable-sort! splits date-comparator?))
-                (set! splits (stable-sort! splits secondary-comparator?))
-                (set! splits (stable-sort! splits primary-comparator?))))
-
           ;; Combined Filter:
           ;; - include/exclude using split->date according to date options
           ;; - include/exclude splits to/from selected accounts
@@ -2012,6 +2006,11 @@ be excluded from periodic reporting.")
                                      (custom-split-filter split))
                                  )))
                         splits))
+
+          (when custom-sort?
+            (set! splits (stable-sort! splits date-comparator?))
+            (set! splits (stable-sort! splits secondary-comparator?))
+            (set! splits (stable-sort! splits primary-comparator?)))
 
           (if (null? splits)
 


### PR DESCRIPTION
This commit mainly amends the reconcile report in a few ways:
1. date filter applies to reconciliation date, rather than posted date. If reconciliation date does not exist (i.e. unreconciled split), the transaction is included anyway.
2. the balances are split to debit & credit (i.e. 'funds in', 'funds out') yet the subtotals are counted separately.

Supporting amendments:
1. test for reconciliation report
2. splits filtering is now done before sorting, because we want to sort a short splitlist.
3. modify trep-renderer to accept keyword args to support reconciliation report.
4. (unrelated) place the render-options summary above subtotal-grid