### PR TITLE
Pr python time64 modifications

### DIFF
--- a/bindings/python/gnucash_business.py
+++ b/bindings/python/gnucash_business.py
@@ -143,7 +143,7 @@ class TaxTableEntry(GnuCashCoreClass):
 class Invoice(GnuCashCoreClass):
     def __init__(self, book=None, id=None, currency=None, owner=None,
                  date_opened=None, instance=None):
-        """Invoice Contstructor
+        """Invoice Constructor
 
         You must provide a book, id, currency and owner
         (Customer, Job, Employee, Vendor) or an existing swig proxy object

--- a/bindings/python/gnucash_core.py
+++ b/bindings/python/gnucash_core.py
@@ -812,7 +812,8 @@ class QueryDatePredicate(GnuCashCoreClass):
     pass
 
 QueryDatePredicate.add_constructor_and_methods_with_prefix(
-    'qof_query_', 'date_predicate')
+    'qof_query_', 'date_predicate', exclude=["qof_query_date_predicate_get_date"])
+QueryDatePredicate.add_method('qof_query_date_predicate_get_date', 'get_date')
 
 class QueryGuidPredicate(GnuCashCoreClass):
     pass

--- a/bindings/python/time64.i
+++ b/bindings/python/time64.i
@@ -35,12 +35,12 @@
 %typemap(in) time64 {
     PyDateTime_IMPORT;
 
-    if (!PyDate_Check($input) && !PyDateTime_Check($input) && !PyInt_Check($input)) {
+    if (!PyDate_Check($input) && !PyInt_Check($input)) {
         PyErr_SetString(PyExc_ValueError,"date, datetime or integer expected");
         return NULL;
     }
 
-    if (PyDateTime_Check($input)) {
+    if (PyDate_Check($input)) {
         struct tm time = {PyDateTime_DATE_GET_SECOND($input),
                           PyDateTime_DATE_GET_MINUTE($input),
                           PyDateTime_DATE_GET_HOUR($input),
@@ -79,12 +79,12 @@
 %typemap(in) time64 * (time64 secs) {
     PyDateTime_IMPORT;
 
-    if (!PyDate_Check($input) && !PyDateTime_Check($input) && !PyInt_Check($input)) {
+    if (!PyDate_Check($input) && !PyInt_Check($input)) {
         PyErr_SetString(PyExc_ValueError,"date, datetime or integer expected");
         return NULL;
     }
     
-    if (PyDateTime_Check($input)) {
+    if (PyDate_Check($input)) {
         struct tm time = {PyDateTime_DATE_GET_SECOND($input),
                           PyDateTime_DATE_GET_MINUTE($input),
                           PyDateTime_DATE_GET_HOUR($input),

--- a/bindings/python/time64.i
+++ b/bindings/python/time64.i
@@ -27,6 +27,7 @@
     @brief SWIG interface file for type translation of time64 types
     @author Mark Jenkins, ParIT Worker Co-operative <mark@parit.ca>
     @author Jeff Green,   ParIT Worker Co-operative <jeff@parit.ca>
+    @author Christoph Holtermann, mail@c-holtermann.net - modifications 2019-04
     @ingroup python_bindings */
 
 // A typemap for converting python dates to time64 in functions that

--- a/bindings/python/time64.i
+++ b/bindings/python/time64.i
@@ -136,12 +136,17 @@
   PyDateTime_IMPORT;
   PyObject *tp;
   struct tm t;
-  gnc_localtime_r($1, &t);
-  tp = PyDateTime_FromDateAndTime(t.tm_year + 1900, t.tm_mon + 1,
-                                             t.tm_mday, t.tm_hour, t.tm_min,
-                                             t.tm_sec, 0);
 
-  $result = SWIG_Python_AppendOutput($result, tp);
+  // directly access return value (result) of function
+  // only return datetime if TRUE
+  if(result) {
+      gnc_localtime_r($1, &t);
+      tp = PyDateTime_FromDateAndTime(t.tm_year + 1900, t.tm_mon + 1,
+                                                 t.tm_mday, t.tm_hour, t.tm_min,
+                                                 t.tm_sec, 0);
+
+      $result = SWIG_Python_AppendOutput($result, tp);
+  } else $result = SWIG_Python_AppendOutput($result, Py_None);
 }
 
 %apply time64 *date { time64 *last_date };

--- a/bindings/python/time64.i
+++ b/bindings/python/time64.i
@@ -35,8 +35,8 @@
 %typemap(in) time64 {
     PyDateTime_IMPORT;
 
-    if (!PyDateTime_Check($input) && !PyInt_Check($input)) {
-        PyErr_SetString(PyExc_ValueError,"datetime or integer expected");
+    if (!PyDate_Check($input) && !PyDateTime_Check($input) && !PyInt_Check($input)) {
+        PyErr_SetString(PyExc_ValueError,"date, datetime or integer expected");
         return NULL;
     }
 
@@ -79,8 +79,8 @@
 %typemap(in) time64 * (time64 secs) {
     PyDateTime_IMPORT;
 
-    if (!PyDateTime_Check($input) && !PyInt_Check($input)) {
-        PyErr_SetString(PyExc_ValueError,"datetime or integer expected");
+    if (!PyDate_Check($input) && !PyDateTime_Check($input) && !PyInt_Check($input)) {
+        PyErr_SetString(PyExc_ValueError,"date, datetime or integer expected");
         return NULL;
     }
     

--- a/bindings/python/time64.i
+++ b/bindings/python/time64.i
@@ -69,6 +69,12 @@
 // stack. (SWIG will name the variables ts1, ts2, ts3...)
 //
 // Mark Jenkins <mark@parit.ca>
+//
+// as far as I can see all occurences of pointers to time64 are now covered
+// by the named typemaps below (2019-04)
+//
+// Christoph Holtermann <mail@c-holtermann.net>
+
 %typemap(in) time64 * (time64 secs) {
     PyDateTime_IMPORT;
 
@@ -92,8 +98,9 @@
     }
 }
 
-// A typemap for converting time64 values returned from functions to
-// python dates. Note that we can't use Python DateTime's fromtimestamp function because it relies upon libc's localtime. Note also that while we create times with timegm we retrieve it with localtime
+/* A typemap for converting time64 values returned from functions to
+   python dates. Note that we can't use Python DateTime's fromtimestamp function because it relies upon libc's
+   localtime. Note also that while we create times with timegm we retrieve it with localtime */
 %typemap(out) time64 {
     if ($1 == INT64_MAX) {
         $result = Py_None;
@@ -106,3 +113,35 @@
                                              t.tm_sec, 0);
     }
 }
+
+// functions using a pointer to time64 to return data
+// these are named typemaps focussing for
+//
+// gboolean qof_query_date_predicate_get_date (const QofQueryPredData *pd, time64 *date)
+// gboolean xaccAccountGetReconcileLastDate (const Account *acc, time64 *last_date)
+// gboolean xaccAccountGetReconcilePostponeDate (const Account *acc, time64 *postpone_date)
+//
+// python functions return a list where the first item is the boolean return value and
+// the second item is a datetime object. This could be reduced to only returning a date or
+// null
+//
+// the modifiable argument is omitted in python function call
+
+%typemap(in, numinputs=0) time64 *date (time64 secs) {
+    $1 = &secs;
+}
+
+%typemap(argout) time64 *date (time64 secs) {
+  PyDateTime_IMPORT;
+  PyObject *tp;
+  struct tm t;
+  gnc_localtime_r($1, &t);
+  tp = PyDateTime_FromDateAndTime(t.tm_year + 1900, t.tm_mon + 1,
+                                             t.tm_mday, t.tm_hour, t.tm_min,
+                                             t.tm_sec, 0);
+
+  $result = SWIG_Python_AppendOutput($result, tp);
+}
+
+%apply time64 *date { time64 *last_date };
+%apply time64 *date { time64 *postpone_date };


### PR DESCRIPTION
Include typechecking for time64 SWIG typemaps. Allow int in addition to datetime.datetime and datetime.date. Use modifiable time64 arguments as return value.

Relates to https://bugs.gnucash.org/show_bug.cgi?id=797177.