### PR TITLE
Bug #408444 - Fix "Smallest fraction" disregarded

### DIFF
--- a/libgnucash/engine/Split.c
+++ b/libgnucash/engine/Split.c
@@ -1313,10 +1313,14 @@ xaccSplitSetBaseValue (Split *s, gnc_numeric value,
             s->amount = gnc_numeric_convert(value,
                                             get_commodity_denom(s),
                                             GNC_HOW_RND_ROUND_HALF_UP);
+            s->value = gnc_numeric_convert(value,
+                                           get_commodity_denom(s),
+                                           GNC_HOW_RND_ROUND_HALF_UP);
+        } else {
+            s->value = gnc_numeric_convert(value,
+                                           get_currency_denom(s),
+                                           GNC_HOW_RND_ROUND_HALF_UP);
         }
-        s->value = gnc_numeric_convert(value,
-                                       get_currency_denom(s),
-                                       GNC_HOW_RND_ROUND_HALF_UP);
     }
     else if (gnc_commodity_equiv(commodity, base_currency))
     {


### PR DESCRIPTION
When importing a CSV-File into a account with a non standard SCU configured, the imported Transactions will still round to the currencies default SCU. This PR fixes that issue.