### PR TITLE
Block registered prefs when preference dialogue loaded

### DIFF
--- a/gnucash/gnome-utils/dialog-preferences.c
+++ b/gnucash/gnome-utils/dialog-preferences.c
@@ -1153,9 +1153,8 @@ gnc_prefs_connect_one (const gchar *name,
         GList* child = gtk_container_get_children(GTK_CONTAINER(widget));
         widget_child = child->data;
         g_list_free(child);
-        DEBUG("  %s - hbox", name);
-        DEBUG("Hbox widget type is %s and name is %s", gtk_widget_get_name(GTK_WIDGET(widget_child)), name);
-
+        DEBUG("  %s - box", name);
+        DEBUG("Box widget type is %s and name is %s", gtk_widget_get_name(GTK_WIDGET(widget_child)), name);
         if (GNC_IS_CURRENCY_EDIT(widget_child))
         {
             DEBUG("  %s - currency_edit", name);
@@ -1163,7 +1162,7 @@ gnc_prefs_connect_one (const gchar *name,
         }
         else if (GNC_IS_PERIOD_SELECT(widget_child))
         {
-            DEBUG("  %s - period_Select", name);
+            DEBUG("  %s - period_select", name);
             gnc_prefs_connect_period_select(GNC_PERIOD_SELECT(widget_child), name );
         }
         else if (GNC_IS_DATE_EDIT(widget_child))
@@ -1173,7 +1172,7 @@ gnc_prefs_connect_one (const gchar *name,
         }
         else if (GTK_FILE_CHOOSER_BUTTON(widget_child))
         {
-            DEBUG("  %s - file chooser buuton", name);
+            DEBUG("  %s - file chooser button", name);
             gnc_prefs_connect_file_chooser_button(GTK_FILE_CHOOSER_BUTTON(widget_child), name );
         }
     }
@@ -1344,7 +1343,9 @@ gnc_preferences_dialog_create(GtkWindow *parent)
     gtk_notebook_set_current_page(GTK_NOTEBOOK(notebook), 0);
 
     DEBUG("We have the following interesting widgets:");
+    gnc_prefs_block_all(); // Block All Registered callbacks
     g_hash_table_foreach(prefs_table, (GHFunc)gnc_prefs_connect_one, dialog);
+    gnc_prefs_unblock_all(); // UnBlock All Registered callbacks
     DEBUG("Done with interesting widgets.");
 
     /* Other stuff */

--- a/libgnucash/app-utils/gnc-gsettings.h
+++ b/libgnucash/app-utils/gnc-gsettings.h
@@ -86,6 +86,16 @@ void gnc_gsettings_set_prefix (const gchar *prefix);
 const gchar *gnc_gsettings_get_prefix (void);
 
 
+/** Block all prefs callbacks, used while preference dialog is loaded.
+ */
+void gnc_gsettings_block_all (void);
+
+
+/** UnBlock all prefs callbacks, used while preference dialog is loaded.
+ */
+void gnc_gsettings_unblock_all (void);
+
+
 /** @name Listening for changes
  @{
 */

--- a/libgnucash/core-utils/gnc-prefs-p.h
+++ b/libgnucash/core-utils/gnc-prefs-p.h
@@ -104,6 +104,10 @@ typedef struct
 
     void (*reset_group) (const gchar *group);
 
+    void (*block_all) (void);
+
+    void (*unblock_all) (void);
+
 } PrefsBackend;
 
 extern PrefsBackend *prefsbackend;

--- a/libgnucash/core-utils/gnc-prefs.c
+++ b/libgnucash/core-utils/gnc-prefs.c
@@ -368,3 +368,14 @@ gboolean gnc_prefs_is_set_up (void)
     return (prefsbackend !=NULL);
 }
 
+void gnc_prefs_block_all (void)
+{
+    if (prefsbackend && prefsbackend->block_all)
+        (prefsbackend->block_all) ();
+}
+
+void gnc_prefs_unblock_all (void)
+{
+    if (prefsbackend && prefsbackend->unblock_all)
+        (prefsbackend->unblock_all) ();
+}

--- a/libgnucash/core-utils/gnc-prefs.h
+++ b/libgnucash/core-utils/gnc-prefs.h
@@ -124,6 +124,14 @@ guint gnc_prefs_get_long_version( void );
 */
 gboolean gnc_prefs_is_set_up (void);
 
+/** Block all preference callbacks
+*/
+void gnc_prefs_block_all (void);
+
+/** Unblock all preferences callbacks
+*/
+void gnc_prefs_unblock_all (void);
+
 /** @name Listening for changes
  @{
 */


### PR DESCRIPTION
When the preference dialogue is loaded and options are set, the ones with registered callbacks fire causing parts of Gnucash to be updated. This was observed with gnc_split_register_load being executed 5 times for each open register when the preference dialogue was loaded.

To overcome this, a couple of functions have been created to block and unblock all registered prefs and used while the preference dialogue is loaded. I checked to see if in the source any had the capability of being blocked but did not find any so I think it would be safe to use in the situation indicated.

There is one thing I want to change but could not work out how, that is the two gsetting functions are defined with a text parameter but should be void but when I made what I thought were the appropriate changes, it compiled OK but would they not execute.

So hopefully the idea is sound but await feedback.