### PR TITLE
Bug797278 Fix for Price import

### DIFF
--- a/gnucash/gnome-utils/dialog-transfer.c
+++ b/gnucash/gnome-utils/dialog-transfer.c
@@ -1619,17 +1619,14 @@ new_price(XferDialog *xferData, time64 time)
     gnc_commodity *to = xferData->to_commodity;
     gnc_numeric value = gnc_amount_edit_get_amount(GNC_AMOUNT_EDIT(xferData->price_edit));
 
-/* We want to store currency rates such that the rate > 1 and commodity
- * prices in terms of a currency regardless of value.
- */
     value = gnc_numeric_abs(value);
-    if (gnc_commodity_is_currency(from) && gnc_commodity_is_currency(to))
-    {
-        if (value.num < value.denom)
-            value = swap_commodities(&from, &to, value);
-    }
-    else if (gnc_commodity_is_currency(from))
-            value = swap_commodities(&from, &to, value);
+
+    /* store price against the non currency commodity */
+    if (gnc_commodity_is_currency (from)  && !gnc_commodity_is_currency (to))
+        value = swap_commodities (&from, &to, value);
+    /* store rate against default currency if present */
+    else if (from == gnc_default_currency() && to != gnc_default_currency())
+        value = swap_commodities (&from, &to, value);
 
     value = round_price (from, to, value);
     price = gnc_price_create (xferData->book);

--- a/gnucash/gtkbuilder/assistant-csv-price-import.glade
+++ b/gnucash/gtkbuilder/assistant-csv-price-import.glade
@@ -52,11 +52,11 @@
         <property name="can_focus">False</property>
         <property name="label" translatable="yes">This assistant will help you import Prices from a CSV file.
 
-There is a minimum number of columns that have to be present for a successful import, these are Date, Amount, Commodity From and Currency To. If all entries are for the same Commodity / Currency then you can select them and then the columns will be Date and Amount.
+There is a minimum number of columns that have to be present for a successful import, these are Date, Amount, From Namespace, From Symbol and Currency To. If all entries are for the same Commodity / Currency then you can select them and then the columns will be Date and Amount.
 
 Various options exist for specifying the delimiter as well as a fixed width option. With the fixed width option, double click on the table of rows displayed to set a column width, then right mouse to change if required.
 
-Examples are "RR.L","21/11/2016",5.345,"GBP" and "USD","2016-11-21",1.56,"GBP"
+Examples are "FTSE","RR.L","21/11/2016",5.345,"GBP" and CURRENCY;USD;2016-11-21;1.56;GBP
 
 There is an option for specifying the start row, end row and an option to skip alternate rows beginning from the start row which can be used if you have some header text. Also there is an option to over write existing prices for that day if required.
 

--- a/gnucash/import-export/csv-imp/assistant-csv-price-import.cpp
+++ b/gnucash/import-export/csv-imp/assistant-csv-price-import.cpp
@@ -1193,11 +1193,13 @@ void CsvImpPriceAssist::preview_update_col_type (GtkComboBox* cbox)
     if (old_col_type == GncPricePropType::TO_CURRENCY)
     {
         // look for a from_commodity column to reparse
-        preview_reparse_col_type (GncPricePropType::FROM_COMMODITY);
+        preview_reparse_col_type (GncPricePropType::FROM_SYMBOL);
+        preview_reparse_col_type (GncPricePropType::FROM_NAMESPACE);
     }
 
-    // if old_col_type is FROM_COMMODITY, force a reparse of currency
-    if (old_col_type == GncPricePropType::FROM_COMMODITY)
+    // if old_col_type is FROM_SYMBOL, or FROM_NAMESPACE force a reparse of currency
+    if ((old_col_type == GncPricePropType::FROM_SYMBOL) ||
+        (old_col_type == GncPricePropType::FROM_NAMESPACE))
     {
         // look for a to_currency column to reparse
         preview_reparse_col_type (GncPricePropType::TO_CURRENCY);
@@ -1624,10 +1626,20 @@ void CsvImpPriceAssist::preview_refresh_table ()
 
     auto column_types = price_imp->column_types_price();
 
-    // look for a commodity column, clear the commodity combo
-    auto col_type_comm = std::find (column_types.begin(),
-                column_types.end(), GncPricePropType::FROM_COMMODITY);
-    if (col_type_comm != column_types.end())
+    // look for a namespace column, clear the commodity combo
+    auto col_type_name = std::find (column_types.begin(),
+                column_types.end(), GncPricePropType::FROM_NAMESPACE);
+    if (col_type_name != column_types.end())
+    {
+        g_signal_handlers_block_by_func (commodity_selector, (gpointer) csv_price_imp_preview_commodity_sel_cb, this);
+        set_commodity_for_combo (GTK_COMBO_BOX(commodity_selector), nullptr);
+        g_signal_handlers_unblock_by_func (commodity_selector, (gpointer) csv_price_imp_preview_commodity_sel_cb, this);
+    }
+
+    // look for a symbol column, clear the commodity combo
+    auto col_type_sym = std::find (column_types.begin(),
+                column_types.end(), GncPricePropType::FROM_SYMBOL);
+    if (col_type_sym != column_types.end())
     {
         g_signal_handlers_block_by_func (commodity_selector, (gpointer) csv_price_imp_preview_commodity_sel_cb, this);
         set_commodity_for_combo (GTK_COMBO_BOX(commodity_selector), nullptr);

--- a/gnucash/import-export/csv-imp/gnc-imp-props-price.hpp
+++ b/gnucash/import-export/csv-imp/gnc-imp-props-price.hpp
@@ -50,7 +50,8 @@ enum class GncPricePropType {
     NONE,
     DATE,
     AMOUNT,
-    FROM_COMMODITY,
+    FROM_SYMBOL,
+    FROM_NAMESPACE,
     TO_CURRENCY,
     PRICE_PROPS = TO_CURRENCY
 };
@@ -77,7 +78,8 @@ private:
     const char *m_name;
 };
 
-gnc_commodity* parse_commodity_price_comm (const std::string& comm_str);
+gnc_commodity* parse_commodity_price_comm (const std::string& symbol_str, const std::string& namespace_str);
+bool parse_namespace (const std::string& namespace_str);
 GncNumeric parse_amount_price (const std::string &str, int currency_format);
 
 struct GncImportPrice
@@ -107,6 +109,8 @@ private:
     boost::optional<GncDate> m_date;
     boost::optional<GncNumeric> m_amount;
     boost::optional<gnc_commodity*> m_from_commodity;
+    boost::optional<std::string> m_from_namespace;
+    boost::optional<std::string> m_from_symbol;
     boost::optional<gnc_commodity*> m_to_currency;
     bool created = false;
 

--- a/gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp
+++ b/gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp
@@ -162,9 +162,8 @@ gnc_commodity* parse_commodity (const std::string& comm_str)
     auto table = gnc_commodity_table_get_table (gnc_get_current_book());
     gnc_commodity* comm = nullptr;
 
-    /* First try commodity as a unique name. */
-    if (comm_str.find("::"))
-        comm = gnc_commodity_table_lookup_unique (table, comm_str.c_str());
+    /* First try commodity as a unique name, returns null if not found */
+    comm = gnc_commodity_table_lookup_unique (table, comm_str.c_str());
 
     /* Then try mnemonic in the currency namespace */
     if (!comm)

--- a/gnucash/import-export/csv-imp/gnc-imp-settings-csv-price.cpp
+++ b/gnucash/import-export/csv-imp/gnc-imp-settings-csv-price.cpp
@@ -76,7 +76,8 @@ static std::shared_ptr<CsvPriceImpSettings> create_int_gnc_exp_preset(void)
     preset->m_column_types_price = {
             GncPricePropType::DATE,
             GncPricePropType::AMOUNT,
-            GncPricePropType::FROM_COMMODITY,
+            GncPricePropType::FROM_SYMBOL,
+            GncPricePropType::FROM_NAMESPACE,
             GncPricePropType::TO_CURRENCY
     };
     return preset;
@@ -152,14 +153,14 @@ CsvPriceImpSettings::load (void)
 
     gchar *key_char = g_key_file_get_string (keyfile, group.c_str(), CSV_TO_CURR, &key_error);
     if (key_char && *key_char != '\0')
-        m_to_currency = parse_commodity_price_comm (key_char);
+        m_to_currency = parse_commodity_price_comm (key_char, "");
     m_load_error |= handle_load_error (&key_error, group);
     if (key_char)
         g_free (key_char);
 
     key_char = g_key_file_get_string (keyfile, group.c_str(), CSV_FROM_COMM, &key_error);
     if (key_char && *key_char != '\0')
-        m_from_commodity = parse_commodity_price_comm (key_char);
+        m_from_commodity = parse_commodity_price_comm (key_char, "");
     m_load_error |= handle_load_error (&key_error, group);
     if (key_char)
         g_free (key_char);
@@ -178,8 +179,8 @@ CsvPriceImpSettings::load (void)
             m_column_types_price.push_back(col_types_it->first);
         }
         else
-            PWARN("Found invalid column type '%s'. Inserting column type 'NONE' instead'.",
-                    col_types_str_price[i]);
+            PWARN("Found invalid column type '%s' in group '%s'. Inserting column type 'NONE' instead'.",
+                    col_types_str_price[i], group.c_str());
     }
     if (col_types_str_price)
         g_strfreev (col_types_str_price);


### PR DESCRIPTION
This PR fixes the Bug797278 by adding 'From Namespace' and 'From Symbol' columns which align with the Security Editor. I have tested all the combinations I could think off with the correct expected results.
I think it is safe for maint but there are a some translation changes so seeking confirmation.

The last commit, Bug797244 removes the inversion of prices if less than 1.
For the import, prices go against the non currency commodity and currency rates go in the direction of the import. For the Transfer dialogue prices are against the non currency commodity and currency to default currency being against the default currency. Not sure if there is more required here or if there is any benefit in rates being against the non default currency?
 