### PR TITLE
Fix XML load CPU hotspot: Scrub.c xaccTransScrubPostedDate

### DIFF
--- a/libgnucash/engine/Scrub.c
+++ b/libgnucash/engine/Scrub.c
@@ -1395,13 +1395,15 @@ void
 xaccTransScrubPostedDate (Transaction *trans)
 {
     time64 orig = xaccTransGetDate(trans);
-    GDate date = xaccTransGetDatePostedGDate(trans);
-    time64 time = gdate_to_time64(date);
-    /* xaccTransGetDatePostedGDate will return a valid time */
-    if (orig == INT64_MAX && orig != time)
+    if(orig == INT64_MAX)
     {
-        /* xaccTransSetDatePostedSecs handles committing the change. */
-        xaccTransSetDatePostedSecs(trans, time);
+	GDate date = xaccTransGetDatePostedGDate(trans);
+	time64 time = gdate_to_time64(date);
+	if(time != INT64_MAX)
+	{
+	    // xaccTransSetDatePostedSecs handles committing the change.
+	    xaccTransSetDatePostedSecs(trans, time);
+	}
     }
 }
 


### PR DESCRIPTION
The refactoring provides roughly 10% reduction in user CPU use for XML file load by moving an expensive function to within an if-clause where the result is used.  The diff look like a full re-write of the function but only the if statements, indenting, and commentary changed.

Disclosure #1:  My first attempt at the pull request mechanism
Disclosure #2: I rebased my branch off of upstream/maint right before submitting this... and tied a holy knot in my own repository, but I don't think it impacts this at all.  Gah.  Learning.
