### PR TITLE
Re-use user locale when formatting time - 10% improvement save speed

### DIFF
--- a/libgnucash/engine/gnc-datetime.cpp
+++ b/libgnucash/engine/gnc-datetime.cpp
@@ -425,11 +425,21 @@ std::string
 GncDateTimeImpl::format(const char* format) const
 {
     using Facet = boost::local_time::local_time_facet;
+    static std::locale cachedLocale;
+    static bool cachedLocaleAvailable = false;
     std::stringstream ss;
+
+    if(!cachedLocaleAvailable)
+    {
+        cachedLocale = std::locale("");
+	cachedLocaleAvailable = true;
+    }
+
     //The stream destructor frees the facet, so it must be heap-allocated.
     auto output_facet(new Facet(normalize_format(format).c_str()));
     // FIXME Rather than imbueing a locale below we probably should set std::locale::global appropriately somewhere.
-    ss.imbue(std::locale(std::locale(""), output_facet));
+    // At that point the use of cachedLocale mechanism should be removed.
+    ss.imbue(std::locale(cachedLocale, output_facet));
     ss << m_time;
     return ss.str();
 }


### PR DESCRIPTION
This 2-liner saves 10-20% of the user CPU for XML save.
Note that the benefit in XML save time is likely temporary given
jralls' effort to switch to UTC for XML save data.