### PR TITLE
Some Possible bug Fixes

### DIFF
--- a/gnucash/gnome-utils/dialog-dup-trans.c
+++ b/gnucash/gnome-utils/dialog-dup-trans.c
@@ -45,12 +45,14 @@ typedef struct
     GtkWidget * date_edit;
     GtkWidget * num_edit;
     GtkWidget * tnum_edit;
+    GtkWidget * assoc_edit;
 
     GtkWidget *duplicate_title_label; // GtkLabel
     GtkWidget *duplicate_table; // GtkTable
     GtkWidget *date_label; // GtkLabel
     GtkWidget *num_label; // GtkLabel
     GtkWidget *tnum_label; // GtkLabel
+    GtkWidget *assoc_label; //GtkLabel
 } DupTransDialog;
 
 /* Parses the string value and returns true if it is a
@@ -169,6 +171,11 @@ gnc_dup_trans_dialog_create (GtkWidget * parent, DupTransDialog *dt_dialog,
         else
             gtk_entry_set_text (GTK_ENTRY (tnum_spin), "");
     }
+    /* Transaction Association */
+    {
+        dt_dialog->assoc_label = GTK_WIDGET(gtk_builder_get_object (builder, "assoc_label"));
+        dt_dialog->assoc_edit = GTK_WIDGET(gtk_builder_get_object (builder, "assoc_check_button"));
+    }
 
     gtk_builder_connect_signals_full (builder, gnc_builder_connect_full_func, dt_dialog);
 
@@ -179,7 +186,8 @@ static gboolean
 gnc_dup_trans_dialog_internal (GtkWidget * parent, const char* title,
                                gboolean show_date, time64 *date_p,
                                GDate *gdate_p, const char *num, char **out_num,
-                               const char *tnum, char **out_tnum)
+                               const char *tnum, char **out_tnum,
+                               const char *tassoc, char **out_tassoc)
 {
     DupTransDialog *dt_dialog;
     GtkWidget *entry;
@@ -243,6 +251,17 @@ gnc_dup_trans_dialog_internal (GtkWidget * parent, const char* title,
         gtk_entry_set_activates_default(GTK_ENTRY(dt_dialog->tnum_edit), TRUE);
     }
 
+    if (tassoc)
+    {
+        gtk_widget_set_visible(dt_dialog->assoc_label, TRUE);
+        gtk_widget_set_visible(dt_dialog->assoc_edit, TRUE);
+    }
+    else
+    {
+        gtk_widget_set_visible(dt_dialog->assoc_label, FALSE);
+        gtk_widget_set_visible(dt_dialog->assoc_edit, FALSE);
+    }
+
     result = gtk_dialog_run (GTK_DIALOG (dt_dialog->dialog));
 
     if (result == GTK_RESPONSE_OK)
@@ -255,6 +274,11 @@ gnc_dup_trans_dialog_internal (GtkWidget * parent, const char* title,
             *out_num = g_strdup (gtk_entry_get_text (GTK_ENTRY (dt_dialog->num_edit)));
         if (tnum)
             *out_tnum = g_strdup (gtk_entry_get_text (GTK_ENTRY (dt_dialog->tnum_edit)));
+        if (tassoc)
+        {
+            if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON(dt_dialog->assoc_edit)))
+                *out_tassoc = g_strdup (tassoc);
+        }
         ok = TRUE;
     }
     else
@@ -269,10 +293,11 @@ gnc_dup_trans_dialog_internal (GtkWidget * parent, const char* title,
 gboolean
 gnc_dup_trans_dialog (GtkWidget * parent, const char* title, gboolean show_date,
                       time64 *date_p, const char *num, char **out_num,
-                      const char *tnum, char **out_tnum)
+                      const char *tnum, char **out_tnum,
+                      const char *tassoc, char **out_tassoc)
 {
     return gnc_dup_trans_dialog_internal(parent, title, show_date, date_p, NULL,
-                                         num, out_num, tnum, out_tnum);
+                                         num, out_num, tnum, out_tnum, tassoc, out_tassoc);
 }
 
 gboolean
@@ -284,7 +309,7 @@ gnc_dup_trans_dialog_gdate (GtkWidget * parent, GDate *gdate_p,
 
     tmp_time = gdate_to_time64 (*gdate_p);
     return gnc_dup_trans_dialog_internal(parent, NULL, TRUE, &tmp_time, gdate_p,
-                                         num, out_num, NULL, NULL);
+                                         num, out_num, NULL, NULL, NULL, NULL);
 }
 
 gboolean
@@ -295,5 +320,5 @@ gnc_dup_date_dialog (GtkWidget * parent, const char* title, GDate *gdate_p)
 
     tmp_time = gdate_to_time64(*gdate_p);
     return gnc_dup_trans_dialog_internal(parent, title, TRUE, &tmp_time, gdate_p,
-                                         NULL, NULL, NULL, NULL);
+                                         NULL, NULL, NULL, NULL, NULL, NULL);
 }

--- a/gnucash/gnome-utils/dialog-dup-trans.h
+++ b/gnucash/gnome-utils/dialog-dup-trans.h
@@ -45,12 +45,15 @@
  *         out_num   - output num field, g_newed string             *
  *         tnum      - input tnum field, if used, else NULL         *
  *         out_tnum  - output tnum field, g_newed string            *
+ *         tassoc    - input association field, if used, else NULL  *
+ *         out_tnum  - output association field, g_newed string     *
  * Return: TRUE if user closes dialog with 'OK'                     *
 \********************************************************************/
 gboolean
 gnc_dup_trans_dialog (GtkWidget * parent, const char* title, gboolean show_date,
                       time64 *date_p, const char *num, char **out_num,
-                      const char *tnum, char **out_tnum);
+                      const char *tnum, char **out_tnum,
+                      const char *tassoc, char **out_tassoc);
 
 gboolean
 gnc_dup_trans_dialog_gdate (GtkWidget * parent, GDate *gdate_p,

--- a/gnucash/gnome-utils/gnc-gnome-utils.c
+++ b/gnucash/gnome-utils/gnc-gnome-utils.c
@@ -482,30 +482,30 @@ void
 gnc_launch_assoc (const char *uri)
 {
     wchar_t *winuri = NULL;
-    char* scheme = g_uri_parse_scheme(uri);
+    char* scheme = gnc_uri_parse_scheme (uri);
     /* ShellExecuteW open doesn't decode http escapes if it's passed a
      * file URI so we have to do it. */
     if (scheme && strcmp (scheme, "file") == 0)
     {
-	gchar *filename = g_filename_from_uri (uri, NULL, NULL);
-	winuri = (wchar_t *)g_utf8_to_utf16(filename, -1, NULL, NULL, NULL);
+        gchar *filename = g_filename_from_uri (uri, NULL, NULL);
+        winuri = (wchar_t *)g_utf8_to_utf16(filename, -1, NULL, NULL, NULL);
     }
     else
-	winuri = (wchar_t *)g_utf8_to_utf16(uri, -1, NULL, NULL, NULL);
+        winuri = (wchar_t *)g_utf8_to_utf16(uri, -1, NULL, NULL, NULL);
 
     if (winuri)
     {
-	wchar_t *wincmd = (wchar_t *)g_utf8_to_utf16("open", -1,
-						     NULL, NULL, NULL);
-	if ((INT_PTR)ShellExecuteW(NULL, wincmd, winuri,
-				   NULL, NULL, SW_SHOWNORMAL) <= 32)
-	{
-	    const gchar *message =
-		_("GnuCash could not find the associated file");
-	    gnc_error_dialog(NULL, "%s: %s", message, uri);
-	}
-	g_free (wincmd);
-	g_free (winuri);
+        wchar_t *wincmd = (wchar_t *)g_utf8_to_utf16("open", -1,
+                                 NULL, NULL, NULL);
+        if ((INT_PTR)ShellExecuteW(NULL, wincmd, winuri,
+                       NULL, NULL, SW_SHOWNORMAL) <= 32)
+        {
+            const gchar *message =
+            _("GnuCash could not find the associated file");
+            gnc_error_dialog(NULL, "%s: %s", message, uri);
+        }
+        g_free (wincmd);
+        g_free (winuri);
     }
     g_free (scheme);
 }

--- a/gnucash/gnome-utils/gnc-tree-control-split-reg.c
+++ b/gnucash/gnome-utils/gnc-tree-control-split-reg.c
@@ -1240,7 +1240,7 @@ gnc_tree_control_split_reg_duplicate_current (GncTreeViewSplitReg *view)
 
         /* We are on a split in an expanded transaction.
          * Just copy the split and add it to the transaction.
-         * However, if the split-action field is being used as the register 
+         * However, if the split-action field is being used as the register
          * number, and the action field is a number, request a new value or
          * cancel. Need to get next number and update account last num from
          * split account not register account, which may be the same or not */
@@ -1260,7 +1260,7 @@ gnc_tree_control_split_reg_duplicate_current (GncTreeViewSplitReg *view)
                     in_num = gnc_get_num_action (NULL, split);
 
                 if (!gnc_dup_trans_dialog (GTK_WIDGET (window), title, FALSE,
-                                           &date, in_num, &out_num, NULL, NULL))
+                                           &date, in_num, &out_num, NULL, NULL, NULL, NULL))
                 {
                     LEAVE("dup cancelled");
                     return FALSE;
@@ -1314,6 +1314,7 @@ gnc_tree_control_split_reg_duplicate_current (GncTreeViewSplitReg *view)
         const char *in_tnum = NULL;
         char *out_num;
         char *out_tnum;
+        char *out_tassoc = NULL;
         time64 date;
         gboolean use_autoreadonly = qof_book_uses_autoreadonly (gnc_get_current_book());
 
@@ -1335,7 +1336,8 @@ gnc_tree_control_split_reg_duplicate_current (GncTreeViewSplitReg *view)
                                         : NULL);
 
         if (!gnc_dup_trans_dialog (GTK_WIDGET (window), NULL, TRUE,
-                                   &date, in_num, &out_num, in_tnum, &out_tnum))
+                                   &date, in_num, &out_num, in_tnum, &out_tnum,
+                                   xaccTransGetAssociation (trans), &out_tassoc))
         {
             LEAVE("dup cancelled");
             return FALSE;
@@ -1379,6 +1381,12 @@ gnc_tree_control_split_reg_duplicate_current (GncTreeViewSplitReg *view)
         /* We also must set a new DateEntered on the new entry
          * because otherwise the ordering is not deterministic */
         xaccTransSetDateEnteredSecs(new_trans, gnc_time(NULL));
+
+        /* clear the associated entry if returned value NULL */
+        if (out_tassoc == NULL)
+            xaccTransSetAssociation (new_trans, "");
+        else
+            g_free (out_tassoc);
 
         /* set per book option */
         gnc_set_num_action (new_trans, NULL, out_num, out_tnum);
@@ -1942,7 +1950,7 @@ gnc_tree_control_split_reg_recn_test (GncTreeViewSplitReg *view, GtkTreePath *sp
 }
 
 
-/* Return the account for name given or create it */ 
+/* Return the account for name given or create it */
 Account *
 gnc_tree_control_split_reg_get_account_by_name (GncTreeViewSplitReg *view, const char *name)
 {
@@ -2163,6 +2171,9 @@ gnc_tree_control_auto_complete (GncTreeViewSplitReg *view, Transaction *trans,  
         if (g_strcmp0 (text, new_text) == 0)
         {
             xaccTransCopyOnto (trans_from, trans);
+            /* if there is an association, lets clear it */
+            if (xaccTransGetAssociation (trans_from) != NULL)
+                xaccTransSetAssociation (trans, "");
             g_free (text);
             break;
         }

--- a/gnucash/gnome/dialog-trans-assoc.c
+++ b/gnucash/gnome/dialog-trans-assoc.c
@@ -42,7 +42,7 @@
 #include "Account.h"
 
 #define DIALOG_ASSOC_CM_CLASS    "dialog-trans-assoc"
-#define GNC_PREFS_GROUP         "dialogs.trans-assoc"
+#define GNC_PREFS_GROUP          "dialogs.trans-assoc"
 
 /** Enumeration for the tree-store */
 enum GncAssocColumn {DATE_TRANS, DESC_TRANS, URI_U, AVAILABLE, URI_SPLIT, URI, URI_RELATIVE};
@@ -356,7 +356,8 @@ get_trans_info (AssocDialog *assoc_dialog)
     GList        *accts, *ptr;
     GtkTreeModel *model;
     GtkTreeIter   iter;
-    GList        *splits, *trans_list = NULL;
+    GList        *splits;
+    GHashTable   *trans_hash = g_hash_table_new (g_direct_hash, g_direct_equal);
 
     /* Get list of Accounts */
     accts = gnc_account_get_descendants_sorted (root);
@@ -382,8 +383,8 @@ get_trans_info (AssocDialog *assoc_dialog)
             Transaction *trans = xaccSplitGetParent (split);
             const gchar *uri;
 
-            // Look for trans already in trans_list
-            if (g_list_find (trans_list, trans) != NULL)
+            // Look for trans already in trans_hash
+            if (g_hash_table_lookup (trans_hash, trans))
                 continue;
 
             // fix an earlier error when storing relative paths in version 3.3
@@ -416,7 +417,7 @@ get_trans_info (AssocDialog *assoc_dialog)
                 g_free (uri_u);
                 g_free (scheme);
             }
-            trans_list = g_list_prepend (trans_list, trans); // add trans to trans_list
+            g_hash_table_insert (trans_hash, trans, trans); // add trans to trans_hash
         }
         qof_query_destroy (query);
         g_list_free (splits);
@@ -426,8 +427,8 @@ get_trans_info (AssocDialog *assoc_dialog)
     gtk_tree_view_set_model (GTK_TREE_VIEW(assoc_dialog->view), model);
     g_object_unref(G_OBJECT(model));
 
+    g_hash_table_destroy (trans_hash);
     g_list_free (accts);
-    g_list_free (trans_list);
 }
 
 static void

--- a/gnucash/gtkbuilder/gnc-plugin-page-register.glade
+++ b/gnucash/gtkbuilder/gnc-plugin-page-register.glade
@@ -1085,6 +1085,47 @@ If 0, all previous days included</property>
                     <property name="top_attach">2</property>
                   </packing>
                 </child>
+                <child>
+                  <object class="GtkBox" id="assoc_hbox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="spacing">5</property>
+                    <child>
+                      <object class="GtkLabel" id="assoc_label">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">Keep Associated Entry</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="assoc_check_button">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="halign">start</property>
+                        <property name="image_position">top</property>
+                        <property name="active">True</property>
+                        <property name="draw_indicator">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">3</property>
+                    <property name="width">2</property>
+                  </packing>
+                </child>
               </object>
             </child>
           </object>

--- a/gnucash/register/ledger-core/split-register-control.c
+++ b/gnucash/register/ledger-core/split-register-control.c
@@ -889,6 +889,9 @@ gnc_split_register_auto_completion (SplitRegister *reg,
         g_assert(pending_trans == trans);
 
         gnc_copy_trans_onto_trans (auto_trans, trans, FALSE, FALSE);
+        /* if there is an association, lets clear it */
+        if (xaccTransGetAssociation (auto_trans) != NULL)
+            xaccTransSetAssociation (trans, "");
         blank_split = NULL;
 
         if (gnc_split_register_get_default_account (reg) != NULL)

--- a/libgnucash/engine/Transaction.c
+++ b/libgnucash/engine/Transaction.c
@@ -757,6 +757,7 @@ xaccTransCopyFromClipBoard(const Transaction *from_trans, Transaction *to_trans,
         xaccTransSetNum(to_trans, xaccTransGetNum(from_trans));
 
     xaccTransSetNotes(to_trans, xaccTransGetNotes(from_trans));
+    xaccTransSetAssociation(to_trans, xaccTransGetAssociation (from_trans));
     if(!no_date)
     {
         xaccTransSetDatePostedSecs(to_trans, xaccTransRetDatePosted (from_trans));

--- a/libgnucash/engine/engine-interface.scm
+++ b/libgnucash/engine/engine-interface.scm
@@ -136,7 +136,7 @@
   (make-record-type
    "gnc:transaction-structure"
    '(transaction-guid currency date-entered date-posted
-                      num description notes split-scms)))
+                      num description notes association split-scms)))
 
 ;; constructor
 (define gnc:make-transaction-scm
@@ -167,6 +167,9 @@
 
 (define gnc:transaction-scm-get-notes
   (record-accessor gnc:transaction-structure 'notes))
+
+(define gnc:transaction-scm-get-association
+  (record-accessor gnc:transaction-structure 'association))
 
 (define gnc:transaction-scm-get-split-scms
   (record-accessor gnc:transaction-structure 'split-scms))
@@ -206,6 +209,9 @@
 (define gnc:transaction-scm-set-notes
   (record-modifier gnc:transaction-structure 'notes))
 
+(define gnc:transaction-scm-set-association
+  (record-modifier gnc:transaction-structure 'association))
+
 (define gnc:transaction-scm-set-split-scms
   (record-modifier gnc:transaction-structure 'split-scms))
 
@@ -235,6 +241,7 @@
        #f)
    (xaccTransGetDescription trans)
    (xaccTransGetNotes trans)
+   (xaccTransGetAssociation trans)
    (trans-splits 0)))
 
 ;; Copy a scheme representation of a transaction onto a C transaction.
@@ -254,11 +261,13 @@
               (description (gnc:transaction-scm-get-description trans-scm))
               (num         (gnc:transaction-scm-get-num trans-scm))
               (notes       (gnc:transaction-scm-get-notes trans-scm))
+              (association (gnc:transaction-scm-get-association trans-scm))
               (date-posted (gnc:transaction-scm-get-date-posted trans-scm)))
           (if currency    (xaccTransSetCurrency trans currency))
           (if description (xaccTransSetDescription trans description))
           (if num         (xaccTransSetNum trans num))
           (if notes       (xaccTransSetNotes trans notes))
+          (if association (xaccTransSetAssociation trans association))
           (if date-posted (xaccTransSetDatePostedSecs trans date-posted)))
 
         ;; strip off the old splits

--- a/libgnucash/engine/gnc-uri-utils.h
+++ b/libgnucash/engine/gnc-uri-utils.h
@@ -225,6 +225,33 @@ gboolean gnc_uri_is_file_uri (const gchar *uri);
  */
 gchar *gnc_uri_add_extension ( const gchar *uri, const gchar *extension );
 
+/**  Creates an absolute path from a relative one and a path head:
+ *  * relative uri should not start with /
+ *  * path head will be a valid file directory uri
+ *
+ *  @param uri The uri to process
+ *  @param path_head The file directory uri for the base directory used to
+ *                   add the relative path too.
+ *                   If path_head does not end in a /, one will be added so
+ *                   to form a valid absolute path the relative path should
+ *                   not start with a /
+ *  @param ret_uri   The returned absolute path
+ *
+ *  @return TRUE if the ret_uri contains an absolute path or FALSE and the
+ *          ret_uri will be NULL
+ */
+gboolean gnc_uri_absolute_associate_file_path (const gchar *uri,
+                                               const gchar *path_head,
+                                               gchar **ret_uri);
+
+/** Returns the scheme for a given uri, like 'file', 'http', 'ftp'
+ *
+ *  @param uri The uri to check
+ *
+ *  @return The scheme used or NULL if one can not be found
+ */
+gchar *gnc_uri_parse_scheme (const gchar *uri);
+
 #endif /* GNCURIUTILS_H_ */
 /** @} */
 /** @} */


### PR DESCRIPTION
Some possible bug fixes.
The 'blank split' one was strange as it was there in 2.6.x also. From the comment in the code, that part of code is used when another row is deleted but I could only get it to run in this situation. To be safe I added an 'if blank split' statement to not destroy the split when it is the blank split.
The Invoice search bug was caused by an update to the other search options to pass the parent window for error messages and this one was missed as it was not in the search-gnome directory. I was going to move it but it would also require other file changes that may be best dealt with on master.