### PR TITLE
Bug796965 - Change the default to show unused accounts

### DIFF
--- a/gnucash/gnome-utils/gnc-tree-view-account.h
+++ b/gnucash/gnome-utils/gnc-tree-view-account.h
@@ -118,6 +118,15 @@ void gnc_tree_view_account_restore(GncTreeViewAccount *view,
                                    GKeyFile *key_file,
                                    const gchar *group_name);
 
+void gnc_tree_view_account_save_filter (GncTreeViewAccount *tree_view,
+                                        AccountFilterDialog *fd,
+                                        GKeyFile *key_file,
+                                        const gchar *group_name);
+void gnc_tree_view_account_restore_filter (GncTreeViewAccount *view,
+                                           AccountFilterDialog *fd,
+                                           GKeyFile *key_file,
+                                           const gchar *group_name);
+
 
 /* Get the GType for an GncTreeViewAccount object. */
 GType gnc_tree_view_account_get_type (void);

--- a/gnucash/gnome/gnc-budget-view.c
+++ b/gnucash/gnome/gnc-budget-view.c
@@ -496,6 +496,10 @@ gbv_create_widget(GncBudgetView *view)
     g_signal_connect(G_OBJECT(tree_view), "size-allocate",
                      G_CALLBACK(gbv_treeview_resized_cb), view);
 
+    // Read account filter state information from budget section
+    gnc_tree_view_account_restore_filter (GNC_TREE_VIEW_ACCOUNT(priv->tree_view), priv->fd,
+       gnc_state_get_current(), gnc_tree_view_get_state_section (GNC_TREE_VIEW(priv->tree_view)));
+
     gnc_budget_view_refresh(view);
 }
 
@@ -526,7 +530,7 @@ gnc_budget_view_save(GncBudgetView *view, GKeyFile *key_file, const gchar *group
 
     priv = GNC_BUDGET_VIEW_GET_PRIVATE(view);
 
-    //FIXME
+    // Save the account filter and page state information to page section
     gnc_tree_view_account_save(GNC_TREE_VIEW_ACCOUNT(priv->tree_view),
                                priv->fd, key_file, group_name);
     LEAVE(" ");
@@ -586,7 +590,7 @@ gnc_budget_view_restore(GncBudgetView* view, GKeyFile *key_file, const gchar *gr
     /* Create the new view */
     priv = GNC_BUDGET_VIEW_GET_PRIVATE(view);
 
-    //FIXME
+    // Restore the account filter and page state information from page section
     gnc_tree_view_account_restore(GNC_TREE_VIEW_ACCOUNT(priv->tree_view),
                                   priv->fd, key_file, group_name);
     LEAVE(" ");
@@ -619,7 +623,28 @@ gnc_budget_view_delete_budget(GncBudgetView *view)
     LEAVE(" ");
 }
 
+/***********************************************************************
+ *  Save the Account filter information for this budget                *
+ *                                                                     *
+ *  @param view The view to which the budget is associated.            *
+ **********************************************************************/
+void
+gnc_budget_view_save_account_filter (GncBudgetView *view)
+{
+    GncBudgetViewPrivate *priv;
 
+    g_return_if_fail(view != NULL);
+
+    ENTER("view %p", view);
+
+    priv = GNC_BUDGET_VIEW_GET_PRIVATE (view);
+
+    // Save account filter state information to budget section
+    gnc_tree_view_account_save_filter (GNC_TREE_VIEW_ACCOUNT(priv->tree_view),
+       priv->fd, gnc_state_get_current(), gnc_tree_view_get_state_section (GNC_TREE_VIEW(priv->tree_view)));
+
+    LEAVE(" ");
+}
 
 #if 0
 /***********************************************************************

--- a/gnucash/gnome/gnc-budget-view.h
+++ b/gnucash/gnome/gnc-budget-view.h
@@ -64,6 +64,7 @@ GncBudgetView *gnc_budget_view_new(GncBudget *budget, AccountFilterDialog* fd);
 void gnc_budget_view_save(GncBudgetView* view, GKeyFile *key_file, const gchar* group_name);
 void gnc_budget_view_refresh(GncBudgetView* view);
 void gnc_budget_view_delete_budget(GncBudgetView* view);
+void gnc_budget_view_save_account_filter(GncBudgetView *view);
 gboolean gnc_budget_view_restore(GncBudgetView* view, GKeyFile *key_file, const gchar* group_name);
 GtkTreeSelection* gnc_budget_view_get_selection(GncBudgetView* view);
 Account* gnc_budget_view_get_account_from_path(GncBudgetView* view, GtkTreePath* path);

--- a/gnucash/gnome/gnc-plugin-page-account-tree.c
+++ b/gnucash/gnome/gnc-plugin-page-account-tree.c
@@ -759,6 +759,10 @@ gnc_plugin_page_account_tree_create_widget (GncPluginPage *plugin_page)
                            gnc_plugin_page_account_tree_summarybar_position_changed,
                            page);
 
+    // Read account filter state information from account section
+    gnc_tree_view_account_restore_filter (GNC_TREE_VIEW_ACCOUNT(priv->tree_view), &priv->fd,
+       gnc_state_get_current(), gnc_tree_view_get_state_section (GNC_TREE_VIEW(priv->tree_view)));
+
     LEAVE("widget = %p", priv->widget);
     return priv->widget;
 }
@@ -781,6 +785,10 @@ gnc_plugin_page_account_tree_destroy_widget (GncPluginPage *plugin_page)
                                  GNC_PREF_SUMMARYBAR_POSITION_BOTTOM,
                                  gnc_plugin_page_account_tree_summarybar_position_changed,
                                  page);
+
+    // Save account filter state information to account section
+    gnc_tree_view_account_save_filter (GNC_TREE_VIEW_ACCOUNT(priv->tree_view), &priv->fd,
+       gnc_state_get_current(), gnc_tree_view_get_state_section (GNC_TREE_VIEW(priv->tree_view)));
 
     // Destroy the filter override hash table
     g_hash_table_destroy(priv->fd.filter_override);

--- a/gnucash/gnome/gnc-plugin-page-budget.c
+++ b/gnucash/gnome/gnc-plugin-page-budget.c
@@ -334,6 +334,7 @@ gnc_plugin_page_budget_init (GncPluginPageBudget *plugin_page)
     /* Visible types */
     priv->fd.visible_types = -1; /* Start with all types */
     priv->fd.show_hidden = FALSE;
+    priv->fd.show_unused = TRUE;
     priv->fd.show_zero_total = TRUE;
     priv->fd.filter_override = g_hash_table_new (g_direct_hash, g_direct_equal);
 

--- a/gnucash/gnome/gnc-plugin-page-budget.c
+++ b/gnucash/gnome/gnc-plugin-page-budget.c
@@ -480,6 +480,9 @@ gnc_plugin_page_budget_destroy_widget (GncPluginPage *plugin_page)
 
     if (priv->budget_view)
     {
+        // save the account filter state information to budget section
+        gnc_budget_view_save_account_filter (priv->budget_view);
+
         if (priv->delete_budget)
         {
             gnc_budget_view_delete_budget (priv->budget_view);
@@ -538,7 +541,7 @@ gnc_plugin_page_budget_save_page (GncPluginPage *plugin_page,
     guid_to_string_buff(gnc_budget_get_guid(priv->budget), guid_str);
     g_key_file_set_string(key_file, group_name, BUDGET_GUID, guid_str);
 
-    //FIXME
+    // Save the Budget page information to state file
     gnc_budget_view_save(priv->budget_view, key_file, group_name);
 
     LEAVE(" ");


### PR DESCRIPTION
Another attempt at this one...
The first commit changes the default for budgets to show unused accounts so it matches the Account Treeview.

With the addition of two functions that will save and restore the account filter settings to the state file the budget will now remember these settings when the page is closed on exit. They are still being saved as part of the page saving routines as well for compatibility and in 4.x these settings could be removed from the those routines.

I have checked in version 2.6.21 that these settings are ignored and left as is but to achieve this I needed to change the key names to include an underscore so that version would not crash, this was fixed in 3.2.

The last commit adds the same capability to the 'Accounts TreeView' so if you do open a new accounts page it will have your preferred default. It doesn't take much imagination in expanding this to saving different account trees based on account type filtering if that would be of use.

