### PR TITLE
Fixes to the appdata file

### DIFF
--- a/gnucash/gnome/gnucash.appdata.xml.in
+++ b/gnucash/gnome/gnucash.appdata.xml.in
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component>
-  <id type="desktop">org.gnucash.Gnucash</id>
+  <id type="desktop">org.gnucash.GnuCash</id>
+  <launchable type="desktop-id">gnucash.desktop</launchable>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0+</project_license>
   <name>GnuCash</name>


### PR DESCRIPTION
Rename the ID from org.gnucash.Gnucash to org.gnucash.GnuCash to match
flathub, and add a launchable ID to link it to the desktop file.