### PR TITLE
Bug 639049 - Asset Barchart Report includes also the first day of next month transactions

### DIFF
--- a/libgnucash/app-utils/test/test-date-utilities.scm
+++ b/libgnucash/app-utils/test/test-date-utilities.scm
@@ -8,6 +8,7 @@
   (test-runner-factory gnc:test-runner)
   (test-begin "test-date-utilities.scm")
   (test-weeknum-calculator)
+  (test-make-date-list)
   (test-date-get-quarter-string)
   (test-end "test-date-utilities.scm"))
 
@@ -76,6 +77,17 @@
      (create-time64 '(1970 1 1 0 0 1))
      (create-time64 '(1970 1 15 0 0 1))
      WeekDelta))
+
+  (test-equal "make-date-list start 30-nov monthly. all dates are month-ends."
+    (list (create-time64 '(1970 11 30 0 0 1))
+          (create-time64 '(1970 12 31 0 0 1))
+          (create-time64 '(1971 1 31 0 0 1))
+          (create-time64 '(1971 2 28 0 0 1))
+          (create-time64 '(1971 3 15 0 0 1)))
+    (gnc:make-date-list
+     (create-time64 '(1970 11 30 0 0 1))
+     (create-time64 '(1971 3 15 0 0 1))
+     MonthDelta))
 
   (test-equal "make-date-list 31-dec-1970 to 15-4-1972 monthly including leapyear"
     (list (create-time64 '(1970 12 31 0 0 1))


### PR DESCRIPTION
If the original date is an end-of-month date, we take it as an indicator they always want month-delta dates to be end-of-months. This works for monthly/quarterly/halfyearly/annual. Also I'd forgotten to activate a test in test-date-utilities. Enable it.

This works for any month-end date, even leapyears.

monthly from 28/02/16 = 28/02/16, 28/03/16, 28/04/16, 28/05/16...
monthly from 29/02/16 = 29/02/16, 31/03/16, 30/04/16, 31/05/16...

Apparently human psychology is preferable to cold logic...