### PR TITLE
replace deprecated g_type_class_add_private

### DIFF
--- a/common/config.h.cmake.in
+++ b/common/config.h.cmake.in
@@ -24,7 +24,7 @@
 /* Using GDK Quartz (not X11) */
 #cmakedefine GDK_QUARTZ
 
-/* GetText version number */
+/* Name of our gettext-domain */
 #define GETTEXT_PACKAGE "@GETTEXT_PACKAGE@"
 
 /* Cocoa/Nexstep/GnuStep framework */

--- a/data/accounts/de_AT/CMakeLists.txt
+++ b/data/accounts/de_AT/CMakeLists.txt
@@ -7,7 +7,8 @@ set(dist_account_DATA
   acctchrt_common.gnucash-xea
   acctchrt_houseown.gnucash-xea
   acctchrt_investment.gnucash-xea
-  acctchrt_kids.gnucash-xea)
+  acctchrt_kids.gnucash-xea
+  acctchrt_ekr2017.gnucash-xea)
 
 set_dist_list(DE_AT_DIST ${dist_account_DATA} CMakeLists.txt)
 

--- a/data/accounts/de_AT/acctchrt_ekr2017.gnucash-xea
+++ b/data/accounts/de_AT/acctchrt_ekr2017.gnucash-xea
@@ -1,0 +1,5951 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<gnc-account-example
+     xmlns="http://www.gnucash.org/XML/"
+     xmlns:act="http://www.gnucash.org/XML/act"
+     xmlns:addr="http://www.gnucash.org/XML/addr"
+     xmlns:bgt="http://www.gnucash.org/XML/bgt"
+     xmlns:billterm="http://www.gnucash.org/XML/billterm"
+     xmlns:book="http://www.gnucash.org/XML/book"
+     xmlns:bt-days="http://www.gnucash.org/XML/bt-days"
+     xmlns:bt-prox="http://www.gnucash.org/XML/bt-prox"
+     xmlns:cd="http://www.gnucash.org/XML/cd"
+     xmlns:cmdty="http://www.gnucash.org/XML/cmdty"
+     xmlns:cust="http://www.gnucash.org/XML/cust"
+     xmlns:employee="http://www.gnucash.org/XML/employee"
+     xmlns:fs="http://www.gnucash.org/XML/fs"
+     xmlns:gnc="http://www.gnucash.org/XML/gnc"
+     xmlns:gnc-act="http://www.gnucash.org/XML/gnc-act"
+     xmlns:invoice="http://www.gnucash.org/XML/invoice"
+     xmlns:job="http://www.gnucash.org/XML/job"
+     xmlns:lot="http://www.gnucash.org/XML/lot"
+     xmlns:order="http://www.gnucash.org/XML/order"
+     xmlns:owner="http://www.gnucash.org/XML/owner"
+     xmlns:price="http://www.gnucash.org/XML/price"
+     xmlns:recurrence="http://www.gnucash.org/XML/recurrence"
+     xmlns:slot="http://www.gnucash.org/XML/slot"
+     xmlns:split="http://www.gnucash.org/XML/split"
+     xmlns:sx="http://www.gnucash.org/XML/sx"
+     xmlns:taxtable="http://www.gnucash.org/XML/taxtable"
+     xmlns:trn="http://www.gnucash.org/XML/trn"
+     xmlns:ts="http://www.gnucash.org/XML/ts"
+     xmlns:tte="http://www.gnucash.org/XML/tte"
+     xmlns:entry="http://www.gnucash.org/XML/entry"
+     xmlns:vendor="http://www.gnucash.org/XML/vendor">
+<gnc-act:title>
+  EKR-2017
+</gnc-act:title>
+<gnc-act:short-description>
+  Österreichischer Einheitskontenrahmen, Stand 2017
+</gnc-act:short-description>
+<gnc-act:long-description>
+Das ist der österreichische Einheitskontenrahmen. Er wurde vom Fachsenat für Betriebswirtschaft der Kammer der Wirtschaftstreuhänder unter der Bezeichnung KFS/BW 6 im Mai 2017 beschlossen und veröffentlich.
+
+
+Bei Gebrauch dieses Kontenrahmens sind die allgemeinen Konten abzuwählen. Dieser Rahmen enthält nur Platzhalterkonten der dreistufigen Hierachie.
+
+
+Alle Konten besitzen eine Kontonummer. Durch Anzeige der Spalte "Kontonummer" in der Kontenübersicht kann die Reihenfolge durch Sortierung dieser richtig dargestellt werden.
+</gnc-act:long-description>
+<gnc-act:exclude-from-select-all>1</gnc-act:exclude-from-select-all>
+<gnc:account version="2.0.0">
+  <act:name>Root Account</act:name>
+  <act:id type="new">59d3eca1e1c2c3a6fa981e0856665bfb</act:id>
+  <act:type>ROOT</act:type>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Anlagevermögen</act:name>
+  <act:id type="new">60805095e127287f17d8444517174fee</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>0</act:code>
+  <act:description>Kontenklasse 0</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">59d3eca1e1c2c3a6fa981e0856665bfb</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Immaterielle Vermögensgegenstände</act:name>
+  <act:id type="new">b4c70ca4b9fdf3ae71cb38978d00bfc1</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>01</act:code>
+  <act:description>Kontengruppe 01</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">60805095e127287f17d8444517174fee</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Konzessionen</act:name>
+  <act:id type="new">8f522ca69f9670780447aa8c217dc526</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>010</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">b4c70ca4b9fdf3ae71cb38978d00bfc1</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Patentrechte und Lizenzen</act:name>
+  <act:id type="new">36e3d367bd88c8d81c5b4d0bc7597e95</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>011</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">b4c70ca4b9fdf3ae71cb38978d00bfc1</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Datenverarbeitungsprogramme</act:name>
+  <act:id type="new">62bcaf85c9dc49ef2c4cf4b253d43f77</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>012</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">b4c70ca4b9fdf3ae71cb38978d00bfc1</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Marken, Warenzeichen und Musterschutzrechte, sonstige Urheberrechte</act:name>
+  <act:id type="new">f5fb361b61b6ffad2536151b868a458b</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>013</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">b4c70ca4b9fdf3ae71cb38978d00bfc1</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Pacht- und Mietrechte</act:name>
+  <act:id type="new">6839350a895cfbc3b2b6de524fabd1ab</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>014</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">b4c70ca4b9fdf3ae71cb38978d00bfc1</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Bezugs- und ähnliche Rechte</act:name>
+  <act:id type="new">19a0faecf3ba13d7c82460d4856aeb6b</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>015</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">b4c70ca4b9fdf3ae71cb38978d00bfc1</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Geschäfts-/Firmenwert</act:name>
+  <act:id type="new">f06f4996775ce0f855a05db6e0c92b50</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>016</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">b4c70ca4b9fdf3ae71cb38978d00bfc1</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Umgründungsmehrwert</act:name>
+  <act:id type="new">b1b710015bb8c3304299b136d7fb6e58</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>017</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">b4c70ca4b9fdf3ae71cb38978d00bfc1</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Geleistete Anzahlungen auf immaterielle Vermögensgegenstände des Anlagemögens</act:name>
+  <act:id type="new">3467d292dccbf95b1f66b8ad692f683e</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>018</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">b4c70ca4b9fdf3ae71cb38978d00bfc1</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Kumulierte Abschreibungen zu immateriellen Vermögensgegenständen des Anlagevermögens</act:name>
+  <act:id type="new">945c6581d7e201de2cf280d48eb42907</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>019</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">b4c70ca4b9fdf3ae71cb38978d00bfc1</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Grundstücke, grundstücksgleiche Rechte und Bauten, einschließlich der Bauten auf fremdem Grund</act:name>
+  <act:id type="new">cbbb8c7c25262a550134b93acb9041fe</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>02-03</act:code>
+  <act:description>Kontengruppe 02-03</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">60805095e127287f17d8444517174fee</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Unbebaute Grundstücke, soweit nicht landwirtschaftlich genutzt</act:name>
+  <act:id type="new">fbbe2bfa50226992876b270d24213f60</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>020</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">cbbb8c7c25262a550134b93acb9041fe</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Bebaute Grundstücke (Grundwert)</act:name>
+  <act:id type="new">603bb2092a3ba09040d10ccca11a04d0</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>021</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">cbbb8c7c25262a550134b93acb9041fe</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Landwirtschaftlich genutzte Grundstücke</act:name>
+  <act:id type="new">0753a65f2353e78ffda801463a4a8257</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>022</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">cbbb8c7c25262a550134b93acb9041fe</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Grundstücksgleiche Rechte</act:name>
+  <act:id type="new">1a071cecc837238758f5f99b7d645cba</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>023</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">cbbb8c7c25262a550134b93acb9041fe</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Betriebs- und Geschäftsgebäude auf eigenem Grund</act:name>
+  <act:id type="new">6df3f7ac34fc7a3ec386f43d6b98a6a7</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>030</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">cbbb8c7c25262a550134b93acb9041fe</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Wohn- und Sozialgebäude auf eigenem Grund</act:name>
+  <act:id type="new">289573f896adf8006bc083bab166d366</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>031</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">cbbb8c7c25262a550134b93acb9041fe</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Betriebs- und Geschäftsgebäude auf fremdem Grund</act:name>
+  <act:id type="new">2ff72c0e3c891895b04dff2509dea364</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>032</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">cbbb8c7c25262a550134b93acb9041fe</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Wohn- und Sozialgebäude auf fremdem Grund</act:name>
+  <act:id type="new">fe163a442cc5dab173992c89d72cc36c</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>033</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">cbbb8c7c25262a550134b93acb9041fe</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Grundstückseinrichtungen auf eigenem Grund</act:name>
+  <act:id type="new">ac6f4b9998141df1af2d2c471edf7316</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>034</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">cbbb8c7c25262a550134b93acb9041fe</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Grundstückseinrichtungen auf fremdem Grund</act:name>
+  <act:id type="new">789fdb3f85864b2d3ba7e50667455c25</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>035</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">cbbb8c7c25262a550134b93acb9041fe</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Bauliche Investitionen in fremden Betriebs- und Geschäftsgebäuden</act:name>
+  <act:id type="new">a191ce3b38e0389e338ed0454a83c20e</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>036</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">cbbb8c7c25262a550134b93acb9041fe</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Bauliche Investitionen in fremden Wohn- und Sozialgebäuden</act:name>
+  <act:id type="new">81c068dc3e14b9e9d3d3085d1e2eb5fc</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>037</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">cbbb8c7c25262a550134b93acb9041fe</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Kumulierte Abschreibungen zu Grundstücken, grundstücksgleichen Rechten und Bauten einschließlich Bauten auf fremdem Grund</act:name>
+  <act:id type="new">612c1d964eda8e6846c565a304eec167</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>039</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">cbbb8c7c25262a550134b93acb9041fe</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Technische Anlagen und Maschinen</act:name>
+  <act:id type="new">365e934251309f690459759536e834ef</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>04-05</act:code>
+  <act:description>Kontengruppe 04-05</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">60805095e127287f17d8444517174fee</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Maschinen und maschinelle Anlagen</act:name>
+  <act:id type="new">3911c724229e43f8d5554493dd2cfbde</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>040-049</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">365e934251309f690459759536e834ef</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Maschinenwerkzeuge</act:name>
+  <act:id type="new">98d72609ef2e05efd0d0c274976e9f48</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>050</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">365e934251309f690459759536e834ef</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Allgemeine Werkzeuge und Handwerkzeuge</act:name>
+  <act:id type="new">29c2dd0c0c07a4807976abd3916e34f2</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>051</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">365e934251309f690459759536e834ef</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Vorrichtungen, Formen und Modelle</act:name>
+  <act:id type="new">6e7d511b4f935cfcee9b2c23f2d804b0</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>052</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">365e934251309f690459759536e834ef</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Andere Erzeugungshilfsmittel</act:name>
+  <act:id type="new">20d7a3e6b8264ae6547f7b543e583492</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>053</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">365e934251309f690459759536e834ef</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Hebezeuge und Montageanlagen</act:name>
+  <act:id type="new">8578382297cf0ea2f278d82156a8077e</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>054</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">365e934251309f690459759536e834ef</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Geringwertige Vermögensgegenstände, soweit im Erzeugungsprozess verwendet</act:name>
+  <act:id type="new">6f16967e35d5b739903cb9c5196e7a39</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>055</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">365e934251309f690459759536e834ef</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Festwerte technische Anlagen und Maschinen</act:name>
+  <act:id type="new">c540c37c4ca748afd5f89f5f630d8b08</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>056</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">365e934251309f690459759536e834ef</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Kumulierte Abschreibungen zu technischen Anlagen und Maschinen</act:name>
+  <act:id type="new">c45c52ab2e2778b45b1503ac43f35dae</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>059</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">365e934251309f690459759536e834ef</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Andere Anlagen, Betriebs- und Geschäftsausstattung</act:name>
+  <act:id type="new">d3655aec0ed027e4c7fc3d081ab1b28d</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>06</act:code>
+  <act:description>Kontengruppe 06</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">60805095e127287f17d8444517174fee</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Betriebs- und Geschäftsausstattung, soweit nicht gesondert angeführt</act:name>
+  <act:id type="new">a22c75c047f795a980b4a75ed63d42cc</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>060</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">d3655aec0ed027e4c7fc3d081ab1b28d</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Andere Anlagen, soweit nicht gesondert angeführt</act:name>
+  <act:id type="new">6df0f8af02daf2a595e841c07b6f8f9b</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>061</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">d3655aec0ed027e4c7fc3d081ab1b28d</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Büromaschinen, EDV-Anlagen</act:name>
+  <act:id type="new">0ac906f63a1fe2ecbc19bd7171ad120d</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>062</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">d3655aec0ed027e4c7fc3d081ab1b28d</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>PKW und Kombis</act:name>
+  <act:id type="new">60a77929aeec837596e77f141b99ac03</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>063</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">d3655aec0ed027e4c7fc3d081ab1b28d</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>LKW</act:name>
+  <act:id type="new">f24d086d3274c23ce1371125fa7de40e</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>064</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">d3655aec0ed027e4c7fc3d081ab1b28d</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Andere Beförderungsmittel</act:name>
+  <act:id type="new">547601170ab3b5318b7a1da2fc87131b</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>065</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">d3655aec0ed027e4c7fc3d081ab1b28d</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Gebinde</act:name>
+  <act:id type="new">6c3603d675c9af7927c7e9a99a77a048</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>066</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">d3655aec0ed027e4c7fc3d081ab1b28d</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Geringwertige Vermögensgegenstände, soweit nicht im Erzeugungsprozess verwendet</act:name>
+  <act:id type="new">dfa7df74b804114199e2024ed5694c45</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>067</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">d3655aec0ed027e4c7fc3d081ab1b28d</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Festwerte außer technische Anlagen und Maschinen</act:name>
+  <act:id type="new">db9fc2989499b175f21fd3a14bd0efcb</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>068</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">d3655aec0ed027e4c7fc3d081ab1b28d</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Kumulierte Abschreibungen zu anderen Anlagen, Betriebs- und Geschäftsausstattung</act:name>
+  <act:id type="new">25ca0c5bc80b152a4569dcdd6a926181</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>069</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">d3655aec0ed027e4c7fc3d081ab1b28d</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Geleistete Anzahlungen und Anlagen in Bau</act:name>
+  <act:id type="new">f1ea50a30c546b27a57e470ac58aaa4f</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>07</act:code>
+  <act:description>Kontengruppe 07</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">60805095e127287f17d8444517174fee</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Geleistete Anzahlungen auf Sachanlagen</act:name>
+  <act:id type="new">08bceeb23b3ade2a3939a7ff1a38fd0d</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>070</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">f1ea50a30c546b27a57e470ac58aaa4f</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Anlagen in Bau</act:name>
+  <act:id type="new">118e726fd00ce9cfc4ba2129c481d045</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>071</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">f1ea50a30c546b27a57e470ac58aaa4f</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Kumulierte Abschreibungen zu geleisteten Anzahlungen auf Sachanlagen und Anlagen in Bau</act:name>
+  <act:id type="new">2978b8fd430a1b7fba212a165ee10601</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>079</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">f1ea50a30c546b27a57e470ac58aaa4f</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Finanzanlagen</act:name>
+  <act:id type="new">78d992301e76cbf3eaeaac3c872099bb</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>08-09</act:code>
+  <act:description>Kontengruppe 08-09</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">60805095e127287f17d8444517174fee</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Anteile an verbundenen Unternehmen außer an Mutterunternehmen</act:name>
+  <act:id type="new">ca3b1e74377138ac0a415cac647ebc20</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>080</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">78d992301e76cbf3eaeaac3c872099bb</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Beteiligungen an Gemeinschaftsunternehmen</act:name>
+  <act:id type="new">39e6626d21bcf0986fd8404cd7c0cccd</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>081</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">78d992301e76cbf3eaeaac3c872099bb</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Beteiligungen an assoziierten Unternehmen</act:name>
+  <act:id type="new">80748b1d9c8f812b84d7a666a3ab29f5</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>082</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">78d992301e76cbf3eaeaac3c872099bb</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Anteile an Mutterunternehmen</act:name>
+  <act:id type="new">2470d906b250f165775847acdadadf0e</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>083</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">78d992301e76cbf3eaeaac3c872099bb</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Sonstige Beteiligungen</act:name>
+  <act:id type="new">70df69598dec0dfccf00657d66ed7e8b</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>084</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">78d992301e76cbf3eaeaac3c872099bb</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Ausleihungen an verbundene Unternehmen</act:name>
+  <act:id type="new">1b449a214e8e4f8731678bd9b7a28e5f</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>085</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">78d992301e76cbf3eaeaac3c872099bb</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Ausleihungen an Unternehmen, mit denen ein Beteiligungsverhältnis besteht</act:name>
+  <act:id type="new">a8467b8960073e9bd5a338f78725372e</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>086</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">78d992301e76cbf3eaeaac3c872099bb</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Ausleihungen an Gesellschafter</act:name>
+  <act:id type="new">6cf8d7e503aeaddec11bb106780e8629</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>087</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">78d992301e76cbf3eaeaac3c872099bb</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Sonstige Ausleihungen</act:name>
+  <act:id type="new">61479ed158215834ce91d257d36c4ec5</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>088</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">78d992301e76cbf3eaeaac3c872099bb</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Sonstige Anteile an Kapitalgesellschaften ohne Beteiligungscharakter</act:name>
+  <act:id type="new">ebe2eaf90900806f3fbe672f542715e8</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>089</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">78d992301e76cbf3eaeaac3c872099bb</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Sonstige Anteile an Personengesellschaften ohne Beteiligungscharakter</act:name>
+  <act:id type="new">4ffcbe5b549fcab733057628c3701479</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>090</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">78d992301e76cbf3eaeaac3c872099bb</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Sonstige Genossenschaftsanteile ohne Beteiligungscharakter</act:name>
+  <act:id type="new">c56be63267c09251f4a342865d818a02</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>091</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">78d992301e76cbf3eaeaac3c872099bb</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Sonstige Anteile an Investmentfonds</act:name>
+  <act:id type="new">15b9372daadd2236235e34741b73abb5</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>092</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">78d992301e76cbf3eaeaac3c872099bb</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Festverzinsliche Wertpapiere des Anlagevermögens</act:name>
+  <act:id type="new">568c9cefa6dccc12132b839ce1bf0707</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>093</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">78d992301e76cbf3eaeaac3c872099bb</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Sonstige Finanzanlagen, Wertrechte</act:name>
+  <act:id type="new">a5a5713c50209154dc280041dfb29552</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>094-097</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">78d992301e76cbf3eaeaac3c872099bb</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Geleistete Anzahlungen auf Finanzanlagen</act:name>
+  <act:id type="new">f03776e925abc3dac4b58edd228651d8</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>098</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">78d992301e76cbf3eaeaac3c872099bb</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Kumulierte Abschreibungen zu Finanzanlagen</act:name>
+  <act:id type="new">c334c39f714f4289ea66d4b68213c5b7</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>099</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">78d992301e76cbf3eaeaac3c872099bb</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Vorräte</act:name>
+  <act:id type="new">3a4ae54c12928246337951ba046c1ea3</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>1</act:code>
+  <act:description>Kontenklasse 1</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">59d3eca1e1c2c3a6fa981e0856665bfb</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Bezugsverrechnung für den Produktionsprozess/für Verwaltung und Vertrieb</act:name>
+  <act:id type="new">8988f575a8b50ed074ef837a9af2ff9e</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>10</act:code>
+  <act:description>Kontengruppe 10</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">3a4ae54c12928246337951ba046c1ea3</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Rohstoffe</act:name>
+  <act:id type="new">eb48c6cfd0b5c0e53a4d58abd3fe858f</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>11</act:code>
+  <act:description>Kontengruppe 11</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">3a4ae54c12928246337951ba046c1ea3</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Bezogene Teile</act:name>
+  <act:id type="new">e83a118d51816bcb6e4f23c3690a19d8</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>12</act:code>
+  <act:description>Kontengruppe 12</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">3a4ae54c12928246337951ba046c1ea3</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Hilfsstoffe, Betriebsstoffe</act:name>
+  <act:id type="new">bffb4e6a99d18d24a1ddf7dac2bd2b3e</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>13</act:code>
+  <act:description>Kontengruppe 13</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">3a4ae54c12928246337951ba046c1ea3</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Hilfsstoffe</act:name>
+  <act:id type="new">fd0a141b34949f3c69ba49810d5bd7c0</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>130-134</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">bffb4e6a99d18d24a1ddf7dac2bd2b3e</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Betriebsstoffe</act:name>
+  <act:id type="new">83039fd59a88d490afba9060ae96618f</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>135-139</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">bffb4e6a99d18d24a1ddf7dac2bd2b3e</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Unfertige Erzeugnisse</act:name>
+  <act:id type="new">60e09c2729f9533dccea613666f94794</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>14</act:code>
+  <act:description>Kontengruppe 14</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">3a4ae54c12928246337951ba046c1ea3</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Fertige Erzeugnisse</act:name>
+  <act:id type="new">e6fd6ca9f824013dba7cbb6f80c5e775</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>15</act:code>
+  <act:description>Kontengruppe 15</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">3a4ae54c12928246337951ba046c1ea3</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Waren</act:name>
+  <act:id type="new">e9dd9788590de192cb8c2c9731b68193</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>16</act:code>
+  <act:description>Kontengruppe 16</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">3a4ae54c12928246337951ba046c1ea3</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Noch nicht abrechenbare Leistungen</act:name>
+  <act:id type="new">db611b9f963622cf23d63fac46029723</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>17</act:code>
+  <act:description>Kontengruppe 17</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">3a4ae54c12928246337951ba046c1ea3</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Geleistete Anzahlungen auf Vorräte</act:name>
+  <act:id type="new">dbd2e9f9490f24e89c022392e67255bd</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>18</act:code>
+  <act:description>Kontengruppe 18</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">3a4ae54c12928246337951ba046c1ea3</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Wertberichtigungen zu Vorräten</act:name>
+  <act:id type="new">ed3c65a7a8342ba4117b3bf5daccd4bc</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>19</act:code>
+  <act:description>Kontengruppe 19</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">3a4ae54c12928246337951ba046c1ea3</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Sonstiges Umlaufvermögen, aktive Rechnungsabgrenzungsposten, aktive latente Steuern</act:name>
+  <act:id type="new">b3e04dd3436621b21ec0ce366d8584c5</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>2</act:code>
+  <act:description>Kontenklasse 2</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">59d3eca1e1c2c3a6fa981e0856665bfb</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Forderungen aus Lieferungen und Leistungen</act:name>
+  <act:id type="new">fe9bfae85534d6c9403cc509b5a72a95</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>20-21</act:code>
+  <act:description>Kontengruppe 20-21</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">b3e04dd3436621b21ec0ce366d8584c5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Forderungen aus Lieferungen und Leistungen Inland (0% USt, umsatzsteuerfrei)</act:name>
+  <act:id type="new">a94255c03ff2d05402f18e6f3d986d80</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>200</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">fe9bfae85534d6c9403cc509b5a72a95</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Forderungen aus Lieferungen und Leistungen Inland (10% USt)</act:name>
+  <act:id type="new">aebd6d37eebc4958e89a3f95e4500be2</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>201</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">fe9bfae85534d6c9403cc509b5a72a95</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Forderungen aus Lieferungen und Leistungen Inland (20% USt)</act:name>
+  <act:id type="new">556c675dd3197701a66e7b8a9b00199b</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>202</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">fe9bfae85534d6c9403cc509b5a72a95</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Forderungen aus Lieferungen und Leistungen Inland (sonstiger USt-Satz)</act:name>
+  <act:id type="new">4932f9a66976df0fb13506e58567c662</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>203-207</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">fe9bfae85534d6c9403cc509b5a72a95</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Einzelwertberichtigungen zu Forderungen aus Lieferungen und Leistungen Inland</act:name>
+  <act:id type="new">2b6480d1e5d16c6514631ade606a370a</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>208</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">fe9bfae85534d6c9403cc509b5a72a95</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Pauschalwertberichtigungen zu Forderungen aus Lieferungen und Leistungen Inland</act:name>
+  <act:id type="new">667c6b9cfd5d95526bb116b8e2cbc013</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>209</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">fe9bfae85534d6c9403cc509b5a72a95</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Forderungen aus Lieferungen und Leistungen Ausland (Euro)</act:name>
+  <act:id type="new">6310782fc0661df06ba491a9e890ad35</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>210-212</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">fe9bfae85534d6c9403cc509b5a72a95</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Einzelwertberichtigungen zu Forderungen aus Lieferungen und Leistungen Ausland (Euro)</act:name>
+  <act:id type="new">835c5c869d8e67695638fd3903ad4630</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>213</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">fe9bfae85534d6c9403cc509b5a72a95</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Pauschalwertberichtigungen zu Forderungen aus Lieferungen und Leistungen Ausland (Euro)</act:name>
+  <act:id type="new">52e3dd38ffa44e70c150da3005c61f3d</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>214</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">fe9bfae85534d6c9403cc509b5a72a95</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Forderungen aus Lieferungen und Leistungen sonstiges Ausland (Fremdwährungen)</act:name>
+  <act:id type="new">017a653c9389993250948a176e81b793</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>215-217</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">fe9bfae85534d6c9403cc509b5a72a95</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Einzelwertberichtigungen zu Forderungen aus Lieferungen und Leistungen sonstiges Ausland (Fremdwährungen)</act:name>
+  <act:id type="new">2e23e351a0c9a53d99f876ee1de957d4</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>218</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">fe9bfae85534d6c9403cc509b5a72a95</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Pauschalwertberichtigungen zu Forderungen aus Lieferungen und Leistungen sonstiges Ausland (Fremdwährungen)</act:name>
+  <act:id type="new">70df8fd64efdfe9a4201d64a221b66dc</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>219</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">fe9bfae85534d6c9403cc509b5a72a95</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Forderungen gegenüber verbundenen Unternehmen und Unternehmen, mit denen ein Beteiligungsverhältnis besteht</act:name>
+  <act:id type="new">49dd1c73276428910708995f39df3c2e</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>22</act:code>
+  <act:description>Kontengruppe 22</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">b3e04dd3436621b21ec0ce366d8584c5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Forderungen aus Lieferungen und Leistungen gegenüber verbundenen Unternehmen</act:name>
+  <act:id type="new">6399e104da05374553a9faf6dc92ccc8</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>220-221</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">49dd1c73276428910708995f39df3c2e</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Sonstige Forderungen gegenüber verbundenen Unternehmen</act:name>
+  <act:id type="new">356aaf621ee58ebedf9d0adf56f7afc0</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>222</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">49dd1c73276428910708995f39df3c2e</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Einzelwertberichtigungen zu Forderungen gegenüber verbundenen Unternehmen</act:name>
+  <act:id type="new">dbbf193c895fdd6e0f22403c67df8e73</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>223</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">49dd1c73276428910708995f39df3c2e</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Pauschalwertberichtigungen zu Forderungen gegenüber verbundenen Unternehmen</act:name>
+  <act:id type="new">b01f99d479a8dd1710584d322c1ef293</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>224</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">49dd1c73276428910708995f39df3c2e</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Forderungen gegenüber Unternehmen, mit denen ein Beteiligungsverhältnis besteht</act:name>
+  <act:id type="new">c4e14b0e0b8d0d6e90c50f57a90a5978</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>225-226</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">49dd1c73276428910708995f39df3c2e</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Einzelwertberichtigungen zu Forderungen gegenüber Unternehmen, mit denen ein Beteiligungsverhältnis besteht</act:name>
+  <act:id type="new">87c8a8ae43539b04ca7b39ed694c98f4</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>227</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">49dd1c73276428910708995f39df3c2e</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Pauschalwertberichtigungen zu Forderungen gegenüber Unternehmen, mit denen ein Beteiligungsverhältnis besteht</act:name>
+  <act:id type="new">69a3f30f93ad6e8e21315ce45e98cd0c</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>228</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">49dd1c73276428910708995f39df3c2e</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Sonstige Forderungen und Vermögensgegenstände</act:name>
+  <act:id type="new">7af75f0573fa306085ac13779dddfd9b</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>23-24</act:code>
+  <act:description>Kontengruppe 23-24</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">b3e04dd3436621b21ec0ce366d8584c5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Sonstige Forderungen und Vermögensgegenstände</act:name>
+  <act:id type="new">ace515e065bd799294a3e21e062bc315</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>230-245</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">7af75f0573fa306085ac13779dddfd9b</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Eingeforderte, aber noch nicht eingezahlte Einlagen</act:name>
+  <act:id type="new">2e1fe45c7dd7c15c9e73c6b1a0e957f0</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>246</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">7af75f0573fa306085ac13779dddfd9b</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Einzelwertberichtigungen zu sonstigen Forderungen und Vermögensgegenständen</act:name>
+  <act:id type="new">53d06b020c9f76f404ca9729d1399ac5</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>247</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">7af75f0573fa306085ac13779dddfd9b</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Pauschalwertberichtigungen zu sonstigen Forderungen und Vermögensgegenständen</act:name>
+  <act:id type="new">0a1f104aeebd6bb7db618df6209361a2</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>248</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">7af75f0573fa306085ac13779dddfd9b</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Geleistete Anzahlungen (außer auf Anlagen und auf Vorräte)</act:name>
+  <act:id type="new">4294b1f1892cc1b6cedf5cfa2215eb48</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>249</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">7af75f0573fa306085ac13779dddfd9b</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Forderungen aus der Abgabenverrechnung</act:name>
+  <act:id type="new">d94af872ca8a613a4d9b214a76f1e9dc</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>25</act:code>
+  <act:description>Kontengruppe 25</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">b3e04dd3436621b21ec0ce366d8584c5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Forderungen aus der Abgabenverrechnung</act:name>
+  <act:id type="new">6d36972fe86220daf70be9f9c1853854</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>250-259</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">d94af872ca8a613a4d9b214a76f1e9dc</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Wertpapiere und Anteile</act:name>
+  <act:id type="new">b9458210c7ff3c790221d6f4683f7790</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>26</act:code>
+  <act:description>Kontengruppe 26</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">b3e04dd3436621b21ec0ce366d8584c5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Anteile an verbundenen Unternehmen außer an Mutterunternehmen</act:name>
+  <act:id type="new">56a1c1ec924fb045cf7f70138362c9e2</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>260</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">b9458210c7ff3c790221d6f4683f7790</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Anteile an Mutterunternehmen</act:name>
+  <act:id type="new">d94e236f5ca03a586144674a7099f628</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>261</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">b9458210c7ff3c790221d6f4683f7790</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Sonstige Anteile des Umlaufvermögens</act:name>
+  <act:id type="new">6f4fc70c680f2885282698bb1826323e</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>262-264</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">b9458210c7ff3c790221d6f4683f7790</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Sonstige Wertpapiere des Umlaufvermögens</act:name>
+  <act:id type="new">c69e8dcb53128b8a98bb4cea91eec5cc</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>265-267</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">b9458210c7ff3c790221d6f4683f7790</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Besitzwechsel, soweit dem Unternehmen nicht die der Ausstellung zugrunde liegenden Forderungen zustehen</act:name>
+  <act:id type="new">042af645c2c8326143dbdbbdd022568a</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>268</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">b9458210c7ff3c790221d6f4683f7790</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Wertberichtigungen zu Wertpapieren und Anteilen (des Umlaufvermögens)</act:name>
+  <act:id type="new">88ae4917a87967fc70bc69aa68beaef0</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>269</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">b9458210c7ff3c790221d6f4683f7790</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Kassenbestand, Schecks, Guthaben bei Kreditinstituten</act:name>
+  <act:id type="new">e2b6b242c225fb1b97245c7ba93c7cd6</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>27-28</act:code>
+  <act:description>Kontengruppe 27-28</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">b3e04dd3436621b21ec0ce366d8584c5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Kassenbestände in Euro</act:name>
+  <act:id type="new">1584e84b555a48685e5f0357b822a0a2</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>270-273</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">e2b6b242c225fb1b97245c7ba93c7cd6</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Postwertzeichen</act:name>
+  <act:id type="new">49dbd8352708ff7cbd75d0585b9aa770</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>274</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">e2b6b242c225fb1b97245c7ba93c7cd6</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Kassenbestände in Fremdwährungen</act:name>
+  <act:id type="new">d9fb0b5fc173c72d342cd619d0b06e87</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>275-277</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">e2b6b242c225fb1b97245c7ba93c7cd6</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Schecks in Euro</act:name>
+  <act:id type="new">aec8a1dab309605d00d131abd8d5c757</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>278</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">e2b6b242c225fb1b97245c7ba93c7cd6</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Schecks in Fremdwährungen</act:name>
+  <act:id type="new">a516b8d26a4c0746c0f0cf1c3808da9a</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>279</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">e2b6b242c225fb1b97245c7ba93c7cd6</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Guthaben bei Kreditinstituten</act:name>
+  <act:id type="new">8cc545d0c3d03f3d1fd2ca375b04dce4</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>280-288</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">e2b6b242c225fb1b97245c7ba93c7cd6</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Schwebende Geldbewegungen</act:name>
+  <act:id type="new">3ca06a5b42670f41ad654700a3eff752</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>289</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">e2b6b242c225fb1b97245c7ba93c7cd6</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Aktive Rechnungsabgrenzungsposten, aktive latente Steuern</act:name>
+  <act:id type="new">595100c1d6fc1e1a18261cdc5cfbb57b</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>29</act:code>
+  <act:description>Kontengruppe 29</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">b3e04dd3436621b21ec0ce366d8584c5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Aktive Rechnungsabgrenzungsposten</act:name>
+  <act:id type="new">24c02368dd9f8ecdec91dc64a6436862</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>290-292</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">595100c1d6fc1e1a18261cdc5cfbb57b</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Mietvorauszahlungen</act:name>
+  <act:id type="new">467310fd8b0f65f22bacabb2ef81c6b4</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>293</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">595100c1d6fc1e1a18261cdc5cfbb57b</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Leasing-Vorauszahlungen</act:name>
+  <act:id type="new">27342cf434f22383fc557fcc50ab1215</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>294</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">595100c1d6fc1e1a18261cdc5cfbb57b</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Disagio</act:name>
+  <act:id type="new">44bb3da478a41ea75be40b5bdbde1f03</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>295</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">595100c1d6fc1e1a18261cdc5cfbb57b</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Aktive latente Steuern</act:name>
+  <act:id type="new">b335c730332715ceb14af42b851cea86</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>298</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">595100c1d6fc1e1a18261cdc5cfbb57b</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Eventualforderungen (Hilfskonto)</act:name>
+  <act:id type="new">7804333fb58156468f5ac4860c988ca0</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>299</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">595100c1d6fc1e1a18261cdc5cfbb57b</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Rückstellungen, Verbindlichkeiten, passive Rechnungsabgrenzungsposten</act:name>
+  <act:id type="new">292e2d37774a8f428362eb235ef25962</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>3</act:code>
+  <act:description>Kontenklasse 3</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">59d3eca1e1c2c3a6fa981e0856665bfb</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Rückstellungen</act:name>
+  <act:id type="new">a5d561dea42bee9d5382976e71b4078a</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>30</act:code>
+  <act:description>Kontengruppe 30</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">292e2d37774a8f428362eb235ef25962</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Rückstellungen für Abfertigungen</act:name>
+  <act:id type="new">d9eb13b6a267fdff1d4abcfc27ed2684</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>300</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">a5d561dea42bee9d5382976e71b4078a</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Rückstellungen für Pensionen</act:name>
+  <act:id type="new">fcb3668740fd1580c6cacf2548c5fa01</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>301</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">a5d561dea42bee9d5382976e71b4078a</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Steuerrückstellungen</act:name>
+  <act:id type="new">dbc44075bbc3db38b40654eecd6fac8d</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>302</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">a5d561dea42bee9d5382976e71b4078a</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Rückstellungen für latente Steuern</act:name>
+  <act:id type="new">354c8b91ab66f3dd1ab8f7bbc84c1b64</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>303</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">a5d561dea42bee9d5382976e71b4078a</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Sonstige Rückstellungen</act:name>
+  <act:id type="new">c1702f85771d3b3659f79057fa7d0a98</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>304-309</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">a5d561dea42bee9d5382976e71b4078a</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Anleihen, Verbindlichkeiten gegenüber Kreditinstituten</act:name>
+  <act:id type="new">8a400738ed7e3fc0b5f629d34b0ee6b9</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>31</act:code>
+  <act:description>Kontengruppe 31</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">292e2d37774a8f428362eb235ef25962</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Anleihen (einschließlich konvertibler)</act:name>
+  <act:id type="new">779ded95d2a05a84a0b1be92abb7493f</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>310-311</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">8a400738ed7e3fc0b5f629d34b0ee6b9</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Verbindlichkeiten gegenüber Kreditinstituten (kurzfristig, z.B. Überziehungsrahmen)</act:name>
+  <act:id type="new">59cfc6fb41ea9aa196558c842724e154</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>312-314</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">8a400738ed7e3fc0b5f629d34b0ee6b9</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Verbindlichkeiten gegenüber Kreditinstituten (langfristig, Darlehen oder Kredit)</act:name>
+  <act:id type="new">c968c8e3153e003585933ddc14b09e62</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>315-319</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">8a400738ed7e3fc0b5f629d34b0ee6b9</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Erhaltene Anzahlungen auf Bestellungen</act:name>
+  <act:id type="new">2a109a739eed614fb006b91779361590</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>32</act:code>
+  <act:description>Kontengruppe 32</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">292e2d37774a8f428362eb235ef25962</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Erhaltene Anzahlungen auf Bestellungen</act:name>
+  <act:id type="new">08240e2797f19c8ebd2ef97e9e4b8744</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>320</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">2a109a739eed614fb006b91779361590</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Nicht von Vorräten absetzbare Anzahlungen</act:name>
+  <act:id type="new">d886197b61fbfd12464adc9ef5a633e8</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>329</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">2a109a739eed614fb006b91779361590</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Verbindlichkeiten aus Lieferungen und Leistungen, Verbindlichkeiten aus der Annahme gezogener und der Ausstellung eigener Wechsel</act:name>
+  <act:id type="new">7ee22938ebf68a1c16e915ae90c660a2</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>33</act:code>
+  <act:description>Kontengruppe 33</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">292e2d37774a8f428362eb235ef25962</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Verbindlichkeiten aus Lieferungen und Leistungen Inland</act:name>
+  <act:id type="new">d986f0412efb81d30c7916de08605af1</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>330-335</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">7ee22938ebf68a1c16e915ae90c660a2</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Verbindlichkeiten aus Lieferungen und Leistungen Ausland (Euro)</act:name>
+  <act:id type="new">fd3bb8d2d05294828ceb6020be2a1bd5</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>336</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">7ee22938ebf68a1c16e915ae90c660a2</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Verbindlichkeiten aus Lieferungen und Leistungen sonstiges Ausland (Fremdwährungen)</act:name>
+  <act:id type="new">17eb2bd71338f9547c228f3d6fbafd3e</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>337</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">7ee22938ebf68a1c16e915ae90c660a2</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Verbindlichkeiten aus der Annahme gezogener Wechsel und der Ausstellung eigener Wechsel</act:name>
+  <act:id type="new">7b62ec98143b0ec38661b7a196880915</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>338</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">7ee22938ebf68a1c16e915ae90c660a2</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Verrechnungskonto Telebanking</act:name>
+  <act:id type="new">d0a6033fef8bfd5a211a6c4123f1fa4b</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>339</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">7ee22938ebf68a1c16e915ae90c660a2</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Verbindlichkeiten gegenüber verbundenen Unternehmen, gegenüber Unternehmen, mit denen ein Beteiligungsverhältnis besteht, und gegenüber Gesellschaftern</act:name>
+  <act:id type="new">0639057ca70974471592b3eeaa7a39c0</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>34</act:code>
+  <act:description>Kontengruppe 34</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">292e2d37774a8f428362eb235ef25962</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Verbindlichkeiten aus Lieferungen und Leistungen gegenüber verbundenen Unternehmen, Verbindlichkeiten aus Lieferungen und Leistungen gegenüber Unternehmen, mit denen ein Beteiligungsverhältnis besteht</act:name>
+  <act:id type="new">521ae1ea6f4c24704703f0c8bebbea11</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>340-342</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">0639057ca70974471592b3eeaa7a39c0</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>sonstige Verbindlichkeiten gegenüber verbundenen Unternehmen, sonstige Verbindlichkeiten gegenüber Unternehmen, mit denen ein Beteiligungsverhältnis besteht</act:name>
+  <act:id type="new">ca5d0827b05695427167699cc14031b2</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>343-345</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">0639057ca70974471592b3eeaa7a39c0</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Verbindlichkeiten gegenüber Gesellschaftern</act:name>
+  <act:id type="new">fcace14a5e3adb9171a9597fa7c20e43</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>346</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">0639057ca70974471592b3eeaa7a39c0</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Einlagen stiller Gesellschafter</act:name>
+  <act:id type="new">0c7e6d03134a3000d19adba99693eaf1</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>347</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">0639057ca70974471592b3eeaa7a39c0</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Sonstige Verbindlichkeiten</act:name>
+  <act:id type="new">54c2dede972b3f29654d071e3123736d</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>35-38</act:code>
+  <act:description>Kontengruppe 35-38</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">292e2d37774a8f428362eb235ef25962</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Verbindlichkeiten aus Steuern</act:name>
+  <act:id type="new">91da724a1c9a32b2c92ee9cb8bab3962</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>350-359</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">54c2dede972b3f29654d071e3123736d</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Verbindlichkeiten im Rahmen der sozialen Sicherheit</act:name>
+  <act:id type="new">4a0c0464377167c8019344e66cf0b230</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>360-369</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">54c2dede972b3f29654d071e3123736d</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Übrige sonstige Verbindlichkeiten</act:name>
+  <act:id type="new">f1aba5a01ba394b383cd2a78abda73b8</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>370-389</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">54c2dede972b3f29654d071e3123736d</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Passive Rechnungsabgrenzungsposten</act:name>
+  <act:id type="new">1ebef8c624485433b4414eb649997073</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>39</act:code>
+  <act:description>Kontengruppe 39</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">292e2d37774a8f428362eb235ef25962</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Passive Rechnungsabgrenzungsposten</act:name>
+  <act:id type="new">0806867a6d10c4672db7511f03dfbb87</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>390-398</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">1ebef8c624485433b4414eb649997073</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Eventualverbindlichkeiten (Hilfskonto)</act:name>
+  <act:id type="new">c35fb9597ce13e93f32af30ae1262c59</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>399</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">1ebef8c624485433b4414eb649997073</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Betriebliche Erträge</act:name>
+  <act:id type="new">fc1d65d26571c9a481060d9c63a1698f</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>4</act:code>
+  <act:description>Kontenklasse 4</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">59d3eca1e1c2c3a6fa981e0856665bfb</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Umsatzerlöse und Erlösschmälerungen</act:name>
+  <act:id type="new">8d125f7fd9f935d932d2ac5be2f9604d</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>40-44</act:code>
+  <act:description>Kontengruppe 40-44</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">fc1d65d26571c9a481060d9c63a1698f</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Umsatzerlöse (Untergliederung nach USt-Satz, Währung usw.)</act:name>
+  <act:id type="new">6a986d953a79d130cfe01d36f493ed28</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>400-439</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">8d125f7fd9f935d932d2ac5be2f9604d</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Erlösschmälerungen (Untergliederung wie Umsatzerlöse)</act:name>
+  <act:id type="new">22cff3ec00ead7ba2a11801302845f83</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>440-449</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">8d125f7fd9f935d932d2ac5be2f9604d</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Bestandsveränderungen und aktivierte Eigenleistungen</act:name>
+  <act:id type="new">29b7c0565aee00e3eef75a0379836d24</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>45</act:code>
+  <act:description>Kontengruppe 45</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">fc1d65d26571c9a481060d9c63a1698f</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Veränderungen des Bestandes an fertigen und unfertigen Erzeugnissen sowie an noch nicht abrechenbaren Leistungen</act:name>
+  <act:id type="new">9e04368402d0976c172a23f4784f94ea</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>450-457</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">29b7c0565aee00e3eef75a0379836d24</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Aktivierte Eigenleistungen</act:name>
+  <act:id type="new">47a1921e02a686b020492566401c2535</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>458-459</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">29b7c0565aee00e3eef75a0379836d24</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Sonstige betriebliche Erträge</act:name>
+  <act:id type="new">1414556a3573a386163cc9a4726094c5</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>46-49</act:code>
+  <act:description>Kontengruppe 46-49</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">fc1d65d26571c9a481060d9c63a1698f</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Erlöse aus dem Abgang von Anlagevermögen, ausgenommen Finanzanlagen</act:name>
+  <act:id type="new">8b5969e387e2292ec6cea12a68706e50</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>460-462</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">1414556a3573a386163cc9a4726094c5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Erträge aus dem Abgang von Anlagevermögen, ausgenommen Finanzanlagen (Abgänge mit Gewinn)</act:name>
+  <act:id type="new">61797aeee666035acb3227a54dbf4075</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>463-465</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">1414556a3573a386163cc9a4726094c5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Erträge aus der Zuschreibung zum Anlagevermögen, ausgenommen Finanzanlagen</act:name>
+  <act:id type="new">738b28ca67a7d8e7bbc5ca4632919f6a</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>466-467</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">1414556a3573a386163cc9a4726094c5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Erträge aus der Auflösung von Rückstellungen</act:name>
+  <act:id type="new">8823813a4e9fb7a02c87e798d46887ca</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>470-479</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">1414556a3573a386163cc9a4726094c5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Übrige sonstige betriebliche Erträge</act:name>
+  <act:id type="new">f98c84496a047c932514b8391e8b3ad1</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>480-499</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">1414556a3573a386163cc9a4726094c5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Materialaufwand und sonstige bezogene Herstellungsleistungen</act:name>
+  <act:id type="new">f816c825339659fffbf658582fa0e8f8</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>5</act:code>
+  <act:description>Kontenklasse 5</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">59d3eca1e1c2c3a6fa981e0856665bfb</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Wareneinsatz</act:name>
+  <act:id type="new">f452407fed0c632386fa1afb681327be</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>50</act:code>
+  <act:description>Kontengruppe 50</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">f816c825339659fffbf658582fa0e8f8</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Verbrauch von Rohstoffen</act:name>
+  <act:id type="new">a52d16afd8759a5ee155b2f47f78cd86</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>51</act:code>
+  <act:description>Kontengruppe 51</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">f816c825339659fffbf658582fa0e8f8</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Verbrauch von bezogenen Teilen</act:name>
+  <act:id type="new">662c0ba4a192ad045d946f479b63c1e5</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>52</act:code>
+  <act:description>Kontengruppe 52</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">f816c825339659fffbf658582fa0e8f8</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Verbrauch von Hilfsstoffen</act:name>
+  <act:id type="new">2a432ceb919f8d3ebc891582103dbef9</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>53</act:code>
+  <act:description>Kontengruppe 53</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">f816c825339659fffbf658582fa0e8f8</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Verbrauch von Betriebsstoffen</act:name>
+  <act:id type="new">ba244926cebdb54f50391b160e6f4ca9</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>54</act:code>
+  <act:description>Kontengruppe 54</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">f816c825339659fffbf658582fa0e8f8</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Verbrauch von Werkzeugen und anderen Erzeugungshilfsmitteln</act:name>
+  <act:id type="new">0a3bb4b9988ee1dad984dd8700ed8fcb</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>55</act:code>
+  <act:description>Kontengruppe 55</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">f816c825339659fffbf658582fa0e8f8</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Betriebskosten</act:name>
+  <act:id type="new">61b4e5a37ac22558d31a144516021fd5</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>56</act:code>
+  <act:description>Kontengruppe 56</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">f816c825339659fffbf658582fa0e8f8</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Bezogene Herstellungsleistungen</act:name>
+  <act:id type="new">95fd839be4b9364aaff1a5a5d0fa2d3f</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>57</act:code>
+  <act:description>Kontengruppe 57</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">f816c825339659fffbf658582fa0e8f8</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Skontoerträge auf Materialaufwand sowie auf bezogene Herstellungsleistungen, Fremdwährungskursdifferenzen</act:name>
+  <act:id type="new">200dbd0e0416e62742ff99692f32c90f</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>58</act:code>
+  <act:description>Kontengruppe 58</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">f816c825339659fffbf658582fa0e8f8</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Skontoerträge auf Materialaufwand</act:name>
+  <act:id type="new">f7ccd5888a2228336b909ef22e17af84</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>580</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">200dbd0e0416e62742ff99692f32c90f</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Skontoerträge auf bezogene Herstellungsleistungen</act:name>
+  <act:id type="new">3f017252749f73f3acc089e2b8d145a4</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>581</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">200dbd0e0416e62742ff99692f32c90f</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Fremdwährungskursdifferenzen (soweit Kontenklasse 5 eindeutig zuordenbar)</act:name>
+  <act:id type="new">7a681b6aa3c90a0df61c88eec7583a5b</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>586</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">200dbd0e0416e62742ff99692f32c90f</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Aufwandsstellenrechnung</act:name>
+  <act:id type="new">b8aa0f1dd8dab7ffb9ba85d9204da94b</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>59</act:code>
+  <act:description>Kontengruppe 59</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">f816c825339659fffbf658582fa0e8f8</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Personalaufwand</act:name>
+  <act:id type="new">5b9cedcb402f030d59fa572a703ef510</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>6</act:code>
+  <act:description>Kontenklasse 6</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">59d3eca1e1c2c3a6fa981e0856665bfb</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Löhne</act:name>
+  <act:id type="new">537d9a8802a8672495fc0cb0f3b3ec9b</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>60-61</act:code>
+  <act:description>Kontengruppe 60-61</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">5b9cedcb402f030d59fa572a703ef510</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Gehälter</act:name>
+  <act:id type="new">d56a3e5def039f6707bb53f376859c4d</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>62-63</act:code>
+  <act:description>Kontengruppe 62-63</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">5b9cedcb402f030d59fa572a703ef510</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Aufwendungen für Abfertigungen, Aufwendungen für Betriebliche Vorsorgekassen, Aufwendungen für Altersversorgung</act:name>
+  <act:id type="new">3de03a0edef64773c4aaabb08e8cee59</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>64</act:code>
+  <act:description>Kontengruppe 64</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">5b9cedcb402f030d59fa572a703ef510</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Aufwendungen für Abfertigungen Arbeiter (gesetzliche/freiwillige)</act:name>
+  <act:id type="new">7402daba6771aa61b968a44220cf4e14</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>640-641</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">3de03a0edef64773c4aaabb08e8cee59</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Aufwendungen für Abfertigungen Angestellte (gesetzliche/freiwillige)</act:name>
+  <act:id type="new">8e778b1b6206d96a13ecca8b204431d6</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>642-643</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">3de03a0edef64773c4aaabb08e8cee59</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Aufwendungen für Betriebliche Vorsorgekassen</act:name>
+  <act:id type="new">c82c9087daae82ef6dab52988f9d6a87</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>644</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">3de03a0edef64773c4aaabb08e8cee59</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Aufwendungen für Altersversorgung</act:name>
+  <act:id type="new">2fb2890240015916bec4160cf6106d5b</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>645-649</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">3de03a0edef64773c4aaabb08e8cee59</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Gesetzlicher Sozialaufwand für Arbeiter und Angestellte</act:name>
+  <act:id type="new">0ed474da5a6111688aa9710b5d03c78f</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>65</act:code>
+  <act:description>Kontengruppe 65</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">5b9cedcb402f030d59fa572a703ef510</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Gesetzlicher Sozialaufwand Arbeiter</act:name>
+  <act:id type="new">4e45f7080dbf27fc1171c08e8bf09f67</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>650-655</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">0ed474da5a6111688aa9710b5d03c78f</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Gesetzlicher Sozialaufwand Angestellte</act:name>
+  <act:id type="new">a21d49b4b6506b8b6e4eb49be9eb5f74</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>656-659</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">0ed474da5a6111688aa9710b5d03c78f</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Lohn- und gehaltsabhängige Abgaben und Pflichtbeiträge</act:name>
+  <act:id type="new">2a5e60b1212bb03392cd4bb76b231c29</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>66</act:code>
+  <act:description>Kontengruppe 66</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">5b9cedcb402f030d59fa572a703ef510</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Lohnabhängige Abgaben und Pflichtbeiträge</act:name>
+  <act:id type="new">e27706f26cfe54a21f0c5eeb7ae64f24</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>660-665</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">2a5e60b1212bb03392cd4bb76b231c29</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Gehaltsabhängige Abgaben und Pflichtbeiträge</act:name>
+  <act:id type="new">b368ed95dca2dc6f1b1b9d9211e4fcb9</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>666-669</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">2a5e60b1212bb03392cd4bb76b231c29</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Sonstige Sozialaufwendungen</act:name>
+  <act:id type="new">8ca3e624a1ea948b68146c37275e2952</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>67-68</act:code>
+  <act:description>Kontengruppe 67-68</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">5b9cedcb402f030d59fa572a703ef510</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Aufwandsstellenrechnung</act:name>
+  <act:id type="new">dac914240f59d4801987cd37807aa954</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>69</act:code>
+  <act:description>Kontengruppe 69</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">5b9cedcb402f030d59fa572a703ef510</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Abschreibungen und sonstige betriebliche Aufwendungen</act:name>
+  <act:id type="new">1c4cbc28aa76e1655758ee3b0c96a2df</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>7</act:code>
+  <act:description>Kontenklasse 7</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">59d3eca1e1c2c3a6fa981e0856665bfb</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Abschreibungen</act:name>
+  <act:id type="new">26ffaed38e5b06afb63c41e8f4a89ecf</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>70</act:code>
+  <act:description>Kontengruppe 70</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">1c4cbc28aa76e1655758ee3b0c96a2df</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Abschreibungen auf das Anlagevermögen, ausgenommen Finanzanlagen</act:name>
+  <act:id type="new">bc51e4dc084452909fc0bd72cdcb83f0</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>700-705</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">26ffaed38e5b06afb63c41e8f4a89ecf</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Sofortabschreibung geringwertiger Vermögensgegenstände</act:name>
+  <act:id type="new">8e63617d877e3e89ca43a1129f6a3e1d</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>706</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">26ffaed38e5b06afb63c41e8f4a89ecf</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Abschreibungen auf das Umlaufvermögen, soweit sie die im Unternehmen üblichen Abschreibungen übersteigen</act:name>
+  <act:id type="new">7f7c5c87be870a4b77a963d77d46fd5f</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>707</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">26ffaed38e5b06afb63c41e8f4a89ecf</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Aufwandsstellenrechnung</act:name>
+  <act:id type="new">a358002825e720697d6c97736c41e766</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>709</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">26ffaed38e5b06afb63c41e8f4a89ecf</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Sonstige Steuern</act:name>
+  <act:id type="new">60dd03cc27ca3bf92bde309180d00e46</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>71</act:code>
+  <act:description>Kontengruppe 71</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">1c4cbc28aa76e1655758ee3b0c96a2df</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Mit den Umsatzerlösen verbundene Steuern</act:name>
+  <act:id type="new">c7d5a5da3befb095f45a3711d94d9bb1</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>710-714</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">60dd03cc27ca3bf92bde309180d00e46</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Sonstige Steuern und mit Steuern in Zusammenhang stehende Aufwendungen</act:name>
+  <act:id type="new">2a6f8a4bc27159f63a40b1fcdc34fc94</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>715-718</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">60dd03cc27ca3bf92bde309180d00e46</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Aufwandsstellenrechnung</act:name>
+  <act:id type="new">866ca0635a3cb7c6a034b7e4451fcdec</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>719</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">60dd03cc27ca3bf92bde309180d00e46</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Instandhaltung und Betriebskosten</act:name>
+  <act:id type="new">cb9a98e26d082bb7b5ed9a5fd17d7891</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>72</act:code>
+  <act:description>Kontengruppe 72</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">1c4cbc28aa76e1655758ee3b0c96a2df</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Instandhaltung und Betriebskosten, Reinigung durch Dritte, Entsorgung, Strom, Heizung, Gas, Energie</act:name>
+  <act:id type="new">7fe96baecf8b703429f4467cf7e9953e</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>720-728</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">cb9a98e26d082bb7b5ed9a5fd17d7891</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Aufwandsstellenrechnung</act:name>
+  <act:id type="new">10e5cfab1868ad65c3a406943dfc9a40</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>729</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">cb9a98e26d082bb7b5ed9a5fd17d7891</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Transport- , Reise- und Fahrtaufwand, Nachrichtenaufwand</act:name>
+  <act:id type="new">02fef18ff62032ecb2963102c8ba6a8f</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>73</act:code>
+  <act:description>Kontengruppe 73</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">1c4cbc28aa76e1655758ee3b0c96a2df</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Transporte durch Dritte</act:name>
+  <act:id type="new">75dabef615d071d535c36a8ee3adb664</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>730-731</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">02fef18ff62032ecb2963102c8ba6a8f</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Kfz-Aufwand (PKW und Kombis)</act:name>
+  <act:id type="new">62db749feb29b65671b76e4e5b97025c</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>732</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">02fef18ff62032ecb2963102c8ba6a8f</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Kfz-Aufwand (LKW)</act:name>
+  <act:id type="new">e48e52e503bad0db247940e0fc049f0b</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>733</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">02fef18ff62032ecb2963102c8ba6a8f</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Reise- und Fahrtaufwand</act:name>
+  <act:id type="new">70eedcd31cb672a47e812f986b1a437b</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>734-735</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">02fef18ff62032ecb2963102c8ba6a8f</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Tag- und Nächtigungsgelder</act:name>
+  <act:id type="new">443de6cbb6c6d06b864babc0195161c9</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>736-737</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">02fef18ff62032ecb2963102c8ba6a8f</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Nachrichtenaufwand</act:name>
+  <act:id type="new">2b585e2db9a27577c346d8bbda3e6d1f</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>738</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">02fef18ff62032ecb2963102c8ba6a8f</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Aufwandsstellenrechnung</act:name>
+  <act:id type="new">f1352dc3b9319320ddc6a0b4e72fb2dd</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>739</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">02fef18ff62032ecb2963102c8ba6a8f</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Miet- , Pacht- , Leasing- und Lizenzaufwand</act:name>
+  <act:id type="new">1d09c48b3fdd845c185f4d3a1f1a882b</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>74</act:code>
+  <act:description>Kontengruppe 74</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">1c4cbc28aa76e1655758ee3b0c96a2df</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Miet- und Pachtaufwand</act:name>
+  <act:id type="new">2e8ff85b757759378d25037bd9ad78e2</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>740-743</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">1d09c48b3fdd845c185f4d3a1f1a882b</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Leasingaufwand</act:name>
+  <act:id type="new">91ecf800bd490c2c837dd8b9dfc59a90</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>744-747</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">1d09c48b3fdd845c185f4d3a1f1a882b</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Lizenzaufwand</act:name>
+  <act:id type="new">4ca1dd54ab13284e0d282a7f1878b383</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>748</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">1d09c48b3fdd845c185f4d3a1f1a882b</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Aufwandsstellenrechnung</act:name>
+  <act:id type="new">1b660713759d696ab91e911777b722cc</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>749</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">1d09c48b3fdd845c185f4d3a1f1a882b</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Aufwand für beigestelltes Personal, Provisionen an Dritte, Aufsichtsratsvergütungen, Geschäftsführerentgelte an Konzerngesellschaften/Komplementär-GmbH</act:name>
+  <act:id type="new">895188c336ee68199ca23d0e61f1527b</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>75</act:code>
+  <act:description>Kontengruppe 75</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">1c4cbc28aa76e1655758ee3b0c96a2df</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Aufwand für beigestelltes Personal</act:name>
+  <act:id type="new">fbf4a25e0445c3522d1de9a8a6abe002</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>750-753</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">895188c336ee68199ca23d0e61f1527b</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Provisionen an Dritte</act:name>
+  <act:id type="new">855c6de241abff5b58c76eb4e912e538</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>754-757</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">895188c336ee68199ca23d0e61f1527b</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Aufsichtsratsvergütungen, Geschäftsführerentgelte an Konzerngesellschaften/Komplementär-GmbH</act:name>
+  <act:id type="new">fe587e482909f3c61e45e15d68e7dd01</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>758</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">895188c336ee68199ca23d0e61f1527b</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Aufwandsstellenrechnung</act:name>
+  <act:id type="new">9ee8a5653d99740e4d7f98b0d9c0f136</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>759</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">895188c336ee68199ca23d0e61f1527b</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Büro- , Werbe- und Repräsentationsaufwand</act:name>
+  <act:id type="new">a192b957b404ccc33e78cc3c80e41768</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>76</act:code>
+  <act:description>Kontengruppe 76</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">1c4cbc28aa76e1655758ee3b0c96a2df</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Büromaterial und Drucksorten</act:name>
+  <act:id type="new">ab10d987c939ec9d0961981e043b3b1c</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>760</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">a192b957b404ccc33e78cc3c80e41768</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Druckerzeugnisse und Vervielfältigungen</act:name>
+  <act:id type="new">b2a380467f385f362c23c84eecbac1fe</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>761-762</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">a192b957b404ccc33e78cc3c80e41768</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Fachliteratur und Zeitungen</act:name>
+  <act:id type="new">82e160215563ea026b9d66284131efd7</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>763-764</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">a192b957b404ccc33e78cc3c80e41768</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Werbung und Repräsentation</act:name>
+  <act:id type="new">0ee9913d48d5ba214f624839d9fb135b</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>765-767</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">a192b957b404ccc33e78cc3c80e41768</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Spenden und Trinkgelder</act:name>
+  <act:id type="new">e4163703ed943db4dc60be0ab6aa2885</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>768</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">a192b957b404ccc33e78cc3c80e41768</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Aufwandsstellenrechnung</act:name>
+  <act:id type="new">4120e09254d3a7ce768221b75d1e3259</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>769</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">a192b957b404ccc33e78cc3c80e41768</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Versicherungen, übrige Aufwendungen</act:name>
+  <act:id type="new">1dc49d1f4c4a8e941f1927e0730768d7</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>77-78</act:code>
+  <act:description>Kontengruppe 77-78</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">1c4cbc28aa76e1655758ee3b0c96a2df</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Versicherungen</act:name>
+  <act:id type="new">e93dc1e5a923f268b4c8f87ccf665f5b</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>770-774</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">1dc49d1f4c4a8e941f1927e0730768d7</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Beratung und Prüfung</act:name>
+  <act:id type="new">2bdc3da313d81d488c634e3dc5bcc1dc</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>775-776</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">1dc49d1f4c4a8e941f1927e0730768d7</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Aus- und Fortbildung</act:name>
+  <act:id type="new">ee90f721b74796bde8e470a3fbefbea2</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>777</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">1dc49d1f4c4a8e941f1927e0730768d7</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Mitgliedsbeiträge</act:name>
+  <act:id type="new">b319e8ef28a756faaa28fc98330f7385</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>778</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">1dc49d1f4c4a8e941f1927e0730768d7</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Spesen des Geldverkehrs</act:name>
+  <act:id type="new">959a1e904048750a95b17aac3adfd95d</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>779</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">1dc49d1f4c4a8e941f1927e0730768d7</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Forderungsverluste, Zuführung Wertberichtigungen zu Forderungen, sonstige Schadensfälle</act:name>
+  <act:id type="new">e51bcc2a2dae0be493fbd24334aed4c0</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>780-781</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">1dc49d1f4c4a8e941f1927e0730768d7</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Buchwert abgegangener Anlagen, ausgenommen Finanzanlagen</act:name>
+  <act:id type="new">db7224100d142677a6c5099e460cc162</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>782</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">1dc49d1f4c4a8e941f1927e0730768d7</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Verluste aus dem Abgang von Anlagevermögen, ausgenommen Finanzanlagen</act:name>
+  <act:id type="new">40f5364eade9d7cac1a831e8bbd3ea8c</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>783</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">1dc49d1f4c4a8e941f1927e0730768d7</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Verschiedene betriebliche Aufwendungen</act:name>
+  <act:id type="new">0c95dd0130c4dbf24db9456f609a89e3</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>784-787</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">1dc49d1f4c4a8e941f1927e0730768d7</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Skontoerträge auf sonstige betriebliche Aufwendungen</act:name>
+  <act:id type="new">f2073de0c9a67c69ab88fbbab5c8d278</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>788</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">1dc49d1f4c4a8e941f1927e0730768d7</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Aufwandsstellenrechnung</act:name>
+  <act:id type="new">374a1c2e82f2fa3265c0efbe5f075dea</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>789</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">1dc49d1f4c4a8e941f1927e0730768d7</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Konten für das Umsatzkostenverfahren</act:name>
+  <act:id type="new">a95f6cd624949874bd0e2b35a086d2d2</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>79</act:code>
+  <act:description>Kontengruppe 79</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">1c4cbc28aa76e1655758ee3b0c96a2df</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Aufwandsstellenrechnung</act:name>
+  <act:id type="new">e72540744b114d1c79edd75e456bcfa6</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>790</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">a95f6cd624949874bd0e2b35a086d2d2</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Aufwandsstellen der Herstellung</act:name>
+  <act:id type="new">9625cf5ba2a34c2ee8910db3ff235c4b</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>791-795</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">a95f6cd624949874bd0e2b35a086d2d2</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Herstellungskosten der zur Erzielung der Umsatzerlöse erbrachten Leistungen</act:name>
+  <act:id type="new">f821a4580a14528c6e45e83e9c8f9269</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>796</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">a95f6cd624949874bd0e2b35a086d2d2</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Vertriebskosten</act:name>
+  <act:id type="new">79dabf4b98fbd1c9ef7ba1ae1319f113</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>797</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">a95f6cd624949874bd0e2b35a086d2d2</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Verwaltungskosten</act:name>
+  <act:id type="new">96949ef15c269896db1950701538c133</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>798</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">a95f6cd624949874bd0e2b35a086d2d2</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Sonstige betriebliche Aufwendungen</act:name>
+  <act:id type="new">7ec860bc86bda3591172e1a3ead23429</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>799</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">a95f6cd624949874bd0e2b35a086d2d2</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Finanzerträge und Finanzaufwendungen, Steuern vom Einkommen und vom Ertrag, Rücklagenbewegung</act:name>
+  <act:id type="new">796745f7bfeb7ae7fb99704338cf711c</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>8</act:code>
+  <act:description>Kontenklasse 8</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">59d3eca1e1c2c3a6fa981e0856665bfb</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Finanzerträge und Finanzaufwendungen</act:name>
+  <act:id type="new">6c0cf1361137ad1696100d644e0b59d5</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>80-83</act:code>
+  <act:description>Kontengruppe 80-83</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">796745f7bfeb7ae7fb99704338cf711c</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Erträge aus Anteilen an verbundenen Unternehmen</act:name>
+  <act:id type="new">06cceba00a0ba203d8d0c151472ab318</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>800</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6c0cf1361137ad1696100d644e0b59d5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Erträge aus Beteiligungen</act:name>
+  <act:id type="new">56c683b407cd197d7be9d71978c2a262</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>801</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6c0cf1361137ad1696100d644e0b59d5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Erträge aus anderen Wertpapieren des Anlagevermögens und Ausleihungen (verbundene Unternehmen)</act:name>
+  <act:id type="new">eefc832b4a467878abf91e7ce63afa79</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>802</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6c0cf1361137ad1696100d644e0b59d5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Erträge aus anderen Wertpapieren des Anlagevermögens und Ausleihungen (andere)</act:name>
+  <act:id type="new">7e73e1e9e1b59d479c795200e91293c7</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>803</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6c0cf1361137ad1696100d644e0b59d5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Sonstige Zinsen und ähnliche Erträge aus verbundenen Unternehmen</act:name>
+  <act:id type="new">17dd993fa25279403d0198956a0a1a4a</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>804</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6c0cf1361137ad1696100d644e0b59d5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Sonstige Zinsen und ähnliche Erträge (andere)</act:name>
+  <act:id type="new">0c06bd4a2504658dd532334a3e31f00c</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>805</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6c0cf1361137ad1696100d644e0b59d5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Erlöse aus dem Abgang von Anteilen an verbundenen Unternehmen</act:name>
+  <act:id type="new">bdf4988fc7f509f68c68812537cacf20</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>806</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6c0cf1361137ad1696100d644e0b59d5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Erlöse aus dem Abgang von Beteiligungen</act:name>
+  <act:id type="new">c20b00ffeed78b06c41a131a1e3c02e3</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>807</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6c0cf1361137ad1696100d644e0b59d5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Erlöse aus dem Abgang von sonstigen Finanzanlagen</act:name>
+  <act:id type="new">083b204d1c14e43ab786a74d1d637443</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>808</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6c0cf1361137ad1696100d644e0b59d5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Erlöse aus dem Abgang von Wertpapieren des Umlaufvermögens</act:name>
+  <act:id type="new">66bb18b946adecfa9496730a93dc3c55</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>809</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6c0cf1361137ad1696100d644e0b59d5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Buchwert abgegangener Anteile an verbundenen Unternehmen</act:name>
+  <act:id type="new">4df6e3dce26bf4e833e54e429ee319de</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>810</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6c0cf1361137ad1696100d644e0b59d5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Buchwert abgegangener Beteiligungen</act:name>
+  <act:id type="new">5c7fce4b51231cba770556719bc680f7</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>811</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6c0cf1361137ad1696100d644e0b59d5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Buchwert abgegangener sonstiger Finanzanlagen</act:name>
+  <act:id type="new">d382eabc7601dd875d87cb4652f631b1</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>812</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6c0cf1361137ad1696100d644e0b59d5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Buchwert abgegangener Wertpapiere des Umlaufvermögens</act:name>
+  <act:id type="new">62bae4157d6ab8b299d71f956e8a2fc3</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>813</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6c0cf1361137ad1696100d644e0b59d5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Erträge aus dem Abgang von Finanzanlagen und Wertpapieren des Umlaufvermögens (Abgänge mit Gewinn)</act:name>
+  <act:id type="new">c7f11b96b2cf6b9c0475f6e884d86545</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>814</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6c0cf1361137ad1696100d644e0b59d5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Erträge aus der Zuschreibung zu Anteilen an verbundenen Unternehmen</act:name>
+  <act:id type="new">5f396b014c7d8bbce8f34fc16ed2db5f</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>815</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6c0cf1361137ad1696100d644e0b59d5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Erträge aus der Zuschreibung zu Beteiligungen</act:name>
+  <act:id type="new">df06bf052ac57dda3530e044f0763efe</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>816</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6c0cf1361137ad1696100d644e0b59d5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Erträge aus der Zuschreibung zu sonstigen Finanzanlagen</act:name>
+  <act:id type="new">fdb9d4f9df109316408ca10e5ba0f68c</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>817</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6c0cf1361137ad1696100d644e0b59d5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Erträge aus der Zuschreibung zu Wertpapieren des Umlaufvermögens</act:name>
+  <act:id type="new">272e634385caf359f26f6929d0eff73d</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>818</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6c0cf1361137ad1696100d644e0b59d5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Abschreibungen auf Anteile an verbundenen Unternehmen</act:name>
+  <act:id type="new">524aab3d4c90310c037a8f37b9a67361</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>819</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6c0cf1361137ad1696100d644e0b59d5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Abschreibungen auf Beteiligungen</act:name>
+  <act:id type="new">b1a0e983e1b0b882a0c3e754a186dba8</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>820</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6c0cf1361137ad1696100d644e0b59d5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Verlustabdeckung für verbundene Unternehmen</act:name>
+  <act:id type="new">10acbc923b3325b90bb486f93e16535a</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>821</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6c0cf1361137ad1696100d644e0b59d5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Verlustabdeckung für Beteiligungsunternehmen</act:name>
+  <act:id type="new">aa4677e583a3d7ffe6bd03e4ae54ef95</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>822</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6c0cf1361137ad1696100d644e0b59d5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Andere Aufwendungen aus Anteilen an verbundenen Unternehmen</act:name>
+  <act:id type="new">f60b27b9f45b9b60aeefc6ab0eceb4a3</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>823-824</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6c0cf1361137ad1696100d644e0b59d5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Andere Aufwendungen aus Beteiligungen</act:name>
+  <act:id type="new">507c0438669719a132c8d5fd489ff4d4</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>825-826</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6c0cf1361137ad1696100d644e0b59d5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Abschreibungen auf sonstige Finanzanlagen und Wertpapiere des Umlaufvermögens</act:name>
+  <act:id type="new">ce597fd0f326723b1c8129a150ae4630</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>827</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6c0cf1361137ad1696100d644e0b59d5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Andere Aufwendungen aus sonstigen Finanzanlagen und Wertpapieren des Umlaufvermögens</act:name>
+  <act:id type="new">9428fbc3109a3ada3be7f7d1d073ef96</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>828-829</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6c0cf1361137ad1696100d644e0b59d5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Zinsen und ähnliche Aufwendungen aus verbundenen Unternehmen</act:name>
+  <act:id type="new">79899afaa4bc8beda87787f51d031bc9</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>830</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6c0cf1361137ad1696100d644e0b59d5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Zinsen und ähnliche Aufwendungen (andere)</act:name>
+  <act:id type="new">ca42afdc96b797436be9b641768650fd</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>831-832</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6c0cf1361137ad1696100d644e0b59d5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Kursänderungen bei Fremdwährungsforderungen/-verbindlichkeiten</act:name>
+  <act:id type="new">a1fb9a78395c0200e208b486c9c43b82</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>833-834</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6c0cf1361137ad1696100d644e0b59d5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Nicht ausgenützte Lieferantenskonti</act:name>
+  <act:id type="new">c3fb79a8fbcff94a1be0f2c97b26a82b</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>835</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6c0cf1361137ad1696100d644e0b59d5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Gewinnüberrechnung verbundener Unternehmen aufgrund von Ergebnisabführungsverträgen</act:name>
+  <act:id type="new">6cdad4151b0ba82a6a9401ccaaf14e4f</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>836</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6c0cf1361137ad1696100d644e0b59d5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Verlustübernahme verbundener Unternehmen aufgrund von Ergebnisabführungsverträgen</act:name>
+  <act:id type="new">eb72a9ed55743af2c2f71e6cc3225297</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>837</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6c0cf1361137ad1696100d644e0b59d5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Steuern vom Einkommen und vom Ertrag</act:name>
+  <act:id type="new">45962dec7f8f944cc12f5590a7b6c4a9</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>84</act:code>
+  <act:description>Kontengruppe 84</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">796745f7bfeb7ae7fb99704338cf711c</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Steuern vom Einkommen und vom Ertrag</act:name>
+  <act:id type="new">dc1c392f1943aea541db85ed7775548d</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>840-849</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">45962dec7f8f944cc12f5590a7b6c4a9</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Rücklagenbewegung, Ergebnisüberrechnung</act:name>
+  <act:id type="new">a21d9092f929aa3b2302e057fae5a1fd</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>85-89</act:code>
+  <act:description>Kontengruppe 85-89</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">796745f7bfeb7ae7fb99704338cf711c</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Auflösung von Kapitalrücklagen</act:name>
+  <act:id type="new">77fd8030b6c6a53f98bfba2816b1aa41</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>850-859</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">a21d9092f929aa3b2302e057fae5a1fd</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Auflösung von Gewinnrücklagen</act:name>
+  <act:id type="new">b96110e58fca9ead9c1c1f99b8ddbb40</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>860-869</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">a21d9092f929aa3b2302e057fae5a1fd</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Zuweisung zu Gewinnrücklagen</act:name>
+  <act:id type="new">6bddc9e1e442179ab6bcc0c7edd00b0b</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>870-889</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">a21d9092f929aa3b2302e057fae5a1fd</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Gewinnabfuhr bzw. Verlustüberrechnung aus Ergebnisabführungsverträgen (eigene Ergebnisse)</act:name>
+  <act:id type="new">502a2d862815f1305f2f689e26bae8f5</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>890</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">a21d9092f929aa3b2302e057fae5a1fd</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Eigenkapital, Einlagen unechter stiller Gesellschafter, Abschluss- und Evidenzkonten</act:name>
+  <act:id type="new">3ea0f7b444b6df1b552a37964d38eb43</act:id>
+  <act:type>EQUITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>9</act:code>
+  <act:description>Kontenklasse 9</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">59d3eca1e1c2c3a6fa981e0856665bfb</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Gezeichnetes bzw. gewidmetes Kapital, nicht eingeforderte ausstehende Einlagen</act:name>
+  <act:id type="new">6ccf60f96f55a809db114f733c1e535c</act:id>
+  <act:type>EQUITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>90</act:code>
+  <act:description>Kontengruppe 90-91</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">3ea0f7b444b6df1b552a37964d38eb43</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Gezeichnetes bzw. gewidmetes Kapital (Stammkapital, Grundkapital, …), Vereinbarte/Bedungene Einlagen (bei Personengesellschaften)</act:name>
+  <act:id type="new">ed523aa8be245fa2e6f4663bbd62443e</act:id>
+  <act:type>EQUITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>900-918</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6ccf60f96f55a809db114f733c1e535c</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Nicht eingeforderte ausstehende Einlagen; genehmigte und berechtigte Entnahmen von Gesellschaftern (bei Personengesellschaften)</act:name>
+  <act:id type="new">822f81ce7f388c34091fbe2d9f85cf29</act:id>
+  <act:type>EQUITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>919</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">6ccf60f96f55a809db114f733c1e535c</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Eigene Anteile</act:name>
+  <act:id type="new">444f887bd582212b73c281e969caba73</act:id>
+  <act:type>EQUITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>92</act:code>
+  <act:description>Kontengruppe 92</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">3ea0f7b444b6df1b552a37964d38eb43</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Kapitalrücklagen</act:name>
+  <act:id type="new">2c040761e9a58643d193cc7ea398417a</act:id>
+  <act:type>EQUITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>93</act:code>
+  <act:description>Kontengruppe 93</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">3ea0f7b444b6df1b552a37964d38eb43</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Gewinnrücklagen</act:name>
+  <act:id type="new">c1543365ba5f8cce95b0dfc86f0ecd37</act:id>
+  <act:type>EQUITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>94</act:code>
+  <act:description>Kontengruppe 94</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">3ea0f7b444b6df1b552a37964d38eb43</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Rücklagen für Anteile an Mutterunternehmen und für eigene Anteile</act:name>
+  <act:id type="new">2d05e185f3fdc87c1c014e83a609be24</act:id>
+  <act:type>EQUITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>95</act:code>
+  <act:description>Kontengruppe 95</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">3ea0f7b444b6df1b552a37964d38eb43</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Privat- und Verrechnungskonten (bei Einzelunternehmen und Personengesellschaften)</act:name>
+  <act:id type="new">5cb09b7c1ffba2268d6c4841e07f30dd</act:id>
+  <act:type>EQUITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>96</act:code>
+  <act:description>Kontengruppe 96</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">3ea0f7b444b6df1b552a37964d38eb43</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Einlagen und Verrechnungskonten unechter stiller Gesellschafter</act:name>
+  <act:id type="new">08f21cbe0d0545d7bbfd3294cb6514f3</act:id>
+  <act:type>EQUITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>97</act:code>
+  <act:description>Kontengruppe 97</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">3ea0f7b444b6df1b552a37964d38eb43</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Eröffnungsbilanz, Gewinn- und Verlustvortrag, Jahresergebnis laut Gewinn- und Verlustrechnung</act:name>
+  <act:id type="new">efc9445b2d9113fce9641db306dc9084</act:id>
+  <act:type>EQUITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>98</act:code>
+  <act:description>Kontengruppe 98</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">3ea0f7b444b6df1b552a37964d38eb43</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Eröffnungsbilanz</act:name>
+  <act:id type="new">674828fb0e6fffa5a24cf1ae39a3ade2</act:id>
+  <act:type>EQUITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>980</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">efc9445b2d9113fce9641db306dc9084</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Gewinn- und Verlustvortrag</act:name>
+  <act:id type="new">a7d21a57d55318ff7957ec46add1aad1</act:id>
+  <act:type>EQUITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>988</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">efc9445b2d9113fce9641db306dc9084</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Jahresergebnis laut Gewinn- und Verlustrechnung</act:name>
+  <act:id type="new">adbc60fa4647a626a5786c1aa4dab43a</act:id>
+  <act:type>EQUITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>989</act:code>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">efc9445b2d9113fce9641db306dc9084</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Evidenzkonten</act:name>
+  <act:id type="new">8bb5bb1ca67d27fb96d5b1fa40372afd</act:id>
+  <act:type>EQUITY</act:type>
+  <act:commodity>
+    <cmdty:space>CURRENCY</cmdty:space>
+    <cmdty:id>EUR</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:code>99</act:code>
+  <act:description>Kontengruppe 99</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="guid">3ea0f7b444b6df1b552a37964d38eb43</act:parent>
+</gnc:account>
+</gnc-account-example>
+

--- a/gnucash/gnome-search/gnc-general-search.c
+++ b/gnucash/gnome-search/gnc-general-search.c
@@ -81,39 +81,7 @@ struct _GNCGeneralSearchPrivate
 static GtkBoxClass *parent_class;
 static guint general_search_signals[LAST_SIGNAL];
 
-
-/**
- * gnc_general_search_get_type:
- *
- * Returns the GType for the GNCGeneralSearch widget
- */
-GType
-gnc_general_search_get_type (void)
-{
-    static GType general_search_type = 0;
-
-    if (!general_search_type)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GNCGeneralSearchClass),    /* class_size */
-            NULL,   			   /* base_init */
-            NULL,				   /* base_finalize */
-            (GClassInitFunc) gnc_general_search_class_init,
-            NULL,				   /* class_finalize */
-            NULL,				   /* class_data */
-            sizeof (GNCGeneralSearch),	   /* */
-            0,				   /* n_preallocs */
-            (GInstanceInitFunc) gnc_general_search_init,
-        };
-
-        general_search_type = g_type_register_static (GTK_TYPE_BOX,
-                              "GNCGeneralSearch",
-                              &our_info, 0);
-    }
-
-    return general_search_type;
-}
+G_DEFINE_TYPE_WITH_PRIVATE(GNCGeneralSearch, gnc_general_search, GTK_TYPE_BOX)
 
 static void
 gnc_general_search_class_init (GNCGeneralSearchClass *klass)
@@ -134,8 +102,6 @@ gnc_general_search_class_init (GNCGeneralSearchClass *klass)
     object_class->destroy = gnc_general_search_destroy;
 
     klass->changed = NULL;
-
-    g_type_class_add_private(klass, sizeof(GNCGeneralSearchPrivate));
 }
 
 static void

--- a/gnucash/gnome-search/search-account.c
+++ b/gnucash/gnome-search/search-account.c
@@ -63,34 +63,7 @@ struct _GNCSearchAccountPrivate
 
 static GNCSearchCoreTypeClass *parent_class;
 
-
-GType
-gnc_search_account_get_type (void)
-{
-    static GType type = 0;
-
-    if (!type)
-    {
-        GTypeInfo type_info =
-        {
-            sizeof(GNCSearchAccountClass),    /* class_size */
-            NULL,   				/* base_init */
-            NULL,				/* base_finalize */
-            (GClassInitFunc)gnc_search_account_class_init,
-            NULL,				/* class_finalize */
-            NULL,				/* class_data */
-            sizeof(GNCSearchAccount),		/* */
-            0,				/* n_preallocs */
-            (GInstanceInitFunc)gnc_search_account_init,
-        };
-
-        type = g_type_register_static (GNC_TYPE_SEARCH_CORE_TYPE,
-                                       "GNCSearchAccount",
-                                       &type_info, 0);
-    }
-
-    return type;
-}
+G_DEFINE_TYPE_WITH_PRIVATE(GNCSearchAccount, gnc_search_account, GNC_TYPE_SEARCH_CORE_TYPE)
 
 static void
 gnc_search_account_class_init (GNCSearchAccountClass *klass)
@@ -109,8 +82,6 @@ gnc_search_account_class_init (GNCSearchAccountClass *klass)
     gnc_search_core_type->get_widget = gncs_get_widget;
     gnc_search_core_type->get_predicate = gncs_get_predicate;
     gnc_search_core_type->clone = gncs_clone;
-
-    g_type_class_add_private(klass, sizeof(GNCSearchAccountPrivate));
 }
 
 static void

--- a/gnucash/gnome-search/search-boolean.c
+++ b/gnucash/gnome-search/search-boolean.c
@@ -58,33 +58,7 @@ struct _GNCSearchBooleanPrivate
 
 static GNCSearchCoreTypeClass *parent_class;
 
-GType
-gnc_search_boolean_get_type (void)
-{
-    static GType type = 0;
-
-    if (!type)
-    {
-        GTypeInfo type_info =
-        {
-            sizeof(GNCSearchBooleanClass),    /* class_size */
-            NULL,   				/* base_init */
-            NULL,				/* base_finalize */
-            (GClassInitFunc)gnc_search_boolean_class_init,
-            NULL,				/* class_finalize */
-            NULL,				/* class_data */
-            sizeof(GNCSearchBoolean),		/* */
-            0,				/* n_preallocs */
-            (GInstanceInitFunc)gnc_search_boolean_init,
-        };
-
-        type = g_type_register_static (GNC_TYPE_SEARCH_CORE_TYPE,
-                                       "GNCSearchBoolean",
-                                       &type_info, 0);
-    }
-
-    return type;
-}
+G_DEFINE_TYPE_WITH_PRIVATE(GNCSearchBoolean, gnc_search_boolean, GNC_TYPE_SEARCH_CORE_TYPE)
 
 static void
 gnc_search_boolean_class_init (GNCSearchBooleanClass *klass)
@@ -103,8 +77,6 @@ gnc_search_boolean_class_init (GNCSearchBooleanClass *klass)
     gnc_search_core_type->get_widget = gncs_get_widget;
     gnc_search_core_type->get_predicate = gncs_get_predicate;
     gnc_search_core_type->clone = gncs_clone;
-
-    g_type_class_add_private(klass, sizeof(GNCSearchBooleanPrivate));
 }
 
 static void

--- a/gnucash/gnome-search/search-core-type.c
+++ b/gnucash/gnome-search/search-core-type.c
@@ -62,31 +62,7 @@ static GObjectClass *parent_class;
 
 static GHashTable *typeTable = NULL;
 
-GType
-gnc_search_core_type_get_type (void)
-{
-    static GType type = 0;
-
-    if (type == 0)
-    {
-        GTypeInfo type_info =
-        {
-            sizeof (GNCSearchCoreTypeClass),
-            NULL,
-            NULL,
-            (GClassInitFunc)gnc_search_core_type_class_init,
-            NULL,
-            NULL,
-            sizeof (GNCSearchCoreType),
-            0,
-            (GInstanceInitFunc)gnc_search_core_type_init
-        };
-
-        type = g_type_register_static (G_TYPE_OBJECT, "GNCSearchCoreType", &type_info, 0);
-    }
-
-    return type;
-}
+G_DEFINE_TYPE_WITH_PRIVATE(GNCSearchCoreType, gnc_search_core_type, G_TYPE_OBJECT)
 
 static void
 gnc_search_core_type_class_init (GNCSearchCoreTypeClass *klass)
@@ -102,8 +78,6 @@ gnc_search_core_type_class_init (GNCSearchCoreTypeClass *klass)
     klass->validate = validate;
     klass->grab_focus = grab_focus;
     klass->editable_enters = editable_enters;
-
-    g_type_class_add_private(klass, sizeof(GNCSearchCoreTypePrivate));
 }
 
 static void

--- a/gnucash/gnome-search/search-date.c
+++ b/gnucash/gnome-search/search-date.c
@@ -62,33 +62,7 @@ struct _GNCSearchDatePrivate
 
 static GNCSearchCoreTypeClass *parent_class;
 
-GType
-gnc_search_date_get_type (void)
-{
-    static GType type = 0;
-
-    if (!type)
-    {
-        GTypeInfo type_info =
-        {
-            sizeof(GNCSearchDateClass),      /* class_size */
-            NULL,                            /* base_init */
-            NULL,                            /* base_finalize */
-            (GClassInitFunc)gnc_search_date_class_init,
-            NULL,                            /* class_finalize */
-            NULL,                            /* class_data */
-            sizeof(GNCSearchDate),           /* */
-            0,                               /* n_preallocs */
-            (GInstanceInitFunc)gnc_search_date_init,
-        };
-
-        type = g_type_register_static (GNC_TYPE_SEARCH_CORE_TYPE,
-                                       "GNCSearchDate",
-                                       &type_info, 0);
-    }
-
-    return type;
-}
+G_DEFINE_TYPE_WITH_PRIVATE(GNCSearchDate, gnc_search_date, GNC_TYPE_SEARCH_CORE_TYPE)
 
 static void
 gnc_search_date_class_init (GNCSearchDateClass *klass)
@@ -109,8 +83,6 @@ gnc_search_date_class_init (GNCSearchDateClass *klass)
     gnc_search_core_type->get_widget = gncs_get_widget;
     gnc_search_core_type->get_predicate = gncs_get_predicate;
     gnc_search_core_type->clone = gncs_clone;
-
-    g_type_class_add_private(klass, sizeof(GNCSearchDatePrivate));
 }
 
 static void

--- a/gnucash/gnome-search/search-double.c
+++ b/gnucash/gnome-search/search-double.c
@@ -62,33 +62,7 @@ struct _GNCSearchDoublePrivate
 
 static GNCSearchCoreTypeClass *parent_class;
 
-GType
-gnc_search_double_get_type (void)
-{
-    static GType type = 0;
-
-    if (!type)
-    {
-        GTypeInfo type_info =
-        {
-            sizeof(GNCSearchDoubleClass),     /* class_size */
-            NULL,   			        /* base_init */
-            NULL,				/* base_finalize */
-            (GClassInitFunc)gnc_search_double_class_init,
-            NULL,				/* class_finalize */
-            NULL,				/* class_data */
-            sizeof(GNCSearchDouble),		/* */
-            0,				/* n_preallocs */
-            (GInstanceInitFunc)gnc_search_double_init,
-        };
-
-        type = g_type_register_static (GNC_TYPE_SEARCH_CORE_TYPE,
-                                       "GNCSearchDouble",
-                                       &type_info, 0);
-    }
-
-    return type;
-}
+G_DEFINE_TYPE_WITH_PRIVATE(GNCSearchDouble, gnc_search_double, GNC_TYPE_SEARCH_CORE_TYPE)
 
 static void
 gnc_search_double_class_init (GNCSearchDoubleClass *klass)
@@ -109,8 +83,6 @@ gnc_search_double_class_init (GNCSearchDoubleClass *klass)
     gnc_search_core_type->get_widget = gncs_get_widget;
     gnc_search_core_type->get_predicate = gncs_get_predicate;
     gnc_search_core_type->clone = gncs_clone;
-
-    g_type_class_add_private(klass, sizeof(GNCSearchDoublePrivate));
 }
 
 static void

--- a/gnucash/gnome-search/search-int64.c
+++ b/gnucash/gnome-search/search-int64.c
@@ -63,33 +63,7 @@ struct _GNCSearchInt64Private
 
 static GNCSearchCoreTypeClass *parent_class;
 
-GType
-gnc_search_int64_get_type (void)
-{
-    static GType type = 0;
-
-    if (!type)
-    {
-        GTypeInfo type_info =
-        {
-            sizeof(GNCSearchInt64Class),      /* class_size */
-            NULL,   				/* base_init */
-            NULL,				/* base_finalize */
-            (GClassInitFunc)gnc_search_int64_class_init,
-            NULL,				/* class_finalize */
-            NULL,				/* class_data */
-            sizeof(GNCSearchInt64),		/* */
-            0,				/* n_preallocs */
-            (GInstanceInitFunc)gnc_search_int64_init,
-        };
-
-        type = g_type_register_static (GNC_TYPE_SEARCH_CORE_TYPE,
-                                       "GNCSearchInt64",
-                                       &type_info, 0);
-    }
-
-    return type;
-}
+G_DEFINE_TYPE_WITH_PRIVATE(GNCSearchInt64, gnc_search_int64, GNC_TYPE_SEARCH_CORE_TYPE)
 
 static void
 gnc_search_int64_class_init (GNCSearchInt64Class *klass)
@@ -110,8 +84,6 @@ gnc_search_int64_class_init (GNCSearchInt64Class *klass)
     gnc_search_core_type->get_widget = gncs_get_widget;
     gnc_search_core_type->get_predicate = gncs_get_predicate;
     gnc_search_core_type->clone = gncs_clone;
-
-    g_type_class_add_private(klass, sizeof(GNCSearchInt64Private));
 }
 
 static void

--- a/gnucash/gnome-search/search-numeric.c
+++ b/gnucash/gnome-search/search-numeric.c
@@ -63,33 +63,7 @@ struct _GNCSearchNumericPrivate
 
 static GNCSearchCoreTypeClass *parent_class;
 
-GType
-gnc_search_numeric_get_type (void)
-{
-    static GType type = 0;
-
-    if (!type)
-    {
-        GTypeInfo type_info =
-        {
-            sizeof(GNCSearchNumericClass),    /* class_size */
-            NULL,   				/* base_init */
-            NULL,				/* base_finalize */
-            (GClassInitFunc)gnc_search_numeric_class_init,
-            NULL,				/* class_finalize */
-            NULL,				/* class_data */
-            sizeof(GNCSearchNumeric),		/* */
-            0,				/* n_preallocs */
-            (GInstanceInitFunc)gnc_search_numeric_init,
-        };
-
-        type = g_type_register_static (GNC_TYPE_SEARCH_CORE_TYPE,
-                                       "GNCSearchNumeric",
-                                       &type_info, 0);
-    }
-
-    return type;
-}
+G_DEFINE_TYPE_WITH_PRIVATE(GNCSearchNumeric, gnc_search_numeric, GNC_TYPE_SEARCH_CORE_TYPE)
 
 static void
 gnc_search_numeric_class_init (GNCSearchNumericClass *klass)
@@ -110,8 +84,6 @@ gnc_search_numeric_class_init (GNCSearchNumericClass *klass)
     gnc_search_core_type->get_widget = gncs_get_widget;
     gnc_search_core_type->get_predicate = gncs_get_predicate;
     gnc_search_core_type->clone = gncs_clone;
-
-    g_type_class_add_private(klass, sizeof(GNCSearchNumericPrivate));
 }
 
 static void

--- a/gnucash/gnome-search/search-reconciled.c
+++ b/gnucash/gnome-search/search-reconciled.c
@@ -59,33 +59,7 @@ struct _GNCSearchReconciledPrivate
 
 static GNCSearchCoreTypeClass *parent_class;
 
-GType
-gnc_search_reconciled_get_type (void)
-{
-    static GType type = 0;
-
-    if (!type)
-    {
-        GTypeInfo type_info =
-        {
-            sizeof(GNCSearchReconciledClass), /* class_size */
-            NULL,   			        /* base_init */
-            NULL,				/* base_finalize */
-            (GClassInitFunc)gnc_search_reconciled_class_init,
-            NULL,				/* class_finalize */
-            NULL,				/* class_data */
-            sizeof(GNCSearchReconciled),	/* */
-            0,				/* n_preallocs */
-            (GInstanceInitFunc)gnc_search_reconciled_init,
-        };
-
-        type = g_type_register_static (GNC_TYPE_SEARCH_CORE_TYPE,
-                                       "GNCSearchReconciled",
-                                       &type_info, 0);
-    }
-
-    return type;
-}
+G_DEFINE_TYPE_WITH_PRIVATE(GNCSearchReconciled, gnc_search_reconciled, GNC_TYPE_SEARCH_CORE_TYPE)
 
 static void
 gnc_search_reconciled_class_init (GNCSearchReconciledClass *klass)
@@ -104,8 +78,6 @@ gnc_search_reconciled_class_init (GNCSearchReconciledClass *klass)
     gnc_search_core_type->get_widget = gncs_get_widget;
     gnc_search_core_type->get_predicate = gncs_get_predicate;
     gnc_search_core_type->clone = gncs_clone;
-
-    g_type_class_add_private(klass, sizeof(GNCSearchReconciledPrivate));
 }
 
 static void

--- a/gnucash/gnome-search/search-string.c
+++ b/gnucash/gnome-search/search-string.c
@@ -62,33 +62,7 @@ struct _GNCSearchStringPrivate
 
 static GNCSearchCoreTypeClass *parent_class;
 
-GType
-gnc_search_string_get_type (void)
-{
-    static GType type = 0;
-
-    if (!type)
-    {
-        GTypeInfo type_info =
-        {
-            sizeof(GNCSearchStringClass),     /* class_size */
-            NULL,   				/* base_init */
-            NULL,				/* base_finalize */
-            (GClassInitFunc)gnc_search_string_class_init,
-            NULL,				/* class_finalize */
-            NULL,				/* class_data */
-            sizeof(GNCSearchString),		/* */
-            0,				/* n_preallocs */
-            (GInstanceInitFunc)gnc_search_string_init,
-        };
-
-        type = g_type_register_static (GNC_TYPE_SEARCH_CORE_TYPE,
-                                       "GNCSearchString",
-                                       &type_info, 0);
-    }
-
-    return type;
-}
+G_DEFINE_TYPE_WITH_PRIVATE(GNCSearchString, gnc_search_string, GNC_TYPE_SEARCH_CORE_TYPE)
 
 static void
 gnc_search_string_class_init (GNCSearchStringClass *klass)
@@ -109,8 +83,6 @@ gnc_search_string_class_init (GNCSearchStringClass *klass)
     gnc_search_core_type->get_widget = gncs_get_widget;
     gnc_search_core_type->get_predicate = gncs_get_predicate;
     gnc_search_core_type->clone = gncs_clone;
-
-    g_type_class_add_private(klass, sizeof(GNCSearchStringPrivate));
 }
 
 static void

--- a/gnucash/gnome-utils/dialog-options.c
+++ b/gnucash/gnome-utils/dialog-options.c
@@ -2505,6 +2505,7 @@ gnc_option_set_ui_widget_text (GNCOption *option, GtkBox *page_box,
     value = gtk_text_view_new();
     gtk_text_view_set_wrap_mode(GTK_TEXT_VIEW(value), GTK_WRAP_WORD);
     gtk_text_view_set_editable(GTK_TEXT_VIEW(value), TRUE);
+    gtk_text_view_set_accepts_tab (GTK_TEXT_VIEW(value), FALSE);
     gtk_container_add (GTK_CONTAINER (scroll), value);
 
     gnc_option_set_widget (option, value);

--- a/gnucash/gnome-utils/gnc-combott.c
+++ b/gnucash/gnome-utils/gnc-combott.c
@@ -76,34 +76,34 @@ typedef struct GncCombottPrivate
 } GncCombottPrivate;
 
 /** Declarations *********************************************************/
-static void gctt_init (GncCombott *combott);
+static void gnc_combott_init (GncCombott *combott);
 
-static void gctt_class_init (GncCombottClass *klass);
+static void gnc_combott_class_init (GncCombottClass *klass);
 
-static void gctt_set_property (GObject *object,
+static void gnc_combott_set_property (GObject *object,
                                guint param_id,
                                const GValue *value,
                                GParamSpec *pspec);
 
-static void gctt_get_property (GObject *object,
+static void gnc_combott_get_property (GObject *object,
                                guint param_id,
                                GValue *value,
                                GParamSpec *pspec);
 
-static void gctt_finalize (GObject *object);
+static void gnc_combott_finalize (GObject *object);
 
 #if !GTK_CHECK_VERSION(3,22,0)
-static void gctt_combott_menu_position (GtkMenu *menu,
+static void gnc_combott_menu_position (GtkMenu *menu,
                                         gint *x,
                                         gint *y,
                                         gint *push_in,
                                         gpointer user_data);
 #endif
 
-static void gctt_changed (GncCombott *combott);
-static void gctt_set_model (GncCombott *combott, GtkTreeModel *model);
-static void gctt_refresh_menu (GncCombott *combott, GtkTreeModel *model);
-static void gctt_rebuild_menu (GncCombott *combott, GtkTreeModel *model);
+static void gnc_combott_changed (GncCombott *combott);
+static void gnc_combott_set_model (GncCombott *combott, GtkTreeModel *model);
+static void gnc_combott_refresh_menu (GncCombott *combott, GtkTreeModel *model);
+static void gnc_combott_rebuild_menu (GncCombott *combott, GtkTreeModel *model);
 
 static gboolean which_tooltip_cb (GtkWidget  *widget, gint x, gint y,
                                   gboolean keyboard_mode, GtkTooltip *tooltip, gpointer user_data);
@@ -118,47 +118,21 @@ static void menuitem_response_cb (GtkMenuItem *item, gpointer *user_data);
 /************************************************************/
 static GObjectClass *parent_class = NULL;
 
-GType
-gnc_combott_get_type (void)
-{
-    static GType combott_type = 0;
-
-    if (!combott_type)
-    {
-        static const GTypeInfo combott_info =
-        {
-            sizeof (GncCombottClass),
-            NULL,		/* base_init */
-            NULL,		/* base_finalize */
-            (GClassInitFunc) gctt_class_init,
-            NULL,		/* class_finalize */
-            NULL,		/* class_data */
-            sizeof (GncCombott),
-            0,              /* n_preallocs */
-            (GInstanceInitFunc) gctt_init,
-        };
-
-        combott_type = g_type_register_static (GTK_TYPE_BOX,
-                                               "GncCombott",
-                                               &combott_info, 0);
-    }
-    return combott_type;
-}
-
+G_DEFINE_TYPE_WITH_PRIVATE(GncCombott, gnc_combott, GTK_TYPE_BOX)
 
 static void
-gctt_class_init (GncCombottClass *klass)
+gnc_combott_class_init (GncCombottClass *klass)
 {
     GObjectClass            *gobject_class;
 
     parent_class = g_type_class_peek_parent (klass);
     gobject_class = G_OBJECT_CLASS (klass);
 
-    gobject_class->set_property = gctt_set_property;
-    gobject_class->get_property = gctt_get_property;
-    gobject_class->finalize = gctt_finalize;
+    gobject_class->set_property = gnc_combott_set_property;
+    gobject_class->get_property = gnc_combott_get_property;
+    gobject_class->finalize = gnc_combott_finalize;
 
-    klass->changed = gctt_changed;
+    klass->changed = gnc_combott_changed;
 
     combott_signals[CHANGED] =
         g_signal_new ("changed",
@@ -199,13 +173,11 @@ gctt_class_init (GncCombottClass *klass)
                           G_MAXINT,
                           1,
                           G_PARAM_READWRITE));
-
-    g_type_class_add_private(klass, sizeof(GncCombottPrivate));
 }
 
 
 static void
-gctt_init (GncCombott *combott)
+gnc_combott_init (GncCombott *combott)
 {
     GtkWidget *hbox;
     GtkWidget *label;
@@ -268,7 +240,7 @@ gctt_init (GncCombott *combott)
 
 
 static void
-gctt_set_property (GObject      *object,
+gnc_combott_set_property (GObject      *object,
                    guint         param_id,
                    const GValue *value,
                    GParamSpec   *pspec)
@@ -279,7 +251,7 @@ gctt_set_property (GObject      *object,
     switch (param_id)
     {
     case PROP_MODEL:
-        gctt_set_model (combott, g_value_get_object (value));
+        gnc_combott_set_model (combott, g_value_get_object (value));
         break;
 
     case PROP_ACTIVE:
@@ -292,7 +264,7 @@ gctt_set_property (GObject      *object,
 
     case PROP_TIP_COL:
         priv->tip_col = g_value_get_int (value);
-        gctt_refresh_menu(combott, priv->model);
+        gnc_combott_refresh_menu(combott, priv->model);
         break;
 
     default:
@@ -308,7 +280,7 @@ gctt_set_property (GObject      *object,
  * ref the object when used in get_property().
  */
 static void
-gctt_get_property (GObject    *object,
+gnc_combott_get_property (GObject    *object,
                    guint       param_id,
                    GValue     *value,
                    GParamSpec *pspec)
@@ -342,7 +314,7 @@ gctt_get_property (GObject    *object,
 
 
 static void
-gctt_finalize (GObject *object)
+gnc_combott_finalize (GObject *object)
 {
     GncCombott *combott;
     GncCombottPrivate *priv;
@@ -368,7 +340,7 @@ gctt_finalize (GObject *object)
 
 
 static void
-gctt_set_model (GncCombott *combott, GtkTreeModel *model)
+gnc_combott_set_model (GncCombott *combott, GtkTreeModel *model)
 {
     GncCombottPrivate *priv;
 
@@ -377,7 +349,7 @@ gctt_set_model (GncCombott *combott, GtkTreeModel *model)
 
     priv = GNC_COMBOTT_GET_PRIVATE (combott);
 
-    gctt_rebuild_menu(combott, model);
+    gnc_combott_rebuild_menu(combott, model);
 
     priv->model = model;
     g_object_ref (priv->model);
@@ -385,7 +357,7 @@ gctt_set_model (GncCombott *combott, GtkTreeModel *model)
 
 
 static void
-gctt_rebuild_menu (GncCombott *combott, GtkTreeModel *model)
+gnc_combott_rebuild_menu (GncCombott *combott, GtkTreeModel *model)
 {
     GncCombottPrivate *priv;
     GtkTreeIter iter;
@@ -454,17 +426,17 @@ gctt_rebuild_menu (GncCombott *combott, GtkTreeModel *model)
 
 
 static void
-gctt_refresh_menu (GncCombott *combott, GtkTreeModel *model)
+gnc_combott_refresh_menu (GncCombott *combott, GtkTreeModel *model)
 {
     g_return_if_fail (GNC_IS_COMBOTT (combott));
     g_return_if_fail (model == NULL || GTK_IS_TREE_MODEL (model));
 
-    gctt_rebuild_menu(combott, model);
+    gnc_combott_rebuild_menu(combott, model);
 }
 
 
 static void
-gctt_changed(GncCombott *combott)
+gnc_combott_changed(GncCombott *combott)
 {
     /*
     g_print("Changed Signal\n");
@@ -474,7 +446,7 @@ gctt_changed(GncCombott *combott)
 
 #if !GTK_CHECK_VERSION(3,22,0)
 static void
-gctt_combott_menu_position (GtkMenu  *menu,
+gnc_combott_menu_position (GtkMenu  *menu,
                             gint     *x,
                             gint     *y,
                             gint     *push_in,
@@ -599,7 +571,7 @@ button_press_cb (GtkWidget *widget, GdkEvent *event, gpointer *user_data )
 #else
             gtk_menu_popup (GTK_MENU (priv->menu),
                             NULL, NULL,
-                            gctt_combott_menu_position, combott,
+                            gnc_combott_menu_position, combott,
                             bevent->button, bevent->time);
 #endif
 

--- a/gnucash/gnome-utils/gnc-currency-edit.c
+++ b/gnucash/gnome-utils/gnc-currency-edit.c
@@ -90,42 +90,13 @@ typedef struct _GNCCurrencyEditPrivate
     gchar *mnemonic;
 } GNCCurrencyEditPrivate;
 
+G_DEFINE_TYPE_WITH_PRIVATE(GNCCurrencyEdit, gnc_currency_edit, GTK_TYPE_COMBO_BOX)
+
 #define GET_PRIVATE(o)  \
    (G_TYPE_INSTANCE_GET_PRIVATE ((o), GNC_TYPE_CURRENCY_EDIT, GNCCurrencyEditPrivate))
 
 /** @name Basic Object Implementation */
 /** @{ */
-
-/*  Return the GType for the GNCCurrencyEdit currency selection widget.
- */
-GType
-gnc_currency_edit_get_type (void)
-{
-    static GType currency_edit_type = 0;
-
-    if (currency_edit_type == 0)
-    {
-        static const GTypeInfo currency_edit_info =
-        {
-            sizeof (GNCCurrencyEditClass),
-            NULL,
-            NULL,
-            (GClassInitFunc) gnc_currency_edit_class_init,
-            NULL,
-            NULL,
-            sizeof (GNCCurrencyEdit),
-            0, /* n_preallocs */
-            (GInstanceInitFunc) gnc_currency_edit_init,
-            NULL
-        };
-
-        currency_edit_type = g_type_register_static (GTK_TYPE_COMBO_BOX,
-                             "GNCCurrencyEdit",
-                             &currency_edit_info, 0);
-    }
-
-    return currency_edit_type;
-}
 
 enum
 {
@@ -184,9 +155,6 @@ gnc_currency_edit_get_property (GObject    *object,
     }
 }
 
-
-
-
 /** Initialize the GncCurrencyEdit class object.
  *
  *  @internal
@@ -198,8 +166,6 @@ gnc_currency_edit_class_init (GNCCurrencyEditClass *klass)
 {
     GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
     parent_class = g_type_class_peek_parent (klass);
-
-    g_type_class_add_private(klass, sizeof(GNCCurrencyEditPrivate));
 
     gobject_class->set_property = gnc_currency_edit_set_property;
     gobject_class->get_property = gnc_currency_edit_get_property;

--- a/gnucash/gnome-utils/gnc-date-format.c
+++ b/gnucash/gnome-utils/gnc-date-format.c
@@ -53,9 +53,9 @@ enum
     LAST_SIGNAL
 };
 
-typedef struct _GNCDateFormatPriv GNCDateFormatPriv;
+typedef struct _GNCDateFormatPrivate GNCDateFormatPrivate;
 
-struct _GNCDateFormatPriv
+struct _GNCDateFormatPrivate
 {
     GtkWidget*	format_combobox;
 
@@ -76,7 +76,7 @@ struct _GNCDateFormatPriv
 };
 
 #define GNC_DATE_FORMAT_GET_PRIVATE(o)  \
-   (G_TYPE_INSTANCE_GET_PRIVATE ((o), GNC_TYPE_DATE_FORMAT, GNCDateFormatPriv))
+   (G_TYPE_INSTANCE_GET_PRIVATE ((o), GNC_TYPE_DATE_FORMAT, GNCDateFormatPrivate))
 
 static guint date_format_signals [LAST_SIGNAL] = { 0 };
 
@@ -89,40 +89,7 @@ void gnc_ui_date_format_changed_cb(GtkWidget *unused, gpointer user_data);
 
 static GtkBoxClass *parent_class;
 
-/**
- * gnc_date_format_get_type:
- *
- * Returns the GType for the GNCDateFormat widget
- */
-GType
-gnc_date_format_get_type (void)
-{
-    static GType date_format_type = 0;
-
-    if (!date_format_type)
-    {
-        static const GTypeInfo date_format_info =
-        {
-            sizeof (GNCDateFormatClass),
-            NULL,
-            NULL,
-            (GClassInitFunc) gnc_date_format_class_init,
-            NULL,
-            NULL,
-            sizeof (GNCDateFormat),
-            0,
-            (GInstanceInitFunc) gnc_date_format_init,
-            NULL,
-        };
-
-        date_format_type = g_type_register_static(GTK_TYPE_BOX,
-                           "GNCDateFormat",
-                           &date_format_info, 0);
-    }
-
-    return date_format_type;
-}
-
+G_DEFINE_TYPE_WITH_PRIVATE(GNCDateFormat, gnc_date_format, GTK_TYPE_BOX)
 
 static void
 gnc_date_format_class_init (GNCDateFormatClass *klass)
@@ -132,8 +99,6 @@ gnc_date_format_class_init (GNCDateFormatClass *klass)
     parent_class = g_type_class_peek_parent(klass);
 
     gobject_class->finalize = gnc_date_format_finalize;
-
-    g_type_class_add_private(klass, sizeof(GNCDateFormatPriv));
 
     date_format_signals [FORMAT_CHANGED] =
         g_signal_new ("format_changed",
@@ -151,7 +116,7 @@ gnc_date_format_class_init (GNCDateFormatClass *klass)
 static void
 gnc_date_format_init (GNCDateFormat *gdf)
 {
-    GNCDateFormatPriv *priv;
+    GNCDateFormatPrivate *priv;
     GtkBuilder *builder;
     GtkWidget *dialog, *table;
 
@@ -238,7 +203,7 @@ gnc_date_format_new_without_label (void)
 {
     GtkWidget *widget = gnc_date_format_new_with_label(NULL);
     GNCDateFormat *gdf = GNC_DATE_FORMAT(widget);
-    GNCDateFormatPriv *priv = GNC_DATE_FORMAT_GET_PRIVATE(gdf);
+    GNCDateFormatPrivate *priv = GNC_DATE_FORMAT_GET_PRIVATE(gdf);
 
     gtk_widget_destroy(priv->label);
     priv->label = NULL;
@@ -260,7 +225,7 @@ GtkWidget *
 gnc_date_format_new_with_label (const char *label)
 {
     GNCDateFormat *gdf;
-    GNCDateFormatPriv *priv;
+    GNCDateFormatPrivate *priv;
 
     gdf = g_object_new(GNC_TYPE_DATE_FORMAT, NULL);
     priv = GNC_DATE_FORMAT_GET_PRIVATE(gdf);
@@ -276,7 +241,7 @@ gnc_date_format_new_with_label (const char *label)
 void
 gnc_date_format_set_format (GNCDateFormat *gdf, QofDateFormat format)
 {
-    GNCDateFormatPriv *priv;
+    GNCDateFormatPrivate *priv;
 
     g_return_if_fail(gdf);
     g_return_if_fail(GNC_IS_DATE_FORMAT(gdf));
@@ -290,7 +255,7 @@ gnc_date_format_set_format (GNCDateFormat *gdf, QofDateFormat format)
 QofDateFormat
 gnc_date_format_get_format (GNCDateFormat *gdf)
 {
-    GNCDateFormatPriv *priv;
+    GNCDateFormatPrivate *priv;
 
     g_return_val_if_fail (gdf, QOF_DATE_FORMAT_LOCALE);
     g_return_val_if_fail (GNC_IS_DATE_FORMAT(gdf), QOF_DATE_FORMAT_LOCALE);
@@ -303,7 +268,7 @@ gnc_date_format_get_format (GNCDateFormat *gdf)
 void
 gnc_date_format_set_months (GNCDateFormat *gdf, GNCDateMonthFormat months)
 {
-    GNCDateFormatPriv *priv;
+    GNCDateFormatPrivate *priv;
     GtkWidget *button = NULL;
 
     g_return_if_fail(gdf);
@@ -335,7 +300,7 @@ gnc_date_format_set_months (GNCDateFormat *gdf, GNCDateMonthFormat months)
 GNCDateMonthFormat
 gnc_date_format_get_months (GNCDateFormat *gdf)
 {
-    GNCDateFormatPriv *priv;
+    GNCDateFormatPrivate *priv;
 
     g_return_val_if_fail(gdf, GNCDATE_MONTH_NUMBER);
     g_return_val_if_fail(GNC_IS_DATE_FORMAT(gdf), GNCDATE_MONTH_NUMBER);
@@ -357,7 +322,7 @@ gnc_date_format_get_months (GNCDateFormat *gdf)
 void
 gnc_date_format_set_years (GNCDateFormat *gdf, gboolean include_century)
 {
-    GNCDateFormatPriv *priv;
+    GNCDateFormatPrivate *priv;
 
     g_return_if_fail(gdf);
     g_return_if_fail(GNC_IS_DATE_FORMAT(gdf));
@@ -372,7 +337,7 @@ gnc_date_format_set_years (GNCDateFormat *gdf, gboolean include_century)
 gboolean
 gnc_date_format_get_years (GNCDateFormat *gdf)
 {
-    GNCDateFormatPriv *priv;
+    GNCDateFormatPrivate *priv;
 
     g_return_val_if_fail(gdf, FALSE);
     g_return_val_if_fail(GNC_IS_DATE_FORMAT(gdf), FALSE);
@@ -385,7 +350,7 @@ gnc_date_format_get_years (GNCDateFormat *gdf)
 void
 gnc_date_format_set_custom (GNCDateFormat *gdf, const char *format)
 {
-    GNCDateFormatPriv *priv;
+    GNCDateFormatPrivate *priv;
 
     g_return_if_fail(gdf);
     g_return_if_fail(GNC_IS_DATE_FORMAT(gdf));
@@ -402,7 +367,7 @@ gnc_date_format_set_custom (GNCDateFormat *gdf, const char *format)
 const char *
 gnc_date_format_get_custom (GNCDateFormat *gdf)
 {
-    GNCDateFormatPriv *priv;
+    GNCDateFormatPrivate *priv;
 
     g_return_val_if_fail(gdf, "");
     g_return_val_if_fail(GNC_IS_DATE_FORMAT(gdf), "");
@@ -424,7 +389,7 @@ gnc_ui_date_format_changed_cb(GtkWidget *unused, gpointer user_data)
 static void
 gnc_date_format_enable_month (GNCDateFormat *gdf, gboolean sensitive)
 {
-    GNCDateFormatPriv *priv;
+    GNCDateFormatPrivate *priv;
 
     priv = GNC_DATE_FORMAT_GET_PRIVATE(gdf);
     gtk_widget_set_sensitive(priv->months_label, sensitive);
@@ -437,7 +402,7 @@ gnc_date_format_enable_month (GNCDateFormat *gdf, gboolean sensitive)
 static void
 gnc_date_format_enable_year (GNCDateFormat *gdf, gboolean sensitive)
 {
-    GNCDateFormatPriv *priv;
+    GNCDateFormatPrivate *priv;
 
     priv = GNC_DATE_FORMAT_GET_PRIVATE(gdf);
     gtk_widget_set_sensitive(priv->years_label, sensitive);
@@ -448,7 +413,7 @@ gnc_date_format_enable_year (GNCDateFormat *gdf, gboolean sensitive)
 static void
 gnc_date_format_enable_format (GNCDateFormat *gdf, gboolean sensitive)
 {
-    GNCDateFormatPriv *priv;
+    GNCDateFormatPrivate *priv;
 
     priv = GNC_DATE_FORMAT_GET_PRIVATE(gdf);
     gtk_widget_set_sensitive(priv->custom_label, sensitive);
@@ -459,7 +424,7 @@ gnc_date_format_enable_format (GNCDateFormat *gdf, gboolean sensitive)
 void
 gnc_date_format_refresh (GNCDateFormat *gdf)
 {
-    GNCDateFormatPriv *priv;
+    GNCDateFormatPrivate *priv;
     int sel_option;
     gboolean enable_year, enable_month, enable_custom, check_modifiers;
     static gchar *format, *c;

--- a/gnucash/gnome-utils/gnc-embedded-window.c
+++ b/gnucash/gnome-utils/gnc-embedded-window.c
@@ -87,8 +87,8 @@ typedef struct GncEmbeddedWindowPrivate
 
 GNC_DEFINE_TYPE_WITH_CODE(GncEmbeddedWindow, gnc_embedded_window, GTK_TYPE_BOX,
                         G_ADD_PRIVATE(GncEmbeddedWindow)
-                        G_IMPLEMENT_INTERFACE(GNC_TYPE_WINDOW,
-                                              gnc_window_embedded_window_init))
+                        GNC_IMPLEMENT_INTERFACE(GNC_TYPE_WINDOW,
+                                                gnc_window_embedded_window_init))
 
 #define GNC_EMBEDDED_WINDOW_GET_PRIVATE(o)  \
    (G_TYPE_INSTANCE_GET_PRIVATE ((o), GNC_TYPE_EMBEDDED_WINDOW, GncEmbeddedWindowPrivate))
@@ -193,9 +193,9 @@ gnc_embedded_window_class_init (GncEmbeddedWindowClass *klass)
  *  @param klass A pointer to the class data structure for this
  *  object. */
 static void
-gnc_embedded_window_init (GncEmbeddedWindow *window,
-                          GncEmbeddedWindowClass *klass)
+gnc_embedded_window_init (GncEmbeddedWindow *window, void *data)
 {
+    GncEmbeddedWindowClass *klass = (GncEmbeddedWindowClass*)data;
     ENTER("window %p", window);
 
     gtk_orientable_set_orientation (GTK_ORIENTABLE(window), GTK_ORIENTATION_VERTICAL);
@@ -205,7 +205,7 @@ gnc_embedded_window_init (GncEmbeddedWindow *window,
 
     gnc_embedded_window_setup_window (window);
 
-    gnc_gobject_tracking_remember(G_OBJECT(window), 
+    gnc_gobject_tracking_remember(G_OBJECT(window),
 		                  G_OBJECT_CLASS(klass));
     LEAVE(" ");
 }

--- a/gnucash/gnome-utils/gnc-embedded-window.c
+++ b/gnucash/gnome-utils/gnc-embedded-window.c
@@ -50,14 +50,12 @@ static GObjectClass *parent_class = NULL;
 
 /* Declarations *********************************************************/
 static void gnc_embedded_window_class_init (GncEmbeddedWindowClass *klass);
-static void gnc_embedded_window_init (GncEmbeddedWindow *window, GncEmbeddedWindowClass *klass);
 static void gnc_embedded_window_finalize (GObject *object);
 static void gnc_embedded_window_dispose (GObject *object);
 
 static void gnc_window_embedded_window_init (GncWindowIface *iface);
 
 static void gnc_embedded_window_setup_window (GncEmbeddedWindow *window);
-
 
 /** The instance private data for an embedded window object. */
 typedef struct GncEmbeddedWindowPrivate
@@ -87,50 +85,13 @@ typedef struct GncEmbeddedWindowPrivate
     GtkWidget *parent_window;
 } GncEmbeddedWindowPrivate;
 
+GNC_DEFINE_TYPE_WITH_CODE(GncEmbeddedWindow, gnc_embedded_window, GTK_TYPE_BOX,
+                        G_ADD_PRIVATE(GncEmbeddedWindow)
+                        G_IMPLEMENT_INTERFACE(GNC_TYPE_WINDOW,
+                                              gnc_window_embedded_window_init))
+
 #define GNC_EMBEDDED_WINDOW_GET_PRIVATE(o)  \
    (G_TYPE_INSTANCE_GET_PRIVATE ((o), GNC_TYPE_EMBEDDED_WINDOW, GncEmbeddedWindowPrivate))
-
-
-
-/*  Get the type of a gnc embedded window. */
-GType
-gnc_embedded_window_get_type (void)
-{
-    static GType gnc_embedded_window_type = 0;
-
-    if (gnc_embedded_window_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncEmbeddedWindowClass),
-            NULL,
-            NULL,
-            (GClassInitFunc) gnc_embedded_window_class_init,
-            NULL,
-            NULL,
-            sizeof (GncEmbeddedWindow),
-            0,
-            (GInstanceInitFunc) gnc_embedded_window_init
-        };
-
-        static const GInterfaceInfo plugin_info =
-        {
-            (GInterfaceInitFunc) gnc_window_embedded_window_init,
-            NULL,
-            NULL
-        };
-
-        gnc_embedded_window_type = g_type_register_static (GTK_TYPE_BOX,
-                                   "GncEmbeddedWindow",
-                                   &our_info, 0);
-        g_type_add_interface_static (gnc_embedded_window_type,
-                                     GNC_TYPE_WINDOW,
-                                     &plugin_info);
-    }
-
-    return gnc_embedded_window_type;
-}
-
 
 /*  Display a data plugin page in a window. */
 void
@@ -218,8 +179,7 @@ gnc_embedded_window_class_init (GncEmbeddedWindowClass *klass)
 
     object_class->finalize = gnc_embedded_window_finalize;
     object_class->dispose = gnc_embedded_window_dispose;
-
-    g_type_class_add_private(klass, sizeof(GncEmbeddedWindowPrivate));
+    
     LEAVE(" ");
 }
 
@@ -241,12 +201,12 @@ gnc_embedded_window_init (GncEmbeddedWindow *window,
     gtk_orientable_set_orientation (GTK_ORIENTABLE(window), GTK_ORIENTATION_VERTICAL);
 
     // Set the style context for this widget so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(window), "GncEmbededWindow");
+    gnc_widget_set_style_context (GTK_WIDGET(window), "GncEmbeddedWindow");
 
     gnc_embedded_window_setup_window (window);
 
-    gnc_gobject_tracking_remember(G_OBJECT(window),
-                                  G_OBJECT_CLASS(klass));
+    gnc_gobject_tracking_remember(G_OBJECT(window), 
+		                  G_OBJECT_CLASS(klass));
     LEAVE(" ");
 }
 

--- a/gnucash/gnome-utils/gnc-gobject-utils.h
+++ b/gnucash/gnome-utils/gnc-gobject-utils.h
@@ -109,14 +109,20 @@ void gnc_gobject_tracking_dump (void);
 
 /** @} */
 
-
+/** Some macros derived from glib type macros.
+ * In glib type_name##init function only has one parameter. We need
+ * the 2nd class parameter in certain calls. The main difference is
+ * static void     type_name##_init         (TypeName        *self, void *class);
+ * instead of
+ * static void     type_name##_init         (TypeName        *self);
+ * this code may need updating in future releases as glib changes.
+ **/
 #define GNC_IMPLEMENT_INTERFACE(TYPE_IFACE, iface_init)       { \
   const GInterfaceInfo g_implement_interface_info = { \
       (GInterfaceInitFunc)(void (*)(void *, void *)) iface_init, NULL, NULL    \
   }; \
   g_type_add_interface_static (g_define_type_id, TYPE_IFACE, &g_implement_interface_info); \
 }
-
 
 #define GNC_DEFINE_TYPE_WITH_CODE(TN, t_n, T_P, _C_)            _GNC_DEFINE_TYPE_EXTENDED_BEGIN (TN, t_n, T_P, 0) {_C_;} _GNC_DEFINE_TYPE_EXTENDED_END()
 
@@ -158,7 +164,6 @@ type_name##_get_type (void) \
     }                                   \
   return g_define_type_id__volatile;    \
 } /* closes type_name##_get_type() */
-
 
 
 #endif /* GNC_GOBJECT_UTILS_H */

--- a/gnucash/gnome-utils/gnc-gobject-utils.h
+++ b/gnucash/gnome-utils/gnc-gobject-utils.h
@@ -110,6 +110,37 @@ void gnc_gobject_tracking_dump (void);
 /** @} */
 
 
+
+#define GNC_DEFINE_TYPE_WITH_CODE(TN, t_n, T_P, _C_)            _GNC_DEFINE_TYPE_EXTENDED_BEGIN (TN, t_n, T_P, 0) {_C_;} _G_DEFINE_TYPE_EXTENDED_END()
+
+#define _GNC_DEFINE_TYPE_EXTENDED_BEGIN_PRE(TypeName, type_name, TYPE_PARENT) \
+\
+static void     type_name##_init              (TypeName        *self, TypeName##Class *klass); \
+static void     type_name##_class_init        (TypeName##Class *klass); \
+static GType    type_name##_get_type_once     (void); \
+static gpointer type_name##_parent_class = NULL; \
+static gint     TypeName##_private_offset; \
+\
+_G_DEFINE_TYPE_EXTENDED_CLASS_INIT(TypeName, type_name) \
+\
+G_GNUC_UNUSED \
+static inline gpointer \
+type_name##_get_instance_private (TypeName *self) \
+{ \
+  return (G_STRUCT_MEMBER_P (self, TypeName##_private_offset)); \
+} \
+\
+GType \
+type_name##_get_type (void) \
+{ \
+  static volatile gsize g_define_type_id__volatile = 0;
+  /* Prelude goes here */
+
+#define _GNC_DEFINE_TYPE_EXTENDED_BEGIN(TypeName, type_name, TYPE_PARENT, flags) \
+  _GNC_DEFINE_TYPE_EXTENDED_BEGIN_PRE(TypeName, type_name, TYPE_PARENT) \
+  _G_DEFINE_TYPE_EXTENDED_BEGIN_REGISTER(TypeName, type_name, TYPE_PARENT, flags) \
+
+
 #endif /* GNC_GOBJECT_UTILS_H */
 /** @} */
 /** @} */

--- a/gnucash/gnome-utils/gnc-main-window.c
+++ b/gnucash/gnome-utils/gnc-main-window.c
@@ -129,7 +129,7 @@ static guint secs_to_save = 0;
 
 /* Declarations *********************************************************/
 static void gnc_main_window_class_init (GncMainWindowClass *klass);
-static void gnc_main_window_init (GncMainWindow *window, GncMainWindowClass *klass);
+static void gnc_main_window_init (GncMainWindow *window);
 static void gnc_main_window_finalize (GObject *object);
 static void gnc_main_window_destroy (GtkWidget *widget);
 
@@ -2461,46 +2461,10 @@ gnc_main_window_tab_entry_key_press_event (GtkWidget *entry,
  *                   Widget Implementation                  *
  ************************************************************/
 
-/*  Get the type of a gnc main window.
- */
-GType
-gnc_main_window_get_type (void)
-{
-    static GType gnc_main_window_type = 0;
-
-    if (gnc_main_window_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncMainWindowClass),
-            NULL,
-            NULL,
-            (GClassInitFunc) gnc_main_window_class_init,
-            NULL,
-            NULL,
-            sizeof (GncMainWindow),
-            0,
-            (GInstanceInitFunc) gnc_main_window_init
-        };
-
-        static const GInterfaceInfo plugin_info =
-        {
-            (GInterfaceInitFunc) gnc_window_main_window_init,
-            NULL,
-            NULL
-        };
-
-        gnc_main_window_type = g_type_register_static (GTK_TYPE_WINDOW,
-                               GNC_MAIN_WINDOW_NAME,
-                               &our_info, 0);
-        g_type_add_interface_static (gnc_main_window_type,
-                                     GNC_TYPE_WINDOW,
-                                     &plugin_info);
-    }
-
-    return gnc_main_window_type;
-}
-
+G_DEFINE_TYPE_WITH_CODE(GncMainWindow, gnc_main_window, GTK_TYPE_WINDOW,
+                        G_ADD_PRIVATE (GncMainWindow)
+                        G_IMPLEMENT_INTERFACE (GNC_TYPE_WINDOW,
+		                               gnc_window_main_window_init))
 
 /** Initialize the class for a new gnucash main window.  This will set
  *  up any function pointers that override functions in the parent
@@ -2523,8 +2487,6 @@ gnc_main_window_class_init (GncMainWindowClass *klass)
 
     /* GtkWidget signals */
     gtkwidget_class->destroy = gnc_main_window_destroy;
-
-    g_type_class_add_private(klass, sizeof(GncMainWindowPrivate));
 
     /**
      * GncMainWindow::page_added:
@@ -2593,8 +2555,7 @@ gnc_main_window_class_init (GncMainWindowClass *klass)
  *  @param klass A pointer to the class data structure for this
  *  object. */
 static void
-gnc_main_window_init (GncMainWindow *window,
-                      GncMainWindowClass *klass)
+gnc_main_window_init (GncMainWindow *window)
 {
     GncMainWindowPrivate *priv;
 
@@ -2618,8 +2579,7 @@ gnc_main_window_init (GncMainWindow *window,
                            window);
 
     gnc_main_window_setup_window (window);
-    gnc_gobject_tracking_remember(G_OBJECT(window),
-                                  G_OBJECT_CLASS(klass));
+    gnc_gobject_tracking_remember(G_OBJECT(window), NULL);
 }
 
 

--- a/gnucash/gnome-utils/gnc-main-window.c
+++ b/gnucash/gnome-utils/gnc-main-window.c
@@ -129,7 +129,8 @@ static guint secs_to_save = 0;
 
 /* Declarations *********************************************************/
 static void gnc_main_window_class_init (GncMainWindowClass *klass);
-static void gnc_main_window_init (GncMainWindow *window);
+static void gnc_main_window_init (GncMainWindow *window,
+		                  void *data);
 static void gnc_main_window_finalize (GObject *object);
 static void gnc_main_window_destroy (GtkWidget *widget);
 
@@ -232,6 +233,11 @@ typedef struct GncMainWindowPrivate
      *  MergedActionEntry. */
     GHashTable *merged_actions_table;
 } GncMainWindowPrivate;
+
+GNC_DEFINE_TYPE_WITH_CODE(GncMainWindow, gnc_main_window, GTK_TYPE_WINDOW,
+                        G_ADD_PRIVATE (GncMainWindow)
+                        G_IMPLEMENT_INTERFACE (GNC_TYPE_WINDOW,
+		                               gnc_window_main_window_init))
 
 #define GNC_MAIN_WINDOW_GET_PRIVATE(o)  \
    (G_TYPE_INSTANCE_GET_PRIVATE ((o), GNC_TYPE_MAIN_WINDOW, GncMainWindowPrivate))
@@ -2461,10 +2467,7 @@ gnc_main_window_tab_entry_key_press_event (GtkWidget *entry,
  *                   Widget Implementation                  *
  ************************************************************/
 
-G_DEFINE_TYPE_WITH_CODE(GncMainWindow, gnc_main_window, GTK_TYPE_WINDOW,
-                        G_ADD_PRIVATE (GncMainWindow)
-                        G_IMPLEMENT_INTERFACE (GNC_TYPE_WINDOW,
-		                               gnc_window_main_window_init))
+
 
 /** Initialize the class for a new gnucash main window.  This will set
  *  up any function pointers that override functions in the parent
@@ -2555,9 +2558,11 @@ gnc_main_window_class_init (GncMainWindowClass *klass)
  *  @param klass A pointer to the class data structure for this
  *  object. */
 static void
-gnc_main_window_init (GncMainWindow *window)
+gnc_main_window_init (GncMainWindow *window, void *data)
 {
     GncMainWindowPrivate *priv;
+
+    GncMainWindowClass *klass = (GncMainWindowClass*)data;
 
     priv = GNC_MAIN_WINDOW_GET_PRIVATE(window);
     priv->merged_actions_table =
@@ -2579,7 +2584,8 @@ gnc_main_window_init (GncMainWindow *window)
                            window);
 
     gnc_main_window_setup_window (window);
-    gnc_gobject_tracking_remember(G_OBJECT(window), NULL);
+    gnc_gobject_tracking_remember(G_OBJECT(window),
+		                  G_OBJECT_CLASS(klass));
 }
 
 

--- a/gnucash/gnome-utils/gnc-period-select.c
+++ b/gnucash/gnome-utils/gnc-period-select.c
@@ -502,38 +502,6 @@ gnc_period_select_set_property (GObject      *object,
 /** @name GncPeriodSelect Core Implementation
  @{ */
 
-/*  Returns the GType of a GncPeriodSelect widget.
- */
-GType
-gnc_period_select_get_type (void)
-{
-    static GType period_select_type = 0;
-
-    if (period_select_type == 0)
-    {
-        static const GTypeInfo period_select_info =
-        {
-            sizeof (GncPeriodSelectClass),
-            NULL,
-            NULL,
-            (GClassInitFunc) gnc_period_select_class_init,
-            NULL,
-            NULL,
-            sizeof (GncPeriodSelect),
-            0, /* n_preallocs */
-            (GInstanceInitFunc) gnc_period_select_init,
-            NULL
-        };
-
-        period_select_type = g_type_register_static(GTK_TYPE_BOX,
-                             "GncPeriodSelect",
-                             &period_select_info, 0);
-    }
-
-    return period_select_type;
-}
-
-
 /** Initialize the class for the a Period Selection widget.  This
  *  will set up any function pointers that override functions in the
  *  parent class, and also installs the proprieties that are unique to
@@ -594,10 +562,9 @@ gnc_period_select_class_init (GncPeriodSelectClass *klass)
                                             G_MAXINT,
                                             0,
                                             G_PARAM_READWRITE));
-
-    g_type_class_add_private(klass, sizeof(GncPeriodSelectPrivate));
 }
 
+G_DEFINE_TYPE_WITH_PRIVATE(GncPeriodSelect, gnc_period_select, GTK_TYPE_BOX)
 
 /** Initialize a new instance of a gnucash accounting period selection
  *  widget.  This function allocates and initializes the object

--- a/gnucash/gnome-utils/gnc-plugin-file-history.c
+++ b/gnucash/gnome-utils/gnc-plugin-file-history.c
@@ -518,37 +518,6 @@ gnc_plugin_history_list_changed (gpointer prefs,
  *                  Object Implementation                   *
  ************************************************************/
 
-/*  Get the type of a file history plugin.  */
-GType
-gnc_plugin_file_history_get_type (void)
-{
-    static GType gnc_plugin_file_history_type = 0;
-
-    if (gnc_plugin_file_history_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncPluginFileHistoryClass),
-            NULL,		/* base_init */
-            NULL,		/* base_finalize */
-            (GClassInitFunc) gnc_plugin_file_history_class_init,
-            NULL,		/* class_finalize */
-            NULL,		/* class_data */
-            sizeof (GncPluginFileHistory),
-            0,
-            (GInstanceInitFunc) gnc_plugin_file_history_init
-        };
-
-        gnc_plugin_file_history_type =
-            g_type_register_static (GNC_TYPE_PLUGIN,
-                                    "GncPluginFileHistory",
-                                    &our_info, 0);
-    }
-
-    return gnc_plugin_file_history_type;
-}
-
-
 /** Initialize the file history plugin class. */
 static void
 gnc_plugin_file_history_class_init (GncPluginFileHistoryClass *klass)
@@ -573,10 +542,9 @@ gnc_plugin_file_history_class_init (GncPluginFileHistoryClass *klass)
     plugin_class->actions       = gnc_plugin_actions;
     plugin_class->n_actions     = gnc_plugin_n_actions;
     plugin_class->ui_filename   = PLUGIN_UI_FILENAME;
-
-    g_type_class_add_private(klass, sizeof(GncPluginFileHistoryPrivate));
 }
 
+G_DEFINE_TYPE_WITH_PRIVATE(GncPluginFileHistory, gnc_plugin_file_history, GNC_TYPE_PLUGIN)
 
 /** Initialize an instance of the file history plugin. */
 static void

--- a/gnucash/gnome-utils/gnc-plugin-manager.c
+++ b/gnucash/gnome-utils/gnc-plugin-manager.c
@@ -59,34 +59,6 @@ static GncPluginManager *singleton = NULL;
 
 static GObjectClass *parent_class = NULL;
 
-GType
-gnc_plugin_manager_get_type (void)
-{
-    static GType gnc_plugin_manager_type = 0;
-
-    if (gnc_plugin_manager_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncPluginManagerClass),
-            NULL,
-            NULL,
-            (GClassInitFunc) gnc_plugin_manager_class_init,
-            NULL,
-            NULL,
-            sizeof (GncPluginManager),
-            0,
-            (GInstanceInitFunc) gnc_plugin_manager_init
-        };
-
-        gnc_plugin_manager_type = g_type_register_static (G_TYPE_OBJECT,
-                                  "GncPluginManager",
-                                  &our_info, 0);
-    }
-
-    return gnc_plugin_manager_type;
-}
-
 GncPluginManager *
 gnc_plugin_manager_get (void)
 {
@@ -179,6 +151,7 @@ gnc_plugin_manager_get_plugin (GncPluginManager *manager,
     return GNC_PLUGIN (g_hash_table_lookup (priv->plugins_table, name));
 }
 
+G_DEFINE_TYPE_WITH_PRIVATE(GncPluginManager, gnc_plugin_manager, G_TYPE_OBJECT)
 
 static void
 gnc_plugin_manager_class_init (GncPluginManagerClass *klass)
@@ -189,8 +162,6 @@ gnc_plugin_manager_class_init (GncPluginManagerClass *klass)
 
     object_class->dispose = gnc_plugin_manager_dispose;
     object_class->finalize = gnc_plugin_manager_finalize;
-
-    g_type_class_add_private(klass, sizeof(GncPluginManagerPrivate));
 
     signals[PLUGIN_ADDED] = g_signal_new ("plugin-added",
                                           G_OBJECT_CLASS_TYPE (klass),

--- a/gnucash/gnome-utils/gnc-plugin-menu-additions.c
+++ b/gnucash/gnome-utils/gnc-plugin-menu-additions.c
@@ -89,33 +89,7 @@ typedef struct _GncPluginMenuAdditionsPerWindow
  *                  Object Implementation                   *
  ************************************************************/
 
-GType
-gnc_plugin_menu_additions_get_type (void)
-{
-    static GType gnc_plugin_menu_additions_type = 0;
-
-    if (gnc_plugin_menu_additions_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncPluginMenuAdditionsClass),
-            NULL,		/* base_init */
-            NULL,		/* base_finalize */
-            (GClassInitFunc) gnc_plugin_menu_additions_class_init,
-            NULL,		/* class_finalize */
-            NULL,		/* class_data */
-            sizeof (GncPluginMenuAdditions),
-            0,
-            (GInstanceInitFunc) gnc_plugin_menu_additions_init
-        };
-
-        gnc_plugin_menu_additions_type = g_type_register_static (GNC_TYPE_PLUGIN,
-                                         "GncPluginMenuAdditions",
-                                         &our_info, 0);
-    }
-
-    return gnc_plugin_menu_additions_type;
-}
+G_DEFINE_TYPE_WITH_PRIVATE(GncPluginMenuAdditions, gnc_plugin_menu_additions, GNC_TYPE_PLUGIN)
 
 static void
 gnc_plugin_menu_additions_class_init (GncPluginMenuAdditionsClass *klass)
@@ -133,8 +107,6 @@ gnc_plugin_menu_additions_class_init (GncPluginMenuAdditionsClass *klass)
     /* function overrides */
     plugin_class->add_to_window = gnc_plugin_menu_additions_add_to_window;
     plugin_class->remove_from_window = gnc_plugin_menu_additions_remove_from_window;
-
-    g_type_class_add_private(klass, sizeof(GncPluginMenuAdditionsPrivate));
 }
 
 static void

--- a/gnucash/gnome-utils/gnc-plugin-page.c
+++ b/gnucash/gnome-utils/gnc-plugin-page.c
@@ -46,8 +46,7 @@ static QofLogModule log_module = GNC_MOD_GUI;
 static gpointer parent_class = NULL;
 
 static void gnc_plugin_page_class_init (GncPluginPageClass *klass);
-static void gnc_plugin_page_init       (GncPluginPage *plugin_page,
-                                        GncPluginPageClass *klass);
+static void gnc_plugin_page_init       (GncPluginPage *plugin_page);
 static void gnc_plugin_page_finalize   (GObject *object);
 static void gnc_plugin_page_set_property (GObject         *object,
         guint            prop_id,
@@ -106,36 +105,6 @@ typedef struct _GncPluginPagePrivate
 
 #define GNC_PLUGIN_PAGE_GET_PRIVATE(o)  \
    (G_TYPE_INSTANCE_GET_PRIVATE ((o), GNC_TYPE_PLUGIN_PAGE, GncPluginPagePrivate))
-
-GType
-gnc_plugin_page_get_type (void)
-{
-    static GType gnc_plugin_page_type = 0;
-
-    if (gnc_plugin_page_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-
-            sizeof (GncPluginPageClass),
-            NULL,		/* base_init */
-            NULL,		/* base_finalize */
-            (GClassInitFunc) gnc_plugin_page_class_init,
-            NULL,		/* class_finalize */
-            NULL,		/* class_data */
-            sizeof (GncPluginPage),
-            0,		/* n_preallocs */
-            (GInstanceInitFunc) gnc_plugin_page_init,
-        };
-
-        gnc_plugin_page_type = g_type_register_static (G_TYPE_OBJECT,
-                               "GncPluginPage",
-                               &our_info, 0);
-    }
-
-    return gnc_plugin_page_type;
-}
-
 
 /*  Create the display widget that corresponds to this plugin.  This
  *  function will be called by the main/embedded window manipulation
@@ -379,6 +348,7 @@ gnc_plugin_page_unselected (GncPluginPage *plugin_page)
     g_signal_emit (G_OBJECT (plugin_page), signals[UNSELECTED], 0);
 }
 
+G_DEFINE_TYPE_WITH_PRIVATE(GncPluginPage, gnc_plugin_page, G_TYPE_OBJECT)
 
 /** Initialize the class for a new generic plugin page.  This will set
  *  up any function pointers that override functions in the parent
@@ -399,8 +369,6 @@ gnc_plugin_page_class_init (GncPluginPageClass *klass)
 
     klass->tab_icon    = NULL;
     klass->plugin_name = NULL;
-
-    g_type_class_add_private(klass, sizeof(GncPluginPagePrivate));
 
     g_object_class_install_property
     (gobject_class,
@@ -533,7 +501,7 @@ gnc_plugin_page_class_init (GncPluginPageClass *klass)
  *  @param klass A pointer to the class data structure for this
  *  object. */
 static void
-gnc_plugin_page_init (GncPluginPage *page, GncPluginPageClass *klass)
+gnc_plugin_page_init (GncPluginPage *page)
 {
     GncPluginPagePrivate *priv;
 
@@ -545,7 +513,7 @@ gnc_plugin_page_init (GncPluginPage *page, GncPluginPageClass *klass)
     page->window      = NULL;
     page->summarybar  = NULL;
 
-    gnc_gobject_tracking_remember(G_OBJECT(page), G_OBJECT_CLASS(klass));
+    gnc_gobject_tracking_remember(G_OBJECT(page), NULL);
 }
 
 

--- a/gnucash/gnome-utils/gnc-plugin-page.c
+++ b/gnucash/gnome-utils/gnc-plugin-page.c
@@ -46,7 +46,8 @@ static QofLogModule log_module = GNC_MOD_GUI;
 static gpointer parent_class = NULL;
 
 static void gnc_plugin_page_class_init (GncPluginPageClass *klass);
-static void gnc_plugin_page_init       (GncPluginPage *plugin_page);
+static void gnc_plugin_page_init       (GncPluginPage *plugin_page,
+		                        void *data);
 static void gnc_plugin_page_finalize   (GObject *object);
 static void gnc_plugin_page_set_property (GObject         *object,
         guint            prop_id,
@@ -102,6 +103,9 @@ typedef struct _GncPluginPagePrivate
     gchar *uri;
     gchar *statusbar_text;
 } GncPluginPagePrivate;
+
+GNC_DEFINE_TYPE_WITH_CODE(GncPluginPage, gnc_plugin_page, G_TYPE_OBJECT,
+		        G_ADD_PRIVATE(GncPluginPage))
 
 #define GNC_PLUGIN_PAGE_GET_PRIVATE(o)  \
    (G_TYPE_INSTANCE_GET_PRIVATE ((o), GNC_TYPE_PLUGIN_PAGE, GncPluginPagePrivate))
@@ -348,8 +352,6 @@ gnc_plugin_page_unselected (GncPluginPage *plugin_page)
     g_signal_emit (G_OBJECT (plugin_page), signals[UNSELECTED], 0);
 }
 
-G_DEFINE_TYPE_WITH_PRIVATE(GncPluginPage, gnc_plugin_page, G_TYPE_OBJECT)
-
 /** Initialize the class for a new generic plugin page.  This will set
  *  up any function pointers that override functions in the parent
  *  class, set up all properties and signals, and also configure the
@@ -501,9 +503,11 @@ gnc_plugin_page_class_init (GncPluginPageClass *klass)
  *  @param klass A pointer to the class data structure for this
  *  object. */
 static void
-gnc_plugin_page_init (GncPluginPage *page)
+gnc_plugin_page_init (GncPluginPage *page, void *data)
 {
     GncPluginPagePrivate *priv;
+    
+    GncPluginPageClass *klass = (GncPluginPageClass*)data;
 
     priv = GNC_PLUGIN_PAGE_GET_PRIVATE(page);
     priv->page_name   = NULL;
@@ -513,7 +517,8 @@ gnc_plugin_page_init (GncPluginPage *page)
     page->window      = NULL;
     page->summarybar  = NULL;
 
-    gnc_gobject_tracking_remember(G_OBJECT(page), NULL);
+    gnc_gobject_tracking_remember(G_OBJECT(page), 
+		                  G_OBJECT_CLASS(klass));
 }
 
 

--- a/gnucash/gnome-utils/gnc-plugin.c
+++ b/gnucash/gnome-utils/gnc-plugin.c
@@ -49,7 +49,8 @@ static QofLogModule log_module = GNC_MOD_GUI;
 static gpointer parent_class = NULL;
 
 static void gnc_plugin_class_init (GncPluginClass *klass);
-static void gnc_plugin_init       (GncPlugin *plugin_page);
+static void gnc_plugin_init       (GncPlugin *plugin_page,
+                                   GncPluginClass *klass);
 static void gnc_plugin_finalize   (GObject *object);
 
 
@@ -91,9 +92,10 @@ gnc_plugin_class_init (GncPluginClass *klass)
  *  @param klass A pointer to the class data structure for this
  *  object. */
 static void
-gnc_plugin_init (GncPlugin *plugin_page)
+gnc_plugin_init (GncPlugin *plugin_page, GncPluginClass *klass)
 {
-    gnc_gobject_tracking_remember(G_OBJECT(plugin_page), NULL);
+    gnc_gobject_tracking_remember(G_OBJECT(plugin_page), \
+                                  G_OBJECT_CLASS(klass));
 }
 
 

--- a/gnucash/gnome-utils/gnc-plugin.c
+++ b/gnucash/gnome-utils/gnc-plugin.c
@@ -49,8 +49,7 @@ static QofLogModule log_module = GNC_MOD_GUI;
 static gpointer parent_class = NULL;
 
 static void gnc_plugin_class_init (GncPluginClass *klass);
-static void gnc_plugin_init       (GncPlugin *plugin_page,
-                                   GncPluginClass *klass);
+static void gnc_plugin_init       (GncPlugin *plugin_page);
 static void gnc_plugin_finalize   (GObject *object);
 
 
@@ -64,37 +63,7 @@ typedef struct GncPluginPrivate
 #define GNC_PLUGIN_GET_PRIVATE(o)  \
    (G_TYPE_INSTANCE_GET_PRIVATE ((o), GNC_TYPE_PLUGIN, GncPluginPrivate))
 
-
-/** Get the type of a gnc window plugin.
- */
-GType
-gnc_plugin_get_type (void)
-{
-    static GType gnc_plugin_type = 0;
-
-    if (gnc_plugin_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncPluginClass),
-            NULL,		/* base_init */
-            NULL,		/* base_finalize */
-            (GClassInitFunc) gnc_plugin_class_init,
-            NULL,		/* class_finalize */
-            NULL,		/* class_data */
-            sizeof (GncPlugin),
-            0,		/* n_preallocs */
-            (GInstanceInitFunc) gnc_plugin_init,
-        };
-
-        gnc_plugin_type = g_type_register_static (G_TYPE_OBJECT,
-                          GNC_PLUGIN_NAME,
-                          &our_info, 0);
-    }
-
-    return gnc_plugin_type;
-}
-
+G_DEFINE_TYPE_WITH_PRIVATE(GncPlugin, gnc_plugin, G_TYPE_OBJECT)
 
 /** Initialize the class for the new gnucash plugin object.  This will
  *  set up any function pointers that override functions in the parent
@@ -110,8 +79,6 @@ gnc_plugin_class_init (GncPluginClass *klass)
 
     parent_class = g_type_class_peek_parent (klass);
     gobject_class->finalize = gnc_plugin_finalize;
-
-    g_type_class_add_private(klass, sizeof(GncPluginPrivate));
 }
 
 
@@ -124,10 +91,9 @@ gnc_plugin_class_init (GncPluginClass *klass)
  *  @param klass A pointer to the class data structure for this
  *  object. */
 static void
-gnc_plugin_init (GncPlugin *plugin_page, GncPluginClass *klass)
+gnc_plugin_init (GncPlugin *plugin_page)
 {
-    gnc_gobject_tracking_remember(G_OBJECT(plugin_page), \
-                                  G_OBJECT_CLASS(klass));
+    gnc_gobject_tracking_remember(G_OBJECT(plugin_page), NULL);
 }
 
 

--- a/gnucash/gnome-utils/gnc-plugin.c
+++ b/gnucash/gnome-utils/gnc-plugin.c
@@ -50,7 +50,7 @@ static gpointer parent_class = NULL;
 
 static void gnc_plugin_class_init (GncPluginClass *klass);
 static void gnc_plugin_init       (GncPlugin *plugin_page,
-                                   GncPluginClass *klass);
+                                   void *data);
 static void gnc_plugin_finalize   (GObject *object);
 
 
@@ -61,10 +61,11 @@ typedef struct GncPluginPrivate
     gpointer dummy;
 } GncPluginPrivate;
 
+GNC_DEFINE_TYPE_WITH_CODE(GncPlugin, gnc_plugin, G_TYPE_OBJECT,
+		        G_ADD_PRIVATE(GncPlugin))
+
 #define GNC_PLUGIN_GET_PRIVATE(o)  \
    (G_TYPE_INSTANCE_GET_PRIVATE ((o), GNC_TYPE_PLUGIN, GncPluginPrivate))
-
-G_DEFINE_TYPE_WITH_PRIVATE(GncPlugin, gnc_plugin, G_TYPE_OBJECT)
 
 /** Initialize the class for the new gnucash plugin object.  This will
  *  set up any function pointers that override functions in the parent
@@ -92,8 +93,10 @@ gnc_plugin_class_init (GncPluginClass *klass)
  *  @param klass A pointer to the class data structure for this
  *  object. */
 static void
-gnc_plugin_init (GncPlugin *plugin_page, GncPluginClass *klass)
+gnc_plugin_init (GncPlugin *plugin_page, void *data)
 {
+    GncPluginClass *klass = (GncPluginClass*)data;
+
     gnc_gobject_tracking_remember(G_OBJECT(plugin_page), \
                                   G_OBJECT_CLASS(klass));
 }

--- a/gnucash/gnome-utils/gnc-query-view.c
+++ b/gnucash/gnome-utils/gnc-query-view.c
@@ -44,16 +44,16 @@ enum
     LAST_SIGNAL
 };
 
-typedef struct _GNCQueryViewPriv GNCQueryViewPriv;
+typedef struct _GNCQueryViewPrivate GNCQueryViewPrivate;
 
-struct _GNCQueryViewPriv
+struct _GNCQueryViewPrivate
 {
     const QofParam *get_guid;
     gint        component_id;
 };
 
 #define GNC_QUERY_VIEW_GET_PRIVATE(o)  \
-   (G_TYPE_INSTANCE_GET_PRIVATE ((o), GNC_TYPE_QUERY_VIEW, GNCQueryViewPriv))
+   (G_TYPE_INSTANCE_GET_PRIVATE ((o), GNC_TYPE_QUERY_VIEW, GNCQueryViewPrivate))
 
 /** Static Globals ****************************************************/
 static GtkTreeViewClass *parent_class = NULL;
@@ -76,34 +76,6 @@ static void gnc_query_view_fill (GNCQueryView *qview);
 static void gnc_query_view_set_query_sort (GNCQueryView *qview, gboolean new_column);
 
 
-GType
-gnc_query_view_get_type (void)
-{
-    static GType gnc_query_view_type = 0;
-
-    if (!gnc_query_view_type)
-    {
-        GTypeInfo type_info =
-        {
-            sizeof(GNCQueryViewClass), /* class_size */
-            NULL,                      /* base_init */
-            NULL,                      /* base_finalize */
-            (GClassInitFunc)gnc_query_view_class_init,
-            NULL,                      /* class_finalize */
-            NULL,                      /* class_data */
-            sizeof (GNCQueryView),     /* */
-            0,                         /* n_preallocs */
-            (GInstanceInitFunc)gnc_query_view_init,
-        };
-
-        gnc_query_view_type = g_type_register_static (GTK_TYPE_TREE_VIEW,
-                              "GNCQueryView",
-                              &type_info, 0);
-    }
-    return gnc_query_view_type;
-}
-
-
 /********************************************************************\
  * gnc_query_view_new                                               *
  *   creates the query view                                         *
@@ -115,7 +87,7 @@ gnc_query_view_get_type (void)
 void
 gnc_query_view_construct (GNCQueryView *qview, GList *param_list, Query *query)
 {
-    GNCQueryViewPriv *priv;
+    GNCQueryViewPrivate *priv;
 
     g_return_if_fail (qview);
     g_return_if_fail (param_list);
@@ -212,11 +184,12 @@ gnc_query_view_refresh_handler (GHashTable *changes, gpointer user_data)
     gnc_query_view_set_query_sort (qview, TRUE);
 }
 
+G_DEFINE_TYPE_WITH_PRIVATE(GNCQueryView, gnc_query_view, GTK_TYPE_TREE_VIEW)
 
 static void
 gnc_query_view_init (GNCQueryView *qview)
 {
-    GNCQueryViewPriv *priv;
+    GNCQueryViewPrivate *priv;
 
     // Set the style context for this dialog so it can be easily manipulated with css
     gnc_widget_set_style_context (GTK_WIDGET(qview), "GncQueryView");
@@ -428,8 +401,6 @@ gnc_query_view_class_init (GNCQueryViewClass *klass)
 
     parent_class = g_type_class_peek (GTK_TYPE_TREE_VIEW);
 
-    g_type_class_add_private (klass, sizeof(GNCQueryViewPriv));
-
     query_view_signals[COLUMN_TOGGLED] =
         g_signal_new("column_toggled",
                      G_TYPE_FROM_CLASS (widget_class),
@@ -543,7 +514,7 @@ static void
 gnc_query_view_destroy (GtkWidget *widget)
 {
     GNCQueryView     *qview = GNC_QUERY_VIEW (widget);
-    GNCQueryViewPriv *priv;
+    GNCQueryViewPrivate *priv;
 
     priv = GNC_QUERY_VIEW_GET_PRIVATE (qview);
     if (priv->component_id > 0)
@@ -765,7 +736,7 @@ gnc_query_view_set_query_sort (GNCQueryView *qview, gboolean new_column)
 static void
 gnc_query_view_fill (GNCQueryView *qview)
 {
-    GNCQueryViewPriv *priv;
+    GNCQueryViewPrivate *priv;
     GtkTreeModel     *model;
     GtkTreeIter       iter;
     GList            *entries, *item;

--- a/gnucash/gnome-utils/gnc-tree-model-account-types.c
+++ b/gnucash/gnome-utils/gnc-tree-model-account-types.c
@@ -61,44 +61,10 @@ typedef struct GncTreeModelAccountTypesPrivate
 
 static GObjectClass *parent_class = NULL;
 
-GType
-gnc_tree_model_account_types_get_type (void)
-{
-    static GType gnc_tree_model_account_types_type = 0;
-
-    if (gnc_tree_model_account_types_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncTreeModelAccountTypesClass),
-            NULL,
-            NULL,
-            (GClassInitFunc) gnc_tree_model_account_types_class_init,
-            NULL,
-            NULL,
-            sizeof (GncTreeModelAccountTypes),
-            0,
-            (GInstanceInitFunc) gnc_tree_model_account_types_init
-        };
-
-        static const GInterfaceInfo tree_model_info =
-        {
-            (GInterfaceInitFunc) gnc_tree_model_account_types_tree_model_init,
-            NULL,
-            NULL
-        };
-
-        gnc_tree_model_account_types_type =
-            g_type_register_static (G_TYPE_OBJECT,
-                                    "GncTreeModelAccountTypes",
-                                    &our_info, 0);
-
-        g_type_add_interface_static (gnc_tree_model_account_types_type,
-                                     GTK_TYPE_TREE_MODEL, &tree_model_info);
-    }
-
-    return gnc_tree_model_account_types_type;
-}
+G_DEFINE_TYPE_WITH_CODE(GncTreeModelAccountTypes, gnc_tree_model_account_types, G_TYPE_OBJECT,
+			G_ADD_PRIVATE(GncTreeModelAccountTypes)
+			G_IMPLEMENT_INTERFACE(GTK_TYPE_TREE_MODEL,
+					      gnc_tree_model_account_types_tree_model_init))
 
 static void
 gnc_tree_model_account_types_class_init (GncTreeModelAccountTypesClass * klass)
@@ -108,8 +74,6 @@ gnc_tree_model_account_types_class_init (GncTreeModelAccountTypesClass * klass)
     parent_class = g_type_class_peek_parent (klass);
 
     object_class->finalize = gnc_tree_model_account_types_finalize;
-
-    g_type_class_add_private(klass, sizeof(GncTreeModelAccountTypesPrivate));
 }
 
 static void

--- a/gnucash/gnome-utils/gnc-tree-model-account.c
+++ b/gnucash/gnome-utils/gnc-tree-model-account.c
@@ -144,44 +144,10 @@ gnc_tree_model_account_update_color (gpointer gsettings, gchar *key, gpointer us
 /** A pointer to the parent class of an account tree model. */
 static GObjectClass *parent_class = NULL;
 
-GType
-gnc_tree_model_account_get_type (void)
-{
-    static GType gnc_tree_model_account_type = 0;
-
-    if (gnc_tree_model_account_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncTreeModelAccountClass), /* class_size */
-            NULL,                              /* base_init */
-            NULL,                              /* base_finalize */
-            (GClassInitFunc) gnc_tree_model_account_class_init,
-            NULL,                              /* class_finalize */
-            NULL,                              /* class_data */
-            sizeof (GncTreeModelAccount),      /* */
-            0,                                 /* n_preallocs */
-            (GInstanceInitFunc) gnc_tree_model_account_init
-        };
-
-        static const GInterfaceInfo tree_model_info =
-        {
-            (GInterfaceInitFunc) gnc_tree_model_account_tree_model_init,
-            NULL,
-            NULL
-        };
-
-        gnc_tree_model_account_type = g_type_register_static (GNC_TYPE_TREE_MODEL,
-                                      GNC_TREE_MODEL_ACCOUNT_NAME,
-                                      &our_info, 0);
-
-        g_type_add_interface_static (gnc_tree_model_account_type,
-                                     GTK_TYPE_TREE_MODEL,
-                                     &tree_model_info);
-    }
-
-    return gnc_tree_model_account_type;
-}
+G_DEFINE_TYPE_WITH_CODE (GncTreeModelAccount, gnc_tree_model_account, GNC_TYPE_TREE_MODEL,
+                         G_ADD_PRIVATE (GncTreeModelAccount)
+                         G_IMPLEMENT_INTERFACE (GTK_TYPE_TREE_MODEL,
+                                                gnc_tree_model_account_tree_model_init))
 
 static void
 gnc_tree_model_account_class_init (GncTreeModelAccountClass *klass)
@@ -195,8 +161,6 @@ gnc_tree_model_account_class_init (GncTreeModelAccountClass *klass)
     /* GObject signals */
     o_class->finalize = gnc_tree_model_account_finalize;
     o_class->dispose = gnc_tree_model_account_dispose;
-
-    g_type_class_add_private(klass, sizeof(GncTreeModelAccountPrivate));
 }
 
 static void

--- a/gnucash/gnome-utils/gnc-tree-model-commodity.c
+++ b/gnucash/gnome-utils/gnc-tree-model-commodity.c
@@ -106,44 +106,10 @@ typedef struct GncTreeModelCommodityPrivate
 /** A pointer to the parent class of a commodity tree model. */
 static GObjectClass *parent_class = NULL;
 
-GType
-gnc_tree_model_commodity_get_type (void)
-{
-    static GType gnc_tree_model_commodity_type = 0;
-
-    if (gnc_tree_model_commodity_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncTreeModelCommodityClass),
-            NULL,
-            NULL,
-            (GClassInitFunc) gnc_tree_model_commodity_class_init,
-            NULL,
-            NULL,
-            sizeof (GncTreeModelCommodity),
-            0,
-            (GInstanceInitFunc) gnc_tree_model_commodity_init
-        };
-
-        static const GInterfaceInfo tree_model_info =
-        {
-            (GInterfaceInitFunc) gnc_tree_model_commodity_tree_model_init,
-            NULL,
-            NULL
-        };
-
-        gnc_tree_model_commodity_type = g_type_register_static (GNC_TYPE_TREE_MODEL,
-                                        GNC_TREE_MODEL_COMMODITY_NAME,
-                                        &our_info, 0);
-
-        g_type_add_interface_static (gnc_tree_model_commodity_type,
-                                     GTK_TYPE_TREE_MODEL,
-                                     &tree_model_info);
-    }
-
-    return gnc_tree_model_commodity_type;
-}
+G_DEFINE_TYPE_WITH_CODE(GncTreeModelCommodity, gnc_tree_model_commodity, GNC_TYPE_TREE_MODEL,
+                        G_ADD_PRIVATE(GncTreeModelCommodity)
+                        G_IMPLEMENT_INTERFACE(GTK_TYPE_TREE_MODEL,
+                                              gnc_tree_model_commodity_tree_model_init))
 
 static void
 gnc_tree_model_commodity_class_init (GncTreeModelCommodityClass *klass)
@@ -154,8 +120,6 @@ gnc_tree_model_commodity_class_init (GncTreeModelCommodityClass *klass)
 
     o_class->finalize = gnc_tree_model_commodity_finalize;
     o_class->dispose = gnc_tree_model_commodity_dispose;
-
-    g_type_class_add_private(klass, sizeof(GncTreeModelCommodityPrivate));
 }
 
 static void

--- a/gnucash/gnome-utils/gnc-tree-model-owner.c
+++ b/gnucash/gnome-utils/gnc-tree-model-owner.c
@@ -132,45 +132,6 @@ gnc_tree_model_owner_update_color (gpointer gsettings, gchar *key, gpointer user
 /** A pointer to the parent class of an owner tree model. */
 static GObjectClass *parent_class = NULL;
 
-GType
-gnc_tree_model_owner_get_type (void)
-{
-    static GType gnc_tree_model_owner_type = 0;
-
-    if (gnc_tree_model_owner_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncTreeModelOwnerClass), /* class_size */
-            NULL,                            /* base_init */
-            NULL,                            /* base_finalize */
-            (GClassInitFunc) gnc_tree_model_owner_class_init,
-            NULL,                            /* class_finalize */
-            NULL,                            /* class_data */
-            sizeof (GncTreeModelOwner),      /* */
-            0,                               /* n_preallocs */
-            (GInstanceInitFunc) gnc_tree_model_owner_init
-        };
-
-        static const GInterfaceInfo tree_model_info =
-        {
-            (GInterfaceInitFunc) gnc_tree_model_owner_tree_model_init,
-            NULL,
-            NULL
-        };
-
-        gnc_tree_model_owner_type = g_type_register_static (GNC_TYPE_TREE_MODEL,
-                                    GNC_TREE_MODEL_OWNER_NAME,
-                                    &our_info, 0);
-
-        g_type_add_interface_static (gnc_tree_model_owner_type,
-                                     GTK_TYPE_TREE_MODEL,
-                                     &tree_model_info);
-    }
-
-    return gnc_tree_model_owner_type;
-}
-
 static void
 gnc_tree_model_owner_class_init (GncTreeModelOwnerClass *klass)
 {
@@ -183,9 +144,12 @@ gnc_tree_model_owner_class_init (GncTreeModelOwnerClass *klass)
     /* GObject signals */
     o_class->finalize = gnc_tree_model_owner_finalize;
     o_class->dispose = gnc_tree_model_owner_dispose;
-
-    g_type_class_add_private(klass, sizeof(GncTreeModelOwnerPrivate));
 }
+
+G_DEFINE_TYPE_WITH_CODE(GncTreeModelOwner, gnc_tree_model_owner, GNC_TYPE_TREE_MODEL,
+		G_ADD_PRIVATE(GncTreeModelOwner)
+                G_IMPLEMENT_INTERFACE(GTK_TYPE_TREE_MODEL,
+                                      gnc_tree_model_owner_tree_model_init))
 
 static void
 gnc_tree_model_owner_init (GncTreeModelOwner *model)

--- a/gnucash/gnome-utils/gnc-tree-model-price.c
+++ b/gnucash/gnome-utils/gnc-tree-model-price.c
@@ -137,44 +137,10 @@ typedef struct GncTreeModelPricePrivate
 /** A pointer to the parent class of a price tree model. */
 static GObjectClass *parent_class = NULL;
 
-GType
-gnc_tree_model_price_get_type (void)
-{
-    static GType gnc_tree_model_price_type = 0;
-
-    if (gnc_tree_model_price_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncTreeModelPriceClass),
-            NULL,
-            NULL,
-            (GClassInitFunc) gnc_tree_model_price_class_init,
-            NULL,
-            NULL,
-            sizeof (GncTreeModelPrice),
-            0,
-            (GInstanceInitFunc) gnc_tree_model_price_init
-        };
-
-        static const GInterfaceInfo tree_model_info =
-        {
-            (GInterfaceInitFunc) gnc_tree_model_price_tree_model_init,
-            NULL,
-            NULL
-        };
-
-        gnc_tree_model_price_type = g_type_register_static (GNC_TYPE_TREE_MODEL,
-                                    GNC_TREE_MODEL_PRICE_NAME,
-                                    &our_info, 0);
-
-        g_type_add_interface_static (gnc_tree_model_price_type,
-                                     GTK_TYPE_TREE_MODEL,
-                                     &tree_model_info);
-    }
-
-    return gnc_tree_model_price_type;
-}
+G_DEFINE_TYPE_WITH_CODE(GncTreeModelPrice, gnc_tree_model_price, GNC_TYPE_TREE_MODEL,
+                        G_ADD_PRIVATE(GncTreeModelPrice)
+                        G_IMPLEMENT_INTERFACE(GTK_TYPE_TREE_MODEL,
+                                              gnc_tree_model_price_tree_model_init))
 
 static void
 gnc_tree_model_price_class_init (GncTreeModelPriceClass *klass)
@@ -185,8 +151,6 @@ gnc_tree_model_price_class_init (GncTreeModelPriceClass *klass)
 
     o_class->finalize = gnc_tree_model_price_finalize;
     o_class->dispose = gnc_tree_model_price_dispose;
-
-    g_type_class_add_private(klass, sizeof(GncTreeModelPricePrivate));
 }
 
 static void

--- a/gnucash/gnome-utils/gnc-tree-model-selection.c
+++ b/gnucash/gnome-utils/gnc-tree-model-selection.c
@@ -101,44 +101,10 @@ typedef struct GncTreeModelSelectionPrivate
 
 static GObjectClass *parent_class = NULL;
 
-GType
-gnc_tree_model_selection_get_type (void)
-{
-    static GType gnc_tree_model_selection_type = 0;
-
-    if (gnc_tree_model_selection_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncTreeModelSelectionClass),
-            NULL,
-            NULL,
-            (GClassInitFunc) gnc_tree_model_selection_class_init,
-            NULL,
-            NULL,
-            sizeof (GncTreeModelSelection),
-            0,
-            (GInstanceInitFunc) gnc_tree_model_selection_init
-        };
-
-        static const GInterfaceInfo tree_model_info =
-        {
-            (GInterfaceInitFunc) gnc_tree_model_selection_tree_model_init,
-            NULL,
-            NULL
-        };
-
-        gnc_tree_model_selection_type = g_type_register_static (G_TYPE_OBJECT,
-                                        "GncTreeModelSelection",
-                                        &our_info, 0);
-
-        g_type_add_interface_static (gnc_tree_model_selection_type,
-                                     GTK_TYPE_TREE_MODEL,
-                                     &tree_model_info);
-    }
-
-    return gnc_tree_model_selection_type;
-}
+G_DEFINE_TYPE_WITH_CODE(GncTreeModelSelection, gnc_tree_model_selection, G_TYPE_OBJECT
+                        G_ADD_PRIVATE(GncTreeModelSelection)
+                        G_IMPLEMENT_INTERFACE(GTK_TYPE_TREE_MODEL,
+                                              gnc_tree_model_selection_tree_model_init))
 
 static void
 gnc_tree_model_selection_class_init (GncTreeModelSelectionClass *klass)
@@ -148,8 +114,6 @@ gnc_tree_model_selection_class_init (GncTreeModelSelectionClass *klass)
     parent_class = g_type_class_peek_parent (klass);
 
     object_class->finalize = gnc_tree_model_selection_finalize;
-
-    g_type_class_add_private(klass, sizeof(GncTreeModelSelectionPrivate));
 }
 
 static void

--- a/gnucash/gnome-utils/gnc-tree-model.c
+++ b/gnucash/gnome-utils/gnc-tree-model.c
@@ -37,7 +37,8 @@ static QofLogModule log_module = GNC_MOD_GUI;
 
 /** Declarations *********************************************************/
 static void gnc_tree_model_class_init (GncTreeModelClass *klass);
-static void gnc_tree_model_init (GncTreeModel *model);
+static void gnc_tree_model_init (GncTreeModel *model,
+		                 void *data);
 static void gnc_tree_model_finalize (GObject *object);
 
 /** The instance private data for a generic tree model. */
@@ -45,6 +46,9 @@ typedef struct GncTreeModelPrivate
 {
     gpointer dummy;
 } GncTreeModelPrivate;
+
+GNC_DEFINE_TYPE_WITH_CODE(GncTreeModel, gnc_tree_model, G_TYPE_OBJECT,
+		        G_ADD_PRIVATE(GncTreeModel))
 
 #define GNC_TREE_MODEL_GET_PRIVATE(o)  \
    (G_TYPE_INSTANCE_GET_PRIVATE ((o), GNC_TYPE_TREE_MODEL, GncTreeModelPrivate))
@@ -56,8 +60,6 @@ typedef struct GncTreeModelPrivate
 
 /** A pointer to the parent class of a generic tree model. */
 static GObjectClass *parent_class = NULL;
-
-G_DEFINE_TYPE_WITH_PRIVATE(GncTreeModel, gnc_tree_model, G_TYPE_OBJECT)
 
 static void
 gnc_tree_model_class_init (GncTreeModelClass *klass)
@@ -73,10 +75,13 @@ gnc_tree_model_class_init (GncTreeModelClass *klass)
 }
 
 static void
-gnc_tree_model_init (GncTreeModel *model)
+gnc_tree_model_init (GncTreeModel *model, void *data)
 {
+    GncTreeModelClass *klass = (GncTreeModelClass*)data;
+
     ENTER("model %p", model);
-    gnc_gobject_tracking_remember(G_OBJECT(model), NULL);
+    gnc_gobject_tracking_remember(G_OBJECT(model),
+		                  G_OBJECT_CLASS(klass));
 
     LEAVE(" ");
 }

--- a/gnucash/gnome-utils/gnc-tree-model.c
+++ b/gnucash/gnome-utils/gnc-tree-model.c
@@ -37,7 +37,7 @@ static QofLogModule log_module = GNC_MOD_GUI;
 
 /** Declarations *********************************************************/
 static void gnc_tree_model_class_init (GncTreeModelClass *klass);
-static void gnc_tree_model_init (GncTreeModel *model, GncTreeModelClass *klass);
+static void gnc_tree_model_init (GncTreeModel *model);
 static void gnc_tree_model_finalize (GObject *object);
 
 /** The instance private data for a generic tree model. */
@@ -57,43 +57,7 @@ typedef struct GncTreeModelPrivate
 /** A pointer to the parent class of a generic tree model. */
 static GObjectClass *parent_class = NULL;
 
-GType
-gnc_tree_model_get_type (void)
-{
-    static GType gnc_tree_model_type = 0;
-
-    if (gnc_tree_model_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncTreeModelClass),          /* class_size */
-            NULL,   			           /* base_init */
-            NULL,				   /* base_finalize */
-            (GClassInitFunc) gnc_tree_model_class_init,
-            NULL,				   /* class_finalize */
-            NULL,				   /* class_data */
-            sizeof (GncTreeModel),	           /* */
-            0,				   /* n_preallocs */
-            (GInstanceInitFunc) gnc_tree_model_init
-        };
-
-        //static const GInterfaceInfo tree_model_info = {
-        //  (GInterfaceInitFunc) gnc_tree_model_tree_model_init,
-        //  NULL,
-        //  NULL
-        //};
-
-        gnc_tree_model_type = g_type_register_static (G_TYPE_OBJECT,
-                              GNC_TREE_MODEL_NAME,
-                              &our_info, 0);
-
-        //g_type_add_interface_static (gnc_tree_model_type,
-        //				 GTK_TYPE_TREE_MODEL,
-        //				 &tree_model_info);
-    }
-
-    return gnc_tree_model_type;
-}
+G_DEFINE_TYPE_WITH_PRIVATE(GncTreeModel, gnc_tree_model, G_TYPE_OBJECT)
 
 static void
 gnc_tree_model_class_init (GncTreeModelClass *klass)
@@ -106,15 +70,13 @@ gnc_tree_model_class_init (GncTreeModelClass *klass)
 
     /* GObject signals */
     o_class->finalize = gnc_tree_model_finalize;
-
-    g_type_class_add_private(klass, sizeof(GncTreeModelPrivate));
 }
 
 static void
-gnc_tree_model_init (GncTreeModel *model, GncTreeModelClass *klass)
+gnc_tree_model_init (GncTreeModel *model)
 {
     ENTER("model %p", model);
-    gnc_gobject_tracking_remember(G_OBJECT(model), G_OBJECT_CLASS(klass));
+    gnc_gobject_tracking_remember(G_OBJECT(model), NULL);
 
     LEAVE(" ");
 }

--- a/gnucash/gnome-utils/gnc-tree-view-account.c
+++ b/gnucash/gnome-utils/gnc-tree-view-account.c
@@ -124,33 +124,7 @@ typedef struct GncTreeViewAccountPrivate
 
 static GObjectClass *parent_class = NULL;
 
-GType
-gnc_tree_view_account_get_type (void)
-{
-    static GType gnc_tree_view_account_type = 0;
-
-    if (gnc_tree_view_account_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncTreeViewAccountClass),
-            NULL,
-            NULL,
-            (GClassInitFunc) gnc_tree_view_account_class_init,
-            NULL,
-            NULL,
-            sizeof (GncTreeViewAccount),
-            0,
-            (GInstanceInitFunc) gnc_tree_view_account_init
-        };
-
-        gnc_tree_view_account_type = g_type_register_static (
-                                         GNC_TYPE_TREE_VIEW, GNC_TREE_VIEW_ACCOUNT_NAME,
-                                         &our_info, 0);
-    }
-
-    return gnc_tree_view_account_type;
-}
+G_DEFINE_TYPE_WITH_PRIVATE(GncTreeViewAccount, gnc_tree_view_account, GNC_TYPE_TREE_VIEW)
 
 static void
 gnc_tree_view_account_class_init (GncTreeViewAccountClass *klass)
@@ -162,8 +136,6 @@ gnc_tree_view_account_class_init (GncTreeViewAccountClass *klass)
     /* GObject signals */
     o_class = G_OBJECT_CLASS (klass);
     o_class->finalize = gnc_tree_view_account_finalize;
-
-    g_type_class_add_private(klass, sizeof(GncTreeViewAccountPrivate));
 
     gnc_hook_add_dangler(HOOK_CURRENCY_CHANGED,
                          (GFunc)gtva_currency_changed_cb, NULL);

--- a/gnucash/gnome-utils/gnc-tree-view-commodity.c
+++ b/gnucash/gnome-utils/gnc-tree-view-commodity.c
@@ -67,33 +67,7 @@ typedef struct GncTreeViewCommodityPrivate
 
 static GObjectClass *parent_class = NULL;
 
-GType
-gnc_tree_view_commodity_get_type (void)
-{
-    static GType gnc_tree_view_commodity_type = 0;
-
-    if (gnc_tree_view_commodity_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncTreeViewCommodityClass),
-            NULL,
-            NULL,
-            (GClassInitFunc) gnc_tree_view_commodity_class_init,
-            NULL,
-            NULL,
-            sizeof (GncTreeViewCommodity),
-            0,
-            (GInstanceInitFunc) gnc_tree_view_commodity_init
-        };
-
-        gnc_tree_view_commodity_type = g_type_register_static (GNC_TYPE_TREE_VIEW,
-                                       "GncTreeViewCommodity",
-                                       &our_info, 0);
-    }
-
-    return gnc_tree_view_commodity_type;
-}
+G_DEFINE_TYPE_WITH_PRIVATE(GncTreeViewCommodity, gnc_tree_view_commodity, GNC_TYPE_TREE_VIEW)
 
 static void
 gnc_tree_view_commodity_class_init (GncTreeViewCommodityClass *klass)
@@ -111,8 +85,6 @@ gnc_tree_view_commodity_class_init (GncTreeViewCommodityClass *klass)
 
     /* GtkWidget signals */
     widget_class->destroy = gnc_tree_view_commodity_destroy;
-
-    g_type_class_add_private(klass, sizeof(GncTreeViewCommodityPrivate));
 }
 
 static void

--- a/gnucash/gnome-utils/gnc-tree-view-owner.c
+++ b/gnucash/gnome-utils/gnc-tree-view-owner.c
@@ -96,33 +96,7 @@ typedef struct GncTreeViewOwnerPrivate
 
 static GObjectClass *parent_class = NULL;
 
-GType
-gnc_tree_view_owner_get_type (void)
-{
-    static GType gnc_tree_view_owner_type = 0;
-
-    if (gnc_tree_view_owner_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncTreeViewOwnerClass),
-            NULL,
-            NULL,
-            (GClassInitFunc) gnc_tree_view_owner_class_init,
-            NULL,
-            NULL,
-            sizeof (GncTreeViewOwner),
-            0,
-            (GInstanceInitFunc) gnc_tree_view_owner_init
-        };
-
-        gnc_tree_view_owner_type = g_type_register_static (
-                                       GNC_TYPE_TREE_VIEW, GNC_TREE_VIEW_OWNER_NAME,
-                                       &our_info, 0);
-    }
-
-    return gnc_tree_view_owner_type;
-}
+G_DEFINE_TYPE_WITH_PRIVATE(GncTreeViewOwner, gnc_tree_view_owner, GNC_TYPE_TREE_VIEW)
 
 static void
 gnc_tree_view_owner_class_init (GncTreeViewOwnerClass *klass)
@@ -134,8 +108,6 @@ gnc_tree_view_owner_class_init (GncTreeViewOwnerClass *klass)
     /* GObject signals */
     o_class = G_OBJECT_CLASS (klass);
     o_class->finalize = gnc_tree_view_owner_finalize;
-
-    g_type_class_add_private(klass, sizeof(GncTreeViewOwnerPrivate));
 
     gnc_hook_add_dangler(HOOK_CURRENCY_CHANGED,
                          (GFunc)gtvo_currency_changed_cb, NULL);

--- a/gnucash/gnome-utils/gnc-tree-view-price.c
+++ b/gnucash/gnome-utils/gnc-tree-view-price.c
@@ -67,33 +67,7 @@ typedef struct GncTreeViewPricePrivate
 
 static GObjectClass *parent_class = NULL;
 
-GType
-gnc_tree_view_price_get_type (void)
-{
-    static GType gnc_tree_view_price_type = 0;
-
-    if (gnc_tree_view_price_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncTreeViewPriceClass),
-            NULL,
-            NULL,
-            (GClassInitFunc) gnc_tree_view_price_class_init,
-            NULL,
-            NULL,
-            sizeof (GncTreeViewPrice),
-            0,
-            (GInstanceInitFunc) gnc_tree_view_price_init
-        };
-
-        gnc_tree_view_price_type = g_type_register_static (GNC_TYPE_TREE_VIEW,
-                                   "GncTreeViewPrice",
-                                   &our_info, 0);
-    }
-
-    return gnc_tree_view_price_type;
-}
+G_DEFINE_TYPE_WITH_PRIVATE(GncTreeViewPrice, gnc_tree_view_price, GNC_TYPE_TREE_VIEW)
 
 static void
 gnc_tree_view_price_class_init (GncTreeViewPriceClass *klass)
@@ -111,8 +85,6 @@ gnc_tree_view_price_class_init (GncTreeViewPriceClass *klass)
 
     /* GtkWidget signals */
     widget_class->destroy = gnc_tree_view_price_destroy;
-
-    g_type_class_add_private(klass, sizeof(GncTreeViewPricePrivate));
 }
 
 static void

--- a/gnucash/gnome-utils/gnc-tree-view-split-reg.c
+++ b/gnucash/gnome-utils/gnc-tree-view-split-reg.c
@@ -305,33 +305,7 @@ struct GncTreeViewSplitRegPrivate
 
 static GObjectClass *parent_class = NULL;
 
-GType
-gnc_tree_view_split_reg_get_type(void)
-{
-    static GType gnc_tree_view_split_reg_type = 0;
-
-    if (gnc_tree_view_split_reg_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncTreeViewSplitRegClass),
-            NULL,
-            NULL,
-            (GClassInitFunc) gnc_tree_view_split_reg_class_init,
-            NULL,
-            NULL,
-            sizeof (GncTreeViewSplitReg),
-            0,
-            (GInstanceInitFunc) gnc_tree_view_split_reg_init
-        };
-
-        gnc_tree_view_split_reg_type = g_type_register_static (GNC_TYPE_TREE_VIEW,
-                                     "GncTreeViewSplitReg",
-                                     &our_info, 0);
-    }
-    return gnc_tree_view_split_reg_type;
-}
-
+G_DEFINE_TYPE_WITH_PRIVATE(GncTreeViewSplitReg, gnc_tree_view_split_reg, GNC_TYPE_TREE_VIEW)
 
 static void
 gnc_tree_view_split_reg_class_init (GncTreeViewSplitRegClass *klass)
@@ -344,8 +318,6 @@ gnc_tree_view_split_reg_class_init (GncTreeViewSplitRegClass *klass)
 
     o_class->dispose =  gnc_tree_view_split_reg_dispose;
     o_class->finalize = gnc_tree_view_split_reg_finalize;
-
-    g_type_class_add_private (klass, sizeof(GncTreeViewSplitRegPrivate));
 
     gnc_tree_view_split_reg_signals[UPDATE_SIGNAL] =
         g_signal_new("update_signal",

--- a/gnucash/gnome-utils/gnc-tree-view-sx-list.c
+++ b/gnucash/gnome-utils/gnc-tree-view-sx-list.c
@@ -63,33 +63,7 @@ typedef struct GncTreeViewSxListPrivate
 
 static GObjectClass *parent_class = NULL;
 
-GType
-gnc_tree_view_sx_list_get_type(void)
-{
-    static GType gnc_tree_view_sx_list_type = 0;
-
-    if (gnc_tree_view_sx_list_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncTreeViewSxListClass),
-            NULL,
-            NULL,
-            (GClassInitFunc) gnc_tree_view_sx_list_class_init,
-            NULL,
-            NULL,
-            sizeof (GncTreeViewSxList),
-            0,
-            (GInstanceInitFunc) gnc_tree_view_sx_list_init
-        };
-
-        gnc_tree_view_sx_list_type = g_type_register_static (GNC_TYPE_TREE_VIEW,
-                                     "GncTreeViewSxList",
-                                     &our_info, 0);
-    }
-
-    return gnc_tree_view_sx_list_type;
-}
+G_DEFINE_TYPE_WITH_PRIVATE(GncTreeViewSxList, gnc_tree_view_sx_list, GNC_TYPE_TREE_VIEW)
 
 static void
 gnc_tree_view_sx_list_class_init(GncTreeViewSxListClass *klass)
@@ -102,8 +76,6 @@ gnc_tree_view_sx_list_class_init(GncTreeViewSxListClass *klass)
 
     o_class->dispose =  gnc_tree_view_sx_list_dispose;
     o_class->finalize = gnc_tree_view_sx_list_finalize;
-
-    g_type_class_add_private(klass, sizeof(GncTreeViewSxListPrivate));
 }
 
 static void

--- a/gnucash/gnome-utils/gnc-tree-view.c
+++ b/gnucash/gnome-utils/gnc-tree-view.c
@@ -76,7 +76,7 @@ static QofLogModule log_module = GNC_MOD_GUI;
 
 /**** Declarations ******************************************************/
 static void gnc_tree_view_class_init (GncTreeViewClass *klass);
-static void gnc_tree_view_init (GncTreeView *view, GncTreeViewClass *klass);
+static void gnc_tree_view_init (GncTreeView *view);
 static void gnc_tree_view_finalize (GObject *object);
 static void gnc_tree_view_destroy (GtkWidget *widget);
 static void gnc_tree_view_set_property (GObject         *object,
@@ -142,39 +142,7 @@ typedef struct GncTreeViewPrivate
 
 static GObjectClass *parent_class = NULL;
 
-/** Create a new glib type for the base gnucash tree view.
- *
- *  @internal
- *
- *  @return The new type value.
- */
-GType
-gnc_tree_view_get_type (void)
-{
-    static GType gnc_tree_view_type = 0;
-
-    if (gnc_tree_view_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncTreeViewClass),
-            NULL,
-            NULL,
-            (GClassInitFunc) gnc_tree_view_class_init,
-            NULL,
-            NULL,
-            sizeof (GncTreeView),
-            0,
-            (GInstanceInitFunc) gnc_tree_view_init
-        };
-
-        gnc_tree_view_type = g_type_register_static (GTK_TYPE_TREE_VIEW,
-                             GNC_TREE_VIEW_NAME,
-                             &our_info, 0);
-    }
-
-    return gnc_tree_view_type;
-}
+G_DEFINE_TYPE_WITH_PRIVATE(GncTreeView, gnc_tree_view, GTK_TYPE_TREE_VIEW)
 
 /** Initialize the class for the new base gnucash tree view.  This
  *  will set up any function pointers that override functions in the
@@ -198,8 +166,6 @@ gnc_tree_view_class_init (GncTreeViewClass *klass)
 
     gobject_class->set_property = gnc_tree_view_set_property;
     gobject_class->get_property = gnc_tree_view_get_property;
-
-    g_type_class_add_private(klass, sizeof(GncTreeViewPrivate));
 
     g_object_class_install_property (gobject_class,
                                      PROP_STATE_SECTION,
@@ -233,14 +199,14 @@ gnc_tree_view_class_init (GncTreeViewClass *klass)
  *  @internal
  */
 static void
-gnc_tree_view_init (GncTreeView *view, GncTreeViewClass *klass)
+gnc_tree_view_init (GncTreeView *view)
 {
     GncTreeViewPrivate *priv;
     GtkTreeViewColumn *column;
     GtkWidget *icon;
     GtkRequisition requisition;
 
-    gnc_gobject_tracking_remember(G_OBJECT(view), G_OBJECT_CLASS(klass));
+    gnc_gobject_tracking_remember(G_OBJECT(view), NULL);
 
     priv = GNC_TREE_VIEW_GET_PRIVATE(view);
     priv->column_menu = NULL;

--- a/gnucash/gnome-utils/gnc-tree-view.c
+++ b/gnucash/gnome-utils/gnc-tree-view.c
@@ -76,7 +76,8 @@ static QofLogModule log_module = GNC_MOD_GUI;
 
 /**** Declarations ******************************************************/
 static void gnc_tree_view_class_init (GncTreeViewClass *klass);
-static void gnc_tree_view_init (GncTreeView *view);
+static void gnc_tree_view_init (GncTreeView *view,
+		                void *data);
 static void gnc_tree_view_finalize (GObject *object);
 static void gnc_tree_view_destroy (GtkWidget *widget);
 static void gnc_tree_view_set_property (GObject         *object,
@@ -129,6 +130,9 @@ typedef struct GncTreeViewPrivate
     gulong             size_allocate_cb_id;
 } GncTreeViewPrivate;
 
+GNC_DEFINE_TYPE_WITH_CODE(GncTreeView, gnc_tree_view, GTK_TYPE_TREE_VIEW,
+		          G_ADD_PRIVATE(GncTreeView))
+
 #define GNC_TREE_VIEW_GET_PRIVATE(o)  \
    (G_TYPE_INSTANCE_GET_PRIVATE ((o), GNC_TYPE_TREE_VIEW, GncTreeViewPrivate))
 
@@ -141,8 +145,6 @@ typedef struct GncTreeViewPrivate
  @{ */
 
 static GObjectClass *parent_class = NULL;
-
-G_DEFINE_TYPE_WITH_PRIVATE(GncTreeView, gnc_tree_view, GTK_TYPE_TREE_VIEW)
 
 /** Initialize the class for the new base gnucash tree view.  This
  *  will set up any function pointers that override functions in the
@@ -199,14 +201,17 @@ gnc_tree_view_class_init (GncTreeViewClass *klass)
  *  @internal
  */
 static void
-gnc_tree_view_init (GncTreeView *view)
+gnc_tree_view_init (GncTreeView *view, void *data)
 {
     GncTreeViewPrivate *priv;
     GtkTreeViewColumn *column;
     GtkWidget *icon;
     GtkRequisition requisition;
 
-    gnc_gobject_tracking_remember(G_OBJECT(view), NULL);
+    GncTreeViewClass *klass = (GncTreeViewClass*)data;
+
+    gnc_gobject_tracking_remember(G_OBJECT(view),
+		                  G_OBJECT_CLASS(klass));
 
     priv = GNC_TREE_VIEW_GET_PRIVATE(view);
     priv->column_menu = NULL;

--- a/gnucash/gnome-utils/search-param.c
+++ b/gnucash/gnome-utils/search-param.c
@@ -95,32 +95,8 @@ static guint signals[LAST_SIGNAL] = { 0 };
 #endif
 
 /* Base class */
-GType
-gnc_search_param_get_type (void)
-{
-    static GType type = 0;
 
-    if (type == 0)
-    {
-        static GTypeInfo type_info =
-        {
-            sizeof(GNCSearchParamClass),
-            NULL,
-            NULL,
-            (GClassInitFunc)gnc_search_param_class_init,
-            NULL,
-            NULL,
-            sizeof(GNCSearchParam),
-            0,
-            (GInstanceInitFunc)gnc_search_param_init
-        };
-
-        type = g_type_register_static (G_TYPE_OBJECT, "GNCSearchParam",
-                                       &type_info, 0);
-    }
-
-    return type;
-}
+G_DEFINE_TYPE_WITH_PRIVATE(GNCSearchParam, gnc_search_param, G_TYPE_OBJECT)
 
 static void
 gnc_search_param_class_init (GNCSearchParamClass *klass)
@@ -130,8 +106,6 @@ gnc_search_param_class_init (GNCSearchParamClass *klass)
     parent_gobject_class = g_type_class_peek_parent (klass);
 
     object_class->finalize = gnc_search_param_finalize;
-
-    g_type_class_add_private(klass, sizeof(GNCSearchParamPrivate));
 }
 
 static void
@@ -149,32 +123,8 @@ gnc_search_param_finalize (GObject *obj)
 }
 
 /* subclass for simple searches of a single element */
-GType
-gnc_search_param_simple_get_type (void)
-{
-    static GType type = 0;
 
-    if (type == 0)
-    {
-        static GTypeInfo type_info =
-        {
-            sizeof(GNCSearchParamSimpleClass),
-            NULL,
-            NULL,
-            (GClassInitFunc)gnc_search_param_simple_class_init,
-            NULL,
-            NULL,
-            sizeof(GNCSearchParamSimple),
-            0,
-            (GInstanceInitFunc)gnc_search_param_simple_init
-        };
-
-        type = g_type_register_static (GNC_TYPE_SEARCH_PARAM, "GNCSearchParamSimple",
-                                       &type_info, 0);
-    }
-
-    return type;
-}
+G_DEFINE_TYPE_WITH_PRIVATE(GNCSearchParamSimple, gnc_search_param_simple, GNC_TYPE_SEARCH_PARAM)
 
 static void
 gnc_search_param_simple_class_init (GNCSearchParamSimpleClass *klass)
@@ -184,8 +134,6 @@ gnc_search_param_simple_class_init (GNCSearchParamSimpleClass *klass)
     parent_search_param_class = g_type_class_peek_parent (klass);
 
     object_class->finalize = gnc_search_param_simple_finalize;
-
-    g_type_class_add_private(klass, sizeof(GNCSearchParamSimplePrivate));
 }
 
 static void
@@ -214,32 +162,8 @@ gnc_search_param_simple_finalize (GObject *obj)
 }
 
 /* Subclass for compound searches consisting of AND/OR of several elements */
-GType
-gnc_search_param_compound_get_type (void)
-{
-    static GType type = 0;
 
-    if (type == 0)
-    {
-        static GTypeInfo type_info =
-        {
-            sizeof(GNCSearchParamCompoundClass),
-            NULL,
-            NULL,
-            (GClassInitFunc)gnc_search_param_compound_class_init,
-            NULL,
-            NULL,
-            sizeof(GNCSearchParamCompound),
-            0,
-            (GInstanceInitFunc)gnc_search_param_compound_init
-        };
-
-        type = g_type_register_static (GNC_TYPE_SEARCH_PARAM, "GNCSearchParamCompound",
-                                       &type_info, 0);
-    }
-
-    return type;
-}
+G_DEFINE_TYPE_WITH_PRIVATE(GNCSearchParamCompound, gnc_search_param_compound, GNC_TYPE_SEARCH_PARAM)
 
 static void
 gnc_search_param_compound_class_init (GNCSearchParamCompoundClass *klass)
@@ -249,8 +173,6 @@ gnc_search_param_compound_class_init (GNCSearchParamCompoundClass *klass)
     parent_search_param_class = g_type_class_peek_parent (klass);
 
     object_class->finalize = gnc_search_param_compound_finalize;
-
-    g_type_class_add_private(klass, sizeof(GNCSearchParamCompoundPrivate));
 }
 
 static void

--- a/gnucash/gnome/dialog-sx-since-last-run.c
+++ b/gnucash/gnome/dialog-sx-since-last-run.c
@@ -1154,6 +1154,7 @@ dialog_response_cb(GtkDialog *dialog, gint response_id, GncSxSinceLastRunDialog 
     gnc_suspend_gui_refresh();
     gnc_sx_slr_model_effect_change(app_dialog->editing_model, FALSE, &app_dialog->created_txns, &creation_errors);
     gnc_resume_gui_refresh();
+    gnc_gui_refresh_all (); // force a refresh of all registers
     if (creation_errors)
         creation_error_dialog(&creation_errors);
 

--- a/gnucash/gnome/gnc-budget-view.c
+++ b/gnucash/gnome/gnc-budget-view.c
@@ -172,7 +172,7 @@ struct GncBudgetViewPrivate
 #define GNC_BUDGET_VIEW_GET_PRIVATE(o)  \
    (G_TYPE_INSTANCE_GET_PRIVATE((o), GNC_TYPE_BUDGET_VIEW, GncBudgetViewPrivate))
 
-G_DEFINE_TYPE(GncBudgetView, gnc_budget_view, GTK_TYPE_BOX)
+G_DEFINE_TYPE_WITH_PRIVATE(GncBudgetView, gnc_budget_view, GTK_TYPE_BOX)
 
 /** \brief Create new gnc budget view.
 
@@ -211,8 +211,6 @@ gnc_budget_view_class_init(GncBudgetViewClass *klass)
 
     g_signal_new("account-activated", GNC_TYPE_BUDGET_VIEW, G_SIGNAL_RUN_LAST, 0, NULL, NULL, NULL,
                  G_TYPE_NONE, 1, GNC_TYPE_ACCOUNT);
-
-    g_type_class_add_private(klass, sizeof(GncBudgetViewPrivate));
 }
 
 

--- a/gnucash/gnome/gnc-plugin-account-tree.c
+++ b/gnucash/gnome/gnc-plugin-account-tree.c
@@ -79,37 +79,6 @@ typedef struct GncPluginAccountTreePrivate
 /** A pointer to the parent class of a plugin page. */
 static GObjectClass *parent_class = NULL;
 
-
-/*  Get the type of the account tree menu plugin. */
-GType
-gnc_plugin_account_tree_get_type (void)
-{
-    static GType gnc_plugin_account_tree_type = 0;
-
-    if (gnc_plugin_account_tree_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncPluginAccountTreeClass),
-            NULL,		/* base_init */
-            NULL,		/* base_finalize */
-            (GClassInitFunc) gnc_plugin_account_tree_class_init,
-            NULL,		/* class_finalize */
-            NULL,		/* class_data */
-            sizeof (GncPluginAccountTree),
-            0,		/* n_preallocs */
-            (GInstanceInitFunc) gnc_plugin_account_tree_init
-        };
-
-        gnc_plugin_account_tree_type = g_type_register_static (GNC_TYPE_PLUGIN,
-                                       "GncPluginAccountTree",
-                                       &our_info, 0);
-    }
-
-    return gnc_plugin_account_tree_type;
-}
-
-
 /*  Create a new account tree menu plugin. */
 GncPlugin *
 gnc_plugin_account_tree_new (void)
@@ -125,7 +94,6 @@ gnc_plugin_account_tree_new (void)
 
     return GNC_PLUGIN (plugin);
 }
-
 
 static void
 gnc_plugin_account_tree_main_window_page_changed (GncMainWindow *window,
@@ -148,6 +116,7 @@ gnc_plugin_account_tree_main_window_page_changed (GncMainWindow *window,
     }
 }
 
+G_DEFINE_TYPE_WITH_PRIVATE(GncPluginAccountTree, gnc_plugin_account_tree, GNC_TYPE_PLUGIN)
 
 /** Initialize the class for a new account tree plugin.  This will set
  *  up any function pointers that override functions in the parent
@@ -177,8 +146,6 @@ gnc_plugin_account_tree_class_init (GncPluginAccountTreeClass *klass)
     plugin_class->actions      = gnc_plugin_actions;
     plugin_class->n_actions    = gnc_plugin_n_actions;
     plugin_class->ui_filename  = PLUGIN_UI_FILENAME;
-
-    g_type_class_add_private(klass, sizeof(GncPluginAccountTreePrivate));
 }
 
 

--- a/gnucash/gnome/gnc-plugin-basic-commands.c
+++ b/gnucash/gnome/gnc-plugin-basic-commands.c
@@ -275,37 +275,6 @@ typedef struct GncPluginBasicCommandsPrivate
 /** A pointer to the parent class of a plugin page. */
 static GObjectClass *parent_class = NULL;
 
-
-/*  Get the type of the basic commands menu plugin. */
-GType
-gnc_plugin_basic_commands_get_type (void)
-{
-    static GType gnc_plugin_basic_commands_type = 0;
-
-    if (gnc_plugin_basic_commands_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncPluginBasicCommandsClass),
-            NULL,		/* base_init */
-            NULL,		/* base_finalize */
-            (GClassInitFunc) gnc_plugin_basic_commands_class_init,
-            NULL,		/* class_finalize */
-            NULL,		/* class_data */
-            sizeof (GncPluginBasicCommands),
-            0,		/* n_preallocs */
-            (GInstanceInitFunc) gnc_plugin_basic_commands_init
-        };
-
-        gnc_plugin_basic_commands_type = g_type_register_static (GNC_TYPE_PLUGIN,
-                                         "GncPluginBasicCommands",
-                                         &our_info, 0);
-    }
-
-    return gnc_plugin_basic_commands_type;
-}
-
-
 /** Create a new basic commands menu plugin. */
 GncPlugin *
 gnc_plugin_basic_commands_new (void)
@@ -385,6 +354,8 @@ gnc_plugin_basic_commands_main_window_page_changed(GncMainWindow *window,
     }
 }
 
+G_DEFINE_TYPE_WITH_PRIVATE(GncPluginBasicCommands, gnc_plugin_basic_commands, GNC_TYPE_PLUGIN)
+
 /** Initialize the class for a new basic commands plugin.  This will
  *  set up any function pointers that override functions in the parent
  *  class, and also configure the private data storage for this
@@ -414,8 +385,6 @@ gnc_plugin_basic_commands_class_init (GncPluginBasicCommandsClass *klass)
     plugin_class->n_actions    	  = gnc_plugin_n_actions;
     plugin_class->important_actions = gnc_plugin_important_actions;
     plugin_class->ui_filename       = PLUGIN_UI_FILENAME;
-
-    g_type_class_add_private(klass, sizeof(GncPluginBasicCommandsPrivate));
 }
 
 

--- a/gnucash/gnome/gnc-plugin-budget.c
+++ b/gnucash/gnome/gnc-plugin-budget.c
@@ -87,33 +87,6 @@ typedef struct GncPluginBudgetPrivate
 
 static GObjectClass *parent_class = NULL;
 
-GType
-gnc_plugin_budget_get_type (void)
-{
-    static GType gnc_plugin_budget_type = 0;
-
-    if (!gnc_plugin_budget_type)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncPluginBudgetClass),
-            NULL,       /* base_init */
-            NULL,       /* base_finalize */
-            (GClassInitFunc) gnc_plugin_budget_class_init,
-            NULL,       /* class_finalize */
-            NULL,       /* class_data */
-            sizeof (GncPluginBudget),
-            0,          /* n_preallocs */
-            (GInstanceInitFunc) gnc_plugin_budget_init
-        };
-
-        gnc_plugin_budget_type = g_type_register_static(
-                                     GNC_TYPE_PLUGIN, "GncPluginBudget", &our_info, 0);
-    }
-
-    return gnc_plugin_budget_type;
-}
-
 GncPlugin * gnc_plugin_budget_new (void)
 {
     GncPluginBudget *plugin;
@@ -149,6 +122,8 @@ gnc_plugin_budget_main_window_page_changed (GncMainWindow *window,
     }
 }
 
+G_DEFINE_TYPE_WITH_PRIVATE(GncPluginBudget, gnc_plugin_budget, GNC_TYPE_PLUGIN)
+
 static void
 gnc_plugin_budget_class_init (GncPluginBudgetClass *klass)
 {
@@ -168,7 +143,6 @@ gnc_plugin_budget_class_init (GncPluginBudgetClass *klass)
     plugin_class->n_actions    = gnc_plugin_n_actions;
     plugin_class->ui_filename  = PLUGIN_UI_FILENAME;
 
-    g_type_class_add_private(klass, sizeof(GncPluginBudgetPrivate));
     LEAVE (" ");
 }
 

--- a/gnucash/gnome/gnc-plugin-business.c
+++ b/gnucash/gnome/gnc-plugin-business.c
@@ -344,34 +344,6 @@ typedef struct GncPluginBusinessPrivate
 
 static GObjectClass *parent_class = NULL;
 
-GType
-gnc_plugin_business_get_type (void)
-{
-    static GType gnc_plugin_business_type = 0;
-
-    if (gnc_plugin_business_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncPluginBusinessClass),
-            NULL,       /* base_init */
-            NULL,       /* base_finalize */
-            (GClassInitFunc) gnc_plugin_business_class_init,
-            NULL,       /* class_finalize */
-            NULL,       /* class_data */
-            sizeof (GncPluginBusiness),
-            0,          /* n_preallocs */
-            (GInstanceInitFunc) gnc_plugin_business_init
-        };
-
-        gnc_plugin_business_type = g_type_register_static (GNC_TYPE_PLUGIN,
-                                   "GncPluginBusiness",
-                                   &our_info, 0);
-    }
-
-    return gnc_plugin_business_type;
-}
-
 GncPlugin *
 gnc_plugin_business_new (void)
 {
@@ -387,6 +359,8 @@ gnc_plugin_business_new (void)
 
     return GNC_PLUGIN (plugin);
 }
+
+G_DEFINE_TYPE_WITH_PRIVATE(GncPluginBusiness, gnc_plugin_business, GNC_TYPE_PLUGIN)
 
 static void
 gnc_plugin_business_class_init (GncPluginBusinessClass *klass)
@@ -409,8 +383,6 @@ gnc_plugin_business_class_init (GncPluginBusinessClass *klass)
     plugin_class->actions      = gnc_plugin_actions;
     plugin_class->n_actions    = gnc_plugin_n_actions;
     plugin_class->ui_filename  = PLUGIN_UI_FILENAME;
-
-    g_type_class_add_private(klass, sizeof(GncPluginBusinessPrivate));
 }
 
 static void

--- a/gnucash/gnome/gnc-plugin-page-account-tree.c
+++ b/gnucash/gnome/gnc-plugin-page-account-tree.c
@@ -368,35 +368,6 @@ static action_toolbar_labels toolbar_labels[] =
     { NULL, NULL },
 };
 
-
-GType
-gnc_plugin_page_account_tree_get_type (void)
-{
-    static GType gnc_plugin_page_account_tree_type = 0;
-
-    if (gnc_plugin_page_account_tree_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncPluginPageAccountTreeClass),
-            NULL,
-            NULL,
-            (GClassInitFunc) gnc_plugin_page_account_tree_class_init,
-            NULL,
-            NULL,
-            sizeof (GncPluginPageAccountTree),
-            0,
-            (GInstanceInitFunc) gnc_plugin_page_account_tree_init
-        };
-
-        gnc_plugin_page_account_tree_type = g_type_register_static (GNC_TYPE_PLUGIN_PAGE,
-                                            GNC_PLUGIN_PAGE_ACCOUNT_TREE_NAME,
-                                            &our_info, 0);
-    }
-
-    return gnc_plugin_page_account_tree_type;
-}
-
 GncPluginPage *
 gnc_plugin_page_account_tree_new (void)
 {
@@ -409,6 +380,8 @@ gnc_plugin_page_account_tree_new (void)
     LEAVE("new account tree page %p", plugin_page);
     return GNC_PLUGIN_PAGE (plugin_page);
 }
+
+G_DEFINE_TYPE_WITH_PRIVATE(GncPluginPageAccountTree, gnc_plugin_page_account_tree, GNC_TYPE_PLUGIN_PAGE)
 
 static void
 gnc_plugin_page_account_tree_class_init (GncPluginPageAccountTreeClass *klass)
@@ -426,8 +399,6 @@ gnc_plugin_page_account_tree_class_init (GncPluginPageAccountTreeClass *klass)
     gnc_plugin_class->destroy_widget  = gnc_plugin_page_account_tree_destroy_widget;
     gnc_plugin_class->save_page       = gnc_plugin_page_account_tree_save_page;
     gnc_plugin_class->recreate_page   = gnc_plugin_page_account_tree_recreate_page;
-
-    g_type_class_add_private(klass, sizeof(GncPluginPageAccountTreePrivate));
 
     plugin_page_signals[ACCOUNT_SELECTED] =
         g_signal_new ("account_selected",
@@ -475,10 +446,10 @@ gnc_plugin_page_account_tree_init (GncPluginPageAccountTree *plugin_page)
     /* Is this the first accounts page? */
     page_list =
         gnc_gobject_tracking_get_list(GNC_PLUGIN_PAGE_ACCOUNT_TREE_NAME);
-    if (plugin_page == page_list->data)
+    if (!page_list || plugin_page == page_list->data)
     {
         g_object_set_data(G_OBJECT(plugin_page), PLUGIN_PAGE_IMMUTABLE,
-                          GINT_TO_POINTER(1));
+		          GINT_TO_POINTER(1));
     }
 
     /* Create menu and toolbar information */

--- a/gnucash/gnome/gnc-plugin-page-budget.c
+++ b/gnucash/gnome/gnc-plugin-page-budget.c
@@ -211,36 +211,6 @@ typedef struct GncPluginPageBudgetPrivate
 
 static GObjectClass *parent_class = NULL;
 
-
-GType
-gnc_plugin_page_budget_get_type (void)
-{
-    static GType gnc_plugin_page_budget_type = 0;
-
-    if (gnc_plugin_page_budget_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncPluginPageBudgetClass),
-            NULL,
-            NULL,
-            (GClassInitFunc) gnc_plugin_page_budget_class_init,
-            NULL,
-            NULL,
-            sizeof (GncPluginPageBudget),
-            0,
-            (GInstanceInitFunc) gnc_plugin_page_budget_init
-        };
-
-        gnc_plugin_page_budget_type =
-            g_type_register_static (GNC_TYPE_PLUGIN_PAGE,
-                                    "GncPluginPageBudget", &our_info, 0);
-    }
-
-    return gnc_plugin_page_budget_type;
-}
-
-
 GncPluginPage *
 gnc_plugin_page_budget_new (GncBudget *budget)
 {
@@ -278,6 +248,7 @@ gnc_plugin_page_budget_new (GncBudget *budget)
     return GNC_PLUGIN_PAGE(plugin_page);
 }
 
+G_DEFINE_TYPE_WITH_PRIVATE(GncPluginPageBudget, gnc_plugin_page_budget, GNC_TYPE_PLUGIN_PAGE)
 
 static void
 gnc_plugin_page_budget_class_init (GncPluginPageBudgetClass *klass)
@@ -295,8 +266,6 @@ gnc_plugin_page_budget_class_init (GncPluginPageBudgetClass *klass)
     gnc_plugin_class->destroy_widget  = gnc_plugin_page_budget_destroy_widget;
     gnc_plugin_class->save_page       = gnc_plugin_page_budget_save_page;
     gnc_plugin_class->recreate_page   = gnc_plugin_page_budget_recreate_page;
-
-    g_type_class_add_private(klass, sizeof(GncPluginPageBudgetPrivate));
 }
 
 

--- a/gnucash/gnome/gnc-plugin-page-invoice.c
+++ b/gnucash/gnome/gnc-plugin-page-invoice.c
@@ -292,34 +292,6 @@ static GObjectClass *parent_class = NULL;
 /*                      Implementation                      */
 /************************************************************/
 
-GType
-gnc_plugin_page_invoice_get_type (void)
-{
-    static GType gnc_plugin_page_invoice_type = 0;
-
-    if (gnc_plugin_page_invoice_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncPluginPageInvoiceClass),
-            NULL,
-            NULL,
-            (GClassInitFunc) gnc_plugin_page_invoice_class_init,
-            NULL,
-            NULL,
-            sizeof (GncPluginPageInvoice),
-            0,
-            (GInstanceInitFunc) gnc_plugin_page_invoice_init
-        };
-
-        gnc_plugin_page_invoice_type = g_type_register_static (GNC_TYPE_PLUGIN_PAGE,
-                                       "GncPluginPageInvoice",
-                                       &our_info, 0);
-    }
-
-    return gnc_plugin_page_invoice_type;
-}
-
 GncPluginPage *
 gnc_plugin_page_invoice_new (InvoiceWindow *iw)
 {
@@ -350,6 +322,8 @@ gnc_plugin_page_invoice_new (InvoiceWindow *iw)
     return plugin_page;
 }
 
+G_DEFINE_TYPE_WITH_PRIVATE(GncPluginPageInvoice, gnc_plugin_page_invoice, GNC_TYPE_PLUGIN_PAGE)
+
 static void
 gnc_plugin_page_invoice_class_init (GncPluginPageInvoiceClass *klass)
 {
@@ -367,8 +341,6 @@ gnc_plugin_page_invoice_class_init (GncPluginPageInvoiceClass *klass)
     gnc_plugin_class->save_page       = gnc_plugin_page_invoice_save_page;
     gnc_plugin_class->recreate_page   = gnc_plugin_page_invoice_recreate_page;
     gnc_plugin_class->window_changed  = gnc_plugin_page_invoice_window_changed;
-
-    g_type_class_add_private(klass, sizeof(GncPluginPageInvoicePrivate));
 }
 
 static void

--- a/gnucash/gnome/gnc-plugin-page-owner-tree.c
+++ b/gnucash/gnome/gnc-plugin-page-owner-tree.c
@@ -310,34 +310,6 @@ static action_owners_struct action_owners[] =
     { NULL, GNC_OWNER_NONE },
 };
 
-GType
-gnc_plugin_page_owner_tree_get_type (void)
-{
-    static GType gnc_plugin_page_owner_tree_type = 0;
-
-    if (gnc_plugin_page_owner_tree_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncPluginPageOwnerTreeClass),
-            NULL,
-            NULL,
-            (GClassInitFunc) gnc_plugin_page_owner_tree_class_init,
-            NULL,
-            NULL,
-            sizeof (GncPluginPageOwnerTree),
-            0,
-            (GInstanceInitFunc) gnc_plugin_page_owner_tree_init
-        };
-
-        gnc_plugin_page_owner_tree_type = g_type_register_static (GNC_TYPE_PLUGIN_PAGE,
-                                          GNC_PLUGIN_PAGE_OWNER_TREE_NAME,
-                                          &our_info, 0);
-    }
-
-    return gnc_plugin_page_owner_tree_type;
-}
-
 GncPluginPage *
 gnc_plugin_page_owner_tree_new (GncOwnerType owner_type)
 {
@@ -431,6 +403,7 @@ gnc_plugin_page_owner_main_window_page_changed (GncMainWindow *window,
     }
 }
 
+G_DEFINE_TYPE_WITH_PRIVATE(GncPluginPageOwnerTree, gnc_plugin_page_owner_tree, GNC_TYPE_PLUGIN_PAGE)
 
 static void
 gnc_plugin_page_owner_tree_class_init (GncPluginPageOwnerTreeClass *klass)
@@ -448,8 +421,6 @@ gnc_plugin_page_owner_tree_class_init (GncPluginPageOwnerTreeClass *klass)
     gnc_plugin_class->destroy_widget  = gnc_plugin_page_owner_tree_destroy_widget;
     gnc_plugin_class->save_page       = gnc_plugin_page_owner_tree_save_page;
     gnc_plugin_class->recreate_page   = gnc_plugin_page_owner_tree_recreate_page;
-
-    g_type_class_add_private(klass, sizeof(GncPluginPageOwnerTreePrivate));
 
     plugin_page_signals[OWNER_SELECTED] =
         g_signal_new ("owner_selected",

--- a/gnucash/gnome/gnc-plugin-page-register.c
+++ b/gnucash/gnome/gnc-plugin-page-register.c
@@ -597,34 +597,6 @@ static GObjectClass *parent_class = NULL;
 /*                      Implementation                      */
 /************************************************************/
 
-GType
-gnc_plugin_page_register_get_type (void)
-{
-    static GType gnc_plugin_page_register_type = 0;
-
-    if (gnc_plugin_page_register_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncPluginPageRegisterClass),
-            NULL,
-            NULL,
-            (GClassInitFunc) gnc_plugin_page_register_class_init,
-            NULL,
-            NULL,
-            sizeof (GncPluginPageRegister),
-            0,
-            (GInstanceInitFunc) gnc_plugin_page_register_init
-        };
-
-        gnc_plugin_page_register_type = g_type_register_static (GNC_TYPE_PLUGIN_PAGE,
-                                        GNC_PLUGIN_PAGE_REGISTER_NAME,
-                                        &our_info, 0);
-    }
-
-    return gnc_plugin_page_register_type;
-}
-
 static GncPluginPage *
 gnc_plugin_page_register_new_common (GNCLedgerDisplay *ledger)
 {
@@ -742,6 +714,8 @@ gnc_plugin_page_register_new_ledger (GNCLedgerDisplay *ledger)
     return gnc_plugin_page_register_new_common(ledger);
 }
 
+G_DEFINE_TYPE_WITH_PRIVATE(GncPluginPageRegister, gnc_plugin_page_register, GNC_TYPE_PLUGIN_PAGE)
+
 static void
 gnc_plugin_page_register_class_init (GncPluginPageRegisterClass *klass)
 {
@@ -761,8 +735,6 @@ gnc_plugin_page_register_class_init (GncPluginPageRegisterClass *klass)
     gnc_plugin_class->recreate_page   = gnc_plugin_page_register_recreate_page;
     gnc_plugin_class->update_edit_menu_actions = gnc_plugin_page_register_update_edit_menu;
     gnc_plugin_class->finish_pending  = gnc_plugin_page_register_finish_pending;
-
-    g_type_class_add_private(klass, sizeof(GncPluginPageRegisterPrivate));
 
     gnc_ui_register_account_destroy_callback (gppr_account_destroy_cb);
 }

--- a/gnucash/gnome/gnc-plugin-page-register2.c
+++ b/gnucash/gnome/gnc-plugin-page-register2.c
@@ -563,34 +563,6 @@ static GObjectClass *parent_class = NULL;
 /*                      Implementation                      */
 /************************************************************/
 
-GType
-gnc_plugin_page_register2_get_type (void)
-{
-    static GType gnc_plugin_page_register2_type = 0;
-
-    if (gnc_plugin_page_register2_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncPluginPageRegister2Class),
-            NULL,
-            NULL,
-            (GClassInitFunc) gnc_plugin_page_register2_class_init,
-            NULL,
-            NULL,
-            sizeof (GncPluginPageRegister2),
-            0,
-            (GInstanceInitFunc) gnc_plugin_page_register2_init
-        };
-
-        gnc_plugin_page_register2_type = g_type_register_static (GNC_TYPE_PLUGIN_PAGE,
-                                        GNC_PLUGIN_PAGE_REGISTER2_NAME,
-                                        &our_info, 0);
-    }
-
-    return gnc_plugin_page_register2_type;
-}
-
 /*#################################################################################*/
 /*#################################################################################*/
 static GncPluginPage *
@@ -714,6 +686,8 @@ gnc_plugin_page_register2_new_ledger (GNCLedgerDisplay2 *ledger)
     return gnc_plugin_page_register2_new_common (ledger);
 }
 
+G_DEFINE_TYPE_WITH_PRIVATE(GncPluginPageRegister2, gnc_plugin_page_register2, GNC_TYPE_PLUGIN_PAGE)
+
 static void
 gnc_plugin_page_register2_class_init (GncPluginPageRegister2Class *klass)
 {
@@ -733,8 +707,6 @@ gnc_plugin_page_register2_class_init (GncPluginPageRegister2Class *klass)
     gnc_plugin_class->recreate_page   = gnc_plugin_page_register2_recreate_page;
     gnc_plugin_class->update_edit_menu_actions = gnc_plugin_page_register2_update_edit_menu;
     gnc_plugin_class->finish_pending  = gnc_plugin_page_register2_finish_pending;
-
-    g_type_class_add_private(klass, sizeof(GncPluginPageRegister2Private));
 
     gnc_ui_register_account_destroy_callback (gppr_account_destroy_cb);
 }

--- a/gnucash/gnome/gnc-plugin-page-sx-list.c
+++ b/gnucash/gnome/gnc-plugin-page-sx-list.c
@@ -164,36 +164,6 @@ static GtkActionEntry gnc_plugin_page_sx_list_actions [] =
 /** The number of actions provided by this plugin. */
 static guint gnc_plugin_page_sx_list_n_actions = G_N_ELEMENTS (gnc_plugin_page_sx_list_actions);
 
-
-GType
-gnc_plugin_page_sx_list_get_type (void)
-{
-    static GType gnc_plugin_page_sx_list_type = 0;
-
-    if (gnc_plugin_page_sx_list_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncPluginPageSxListClass),
-            NULL,
-            NULL,
-            (GClassInitFunc) gnc_plugin_page_sx_list_class_init,
-            NULL,
-            NULL,
-            sizeof (GncPluginPageSxList),
-            0,
-            (GInstanceInitFunc) gnc_plugin_page_sx_list_init
-        };
-
-        gnc_plugin_page_sx_list_type = g_type_register_static (GNC_TYPE_PLUGIN_PAGE,
-                                       GNC_PLUGIN_PAGE_SX_LIST_NAME,
-                                       &our_info, 0);
-    }
-
-    return gnc_plugin_page_sx_list_type;
-}
-
-
 GncPluginPage *
 gnc_plugin_page_sx_list_new (void)
 {
@@ -252,6 +222,7 @@ gnc_plugin_page_sx_list_main_window_page_changed (GncMainWindow *window,
     }
 }
 
+G_DEFINE_TYPE_WITH_PRIVATE(GncPluginPageSxList, gnc_plugin_page_sx_list, GNC_TYPE_PLUGIN_PAGE)
 
 static void
 gnc_plugin_page_sx_list_class_init (GncPluginPageSxListClass *klass)
@@ -270,8 +241,6 @@ gnc_plugin_page_sx_list_class_init (GncPluginPageSxListClass *klass)
     gnc_plugin_class->destroy_widget  = gnc_plugin_page_sx_list_destroy_widget;
     gnc_plugin_class->save_page       = gnc_plugin_page_sx_list_save_page;
     gnc_plugin_class->recreate_page   = gnc_plugin_page_sx_list_recreate_page;
-
-    g_type_class_add_private(klass, sizeof(GncPluginPageSxListPrivate));
 }
 
 

--- a/gnucash/gnome/gnc-plugin-register.c
+++ b/gnucash/gnome/gnc-plugin-register.c
@@ -103,34 +103,6 @@ gnc_plugin_register_pref_changed (gpointer prefs, gchar *pref,
  *                  Object Implementation                   *
  ************************************************************/
 
-GType
-gnc_plugin_register_get_type (void)
-{
-    static GType gnc_plugin_register_type = 0;
-
-    if (gnc_plugin_register_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncPluginRegisterClass),
-            NULL,		/* base_init */
-            NULL,		/* base_finalize */
-            (GClassInitFunc) gnc_plugin_register_class_init,
-            NULL,		/* class_finalize */
-            NULL,		/* class_data */
-            sizeof (GncPluginRegister),
-            0,		/* n_preallocs */
-            (GInstanceInitFunc) gnc_plugin_register_init
-        };
-
-        gnc_plugin_register_type = g_type_register_static (GNC_TYPE_PLUGIN,
-                                   "GncPluginRegister",
-                                   &our_info, 0);
-    }
-
-    return gnc_plugin_register_type;
-}
-
 GncPlugin *
 gnc_plugin_register_new (void)
 {
@@ -167,6 +139,8 @@ gnc_plugin_register_main_window_page_changed(GncMainWindow *window,
     }
 }
 
+G_DEFINE_TYPE_WITH_PRIVATE(GncPluginRegister, gnc_plugin_register, GNC_TYPE_PLUGIN)
+
 static void
 gnc_plugin_register_class_init (GncPluginRegisterClass *klass)
 {
@@ -190,8 +164,6 @@ gnc_plugin_register_class_init (GncPluginRegisterClass *klass)
     plugin_class->actions      = gnc_plugin_actions;
     plugin_class->n_actions    = gnc_plugin_n_actions;
     plugin_class->ui_filename  = PLUGIN_UI_FILENAME;
-
-    g_type_class_add_private(klass, sizeof(GncPluginRegisterPrivate));
 }
 
 static void

--- a/gnucash/gnome/gnc-plugin-register2.c
+++ b/gnucash/gnome/gnc-plugin-register2.c
@@ -110,34 +110,6 @@ gnc_plugin_register2_pref_changed (gpointer prefs, gchar *pref,
  *                  Object Implementation                   *
  ************************************************************/
 
-GType
-gnc_plugin_register2_get_type (void)
-{
-    static GType gnc_plugin_register2_type = 0;
-
-    if (gnc_plugin_register2_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncPluginRegister2Class),
-            NULL,		/* base_init */
-            NULL,		/* base_finalize */
-            (GClassInitFunc) gnc_plugin_register2_class_init,
-            NULL,		/* class_finalize */
-            NULL,		/* class_data */
-            sizeof (GncPluginRegister2),
-            0,		/* n_preallocs */
-            (GInstanceInitFunc) gnc_plugin_register2_init
-        };
-
-        gnc_plugin_register2_type = g_type_register_static (GNC_TYPE_PLUGIN,
-                                   "GncPluginRegister2",
-                                   &our_info, 0);
-    }
-
-    return gnc_plugin_register2_type;
-}
-
 GncPlugin *
 gnc_plugin_register2_new (void)
 {
@@ -152,6 +124,8 @@ gnc_plugin_register2_new (void)
 
     return GNC_PLUGIN (plugin);
 }
+
+G_DEFINE_TYPE_WITH_PRIVATE(GncPluginRegister2, gnc_plugin_register2, GNC_TYPE_PLUGIN)
 
 static void
 gnc_plugin_register2_class_init (GncPluginRegister2Class *klass)
@@ -176,8 +150,6 @@ gnc_plugin_register2_class_init (GncPluginRegister2Class *klass)
     plugin_class->actions      = gnc_plugin_actions;
     plugin_class->n_actions    = gnc_plugin_n_actions;
     plugin_class->ui_filename  = PLUGIN_UI_FILENAME;
-
-    g_type_class_add_private(klass, sizeof(GncPluginRegister2Private));
 }
 
 static void

--- a/gnucash/gnome/search-owner.c
+++ b/gnucash/gnome/search-owner.c
@@ -73,33 +73,7 @@ enum
 static guint signals[LAST_SIGNAL] = { 0 };
 #endif
 
-GType
-gnc_search_owner_get_type (void)
-{
-    static GType type = 0;
-
-    if (!type)
-    {
-        GTypeInfo type_info =
-        {
-            sizeof(GNCSearchOwnerClass),    /* class_size */
-            NULL,                           /* base_init */
-            NULL,                           /* base_finalize */
-            (GClassInitFunc)gnc_search_owner_class_init,
-            NULL,                           /* class_finalize */
-            NULL,                           /* class_data */
-            sizeof(GNCSearchOwner),         /* */
-            0,                              /* n_preallocs */
-            (GInstanceInitFunc)gnc_search_owner_init,
-        };
-
-        type = g_type_register_static (GNC_TYPE_SEARCH_CORE_TYPE,
-                                       "GNCSearchOwner",
-                                       &type_info, 0);
-    }
-
-    return type;
-}
+G_DEFINE_TYPE_WITH_PRIVATE(GNCSearchOwner, gnc_search_owner, GNC_TYPE_SEARCH_CORE_TYPE);
 
 static void
 gnc_search_owner_class_init (GNCSearchOwnerClass *klass)
@@ -118,8 +92,6 @@ gnc_search_owner_class_init (GNCSearchOwnerClass *klass)
     gnc_search_core_type->get_widget = gncs_get_widget;
     gnc_search_core_type->get_predicate = gncs_get_predicate;
     gnc_search_core_type->clone = gncs_clone;
-
-    g_type_class_add_private(klass, sizeof(GNCSearchOwnerPrivate));
 }
 
 static void

--- a/gnucash/gtkbuilder/assistant-csv-price-import.glade
+++ b/gnucash/gtkbuilder/assistant-csv-price-import.glade
@@ -433,6 +433,7 @@ Select location and file name for the Import, then click 'OK'...
                               <object class="GtkGrid" id="table2">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
+                                <property name="column_spacing">5</property>
                                 <child>
                                   <object class="GtkLabel" id="label2">
                                     <property name="visible">True</property>

--- a/gnucash/gtkbuilder/assistant-csv-trans-import.glade
+++ b/gnucash/gtkbuilder/assistant-csv-trans-import.glade
@@ -433,6 +433,7 @@ Select location and file name for the Import, then click 'OK'...
                               <object class="GtkGrid" id="table2">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
+                                <property name="column_spacing">5</property>
                                 <child>
                                   <object class="GtkLabel" id="label2">
                                     <property name="visible">True</property>

--- a/gnucash/gtkbuilder/dialog-account.glade
+++ b/gnucash/gtkbuilder/dialog-account.glade
@@ -1253,6 +1253,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="wrap_mode">word</property>
+                                <property name="accepts_tab">False</property>
                               </object>
                             </child>
                           </object>

--- a/gnucash/gtkbuilder/dialog-import.glade
+++ b/gnucash/gtkbuilder/dialog-import.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 -->
+<!-- Generated with glade 3.20.4 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkImage" id="account_new_icon">
@@ -1121,6 +1121,21 @@
     </child>
     <child>
       <placeholder/>
+    </child>
+    <child>
+      <object class="GtkCheckButton" id="show_source_account_button">
+        <property name="label" translatable="yes">Show the Source Account column</property>
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="receives_default">False</property>
+        <property name="halign">center</property>
+        <property name="draw_indicator">True</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">3</property>
+      </packing>
     </child>
   </object>
   <object class="GtkDialog" id="transaction_matcher_dialog">

--- a/gnucash/import-export/bi-import/dialog-bi-import.c
+++ b/gnucash/import-export/bi-import/dialog-bi-import.c
@@ -876,30 +876,26 @@ gnc_bi_import_create_bis (GtkListStore * store, QofBook * book,
  * @param char* String to be modified
  * @return char* Modified string.
 */
-static char * un_escape(char *str)
+static char*
+un_escape(char *str)
 {
     gchar quote = '"';
     gchar *newStr = NULL, *tmpstr = str;
     int n = 0;
+
     newStr = g_malloc(strlen(str)+1); // This must be freed in the calling code.
     while(*tmpstr != '\0')
     {
         if(*tmpstr == quote)
-        {
-            tmpstr++;
-            if(*tmpstr == quote)
-            {
-                newStr[n] = quote;
-            }
-        }
+            // We always want the character after a quote.
+            newStr[n] = *(++tmpstr);
         else
-        {
-            newStr[n] = *str;
-        }
-            tmpstr++;
-            n++;
+            newStr[n] = *tmpstr;
+        ++tmpstr;
+        ++n;
     }
+
     g_free (str);
-	newStr[n] = '\0'; //ending the character array
+    newStr[n] = '\0'; //ending the character array
     return newStr;
 }

--- a/gnucash/import-export/bi-import/dialog-bi-import.c
+++ b/gnucash/import-export/bi-import/dialog-bi-import.c
@@ -877,25 +877,21 @@ gnc_bi_import_create_bis (GtkListStore * store, QofBook * book,
  * @return char* Modified string.
 */
 static char*
+static char*
 un_escape(char *str)
 {
     gchar quote = '"';
     gchar *newStr = NULL, *tmpstr = str;
-    int n = 0;
+    int n = strlen (str), i;
+    newStr = g_malloc (n + 1);
+    memset (newStr, 0, n + 1);
 
-    newStr = g_malloc(strlen(str)+1); // This must be freed in the calling code.
-    while(*tmpstr != '\0')
+    for (i = 0; *tmpstr != '\0'; ++i, ++tmpstr)
     {
-        if(*tmpstr == quote)
-            // We always want the character after a quote.
-            newStr[n] = *(++tmpstr);
-        else
-            newStr[n] = *tmpstr;
-        ++tmpstr;
-        ++n;
+        newStr[i] = *tmpstr == quote ? *(++tmpstr) : *(tmpstr);
+        if (*tmpstr == '\0')
+            break;
     }
-
     g_free (str);
-    newStr[n] = '\0'; //ending the character array
     return newStr;
 }

--- a/gnucash/import-export/bi-import/dialog-bi-import.c
+++ b/gnucash/import-export/bi-import/dialog-bi-import.c
@@ -877,7 +877,6 @@ gnc_bi_import_create_bis (GtkListStore * store, QofBook * book,
  * @return char* Modified string.
 */
 static char*
-static char*
 un_escape(char *str)
 {
     gchar quote = '"';

--- a/gnucash/import-export/csv-exp/assistant-csv-export.c
+++ b/gnucash/import-export/csv-exp/assistant-csv-export.c
@@ -73,6 +73,7 @@ void csv_export_show_range_cb (GtkRadioButton *button, gpointer user_data);
 void csv_export_start_date_cb (GtkWidget *radio, gpointer user_data);
 void csv_export_end_date_cb (GtkWidget *radio, gpointer user_data);
 
+void csv_export_file_chooser_file_activated_cb (GtkFileChooser *chooser, CsvExportInfo *info);
 void csv_export_file_chooser_selection_changed_cb (GtkFileChooser *chooser, CsvExportInfo *info);
 
 static const gchar *finish_tree_string = N_(
@@ -121,21 +122,15 @@ static const gchar *start_trans_simple_string = N_(
 
 
 /**************************************************
- * csv_export_file_chooser_selection_changed_cb
+ * csv_export_assistant_check_filename
  *
- * call back for GtkFileChooser widget
+ * check for a valid filename for GtkFileChooser callbacks
  **************************************************/
-void
-csv_export_file_chooser_selection_changed_cb (GtkFileChooser *chooser, CsvExportInfo *info)
+static gboolean
+csv_export_assistant_check_filename (GtkFileChooser *chooser,
+                                     CsvExportInfo *info)
 {
-    GtkAssistant *assistant = GTK_ASSISTANT(info->window);
-    gint num = gtk_assistant_get_current_page (assistant);
-    GtkWidget *page = gtk_assistant_get_nth_page (assistant, num);
-    gchar *file_name;
-
-    gtk_assistant_set_page_complete (assistant, page, FALSE);
-
-    file_name = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER(info->file_chooser));
+    gchar *file_name = gtk_file_chooser_get_filename (chooser);
 
     /* Test for a valid filename and not a directory */
     if (file_name && !g_file_test (file_name, G_FILE_TEST_IS_DIR))
@@ -151,13 +146,52 @@ csv_export_file_chooser_selection_changed_cb (GtkFileChooser *chooser, CsvExport
 
         g_free (filedir);
         g_free (filepath);
+        g_free (file_name);
 
-        gtk_assistant_set_page_complete (assistant, page, TRUE);
+        DEBUG("file_name selected is %s", info->file_name);
+        DEBUG("starting directory is %s", info->starting_dir);
+        return TRUE;
     }
     g_free (file_name);
+    return FALSE;
+}
 
-    DEBUG("file_name selected is %s", info->file_name);
-    DEBUG("starting directory is %s", info->starting_dir);
+
+/**************************************************
+ * csv_export_file_chooser_file_activated_cb
+ *
+ * call back for GtkFileChooser file-activated signal
+ **************************************************/
+void
+csv_export_file_chooser_file_activated_cb (GtkFileChooser *chooser,
+                                           CsvExportInfo *info)
+{
+    GtkAssistant *assistant = GTK_ASSISTANT(info->assistant);
+    gtk_assistant_set_page_complete (assistant, info->file_page, FALSE);
+
+    /* Test for a valid filename and not a directory */
+    if (csv_export_assistant_check_filename (chooser, info))
+    {
+        gtk_assistant_set_page_complete (assistant, info->file_page, TRUE);
+        gtk_assistant_next_page (assistant);
+    }
+}
+
+
+/**************************************************
+ * csv_export_file_chooser_selection_changed_cb
+ *
+ * call back for GtkFileChooser widget
+ **************************************************/
+void
+csv_export_file_chooser_selection_changed_cb (GtkFileChooser *chooser,
+                                              CsvExportInfo *info)
+{
+    GtkAssistant *assistant = GTK_ASSISTANT(info->assistant);
+
+    /* Enable the forward button based on a valid filename */
+    gtk_assistant_set_page_complete (assistant, info->file_page,
+        csv_export_assistant_check_filename (chooser, info));
 }
 
 
@@ -170,11 +204,8 @@ void
 csv_export_sep_cb (GtkWidget *radio, gpointer user_data)
 {
     CsvExportInfo *info = user_data;
+    GtkAssistant *assistant = GTK_ASSISTANT(info->assistant);
     const gchar *name;
-
-    GtkAssistant *assistant = GTK_ASSISTANT(info->window);
-    gint num = gtk_assistant_get_current_page (assistant);
-    GtkWidget *page = gtk_assistant_get_nth_page (assistant, num);
 
     if (!gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON(radio)))
     {
@@ -186,7 +217,7 @@ csv_export_sep_cb (GtkWidget *radio, gpointer user_data)
 
     gtk_widget_set_sensitive (info->custom_entry, FALSE);
     info->use_custom = FALSE;
-    gtk_assistant_set_page_complete (assistant, page, TRUE);
+    gtk_assistant_set_page_complete (assistant, info->start_page, TRUE);
 
     if (g_strcmp0 (name, "comma_radio") == 0)
         info->separator_str = ",";
@@ -200,7 +231,7 @@ csv_export_sep_cb (GtkWidget *radio, gpointer user_data)
         gtk_widget_set_sensitive (info->custom_entry, TRUE);
         info->use_custom = TRUE;
         if (gtk_entry_get_text_length (GTK_ENTRY(info->custom_entry)) == 0)
-            gtk_assistant_set_page_complete (assistant, page, FALSE);
+            gtk_assistant_set_page_complete (assistant, info->start_page, FALSE);
     }
 }
 
@@ -246,19 +277,16 @@ void
 csv_export_custom_entry_cb (GtkWidget *widget, gpointer user_data)
 {
     CsvExportInfo *info = user_data;
+    GtkAssistant *assistant = GTK_ASSISTANT(info->assistant);
     const gchar *custom_str;
-
-    GtkAssistant *assistant = GTK_ASSISTANT(info->window);
-    gint num = gtk_assistant_get_current_page (assistant);
-    GtkWidget *page = gtk_assistant_get_nth_page (assistant, num);
 
     custom_str = gtk_entry_get_text (GTK_ENTRY(info->custom_entry));
     info->separator_str = strdup (custom_str);
 
     if (info->use_custom == TRUE && gtk_entry_get_text_length (GTK_ENTRY(info->custom_entry)) == 0)
-        gtk_assistant_set_page_complete (assistant, page, FALSE);
+        gtk_assistant_set_page_complete (assistant, info->start_page, FALSE);
     else
-        gtk_assistant_set_page_complete (assistant, page, TRUE);
+        gtk_assistant_set_page_complete (assistant, info->start_page, TRUE);
 }
 
 
@@ -384,10 +412,7 @@ csv_export_account_changed_cb (GtkTreeSelection *selection,
                                gpointer user_data)
 {
     CsvExportInfo *info = user_data;
-    GtkAssistant *assistant = GTK_ASSISTANT(info->window);
-    gint num = gtk_assistant_get_current_page (assistant);
-    GtkWidget *page = gtk_assistant_get_nth_page (assistant, num);
-
+    GtkAssistant *assistant = GTK_ASSISTANT(info->assistant);
     GncTreeViewAccount *view;
 
     g_return_if_fail(GTK_IS_TREE_SELECTION(selection));
@@ -396,9 +421,9 @@ csv_export_account_changed_cb (GtkTreeSelection *selection,
 
     /* Enable the Forward Assistant Button if we have accounts */
     if (info->csva.num_accounts > 0)
-        gtk_assistant_set_page_complete (assistant, page, TRUE);
+        gtk_assistant_set_page_complete (assistant, info->account_page, TRUE);
     else
-        gtk_assistant_set_page_complete (assistant, page, FALSE);
+        gtk_assistant_set_page_complete (assistant, info->account_page, FALSE);
 
     view = GNC_TREE_VIEW_ACCOUNT(info->csva.account_treeview);
     info->csva.account_list = gnc_tree_view_account_get_selected_accounts (view);
@@ -612,8 +637,6 @@ csv_export_assistant_start_page_prepare (GtkAssistant *assistant,
         gpointer user_data)
 {
     CsvExportInfo *info = user_data;
-    gint num = gtk_assistant_get_current_page (assistant);
-    GtkWidget *page = gtk_assistant_get_nth_page (assistant, num);
 
     /* Set Start page text */
     if (info->export_type == XML_EXPORT_TREE)
@@ -628,7 +651,7 @@ csv_export_assistant_start_page_prepare (GtkAssistant *assistant,
     }
 
     /* Enable the Assistant Buttons */
-    gtk_assistant_set_page_complete (assistant, page, TRUE);
+    gtk_assistant_set_page_complete (assistant, info->start_page, TRUE);
 }
 
 
@@ -637,14 +660,12 @@ csv_export_assistant_account_page_prepare (GtkAssistant *assistant,
         gpointer user_data)
 {
     CsvExportInfo *info = user_data;
-    gint num = gtk_assistant_get_current_page (assistant);
-    GtkWidget *page = gtk_assistant_get_nth_page (assistant, num);
 
     /* Enable the Forward Assistant Button if we have accounts */
     if (info->csva.num_accounts > 0)
-        gtk_assistant_set_page_complete (assistant, page, TRUE);
+        gtk_assistant_set_page_complete (assistant, info->account_page, TRUE);
     else
-        gtk_assistant_set_page_complete (assistant, page, FALSE);
+        gtk_assistant_set_page_complete (assistant, info->account_page, FALSE);
 }
 
 
@@ -653,8 +674,6 @@ csv_export_assistant_file_page_prepare (GtkAssistant *assistant,
                                         gpointer user_data)
 {
     CsvExportInfo *info = user_data;
-    gint num = gtk_assistant_get_current_page (assistant);
-    GtkWidget *page = gtk_assistant_get_nth_page (assistant, num);
 
     /* Set the default directory */
     if (info->starting_dir)
@@ -662,7 +681,7 @@ csv_export_assistant_file_page_prepare (GtkAssistant *assistant,
     gtk_file_chooser_set_current_name (GTK_FILE_CHOOSER(info->file_chooser), "");
 
     /* Disable the Forward Assistant Button */
-    gtk_assistant_set_page_complete (assistant, page, FALSE);
+    gtk_assistant_set_page_complete (assistant, info->file_page, FALSE);
 }
 
 
@@ -671,8 +690,6 @@ csv_export_assistant_finish_page_prepare (GtkAssistant *assistant,
         gpointer user_data)
 {
     CsvExportInfo *info = user_data;
-    gint num = gtk_assistant_get_current_page (assistant);
-    GtkWidget *page = gtk_assistant_get_nth_page (assistant, num);
     gchar *text;
 
     /* Set Finish page text */
@@ -699,7 +716,7 @@ csv_export_assistant_finish_page_prepare (GtkAssistant *assistant,
             gtk_assistant_previous_page (assistant);
     }
     /* Enable the Assistant Buttons */
-    gtk_assistant_set_page_complete (assistant, page, TRUE);
+    gtk_assistant_set_page_complete (assistant, info->finish_label, TRUE);
 }
 
 
@@ -793,8 +810,8 @@ csv_export_close_handler (gpointer user_data)
     if (info->mid_sep)
         g_free (info->mid_sep);
 
-    gnc_save_window_size (GNC_PREFS_GROUP, GTK_WINDOW(info->window));
-    gtk_widget_destroy (info->window);
+    gnc_save_window_size (GNC_PREFS_GROUP, GTK_WINDOW(info->assistant));
+    gtk_widget_destroy (info->assistant);
 }
 
 /*******************************************************
@@ -804,19 +821,17 @@ static GtkWidget *
 csv_export_assistant_create (CsvExportInfo *info)
 {
     GtkBuilder *builder;
-    GtkWidget *window;
-    GtkWidget *box, *h_box;
+    GtkWidget *h_box;
     GtkWidget *button;
     GtkWidget *table, *hbox;
     time64 start_time, end_time;
 
     builder = gtk_builder_new();
     gnc_builder_add_from_file  (builder , "assistant-csv-export.glade", "csv_export_assistant");
-    window = GTK_WIDGET(gtk_builder_get_object (builder, "csv_export_assistant"));
-    info->window = window;
+    info->assistant = GTK_WIDGET(gtk_builder_get_object (builder, "csv_export_assistant"));
 
     // Set the style context for this assistant so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(window), "GncAssistExport");
+    gnc_widget_set_style_context (GTK_WIDGET(info->assistant), "GncAssistExport");
 
     /* Load default settings */
     load_settings (info);
@@ -837,7 +852,7 @@ csv_export_assistant_create (CsvExportInfo *info)
         // Don't provide simple export layout for search registers and General Journal
         if ((info->export_type == XML_EXPORT_TREE) || (info->account == NULL))
             gtk_widget_destroy (chkbox);
-        gtk_assistant_remove_page (GTK_ASSISTANT(window), 1); //remove accounts page
+        gtk_assistant_remove_page (GTK_ASSISTANT(info->assistant), 1); //remove accounts page
     }
     else
     {
@@ -922,8 +937,10 @@ csv_export_assistant_create (CsvExportInfo *info)
     g_signal_connect (G_OBJECT(info->file_chooser), "selection-changed",
                       G_CALLBACK(csv_export_file_chooser_selection_changed_cb), info);
 
-    box = GTK_WIDGET(gtk_builder_get_object (builder, "file_page"));
-    gtk_box_pack_start (GTK_BOX (box), info->file_chooser, TRUE, TRUE, 6);
+    g_signal_connect (G_OBJECT(info->file_chooser), "file-activated",
+                      G_CALLBACK(csv_export_file_chooser_file_activated_cb), info);
+
+    gtk_box_pack_start (GTK_BOX (info->file_page), info->file_chooser, TRUE, TRUE, 6);
     gtk_widget_show (info->file_chooser);
 
     /* Finish Page */
@@ -932,11 +949,11 @@ csv_export_assistant_create (CsvExportInfo *info)
     /* Summary Page */
     info->summary_label = GTK_WIDGET(gtk_builder_get_object (builder, "summary_page"));
 
-    g_signal_connect (G_OBJECT(window), "destroy",
+    g_signal_connect (G_OBJECT(info->assistant), "destroy",
                       G_CALLBACK(csv_export_assistant_destroy_cb), info);
 
     gnc_restore_window_size (GNC_PREFS_GROUP,
-                             GTK_WINDOW(info->window), gnc_ui_get_main_window(NULL));
+                             GTK_WINDOW(info->assistant), gnc_ui_get_main_window(NULL));
     if (gnc_prefs_get_bool (GNC_PREFS_GROUP_GENERAL, GNC_PREF_SAVE_GEOMETRY))
     {
         GObject *object = gtk_builder_get_object (builder, "paned");
@@ -945,7 +962,7 @@ csv_export_assistant_create (CsvExportInfo *info)
 
     gtk_builder_connect_signals (builder, info);
     g_object_unref (G_OBJECT(builder));
-    return window;
+    return info->assistant;
 }
 
 static void
@@ -967,8 +984,8 @@ gnc_file_csv_export_internal (CsvExportType export_type, Query *q, Account *acc)
     gnc_register_gui_component (ASSISTANT_CSV_EXPORT_CM_CLASS,
                                 NULL, csv_export_close_handler,
                                 info);
-    gtk_widget_show_all (info->window);
-    gnc_window_adjust_for_screen (GTK_WINDOW(info->window));
+    gtk_widget_show_all (info->assistant);
+    gnc_window_adjust_for_screen (GTK_WINDOW(info->assistant));
 }
 
 

--- a/gnucash/import-export/csv-exp/assistant-csv-export.h
+++ b/gnucash/import-export/csv-exp/assistant-csv-export.h
@@ -73,12 +73,11 @@ typedef struct
 
     Query          *query;
     Account        *account;
-    
+
     GtkWidget      *start_page;
     GtkWidget      *account_page;
     GtkWidget      *file_page;
 
-    GtkWidget      *window;
     GtkWidget      *assistant;
     GtkWidget      *start_label;
     GtkWidget      *custom_entry;

--- a/gnucash/import-export/csv-exp/gnc-plugin-csv-export.c
+++ b/gnucash/import-export/csv-exp/gnc-plugin-csv-export.c
@@ -78,39 +78,13 @@ typedef struct GncPluginCsvExportPrivate
 
 static GObjectClass *parent_class = NULL;
 
-GType
-gnc_plugin_csv_export_get_type (void)
-{
-    static GType gnc_plugin_csv_export_type = 0;
-
-    if (gnc_plugin_csv_export_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncPluginCsvExportClass),
-            NULL,		/* base_init */
-            NULL,		/* base_finalize */
-            (GClassInitFunc) gnc_plugin_csv_export_class_init,
-            NULL,		/* class_finalize */
-            NULL,		/* class_data */
-            sizeof (GncPluginCsvExport),
-            0,		/* n_preallocs */
-            (GInstanceInitFunc) gnc_plugin_csv_export_init,
-        };
-
-        gnc_plugin_csv_export_type = g_type_register_static (GNC_TYPE_PLUGIN,
-                                     "GncPluginCsvExport",
-                                     &our_info, 0);
-    }
-
-    return gnc_plugin_csv_export_type;
-}
-
 GncPlugin *
 gnc_plugin_csv_export_new (void)
 {
     return GNC_PLUGIN (g_object_new (GNC_TYPE_PLUGIN_CSV_EXPORT, NULL));
 }
+
+G_DEFINE_TYPE_WITH_PRIVATE(GncPluginCsvExport, gnc_plugin_csv_export, GNC_TYPE_PLUGIN)
 
 static void
 gnc_plugin_csv_export_class_init (GncPluginCsvExportClass *klass)
@@ -130,8 +104,6 @@ gnc_plugin_csv_export_class_init (GncPluginCsvExportClass *klass)
     plugin_class->actions      = gnc_plugin_actions;
     plugin_class->n_actions    = gnc_plugin_n_actions;
     plugin_class->ui_filename  = PLUGIN_UI_FILENAME;
-
-    g_type_class_add_private(klass, sizeof(GncPluginCsvExportPrivate));
 }
 
 static void

--- a/gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp
+++ b/gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp
@@ -159,6 +159,7 @@ public:
     void assist_finish ();
     void assist_compmgr_close ();
 
+    void file_activated_cb ();
     void file_selection_changed_cb ();
 
     void preview_settings_delete ();
@@ -202,6 +203,8 @@ private:
     GtkWidget* preview_cbox_factory (GtkTreeModel* model, uint32_t colnum);
     /* helper function to set rendering parameters for preview data columns */
     void preview_style_column (uint32_t col_num, GtkTreeModel* model);
+    /* helper function to check for a valid filename as opposed to a directory */
+    bool check_for_valid_filename ();
 
     GtkAssistant    *csv_imp_asst;
 
@@ -269,6 +272,7 @@ extern "C"
 void csv_tximp_assist_prepare_cb (GtkAssistant  *assistant, GtkWidget *page, CsvImpTransAssist* info);
 void csv_tximp_assist_close_cb (GtkAssistant *gtkassistant, CsvImpTransAssist* info);
 void csv_tximp_assist_finish_cb (GtkAssistant *gtkassistant, CsvImpTransAssist* info);
+void csv_tximp_file_activated_cb (GtkFileChooser *chooser,  CsvImpTransAssist *info);
 void csv_tximp_file_selection_changed_cb (GtkFileChooser *chooser,  CsvImpTransAssist *info);
 void csv_tximp_preview_del_settings_cb (GtkWidget *button, CsvImpTransAssist *info);
 void csv_tximp_preview_save_settings_cb (GtkWidget *button, CsvImpTransAssist *info);
@@ -309,6 +313,10 @@ csv_tximp_assist_finish_cb (GtkAssistant *assistant, CsvImpTransAssist* info)
     info->assist_finish ();
 }
 
+void csv_tximp_file_activated_cb (GtkFileChooser *chooser, CsvImpTransAssist *info)
+{
+    info->file_activated_cb();
+}
 
 void csv_tximp_file_selection_changed_cb (GtkFileChooser *chooser, CsvImpTransAssist *info)
 {
@@ -481,6 +489,8 @@ CsvImpTransAssist::CsvImpTransAssist ()
     file_chooser = gtk_file_chooser_widget_new (GTK_FILE_CHOOSER_ACTION_OPEN);
     g_signal_connect (G_OBJECT(file_chooser), "selection-changed",
                       G_CALLBACK(csv_tximp_file_selection_changed_cb), this);
+    g_signal_connect (G_OBJECT(file_chooser), "file-activated",
+                      G_CALLBACK(csv_tximp_file_activated_cb), this);
 
     auto box = GTK_WIDGET(gtk_builder_get_object (builder, "file_page"));
     gtk_box_pack_start (GTK_BOX(box), file_chooser, TRUE, TRUE, 6);
@@ -671,18 +681,14 @@ CsvImpTransAssist::~CsvImpTransAssist ()
  * Code related to the file chooser page
  **************************************************/
 
-/* csv_tximp_file_selection_changed_cb
- *
- * call back for ok button in file chooser widget
+/* check_for_valid_filename for a valid file to activate the forward button
  */
-void
-CsvImpTransAssist::file_selection_changed_cb ()
+bool
+CsvImpTransAssist::check_for_valid_filename ()
 {
-    gtk_assistant_set_page_complete (csv_imp_asst, file_page, false);
-
     auto file_name = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER(file_chooser));
     if (!file_name || g_file_test (file_name, G_FILE_TEST_IS_DIR))
-        return;
+        return false;
 
     auto filepath = gnc_uri_get_path (file_name);
     auto starting_dir = g_path_get_dirname (filepath);
@@ -697,7 +703,36 @@ CsvImpTransAssist::file_selection_changed_cb ()
     g_free (file_name);
     g_free (starting_dir);
 
-    gtk_assistant_set_page_complete (csv_imp_asst, file_page, true);
+    return true;
+}
+
+/* csv_tximp_file_activated_cb
+ *
+ * call back for file chooser widget
+ */
+void
+CsvImpTransAssist::file_activated_cb ()
+{
+    gtk_assistant_set_page_complete (csv_imp_asst, file_page, false);
+
+    /* Test for a valid filename and not a directory */
+    if (check_for_valid_filename ())
+    {
+        gtk_assistant_set_page_complete (csv_imp_asst, file_page, true);
+        gtk_assistant_next_page (csv_imp_asst);
+    }
+}
+
+/* csv_tximp_file_selection_changed_cb
+ *
+ * call back for file chooser widget
+ */
+void
+CsvImpTransAssist::file_selection_changed_cb ()
+{
+    /* Enable the forward button based on a valid filename */
+    gtk_assistant_set_page_complete (csv_imp_asst, file_page,
+        check_for_valid_filename ());
 }
 
 
@@ -1846,11 +1881,11 @@ void
 CsvImpTransAssist::assist_preview_page_prepare ()
 {
     auto go_back = false;
- 
-    /* Load the file into parse_data, reset it if altrady loaded. */
+
+    /* Load the file into parse_data, reset if already loaded. */
     if (tx_imp)
         tx_imp.reset();
- 
+
     tx_imp = std::unique_ptr<GncTxImport>(new GncTxImport);
 
     /* Assume data is CSV. User can later override to Fixed Width if needed */

--- a/gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp
+++ b/gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp
@@ -2059,11 +2059,11 @@ CsvImpTransAssist::assist_summary_page_prepare ()
     gtk_assistant_remove_action_widget (csv_imp_asst, help_button);
     gtk_assistant_remove_action_widget (csv_imp_asst, cancel_button);
 
-    bl::generator gen;
-    gen.add_messages_path(gnc_path_get_datadir());
-    gen.add_messages_domain(PACKAGE);
-
     // FIXME Rather than passing a locale generator below we probably should set std::locale::global appropriately somewhere.
+    bl::generator gen;
+    gen.add_messages_path(gnc_path_get_localedir());
+    gen.add_messages_domain(GETTEXT_PACKAGE);
+
     auto text = std::string("<span size=\"medium\"><b>");
     /* Translators: {1} will be replaced with a filename */
     text += (bl::format (bl::translate ("The transactions were imported from file '{1}'.")) % m_file_name).str(gen(""));

--- a/gnucash/import-export/csv-imp/csv-account-import.c
+++ b/gnucash/import-export/csv-imp/csv-account-import.c
@@ -78,7 +78,7 @@ fill_model_with_match(GMatchInfo *match_info,
  * Parse the file for a correctly formatted file
  *******************************************************/
 csv_import_result
-csv_import_read_file (GtkWindow *win, const gchar *filename,
+csv_import_read_file (GtkWindow *window, const gchar *filename,
                       const gchar *parser_regexp,
                       GtkListStore *store, guint max_rows)
 {
@@ -114,7 +114,7 @@ csv_import_read_file (GtkWindow *win, const gchar *filename,
                                   parser_regexp, err->message);
         g_error_free (err);
 
-        dialog = gtk_message_dialog_new (NULL,
+        dialog = gtk_message_dialog_new (window,
                                          GTK_DIALOG_MODAL,
                                          GTK_MESSAGE_ERROR,
                                          GTK_BUTTONS_OK, "%s", errmsg);

--- a/gnucash/import-export/csv-imp/gnc-plugin-csv-import.c
+++ b/gnucash/import-export/csv-imp/gnc-plugin-csv-import.c
@@ -74,39 +74,13 @@ typedef struct GncPluginCsvImportPrivate
 
 static GObjectClass *parent_class = NULL;
 
-GType
-gnc_plugin_csv_import_get_type (void)
-{
-    static GType gnc_plugin_csv_import_type = 0;
-
-    if (gnc_plugin_csv_import_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncPluginCsvImportClass),
-            NULL,		/* base_init */
-            NULL,		/* base_finalize */
-            (GClassInitFunc) gnc_plugin_csv_import_class_init,
-            NULL,		/* class_finalize */
-            NULL,		/* class_data */
-            sizeof (GncPluginCsvImport),
-            0,		/* n_preallocs */
-            (GInstanceInitFunc) gnc_plugin_csv_import_init,
-        };
-
-        gnc_plugin_csv_import_type = g_type_register_static (GNC_TYPE_PLUGIN,
-                                     "GncPluginCsvImport",
-                                     &our_info, 0);
-    }
-
-    return gnc_plugin_csv_import_type;
-}
-
 GncPlugin *
 gnc_plugin_csv_import_new (void)
 {
     return GNC_PLUGIN (g_object_new (GNC_TYPE_PLUGIN_CSV_IMPORT, NULL));
 }
+
+G_DEFINE_TYPE_WITH_PRIVATE(GncPluginCsvImport, gnc_plugin_csv_import, GNC_TYPE_PLUGIN)
 
 static void
 gnc_plugin_csv_import_class_init (GncPluginCsvImportClass *klass)
@@ -126,8 +100,6 @@ gnc_plugin_csv_import_class_init (GncPluginCsvImportClass *klass)
     plugin_class->actions      = gnc_plugin_actions;
     plugin_class->n_actions    = gnc_plugin_n_actions;
     plugin_class->ui_filename  = PLUGIN_UI_FILENAME;
-
-    g_type_class_add_private(klass, sizeof(GncPluginCsvImportPrivate));
 }
 
 static void

--- a/gnucash/import-export/import-main-matcher.c
+++ b/gnucash/import-export/import-main-matcher.c
@@ -64,6 +64,7 @@ struct _main_matcher_info
     GNCTransactionProcessedCB transaction_processed_cb;
     gpointer user_data;
     GNCImportPendingMatches *pending_matches;
+    GtkTreeViewColumn *account_column;
 };
 
 enum downloaded_cols
@@ -72,6 +73,7 @@ enum downloaded_cols
     DOWNLOADED_COL_DATE_INT64,
     DOWNLOADED_COL_ACCOUNT,
     DOWNLOADED_COL_AMOUNT,
+    DOWNLOADED_COL_AMOUNT_DOUBLE,
     DOWNLOADED_COL_DESCRIPTION,
     DOWNLOADED_COL_MEMO,
     DOWNLOADED_COL_ACTION_ADD,
@@ -423,6 +425,12 @@ add_text_column(GtkTreeView *view, const gchar *title, int col_num)
     // If date column, use the time64 value for the sorting.
     if (col_num == DOWNLOADED_COL_DATE_TXT)
         gtk_tree_view_column_set_sort_column_id(column, DOWNLOADED_COL_DATE_INT64);
+    else if (col_num == DOWNLOADED_COL_AMOUNT) // If amount column, use double value
+    {
+        gtk_cell_renderer_set_alignment (renderer, 1.0, 0.5); // right align amount column
+        gtk_cell_renderer_set_padding (renderer, 5, 0); // add padding so its not close to description
+        gtk_tree_view_column_set_sort_column_id(column, DOWNLOADED_COL_AMOUNT_DOUBLE);
+    }
     else
         gtk_tree_view_column_set_sort_column_id(column, col_num);
 
@@ -468,8 +476,8 @@ gnc_gen_trans_init_view (GNCImportMainMatcher *info,
     GtkTreeSelection *selection;
 
     view = info->view;
-    store = gtk_list_store_new(NUM_DOWNLOADED_COLS, G_TYPE_STRING,
-                               G_TYPE_INT64, G_TYPE_STRING, G_TYPE_STRING,
+    store = gtk_list_store_new(NUM_DOWNLOADED_COLS, G_TYPE_STRING, G_TYPE_INT64,
+                               G_TYPE_STRING, G_TYPE_STRING, G_TYPE_DOUBLE,
                                G_TYPE_STRING, G_TYPE_STRING, G_TYPE_BOOLEAN,
                                G_TYPE_BOOLEAN, G_TYPE_BOOLEAN, G_TYPE_STRING,
                                GDK_TYPE_PIXBUF, G_TYPE_POINTER, G_TYPE_STRING);
@@ -483,8 +491,8 @@ gnc_gen_trans_init_view (GNCImportMainMatcher *info,
      * (keep the line break below to avoid a translator comment) */
     add_text_column(view,
                     _("Date"), DOWNLOADED_COL_DATE_TXT);
-    column = add_text_column(view, _("Account"), DOWNLOADED_COL_ACCOUNT);
-    gtk_tree_view_column_set_visible(column, show_account);
+    info->account_column = add_text_column(view, _("Account"), DOWNLOADED_COL_ACCOUNT);
+    gtk_tree_view_column_set_visible(info->account_column, show_account);
     add_text_column(view, _("Amount"), DOWNLOADED_COL_AMOUNT);
     add_text_column(view, _("Description"), DOWNLOADED_COL_DESCRIPTION);
     add_text_column(view, _("Memo"), DOWNLOADED_COL_MEMO);
@@ -530,7 +538,13 @@ gnc_gen_trans_init_view (GNCImportMainMatcher *info,
                      G_CALLBACK(gnc_gen_trans_row_changed_cb), info);
 }
 
-
+static void
+show_account_column_toggled_cb (GtkToggleButton *togglebutton,
+               GNCImportMainMatcher *info)
+{
+    gtk_tree_view_column_set_visible (info->account_column,
+         gtk_toggle_button_get_active (togglebutton));
+}
 
 GNCImportMainMatcher *gnc_gen_trans_list_new (GtkWidget *parent,
         const gchar* heading,
@@ -544,6 +558,7 @@ GNCImportMainMatcher *gnc_gen_trans_list_new (GtkWidget *parent,
     gboolean show_update;
     GtkStyleContext *stylectxt;
     GdkRGBA color;
+    GtkWidget *button;
 
     info = g_new0 (GNCImportMainMatcher, 1);
     info->pending_matches = gnc_import_PendingMatches_new();
@@ -571,6 +586,11 @@ GNCImportMainMatcher *gnc_gen_trans_list_new (GtkWidget *parent,
     /* Get the view */
     info->view = GTK_TREE_VIEW(gtk_builder_get_object (builder, "downloaded_view"));
     g_assert (info->view != NULL);
+
+    button = GTK_WIDGET(gtk_builder_get_object (builder, "show_source_account_button"));
+    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON(button), all_from_same_account);
+    g_signal_connect(G_OBJECT(button), "toggled",
+                     G_CALLBACK(show_account_column_toggled_cb), info);
 
     show_update = gnc_import_Settings_get_action_update_enabled(info->user_settings);
     gnc_gen_trans_init_view(info, all_from_same_account, show_update);
@@ -611,6 +631,7 @@ GNCImportMainMatcher * gnc_gen_trans_assist_new (GtkWidget *parent,
     gboolean show_update;
     GtkStyleContext *stylectxt;
     GdkRGBA color;
+    GtkWidget *button;
 
     info = g_new0 (GNCImportMainMatcher, 1);
     info->pending_matches = gnc_import_PendingMatches_new();
@@ -638,6 +659,11 @@ GNCImportMainMatcher * gnc_gen_trans_assist_new (GtkWidget *parent,
     /* Get the view */
     info->view = GTK_TREE_VIEW(gtk_builder_get_object (builder, "downloaded_view"));
     g_assert (info->view != NULL);
+
+    button = GTK_WIDGET(gtk_builder_get_object (builder, "show_source_account_button"));
+    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON(button), all_from_same_account);
+    g_signal_connect(G_OBJECT(button), "toggled",
+                     G_CALLBACK(show_account_column_toggled_cb), info);
 
     show_update = gnc_import_Settings_get_action_update_enabled(info->user_settings);
     gnc_gen_trans_init_view(info, all_from_same_account, show_update);
@@ -713,6 +739,7 @@ refresh_model_row (GNCImportMainMatcher *gui,
     gchar *class_extension = NULL;
     Split *split;
     time64 date;
+    gnc_numeric amount;
     g_assert (gui);
     g_assert (model);
     g_assert (info);
@@ -742,11 +769,10 @@ refresh_model_row (GNCImportMainMatcher *gui,
     g_free(text);
 
     /*Amount*/
-    ro_text = xaccPrintAmount
-              (xaccSplitGetAmount (split),
-               gnc_split_amount_print_info(split, TRUE)
-              );
+    amount = xaccSplitGetAmount (split);
+    ro_text = xaccPrintAmount (amount, gnc_split_amount_print_info(split, TRUE));
     gtk_list_store_set(store, iter, DOWNLOADED_COL_AMOUNT, ro_text, -1);
+    gtk_list_store_set(store, iter, DOWNLOADED_COL_AMOUNT_DOUBLE, gnc_numeric_to_double (amount), -1);
 
     /*Description*/
     ro_text = xaccTransGetDescription(gnc_import_TransInfo_get_trans(info) );

--- a/gnucash/import-export/log-replay/gnc-plugin-log-replay.c
+++ b/gnucash/import-export/log-replay/gnc-plugin-log-replay.c
@@ -62,39 +62,13 @@ typedef struct GncPluginLogreplayPrivate
 
 static GObjectClass *parent_class = NULL;
 
-GType
-gnc_plugin_log_replay_get_type (void)
-{
-    static GType gnc_plugin_log_replay_type = 0;
-
-    if (gnc_plugin_log_replay_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncPluginLogreplayClass),
-            NULL,		/* base_init */
-            NULL,		/* base_finalize */
-            (GClassInitFunc) gnc_plugin_log_replay_class_init,
-            NULL,		/* class_finalize */
-            NULL,		/* class_data */
-            sizeof (GncPluginLogreplay),
-            0,		/* n_preallocs */
-            (GInstanceInitFunc) gnc_plugin_log_replay_init,
-        };
-
-        gnc_plugin_log_replay_type = g_type_register_static (GNC_TYPE_PLUGIN,
-                                     "GncPluginLogreplay",
-                                     &our_info, 0);
-    }
-
-    return gnc_plugin_log_replay_type;
-}
-
 GncPlugin *
 gnc_plugin_log_replay_new (void)
 {
     return GNC_PLUGIN (g_object_new (GNC_TYPE_PLUGIN_LOG_REPLAY, NULL));
 }
+
+G_DEFINE_TYPE_WITH_PRIVATE(GncPluginLogreplay, gnc_plugin_log_replay, GNC_TYPE_PLUGIN)
 
 static void
 gnc_plugin_log_replay_class_init (GncPluginLogreplayClass *klass)
@@ -114,8 +88,6 @@ gnc_plugin_log_replay_class_init (GncPluginLogreplayClass *klass)
     plugin_class->actions      = gnc_plugin_actions;
     plugin_class->n_actions    = gnc_plugin_n_actions;
     plugin_class->ui_filename  = PLUGIN_UI_FILENAME;
-
-    g_type_class_add_private(klass, sizeof(GncPluginLogreplayPrivate));
 }
 
 static void

--- a/gnucash/import-export/ofx/gnc-plugin-ofx.c
+++ b/gnucash/import-export/ofx/gnc-plugin-ofx.c
@@ -60,39 +60,13 @@ typedef struct GncPluginOfxPrivate
 
 static GObjectClass *parent_class = NULL;
 
-GType
-gnc_plugin_ofx_get_type (void)
-{
-    static GType gnc_plugin_ofx_type = 0;
-
-    if (gnc_plugin_ofx_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncPluginOfxClass),
-            NULL,		/* base_init */
-            NULL,		/* base_finalize */
-            (GClassInitFunc) gnc_plugin_ofx_class_init,
-            NULL,		/* class_finalize */
-            NULL,		/* class_data */
-            sizeof (GncPluginOfx),
-            0,		/* n_preallocs */
-            (GInstanceInitFunc) gnc_plugin_ofx_init,
-        };
-
-        gnc_plugin_ofx_type = g_type_register_static (GNC_TYPE_PLUGIN,
-                              "GncPluginOfx",
-                              &our_info, 0);
-    }
-
-    return gnc_plugin_ofx_type;
-}
-
 GncPlugin *
 gnc_plugin_ofx_new (void)
 {
     return GNC_PLUGIN (g_object_new (GNC_TYPE_PLUGIN_OFX, NULL));
 }
+
+G_DEFINE_TYPE_WITH_PRIVATE(GncPluginOfx, gnc_plugin_ofx, GNC_TYPE_PLUGIN)
 
 static void
 gnc_plugin_ofx_class_init (GncPluginOfxClass *klass)
@@ -112,8 +86,6 @@ gnc_plugin_ofx_class_init (GncPluginOfxClass *klass)
     plugin_class->actions      = gnc_plugin_actions;
     plugin_class->n_actions    = gnc_plugin_n_actions;
     plugin_class->ui_filename  = PLUGIN_UI_FILENAME;
-
-    g_type_class_add_private(klass, sizeof(GncPluginOfxPrivate));
 }
 
 static void

--- a/gnucash/import-export/qif-imp/gnc-plugin-qif-import.c
+++ b/gnucash/import-export/qif-imp/gnc-plugin-qif-import.c
@@ -31,6 +31,8 @@
 #include "gnc-plugin-manager.h"
 #include "gnc-plugin-qif-import.h"
 
+
+
 static void gnc_plugin_qif_import_class_init (GncPluginQifImportClass *klass);
 static void gnc_plugin_qif_import_init (GncPluginQifImport *plugin);
 static void gnc_plugin_qif_import_finalize (GObject *object);
@@ -59,35 +61,8 @@ typedef struct GncPluginQifImportPrivate
 #define GNC_PLUGIN_QIF_IMPORT_GET_PRIVATE(o)  \
    (G_TYPE_INSTANCE_GET_PRIVATE ((o), GNC_TYPE_PLUGIN_QIF_IMPORT, GncPluginQifImportPrivate))
 
+G_DEFINE_TYPE_WITH_PRIVATE(GncPluginQifImport, gnc_plugin_qif_import, GNC_TYPE_PLUGIN);
 static GObjectClass *parent_class = NULL;
-
-GType
-gnc_plugin_qif_import_get_type (void)
-{
-    static GType gnc_plugin_qif_import_type = 0;
-
-    if (gnc_plugin_qif_import_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncPluginQifImportClass),
-            NULL,		/* base_init */
-            NULL,		/* base_finalize */
-            (GClassInitFunc) gnc_plugin_qif_import_class_init,
-            NULL,		/* class_finalize */
-            NULL,		/* class_data */
-            sizeof (GncPluginQifImport),
-            0,		/* n_preallocs */
-            (GInstanceInitFunc) gnc_plugin_qif_import_init,
-        };
-
-        gnc_plugin_qif_import_type = g_type_register_static (GNC_TYPE_PLUGIN,
-                                     "GncPluginQifImport",
-                                     &our_info, 0);
-    }
-
-    return gnc_plugin_qif_import_type;
-}
 
 GncPlugin *
 gnc_plugin_qif_import_new (void)
@@ -113,8 +88,6 @@ gnc_plugin_qif_import_class_init (GncPluginQifImportClass *klass)
     plugin_class->actions      = gnc_plugin_actions;
     plugin_class->n_actions    = gnc_plugin_n_actions;
     plugin_class->ui_filename  = PLUGIN_UI_FILENAME;
-
-    g_type_class_add_private(klass, sizeof(GncPluginQifImportPrivate));
 }
 
 static void

--- a/gnucash/register/register-gnome/gnucash-sheet.c
+++ b/gnucash/register/register-gnome/gnucash-sheet.c
@@ -1809,6 +1809,8 @@ gnucash_sheet_key_press_event_internal (GtkWidget *widget, GdkEventKey *event)
         case GDK_KEY_Right:
         case GDK_KEY_KP_Left:
         case GDK_KEY_Left:
+        case GDK_KEY_Home:
+        case GDK_KEY_End:
 	    /* Clear the saved selection, we're not using it. */
 	    sheet->end_sel = sheet->start_sel;
 	    pass_on = TRUE;

--- a/gnucash/report/report-gnome/gnc-plugin-page-report.c
+++ b/gnucash/report/report-gnome/gnc-plugin-page-report.c
@@ -393,8 +393,9 @@ gnc_plugin_page_report_load_uri (GncPluginPage *page)
 
     report = GNC_PLUGIN_PAGE_REPORT(page);
     priv = GNC_PLUGIN_PAGE_REPORT_GET_PRIVATE(report);
+    if (!priv)
+        return FALSE; // No priv means the page doesn't exist anymore.
 
-    // FIXME.  This is f^-1(f(x)), isn't it?
     DEBUG( "Load uri id=%d", priv->reportId );
     id_name = g_strdup_printf("id=%d", priv->reportId );
     child_name = gnc_build_url( URL_TYPE_REPORT, id_name, NULL );

--- a/gnucash/report/report-gnome/gnc-plugin-page-report.c
+++ b/gnucash/report/report-gnome/gnc-plugin-page-report.c
@@ -180,34 +180,6 @@ static void gnc_plugin_page_report_print_cb(GtkAction *action, GncPluginPageRepo
 static void gnc_plugin_page_report_exportpdf_cb(GtkAction *action, GncPluginPageReport *rep);
 static void gnc_plugin_page_report_copy_cb(GtkAction *action, GncPluginPageReport *rep);
 
-GType
-gnc_plugin_page_report_get_type (void)
-{
-    static GType gnc_plugin_page_report_type = 0;
-
-    if (gnc_plugin_page_report_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncPluginPageReportClass),
-            NULL,
-            NULL,
-            (GClassInitFunc) gnc_plugin_page_report_class_init,
-            NULL,
-            NULL,
-            sizeof (GncPluginPageReport),
-            0,
-            (GInstanceInitFunc) gnc_plugin_page_report_init
-        };
-
-        gnc_plugin_page_report_type = g_type_register_static (GNC_TYPE_PLUGIN_PAGE,
-                                      "GncPluginPageReport",
-                                      &our_info, 0);
-    }
-
-    return gnc_plugin_page_report_type;
-}
-
 static void
 gnc_plugin_page_report_get_property( GObject *obj,
                                      guint prop_id,
@@ -301,6 +273,8 @@ gnc_plugin_page_report_main_window_page_changed (GncMainWindow *window,
     }
 }
 
+G_DEFINE_TYPE_WITH_PRIVATE(GncPluginPageReport, gnc_plugin_page_report, GNC_TYPE_PLUGIN_PAGE)
+
 static void
 gnc_plugin_page_report_class_init (GncPluginPageReportClass *klass)
 {
@@ -325,8 +299,6 @@ gnc_plugin_page_report_class_init (GncPluginPageReportClass *klass)
     gnc_plugin_page_class->page_name_changed = gnc_plugin_page_report_name_changed;
     gnc_plugin_page_class->update_edit_menu_actions = gnc_plugin_page_report_update_edit_menu;
     gnc_plugin_page_class->finish_pending   = gnc_plugin_page_report_finish_pending;
-
-    g_type_class_add_private(klass, sizeof(GncPluginPageReportPrivate));
 
     // create the "reportId" property
     g_object_class_install_property( object_class,

--- a/gnucash/report/stylesheets/gnc-plugin-stylesheets.c
+++ b/gnucash/report/stylesheets/gnc-plugin-stylesheets.c
@@ -70,39 +70,13 @@ static GObjectClass *parent_class = NULL;
  *                   Object Implementation                  *
  ************************************************************/
 
-GType
-gnc_plugin_stylesheets_get_type (void)
-{
-    static GType gnc_plugin_stylesheets_type = 0;
-
-    if (gnc_plugin_stylesheets_type == 0)
-    {
-        static const GTypeInfo our_info =
-        {
-            sizeof (GncPluginStylesheetsClass),
-            NULL,		/* base_init */
-            NULL,		/* base_finalize */
-            (GClassInitFunc) gnc_plugin_stylesheets_class_init,
-            NULL,		/* class_finalize */
-            NULL,		/* class_data */
-            sizeof (GncPluginStylesheets),
-            0,		/* n_preallocs */
-            (GInstanceInitFunc) gnc_plugin_stylesheets_init,
-        };
-
-        gnc_plugin_stylesheets_type = g_type_register_static (GNC_TYPE_PLUGIN,
-                                      "GncPluginStylesheets",
-                                      &our_info, 0);
-    }
-
-    return gnc_plugin_stylesheets_type;
-}
-
 GncPlugin *
 gnc_plugin_stylesheets_new (void)
 {
     return GNC_PLUGIN (g_object_new (GNC_TYPE_PLUGIN_STYLESHEETS, NULL));
 }
+
+G_DEFINE_TYPE_WITH_PRIVATE(GncPluginStylesheets, gnc_plugin_stylesheets, GNC_TYPE_PLUGIN)
 
 static void
 gnc_plugin_stylesheets_class_init (GncPluginStylesheetsClass *klass)
@@ -122,8 +96,6 @@ gnc_plugin_stylesheets_class_init (GncPluginStylesheetsClass *klass)
     plugin_class->actions       	   = gnc_plugin_actions;
     plugin_class->n_actions     	   = gnc_plugin_n_actions;
     plugin_class->ui_filename   	   = PLUGIN_UI_FILENAME;
-
-    g_type_class_add_private(klass, sizeof(GncPluginStylesheetsPrivate));
 }
 
 static void

--- a/libgnucash/engine/Account.cpp
+++ b/libgnucash/engine/Account.cpp
@@ -252,7 +252,7 @@ mark_account (Account *acc)
 \********************************************************************/
 
 /* GObject Initialization */
-G_DEFINE_TYPE(Account, gnc_account, QOF_TYPE_INSTANCE)
+G_DEFINE_TYPE_WITH_PRIVATE(Account, gnc_account, QOF_TYPE_INSTANCE)
 
 static void
 gnc_account_init(Account* acc)
@@ -576,8 +576,6 @@ gnc_account_class_init (AccountClass *klass)
     gobject_class->finalize = gnc_account_finalize;
     gobject_class->set_property = gnc_account_set_property;
     gobject_class->get_property = gnc_account_get_property;
-
-    g_type_class_add_private(klass, sizeof(AccountPrivate));
 
     g_object_class_install_property
     (gobject_class,

--- a/libgnucash/engine/CMakeLists.txt
+++ b/libgnucash/engine/CMakeLists.txt
@@ -231,7 +231,7 @@ add_library (gncmod-engine
 
 # Add dependency on swig-runtime.h and iso-4217-currencies.c
 add_dependencies (gncmod-engine swig-runtime-h iso-4217-c)
-if (WIN32 AND ${CMAKE_HOST_SYSTEM_VERSION} VERSION_LESS "10.0")
+if (WIN32)
   set(BCRYPT "bcrypt.lib")
 else()
   set(BCRYPT "")

--- a/libgnucash/engine/gnc-budget.c
+++ b/libgnucash/engine/gnc-budget.c
@@ -58,7 +58,7 @@ typedef struct
     QofInstanceClass parent_class;
 } BudgetClass;
 
-typedef struct BudgetPrivate
+typedef struct GncBudgetPrivate
 {
     /* The name is an arbitrary string assigned by the user. */
     gchar* name;
@@ -71,10 +71,10 @@ typedef struct BudgetPrivate
 
     /* Number of periods */
     guint  num_periods;
-} BudgetPrivate;
+} GncBudgetPrivate;
 
 #define GET_PRIVATE(o) \
-  (G_TYPE_INSTANCE_GET_PRIVATE((o), GNC_TYPE_BUDGET, BudgetPrivate))
+  (G_TYPE_INSTANCE_GET_PRIVATE((o), GNC_TYPE_BUDGET, GncBudgetPrivate))
 
 struct _GncBudgetClass
 {
@@ -82,12 +82,12 @@ struct _GncBudgetClass
 };
 
 /* GObject Initialization */
-G_DEFINE_TYPE(GncBudget, gnc_budget, QOF_TYPE_INSTANCE)
+G_DEFINE_TYPE_WITH_PRIVATE(GncBudget, gnc_budget, QOF_TYPE_INSTANCE)
 
 static void
 gnc_budget_init(GncBudget* budget)
 {
-    BudgetPrivate* priv;
+    GncBudgetPrivate* priv;
     GDate *date;
 
     priv = GET_PRIVATE(budget);
@@ -120,7 +120,7 @@ gnc_budget_get_property( GObject* object,
                          GParamSpec* pspec)
 {
     GncBudget* budget;
-    BudgetPrivate* priv;
+    GncBudgetPrivate* priv;
 
     g_return_if_fail(GNC_IS_BUDGET(object));
 
@@ -191,8 +191,6 @@ gnc_budget_class_init(GncBudgetClass* klass)
     gobject_class->get_property = gnc_budget_get_property;
     gobject_class->set_property = gnc_budget_set_property;
 
-    g_type_class_add_private(klass, sizeof(BudgetPrivate));
-
     g_object_class_install_property(
         gobject_class,
         PROP_NAME,
@@ -248,7 +246,7 @@ static void
 gnc_budget_free(QofInstance *inst)
 {
     GncBudget *budget;
-    BudgetPrivate* priv;
+    GncBudgetPrivate* priv;
 
     if (inst == NULL)
         return;
@@ -370,7 +368,7 @@ gnc_budget_clone(const GncBudget* old_b)
 void
 gnc_budget_set_name(GncBudget* budget, const gchar* name)
 {
-    BudgetPrivate* priv;
+    GncBudgetPrivate* priv;
 
     g_return_if_fail(GNC_IS_BUDGET(budget) && name);
 
@@ -395,7 +393,7 @@ gnc_budget_get_name(const GncBudget* budget)
 void
 gnc_budget_set_description(GncBudget* budget, const gchar* description)
 {
-    BudgetPrivate* priv;
+    GncBudgetPrivate* priv;
 
     g_return_if_fail(GNC_IS_BUDGET(budget));
     g_return_if_fail(description);
@@ -420,7 +418,7 @@ gnc_budget_get_description(const GncBudget* budget)
 void
 gnc_budget_set_recurrence(GncBudget *budget, const Recurrence *r)
 {
-    BudgetPrivate* priv;
+    GncBudgetPrivate* priv;
 
     g_return_if_fail(budget && r);
     priv = GET_PRIVATE(budget);
@@ -451,7 +449,7 @@ gnc_budget_get_guid(const GncBudget* budget)
 void
 gnc_budget_set_num_periods(GncBudget* budget, guint num_periods)
 {
-    BudgetPrivate* priv;
+    GncBudgetPrivate* priv;
 
     g_return_if_fail(GNC_IS_BUDGET(budget));
 

--- a/libgnucash/engine/gnc-commodity.c
+++ b/libgnucash/engine/gnc-commodity.c
@@ -66,7 +66,7 @@ struct gnc_commodity_s
     QofInstance inst;
 };
 
-typedef struct CommodityPrivate
+typedef struct gnc_commodityPrivate
 {
     gnc_commodity_namespace *name_space;
 
@@ -87,10 +87,10 @@ typedef struct CommodityPrivate
 
     /* the default display_symbol, set in iso-4217-currencies at start-up */
     const char * default_symbol;
-} CommodityPrivate;
+} gnc_commodityPrivate;
 
 #define GET_PRIVATE(o) \
-    (G_TYPE_INSTANCE_GET_PRIVATE((o), GNC_TYPE_COMMODITY, CommodityPrivate))
+    (G_TYPE_INSTANCE_GET_PRIVATE((o), GNC_TYPE_COMMODITY, gnc_commodityPrivate))
 
 struct _GncCommodityClass
 {
@@ -629,7 +629,7 @@ mark_commodity_dirty (gnc_commodity *cm)
 }
 
 static void
-reset_printname(CommodityPrivate *priv)
+reset_printname(gnc_commodityPrivate *priv)
 {
     g_free(priv->printname);
     priv->printname = g_strdup_printf("%s (%s)",
@@ -638,7 +638,7 @@ reset_printname(CommodityPrivate *priv)
 }
 
 static void
-reset_unique_name(CommodityPrivate *priv)
+reset_unique_name(gnc_commodityPrivate *priv)
 {
     gnc_commodity_namespace *ns;
 
@@ -650,12 +650,12 @@ reset_unique_name(CommodityPrivate *priv)
 }
 
 /* GObject Initialization */
-G_DEFINE_TYPE(gnc_commodity, gnc_commodity, QOF_TYPE_INSTANCE);
+G_DEFINE_TYPE_WITH_PRIVATE(gnc_commodity, gnc_commodity, QOF_TYPE_INSTANCE);
 
 static void
 gnc_commodity_init(gnc_commodity* com)
 {
-    CommodityPrivate* priv;
+    gnc_commodityPrivate* priv;
 
     priv = GET_PRIVATE(com);
 
@@ -696,7 +696,7 @@ gnc_commodity_get_property (GObject         *object,
                             GParamSpec      *pspec)
 {
     gnc_commodity *commodity;
-    CommodityPrivate* priv;
+    gnc_commodityPrivate* priv;
 
     g_return_if_fail(GNC_IS_COMMODITY(object));
 
@@ -793,8 +793,6 @@ gnc_commodity_class_init(struct _GncCommodityClass* klass)
     gobject_class->finalize = gnc_commodity_finalize;
     gobject_class->set_property = gnc_commodity_set_property;
     gobject_class->get_property = gnc_commodity_get_property;
-
-    g_type_class_add_private(klass, sizeof(CommodityPrivate));
 
     g_object_class_install_property(gobject_class,
                                     PROP_NAMESPACE,
@@ -925,7 +923,7 @@ commodity_free(gnc_commodity * cm)
 {
     QofBook *book;
     gnc_commodity_table *table;
-    CommodityPrivate* priv;
+    gnc_commodityPrivate* priv;
 
     if (!cm) return;
 
@@ -980,8 +978,8 @@ gnc_commodity_destroy(gnc_commodity * cm)
 void
 gnc_commodity_copy(gnc_commodity * dest, const gnc_commodity *src)
 {
-    CommodityPrivate* src_priv = GET_PRIVATE(src);
-    CommodityPrivate* dest_priv = GET_PRIVATE(dest);
+    gnc_commodityPrivate* src_priv = GET_PRIVATE(src);
+    gnc_commodityPrivate* dest_priv = GET_PRIVATE(dest);
 
     gnc_commodity_set_fullname (dest, src_priv->fullname);
     gnc_commodity_set_mnemonic (dest, src_priv->mnemonic);
@@ -997,8 +995,8 @@ gnc_commodity_copy(gnc_commodity * dest, const gnc_commodity *src)
 gnc_commodity *
 gnc_commodity_clone(const gnc_commodity *src, QofBook *dest_book)
 {
-    CommodityPrivate* src_priv;
-    CommodityPrivate* dest_priv;
+    gnc_commodityPrivate* src_priv;
+    gnc_commodityPrivate* dest_priv;
 
     gnc_commodity * dest = g_object_new(GNC_TYPE_COMMODITY, NULL);
     qof_instance_init_data (&dest->inst, GNC_ID_COMMODITY, dest_book);
@@ -1147,7 +1145,7 @@ gnc_commodity_get_quote_flag(const gnc_commodity *cm)
 gnc_quote_source*
 gnc_commodity_get_quote_source(const gnc_commodity *cm)
 {
-    CommodityPrivate* priv;
+    gnc_commodityPrivate* priv;
 
     if (!cm) return NULL;
     priv = GET_PRIVATE(cm);
@@ -1233,7 +1231,7 @@ gnc_commodity_get_nice_symbol (const gnc_commodity *cm)
 void
 gnc_commodity_set_mnemonic(gnc_commodity * cm, const char * mnemonic)
 {
-    CommodityPrivate* priv;
+    gnc_commodityPrivate* priv;
 
     if (!cm) return;
     priv = GET_PRIVATE(cm);
@@ -1259,7 +1257,7 @@ gnc_commodity_set_namespace(gnc_commodity * cm, const char * name_space)
     QofBook *book;
     gnc_commodity_table *table;
     gnc_commodity_namespace *nsp;
-    CommodityPrivate* priv;
+    gnc_commodityPrivate* priv;
 
     if (!cm) return;
     priv = GET_PRIVATE(cm);
@@ -1286,7 +1284,7 @@ gnc_commodity_set_namespace(gnc_commodity * cm, const char * name_space)
 void
 gnc_commodity_set_fullname(gnc_commodity * cm, const char * fullname)
 {
-    CommodityPrivate* priv;
+    gnc_commodityPrivate* priv;
 
     if (!cm) return;
     priv = GET_PRIVATE(cm);
@@ -1309,7 +1307,7 @@ void
 gnc_commodity_set_cusip(gnc_commodity * cm,
                         const char * cusip)
 {
-    CommodityPrivate* priv;
+    gnc_commodityPrivate* priv;
 
     if (!cm) return;
 
@@ -1374,7 +1372,7 @@ gnc_commodity_set_auto_quote_control_flag(gnc_commodity *cm,
 void
 gnc_commodity_user_set_quote_flag(gnc_commodity *cm, const gboolean flag)
 {
-    CommodityPrivate* priv;
+    gnc_commodityPrivate* priv;
 
     ENTER ("(cm=%p, flag=%d)", cm, flag);
 
@@ -1444,7 +1442,7 @@ gnc_commodity_set_quote_source(gnc_commodity *cm, gnc_quote_source *src)
 void
 gnc_commodity_set_quote_tz(gnc_commodity *cm, const char *tz)
 {
-    CommodityPrivate* priv;
+    gnc_commodityPrivate* priv;
 
     if (!cm) return;
 
@@ -1525,7 +1523,7 @@ gnc_commodity_set_default_symbol(gnc_commodity * cm,
 void
 gnc_commodity_increment_usage_count(gnc_commodity *cm)
 {
-    CommodityPrivate* priv;
+    gnc_commodityPrivate* priv;
 
     ENTER("(cm=%p)", cm);
 
@@ -1560,7 +1558,7 @@ gnc_commodity_increment_usage_count(gnc_commodity *cm)
 void
 gnc_commodity_decrement_usage_count(gnc_commodity *cm)
 {
-    CommodityPrivate* priv;
+    gnc_commodityPrivate* priv;
 
     ENTER("(cm=%p)", cm);
 
@@ -1603,8 +1601,8 @@ gnc_commodity_decrement_usage_count(gnc_commodity *cm)
 gboolean
 gnc_commodity_equiv(const gnc_commodity * a, const gnc_commodity * b)
 {
-    CommodityPrivate* priv_a;
-    CommodityPrivate* priv_b;
+    gnc_commodityPrivate* priv_a;
+    gnc_commodityPrivate* priv_b;
 
     if (a == b) return TRUE;
     if (!a || !b) return FALSE;
@@ -1619,8 +1617,8 @@ gnc_commodity_equiv(const gnc_commodity * a, const gnc_commodity * b)
 gboolean
 gnc_commodity_equal(const gnc_commodity * a, const gnc_commodity * b)
 {
-    CommodityPrivate* priv_a;
-    CommodityPrivate* priv_b;
+    gnc_commodityPrivate* priv_a;
+    gnc_commodityPrivate* priv_b;
     gboolean same_book;
 
     if (a == b) return TRUE;
@@ -1935,7 +1933,7 @@ gnc_commodity_table_insert(gnc_commodity_table * table,
     gnc_commodity_namespace * nsp = NULL;
     gnc_commodity *c;
     const char *ns_name;
-    CommodityPrivate* priv;
+    gnc_commodityPrivate* priv;
     QofBook *book;
 
     if (!table) return NULL;
@@ -2015,7 +2013,7 @@ gnc_commodity_table_remove(gnc_commodity_table * table,
 {
     gnc_commodity_namespace * nsp;
     gnc_commodity *c;
-    CommodityPrivate* priv;
+    gnc_commodityPrivate* priv;
     const char *ns_name;
 
     if (!table) return;
@@ -2125,7 +2123,7 @@ gnc_commodity_table_get_namespaces_list(const gnc_commodity_table * table)
 gboolean
 gnc_commodity_is_iso(const gnc_commodity * cm)
 {
-    CommodityPrivate* priv;
+    gnc_commodityPrivate* priv;
 
     if (!cm) return FALSE;
 
@@ -2196,7 +2194,7 @@ static void
 get_quotables_helper1(gpointer key, gpointer value, gpointer data)
 {
     gnc_commodity *comm = value;
-    CommodityPrivate* priv = GET_PRIVATE(comm);
+    gnc_commodityPrivate* priv = GET_PRIVATE(comm);
     GList ** l = data;
 
     if (!priv->quote_flag ||
@@ -2209,7 +2207,7 @@ static gboolean
 get_quotables_helper2 (gnc_commodity *comm, gpointer data)
 {
     GList ** l = data;
-    CommodityPrivate* priv = GET_PRIVATE(comm);
+    gnc_commodityPrivate* priv = GET_PRIVATE(comm);
 
     if (!priv->quote_flag ||
             !priv->quote_source || !priv->quote_source->supported)

--- a/libgnucash/engine/gnc-datetime.cpp
+++ b/libgnucash/engine/gnc-datetime.cpp
@@ -428,7 +428,8 @@ GncDateTimeImpl::format(const char* format) const
     std::stringstream ss;
     //The stream destructor frees the facet, so it must be heap-allocated.
     auto output_facet(new Facet(normalize_format(format).c_str()));
-    ss.imbue(std::locale(std::locale(), output_facet));
+    // FIXME Rather than imbueing a locale below we probably should set std::locale::global appropriately somewhere.
+    ss.imbue(std::locale(std::locale(""), output_facet));
     ss << m_time;
     return ss.str();
 }
@@ -439,8 +440,9 @@ GncDateTimeImpl::format_zulu(const char* format) const
     using Facet = boost::posix_time::time_facet;
     std::stringstream ss;
     //The stream destructor frees the facet, so it must be heap-allocated.
-    auto output_facet(new Facet(normalize_format(format).c_str()));
-    ss.imbue(std::locale(std::locale(), output_facet));
+    auto output_facet(new Facet(normalize_format(format).c_str())); 
+    // FIXME Rather than imbueing a locale below we probably should set std::locale::global appropriately somewhere.
+    ss.imbue(std::locale(std::locale(""), output_facet));
     ss << m_time.utc_time();
     return ss.str();
 }
@@ -499,7 +501,8 @@ GncDateImpl::format(const char* format) const
     std::stringstream ss;
     //The stream destructor frees the facet, so it must be heap-allocated.
     auto output_facet(new Facet(normalize_format(format).c_str()));
-    ss.imbue(std::locale(std::locale(), output_facet));
+    // FIXME Rather than imbueing a locale below we probably should set std::locale::global appropriately somewhere.
+    ss.imbue(std::locale(std::locale(""), output_facet));
     ss << m_greg;
     return ss.str();
 }

--- a/libgnucash/engine/gnc-lot.c
+++ b/libgnucash/engine/gnc-lot.c
@@ -75,7 +75,7 @@ enum
     PROP_MARKER,        /* Runtime */
 };
 
-typedef struct LotPrivate
+typedef struct GNCLotPrivate
 {
     /* Account to which this lot applies.  All splits in the lot must
      * belong to this account.
@@ -92,22 +92,22 @@ typedef struct LotPrivate
 
     /* traversal marker, handy for preventing recursion */
     unsigned char marker;
-} LotPrivate;
+} GNCLotPrivate;
 
 #define GET_PRIVATE(o) \
-    (G_TYPE_INSTANCE_GET_PRIVATE((o), GNC_TYPE_LOT, LotPrivate))
+    (G_TYPE_INSTANCE_GET_PRIVATE((o), GNC_TYPE_LOT, GNCLotPrivate))
 
 #define gnc_lot_set_guid(L,G)  qof_instance_set_guid(QOF_INSTANCE(L),&(G))
 
 /* ============================================================= */
 
 /* GObject Initialization */
-G_DEFINE_TYPE(GNCLot, gnc_lot, QOF_TYPE_INSTANCE)
+G_DEFINE_TYPE_WITH_PRIVATE(GNCLot, gnc_lot, QOF_TYPE_INSTANCE)
 
 static void
 gnc_lot_init(GNCLot* lot)
 {
-    LotPrivate* priv;
+    GNCLotPrivate* priv;
 
     priv = GET_PRIVATE(lot);
     priv->account = NULL;
@@ -132,7 +132,7 @@ static void
 gnc_lot_get_property(GObject* object, guint prop_id, GValue* value, GParamSpec* pspec)
 {
     GNCLot* lot;
-    LotPrivate* priv;
+    GNCLotPrivate* priv;
     gchar *key;
 
     g_return_if_fail(GNC_IS_LOT(object));
@@ -169,7 +169,7 @@ gnc_lot_set_property (GObject* object,
                       GParamSpec* pspec)
 {
     GNCLot* lot;
-    LotPrivate* priv;
+    GNCLotPrivate* priv;
     gchar *key = NULL;
 
     g_return_if_fail(GNC_IS_LOT(object));
@@ -211,8 +211,6 @@ gnc_lot_class_init(GNCLotClass* klass)
     gobject_class->finalize = gnc_lot_finalize;
     gobject_class->get_property = gnc_lot_get_property;
     gobject_class->set_property = gnc_lot_set_property;
-
-    g_type_class_add_private(klass, sizeof(LotPrivate));
 
     g_object_class_install_property(
         gobject_class,
@@ -277,7 +275,7 @@ static void
 gnc_lot_free(GNCLot* lot)
 {
     GList *node;
-    LotPrivate* priv;
+    GNCLotPrivate* priv;
     if (!lot) return;
 
     ENTER ("(lot=%p)", lot);
@@ -364,7 +362,7 @@ gnc_lot_get_book (GNCLot *lot)
 gboolean
 gnc_lot_is_closed (GNCLot *lot)
 {
-    LotPrivate* priv;
+    GNCLotPrivate* priv;
     if (!lot) return TRUE;
     priv = GET_PRIVATE(lot);
     if (0 > priv->is_closed) gnc_lot_get_balance (lot);
@@ -374,7 +372,7 @@ gnc_lot_is_closed (GNCLot *lot)
 Account *
 gnc_lot_get_account (const GNCLot *lot)
 {
-    LotPrivate* priv;
+    GNCLotPrivate* priv;
     if (!lot) return NULL;
     priv = GET_PRIVATE(lot);
     return priv->account;
@@ -385,7 +383,7 @@ gnc_lot_set_account(GNCLot* lot, Account* account)
 {
     if (lot != NULL)
     {
-        LotPrivate* priv;
+        GNCLotPrivate* priv;
         priv = GET_PRIVATE(lot);
         priv->account = account;
     }
@@ -394,7 +392,7 @@ gnc_lot_set_account(GNCLot* lot, Account* account)
 void
 gnc_lot_set_closed_unknown(GNCLot* lot)
 {
-    LotPrivate* priv;
+    GNCLotPrivate* priv;
     if (lot != NULL)
     {
         priv = GET_PRIVATE(lot);
@@ -405,7 +403,7 @@ gnc_lot_set_closed_unknown(GNCLot* lot)
 SplitList *
 gnc_lot_get_split_list (const GNCLot *lot)
 {
-    LotPrivate* priv;
+    GNCLotPrivate* priv;
     if (!lot) return NULL;
     priv = GET_PRIVATE(lot);
     return priv->splits;
@@ -413,7 +411,7 @@ gnc_lot_get_split_list (const GNCLot *lot)
 
 gint gnc_lot_count_splits (const GNCLot *lot)
 {
-    LotPrivate* priv;
+    GNCLotPrivate* priv;
     if (!lot) return 0;
     priv = GET_PRIVATE(lot);
     return g_list_length (priv->splits);
@@ -475,7 +473,7 @@ gnc_lot_set_notes (GNCLot *lot, const char *str)
 gnc_numeric
 gnc_lot_get_balance (GNCLot *lot)
 {
-    LotPrivate* priv;
+    GNCLotPrivate* priv;
     GList *node;
     gnc_numeric zero = gnc_numeric_zero();
     gnc_numeric baln = zero;
@@ -518,7 +516,7 @@ void
 gnc_lot_get_balance_before (const GNCLot *lot, const Split *split,
                             gnc_numeric *amount, gnc_numeric *value)
 {
-    LotPrivate* priv;
+    GNCLotPrivate* priv;
     GList *node;
     gnc_numeric zero = gnc_numeric_zero();
     gnc_numeric amt = zero;
@@ -567,7 +565,7 @@ gnc_lot_get_balance_before (const GNCLot *lot, const Split *split,
 void
 gnc_lot_add_split (GNCLot *lot, Split *split)
 {
-    LotPrivate* priv;
+    GNCLotPrivate* priv;
     Account * acc;
     if (!lot || !split) return;
     priv = GET_PRIVATE(lot);
@@ -619,7 +617,7 @@ gnc_lot_add_split (GNCLot *lot, Split *split)
 void
 gnc_lot_remove_split (GNCLot *lot, Split *split)
 {
-    LotPrivate* priv;
+    GNCLotPrivate* priv;
     if (!lot || !split) return;
     priv = GET_PRIVATE(lot);
 
@@ -646,7 +644,7 @@ gnc_lot_remove_split (GNCLot *lot, Split *split)
 Split *
 gnc_lot_get_earliest_split (GNCLot *lot)
 {
-    LotPrivate* priv;
+    GNCLotPrivate* priv;
     if (!lot) return NULL;
     priv = GET_PRIVATE(lot);
     if (! priv->splits) return NULL;
@@ -658,7 +656,7 @@ gnc_lot_get_earliest_split (GNCLot *lot)
 Split *
 gnc_lot_get_latest_split (GNCLot *lot)
 {
-    LotPrivate* priv;
+    GNCLotPrivate* priv;
     SplitList *node;
 
     if (!lot) return NULL;

--- a/libgnucash/engine/qofbook.cpp
+++ b/libgnucash/engine/qofbook.cpp
@@ -107,7 +107,7 @@ qof_book_option_num_autoreadonly_changed_cb (GObject *gobject,
 #define PARAM_NAME_NUM_FIELD_SOURCE "split-action-num-field"
 #define PARAM_NAME_NUM_AUTOREAD_ONLY "autoreadonly-days"
 
-QOF_GOBJECT_GET_TYPE(QofBook, qof_book, QOF_TYPE_INSTANCE, {});
+G_DEFINE_TYPE(QofBook, qof_book, QOF_TYPE_INSTANCE);
 QOF_GOBJECT_DISPOSE(qof_book);
 QOF_GOBJECT_FINALIZE(qof_book);
 

--- a/libgnucash/engine/qofinstance.cpp
+++ b/libgnucash/engine/qofinstance.cpp
@@ -114,7 +114,7 @@ typedef struct QofInstancePrivate
 #define GET_PRIVATE(o)  \
    (G_TYPE_INSTANCE_GET_PRIVATE ((o), QOF_TYPE_INSTANCE,  QofInstancePrivate))
 
-QOF_GOBJECT_GET_TYPE(QofInstance, qof_instance, G_TYPE_OBJECT, {});
+G_DEFINE_TYPE_WITH_PRIVATE(QofInstance, qof_instance, G_TYPE_OBJECT);
 QOF_GOBJECT_FINALIZE(qof_instance);
 #undef G_PARAM_READWRITE
 #define G_PARAM_READWRITE static_cast<GParamFlags>(G_PARAM_READABLE | G_PARAM_WRITABLE)
@@ -135,8 +135,6 @@ static void qof_instance_class_init(QofInstanceClass *klass)
     object_class->dispose = qof_instance_dispose;
     object_class->set_property = qof_instance_set_property;
     object_class->get_property = qof_instance_get_property;
-
-    g_type_class_add_private(klass, sizeof(QofInstancePrivate));
 
     klass->get_display_name = NULL;
     klass->refers_to_object = NULL;

--- a/po/de.po
+++ b/po/de.po
@@ -8527,7 +8527,7 @@ msgstr "-- Aktienteilung --"
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:576
 #: gnucash/register/ledger-core/split-register-model.c:980
 msgid "%A %d %B %Y"
-msgstr "%A %d %B %Y"
+msgstr "%A, %d. %B %Y"
 
 #: gnucash/gnome-utils/gnc-tree-util-split-reg.c:479
 msgid ""

--- a/po/de.po
+++ b/po/de.po
@@ -19865,9 +19865,8 @@ msgstr ""
 
 #. Translators: {1} will be replaced with a filename
 #: gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp:2034
-#, fuzzy
 msgid "The transactions were imported from file '{1}'."
-msgstr "Die Buchungen wurden aus der Datei »%s« importiert."
+msgstr "Die Buchungen wurden aus der Datei »{1}« importiert."
 
 #: gnucash/import-export/csv-imp/csv-account-import.c:251
 #, c-format


### PR DESCRIPTION
g_type_class_add_private() is deprecated as described in https://gitlab.gnome.org/GNOME/glib/commit/7e5db31d36532274c2b2428ef9bace796928785e

This PR replaces its use with variations of G_DEFINE_TYPE.

There are two cpp and multiple c files affected.

For the cpp files: I'm not experienced with c/c++ but this seems to work. Please have a look at it.
For the c files: I'm trying to get a grip on them as well so I'm working on this PR. The work is not yet done.