### PR TITLE
Some Bug Fixes

### DIFF
--- a/gnucash/gnome-utils/dialog-preferences.c
+++ b/gnucash/gnome-utils/dialog-preferences.c
@@ -1229,6 +1229,8 @@ gnc_preferences_dialog_create(GtkWindow *parent)
     gnc_builder_add_from_file (builder, "dialog-preferences.glade", "retain_days_adj");
     gnc_builder_add_from_file (builder, "dialog-preferences.glade", "tab_width_adj");
     gnc_builder_add_from_file (builder, "dialog-preferences.glade", "date_formats");
+    gnc_builder_add_from_file (builder, "dialog-preferences.glade", "toolbar-styles");
+    gnc_builder_add_from_file (builder, "dialog-preferences.glade", "toolbar-icon-sizes");
     gnc_builder_add_from_file (builder, "dialog-preferences.glade", "gnucash_preferences_dialog");
 
     dialog = GTK_WIDGET(gtk_builder_get_object (builder, "gnucash_preferences_dialog"));

--- a/gnucash/gnome-utils/gnc-embedded-window.c
+++ b/gnucash/gnome-utils/gnc-embedded-window.c
@@ -1,6 +1,6 @@
 /*
  * gnc-main-window.c -- GtkWindow which represents the
- *	GnuCash main window.
+ *  GnuCash main window.
  *
  * Copyright (C) 2003 Jan Arne Petersen <jpetersen@uni-bonn.de>
  * Copyright (C) 2003 David Hampton <hampton@employees.org>
@@ -38,6 +38,7 @@
 #include "gnc-plugin-manager.h"
 #include "gnc-ui.h"
 #include "gnc-window.h"
+#include "gnc-prefs.h"
 #include "dialog-utils.h"
 
 /* Static Globals *******************************************************/
@@ -308,6 +309,13 @@ gnc_embedded_window_add_widget (GtkUIManager *merge,
     if (GTK_IS_TOOLBAR (widget))
     {
         priv->toolbar = widget;
+
+        gtk_toolbar_set_style (GTK_TOOLBAR(priv->toolbar),
+            gnc_prefs_get_int (GNC_PREFS_GROUP_GENERAL, GNC_PREF_TOOLBAR_STYLE));
+
+        // prefs has only small and large icons so add 2 to get right enum
+        gtk_toolbar_set_icon_size (GTK_TOOLBAR(priv->toolbar),
+           (gnc_prefs_get_int (GNC_PREFS_GROUP_GENERAL, GNC_PREF_TOOLBAR_ICON_SIZE)) + 2);
     }
 
     gtk_box_pack_start (GTK_BOX (priv->menu_dock), widget, FALSE, FALSE, 0);

--- a/gnucash/gnome-utils/gnc-main-window.c
+++ b/gnucash/gnome-utils/gnc-main-window.c
@@ -3341,6 +3341,28 @@ gnc_main_window_update_tab_position (gpointer prefs, gchar *pref, gpointer user_
     LEAVE ("");
 }
 
+static void
+gnc_main_window_update_toolbar (gpointer prefs, gchar *pref, gpointer user_data)
+{
+    GncMainWindow *window;
+    GtkToolbar *tb;
+    GncMainWindowPrivate *priv;
+    gint selection;
+
+    window = GNC_MAIN_WINDOW(user_data);
+    priv = GNC_MAIN_WINDOW_GET_PRIVATE (window);
+    tb = GTK_TOOLBAR(priv->toolbar);
+
+    selection = gnc_prefs_get_int (GNC_PREFS_GROUP_GENERAL, GNC_PREF_TOOLBAR_STYLE);
+    if (gtk_toolbar_get_style (tb) != selection)
+        gtk_toolbar_set_style (tb, selection);
+
+    selection = gnc_prefs_get_int (GNC_PREFS_GROUP_GENERAL, GNC_PREF_TOOLBAR_ICON_SIZE);
+    // prefs has only small and large icons so add 2 to get right enum
+    if (gtk_toolbar_get_icon_size (tb) != selection + 2)
+        gtk_toolbar_set_icon_size (tb, selection + 2);
+}
+
 /*
  * Based on code from Epiphany (src/ephy-window.c)
  */
@@ -3707,6 +3729,13 @@ gnc_main_window_setup_window (GncMainWindow *window)
                            GNC_PREF_TAB_POSITION_RIGHT,
                            gnc_main_window_update_tab_position,
                            window);
+
+    gnc_prefs_register_cb (GNC_PREFS_GROUP_GENERAL, GNC_PREF_TOOLBAR_STYLE,
+                           gnc_main_window_update_toolbar, window);
+
+    gnc_prefs_register_cb (GNC_PREFS_GROUP_GENERAL, GNC_PREF_TOOLBAR_ICON_SIZE,
+                           gnc_main_window_update_toolbar, window);
+
     gnc_main_window_update_tab_position(NULL, NULL, window);
 
     gnc_main_window_init_menu_updaters(window);
@@ -3839,6 +3868,13 @@ gnc_main_window_add_widget (GtkUIManager *merge,
     if (GTK_IS_TOOLBAR (widget))
     {
         priv->toolbar = widget;
+
+        gtk_toolbar_set_style (GTK_TOOLBAR(priv->toolbar),
+            gnc_prefs_get_int (GNC_PREFS_GROUP_GENERAL, GNC_PREF_TOOLBAR_STYLE));
+
+        // prefs has only small and large icons so add 2 to get right enum
+        gtk_toolbar_set_icon_size (GTK_TOOLBAR(priv->toolbar),
+           (gnc_prefs_get_int (GNC_PREFS_GROUP_GENERAL, GNC_PREF_TOOLBAR_ICON_SIZE)) + 2);
     }
 
     gtk_box_pack_start (GTK_BOX (priv->menu_dock), widget, FALSE, FALSE, 0);

--- a/gnucash/gnome-utils/gnc-main-window.c
+++ b/gnucash/gnome-utils/gnc-main-window.c
@@ -1,6 +1,6 @@
 /*
  * gnc-main-window.c -- GtkWindow which represents the
- *	GnuCash main window.
+ *  GnuCash main window.
  *
  * Copyright (C) 2003 Jan Arne Petersen <jpetersen@uni-bonn.de>
  * Copyright (C) 2003,2005,2006 David Hampton <hampton@employees.org>
@@ -1670,9 +1670,8 @@ static gchar *generate_statusbar_lastmodified_message()
                     last modification. The string is a format string using
                     boost::date_time's format flags, see the boost docs for an
                     explanation of the modifiers. */
-                    char *time_string =
-			gnc_print_time64(statbuf.st_mtime,
-					 _("Last modified on %a, %b %d, %Y at %I:%M %p"));
+                    char *time_string = gnc_print_time64(statbuf.st_mtime,
+                     _("Last modified on %a, %b %d, %Y at %I:%M %p"));
                     //g_warning("got time %ld, str=%s\n", mtime, time_string);
                     /* Translators: This message appears in the status bar after opening the file. */
                     message = g_strdup_printf(_("File %s opened. %s"),
@@ -2695,7 +2694,7 @@ gnc_main_window_destroy (GtkWidget *widget)
         g_list_free (plugins);
     }
     if (priv->about_dialog)
-	g_object_unref (priv->about_dialog);
+        g_object_unref (priv->about_dialog);
     GTK_WIDGET_CLASS (parent_class)->destroy (widget);
 }
 
@@ -4481,11 +4480,11 @@ get_file (const gchar *partial)
     filename = gnc_filepath_locate_doc_file(partial);
     if (filename && g_file_get_contents(filename, &text, &length, NULL))
     {
-	if (length)
-	{
-	    g_free(filename);
-	    return text;
-	}
+        if (length)
+        {
+            g_free(filename);
+            return text;
+        }
         g_free(text);
     }
     g_free (filename);
@@ -4544,15 +4543,15 @@ gnc_main_window_cmd_help_about (GtkAction *action, GncMainWindow *window)
     if (priv->about_dialog == NULL)
     {
         /* Translators: %s will be replaced with the current year */
-	gchar *copyright = g_strdup_printf(_("Copyright © 1997-%s The GnuCash contributors."),
+        gchar *copyright = g_strdup_printf(_("Copyright © 1997-%s The GnuCash contributors."),
                                            GNC_VCS_REV_YEAR);
-	gchar **authors = get_file_strsplit("AUTHORS");
-	gchar **documenters = get_file_strsplit("DOCUMENTERS");
-	gchar *license = get_file("LICENSE");
+        gchar **authors = get_file_strsplit("AUTHORS");
+        gchar **documenters = get_file_strsplit("DOCUMENTERS");
+        gchar *license = get_file("LICENSE");
         gchar *version = NULL;
         gchar *vcs = NULL;
         GtkIconTheme *icon_theme = gtk_icon_theme_get_default ();
-	GdkPixbuf *logo = gtk_icon_theme_load_icon (icon_theme,
+        GdkPixbuf *logo = gtk_icon_theme_load_icon (icon_theme,
                                                     GNC_ICON_APP,
                                                     128,
                                                     GTK_ICON_LOOKUP_USE_BUILTIN,
@@ -4574,41 +4573,44 @@ gnc_main_window_cmd_help_about (GtkAction *action, GncMainWindow *window)
             version = g_strdup_printf ("%s: %s\n%s: %s%s (%s)\nFinance::Quote: %s", _("Version"), VERSION,
                                        _("Build ID"), vcs, GNC_VCS_REV, GNC_VCS_REV_DATE,
                                        gnc_quote_source_fq_version () ? gnc_quote_source_fq_version () : "-");
-	priv->about_dialog = gtk_about_dialog_new ();
-	g_object_set (priv->about_dialog,
-		      "authors", authors,
-		      "documenters", documenters,
-		      "comments", _("Accounting for personal and small business finance."),
-		      "copyright", copyright,
-		      "license", license,
-		      "logo", logo,
-		      "name", "GnuCash",
-     /* Translators: the following string will be shown in Help->About->Credits
-      * Enter your name or that of your team and an email contact for feedback.
-      * The string can have multiple rows, so you can also add a list of
-      * contributors. */
-		      "translator-credits", _("translator_credits"),
-		      "version", version,
-		      "website", "http://www.gnucash.org",
-		      "website_label", _("Visit the GnuCash website."),
-		      NULL);
+        priv->about_dialog = gtk_about_dialog_new ();
+        g_object_set (priv->about_dialog,
+                  "authors", authors,
+                  "documenters", documenters,
+                  "comments", _("Accounting for personal and small business finance."),
+                  "copyright", copyright,
+                  "license", license,
+                  "logo", logo,
+                  "name", "GnuCash",
+         /* Translators: the following string will be shown in Help->About->Credits
+          * Enter your name or that of your team and an email contact for feedback.
+          * The string can have multiple rows, so you can also add a list of
+          * contributors. */
+                  "translator-credits", _("translator_credits"),
+                  "version", version,
+                  "website", "http://www.gnucash.org",
+                  "website_label", _("Visit the GnuCash website."),
+                  NULL);
 
         g_free(version);
-	g_free(copyright);
-	if (license)     g_free(license);
-	if (documenters) g_strfreev(documenters);
-	if (authors)     g_strfreev(authors);
-	g_object_unref (logo);
-	g_signal_connect (priv->about_dialog, "activate-link",
-			  G_CALLBACK (url_signal_cb), NULL);
-	g_signal_connect (priv->about_dialog, "response",
-			  G_CALLBACK (gtk_widget_hide), NULL);
+        g_free(copyright);
+        if (license)
+             g_free(license);
+        if (documenters)
+             g_strfreev(documenters);
+        if (authors)
+             g_strfreev(authors);
+        g_object_unref (logo);
+        g_signal_connect (priv->about_dialog, "activate-link",
+              G_CALLBACK (url_signal_cb), NULL);
+        g_signal_connect (priv->about_dialog, "response",
+              G_CALLBACK (gtk_widget_hide), NULL);
 
         /* Set dialog to resize. */
         gtk_window_set_resizable(GTK_WINDOW(priv->about_dialog), TRUE);
 
-	gtk_window_set_transient_for (GTK_WINDOW (priv->about_dialog),
-				      GTK_WINDOW (window));
+        gtk_window_set_transient_for (GTK_WINDOW (priv->about_dialog),
+                          GTK_WINDOW (window));
     }
     gtk_dialog_run (GTK_DIALOG (priv->about_dialog));
 }

--- a/gnucash/gnome/reconcile-view.c
+++ b/gnucash/gnome/reconcile-view.c
@@ -233,6 +233,25 @@ gnc_reconcile_view_tooltip_cb (GNCQueryView *qview, gint x, gint y,
 }
 
 
+void
+gnc_reconcile_view_add_padding (GNCReconcileView *view, gint column, gint xpadding)
+{
+    GNCQueryView      *qview = GNC_QUERY_VIEW (view);
+    GtkTreeViewColumn *col;
+    GList             *renderers;
+    GtkCellRenderer   *cr0;
+    gint xpad, ypad;
+
+    col = gtk_tree_view_get_column (GTK_TREE_VIEW (qview), (column - 1));
+    renderers = gtk_cell_layout_get_cells (GTK_CELL_LAYOUT (col));
+    cr0 = g_list_nth_data (renderers, 0);
+    g_list_free (renderers);
+
+    gtk_cell_renderer_get_padding (cr0, &xpad, &ypad);
+    gtk_cell_renderer_set_padding (cr0, xpadding, ypad);
+}
+
+
 /****************************************************************************\
  * gnc_reconcile_view_new                                                   *
  *   creates the account tree                                               *

--- a/gnucash/gnome/reconcile-view.c
+++ b/gnucash/gnome/reconcile-view.c
@@ -233,6 +233,18 @@ gnc_reconcile_view_tooltip_cb (GNCQueryView *qview, gint x, gint y,
 }
 
 
+gint
+gnc_reconcile_view_get_column_width (GNCReconcileView *view, gint column)
+{
+    GNCQueryView      *qview = GNC_QUERY_VIEW (view);
+    GtkTreeViewColumn *col;
+
+    //allow for pointer model column at column 0
+    col = gtk_tree_view_get_column (GTK_TREE_VIEW (qview), (column - 1));
+    return  gtk_tree_view_column_get_width (col);
+}
+
+
 void
 gnc_reconcile_view_add_padding (GNCReconcileView *view, gint column, gint xpadding)
 {

--- a/gnucash/gnome/reconcile-view.c
+++ b/gnucash/gnome/reconcile-view.c
@@ -242,6 +242,7 @@ gnc_reconcile_view_add_padding (GNCReconcileView *view, gint column, gint xpaddi
     GtkCellRenderer   *cr0;
     gint xpad, ypad;
 
+    //allow for pointer model column at column 0
     col = gtk_tree_view_get_column (GTK_TREE_VIEW (qview), (column - 1));
     renderers = gtk_cell_layout_get_cells (GTK_CELL_LAYOUT (col));
     cr0 = g_list_nth_data (renderers, 0);
@@ -328,8 +329,8 @@ gnc_reconcile_view_new (Account *account, GNCReconcileViewType type,
 
     /* Create the list store with 6 columns and add to treeview,
        column 0 will be a pointer to the entry */
-    liststore = gtk_list_store_new (6, G_TYPE_POINTER, G_TYPE_BOOLEAN,
-                G_TYPE_STRING, G_TYPE_STRING, G_TYPE_STRING, G_TYPE_STRING );
+    liststore = gtk_list_store_new (6, G_TYPE_POINTER, G_TYPE_STRING,
+                G_TYPE_STRING, G_TYPE_STRING, G_TYPE_STRING,  G_TYPE_BOOLEAN );
     gtk_tree_view_set_model (GTK_TREE_VIEW (view), GTK_TREE_MODEL (liststore));
     g_object_unref (liststore);
 
@@ -407,6 +408,15 @@ gnc_reconcile_view_init (GNCReconcileView *view)
     view->account = NULL;
     view->sibling = NULL;
 
+    param = gnc_search_param_simple_new();
+    gnc_search_param_set_param_fcn (param, QOF_TYPE_BOOLEAN,
+                                    gnc_reconcile_view_is_reconciled, view);
+    gnc_search_param_set_title ((GNCSearchParam *) param, _("Reconciled:R") + 11);
+    gnc_search_param_set_justify ((GNCSearchParam *) param, GTK_JUSTIFY_CENTER);
+    gnc_search_param_set_passive ((GNCSearchParam *) param, FALSE);
+    gnc_search_param_set_non_resizeable ((GNCSearchParam *) param, TRUE);
+    columns = g_list_prepend (columns, param);
+
     columns = gnc_search_param_prepend_with_justify (columns, _("Amount"),
               GTK_JUSTIFY_RIGHT,
               NULL, GNC_ID_SPLIT,
@@ -425,15 +435,6 @@ gnc_reconcile_view_init (GNCReconcileView *view)
               SPLIT_TRANS, TRANS_NUM, NULL);
     columns = gnc_search_param_prepend (columns, _("Date"), NULL, GNC_ID_SPLIT,
                                         SPLIT_TRANS, TRANS_DATE_POSTED, NULL);
-
-    param = gnc_search_param_simple_new();
-    gnc_search_param_set_param_fcn (param, QOF_TYPE_BOOLEAN,
-                                    gnc_reconcile_view_is_reconciled, view);
-    gnc_search_param_set_title ((GNCSearchParam *) param, _("Reconciled:R") + 11);
-    gnc_search_param_set_justify ((GNCSearchParam *) param, GTK_JUSTIFY_CENTER);
-    gnc_search_param_set_passive ((GNCSearchParam *) param, FALSE);
-    gnc_search_param_set_non_resizeable ((GNCSearchParam *) param, TRUE);
-    columns = g_list_prepend (columns, param);
 
     view->column_list = columns;
 }

--- a/gnucash/gnome/reconcile-view.h
+++ b/gnucash/gnome/reconcile-view.h
@@ -112,6 +112,8 @@ gboolean gnc_reconcile_view_changed (GNCReconcileView *view);
 
 void gnc_reconcile_view_add_padding (GNCReconcileView *view, gint column, gint xpadding);
 
+gint gnc_reconcile_view_get_column_width (GNCReconcileView *view, gint column);
+
 G_END_DECLS
 
 #endif /* GNC_RECONCILE_VIEW_H */

--- a/gnucash/gnome/reconcile-view.h
+++ b/gnucash/gnome/reconcile-view.h
@@ -47,11 +47,11 @@ typedef enum
 enum
 {
     REC_POINTER, //0
-    REC_RECN,    //1
-    REC_DATE,    //2
-    REC_NUM,     //3
-    REC_DESC,    //4
-    REC_AMOUNT   //5
+    REC_DATE,    //1
+    REC_NUM,     //2
+    REC_DESC,    //3
+    REC_AMOUNT,  //4
+    REC_RECN,    //5
 };
 
 struct GNCReconcileView

--- a/gnucash/gnome/reconcile-view.h
+++ b/gnucash/gnome/reconcile-view.h
@@ -110,6 +110,8 @@ void gnc_reconcile_view_unselect_all (GNCReconcileView *view);
 
 gboolean gnc_reconcile_view_changed (GNCReconcileView *view);
 
+void gnc_reconcile_view_add_padding (GNCReconcileView *view, gint column, gint xpadding);
+
 G_END_DECLS
 
 #endif /* GNC_RECONCILE_VIEW_H */

--- a/gnucash/gnome/window-reconcile.c
+++ b/gnucash/gnome/window-reconcile.c
@@ -1141,6 +1141,8 @@ gnc_reconcile_window_create_view_box(Account *account,
                                      GtkWidget **total_save)
 {
     GtkWidget *frame, *scrollWin, *view, *vbox, *label, *hbox;
+    GtkWidget *vscroll;
+    GtkRequisition nat_sb;
 
     frame = gtk_frame_new(NULL);
 
@@ -1184,6 +1186,13 @@ gnc_reconcile_window_create_view_box(Account *account,
     gtk_container_add(GTK_CONTAINER(scrollWin), view);
     gtk_box_pack_start(GTK_BOX(vbox), frame, TRUE, TRUE, 0);
 
+    // get the vertical scroll bar width
+    vscroll = gtk_scrolled_window_get_vscrollbar (GTK_SCROLLED_WINDOW (scrollWin));
+    gtk_widget_get_preferred_size (vscroll, NULL, &nat_sb);
+
+    // add xpadding to amount column so scrollbar does not cover
+    gnc_reconcile_view_add_padding (GNC_RECONCILE_VIEW(view), REC_AMOUNT, nat_sb.width);
+
     hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
     gtk_box_set_homogeneous (GTK_BOX (hbox), FALSE);
     gtk_box_pack_start(GTK_BOX(vbox), hbox, FALSE, FALSE, 0);
@@ -1197,9 +1206,9 @@ gnc_reconcile_window_create_view_box(Account *account,
     *total_save = label;
 
 #if GTK_CHECK_VERSION(3,12,0)
-    gtk_widget_set_margin_end (GTK_WIDGET(label), 10);
+    gtk_widget_set_margin_end (GTK_WIDGET(label), 10 + nat_sb.width);
 #else
-    gtk_widget_set_margin_right (GTK_WIDGET(label), 10);
+    gtk_widget_set_margin_right (GTK_WIDGET(label), 10 + nat_sb.width);
 #endif
 
     return vbox;

--- a/gnucash/gnome/window-reconcile.c
+++ b/gnucash/gnome/window-reconcile.c
@@ -81,6 +81,8 @@ struct _RecnWindow
 
     GtkUIManager *ui_merge;
     GtkActionGroup *action_group;
+    GtkWidget *dock;
+    GtkWidget *toolbar;
 
     GtkWidget *starting;         /* The starting balance                 */
     GtkWidget *ending;           /* The ending balance                   */
@@ -1670,12 +1672,43 @@ recnWindow (GtkWidget *parent, Account *account)
 static void
 recnWindow_add_widget (GtkUIManager *merge,
                        GtkWidget *widget,
-                       GtkBox *dock)
+                       RecnWindow *recnData)
 {
-    gtk_box_pack_start (GTK_BOX (dock), widget, FALSE, FALSE, 0);
+
+    if (GTK_IS_TOOLBAR (widget))
+    {
+      recnData->toolbar = widget;
+
+        gtk_toolbar_set_style (GTK_TOOLBAR(widget),
+            gnc_prefs_get_int (GNC_PREFS_GROUP_GENERAL, GNC_PREF_TOOLBAR_STYLE));
+
+        // prefs has only small and large icons so add 2 to get right enum
+        gtk_toolbar_set_icon_size (GTK_TOOLBAR(widget),
+           (gnc_prefs_get_int (GNC_PREFS_GROUP_GENERAL, GNC_PREF_TOOLBAR_ICON_SIZE)) + 2);
+    }
+
+    gtk_box_pack_start (GTK_BOX (recnData->dock), widget, FALSE, FALSE, 0);
     gtk_widget_show (widget);
 }
 
+
+static void
+recn_window_update_toolbar (gpointer prefs, gchar *pref, RecnWindow *recnData)
+{
+    GtkToolbar *tb;
+    gint selection;
+
+    tb = GTK_TOOLBAR(recnData->toolbar);
+
+    selection = gnc_prefs_get_int (GNC_PREFS_GROUP_GENERAL, GNC_PREF_TOOLBAR_STYLE);
+    if (gtk_toolbar_get_style (tb) != selection)
+        gtk_toolbar_set_style (tb, selection);
+
+    selection = gnc_prefs_get_int (GNC_PREFS_GROUP_GENERAL, GNC_PREF_TOOLBAR_ICON_SIZE);
+    // prefs has only small and large icons so add 2 to get right enum
+    if (gtk_toolbar_get_icon_size (tb) != selection + 2)
+        gtk_toolbar_set_icon_size (tb, selection + 2);
+}
 
 /********************************************************************\
  * recnWindowWithBalance
@@ -1743,8 +1776,9 @@ recnWindowWithBalance (Account *account, gnc_numeric new_ending,
         GError *error = NULL;
 
         recnData->ui_merge = gtk_ui_manager_new ();
+        recnData->dock = dock;
         g_signal_connect (recnData->ui_merge, "add_widget",
-                          G_CALLBACK (recnWindow_add_widget), dock);
+                          G_CALLBACK (recnWindow_add_widget), recnData);
 
         action_group = gtk_action_group_new ("ReconcileWindowActions");
         recnData->action_group = action_group;
@@ -1922,6 +1956,13 @@ recnWindowWithBalance (Account *account, gnc_numeric new_ending,
         recnRefresh (recnData);
     }
 
+    /* track toolbar preference changes */
+    gnc_prefs_register_cb (GNC_PREFS_GROUP_GENERAL, GNC_PREF_TOOLBAR_STYLE,
+                           recn_window_update_toolbar, recnData);
+
+    gnc_prefs_register_cb (GNC_PREFS_GROUP_GENERAL, GNC_PREF_TOOLBAR_ICON_SIZE,
+                           recn_window_update_toolbar, recnData);
+
     /* Allow resize */
     gtk_window_set_resizable(GTK_WINDOW(recnData->window), TRUE);
     gtk_widget_show_all(recnData->window);
@@ -1992,6 +2033,12 @@ recn_destroy_cb (GtkWidget *w, gpointer data)
 
     if (recnData->delete_refresh)
         gnc_resume_gui_refresh ();
+
+    gnc_prefs_remove_cb_by_func (GNC_PREFS_GROUP_GENERAL, GNC_PREF_TOOLBAR_STYLE,
+                                 recn_window_update_toolbar, recnData);
+
+    gnc_prefs_remove_cb_by_func (GNC_PREFS_GROUP_GENERAL, GNC_PREF_TOOLBAR_ICON_SIZE,
+                                 recn_window_update_toolbar, recnData);
 
     g_free (recnData);
 }

--- a/gnucash/gnome/window-reconcile.c
+++ b/gnucash/gnome/window-reconcile.c
@@ -1190,8 +1190,8 @@ gnc_reconcile_window_create_view_box(Account *account,
     vscroll = gtk_scrolled_window_get_vscrollbar (GTK_SCROLLED_WINDOW (scrollWin));
     gtk_widget_get_preferred_size (vscroll, NULL, &nat_sb);
 
-    // add xpadding to amount column so scrollbar does not cover
-    gnc_reconcile_view_add_padding (GNC_RECONCILE_VIEW(view), REC_AMOUNT, nat_sb.width);
+    // add xpadding to recn column so scrollbar does not cover
+    gnc_reconcile_view_add_padding (GNC_RECONCILE_VIEW(view), REC_RECN, nat_sb.width);
 
     hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
     gtk_box_set_homogeneous (GTK_BOX (hbox), FALSE);

--- a/gnucash/gnome/window-reconcile.c
+++ b/gnucash/gnome/window-reconcile.c
@@ -2001,6 +2001,18 @@ recnWindowWithBalance (Account *account, gnc_numeric new_ending,
 
     gtk_widget_grab_focus (recnData->debit);
 
+    {   // align the Totals value with that of the amount column
+        gint recn_widthc = gnc_reconcile_view_get_column_width (GNC_RECONCILE_VIEW(recnData->credit), REC_RECN);
+        gint recn_widthd = gnc_reconcile_view_get_column_width (GNC_RECONCILE_VIEW(recnData->debit), REC_RECN);
+
+#if GTK_CHECK_VERSION(3,12,0)
+        gtk_widget_set_margin_end (GTK_WIDGET(recnData->total_credit), 10 + recn_widthc);
+        gtk_widget_set_margin_end (GTK_WIDGET(recnData->total_debit), 10 + recn_widthd);
+#else
+        gtk_widget_set_margin_right (GTK_WIDGET(recnData->total_credit), 10 + recn_widthc);
+        gtk_widget_set_margin_right (GTK_WIDGET(recnData->total_debit), 10 + recn_widthd);
+#endif
+    }
     return recnData;
 }
 

--- a/gnucash/gschemas/org.gnucash.gschema.xml.in
+++ b/gnucash/gschemas/org.gnucash.gschema.xml.in
@@ -205,6 +205,16 @@
       <summary>Display the notebook tabs at the right of the window.</summary>
       <description>This setting determines the edge at which the tabs for switching pages in notebooks are drawn. Possible values are "top", "left", "bottom" and "right". It defaults to "top".</description>
     </key>
+    <key name="toolbar-style" type="i">
+      <default>3</default>
+      <summary>Toolbar Style choice</summary>
+      <description>This setting controls how the toolbar icons are displayed.</description>
+    </key>
+        <key name="toolbar-icon-size" type="i">
+      <default>1</default>
+      <summary>Toolbar Icon Size</summary>
+      <description>This setting controls the size of the toolbar icons.</description>
+    </key>
     <key name="summarybar-position-top" type="b">
       <default>false</default>
       <summary>Display the summary bar at the top of the page.</summary>
@@ -336,7 +346,7 @@
       <description>This sets the number of characters before auto complete starts for description, notes and memo fields.</description>
     </key>
   </schema>
-  
+
   <schema id="org.gnucash.general.report" path="/org/gnucash/general/report/">
     <key name="use-new-window" type="b">
       <default>false</default>

--- a/gnucash/gtkbuilder/dialog-preferences.glade
+++ b/gnucash/gtkbuilder/dialog-preferences.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.2 -->
+<!-- Generated with glade 3.20.4 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkAdjustment" id="auto_decimal_places_adj">
@@ -96,6 +96,40 @@
     <property name="value">30</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
+  </object>
+  <object class="GtkListStore" id="toolbar-icon-sizes">
+    <columns>
+      <!-- column-name sizes-text -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">Small Icons</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Large Icons</col>
+      </row>
+    </data>
+  </object>
+  <object class="GtkListStore" id="toolbar-styles">
+    <columns>
+      <!-- column-name styles-text -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">Icons</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Text</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Icons and Text</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Icons and Important Text</col>
+      </row>
+    </data>
   </object>
   <object class="GtkDialog" id="gnucash_preferences_dialog">
     <property name="can_focus">False</property>
@@ -3220,6 +3254,114 @@ many months before the current month:</property>
                     <property name="left_attach">1</property>
                     <property name="top_attach">6</property>
                   </packing>
+                </child>
+                <child>
+                  <object class="GtkComboBox" id="pref/general/toolbar-icon-size">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="has_tooltip">True</property>
+                    <property name="tooltip_markup">Specify the icon size for the toolbars.</property>
+                    <property name="tooltip_text" translatable="yes">Specify the icon size for the toolbars.</property>
+                    <property name="halign">start</property>
+                    <property name="margin_left">12</property>
+                    <property name="model">toolbar-icon-sizes</property>
+                    <property name="active">1</property>
+                    <property name="id_column">0</property>
+                    <child>
+                      <object class="GtkCellRendererText" id="toolbar-icon-renderer"/>
+                      <attributes>
+                        <attribute name="text">0</attribute>
+                      </attributes>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">15</property>
+                    <property name="width">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkComboBox" id="pref/general/toolbar-style">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="has_tooltip">True</property>
+                    <property name="tooltip_markup">Change the way the toolbar items are displayed.</property>
+                    <property name="tooltip_text" translatable="yes">Change the way the toolbar items are displayed.</property>
+                    <property name="halign">start</property>
+                    <property name="margin_left">12</property>
+                    <property name="model">toolbar-styles</property>
+                    <property name="active">3</property>
+                    <property name="id_column">0</property>
+                    <child>
+                      <object class="GtkCellRendererText" id="toolbar-style-renderer"/>
+                      <attributes>
+                        <attribute name="text">0</attribute>
+                      </attributes>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">18</property>
+                    <property name="width">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label22">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">&lt;b&gt;Toolbar Icon Size&lt;/b&gt;</property>
+                    <property name="use_markup">True</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">14</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label23">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">&lt;b&gt;Toolbar Style&lt;/b&gt;</property>
+                    <property name="use_markup">True</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">17</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label24">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">13</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label25">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">16</property>
+                  </packing>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
                 </child>
                 <child>
                   <placeholder/>

--- a/gnucash/register/register-gnome/gnucash-sheet.c
+++ b/gnucash/register/register-gnome/gnucash-sheet.c
@@ -2451,8 +2451,11 @@ gnucash_get_style_classes (GnucashSheet *sheet, GtkStyleContext *stylectxt,
         field_type -= COLOR_NEGATIVE;
     }
     else
-        gtk_style_context_add_class (stylectxt, "register-foreground");
-
+    {
+        if (sheet->use_gnc_color_theme) // only add this class if builtin colors used
+            gtk_style_context_add_class (stylectxt, "register-foreground");
+    }
+    
     switch (field_type)
     {
     default:

--- a/libgnucash/core-utils/gnc-prefs.h
+++ b/libgnucash/core-utils/gnc-prefs.h
@@ -71,6 +71,8 @@
 #define GNC_PREF_DATE_BACKMONTHS     "date-backmonths"
 #define GNC_PREF_SHOW_LEAF_ACCT_NAMES "show-leaf-account-names"
 #define GNC_PREF_ENTER_MOVES_TO_END  "enter-moves-to-end"
+#define GNC_PREF_TOOLBAR_STYLE        "toolbar-style"
+#define GNC_PREF_TOOLBAR_ICON_SIZE    "toolbar-icon-size"
 /* Register preferences */
 #define GNC_PREF_DRAW_HOR_LINES      "draw-horizontal-lines"
 #define GNC_PREF_DRAW_VERT_LINES     "draw-vertical-lines"


### PR DESCRIPTION
Bug 796739 has also been mentioned on the user list
Also another stab at the reconcile tree views, had some inspiration about getting the vertical scrollbar width and using that as padding for the last column.
Bug 796751 restores the column order and by using previous commit the tick boxes are not covered.
The last commit aligns the totals label with the account column at first display but does not track it just like before. 