### PR TITLE
Ignore deprecation warnings from glib

### DIFF
--- a/libgnucash/engine/CMakeLists.txt
+++ b/libgnucash/engine/CMakeLists.txt
@@ -235,7 +235,7 @@ add_dependencies (gncmod-engine swig-runtime-h iso-4217-c)
 target_link_libraries(gncmod-engine gnc-core-utils gnc-module ${Boost_DATE_TIME_LIBRARIES}  ${Boost_REGEX_LIBRARIES} ${REGEX_LDFLAGS} ${GMODULE_LDFLAGS} ${GLIB2_LDFLAGS} ${GOBJECT_LDFLAGS} ${GUILE_LDFLAGS})
 
 target_compile_definitions (gncmod-engine PRIVATE -DG_LOG_DOMAIN=\"gnc.engine\")
-target_compile_options (gncmod-engine PRIVATE -Wno-deprecated-register)
+target_compile_options (gncmod-engine PRIVATE -Wno-error=deprecated-declarations)
 
 target_include_directories (gncmod-engine
     PRIVATE ${CMAKE_CURRENT_BINARY_DIR} # for iso-4217-currencies.c


### PR DESCRIPTION
In glib 2.58, g_type_class_add_private is deprecated, which causes gnucash
to fail to build due to -Werror.  To get gnucash building in Ubuntu, we have
turned this particular error back into a warning with
-Wno-error=deprecated-declarations.

This also drops the -Wno-deprecated-register flag, which doesn't appear
to be recognized at all by gcc-8.

An alternate solution of course is to update gnucash to use the current glib API.

https://launchpad.net/ubuntu/+source/gnucash/1:3.2-1build1/+build/15137868