### PR TITLE
Bugfix 796783 - handling invalid date range in "get transaction..."

### DIFF
--- a/gnucash/import-export/aqb/gnc-ab-gettrans.c
+++ b/gnucash/import-export/aqb/gnc-ab-gettrans.c
@@ -143,6 +143,23 @@ gnc_ab_gettrans(GtkWidget *parent, Account *gnc_acc)
         g_debug("gnc_ab_gettrans: gettrans_dates aborted");
         goto cleanup;
     }
+
+    /* validate date range: from_date should be less than or equal to to_date. */
+    if(GWEN_Time_toTime_t(from_date) > GWEN_Time_toTime_t(to_date))
+    {
+        g_debug("gnc_ab_gettrans: invalid date range - from_date is greater than to_date");
+        gnc_error_dialog (GTK_WINDOW (parent), _("Invalid date range: \nStart date cannot be greater than the End date!"));
+        goto cleanup;
+    }
+
+    /* validate to_date: to_date cann't be in the future */
+    if(GWEN_Time_toTime_t(to_date) > gnc_time(NULL))
+    {
+        g_debug("gnc_ab_gettrans: invalid date range - to_date is in the future");
+        gnc_error_dialog (GTK_WINDOW (parent), _("Invalid date range: \nEnd date cannot be in the future!"));
+        goto cleanup;
+    }
+
     /* Use this as a local storage for the until_time below. */
     until = GWEN_Time_toTime_t(to_date);
 


### PR DESCRIPTION
The GnuCash attempts to get the transactions from the online bank even
though the date range entered is incorrect.

Examples for incorrect user inputs:
1) "to"-date is smaller than "from"-date
2) "to"-date is in the future

In both cases GnuCash tries to get a connection to the online bank.
It takes a while. After that GnuCash shows an error message:
"Error on executing job. Status: error - job contains errors".
The error message is very general and does not say what is wrong.

It is better to check the user inputs *before* the request
will be send to the bank, and to show a error message if the entered date
range is wrong, *without* creating the connection to the online bank.