### PR TITLE
Implement "printing" to a pdf.

### DIFF
--- a/gnucash/html/gnc-html-webkit2.h
+++ b/gnucash/html/gnc-html-webkit2.h
@@ -39,6 +39,9 @@ typedef struct _GncHtmlWebkit GncHtmlWebkit;
 typedef struct _GncHtmlWebkitClass GncHtmlWebkitClass;
 typedef struct _GncHtmlWebkitPrivate GncHtmlWebkitPrivate;
 
+/** Key for saving the PDF-export directory in the print settings */
+#define GNC_GTK_PRINT_SETTINGS_EXPORT_DIR "gnc-pdf-export-directory"
+
 struct _GncHtmlWebkit
 {
     GncHtml parent_instance;

--- a/gnucash/html/gnc-html.c
+++ b/gnucash/html/gnc-html.c
@@ -535,10 +535,11 @@ void
 gnc_html_print (GncHtml* self, const char *jobname, gboolean export_pdf)
 #else
 void
-gnc_html_print (GncHtml* self)
+gnc_html_print (GncHtml* self, const char *jobname)
 #endif
 {
     g_return_if_fail( self != NULL );
+     g_return_if_fail( jobname != NULL );
     g_return_if_fail( GNC_IS_HTML(self) );
 
     if ( GNC_HTML_GET_CLASS(self)->print != NULL )
@@ -546,7 +547,7 @@ gnc_html_print (GncHtml* self)
 #ifdef WEBKIT1
       GNC_HTML_GET_CLASS(self)->print (self, jobname, export_pdf);
 #else
-        GNC_HTML_GET_CLASS(self)->print (self);
+        GNC_HTML_GET_CLASS(self)->print (self, jobname);
 #endif
     }
     else

--- a/gnucash/html/gnc-html.h
+++ b/gnucash/html/gnc-html.h
@@ -141,7 +141,7 @@ struct _GncHtmlClass
 #ifdef WEBKIT1
   void (*print) (GncHtml* html, const gchar* jobname, gboolean export_pdf);
 #else
-    void (*print) (GncHtml* html);
+    void (*print) (GncHtml* html, const gchar* jobname);
 #endif
     void (*cancel)( GncHtml* html );
     URLType (*parse_url)( GncHtml* html, const gchar* url,
@@ -220,7 +220,7 @@ void gnc_html_print (GncHtml* html, const char* jobname, gboolean export_pdf);
  *
  * @param html GncHtml object
  */
-void gnc_html_print (GncHtml* html);
+void gnc_html_print (GncHtml* html, const char* jobname);
 #endif
 /**
  * Cancels the current operation

--- a/gnucash/report/report-gnome/gnc-plugin-page-report.c
+++ b/gnucash/report/report-gnome/gnc-plugin-page-report.c
@@ -1166,11 +1166,7 @@ gnc_plugin_page_report_constr_init(GncPluginPageReport *plugin_page, gint report
             N_("Print the current report"),
             G_CALLBACK(gnc_plugin_page_report_print_cb)
         },
-        {
-            "FilePrintPDFAction", GNC_ICON_PDF_EXPORT, N_("Export as P_DF..."), NULL,
-            N_("Export the current report as a PDF document"),
-            G_CALLBACK(gnc_plugin_page_report_exportpdf_cb)
-        },
+
         {
             "EditCutAction", "edit-cut", N_("Cu_t"), "<primary>X",
             N_("Cut the current selection and copy it to clipboard"),
@@ -1870,11 +1866,9 @@ gnc_plugin_page_report_print_cb( GtkAction *action, GncPluginPageReport *report 
 
     //g_warning("Setting job name=%s", job_name);
 
-#ifdef WEBKIT1
-    gnc_html_print (priv->html, job_name, FALSE);
-#else
-    gnc_html_print (priv->html);
-#endif
+
+    gnc_html_print (priv->html, job_name);
+
 
     g_free (job_name);
 }
@@ -1916,7 +1910,7 @@ gnc_plugin_page_report_exportpdf_cb( GtkAction *action, GncPluginPageReport *rep
 #ifdef WEBKIT1
     gnc_html_print (priv->html, job_name, TRUE);
 #else
-    gnc_html_print (priv->html);
+    gnc_html_print (priv->html, job_name);
 #endif
 
     if (owner)


### PR DESCRIPTION
This removes the export to PDF button and uses the standard print
dialog with an option to print tp pdf.
The filename is pre-populated, with the path set to the default, $HOME
on linux.
There is no remembering of past output directories.  Maybe a later
update will do this.