### PR TITLE
scheme progress

### DIFF
--- a/gnucash/report/report-system/commodity-utilities.scm
+++ b/gnucash/report/report-system/commodity-utilities.scm
@@ -94,7 +94,8 @@
 
 ;; Helper for warnings below.
 (define (gnc-commodity-numeric->string commodity numeric)
-  (issue-deprecation-warning "gnc-commodity-numeric->string deprecated.")
+  (issue-deprecation-warning "gnc-commodity-numeric->string deprecated. \
+construct with gnc:make-gnc-monetary and gnc:monetary->string instead.")
   (gnc:monetary->string
    (gnc:make-gnc-monetary commodity numeric)))
 

--- a/gnucash/report/report-system/commodity-utilities.scm
+++ b/gnucash/report/report-system/commodity-utilities.scm
@@ -94,6 +94,7 @@
 
 ;; Helper for warnings below.
 (define (gnc-commodity-numeric->string commodity numeric)
+  (issue-deprecation-warning "gnc-commodity-numeric->string deprecated.")
   (gnc:monetary->string
    (gnc:make-gnc-monetary commodity numeric)))
 
@@ -157,13 +158,6 @@
                               value-amount share-amount))
                     #f)))
 
-          ;;(warn "gnc:get-commodity-totalavg-prices: value "
-          ;;    (gnc-commodity-numeric->string
-          ;;(first foreignlist) (second foreignlist))
-          ;;      " bought shares "
-          ;;    (gnc-commodity-numeric->string
-          ;;price-commodity (third foreignlist)))
-
           ;; Try EURO exchange if necessary
           (if (and foreignlist
                    (not (gnc-commodity-equiv (first foreignlist)
@@ -185,14 +179,17 @@
                    (begin
                      (warn "gnc:get-commodity-totalavg-prices: "
                            "Sorry, currency exchange not yet implemented:"
-                           (gnc-commodity-numeric->string
-                            (first foreignlist) (second foreignlist))
+                           (gnc:monetary->string
+                            (gnc:make-gnc-monetary
+                             (first foreignlist) (second foreignlist)))
                            " (buying "
-                           (gnc-commodity-numeric->string
-                            price-commodity (third foreignlist))
+                           (gnc:monetary->string
+                            (gnc:make-gnc-monetary
+                             price-commodity (third foreignlist)))
                            ") =? "
-                           (gnc-commodity-numeric->string
-                            report-currency (gnc-numeric-zero)))
+                           (gnc:monetary->string
+                            (gnc:make-gnc-monetary
+                            report-currency (gnc-numeric-zero))))
                      (gnc-numeric-zero))
                    (begin
                      (set! total-foreign (gnc-numeric-add total-foreign
@@ -272,13 +269,6 @@
                   (list transaction-comm
                         value-amount share-amount))))
 
-        ;;(warn "get-commodity-inst-prices: value "
-        ;;    (gnc-commodity-numeric->string
-        ;;   (first foreignlist) (second foreignlist))
-        ;; " bought shares "
-        ;;(gnc-commodity-numeric->string
-        ;; price-commodity (third foreignlist)))
-
         ;; Try EURO exchange if necessary
         (if (not (gnc-commodity-equiv (first foreignlist)
                                       report-currency))
@@ -298,14 +288,17 @@
              (begin
                (warn "get-commodity-inst-prices: "
                      "Sorry, currency exchange not yet implemented:"
-                     (gnc-commodity-numeric->string
-                      (first foreignlist) (second foreignlist))
-                     " (buying "
-                     (gnc-commodity-numeric->string
-                      price-commodity (third foreignlist))
-                     ") =? "
-                     (gnc-commodity-numeric->string
-                      report-currency (gnc-numeric-zero)))
+                       (gnc:monetary->string
+                        (gnc:make-gnc-monetary
+                         (first foreignlist) (second foreignlist)))
+                       " (buying "
+                       (gnc:monetary->string
+                        (gnc:make-gnc-monetary
+                         price-commodity (third foreignlist)))
+                       ") =? "
+                       (gnc:monetary->string
+                        (gnc:make-gnc-monetary
+                         report-currency (gnc-numeric-zero))))
                (gnc-numeric-zero))
              (if (not (zero? (third foreignlist)))
                  (gnc-numeric-div

--- a/gnucash/report/report-system/commodity-utilities.scm
+++ b/gnucash/report/report-system/commodity-utilities.scm
@@ -487,14 +487,14 @@
                      ;; resolve the exchange rate to this currency.
                      (warn "gnc:resolve-unknown-comm:"
                            "can't calculate rate for "
-                           (gnc-commodity-value->string
-                            (list (car pair) ((caadr pair) 'total #f)))
+                           (gnc:monetary->string
+                            (gnc:make-gnc-monetary (car pair) ((caadr pair) 'total #f)))
                            " = "
-                           (gnc-commodity-value->string
-                            (list (car otherlist) ((cdadr pair) 'total #f)))
+                           (gnc:monetary->string
+                            (gnc:make-gnc-monetary (car otherlist) ((cdadr pair) 'total #f)))
                            " to "
-                           (gnc-commodity-value->string
-                            (list report-commodity (gnc-numeric-zero))))
+                           (gnc:monetary->string
+                            (gnc:make-gnc-monetary report-commodity (gnc-numeric-zero))))
                      (if (and pair-a pair-b)
                          ;; If both currencies are found then something
                          ;; went wrong inside
@@ -502,11 +502,11 @@
                          ;; better thing to do in this case.
                          (warn "gnc:resolve-unknown-comm:"
                                "Oops - exchange rate ambiguity error: "
-                               (gnc-commodity-value->string
-                                (list (car pair) ((caadr pair) 'total #f)))
+                               (gnc:monetary->string
+                                (gnc:make-gnc-monetary (car pair) ((caadr pair) 'total #f)))
                                " = "
-                               (gnc-commodity-value->string
-                                (list (car otherlist)
+                               (gnc:monetary->string
+                                (gnc:make-gnc-monetary (car otherlist)
                                       ((cdadr pair) 'total #f))))
                          (let
                              ;; Usual case: one of pair-{a,b} was found
@@ -520,23 +520,12 @@
                                    (list (car pair)
                                          (make-newrate (caadr pair)
                                                        (cdadr pair) pair-a)))))
-                           ;; (warn "created new rate: "
-                           ;; (gnc-commodity-value->string (list (car
-                           ;; newrate) ((caadr newrate) 'total #f))) "
-                           ;; = " (gnc-commodity-value->string (list
-                           ;; report-commodity ((cdadr newrate) 'total
-                           ;; #f))))
                            (set! reportlist (cons newrate reportlist))))))
                ;; Huh, the report-currency showed up on the wrong side
                ;; -- we will just add it to the reportlist on the
                ;; right side.
                (let ((newrate (list (car otherlist)
                                     (cons (cdadr pair) (caadr pair)))))
-                 ;; (warn "created new rate: "
-                 ;; (gnc-commodity-value->string (list (car newrate)
-                 ;; ((caadr newrate) 'total #f))) " = "
-                 ;; (gnc-commodity-value->string (list
-                 ;; report-commodity ((cdadr newrate) 'total #f))))
                  (set! reportlist (cons newrate reportlist)))))
             (cadr otherlist))))
      sumlist)

--- a/gnucash/report/report-system/commodity-utilities.scm
+++ b/gnucash/report/report-system/commodity-utilities.scm
@@ -20,16 +20,6 @@
 ;; Boston, MA  02110-1301,  USA       gnu@gnu.org
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-
-(define (gnc-commodity-collector-contains-commodity? collector commodity)
-  (let ((ret #f))
-    (gnc-commodity-collector-map
-     collector
-     (lambda (comm amt)
-       (set! ret (or ret (gnc-commodity-equiv comm commodity)))))
-    ret
-    ))
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Functions to get splits with interesting data from accounts.
 
@@ -1063,23 +1053,19 @@
           #f)
          balance)))
 
-;; Returns the number of commodities in a commodity-collector.
-;; (If this were implemented as a record, I would be able to
-;; just (length ...) the alist, but....)
 (define (gnc-commodity-collector-commodity-count collector)
-  (let ((commodities 0))
-    (gnc-commodity-collector-map
-     collector
-     (lambda (comm amt)
-       (set! commodities (+ commodities 1))))
-    commodities
-    ))
+  (length (collector 'format (lambda (comm amt) comm) #f)))
+
+(define (gnc-commodity-collector-contains-commodity? collector commodity)
+  (member commodity
+          (collector 'format (lambda (comm amt) comm) #f)
+          gnc-commodity-equiv))
 
 (define (gnc:uniform-commodity? amt report-commodity)
   ;; function to see if the commodity-collector amt
   ;; contains any foreign commodities
   (let ((elts (gnc-commodity-collector-commodity-count amt)))
-    (or (equal? elts 0)
-        (and (equal? elts 1)
+    (or (zero? elts)
+        (and (= elts 1)
              (gnc-commodity-collector-contains-commodity?
               amt report-commodity)))))

--- a/gnucash/report/report-system/html-acct-table.scm
+++ b/gnucash/report/report-system/html-acct-table.scm
@@ -732,13 +732,12 @@
       ;; ( acct . balance ) cells
       (define (get-balance acct-balances acct)
 	(let ((this-collector (gnc:make-commodity-collector)))
-	  (gnc-commodity-collector-merge 
-	   this-collector 
+	  (this-collector
+           'merge
 	   (or (hash-ref acct-balances (gncAccountGetGUID acct))
 	       ;; return a zero commodity collector
-	       (gnc:make-commodity-collector)
-	       )
-	   )
+	       (gnc:make-commodity-collector))
+	   #f)
 	  this-collector
 	  )
 	)
@@ -754,9 +753,9 @@
 	(let ((this-collector (gnc:make-commodity-collector)))
 	  ;; get the balance of the parent account and stick it on the collector
 	  ;; that nice shiny *NEW* collector!!
-	  (gnc-commodity-collector-merge this-collector (get-balance acct-balances account))
+	  (this-collector 'merge (get-balance acct-balances account) #f)
 	  (for-each
-	   (lambda (x) (if x (gnc-commodity-collector-merge this-collector x)))
+	   (lambda (x) (if x (this-collector 'merge x #f)))
 	   (gnc:account-map-descendants
 	    (lambda (a)
 	      (get-balance acct-balances a ))
@@ -1143,8 +1142,8 @@
   ;; readable.
   (let* ((table (gnc:make-html-table))
 	 )
-    (gnc-commodity-collector-map
-     amount
+    (amount
+     'format
      (lambda (curr val)
        (let ((bal (gnc:make-gnc-monetary curr val)))
 	 (gnc:html-table-append-row!
@@ -1162,7 +1161,8 @@
 	    "number-cell" (exchange-fn bal report-commodity))
 	   )
 	  )
-	 )))
+	 ))
+     #f)
     (gnc:html-table-set-style! table "table" 'attribute(list "style" "width:100%; max-width:20em") 'attribute (list "cellpadding" "0"))
     table))
 

--- a/gnucash/report/report-system/html-acct-table.scm
+++ b/gnucash/report/report-system/html-acct-table.scm
@@ -675,9 +675,6 @@
                     (acct-comm (xaccAccountGetCommodity acct))
                     (shares (xaccSplitGetAmount split))
                     (hash (hash-ref hash-table guid)))
-;                (gnc:debug "Merging split for " (xaccAccountGetName acct) " for "
-;                           (gnc-commodity-numeric->string acct-comm shares)
-;                           " into hash entry " hash)
                (if (not hash)
                    (begin (set! hash (gnc:make-commodity-collector))
                           (hash-set! hash-table guid hash)))

--- a/gnucash/report/report-system/html-utilities.scm
+++ b/gnucash/report/report-system/html-utilities.scm
@@ -281,18 +281,15 @@
 	;; commodity
 	(commodity-row-helper! 
 	 my-name #f
-	 (if balance 
-	     (gnc-commodity-collector-assoc
-	      balance report-commodity reverse-balance?)
-	     #f)
+	 (and balance
+              (balance 'getmonetary report-commodity reverse-balance?))
 	 main-row-style)
 	;; Special case for stock-accounts: then the foreign commodity
 	;; gets displayed in this line rather then the following lines
 	;; (loop below). Is also used if is-stock-account? is true.
-	(let ((my-balance 
-	       (if balance 
-		   (gnc-commodity-collector-assoc
-		    balance my-commodity reverse-balance?) #f)))
+	(let ((my-balance
+               (and balance
+                    (balance 'getmonetary my-commodity reverse-balance?))))
 	  (set! already-printed my-commodity)
 	  (commodity-row-helper! 
 	   my-name
@@ -304,8 +301,8 @@
     ;; balance and its corresponding value in the
     ;; report-currency. One row for each non-report-currency. 
     (if (and balance (not is-stock-account?))
-	(gnc-commodity-collector-map
-	 balance 
+	(balance
+         'format
 	 (lambda (curr val)
 	   (if (or (gnc-commodity-equiv curr report-commodity)
 		   (and already-printed
@@ -323,7 +320,7 @@
 		  bal
 		  (exchange-fn bal report-commodity)
 		  other-rows-style))))
-	 ))))
+	 #f))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -466,8 +463,7 @@
       (let ((this-collector (my-get-balance-nosub account)))
 	(for-each 
 	 (lambda (x) (if x 
-			 (gnc-commodity-collector-merge
-			  this-collector x )))
+			 (this-collector 'merge x #f)))
 	 (gnc:account-map-descendants
 	  (lambda (a)
 	    ;; Important: Calculate the balance if and only if the
@@ -639,7 +635,7 @@
 				  subaccounts my-get-balance 
 				  gnc-reverse-balance)))
 		 (if thisbalance 
-		     (gnc-commodity-collector-merge subbalance thisbalance))
+		     (subbalance 'merge thisbalance #f))
 		 subbalance)
 	       heading-style
 	       #t #f)))))

--- a/gnucash/report/report-system/report-utilities.scm
+++ b/gnucash/report/report-system/report-utilities.scm
@@ -699,21 +699,15 @@
 ;; If type is #f, sums all splits in the interval (even closing splits)
 (define (gnc:account-get-trans-type-balance-interval-with-closing
 	 account-list type start-date end-date)
-  (let* ((total (gnc:make-commodity-collector)))
+  (let ((total (gnc:make-commodity-collector)))
     (map (lambda (split)
            (let* ((shares (xaccSplitGetAmount split))
                   (acct-comm (xaccAccountGetCommodity
-                              (xaccSplitGetAccount split)))
-                  )
-                (gnc-commodity-collector-add total acct-comm shares)
-             )
-           )
+                              (xaccSplitGetAccount split))))
+             (gnc-commodity-collector-add total acct-comm shares)))
 	 (gnc:account-get-trans-type-splits-interval
-          account-list type start-date end-date)
-	 )
-    total
-    )
-  )
+          account-list type start-date end-date))
+    total))
 
 ;; Filters the splits from the source to the target accounts
 ;; returns a commodity collector
@@ -904,15 +898,11 @@
 
 
 (define (gnc:budget-accountlist-helper accountlist get-fn)
-  (let
-    (
-      (net (gnc:make-commodity-collector)))
+  (let ((net (gnc:make-commodity-collector)))
     (for-each
-      (lambda (account)
-        (net 'merge
-          (get-fn account)
-          #f))
-      accountlist)
+     (lambda (account)
+       (net 'merge (get-fn account) #f))
+     accountlist)
     net))
 
 ;; Sums budget values for a single account from start-period (inclusive) to
@@ -923,17 +913,14 @@
 ;;
 ;; Returns a commodity-collector.
 (define (gnc:budget-account-get-net budget account start-period end-period)
-  (if (not start-period) (set! start-period 0))
   (if (not end-period) (set! end-period (gnc-budget-get-num-periods budget)))
-  (let*
-    (
-      (period start-period)
-      (net (gnc:make-commodity-collector))
-      (acct-comm (xaccAccountGetCommodity account)))
+  (let* ((period (or start-period 0))
+         (net (gnc:make-commodity-collector))
+         (acct-comm (xaccAccountGetCommodity account)))
     (while (< period end-period)
       (net 'add acct-comm
-          (gnc-budget-get-account-period-value budget account period))
-      (set! period (+ period 1)))
+           (gnc-budget-get-account-period-value budget account period))
+      (set! period (1+ period)))
     net))
 
 ;; Sums budget values for accounts in accountlist from start-period (inclusive)
@@ -1016,17 +1003,14 @@
 ;;
 ;; Returns a gnc-numeric value
 (define (gnc:budget-account-get-rolledup-net budget account start-period end-period)
-  (if (not start-period) (set! start-period 0))
   (if (not end-period) (set! end-period (gnc-budget-get-num-periods budget)))
-  (let*
-    (
-      (period start-period)
-      (net (gnc-numeric-zero))
-      (acct-comm (xaccAccountGetCommodity account)))
+  (let* ((period (or start-period 0))
+         (net (gnc-numeric-zero))
+         (acct-comm (xaccAccountGetCommodity account)))
     (while (< period end-period)
       (set! net (gnc-numeric-add net
-          (gnc:get-account-period-rolledup-budget-value budget account period)
-	  GNC-DENOM-AUTO GNC-RND-ROUND))
+                                 (gnc:get-account-period-rolledup-budget-value budget account period)
+                                 GNC-DENOM-AUTO GNC-RND-ROUND))
       (set! period (+ period 1)))
     net))
 
@@ -1043,29 +1027,20 @@
     initial-balances))
 
 (define (gnc:select-assoc-account-balance account-balances account)
-  (let*
-    (
-      (account-balance (car account-balances))
-      (result
-        (if
-          (equal? account-balance '())
-          #f
-          (if
-            (equal? (car account-balance) account)
-            (car (cdr account-balance))
-            (gnc:select-assoc-account-balance
+  (let ((account-balance (car account-balances)))
+    (and (pair? account-balance)
+         (if (equal? (car account-balance) account)
+             (cadr account-balance)
+             (gnc:select-assoc-account-balance
               (cdr account-balances)
               account)))))
-    result))
 
 (define (gnc:get-assoc-account-balances-total account-balances)
-  (let
-    (
-      (total (gnc:make-commodity-collector)))
+  (let ((total (gnc:make-commodity-collector)))
     (for-each
-      (lambda (account-balance)
-        (total 'merge (car (cdr account-balance)) #f))
-      account-balances)
+     (lambda (account-balance)
+       (total 'merge (cadr account-balance) #f))
+     account-balances)
     total))
 
 ;; Adds "file:///" to the beginning of a URL if it doesn't already exist

--- a/gnucash/report/report-system/report-utilities.scm
+++ b/gnucash/report/report-system/report-utilities.scm
@@ -425,14 +425,11 @@
 
 ;; Returns zero if all entries in this collector are zero.
 (define (gnc-commodity-collector-allzero? collector)
-  (let ((result #t))
-    (gnc-commodity-collector-map
-     collector
-     (lambda (commodity amount)
-       (if (not (gnc-numeric-zero-p amount))
-	   (set! result #f))))
-    result))
-
+  (every zero?
+         (gnc-commodity-collector-map
+          collector
+          (lambda (commodity amount)
+            amount))))
 
 ;; get the account balance at the specified date. if include-children?
 ;; is true, the balances of all children (not just direct children)

--- a/gnucash/report/report-system/report-utilities.scm
+++ b/gnucash/report/report-system/report-utilities.scm
@@ -980,18 +980,10 @@
 ;; Return value:
 ;;   budget value to use for account for specified period.
 (define (budget-account-sum budget children period)
-  (let* ((sum
-           (cond
-             ((null? children) (gnc-numeric-zero))
-             (else
-               (gnc-numeric-add
-                 (gnc:get-account-period-rolledup-budget-value budget (car children) period)
-                 (budget-account-sum budget (cdr children) period)
-                 GNC-DENOM-AUTO GNC-RND-ROUND))
-               )
-        ))
-  sum)
-)
+  (apply + (map
+            (lambda (child)
+              (gnc:get-account-period-rolledup-budget-value budget child period))
+            children)))
 
 ;; Calculate the value to use for the budget of an account for a specific period.
 ;; - If the account has a budget value set for the period, use it
@@ -1007,14 +999,11 @@
 ;;   sum of all budgets for list of children for specified period.
 (define (gnc:get-account-period-rolledup-budget-value budget acct period)
   (let* ((bgt-set? (gnc-budget-is-account-period-value-set budget acct period))
-        (children (gnc-account-get-children acct))
-        (amount (cond
-                  (bgt-set? (gnc-budget-get-account-period-value budget acct period))
-          ((not (null? children)) (budget-account-sum budget children period))
-          (else (gnc-numeric-zero)))
-        ))
-  amount)
-)
+         (children (gnc-account-get-children acct)))
+    (cond
+     (bgt-set? (gnc-budget-get-account-period-value budget acct period))
+     ((not (null? children)) (budget-account-sum budget children period))
+     (else 0))))
 
 ;; Sums rolled-up budget values for a single account from start-period (inclusive) to
 ;; end-period (exclusive).

--- a/gnucash/report/report-system/report-utilities.scm
+++ b/gnucash/report/report-system/report-utilities.scm
@@ -41,6 +41,7 @@
 ;; pair is a list of one gnc:commodity and one gnc:numeric
 ;; value. Deprecated -- use <gnc-monetary> instead.
 (define (gnc-commodity-value->string pair)
+  (issue-deprecation-warning "gnc-commodity-value->string deprecated")
   (xaccPrintAmount
    (cadr pair) (gnc-commodity-print-info (car pair) #t)))
 

--- a/gnucash/report/report-system/report-utilities.scm
+++ b/gnucash/report/report-system/report-utilities.scm
@@ -24,17 +24,15 @@
        (list-ref list elt)))
 
 (define (list-set-safe! l elt val)
-  (if (and (list? l) (> (length l) elt))
+  (unless (list? l)
+    (set! l '()))
+  (if (> (length l) elt)
       (list-set! l elt val)
-      (let ((filler (list val)))
-        (if (not (list? l))
-            (set! l '()))
-        (let loop ((i (length l)))
-          (if (< i elt)
-              (begin 
-                (set! filler (cons #f filler))
-                (loop (+ 1 i)))))
-        (set! l (append! l filler))))
+      (let loop ((filler (list val))
+                 (i (length l)))
+        (if (< i elt)
+            (loop (cons #f filler) (1+ i))
+            (set! l (append! l filler)))))
   l)
 
 ;; pair is a list of one gnc:commodity and one gnc:numeric

--- a/gnucash/report/report-system/report-utilities.scm
+++ b/gnucash/report/report-system/report-utilities.scm
@@ -38,7 +38,8 @@
 ;; pair is a list of one gnc:commodity and one gnc:numeric
 ;; value. Deprecated -- use <gnc-monetary> instead.
 (define (gnc-commodity-value->string pair)
-  (issue-deprecation-warning "gnc-commodity-value->string deprecated")
+  (issue-deprecation-warning "gnc-commodity-value->string deprecated. \
+construct gnc:make-gnc-monetary and use gnc:monetary->string instead.")
   (xaccPrintAmount
    (cadr pair) (gnc-commodity-print-info (car pair) #t)))
 

--- a/gnucash/report/report-system/report.scm
+++ b/gnucash/report/report-system/report.scm
@@ -72,9 +72,6 @@
 (define gnc:optname-stylesheet (N_ "Stylesheet"))
 (define gnc:menuname-business-reports (N_ "_Business"))
 (define gnc:optname-invoice-number (N_ "Invoice Number"))
-(define test-report-system-flag #f)
-
-(export test-report-system-flag)
 
 ;; We want to warn users if they've got an old-style, non-guid custom
 ;; report-template, but only once
@@ -142,7 +139,7 @@
 		;; FIXME: We should pass the top-level window
 		;; instead of the '() to gnc-error-dialog, but I
 		;; have no idea where to get it from.
-                (if (not test-report-system-flag)
+                (if (gnucash-ui-is-running)
 		  (gnc-error-dialog '() (string-append
           (_ "One of your reports has a report-guid that is a duplicate. Please check the report system, especially your saved reports, for a report with this report-guid: ")
           report-guid))
@@ -175,14 +172,14 @@
                     (if (not gnc:old-style-report-warned)
 	              (begin
 		        (set! gnc:old-style-report-warned #t)
-                        (if (not test-report-system-flag) ;; do not call this during "make test"
+                        (if (gnucash-ui-is-running)
 		          (gnc-error-dialog '() (string-append (_ "The GnuCash report system has been upgraded. Your old saved reports have been transferred into a new format. If you experience trouble with saved reports, please contact the GnuCash development team."))))
 	                (hash-set! *gnc:_report-templates_* (gnc:report-template-report-guid report-rec) report-rec)
                       )
                     )
                   )
                   ;;there is no parent -> this is an inital faulty report definition
-                  (if (not test-report-system-flag) ;; do not call this during "make test"
+                  (if (gnucash-ui-is-running)
                     (gnc-error-dialog '() (string-append (_ "Wrong report definition: ")
                                                             (gnc:report-template-name report-rec)
                                                          (_ " Report is missing a GUID.")))

--- a/gnucash/report/report-system/test/test-report-system.scm
+++ b/gnucash/report/report-system/test/test-report-system.scm
@@ -8,7 +8,6 @@
 (use-modules (gnucash engine test srfi64-extras))
 
 (define (run-test)
-    (set! test-report-system-flag #t)
     (test-runner-factory gnc:test-runner)
     (test-begin "Testing/Temporary/test-report-system") ;; if (test-runner-factory gnc:test-runner) is commented out, this
                                                             ;; will create Testing/Temporary/test-asset-performance.log
@@ -16,7 +15,6 @@
     (test-assert "Missing GUID detection" (test-check2))
     (test-assert "Detect double GUID" (test-check3))
     (test-assert "Report with Full Argument Set" (test-check4))
-    (set! test-report-system-flag #f)
     (test-end "Testing/Temporary/test-report-system")
 )
 

--- a/gnucash/report/standard-reports/advanced-portfolio.scm
+++ b/gnucash/report/standard-reports/advanced-portfolio.scm
@@ -473,10 +473,10 @@ by preventing negative stock balances.<br/>")
                     (exchange-fn fromunits tocurrency)))
 
             (gnc:debug "Starting account " (xaccAccountGetName current) ", initial price: "
-                   (if price
-                     (gnc-commodity-value->string
-	 	         (list (gnc-price-get-currency price) (gnc-price-get-value price)))
-	 	     #f))
+                       (and price
+                            (gnc:monetary->string
+                             (gnc:make-gnc-monetary
+                              (gnc-price-get-currency price) (gnc-price-get-value price)))))
 
             ;; If we have a price that can't be converted to the report currency
             ;; don't use it

--- a/gnucash/report/standard-reports/advanced-portfolio.scm
+++ b/gnucash/report/standard-reports/advanced-portfolio.scm
@@ -535,7 +535,8 @@ by preventing negative stock balances.<br/>")
             ;; Now that we have a pricing transaction if needed, set the value of the asset
             (set! value (my-exchange-fn (gnc:make-gnc-monetary commodity units) currency))
             (gnc:debug "Value " (gnc:monetary->string value)
-                       " from " (gnc-commodity-numeric->string commodity units))
+                       " from " (gnc:monetary->string
+                                 (gnc:make-gnc-monetary commodity units)))
 
 	    (for-each
 	     ;; we're looking at each split we find in the account. these splits

--- a/gnucash/report/standard-reports/transaction.scm
+++ b/gnucash/report/standard-reports/transaction.scm
@@ -1605,23 +1605,23 @@ be excluded from periodic reporting.")
                    (add-split-row othersplits calculated-cells def:alternate-row-style #f))
                  (delete current (xaccTransGetSplitList (xaccSplitGetParent current)))))
 
-            (map (lambda (collector value)
-                   (if value
-                       (collector 'add (gnc:gnc-monetary-commodity value) (gnc:gnc-monetary-amount value))))
-                 primary-subtotal-collectors
-                 split-values)
+            (for-each
+             (lambda (collector value)
+               (if value
+                   (collector 'add (gnc:gnc-monetary-commodity value) (gnc:gnc-monetary-amount value))))
+             primary-subtotal-collectors split-values)
 
-            (map (lambda (collector value)
-                   (if value
-                       (collector 'add (gnc:gnc-monetary-commodity value) (gnc:gnc-monetary-amount value))))
-                 secondary-subtotal-collectors
-                 split-values)
+            (for-each
+             (lambda (collector value)
+               (if value
+                   (collector 'add (gnc:gnc-monetary-commodity value) (gnc:gnc-monetary-amount value))))
+             secondary-subtotal-collectors split-values)
 
-            (map (lambda (collector value)
-                   (if value
-                       (collector 'add (gnc:gnc-monetary-commodity value) (gnc:gnc-monetary-amount value))))
-                 total-collectors
-                 split-values)
+            (for-each
+             (lambda (collector value)
+               (if value
+                   (collector 'add (gnc:gnc-monetary-commodity value) (gnc:gnc-monetary-amount value))))
+             total-collectors split-values)
 
             (if (and primary-subtotal-comparator
                      (or (not next)


### PR DESCRIPTION
~This commit will modify gnome-utils.scm to maintain an internal list of gui-log messages. This list is modified by calling (addto-gui-log type str), type being either 'warning or 'error.~

~When the GUI is ready, a call to (process-gui-log) will call the gnc-warning-dialog or gnc-error-dialog calls, and empty gui-log.~

~I'm not 100% sure of function call names. Ideally the list would be maintained in C[++] but this can be a useful stop-gap to separate report definition and gui calls. The only functional change is that the report error dialogs will now be displayed *after* all reports are loaded, instead of *during* each report load.~

~The main benefit here is to separate GUI calls from scheme reports. There's now no need to maintain a test-report-system-flag boolean in report.scm.~

Strategy updated to use much simpler (gnucash-ui-is-running) call. I think it'd be nicer to handle errors outside report definition, but this would require some C work I think.