### PR TITLE
Set the summarybar currency to default_currency

### DIFF
--- a/gnucash/gnome-utils/window-main-summarybar.c
+++ b/gnucash/gnome-utils/window-main-summarybar.c
@@ -359,10 +359,10 @@ gnc_main_window_summary_refresh (GNCMainSummary * summary)
 
 
     root = gnc_get_current_root_account ();
-    options.default_currency = xaccAccountGetCommodity(root);
+    options.default_currency = gnc_default_currency ();
     if (options.default_currency == NULL)
     {
-        options.default_currency = gnc_default_currency ();
+        options.default_currency = xaccAccountGetCommodity(root);
     }
 
     options.grand_total =


### PR DESCRIPTION
Offshoot from #524 -- sets the summary-bar display currency to default_currency.

This seems uncontroversial -- modifies display currency only. It's also updated live in Edit / Preferences.