### PR TITLE
Bug fixes and improvements for import bills & invoices

### DIFF
--- a/gnucash/import-export/bi-import/dialog-bi-import-gui.c
+++ b/gnucash/import-export/bi-import/dialog-bi-import-gui.c
@@ -124,7 +124,7 @@ gnc_plugin_bi_import_showGUI (GtkWindow *parent)
 
     gui->book = gnc_get_current_book();
 
-    gui->regexp = g_string_new ( "^(\\x{FEFF})?(?<id>[^;]*);(?<date_opened>[^;]*);(?<owner_id>[^;]*);(?<billing_id>[^;]*);?(?<notes>[^;]*);?(?<date>[^;]*);?(?<desc>[^;]*);?(?<action>[^;]*);?(?<account>[^;]*);?(?<quantity>[^;]*);?(?<price>[^;]*);?(?<disc_type>[^;]*);?(?<disc_how>[^;]*);?(?<discount>[^;]*);?(?<taxable>[^;]*);?(?<taxincluded>[^;]*);?(?<tax_table>[^;]*);(?<date_posted>[^;]*);(?<due_date>[^;]*);(?<account_posted>[^;]*);(?<memo_posted>[^;]*);(?<accu_splits>[^;]*)$");
+    gui->regexp = g_string_new ( "^(\\x{FEFF})?(?<id>[^;]*);(?<date_opened>[^;]*);(?<owner_id>[^;]*);(?<billing_id>[^;]*);(?<notes>[^;]*);(?<date>[^;]*);(?<desc>[^;]*);(?<action>[^;]*);(?<account>[^;]*);(?<quantity>[^;]*);(?<price>[^;]*);(?<disc_type>[^;]*);(?<disc_how>[^;]*);(?<discount>[^;]*);(?<taxable>[^;]*);(?<taxincluded>[^;]*);(?<tax_table>[^;]*);(?<date_posted>[^;]*);(?<due_date>[^;]*);(?<account_posted>[^;]*);(?<memo_posted>[^;]*);(?<accu_splits>[^;]*)$");
 
     // create model and bind to view
     gui->store = gtk_list_store_new (N_COLUMNS,
@@ -216,12 +216,12 @@ gnc_bi_import_gui_ok_cb (GtkWidget *widget, gpointer data)
     if (res == RESULT_OK)
     {
         gnc_bi_import_fix_bis (gui->store, &n_fixed, &n_deleted, info, gui->type);
-        gnc_bi_import_create_bis (gui->store, gui->book, &n_invoices_created, &n_invoices_updated,
+        gnc_bi_import_create_bis (gui->store, gui->book, &n_invoices_created, &n_invoices_updated, &n_deleted,
                                   gui->type, gui->open_mode, info, gui->parent);
         if (info->len > 0)
             gnc_info_dialog (GTK_WINDOW (gui->dialog), "%s", info->str);
         g_string_free( info, TRUE );
-        gnc_info_dialog (GTK_WINDOW (gui->dialog), _("Import results:\n%i lines were ignored\n%i lines imported:\n   %u fixes\n   %u ignored (not fixable)\n\n   %u created\n   %u updated (based on id)"), stats.n_ignored, stats.n_imported, n_fixed, n_deleted, n_invoices_created, n_invoices_updated);
+        gnc_info_dialog (GTK_WINDOW (gui->dialog), _("Import:\n- rows ignored: %i\n- rows imported: %i\n\nValidation & processing:\n- rows fixed: %u\n- rows ignored: %u\n- invoices created: %u\n- invoices updated: %u"), stats.n_ignored, stats.n_imported, n_fixed, n_deleted, n_invoices_created, n_invoices_updated);
         if (stats.n_ignored > 0)
             gnc_info2_dialog (gui->dialog, _("These lines were ignored during import"), stats.ignored_lines->str);
 
@@ -309,7 +309,7 @@ void gnc_bi_import_gui_option1_cb (GtkWidget *widget, gpointer data)
     BillImportGui *gui = data;
     if (!gtk_toggle_button_get_active( GTK_TOGGLE_BUTTON(widget) ))
         return;
-    g_string_assign (gui->regexp, "^(\\x{FEFF})?(?<id>[^;]*);(?<date_opened>[^;]*);(?<owner_id>[^;]*);(?<billing_id>[^;]*);?(?<notes>[^;]*);?(?<date>[^;]*);?(?<desc>[^;]*);?(?<action>[^;]*);?(?<account>[^;]*);?(?<quantity>[^;]*);?(?<price>[^;]*);?(?<disc_type>[^;]*);?(?<disc_how>[^;]*);?(?<discount>[^;]*);?(?<taxable>[^;]*);?(?<taxincluded>[^;]*);?(?<tax_table>[^;]*);(?<date_posted>[^;]*);(?<due_date>[^;]*);(?<account_posted>[^;]*);(?<memo_posted>[^;]*);(?<accu_splits>[^;]*)$");
+    g_string_assign (gui->regexp, "^(\\x{FEFF})?(?<id>[^;]*);(?<date_opened>[^;]*);(?<owner_id>[^;]*);(?<billing_id>[^;]*);(?<notes>[^;]*);(?<date>[^;]*);(?<desc>[^;]*);(?<action>[^;]*);(?<account>[^;]*);(?<quantity>[^;]*);(?<price>[^;]*);(?<disc_type>[^;]*);(?<disc_how>[^;]*);(?<discount>[^;]*);(?<taxable>[^;]*);(?<taxincluded>[^;]*);(?<tax_table>[^;]*);(?<date_posted>[^;]*);(?<due_date>[^;]*);(?<account_posted>[^;]*);(?<memo_posted>[^;]*);(?<accu_splits>[^;]*)$");
     gnc_bi_import_gui_filenameChanged_cb (gui->entryFilename, gui);
 }
 
@@ -319,7 +319,7 @@ void gnc_bi_import_gui_option2_cb (GtkWidget *widget, gpointer data)
     BillImportGui *gui = data;
     if (!gtk_toggle_button_get_active( GTK_TOGGLE_BUTTON(widget) ))
         return;
-    g_string_assign (gui->regexp, "^(\\x{FEFF})?(?<id>[^,]*),(?<date_opened>[^,]*),(?<owner_id>[^,]*),(?<billing_id>[^,]*),?(?<notes>[^,]*),?(?<date>[^,]*),?(?<desc>[^,]*),?(?<action>[^,]*),?(?<account>[^,]*),?(?<quantity>[^,]*),?(?<price>[^,]*),?(?<disc_type>[^,]*),?(?<disc_how>[^,]*),?(?<discount>[^,]*),?(?<taxable>[^,]*),?(?<taxincluded>[^,]*),?(?<tax_table>[^,]*),(?<date_posted>[^,]*),(?<due_date>[^,]*),(?<account_posted>[^,]*),(?<memo_posted>[^,]*),(?<accu_splits>[^,]*)$");
+    g_string_assign (gui->regexp, "^(\\x{FEFF})?(?<id>[^,]*),(?<date_opened>[^,]*),(?<owner_id>[^,]*),(?<billing_id>[^,]*),(?<notes>[^,]*),(?<date>[^,]*),(?<desc>[^,]*),(?<action>[^,]*),(?<account>[^,]*),(?<quantity>[^,]*),(?<price>[^,]*),(?<disc_type>[^,]*),(?<disc_how>[^,]*),(?<discount>[^,]*),(?<taxable>[^,]*),(?<taxincluded>[^,]*),(?<tax_table>[^,]*),(?<date_posted>[^,]*),(?<due_date>[^,]*),(?<account_posted>[^,]*),(?<memo_posted>[^,]*),(?<accu_splits>[^,]*)$");
     gnc_bi_import_gui_filenameChanged_cb (gui->entryFilename, gui);
 }
 

--- a/gnucash/import-export/bi-import/dialog-bi-import.h
+++ b/gnucash/import-export/bi-import/dialog-bi-import.h
@@ -69,7 +69,7 @@ gnc_bi_import_fix_bis (GtkListStore *store, guint *fixed, guint *deleted, GStrin
 
 void
 gnc_bi_import_create_bis (GtkListStore *store, QofBook *book, guint *n_invoices_created,
-                          guint *n_invoices_updated,	gchar *type, gchar *open_mode, GString * info,
+                          guint *n_invoices_updated, guint *n_rows_ignored,	gchar *type, gchar *open_mode, GString * info,
                           GtkWindow *parent);
 
 


### PR DESCRIPTION
Bug [796984 Import Bills & Invoices: date of line item is not validated; can lead to unexpected results](
https://bugs.gnucash.org/show_bug.cgi?id=796984)
Bug [797022 Import Bills & Invoices: expense/income account is not validated - leads to one-sided posting if account is invalid](https://bugs.gnucash.org/show_bug.cgi?id=797022)
Bug [796987 Import Bills & Invoices: fixing import items only works in special case](https://bugs.gnucash.org/show_bug.cgi?id=796987)
Bug [797024 Import Bills & Invoices: import matches csv data rows with too few separators, messing up the import data](https://bugs.gnucash.org/show_bug.cgi?id=797024)
Bug [796986 Import Bills & Invoices: in case of invalid posting date in import file, invoice is posted with unexpected date](https://bugs.gnucash.org/show_bug.cgi?id=796986)
Bug [797023 Import Bills & Invoices: no user confirmation requested for update of invoices, if new invoices is created first](https://bugs.gnucash.org/show_bug.cgi?id=797023)
Bug [796985 Import Bills & Invoices: option 'open not yet posted docs in tab' does not open tab if invoice could not be posted](https://bugs.gnucash.org/show_bug.cgi?id=796985)
Bug [797025 Import Bills & Invoices: the type of the post to account is not validated - enabling A/P and A/R postings on regular accounts](https://bugs.gnucash.org/show_bug.cgi?id=797025)

Other improvements:
- moved most validations to gnc_bi_import_fix_bis (previously some were in gnc_bi_import_create_bis, some in gnc_bi_import_fix_bis)
- only the currency related validations remain in gnc_bi_import_create_bis, because they are based on a saved invoice
- improved error reporting and feedback
- changed behaviour: an error in a data row will cause the full invoice to be ignored; previously only that row would be ignored
- added and updated doxygen information

Rewrote chapter Import Business Data of the guide, to document the functionality; submitted in pull request to gnucash-docs.