### PR TITLE
Improve TR display/other-account and Sortkey=other-account renders

### DIFF
--- a/gnucash/report/standard-reports/transaction.scm
+++ b/gnucash/report/standard-reports/transaction.scm
@@ -1157,14 +1157,18 @@ be excluded from periodic reporting.")
                                                      (column-uses? 'account-name)
                                                      (column-uses? 'account-full-name)))))
 
-               (add-if (or (column-uses? 'other-account-name) (column-uses? 'other-account-code))
+               (add-if (or (column-uses? 'other-account-name)
+                           (column-uses? 'other-account-code))
                        (vector (_ "Transfer from/to")
                                (lambda (split transaction-row?)
-                                 (define other-account (xaccSplitGetAccount (xaccSplitGetOtherSplit split)))
-                                 (account-namestring other-account
-                                                     (column-uses? 'other-account-code)
-                                                     (column-uses? 'other-account-name)
-                                                     (column-uses? 'other-account-full-name)))))
+                                 (and (< 1 (xaccTransCountSplits
+                                            (xaccSplitGetParent split)))
+                                      (account-namestring
+                                       (xaccSplitGetAccount
+                                        (xaccSplitGetOtherSplit split))
+                                       (column-uses? 'other-account-code)
+                                       (column-uses? 'other-account-name)
+                                       (column-uses? 'other-account-full-name))))))
 
                (add-if (column-uses? 'shares)
                        (vector (_ "Shares")


### PR DESCRIPTION
A few scheme housekeeping commits.

Transaction Report can be amended to render other-account better in single-split and compound-txn cases. This amends display for both Display/Other-account-name/code, and Sortkey=corresponding-account-name.

![image](https://user-images.githubusercontent.com/1975870/54866062-81dc7a80-4daa-11e9-8afc-6eb4152ccf38.png)
