### PR TITLE
Bug796839

### DIFF
--- a/gnucash/gnome/gnc-split-reg.c
+++ b/gnucash/gnome/gnc-split-reg.c
@@ -1749,7 +1749,7 @@ gnc_split_reg_jump_cb( GtkWidget *widget, gpointer data )
 }
 
 void
-gnc_split_reg_change_style (GNCSplitReg *gsr, SplitRegisterStyle style)
+gnc_split_reg_change_style (GNCSplitReg *gsr, SplitRegisterStyle style, gboolean refresh)
 {
     SplitRegister *reg = gnc_ledger_display_get_split_register (gsr->ledger);
 
@@ -1757,7 +1757,8 @@ gnc_split_reg_change_style (GNCSplitReg *gsr, SplitRegisterStyle style)
         return;
 
     gnc_split_register_config (reg, reg->type, style, reg->use_double_line);
-    gnc_ledger_display_refresh (gsr->ledger);
+    if (refresh)
+        gnc_ledger_display_refresh (gsr->ledger);
 }
 
 void
@@ -1768,7 +1769,7 @@ gnc_split_reg_style_ledger_cb (GtkWidget *w, gpointer data)
     if (!gtk_check_menu_item_get_active (GTK_CHECK_MENU_ITEM(w)))
         return;
 
-    gnc_split_reg_change_style (gsr, REG_STYLE_LEDGER);
+    gnc_split_reg_change_style (gsr, REG_STYLE_LEDGER, TRUE);
 }
 
 void
@@ -1779,7 +1780,7 @@ gnc_split_reg_style_auto_ledger_cb (GtkWidget *w, gpointer data)
     if (!gtk_check_menu_item_get_active (GTK_CHECK_MENU_ITEM(w)))
         return;
 
-    gnc_split_reg_change_style (gsr, REG_STYLE_AUTO_LEDGER);
+    gnc_split_reg_change_style (gsr, REG_STYLE_AUTO_LEDGER, TRUE);
 }
 
 void
@@ -1790,7 +1791,7 @@ gnc_split_reg_style_journal_cb (GtkWidget *w, gpointer data)
     if (!gtk_check_menu_item_get_active (GTK_CHECK_MENU_ITEM(w)))
         return;
 
-    gnc_split_reg_change_style (gsr, REG_STYLE_JOURNAL);
+    gnc_split_reg_change_style (gsr, REG_STYLE_JOURNAL, TRUE);
 }
 
 void

--- a/gnucash/gnome/gnc-split-reg.h
+++ b/gnucash/gnome/gnc-split-reg.h
@@ -206,13 +206,15 @@ void gnc_split_reg_set_sort_type_force( GNCSplitReg *gsr, SortType t, gboolean f
 /**
  * Set/get sort order of register
  **/
-void gnc_split_reg_set_sort_reversed(GNCSplitReg *gsr, gboolean rev, gboolean refresh);
+void gnc_split_reg_set_sort_reversed(GNCSplitReg *gsr,
+                                     gboolean rev, gboolean refresh);
 
 
 /**
  * Gets/sets the style of the GNCSplitReg.
  **/
-void gnc_split_reg_change_style (GNCSplitReg *gsr, SplitRegisterStyle style);
+void gnc_split_reg_change_style (GNCSplitReg *gsr,
+                                 SplitRegisterStyle style, gboolean refresh);
 
 /**
  * Can return NULL if the indicated subwidget was not created.


### PR DESCRIPTION
The first commit I think fixes Bug796839, in my testing it does what I think it should but as always another take on it may find some thing I missed.

The second commit updates a previous commit to reduce the number of times the display ledger is refreshed at start, I had missed the setting of double line mode and register style. As these are set via callbacks I have changed to setting/resetting the register parameter 'enable_refresh' to control the enabling/disabling of the display ledger refresh, this is now potentially reducing it from 7 to 2.