### PR TITLE
Adds Notes to budgets

### DIFF
--- a/gnucash/gnome-utils/CMakeLists.txt
+++ b/gnucash/gnome-utils/CMakeLists.txt
@@ -59,6 +59,7 @@ set (gnome_utils_SOURCES
   gnc-cell-renderer-date.c
   gnc-cell-renderer-popup.c
   gnc-cell-renderer-popup-entry.c
+  gnc-cell-renderer-text-flag.c
   gnc-combott.c
   gnc-commodity-edit.c
   gnc-currency-edit.c
@@ -146,6 +147,7 @@ set (gnome_utils_HEADERS
   gnc-cell-renderer-date.h
   gnc-cell-renderer-popup.h
   gnc-cell-renderer-popup-entry.h
+  gnc-cell-renderer-text-flag.h
   gnc-combott.h
   gnc-commodity-edit.h
   gnc-currency-edit.h

--- a/gnucash/gnome-utils/gnc-cell-renderer-text-flag.c
+++ b/gnucash/gnome-utils/gnc-cell-renderer-text-flag.c
@@ -1,0 +1,238 @@
+/**
+ * gnc-cell-renderer-text-flag.c -- text cell renderer with flag.
+ *
+ * Copyright (C) 2019 Adrian Panella <ianchi74@outlook.com>
+ * All rights reserved.
+ **/
+
+/* GnuCash is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Library General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * Gnucash is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, contact:
+ *
+ * Free Software Foundation           Voice:  +1-617-542-5942
+ * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652
+ * Boston, MA  02110-1301,  USA       gnu@gnu.org
+ */
+
+#include <config.h>
+#include <gtk/gtk.h>
+
+#include "gnc-cell-renderer-text-flag.h"
+
+/**
+ * @Title: GncCellRendererTextFlag
+ *
+ * A #GncCellRendererTextFlag extends the GtkCellRendererText
+ * adding the avility to show a color triangle on the top right corner
+ * to flag the cell.
+ */
+
+
+static void gnc_cell_renderer_text_flag_get_property(GObject *object,
+                                                     guint param_id,
+                                                     GValue *value,
+                                                     GParamSpec *pspec);
+static void gnc_cell_renderer_text_flag_set_property(GObject *object,
+                                                     guint param_id,
+                                                     const GValue *value,
+                                                     GParamSpec *pspec);
+
+static void gnc_cell_renderer_text_flag_render(
+    GtkCellRenderer *cell, cairo_t *cr, GtkWidget *widget,
+    const GdkRectangle *background_area, const GdkRectangle *cell_area,
+    GtkCellRendererState flags);
+
+enum
+{
+    PROP_0,
+
+    PROP_FLAG_SIZE,
+    PROP_FLAG_COLOR,
+    PROP_FLAG_COLOR_RGBA,
+    PROP_FLAGGED,
+
+    LAST_PROP
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(GncCellRendererTextFlag,
+                           gnc_cell_renderer_text_flag,
+                           GTK_TYPE_CELL_RENDERER_TEXT)
+
+static void
+gnc_cell_renderer_text_flag_init(GncCellRendererTextFlag *celltext)
+{
+    GncCellRendererTextFlagPrivate *priv;
+    GtkCellRendererText *cell = GTK_CELL_RENDERER_TEXT(celltext);
+
+    celltext->priv =
+        gnc_cell_renderer_text_flag_get_instance_private(celltext);
+    priv = celltext->priv;
+
+    priv->size = 8;
+    gdk_rgba_parse(&priv->color, "red");
+    priv->flagged = FALSE;
+}
+
+static void
+gnc_cell_renderer_text_flag_class_init(GncCellRendererTextFlagClass *class)
+{
+    GObjectClass *object_class       = G_OBJECT_CLASS(class);
+    GtkCellRendererClass *cell_class = GTK_CELL_RENDERER_CLASS(class);
+
+    object_class->get_property = gnc_cell_renderer_text_flag_get_property;
+    object_class->set_property = gnc_cell_renderer_text_flag_set_property;
+
+    cell_class->render = gnc_cell_renderer_text_flag_render;
+
+    g_object_class_install_property(
+        object_class, PROP_FLAG_SIZE,
+        g_param_spec_int("flag-size", "Flag size", "Flag size", 0, 50,
+                         8, G_PARAM_READWRITE));
+
+    g_object_class_install_property(
+        object_class, PROP_FLAG_COLOR,
+        g_param_spec_string("flag-color", "Flag color name",
+                            "Flag color as a string", "red",
+                            G_PARAM_WRITABLE));
+
+    g_object_class_install_property(
+        object_class, PROP_FLAG_COLOR_RGBA,
+        g_param_spec_boxed("flag-color-rgba", "Flag color as RGBA",
+                           "Flag color as a GdkRGBA", GDK_TYPE_RGBA,
+                           G_PARAM_READWRITE));
+
+    g_object_class_install_property(
+        object_class, PROP_FLAGGED,
+        g_param_spec_boolean("flagged", "Flag set",
+                             "Flag indicator is set", FALSE,
+                             G_PARAM_READWRITE));
+}
+
+static void
+gnc_cell_renderer_text_flag_get_property(GObject *object, guint param_id,
+                                         GValue *value, GParamSpec *pspec)
+{
+    GncCellRendererTextFlag *celltext    = GNC_CELL_RENDERER_TEXT_FLAG(object);
+    GncCellRendererTextFlagPrivate *priv = celltext->priv;
+
+    switch (param_id)
+    {
+    case PROP_FLAGGED:
+        g_value_set_boolean(value, priv->flagged);
+        break;
+
+    case PROP_FLAG_SIZE:
+        g_value_set_int(value, priv->size);
+        break;
+
+    case PROP_FLAG_COLOR_RGBA:
+      g_value_set_boxed (value, &priv->color);
+      break;
+
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, param_id, pspec);
+        break;
+    }
+}
+
+static void
+gnc_cell_renderer_text_flag_set_property(GObject *object, guint param_id,
+                                         const GValue *value,
+                                         GParamSpec *pspec)
+{
+    GncCellRendererTextFlag *celltext    = GNC_CELL_RENDERER_TEXT_FLAG(object);
+    GncCellRendererTextFlagPrivate *priv = celltext->priv;
+    switch (param_id)
+    {
+    case PROP_FLAG_COLOR:
+    {
+        GdkRGBA rgba;
+
+        if (!g_value_get_string(value))
+            break;
+        else if (gdk_rgba_parse(&rgba, g_value_get_string(value)))
+            priv->color = rgba;
+        else
+            g_warning("Don't know color '%s'", g_value_get_string(value));
+    }
+    break;
+
+    case PROP_FLAG_COLOR_RGBA:
+    {
+        GdkRGBA *rgba;
+
+        rgba = g_value_get_boxed(value);
+        if (rgba) 
+            priv->color = *rgba;
+    }
+    break;
+
+    case PROP_FLAGGED:
+        priv->flagged = g_value_get_boolean(value);
+        break;
+
+    case PROP_FLAG_SIZE:
+        priv->size = g_value_get_int(value);
+        break;
+
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, param_id, pspec);
+        break;
+    }
+}
+
+/**
+ * gnc_cell_renderer_text_flag_new:
+ *
+ * Creates a new #GtkCellRendererTextFlag. 
+ * It is a standard GtkCellRendererText extended to optionally show a
+ * coloured triangle as a flag in the top right corner
+ *
+ * Returns: the new cell renderer
+ **/
+GtkCellRenderer *
+gnc_cell_renderer_text_flag_new(void)
+{
+    return g_object_new(GNC_TYPE_CELL_RENDERER_TEXT_FLAG, NULL);
+}
+
+static void
+gnc_cell_renderer_text_flag_render(GtkCellRenderer *cell, cairo_t *cr,
+                                   GtkWidget *widget,
+                                   const GdkRectangle *background_area,
+                                   const GdkRectangle *cell_area,
+                                   GtkCellRendererState flags)
+
+{
+    GncCellRendererTextFlag *celltext    = GNC_CELL_RENDERER_TEXT_FLAG(cell);
+    GncCellRendererTextFlagPrivate *priv = celltext->priv;
+
+    // call the parent renderer to do the standard drawing
+    GTK_CELL_RENDERER_CLASS(gnc_cell_renderer_text_flag_parent_class)
+        ->render(cell, cr, widget, background_area, cell_area, flags);
+
+    // add the flag (triangle in the top right corner)
+    if (priv->flagged) 
+    {
+        guint size = MIN(MIN(background_area->height, priv->size),
+                         background_area->width);
+        double x   = background_area->x + background_area->width - size;
+        double y   = background_area->y;
+
+        cairo_move_to(cr, x, y);
+        cairo_rel_line_to(cr, size, 0);
+        cairo_rel_line_to(cr, 0, size);
+        cairo_close_path(cr);
+        gdk_cairo_set_source_rgba(cr, &priv->color);
+        cairo_fill(cr);
+    }
+}

--- a/gnucash/gnome-utils/gnc-cell-renderer-text-flag.h
+++ b/gnucash/gnome-utils/gnc-cell-renderer-text-flag.h
@@ -1,0 +1,64 @@
+/**
+ * gnc-cell-renderer-text-flag.h -- text cell renderer with flag.
+ * 
+ * Copyright (C) 2019 Adrian Panella <ianchi74@outlook.com>
+ * All rights reserved.
+ **/
+
+/* GnuCash is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Library General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * Gnucash is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, contact:
+ *
+ * Free Software Foundation           Voice:  +1-617-542-5942
+ * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652
+ * Boston, MA  02110-1301,  USA       gnu@gnu.org
+ */
+
+#ifndef __GNC_CELL_RENDERER_TEXT_FLAG_H__
+#define __GNC_CELL_RENDERER_TEXT_FLAG_H__
+
+#include <gtk/gtkcellrenderertext.h>
+
+
+#define GNC_TYPE_CELL_RENDERER_TEXT_FLAG		(gnc_cell_renderer_text_flag_get_type ())
+#define GNC_CELL_RENDERER_TEXT_FLAG(obj)		(G_TYPE_CHECK_INSTANCE_CAST ((obj), GNC_TYPE_CELL_RENDERER_TEXT_FLAG, GncCellRendererTextFlag))
+#define GNC_CELL_RENDERER_TEXT_FLAG_CLASS(klass)	(G_TYPE_CHECK_CLASS_CAST ((klass), GNC_TYPE_CELL_RENDERER_TEXT_FLAG, GncCellRendererTextFlagClass))
+#define GNC_IS_CELL_RENDERER_TEXT_FLAG(obj)		(G_TYPE_CHECK_INSTANCE_TYPE ((obj), GNC_TYPE_CELL_RENDERER_TEXT_FLAG))
+#define GNC_IS_CELL_RENDERER_TEXT_FLAG_CLASS(klass)	(G_TYPE_CHECK_CLASS_TYPE ((klass), GNC_TYPE_CELL_RENDERER_TEXT_FLAG))
+#define GNC_CELL_RENDERER_TEXT_FLAG_GET_CLASS(obj)   (G_TYPE_INSTANCE_GET_CLASS ((obj), GNC_TYPE_CELL_RENDERER_TEXT_FLAG, GncCellRendererTextFlagClass))
+
+typedef struct _GncCellRendererTextFlag              GncCellRendererTextFlag;
+typedef struct _GncCellRendererTextFlagClass         GncCellRendererTextFlagClass;
+typedef struct _GtkCellRendererTextPrivate
+{
+    guint size;
+    GdkRGBA color;
+    gboolean flagged;
+} GncCellRendererTextFlagPrivate;
+
+struct _GncCellRendererTextFlag
+{
+  GtkCellRendererText parent;
+
+  /*< private >*/
+  GncCellRendererTextFlagPrivate *priv;
+};
+
+struct _GncCellRendererTextFlagClass
+{
+  GtkCellRendererTextClass parent_class;
+};
+
+GType gnc_cell_renderer_text_flag_get_type(void) G_GNUC_CONST;
+GtkCellRenderer *gnc_cell_renderer_text_flag_new(void);
+
+#endif /* __GNC_CELL_RENDERER_TEXT_FLAG_H__ */

--- a/gnucash/gnome-utils/gnc-cell-renderer-text-flag.h
+++ b/gnucash/gnome-utils/gnc-cell-renderer-text-flag.h
@@ -42,6 +42,7 @@ typedef struct _GtkCellRendererTextPrivate
 {
     guint size;
     GdkRGBA color;
+    GdkRGBA color_selected;
     gboolean flagged;
 } GncCellRendererTextFlagPrivate;
 

--- a/gnucash/gnome-utils/gnc-tree-view-account.c
+++ b/gnucash/gnome-utils/gnc-tree-view-account.c
@@ -1882,11 +1882,28 @@ gnc_tree_view_account_add_custom_column(GncTreeViewAccount *account_view,
                                         col_edited_cb)
 {
     GtkCellRenderer *renderer;
+
+    g_return_val_if_fail(GNC_IS_TREE_VIEW_ACCOUNT(account_view), NULL);
+
+    renderer = gtk_cell_renderer_text_new();
+
+    return gnc_tree_view_account_add_custom_column_renderer(
+        account_view, column_title, col_source_cb, col_edited_cb, renderer);
+}
+
+GtkTreeViewColumn *
+gnc_tree_view_account_add_custom_column_renderer(GncTreeViewAccount *account_view,
+                                        const gchar *column_title,
+                                        GncTreeViewAccountColumnSource
+                                        col_source_cb,
+                                        GncTreeViewAccountColumnTextEdited
+                                        col_edited_cb,
+                                        GtkCellRenderer *renderer)
+{
     GtkTreeViewColumn *column;
 
     g_return_val_if_fail (GNC_IS_TREE_VIEW_ACCOUNT (account_view), NULL);
 
-    renderer = gtk_cell_renderer_text_new ();
     g_object_set (G_OBJECT (renderer), "xalign", 1.0, NULL);
 
     column = gtk_tree_view_column_new_with_attributes (column_title,

--- a/gnucash/gnome-utils/gnc-tree-view-account.h
+++ b/gnucash/gnome-utils/gnc-tree-view-account.h
@@ -198,7 +198,11 @@ GtkTreeViewColumn * gnc_tree_view_account_add_custom_column(
     GncTreeViewAccount *view, const gchar *column_title,
     GncTreeViewAccountColumnSource source_cb,
     GncTreeViewAccountColumnTextEdited edited_cb);
-
+GtkTreeViewColumn *gnc_tree_view_account_add_custom_column_renderer(
+    GncTreeViewAccount *account_view, const gchar *column_title,
+    GncTreeViewAccountColumnSource col_source_cb,
+    GncTreeViewAccountColumnTextEdited col_edited_cb,
+    GtkCellRenderer *renderer);
 void gnc_tree_view_account_set_name_edited(GncTreeViewAccount *view,
         GncTreeViewAccountColumnTextEdited edited_cb);
 void gnc_tree_view_account_name_edited_cb(Account *account, GtkTreeViewColumn *col, const gchar *new_name);

--- a/gnucash/gnome/gnc-budget-view.c
+++ b/gnucash/gnome/gnc-budget-view.c
@@ -215,7 +215,6 @@ static void
 gnc_budget_view_init(GncBudgetView *budget_view)
 {
     GncBudgetViewPrivate *priv;
-    Account* root;
     gint num_top_accounts;
     gint i;
 
@@ -225,11 +224,8 @@ gnc_budget_view_init(GncBudgetView *budget_view)
 
     priv = GNC_BUDGET_VIEW_GET_PRIVATE(budget_view);
 
-    /* Keep track of the root and top level asset, liability, income and expense accounts */
-    root = gnc_book_get_root_account(gnc_get_current_book());
-    num_top_accounts = gnc_account_n_children(root);
-
-    priv->rootAcct = root;
+    /* Keep track of the root account */
+    priv->rootAcct = gnc_book_get_root_account(gnc_get_current_book());
 
     LEAVE("");
 }

--- a/gnucash/gnome/gnc-plugin-page-budget.c
+++ b/gnucash/gnome/gnc-plugin-page-budget.c
@@ -48,6 +48,7 @@
 #include "dialog-options.h"
 #include "dialog-utils.h"
 #include "gnc-gnome-utils.h"
+#include "misc-gnome-utils.h"
 #include "gnc-gobject-utils.h"
 #include "gnc-icons.h"
 #include "gnc-plugin-page-budget.h"
@@ -119,6 +120,10 @@ static void gnc_plugin_page_budget_cmd_allperiods_budget(
     GtkAction *action, GncPluginPageBudget *page);
 static void gnc_plugin_page_budget_cmd_refresh (
     GtkAction *action, GncPluginPageBudget *page);
+static void gnc_plugin_page_budget_cmd_budget_note(
+    GtkAction *action, GncPluginPageBudget *page);
+static void allperiods_budget_helper(GtkTreeModel *model, GtkTreePath *path,
+    GtkTreeIter *iter, gpointer data);
 
 static GtkActionEntry gnc_plugin_page_budget_actions [] =
 {
@@ -161,7 +166,12 @@ static GtkActionEntry gnc_plugin_page_budget_actions [] =
         N_("Edit budget for all periods for the selected accounts"),
         G_CALLBACK (gnc_plugin_page_budget_cmd_allperiods_budget)
     },
-
+    {
+        "BudgetNoteAction", "system-run", N_("Edit Note"),
+        NULL,
+        N_("Edit note for the selected account and period"),
+        G_CALLBACK (gnc_plugin_page_budget_cmd_budget_note)
+    },
     /* View menu */
     {
         "ViewFilterByAction", NULL, N_("_Filter By..."), NULL, NULL,
@@ -195,6 +205,7 @@ static action_toolbar_labels toolbar_labels[] =
     { "OptionsBudgetAction",        N_("Options") },
     { "EstimateBudgetAction",       N_("Estimate") },
     { "AllPeriodsBudgetAction",     N_("All Periods") },
+    { "BudgetNoteAction",           N_("Note") },
     { NULL, NULL },
 };
 
@@ -1130,6 +1141,82 @@ gnc_plugin_page_budget_cmd_allperiods_budget(GtkAction *action,
             priv->action == UNSET)
             gtk_tree_selection_selected_foreach(sel, allperiods_budget_helper,
                                                 page);
+        break;
+    default:
+        break;
+    }
+    gtk_widget_destroy(dialog);
+    g_object_unref(G_OBJECT(builder));
+}
+
+static void
+gnc_plugin_page_budget_cmd_budget_note(GtkAction *action,
+                                       GncPluginPageBudget *page)
+{
+    GncPluginPageBudgetPrivate *priv;
+    GtkTreeSelection *sel;
+    GtkWidget *dialog, *note;
+    gint result;
+    GtkBuilder *builder;
+    const gchar *txt;
+    GtkTreeViewColumn *col = NULL;
+    GtkTreePath *path = NULL;
+    guint period_num = 0;
+    Account *acc = NULL;
+
+    g_return_if_fail(GNC_IS_PLUGIN_PAGE_BUDGET(page));
+    priv = GNC_PLUGIN_PAGE_BUDGET_GET_PRIVATE(page);
+    sel  = gnc_budget_view_get_selection(priv->budget_view);
+
+    gtk_tree_view_get_cursor(
+        GTK_TREE_VIEW(gnc_budget_view_get_account_tree_view(priv->budget_view)),
+        &path, &col);
+
+    if (path)
+    {
+        period_num = col ? GPOINTER_TO_UINT(
+                               g_object_get_data(G_OBJECT(col), "period_num"))
+                         : 0;
+
+        acc = gnc_budget_view_get_account_from_path(priv->budget_view, path);
+        gtk_tree_path_free(path);
+    }
+
+    if (!acc)
+    {
+        dialog = gtk_message_dialog_new(
+            GTK_WINDOW(gnc_plugin_page_get_window(GNC_PLUGIN_PAGE(page))),
+            GTK_DIALOG_DESTROY_WITH_PARENT | GTK_DIALOG_MODAL,
+            GTK_MESSAGE_INFO, GTK_BUTTONS_CLOSE, "%s",
+            _("You must select one budget cell to edit."));
+        gtk_dialog_run(GTK_DIALOG(dialog));
+        gtk_widget_destroy(dialog);
+        return;
+    }
+
+    builder = gtk_builder_new();
+    gnc_builder_add_from_file(builder, "gnc-plugin-page-budget.glade",
+                              "budget_note_dialog");
+
+    dialog = GTK_WIDGET(gtk_builder_get_object(builder, "budget_note_dialog"));
+
+    gtk_window_set_transient_for(
+        GTK_WINDOW(dialog),
+        GTK_WINDOW(gnc_plugin_page_get_window(GNC_PLUGIN_PAGE(page))));
+
+    note = GTK_WIDGET(gtk_builder_get_object(builder, "BudgetNote"));
+    txt  = gnc_budget_get_account_period_note(priv->budget, acc, period_num);
+    xxxgtk_textview_set_text(GTK_TEXT_VIEW(note), txt);
+
+    gtk_widget_show_all(dialog);
+    result = gtk_dialog_run(GTK_DIALOG(dialog));
+    switch (result)
+    {
+    case GTK_RESPONSE_OK:
+        txt = xxxgtk_textview_get_text(GTK_TEXT_VIEW(note));
+        if (!strlen(txt))
+            txt = NULL;
+        gnc_budget_set_account_period_note(priv->budget, acc, period_num, txt);
         break;
     default:
         break;

--- a/gnucash/gnucash-fallback-310.css
+++ b/gnucash/gnucash-fallback-310.css
@@ -75,4 +75,3 @@
 *.markers-dark {
   background-color: shade (@marker_bg_color, 0.8);
 }
-

--- a/gnucash/gtkbuilder/gnc-plugin-page-budget.glade
+++ b/gnucash/gtkbuilder/gnc-plugin-page-budget.glade
@@ -808,4 +808,119 @@
       <action-widget response="-7">close_button</action-widget>
     </action-widgets>
   </object>
+  <object class="GtkDialog" id="budget_note_dialog">
+    <property name="can_focus">False</property>
+    <property name="border_width">5</property>
+    <property name="title" translatable="yes">Budget Notes</property>
+    <property name="modal">True</property>
+    <property name="type_hint">dialog</property>
+    <child>
+      <placeholder/>
+    </child>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="cancelbutton4">
+                <property name="label" translatable="yes">_Cancel</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="can_default">True</property>
+                <property name="receives_default">False</property>
+                <property name="use_underline">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="okbutton4">
+                <property name="label" translatable="yes">_OK</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="can_default">True</property>
+                <property name="receives_default">False</property>
+                <property name="use_underline">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="vbox2">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkLabel" id="NoteLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">start</property>
+                <property name="valign">start</property>
+                <property name="label" translatable="yes">
+Enter Note:
+</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkScrolledWindow">
+            <property name="width_request">450</property>
+            <property name="height_request">100</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="margin_bottom">5</property>
+            <property name="shadow_type">in</property>
+            <child>
+              <object class="GtkTextView" id="BudgetNote">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="hexpand">True</property>
+                <property name="vexpand">True</property>
+                <property name="wrap_mode">word</property>
+                <property name="accepts_tab">False</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="-6">cancelbutton4</action-widget>
+      <action-widget response="-5">okbutton4</action-widget>
+    </action-widgets>
+  </object>
 </interface>

--- a/gnucash/ui/gnc-plugin-page-budget-ui.xml
+++ b/gnucash/ui/gnc-plugin-page-budget-ui.xml
@@ -5,6 +5,7 @@
         <menuitem name="Estimate" action="EstimateBudgetAction"/>
         <menuitem name="AllPeriods" action="AllPeriodsBudgetAction"/>
         <menuitem name="Delete" action="DeleteBudgetAction"/>
+        <menuitem name="Note" action="BudgetNoteAction"/>
       </placeholder>
       <menuitem name="Options" action="OptionsBudgetAction"/>
     </menu>
@@ -13,6 +14,9 @@
   <popup name="MainPopup" action="FakeToplevel">
     <placeholder name="PopupPlaceholder1">
       <menuitem name="Options" action="OptionsBudgetAction"/>
+    </placeholder>
+    <placeholder name="PopupPlaceholder2">
+      <menuitem name="Note" action="BudgetNoteAction"/>
     </placeholder>
   </popup>
 
@@ -25,6 +29,7 @@
       <toolitem name="Estimate" action="EstimateBudgetAction"/>
       <toolitem name="AllPeriods" action="AllPeriodsBudgetAction"/>
       <toolitem name="Delete" action="DeleteBudgetAction"/>
+      <toolitem name="Note" action="BudgetNoteAction"/>
     </placeholder>
   </toolbar>
 </ui>

--- a/libgnucash/engine/gnc-budget.c
+++ b/libgnucash/engine/gnc-budget.c
@@ -589,6 +589,60 @@ gnc_budget_get_account_period_value(const GncBudget *budget,
 }
 
 
+void
+gnc_budget_set_account_period_note(GncBudget *budget, const Account *account,
+                                    guint period_num, const gchar *note)
+{
+    gchar path_part_one [GUID_ENCODING_LENGTH + 1];
+    gchar path_part_two [GNC_BUDGET_MAX_NUM_PERIODS_DIGITS];
+
+    /* Watch out for an off-by-one error here:
+     * period_num starts from 0 while num_periods starts from 1 */
+    if (period_num >= GET_PRIVATE(budget)->num_periods)
+    {
+        PWARN("Period %i does not exist", period_num);
+        return;
+    }
+
+    g_return_if_fail (budget != NULL);
+    g_return_if_fail (account != NULL);
+
+    make_period_path (account, period_num, path_part_one, path_part_two);
+
+    gnc_budget_begin_edit(budget);
+    if (note == NULL)
+        qof_instance_set_kvp (QOF_INSTANCE (budget), NULL, 3, GNC_BUDGET_NOTES_PATH, path_part_one, path_part_two);
+    else
+    {
+        GValue v = G_VALUE_INIT;
+        g_value_init (&v, G_TYPE_STRING);
+        g_value_set_string (&v, note);
+
+        qof_instance_set_kvp (QOF_INSTANCE (budget), &v, 3, GNC_BUDGET_NOTES_PATH, path_part_one, path_part_two);
+    }
+    qof_instance_set_dirty(&budget->inst);
+    gnc_budget_commit_edit(budget);
+
+    qof_event_gen( &budget->inst, QOF_EVENT_MODIFY, NULL);
+
+}
+
+const gchar *
+gnc_budget_get_account_period_note(const GncBudget *budget,
+                                   const Account *account, guint period_num)
+{
+    gchar path_part_one [GUID_ENCODING_LENGTH + 1];
+    gchar path_part_two [GNC_BUDGET_MAX_NUM_PERIODS_DIGITS];
+    GValue v = G_VALUE_INIT;
+
+    g_return_val_if_fail(GNC_IS_BUDGET(budget), NULL);
+    g_return_val_if_fail(account, NULL);
+
+    make_period_path (account, period_num, path_part_one, path_part_two);
+    qof_instance_get_kvp (QOF_INSTANCE (budget), &v, 3, GNC_BUDGET_NOTES_PATH, path_part_one, path_part_two);
+    return (G_VALUE_HOLDS_STRING(&v)) ? g_value_get_string(&v) : NULL;
+}
+
 time64
 gnc_budget_get_period_start_date(const GncBudget *budget, guint period_num)
 {

--- a/libgnucash/engine/gnc-budget.h
+++ b/libgnucash/engine/gnc-budget.h
@@ -90,6 +90,8 @@ GType gnc_budget_get_type(void);
 
 #define GNC_BUDGET_MAX_NUM_PERIODS_DIGITS 3 // max num periods == 999
 
+#define GNC_BUDGET_NOTES_PATH "notes"
+
 gboolean gnc_budget_register(void);
 
 /**
@@ -149,6 +151,11 @@ gnc_numeric gnc_budget_get_account_period_value(
     const GncBudget *budget, const Account *account, guint period_num);
 gnc_numeric gnc_budget_get_account_period_actual_value(
     const GncBudget *budget, Account *account, guint period_num);
+
+void gnc_budget_set_account_period_note(GncBudget *budget,
+    const Account *account, guint period_num, const gchar *note);
+const gchar *gnc_budget_get_account_period_note(const GncBudget *budget,
+    const Account *account, guint period_num);
 
 /* Returns some budget in the book, or NULL. */
 GncBudget* gnc_budget_get_default(QofBook *book);

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -134,6 +134,7 @@ gnucash/gnome-utils/gnc-autosave.c
 gnucash/gnome-utils/gnc-cell-renderer-date.c
 gnucash/gnome-utils/gnc-cell-renderer-popup.c
 gnucash/gnome-utils/gnc-cell-renderer-popup-entry.c
+gnucash/gnome-utils/gnc-cell-renderer-text-flag.c
 gnucash/gnome-utils/gnc-combott.c
 gnucash/gnome-utils/gnc-commodity-edit.c
 gnucash/gnome-utils/gnc-currency-edit.c


### PR DESCRIPTION
Functionality to add "notes" to budget values. This solves:
`Bug 693180 - Add notes to budgeting values`

@jralls I've dropped the commit with BE changes, so this version stores notes in slots.

I leave all the BE issues for a future PR to the master branch.