### PR TITLE
Multicolumn balsheet & profit'n'loss report :)

### DIFF
--- a/gnucash/report/standard-reports/CMakeLists.txt
+++ b/gnucash/report/standard-reports/CMakeLists.txt
@@ -9,6 +9,7 @@ set (standard_reports_SCHEME_2
     advanced-portfolio.scm
     average-balance.scm
     balance-sheet.scm
+    balsheet-pnl.scm
     budget-balance-sheet.scm
     budget-barchart.scm
     budget-flow.scm

--- a/gnucash/report/standard-reports/balsheet-pnl.scm
+++ b/gnucash/report/standard-reports/balsheet-pnl.scm
@@ -508,28 +508,21 @@
                                                                         (gnc:time64-end-day-time
                                                                          (list-ref reportdates col-idx))))))
                   (reportheaders (map qof-print-date reportdates))
-                  (add-to-table (lambda (title accounts)
+                  (add-to-table (lambda (title accounts summary?)
                                   (add-multicolumn-acct-table
                                    multicol-table title accounts
                                    maxindent get-cell-amount-fn reportheaders
                                    #:omit-zb-bals? omit-zb-bals?
                                    #:show-zb-accts? show-zb-accts?
                                    #:disable-indenting? export?
-                                   #:hierarchical-subtotals? subtotal-mode
-                                   #:depth-limit depth-limit))))
+                                   #:hierarchical-subtotals? (and (not summary?) subtotal-mode)
+                                   #:depth-limit (if summary? 0 depth-limit)))))
 
-             (add-to-table (_ "Asset") asset-accounts)
-             (add-to-table (_ "Liability") liability-accounts)
-             (add-to-table (_ "Equity") equity-accounts)
-             (add-multicolumn-acct-table
-              multicol-table (_ "Net Worth") (append asset-accounts liability-accounts)
-              maxindent get-cell-amount-fn reportheaders
-              #:disable-indenting? export?
-              #:hierarchical-subtotals? #f
-              #:depth-limit 0)
-
-             (unless (null? trading-accounts)
-               (add-to-table "TRADING" trading-accounts))
+             (add-to-table (_ "Asset") asset-accounts #f)
+             (add-to-table (_ "Liability") liability-accounts #f)
+             (add-to-table (_ "Equity") equity-accounts #f)
+             (add-to-table (_ "Trading Accounts") trading-accounts #f)
+             (add-to-table (_ "Net Worth") (append asset-accounts liability-accounts trading-accounts) #t
 
              (gnc:html-document-add-object!
               doc (gnc:html-render-options-changed (gnc:report-options report-obj)))
@@ -591,24 +584,19 @@
                                          (_ " to ")
                                          (qof-print-date (cdr pair))))
                                       report-datepairs))
-                  (add-to-table (lambda (title accounts)
+                  (add-to-table (lambda (title accounts summary?)
                                   (add-multicolumn-acct-table
                                    multicol-table title accounts
                                    maxindent get-cell-amount-fn reportheaders
                                    #:omit-zb-bals? omit-zb-bals?
                                    #:show-zb-accts? show-zb-accts?
                                    #:disable-indenting? export?
-                                   #:hierarchical-subtotals? subtotal-mode
-                                   #:depth-limit depth-limit))))
+                                   #:hierarchical-subtotals? (and (not summary?) subtotal-mode)
+                                   #:depth-limit (if summary? 0 depth-limit)))))
 
-             (add-to-table (_ "Income") income-accounts)
-             (add-to-table (_ "Expense") expense-accounts)
-             (add-multicolumn-acct-table
-              multicol-table (_ "Net Income") (append income-accounts expense-accounts)
-              maxindent get-cell-amount-fn reportheaders
-              #:disable-indenting? export?
-              #:hierarchical-subtotals? #f
-              #:depth-limit 0)
+             (add-to-table (_ "Income") income-accounts #f)
+             (add-to-table (_ "Expense") expense-accounts #f)
+             (add-to-table (_ "Net Income") (append income-accounts expense-accounts) #t)
 
              (gnc:html-document-add-object!
               doc (gnc:html-render-options-changed (gnc:report-options report-obj)))

--- a/gnucash/report/standard-reports/balsheet-pnl.scm
+++ b/gnucash/report/standard-reports/balsheet-pnl.scm
@@ -34,9 +34,6 @@
 (gnc:module-load "gnucash/report/report-system" 0)
 
 ;; define all option's names and help text so that they are properly
-;; defined in *one* place.
-(define optname-report-title (N_ "Report Title"))
-(define opthelp-report-title (N_ "Title for this report."))
 
 (define optname-company-name (N_ "Company name"))
 (define opthelp-company-name (N_ "Name of company/individual."))
@@ -183,17 +180,12 @@ available, i.e. closest to today's prices."))))))
   (cdr (assq info (cdr (assq key keylist)))))
 
 ;; options generator
-(define (multicol-report-options-generator report-type reportname)
+(define (multicol-report-options-generator report-type)
   (let* ((options (gnc:new-options))
          (book (gnc-get-current-book))
          (add-option
           (lambda (new-option)
             (gnc:register-option options new-option))))
-
-    (add-option
-     (gnc:make-string-option
-      gnc:pagename-general optname-report-title
-      "a" opthelp-report-title (_ reportname)))
 
     (add-option
      (gnc:make-string-option
@@ -271,12 +263,12 @@ available, i.e. closest to today's prices."))))))
          ((pnl) pricesource-list-pnl)
          ((balsheet) pricesource-list-balsheet)))))
 
-    ;; what to show for zero-balance accounts
     (add-option
      (gnc:make-simple-boolean-option
       pagename-commodities optname-show-foreign
       "e" opthelp-show-foreign #t))
 
+    ;; what to show for zero-balance accounts
     (add-option
      (gnc:make-simple-boolean-option
       gnc:pagename-display optname-show-zb-accts
@@ -551,16 +543,16 @@ available, i.e. closest to today's prices."))))))
 ;; multicol-report-renderer
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define (multicol-report-renderer report-obj report-type reportname)
+(define (multicol-report-renderer report-obj report-type)
   (define (get-option pagename optname)
     (gnc:option-value
      (gnc:lookup-option
       (gnc:report-options report-obj) pagename optname)))
 
-  (gnc:report-starting reportname)
+  (gnc:report-starting (get-option gnc:pagename-general gnc:optname-reportname))
 
   ;; get all options values
-  (let* ((report-title (get-option gnc:pagename-general optname-report-title))
+  (let* ((report-title (get-option gnc:pagename-general gnc:optname-reportname))
          (company-name (get-option gnc:pagename-general optname-company-name))
          (startdate (gnc:date-option-absolute-time
                      (get-option gnc:pagename-general
@@ -619,7 +611,7 @@ available, i.e. closest to today's prices."))))))
         (gnc:html-document-add-object!
          doc
          (gnc:html-make-no-account-warning
-          reportname (gnc:report-id report-obj)))
+          report-title (gnc:report-id report-obj)))
 
         (case report-type
           ((balsheet)
@@ -837,15 +829,15 @@ td.total-number-cell { border-top-style:solid; border-top-width: 1px; border-bot
  'name balsheet-reportname
  'report-guid "065d5d5a77ba11e8b31e83ada73c5eea"
  'menu-path (list gnc:menuname-asset-liability)
- 'options-generator (lambda () (multicol-report-options-generator 'balsheet balsheet-reportname))
- 'renderer (lambda (rpt) (multicol-report-renderer rpt 'balsheet balsheet-reportname)))
+ 'options-generator (lambda () (multicol-report-options-generator 'balsheet))
+ 'renderer (lambda (rpt) (multicol-report-renderer rpt 'balsheet)))
 
 (gnc:define-report
  'version 1
  'name pnl-reportname
  'report-guid "0e94fd0277ba11e8825d43e27232c9d4"
  'menu-path (list gnc:menuname-income-expense)
- 'options-generator (lambda () (multicol-report-options-generator 'pnl pnl-reportname))
- 'renderer (lambda (rpt) (multicol-report-renderer rpt 'pnl pnl-reportname)))
+ 'options-generator (lambda () (multicol-report-options-generator 'pnl))
+ 'renderer (lambda (rpt) (multicol-report-renderer rpt 'pnl)))
 
 ;; END

--- a/gnucash/report/standard-reports/balsheet-pnl.scm
+++ b/gnucash/report/standard-reports/balsheet-pnl.scm
@@ -45,7 +45,7 @@
 (define opthelp-period (_ "Duration between time periods"))
 
 (define optname-export (_ "Disable indenting for export?"))
-(define opthelp-export (_ "Selecting this option disables indenting for export"))
+(define opthelp-export (_ "Selecting this option disables indenting for export, and enables full account name instead."))
 
 (define optname-accounts (N_ "Accounts"))
 (define opthelp-accounts (N_ "Report on these accounts, if display depth allows."))
@@ -430,7 +430,9 @@ available, i.e. closest to today's prices."))))))
                (next (and (pair? rest) (car rest)))
                (lvl-curr (gnc-account-get-current-depth curr))
                (lvl-next (if next (gnc-account-get-current-depth next) 0))
-               (curr-label (xaccAccountGetName curr))
+               (curr-label ((if disable-indenting?
+                                gnc-account-get-full-name
+                                xaccAccountGetName) curr))
                (curr-commodity (xaccAccountGetCommodity curr))
                (curr-descendants-list (if (not hierarchical-subtotals?)
                                           (gnc-account-get-descendants curr)

--- a/gnucash/report/standard-reports/balsheet-pnl.scm
+++ b/gnucash/report/standard-reports/balsheet-pnl.scm
@@ -83,8 +83,8 @@
   (N_ "Causes the Closing Entries Pattern to be treated as a regular expression."))
 
 (define pagename-commodities (N_ "Commodities"))
-(define optname-include-chart (N_ "Include a chart"))
-(define opthelp-include-chart (N_ "Include a barchart"))
+(define optname-include-chart (N_ "Enable chart"))
+(define opthelp-include-chart (N_ "Enable link to barchart report"))
 
 (define optname-common-currency (N_ "Convert to common currency"))
 (define opthelp-common-currency (N_ "Convert all amounts to a single currency."))
@@ -101,6 +101,8 @@
 ;; (define opthelp-show-rates (N_ "Show the exchange rates used."))
 
 (define trep-uuid "2fe3b9833af044abb929a88d5a59620f")
+(define networth-barchart-uuid "cbba1696c8c24744848062c7f1cf4a72")
+(define pnl-barchart-uuid "80769921e87943adade887b9835a7685")
 
 (define periodlist
   (list
@@ -214,6 +216,11 @@ available, i.e. closest to today's prices."))))))
       gnc:pagename-general optname-export
       "c3" opthelp-export #f))
 
+    (add-option
+     (gnc:make-simple-boolean-option
+      gnc:pagename-general optname-include-chart
+      "d" opthelp-include-chart #f))
+
     #;
     (add-option
     (gnc:make-simple-boolean-option
@@ -242,16 +249,6 @@ available, i.e. closest to today's prices."))))))
      "b" opthelp-depth-limit 'all)
 
     ;; all about currencies
-    ;; chart not implemented yet
-    ;; (add-option
-    ;;  (gnc:make-simple-boolean-option
-    ;;   pagename-commodities optname-include-chart
-    ;;   "a" opthelp-include-chart #f))
-
-    (add-option
-     (gnc:make-internal-option
-      pagename-commodities optname-include-chart #f))
-
     (add-option
      (gnc:make-simple-boolean-option
       pagename-commodities optname-common-currency
@@ -588,7 +585,7 @@ available, i.e. closest to today's prices."))))))
                                     optname-omit-zb-bals))
          (use-links? (get-option gnc:pagename-display
                                  optname-account-links))
-         (include-chart? (get-option pagename-commodities optname-include-chart))
+         (include-chart? (get-option gnc:pagename-general optname-include-chart))
          (common-currency (and (or include-chart?
                                    (get-option pagename-commodities optname-common-currency))
                                (get-option pagename-commodities optname-report-commodity)))
@@ -660,8 +657,17 @@ available, i.e. closest to today's prices."))))))
                                                                               (< (split-date a) (split-date b)))))
                                                (split (and (pair? sorted-splits) (last sorted-splits))))
                                           (and split
-                                               (gnc:split-anchor-text split)
-                                               #;(gnc:account-anchor-text account)))))
+                                               (gnc:split-anchor-text split)))))
+                  (chart (and include-chart?
+                              (gnc:make-report-anchor
+                               networth-barchart-uuid report-obj
+                               (list (list "General" "Start Date" (cons 'absolute startdate))
+                                     (list "General" "End Date" (cons 'absolute enddate))
+                                     (list "General" "Report's currency" common-currency)
+                                     (list "General" "Price Source" (case price-source
+                                                                      ((nearest) 'pricedb-nearest)
+                                                                      ((latest) 'pricedb-latest)))
+                                     (list "Accounts" "Accounts" (append asset-accounts liability-accounts))))))
                   (add-to-table (lambda (title accounts disable-headers? summary?)
                                   (add-multicolumn-acct-table
                                    multicol-table title accounts
@@ -687,6 +693,12 @@ available, i.e. closest to today's prices."))))))
 
              (gnc:html-document-add-object!
               doc (gnc:html-render-options-changed (gnc:report-options report-obj)))
+
+             (if include-chart?
+                 (gnc:html-document-add-object!
+                  doc
+                  (gnc:make-html-text
+                   (gnc:html-markup-anchor chart "Barchart"))))
 
              (gnc:html-document-add-object!
               doc multicol-table)))
@@ -755,13 +767,22 @@ available, i.e. closest to today's prices."))))))
                                                  ((endperiod) col-enddate)
                                                  ((latest) (current-time))))
                                               monetary))))
-                  (get-cell-anchor-fn (lambda (account col-datum)
-                                        (let ((datepair col-datum))
-                                          (gnc:make-report-anchor
-                                           trep-uuid report-obj
-                                           (list (list "General" "Start Date" (cons 'absolute (car datepair)))
-                                                 (list "General" "End Date" (cons 'absolute (cdr datepair)))
-                                                 (list "Accounts" "Accounts" (list account)))))))
+                  (get-cell-anchor-fn (lambda (account datepair)
+                                        (gnc:make-report-anchor
+                                         trep-uuid report-obj
+                                         (list (list "General" "Start Date" (cons 'absolute (car datepair)))
+                                               (list "General" "End Date" (cons 'absolute (cdr datepair)))
+                                               (list "Accounts" "Accounts" (list account))))))
+                  (chart (and include-chart?
+                              (gnc:make-report-anchor
+                               pnl-barchart-uuid report-obj
+                               (list (list "General" "Start Date" (cons 'absolute startdate))
+                                     (list "General" "End Date" (cons 'absolute enddate))
+                                     (list "General" "Report's currency" common-currency)
+                                     (list "General" "Price Source" (case price-source
+                                                                      ((latest) 'pricedb-latest)
+                                                                      (else 'pricedb-nearest)))
+                                     (list "Accounts" "Accounts" (append income-accounts expense-accounts))))))
                   (get-col-header-fn (lambda (col-datum)
                                        (gnc:make-html-text
                                         (qof-print-date (car col-datum))
@@ -790,8 +811,15 @@ available, i.e. closest to today's prices."))))))
              (gnc:html-document-add-object!
               doc (gnc:html-render-options-changed (gnc:report-options report-obj)))
 
+             (if include-chart?
+                 (gnc:html-document-add-object!
+                  doc
+                  (gnc:make-html-text
+                   (gnc:html-markup-anchor chart "Barchart"))))
+
              (gnc:html-document-add-object!
               doc multicol-table)))))
+
     (gnc:report-finished)
     (gnc:html-document-set-style-text!
      doc "

--- a/gnucash/report/standard-reports/balsheet-pnl.scm
+++ b/gnucash/report/standard-reports/balsheet-pnl.scm
@@ -94,8 +94,9 @@
 (define optname-price-source (N_ "Price Source"))
 (define opthelp-price-source (N_ "How to determine exchange rates."))
 
-;; (define optname-show-foreign (N_ "Show Foreign Currencies"))
-;; (define opthelp-show-foreign (N_ "Display any foreign currency amount in an account."))
+(define optname-show-foreign (N_ "Show Foreign Currencies"))
+(define opthelp-show-foreign (N_ "Display any foreign currency amount in an account."))
+
 ;; (define optname-show-rates (N_ "Show Exchange Rates"))
 ;; (define opthelp-show-rates (N_ "Show the exchange rates used."))
 
@@ -275,8 +276,14 @@ available, i.e. closest to today's prices."))))))
     ;; what to show for zero-balance accounts
     (add-option
      (gnc:make-simple-boolean-option
+      pagename-commodities optname-show-foreign
+      "e" opthelp-show-foreign #t))
+
+    (add-option
+     (gnc:make-simple-boolean-option
       gnc:pagename-display optname-show-zb-accts
       "a" opthelp-show-zb-accts #t))
+
     (add-option
      (gnc:make-simple-boolean-option
       gnc:pagename-display optname-omit-zb-bals
@@ -588,6 +595,7 @@ available, i.e. closest to today's prices."))))))
          (price-source (get-option pagename-commodities optname-price-source))
 
          ;; decompose the account list
+         (show-foreign? (get-option pagename-commodities optname-show-foreign))
          (split-up-accounts (gnc:decompose-accountlist accounts))
          (asset-accounts
           (assoc-ref split-up-accounts ACCT-TYPE-ASSET))
@@ -621,13 +629,14 @@ available, i.e. closest to today's prices."))))))
                   (maxindent (gnc-account-get-tree-depth (gnc-get-current-root-account)))
                   (report-dates (gnc:make-date-list startdate enddate incr))
                   (amount-col-amount (lambda (account col-datum)
-                                        (gnc:make-gnc-monetary
-                                         (xaccAccountGetCommodity account)
-                                         (xaccAccountGetBalanceAsOfDate
-                                          account
-                                          (gnc:time64-end-day-time col-datum)))))
+                                       (gnc:make-gnc-monetary
+                                        (xaccAccountGetCommodity account)
+                                        (xaccAccountGetBalanceAsOfDate
+                                         account
+                                         (gnc:time64-end-day-time col-datum)))))
                   (get-cell-fcur-fn (lambda (account col-datum)
                                       (and common-currency
+                                           show-foreign?
                                            (not (gnc-commodity-equal (xaccAccountGetCommodity account) common-currency))
                                            (amount-col-amount account col-datum))))
                   (get-cell-amount-fn (lambda (account col-datum)
@@ -730,6 +739,7 @@ available, i.e. closest to today's prices."))))))
                                               (closing-adjustment account startdate enddate))))))
                   (get-cell-fcur-fn (lambda (account col-datum)
                                       (and common-currency
+                                           show-foreign?
                                            (not (gnc-commodity-equal (xaccAccountGetCommodity account) common-currency))
                                            (account-col-amount account col-datum))))
                   (get-cell-amount-fn (lambda (account col-datum)

--- a/gnucash/report/standard-reports/balsheet-pnl.scm
+++ b/gnucash/report/standard-reports/balsheet-pnl.scm
@@ -322,24 +322,32 @@ available, i.e. closest to today's prices."))))))
           (get-col-header-fn #f)
           (get-cell-fcur-fn #f)
           (get-cell-anchor-fn #f))
-  ;; table - an existing html-table object
-  ;; title - string as the first row
-  ;; accountlist - list of accounts
-  ;; maxindent - maximum account depth
-
-  ;; cols-data - list of data to be passed as parameter to the following helper functions
-  ;; get-col-header-fn  - a lambda (cols-data) to produce html-object
-  ;; get-cell-amount-fn - a lambda (account cols-data) which produces a gnc-monetary
-  ;; get-cell-fcur-fn   - a lambda (account cols-data) which produces a gnc-monetary or #f
-  ;; get-cell-anchor-fn - a lambda (account cols-data) which produces a url string
 
   ;; this function will add a 2D grid into the html-table
   ;; the data cells are generated from (get-cell-amount-fn account col-datum)
   ;; the data cells may request an alternative (eg. original currency) monetary
-  ;;     by calling (get-cell-fcur-fn account datum)
   ;; horizontal labels are generated from calling (get-col-header-fn col-datum)
-  ;; vertical labels are the account list
-  ;; ^ the accountlist can have hierarchical multilevel subtotals displayed
+  ;; vertical labels are the account list. it can have multilevel subtotals.
+
+  ;; the following are compulsory arguments:
+  ;; table - an existing html-table object
+  ;; title - string as the first row
+  ;; accountlist - list of accounts
+  ;; maxindent - maximum account depth
+  ;; cols-data - list of data to be passed as parameter to the following helper functions
+  ;; get-cell-amount-fn - a lambda (account cols-data) which produces a gnc-monetary - this is compulsory
+
+  ;; the following are optional:
+  ;; omit-zb-bals?      - a boolean to omit "$0.00" amounts
+  ;; show-zb-accts?     - a boolean to omit whole account lines where all amounts are $0.00 (eg closed accts)
+  ;; disable-headers?   - a boolean to disable rendering headers
+  ;; disable-indenting? - a boolean to disable narrow-cell indenting, and render account full-name instead
+  ;; hierarchical-subtotals? - a boolean to enable multilevel subtotals. if disabled, the subtotal strategy is
+  ;;                           changed to 'recursive-balance' ie parents will receive all children amounts.
+  ;; depth-limit        - (untested) accounts whose levels exceed this depth limit are not shown
+  ;; get-col-header-fn  - a lambda (cols-data) to produce html-object - this is optional
+  ;; get-cell-fcur-fn   - a lambda (account cols-data) which produces a gnc-monetary or #f - optional
+  ;; get-cell-anchor-fn - a lambda (account cols-data) which produces a url string - optional
 
   (define num-columns (length cols-data))
 
@@ -464,7 +472,8 @@ available, i.e. closest to today's prices."))))))
                                                         (apply monetary+
                                                                (filter identity (curr-balance-display get-cell-fcur-fn col-datum))))
                                                    omit-zb-bals?
-                                                   (get-cell-anchor-fn curr col-datum))))
+                                                   (and get-cell-anchor-fn
+                                                        (get-cell-anchor-fn curr col-datum)))))
                                  cols-data)))
 
           (list-set! labels lvl-curr (gnc-account-get-full-name curr))

--- a/gnucash/report/standard-reports/balsheet-pnl.scm
+++ b/gnucash/report/standard-reports/balsheet-pnl.scm
@@ -270,11 +270,13 @@
       (gnc:html-table-cell-set-style! narrow "text-cell" 'attribute '("style" "width:1px"))
       narrow))
 
-  (define (add-indented-row indent label rest)
+  (define (add-indented-row indent label label-markup rest)
     (gnc:html-table-append-row!
      table
      (append (if disable-indenting? '() (make-list-thunk indent make-narrow-cell))
-             (list (gnc:make-html-table-cell/size 1 (if disable-indenting? 1 (- maxindent indent)) label))
+             (list (if label-markup
+                       (gnc:make-html-table-cell/size/markup 1 (if disable-indenting? 1 (- maxindent indent)) label-markup label)
+                       (gnc:make-html-table-cell/size 1 (if disable-indenting? 1 (- maxindent indent)) label)))
              rest)))
 
   (define (monetary+ . monetaries)
@@ -316,10 +318,11 @@
 
   ;; header ASSET/LIABILITY etc
   (add-indented-row 0
-                    (gnc:make-html-text (gnc:html-markup-b title))
+                    title
+                    "total-label-cell"
                     (map
                      (lambda (header)
-                       (gnc:make-html-text (gnc:html-markup-b header)))
+                       (gnc:make-html-table-cell/markup "total-number-cell" header))
                      list-of-headers))
 
   (let loop ((accountlist accountlist))
@@ -345,6 +348,7 @@
                    (or (not depth-limit) (<= lvl-curr depth-limit)))
               (add-indented-row lvl-curr
                                 (string-append curr-label (if (null? curr-descendants-list) "" "+"))
+                                "text-cell"
                                 (map
                                  (lambda (col-idx)
                                    (gnc:make-html-table-cell/markup
@@ -390,10 +394,10 @@
                                    (or (not depth-limit) (<= lvl depth-limit))
                                    (list-ref labels lvl)))
                           (add-indented-row lvl
-                                            (gnc:make-html-text
-                                             (gnc:html-markup-b
-                                              "Total for "
-                                              (list-ref labels lvl)))
+                                            (string-append
+                                             "Total for "
+                                             (list-ref labels lvl))
+                                            "total-label-cell"
                                             (map
                                              (lambda (level-subtotal)
                                                (gnc:make-html-table-cell/markup

--- a/gnucash/report/standard-reports/balsheet-pnl.scm
+++ b/gnucash/report/standard-reports/balsheet-pnl.scm
@@ -300,7 +300,7 @@ available, i.e. closest to today's prices."))))))
       (add-option
        (gnc:make-simple-boolean-option
         gnc:pagename-general optname-include-overall-period
-        "e" opthepl-include-overall-period #t))
+        "e" opthelp-include-overall-period #f))
 
       ;; closing entry match criteria
       (add-option
@@ -811,9 +811,9 @@ available, i.e. closest to today's prices."))))))
                                                    (gnc:exchange-by-pricedb-nearest
                                                     monetary common-currency
                                                     (case price-source
-                                                      ((startperiod) col-startdate)
-                                                      ((midperiod) (floor (/ (+ col-startdate col-enddate) 2)))
-                                                      ((endperiod) col-enddate)
+                                                      ((startperiod) startdate)
+                                                      ((midperiod) (floor (/ (+ startdate enddate) 2)))
+                                                      ((endperiod) enddate)
                                                       ((latest) (current-time)))))
                                               monetary))))
                   (get-cell-anchor-fn (lambda (account datepair)

--- a/gnucash/report/standard-reports/balsheet-pnl.scm
+++ b/gnucash/report/standard-reports/balsheet-pnl.scm
@@ -407,10 +407,16 @@ available, i.e. closest to today's prices."))))))
                                        (map (lambda (acc) (get-cell-fn acc idx))
                                             (cons curr curr-descendants-list)))))
 
-          (if (and (or show-zb-accts? (not (every zero? (map (lambda (col-idx)
-                                                               (gnc:gnc-monetary-amount
-                                                                (get-cell-amount-fn curr col-idx)))
-                                                             (iota num-columns)))))
+          (if (and (or show-zb-accts?
+                       ;; the following function tests whether accounts (with descendants) of
+                       ;; all columns are zero
+                       (not (every zero? (concatenate
+                                          (map (lambda (acc)
+                                                 (map (lambda (col-idx)
+                                                        (gnc:gnc-monetary-amount
+                                                         (get-cell-amount-fn acc col-idx)))
+                                                      (iota num-columns)))
+                                               (cons curr (gnc-account-get-descendants curr)))))))
                    (or (not depth-limit) (<= lvl-curr depth-limit)))
               (add-indented-row lvl-curr
                                 (string-append curr-label (if (null? curr-descendants-list) "" "+"))

--- a/gnucash/report/standard-reports/balsheet-pnl.scm
+++ b/gnucash/report/standard-reports/balsheet-pnl.scm
@@ -133,17 +133,38 @@
                 (cons 'text (_ "week"))
                 (cons 'tip (_ "every 7 days"))))))
 
-(define pricesource-list
+(define pricesource-list-balsheet
   (list
    (cons 'nearest (list
                    (cons 'text (_ "nearest"))
-                   (cons 'tip (_ "Nearest to date. Balance sheet prices
-are converted using the price on the balance sheet date. Profit & loss prices are
-converted to a price midpoint in the reporting period."))))
+                   (cons 'tip (_ "Nearest to date. Balance sheet prices \
+are converted using the price on the balance sheet date."))))
 
    (cons 'latest (list
                   (cons 'text (_ "latest"))
-                  (cons 'tip (_ "Latest price. This uses the latest prices
+                  (cons 'tip (_ "Latest price. This uses the latest prices \
+available, i.e. closest to today's prices."))))))
+
+(define pricesource-list-pnl
+  (list
+   (cons 'startperiod (list
+                       (cons 'text (_ "start-period"))
+                       (cons 'tip (_ "Prices closest to the start of the reporting period \
+are used."))))
+
+   (cons 'midperiod (list
+                     (cons 'text (_ "mid-period"))
+                     (cons 'tip (_ "Prices in the middle of the reporting period \
+are used."))))
+
+   (cons 'endperiod (list
+                     (cons 'text (_ "end-period"))
+                     (cons 'tip (_ "Prices in the end of the reporting period \
+are used."))))
+
+   (cons 'latest (list
+                  (cons 'text (_ "latest"))
+                  (cons 'tip (_ "Latest price. This uses the latest prices \
 available, i.e. closest to today's prices."))))))
 
 (define (keylist->vectorlist keylist)
@@ -243,8 +264,13 @@ available, i.e. closest to today's prices."))))))
      (gnc:make-multichoice-option
       pagename-commodities optname-price-source
       "d" opthelp-price-source
-      'nearest
-      (keylist->vectorlist pricesource-list)))
+      (case report-type
+        ((pnl) 'midperiod)
+        ((balsheet) 'nearest))
+      (keylist->vectorlist
+       (case report-type
+         ((pnl) pricesource-list-pnl)
+         ((balsheet) pricesource-list-balsheet)))))
 
     ;; what to show for zero-balance accounts
     (add-option
@@ -708,7 +734,9 @@ available, i.e. closest to today's prices."))))))
                                               (gnc:exchange-by-pricedb-nearest
                                                monetary common-currency
                                                (case price-source
-                                                 ((nearest) (floor (/ (+ col-startdate col-enddate) 2)))
+                                                 ((startperiod) col-startdate)
+                                                 ((midperiod) (floor (/ (+ col-startdate col-enddate) 2)))
+                                                 ((endperiod) col-enddate)
                                                  ((latest) (current-time))))
                                               monetary))))
                   (get-cell-anchor-fn (lambda (account col-idx)

--- a/gnucash/report/standard-reports/balsheet-pnl.scm
+++ b/gnucash/report/standard-reports/balsheet-pnl.scm
@@ -82,9 +82,18 @@
 (define opthelp-closing-regexp
   (N_ "Causes the Closing Entries Pattern to be treated as a regular expression."))
 
-;; (define pagename-commodities (N_ "Commodities"))
-;; (define optname-report-commodity (N_ "Report's currency"))
-;; (define optname-price-source (N_ "Price Source"))
+(define pagename-commodities (N_ "Commodities"))
+(define optname-include-chart (N_ "Include a chart"))
+(define opthelp-include-chart (N_ "Include a barchart"))
+
+(define optname-common-currency (N_ "Convert to common currency"))
+(define opthelp-common-currency (N_ "Convert all amounts to a single currency."))
+
+(define optname-report-commodity (N_ "Report's currency"))
+
+(define optname-price-source (N_ "Price Source"))
+(define opthelp-price-source (N_ "How to determine exchange rates."))
+
 ;; (define optname-show-foreign (N_ "Show Foreign Currencies"))
 ;; (define opthelp-show-foreign (N_ "Display any foreign currency amount in an account."))
 ;; (define optname-show-rates (N_ "Show Exchange Rates"))
@@ -123,6 +132,19 @@
                 (cons 'delta WeekDelta)
                 (cons 'text (_ "week"))
                 (cons 'tip (_ "every 7 days"))))))
+
+(define pricesource-list
+  (list
+   (cons 'nearest (list
+                   (cons 'text (_ "nearest"))
+                   (cons 'tip (_ "Nearest to date. Balance sheet prices
+are converted using the price on the balance sheet date. Profit & loss prices are
+converted to a price midpoint in the reporting period."))))
+
+   (cons 'latest (list
+                  (cons 'text (_ "latest"))
+                  (cons 'tip (_ "Latest price. This uses the latest prices
+available, i.e. closest to today's prices."))))))
 
 (define (keylist->vectorlist keylist)
   (map
@@ -197,6 +219,33 @@
      options gnc:pagename-accounts optname-depth-limit
      "b" opthelp-depth-limit 'all)
 
+    ;; all about currencies
+    ;; chart not implemented yet
+    ;; (add-option
+    ;;  (gnc:make-simple-boolean-option
+    ;;   pagename-commodities optname-include-chart
+    ;;   "a" opthelp-include-chart #f))
+
+    (add-option
+     (gnc:make-internal-option
+      pagename-commodities optname-include-chart #f))
+
+    (add-option
+     (gnc:make-simple-boolean-option
+      pagename-commodities optname-common-currency
+      "b" opthelp-common-currency #f))
+
+    (gnc:options-add-currency!
+     options pagename-commodities
+     optname-report-commodity "c")
+
+    (add-option
+     (gnc:make-multichoice-option
+      pagename-commodities optname-price-source
+      "d" opthelp-price-source
+      'nearest
+      (keylist->vectorlist pricesource-list)))
+
     ;; what to show for zero-balance accounts
     (add-option
      (gnc:make-simple-boolean-option
@@ -246,6 +295,7 @@
           (disable-indenting? #f)
           (hierarchical-subtotals? #t)
           (depth-limit #f)
+          (get-cell-fcur-fn #f)
           (get-cell-anchor-fn #f))
   ;; table - an existing html-table object
   ;; title - string as the first row
@@ -294,8 +344,14 @@
        monetaries)
       (coll 'format gnc:make-gnc-monetary #f)))
 
-  (define (list-of-monetary->html-text monetaries omit-zero? anchor)
+  (define (list-of-monetary->html-text monetaries monetaries-fcur omit-zero? anchor)
     (let ((text (gnc:make-html-text)))
+      (if monetaries-fcur
+          (for-each
+           (lambda (monetary)
+             (if (not (and omit-zero? (zero? (gnc:gnc-monetary-amount monetary))))
+                 (gnc:html-text-append! text monetary (gnc:html-markup-br))))
+           monetaries-fcur))
       (for-each
        (lambda (monetary)
          (if (not (and omit-zero? (zero? (gnc:gnc-monetary-amount monetary))))
@@ -343,8 +399,8 @@
                (curr-descendants-list (if (not hierarchical-subtotals?)
                                           (gnc-account-get-descendants curr)
                                           '()))
-               (curr-balance-display (lambda (idx)
-                                       (map (lambda (acc) (get-cell-amount-fn acc idx))
+               (curr-balance-display (lambda (get-cell-fn idx)
+                                       (map (lambda (acc) (get-cell-fn acc idx))
                                             (cons curr curr-descendants-list)))))
 
           (if (and (or show-zb-accts? (not (every zero? (map (lambda (col-idx)
@@ -359,7 +415,10 @@
                                  (lambda (col-idx)
                                    (gnc:make-html-table-cell/markup
                                     "number-cell" (list-of-monetary->html-text
-                                                   (apply monetary+ (curr-balance-display col-idx))
+                                                   (apply monetary+ (curr-balance-display get-cell-amount-fn col-idx))
+                                                   (and get-cell-fcur-fn
+                                                        (apply monetary+
+                                                               (filter identity (curr-balance-display get-cell-fcur-fn col-idx))))
                                                    omit-zb-bals?
                                                    (get-cell-anchor-fn curr col-idx))))
                                  (iota num-columns))))
@@ -419,7 +478,7 @@
                                            (lambda (level-subtotal)
                                              (gnc:make-html-table-cell/markup
                                               "total-number-cell"
-                                              (list-of-monetary->html-text level-subtotal #f #f)))
+                                              (list-of-monetary->html-text level-subtotal #f #f #f)))
                                            level-subtotals)))
                     (list-set! labels lvl #f)
                     (for-each
@@ -475,6 +534,11 @@
                                     optname-omit-zb-bals))
          (use-links? (get-option gnc:pagename-display
                                  optname-account-links))
+         (include-chart? (get-option pagename-commodities optname-include-chart))
+         (common-currency (and (or include-chart?
+                                   (get-option pagename-commodities optname-common-currency))
+                               (get-option pagename-commodities optname-report-commodity)))
+         (price-source (get-option pagename-commodities optname-price-source))
 
          ;; decompose the account list
          (split-up-accounts (gnc:decompose-accountlist accounts))
@@ -509,12 +573,29 @@
            (let* ((multicol-table (gnc:make-html-table))
                   (maxindent (gnc-account-get-tree-depth (gnc-get-current-root-account)))
                   (reportdates (gnc:make-date-list startdate enddate incr))
-                  (get-cell-amount-fn (lambda (account col-idx)
+                  (amount-col-amount (lambda (account col-idx)
                                         (gnc:make-gnc-monetary
                                          (xaccAccountGetCommodity account)
-                                         (xaccAccountGetBalanceAsOfDate account
-                                                                        (gnc:time64-end-day-time
-                                                                         (list-ref reportdates col-idx))))))
+                                         (xaccAccountGetBalanceAsOfDate
+                                          account
+                                          (gnc:time64-end-day-time
+                                           (list-ref reportdates col-idx))))))
+                  (get-cell-fcur-fn (lambda (account col-idx)
+                                      (and common-currency
+                                           (not (gnc-commodity-equal (xaccAccountGetCommodity account) common-currency))
+                                           (amount-col-amount account col-idx))))
+                  (get-cell-amount-fn (lambda (account col-idx)
+                                        (let* ((col-date (gnc:time64-end-day-time (list-ref reportdates col-idx)))
+                                               (monetary (gnc:make-gnc-monetary
+                                                          (xaccAccountGetCommodity account)
+                                                          (xaccAccountGetBalanceAsOfDate account col-date))))
+                                          (if common-currency
+                                              (gnc:exchange-by-pricedb-nearest
+                                               monetary common-currency
+                                               (case price-source
+                                                 ((nearest) col-date)
+                                                 ((latest) (current-time))))
+                                              monetary))))
                   (get-cell-anchor-fn (lambda (account col-idx)
                                         (let* ((splits (xaccAccountGetSplitList account))
                                                (split-date (lambda (s) (xaccTransGetDate (xaccSplitGetParent s))))
@@ -538,6 +619,7 @@
                                    #:disable-indenting? export?
                                    #:hierarchical-subtotals? (and (not summary?) subtotal-mode)
                                    #:depth-limit (if summary? 0 depth-limit)
+                                   #:get-cell-fcur-fn (and common-currency get-cell-fcur-fn)
                                    #:get-cell-anchor-fn get-cell-anchor-fn
                                    ))))
 
@@ -591,7 +673,7 @@
                                                    todate)))
                                         (let ((account-closing-splits (filter include-split? closing-entries)))
                                           (apply + (map xaccSplitGetAmount account-closing-splits)))))
-                  (get-cell-amount-fn (lambda (account col-idx)
+                  (account-col-amount (lambda (account col-idx)
                                         (let* ((datepair (list-ref report-datepairs col-idx))
                                                (startdate (gnc:time64-start-day-time (car datepair)))
                                                (enddate (gnc:time64-end-day-time (cdr datepair))))
@@ -600,6 +682,22 @@
                                            (- (xaccAccountGetBalanceAsOfDate account enddate)
                                               (xaccAccountGetBalanceAsOfDate account startdate)
                                               (closing-adjustment account startdate enddate))))))
+                  (get-cell-fcur-fn (lambda (account col-idx)
+                                      (and common-currency
+                                           (not (gnc-commodity-equal (xaccAccountGetCommodity account) common-currency))
+                                           (account-col-amount account col-idx))))
+                  (get-cell-amount-fn (lambda (account col-idx)
+                                        (let* ((monetary (account-col-amount account col-idx))
+                                               (datepair (list-ref report-datepairs col-idx))
+                                               (col-startdate (car datepair))
+                                               (col-enddate (cdr datepair)))
+                                          (if common-currency
+                                              (gnc:exchange-by-pricedb-nearest
+                                               monetary common-currency
+                                               (case price-source
+                                                 ((nearest) (floor (/ (+ col-startdate col-enddate) 2)))
+                                                 ((latest) (current-time))))
+                                              monetary))))
                   (get-cell-anchor-fn (lambda (account col-idx)
                                         (let ((datepair (list-ref report-datepairs col-idx)))
                                           (gnc:make-report-anchor
@@ -621,8 +719,11 @@
                                    #:omit-zb-bals? omit-zb-bals?
                                    #:show-zb-accts? show-zb-accts?
                                    #:disable-indenting? export?
+                                   #:get-cell-fcur-fn get-cell-fcur-fn
+                                   #:disable-headers? disable-headers?
                                    #:hierarchical-subtotals? (and (not summary?) subtotal-mode)
                                    #:depth-limit (if summary? 0 depth-limit)
+                                   #:get-cell-fcur-fn (and common-currency get-cell-fcur-fn)
                                    #:get-cell-anchor-fn get-cell-anchor-fn))))
 
              (add-to-table (_ "Income") income-accounts #f)

--- a/gnucash/report/standard-reports/balsheet-pnl.scm
+++ b/gnucash/report/standard-reports/balsheet-pnl.scm
@@ -315,29 +315,36 @@ available, i.e. closest to today's prices."))))))
     options))
 
 (define* (add-multicolumn-acct-table
-          table title accountlist maxindent get-cell-amount-fn list-of-headers #:key
+          table title accountlist maxindent get-cell-amount-fn cols-data #:key
           (omit-zb-bals? #f)
           (show-zb-accts? #t)
           (disable-headers? #f)
           (disable-indenting? #f)
           (hierarchical-subtotals? #t)
           (depth-limit #f)
+          (get-col-header-fn #f)
           (get-cell-fcur-fn #f)
           (get-cell-anchor-fn #f))
   ;; table - an existing html-table object
   ;; title - string as the first row
   ;; accountlist - list of accounts
   ;; maxindent - maximum account depth
-  ;; list-of-headers - list of string
-  ;; get-cell-amount-fn - a lambda (account col-idx) which produces a gnc-monetary
+
+  ;; cols-data - list of data to be passed as parameter to the following helper functions
+  ;; get-col-header-fn  - a lambda (cols-data) to produce html-object
+  ;; get-cell-amount-fn - a lambda (account cols-data) which produces a gnc-monetary
+  ;; get-cell-fcur-fn   - a lambda (account cols-data) which produces a gnc-monetary or #f
+  ;; get-cell-anchor-fn - a lambda (account cols-data) which produces a url string
 
   ;; this function will add a 2D grid into the html-table
-  ;; the data cells are generated from (get-cell-amount account col-idx)
-  ;; horizontal labels are from list-of-headers
+  ;; the data cells are generated from (get-cell-amount-fn account col-datum)
+  ;; the data cells may request an alternative (eg. original currency) monetary
+  ;;     by calling (get-cell-fcur-fn account datum)
+  ;; horizontal labels are generated from calling (get-col-header-fn col-datum)
   ;; vertical labels are the account list
-  ;; ^ the accountlist will have hierarchical multilevel subtotals displayed
+  ;; ^ the accountlist can have hierarchical multilevel subtotals displayed
 
-  (define num-columns (length list-of-headers))
+  (define num-columns (length cols-data))
 
   (define (make-list-thunk n thunk)
     (let loop ((result '()) (n n))
@@ -399,23 +406,25 @@ available, i.e. closest to today's prices."))))))
 
   (define collectors
     (let loop ((result '())
-               (list-of-headers list-of-headers))
-      (if (null? list-of-headers) result
+               (i 0))
+      (if (= i num-columns) result
           (loop (cons (make-list-thunk maxindent gnc:make-commodity-collector)
                       result)
-                (cdr list-of-headers)))))
+                (1+ i)))))
 
   ;; header ASSET/LIABILITY etc
   (add-indented-row 0
                     title
                     "total-label-cell"
-                    (if disable-headers? '()
+                    (if (or disable-headers? (not get-col-header-fn))
+                        '()
                         (map
-                         (lambda (header)
-                           (let ((cell (gnc:make-html-table-cell/markup "total-label-cell" header)))
+                         (lambda (col-datum)
+                           (let* ((header (get-col-header-fn col-datum))
+                                  (cell (gnc:make-html-table-cell/markup "total-label-cell" header)))
                              (gnc:html-table-cell-set-style! cell "total-label-cell" 'attribute '("style" "text-align:right"))
                              cell))
-                         list-of-headers)))
+                         cols-data)))
 
   (let loop ((accountlist accountlist))
     (if (pair? accountlist)
@@ -438,26 +447,26 @@ available, i.e. closest to today's prices."))))))
                        ;; all columns are zero
                        (not (every zero? (concatenate
                                           (map (lambda (acc)
-                                                 (map (lambda (col-idx)
+                                                 (map (lambda (col-datum)
                                                         (gnc:gnc-monetary-amount
-                                                         (get-cell-amount-fn acc col-idx)))
-                                                      (iota num-columns)))
+                                                         (get-cell-amount-fn acc col-datum)))
+                                                      cols-data))
                                                (cons curr (gnc-account-get-descendants curr)))))))
                    (or (not depth-limit) (<= lvl-curr depth-limit)))
               (add-indented-row lvl-curr
                                 (string-append curr-label (if (null? curr-descendants-list) "" "+"))
                                 "text-cell"
                                 (map
-                                 (lambda (col-idx)
+                                 (lambda (col-datum)
                                    (gnc:make-html-table-cell/markup
                                     "number-cell" (list-of-monetary->html-text
-                                                   (apply monetary+ (curr-balance-display get-cell-amount-fn col-idx))
+                                                   (apply monetary+ (curr-balance-display get-cell-amount-fn col-datum))
                                                    (and get-cell-fcur-fn
                                                         (apply monetary+
-                                                               (filter identity (curr-balance-display get-cell-fcur-fn col-idx))))
+                                                               (filter identity (curr-balance-display get-cell-fcur-fn col-datum))))
                                                    omit-zb-bals?
-                                                   (get-cell-anchor-fn curr col-idx))))
-                                 (iota num-columns))))
+                                                   (get-cell-anchor-fn curr col-datum))))
+                                 cols-data)))
 
           (list-set! labels lvl-curr (gnc-account-get-full-name curr))
           ;; where the magic happens. this section will cycle
@@ -465,24 +474,26 @@ available, i.e. closest to today's prices."))))))
           ;; ALL account-depth levels from root to & including
           ;; current account-depth. each column/level collector
           ;; will accumulate account amount.
-          (let columns-loop ((col-idx 0))
-            (when (< col-idx num-columns)
+          (let columns-loop ((col-idx 0)
+                             (cols-data cols-data))
+            (when (pair? cols-data)
               (let level-loop ((level 0))
                 (when (<= level lvl-curr)
-                  (let ((mon (get-cell-amount-fn curr col-idx)))
+                  (let ((mon (get-cell-amount-fn curr (car cols-data))))
                     ((list-ref (list-ref collectors col-idx) level) 'add
                      (gnc:gnc-monetary-commodity mon)
                      (gnc:gnc-monetary-amount mon)))
                   (level-loop (1+ level))))
-              (columns-loop (1+ col-idx))))
+              (columns-loop (1+ col-idx) (cdr cols-data))))
 
           (cond
            ;; no change in level. reset the current level accumulator.
            ((= lvl-curr lvl-next)
-            (let columns-loop ((col-idx 0))
-              (when (< col-idx num-columns)
+            (let columns-loop ((col-idx 0)
+                               (cols-data cols-data))
+              (when (pair? cols-data)
                 ((list-ref (list-ref collectors col-idx) lvl-curr) 'reset #f #f)
-                (columns-loop (1+ col-idx)))))
+                (columns-loop (1+ col-idx) (cdr cols-data)))))
 
            ;; hierarchical subtotals. we're going UP hierarchy
            ;; towards the root. start from the current level (minus
@@ -608,23 +619,20 @@ available, i.e. closest to today's prices."))))))
           ((balsheet)
            (let* ((multicol-table (gnc:make-html-table))
                   (maxindent (gnc-account-get-tree-depth (gnc-get-current-root-account)))
-                  (reportdates (gnc:make-date-list startdate enddate incr))
-                  (amount-col-amount (lambda (account col-idx)
+                  (report-dates (gnc:make-date-list startdate enddate incr))
+                  (amount-col-amount (lambda (account col-datum)
                                         (gnc:make-gnc-monetary
                                          (xaccAccountGetCommodity account)
                                          (xaccAccountGetBalanceAsOfDate
                                           account
-                                          (gnc:time64-end-day-time
-                                           (list-ref reportdates col-idx))))))
-                  (get-cell-fcur-fn (lambda (account col-idx)
+                                          (gnc:time64-end-day-time col-datum)))))
+                  (get-cell-fcur-fn (lambda (account col-datum)
                                       (and common-currency
                                            (not (gnc-commodity-equal (xaccAccountGetCommodity account) common-currency))
-                                           (amount-col-amount account col-idx))))
-                  (get-cell-amount-fn (lambda (account col-idx)
-                                        (let* ((col-date (gnc:time64-end-day-time (list-ref reportdates col-idx)))
-                                               (monetary (gnc:make-gnc-monetary
-                                                          (xaccAccountGetCommodity account)
-                                                          (xaccAccountGetBalanceAsOfDate account col-date))))
+                                           (amount-col-amount account col-datum))))
+                  (get-cell-amount-fn (lambda (account col-datum)
+                                        (let* ((col-date (gnc:time64-end-day-time col-datum))
+                                               (monetary (amount-col-amount account col-datum)))
                                           (if common-currency
                                               (gnc:exchange-by-pricedb-nearest
                                                monetary common-currency
@@ -632,10 +640,10 @@ available, i.e. closest to today's prices."))))))
                                                  ((nearest) col-date)
                                                  ((latest) (current-time))))
                                               monetary))))
-                  (get-cell-anchor-fn (lambda (account col-idx)
+                  (get-cell-anchor-fn (lambda (account col-datum)
                                         (let* ((splits (xaccAccountGetSplitList account))
                                                (split-date (lambda (s) (xaccTransGetDate (xaccSplitGetParent s))))
-                                               (date (gnc:time64-end-day-time (list-ref reportdates col-idx)))
+                                               (date (gnc:time64-end-day-time col-datum))
                                                (valid-split? (lambda (s) (< (split-date s) date)))
                                                (valid-splits (filter valid-split? splits))
                                                (sorted-splits (stable-sort! valid-splits
@@ -645,11 +653,10 @@ available, i.e. closest to today's prices."))))))
                                           (and split
                                                (gnc:split-anchor-text split)
                                                #;(gnc:account-anchor-text account)))))
-                  (reportheaders (map qof-print-date reportdates))
                   (add-to-table (lambda (title accounts disable-headers? summary?)
                                   (add-multicolumn-acct-table
                                    multicol-table title accounts
-                                   maxindent get-cell-amount-fn reportheaders
+                                   maxindent get-cell-amount-fn report-dates
                                    #:omit-zb-bals? omit-zb-bals?
                                    #:show-zb-accts? show-zb-accts?
                                    #:disable-indenting? export?
@@ -657,6 +664,7 @@ available, i.e. closest to today's prices."))))))
                                    #:hierarchical-subtotals? (and (not summary?) subtotal-mode)
                                    #:depth-limit (if summary? 0 depth-limit)
                                    #:get-cell-fcur-fn (and common-currency get-cell-fcur-fn)
+                                   #:get-col-header-fn qof-print-date
                                    #:get-cell-anchor-fn get-cell-anchor-fn
                                    ))))
 
@@ -712,24 +720,22 @@ available, i.e. closest to today's prices."))))))
                                                    todate)))
                                         (let ((account-closing-splits (filter include-split? closing-entries)))
                                           (apply + (map xaccSplitGetAmount account-closing-splits)))))
-                  (account-col-amount (lambda (account col-idx)
-                                        (let* ((datepair (list-ref report-datepairs col-idx))
-                                               (startdate (gnc:time64-start-day-time (car datepair)))
-                                               (enddate (gnc:time64-end-day-time (cdr datepair))))
+                  (account-col-amount (lambda (account col-datum)
+                                        (let* ((startdate (gnc:time64-start-day-time (car col-datum)))
+                                               (enddate (gnc:time64-end-day-time (cdr col-datum))))
                                           (gnc:make-gnc-monetary
                                            (xaccAccountGetCommodity account)
                                            (- (xaccAccountGetBalanceAsOfDate account enddate)
                                               (xaccAccountGetBalanceAsOfDate account startdate)
                                               (closing-adjustment account startdate enddate))))))
-                  (get-cell-fcur-fn (lambda (account col-idx)
+                  (get-cell-fcur-fn (lambda (account col-datum)
                                       (and common-currency
                                            (not (gnc-commodity-equal (xaccAccountGetCommodity account) common-currency))
-                                           (account-col-amount account col-idx))))
-                  (get-cell-amount-fn (lambda (account col-idx)
-                                        (let* ((monetary (account-col-amount account col-idx))
-                                               (datepair (list-ref report-datepairs col-idx))
-                                               (col-startdate (car datepair))
-                                               (col-enddate (cdr datepair)))
+                                           (account-col-amount account col-datum))))
+                  (get-cell-amount-fn (lambda (account col-datum)
+                                        (let* ((monetary (account-col-amount account col-datum))
+                                               (col-startdate (car col-datum))
+                                               (col-enddate (cdr col-datum)))
                                           (if common-currency
                                               (gnc:exchange-by-pricedb-nearest
                                                monetary common-currency
@@ -739,24 +745,23 @@ available, i.e. closest to today's prices."))))))
                                                  ((endperiod) col-enddate)
                                                  ((latest) (current-time))))
                                               monetary))))
-                  (get-cell-anchor-fn (lambda (account col-idx)
-                                        (let ((datepair (list-ref report-datepairs col-idx)))
+                  (get-cell-anchor-fn (lambda (account col-datum)
+                                        (let ((datepair col-datum))
                                           (gnc:make-report-anchor
                                            trep-uuid report-obj
                                            (list (list "General" "Start Date" (cons 'absolute (car datepair)))
                                                  (list "General" "End Date" (cons 'absolute (cdr datepair)))
                                                  (list "Accounts" "Accounts" (list account)))))))
-                  (reportheaders (map (lambda (pair)
-                                        (gnc:make-html-text
-                                         (qof-print-date (car pair))
-                                         (gnc:html-markup-br)
-                                         (_ " to ")
-                                         (qof-print-date (cdr pair))))
-                                      report-datepairs))
+                  (get-col-header-fn (lambda (col-datum)
+                                       (gnc:make-html-text
+                                        (qof-print-date (car col-datum))
+                                        (gnc:html-markup-br)
+                                        (_ " to ")
+                                        (qof-print-date (cdr col-datum)))))
                   (add-to-table (lambda (title accounts disable-headers? summary?)
                                   (add-multicolumn-acct-table
                                    multicol-table title accounts
-                                   maxindent get-cell-amount-fn reportheaders
+                                   maxindent get-cell-amount-fn report-datepairs
                                    #:omit-zb-bals? omit-zb-bals?
                                    #:show-zb-accts? show-zb-accts?
                                    #:disable-indenting? export?
@@ -764,7 +769,9 @@ available, i.e. closest to today's prices."))))))
                                    #:hierarchical-subtotals? (and (not summary?) subtotal-mode)
                                    #:depth-limit (if summary? 0 depth-limit)
                                    #:get-cell-fcur-fn (and common-currency get-cell-fcur-fn)
-                                   #:get-cell-anchor-fn get-cell-anchor-fn))))
+                                   #:get-col-header-fn get-col-header-fn
+                                   #:get-cell-anchor-fn get-cell-anchor-fn
+                                   ))))
 
              (add-to-table (_ "Income") income-accounts #f #f)
              (add-to-table (_ "Expense") expense-accounts #t #f)

--- a/gnucash/report/standard-reports/balsheet-pnl.scm
+++ b/gnucash/report/standard-reports/balsheet-pnl.scm
@@ -510,6 +510,13 @@
              (add-to-table "ASSET" asset-accounts)
              (add-to-table "LIABILITY" liability-accounts)
              (add-to-table "EQUITY" equity-accounts)
+             (add-multicolumn-acct-table
+              multicol-table "Net Worth" (append asset-accounts liability-accounts)
+              maxindent get-cell-amount-fn reportheaders
+              #:disable-indenting? export?
+              #:hierarchical-subtotals? #f
+              #:depth-limit 0)
+
              (unless (null? trading-accounts)
                (add-to-table "TRADING" trading-accounts))
 
@@ -579,10 +586,14 @@
                                    #:hierarchical-subtotals? subtotal-mode
                                    #:depth-limit depth-limit))))
 
-             (add-to-table "INCOME" income-accounts)
-             (add-to-table "EXPENSE" expense-accounts)
-             (unless (null? trading-accounts)
-               (add-to-table "TRADING" trading-accounts))
+             (add-to-table (_ "Income") income-accounts)
+             (add-to-table (_ "Expense") expense-accounts)
+             (add-multicolumn-acct-table
+              multicol-table "Net Income" (append income-accounts expense-accounts)
+              maxindent get-cell-amount-fn reportheaders
+              #:disable-indenting? export?
+              #:hierarchical-subtotals? #f
+              #:depth-limit 0)
 
              (gnc:html-document-add-object!
               doc (gnc:html-render-options-changed (gnc:report-options report-obj)))

--- a/gnucash/report/standard-reports/balsheet-pnl.scm
+++ b/gnucash/report/standard-reports/balsheet-pnl.scm
@@ -244,9 +244,10 @@ available, i.e. closest to today's prices."))))))
          (gnc-account-get-descendants-sorted (gnc-get-current-root-account))))
       #f #t))
 
-    (gnc:options-add-account-levels!
-     options gnc:pagename-accounts optname-depth-limit
-     "b" opthelp-depth-limit 'all)
+    (add-option
+     (gnc:make-internal-option
+      gnc:pagename-accounts optname-depth-limit
+      'all))
 
     ;; all about currencies
     (add-option

--- a/gnucash/report/standard-reports/balsheet-pnl.scm
+++ b/gnucash/report/standard-reports/balsheet-pnl.scm
@@ -445,12 +445,14 @@ available, i.e. closest to today's prices."))))))
                                 gnc-account-get-full-name
                                 xaccAccountGetName) curr))
                (curr-commodity (xaccAccountGetCommodity curr))
-               (curr-descendants-list (if (not hierarchical-subtotals?)
-                                          (gnc-account-get-descendants curr)
-                                          '()))
-               (curr-balance-display (lambda (get-cell-fn idx)
+               (curr-descendants-list (if hierarchical-subtotals?
+                                          '()
+                                          (gnc-account-get-descendants curr)))
+               (curr-balance-display (lambda (get-cell-fn idx include-descendants?)
                                        (map (lambda (acc) (get-cell-fn acc idx))
-                                            (cons curr curr-descendants-list)))))
+                                            (cons curr (if include-descendants?
+                                                           curr-descendants-list
+                                                           '()))))))
 
           (if (and (or show-zb-accts?
                        ;; the following function tests whether accounts (with descendants) of
@@ -472,10 +474,10 @@ available, i.e. closest to today's prices."))))))
                                    (gnc:make-html-table-cell/markup
                                     "number-cell" (list-of-monetary->html-text
                                                    (apply monetary+
-                                                          (filter identity (curr-balance-display get-cell-amount-fn col-datum)))
+                                                          (filter identity (curr-balance-display get-cell-amount-fn col-datum #t)))
                                                    (and get-cell-fcur-fn
                                                         (apply monetary+
-                                                               (filter identity (curr-balance-display get-cell-fcur-fn col-datum))))
+                                                               (filter identity (curr-balance-display get-cell-fcur-fn col-datum #f))))
                                                    omit-zb-bals?
                                                    (and get-cell-anchor-fn
                                                         (get-cell-anchor-fn curr col-datum)))))

--- a/gnucash/report/standard-reports/balsheet-pnl.scm
+++ b/gnucash/report/standard-reports/balsheet-pnl.scm
@@ -1,0 +1,612 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; balsheet-pnl.scm: multi-column report. includes
+;; balance-sheet and p&l reports.
+;; 
+;; By Christopher Lam, 2018
+;;
+;; Improved from balance-sheet.scm
+;;
+;; This program is free software; you can redistribute it and/or    
+;; modify it under the terms of the GNU General Public License as   
+;; published by the Free Software Foundation; either version 2 of   
+;; the License, or (at your option) any later version.              
+;;                                                                  
+;; This program is distributed in the hope that it will be useful,  
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of   
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    
+;; GNU General Public License for more details.                     
+;;                                                                  
+;; You should have received a copy of the GNU General Public License
+;; along with this program; if not, contact:
+;;
+;; Free Software Foundation           Voice:  +1-617-542-5942
+;; 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652
+;; Boston, MA  02110-1301,  USA       gnu@gnu.org
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define-module (gnucash report standard-reports balsheet-pnl))
+(use-modules (gnucash utilities))
+(use-modules (gnucash gnc-module))
+(use-modules (gnucash gettext))
+(use-modules (srfi srfi-1))
+
+(gnc:module-load "gnucash/report/report-system" 0)
+
+;; define all option's names and help text so that they are properly
+;; defined in *one* place.
+(define optname-report-title (N_ "Report Title"))
+(define opthelp-report-title (N_ "Title for this report."))
+
+(define optname-company-name (N_ "Company name"))
+(define opthelp-company-name (N_ "Name of company/individual."))
+
+(define optname-startdate (N_ "Start Date"))
+(define optname-enddate (N_ "End Date"))
+
+(define optname-period (_ "Period duration"))
+(define opthelp-period (_ "Duration between time periods"))
+
+(define optname-export (_ "Disable indenting for export?"))
+(define opthelp-export (_ "Selecting this option disables indenting for export"))
+
+(define optname-accounts (N_ "Accounts"))
+(define opthelp-accounts (N_ "Report on these accounts, if display depth allows."))
+
+(define optname-depth-limit (N_ "Levels of Subaccounts"))
+(define opthelp-depth-limit (N_ "Maximum number of levels in the account tree displayed."))
+
+(define optname-subtotal-mode (N_ "Hierarchical subtotals"))
+(define opthelp-subtotal-mode (N_ "This option enables hierarchical subtotals, otherwise parent accounts receive children account balances"))
+
+(define optname-show-zb-accts (N_ "Include accounts with zero total balances"))
+(define opthelp-show-zb-accts (N_ "Include accounts with zero total (recursive) balances in this report."))
+
+(define optname-omit-zb-bals (N_ "Omit zero balance figures"))
+(define opthelp-omit-zb-bals (N_ "Show blank space in place of any zero balances which would be shown."))
+
+(define optname-account-links (N_ "Display accounts as hyperlinks"))
+(define opthelp-account-links (N_ "Shows each account in the table as a hyperlink to its register window."))
+
+;; closing entries filter - for P&L report
+(define pagename-entries "Entries")
+(define optname-closing-pattern (N_ "Closing Entries pattern"))
+(define opthelp-closing-pattern
+  (N_ "Any text in the Description column which identifies closing entries."))
+(define optname-closing-casing
+  (N_ "Closing Entries pattern is case-sensitive"))
+(define opthelp-closing-casing
+  (N_ "Causes the Closing Entries Pattern match to be case-sensitive."))
+(define optname-closing-regexp
+  (N_ "Closing Entries Pattern is regular expression"))
+(define opthelp-closing-regexp
+  (N_ "Causes the Closing Entries Pattern to be treated as a regular expression."))
+
+;; (define pagename-commodities (N_ "Commodities"))
+;; (define optname-report-commodity (N_ "Report's currency"))
+;; (define optname-price-source (N_ "Price Source"))
+;; (define optname-show-foreign (N_ "Show Foreign Currencies"))
+;; (define opthelp-show-foreign (N_ "Display any foreign currency amount in an account."))
+;; (define optname-show-rates (N_ "Show Exchange Rates"))
+;; (define opthelp-show-rates (N_ "Show the exchange rates used."))
+
+(define periodlist
+  (list
+   (cons 'year (list
+                (cons 'delta YearDelta)
+                (cons 'text (_ "year"))
+                (cons 'tip (_ "every year"))))
+
+   (cons 'halfyear (list
+                    (cons 'delta HalfYearDelta)
+                    (cons 'text (_ "half-year"))
+                    (cons 'tip (_ "every half year"))))
+
+   (cons 'quarter (list
+                   (cons 'delta QuarterDelta)
+                   (cons 'text (_ "quarter"))
+                   (cons 'tip (_ "every three months"))))
+
+   (cons 'month (list
+                 (cons 'delta MonthDelta)
+                 (cons 'text (_ "month"))
+                 (cons 'tip (_ "every month"))))
+
+   (cons 'twoweek (list
+                   (cons 'delta TwoWeekDelta)
+                   (cons 'text (_ "two weeks"))
+                   (cons 'tip (_ "every fortnight"))))
+
+   (cons 'week (list
+                (cons 'delta WeekDelta)
+                (cons 'text (_ "week"))
+                (cons 'tip (_ "every 7 days"))))))
+
+(define (keylist->vectorlist keylist)
+  (map
+   (lambda (item)
+     (vector
+      (car item)
+      (keylist-get-info keylist (car item) 'text)
+      (keylist-get-info keylist (car item) 'tip)))
+   keylist))
+
+(define (keylist-get-info keylist key info)
+  (cdr (assq info (cdr (assq key keylist)))))
+
+;; options generator
+(define (multicol-report-options-generator report-type reportname)
+  (let* ((options (gnc:new-options))
+         (book (gnc-get-current-book))
+         (add-option
+          (lambda (new-option)
+            (gnc:register-option options new-option))))
+
+    (add-option
+     (gnc:make-string-option
+      gnc:pagename-general optname-report-title
+      "a" opthelp-report-title (_ reportname)))
+
+    (add-option
+     (gnc:make-string-option
+      gnc:pagename-general optname-company-name
+      "b" opthelp-company-name (or (gnc:company-info book gnc:*company-name*) "")))
+
+    ;; date at which to report balance
+    (gnc:options-add-date-interval!
+     options gnc:pagename-general optname-startdate optname-enddate "c")
+
+    (add-option
+     (gnc:make-multichoice-option
+      gnc:pagename-general optname-period
+      "c2" opthelp-period
+      'halfyear
+      (keylist->vectorlist periodlist)))
+
+    (add-option
+     (gnc:make-simple-boolean-option
+      gnc:pagename-general optname-export
+      "c3" opthelp-export #f))
+
+    #;
+    (add-option
+    (gnc:make-simple-boolean-option
+    gnc:pagename-general optname-single-column
+    "d" opthelp-single-column #t))
+
+    ;; accounts to work on
+    (add-option
+     (gnc:make-account-list-option
+      gnc:pagename-accounts optname-accounts
+      "a"
+      opthelp-accounts
+      (lambda ()
+        (gnc:filter-accountlist-type
+         (list ACCT-TYPE-BANK ACCT-TYPE-CASH ACCT-TYPE-CREDIT
+               ACCT-TYPE-ASSET ACCT-TYPE-LIABILITY
+               ACCT-TYPE-STOCK ACCT-TYPE-MUTUAL ACCT-TYPE-CURRENCY
+               ACCT-TYPE-PAYABLE ACCT-TYPE-RECEIVABLE
+               ACCT-TYPE-EQUITY ACCT-TYPE-INCOME ACCT-TYPE-EXPENSE
+               ACCT-TYPE-TRADING)
+         (gnc-account-get-descendants-sorted (gnc-get-current-root-account))))
+      #f #t))
+
+    (gnc:options-add-account-levels!
+     options gnc:pagename-accounts optname-depth-limit
+     "b" opthelp-depth-limit 'all)
+
+    ;; what to show for zero-balance accounts
+    (add-option
+     (gnc:make-simple-boolean-option
+      gnc:pagename-display optname-show-zb-accts
+      "a" opthelp-show-zb-accts #t))
+    (add-option
+     (gnc:make-simple-boolean-option
+      gnc:pagename-display optname-omit-zb-bals
+      "b" opthelp-omit-zb-bals #f))
+
+    (add-option
+     (gnc:make-simple-boolean-option
+      gnc:pagename-display
+      optname-subtotal-mode 
+      "c" opthelp-subtotal-mode #t))
+
+    ;; some detailed formatting options
+    (add-option
+     (gnc:make-simple-boolean-option
+      gnc:pagename-display optname-account-links
+      "e" opthelp-account-links #t))
+    
+    (when (eq? report-type 'pnl)
+      ;; closing entry match criteria
+      (add-option
+       (gnc:make-string-option
+        pagename-entries optname-closing-pattern
+        "a" opthelp-closing-pattern (_ "Closing Entries")))
+      (add-option
+       (gnc:make-simple-boolean-option
+        pagename-entries optname-closing-casing
+        "b" opthelp-closing-casing #f))
+      (add-option
+       (gnc:make-simple-boolean-option
+        pagename-entries optname-closing-regexp
+        "c" opthelp-closing-regexp #f)))
+
+    ;; Set the accounts page as default option tab
+    (gnc:options-set-default-section options gnc:pagename-accounts)
+
+    options))
+
+(define* (add-multicolumn-acct-table
+          table title accountlist maxindent get-cell-amount-fn list-of-headers #:key
+          (omit-zb-bals? #f)
+          (show-zb-accts? #t)
+          (disable-indenting? #f)
+          (hierarchical-subtotals? #t)
+          (depth-limit #f))
+  ;; table - an existing html-table object
+  ;; title - string as the first row
+  ;; accountlist - list of accounts
+  ;; maxindent - maximum account depth
+  ;; list-of-headers - list of string
+  ;; get-cell-amount-fn - a lambda (account col-idx) which produces a numeric amount
+  ;;  of the same commodity as the account
+
+  ;; this function will add a 2D grid into the html-table
+  ;; the data cells are generated from (get-cell-amount account col-idx)
+  ;; horizontal labels are from list-of-headers
+  ;; vertical labels are the account list
+  ;; ^ the accountlist will have hierarchical multilevel subtotals displayed
+
+  (define num-columns (length list-of-headers))
+
+  (define (make-list-thunk n thunk)
+    (let loop ((result '()) (n n))
+      (if (zero? n) result
+          (loop (cons (thunk) result) (1- n)))))
+
+  (define (make-narrow-cell)
+    (let ((narrow (gnc:make-html-table-cell/markup "text-cell" #f)))
+      (gnc:html-table-cell-set-style! narrow "text-cell" 'attribute '("style" "width:1px"))
+      narrow))
+
+  (define (add-indented-row indent label rest)
+    (gnc:html-table-append-row!
+     table
+     (append (if disable-indenting? '() (make-list-thunk indent make-narrow-cell))
+             (list (gnc:make-html-table-cell/size 1 (if disable-indenting? 1 (- maxindent indent)) label))
+             rest)))
+
+  (define (monetary+ . monetaries)
+    ;; usage: (monetary+ monetary...)
+    ;; inputs: list of gnc-monetary (e.g. USD 10, USD 25, GBP 5, GBP 8)
+    ;; outputs: list of gnc-monetary (e.g. USD 35, GBP 13)
+    (let ((coll (gnc:make-commodity-collector)))
+      (for-each
+       (lambda (monetary)
+         (coll 'add
+               (gnc:gnc-monetary-commodity monetary)
+               (gnc:gnc-monetary-amount monetary)))
+       monetaries)
+      (coll 'format gnc:make-gnc-monetary #f)))
+
+  (define (list-of-monetary->html-text monetaries omit-zero?)
+    (let ((text (gnc:make-html-text)))
+      (for-each
+       (lambda (monetary)
+         (if (not (and omit-zero? (zero? (gnc:gnc-monetary-amount monetary))))
+             (gnc:html-text-append! text monetary (gnc:html-markup-br))))
+       monetaries)
+      text))
+
+  (define (add-whole-line contents)
+    (gnc:html-table-append-row!
+     table (gnc:make-html-table-cell/size 1 (+ 1 (if disable-indenting? 0 maxindent) num-columns) contents)))
+
+  (define labels
+    (cons title (make-list (1- maxindent) #f)))
+
+  (define collectors
+    (let loop ((result '())
+               (list-of-headers list-of-headers))
+      (if (null? list-of-headers) result
+          (loop (cons (make-list-thunk maxindent gnc:make-commodity-collector)
+                      result)
+                (cdr list-of-headers)))))
+
+  ;; header ASSET/LIABILITY etc
+  (add-indented-row 0
+                    (gnc:make-html-text (gnc:html-markup-b title))
+                    (map
+                     (lambda (header)
+                       (gnc:make-html-text (gnc:html-markup-b header)))
+                     list-of-headers))
+
+  (let loop ((accountlist accountlist))
+    (if (pair? accountlist)
+        (let* ((curr (car accountlist))
+               (rest (cdr accountlist))
+               (next (and (pair? rest) (car rest)))
+               (lvl-curr (gnc-account-get-current-depth curr))
+               (lvl-next (if next (gnc-account-get-current-depth next) 0))
+               (curr-label (xaccAccountGetName curr))
+               (curr-commodity (xaccAccountGetCommodity curr))
+               (curr-descendants-list (if (not hierarchical-subtotals?)
+                                          (gnc-account-get-descendants curr)
+                                          '()))
+               (curr-balance-display (lambda (idx)
+                                       (map (lambda (acc) (gnc:make-gnc-monetary
+                                                           (xaccAccountGetCommodity acc)
+                                                           (get-cell-amount-fn acc idx)))
+                                            (cons curr curr-descendants-list)))))
+
+          (if (and (or show-zb-accts? (not (every zero? (map (lambda (col-idx) (get-cell-amount-fn curr col-idx))
+                                                             (iota num-columns)))))
+                   (or (not depth-limit) (<= lvl-curr depth-limit)))
+              (add-indented-row lvl-curr
+                                (string-append curr-label (if (null? curr-descendants-list) "" "+"))
+                                (map
+                                 (lambda (col-idx)
+                                   (gnc:make-html-table-cell/markup
+                                    "number-cell" (list-of-monetary->html-text
+                                                   (apply monetary+ (curr-balance-display col-idx))
+                                                   omit-zb-bals?)))
+                                 (iota num-columns))))
+
+          (list-set! labels lvl-curr (gnc-account-get-full-name curr))
+          ;; where the magic happens. this section will cycle
+          ;; through ALL columns. each column will cycle through
+          ;; ALL account-depth levels from root to & including
+          ;; current account-depth. each column/level collector
+          ;; will accumulate account amount.
+          (let columns-loop ((col-idx 0))
+            (when (< col-idx num-columns)
+              (let level-loop ((level 0))
+                (when (<= level lvl-curr)
+                  ((list-ref (list-ref collectors col-idx) level)
+                   'add curr-commodity (get-cell-amount-fn curr col-idx))
+                  (level-loop (1+ level))))
+              (columns-loop (1+ col-idx))))
+
+          ;; hierarchical subtotals. we're going UP hierarchy
+          ;; towards the root. start from the current level (minus
+          ;; 1), and cycle until the next account level. add level
+          ;; subtotals if conditions are met below. when all
+          ;; subtotals complete, add a single empty row before
+          ;; moving on to the next (higher level) account.
+          (if (> lvl-curr lvl-next)
+              (let add-subtotal-row ((lvl (1- lvl-curr)))
+                (if (< lvl lvl-next)
+                    (if hierarchical-subtotals?
+                        (add-whole-line #f))
+                    (let* ((level-subtotals (map (lambda (col-idx) ((list-ref (list-ref collectors col-idx) lvl)
+                                                                    'format gnc:make-gnc-monetary #f))
+                                                 (iota num-columns))))
+
+                      ;; the following conditions tests whether we should display the subtotal
+                      (if (or (zero? lvl)
+                              (and hierarchical-subtotals?
+                                   (or show-zb-accts? (not (every zero? (map gnc:gnc-monetary-amount (concatenate level-subtotals)))))
+                                   (or (not depth-limit) (<= lvl depth-limit))
+                                   (list-ref labels lvl)))
+                          (add-indented-row lvl
+                                            (gnc:make-html-text
+                                             (gnc:html-markup-b
+                                              "Total for "
+                                              (list-ref labels lvl)))
+                                            (map
+                                             (lambda (level-subtotal)
+                                               (gnc:make-html-table-cell/markup
+                                                "total-number-cell"
+                                                (list-of-monetary->html-text level-subtotal #f)))
+                                             level-subtotals)))
+                      (list-set! labels lvl #f)
+                      (for-each
+                       (lambda (col-idx)
+                         ((list-ref (list-ref collectors col-idx) lvl) 'reset #f #f)
+                         ((list-ref (list-ref collectors col-idx) (1+ lvl)) 'reset #f #f))
+                       (iota num-columns))
+                      (add-subtotal-row (1- lvl))))))
+
+          (loop rest))))
+  (add-whole-line #f)
+  ;; return collector level 0 total
+  (map (lambda (col-idx) (car (list-ref collectors col-idx))
+               'format gnc:make-gnc-monetary #f)
+       (iota num-columns)))
+
+  ;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; multicol-report-renderer
+  ;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (multicol-report-renderer report-obj report-type reportname)
+  (define (get-option pagename optname)
+    (gnc:option-value
+     (gnc:lookup-option
+      (gnc:report-options report-obj) pagename optname)))
+
+  (gnc:report-starting reportname)
+
+  ;; get all options values
+  (let* ((report-title (get-option gnc:pagename-general optname-report-title))
+         (company-name (get-option gnc:pagename-general optname-company-name))
+         (startdate (gnc:date-option-absolute-time
+                     (get-option gnc:pagename-general
+                                 optname-startdate)))
+         (enddate (gnc:date-option-absolute-time
+                   (get-option gnc:pagename-general
+                               optname-enddate)))
+         (export? (get-option gnc:pagename-general
+                              optname-export))
+         (incr (keylist-get-info periodlist
+                                 (get-option gnc:pagename-general optname-period)
+                                 'delta))
+         (accounts (get-option gnc:pagename-accounts
+                               optname-accounts))
+         (depth-limit (let ((limit (get-option gnc:pagename-accounts
+                                               optname-depth-limit)))
+                        (and (not (eq? limit 'all)) limit)))
+         (subtotal-mode (get-option gnc:pagename-display
+                                    optname-subtotal-mode))
+         (show-zb-accts? (get-option gnc:pagename-display
+                                     optname-show-zb-accts))
+         (omit-zb-bals? (get-option gnc:pagename-display
+                                    optname-omit-zb-bals))
+         (use-links? (get-option gnc:pagename-display
+                                 optname-account-links))
+
+         ;; decompose the account list
+         (split-up-accounts (gnc:decompose-accountlist accounts))
+         (asset-accounts
+          (assoc-ref split-up-accounts ACCT-TYPE-ASSET))
+         (liability-accounts
+          (assoc-ref split-up-accounts ACCT-TYPE-LIABILITY))
+         (income-accounts
+          (assoc-ref split-up-accounts ACCT-TYPE-INCOME))
+         (expense-accounts
+          (assoc-ref split-up-accounts ACCT-TYPE-EXPENSE))
+         (equity-accounts
+          (assoc-ref split-up-accounts ACCT-TYPE-EQUITY))
+         (trading-accounts
+          (assoc-ref split-up-accounts ACCT-TYPE-TRADING))
+         (doc (gnc:make-html-document)))
+
+    (gnc:html-document-set-title!
+     doc (string-append company-name " " report-title " "
+                        (qof-print-date startdate) " - "
+                        (qof-print-date enddate)))
+
+    (if (null? accounts)
+
+        (gnc:html-document-add-object!
+         doc
+         (gnc:html-make-no-account-warning
+          reportname (gnc:report-id report-obj)))
+
+        (case report-type
+          ((balsheet)
+           (let* ((multicol-table (gnc:make-html-table))
+                  (maxindent (gnc-account-get-tree-depth (gnc-get-current-root-account)))
+                  (reportdates (gnc:make-date-list startdate enddate incr))
+                  (get-cell-amount-fn (lambda (account col-idx)
+                                        (xaccAccountGetBalanceAsOfDate account
+                                                                       (gnc:time64-end-day-time
+                                                                        (list-ref reportdates col-idx)))))
+                  (reportheaders (map qof-print-date reportdates))
+                  (add-to-table (lambda (title accounts)
+                                  (add-multicolumn-acct-table
+                                   multicol-table title accounts
+                                   maxindent get-cell-amount-fn reportheaders
+                                   #:omit-zb-bals? omit-zb-bals?
+                                   #:show-zb-accts? show-zb-accts?
+                                   #:disable-indenting? export?
+                                   #:hierarchical-subtotals? subtotal-mode
+                                   #:depth-limit depth-limit))))
+
+             (add-to-table "ASSET" asset-accounts)
+             (add-to-table "LIABILITY" liability-accounts)
+             (add-to-table "EQUITY" equity-accounts)
+             (unless (null? trading-accounts)
+               (add-to-table "TRADING" trading-accounts))
+
+             (gnc:html-document-add-object!
+              doc (gnc:html-render-options-changed (gnc:report-options report-obj)))
+
+             (gnc:html-document-add-object!
+              doc multicol-table)))
+
+          ((pnl)
+           (let* ((multicol-table (gnc:make-html-table))
+                  (maxindent (gnc-account-get-tree-depth (gnc-get-current-root-account)))
+                  (closing-str (get-option pagename-entries optname-closing-pattern))
+                  (closing-cased (get-option pagename-entries optname-closing-casing))
+                  (closing-regexp (get-option pagename-entries optname-closing-regexp))
+                  ;; datepairs - start from startdate to startdate + incr - 1day
+                  ;; repeat until enddate is reached. e.g. 1/1/18 - 31/1/18, 1/2/18 - 28/2/18, etc
+                  (report-datepairs (let loop ((result '())
+                                               (date startdate))
+                                      (if (> date enddate) (reverse result)
+                                          (let ((nextdate (incdate date incr)))
+                                            (loop (cons (cons date (min enddate (decdate nextdate DayDelta)))
+                                                        result)
+                                                  nextdate)))))
+                  ;; this object will cache *all* closing entries from inc/exp accounts to equity.
+                  ;; retrieve both KVP-based transaction flags, and the closing-entries string above.
+                  (closing-entries (let ((query (qof-query-create-for-splits)))
+                                     (qof-query-set-book query (gnc-get-current-book))
+                                     (xaccQueryAddAccountMatch query (append income-accounts expense-accounts)
+                                                               QOF-GUID-MATCH-ANY QOF-QUERY-AND)
+                                     (if (and closing-str (not (string-null? closing-str)))
+                                         (xaccQueryAddDescriptionMatch query closing-str closing-cased closing-regexp
+                                                                       QOF-COMPARE-CONTAINS QOF-QUERY-AND))
+                                     (xaccQueryAddClosingTransMatch query #t QOF-QUERY-OR)
+                                     (let ((splits (qof-query-run query)))
+                                       (qof-query-destroy query)
+                                       splits)))
+                  ;; this function will query the above closing-entries for splits within the date range,
+                  ;; and produce the total amount for these closing entries
+                  (closing-adjustment (lambda (account fromdate todate)
+                                        (define (include-split? split)
+                                          (and (equal? (xaccSplitGetAccount split) account)
+                                               (<= fromdate
+                                                   (xaccTransGetDate (xaccSplitGetParent split))
+                                                   todate)))
+                                        (let ((account-closing-splits (filter include-split? closing-entries)))
+                                          (apply + (map xaccSplitGetAmount account-closing-splits)))))
+                  (get-cell-amount-fn (lambda (account col-idx)
+                                        (let* ((datepair (list-ref report-datepairs col-idx))
+                                               (startdate (gnc:time64-start-day-time (car datepair)))
+                                               (enddate (gnc:time64-end-day-time (cdr datepair))))
+                                          (- (xaccAccountGetBalanceAsOfDate account enddate)
+                                             (xaccAccountGetBalanceAsOfDate account startdate)
+                                             (closing-adjustment account startdate enddate)))))
+                  (reportheaders (map (lambda (pair)
+                                        (format #f "~a - ~a"
+                                                (qof-print-date (car pair))
+                                                (qof-print-date (cdr pair))))
+                                      report-datepairs))
+                  (add-to-table (lambda (title accounts)
+                                  (add-multicolumn-acct-table
+                                   multicol-table title accounts
+                                   maxindent get-cell-amount-fn reportheaders
+                                   #:omit-zb-bals? omit-zb-bals?
+                                   #:show-zb-accts? show-zb-accts?
+                                   #:disable-indenting? export?
+                                   #:hierarchical-subtotals? subtotal-mode
+                                   #:depth-limit depth-limit))))
+
+             (add-to-table "INCOME" income-accounts)
+             (add-to-table "EXPENSE" expense-accounts)
+             (unless (null? trading-accounts)
+               (add-to-table "TRADING" trading-accounts))
+
+             (gnc:html-document-add-object!
+              doc (gnc:html-render-options-changed (gnc:report-options report-obj)))
+
+             (gnc:html-document-add-object!
+              doc multicol-table)))))
+    (gnc:report-finished)
+    ;; (gnc:html-document-set-style-text!
+    ;;  doc " table, td{ border-width: 1px; border-style:solid; border-color: lightgray; border-collapse: collapse}")
+    doc))
+
+(define balsheet-reportname (_ "Balance Sheet (Multicolumn)"))
+(define pnl-reportname (_ "Income Statement (Multicolumn)"))
+
+(gnc:define-report
+ 'version 1
+ 'name balsheet-reportname
+ 'report-guid "065d5d5a77ba11e8b31e83ada73c5eea"
+ 'menu-path (list gnc:menuname-asset-liability)
+ 'options-generator (lambda () (multicol-report-options-generator 'balsheet balsheet-reportname))
+ 'renderer (lambda (rpt) (multicol-report-renderer rpt 'balsheet balsheet-reportname)))
+
+(gnc:define-report
+ 'version 1
+ 'name pnl-reportname
+ 'report-guid "0e94fd0277ba11e8825d43e27232c9d4"
+ 'menu-path (list gnc:menuname-income-expense)
+ 'options-generator (lambda () (multicol-report-options-generator 'pnl pnl-reportname))
+ 'renderer (lambda (rpt) (multicol-report-renderer rpt 'pnl pnl-reportname)))
+
+;; END

--- a/gnucash/report/standard-reports/balsheet-pnl.scm
+++ b/gnucash/report/standard-reports/balsheet-pnl.scm
@@ -395,7 +395,7 @@
                                    (list-ref labels lvl)))
                           (add-indented-row lvl
                                             (string-append
-                                             "Total for "
+                                             (_ "Total for ")
                                              (list-ref labels lvl))
                                             "total-label-cell"
                                             (map
@@ -507,11 +507,11 @@
                                    #:hierarchical-subtotals? subtotal-mode
                                    #:depth-limit depth-limit))))
 
-             (add-to-table "ASSET" asset-accounts)
-             (add-to-table "LIABILITY" liability-accounts)
-             (add-to-table "EQUITY" equity-accounts)
+             (add-to-table (_ "Asset") asset-accounts)
+             (add-to-table (_ "Liability") liability-accounts)
+             (add-to-table (_ "Equity") equity-accounts)
              (add-multicolumn-acct-table
-              multicol-table "Net Worth" (append asset-accounts liability-accounts)
+              multicol-table (_ "Net Worth") (append asset-accounts liability-accounts)
               maxindent get-cell-amount-fn reportheaders
               #:disable-indenting? export?
               #:hierarchical-subtotals? #f
@@ -572,9 +572,11 @@
                                              (xaccAccountGetBalanceAsOfDate account startdate)
                                              (closing-adjustment account startdate enddate)))))
                   (reportheaders (map (lambda (pair)
-                                        (format #f "~a - ~a"
-                                                (qof-print-date (car pair))
-                                                (qof-print-date (cdr pair))))
+                                        (gnc:make-html-text
+                                         (qof-print-date (car pair))
+                                         (gnc:html-markup-br)
+                                         (_ " to ")
+                                         (qof-print-date (cdr pair))))
                                       report-datepairs))
                   (add-to-table (lambda (title accounts)
                                   (add-multicolumn-acct-table
@@ -589,7 +591,7 @@
              (add-to-table (_ "Income") income-accounts)
              (add-to-table (_ "Expense") expense-accounts)
              (add-multicolumn-acct-table
-              multicol-table "Net Income" (append income-accounts expense-accounts)
+              multicol-table (_ "Net Income") (append income-accounts expense-accounts)
               maxindent get-cell-amount-fn reportheaders
               #:disable-indenting? export?
               #:hierarchical-subtotals? #f

--- a/gnucash/report/standard-reports/test/CMakeLists.txt
+++ b/gnucash/report/standard-reports/test/CMakeLists.txt
@@ -10,7 +10,7 @@ set(scm_test_with_srfi64_SOURCES
   test-charts.scm
   test-transaction.scm
   test-balance-sheet.scm
-  test-pnl.scm
+  test-balsheet-pnl.scm
   test-income-gst.scm
 )
 

--- a/gnucash/report/standard-reports/test/CMakeLists.txt
+++ b/gnucash/report/standard-reports/test/CMakeLists.txt
@@ -10,6 +10,7 @@ set(scm_test_with_srfi64_SOURCES
   test-charts.scm
   test-transaction.scm
   test-balance-sheet.scm
+  test-pnl.scm
   test-income-gst.scm
 )
 

--- a/gnucash/report/standard-reports/test/test-balsheet-pnl.scm
+++ b/gnucash/report/standard-reports/test/test-balsheet-pnl.scm
@@ -1,0 +1,252 @@
+(use-modules (gnucash gnc-module))
+(gnc:module-begin-syntax (gnc:module-load "gnucash/app-utils" 0))
+(use-modules (gnucash engine test test-extras))
+(use-modules (gnucash report standard-reports))
+(use-modules (gnucash report stylesheets))
+(use-modules (gnucash report report-system))
+(use-modules (gnucash report report-system test test-extras))
+(use-modules (srfi srfi-64))
+(use-modules (gnucash engine test srfi64-extras))
+(use-modules (sxml simple))
+(use-modules (sxml xpath))
+
+;; This is implementation testing for balsheet-pnl report.
+
+(define uuid-list
+  (list (cons 'pnl "0e94fd0277ba11e8825d43e27232c9d4")
+        (cons 'balsheet "065d5d5a77ba11e8b31e83ada73c5eea")))
+
+;; Explicitly set locale to make the report output predictable
+(setlocale LC_ALL "C")
+
+(define (run-test)
+  (test-runner-factory gnc:test-runner)
+  (test-begin "balsheet-pnl.scm")
+  (null-test 'pnl)
+  (null-test 'balsheet)
+  (balsheet-pnl-tests)
+  (test-end "balsheet-pnl.scm"))
+
+(define (options->sxml uuid options test-title)
+  (gnc:options->sxml uuid options "test-pnl" test-title))
+
+(define (set-option! options section name value)
+  (let ((option (gnc:lookup-option options section name)))
+    (if option
+        (gnc:option-set-value option value)
+        (test-assert (format #f "wrong-option ~a ~a" section name) #f))))
+
+(define (symbol->commodity symbol)
+  (gnc-commodity-table-lookup
+   (gnc-commodity-table-get-table (gnc-get-current-book))
+   (gnc-commodity-get-namespace (gnc-default-report-currency))
+   symbol))
+
+(gnc-commodity-set-user-symbol (symbol->commodity "GBP") "#")
+
+(define structure
+  (list "Root" (list (cons 'type ACCT-TYPE-ROOT))
+        (list "Asset" (list (cons 'type ACCT-TYPE-ASSET))
+              (list "A/Receivable" (list (cons 'type ACCT-TYPE-RECEIVABLE)))
+              (list "Bank-GBP" (list (cons 'commodity (symbol->commodity "GBP"))))
+              (list "Bank"
+                    (list "Bank-1"
+                          (list "Bank-1-1"
+                                (list "Bank-1-1-1")
+                                (list "Bank-1-1-2"))
+                          (list "Bank-1-2")
+                          (list "Bank-1-3"))))
+        (list "Liability" (list (cons 'type ACCT-TYPE-PAYABLE))
+              (list "Bank1"
+                    (list "Loan1")
+                    (list "Loan2"))
+              (list "CreditCard")
+              (list "A/Payable"))
+        (list "GST" (list (cons 'type ACCT-TYPE-ASSET))
+              (list "BAS")
+              (list "GST Sales" (list (cons 'type ACCT-TYPE-LIABILITY)))
+              (list "GST Purchases"))
+        (list "Equity" (list (cons 'type ACCT-TYPE-EQUITY)))
+        (list "Income" (list (cons 'type ACCT-TYPE-INCOME)))
+        (list "Income-GBP" (list (cons 'type ACCT-TYPE-INCOME)
+                                 (cons 'commodity (symbol->commodity "GBP"))))
+        (list "Expenses" (list (cons 'type ACCT-TYPE-EXPENSE)))))
+
+(define (null-test variant)
+  ;; This null-test tests for the presence of report.
+  (let* ((uuid (assq-ref uuid-list variant))
+         (options (gnc:make-report-options uuid)))
+    (test-assert "null-test" (options->sxml uuid options "null-test"))))
+
+(define (balsheet-pnl-tests)
+  (let* ((env (create-test-env))
+         (account-alist (env-create-account-structure-alist env structure))
+         (bank1 (cdr (assoc "Bank" account-alist)))
+         (bank2 (cdr (assoc "Bank-1" account-alist)))
+         (bank3 (cdr (assoc "Bank-1-1" account-alist)))
+         (bank4 (cdr (assoc "Bank-1-1-1" account-alist)))
+         (bank5 (cdr (assoc "Bank-1-1-2" account-alist)))
+         (bank6 (cdr (assoc "A/Receivable" account-alist)))
+         (bank-gbp (cdr (assoc "Bank-GBP" account-alist)))
+         (income (cdr (assoc "Income" account-alist)))
+         (income-gbp (cdr (assoc "Income-GBP" account-alist)))
+         (expense (cdr (assoc "Expenses" account-alist)))
+         (equity (cdr (assoc "Equity" account-alist)))
+         (creditcard (cdr (assoc "CreditCard" account-alist)))
+         (payable (cdr (assoc "A/Payable" account-alist)))
+         (receivable (cdr (assoc "A/Receivable" account-alist)))
+         (YEAR (1- (gnc:time64-get-year (gnc:get-today)))))
+
+    (define (default-testing-options uuid)
+      (let ((options (gnc:make-report-options uuid)))
+        ;; (set-option! options "General" "Start Date" (cons 'relative 'start-cal-year))
+        ;; (set-option! options "General" "End Date" (cons 'relative 'end-cal-year))
+        ;; (set-option! options "Display" "Hierarchical subtotals" #t)
+        (set-option! options "General" "Disable indenting for export?" #t)
+        options))
+
+    (define* (create-txn DD MM YY DESC list-of-splits #:optional txn-type)
+      (let ((txn (xaccMallocTransaction (gnc-get-current-book))))
+        (xaccTransBeginEdit txn)
+        (xaccTransSetDescription txn DESC)
+        (xaccTransSetCurrency txn (gnc-default-report-currency))
+        (xaccTransSetDate txn DD MM YY)
+        (for-each
+         (lambda (tfr)
+           (let ((split (xaccMallocSplit (gnc-get-current-book))))
+             (xaccSplitSetParent split txn)
+             (xaccSplitSetAccount split (cdr tfr))
+             (xaccSplitSetValue split (car tfr))
+             (xaccSplitSetAmount split (car tfr))))
+         list-of-splits)
+        (if txn-type
+            (xaccTransSetTxnType txn txn-type))
+        (xaccTransCommitEdit txn)
+        txn))
+
+    (create-txn 1 3 YEAR "receive #100 in GBP"
+                (list (cons -100 income-gbp)
+                      (cons  100 bank-gbp)))
+
+    (gnc-pricedb-create (gnc-default-report-currency) (symbol->commodity "GBP")
+                        (gnc-dmy2time64 1 3 YEAR) 125/100)
+
+    (gnc-pricedb-create (gnc-default-report-currency) (symbol->commodity "GBP")
+                        (gnc:get-today) 130/100)
+
+    (create-txn 1 3 YEAR "multiplebank income"
+                (list (cons -1111110 income)
+                      (cons 1000000 bank1)
+                      (cons 100000 bank2)
+                      (cons 10000 bank3)
+                      (cons 1000 bank4)
+                      (cons 100 bank5)
+                      (cons 10 bank6)))
+
+    ;; Finally we can begin testing
+    (test-begin "balsheet tests")
+    (let* ((uuid (assq-ref uuid-list 'balsheet))
+           (options (default-testing-options uuid)))
+      (let ((sxml (options->sxml uuid options "balsheet-default")))
+        (test-equal "balsheet default options. net worth is #100 $1,111,110.00"
+          '("#100.00" "$1,111,110.00")
+          (sxml->table-row-col sxml 1 49 2))
+        (test-equal "balsheet default amounts column are as expected"
+          '("$0.00" "$1,000,000.00" "$100,000.00" "$10,000.00" "$1,000.00"
+            "$100.00" "$11,100.00" "$0.00" "$0.00" "$111,100.00" "$1,111,100.00" "#100.00"
+            "$10.00" "#100.00" "$1,111,110.00" "$0.00" "$0.00" "$0.00" "$0.00" "#100.00"
+            "$1,111,110.00" "$0.00" "$0.00" "$0.00" "$0.00" "$0.00" "$0.00" "$0.00"
+            "$0.00" "$0.00" "$0.00" "$0.00" "$0.00" "#100.00" "$1,111,110.00")
+          (cdr (sxml->table-row-col sxml 1 #f 2))))
+
+      (set-option! options "Display" "Include accounts with zero total balances" #f)
+      (set-option! options "Display" "Omit zero balance figures" #t)
+      (set-option! options "Display" "Hierarchical subtotals" #f)
+      (let ((sxml (options->sxml uuid options "balsheet-swap-display-options")))
+        (test-equal "balsheet swap display options. amounts are as expected."
+          '("#100.00" "$1,111,110.00" "$1,111,100.00" "$111,100.00" "$11,100.00"
+            "$1,000.00" "$100.00" "#100.00" "$10.00" "#100.00" "$1,111,110.00" "$0.00"
+            "$0.00" "#100.00" "$1,111,110.00")
+          (cdr (sxml->table-row-col sxml 1 #f 2))))
+
+      (set-option! options "Commodities" "Convert to common currency" #t)
+      (set-option! options "Commodities" "Report's currency" (gnc-default-report-currency))
+      (set-option! options "Commodities" "Price Source" 'nearest)
+      (set-option! options "General" "Start Date" (cons 'absolute (gnc-dmy2time64 1 1 YEAR)))
+      (set-option! options "General" "End Date" (cons 'absolute (gnc-dmy2time64 1 3 YEAR)))
+      (let ((sxml (options->sxml uuid options "balsheet-common-currency nearest")))
+        (test-equal "balsheet common-currency. price-source=nearest. net worth is $1,111,235.00"
+          '("$1,111,235.00")
+          (sxml->table-row-col sxml 1 22 3))
+        (test-equal "balsheet common-currency. nearest. amounts are as expected."
+          '("#100.00" "$1,111,235.00" "$1,111,100.00" "$111,100.00"
+            "$11,100.00" "$1,000.00" "$100.00" "#100.00" "$125.00" "$10.00"
+            "$1,111,235.00" "$0.00" "$0.00" "$1,111,235.00")
+          (cdr (sxml->table-row-col sxml 1 #f 3))))
+
+      (set-option! options "Commodities" "Price Source" 'latest)
+      (let ((sxml (options->sxml uuid options "balsheet-common-currency latest")))
+        (test-equal "balsheet common-currency. price-source=latest. net worth is $1,111,240.00"
+          '("$1,111,240.00")
+          (sxml->table-row-col sxml 1 22 3))
+        (test-equal "balsheet common-currency. latest. amounts are as expected."
+          '("#100.00" "$1,111,240.00" "$1,111,100.00" "$111,100.00"
+            "$11,100.00" "$1,000.00" "$100.00" "#100.00" "$130.00" "$10.00"
+            "$1,111,240.00" "$0.00" "$0.00" "$1,111,240.00")
+          (cdr (sxml->table-row-col sxml 1 #f 3))))
+      )
+
+    (test-end "balsheet tests")
+
+    ;; Finally we can begin testing
+    (test-begin "pnl tests")
+    (let* ((uuid (assq-ref uuid-list 'pnl))
+           (options (default-testing-options uuid)))
+      (let ((sxml (options->sxml uuid options "pnl-default")))
+        (test-equal "pnl default options. profit is #0.00, $0.00"
+          '("#0.00" "$0.00")
+          (sxml->table-row-col sxml 1 13 2)))
+
+      (set-option! options "General" "Start Date" (cons 'absolute (gnc-dmy2time64 1 1 YEAR)))
+      (set-option! options "General" "End Date" (cons 'absolute (gnc-dmy2time64 1 3 YEAR)))
+      (let ((sxml (options->sxml uuid options "pnl-basic")))
+        (test-equal "pnl basic options. profit is -#100.00 -$1,111,110.00"
+          '("-#100.00" "-$1,111,110.00")
+          (sxml->table-row-col sxml 1 13 2)))
+
+      (set-option! options "Display" "Include accounts with zero total balances" #f)
+      (set-option! options "Display" "Omit zero balance figures" #t)
+      (set-option! options "Display" "Hierarchical subtotals" #f)
+      (let ((sxml (options->sxml uuid options "pnl-swap-display-options")))
+        (test-equal "pnl swap display options. amounts are as expected."
+          '("-$1,111,110.00" "-#100.00" "-#100.00"
+            "-$1,111,110.00" "$0.00" "-#100.00" "-$1,111,110.00")
+          (cddr (sxml->table-row-col sxml 1 #f 2))))
+
+      (set-option! options "Commodities" "Convert to common currency" #t)
+      (set-option! options "Commodities" "Report's currency" (gnc-default-report-currency))
+      (set-option! options "Commodities" "Price Source" 'midperiod)
+      (set-option! options "Commodities" "Show Foreign Currencies" #f)
+      (set-option! options "General" "Start Date" (cons 'absolute (gnc-dmy2time64 1 1 YEAR)))
+      (set-option! options "General" "End Date" (cons 'absolute (gnc-dmy2time64 1 3 YEAR)))
+      (let ((sxml (options->sxml uuid options "pnl-common-currency midperiod")))
+        (test-equal "pnl common-currency. price-source=midperiod. net worth is $1,111,235.00"
+          '("-$1,111,235.00")
+          (sxml->table-row-col sxml 1 12 2))
+        (test-equal "pnl common-currency. amounts are as expected."
+          '("-$1,111,110.00" "-$125.00" "-$1,111,235.00" "$0.00" "-$1,111,235.00")
+          (cddr (sxml->table-row-col sxml 1 #f 2)))
+        )
+
+      (set-option! options "Commodities" "Price Source" 'latest)
+      (let ((sxml (options->sxml uuid options "pnl-common-currency latest")))
+        (test-equal "pnl common-currency. price-source=latest. net worth is $1,111,240.00"
+          '("-$1,111,240.00")
+          (sxml->table-row-col sxml 1 12 2))
+        (test-equal "pnl common-currency. amounts are as expected."
+          '("-$1,111,110.00" "-#100.00" "-$130.00" "-$1,111,240.00" "$0.00" "-$1,111,240.00")
+          (cddr (sxml->table-row-col sxml 1 #f 2))))
+      )
+    (test-end "pnl tests")
+
+    ))

--- a/gnucash/report/standard-reports/test/test-balsheet-pnl.scm
+++ b/gnucash/report/standard-reports/test/test-balsheet-pnl.scm
@@ -239,6 +239,7 @@
         )
 
       (set-option! options "Commodities" "Price Source" 'latest)
+      (set-option! options "Commodities" "Show Foreign Currencies" #t)
       (let ((sxml (options->sxml uuid options "pnl-common-currency latest")))
         (test-equal "pnl common-currency. price-source=latest. net worth is $1,111,240.00"
           '("-$1,111,240.00")

--- a/gnucash/report/standard-reports/test/test-balsheet-pnl.scm
+++ b/gnucash/report/standard-reports/test/test-balsheet-pnl.scm
@@ -95,7 +95,7 @@
          (creditcard (cdr (assoc "CreditCard" account-alist)))
          (payable (cdr (assoc "A/Payable" account-alist)))
          (receivable (cdr (assoc "A/Receivable" account-alist)))
-         (YEAR (1- (gnc:time64-get-year (gnc:get-today)))))
+         (YEAR (- (gnc:time64-get-year (gnc:get-today)) 5)))
 
     (define (default-testing-options uuid)
       (let ((options (gnc:make-report-options uuid)))
@@ -179,9 +179,8 @@
           '("$1,111,235.00")
           (sxml->table-row-col sxml 1 22 3))
         (test-equal "balsheet common-currency. nearest. amounts are as expected."
-          '("#100.00" "$1,111,235.00" "$1,111,100.00" "$111,100.00"
-            "$11,100.00" "$1,000.00" "$100.00" "#100.00" "$125.00" "$10.00"
-            "$1,111,235.00" "$0.00" "$0.00" "$1,111,235.00")
+          '("$1,111,235.00" "$1,111,100.00" "$111,100.00" "$11,100.00" "$1,000.00" "$100.00"
+            "#100.00" "$125.00" "$10.00" "$1,111,235.00" "$0.00" "$0.00" "$1,111,235.00")
           (cdr (sxml->table-row-col sxml 1 #f 3))))
 
       (set-option! options "Commodities" "Price Source" 'latest)
@@ -190,9 +189,8 @@
           '("$1,111,240.00")
           (sxml->table-row-col sxml 1 22 3))
         (test-equal "balsheet common-currency. latest. amounts are as expected."
-          '("#100.00" "$1,111,240.00" "$1,111,100.00" "$111,100.00"
-            "$11,100.00" "$1,000.00" "$100.00" "#100.00" "$130.00" "$10.00"
-            "$1,111,240.00" "$0.00" "$0.00" "$1,111,240.00")
+          '("$1,111,240.00" "$1,111,100.00" "$111,100.00" "$11,100.00" "$1,000.00" "$100.00"
+            "#100.00" "$130.00" "$10.00" "$1,111,240.00" "$0.00" "$0.00" "$1,111,240.00")
           (cdr (sxml->table-row-col sxml 1 #f 3))))
       )
 

--- a/libgnucash/engine/test/test-extras.scm
+++ b/libgnucash/engine/test/test-extras.scm
@@ -40,6 +40,7 @@
 (export env-select-price-source)
 (export env-any-date)
 (export env-transfer)
+(export gnc-pricedb-create)
 (export env-transfer-foreign)
 (export env-create-transaction)
 (export env-create-account)


### PR DESCRIPTION
Features
1. as above
2. balsheet has anchors which lead to the exact split that documents the account balance
3. profit&loss has anchor to TR to 'expand' income/expense period
4. both have anchor to charts in net-charts.scm
5. testing included

Both original-currency and report common-currency supported
Balsheet common-currency will use prices appropriate to balsheet date, or latest.
Profit&Loss common-currency will use prices appropriate for begin/midpoint/end of period, or latest.
NO cost-price valuation is implemented.
Almost 100% functional approach.... there's no multicolumn-acct-table-add-row or multicolumn-acct-add-accounts or add-columns API... all data and options are sent and processed immediately in add-multicolumn-acct-table. 
I wonder if it should be labelled "beta, please verify numbers and totals are correct."?

It is planned that the add-multicolumn-acct-table eventually gets upgraded into report-utilities.scm... It can be a nice replacement in other reports - trial-balance etc. Perhaps in the future I'll add 'contracts' i.e. `(if (not (list? col-data)) (throw "col-data must be a list"))` to aid in development.