### PR TITLE
Increase of MAX_TAB_COUNT to change appearance of dialog "Book Options"

### DIFF
--- a/gnucash/gnome-utils/dialog-options.c
+++ b/gnucash/gnome-utils/dialog-options.c
@@ -74,7 +74,7 @@ static QofLogModule log_module = GNC_MOD_GUI;
  * Point where preferences switch control method from a set of
  * notebook tabs to a list.
  */
-#define MAX_TAB_COUNT 5
+#define MAX_TAB_COUNT 8
 
 /* A pointer to the last selected filename */
 #define LAST_SELECTION "last-selection"

--- a/gnucash/gnome-utils/dialog-options.c
+++ b/gnucash/gnome-utils/dialog-options.c
@@ -74,7 +74,7 @@ static QofLogModule log_module = GNC_MOD_GUI;
  * Point where preferences switch control method from a set of
  * notebook tabs to a list.
  */
-#define MAX_TAB_COUNT 4
+#define MAX_TAB_COUNT 5
 
 /* A pointer to the last selected filename */
 #define LAST_SELECTION "last-selection"


### PR DESCRIPTION
Increase of MAX_TAB_COUNT to change appearance of dialog "Book Options" in german language.

The dialog "Book Options" looks in german different, because it has 5 tabs: four standard tabs and additionaly one tab for tax settings, which appears only for german language. The 1 to 4 tabs appearance on top (horizontal mode). The appearance switchs to vertical mode (with tabs on the left side) for 5 and more tabs. Here the setting MAX_TAB_COUNT is increased to 5. This change should make the appearance of dialog "Book Options" similar in german and other languages.

Dialog "Book Options" in english, only for comparison:
![bildschirmfoto_2018-07-14_20-58-57](https://user-images.githubusercontent.com/426910/42728010-2c121ebc-87b1-11e8-9295-28b0de918071.png)

Dialog "Book Options" in german before change:
![bildschirmfoto_2018-07-14_20-58-05](https://user-images.githubusercontent.com/426910/42728015-4bfe8954-87b1-11e8-911b-ea4405f97b9e.png)

Dialog "Book Options" in german after change:
![bildschirmfoto_2018-07-14_20-52-51](https://user-images.githubusercontent.com/426910/42728023-5f559272-87b1-11e8-9b89-275538bf037a.png)


