### PR TITLE
Do not execute test-real-data.sh with $SHELL

### DIFF
--- a/libgnucash/backend/xml/test/CMakeLists.txt
+++ b/libgnucash/backend/xml/test/CMakeLists.txt
@@ -103,6 +103,6 @@ set(test-real-data-env
 )
 add_test(NAME test-real-data
    COMMAND ${CMAKE_COMMAND_TMP}
-    ${SHELL} ${CMAKE_CURRENT_SOURCE_DIR}/test-real-data.sh
+    ${CMAKE_CURRENT_SOURCE_DIR}/test-real-data.sh
 )
 set_tests_properties(test-real-data PROPERTIES ENVIRONMENT "${test-real-data-env}")


### PR DESCRIPTION
Avoid a failure when the SHELL environment variable is set to /bin/zsh, for instance.
Fixes https://bugs.gnucash.org/show_bug.cgi?id=796763