### PR TITLE
Transaction Association Changes

### DIFF
--- a/gnucash/gnome-utils/dialog-preferences.c
+++ b/gnucash/gnome-utils/dialog-preferences.c
@@ -752,6 +752,15 @@ file_chooser_selected_cb (GtkFileChooser *fc, gpointer user_data)
     const gchar *pref = g_object_get_data (G_OBJECT(fc), "pref");
     gchar       *folder = gtk_file_chooser_get_uri (fc);
 
+    // make sure path_head ends with a trailing '/', 3.5 onwards
+    if (!g_str_has_suffix (folder, "/"))
+    {
+        gchar *folder_with_slash = g_strconcat (folder, "/", NULL);
+        g_free (folder);
+        folder = g_strdup (folder_with_slash);
+        g_free (folder_with_slash);
+    }
+
     gtk_widget_hide (GTK_WIDGET(image));
 
     if (!gnc_prefs_set_string (group, pref, folder))
@@ -787,7 +796,7 @@ gnc_prefs_connect_file_chooser_button (GtkFileChooserButton *fcb, const gchar *b
 
     PINFO("Uri is %s", uri);
 
-    if ((uri != NULL) && (g_strcmp0 (uri, "") != 0)) // default entry
+    if (uri && *uri != '\0') // default entry
     {
         gchar *path_head = g_filename_from_uri (uri, NULL, NULL);
 

--- a/gnucash/gnome/dialog-trans-assoc.c
+++ b/gnucash/gnome/dialog-trans-assoc.c
@@ -525,7 +525,6 @@ gnc_assoc_dialog_create (GtkWindow *parent, AssocDialog *assoc_dialog)
     gtk_tree_view_column_set_title (tree_column, _("Relative"));
     gtk_tree_view_append_column (GTK_TREE_VIEW(assoc_dialog->view), tree_column);
     gtk_tree_view_column_set_alignment (tree_column, 0.5);
-    gtk_tree_view_column_set_expand (tree_column, TRUE);
     cr = gtk_cell_renderer_pixbuf_new();
     gtk_tree_view_column_pack_start (tree_column, cr, TRUE);
     // connect 'active' and set 'xalign' property of the cell renderer
@@ -534,6 +533,10 @@ gnc_assoc_dialog_create (GtkWindow *parent, AssocDialog *assoc_dialog)
 
     g_signal_connect (assoc_dialog->view, "row-activated",
                       G_CALLBACK(row_selected_cb), (gpointer)assoc_dialog);
+
+    // set the Associate column to be the one that expands
+    tree_column = GTK_TREE_VIEW_COLUMN(gtk_builder_get_object (builder, "uri-entry"));
+    gtk_tree_view_column_set_expand (tree_column, TRUE);
 
     // Set grid lines option to preference
     gtk_tree_view_set_grid_lines (GTK_TREE_VIEW(assoc_dialog->view), gnc_tree_view_get_grid_lines_pref ());

--- a/gnucash/gnome/dialog-trans-assoc.c
+++ b/gnucash/gnome/dialog-trans-assoc.c
@@ -43,7 +43,7 @@
 #include "Account.h"
 
 #define DIALOG_ASSOC_CM_CLASS    "dialog-trans-assoc"
-#define GNC_PREFS_GROUP         "dialogs.trans-assoc"
+#define GNC_PREFS_GROUP          "dialogs.trans-assoc"
 
 /** Enumeration for the tree-store */
 enum GncAssocColumn {DATE_TRANS, DESC_TRANS, URI_U, AVAILABLE, URI_SPLIT, URI, URI_RELATIVE};
@@ -373,7 +373,8 @@ get_trans_info (AssocDialog *assoc_dialog)
     GList        *accts, *ptr;
     GtkTreeModel *model;
     GtkTreeIter   iter;
-    GList        *splits, *trans_list = NULL;
+    GList        *splits;
+    GHashTable   *trans_hash = g_hash_table_new (g_direct_hash, g_direct_equal);
 
     /* Get list of Accounts */
     accts = gnc_account_get_descendants_sorted (root);
@@ -399,8 +400,8 @@ get_trans_info (AssocDialog *assoc_dialog)
             Transaction *trans = xaccSplitGetParent (split);
             const gchar *uri;
 
-            // Look for trans already in trans_list
-            if (g_list_find (trans_list, trans) != NULL)
+            // Look for trans already in trans_hash
+            if (g_hash_table_lookup (trans_hash, trans))
                 continue;
 
             // fix an earlier error when storing relative paths in version 3.3
@@ -433,7 +434,7 @@ get_trans_info (AssocDialog *assoc_dialog)
                 g_free (uri_u);
                 g_free (scheme);
             }
-            trans_list = g_list_prepend (trans_list, trans); // add trans to trans_list
+            g_hash_table_insert (trans_hash, trans, trans); // add trans to trans_hash
         }
         qof_query_destroy (query);
         g_list_free (splits);
@@ -443,8 +444,8 @@ get_trans_info (AssocDialog *assoc_dialog)
     gtk_tree_view_set_model (GTK_TREE_VIEW(assoc_dialog->view), model);
     g_object_unref(G_OBJECT(model));
 
+    g_hash_table_destroy (trans_hash);
     g_list_free (accts);
-    g_list_free (trans_list);
 }
 
 static void

--- a/gnucash/gnome/gnc-split-reg.c
+++ b/gnucash/gnome/gnc-split-reg.c
@@ -51,6 +51,7 @@
 #include "gnc-ui-util.h"
 #include "gnc-ui.h"
 #include "gnc-uri-utils.h"
+#include "gnc-filepath-utils.h"
 #include "gnc-warnings.h"
 #include "gnucash-sheet.h"
 #include "gnucash-register.h"
@@ -1041,7 +1042,7 @@ gsr_default_associate_handler_file (GNCSplitReg *gsr, Transaction *trans, gboole
 {
     GtkWidget *dialog;
     gint       response;
-    gboolean   valid_path_head = FALSE;
+    gboolean   path_head_set = FALSE;
     gchar     *path_head = gnc_prefs_get_string (GNC_PREFS_GROUP_GENERAL, "assoc-head");
 
     dialog = gtk_file_chooser_dialog_new (_("Associate File with Transaction"),
@@ -1054,33 +1055,49 @@ gsr_default_associate_handler_file (GNCSplitReg *gsr, Transaction *trans, gboole
 
     gtk_file_chooser_set_local_only (GTK_FILE_CHOOSER(dialog), FALSE);
 
-    if ((path_head != NULL) && (g_strcmp0 (path_head, "") != 0)) // not default entry
-        valid_path_head = TRUE;
+    path_head_set = (path_head && *path_head != '\0'); // not default entry
 
     if (have_uri)
     {
-        gchar *new_uri;
-        gchar *uri_label;
-        gchar *filename;
-
+        gchar *file_uri = NULL;
         const gchar *uri = xaccTransGetAssociation (trans);
+        gchar *scheme = gnc_uri_get_scheme (uri);
 
-        if (valid_path_head && g_str_has_prefix (uri,"file:/") && !g_str_has_prefix (uri,"file://"))
+        if (!scheme) // relative path
         {
-            const gchar *part = uri + strlen ("file:");
-            new_uri = g_strconcat (path_head, part, NULL);
+            gchar *file_path = NULL;
+            if (path_head_set) // not default entry
+                file_path = gnc_file_path_absolute (gnc_uri_get_path (path_head), uri);
+            else
+                file_path = gnc_file_path_absolute (NULL, uri);
+
+            file_uri = gnc_uri_create_uri ("file", NULL, 0, NULL, NULL, file_path);
+            g_free (file_path);
         }
-        else
-            new_uri = g_strdup (uri);
 
-        filename = g_uri_unescape_string (new_uri, NULL);
-        uri_label = g_strconcat (_("Existing Association is "), filename, NULL);
-        gtk_file_chooser_set_extra_widget (GTK_FILE_CHOOSER(dialog), gtk_label_new (uri_label));
-        gtk_file_chooser_set_uri (GTK_FILE_CHOOSER(dialog), new_uri);
+        if (g_strcmp0 (scheme, "file") == 0) // absolute path
+            file_uri = g_strdup (uri);
 
-        g_free (uri_label);
-        g_free (new_uri);
-        g_free (filename);
+        if (file_uri)
+        {
+            GtkWidget *label;
+            gchar *file_uri_u = g_uri_unescape_string (file_uri, NULL);
+            gchar *filename = gnc_uri_get_path (file_uri_u);
+            gchar *uri_label = g_strconcat (_("Existing Association is '"), filename, "'", NULL);
+            PINFO("Path head: '%s', URI: '%s', Filename: '%s'", path_head, uri, filename);
+            label = gtk_label_new (uri_label);
+            gtk_file_chooser_set_extra_widget (GTK_FILE_CHOOSER(dialog), label);
+            gtk_label_set_ellipsize (GTK_LABEL(label), PANGO_ELLIPSIZE_START);
+
+            // Set the style context for this label so it can be easily manipulated with css
+            gnc_widget_set_style_context (GTK_WIDGET(label), "gnc-class-highlight");
+            gtk_file_chooser_set_uri (GTK_FILE_CHOOSER(dialog), file_uri);
+
+            g_free (uri_label);
+            g_free (filename);
+            g_free (file_uri_u);
+            g_free (file_uri);
+        }
     }
     response = gtk_dialog_run (GTK_DIALOG (dialog));
 
@@ -1091,21 +1108,37 @@ gsr_default_associate_handler_file (GNCSplitReg *gsr, Transaction *trans, gboole
     {
         gchar *dialog_uri = gtk_file_chooser_get_uri (GTK_FILE_CHOOSER (dialog));
 
-        PINFO("Dialog File URI: %s\n", dialog_uri);
-
-        if (valid_path_head && g_str_has_prefix (dialog_uri, path_head))
+        // prior to 3.5, assoc-head could be with or without a trailing '/'
+        if (path_head_set && !g_str_has_suffix (path_head, "/"))
         {
-            gchar *part = dialog_uri + strlen (path_head);
-            gchar *new_uri = g_strconcat ("file:", part, NULL);
-            xaccTransSetAssociation (trans, new_uri);
-            g_free (new_uri);
+            gchar *folder_with_slash = g_strconcat (path_head, "/", NULL);
+            g_free (path_head);
+            path_head = g_strdup (folder_with_slash);
+            g_free (folder_with_slash);
+
+            if (!gnc_prefs_set_string (GNC_PREFS_GROUP_GENERAL, "assoc-head", path_head))
+                PINFO("Failed to save preference at %s, %s with %s",
+                       GNC_PREFS_GROUP_GENERAL, "assoc-head", path_head);
+        }
+
+        PINFO("Dialog File URI: '%s', Path head: '%s'", dialog_uri, path_head);
+
+        // relative paths do not start with a '/'
+        if (path_head_set && g_str_has_prefix (dialog_uri, path_head))
+        {
+            const gchar *part = dialog_uri + strlen (path_head);
+
+            PINFO("Dialog URI: '%s', Part: '%s'", dialog_uri, part);
+            xaccTransSetAssociation (trans, part);
         }
         else
+        {
+            PINFO("Dialog URI: '%s'", dialog_uri);
             xaccTransSetAssociation (trans, dialog_uri);
-
+        }
         g_free (dialog_uri);
     }
-    g_free (path_head);
+
     gtk_widget_destroy (dialog);
 }
 
@@ -1113,17 +1146,19 @@ static void
 gsr_default_associate_handler_location_ok_cb (GtkEditable *editable, gpointer user_data)
 {
     GtkWidget *ok_button = user_data;
-    gboolean have_scheme = TRUE;
+    gboolean have_scheme = FALSE;
     gchar *text = gtk_editable_get_chars (editable, 0, -1);
-    gchar *scheme = gnc_uri_get_scheme (text);
+    gchar *scheme;
 
-    if (!scheme)
-        have_scheme = FALSE;
-
+    if (text && *text != '\0')
+    {
+        scheme = gnc_uri_get_scheme (text);
+        if (scheme)
+            have_scheme = TRUE;
+        g_free (scheme);
+    }
     gtk_widget_set_sensitive (ok_button, have_scheme);
-
     g_free (text);
-    g_free (scheme);
 }
 
 static void
@@ -1191,6 +1226,33 @@ gsr_default_associate_handler_location (GNCSplitReg *gsr, Transaction *trans, gb
     gtk_widget_destroy (dialog);
 }
 
+static gchar*
+gsr_convert_associate_uri (Transaction *trans)
+{
+    const gchar *uri = xaccTransGetAssociation (trans); // get the existing uri
+    const gchar *part = NULL;
+
+    if (!uri)
+        return NULL;
+
+    if (g_str_has_prefix (uri, "file:") && !g_str_has_prefix (uri,"file://"))
+    {
+        // fix an error when storing relative paths in version earlier than 3.5
+        // relative paths are stored without a leading "/" and in native form
+        if (g_str_has_prefix (uri,"file:/") && !g_str_has_prefix (uri,"file://"))
+            part = uri + strlen ("file:/");
+        else if (g_str_has_prefix (uri,"file:") && !g_str_has_prefix (uri,"file://"))
+            part = uri + strlen ("file:");
+
+        if (part)
+        {
+            xaccTransSetAssociation (trans, part);
+            return g_strdup (part);
+        }
+    }
+    return g_strdup (uri);
+}
+
 /**
  * Associates a URI with the current transaction.
  **/
@@ -1205,7 +1267,7 @@ gsr_default_associate_handler (GNCSplitReg *gsr, gboolean uri_is_file)
     gboolean have_uri = FALSE;
 
     /* get the current split based on cursor position */
-    if (split == NULL)
+    if (!split)
     {
         gnc_split_register_cancel_cursor_split_changes (reg);
         return;
@@ -1217,21 +1279,24 @@ gsr_default_associate_handler (GNCSplitReg *gsr, gboolean uri_is_file)
     if (cursor_class == CURSOR_CLASS_NONE)
         return;
 
+    // fix an earlier error when storing relative paths in version 3.3
+    uri = gsr_convert_associate_uri (trans);
+
     if (is_trans_readonly_and_warn (GTK_WINDOW(gsr->window), trans))
         return;
 
-    // get the existing uri
-    uri = xaccTransGetAssociation (trans);
-
     // Check for uri is empty or NULL
-    if (g_strcmp0 (uri, "") != 0 && g_strcmp0 (uri, NULL) != 0)
+    if (uri && *uri != '\0')
     {
+        gchar *scheme = gnc_uri_get_scheme (uri);
         have_uri = TRUE;
 
-        if (g_str_has_prefix (uri, "file:")) // use the correct dialog
+        if (!scheme || g_strcmp0 (scheme, "file") == 0) // use the correct dialog
             uri_is_file = TRUE;
         else
             uri_is_file = FALSE;
+
+        g_free (scheme);
     }
 
     if (uri_is_file == TRUE)
@@ -1251,11 +1316,11 @@ gsr_default_execassociated_handler (GNCSplitReg *gsr, gpointer data)
     Transaction *trans;
     Split *split = gnc_split_register_get_current_split (reg);
     const char *uri;
-    const char *run_uri;
+    const char *run_uri = NULL;
     gchar *uri_scheme;
 
     /* get the current split based on cursor position */
-    if (split == NULL)
+    if (!split)
     {
         gnc_split_register_cancel_cursor_split_changes (reg);
         return;
@@ -1272,30 +1337,36 @@ gsr_default_execassociated_handler (GNCSplitReg *gsr, gpointer data)
         xaccTransDump (trans, "ExecAssociated");
 #endif
 
-    uri = xaccTransGetAssociation (trans);
+    // fix an earlier error when storing relative paths in version 3.3
+    uri = gsr_convert_associate_uri (trans);
 
-    if (g_strcmp0 (uri, "") == 0 && g_strcmp0 (uri, NULL) == 0)
+    if (!uri && g_strcmp0 (uri, "") == 0)
         gnc_error_dialog (GTK_WINDOW (gsr->window), "%s", _("This transaction is not associated with a URI."));
     else
     {
-        if (g_str_has_prefix (uri,"file:/") && !g_str_has_prefix (uri,"file://")) // Check for relative path
+        gchar *scheme = gnc_uri_get_scheme (uri);
+
+        if (!scheme) // relative path
         {
             gchar *path_head = gnc_prefs_get_string (GNC_PREFS_GROUP_GENERAL, "assoc-head");
+            gchar *file_path;
 
-            if ((path_head != NULL) && (g_strcmp0 (path_head, "") != 0)) // not default entry
-            {
-                const gchar *part = uri + strlen ("file:");
-                run_uri = g_strconcat (path_head, part, NULL);
-            }
+            if (path_head && g_strcmp0 (path_head, "") != 0) // not default entry
+                file_path = gnc_file_path_absolute (gnc_uri_get_path (path_head), uri);
             else
-                run_uri = g_strdup (uri);
+                file_path = gnc_file_path_absolute (NULL, uri);
+
+            run_uri = gnc_uri_create_uri ("file", NULL, 0, NULL, NULL, file_path);
+            g_free (path_head);
+            g_free (file_path);
         }
-        else
+
+        if (!run_uri)
             run_uri = g_strdup (uri);
 
-        uri_scheme = g_uri_parse_scheme (run_uri);
+        uri_scheme = gnc_uri_get_scheme (run_uri);
 
-        if (uri_scheme != NULL) // make sure we have a scheme entry
+        if (uri_scheme) // make sure we have a scheme entry
         {
             gnc_launch_assoc (run_uri);
             g_free (uri_scheme);

--- a/gnucash/gtkbuilder/dialog-trans-assoc.glade
+++ b/gnucash/gtkbuilder/dialog-trans-assoc.glade
@@ -152,7 +152,9 @@
                     <property name="title" translatable="yes">Association</property>
                     <property name="alignment">0.5</property>
                     <child>
-                      <object class="GtkCellRendererText" id="cellrenderertext3"/>
+                      <object class="GtkCellRendererText" id="cellrenderertext3">
+                        <property name="ellipsize">start</property>
+                      </object>
                       <attributes>
                         <attribute name="text">2</attribute>
                       </attributes>

--- a/gnucash/register/register-gnome/gnucash-sheet.c
+++ b/gnucash/register/register-gnome/gnucash-sheet.c
@@ -2496,7 +2496,7 @@ gnucash_get_style_classes (GnucashSheet *sheet, GtkStyleContext *stylectxt,
         if (sheet->use_gnc_color_theme) // only add this class if builtin colors used
             gtk_style_context_add_class (stylectxt, "register-foreground");
     }
-    
+
     switch (field_type)
     {
     default:
@@ -2694,15 +2694,18 @@ gnucash_sheet_tooltip (GtkWidget  *widget, gint x, gint y,
     tooltip_text = gnc_table_get_tooltip (table, virt_loc);
 
     // if tooltip_text empty, clear tooltip and return FALSE
-    if ((tooltip_text == NULL) || (g_strcmp0 (tooltip_text,"") == 0))
+    if (!tooltip_text || (g_strcmp0 (tooltip_text,"") == 0))
     {
         gtk_tooltip_set_text (tooltip, NULL);
         return FALSE;
     }
 
     block = gnucash_sheet_get_block (sheet, virt_loc.vcell_loc);
-    if (block == NULL)
+    if (!block)
+    {
+        g_free (tooltip_text);
         return FALSE;
+    }
 
     bx = block->origin_x;
     by = block->origin_y;
@@ -2712,15 +2715,15 @@ gnucash_sheet_tooltip (GtkWidget  *widget, gint x, gint y,
             virt_loc.phys_row_offset, virt_loc.phys_col_offset,
             &cx, &cy, &cw, &ch);
 
-     rect.x = cx + bx - hscroll_val;
-     rect.y = cy + by - vscroll_val;
-     rect.width = cw;
-     rect.height = ch;
+    rect.x = cx + bx - hscroll_val;
+    rect.y = cy + by - vscroll_val;
+    rect.width = cw;
+    rect.height = ch;
 
-     gtk_tooltip_set_tip_area (tooltip, &rect);
-     gtk_tooltip_set_text (tooltip, tooltip_text);
-     g_free (tooltip_text);
-     return TRUE;
+    gtk_tooltip_set_tip_area (tooltip, &rect);
+    gtk_tooltip_set_text (tooltip, tooltip_text);
+    g_free (tooltip_text);
+    return TRUE;
 }
 
 

--- a/libgnucash/core-utils/gnc-filepath-utils.cpp
+++ b/libgnucash/core-utils/gnc-filepath-utils.cpp
@@ -728,6 +728,7 @@ static std::string migrate_gnc_datahome()
 }
 
 
+
 #if defined G_OS_WIN32 ||defined MAC_INTEGRATION
 constexpr auto path_package = PACKAGE_NAME;
 #else
@@ -1015,6 +1016,35 @@ gnc_userdata_dir_as_path (void)
         gnc_filepath_init();
 
     return gnc_userdata_home;
+}
+
+gchar *gnc_file_path_absolute (const gchar *prefix, const gchar *relative)
+{
+    bfs::path path_relative (relative);
+    path_relative.imbue (bfs_locale);
+    bfs::path path_absolute;
+    bfs::path path_head;
+
+    if (prefix == nullptr)
+    {
+        const gchar *doc_dir = g_get_user_special_dir (G_USER_DIRECTORY_DOCUMENTS);
+        if (doc_dir == nullptr)
+            path_head = bfs::path (gnc_userdata_dir ()); // running as root maybe
+        else
+            path_head = bfs::path (doc_dir);
+
+        path_head.imbue (bfs_locale);
+        path_absolute = absolute (path_relative, path_head);
+    }
+    else
+    {
+        bfs::path path_head (prefix);
+        path_head.imbue (bfs_locale);
+        path_absolute = absolute (path_relative, path_head);
+    }
+    path_absolute.imbue (bfs_locale);
+
+    return g_strdup (path_absolute.string().c_str());
 }
 
 /** @fn gchar * gnc_build_userdata_path (const gchar *filename)

--- a/libgnucash/core-utils/gnc-filepath-utils.cpp
+++ b/libgnucash/core-utils/gnc-filepath-utils.cpp
@@ -374,8 +374,8 @@ gnc_validate_directory (const bfs::path &dirname)
          * we need to overrule it during build (when guile interferes)
          * and testing.
          */
-	bfs::path home_dir(g_get_home_dir(), cvt);
-	home_dir.imbue(bfs_locale);
+        bfs::path home_dir(g_get_home_dir(), cvt);
+        home_dir.imbue(bfs_locale);
         auto homedir_exists = bfs::exists(home_dir);
         auto is_descendant = dir_is_descendant (dirname, home_dir);
         if (!homedir_exists && is_descendant)
@@ -447,10 +447,10 @@ copy_recursive(const bfs::path& src, const bfs::path& dest)
             string cur_str = direntry->path().string();
 #endif
             auto cur_len = cur_str.size();
-	    string rel_str(cur_str, old_len, cur_len - old_len);
-	    bfs::path relpath(rel_str, cvt);
+            string rel_str(cur_str, old_len, cur_len - old_len);
+            bfs::path relpath(rel_str, cvt);
             auto newpath = bfs::absolute (relpath.relative_path(), dest);
-	    newpath.imbue(bfs_locale);
+            newpath.imbue(bfs_locale);
             bfs::copy(direntry->path(), newpath);
         }
     }
@@ -526,7 +526,6 @@ get_userdata_home(void)
     auto try_tmp_dir = true;
     auto userdata_home = get_user_data_dir();
 
-
     /* g_get_user_data_dir doesn't check whether the path exists nor attempts to
      * create it. So while it may return an actual path we may not be able to use it.
      * Let's check that now */
@@ -550,9 +549,9 @@ get_userdata_home(void)
        Hopefully we can always write there. */
     if (try_tmp_dir)
     {
-	bfs::path newpath(g_get_tmp_dir (), cvt);
+        bfs::path newpath(g_get_tmp_dir (), cvt);
         userdata_home = newpath / g_get_user_name ();
-	userdata_home.imbue(bfs_locale);
+        userdata_home.imbue(bfs_locale);
     }
     g_assert(!userdata_home.empty());
 

--- a/libgnucash/core-utils/gnc-filepath-utils.h
+++ b/libgnucash/core-utils/gnc-filepath-utils.h
@@ -49,6 +49,15 @@ gchar *gnc_resolve_file_path (const gchar *filefrag);
  */
 gchar *gnc_file_path_relative_part (const gchar *prefix, const gchar *path);
 
+/** Given a prefix and a relative path, return the absolute path.
+ * @param prefix The prefix that is the head of the path
+ * @param relative The path to add to the prefix to form an absolute path
+ * @return a char* that must be g_freed containing the absolute path.
+ *
+ * If prefix is null, then the gnc_userdata_home is used as the prefix.
+ */
+gchar *gnc_file_path_absolute (const gchar *prefix, const gchar *relative);
+
 /** @brief Find an absolute path to a localized version of a given
  *  relative path to a html or html related file.
  *  If no localized version exists, an absolute path to the file

--- a/libgnucash/engine/gnc-uri-utils.c
+++ b/libgnucash/engine/gnc-uri-utils.c
@@ -176,7 +176,15 @@ void gnc_uri_get_components (const gchar *uri,
 
     if ( gnc_uri_is_file_scheme ( *scheme ) )
     {
-        *path     = gnc_resolve_file_path ( splituri[1] );
+        /* a true file uri on windows can start file:///N:/
+           so we come here with /N:/                       */
+        if (g_str_has_prefix (splituri[1], "/") && g_strstr_len (splituri[1], -1,  ":") != NULL)
+        {
+            gchar *ptr = splituri[1];
+            *path = gnc_resolve_file_path ( ptr + 1 );
+        }
+        else
+            *path = gnc_resolve_file_path ( splituri[1] );
         g_strfreev ( splituri );
         return;
     }
@@ -304,15 +312,25 @@ gchar *gnc_uri_create_uri (const gchar *scheme,
          * path info as is.
          */
         gchar *abs_path;
+        gchar *uri_scheme;
         if (scheme && (!gnc_uri_is_known_scheme (scheme)) )
             abs_path = g_strdup ( path );
         else
             abs_path = gnc_resolve_file_path ( path );
-        if ( scheme == NULL )
-            uri = g_strdup_printf ( "file://%s", abs_path );
+
+        if (!scheme)
+            uri_scheme = g_strdup ("file");
         else
-            uri = g_strdup_printf ( "%s://%s", scheme, abs_path );
+            uri_scheme = g_strdup (scheme);
+
+        if (g_str_has_prefix (abs_path, "/"))
+            uri = g_strdup_printf ( "%s://%s", uri_scheme, abs_path );
+        else // for windows add an extra "/"
+            uri = g_strdup_printf ( "%s:///%s", uri_scheme, abs_path );
+
+        g_free (uri_scheme);
         g_free (abs_path);
+
         return uri;
     }
 


### PR DESCRIPTION
I decided to create a new PR with the transaction association changes highlighted in PR432 and when this is accepted both can be closed as follows...

Changed the location association to require a scheme to be present, normally that would be http:// or https:// but if the user knows what they are doing it could be any valid uri with a scheme.

This allows the associate kvp to have the following...
* `file:///c:/somedir/some_file` is absolute file path on windows

* `file:///usr/somedir/some_file` is absolute as well on linux

* `somedir/some_file` is relative file path on both linux and windows

* `some_file` is relative file on both linux and windows

* `http://www.gnucash.org` is location url

So if the kvp entry does not have a valid scheme, it is treated as a relative file path.

The relative path head is only set by the GtkFileChooser so it will be an absolute file path uri of the form...
* `file:///n:/` is a root of a network share on windows

* `file:///n:/somedir` is a subdirectory on network share on windows

* `file:///mnt/somedir` is subdirectory on linux

When a file is selected in the file chooser, the prefix of the file path is compared to that of the path head setting, if they match then the path head is removed from the chosen file path and this remainder is stored in the kvp entry.

I have used the existing uri's functions to achieve this and tested both on Windows 10 and Linux and it does what I think it should do but as always will wait and see.
