### PR TITLE
Bug 797249 - Cutting home account causes transaction to disappear

### DIFF
--- a/gnucash/gnome/gnc-plugin-page-register.c
+++ b/gnucash/gnome/gnc-plugin-page-register.c
@@ -3582,17 +3582,16 @@ gnc_plugin_page_register_cmd_find_transactions (GtkAction *action,
 
 static void
 gnc_plugin_page_register_cmd_cut_transaction (GtkAction *action,
-        GncPluginPageRegister *page)
+        GncPluginPageRegister *plugin_page)
 {
     GncPluginPageRegisterPrivate *priv;
-    SplitRegister *reg;
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
+    ENTER("(action %p, plugin_page %p)", action, plugin_page);
 
-    ENTER("(action %p, page %p)", action, page);
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
-    reg = gnc_ledger_display_get_split_register(priv->ledger);
-    gnc_split_register_cut_current(reg);
+    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(plugin_page));
+
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
+    gsr_default_cut_txn_handler (priv->gsr, NULL);
     LEAVE(" ");
 }
 

--- a/gnucash/gnome/gnc-split-reg.c
+++ b/gnucash/gnome/gnc-split-reg.c
@@ -1448,19 +1448,22 @@ gsr_default_delete_handler( GNCSplitReg *gsr, gpointer data )
         const char *desc;
         char recn;
 
-        if (split == gnc_split_register_get_current_trans_split (reg, NULL))
+        if (reg->type != GENERAL_JOURNAL) // no anchoring split
         {
-            dialog = gtk_message_dialog_new(GTK_WINDOW(gsr->window),
-                                            GTK_DIALOG_MODAL
-                                            | GTK_DIALOG_DESTROY_WITH_PARENT,
-                                            GTK_MESSAGE_ERROR,
-                                            GTK_BUTTONS_OK,
-                                            "%s", anchor_error);
-            gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog),
-                    "%s", anchor_split);
-            gtk_dialog_run(GTK_DIALOG(dialog));
-            gtk_widget_destroy (dialog);
-            return;
+            if (split == gnc_split_register_get_current_trans_split (reg, NULL))
+            {
+                dialog = gtk_message_dialog_new(GTK_WINDOW(gsr->window),
+                                                GTK_DIALOG_MODAL
+                                                | GTK_DIALOG_DESTROY_WITH_PARENT,
+                                                GTK_MESSAGE_ERROR,
+                                                GTK_BUTTONS_OK,
+                                                "%s", anchor_error);
+                gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog),
+                        "%s", anchor_split);
+                gtk_dialog_run(GTK_DIALOG(dialog));
+                gtk_widget_destroy (dialog);
+                return;
+            }
         }
 
         memo = xaccSplitGetMemo (split);

--- a/gnucash/gnome/gnc-split-reg.h
+++ b/gnucash/gnome/gnc-split-reg.h
@@ -263,6 +263,7 @@ void gsr_default_associate_handler (GNCSplitReg *gsr, gboolean uri_is_file);
 void gsr_default_execassociated_handler( GNCSplitReg *gsr, gpointer data );
 void gnc_split_reg_enter( GNCSplitReg *gsr, gboolean next_transaction );
 void gsr_default_delete_handler( GNCSplitReg *gsr, gpointer data );
+void gsr_default_cut_txn_handler( GNCSplitReg *gsr, gpointer data );
 void gsr_default_reinit_handler( GNCSplitReg *gsr, gpointer data );
 void gsr_default_expand_handler( GNCSplitReg *gsr, gpointer data );
 void gsr_default_schedule_handler( GNCSplitReg *gsr, gpointer data );

--- a/gnucash/register/ledger-core/split-register-model.c
+++ b/gnucash/register/ledger-core/split-register-model.c
@@ -1954,7 +1954,19 @@ gnc_split_register_cursor_is_readonly (VirtualLocation virt_loc,
     char type;
 
     split = gnc_split_register_get_split (reg, virt_loc.vcell_loc);
-    if (!split) return FALSE;
+
+    if (!split) // this could be the blank split
+    {
+        txn = gnc_split_register_get_current_trans (reg);
+
+        if (txn) // get the current trans and see if read_only required
+        {
+            if (xaccTransGetReadOnly (txn)
+                    || xaccTransIsReadonlyByPostedDate (txn))
+                return (TRUE);
+        }
+        return FALSE;
+    }
 
     txn = xaccSplitGetParent (split);
     if (!txn) return FALSE;

--- a/gnucash/register/ledger-core/split-register.c
+++ b/gnucash/register/ledger-core/split-register.c
@@ -921,6 +921,11 @@ gnc_split_register_paste_current (SplitRegister *reg)
     {
         const char *message = _("You are about to overwrite an existing split. "
                                 "Are you sure you want to do that?");
+        const char *anchor_message = _("This is the split anchoring this transaction "
+                                       "to the register. You may not overwrite it from "
+                                       "this register window. You may overwrite it if "
+                                       "you navigate to a register that shows another "
+                                       "side of this same transaction.");
 
         if (copied_class == CURSOR_CLASS_TRANS)
         {
@@ -929,12 +934,25 @@ gnc_split_register_paste_current (SplitRegister *reg)
             return;
         }
 
-        /* Ask before overwriting an existing split. */
-        if (split != NULL &&
-                !gnc_verify_dialog (GTK_WINDOW (gnc_split_register_get_parent (reg)),
-                                    FALSE, "%s", message))
+        if (split != NULL)
         {
-            LEAVE("user cancelled");
+            /* the General Journal does not have any anchoring splits */
+            if ((reg->type != GENERAL_JOURNAL) &&
+                split == gnc_split_register_get_current_trans_split (reg, NULL))
+            {
+                gnc_warning_dialog (GTK_WINDOW (gnc_split_register_get_parent (reg)),
+                                    "%s", anchor_message);
+                LEAVE("anchore split");
+                return;
+            }
+            else if (!gnc_verify_dialog (GTK_WINDOW (gnc_split_register_get_parent (reg)),
+                                         FALSE, "%s", message))
+            {
+                LEAVE("user cancelled");
+                return;
+            }
+        }
+
             return;
         }
 
@@ -1040,7 +1058,7 @@ gnc_split_register_is_blank_split (SplitRegister *reg, Split *split)
 {
     SRInfo *info = gnc_split_register_get_info (reg);
     Split *current_blank_split = xaccSplitLookup (&info->blank_split_guid, gnc_get_current_book ());
-    
+
     if (split == current_blank_split)
         return TRUE;
 

--- a/gnucash/register/ledger-core/split-register.c
+++ b/gnucash/register/ledger-core/split-register.c
@@ -953,6 +953,10 @@ gnc_split_register_paste_current (SplitRegister *reg)
             }
         }
 
+        /* Open the transaction for editing. */
+        if (gnc_split_register_begin_edit_or_warn (info, trans))
+        {
+            LEAVE("can't begin editing");
             return;
         }
 


### PR DESCRIPTION
I had a look at this one and I started off thinking about adding the warning dialogue but then thought why not disable the menu options when not appropriate which is probably the correct option.

So this commit does that, disables the 'Cut' option when the cursor is on the anchor split along with 'Delete' and 'Paste'. Also added tests for the transaction being read only with appropriate options being disabled.

The only thing I am concerned with is if having some options disabled on some splits will raise questions from users.