### PR TITLE
Use alignment-safe buffer handling

### DIFF
--- a/libgnucash/engine/gnc-timezone.cpp
+++ b/libgnucash/engine/gnc-timezone.cpp
@@ -471,7 +471,10 @@ namespace IANAParser
 	for(uint32_t index = 0; index < type_count; ++index)
 	{
 	    fb_index = start_index + index * tzinfo_size;
-	    TTInfo info = *reinterpret_cast<TTInfo*>(&fileblock[fb_index]);
+	    /* alignment */
+	    uint32_t ttinfo_raw[2];
+	    memcpy(ttinfo_raw, &fileblock[fb_index], ttinfo_size);
+	    TTInfo info = *reinterpret_cast<TTInfo*>(ttinfo_raw);
 	    endian_swap(&info.gmtoff);
 	    tzinfo.push_back(
 		{info, &fileblock[abbrev + info.abbrind],


### PR DESCRIPTION
Casting a char* to a struct containing a uint32_t is not universally safe
due to alignment constraints on reads on some platforms.  Copy our possibly
unaligned source data into an aligned area of memory to avoid SIGBUS on
armhf.