### PR TITLE
Update iso-4217-currencies.xml

### DIFF
--- a/libgnucash/engine/iso-4217-currencies.xml
+++ b/libgnucash/engine/iso-4217-currencies.xml
@@ -2414,6 +2414,7 @@
   local-symbol=""
 />
 <!-- "SZL" - "Lilangeni"
+  2019-02-16 : The plural "E" is the common local-symbol; Bug 797105
 -->
 <currency
   isocode="SZL"

--- a/libgnucash/engine/iso-4217-currencies.xml
+++ b/libgnucash/engine/iso-4217-currencies.xml
@@ -2414,7 +2414,7 @@
   local-symbol=""
 />
 <!-- "SZL" - "Lilangeni"
-  2019-02-16 : The plural "E" is the common local-symbol; Bug 797105
+  The plural "E" is the common local-symbol; Bug 797105
 -->
 <currency
   isocode="SZL"

--- a/libgnucash/engine/iso-4217-currencies.xml
+++ b/libgnucash/engine/iso-4217-currencies.xml
@@ -2424,7 +2424,7 @@
   exchange-code="748"
   parts-per-unit="100"
   smallest-fraction="100"
-  local-symbol="L"
+  local-symbol="E"
 />
 <!-- "THB" - "Baht"
 -->


### PR DESCRIPTION
Change the 'local-symbol' property for the SZL currency from "L" to "E."
Fixes https://bugs.gnucash.org/show_bug.cgi?id=797105.