### PR TITLE
S390x build fixes

### DIFF
--- a/common/config.h.cmake.in
+++ b/common/config.h.cmake.in
@@ -1,3 +1,5 @@
+#include <endian.h>
+
 /* Template file for processing by the cmake command CONFIGURE_FILE */
 
 /* If we're using this file it's a CMAKE build, so say so */
@@ -356,7 +358,11 @@
 # endif
 #else
 # ifndef WORDS_BIGENDIAN
+#  if __BYTE_ORDER == __BIG_ENDIAN
+#   define WORDS_BIGENDIAN 1
+#  else
 #cmakedefine WORDS_BIGENDIAN
+#  endif
 # endif
 #endif
 

--- a/gnucash/gnome-utils/dialog-utils.c
+++ b/gnucash/gnome-utils/dialog-utils.c
@@ -23,6 +23,9 @@
  *                                                                  *
 \********************************************************************/
 
+/* RTLD_DEFAULT */
+#define _GNU_SOURCE
+
 #include <config.h>
 
 #include <gtk/gtk.h>

--- a/gnucash/import-export/bi-import/dialog-bi-import-helper.c
+++ b/gnucash/import-export/bi-import/dialog-bi-import-helper.c
@@ -19,6 +19,8 @@
  * Boston, MA  02110-1301,  USA       gnu@gnu.org
  */
 
+/* strptime */
+#define _XOPEN_SOURCE
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif

--- a/libgnucash/app-utils/guile-util.c
+++ b/libgnucash/app-utils/guile-util.c
@@ -19,6 +19,8 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.        *
 \********************************************************************/
 
+/* strptime */
+#define _XOPEN_SOURCE
 #include <config.h>
 
 #include "swig-runtime.h"

--- a/libgnucash/engine/test/test-gnc-date.c
+++ b/libgnucash/engine/test/test-gnc-date.c
@@ -26,6 +26,10 @@ extern "C"
 {
 #endif
 
+/* strptime */
+#define _XOPEN_SOURCE
+/* struct tm.tm_gmtoff */
+#define _DEFAULT_SOURCE
 #include <config.h>
 #include "platform.h"
 #include <string.h>


### PR DESCRIPTION
Debugging a build failure of gnucash 3.2 on Ubuntu s390x, I identified a number of issues.  Here is a series of patches that address these issues and allow gnucash to build on this architecture.