### PR TITLE
python console - fix deprecated positional arguments with the GObject constructor 

### DIFF
--- a/gnucash/python/init.py
+++ b/gnucash/python/init.py
@@ -98,7 +98,7 @@ class Console (cons.Console):
 if False:
     console = Console(argv = [], shelltype = 'python', banner = [['woop', 'title']], size = 100)
 
-    window = Gtk.Window(Gtk.WindowType.TOPLEVEL)
+    window = Gtk.Window(type = Gtk.WindowType.TOPLEVEL)
     window.set_position(Gtk.WindowPosition.CENTER)
     window.set_default_size(800,600)
     window.set_border_width(0)


### PR DESCRIPTION
fix Bug 797205
https://bugs.gnucash.org/show_bug.cgi?id=797205