### PR TITLE
Some more fixes hopefully

### DIFF
--- a/gnucash/gnome-search/dialog-search.c
+++ b/gnucash/gnome-search/dialog-search.c
@@ -1345,7 +1345,7 @@ gnc_search_dialog_create (GtkWindow *parent,
 
     gnc_search_dialog_init_widgets (sw, title);
     if (sw->prefs_group)
-        gnc_restore_window_size(sw->prefs_group, GTK_WINDOW(sw->dialog));
+        gnc_restore_window_size(sw->prefs_group, GTK_WINDOW(sw->dialog), parent);
     gtk_window_set_transient_for(GTK_WINDOW(sw->dialog), parent);
     gtk_widget_show(sw->dialog);
 

--- a/gnucash/gnome-search/dialog-search.c
+++ b/gnucash/gnome-search/dialog-search.c
@@ -716,6 +716,8 @@ attach_element (GtkWidget *element, GNCSearchWindow *sw, int row)
 
     data = g_object_get_data (G_OBJECT (element), "data");
 
+    gnc_search_core_type_pass_parent (data->element, GTK_WINDOW(sw->dialog));
+
     gtk_grid_attach (GTK_GRID (sw->criteria_table), element, 0, row, 1, 1);
     gtk_widget_set_hexpand (element, TRUE);
     gtk_widget_set_halign (element, GTK_ALIGN_FILL);
@@ -773,6 +775,8 @@ combo_box_changed (GtkComboBox *combo_box, struct _crit_data *data)
         gtk_box_pack_start (GTK_BOX (data->container), data->elemwidget,
                             FALSE, FALSE, 0);
     }
+
+    gnc_search_core_type_pass_parent (data->element, GTK_WINDOW(data->dialog));
 
     /* Make sure it's visible */
     gtk_widget_show_all (data->container);

--- a/gnucash/gnome-search/search-boolean.c
+++ b/gnucash/gnome-search/search-boolean.c
@@ -35,6 +35,7 @@
 
 #define d(x)
 
+static void pass_parent (GNCSearchCoreType *fe, gpointer parent);
 static GNCSearchCoreType *gncs_clone(GNCSearchCoreType *fe);
 static gboolean gncs_validate (GNCSearchCoreType *fe);
 static GtkWidget *gncs_get_widget(GNCSearchCoreType *fe);
@@ -48,6 +49,7 @@ typedef struct _GNCSearchBooleanPrivate GNCSearchBooleanPrivate;
 
 struct _GNCSearchBooleanPrivate
 {
+    GtkWindow *parent;
     gpointer dummy;
 };
 
@@ -96,6 +98,7 @@ gnc_search_boolean_class_init (GNCSearchBooleanClass *klass)
     object_class->finalize = gnc_search_boolean_finalize;
 
     /* override methods */
+    gnc_search_core_type->pass_parent = pass_parent;
     gnc_search_core_type->validate = gncs_validate;
     gnc_search_core_type->get_widget = gncs_get_widget;
     gnc_search_core_type->get_predicate = gncs_get_predicate;
@@ -140,6 +143,19 @@ gnc_search_boolean_set_value (GNCSearchBoolean *fi, gboolean value)
     g_return_if_fail (IS_GNCSEARCH_BOOLEAN (fi));
 
     fi->value = value;
+}
+
+static void
+pass_parent (GNCSearchCoreType *fe, gpointer parent)
+{
+    GNCSearchBoolean *fi = (GNCSearchBoolean *)fe;
+    GNCSearchBooleanPrivate *priv;
+
+    g_return_if_fail (fi);
+    g_return_if_fail (IS_GNCSEARCH_BOOLEAN (fi));
+
+    priv = _PRIVATE(fi);
+    priv->parent = GTK_WINDOW(parent);
 }
 
 static gboolean

--- a/gnucash/gnome-search/search-core-type.c
+++ b/gnucash/gnome-search/search-core-type.c
@@ -149,6 +149,12 @@ gnc_search_core_type_grab_focus (GNCSearchCoreType *fe)
     GNC_SEARCH_CORE_TYPE_GET_CLASS (fe)->grab_focus (fe);
 }
 
+void
+gnc_search_core_type_pass_parent (GNCSearchCoreType *fe, gpointer parent)
+{
+    GNC_SEARCH_CORE_TYPE_GET_CLASS (fe)->pass_parent (fe, parent);
+}
+
 gboolean
 gnc_search_core_type_validate (GNCSearchCoreType *fe)
 {

--- a/gnucash/gnome-search/search-core-type.h
+++ b/gnucash/gnome-search/search-core-type.h
@@ -46,6 +46,7 @@ typedef struct
     /* virtual methods */
     void			(*grab_focus) (GNCSearchCoreType *fe);
     void			(*editable_enters) (GNCSearchCoreType *fe);
+    void			(*pass_parent) (GNCSearchCoreType *fe, gpointer parent);
     gboolean		(*validate) (GNCSearchCoreType *fe);
     GNCSearchCoreType *	(*clone) (GNCSearchCoreType *fe);
     GtkWidget *		(*get_widget) (GNCSearchCoreType *);
@@ -64,6 +65,7 @@ GNCSearchCoreType *	gnc_search_core_type_new_type_name (const char *type);
 /* methods */
 void			gnc_search_core_type_grab_focus (GNCSearchCoreType *fe);
 void			gnc_search_core_type_editable_enters (GNCSearchCoreType *fe);
+void			gnc_search_core_type_pass_parent (GNCSearchCoreType *fe, gpointer parent);
 gboolean        	gnc_search_core_type_validate (GNCSearchCoreType *fe);
 GNCSearchCoreType *	gnc_search_core_type_clone (GNCSearchCoreType *fe);
 GtkWidget *		gnc_search_core_type_get_widget (GNCSearchCoreType *fe);

--- a/gnucash/gnome-search/search-date.c
+++ b/gnucash/gnome-search/search-date.c
@@ -37,6 +37,7 @@
 
 #define d(x)
 
+static void pass_parent (GNCSearchCoreType *fe, gpointer parent);
 static void editable_enters (GNCSearchCoreType *fe);
 static void grab_focus (GNCSearchCoreType *fe);
 static GNCSearchCoreType *gncs_clone(GNCSearchCoreType *fe);
@@ -53,6 +54,7 @@ typedef struct _GNCSearchDatePrivate GNCSearchDatePrivate;
 struct _GNCSearchDatePrivate
 {
     GtkWidget *entry;
+    GtkWindow *parent;
 };
 
 #define _PRIVATE(o) \
@@ -100,6 +102,7 @@ gnc_search_date_class_init (GNCSearchDateClass *klass)
     object_class->finalize = gnc_search_date_finalize;
 
     /* override methods */
+    gnc_search_core_type->pass_parent = pass_parent;
     gnc_search_core_type->editable_enters = editable_enters;
     gnc_search_core_type->grab_focus = grab_focus;
     gnc_search_core_type->validate = gncs_validate;
@@ -162,6 +165,19 @@ gnc_search_date_set_how (GNCSearchDate *fi, QofQueryCompare how)
     g_return_if_fail (fi);
     g_return_if_fail (IS_GNCSEARCH_DATE (fi));
     fi->how = how;
+}
+
+static void
+pass_parent (GNCSearchCoreType *fe, gpointer parent)
+{
+    GNCSearchDate *fi = (GNCSearchDate *)fe;
+    GNCSearchDatePrivate *priv;
+
+    g_return_if_fail (fi);
+    g_return_if_fail (IS_GNCSEARCH_DATE (fi));
+
+    priv = _PRIVATE(fi);
+    priv->parent = GTK_WINDOW(parent);
 }
 
 static gboolean

--- a/gnucash/gnome-search/search-double.c
+++ b/gnucash/gnome-search/search-double.c
@@ -36,6 +36,7 @@
 
 #define d(x)
 
+static void pass_parent (GNCSearchCoreType *fe, gpointer parent);
 static void editable_enters (GNCSearchCoreType *fe);
 static void grab_focus (GNCSearchCoreType *fe);
 static GNCSearchCoreType *gncs_clone(GNCSearchCoreType *fe);
@@ -53,6 +54,7 @@ struct _GNCSearchDoublePrivate
 {
     GtkWidget * entry;
     GNCAmountEdit *gae;
+    GtkWindow *parent;
 };
 
 #define _PRIVATE(o) \
@@ -100,6 +102,7 @@ gnc_search_double_class_init (GNCSearchDoubleClass *klass)
     object_class->finalize = gnc_search_double_finalize;
 
     /* override methods */
+    gnc_search_core_type->pass_parent = pass_parent;
     gnc_search_core_type->editable_enters = editable_enters;
     gnc_search_core_type->grab_focus = grab_focus;
     gnc_search_core_type->validate = gncs_validate;
@@ -154,6 +157,19 @@ gnc_search_double_set_how (GNCSearchDouble *fi, QofQueryCompare how)
     g_return_if_fail (fi);
     g_return_if_fail (IS_GNCSEARCH_DOUBLE (fi));
     fi->how = how;
+}
+
+static void
+pass_parent (GNCSearchCoreType *fe, gpointer parent)
+{
+    GNCSearchDouble *fi = (GNCSearchDouble *)fe;
+    GNCSearchDoublePrivate *priv;
+
+    g_return_if_fail (fi);
+    g_return_if_fail (IS_GNCSEARCH_DOUBLE (fi));
+
+    priv = _PRIVATE(fi);
+    priv->parent = GTK_WINDOW(parent);
 }
 
 static gboolean

--- a/gnucash/gnome-search/search-int64.c
+++ b/gnucash/gnome-search/search-int64.c
@@ -36,6 +36,7 @@
 
 #define d(x)
 
+static void pass_parent (GNCSearchCoreType *fe, gpointer parent);
 static void editable_enters (GNCSearchCoreType *fe);
 static void grab_focus (GNCSearchCoreType *fe);
 static GNCSearchCoreType *gncs_clone(GNCSearchCoreType *fe);
@@ -54,6 +55,7 @@ struct _GNCSearchInt64Private
 {
     GtkWidget *entry;
     GNCAmountEdit *gae;
+    GtkWindow *parent;
 };
 
 #define _PRIVATE(o) \
@@ -101,6 +103,7 @@ gnc_search_int64_class_init (GNCSearchInt64Class *klass)
     object_class->finalize = gnc_search_int64_finalize;
 
     /* override methods */
+    gnc_search_core_type->pass_parent = pass_parent;
     gnc_search_core_type->editable_enters = editable_enters;
     gnc_search_core_type->grab_focus = grab_focus;
     gnc_search_core_type->validate = gncs_validate;
@@ -155,6 +158,19 @@ gnc_search_int64_set_how (GNCSearchInt64 *fi, QofQueryCompare how)
     g_return_if_fail (fi);
     g_return_if_fail (IS_GNCSEARCH_INT64 (fi));
     fi->how = how;
+}
+
+static void
+pass_parent (GNCSearchCoreType *fe, gpointer parent)
+{
+    GNCSearchInt64 *fi = (GNCSearchInt64 *)fe;
+    GNCSearchInt64Private *priv;
+
+    g_return_if_fail (fi);
+    g_return_if_fail (IS_GNCSEARCH_INT64 (fi));
+
+    priv = _PRIVATE(fi);
+    priv->parent = GTK_WINDOW(parent);
 }
 
 static gboolean

--- a/gnucash/gnome-search/search-numeric.c
+++ b/gnucash/gnome-search/search-numeric.c
@@ -36,6 +36,7 @@
 
 #define d(x)
 
+static void pass_parent (GNCSearchCoreType *fe, gpointer parent);
 static void editable_enters (GNCSearchCoreType *fe);
 static void grab_focus (GNCSearchCoreType *fe);
 static GNCSearchCoreType *gncs_clone(GNCSearchCoreType *fe);
@@ -54,6 +55,7 @@ struct _GNCSearchNumericPrivate
     gboolean	is_debcred;
     GtkWidget * 	entry;
     GNCAmountEdit *gae;
+    GtkWindow *parent;
 };
 
 #define _PRIVATE(o) \
@@ -101,6 +103,7 @@ gnc_search_numeric_class_init (GNCSearchNumericClass *klass)
     object_class->finalize = gnc_search_numeric_finalize;
 
     /* override methods */
+    gnc_search_core_type->pass_parent = pass_parent;
     gnc_search_core_type->editable_enters = editable_enters;
     gnc_search_core_type->grab_focus = grab_focus;
     gnc_search_core_type->validate = gncs_validate;
@@ -184,6 +187,19 @@ gnc_search_numeric_set_option (GNCSearchNumeric *fi, QofNumericMatch option)
     g_return_if_fail (fi);
     g_return_if_fail (IS_GNCSEARCH_NUMERIC (fi));
     fi->option = option;
+}
+
+static void
+pass_parent (GNCSearchCoreType *fe, gpointer parent)
+{
+    GNCSearchNumeric *fi = (GNCSearchNumeric *)fe;
+    GNCSearchNumericPrivate *priv;
+
+    g_return_if_fail (fi);
+    g_return_if_fail (IS_GNCSEARCH_NUMERIC (fi));
+
+    priv = _PRIVATE(fi);
+    priv->parent = GTK_WINDOW(parent);
 }
 
 static gboolean

--- a/gnucash/gnome-search/search-reconciled.c
+++ b/gnucash/gnome-search/search-reconciled.c
@@ -36,6 +36,7 @@
 
 #define d(x)
 
+static void pass_parent (GNCSearchCoreType *fe, gpointer parent);
 static GNCSearchCoreType *gncs_clone(GNCSearchCoreType *fe);
 static gboolean gncs_validate (GNCSearchCoreType *fe);
 static GtkWidget *gncs_get_widget(GNCSearchCoreType *fe);
@@ -49,6 +50,7 @@ typedef struct _GNCSearchReconciledPrivate GNCSearchReconciledPrivate;
 
 struct _GNCSearchReconciledPrivate
 {
+    GtkWindow *parent;
     gpointer dummy;
 };
 
@@ -97,6 +99,7 @@ gnc_search_reconciled_class_init (GNCSearchReconciledClass *klass)
     object_class->finalize = gnc_search_reconciled_finalize;
 
     /* override methods */
+    gnc_search_core_type->pass_parent = pass_parent;
     gnc_search_core_type->validate = gncs_validate;
     gnc_search_core_type->get_widget = gncs_get_widget;
     gnc_search_core_type->get_predicate = gncs_get_predicate;
@@ -150,6 +153,19 @@ gnc_search_reconciled_set_how (GNCSearchReconciled *fi, QofCharMatch how)
     g_return_if_fail (fi);
     g_return_if_fail (IS_GNCSEARCH_RECONCILED (fi));
     fi->how = how;
+}
+
+static void
+pass_parent (GNCSearchCoreType *fe, gpointer parent)
+{
+    GNCSearchReconciled *fi = (GNCSearchReconciled *)fe;
+    GNCSearchReconciledPrivate *priv;
+
+    g_return_if_fail (fi);
+    g_return_if_fail (IS_GNCSEARCH_RECONCILED (fi));
+
+    priv = _PRIVATE(fi);
+    priv->parent = GTK_WINDOW(parent);
 }
 
 static gboolean

--- a/gnucash/gnome-utils/dialog-account.c
+++ b/gnucash/gnome-utils/dialog-account.c
@@ -1435,7 +1435,7 @@ gnc_account_window_create(GtkWindow *parent, AccountWindow *aw)
     }
     gnc_account_type_view_create (aw, compat_types);
 
-    gnc_restore_window_size (GNC_PREFS_GROUP, GTK_WINDOW(aw->dialog));
+    gnc_restore_window_size (GNC_PREFS_GROUP, GTK_WINDOW(aw->dialog), parent);
 
     gtk_widget_grab_focus(GTK_WIDGET(aw->name_entry));
 

--- a/gnucash/gnome-utils/dialog-book-close.c
+++ b/gnucash/gnome-utils/dialog-book-close.c
@@ -322,7 +322,7 @@ gnc_book_close_response_cb(GtkDialog *dialog, gint response, GtkDialog *unused)
     LEAVE("");
 }
 
-void gnc_ui_close_book (QofBook* book)
+void gnc_ui_close_book (QofBook* book, GtkWindow *parent)
 {
     struct CloseBookWindow *cbw;
     GtkBuilder* builder;
@@ -342,6 +342,10 @@ void gnc_ui_close_book (QofBook* book)
 
     // Set the style context for this dialog so it can be easily manipulated with css
     gnc_widget_set_style_context (GTK_WIDGET(cbw->dialog), "GncBookCloseDialog");
+
+    /* parent */
+    if (parent != NULL)
+        gtk_window_set_transient_for (GTK_WINDOW(cbw->dialog), GTK_WINDOW(parent));
 
     PINFO("Closed Book Window is %p, Dialog is %p", cbw, cbw->dialog);
 

--- a/gnucash/gnome-utils/dialog-book-close.h
+++ b/gnucash/gnome-utils/dialog-book-close.h
@@ -40,8 +40,9 @@
  *
  *  @param book This parameter specifies the book whose data
  *  will be closed.
+ *  @param parent This parameter specifies the parent window
  */
-void gnc_ui_close_book (QofBook* book);
+void gnc_ui_close_book (QofBook* book, GtkWindow *parent);
 
 
 /** @} */

--- a/gnucash/gnome-utils/dialog-options.c
+++ b/gnucash/gnome-utils/dialog-options.c
@@ -2268,7 +2268,7 @@ gnc_options_dialog_new_modal(gboolean modal, gchar *title,
 
     gtk_builder_connect_signals_full (builder, gnc_builder_connect_full_func, retval);
 
-    gnc_restore_window_size (GNC_PREFS_GROUP, GTK_WINDOW(retval->window));
+    gnc_restore_window_size (GNC_PREFS_GROUP, GTK_WINDOW(retval->window), parent);
 
     if (title)
         gtk_window_set_title(GTK_WINDOW(retval->window), title);

--- a/gnucash/gnome-utils/dialog-options.c
+++ b/gnucash/gnome-utils/dialog-options.c
@@ -165,6 +165,7 @@ void gnc_option_changed_gain_loss_account_widget_cb(GtkTreeSelection *selection,
                                                     gpointer data);
 void gnc_option_changed_gain_loss_account_del_button_widget_cb (GtkButton *button,
                                                     gpointer data);
+static void component_close_handler (gpointer data);
 
 GtkWidget *
 gnc_option_get_gtk_widget (GNCOption *option)
@@ -2028,6 +2029,8 @@ gnc_options_dialog_help_button_cb(GtkWidget * widget, GNCOptionWin *win)
 static void
 gnc_options_dialog_cancel_button_cb(GtkWidget * widget, GNCOptionWin *win)
 {
+    gnc_save_window_size (GNC_PREFS_GROUP, GTK_WINDOW(win->window));
+
     if (win->close_cb)
         (win->close_cb)(win, win->close_cb_data);
     else
@@ -2075,6 +2078,20 @@ gnc_options_dialog_destroy_cb (GtkWidget *object, GNCOptionWin *win)
         if (win->close_cb)
             (win->close_cb)(win, win->close_cb_data);
     }
+}
+
+static gboolean
+gnc_options_dialog_window_key_press_cb(GtkWidget *widget, GdkEventKey *event, gpointer data)
+{
+    GNCOptionWin *win = data;
+
+    if (event->keyval == GDK_KEY_Escape)
+    {
+        component_close_handler (win);
+        return TRUE;
+    }
+    else
+        return FALSE;
 }
 
 static void
@@ -2139,6 +2156,7 @@ static void
 component_close_handler (gpointer data)
 {
     GNCOptionWin *win = data;
+    gnc_save_window_size (GNC_PREFS_GROUP, GTK_WINDOW(win->window));
     gnc_options_dialog_cancel_button_cb (NULL, win);
 }
 
@@ -2290,6 +2308,9 @@ gnc_options_dialog_new_modal(gboolean modal, gchar *title,
 
     g_signal_connect (retval->window, "destroy",
                       G_CALLBACK(gnc_options_dialog_destroy_cb), retval);
+
+    g_signal_connect (retval->window, "key_press_event",
+                      G_CALLBACK(gnc_options_dialog_window_key_press_cb), retval);
 
     g_object_unref(G_OBJECT(builder));
 

--- a/gnucash/gnome-utils/dialog-preferences.c
+++ b/gnucash/gnome-utils/dialog-preferences.c
@@ -1444,7 +1444,7 @@ gnc_preferences_dialog (GtkWindow *parent)
 
     dialog = gnc_preferences_dialog_create(parent);
 
-    gnc_restore_window_size(GNC_PREFS_GROUP, GTK_WINDOW(dialog));
+    gnc_restore_window_size(GNC_PREFS_GROUP, GTK_WINDOW(dialog), parent);
     gtk_widget_show(dialog);
 
     gnc_register_gui_component(DIALOG_PREFERENCES_CM_CLASS,

--- a/gnucash/gnome-utils/dialog-reset-warnings.c
+++ b/gnucash/gnome-utils/dialog-reset-warnings.c
@@ -413,7 +413,7 @@ gnc_reset_warnings_dialog (GtkWindow *parent)
     /* Record the pointer to the rw data structure and clean up after */
     g_object_set_data_full(G_OBJECT(rw_dialog->dialog), "dialog-structure", rw_dialog, g_free);
 
-    gnc_restore_window_size(GNC_PREFS_GROUP, GTK_WINDOW(rw_dialog->dialog));
+    gnc_restore_window_size(GNC_PREFS_GROUP, GTK_WINDOW(rw_dialog->dialog), parent);
 
     gnc_register_gui_component (DIALOG_RESET_WARNINGS_CM_CLASS,
                                 NULL, close_handler, rw_dialog);

--- a/gnucash/gnome-utils/dialog-tax-table.c
+++ b/gnucash/gnome-utils/dialog-tax-table.c
@@ -768,7 +768,7 @@ gnc_ui_tax_table_window_new (GtkWindow *parent, QofBook *book)
                                     ttw);
 
     tax_table_window_refresh (ttw);
-    gnc_restore_window_size (GNC_PREFS_GROUP, GTK_WINDOW (ttw->dialog));
+    gnc_restore_window_size (GNC_PREFS_GROUP, GTK_WINDOW (ttw->dialog), parent);
     gtk_widget_show_all (ttw->dialog);
 
     g_object_unref(G_OBJECT(builder));

--- a/gnucash/gnome-utils/dialog-totd.c
+++ b/gnucash/gnome-utils/dialog-totd.c
@@ -366,7 +366,7 @@ gnc_totd_dialog (GtkWindow *parent, gboolean startup)
 
     gnc_new_tip_number(totd_dialog, 1);
 
-    gnc_restore_window_size(GNC_PREFS_GROUP, GTK_WINDOW(totd_dialog->dialog));
+    gnc_restore_window_size(GNC_PREFS_GROUP, GTK_WINDOW(totd_dialog->dialog), parent);
     gtk_widget_show(GTK_WIDGET (totd_dialog->dialog));
 
     gnc_register_gui_component(DIALOG_TOTD_CM_CLASS,

--- a/gnucash/gnome-utils/dialog-transfer.c
+++ b/gnucash/gnome-utils/dialog-transfer.c
@@ -2046,7 +2046,8 @@ gnc_xfer_dialog_create(GtkWidget *parent, XferDialog *xferData)
     }
 
     gtk_builder_connect_signals(builder, xferData);
-    gnc_restore_window_size (GNC_PREFS_GROUP, GTK_WINDOW (xferData->dialog));
+    gnc_restore_window_size (GNC_PREFS_GROUP,
+                             GTK_WINDOW (xferData->dialog), GTK_WINDOW (parent));
     LEAVE(" ");
 }
 

--- a/gnucash/gnome-utils/dialog-utils.c
+++ b/gnucash/gnome-utils/dialog-utils.c
@@ -195,7 +195,7 @@ gnc_restore_window_size(const char *group, GtkWindow *window, GtkWindow *parent)
 /********************************************************************\
  * gnc_save_window_size                                             *
  *   save the window position and size into options whose names are *
- *   prefixed by the group name.                                   *
+ *   prefixed by the group name.                                    *
  *                                                                  *
  * Args: group - preferences group to save the options in           *
  *       window - the window for which current position and size    *
@@ -208,6 +208,8 @@ gnc_save_window_size(const char *group, GtkWindow *window)
     gint wpos[2], wsize[2];
     GVariant *geometry;
 
+    ENTER("");
+
     g_return_if_fail(group != NULL);
     g_return_if_fail(window != NULL);
 
@@ -216,10 +218,15 @@ gnc_save_window_size(const char *group, GtkWindow *window)
 
     gtk_window_get_position(GTK_WINDOW(window), &wpos[0], &wpos[1]);
     gtk_window_get_size(GTK_WINDOW(window), &wsize[0], &wsize[1]);
+
+    DEBUG("save geometry - wpos[0]: %d, wpos[1]: %d, wsize[0]: %d, wsize[1]: %d",
+                  wpos[0],  wpos[1], wsize[0], wsize[1]);
+
     geometry = g_variant_new ("(iiii)", wpos[0],  wpos[1],
                               wsize[0], wsize[1]);
     gnc_prefs_set_value (group, GNC_PREF_LAST_GEOMETRY, geometry);
     /* Don't unref geometry here, it is consumed by gnc_prefs_set_value */
+    LEAVE("");
 }
 
 

--- a/gnucash/gnome-utils/dialog-utils.h
+++ b/gnucash/gnome-utils/dialog-utils.h
@@ -48,8 +48,7 @@ void gnc_restore_window_size (const char *prefix, GtkWindow *window,
  * by the string prefix.                                            *
  *                                                                  *
  * Args: prefix - determines the options used to save the values    *
- *       width  - width of the window to save                       *
- *       height - height of the window to save                      *
+ *       window - the window being saved                            *
  * Returns: nothing                                                 *
 \********************************************************************/
 void gnc_save_window_size (const char *section, GtkWindow *window);

--- a/gnucash/gnome-utils/dialog-utils.h
+++ b/gnucash/gnome-utils/dialog-utils.h
@@ -36,11 +36,12 @@ void gnc_set_label_color (GtkWidget *label, gnc_numeric value);
  * if window sizes are being saved, otherwise returns 0 for both.   *
  *                                                                  *
  * Args: prefix - the option name prefix                            *
- *       width  - pointer to width                                  *
- *       height - pointer to height                                 *
+ *       window - the window being restored                         *
+ *       parent - the parent window for first use alignment         *
  * Returns: nothing                                                 *
  \*******************************************************************/
-void gnc_restore_window_size (const char *prefix, GtkWindow *window);
+void gnc_restore_window_size (const char *prefix, GtkWindow *window,
+                              GtkWindow *parent);
 
 /********************************************************************\
  * Save the window size into options whose names are determined     *

--- a/gnucash/gnome/assistant-hierarchy.c
+++ b/gnucash/gnome/assistant-hierarchy.c
@@ -1317,7 +1317,8 @@ gnc_create_hierarchy_assistant (gboolean use_defaults, GncHierarchyAssistantFini
 
     data->balance_hash = g_hash_table_new(NULL, NULL);
 
-    gnc_restore_window_size (GNC_PREFS_GROUP, GTK_WINDOW(data->dialog));
+    gnc_restore_window_size (GNC_PREFS_GROUP,
+                             GTK_WINDOW(data->dialog), gnc_ui_get_main_window(NULL));
 
     g_signal_connect (G_OBJECT(dialog), "destroy",
                       G_CALLBACK (gnc_hierarchy_destroy_cb), data);

--- a/gnucash/gnome/dialog-commodities.c
+++ b/gnucash/gnome/dialog-commodities.c
@@ -362,7 +362,7 @@ gnc_commodities_dialog_create (GtkWidget * parent, CommoditiesDialog *cd)
     gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON(button), cd->show_currencies);
 
     g_object_unref(G_OBJECT(builder));
-    gnc_restore_window_size (GNC_PREFS_GROUP, GTK_WINDOW(cd->dialog));
+    gnc_restore_window_size (GNC_PREFS_GROUP, GTK_WINDOW(cd->dialog), GTK_WINDOW(parent));
 }
 
 static void

--- a/gnucash/gnome/dialog-fincalc.c
+++ b/gnucash/gnome/dialog-fincalc.c
@@ -676,7 +676,7 @@ gnc_ui_fincalc_dialog_create(GtkWindow *parent)
     gtk_builder_connect_signals(builder, fcd);
     g_object_unref(G_OBJECT(builder));
 
-    gnc_restore_window_size(GNC_PREFS_GROUP, GTK_WINDOW(fcd->dialog));
+    gnc_restore_window_size(GNC_PREFS_GROUP, GTK_WINDOW(fcd->dialog), parent);
     gtk_widget_show(fcd->dialog);
 }
 

--- a/gnucash/gnome/dialog-find-account.c
+++ b/gnucash/gnome/dialog-find-account.c
@@ -377,7 +377,7 @@ gnc_find_account_dialog_create (GtkWidget *parent, FindAccountDialog *facc_dialo
 
     g_object_unref (G_OBJECT(builder));
 
-    gnc_restore_window_size (GNC_PREFS_GROUP, GTK_WINDOW(facc_dialog->window));
+    gnc_restore_window_size (GNC_PREFS_GROUP, GTK_WINDOW(facc_dialog->window), GTK_WINDOW(parent));
 
     gtk_widget_show_all (GTK_WIDGET(facc_dialog->window));
 

--- a/gnucash/gnome/dialog-find-account.c
+++ b/gnucash/gnome/dialog-find-account.c
@@ -65,6 +65,8 @@ typedef struct
 /* This static indicates the debugging module that this .o belongs to.  */
 static QofLogModule log_module = GNC_MOD_GUI;
 
+static void close_handler (gpointer user_data);
+
 static void
 gnc_find_account_dialog_window_destroy_cb (GtkWidget *object, gpointer user_data)
 {
@@ -80,6 +82,20 @@ gnc_find_account_dialog_window_destroy_cb (GtkWidget *object, gpointer user_data
     }
     g_free (facc_dialog);
     LEAVE(" ");
+}
+
+static gboolean
+gnc_find_account_dialog_window_key_press_cb(GtkWidget *widget, GdkEventKey *event, gpointer user_data)
+{
+    FindAccountDialog *facc_dialog = user_data;
+
+    if (event->keyval == GDK_KEY_Escape)
+    {
+        close_handler (facc_dialog);
+        return TRUE;
+    }
+    else
+        return FALSE;
 }
 
 static void
@@ -353,6 +369,9 @@ gnc_find_account_dialog_create (GtkWidget *parent, FindAccountDialog *facc_dialo
 
     g_signal_connect (facc_dialog->window, "destroy",
                       G_CALLBACK(gnc_find_account_dialog_window_destroy_cb), facc_dialog);
+
+    g_signal_connect (facc_dialog->window, "key_press_event",
+                      G_CALLBACK(gnc_find_account_dialog_window_key_press_cb), facc_dialog);
 
     gtk_builder_connect_signals_full (builder, gnc_builder_connect_full_func, facc_dialog);
 

--- a/gnucash/gnome/dialog-imap-editor.c
+++ b/gnucash/gnome/dialog-imap-editor.c
@@ -716,7 +716,7 @@ gnc_imap_dialog_create (GtkWidget *parent, ImapDialog *imap_dialog)
 
     g_object_unref (G_OBJECT(builder));
 
-    gnc_restore_window_size (GNC_PREFS_GROUP, GTK_WINDOW(imap_dialog->dialog));
+    gnc_restore_window_size (GNC_PREFS_GROUP, GTK_WINDOW(imap_dialog->dialog), GTK_WINDOW(parent));
     get_account_info (imap_dialog);
 
     LEAVE(" ");

--- a/gnucash/gnome/dialog-lot-viewer.c
+++ b/gnucash/gnome/dialog-lot-viewer.c
@@ -667,7 +667,6 @@ void
 lv_window_destroy_cb (GtkWidget *object, gpointer user_data)
 {
     GNCLotViewer *lv = user_data;
-    gnc_close_gui_component_by_data (LOT_VIEWER_CM_CLASS, lv);
     gnc_unregister_gui_component_by_data (LOT_VIEWER_CM_CLASS, lv);
     g_free (lv);
 }
@@ -732,7 +731,7 @@ lv_response_cb (GtkDialog *dialog, gint response, gpointer data)
     switch (response)
     {
     case GTK_RESPONSE_CLOSE:
-        lv_close_handler(lv);
+        gnc_close_gui_component_by_data (LOT_VIEWER_CM_CLASS, lv);
         return;
 
     case RESPONSE_VIEW:
@@ -979,7 +978,7 @@ lv_init_split_buttons (GNCLotViewer *lv)
 /* ======================================================================== */
 
 static void
-lv_create (GNCLotViewer *lv)
+lv_create (GNCLotViewer *lv, GtkWindow *parent)
 {
     gchar *win_title;
     GtkBuilder *builder;
@@ -988,6 +987,8 @@ lv_create (GNCLotViewer *lv)
     gnc_builder_add_from_file (builder, "dialog-lot-viewer.glade", "lot_viewer_dialog");
 
     lv->window = GTK_WIDGET(gtk_builder_get_object (builder, "lot_viewer_dialog"));
+
+    gtk_window_set_transient_for (GTK_WINDOW (lv->window), parent);
 
     // Set the style context for this dialog so it can be easily manipulated with css
     gnc_widget_set_style_context (GTK_WIDGET(lv->window), "GncLotViewerDialog");
@@ -1046,13 +1047,13 @@ lv_create (GNCLotViewer *lv)
 
     lv_update_split_buttons(lv);
 
-    gnc_restore_window_size(GNC_PREFS_GROUP, GTK_WINDOW(lv->window));
+    gnc_restore_window_size(GNC_PREFS_GROUP, GTK_WINDOW(lv->window), parent);
 }
 
 /* ======================================================================== */
 
 GNCLotViewer *
-gnc_lot_viewer_dialog (Account *account)
+gnc_lot_viewer_dialog (GtkWindow *parent, Account *account)
 {
     GNCLotViewer *lv;
     gint component_id;
@@ -1061,7 +1062,7 @@ gnc_lot_viewer_dialog (Account *account)
 
     lv = g_new0 (GNCLotViewer, 1);
     lv->account = account;
-    lv_create (lv);
+    lv_create (lv, parent);
     gnc_lot_viewer_fill (lv);
     lv_show_splits_free (lv);
 

--- a/gnucash/gnome/dialog-lot-viewer.h
+++ b/gnucash/gnome/dialog-lot-viewer.h
@@ -30,6 +30,6 @@
 typedef struct _GNCLotViewer GNCLotViewer;
 
 /** Create and realize and show a lot-viewing dialog. */
-GNCLotViewer * gnc_lot_viewer_dialog (Account *);
+GNCLotViewer * gnc_lot_viewer_dialog (GtkWindow *parent, Account *account);
 
 #endif /* LOT_VIEWER_H */

--- a/gnucash/gnome/dialog-price-edit-db.c
+++ b/gnucash/gnome/dialog-price-edit-db.c
@@ -735,7 +735,7 @@ gnc_prices_dialog_create (GtkWidget * parent, PricesDialog *pdb_dialog)
 
     g_object_unref(G_OBJECT(builder));
 
-    gnc_restore_window_size(GNC_PREFS_GROUP, GTK_WINDOW(pdb_dialog->dialog));
+    gnc_restore_window_size(GNC_PREFS_GROUP, GTK_WINDOW(pdb_dialog->dialog), GTK_WINDOW (parent));
     LEAVE(" ");
 }
 

--- a/gnucash/gnome/dialog-price-editor.c
+++ b/gnucash/gnome/dialog-price-editor.c
@@ -544,7 +544,7 @@ gnc_price_edit_dialog (GtkWidget * parent,
 
     pedit_dialog = g_new0 (PriceEditDialog, 1);
     gnc_price_pedit_dialog_create (parent, pedit_dialog, session);
-    gnc_restore_window_size(GNC_PREFS_GROUP, GTK_WINDOW(pedit_dialog->dialog));
+    gnc_restore_window_size(GNC_PREFS_GROUP, GTK_WINDOW(pedit_dialog->dialog), GTK_WINDOW(parent));
     pedit_dialog->type = type;
 
     switch (type)

--- a/gnucash/gnome/dialog-print-check.c
+++ b/gnucash/gnome/dialog-print-check.c
@@ -1732,7 +1732,7 @@ gnc_ui_print_check_dialog_create(GtkWidget *parent,
     gtk_widget_destroy(GTK_WIDGET(gtk_builder_get_object (builder, "lower_left")));
 
     gnc_ui_print_restore_dialog(pcd);
-    gnc_restore_window_size(GNC_PREFS_GROUP, GTK_WINDOW(pcd->dialog));
+    gnc_restore_window_size(GNC_PREFS_GROUP, GTK_WINDOW(pcd->dialog), GTK_WINDOW (parent));
 
     g_object_unref(G_OBJECT(builder));
     gtk_widget_show_all(pcd->dialog);

--- a/gnucash/gnome/dialog-sx-editor.c
+++ b/gnucash/gnome/dialog-sx-editor.c
@@ -1240,7 +1240,7 @@ gnc_ui_scheduled_xaction_editor_dialog_create (GtkWindow *parent,
 
     /* Allow resize */
     gtk_window_set_resizable (GTK_WINDOW(sxed->dialog), TRUE);
-    gnc_restore_window_size(GNC_PREFS_GROUP_SXED, GTK_WINDOW(sxed->dialog));
+    gnc_restore_window_size(GNC_PREFS_GROUP_SXED, GTK_WINDOW(sxed->dialog), parent);
 
     /* create the frequency-selection widget and example [dense-]calendar. */
     schedXact_editor_create_freq_sel( sxed );

--- a/gnucash/gnome/dialog-sx-editor2.c
+++ b/gnucash/gnome/dialog-sx-editor2.c
@@ -1213,7 +1213,7 @@ gnc_ui_scheduled_xaction_editor_dialog_create2 (GtkWindow *parent,
 
     /* Allow resize */
     gtk_window_set_resizable (GTK_WINDOW (sxed->dialog), TRUE);
-    gnc_restore_window_size (GNC_PREFS_GROUP_SXED, GTK_WINDOW (sxed->dialog));
+    gnc_restore_window_size (GNC_PREFS_GROUP_SXED, GTK_WINDOW (sxed->dialog), parent);
 
     /* create the frequency-selection widget and example [dense-]calendar. */
     schedXact_editor_create_freq_sel (sxed);

--- a/gnucash/gnome/dialog-sx-since-last-run.c
+++ b/gnucash/gnome/dialog-sx-since-last-run.c
@@ -1040,7 +1040,7 @@ gnc_ui_sx_since_last_run_dialog (GtkWindow *parent, GncSxInstanceModel *sx_insta
     g_signal_connect(G_OBJECT(dialog->dialog), "response", G_CALLBACK(dialog_response_cb), dialog);
     g_signal_connect(G_OBJECT(dialog->dialog), "destroy", G_CALLBACK(dialog_destroy_cb), dialog);
 
-    gnc_restore_window_size(GNC_PREFS_GROUP_STARTUP, GTK_WINDOW(dialog->dialog));
+    gnc_restore_window_size(GNC_PREFS_GROUP_STARTUP, GTK_WINDOW(dialog->dialog), parent);
 
     dialog->component_id = gnc_register_gui_component
                            (DIALOG_SX_SINCE_LAST_RUN_CM_CLASS, NULL, close_handler, dialog);

--- a/gnucash/gnome/dialog-tax-info.c
+++ b/gnucash/gnome/dialog-tax-info.c
@@ -1456,7 +1456,8 @@ gnc_tax_info_dialog_create (GtkWidget * parent, TaxInfoDialog *ti_dialog)
     clear_gui (ti_dialog);
     gnc_tax_info_set_changed (ti_dialog, FALSE);
 
-    gnc_restore_window_size(GNC_PREFS_GROUP, GTK_WINDOW(ti_dialog->dialog));
+    gnc_restore_window_size(GNC_PREFS_GROUP,
+                            GTK_WINDOW(ti_dialog->dialog), GTK_WINDOW (parent));
 
 
     if (gnc_prefs_get_bool(GNC_PREFS_GROUP_GENERAL, GNC_PREF_SAVE_GEOMETRY))

--- a/gnucash/gnome/dialog-trans-assoc.c
+++ b/gnucash/gnome/dialog-trans-assoc.c
@@ -57,6 +57,8 @@ typedef struct
 /* This static indicates the debugging module that this .o belongs to.  */
 static QofLogModule log_module = GNC_MOD_GUI;
 
+static void close_handler (gpointer user_data);
+
 static void
 gnc_assoc_dialog_window_destroy_cb (GtkWidget *object, gpointer user_data)
 {
@@ -71,6 +73,20 @@ gnc_assoc_dialog_window_destroy_cb (GtkWidget *object, gpointer user_data)
     }
     g_free (assoc_dialog);
     LEAVE(" ");
+}
+
+static gboolean
+gnc_assoc_dialog_window_key_press_cb(GtkWidget *widget, GdkEventKey *event, gpointer user_data)
+{
+    AssocDialog *assoc_dialog = user_data;
+
+    if (event->keyval == GDK_KEY_Escape)
+    {
+        close_handler (assoc_dialog);
+        return TRUE;
+    }
+    else
+        return FALSE;
 }
 
 static gint
@@ -451,6 +467,9 @@ gnc_assoc_dialog_create (AssocDialog *assoc_dialog)
 
     g_signal_connect (assoc_dialog->window, "destroy",
                       G_CALLBACK(gnc_assoc_dialog_window_destroy_cb), assoc_dialog);
+
+    g_signal_connect (assoc_dialog->window, "key_press_event",
+                      G_CALLBACK(gnc_assoc_dialog_window_key_press_cb), assoc_dialog);
 
     gtk_builder_connect_signals_full (builder, gnc_builder_connect_full_func, assoc_dialog);
 

--- a/gnucash/gnome/dialog-trans-assoc.c
+++ b/gnucash/gnome/dialog-trans-assoc.c
@@ -387,7 +387,7 @@ get_trans_info (AssocDialog *assoc_dialog)
 }
 
 static void
-gnc_assoc_dialog_create (AssocDialog *assoc_dialog)
+gnc_assoc_dialog_create (GtkWindow *parent, AssocDialog *assoc_dialog)
 {
     GtkWidget         *window;
     GtkBuilder        *builder;
@@ -475,7 +475,7 @@ gnc_assoc_dialog_create (AssocDialog *assoc_dialog)
 
     g_object_unref (G_OBJECT(builder));
 
-    gnc_restore_window_size (GNC_PREFS_GROUP, GTK_WINDOW(assoc_dialog->window));
+    gnc_restore_window_size (GNC_PREFS_GROUP, GTK_WINDOW(assoc_dialog->window), parent);
     get_trans_info (assoc_dialog);
     gtk_widget_show_all (GTK_WIDGET(window));
 
@@ -525,7 +525,7 @@ show_handler (const char *klass, gint component_id,
  * Return: nothing                                                  *
 \********************************************************************/
 void
-gnc_trans_assoc_dialog (void)
+gnc_trans_assoc_dialog (GtkWindow *parent)
 {
     AssocDialog *assoc_dialog;
 
@@ -537,12 +537,11 @@ gnc_trans_assoc_dialog (void)
     }
     assoc_dialog = g_new0 (AssocDialog, 1);
 
-    gnc_assoc_dialog_create (assoc_dialog);
+    gnc_assoc_dialog_create (parent, assoc_dialog);
 
     gnc_register_gui_component (DIALOG_ASSOC_CM_CLASS,
                    refresh_handler, close_handler,
                    assoc_dialog);
 
-//    gtk_widget_show (assoc_dialog->window);
     LEAVE(" ");
 }

--- a/gnucash/gnome/dialog-trans-assoc.h
+++ b/gnucash/gnome/dialog-trans-assoc.h
@@ -23,6 +23,6 @@
 #ifndef DIALOG_TRANS_ASSOC_H
 #define DIALOG_TRANS_ASSOC_H
 
-void gnc_trans_assoc_dialog (void);
+void gnc_trans_assoc_dialog (GtkWindow *parent);
 
 #endif

--- a/gnucash/gnome/gnc-plugin-basic-commands.c
+++ b/gnucash/gnome/gnc-plugin-basic-commands.c
@@ -653,7 +653,7 @@ gnc_main_window_cmd_tools_financial_calculator (GtkAction *action, GncMainWindow
 static void
 gnc_main_window_cmd_tools_close_book (GtkAction *action, GncMainWindowActionData *data)
 {
-    gnc_ui_close_book(gnc_get_current_book());
+    gnc_ui_close_book(gnc_get_current_book(), GTK_WINDOW (data->window));
 }
 
 static void

--- a/gnucash/gnome/gnc-plugin-basic-commands.c
+++ b/gnucash/gnome/gnc-plugin-basic-commands.c
@@ -624,7 +624,7 @@ static void
 gnc_main_window_cmd_tools_trans_assoc (GtkAction *action, GncMainWindowActionData *data)
 {
     gnc_set_busy_cursor (NULL, TRUE);
-    gnc_trans_assoc_dialog ();
+    gnc_trans_assoc_dialog (GTK_WINDOW (data->window));
     gnc_unset_busy_cursor (NULL);
 }
 

--- a/gnucash/gnome/gnc-plugin-page-account-tree.c
+++ b/gnucash/gnome/gnc-plugin-page-account-tree.c
@@ -1749,10 +1749,9 @@ static void
 gnc_plugin_page_account_tree_cmd_lots (GtkAction *action,
                                        GncPluginPageAccountTree *page)
 {
-    Account *account;
-
-    account = gnc_plugin_page_account_tree_get_current_account (page);
-    gnc_lot_viewer_dialog (account);
+    Account *account = gnc_plugin_page_account_tree_get_current_account (page);
+    GtkWidget *window = GNC_PLUGIN_PAGE (page)->window;
+    gnc_lot_viewer_dialog (GTK_WINDOW(window), account);
 }
 
 static void

--- a/gnucash/gnome/gnc-plugin-page-register.c
+++ b/gnucash/gnome/gnc-plugin-page-register.c
@@ -3547,14 +3547,16 @@ static void
 gnc_plugin_page_register_cmd_lots (GtkAction *action,
                                    GncPluginPageRegister *page)
 {
+    GtkWindow *window;
     Account *account;
 
     ENTER("(action %p, plugin_page %p)", action, page);
 
     g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
 
+    window = gnc_window_get_gtk_window(GNC_WINDOW(GNC_PLUGIN_PAGE (page)->window));
     account = gnc_plugin_page_register_get_account (page);
-    gnc_lot_viewer_dialog (account);
+    gnc_lot_viewer_dialog (window, account);
     LEAVE(" ");
 }
 

--- a/gnucash/gnome/gnc-plugin-page-register2.c
+++ b/gnucash/gnome/gnc-plugin-page-register2.c
@@ -3347,14 +3347,16 @@ static void
 gnc_plugin_page_register2_cmd_lots (GtkAction *action,
                                    GncPluginPageRegister2 *page) // this works
 {
+    GtkWindow *window;
     Account *account;
 
     ENTER("(action %p, plugin_page %p)", action, page);
 
     g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER2(page));
 
+    window = gnc_window_get_gtk_window(GNC_WINDOW(GNC_PLUGIN_PAGE (page)->window));
     account = gnc_plugin_page_register2_get_account (page);
-    gnc_lot_viewer_dialog (account);
+    gnc_lot_viewer_dialog (window, account);
     LEAVE(" ");
 }
 

--- a/gnucash/gnome/window-reconcile.c
+++ b/gnucash/gnome/window-reconcile.c
@@ -1674,7 +1674,7 @@ recnWindow (GtkWidget *parent, Account *account)
             enable_subaccounts))
         return NULL;
 
-    return recnWindowWithBalance (account, new_ending, statement_date);
+    return recnWindowWithBalance (parent, account, new_ending, statement_date);
 }
 
 
@@ -1725,13 +1725,14 @@ recn_window_update_toolbar (gpointer prefs, gchar *pref, RecnWindow *recnData)
  *   Opens up the window to reconcile an account, but with ending
  *   balance and statement date already given.
  *
- * Args:   account        - The account to reconcile
+ * Args:   parent         - The parent widget of the new window
+ *         account        - The account to reconcile
  *         new_ending     - The amount for ending balance
  *         statement_date - The date of the statement
  * Return: recnData - the instance of this RecnWindow
 \********************************************************************/
 RecnWindow *
-recnWindowWithBalance (Account *account, gnc_numeric new_ending,
+recnWindowWithBalance (GtkWidget *parent, Account *account, gnc_numeric new_ending,
                        time64 statement_date)
 {
     RecnWindow *recnData;
@@ -1849,7 +1850,8 @@ recnWindowWithBalance (Account *account, gnc_numeric new_ending,
 
         /* Force a reasonable starting size */
         gtk_window_set_default_size(GTK_WINDOW(recnData->window), 800, 600);
-        gnc_restore_window_size (GNC_PREFS_GROUP_RECONCILE, GTK_WINDOW(recnData->window));
+        gnc_restore_window_size (GNC_PREFS_GROUP_RECONCILE,
+                                 GTK_WINDOW(recnData->window), GTK_WINDOW(parent));
 
         gtk_container_add(GTK_CONTAINER(frame), main_area);
         gtk_container_set_border_width(GTK_CONTAINER(main_area), 10);

--- a/gnucash/gnome/window-reconcile.h
+++ b/gnucash/gnome/window-reconcile.h
@@ -52,12 +52,13 @@ RecnWindow *recnWindow (GtkWidget *parent, Account *account);
  *   Opens up the window to reconcile an account, but with ending
  *   balance and statement date already given.
  *
- * Args:   account        - The account to reconcile
+ * Args:   parent         - The parent widget of the new window
+ *         account        - The account to reconcile
  *         new_ending     - The amount for ending balance
  *         statement_date - The date of the statement
  * Return: recnData - the instance of this RecnWindow
 \********************************************************************/
-RecnWindow *recnWindowWithBalance (Account *account,
+RecnWindow *recnWindowWithBalance (GtkWidget *parent, Account *account,
                                    gnc_numeric new_ending,
                                    time64 statement_date);
 

--- a/gnucash/gnome/window-reconcile2.c
+++ b/gnucash/gnome/window-reconcile2.c
@@ -1764,7 +1764,8 @@ recnWindow2WithBalance (GtkWidget *parent, Account *account,
 
         /* Force a reasonable starting size */
         gtk_window_set_default_size (GTK_WINDOW (recnData->window), 800, 600);
-        gnc_restore_window_size (GNC_PREFS_GROUP_RECONCILE, GTK_WINDOW (recnData->window));
+        gnc_restore_window_size (GNC_PREFS_GROUP_RECONCILE,
+                                 GTK_WINDOW (recnData->window), GTK_WINDOW(parent));
 
         gtk_container_add(GTK_CONTAINER(frame), main_area);
         gtk_container_set_border_width(GTK_CONTAINER(main_area), 10);

--- a/gnucash/import-export/aqb/assistant-ab-initial.c
+++ b/gnucash/import-export/aqb/assistant-ab-initial.c
@@ -898,7 +898,8 @@ gnc_ab_initial_assistant_new(void)
     selection = gtk_tree_view_get_selection(info->account_view);
     gtk_tree_selection_set_mode (selection, GTK_SELECTION_SINGLE);
 
-    gnc_restore_window_size (GNC_PREFS_GROUP, GTK_WINDOW(info->window));
+    gnc_restore_window_size (GNC_PREFS_GROUP,
+                             GTK_WINDOW(info->window), gnc_ui_get_main_window(NULL));
 
     g_signal_connect(info->account_view, "row-activated",
                      G_CALLBACK(account_list_clicked_cb), info);

--- a/gnucash/import-export/aqb/gnc-ab-utils.c
+++ b/gnucash/import-export/aqb/gnc-ab-utils.c
@@ -1060,7 +1060,7 @@ bal_accountinfo_cb(AB_IMEXPORTER_ACCOUNTINFO *element, gpointer user_data)
 
     /* Show reconciliation window */
     if (show_recn_window)
-        recnWindowWithBalance(gnc_acc, value, booked_tt);
+        recnWindowWithBalance(GTK_WIDGET (data->parent), gnc_acc, value, booked_tt);
 
     return NULL;
 }

--- a/gnucash/import-export/aqb/gnc-gwen-gui.c
+++ b/gnucash/import-export/aqb/gnc-gwen-gui.c
@@ -626,7 +626,8 @@ reset_dialog(GncGWENGui *gui)
     if (gui->parent)
         gtk_window_set_transient_for(GTK_WINDOW(gui->dialog),
                                      GTK_WINDOW(gui->parent));
-    gnc_restore_window_size(GNC_PREFS_GROUP_CONNECTION, GTK_WINDOW(gui->dialog));
+    gnc_restore_window_size(GNC_PREFS_GROUP_CONNECTION,
+                            GTK_WINDOW(gui->dialog), GTK_WINDOW(gui->parent));
 
     gui->keep_alive = TRUE;
     gui->state = INIT;

--- a/gnucash/import-export/csv-exp/assistant-csv-export.c
+++ b/gnucash/import-export/csv-exp/assistant-csv-export.c
@@ -944,7 +944,8 @@ csv_export_assistant_create (CsvExportInfo *info)
     g_signal_connect (G_OBJECT(window), "destroy",
                       G_CALLBACK(csv_export_assistant_destroy_cb), info);
 
-    gnc_restore_window_size (GNC_PREFS_GROUP, GTK_WINDOW(info->window));
+    gnc_restore_window_size (GNC_PREFS_GROUP,
+                             GTK_WINDOW(info->window), gnc_ui_get_main_window(NULL));
     if (gnc_prefs_get_bool (GNC_PREFS_GROUP_GENERAL, GNC_PREF_SAVE_GEOMETRY))
     {
         GObject *object = gtk_builder_get_object (builder, "paned");

--- a/gnucash/import-export/csv-imp/assistant-csv-account-import.c
+++ b/gnucash/import-export/csv-imp/assistant-csv-account-import.c
@@ -668,7 +668,8 @@ csv_import_assistant_create (CsvImportInfo *info)
     g_signal_connect (G_OBJECT(window), "destroy",
                       G_CALLBACK(csv_import_assistant_destroy_cb), info);
 
-    gnc_restore_window_size (GNC_PREFS_GROUP, GTK_WINDOW(info->window));
+    gnc_restore_window_size (GNC_PREFS_GROUP,
+                             GTK_WINDOW(info->window), gnc_ui_get_main_window(NULL));
 
     gtk_builder_connect_signals (builder, info);
     g_object_unref (G_OBJECT(builder));

--- a/gnucash/import-export/csv-imp/assistant-csv-price-import.cpp
+++ b/gnucash/import-export/csv-imp/assistant-csv-price-import.cpp
@@ -654,7 +654,8 @@ CsvImpPriceAssist::CsvImpPriceAssist ()
     summary_page  = GTK_WIDGET(gtk_builder_get_object (builder, "summary_page"));
     summary_label = GTK_WIDGET(gtk_builder_get_object (builder, "summary_label"));
 
-    gnc_restore_window_size (GNC_PREFS_GROUP, GTK_WINDOW(csv_imp_asst));
+    gnc_restore_window_size (GNC_PREFS_GROUP,
+                             GTK_WINDOW(csv_imp_asst), gnc_ui_get_main_window(nullptr));
 
     gtk_builder_connect_signals (builder, this);
     g_object_unref (G_OBJECT(builder));

--- a/gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp
+++ b/gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp
@@ -648,7 +648,8 @@ CsvImpTransAssist::CsvImpTransAssist ()
     summary_page  = GTK_WIDGET(gtk_builder_get_object (builder, "summary_page"));
     summary_label = GTK_WIDGET(gtk_builder_get_object (builder, "summary_label"));
 
-    gnc_restore_window_size (GNC_PREFS_GROUP, GTK_WINDOW(csv_imp_asst));
+    gnc_restore_window_size (GNC_PREFS_GROUP,
+                             GTK_WINDOW(csv_imp_asst), gnc_ui_get_main_window(nullptr));
 
     gtk_builder_connect_signals (builder, this);
     g_object_unref (G_OBJECT(builder));

--- a/gnucash/import-export/import-main-matcher.c
+++ b/gnucash/import-export/import-main-matcher.c
@@ -573,7 +573,7 @@ GNCImportMainMatcher *gnc_gen_trans_list_new (GtkWidget *parent,
     if (heading)
         gtk_label_set_text (GTK_LABEL (heading_label), heading);
 
-    gnc_restore_window_size(GNC_PREFS_GROUP, GTK_WINDOW(info->main_widget));
+    gnc_restore_window_size(GNC_PREFS_GROUP, GTK_WINDOW(info->main_widget), GTK_WINDOW (parent));
     gtk_widget_show_all (GTK_WIDGET (info->main_widget));
 
     info->transaction_processed_cb = NULL;

--- a/gnucash/import-export/import-match-picker.c
+++ b/gnucash/import-export/import-match-picker.c
@@ -492,7 +492,7 @@ init_match_picker_gui(GtkWidget *parent, GNCImportMatchPicker * matcher)
     g_signal_connect((GObject *)matcher->reconciled_chk, "toggled", G_CALLBACK(match_show_reconciled_changed_cb), matcher);
     
     gnc_restore_window_size(GNC_PREFS_GROUP,
-                            GTK_WINDOW (matcher->transaction_matcher));
+                            GTK_WINDOW (matcher->transaction_matcher), GTK_WINDOW(parent));
     gtk_widget_show(matcher->transaction_matcher);
 
     g_object_unref(G_OBJECT(builder));

--- a/gnucash/import-export/qif-imp/assistant-qif-import.c
+++ b/gnucash/import-export/qif-imp/assistant-qif-import.c
@@ -3653,7 +3653,8 @@ gnc_ui_qif_import_assistant_make(QIFImportWindow *qif_win)
     box = GTK_WIDGET(gtk_builder_get_object (builder, "currency_picker_hbox"));
     gtk_box_pack_start(GTK_BOX(box), qif_win->currency_picker, TRUE, TRUE, 0);
 
-    gnc_restore_window_size (GNC_PREFS_GROUP, GTK_WINDOW(qif_win->window));
+    gnc_restore_window_size (GNC_PREFS_GROUP,
+                             GTK_WINDOW(qif_win->window), gnc_ui_get_main_window(NULL));
 
     g_signal_connect( qif_win->window, "destroy",
                       G_CALLBACK(gnc_ui_qif_import_assistant_destroy), qif_win );

--- a/gnucash/report/report-gnome/dialog-custom-report.c
+++ b/gnucash/report/report-gnome/dialog-custom-report.c
@@ -533,7 +533,8 @@ gnc_ui_custom_report_internal(GncMainWindow * window)
     // Set the style context for this dialog so it can be easily manipulated with css
     gnc_widget_set_style_context (GTK_WIDGET(crd->dialog), "GncCustomReportDialog");
 
-    gnc_restore_window_size (GNC_PREFS_GROUP_REPORT_SAVED_CONFIGS, GTK_WINDOW(crd->dialog));
+    gnc_restore_window_size (GNC_PREFS_GROUP_REPORT_SAVED_CONFIGS,
+                             GTK_WINDOW(crd->dialog), GTK_WINDOW(window));
 
     /* connect the signals */
     gtk_builder_connect_signals_full (builder, gnc_builder_connect_full_func, crd);


### PR DESCRIPTION
The first commit adds the use of the Escape key to close the GtkWindow on the three dialogues I had changed previously.

In the next commit I think I fixed the restoring of the dialogues geometry when multiple monitors are used as it was previously only looking at the primary one. I do not have multiple monitors but was able to test it by adding one to a VirtualBox VM which seemed to work.
There is also a similar fix to the adjust for screen size function that was also only looking at the primary monitor.

On first use of these dialogues, with the dialogues that do not have any dimensions specified, GTK seems to align the new dialogue on top of the parent but if a dimension is specified it would be located on the left side of the monitor. The next commit tries to locate these dialogues when first used by using the parent window as a reference point. The subsequent two commits could be squashed but wanted to distinguish between the changes to the other files as simple changes and the slightly more involved.

Also fixed a couple of transient parent warnings on some dialogues.