### PR TITLE
Add option to display the Description / Memo in the matcher [Master]

### DIFF
--- a/gnucash/gtkbuilder/dialog-import.glade
+++ b/gnucash/gtkbuilder/dialog-import.glade
@@ -123,14 +123,14 @@
           </packing>
         </child>
         <child>
-          <object class="GtkBox" id="placeholder_warning_hbox">
+          <object class="GtkBox" id="warning_hbox">
             <property name="can_focus">False</property>
             <property name="margin_left">6</property>
             <property name="margin_right">6</property>
             <property name="margin_top">6</property>
             <property name="spacing">6</property>
             <child>
-              <object class="GtkImage" id="placeholder_warning_image">
+              <object class="GtkImage" id="warning_image">
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
                 <property name="stock">gtk-dialog-warning</property>
@@ -142,7 +142,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel" id="placeholder_warning_label">
+              <object class="GtkLabel" id="warning_label">
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
                 <property name="wrap">True</property>

--- a/gnucash/gtkbuilder/dialog-import.glade
+++ b/gnucash/gtkbuilder/dialog-import.glade
@@ -1159,18 +1159,43 @@
       </packing>
     </child>
     <child>
-      <object class="GtkCheckButton" id="show_source_account_button">
-        <property name="label" translatable="yes">Show the Source Account column</property>
+      <object class="GtkBox">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">False</property>
+        <property name="can_focus">False</property>
         <property name="halign">center</property>
-        <property name="draw_indicator">True</property>
+        <child>
+          <object class="GtkCheckButton" id="show_source_account_button">
+            <property name="label" translatable="yes">Show the Source Account column</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="draw_indicator">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="show_desc_memo_match">
+            <property name="label" translatable="yes">Show Description / Memo of Match</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="draw_indicator">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
       </object>
       <packing>
         <property name="expand">False</property>
         <property name="fill">True</property>
-        <property name="position">3</property>
+        <property name="position">2</property>
       </packing>
     </child>
   </object>

--- a/gnucash/gtkbuilder/dialog-import.glade
+++ b/gnucash/gtkbuilder/dialog-import.glade
@@ -109,6 +109,20 @@
           </packing>
         </child>
         <child>
+          <object class="GtkScrolledWindow" id="account_tree_sw">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkBox" id="placeholder_warning_hbox">
             <property name="can_focus">False</property>
             <property name="margin_left">6</property>
@@ -143,22 +157,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="pack_type">end</property>
-            <property name="position">2</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkScrolledWindow" id="account_tree_sw">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <child>
-              <placeholder/>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">4</property>
+            <property name="position">3</property>
           </packing>
         </child>
       </object>
@@ -1282,9 +1281,9 @@
       </object>
     </child>
     <action-widgets>
-      <action-widget response="-11">matcher__help</action-widget>
       <action-widget response="-6">matcher_cancel</action-widget>
       <action-widget response="-5">matcher_ok</action-widget>
+      <action-widget response="-11">matcher__help</action-widget>
     </action-widgets>
   </object>
 </interface>

--- a/gnucash/import-export/import-account-matcher.c
+++ b/gnucash/import-export/import-account-matcher.c
@@ -169,25 +169,52 @@ gnc_import_add_account(GtkWidget *button, AccountPickerDialog *picker)
 
 
 /***********************************************************
- * show_placeholder_warning
+ * show_warning
  *
- * show the warning when account is a place holder and disable
- * OK button
+ * show the warning and disable OK button
  ************************************************************/
 static void
-show_placeholder_warning (AccountPickerDialog *picker, const gchar *name)
+show_warning (AccountPickerDialog *picker, gchar *text)
 {
-    gchar *text = g_strdup_printf (_("The account %s is a placeholder account and does not allow "
-                                     "transactions. Please choose a different account."), name);
-
-    gtk_label_set_text (GTK_LABEL(picker->pwarning), text);
-    gnc_label_set_alignment (picker->pwarning, 0.0, 0.5);
-    gtk_widget_show_all (GTK_WIDGET(picker->pwhbox));
+    gtk_label_set_text (GTK_LABEL(picker->warning), text);
+    gnc_label_set_alignment (picker->warning, 0.0, 0.5);
+    gtk_widget_show_all (GTK_WIDGET(picker->whbox));
     g_free (text);
 
     gtk_widget_set_sensitive (picker->ok_button, FALSE); // disable OK button
 }
 
+/***********************************************************
+ * show_placeholder_warning
+ *
+ * show the warning when account is a place holder
+ ************************************************************/
+static void
+show_placeholder_warning (AccountPickerDialog *picker, const gchar *name)
+{
+    gchar *text = g_strdup_printf (_("The account '%s' is a placeholder account and does not allow "
+                                     "transactions. Please choose a different account."), name);
+
+    show_warning (picker, text);
+}
+
+
+/***********************************************************
+ * show_commodity_warning
+ *
+ * show the warning when account is a different commodity to that
+ * required
+ ************************************************************/
+static void
+show_commodity_warning (AccountPickerDialog *picker, const gchar *name)
+{
+    const gchar *com_name = gnc_commodity_get_fullname (picker->new_account_default_commodity);
+    gchar *text = g_strdup_printf (_("The account '%s' has a different commodity to the "
+                                     "one required, '%s'. Please choose a different account."),
+                                      name, com_name);
+
+    show_warning (picker, text);
+}
 
 /*******************************************************
  * account_tree_row_changed_cb
@@ -198,9 +225,14 @@ static void
 account_tree_row_changed_cb (GtkTreeSelection *selection,
                              AccountPickerDialog *picker)
 {
-
     Account *sel_account = gnc_tree_view_account_get_selected_account (picker->account_tree);
 
+    if (!sel_account)
+    {
+        gtk_widget_hide (GTK_WIDGET(picker->whbox)); // hide the warning
+        gtk_widget_set_sensitive (picker->ok_button, FALSE); // disable OK button
+        return;
+    }
     gtk_widget_set_sensitive (picker->ok_button, TRUE); // enable OK button
 
     /* See if the selected account is a placeholder. */
@@ -210,8 +242,15 @@ account_tree_row_changed_cb (GtkTreeSelection *selection,
 
         show_placeholder_warning (picker, retval_name);
     }
+    else if (picker->new_account_default_commodity &&
+                (!gnc_commodity_equal (xaccAccountGetCommodity (sel_account),
+                 picker->new_account_default_commodity))) // check commodity
+    {
+        const gchar *retval_name = xaccAccountGetName (sel_account);
+        show_commodity_warning (picker, retval_name);
+    }
     else
-        gtk_widget_hide (GTK_WIDGET(picker->pwhbox)); // hide the placeholder warning
+        gtk_widget_hide (GTK_WIDGET(picker->whbox)); // hide the warning
 }
 
 
@@ -312,8 +351,8 @@ Account * gnc_import_select_account(GtkWidget *parent,
             PERR("Error opening the glade builder interface");
         }
         picker->dialog = GTK_WIDGET(gtk_builder_get_object (builder, "account_picker_dialog"));
-        picker->pwhbox = GTK_WIDGET(gtk_builder_get_object (builder, "placeholder_warning_hbox"));
-        picker->pwarning = GTK_WIDGET(gtk_builder_get_object (builder, "placeholder_warning_label"));
+        picker->whbox = GTK_WIDGET(gtk_builder_get_object (builder, "warning_hbox"));
+        picker->warning = GTK_WIDGET(gtk_builder_get_object (builder, "warning_label"));
         picker->ok_button = GTK_WIDGET(gtk_builder_get_object (builder, "okbutton"));
 
         if (parent)
@@ -384,6 +423,14 @@ Account * gnc_import_select_account(GtkWidget *parent,
                 if (retval && xaccAccountGetPlaceholder (retval))
                 {
                     show_placeholder_warning (picker, retval_name);
+                    response = GNC_RESPONSE_NEW;
+                    break;
+                }
+                else if (picker->new_account_default_commodity &&
+                            (!gnc_commodity_equal (xaccAccountGetCommodity (retval),
+                             picker->new_account_default_commodity))) // check commodity
+                {
+                    show_commodity_warning (picker, retval_name);
                     response = GNC_RESPONSE_NEW;
                     break;
                 }

--- a/gnucash/import-export/import-account-matcher.c
+++ b/gnucash/import-export/import-account-matcher.c
@@ -24,7 +24,7 @@
 /** @addtogroup Import_Export
     @{ */
 /**@internal
-	@file import-account-matcher.c
+    @file import-account-matcher.c
  * \brief A very generic and flexible account matcher/picker
  \author Copyright (C) 2002 Benoit Grégoire <bock@step.polymtl.ca>
  */
@@ -58,7 +58,7 @@ static QofLogModule log_module = GNC_MOD_IMPORT;
 /** Constructor for AccountPickerDialog.
  * @return Pointer to a new AccountPickerDialog
  */
-static AccountPickerDialog* gnc_import_new_account_picker(void)
+static AccountPickerDialog* gnc_import_new_account_picker (void)
 {
     AccountPickerDialog* picker = g_new(AccountPickerDialog, 1);
     picker->dialog = NULL;
@@ -81,12 +81,12 @@ static AccountPickerDialog* gnc_import_new_account_picker(void)
  *
  * test for match of account online_ids.
  **************************************************/
-static gpointer test_acct_online_id_match(Account *acct, gpointer param_online_id)
+static gpointer test_acct_online_id_match (Account *acct, gpointer param_online_id)
 {
-    const gchar * current_online_id = gnc_import_get_acc_online_id(acct);
-    if ( (current_online_id != NULL
-            && param_online_id != NULL )
-            && strcmp( current_online_id, param_online_id ) == 0 )
+    const gchar * current_online_id = gnc_import_get_acc_online_id (acct);
+    if ((current_online_id != NULL
+            && param_online_id != NULL)
+            && strcmp (current_online_id, param_online_id ) == 0)
     {
         return (gpointer *) acct;
     }
@@ -103,36 +103,36 @@ static gpointer test_acct_online_id_match(Account *acct, gpointer param_online_i
  * build the account tree with the custome column, online_id
  ************************************************************/
 static void
-build_acct_tree(AccountPickerDialog *picker)
+build_acct_tree (AccountPickerDialog *picker)
 {
     GtkTreeView *account_tree;
     GtkTreeViewColumn *col;
 
     /* Build a new account tree */
     DEBUG("Begin");
-    account_tree = gnc_tree_view_account_new(FALSE);
+    account_tree = gnc_tree_view_account_new (FALSE);
     picker->account_tree = GNC_TREE_VIEW_ACCOUNT(account_tree);
     gtk_tree_view_set_headers_visible (account_tree, TRUE);
-    col = gnc_tree_view_find_column_by_name(GNC_TREE_VIEW(account_tree), "type");
-    g_object_set_data(G_OBJECT(col), DEFAULT_VISIBLE, GINT_TO_POINTER(1));
+    col = gnc_tree_view_find_column_by_name (GNC_TREE_VIEW(account_tree), "type");
+    g_object_set_data (G_OBJECT(col), DEFAULT_VISIBLE, GINT_TO_POINTER(1));
 
     /* Add our custom column. */
     col = gnc_tree_view_account_add_property_column (picker->account_tree,
             _("Account ID"), "online-id");
-    g_object_set_data(G_OBJECT(col), DEFAULT_VISIBLE, GINT_TO_POINTER(1));
+    g_object_set_data (G_OBJECT(col), DEFAULT_VISIBLE, GINT_TO_POINTER(1));
 
     // the color background data function is part of the add_property_column
     // function which will color the background based on preference setting
 
-    gtk_container_add(GTK_CONTAINER(picker->account_tree_sw),
-                      GTK_WIDGET(picker->account_tree));
+    gtk_container_add (GTK_CONTAINER(picker->account_tree_sw),
+                       GTK_WIDGET(picker->account_tree));
 
     /* Configure the columns */
     gnc_tree_view_configure_columns (GNC_TREE_VIEW(picker->account_tree));
-    g_object_set(account_tree,
-                 "state-section", STATE_SECTION,
-                 "show-column-menu", TRUE,
-                 (gchar*) NULL);
+    g_object_set (account_tree,
+                  "state-section", STATE_SECTION,
+                  "show-column-menu", TRUE,
+                  (gchar*) NULL);
 }
 
 
@@ -142,7 +142,7 @@ build_acct_tree(AccountPickerDialog *picker)
  * Callback for when user clicks to create a new account
  *******************************************************/
 static void
-gnc_import_add_account(GtkWidget *button, AccountPickerDialog *picker)
+gnc_import_add_account (GtkWidget *button, AccountPickerDialog *picker)
 {
     Account *selected_account, *new_account;
     GList * valid_types = NULL;
@@ -155,16 +155,16 @@ gnc_import_add_account(GtkWidget *button, AccountPickerDialog *picker)
     if (picker->new_account_default_type != ACCT_TYPE_NONE)
     {
         /*Yes, this is weird, but we really DO want to pass the value instead of the pointer...*/
-        valid_types = g_list_prepend(valid_types, GINT_TO_POINTER(picker->new_account_default_type));
+        valid_types = g_list_prepend (valid_types, GINT_TO_POINTER(picker->new_account_default_type));
     }
-    selected_account = gnc_tree_view_account_get_selected_account(picker->account_tree);
+    selected_account = gnc_tree_view_account_get_selected_account (picker->account_tree);
     new_account = gnc_ui_new_accounts_from_name_with_defaults (parent,
                                           picker->account_human_description,
                                           valid_types,
                                           picker->new_account_default_commodity,
                                           selected_account);
-    g_list_free(valid_types);
-    gnc_tree_view_account_set_selected_account(picker->account_tree, new_account);
+    g_list_free (valid_types);
+    gnc_tree_view_account_set_selected_account (picker->account_tree, new_account);
 }
 
 
@@ -260,11 +260,11 @@ account_tree_row_changed_cb (GtkTreeSelection *selection,
  * Callback for when user double clicks on an account
  *******************************************************/
 static void
-account_tree_row_activated_cb(GtkTreeView *view, GtkTreePath *path,
-                              GtkTreeViewColumn *column,
-                              AccountPickerDialog *picker)
+account_tree_row_activated_cb (GtkTreeView *view, GtkTreePath *path,
+                               GtkTreeViewColumn *column,
+                               AccountPickerDialog *picker)
 {
-    gtk_dialog_response(GTK_DIALOG(picker->dialog), GTK_RESPONSE_OK);
+    gtk_dialog_response (GTK_DIALOG(picker->dialog), GTK_RESPONSE_OK);
 }
 
 
@@ -273,14 +273,14 @@ account_tree_row_activated_cb(GtkTreeView *view, GtkTreePath *path,
  *
  * Main call for use with a dialog
  *******************************************************/
-Account * gnc_import_select_account(GtkWidget *parent,
-                                    const gchar * account_online_id_value,
-                                    gboolean auto_create,
-                                    const gchar * account_human_description,
-                                    const gnc_commodity * new_account_default_commodity,
-                                    GNCAccountType new_account_default_type,
-                                    Account * default_selection,
-                                    gboolean * ok_pressed)
+Account * gnc_import_select_account (GtkWidget *parent,
+                                     const gchar * account_online_id_value,
+                                     gboolean auto_create,
+                                     const gchar * account_human_description,
+                                     const gnc_commodity * new_account_default_commodity,
+                                     GNCAccountType new_account_default_type,
+                                     Account * default_selection,
+                                     gboolean * ok_pressed)
 {
 #define ACCOUNT_DESCRIPTION_MAX_SIZE 255
     AccountPickerDialog * picker;
@@ -290,11 +290,11 @@ Account * gnc_import_select_account(GtkWidget *parent,
     GtkBuilder *builder;
     GtkTreeSelection *selection;
     GtkWidget * online_id_label;
-    gchar account_description_text[ACCOUNT_DESCRIPTION_MAX_SIZE + 1] = "";
+    gchar account_description_text [ACCOUNT_DESCRIPTION_MAX_SIZE + 1] = "";
     gboolean ok_pressed_retval = FALSE;
 
-    ENTER("Default commodity received: %s", gnc_commodity_get_fullname( new_account_default_commodity));
-    DEBUG("Default account type received: %s", xaccAccountGetTypeStr( new_account_default_type));
+    ENTER("Default commodity received: %s", gnc_commodity_get_fullname (new_account_default_commodity));
+    DEBUG("Default account type received: %s", xaccAccountGetTypeStr (new_account_default_type));
     picker = g_new0(AccountPickerDialog, 1);
 
     picker->account_online_id_value = account_online_id_value;
@@ -306,7 +306,7 @@ Account * gnc_import_select_account(GtkWidget *parent,
     if (account_online_id_value != NULL)
     {
         retval =
-            gnc_account_foreach_descendant_until(gnc_get_current_root_account (),
+            gnc_account_foreach_descendant_until (gnc_get_current_root_account (),
                     test_acct_online_id_match,
                     /* This argument will only be used as a "const char*" */
                     (void*)account_online_id_value);
@@ -325,17 +325,17 @@ Account * gnc_import_select_account(GtkWidget *parent,
          *
          * This is a hack to overcome that problem.
          */
-        if ((retval == NULL) && g_str_has_suffix(account_online_id_value, " "))
+        if ((retval == NULL) && g_str_has_suffix (account_online_id_value, " "))
         {
-            gchar *trimmed = g_strndup(account_online_id_value, strlen(account_online_id_value) - 1);
+            gchar *trimmed = g_strndup(account_online_id_value, strlen (account_online_id_value) - 1);
             if (trimmed)
             {
-                retval = gnc_account_foreach_descendant_until(
+                retval = gnc_account_foreach_descendant_until (
                              gnc_get_current_root_account (),
                              test_acct_online_id_match,
                              (void *)trimmed);
             }
-            g_free(trimmed);
+            g_free (trimmed);
         }
         /* END: try again without extra space at the end */
     }
@@ -369,52 +369,52 @@ Account * gnc_import_select_account(GtkWidget *parent,
 
         if (account_human_description != NULL)
         {
-            strncat(account_description_text, account_human_description,
-                    ACCOUNT_DESCRIPTION_MAX_SIZE - strlen(account_description_text));
-            strncat(account_description_text, "\n",
-                    ACCOUNT_DESCRIPTION_MAX_SIZE - strlen(account_description_text));
+            strncat (account_description_text, account_human_description,
+                    ACCOUNT_DESCRIPTION_MAX_SIZE - strlen (account_description_text));
+            strncat (account_description_text, "\n",
+                    ACCOUNT_DESCRIPTION_MAX_SIZE - strlen (account_description_text));
         }
         if (account_online_id_value != NULL)
         {
-            strncat(account_description_text, _("(Full account ID: "),
-                    ACCOUNT_DESCRIPTION_MAX_SIZE - strlen(account_description_text));
-            strncat(account_description_text, account_online_id_value,
-                    ACCOUNT_DESCRIPTION_MAX_SIZE - strlen(account_description_text));
-            strncat(account_description_text, ")",
-                    ACCOUNT_DESCRIPTION_MAX_SIZE - strlen(account_description_text));
+            strncat (account_description_text, _("(Full account ID: "),
+                    ACCOUNT_DESCRIPTION_MAX_SIZE - strlen (account_description_text));
+            strncat (account_description_text, account_online_id_value,
+                    ACCOUNT_DESCRIPTION_MAX_SIZE - strlen (account_description_text));
+            strncat (account_description_text, ")",
+                    ACCOUNT_DESCRIPTION_MAX_SIZE - strlen (account_description_text));
         }
-        gtk_label_set_text((GtkLabel*)online_id_label, account_description_text);
-        build_acct_tree(picker);
+        gtk_label_set_text ((GtkLabel*)online_id_label, account_description_text);
+        build_acct_tree (picker);
 
-        gtk_window_set_modal(GTK_WINDOW(picker->dialog), TRUE);
-        g_signal_connect(picker->account_tree, "row-activated",
-                         G_CALLBACK(account_tree_row_activated_cb), picker);
+        gtk_window_set_modal (GTK_WINDOW(picker->dialog), TRUE);
+        g_signal_connect (picker->account_tree, "row-activated",
+                          G_CALLBACK(account_tree_row_activated_cb), picker);
 
-        selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(picker->account_tree));
-        g_signal_connect(selection, "changed",
-                         G_CALLBACK(account_tree_row_changed_cb), picker);
+        selection = gtk_tree_view_get_selection (GTK_TREE_VIEW(picker->account_tree));
+        g_signal_connect (selection, "changed",
+                          G_CALLBACK(account_tree_row_changed_cb), picker);
 
-        gnc_tree_view_account_set_selected_account(picker->account_tree, default_selection);
+        gnc_tree_view_account_set_selected_account (picker->account_tree, default_selection);
 
         do
         {
-            response = gtk_dialog_run(GTK_DIALOG(picker->dialog));
+            response = gtk_dialog_run (GTK_DIALOG(picker->dialog));
             switch (response)
             {
             case GNC_RESPONSE_NEW:
-                gnc_import_add_account(NULL, picker);
+                gnc_import_add_account (NULL, picker);
                 response = GTK_RESPONSE_OK;
                 /* no break */
 
             case GTK_RESPONSE_OK:
-                retval = gnc_tree_view_account_get_selected_account(picker->account_tree);
+                retval = gnc_tree_view_account_get_selected_account (picker->account_tree);
                 if (retval == NULL)
                 {
                     response = GNC_RESPONSE_NEW;
                     break;
                 }
                 if (retval)
-                    retval_name = xaccAccountGetName(retval);
+                    retval_name = xaccAccountGetName (retval);
                 if (!retval_name)
                     retval_name = "(null)";
                 DEBUG("Selected account %p, %s", retval, retval_name);
@@ -435,9 +435,9 @@ Account * gnc_import_select_account(GtkWidget *parent,
                     break;
                 }
 
-                if ( account_online_id_value != NULL)
+                if (account_online_id_value != NULL)
                 {
-                    gnc_import_set_acc_online_id(retval, account_online_id_value);
+                    gnc_import_set_acc_online_id (retval, account_online_id_value);
                 }
                 ok_pressed_retval = TRUE;
                 break;
@@ -449,13 +449,13 @@ Account * gnc_import_select_account(GtkWidget *parent,
         }
         while (response == GNC_RESPONSE_NEW);
 
-        g_object_unref(G_OBJECT(builder));
+        g_object_unref (G_OBJECT(builder));
         gnc_save_window_size (GNC_PREFS_GROUP, GTK_WINDOW(picker->dialog));
-        gtk_widget_destroy(picker->dialog);
+        gtk_widget_destroy (picker->dialog);
     }
     else
     {
-        retval_name = retval ? xaccAccountGetName(retval) : NULL;
+        retval_name = retval ? xaccAccountGetName (retval) : NULL;
         ok_pressed_retval = TRUE; /* There was no dialog involved, so the computer "pressed" ok */
     }
     /*FIXME: DEBUG("WRITEME: gnc_import_select_account() Here we should check if account type is compatible, currency matches, etc.\n"); */

--- a/gnucash/import-export/import-account-matcher.h
+++ b/gnucash/import-export/import-account-matcher.h
@@ -77,20 +77,20 @@ typedef struct
     auto_create must NOT be set to 0.
 
     @param account_human_description
-	 A human-readable description of
+     A human-readable description of
     the account.  Can be NULL. If it is not NULL, it will be shown before
     the id in the account matching dialog.  It will also be used as
     the default account name if a new account is created.
 
     @param new_account_default_commodity
-	 Default commodity of
+     Default commodity of
     the new account. Can be NULL. If not NULL, it will be the
     account's commodity if a new account is created.  Also, if not
     NULL, the function will also warn the user if the found or created
     account's commodity doesn't match.
 
     @param new_account_default_type
-	 Default account type of a
+     Default account type of a
     new account. Can be NULL.  If not ACCT_TYPE_NONE, it will be the
     account's type if a new account is created.  If not
     ACCT_TYPE_NONE, the function will also warn the user if the found
@@ -115,15 +115,14 @@ typedef struct
   @return A pointer to the found or created Account, or NULL if no
   account was found or created.
 */
-Account * gnc_import_select_account(GtkWidget *parent,
-                                    const gchar * account_online_id_value,
-                                    gboolean auto_create,
-                                    const gchar * account_human_description,
-                                    const gnc_commodity * new_account_default_commodity,
-                                    GNCAccountType new_account_default_type,
-                                    Account * default_selection,
-                                    gboolean * ok_pressed
-                                   );
+Account * gnc_import_select_account (GtkWidget *parent,
+                                     const gchar * account_online_id_value,
+                                     gboolean auto_create,
+                                     const gchar * account_human_description,
+                                     const gnc_commodity * new_account_default_commodity,
+                                     GNCAccountType new_account_default_type,
+                                     Account * default_selection,
+                                     gboolean * ok_pressed);
 
 #endif
 /**@}*/

--- a/gnucash/import-export/import-account-matcher.h
+++ b/gnucash/import-export/import-account-matcher.h
@@ -50,8 +50,8 @@ typedef struct
     GNCAccountType       new_account_default_type;       /* new account default type, incoming */
     Account             *default_account;                /* default account for selection, incoming */
     Account             *retAccount;                     /* Account value returned to caller */
-    GtkWidget           *pwhbox;                         /* Placeholder Warning HBox */
-    GtkWidget           *pwarning;                       /* Placeholder Warning Label */
+    GtkWidget           *whbox;                          /* Warning HBox */
+    GtkWidget           *warning;                        /* Warning Label */
 } AccountPickerDialog;
 
 /**  Must be called with a string containing a unique identifier for the

--- a/gnucash/import-export/import-main-matcher.c
+++ b/gnucash/import-export/import-main-matcher.c
@@ -627,7 +627,7 @@ gnc_gen_trans_onPopupMenu_cb (GtkTreeView *treeview,
 
 
 static GtkTreeViewColumn *
-add_text_column(GtkTreeView *view, const gchar *title, int col_num)
+add_text_column(GtkTreeView *view, const gchar *title, int col_num, gboolean ellipsize)
 {
     GtkCellRenderer *renderer;
     GtkTreeViewColumn *column;
@@ -638,6 +638,9 @@ add_text_column(GtkTreeView *view, const gchar *title, int col_num)
               "text", col_num,
               "background", DOWNLOADED_COL_COLOR,
               NULL);
+
+    if (ellipsize)
+        g_object_set (renderer, "ellipsize", PANGO_ELLIPSIZE_END, NULL);
 
     // If date column, use the time64 value for the sorting.
     if (col_num == DOWNLOADED_COL_DATE_TXT)
@@ -706,12 +709,14 @@ gnc_gen_trans_init_view (GNCImportMainMatcher *info,
 
     /* Add the columns *
      * (keep the line break below to avoid a translator comment) */
-    add_text_column (view, _("Date"), DOWNLOADED_COL_DATE_TXT);
-    info->account_column = add_text_column (view, _("Account"), DOWNLOADED_COL_ACCOUNT);
+    add_text_column (view, _("Date"), DOWNLOADED_COL_DATE_TXT, FALSE);
+    info->account_column = add_text_column (view, _("Account"), DOWNLOADED_COL_ACCOUNT, FALSE);
     gtk_tree_view_column_set_visible (info->account_column, show_account);
-    add_text_column (view, _("Amount"), DOWNLOADED_COL_AMOUNT);
-    add_text_column (view, _("Description"), DOWNLOADED_COL_DESCRIPTION);
-    add_text_column (view, _("Memo"), DOWNLOADED_COL_MEMO);
+    add_text_column (view, _("Amount"), DOWNLOADED_COL_AMOUNT, FALSE);
+    add_text_column (view, _("Description"), DOWNLOADED_COL_DESCRIPTION, FALSE);
+    column = add_text_column (view, _("Memo"), DOWNLOADED_COL_MEMO, TRUE);
+    gtk_tree_view_column_set_expand (column, TRUE);
+
     add_toggle_column (view,
                        /* toggle column: add new transaction */
                        _("A"), DOWNLOADED_COL_ACTION_ADD,
@@ -735,7 +740,8 @@ gnc_gen_trans_init_view (GNCImportMainMatcher *info,
              NULL);
     gtk_tree_view_append_column (info->view, column);
 
-    add_text_column (view, _("Additional Comments"), DOWNLOADED_COL_ACTION_INFO);
+    column = add_text_column (view, _("Additional Comments"), DOWNLOADED_COL_ACTION_INFO, FALSE);
+    gtk_tree_view_column_set_sizing (column, GTK_TREE_VIEW_COLUMN_AUTOSIZE);
 
     /* default sort order */
     gtk_tree_sortable_set_sort_column_id (GTK_TREE_SORTABLE(store),

--- a/gnucash/import-export/import-main-matcher.c
+++ b/gnucash/import-export/import-main-matcher.c
@@ -1205,14 +1205,8 @@ refresh_model_row (GNCImportMainMatcher *gui,
                         -1);
     if (gnc_import_TransInfo_get_action (info) == GNCImport_SKIP)
     {
-        /*Show the best match's confidence pixmap in the info column*/
-        gtk_list_store_set (store, iter,
-                            DOWNLOADED_COL_ACTION_PIXBUF,
-                            gen_probability_pixbuf (gnc_import_MatchInfo_get_probability
-                                    (gnc_import_TransInfo_get_selected_match (info)),
-                                    gui->user_settings,
-                                    GTK_WIDGET(gui->view)),
-                            -1);
+        /*If skipping the row, there is no best match's confidence pixmap*/
+        gtk_list_store_set (store, iter, DOWNLOADED_COL_ACTION_PIXBUF, NULL, -1);
     }
 
     gtk_list_store_set (store, iter,

--- a/gnucash/import-export/import-main-matcher.c
+++ b/gnucash/import-export/import-main-matcher.c
@@ -733,18 +733,9 @@ gnc_gen_trans_init_view (GNCImportMainMatcher *info,
              "pixbuf", DOWNLOADED_COL_ACTION_PIXBUF,
              "cell-background", DOWNLOADED_COL_COLOR,
              NULL);
-    renderer = gtk_cell_renderer_text_new();
-    gtk_tree_view_column_pack_start (column, renderer, TRUE);
-    gtk_tree_view_column_set_attributes (column, renderer,
-                                         "text", DOWNLOADED_COL_ACTION_INFO,
-                                         "background", DOWNLOADED_COL_COLOR,
-                                         NULL);
-    gtk_tree_view_column_set_sort_column_id (column, DOWNLOADED_COL_ACTION_INFO);
-    g_object_set (G_OBJECT(column),
-                  "reorderable", TRUE,
-                  "resizable", TRUE,
-                  NULL);
     gtk_tree_view_append_column (info->view, column);
+
+    add_text_column (view, _("Additional Comments"), DOWNLOADED_COL_ACTION_INFO);
 
     /* default sort order */
     gtk_tree_sortable_set_sort_column_id (GTK_TREE_SORTABLE(store),


### PR DESCRIPTION
On the Import matcher window, with reconciled matches it is not obvious
which transaction / split was matched so add the option to display the
transaction description and the split memo.

I would of pushed this but not sure if I have affected the translations ?