### PR TITLE
Resolve 'basic_string::_M_construct null not valid' error

### DIFF
--- a/libgnucash/backend/dbi/gnc-backend-dbi.cpp
+++ b/libgnucash/backend/dbi/gnc-backend-dbi.cpp
@@ -159,7 +159,8 @@ UriStrings::UriStrings(const std::string& uri)
                            &password, &dbname);
     m_protocol = std::string{scheme};
     m_host = std::string{host};
-    m_dbname = std::string{dbname};
+    if (dbname)
+	m_dbname = std::string{dbname};
     if (username)
         m_username = std::string{username};
     if (password)


### PR DESCRIPTION
When a session is opened in the Python bindings which doesn't contain a database e.g.:

session = gnucash.Session('mysql://xxxx', is_new=False, ignore_lock=True)

The following error occurs:

terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string::_M_construct null not valid
During startup program terminated with signal SIGABRT, Aborted.

Looking though the code in gnc-backend-dbi.cpp it looks as though there's some possiblity of using 'default' databases if a dbname isn't supplied, so I think it should be possible for a dbname to be empty at this point.

With the change the error is now replaced with a 'ERR_BACKEND_SERVER_ERR' exception in Python (which I think is correct if a default database can be used).

Any comments or feedback welcome - thanks.