### PR TITLE
Summary bar update to previous commit

### DIFF
--- a/gnucash/gnome-utils/dialog-preferences.c
+++ b/gnucash/gnome-utils/dialog-preferences.c
@@ -1348,6 +1348,7 @@ gnc_preferences_dialog_create (GtkWindow *parent)
     GtkTreePath *path;
     GtkTreeIter iter;
     gnc_commodity *locale_currency;
+    gnc_commodity *root_currency;
     const gchar *currency_name;
     GDate fy_end;
     gboolean date_is_valid = FALSE;
@@ -1501,6 +1502,13 @@ gnc_preferences_dialog_create (GtkWindow *parent)
     label = GTK_WIDGET(gtk_builder_get_object (builder, "locale_currency"));
     gtk_label_set_label (GTK_LABEL(label), currency_name);
     label = GTK_WIDGET(gtk_builder_get_object (builder, "locale_currency2"));
+    gtk_label_set_label (GTK_LABEL(label), currency_name);
+
+    root_currency = xaccAccountGetCommodity (gnc_get_current_root_account ());
+    currency_name = gnc_commodity_get_printname (root_currency);
+    label = GTK_WIDGET(gtk_builder_get_object (builder, "root_currency"));
+    gtk_label_set_label (GTK_LABEL(label), currency_name);
+    label = GTK_WIDGET(gtk_builder_get_object (builder, "root_currency2"));
     gtk_label_set_label (GTK_LABEL(label), currency_name);
 
     button = GTK_WIDGET(gtk_builder_get_object (builder, "pref/general/save-on-close-expires"));

--- a/gnucash/gnome-utils/dialog-preferences.c
+++ b/gnucash/gnome-utils/dialog-preferences.c
@@ -80,6 +80,7 @@
 #include "gnc-component-manager.h"
 #include "dialog-preferences.h"
 #include "dialog-doclink-utils.h"
+#include "qofinstance.h"
 
 #define DIALOG_PREFERENCES_CM_CLASS "dialog-newpreferences"
 #define GNC_PREFS_GROUP             "dialogs.preferences"
@@ -1505,7 +1506,21 @@ gnc_preferences_dialog_create (GtkWindow *parent)
     gtk_label_set_label (GTK_LABEL(label), currency_name);
 
     root_currency = xaccAccountGetCommodity (gnc_get_current_root_account ());
-    currency_name = gnc_commodity_get_printname (root_currency);
+
+    /* Prior to version 5.0, if the qif importer was used from 'New User'
+       dialog the Root Account currency was not set */
+    if (!root_currency)
+    {
+        QofBook *book = gnc_get_current_book();
+        Account *root = gnc_get_current_root_account ();
+        xaccAccountBeginEdit (root);
+        xaccAccountSetCommodity (root, locale_currency);
+        xaccAccountCommitEdit (root);
+        qof_book_mark_session_dirty (book);
+        currency_name = gnc_commodity_get_printname (locale_currency);
+    }
+    else
+        currency_name = gnc_commodity_get_printname (root_currency);
     label = GTK_WIDGET(gtk_builder_get_object (builder, "root_currency"));
     gtk_label_set_label (GTK_LABEL(label), currency_name);
     label = GTK_WIDGET(gtk_builder_get_object (builder, "root_currency2"));

--- a/gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in
+++ b/gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in
@@ -136,9 +136,14 @@
       <description>If active, new tabs are opened adjacent to current tab. If inactive, the new tabs are opened instead at the end.</description>
     </key>
     <key name="currency-choice-locale" type="b">
-      <default>true</default>
+      <default>false</default>
       <summary>Use the system locale currency for all newly created accounts.</summary>
       <description>This setting controls the source of the default currency for new accounts. If set to "locale" then GnuCash will retrieve the default currency from the user's locale setting. If set to "other", GnuCash will use the setting specified by the currency-other key.</description>
+    </key>
+    <key name="currency-choice-root" type="b">
+      <default>true</default>
+      <summary>Use the root account currency for all newly created accounts.</summary>
+      <description>This setting controls the source of the default currency for new accounts. If set to "locale" then GnuCash will retrieve the default currency from the user's locale setting. If set to "Root Account", the root account currency will be used. If set to "other", GnuCash will use the setting specified by the currency-other key.</description>
     </key>
     <key name="currency-choice-other" type="b">
       <default>false</default>
@@ -356,9 +361,14 @@
       <description>If active, each new report will be opened in its own window. Otherwise new reports will be opened as tabs in the main window.</description>
     </key>
     <key name="currency-choice-locale" type="b">
-      <default>true</default>
+      <default>false</default>
       <summary>Use the system locale currency for all newly created reports.</summary>
       <description>This setting controls the default currency used for reports. If set to "locale" then GnuCash will retrieve the default currency from the user's locale setting. If set to "other", GnuCash will use the setting specified by the currency-other key.</description>
+    </key>
+    <key name="currency-choice-root" type="b">
+      <default>true</default>
+      <summary>Use the root account currency for all newly created accounts.</summary>
+      <description>This setting controls the source of the default currency for new accounts. If set to "locale" then GnuCash will retrieve the default currency from the user's locale setting. If set to "Root Account", the root account currency will be used. If set to "other", GnuCash will use the setting specified by the currency-other key.</description>
     </key>
     <key name="currency-choice-other" type="b">
       <default>false</default>

--- a/gnucash/gtkbuilder/dialog-preferences.glade
+++ b/gnucash/gtkbuilder/dialog-preferences.glade
@@ -805,7 +805,7 @@ Press 'Close' to return to the preference window
                   </object>
                   <packing>
                     <property name="left-attach">1</property>
-                    <property name="top-attach">14</property>
+                    <property name="top-attach">15</property>
                   </packing>
                 </child>
                 <child>
@@ -820,7 +820,7 @@ Press 'Close' to return to the preference window
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
-                    <property name="top-attach">16</property>
+                    <property name="top-attach">17</property>
                   </packing>
                 </child>
                 <child>
@@ -837,7 +837,7 @@ Press 'Close' to return to the preference window
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
-                    <property name="top-attach">17</property>
+                    <property name="top-attach">18</property>
                     <property name="width">2</property>
                   </packing>
                 </child>
@@ -865,7 +865,7 @@ Press 'Close' to return to the preference window
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
-                    <property name="top-attach">18</property>
+                    <property name="top-attach">19</property>
                     <property name="width">2</property>
                   </packing>
                 </child>
@@ -912,15 +912,55 @@ Press 'Close' to return to the preference window
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkRadioButton" id="pref/general/currency-choice-other">
-                    <property name="label" translatable="yes">Ch_oose</property>
+                  <object class="GtkRadioButton" id="pref/general/currency-choice-locale">
+                    <property name="label" translatable="yes">Loc_ale:</property>
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="receives-default">False</property>
-                    <property name="has-tooltip">True</property>
-                    <property name="tooltip-markup">Use the specified currency for all newly created accounts.</property>
-                    <property name="tooltip-text" translatable="yes">Use the specified currency for all newly created accounts.</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="has_tooltip">True</property>
+                    <property name="tooltip_markup">Use the system locale currency for all newly created accounts.</property>
+                    <property name="tooltip_text" translatable="yes">Use the system locale currency for all newly created accounts.</property>
                     <property name="halign">start</property>
+                    <property name="margin_left">12</property>
+                    <property name="use_underline">True</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">13</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkRadioButton" id="pref/general/currency-choice-other">
+                    <property name="label" translatable="yes">Ch_oose:</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="has_tooltip">True</property>
+                    <property name="tooltip_markup">Use the specified currency for all newly created accounts.</property>
+                    <property name="tooltip_text" translatable="yes">Use the specified currency for all newly created accounts.</property>
+                    <property name="halign">start</property>
+                    <property name="margin-left">12</property>
+                    <property name="use-underline">True</property>
+                    <property name="draw-indicator">True</property>
+                    <property name="group">pref/general/currency-choice-locale</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">15</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkRadioButton" id="pref/general/currency-choice-root">
+                    <property name="label" translatable="yes">Roo_t Account:</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="has_tooltip">True</property>
+                    <property name="tooltip-markup">Use the root account currency for all newly created accounts.</property>
+                    <property name="tooltip-text" translatable="yes">Use the root account currency for all newly created accounts.</property>
+                    <property name="halign">start</property>
+                    <property name="margin-left">12</property>
                     <property name="use-underline">True</property>
                     <property name="active">True</property>
                     <property name="draw-indicator">True</property>
@@ -932,22 +972,25 @@ Press 'Close' to return to the preference window
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkRadioButton" id="pref/general/currency-choice-locale">
-                    <property name="label" translatable="yes">Loc_ale</property>
+                  <object class="GtkLabel">
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="receives-default">False</property>
-                    <property name="has-tooltip">True</property>
-                    <property name="tooltip-markup">Use the system locale currency for all newly created accounts.</property>
-                    <property name="tooltip-text" translatable="yes">Use the system locale currency for all newly created accounts.</property>
-                    <property name="halign">start</property>
-                    <property name="use-underline">True</property>
-                    <property name="active">True</property>
-                    <property name="draw-indicator">True</property>
+                    <property name="can-focus">False</property>
                   </object>
                   <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">13</property>
+                    <property name="left_attach">0</property>
+                    <property name="top-attach">16</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="root_currency">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">US Dollars (USD)</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">14</property>
                   </packing>
                 </child>
                 <child>
@@ -3197,7 +3240,7 @@ many months before the current month</property>
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
-                    <property name="top-attach">4</property>
+                    <property name="top-attach">5</property>
                   </packing>
                 </child>
                 <child>
@@ -3215,7 +3258,7 @@ many months before the current month</property>
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
-                    <property name="top-attach">5</property>
+                    <property name="top-attach">6</property>
                   </packing>
                 </child>
                 <child>
@@ -3228,7 +3271,7 @@ many months before the current month</property>
                   </object>
                   <packing>
                     <property name="left-attach">1</property>
-                    <property name="top-attach">2</property>
+                    <property name="top-attach">3</property>
                   </packing>
                 </child>
                 <child>
@@ -3243,7 +3286,34 @@ many months before the current month</property>
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
-                    <property name="top-attach">7</property>
+                    <property name="top-attach">8</property>
+                  </packing>
+                </child>
+
+                <child>
+                  <object class="GtkBox" id="hbox5">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <object class="GtkSpinButton" id="pref/general.report/default-zoom">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="tooltip-text" translatable="yes">On high resolution screens reports tend to be hard to read. This option allows you to scale reports up by the set factor. For example setting this to 2.0 will display reports at twice their typical size.</property>
+                        <property name="halign">start</property>
+                        <property name="margin-left">12</property>
+                        <property name="adjustment">default_zoom_adj</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">9</property>
                   </packing>
                 </child>
                 <child>
@@ -3253,12 +3323,32 @@ many months before the current month</property>
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
-                    <property name="top-attach">6</property>
+                    <property name="top-attach">7</property>
+                  </packing>
+                </child>
+
+                <child>
+                  <object class="GtkRadioButton" id="pref/general.report/currency-choice-locale">
+                    <property name="label" translatable="yes">Loc_ale:</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="has-tooltip">True</property>
+                    <property name="tooltip-markup">Use the system locale currency for all newly created reports.</property>
+                    <property name="tooltip-text" translatable="yes">Use the system locale currency for all newly created reports.</property>
+                    <property name="halign">start</property>
+                    <property name="margin-left">12</property>
+                    <property name="use-underline">True</property>
+                    <property name="draw-indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">1</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="pref/general.report/currency-choice-other">
-                    <property name="label" translatable="yes">Ch_oose</property>
+                    <property name="label" translatable="yes">Ch_oose:</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -3266,6 +3356,28 @@ many months before the current month</property>
                     <property name="tooltip-markup">Use the specified currency for all newly created reports.</property>
                     <property name="tooltip-text" translatable="yes">Use the specified currency for all newly created reports.</property>
                     <property name="halign">start</property>
+                    <property name="margin-left">12</property>
+                    <property name="use-underline">True</property>
+                    <property name="active">True</property>
+                    <property name="draw-indicator">True</property>
+                    <property name="group">pref/general.report/currency-choice-locale</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">3</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkRadioButton" id="pref/general.report/currency-choice-root">
+                    <property name="label" translatable="yes">Roo_t Account:</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="has-tooltip">True</property>
+                    <property name="tooltip-markup">Use the root account currency for all newly created reports.</property>
+                    <property name="tooltip-text" translatable="yes">Use the root account currency for all newly created reports.</property>
+                    <property name="halign">start</property>
+                    <property name="margin-left">12</property>
                     <property name="use-underline">True</property>
                     <property name="active">True</property>
                     <property name="draw-indicator">True</property>
@@ -3277,50 +3389,25 @@ many months before the current month</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkRadioButton" id="pref/general.report/currency-choice-locale">
-                    <property name="label" translatable="yes">Loc_ale</property>
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="receives-default">False</property>
-                    <property name="has-tooltip">True</property>
-                    <property name="tooltip-markup">Use the system locale currency for all newly created reports.</property>
-                    <property name="tooltip-text" translatable="yes">Use the system locale currency for all newly created reports.</property>
-                    <property name="halign">start</property>
-                    <property name="use-underline">True</property>
-                    <property name="active">True</property>
-                    <property name="draw-indicator">True</property>
-                  </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkSpinButton" id="pref/general.report/default-zoom">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="tooltip-text" translatable="yes">On high resolution screens reports tend to be hard to read. This option allows you to scale reports up by the set factor. For example setting this to 2.0 will display reports at twice their typical size.</property>
-                    <property name="halign">start</property>
-                    <property name="text">1</property>
-                    <property name="adjustment">default_zoom_adj</property>
-                    <property name="digits">1</property>
-                    <property name="value">1</property>
-                  </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">8</property>
-                  </packing>
-                </child>
-                <child>
                   <object class="GtkLabel">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="halign">start</property>
-                    <property name="label" translatable="yes">Default zoom level</property>
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
-                    <property name="top-attach">8</property>
+                    <property name="top-attach">4</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="root_currency2">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">US Dollars (USD)</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">2</property>
                   </packing>
                 </child>
                 <child>

--- a/gnucash/import-export/qif-imp/assistant-qif-import.c
+++ b/gnucash/import-export/qif-imp/assistant-qif-import.c
@@ -3525,6 +3525,16 @@ gnc_ui_qif_import_finish_cb (GtkAssistant *assistant,
                    scm_c_eval_string ("(gnc-get-current-root-account)"),
                    wind->imported_account_tree);
 
+    /* Set the currency of the root account, if this is a new user import it may be null */
+    if (!xaccAccountGetCommodity (gnc_get_current_root_account ()))
+    {
+        Account *root = gnc_get_current_root_account ();
+        xaccAccountBeginEdit (root);
+        xaccAccountSetCommodity (root, gnc_currency_edit_get_currency
+                                       (GNC_CURRENCY_EDIT(wind->currency_picker)));
+        xaccAccountCommitEdit (root);
+    }
+
     gnc_resume_gui_refresh ();
 
     /* Save the user's mapping preferences. */

--- a/libgnucash/app-utils/gnc-ui-util.cpp
+++ b/libgnucash/app-utils/gnc-ui-util.cpp
@@ -56,6 +56,7 @@
 #include "gnc-locale-utils.h"
 
 #define GNC_PREF_CURRENCY_CHOICE_LOCALE "currency-choice-locale"
+#define GNC_PREF_CURRENCY_CHOICE_ROOT   "currency-choice-root"
 #define GNC_PREF_CURRENCY_CHOICE_OTHER  "currency-choice-other"
 #define GNC_PREF_CURRENCY_OTHER         "currency-other"
 #define GNC_PREF_REVERSED_ACCTS_NONE    "reversed-accounts-none"
@@ -752,6 +753,9 @@ gnc_default_currency_common (char* requested_currency,
         return gnc_commodity_table_lookup(gnc_get_current_commodities(),
                                           GNC_COMMODITY_NS_CURRENCY,
                                           requested_currency);
+
+    if (gnc_prefs_get_bool (section, GNC_PREF_CURRENCY_CHOICE_ROOT))
+        currency = xaccAccountGetCommodity (gnc_get_current_root_account ());
 
     if (gnc_current_session_exist() &&
         gnc_prefs_get_bool (section, GNC_PREF_CURRENCY_CHOICE_OTHER))
@@ -2098,6 +2102,8 @@ gnc_ui_util_init (void)
     gnc_prefs_register_cb(GNC_PREFS_GROUP_GENERAL, GNC_PREF_CURRENCY_OTHER,
                           (void*)gnc_currency_changed_cb, nullptr);
     gnc_prefs_register_cb(GNC_PREFS_GROUP_GENERAL_REPORT, GNC_PREF_CURRENCY_CHOICE_LOCALE,
+                          (void*)gnc_currency_changed_cb, nullptr);
+    gnc_prefs_register_cb(GNC_PREFS_GROUP_GENERAL, GNC_PREF_CURRENCY_CHOICE_ROOT,
                           (void*)gnc_currency_changed_cb, nullptr);
     gnc_prefs_register_cb(GNC_PREFS_GROUP_GENERAL_REPORT, GNC_PREF_CURRENCY_CHOICE_OTHER,
                           (void*)gnc_currency_changed_cb, nullptr);

--- a/libgnucash/core-utils/gnc-prefs.h
+++ b/libgnucash/core-utils/gnc-prefs.h
@@ -90,8 +90,9 @@
 #define GNC_PREF_END_DATE            "end-date"
 #define GNC_PREF_END_PERIOD          "end-period"
 /* Currency preferences */
-#define GNC_PREF_CURRENCY_OTHER      "currency-other"
+#define GNC_PREF_CURRENCY_OTHER         "currency-other"
 #define GNC_PREF_CURRENCY_CHOICE_LOCALE "currency-choice-locale"
+#define GNC_PREF_CURRENCY_CHOICE_ROOT   "currency-choice-root"
 #define GNC_PREF_CURRENCY_CHOICE_OTHER  "currency-choice-other"
 
 #ifdef __cplusplus


### PR DESCRIPTION
Add preference options to select root account currency.
This was requested in PR #526 for the preference gui to be updated.
Screen shot below, report option is the same as account option but tooltip different wording but along the same lines of the other options.

![Screenshot_2019-06-24_11-39-10](https://user-images.githubusercontent.com/15702727/60015340-2789d900-967b-11e9-83d6-64fbd2c9169a.png)
 