### PR TITLE
[master] UI to change currency of root account

### DIFF
--- a/libgnucash/app-utils/app-utils.scm
+++ b/libgnucash/app-utils/app-utils.scm
@@ -77,6 +77,7 @@
 (export gnc:make-text-option)
 (export gnc:make-font-option)
 (export gnc:make-currency-option)
+(export gnc:make-currency-complex-option)
 (export gnc:make-commodity-option)
 (export gnc:make-simple-boolean-option)
 (export gnc:make-complex-boolean-option)
@@ -272,6 +273,7 @@
 (load-from-path "date-utilities")
 
 ;; Business options
+(define gnc:*book-base-currency* (N_ "Book Base Currency"))
 (define gnc:*business-label* (N_ "Business"))
 (define gnc:*company-name* (N_ "Company Name"))
 (define gnc:*company-addy* (N_ "Company Address"))
@@ -295,6 +297,7 @@
 (export gnc:*business-label* gnc:*company-name*  gnc:*company-addy* 
         gnc:*company-id*     gnc:*company-phone* gnc:*company-fax* 
         gnc:*company-url*    gnc:*company-email* gnc:*company-contact*
+        gnc:*book-base-currency*
         gnc:*fancy-date-label* gnc:*fancy-date-format*
         gnc:company-info gnc:fancy-date-info)
 

--- a/libgnucash/app-utils/business-prefs.scm
+++ b/libgnucash/app-utils/business-prefs.scm
@@ -128,6 +128,14 @@
   ;; Accounts tab
 
   (reg-option
+   (gnc:make-currency-complex-option
+    gnc:*option-section-accounts* gnc:*book-base-currency*
+    "z" (_ "Currency of root account")
+    (xaccAccountGetCommodity (gnc-get-current-root-account))
+    (lambda (x) (xaccAccountSetCommodity (gnc-get-current-root-account) x))
+    #f))
+
+  (reg-option
    (gnc:make-number-range-option
 	gnc:*option-section-accounts* gnc:*option-name-auto-readonly-days*
 	"a" (N_ "Choose the number of days after which transactions will be read-only and cannot be edited anymore. This threshold is marked by a red line in the account register windows. If zero, all transactions can be edited and none are read-only.")

--- a/libgnucash/app-utils/options.scm
+++ b/libgnucash/app-utils/options.scm
@@ -299,6 +299,21 @@ the option '~a'."))
          sort-tag
          documentation-string
          default-value)
+  (gnc:make-currency-complex-option section
+                                    name
+                                    sort-tag
+                                    documentation-string
+                                    default-value
+                                    #f #f))
+
+(define (gnc:make-currency-complex-option
+         section
+         name
+         sort-tag
+         documentation-string
+         default-value
+         setter-function-called-cb
+         option-widget-changed-cb)
 
   (define (currency->scm currency)
     (if (string? currency)
@@ -317,7 +332,10 @@ the option '~a'."))
      (gnc:make-option
       section name sort-tag 'currency documentation-string
       (lambda ()  (scm->currency value))
-      (lambda (x) (set! value (currency->scm x)))
+      (lambda (x)
+        (set! value (currency->scm x))
+        (and (procedure? setter-function-called-cb)
+             (setter-function-called-cb x)))
       (lambda ()  (scm->currency default-value))
       (gnc:restore-form-generator value->string)
       (lambda (b p) (qof-book-set-option b value p))
@@ -326,7 +344,9 @@ the option '~a'."))
           (if (and v (string? v))
               (set! value v))))
       (lambda (x) (list #t x))
-      #f #f #f #f)))
+      #f #f #f
+      (and (procedure? option-widget-changed-cb)
+           (lambda (x) (option-widget-changed-cb x))))))
 
 ;; budget option
 ;; TODO: need to double-check this proc (dates back to r11545 or eariler)


### PR DESCRIPTION
## UI to set root currency
Effects: it changes the currency of the summary bar. I am not sure any other side effects.
This does not change format of datafile, so, it could be merged into maint if wished.

## Internal
It adds `gnc:make-currency-complex-option` with callbacks.