### PR TITLE
Rewrite price calculators

### DIFF
--- a/gnucash/report/report-system/commodity-utilities.scm
+++ b/gnucash/report/report-system/commodity-utilities.scm
@@ -306,14 +306,6 @@ construct with gnc:make-gnc-monetary and gnc:monetary->string instead.")
                        pricelist))
          (earlier (and (not (null? earlierlist))
                        (last earlierlist))))
-    ;;          (if earlier
-    ;;              (warn "earlier"
-    ;;                    (qof-print-date (car earlier))
-    ;;                    (gnc-numeric-to-double (cadr earlier))))
-    ;;          (if later
-    ;;              (warn "later"
-    ;;                    (qof-print-date (car later))
-    ;;                    (gnc-numeric-to-double (cadr later))))
 
     (if (and earlier later)
         (if (< (abs (- date (car earlier)))
@@ -637,11 +629,8 @@ construct with gnc:make-gnc-monetary and gnc:monetary->string instead.")
   (map
    (lambda (e)
      (list (car e)
-           (abs
-            (gnc-numeric-div ((cdadr e) 'total #f)
-                             ((caadr e) 'total #f)
-                             GNC-DENOM-AUTO
-                             (logior (GNC-DENOM-SIGFIGS 8) GNC-RND-ROUND)))))
+           (abs (/ ((cdadr e) 'total #f)
+                   ((caadr e) 'total #f)))))
    (gnc:get-exchange-totals report-commodity end-date)))
 
 (define (gnc:make-exchange-cost-alist report-commodity end-date)
@@ -651,12 +640,10 @@ construct with gnc:make-gnc-monetary and gnc:monetary->string instead.")
   (map
    (lambda (e)
      (list (car e)
-           (if (zero? ((caadr e) 'total #f)) 0
-           (abs
-            (gnc-numeric-div ((cdadr e) 'total #f)
-                             ((caadr e) 'total #f)
-                             GNC-DENOM-AUTO
-                             (logior (GNC-DENOM-SIGFIGS 8) GNC-RND-ROUND))))))
+           (if (zero? ((caadr e) 'total #f))
+               0
+               (abs (/ ((cdadr e) 'total #f)
+                       ((caadr e) 'total #f))))))
    (gnc:get-exchange-cost-totals report-commodity end-date)))
 
 
@@ -734,10 +721,8 @@ construct with gnc:make-gnc-monetary and gnc:monetary->string instead.")
        (gnc:make-gnc-monetary
         domestic
         (if price-value
-            (gnc-numeric-mul (gnc:gnc-monetary-amount foreign)
-                             price-value
-                             (gnc-commodity-get-fraction domestic)
-                             GNC-RND-ROUND)
+            (* (gnc:gnc-monetary-amount foreign)
+               price-value)
             (begin
               (warn "gnc:exchange-by-pricevalue-helper: No price found for "
                     (gnc:monetary->string foreign) " into "
@@ -758,10 +743,8 @@ construct with gnc:make-gnc-monetary and gnc:monetary->string instead.")
         domestic
         (if price
             (let ((result
-                   (gnc-numeric-mul (gnc:gnc-monetary-amount foreign)
-                                    (gnc-price-get-value price)
-                                    (gnc-commodity-get-fraction domestic)
-                                    GNC-RND-ROUND)))
+                   (* (gnc:gnc-monetary-amount foreign)
+                      (gnc-price-get-value price))))
               (gnc-price-unref price)
               result)
             (begin

--- a/gnucash/report/report-system/commodity-utilities.scm
+++ b/gnucash/report/report-system/commodity-utilities.scm
@@ -705,10 +705,8 @@ construct with gnc:make-gnc-monetary and gnc:monetary->string instead.")
                   (if (or (not pair)
                           (zero? foreign-amount))
                       0
-                      (gnc-numeric-mul foreign-amount
-                                       (cadr pair)
-                                       (gnc-commodity-get-fraction domestic)
-                                       GNC-RND-ROUND)))))))))
+                      (* foreign-amount
+                         (cadr pair))))))))))
 
 ;; Helper for the gnc:exchange-by-pricalist* below. Exchange the
 ;; <gnc:monetary> 'foreign' into the <gnc:commodity*> 'domestic' by

--- a/gnucash/report/report-system/commodity-utilities.scm
+++ b/gnucash/report/report-system/commodity-utilities.scm
@@ -690,23 +690,18 @@ construct with gnc:make-gnc-monetary and gnc:monetary->string instead.")
 ;; the <gnc:commodity*> domestic-commodity, exchanges the amount into
 ;; the domestic currency and returns a <gnc-monetary>.
 (define (gnc:make-exchange-function exchange-alist)
-  (let ((exchangelist exchange-alist))
-    (lambda (foreign domestic)
-      (gnc:debug "foreign: " (gnc:monetary->string foreign))
-      (gnc:debug "domestic: " (gnc-commodity-get-printname domestic))
-      (and foreign
-           (or (gnc:exchange-by-euro foreign domestic #f)
-               (gnc:exchange-if-same foreign domestic)
-               (gnc:make-gnc-monetary
-                domestic
-                (let ((pair (assoc (gnc:gnc-monetary-commodity foreign)
-                                   exchangelist))
-                      (foreign-amount (gnc:gnc-monetary-amount foreign)))
-                  (if (or (not pair)
-                          (zero? foreign-amount))
-                      0
-                      (* foreign-amount
-                         (cadr pair))))))))))
+  (lambda (foreign domestic)
+    (gnc:debug "foreign: " (gnc:monetary->string foreign))
+    (gnc:debug "domestic: " (gnc-commodity-get-printname domestic))
+    (and foreign
+         (or (gnc:exchange-by-euro foreign domestic #f)
+             (gnc:exchange-if-same foreign domestic)
+             (let* ((foreign-comm (gnc:gnc-monetary-commodity foreign))
+                    (pair (assoc foreign-comm exchange-alist)))
+               (and pair
+                    (gnc:make-gnc-monetary
+                     domestic
+                     (* (gnc:gnc-monetary-amount foreign) (cadr pair)))))))))
 
 ;; Helper for the gnc:exchange-by-pricalist* below. Exchange the
 ;; <gnc:monetary> 'foreign' into the <gnc:commodity*> 'domestic' by

--- a/gnucash/report/report-system/test/test-commodity-utils.scm
+++ b/gnucash/report/report-system/test/test-commodity-utils.scm
@@ -566,26 +566,22 @@
        (test-equal "MSFT totalavg 2012-01-15" (/ 4216500/100 1500)
                    (cadr (assoc (gnc-dmy2time64-neutral 15 01 2012)
                                 report-list)))
-;; We have to use gnc-numeric-div with rounding in order to match the results
-;; from the function. Astute observers will notice that the totals include the
+;; Astute observers will notice that the totals include the
 ;; capital gain split but not the acutal sell split on the day because the
 ;; capital gain price is first in the list so that's the one (assoc) finds. See
 ;; the comment at the gnc:get-commodity-totalavg-prices definition for more
 ;; about the prices from this function.
        (test-equal "MSFT totalavg 2014-12-05"
-                   (gnc-numeric-div 6637500/100 2000 GNC-DENOM-AUTO
-                                    (logior (GNC-DENOM-SIGFIGS 8) GNC-RND-ROUND))
-                   (cadr (assoc (gnc-dmy2time64-neutral 5 12 2014)
-                                report-list)))
+         (/ 6637500/100 2000)
+         (cadr (assoc (gnc-dmy2time64-neutral 5 12 2014)
+                      report-list)))
        (test-equal "MSFT totalavg 2015-04-02"
-                   (gnc-numeric-div 9860700/100 2800 GNC-DENOM-AUTO
-                                    (logior (GNC-DENOM-SIGFIGS 8) GNC-RND-ROUND))
-                   (cadr (assoc (gnc-dmy2time64-neutral 2 4 2015) report-list)))
+         (/ 9860700/100 2800)
+         (cadr (assoc (gnc-dmy2time64-neutral 2 4 2015) report-list)))
        (test-equal "MSFT totalavg 2016-03-11"
-                   (gnc-numeric-div 14637000/100 3700 GNC-DENOM-AUTO
-                                    (logior (GNC-DENOM-SIGFIGS 8) GNC-RND-ROUND))
-                   (cadr (assoc (gnc-dmy2time64-neutral 11 3 2016)
-                                report-list))))
+         (/ 14637000/100 3700)
+         (cadr (assoc (gnc-dmy2time64-neutral 11 3 2016)
+                      report-list))))
      (test-end "Microsoft-USD")
 
      (test-begin "Daimler-DEM")

--- a/gnucash/report/report-system/test/test-commodity-utils.scm
+++ b/gnucash/report/report-system/test/test-commodity-utils.scm
@@ -697,7 +697,7 @@
                           (gnc-dmy2time64-neutral 20 02 2016)
                           #f #f)))
         (test-equal "gnc:case-exchange-time-fn average-cost 20/02/2012"
-          8073/100
+          14127/175
           (gnc:gnc-monetary-amount
            (exchange-fn
             (gnc:make-gnc-monetary AAPL 1)


### PR DESCRIPTION
This is upcoming... I'm trusting that `test-commodity-utils` has ~nearly~ 100% coverage of the relevant price calculators... ~if not I'll analyse in the near future and add more tests.~

Rewrite loops, cleaner IMHO and uses scheme rational arithmetic. `set!` is banished. Instead of building price-lists and removing invalid prices, build price-list using valid prices only. Fewer conditionals. Tail-calls. As a result these loops should allocate vars on stack rather than heap.

Pending:
- [x] confirm 100% test code coverage
- [ ] consider renaming vars to show clearer intent.
- [ ] more documentation how these calculators work
- [ ] in future - consider using scheme numbers instead of value-collectors - these `cdadr` are annoying. would need amending test suite.