### PR TITLE
Decorate Python GetBalTaxValues to return tuples of GncCommodity and GncNumeric

### DIFF
--- a/bindings/python/gnucash_business.py
+++ b/bindings/python/gnucash_business.py
@@ -374,3 +374,6 @@ methods_return_instance(Entry, entry_dict)
 Entry.decorate_functions(
     decorate_to_return_instance_instead_of_owner,
     'GetBillTo' )
+
+from gnucash.gnucash_core import decorate_monetary_list_returning_function
+Entry.decorate_functions(decorate_monetary_list_returning_function, 'GetBalTaxValues')

--- a/bindings/python/gnucash_core.py
+++ b/bindings/python/gnucash_core.py
@@ -435,12 +435,22 @@ class Transaction(GnuCashCoreClass):
             gncInvoiceGetInvoiceFromTxn, Transaction )
 
 def decorate_monetary_list_returning_function(orig_function):
-    def new_function(self):
+    def new_function(self, *args):
+        """decorate function that returns list of gnc_monetary to return tuples of GncCommodity and GncNumeric
+
+        Args:
+            *args: Variable length argument list. Will get passed to orig_function
+
+        Returns:
+            array of tuples: (GncCommodity, GncNumeric)
+
+        ToDo:
+            Maybe this function should better reside in module function_class (?)"""
         # warning, item.commodity has been shown to be None
         # when the transaction doesn't have a currency
         return [(GncCommodity(instance=item.commodity),
                  GncNumeric(instance=item.value))
-                for item in orig_function(self) ]
+                for item in orig_function(self, *args) ]
     return new_function
 
 class Split(GnuCashCoreClass):

--- a/bindings/python/gnucash_core.py
+++ b/bindings/python/gnucash_core.py
@@ -445,7 +445,8 @@ def decorate_monetary_list_returning_function(orig_function):
             array of tuples: (GncCommodity, GncNumeric)
 
         ToDo:
-            Maybe this function should better reside in module function_class (?)"""
+            * Maybe this function should better reside in module function_class ?
+            * Should it be tuples anyway ? Wouldn't it be better to have GncMonetary to reflect gnc_monetary in c ?"""
         # warning, item.commodity has been shown to be None
         # when the transaction doesn't have a currency
         return [(GncCommodity(instance=item.commodity),

--- a/bindings/python/gnucash_core.py
+++ b/bindings/python/gnucash_core.py
@@ -445,8 +445,7 @@ def decorate_monetary_list_returning_function(orig_function):
             array of tuples: (GncCommodity, GncNumeric)
 
         ToDo:
-            * Maybe this function should better reside in module function_class ?
-            * Should it be tuples anyway ? Wouldn't it be better to have GncMonetary to reflect gnc_monetary in c ?"""
+            Maybe this function should better reside in module function_class (?)"""
         # warning, item.commodity has been shown to be None
         # when the transaction doesn't have a currency
         return [(GncCommodity(instance=item.commodity),


### PR DESCRIPTION
Let GetBalTaxValues return a list of tuples (GncCommodity, GncNumeric) by using decorate_monetary_list_returning_function. This function needs an additional arg to work here. So add args and pass them through to original function. Add some doc as well.

I used this tuple solution because there was a function that did it this way (decorate_monetary_list_returning_function). I wonder if it makes more sense to create a GncMonetary class instead.