### PR TITLE
Bug 797195 - computeInterestIncrement function in fin.scm only works for annual compounding

### DIFF
--- a/libgnucash/app-utils/fin.scm
+++ b/libgnucash/app-utils/fin.scm
@@ -63,12 +63,9 @@
     ;; formula from http://www.riskglossary.com/articles/compounding.htm
   (* a (expt (+ 1 (/ r n)) (* n t))))
 
-(define (gnc:computeInterestIncrement amount interest periods i)
-  (let ((thisVal (gnc:futureValue amount interest periods i))
-        (prevVal (gnc:futureValue amount interest periods (- i 1))))
-    (- thisVal prevVal)
-  )
-)
+(define (gnc:computeInterestIncrement pv ann-rate compounds period)
+  (let ((rate (/ ann-rate compounds)))  
+    (* rate (* pv (expt (+ 1 rate) (- period 1))))))
 
 ;;;;;
 ;; below: not-exposed/"private" functions, used by the "public" functions


### PR DESCRIPTION
https://bugs.gnucash.org/show_bug.cgi?id=797195
Changed gnc:computeInterestIncrement to use a new futureValue calculation that takes time as a number of periods.