### PR TITLE
 Fix string handling in qof_query_search_for to work with python3 

### DIFF
--- a/bindings/python/function_class.py
+++ b/bindings/python/function_class.py
@@ -125,19 +125,23 @@ class ClassFromFunctions(object):
         return method_function
 
     @classmethod
-    def add_methods_with_prefix(cls, prefix):
-        """Add a group of functions with the same prefix
+    def add_methods_with_prefix(cls, prefix, exclude=[]):
+        """Add a group of functions with the same prefix, exclude methods
+        in array exclude.
         """
         for function_name, function_value, after_prefix in \
-            extract_attributes_with_prefix(cls._module, prefix):
+                extract_attributes_with_prefix(cls._module, prefix):
+
+            if not (function_name in exclude):
                 cls.add_method(function_name, after_prefix)
 
     @classmethod
-    def add_constructor_and_methods_with_prefix(cls, prefix, constructor):
+    def add_constructor_and_methods_with_prefix(cls, prefix, constructor, exclude=[]):
         """Add a group of functions with the same prefix, and set the
-        _new_instance attribute to prefix + constructor
+        _new_instance attribute to prefix + constructor. Don't add methods
+        in array exclude.
         """
-        cls.add_methods_with_prefix(prefix)
+        cls.add_methods_with_prefix(prefix, exclude=exclude)
         cls._new_instance = prefix + constructor
 
     @classmethod

--- a/bindings/python/gnucash_core.py
+++ b/bindings/python/gnucash_core.py
@@ -760,12 +760,19 @@ from gnucash.gnucash_core_c import \
     INVOICE_IS_PAID
 
 class Query(GnuCashCoreClass):
-    pass
 
-Query.add_constructor_and_methods_with_prefix('qof_query_', 'create')
+    def search_for(self, obj_type):
+        """Set search_for to obj_type
+
+        calls qof_query_search_for. Buffers search string for queries lifetime.
+        @see https://bugs.gnucash.org/show_bug.cgi?id=796137"""
+        self.__search_for_buf = obj_type
+        self._search_for(self.__search_for_buf)
+
+Query.add_constructor_and_methods_with_prefix('qof_query_', 'create', exclude=["qof_query_search_for"])
 
 Query.add_method('qof_query_set_book', 'set_book')
-Query.add_method('qof_query_search_for', 'search_for')
+Query.add_method('qof_query_search_for', '_search_for')
 Query.add_method('qof_query_run', 'run')
 Query.add_method('qof_query_add_term', 'add_term')
 Query.add_method('qof_query_add_boolean_match', 'add_boolean_match')

--- a/common/base-typemaps.i
+++ b/common/base-typemaps.i
@@ -220,6 +220,28 @@ typedef char gchar;
     }
 }
 
+%typemap(in) QofIdType {
+    if (PyUnicode_Check($input)) {
+      $1 = PyUnicode_AsUTF8($input);
+    } else if (PyBytes_Check($input)) {
+      $1 = PyBytes_AsString($input);
+    } else {
+      PyErr_SetString(PyExc_TypeError, "not a string or bytes object");
+      return NULL;
+    }
+}
+
+%typemap(in) QofIdTypeConst {
+    if (PyUnicode_Check($input)) {
+      $1 = PyUnicode_AsUTF8($input);
+    } else if (PyBytes_Check($input)) {
+      $1 = PyBytes_AsString($input);
+    } else {
+      PyErr_SetString(PyExc_TypeError, "not a string or bytes object");
+      return NULL;
+    }
+}
+
 %typemap(in) GSList *, QofQueryParamList * {
     $1 = NULL;
     /* Check if is a list */


### PR DESCRIPTION
Fix problems with qof_query_search_for in python bindings resulting from switch to Python 3 and different string handling.

1) Provides typemaps for QofIdType and QofIdTypeConst (patch by David Osguthorpe)
2) modification to python Query class so that search_for is a python method that creates a buffer string that stays alive as long as the query lives and calls qof_query_search_for. The latter is being imported as python Query object method _search_for.
3) Prevent Query.search_for to be overwritten by add_constructor_and_methods_with_prefix after declaration of method search_for as described above. To get that an exclude option is being added to add_constructor_and_methods_with_prefix.

Based on discussion on bugtracker: https://bugs.gnucash.org/show_bug.cgi?id=796137

This is a cleanup of pull request https://github.com/Gnucash/gnucash/pull/408.