### PR TITLE
Bug796725 Date Posted options fail

### DIFF
--- a/gnucash/gnome-search/search-date.c
+++ b/gnucash/gnome-search/search-date.c
@@ -39,14 +39,14 @@
 
 static void editable_enters (GNCSearchCoreType *fe);
 static void grab_focus (GNCSearchCoreType *fe);
-static GNCSearchCoreType *gncs_clone(GNCSearchCoreType *fe);
+static GNCSearchCoreType *gncs_clone (GNCSearchCoreType *fe);
 static gboolean gncs_validate (GNCSearchCoreType *fe);
-static GtkWidget *gncs_get_widget(GNCSearchCoreType *fe);
+static GtkWidget *gncs_get_widget (GNCSearchCoreType *fe);
 static QofQueryPredData* gncs_get_predicate (GNCSearchCoreType *fe);
 
-static void gnc_search_date_class_init	(GNCSearchDateClass *klass);
-static void gnc_search_date_init	(GNCSearchDate *gspaper);
-static void gnc_search_date_finalize	(GObject *obj);
+static void gnc_search_date_class_init (GNCSearchDateClass *klass);
+static void gnc_search_date_init (GNCSearchDate *gspaper);
+static void gnc_search_date_finalize (GObject *obj);
 
 typedef struct _GNCSearchDatePrivate GNCSearchDatePrivate;
 
@@ -69,14 +69,14 @@ gnc_search_date_get_type (void)
     {
         GTypeInfo type_info =
         {
-            sizeof(GNCSearchDateClass),       /* class_size */
-            NULL,   				/* base_init */
-            NULL,				/* base_finalize */
+            sizeof(GNCSearchDateClass),      /* class_size */
+            NULL,                            /* base_init */
+            NULL,                            /* base_finalize */
             (GClassInitFunc)gnc_search_date_class_init,
-            NULL,				/* class_finalize */
-            NULL,				/* class_data */
-            sizeof(GNCSearchDate),		/* */
-            0,				/* n_preallocs */
+            NULL,                            /* class_finalize */
+            NULL,                            /* class_data */
+            sizeof(GNCSearchDate),           /* */
+            0,                               /* n_preallocs */
             (GInstanceInitFunc)gnc_search_date_init,
         };
 


### PR DESCRIPTION
gnc_date_edit_get_date returns a value set to the start of the day 00:00:00 so there is a need to adjust value to 23:59:59 for LessThanEqual and GreaterThan and also use QOF_DATE_MATCH_DAY when comparing dates on one day only.