### PR TITLE
[numeric] Fix constructor from strings in range (0 ,1)

### DIFF
--- a/libgnucash/engine/gnc-numeric.cpp
+++ b/libgnucash/engine/gnc-numeric.cpp
@@ -178,7 +178,7 @@ GncNumeric::GncNumeric(const std::string& str, bool autoround)
         GncInt128 high(stoll(m[1].str()));
         GncInt128 low(stoll(m[2].str()));
         int64_t d = powten(m[2].str().length());
-        GncInt128 n = high * d + (high > 0 ? low : -low);
+        GncInt128 n = high * d + (high >= 0 ? low : -low);
         if (!autoround && n.isBig())
         {
             std::ostringstream errmsg;


### PR DESCRIPTION
Fix error that caused strings in the form 0.nnn to be
converted to negative numerics.