### PR TITLE
Croatian accounts correction

### DIFF
--- a/data/accounts/hr/acctchrt_common.gnucash-xea
+++ b/data/accounts/hr/acctchrt_common.gnucash-xea
@@ -43,7 +43,7 @@
 <gnc-act:start-selected>1</gnc-act:start-selected>
 <gnc:account version="2.0.0">
   <act:name>Root Account</act:name>
-  <act:id type="guid">383024c7e78448be8c5096c789a84da7</act:id>
+  <act:id type="new">383024c7e78448be8c5096c789a84da7</act:id>
   <act:type>ROOT</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
@@ -52,7 +52,7 @@
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Rashod</act:name>
-  <act:id type="guid">0434759d91f44cbb8d25bf4b334d82a2</act:id>
+  <act:id type="new">0434759d91f44cbb8d25bf4b334d82a2</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
@@ -65,11 +65,11 @@
       <slot:value type="string">true</slot:value>
     </slot>
   </act:slots>
-  <act:parent type="guid">383024c7e78448be8c5096c789a84da7</act:parent>
+  <act:parent type="new">383024c7e78448be8c5096c789a84da7</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Osiguranje</act:name>
-  <act:id type="guid">c5f64b3110ea4ea8858771f67d23b231</act:id>
+  <act:id type="new">c5f64b3110ea4ea8858771f67d23b231</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
@@ -82,44 +82,44 @@
       <slot:value type="string">true</slot:value>
     </slot>
   </act:slots>
-  <act:parent type="guid">0434759d91f44cbb8d25bf4b334d82a2</act:parent>
+  <act:parent type="new">0434759d91f44cbb8d25bf4b334d82a2</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Osiguranje kućanstva</act:name>
-  <act:id type="guid">f171c064636844d8b90685720cf04ed0</act:id>
+  <act:id type="new">f171c064636844d8b90685720cf04ed0</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Osiguranje stvari kućanstva</act:description>
-  <act:parent type="guid">c5f64b3110ea4ea8858771f67d23b231</act:parent>
+  <act:parent type="new">c5f64b3110ea4ea8858771f67d23b231</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Osiguranje imovine</act:name>
-  <act:id type="guid">6d66ccd28ffb4d43b4736ddd3d54db7f</act:id>
+  <act:id type="new">6d66ccd28ffb4d43b4736ddd3d54db7f</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Osiguranje kuće, stana, apartmana</act:description>
-  <act:parent type="guid">c5f64b3110ea4ea8858771f67d23b231</act:parent>
+  <act:parent type="new">c5f64b3110ea4ea8858771f67d23b231</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Zdravstveno osiguranje</act:name>
-  <act:id type="guid">43aa71fc7f714f8cb6f5c1543eb9be22</act:id>
+  <act:id type="new">43aa71fc7f714f8cb6f5c1543eb9be22</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Zdravstveno osiguranje</act:description>
-  <act:parent type="guid">c5f64b3110ea4ea8858771f67d23b231</act:parent>
+  <act:parent type="new">c5f64b3110ea4ea8858771f67d23b231</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Stanovanje</act:name>
-  <act:id type="guid">87b103c52b044a45bebfb72b8b2e552e</act:id>
+  <act:id type="new">87b103c52b044a45bebfb72b8b2e552e</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
@@ -132,22 +132,22 @@
       <slot:value type="string">true</slot:value>
     </slot>
   </act:slots>
-  <act:parent type="guid">0434759d91f44cbb8d25bf4b334d82a2</act:parent>
+  <act:parent type="new">0434759d91f44cbb8d25bf4b334d82a2</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Najamnina</act:name>
-  <act:id type="guid">214bfab8093b4656a845f104ad2a943c</act:id>
+  <act:id type="new">214bfab8093b4656a845f104ad2a943c</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Najamnina</act:description>
-  <act:parent type="guid">87b103c52b044a45bebfb72b8b2e552e</act:parent>
+  <act:parent type="new">87b103c52b044a45bebfb72b8b2e552e</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Režije</act:name>
-  <act:id type="guid">cb6ae3f25c03449b8cee8d14c072e0f5</act:id>
+  <act:id type="new">cb6ae3f25c03449b8cee8d14c072e0f5</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
@@ -160,88 +160,88 @@
       <slot:value type="string">true</slot:value>
     </slot>
   </act:slots>
-  <act:parent type="guid">87b103c52b044a45bebfb72b8b2e552e</act:parent>
+  <act:parent type="new">87b103c52b044a45bebfb72b8b2e552e</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Plin</act:name>
-  <act:id type="guid">c4a28f5cda4249ecb1fa17d567f77074</act:id>
+  <act:id type="new">c4a28f5cda4249ecb1fa17d567f77074</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Plin</act:description>
-  <act:parent type="guid">cb6ae3f25c03449b8cee8d14c072e0f5</act:parent>
+  <act:parent type="new">cb6ae3f25c03449b8cee8d14c072e0f5</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Struja</act:name>
-  <act:id type="guid">d10c3b2bf9124648b4ac35d1956fce80</act:id>
+  <act:id type="new">d10c3b2bf9124648b4ac35d1956fce80</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Struja</act:description>
-  <act:parent type="guid">cb6ae3f25c03449b8cee8d14c072e0f5</act:parent>
+  <act:parent type="new">cb6ae3f25c03449b8cee8d14c072e0f5</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Voda</act:name>
-  <act:id type="guid">c3f006cbdabe40a8a5b5b85b321806a0</act:id>
+  <act:id type="new">c3f006cbdabe40a8a5b5b85b321806a0</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Voda</act:description>
-  <act:parent type="guid">cb6ae3f25c03449b8cee8d14c072e0f5</act:parent>
+  <act:parent type="new">cb6ae3f25c03449b8cee8d14c072e0f5</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Grijanje</act:name>
-  <act:id type="guid">2a0754b129c5401da07bd54e39f5dd8c</act:id>
+  <act:id type="new">2a0754b129c5401da07bd54e39f5dd8c</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Grijanje</act:description>
-  <act:parent type="guid">cb6ae3f25c03449b8cee8d14c072e0f5</act:parent>
+  <act:parent type="new">cb6ae3f25c03449b8cee8d14c072e0f5</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Čistoća</act:name>
-  <act:id type="guid">cb49fce6b6ac46cfa3fa221039b5f3f0</act:id>
+  <act:id type="new">cb49fce6b6ac46cfa3fa221039b5f3f0</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Čistoća</act:description>
-  <act:parent type="guid">cb6ae3f25c03449b8cee8d14c072e0f5</act:parent>
+  <act:parent type="new">cb6ae3f25c03449b8cee8d14c072e0f5</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Komunalna naknada</act:name>
-  <act:id type="guid">207f61dabd8541879861bbaaf75d6631</act:id>
+  <act:id type="new">207f61dabd8541879861bbaaf75d6631</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Komunalna naknada</act:description>
-  <act:parent type="guid">cb6ae3f25c03449b8cee8d14c072e0f5</act:parent>
+  <act:parent type="new">cb6ae3f25c03449b8cee8d14c072e0f5</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Pričuva</act:name>
-  <act:id type="guid">48f1216ab6ca4bad908b6ded9d4b326d</act:id>
+  <act:id type="new">48f1216ab6ca4bad908b6ded9d4b326d</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Pričuva</act:description>
-  <act:parent type="guid">cb6ae3f25c03449b8cee8d14c072e0f5</act:parent>
+  <act:parent type="new">cb6ae3f25c03449b8cee8d14c072e0f5</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Telekomunikacija</act:name>
-  <act:id type="guid">7968c3c636c24c99bff2c1d31e0cb054</act:id>
+  <act:id type="new">7968c3c636c24c99bff2c1d31e0cb054</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
@@ -254,55 +254,55 @@
       <slot:value type="string">true</slot:value>
     </slot>
   </act:slots>
-  <act:parent type="guid">87b103c52b044a45bebfb72b8b2e552e</act:parent>
+  <act:parent type="new">87b103c52b044a45bebfb72b8b2e552e</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Televizija</act:name>
-  <act:id type="guid">31fd4b65d9274fd5a7fe8521bfafa356</act:id>
+  <act:id type="new">31fd4b65d9274fd5a7fe8521bfafa356</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>RTV pretplata</act:description>
-  <act:parent type="guid">7968c3c636c24c99bff2c1d31e0cb054</act:parent>
+  <act:parent type="new">7968c3c636c24c99bff2c1d31e0cb054</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Internet</act:name>
-  <act:id type="guid">5a300d17bf6e47d1864d8fa7315afde5</act:id>
+  <act:id type="new">5a300d17bf6e47d1864d8fa7315afde5</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Internet</act:description>
-  <act:parent type="guid">7968c3c636c24c99bff2c1d31e0cb054</act:parent>
+  <act:parent type="new">7968c3c636c24c99bff2c1d31e0cb054</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Telefon</act:name>
-  <act:id type="guid">52d848407b4c4840853bd0bbf95b891c</act:id>
+  <act:id type="new">52d848407b4c4840853bd0bbf95b891c</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Telefon/Mobitel</act:description>
-  <act:parent type="guid">7968c3c636c24c99bff2c1d31e0cb054</act:parent>
+  <act:parent type="new">7968c3c636c24c99bff2c1d31e0cb054</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Mrežne usluge</act:name>
-  <act:id type="guid">397f7fb2267a48ce9af52c5ccb512748</act:id>
+  <act:id type="new">397f7fb2267a48ce9af52c5ccb512748</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Mrežne usluge</act:description>
-  <act:parent type="guid">7968c3c636c24c99bff2c1d31e0cb054</act:parent>
+  <act:parent type="new">7968c3c636c24c99bff2c1d31e0cb054</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Obrazovanje</act:name>
-  <act:id type="guid">89d5a109a68d4ddb980589dfa502be8c</act:id>
+  <act:id type="new">89d5a109a68d4ddb980589dfa502be8c</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
@@ -315,77 +315,77 @@
       <slot:value type="string">true</slot:value>
     </slot>
   </act:slots>
-  <act:parent type="guid">0434759d91f44cbb8d25bf4b334d82a2</act:parent>
+  <act:parent type="new">0434759d91f44cbb8d25bf4b334d82a2</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Pretplate</act:name>
-  <act:id type="guid">f8de6278bb10489084997d9ff735c401</act:id>
+  <act:id type="new">f8de6278bb10489084997d9ff735c401</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Pretplate, npr. na časopise</act:description>
-  <act:parent type="guid">89d5a109a68d4ddb980589dfa502be8c</act:parent>
+  <act:parent type="new">89d5a109a68d4ddb980589dfa502be8c</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Knjige</act:name>
-  <act:id type="guid">c684628652fe473c97a9f516388765e7</act:id>
+  <act:id type="new">c684628652fe473c97a9f516388765e7</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Knjige</act:description>
-  <act:parent type="guid">89d5a109a68d4ddb980589dfa502be8c</act:parent>
+  <act:parent type="new">89d5a109a68d4ddb980589dfa502be8c</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Uredski materijal</act:name>
-  <act:id type="guid">2413f9293af047dd81a531ab72d9520b</act:id>
+  <act:id type="new">2413f9293af047dd81a531ab72d9520b</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Uredski materijal</act:description>
-  <act:parent type="guid">89d5a109a68d4ddb980589dfa502be8c</act:parent>
+  <act:parent type="new">89d5a109a68d4ddb980589dfa502be8c</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Odjeća i obuća</act:name>
-  <act:id type="guid">79ba1d0622e04b198d21b3b019660404</act:id>
+  <act:id type="new">79ba1d0622e04b198d21b3b019660404</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Odjeća i obuća</act:description>
-  <act:parent type="guid">0434759d91f44cbb8d25bf4b334d82a2</act:parent>
+  <act:parent type="new">0434759d91f44cbb8d25bf4b334d82a2</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Namirnice</act:name>
-  <act:id type="guid">88a0a0bbc5b9448db43472ff7a078680</act:id>
+  <act:id type="new">88a0a0bbc5b9448db43472ff7a078680</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Namirnice</act:description>
-  <act:parent type="guid">0434759d91f44cbb8d25bf4b334d82a2</act:parent>
+  <act:parent type="new">0434759d91f44cbb8d25bf4b334d82a2</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Lijekovi</act:name>
-  <act:id type="guid">5bf92de9242448c5aea5af88d540acff</act:id>
+  <act:id type="new">5bf92de9242448c5aea5af88d540acff</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Lijekovi</act:description>
-  <act:parent type="guid">0434759d91f44cbb8d25bf4b334d82a2</act:parent>
+  <act:parent type="new">0434759d91f44cbb8d25bf4b334d82a2</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Razni troškovi</act:name>
-  <act:id type="guid">ccf0006435b94d17a4a9aade6edadb38</act:id>
+  <act:id type="new">ccf0006435b94d17a4a9aade6edadb38</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
@@ -398,66 +398,66 @@
       <slot:value type="string">true</slot:value>
     </slot>
   </act:slots>
-  <act:parent type="guid">0434759d91f44cbb8d25bf4b334d82a2</act:parent>
+  <act:parent type="new">0434759d91f44cbb8d25bf4b334d82a2</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Bankovne naknade</act:name>
-  <act:id type="guid">310f26bd5e724482ba20e204e8226c22</act:id>
+  <act:id type="new">310f26bd5e724482ba20e204e8226c22</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Bankovne naknade</act:description>
-  <act:parent type="guid">ccf0006435b94d17a4a9aade6edadb38</act:parent>
+  <act:parent type="new">ccf0006435b94d17a4a9aade6edadb38</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Razno</act:name>
-  <act:id type="guid">4a49d6f6806d4474b2ee2f5bbb9119ad</act:id>
+  <act:id type="new">4a49d6f6806d4474b2ee2f5bbb9119ad</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Neodređeni troškovi</act:description>
-  <act:parent type="guid">ccf0006435b94d17a4a9aade6edadb38</act:parent>
+  <act:parent type="new">ccf0006435b94d17a4a9aade6edadb38</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Izlasci</act:name>
-  <act:id type="guid">1b37595ecb9641c5ade7b3657c23fe2f</act:id>
+  <act:id type="new">1b37595ecb9641c5ade7b3657c23fe2f</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Koncerti, kino, kafići i sl.</act:description>
-  <act:parent type="guid">ccf0006435b94d17a4a9aade6edadb38</act:parent>
+  <act:parent type="new">ccf0006435b94d17a4a9aade6edadb38</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Putovanja</act:name>
-  <act:id type="guid">3d27b411c24842d4a09b6db93f70e687</act:id>
+  <act:id type="new">3d27b411c24842d4a09b6db93f70e687</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Putovanja, ljetovanje, skijanje</act:description>
-  <act:parent type="guid">ccf0006435b94d17a4a9aade6edadb38</act:parent>
+  <act:parent type="new">ccf0006435b94d17a4a9aade6edadb38</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Sport</act:name>
-  <act:id type="guid">20be1a04b8374ddeb54525616dfaa526</act:id>
+  <act:id type="new">20be1a04b8374ddeb54525616dfaa526</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Sport</act:description>
-  <act:parent type="guid">ccf0006435b94d17a4a9aade6edadb38</act:parent>
+  <act:parent type="new">ccf0006435b94d17a4a9aade6edadb38</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Porezi</act:name>
-  <act:id type="guid">025494cce4aa4c608ad81efabf6750a8</act:id>
+  <act:id type="new">025494cce4aa4c608ad81efabf6750a8</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
@@ -470,22 +470,22 @@
       <slot:value type="string">true</slot:value>
     </slot>
   </act:slots>
-  <act:parent type="guid">0434759d91f44cbb8d25bf4b334d82a2</act:parent>
+  <act:parent type="new">0434759d91f44cbb8d25bf4b334d82a2</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Ostali porezi</act:name>
-  <act:id type="guid">b2715e701f5642daaeea86205dda12e1</act:id>
+  <act:id type="new">b2715e701f5642daaeea86205dda12e1</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Ostali porezi</act:description>
-  <act:parent type="guid">025494cce4aa4c608ad81efabf6750a8</act:parent>
+  <act:parent type="new">025494cce4aa4c608ad81efabf6750a8</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Kamate</act:name>
-  <act:id type="guid">01926d53adca48febc7d21a858e36b6b</act:id>
+  <act:id type="new">01926d53adca48febc7d21a858e36b6b</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
@@ -498,33 +498,33 @@
       <slot:value type="string">true</slot:value>
     </slot>
   </act:slots>
-  <act:parent type="guid">0434759d91f44cbb8d25bf4b334d82a2</act:parent>
+  <act:parent type="new">0434759d91f44cbb8d25bf4b334d82a2</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Kamate na kredit</act:name>
-  <act:id type="guid">4d281b5cc45140418c00aa1466c3ab5c</act:id>
+  <act:id type="new">4d281b5cc45140418c00aa1466c3ab5c</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Kamate na kredit</act:description>
-  <act:parent type="guid">01926d53adca48febc7d21a858e36b6b</act:parent>
+  <act:parent type="new">01926d53adca48febc7d21a858e36b6b</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Prijevoz</act:name>
-  <act:id type="guid">54dc415ff80e4fb199a3ab4d596a1207</act:id>
+  <act:id type="new">54dc415ff80e4fb199a3ab4d596a1207</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Javni prijevoz</act:description>
-  <act:parent type="guid">0434759d91f44cbb8d25bf4b334d82a2</act:parent>
+  <act:parent type="new">0434759d91f44cbb8d25bf4b334d82a2</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Imovina</act:name>
-  <act:id type="guid">31f96d98748c44aeae8d1f650b50a0ac</act:id>
+  <act:id type="new">31f96d98748c44aeae8d1f650b50a0ac</act:id>
   <act:type>ASSET</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
@@ -537,11 +537,11 @@
       <slot:value type="string">true</slot:value>
     </slot>
   </act:slots>
-  <act:parent type="guid">383024c7e78448be8c5096c789a84da7</act:parent>
+  <act:parent type="new">383024c7e78448be8c5096c789a84da7</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Trenutačna imovina</act:name>
-  <act:id type="guid">ea311d5363cd434bb931eeffb975f170</act:id>
+  <act:id type="new">ea311d5363cd434bb931eeffb975f170</act:id>
   <act:type>ASSET</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
@@ -554,55 +554,55 @@
       <slot:value type="string">true</slot:value>
     </slot>
   </act:slots>
-  <act:parent type="guid">31f96d98748c44aeae8d1f650b50a0ac</act:parent>
+  <act:parent type="new">31f96d98748c44aeae8d1f650b50a0ac</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Žiro račun</act:name>
-  <act:id type="guid">264ad7494918494499246d39cbfd4862</act:id>
+  <act:id type="new">264ad7494918494499246d39cbfd4862</act:id>
   <act:type>BANK</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Žiro račun</act:description>
-  <act:parent type="guid">ea311d5363cd434bb931eeffb975f170</act:parent>
+  <act:parent type="new">ea311d5363cd434bb931eeffb975f170</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Štedni račun</act:name>
-  <act:id type="guid">e4b645518256492fb7aaeea0729249b8</act:id>
+  <act:id type="new">e4b645518256492fb7aaeea0729249b8</act:id>
   <act:type>BANK</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Štedni račun</act:description>
-  <act:parent type="guid">ea311d5363cd434bb931eeffb975f170</act:parent>
+  <act:parent type="new">ea311d5363cd434bb931eeffb975f170</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Gotovina</act:name>
-  <act:id type="guid">365eba65f2eb4a3588dc018a244c6605</act:id>
+  <act:id type="new">365eba65f2eb4a3588dc018a244c6605</act:id>
   <act:type>CASH</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Gotovina</act:description>
-  <act:parent type="guid">ea311d5363cd434bb931eeffb975f170</act:parent>
+  <act:parent type="new">ea311d5363cd434bb931eeffb975f170</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Tekući račun</act:name>
-  <act:id type="guid">f381d3cdfb9344728a511322323d69d8</act:id>
+  <act:id type="new">f381d3cdfb9344728a511322323d69d8</act:id>
   <act:type>BANK</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Tekući račun</act:description>
-  <act:parent type="guid">ea311d5363cd434bb931eeffb975f170</act:parent>
+  <act:parent type="new">ea311d5363cd434bb931eeffb975f170</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Obveze</act:name>
-  <act:id type="guid">ab79a1333ce7482bb6324663b56114db</act:id>
+  <act:id type="new">ab79a1333ce7482bb6324663b56114db</act:id>
   <act:type>LIABILITY</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
@@ -615,22 +615,22 @@
       <slot:value type="string">true</slot:value>
     </slot>
   </act:slots>
-  <act:parent type="guid">383024c7e78448be8c5096c789a84da7</act:parent>
+  <act:parent type="new">383024c7e78448be8c5096c789a84da7</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Kreditna kartica</act:name>
-  <act:id type="guid">5dcaa18ae9434d0ca945bfb124f35a64</act:id>
+  <act:id type="new">5dcaa18ae9434d0ca945bfb124f35a64</act:id>
   <act:type>CREDIT</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Kreditna kartica</act:description>
-  <act:parent type="guid">ab79a1333ce7482bb6324663b56114db</act:parent>
+  <act:parent type="new">ab79a1333ce7482bb6324663b56114db</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Krediti</act:name>
-  <act:id type="guid">9500dff5bdbd4c5ba01e0d4028624caf</act:id>
+  <act:id type="new">9500dff5bdbd4c5ba01e0d4028624caf</act:id>
   <act:type>LIABILITY</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
@@ -643,22 +643,22 @@
       <slot:value type="string">true</slot:value>
     </slot>
   </act:slots>
-  <act:parent type="guid">ab79a1333ce7482bb6324663b56114db</act:parent>
+  <act:parent type="new">ab79a1333ce7482bb6324663b56114db</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Kredit</act:name>
-  <act:id type="guid">c51053321a2f46ea81ade293d422b287</act:id>
+  <act:id type="new">c51053321a2f46ea81ade293d422b287</act:id>
   <act:type>LIABILITY</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Kredit</act:description>
-  <act:parent type="guid">9500dff5bdbd4c5ba01e0d4028624caf</act:parent>
+  <act:parent type="new">9500dff5bdbd4c5ba01e0d4028624caf</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Prihod</act:name>
-  <act:id type="guid">5c4f1206f6b343e29b9d660d2182e3b7</act:id>
+  <act:id type="new">5c4f1206f6b343e29b9d660d2182e3b7</act:id>
   <act:type>INCOME</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
@@ -671,11 +671,11 @@
       <slot:value type="string">true</slot:value>
     </slot>
   </act:slots>
-  <act:parent type="guid">383024c7e78448be8c5096c789a84da7</act:parent>
+  <act:parent type="new">383024c7e78448be8c5096c789a84da7</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Dohodak</act:name>
-  <act:id type="guid">d4e9709bc58e4fbc9f863932d8e5d774</act:id>
+  <act:id type="new">d4e9709bc58e4fbc9f863932d8e5d774</act:id>
   <act:type>INCOME</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
@@ -688,44 +688,44 @@
       <slot:value type="string">true</slot:value>
     </slot>
   </act:slots>
-  <act:parent type="guid">5c4f1206f6b343e29b9d660d2182e3b7</act:parent>
+  <act:parent type="new">5c4f1206f6b343e29b9d660d2182e3b7</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Osobni dohodak</act:name>
-  <act:id type="guid">d4bfc34ae64b4e33a18653b0bac5f76c</act:id>
+  <act:id type="new">d4bfc34ae64b4e33a18653b0bac5f76c</act:id>
   <act:type>INCOME</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Osobni dohodak</act:description>
-  <act:parent type="guid">d4e9709bc58e4fbc9f863932d8e5d774</act:parent>
+  <act:parent type="new">d4e9709bc58e4fbc9f863932d8e5d774</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Dodaci</act:name>
-  <act:id type="guid">cc401ac7698342a7963c6b4c03dd3a4b</act:id>
+  <act:id type="new">cc401ac7698342a7963c6b4c03dd3a4b</act:id>
   <act:type>INCOME</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Dodaci, bonusi, dnevnica i sl.</act:description>
-  <act:parent type="guid">d4e9709bc58e4fbc9f863932d8e5d774</act:parent>
+  <act:parent type="new">d4e9709bc58e4fbc9f863932d8e5d774</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Ostalo</act:name>
-  <act:id type="guid">a3b7c96cdb0f44aab4d550dba0233c00</act:id>
+  <act:id type="new">a3b7c96cdb0f44aab4d550dba0233c00</act:id>
   <act:type>INCOME</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Ostali prihodi</act:description>
-  <act:parent type="guid">5c4f1206f6b343e29b9d660d2182e3b7</act:parent>
+  <act:parent type="new">5c4f1206f6b343e29b9d660d2182e3b7</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Kamate</act:name>
-  <act:id type="guid">4bcbb5eb33df4af9b5d692c6aab2c8c9</act:id>
+  <act:id type="new">4bcbb5eb33df4af9b5d692c6aab2c8c9</act:id>
   <act:type>INCOME</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
@@ -738,44 +738,44 @@
       <slot:value type="string">true</slot:value>
     </slot>
   </act:slots>
-  <act:parent type="guid">5c4f1206f6b343e29b9d660d2182e3b7</act:parent>
+  <act:parent type="new">5c4f1206f6b343e29b9d660d2182e3b7</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Kamate po žiro računu</act:name>
-  <act:id type="guid">7bc08bbdc68c41679cc5eb28f1e24e73</act:id>
+  <act:id type="new">7bc08bbdc68c41679cc5eb28f1e24e73</act:id>
   <act:type>INCOME</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Kamate po žiro računu</act:description>
-  <act:parent type="guid">4bcbb5eb33df4af9b5d692c6aab2c8c9</act:parent>
+  <act:parent type="new">4bcbb5eb33df4af9b5d692c6aab2c8c9</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Kamate po štednom računu</act:name>
-  <act:id type="guid">346341eff38e4dda878ea780980404c5</act:id>
+  <act:id type="new">346341eff38e4dda878ea780980404c5</act:id>
   <act:type>INCOME</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Kamate po štednom računu</act:description>
-  <act:parent type="guid">4bcbb5eb33df4af9b5d692c6aab2c8c9</act:parent>
+  <act:parent type="new">4bcbb5eb33df4af9b5d692c6aab2c8c9</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Kamate po tekućem računu</act:name>
-  <act:id type="guid">5d9bb56dde7d4b8b893083955205ed65</act:id>
+  <act:id type="new">5d9bb56dde7d4b8b893083955205ed65</act:id>
   <act:type>INCOME</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Kamate po tekućem računu</act:description>
-  <act:parent type="guid">4bcbb5eb33df4af9b5d692c6aab2c8c9</act:parent>
+  <act:parent type="new">4bcbb5eb33df4af9b5d692c6aab2c8c9</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Kapital</act:name>
-  <act:id type="guid">73f3a388cebe42a3bc40ab8db179d32d</act:id>
+  <act:id type="new">73f3a388cebe42a3bc40ab8db179d32d</act:id>
   <act:type>EQUITY</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
@@ -788,18 +788,18 @@
       <slot:value type="string">true</slot:value>
     </slot>
   </act:slots>
-  <act:parent type="guid">383024c7e78448be8c5096c789a84da7</act:parent>
+  <act:parent type="new">383024c7e78448be8c5096c789a84da7</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Početni saldo</act:name>
-  <act:id type="guid">7957f9604ba842b7831c5df4e4db80a0</act:id>
+  <act:id type="new">7957f9604ba842b7831c5df4e4db80a0</act:id>
   <act:type>EQUITY</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Početni saldo</act:description>
-  <act:parent type="guid">73f3a388cebe42a3bc40ab8db179d32d</act:parent>
+  <act:parent type="new">73f3a388cebe42a3bc40ab8db179d32d</act:parent>
 </gnc:account>
 </gnc-account-example>
 

--- a/data/accounts/hr/acctchrt_eduloan.gnucash-xea
+++ b/data/accounts/hr/acctchrt_eduloan.gnucash-xea
@@ -43,7 +43,7 @@
   </gnc-act:long-description>    
 <gnc:account version="2.0.0">
   <act:name>Root Account</act:name>
-  <act:id type="guid">8e5d714821424284a5750faf748ae3b5</act:id>
+  <act:id type="new">8e5d714821424284a5750faf748ae3b5</act:id>
   <act:type>ROOT</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
@@ -52,7 +52,7 @@
 HRK</gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Obveze</act:name>
-  <act:id type="guid">606f2b17b88c4215b1e3286a376b2dcd</act:id>
+  <act:id type="new">606f2b17b88c4215b1e3286a376b2dcd</act:id>
   <act:type>LIABILITY</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
@@ -65,11 +65,11 @@ HRK  <act:description>Obveze</act:description>
       <slot:value type="string">true</slot:value>
     </slot>
   </act:slots>
-  <act:parent type="guid">8e5d714821424284a5750faf748ae3b5</act:parent>
+  <act:parent type="new">8e5d714821424284a5750faf748ae3b5</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Krediti</act:name>
-  <act:id type="guid">7717fa79db024dea9c843fe9cafce52a</act:id>
+  <act:id type="new">7717fa79db024dea9c843fe9cafce52a</act:id>
   <act:type>LIABILITY</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
@@ -82,22 +82,22 @@ HRK  <act:description>Krediti</act:description>
       <slot:value type="string">true</slot:value>
     </slot>
   </act:slots>
-  <act:parent type="guid">606f2b17b88c4215b1e3286a376b2dcd</act:parent>
+  <act:parent type="new">606f2b17b88c4215b1e3286a376b2dcd</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Kredit za obrazovanje</act:name>
-  <act:id type="guid">0116545dabfe4e779c23e12cfb4859e8</act:id>
+  <act:id type="new">0116545dabfe4e779c23e12cfb4859e8</act:id>
   <act:type>LIABILITY</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
 HRK  <act:description>Kredit za obrazovanje</act:description>
-  <act:parent type="guid">7717fa79db024dea9c843fe9cafce52a</act:parent>
+  <act:parent type="new">7717fa79db024dea9c843fe9cafce52a</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Rashod</act:name>
-  <act:id type="guid">13458f5113db491195e0147deb80fdd2</act:id>
+  <act:id type="new">13458f5113db491195e0147deb80fdd2</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
@@ -110,11 +110,11 @@ HRK  <act:description>Rashod</act:description>
       <slot:value type="string">true</slot:value>
     </slot>
   </act:slots>
-  <act:parent type="guid">8e5d714821424284a5750faf748ae3b5</act:parent>
+  <act:parent type="new">8e5d714821424284a5750faf748ae3b5</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Kamate</act:name>
-  <act:id type="guid">5ada18bd2b6a4d0eb08a611e17a1fd69</act:id>
+  <act:id type="new">5ada18bd2b6a4d0eb08a611e17a1fd69</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
@@ -127,17 +127,17 @@ HRK  <act:description>Kamate</act:description>
       <slot:value type="string">true</slot:value>
     </slot>
   </act:slots>
-  <act:parent type="guid">13458f5113db491195e0147deb80fdd2</act:parent>
+  <act:parent type="new">13458f5113db491195e0147deb80fdd2</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Kamate na kredit za obrazovanje</act:name>
-  <act:id type="guid">ae4c3a47e1f14d0582804d1f17025180</act:id>
+  <act:id type="new">ae4c3a47e1f14d0582804d1f17025180</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
 HRK  <act:description>Kamate na kredit za obrazovanje</act:description>
-  <act:parent type="guid">5ada18bd2b6a4d0eb08a611e17a1fd69</act:parent>
+  <act:parent type="new">5ada18bd2b6a4d0eb08a611e17a1fd69</act:parent>
 </gnc:account>
 </gnc-account-example>

--- a/data/accounts/hr/acctchrt_fixedassets.gnucash-xea
+++ b/data/accounts/hr/acctchrt_fixedassets.gnucash-xea
@@ -42,7 +42,7 @@
   </gnc-act:long-description>    
 <gnc:account version="2.0.0">
   <act:name>Root Account</act:name>
-  <act:id type="guid">0a569e997fae4b358f01c12e58ddffa0</act:id>
+  <act:id type="new">0a569e997fae4b358f01c12e58ddffa0</act:id>
   <act:type>ROOT</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
@@ -51,7 +51,7 @@
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Imovina</act:name>
-  <act:id type="guid">a0091a3993344b9b933842cd66d933c6</act:id>
+  <act:id type="new">a0091a3993344b9b933842cd66d933c6</act:id>
   <act:type>ASSET</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
@@ -64,11 +64,11 @@
       <slot:value type="string">true</slot:value>
     </slot>
   </act:slots>
-  <act:parent type="guid">0a569e997fae4b358f01c12e58ddffa0</act:parent>
+  <act:parent type="new">0a569e997fae4b358f01c12e58ddffa0</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Dugotrajna imovina</act:name>
-  <act:id type="guid">cfefd5176b9e4f7da7132db9a07fe37a</act:id>
+  <act:id type="new">cfefd5176b9e4f7da7132db9a07fe37a</act:id>
   <act:type>ASSET</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
@@ -81,39 +81,39 @@
       <slot:value type="string">true</slot:value>
     </slot>
   </act:slots>
-  <act:parent type="guid">a0091a3993344b9b933842cd66d933c6</act:parent>
+  <act:parent type="new">a0091a3993344b9b933842cd66d933c6</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Kuća/Stan</act:name>
-  <act:id type="guid">fbc196e583634b92a1beca16dd1eaacf</act:id>
+  <act:id type="new">fbc196e583634b92a1beca16dd1eaacf</act:id>
   <act:type>ASSET</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Kuća/Stan</act:description>
-  <act:parent type="guid">cfefd5176b9e4f7da7132db9a07fe37a</act:parent>
+  <act:parent type="new">cfefd5176b9e4f7da7132db9a07fe37a</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Ostala imovina</act:name>
-  <act:id type="guid">000cca13f15844ff9e01d2ca2bcd2614</act:id>
+  <act:id type="new">000cca13f15844ff9e01d2ca2bcd2614</act:id>
   <act:type>ASSET</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Ostala imovina</act:description>
-  <act:parent type="guid">cfefd5176b9e4f7da7132db9a07fe37a</act:parent>
+  <act:parent type="new">cfefd5176b9e4f7da7132db9a07fe37a</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Osobno vozilo</act:name>
-  <act:id type="guid">706a01efcaef48d89066c05b648ba5ef</act:id>
+  <act:id type="new">706a01efcaef48d89066c05b648ba5ef</act:id>
   <act:type>ASSET</act:type>
   <act:commodity>
     <cmdty:space>ISO4217</cmdty:space>
     <cmdty:id>HRK</cmdty:id>
   </act:commodity>
   <act:description>Osobno vozilo</act:description>
-  <act:parent type="guid">cfefd5176b9e4f7da7132db9a07fe37a</act:parent>
+  <act:parent type="new">cfefd5176b9e4f7da7132db9a07fe37a</act:parent>
 </gnc:account>
 </gnc-account-example>


### PR DESCRIPTION
Just noticed, that I forgott to change the "guid" string in these two files, as specified in the wiki: "Just replace all occurrences of <act:id type="guid"> by <act:id type="new">".

Only the croatian files for "eduloan" and "fixedassets" needed the change. Sorry for the inconvienience!