### PR TITLE
Fixes for time64 setter/getters in Python examples

### DIFF
--- a/bindings/python/example_scripts/priceDB_test.py
+++ b/bindings/python/example_scripts/priceDB_test.py
@@ -38,7 +38,7 @@ value = latest.get_value()
 pl = pdb.get_prices(arm,gbp)
 for pr in pl:
    source = pr.get_source()
-   time = pr.get_time()
+   time = pr.get_time64()
    v=pr.get_value()
    price = float(v.num)/v.denom
    print(time, source, price)

--- a/bindings/python/example_scripts/price_database_example.py
+++ b/bindings/python/example_scripts/price_database_example.py
@@ -79,7 +79,7 @@ for namespace in namespaces:
             for pr in pl:
 
                source = pr.get_source()
-               time = pr.get_time()
+               time = pr.get_time64()
                v=pr.get_value()
                price = float(v.num)/v.denom
 

--- a/bindings/python/example_scripts/quotes_historic.py
+++ b/bindings/python/example_scripts/quotes_historic.py
@@ -78,7 +78,7 @@ for i in range(0,len(stock_date)):
   p_new = pl0.clone(book)
   p_new = gnucash.GncPrice(instance=p_new)
   print('Adding',i,stock_date[i],stock_price[i])
-  p_new.set_time(stock_date[i])
+  p_new.set_time64(stock_date[i])
   v = p_new.get_value()
   v.num = int(Fraction.from_float(stock_price[i]).limit_denominator(100000).numerator)
   v.denom = int(Fraction.from_float(stock_price[i]).limit_denominator(100000).denominator)


### PR DESCRIPTION
The Python examples were updated for Python3, but not the breaking changes in the bindings.  From the 3.0 release notes:

> Replaced Timespec with time64 in the Scheme and Python bindings, introducing many new C time64 functions to accomodate the replacement.

This PR fixes the examples to use the time64 bindings.