### PR TITLE
Pr pycons2to3 - fix python console in python3

### DIFF
--- a/gnucash/python/pycons/console.py
+++ b/gnucash/python/pycons/console.py
@@ -35,6 +35,7 @@ import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import GObject
 from gi.repository import Gtk
+from gi.repository import Gdk
 from gi.repository import Pango
 import io
 import pycons.shell as shell

--- a/gnucash/python/pycons/console.py
+++ b/gnucash/python/pycons/console.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 #
 # Copyright (c) 2008, Nicolas Rougier
 # All rights reserved.

--- a/gnucash/python/pycons/ishell.py
+++ b/gnucash/python/pycons/ishell.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 #
 # Adapted from:
 #

--- a/gnucash/python/pycons/shell.py
+++ b/gnucash/python/pycons/shell.py
@@ -63,9 +63,9 @@ class Shell:
         """
         
         s = line
-        s = filter(lambda x: x in '()[]{}"\'', s)
-        s = s.replace ("'''", "'")
-        s = s.replace ('"""', '"')
+        s = list(filter(lambda x: x in '()[]{}"\'', s))
+        # s = s.replace ("'''", "'")
+        # s = s.replace ('"""', '"')
         instring = False
         brackets = {'(':')', '[':']', '{':'}', '"':'"', '\'':'\''}
         stack = []

--- a/gnucash/python/pycons/shell.py
+++ b/gnucash/python/pycons/shell.py
@@ -155,7 +155,7 @@ class Shell:
                     # Command output
                     print(repr(r))
             except SyntaxError:
-                exec(self.command in self.globals)
+                exec(str(self.command), self.globals)
         except:
             if hasattr (sys, 'last_type') and sys.last_type == SystemExit:
                 console.quit()

--- a/gnucash/python/pycons/shell.py
+++ b/gnucash/python/pycons/shell.py
@@ -163,10 +163,10 @@ class Shell:
                 console.quit()
             else:
                 try:
-                    tb = sys.exc_traceback
+                    tb = sys.exc_info()[2]
                     if tb:
                         tb=tb.tb_next
-                    traceback.print_exception(sys.exc_type, sys.exc_value, tb)
+                    traceback.print_exception(sys.exc_info()[0], sys.exc_info()[1], tb)
                 except:
                     sys.stderr, console.stderr = console.stderr, sys.stderr
                     traceback.print_exc()

--- a/gnucash/python/pycons/shell.py
+++ b/gnucash/python/pycons/shell.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 #
 # Copyright (c) 2008, Nicolas Rougier
 # All rights reserved.


### PR DESCRIPTION
Make pycons great again. Turning on the ipython shell does not yet work as the ipython api from 5 on has changed a lot.