### PR TITLE
Make version information constansts available to Python bindings

### DIFF
--- a/bindings/python/gnucash_core.i
+++ b/bindings/python/gnucash_core.i
@@ -47,6 +47,7 @@
 %{
 #include <config.h>
 #include <datetime.h>
+#include "gnc-vcs-info.h"
 #include "qofsession.h"
 #include "qofbook.h"
 #include "qofbackend.h"
@@ -215,6 +216,32 @@ static const GncGUID * gncEntryGetGUID(GncEntry *x);
 
 %include <cap-gains.h>
 %include <Scrub3.h>
+
+%inline %{
+
+const gchar *gnc_version(void)
+{ return VERSION; }
+
+const gchar *gnc_build_id(void)
+{ return GNUCASH_BUILD_ID; }
+
+const gchar *gnc_vcs_rev(void)
+{ return GNC_VCS_REV; }
+
+const gchar *gnc_vcs_rev_date(void)
+{ return GNC_VCS_REV_DATE; }
+
+const gint gnc_gnucash_major_version(void)
+{ return GNUCASH_MAJOR_VERSION; }
+
+%}
+
+
+%constant char *VERSION = VERSION;
+%constant char *GNUCASH_BUILD_ID = GNUCASH_BUILD_ID;
+%constant char *GNC_VCS_REV = GNC_VCS_REV;
+%constant char *GNC_VCS_REV_DATE = GNC_VCS_REV_DATE;
+%constant int GNUCASH_MAJOR_VERSION = GNUCASH_MAJOR_VERSION;
 
 %init %{
 gnc_environment_setup();

--- a/bindings/python/gnucash_core.py
+++ b/bindings/python/gnucash_core.py
@@ -46,6 +46,9 @@ from gnucash.gnucash_core_c import gncInvoiceLookup, gncInvoiceGetInvoiceFromTxn
     gnc_numeric_create, double_to_gnc_numeric, string_to_gnc_numeric, \
     gnc_numeric_to_string
 
+from gnucash.gnucash_core_c import VERSION, GNUCASH_BUILD_ID, GNC_VCS_REV, \
+    GNC_VCS_REV_DATE, GNUCASH_MAJOR_VERSION
+
 class GnuCashCoreClass(ClassFromFunctions):
     _module = gnucash_core_c
 


### PR DESCRIPTION
This pull request exposes the following constants to the Python bindings:

VERSION
GNUCASH_BUILD_ID
GNC_VCS_REV
GNC_VCS_REV_DATE
GNUCASH_MAJOR_VERSION

To allow for checking version information etc. in the bindings.