### PR TITLE
Price dialog changes and a couple of bug fixes

### DIFF
--- a/gnucash/gnome-utils/gnc-tree-model-price.c
+++ b/gnucash/gnome-utils/gnc-tree-model-price.c
@@ -219,6 +219,8 @@ gnc_tree_model_price_new (QofBook *book, GNCPriceDB *price_db)
     GncTreeModelPricePrivate *priv;
     const GList *item;
 
+    ENTER(" ");
+
     item = gnc_gobject_tracking_get_list(GNC_TREE_MODEL_PRICE_NAME);
     for ( ; item; item = g_list_next(item))
     {
@@ -232,8 +234,7 @@ gnc_tree_model_price_new (QofBook *book, GNCPriceDB *price_db)
         }
     }
 
-    model = g_object_new (GNC_TYPE_TREE_MODEL_PRICE,
-                          NULL);
+    model = g_object_new (GNC_TYPE_TREE_MODEL_PRICE, NULL);
 
     priv = GNC_TREE_MODEL_PRICE_GET_PRIVATE(model);
     priv->book = book;
@@ -242,6 +243,7 @@ gnc_tree_model_price_new (QofBook *book, GNCPriceDB *price_db)
     priv->event_handler_id =
         qof_event_register_handler (gnc_tree_model_price_event_handler, model);
 
+    LEAVE("returning new model %p", model);
     return GTK_TREE_MODEL (model);
 }
 
@@ -1244,7 +1246,7 @@ gnc_tree_model_price_get_iter_from_commodity (GncTreeModelPrice *model,
     n = g_list_index(list, commodity);
     if (n == -1)
     {
-        LEAVE("not in list");
+        LEAVE("commodity not in list");
         return FALSE;
     }
 
@@ -1280,11 +1282,17 @@ gnc_tree_model_price_get_iter_from_namespace (GncTreeModelPrice *model,
     ct = qof_book_get_data (priv->book, GNC_COMMODITY_TABLE);
     list = gnc_commodity_table_get_namespaces_list(ct);
     if (list == NULL)
+    {
+        LEAVE("namespace list empty");
         return FALSE;
+    }
 
     n = g_list_index(list, name_space);
     if (n == -1)
+    {
+        LEAVE("namespace not found");
         return FALSE;
+    }
 
     iter->stamp = model->stamp;
     iter->user_data  = ITER_IS_NAMESPACE;
@@ -1596,6 +1604,7 @@ gnc_tree_model_price_event_handler (QofInstance *entity,
     }
     else
     {
+        LEAVE(" ");
         return;
     }
 

--- a/gnucash/gnome-utils/gnc-tree-view-commodity.c
+++ b/gnucash/gnome-utils/gnc-tree-view-commodity.c
@@ -576,6 +576,11 @@ gnc_tree_view_commodity_set_filter (GncTreeViewCommodity *view,
 
     s_model = gtk_tree_view_get_model(GTK_TREE_VIEW(view));
     f_model = gtk_tree_model_sort_get_model(GTK_TREE_MODEL_SORT(s_model));
+
+    /* disconnect model from view */
+    g_object_ref (G_OBJECT(s_model));
+    gtk_tree_view_set_model (GTK_TREE_VIEW(view), NULL);
+
     gtk_tree_model_filter_set_visible_func (GTK_TREE_MODEL_FILTER (f_model),
                                             gnc_tree_view_commodity_filter_helper,
                                             fd,
@@ -584,6 +589,11 @@ gnc_tree_view_commodity_set_filter (GncTreeViewCommodity *view,
     /* Whack any existing levels. The top two levels have been created
      * before this routine can be called. */
     gtk_tree_model_filter_refilter (GTK_TREE_MODEL_FILTER (f_model));
+
+    /* connect model to view */
+    gtk_tree_view_set_model (GTK_TREE_VIEW(view), s_model);
+    g_object_unref (G_OBJECT(s_model));
+
     LEAVE(" ");
 }
 

--- a/gnucash/gnome-utils/gnc-tree-view-commodity.c
+++ b/gnucash/gnome-utils/gnc-tree-view-commodity.c
@@ -647,6 +647,44 @@ gnc_tree_view_commodity_get_selected_commodity (GncTreeViewCommodity *view)
     return commodity;
 }
 
+/*
+ * Select the commodity in the commodity tree view.
+ */
+void
+gnc_tree_view_commodity_select_commodity (GncTreeViewCommodity *view, gnc_commodity *commodity)
+{
+    GtkTreeSelection *selection;
+    GtkTreeModel *model, *f_model, *s_model;
+    GtkTreePath *tree_path;
+    GtkTreePath *f_tree_path;
+    GtkTreePath *s_tree_path;
+
+    g_return_if_fail (GNC_IS_TREE_VIEW_COMMODITY(view));
+    g_return_if_fail (commodity != NULL);
+
+    selection = gtk_tree_view_get_selection (GTK_TREE_VIEW(view));
+
+    s_model = gtk_tree_view_get_model (GTK_TREE_VIEW(view));
+    f_model = gtk_tree_model_sort_get_model (GTK_TREE_MODEL_SORT (s_model));
+    model = gtk_tree_model_filter_get_model (GTK_TREE_MODEL_FILTER (f_model));
+
+    tree_path = gnc_tree_model_commodity_get_path_from_commodity (GNC_TREE_MODEL_COMMODITY(model), commodity);
+
+    if (tree_path)
+    {
+        f_tree_path = gtk_tree_model_filter_convert_child_path_to_path
+                                   (GTK_TREE_MODEL_FILTER (f_model), tree_path);
+
+        s_tree_path = gtk_tree_model_sort_convert_child_path_to_path
+                                   (GTK_TREE_MODEL_SORT (s_model), f_tree_path);
+
+        gtk_tree_view_expand_to_path (GTK_TREE_VIEW(view), s_tree_path);
+        gtk_tree_selection_select_path (selection, s_tree_path);
+        gtk_tree_path_free (tree_path);
+        gtk_tree_path_free (f_tree_path);
+        gtk_tree_path_free (s_tree_path);
+    }
+}
 
 #if 0 /* Not Used */
 /*

--- a/gnucash/gnome-utils/gnc-tree-view-commodity.h
+++ b/gnucash/gnome-utils/gnc-tree-view-commodity.h
@@ -203,6 +203,16 @@ gnc_commodity * gnc_tree_view_commodity_get_cursor_commodity (GncTreeViewCommodi
  */
 gnc_commodity * gnc_tree_view_commodity_get_selected_commodity  (GncTreeViewCommodity *view);
 
+
+/** Select the commodity in the associated commodity tree view.
+ *
+ *  @param view A pointer to an commodity tree view.
+ *
+ *  @param The commodity to select.
+ */
+void gnc_tree_view_commodity_select_commodity (GncTreeViewCommodity *view, gnc_commodity *commodity);
+
+
 /** This function selects all sub-commodities of an commodity in the
  *  commodity tree view.  All other commodities will be unselected.
  *

--- a/gnucash/gnome-utils/gnc-tree-view-price.c
+++ b/gnucash/gnome-utils/gnc-tree-view-price.c
@@ -601,6 +601,11 @@ gnc_tree_view_price_set_filter (GncTreeViewPrice *view,
 
     s_model = gtk_tree_view_get_model(GTK_TREE_VIEW(view));
     f_model = gtk_tree_model_sort_get_model(GTK_TREE_MODEL_SORT(s_model));
+
+    /* disconnect model from view */
+    g_object_ref (G_OBJECT(s_model));
+    gtk_tree_view_set_model (GTK_TREE_VIEW(view), NULL);
+
     gtk_tree_model_filter_set_visible_func (GTK_TREE_MODEL_FILTER (f_model),
                                             gnc_tree_view_price_filter_helper,
                                             fd,
@@ -613,6 +618,11 @@ gnc_tree_view_price_set_filter (GncTreeViewPrice *view,
      * prices in the price database.  Once the very first price has been
      * added this error message goes away. */
     gtk_tree_model_filter_refilter (GTK_TREE_MODEL_FILTER (f_model));
+
+    /* connect model to view */
+    gtk_tree_view_set_model (GTK_TREE_VIEW(view), s_model);
+    g_object_unref (G_OBJECT(s_model));
+
     LEAVE(" ");
 }
 

--- a/gnucash/gnome/dialog-commodities.c
+++ b/gnucash/gnome/dialog-commodities.c
@@ -96,7 +96,10 @@ gnc_commodities_dialog_edit_clicked (GtkWidget *widget, gpointer data)
         return;
 
     if (gnc_ui_edit_commodity_modal (commodity, cd->window))
+    {
+        gnc_tree_view_commodity_select_commodity (cd->commodity_tree, commodity);
         gnc_gui_refresh_all ();
+    }
 }
 
 static void
@@ -213,6 +216,9 @@ gnc_commodities_dialog_remove_clicked (GtkWidget *widget, gpointer data)
         gnc_commodity_table_remove (ct, commodity);
         gnc_commodity_destroy (commodity);
         commodity = NULL;
+
+        // to be consistent, unselect all after remove
+        gtk_tree_selection_unselect_all (gtk_tree_view_get_selection (GTK_TREE_VIEW(cd->commodity_tree)));
     }
 
     gnc_price_list_destroy(prices);
@@ -224,6 +230,7 @@ gnc_commodities_dialog_add_clicked (GtkWidget *widget, gpointer data)
 {
     CommoditiesDialog *cd = data;
     gnc_commodity *commodity;
+    gnc_commodity *ret_commodity;
     const char *name_space;
 
     commodity = gnc_tree_view_commodity_get_selected_commodity (cd->commodity_tree);
@@ -232,7 +239,8 @@ gnc_commodities_dialog_add_clicked (GtkWidget *widget, gpointer data)
     else
         name_space = NULL;
 
-    gnc_ui_new_commodity_modal (name_space, cd->window);
+    ret_commodity = gnc_ui_new_commodity_modal (name_space, cd->window);
+    gnc_tree_view_commodity_select_commodity (cd->commodity_tree, ret_commodity);
 }
 
 void

--- a/gnucash/gnome/dialog-price-edit-db.c
+++ b/gnucash/gnome/dialog-price-edit-db.c
@@ -80,6 +80,7 @@ typedef struct
 
     GtkWidget * edit_button;
     GtkWidget * remove_button;
+    GtkWidget * add_button;
 
     GtkWidget *remove_dialog;
     GtkTreeView *remove_view;
@@ -580,6 +581,8 @@ gnc_prices_dialog_selection_changed (GtkTreeSelection *treeselection,
                               length == 1);
     gtk_widget_set_sensitive (pdb_dialog->remove_button,
                               length >= 1);
+    gtk_widget_set_sensitive (pdb_dialog->add_button,
+                              length <= 1);
     LEAVE("%d prices selected", length);
 }
 
@@ -707,6 +710,9 @@ gnc_prices_dialog_create (GtkWidget * parent, PricesDialog *pdb_dialog)
 
         button = GTK_WIDGET(gtk_builder_get_object (builder, "remove_button"));
         pdb_dialog->remove_button = button;
+
+        button = GTK_WIDGET(gtk_builder_get_object (builder, "add_button"));
+        pdb_dialog->add_button = button;
 
         if (!gnc_quote_source_fq_installed())
         {

--- a/gnucash/gschemas/org.gnucash.warnings.gschema.xml.in
+++ b/gnucash/gschemas/org.gnucash.warnings.gschema.xml.in
@@ -34,6 +34,11 @@
       <summary>Delete multiple price quotes</summary>
       <description>This dialog is presented before allowing you to delete multiple price quotes at one time.</description>
     </key>
+    <key name="price-quotes-replace" type="i">
+      <default>0</default>
+      <summary>Replace existing price</summary>
+      <description>This dialog is presented before allowing you to replace an existing price.</description>
+    </key>
     <key name="reg-is-acct-pay-rec" type="i">
       <default>0</default>
       <summary>Edit account payable/accounts receivable register</summary>
@@ -126,6 +131,11 @@
       <default>0</default>
       <summary>Delete multiple price quotes</summary>
       <description>This dialog is presented before allowing you to delete multiple price quotes at one time.</description>
+    </key>
+    <key name="price-quotes-replace" type="i">
+      <default>0</default>
+      <summary>Replace existing price</summary>
+      <description>This dialog is presented before allowing you to replace an existing price.</description>
     </key>
     <key name="reg-is-acct-pay-rec" type="i">
       <default>0</default>

--- a/gnucash/gtkbuilder/dialog-commodities.glade
+++ b/gnucash/gtkbuilder/dialog-commodities.glade
@@ -1,108 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
-  <object class="GtkDialog" id="securities_dialog">
+  <object class="GtkWindow" id="securities_window">
     <property name="can_focus">False</property>
+    <property name="border_width">6</property>
     <property name="title" translatable="yes">Securities</property>
     <property name="default_width">400</property>
     <property name="default_height">400</property>
-    <property name="type_hint">normal</property>
-    <signal name="destroy" handler="gnc_commodities_window_destroy_cb" swapped="no"/>
-    <signal name="response" handler="gnc_commodities_dialog_response" swapped="no"/>
-    <child internal-child="vbox">
-      <object class="GtkBox" id="vbox127">
+    <child>
+      <placeholder/>
+    </child>
+    <child>
+      <object class="GtkBox" id="vbox12">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
-        <child internal-child="action_area">
-          <object class="GtkButtonBox" id="hbuttonbox6">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
-            <child>
-              <object class="GtkButton" id="add_button">
-                <property name="label" translatable="yes">_Add</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="can_default">True</property>
-                <property name="receives_default">False</property>
-                <property name="tooltip_text" translatable="yes">Add a new commodity.</property>
-                <property name="use_underline">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="remove_button">
-                <property name="label" translatable="yes">_Remove</property>
-                <property name="visible">True</property>
-                <property name="sensitive">False</property>
-                <property name="can_focus">True</property>
-                <property name="can_default">True</property>
-                <property name="receives_default">False</property>
-                <property name="tooltip_text" translatable="yes">Remove the current commodity.</property>
-                <property name="use_underline">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="edit_button">
-                <property name="label" translatable="yes">_Edit</property>
-                <property name="visible">True</property>
-                <property name="sensitive">False</property>
-                <property name="can_focus">True</property>
-                <property name="can_default">True</property>
-                <property name="receives_default">False</property>
-                <property name="tooltip_text" translatable="yes">Edit the current commodity.</property>
-                <property name="use_underline">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="close_button">
-                <property name="label" translatable="yes">_Close</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="can_default">True</property>
-                <property name="has_default">True</property>
-                <property name="receives_default">False</property>
-                <property name="use_underline">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">3</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="pack_type">end</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
         <child>
-          <object class="GtkBox" id="commodities_vbox">
+          <object class="GtkBox" id="commodities_vbox1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="border_width">12</property>
             <property name="orientation">vertical</property>
             <property name="spacing">6</property>
             <child>
-              <object class="GtkLabel" id="label1">
+              <object class="GtkLabel" id="label3">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes">&lt;b&gt;Securities&lt;/b&gt;</property>
@@ -116,12 +38,12 @@
               </packing>
             </child>
             <child>
-              <object class="GtkBox" id="hbox1">
+              <object class="GtkBox" id="hbox2">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="spacing">6</property>
                 <child>
-                  <object class="GtkLabel" id="label2">
+                  <object class="GtkLabel" id="label4">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label">    </property>
@@ -133,7 +55,7 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkBox" id="vbox128">
+                  <object class="GtkBox" id="vbox1">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="orientation">vertical</property>
@@ -145,9 +67,6 @@
                         <property name="hexpand">True</property>
                         <property name="vexpand">True</property>
                         <property name="shadow_type">in</property>
-                        <child>
-                          <placeholder/>
-                        </child>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -191,16 +110,93 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">2</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButtonBox" id="hbuttonbox1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="add_button">
+                <property name="label" translatable="yes">_Add</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="can_default">True</property>
+                <property name="receives_default">False</property>
+                <property name="tooltip_text" translatable="yes">Add a new commodity.</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="gnc_commodities_dialog_add_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="remove_button">
+                <property name="label" translatable="yes">_Remove</property>
+                <property name="visible">True</property>
+                <property name="sensitive">False</property>
+                <property name="can_focus">True</property>
+                <property name="can_default">True</property>
+                <property name="receives_default">False</property>
+                <property name="tooltip_text" translatable="yes">Remove the current commodity.</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="gnc_commodities_dialog_remove_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="edit_button">
+                <property name="label" translatable="yes">_Edit</property>
+                <property name="visible">True</property>
+                <property name="sensitive">False</property>
+                <property name="can_focus">True</property>
+                <property name="can_default">True</property>
+                <property name="receives_default">False</property>
+                <property name="tooltip_text" translatable="yes">Edit the current commodity.</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="gnc_commodities_dialog_edit_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="close_button">
+                <property name="label" translatable="yes">_Close</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="can_default">True</property>
+                <property name="has_default">True</property>
+                <property name="receives_default">False</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="gnc_commodities_dialog_close_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack_type">end</property>
+            <property name="position">1</property>
           </packing>
         </child>
       </object>
     </child>
-    <action-widgets>
-      <action-widget response="1">add_button</action-widget>
-      <action-widget response="2">remove_button</action-widget>
-      <action-widget response="3">edit_button</action-widget>
-      <action-widget response="-6">close_button</action-widget>
-    </action-widgets>
   </object>
 </interface>

--- a/gnucash/gtkbuilder/dialog-price.glade
+++ b/gnucash/gtkbuilder/dialog-price.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkListStore" id="liststore1">
@@ -54,6 +54,9 @@
     <property name="modal">True</property>
     <property name="type_hint">dialog</property>
     <signal name="response" handler="pedit_dialog_response_cb" swapped="no"/>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox18">
         <property name="visible">True</property>
@@ -366,6 +369,9 @@
     <property name="title" translatable="yes">Remove Old Prices</property>
     <property name="default_height">500</property>
     <property name="type_hint">dialog</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox2">
         <property name="visible">True</property>
@@ -778,64 +784,30 @@ These prices were added so that there's always a "nearest in time" price for eve
       <action-widget response="-5">ok_button</action-widget>
     </action-widgets>
   </object>
-  <object class="GtkDialog" id="prices_dialog">
+  <object class="GtkWindow" id="prices_window">
     <property name="can_focus">False</property>
-    <property name="border_width">6</property>
     <property name="title" translatable="yes">Price Database</property>
-    <property name="default_width">400</property>
+    <property name="default_width">800</property>
     <property name="default_height">400</property>
-    <property name="type_hint">normal</property>
-    <signal name="close" handler="gnc_prices_dialog_close_cb" after="yes" swapped="no"/>
-    <signal name="destroy" handler="gnc_prices_dialog_window_destroy_cb" swapped="no"/>
-    <signal name="response" handler="gnc_prices_dialog_response" swapped="no"/>
-    <child internal-child="vbox">
-      <object class="GtkBox" id="vbox121">
+    <child>
+      <placeholder/>
+    </child>
+    <child>
+      <object class="GtkBox" id="vbox11">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="spacing">6</property>
-        <child internal-child="action_area">
-          <object class="GtkButtonBox" id="hbuttonbox4">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
-            <child>
-              <object class="GtkButton" id="close_button">
-                <property name="label" translatable="yes">_Close</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="can_default">True</property>
-                <property name="receives_default">False</property>
-                <property name="use_underline">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="pack_type">end</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
         <child>
-          <object class="GtkBox" id="hbox118">
+          <object class="GtkBox" id="hbox1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <child>
               <object class="GtkScrolledWindow" id="price_list_window">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can_focus">True</property>
                 <property name="hexpand">True</property>
                 <property name="vexpand">True</property>
                 <property name="border_width">3</property>
                 <property name="shadow_type">in</property>
-                <child>
-                  <placeholder/>
-                </child>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -844,22 +816,106 @@ These prices were added so that there's always a "nearest in time" price for eve
               </packing>
             </child>
             <child>
-              <object class="GtkButtonBox" id="vbuttonbox5">
+              <object class="GtkBox">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="border_width">5</property>
+                <property name="margin_bottom">12</property>
                 <property name="orientation">vertical</property>
-                <property name="layout_style">spread</property>
                 <child>
-                  <object class="GtkButton" id="get_quotes_button">
-                    <property name="label" translatable="yes">_Get Quotes</property>
+                  <object class="GtkButtonBox" id="vbuttonbox1">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="can_default">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Get new online quotes for stock accounts.</property>
-                    <property name="use_underline">True</property>
-                    <signal name="clicked" handler="gnc_prices_dialog_get_quotes_clicked" swapped="no"/>
+                    <property name="can_focus">False</property>
+                    <property name="border_width">5</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">12</property>
+                    <property name="layout_style">start</property>
+                    <child>
+                      <object class="GtkButton" id="add_button">
+                        <property name="label" translatable="yes">_Add</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="can_default">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="tooltip_text" translatable="yes">Add a new price.</property>
+                        <property name="use_underline">True</property>
+                        <signal name="clicked" handler="gnc_prices_dialog_add_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="remove_button">
+                        <property name="label" translatable="yes">_Remove</property>
+                        <property name="visible">True</property>
+                        <property name="sensitive">False</property>
+                        <property name="can_focus">True</property>
+                        <property name="can_default">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="tooltip_text" translatable="yes">Remove the current price.</property>
+                        <property name="use_underline">True</property>
+                        <signal name="clicked" handler="gnc_prices_dialog_remove_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="edit_button">
+                        <property name="label" translatable="yes">_Edit</property>
+                        <property name="visible">True</property>
+                        <property name="sensitive">False</property>
+                        <property name="can_focus">True</property>
+                        <property name="can_default">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="tooltip_text" translatable="yes">Edit the current price.</property>
+                        <property name="use_underline">True</property>
+                        <signal name="clicked" handler="gnc_prices_dialog_edit_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="remove_old_button">
+                        <property name="label" translatable="yes">Remove _Old</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="can_default">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="tooltip_text" translatable="yes">Remove prices older than a user-entered date.</property>
+                        <property name="use_underline">True</property>
+                        <signal name="clicked" handler="gnc_prices_dialog_remove_old_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="get_quotes_button">
+                        <property name="label" translatable="yes">_Get Quotes</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="can_default">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="tooltip_text" translatable="yes">Get new online quotes for stock accounts.</property>
+                        <property name="use_underline">True</property>
+                        <signal name="clicked" handler="gnc_prices_dialog_get_quotes_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">4</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">True</property>
@@ -868,93 +924,52 @@ These prices were added so that there's always a "nearest in time" price for eve
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkButton" id="add_button">
-                    <property name="label" translatable="yes">_Add</property>
+                  <object class="GtkButtonBox" id="vbuttonbox2">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="can_default">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Add a new price.</property>
-                    <property name="use_underline">True</property>
-                    <signal name="clicked" handler="gnc_prices_dialog_add_clicked" swapped="no"/>
+                    <property name="can_focus">False</property>
+                    <property name="valign">end</property>
+                    <property name="border_width">5</property>
+                    <property name="orientation">vertical</property>
+                    <property name="layout_style">start</property>
+                    <child>
+                      <object class="GtkButton" id="close_button">
+                        <property name="label" translatable="yes">_Close</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="can_default">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="valign">start</property>
+                        <property name="use_underline">True</property>
+                        <signal name="clicked" handler="gnc_prices_dialog_close_cb" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkButton" id="remove_button">
-                    <property name="label" translatable="yes">_Remove</property>
-                    <property name="visible">True</property>
-                    <property name="sensitive">False</property>
-                    <property name="can_focus">True</property>
-                    <property name="can_default">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Remove the current price.</property>
-                    <property name="use_underline">True</property>
-                    <signal name="clicked" handler="gnc_prices_dialog_remove_clicked" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
+                    <property name="fill">True</property>
                     <property name="position">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkButton" id="edit_button">
-                    <property name="label" translatable="yes">_Edit</property>
-                    <property name="visible">True</property>
-                    <property name="sensitive">False</property>
-                    <property name="can_focus">True</property>
-                    <property name="can_default">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Edit the current price.</property>
-                    <property name="use_underline">True</property>
-                    <signal name="clicked" handler="gnc_prices_dialog_edit_clicked" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">2</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkButton" id="remove_old_button">
-                    <property name="label" translatable="yes">Remove _Old</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="can_default">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Remove prices older than a user-entered date.</property>
-                    <property name="use_underline">True</property>
-                    <signal name="clicked" handler="gnc_prices_dialog_remove_old_clicked" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">3</property>
                   </packing>
                 </child>
               </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">1</property>
+                <property name="position">2</property>
               </packing>
             </child>
           </object>
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="position">2</property>
+            <property name="position">0</property>
           </packing>
         </child>
       </object>
     </child>
-    <action-widgets>
-      <action-widget response="-7">close_button</action-widget>
-    </action-widgets>
   </object>
 </interface>

--- a/libgnucash/engine/gnc-pricedb-p.h
+++ b/libgnucash/engine/gnc-pricedb-p.h
@@ -57,6 +57,7 @@ struct gnc_price_db_s
     QofInstance inst;              /* globally unique object identifier */
     GHashTable *commodity_hash;
     gboolean bulk_update;		 /* TRUE while reading XML file, etc. */
+    gboolean reset_nth_price_cache;
 };
 
 struct _GncPriceDBClass

--- a/libgnucash/engine/gnc-pricedb.c
+++ b/libgnucash/engine/gnc-pricedb.c
@@ -839,6 +839,7 @@ QOF_GOBJECT_IMPL(gnc_pricedb, GNCPriceDB, QOF_TYPE_INSTANCE);
 static void
 gnc_pricedb_init(GNCPriceDB* pdb)
 {
+    pdb->reset_nth_price_cache = FALSE;
 }
 
 static void
@@ -2202,7 +2203,7 @@ gnc_pricedb_nth_price (GNCPriceDB *db,
     if (!db || !c || n < 0) return NULL;
     ENTER ("db=%p commodity=%s index=%d", db, gnc_commodity_get_mnemonic(c), n);
 
-    if (last_c && prices && last_c == c)
+    if (last_c && prices && last_c == c && db->reset_nth_price_cache == FALSE)
     {
         result = g_list_nth_data (prices, n);
         LEAVE ("price=%p", result);
@@ -2217,6 +2218,8 @@ gnc_pricedb_nth_price (GNCPriceDB *db,
         prices = NULL;
     }
 
+    db->reset_nth_price_cache = FALSE;
+
     currency_hash = g_hash_table_lookup (db->commodity_hash, c);
     if (currency_hash)
     {
@@ -2228,6 +2231,13 @@ gnc_pricedb_nth_price (GNCPriceDB *db,
 
     LEAVE ("price=%p", result);
     return result;
+}
+
+void
+gnc_pricedb_nth_price_reset_cache (GNCPriceDB *db)
+{
+    if (db)
+        db->reset_nth_price_cache = TRUE;
 }
 
 GNCPrice *

--- a/libgnucash/engine/gnc-pricedb.c
+++ b/libgnucash/engine/gnc-pricedb.c
@@ -309,18 +309,19 @@ gnc_price_create (QofBook *book)
 
     g_return_val_if_fail (book, NULL);
 
+    ENTER(" ");
     p = g_object_new(GNC_TYPE_PRICE, NULL);
 
     qof_instance_init_data (&p->inst, GNC_ID_PRICE, book);
     qof_event_gen (&p->inst, QOF_EVENT_CREATE, NULL);
-
+    LEAVE ("price created %p", p);
     return p;
 }
 
 static void
 gnc_price_destroy (GNCPrice *p)
 {
-    ENTER(" ");
+    ENTER("destroy price %p", p);
     qof_event_gen (&p->inst, QOF_EVENT_DESTROY, NULL);
 
     if (p->type) CACHE_REMOVE(p->type);
@@ -372,14 +373,14 @@ gnc_price_clone (GNCPrice* p, QofBook *book)
 
     if (!p)
     {
-        LEAVE (" ");
+        LEAVE ("return NULL");
         return NULL;
     }
 
     new_p = gnc_price_create(book);
     if (!new_p)
     {
-        LEAVE (" ");
+        LEAVE ("return NULL");
         return NULL;
     }
 
@@ -394,7 +395,7 @@ gnc_price_clone (GNCPrice* p, QofBook *book)
     gnc_price_set_value(new_p, gnc_price_get_value(p));
     gnc_price_set_currency(new_p, gnc_price_get_currency(p));
     gnc_price_commit_edit(new_p);
-    LEAVE (" ");
+    LEAVE ("return cloned price %p", new_p);
     return(new_p);
 }
 
@@ -1801,7 +1802,7 @@ GNCPrice *gnc_pricedb_lookup_latest(GNCPriceDB *db,
     result = price_list->data;
     gnc_price_ref(result);
     g_list_free (price_list);
-    LEAVE(" ");
+    LEAVE("price is %p", result);
     return result;
 }
 
@@ -2202,7 +2203,11 @@ gnc_pricedb_nth_price (GNCPriceDB *db,
     ENTER ("db=%p commodity=%s index=%d", db, gnc_commodity_get_mnemonic(c), n);
 
     if (last_c && prices && last_c == c)
-        return g_list_nth_data (prices, n);
+    {
+        result = g_list_nth_data (prices, n);
+        LEAVE ("price=%p", result);
+        return result;
+    }
 
     last_c = c;
 
@@ -2255,6 +2260,7 @@ gnc_pricedb_lookup_at_time64(GNCPriceDB *db,
         {
             gnc_price_ref(p);
             g_list_free (price_list);
+            LEAVE("price is %p", p);
             return p;
         }
         item = item->next;

--- a/libgnucash/engine/gnc-pricedb.h
+++ b/libgnucash/engine/gnc-pricedb.h
@@ -633,6 +633,8 @@ gnc_pricedb_nth_price (GNCPriceDB *db,
                        const gnc_commodity *c,
                        const int n);
 
+void gnc_pricedb_nth_price_reset_cache (GNCPriceDB *db);
+
 /* The following two convenience functions are used to test the xml backend */
 /** @brief Return the number of prices in the database.
  *


### PR DESCRIPTION
Create a PR for this lot, it all looks OK to me and does what I intended but thought I would run it pass you before pushing.
Changed the security and price dialogues to use GkWindows which allows them to both be open at the same time just like in 2.6
Fixed Bug797165 and added a gnc-warning for overwriting/replacing existing prices.
The last commit made reading of the log file easier by eliminating false indents based on logger names for when the log.conf file is used, My log.conf is full of these just commented out so I can remember them and use them by removing the comment maker.

