### PR TITLE
 Appdata: remove old property 

### DIFF
--- a/gnucash/gnome/CMakeLists.txt
+++ b/gnucash/gnome/CMakeLists.txt
@@ -180,7 +180,7 @@ endif()
 
 add_custom_target(gnucash-appdata ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/gnucash.appdata.xml)
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/gnucash.appdata.xml DESTINATION  ${CMAKE_INSTALL_DATADIR}/appdata)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/gnucash.appdata.xml DESTINATION  ${CMAKE_INSTALL_DATADIR}/metainfo)
 
 #=======
 

--- a/gnucash/gnome/gnucash.appdata.xml.in
+++ b/gnucash/gnome/gnucash.appdata.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component>
-  <id type="desktop">org.gnucash.GnuCash</id>
+  <id>org.gnucash.GnuCash</id>
   <launchable type="desktop-id">gnucash.desktop</launchable>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0+</project_license>


### PR DESCRIPTION
This fixes the following notice detected by `appstreamcli validate cherrytree.appdata.xml`:
```
I - gnucash.appdata.xml.in:org.gnucash.GnuCash:3
    The id tag for "org.gnucash.GnuCash" still contains a 'type' property, probably 
    from an old conversion.
```
And the metainfo files should be installed into /usr/share/metainfo.

See: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#spec-component-location