### PR TITLE
add CMAKE CXX compile flag -Wno-deprecated-declarations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -569,7 +569,7 @@ set(CMAKE_CXX_FLAGS "-std=gnu++11 ${CMAKE_CXX_FLAGS}")  # FIXME: should be -std=
 if (UNIX)
   set( CMAKE_C_FLAGS "-Werror -Wdeclaration-after-statement -Wno-pointer-sign -Wall -Wmissing-prototypes -Wmissing-declarations -Wno-unused ${CMAKE_C_FLAGS}")
   set( CMAKE_C_FLAGS "-Wno-deprecated-declarations -std=gnu11 -Wno-error=parentheses ${CMAKE_C_FLAGS}")
-  set( CMAKE_CXX_FLAGS "-Werror -Wall -Wmissing-declarations -Wno-unused -Wno-error=parentheses ${CMAKE_CXX_FLAGS}")
+  set( CMAKE_CXX_FLAGS "-Werror -Wall -Wmissing-declarations  -Wno-deprecated-declarations -Wno-unused -Wno-error=parentheses ${CMAKE_CXX_FLAGS}")
   set( CMAKE_CXX_FLAGS "-Wno-deprecated-declarations ${REGISTER_CXXFLAG} ${CMAKE_CXX_FLAGS}")
   set( CMAKE_C_FLAGS_RELEASE "-O3 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 ${CMAKE_C_FLAGS}")
 endif (UNIX)


### PR DESCRIPTION
As discussed on the mailing list compilation fails (on recent OpenSuse Tumbleweed) because of
https://gitlab.gnome.org/GNOME/glib/commit/7e5db31d36532274c2b2428ef9bace796928785e
as `g_type_class_add_private()` is deprecated. It's in use fairly often in the source.
`grep g_type_class_add_private * -R | grep ':'` leads to 68 files. But that is mainly c files. The only cpp ones are libgnucash/engine/Account.cpp and libgnucash/engine/qofinstance.cpp.