### PR TITLE
General progress .scm files

### DIFF
--- a/gnucash/report/business-reports/customer-summary.scm
+++ b/gnucash/report/business-reports/customer-summary.scm
@@ -650,8 +650,8 @@
     (gnc:html-markup-br))))
 
 (define (markup-percent profit sales)
-  (let ((m (gnc-numeric-div profit sales 1000 GNC-HOW-RND-ROUND)))
-    (* 100 (gnc-numeric-to-double m))))
+  (if (zero? sales) 0
+      (* 100 (gnc-numeric-div profit sales 1000 GNC-HOW-RND-ROUND))))
 
 (define (query-split-value sub-query toplevel-query)
   (let ((splits (qof-query-run-subquery sub-query toplevel-query))

--- a/gnucash/report/business-reports/invoice.scm
+++ b/gnucash/report/business-reports/invoice.scm
@@ -675,7 +675,8 @@ for styling the invoice. Please see the exported report for the CSS class names.
 (define (make-img img-url)
   ;; just an image
   (gnc:make-html-text
-   (gnc:html-markup-img img-url)))
+   (gnc:html-markup-img
+    (make-file-url img-url))))
 
 (define (make-client-table owner orders options)
   (define (opt-val section name)

--- a/gnucash/report/report-system/report-utilities.scm
+++ b/gnucash/report/report-system/report-utilities.scm
@@ -386,7 +386,22 @@ construct gnc:make-gnc-monetary and use gnc:monetary->string instead.")
 ;; get the account balance at the specified date. if include-children?
 ;; is true, the balances of all children (not just direct children)
 ;; are included in the calculation.
+;; I think this (gnc:account-get-balance-at-date) is flawed in sub-acct handling.
+;; Consider account structure:
+;; Assets [USD] - bal=$0
+;;    Bank [USD] - bal=$100
+;;    Broker [USD] - bal=$200
+;;       Cash [USD] - bal=$800
+;;       Funds [FUND] - bal=3 FUND @ $1000 each = $3000
+;; - Calling (gnc:account-get-balance-at-date BANK TODAY #f) returns 100
+;; - Calling (gnc:account-get-balance-at-date BROKER TODAY #f) returns 200
+;; - Calling (gnc:account-get-balance-at-date BROKER TODAY #t) returns 1000
+;;   this is because although it counts all subaccounts bal $200 + $800 + 3FUND,
+;;   it retrieves the parent account commodity USD $1000 only.
+;; It needs to be deprecated.
 (define (gnc:account-get-balance-at-date account date include-children?)
+  (issue-deprecation-warning "this gnc:account-get-balance-at-date function is \
+flawed. see report-utilities.scm. please update reports.")
   (let ((collector (gnc:account-get-comm-balance-at-date
                     account date include-children?)))
     (cadr (collector 'getpair (xaccAccountGetCommodity account) #f))))

--- a/gnucash/report/standard-reports/test/test-transaction.scm
+++ b/gnucash/report/standard-reports/test/test-transaction.scm
@@ -472,6 +472,16 @@
              (length ((sxpath '(// (table 1) // (tr -1) // td)) sxml))
              1)))
 
+      (set-option! options "Display" "Enable links" #f)
+      (let ((sxml (options->sxml options "disable hyperlinks")))
+        (test-assert "no anchor when disabling hyperlinks"
+          (zero? (length ((sxpath '(// a // *text*)) sxml)))))
+
+      (set-option! options "Display" "Enable links" #t)
+      (let ((sxml (options->sxml options "enable hyperlinks")))
+        (test-assert "anchors exist when enabling hyperlinks"
+          (positive? (length ((sxpath '(// a // *text*)) sxml)))))
+
       (set-option! options "Display" "Amount" 'none)
       (let ((sxml (options->sxml options "no columns")))
         (test-assert "all display columns off, without amount nor subtotals, there should be 0 column"

--- a/libgnucash/engine/test/test-extras.scm
+++ b/libgnucash/engine/test/test-extras.scm
@@ -142,20 +142,20 @@
     txn))
 
 (define (gnc-pricedb-create currency commodity time64 value)
-  ;; I think adding pricedb for a DMY date will clobber any existing
-  ;; pricedb entry for that date.
-  (let ((price (gnc-price-create (gnc-get-current-book)))
-        (pricedb (gnc-pricedb-get-db (gnc-get-current-book))))
-    (gnc-price-begin-edit price)
-    (gnc-price-set-commodity price commodity)
-    (gnc-price-set-currency price currency)
-    (gnc-price-set-time64 price time64)
-    (gnc-price-set-source price PRICE-SOURCE-XFER-DLG-VAL)
-    (gnc-price-set-source-string price "test-price")
-    (gnc-price-set-typestr price "test")
-    (gnc-price-set-value price value)
-    (gnc-price-commit-edit price)
-    (gnc-pricedb-add-price pricedb price)))
+  ;; does not check for pre-existing pricedb data on date
+  (unless (gnc-commodity-equiv currency commodity)
+    (let ((price (gnc-price-create (gnc-get-current-book)))
+          (pricedb (gnc-pricedb-get-db (gnc-get-current-book))))
+      (gnc-price-begin-edit price)
+      (gnc-price-set-commodity price commodity)
+      (gnc-price-set-currency price currency)
+      (gnc-price-set-time64 price time64)
+      (gnc-price-set-source price PRICE-SOURCE-XFER-DLG-VAL)
+      (gnc-price-set-source-string price "test-price")
+      (gnc-price-set-typestr price "test")
+      (gnc-price-set-value price value)
+      (gnc-price-commit-edit price)
+      (gnc-pricedb-add-price pricedb price))))
 
 ;; When creating stock transactions always put the stock account and the number
 ;; of shares second, using negative numbers for a sale. e.g., to buy 100 shares


### PR DESCRIPTION
~(gnc:pk) is a generally useful debugging tool. Surround any procedure call, or object, with (gnc:pk) and the program will run unchanged, yet the object will be dumped in the tracefile and 2 timestamps printed; both running timestamp and delta timestamp since the last (gnc:pk) call.~

transaction.scm upgraded to optionally toggle transaction/account anchors. seems to be an often-requested feature upgrade.