### PR TITLE
[dialog-tax-table] implement editing of Tax Table name (WIP)

### DIFF
--- a/gnucash/gtkbuilder/dialog-tax-table.glade
+++ b/gnucash/gtkbuilder/dialog-tax-table.glade
@@ -121,7 +121,7 @@
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">False</property>
-                            <property name="position">0</property>
+                            <property name="position">1</property>
                           </packing>
                         </child>
                         <child>
@@ -136,7 +136,22 @@
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">False</property>
-                            <property name="position">1</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="rename_table_button">
+                            <property name="label" translatable="yes">_Rename</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="use_underline">True</property>
+                            <signal name="clicked" handler="tax_table_rename_table_cb" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">0</property>
                           </packing>
                         </child>
                       </object>


### PR DESCRIPTION
Adventures into C and GLADE :-)
This commit aims to implement tax-table name editing.

So far - managed to copy current taxtable's name into textbox, handled OK, but can't get gtk_entry's contents. Clues requested -- why I can't retrieve textbox's contents via `gtk_entry_get_text GTK_ENTRY(textbox)` !

![image](https://user-images.githubusercontent.com/1975870/57607025-b3c3bf00-7559-11e9-9a01-bf10e1762801.png)
![image](https://user-images.githubusercontent.com/1975870/57607041-bc1bfa00-7559-11e9-8cd3-d11c7a40122a.png)
![image](https://user-images.githubusercontent.com/1975870/57607196-0d2bee00-755a-11e9-84a6-95babc13f9b7.png)

```
This is a development version. It may or may not work.
Report bugs and other problems to gnucash-devel@gnucash.org
You can also lookup and file bug reports at https://bugs.gnucash.org
To find the last stable version, please refer to https://www.gnucash.org/
Found Finance::Quote version 1.47.
* 16:32:51  WARN <GLib-GObject> invalid unclassed pointer in cast to 'GtkEntry'
* 16:32:51 ERROR <Gtk> gtk_entry_get_text: assertion 'GTK_IS_ENTRY (entry)' failed
```
PS I am fully aware `char_dialog` should have a better name and belongs somewhere else, but not sure where. It's a copypasta from `gnc_choose_radio_option_dialog`.