### PR TITLE
[customer-summary] work with multiple currencies

### DIFF
--- a/gnucash/report/business-reports/business-reports.scm
+++ b/gnucash/report/business-reports/business-reports.scm
@@ -28,6 +28,7 @@
 (use-modules (gnucash app-utils))
 (use-modules (gnucash report report-system))
 (use-modules (gnucash report standard-reports))
+(use-modules (srfi srfi-8))
 
 ;; to define gnc-build-url
 (gnc:module-load "gnucash/html" 0)
@@ -126,10 +127,10 @@
 (define (gnc:receivables-report-create account title show-zeros?)
   (receivables-report-create-internal account title show-zeros?))
 
-(define (gnc:owner-report-create owner account)
+(define* (gnc:owner-report-create owner account #:key currency)
   ; Figure out an account to use if nothing exists here.
   (if (null? account)
-      (set! account (find-first-account-for-owner owner)))
+      (set! account (find-first-account-for-owner owner #:currency currency)))
   (owner-report-create owner account))
 
 (export gnc:invoice-report-create

--- a/gnucash/report/business-reports/customer-summary.scm
+++ b/gnucash/report/business-reports/customer-summary.scm
@@ -317,8 +317,6 @@
          (end-date (gnc:time64-end-day-time
                     (gnc:date-option-absolute-time
                      (opt-val gnc:pagename-general optname-to-date))))
-         (print-invoices? #t);;(opt-val gnc:pagename-general optname-invoicelines))
-         ;;(show-txn-table? (opt-val gnc:pagename-display optname-show-txn-table))
          (show-zero-lines? (opt-val gnc:pagename-display optname-show-zero-lines))
          (show-column-expense? (opt-val gnc:pagename-display optname-show-column-expense))
          (table-num-columns (if show-column-expense? 5 4))
@@ -340,17 +338,12 @@
          (toplevel-total-expense #f)
          (owner-query (qof-query-create-for-splits))
          (any-valid-owner? #f)
-         (type-str "")
-         (notification-str "")
+         (type-str (cond
+                    ((eqv? type GNC-OWNER-CUSTOMER) (N_ "Customer"))
+                    ((eqv? type GNC-OWNER-VENDOR)   (N_ "Vendor"))
+                    ((eqv? type GNC-OWNER-EMPLOYEE) (N_ "Employee"))
+                    (else "")))
          (currency (gnc-default-currency)))
-
-    (cond
-     ((eqv? type GNC-OWNER-CUSTOMER)
-      (set! type-str (N_ "Customer")))
-     ((eqv? type GNC-OWNER-VENDOR)
-      (set! type-str (N_ "Vendor")))
-     ((eqv? type GNC-OWNER-EMPLOYEE)
-      (set! type-str (N_ "Employee"))))
 
     (gnc:html-document-set-title!
      document (string-append (_ type-str) " " (_ "Report")))
@@ -596,13 +589,7 @@
                                 report-title
                                 (qof-print-date start-date)
                                 (qof-print-date end-date))))
-          (gnc:html-document-set-title! document headline)
-
-          ;; Check the settings for taking invoice/payment lines into
-          ;; account and print the ch
-          (make-break! document)
-          (gnc:html-document-add-object!
-           document (gnc:make-html-text notification-str)))
+          (gnc:html-document-set-title! document headline))
 
         ;; else....
         (gnc:html-document-add-object!

--- a/gnucash/report/business-reports/customer-summary.scm
+++ b/gnucash/report/business-reports/customer-summary.scm
@@ -43,6 +43,7 @@
 
 ;; let's define a name for the report-guid's, much prettier
 (define customer-report-guid "4166a20981985fd2b07ff8cb3b7d384e")
+(define owner-report-guid "c146317be32e4948a561ec7fc89d15c1")
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -337,9 +338,7 @@
       (gnc:html-document-add-object!
        document
        (gnc:make-html-text
-        (string-append
-         (_ "No valid customer selected.")
-         " " (_ "Click on the \"Options\" button to select a company.")))))
+        (_ "No valid customer found."))))
 
      (else
       (let ((all-splits (query #f all-accounts start-date end-date))
@@ -367,9 +366,11 @@
                                 (gnc:make-gnc-monetary currency expense))))
                       ownerlist)))
 
-        (define (add-row owner markup profit sales expense)
+        (define (add-row str markup profit sales expense url)
           (gnc:html-table-append-row!
-           table (cons owner
+           table (cons (if url
+                           (gnc:make-html-text (gnc:html-markup-anchor url str))
+                           str)
                        (map
                         (lambda (cell)
                           (gnc:make-html-table-cell/markup "number-cell" cell))
@@ -414,7 +415,9 @@
              (if (or show-zero-lines?
                      (not (and (zero? (gnc:gnc-monetary-amount profit))
                                (zero? (gnc:gnc-monetary-amount sales)))))
-                 (add-row (gncOwnerGetName owner) markupfloat profit sales expense))))
+                 (add-row (gncOwnerGetName owner) markupfloat profit sales expense
+                          (gnc:report-anchor-text
+                           (gnc:owner-report-create owner '()))))))
          results)
 
         ;; The "No Customer" lines
@@ -433,7 +436,8 @@
                           markupfloat
                           (gnc:make-gnc-monetary comm profit)
                           (gnc:make-gnc-monetary comm sales)
-                          (gnc:make-gnc-monetary comm expense)))))
+                          (gnc:make-gnc-monetary comm expense)
+                          #f))))
            commodities))
 
         ;; One horizontal ruler before the summary
@@ -456,7 +460,8 @@
                         markupfloat
                         (gnc:make-gnc-monetary comm profit)
                         (gnc:make-gnc-monetary comm sales)
-                        (gnc:make-gnc-monetary comm expense))))
+                        (gnc:make-gnc-monetary comm expense)
+                        #f)))
            commodities))
 
         ;; Set the formatting styles

--- a/gnucash/report/business-reports/customer-summary.scm
+++ b/gnucash/report/business-reports/customer-summary.scm
@@ -54,12 +54,12 @@
 ;; The line break in the next expressions will suppress above comment as translator comments.
 
 (define pagename-expenseaccounts
-        (N_ "Expense Accounts"))
+  (N_ "Expense Accounts"))
 (define optname-expenseaccounts (N_ "Expense Accounts"))
 
 ;; The line break in the next expressions will suppress above comment as translator comments.
 (define opthelp-expenseaccounts
-        (N_ "The expense accounts where the expenses are recorded which are subtracted from the sales to give the profit."))
+  (N_ "The expense accounts where the expenses are recorded which are subtracted from the sales to give the profit."))
 
 (define optname-show-column-expense (N_ "Show Expense Column"))
 (define opthelp-show-column-expense (N_ "Show the column with the expenses per customer."))
@@ -76,7 +76,7 @@
 ;; The line break in the next expression will suppress above comments as translator comments.
 
 (define optname-show-zero-lines
-         (N_ "Show Lines with All Zeros"))
+  (N_ "Show Lines with All Zeros"))
 (define opthelp-show-zero-lines (N_ "Show the table lines with customers which did not have any transactions in the reporting period, hence would show all zeros in the columns."))
 (define optname-show-inactive (N_ "Show Inactive Customers"))
 (define opthelp-show-inactive (N_ "Include customers that have been marked inactive."))
@@ -116,7 +116,7 @@
     ;; This default-getter finds the first account of this type. TODO:
     ;; Find not only the first one, but all of them!
     (lambda ()
-      (gnc:filter-accountlist-type 
+      (gnc:filter-accountlist-type
        (list ACCT-TYPE-INCOME)
        (gnc-account-get-descendants-sorted (gnc-get-current-root-account))))
     #f #t))
@@ -129,7 +129,7 @@
     ;; This default-getter finds the first account of this type. TODO:
     ;; Find not only the first one, but all of them!
     (lambda ()
-      (gnc:filter-accountlist-type 
+      (gnc:filter-accountlist-type
        (list ACCT-TYPE-EXPENSE)
        (gnc-account-get-descendants-sorted (gnc-get-current-root-account))))
     #f #t))
@@ -220,33 +220,32 @@
 
 (define (query-owner-setup q owner)
   (let* ((guid (gncOwnerReturnGUID (gncOwnerGetEndOwner owner))))
-
     (qof-query-add-guid-match
-     q 
+     q
      (list SPLIT-TRANS INVOICE-FROM-TXN INVOICE-OWNER
            OWNER-PARENTG)
      guid QOF-QUERY-OR)
     (qof-query-add-guid-match
-     q 
+     q
      (list SPLIT-TRANS INVOICE-FROM-TXN INVOICE-BILLTO
            OWNER-PARENTG)
      guid QOF-QUERY-OR)
-;; Apparently those query terms are unneeded because we never take
-;; lots into account?!?
-;    (qof-query-add-guid-match
-;     q
-;     (list SPLIT-LOT OWNER-FROM-LOT OWNER-PARENTG)
-;     guid QOF-QUERY-OR)
-;    (qof-query-add-guid-match
-;     q
-;     (list SPLIT-LOT INVOICE-FROM-LOT INVOICE-OWNER
-;           OWNER-PARENTG)
-;     guid QOF-QUERY-OR)
-;    (qof-query-add-guid-match
-;     q
-;     (list SPLIT-LOT INVOICE-FROM-LOT INVOICE-BILLTO
-;           OWNER-PARENTG)
-;     guid QOF-QUERY-OR)
+    ;; Apparently those query terms are unneeded because we never take
+    ;; lots into account?!?
+    ;;    (qof-query-add-guid-match
+    ;;     q
+    ;;     (list SPLIT-LOT OWNER-FROM-LOT OWNER-PARENTG)
+    ;;     guid QOF-QUERY-OR)
+    ;;    (qof-query-add-guid-match
+    ;;     q
+    ;;     (list SPLIT-LOT INVOICE-FROM-LOT INVOICE-OWNER
+    ;;           OWNER-PARENTG)
+    ;;     guid QOF-QUERY-OR)
+    ;;    (qof-query-add-guid-match
+    ;;     q
+    ;;     (list SPLIT-LOT INVOICE-FROM-LOT INVOICE-BILLTO
+    ;;           OWNER-PARENTG)
+    ;;     guid QOF-QUERY-OR)
     (qof-query-set-book q (gnc-get-current-book))
     q))
 
@@ -312,14 +311,14 @@
 
   (let* ((document (gnc:make-html-document))
          (report-title (opt-val gnc:pagename-general gnc:optname-reportname))
-         (start-date (gnc:time64-start-day-time 
+         (start-date (gnc:time64-start-day-time
                       (gnc:date-option-absolute-time
                        (opt-val gnc:pagename-general optname-from-date))))
-         (end-date (gnc:time64-end-day-time 
+         (end-date (gnc:time64-end-day-time
                     (gnc:date-option-absolute-time
                      (opt-val gnc:pagename-general optname-to-date))))
          (print-invoices? #t);;(opt-val gnc:pagename-general optname-invoicelines))
-;         (show-txn-table? (opt-val gnc:pagename-display optname-show-txn-table))
+         ;;(show-txn-table? (opt-val gnc:pagename-display optname-show-txn-table))
          (show-zero-lines? (opt-val gnc:pagename-display optname-show-zero-lines))
          (show-column-expense? (opt-val gnc:pagename-display optname-show-column-expense))
          (table-num-columns (if show-column-expense? 5 4))
@@ -332,9 +331,9 @@
          (type (opt-val "__reg" "owner-type"))
          (reverse? (opt-val "__reg" "reverse?"))
          (ownerlist (gncBusinessGetOwnerList
-                        book
-                        (gncOwnerTypeToQofIdType type)
-                        (opt-val gnc:pagename-display optname-show-inactive)))
+                     book
+                     (gncOwnerTypeToQofIdType type)
+                     (opt-val gnc:pagename-display optname-show-inactive)))
          (toplevel-income-query (qof-query-create-for-splits))
          (toplevel-expense-query (qof-query-create-for-splits))
          (toplevel-total-income #f)
@@ -363,28 +362,28 @@
     ;; also use the amount as the actual grand total (both assigned
     ;; and not assigned to customers)
     (set! toplevel-total-income
-          (single-query-split-value toplevel-income-query))
+      (single-query-split-value toplevel-income-query))
     (if reverse?
         (set! toplevel-total-income (gnc-numeric-neg toplevel-total-income)))
 
     ;; Total expenses as well
     (query-toplevel-setup toplevel-expense-query expense-accounts start-date end-date)
     (set! toplevel-total-expense
-          (single-query-split-value toplevel-expense-query))
+      (single-query-split-value toplevel-expense-query))
     (if reverse?
         (set! toplevel-total-expense (gnc-numeric-neg toplevel-total-expense)))
 
     ;; Continue if we have non-null accounts
     (if (null? income-accounts)
-        
+
         ;; error condition: no accounts specified
         ;; is this *really* necessary??  i'd be fine with an all-zero
         ;; account summary that would, technically, be correct....
-        (gnc:html-document-add-object! 
+        (gnc:html-document-add-object!
          document
-         (gnc:html-make-no-account-warning 
+         (gnc:html-make-no-account-warning
           report-title (gnc:report-id report-obj)))
-        
+
         ;; otherwise, generate the report...
 
         (let ((resulttable
@@ -424,20 +423,11 @@
 
                      ;; We print the summary now
                      (let* ((profit (gnc-numeric-add-fixed total-income total-expense))
-                            (markupfloat (markup-percent profit total-income))
-                            )
+                            (markupfloat (markup-percent profit total-income)))
 
                        ;; Result of this customer
-                       (list owner profit markupfloat total-income total-expense)
-
-                       )
-
-                     ) ;; END let
-                   ) ;; END if owner-is-valid
-                  )
-                ownerlist) ;; END for-each all owners
-
-               ))
+                       (list owner profit markupfloat total-income total-expense)))))
+                ownerlist)))
 
           ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -457,9 +447,11 @@
                 (total-sales (gnc-numeric-zero))
                 (total-expense (gnc-numeric-zero))
                 (heading-list
-                 (list (_ "Customer") (_ "Profit")
-                  ;; Translators: "Markup" is profit amount divided by sales amount
-                  (_ "Markup") (_ "Sales"))))
+                 (list (_ "Customer")
+                       (_ "Profit")
+                       ;; Translators: "Markup" is profit amount divided by sales amount
+                       (_ "Markup")
+                       (_ "Sales"))))
 
             ;; helper for sorting an owner list
             (define (owner-name<? a b)
@@ -468,72 +460,65 @@
             ;; Heading line
             (if show-column-expense?
                 (set! heading-list (append heading-list (list (_ "Expense")))))
-            (gnc:html-table-set-col-headers!
-             table heading-list)
+            (gnc:html-table-set-col-headers! table heading-list)
 
             ;; Sorting: First sort everything alphabetically
             ;; (ascending) so that we have one stable sorting order
             (set! resulttable
-                  (sort resulttable (lambda (a b) (owner-name<? (car a) (car b)))))
+              (sort resulttable
+                    (lambda (a b)
+                      (owner-name<? (car a) (car b)))))
 
             ;; Secondly sort by the actual sort key
             (let ((cmp (if sort-descending? > <))
                   (strcmp (if sort-descending? string>? string<?)))
-              (set!
-               resulttable
-               (sort resulttable
-                     (cond
-                      ((eq? sort-key 'customername)
-                       (lambda (a b)
-                         (strcmp (gncOwnerGetName (car a)) (gncOwnerGetName (car b)))))
-                      ((eq? sort-key 'profit)
-                       (lambda (a b)
-                         (cmp (gnc-numeric-compare (cadr a) (cadr b)) 0)))
-                      ((eq? sort-key 'markup)
-                       (lambda (a b)
-                         (cmp (list-ref a 2) (list-ref b 2))))
-                      ((eq? sort-key 'sales)
-                       (lambda (a b)
-                         (cmp (gnc-numeric-compare (list-ref a 3) (list-ref b 3)) 0)))
-                      ((eq? sort-key 'expense)
-                       (lambda (a b)
-                         (cmp (gnc-numeric-compare (list-ref a 4) (list-ref b 4)) 0)))
-                      ) ;; END cond
-                     ) ;; END sort
-               )) ;; END let
+              (set! resulttable
+                (sort resulttable
+                      (cond
+                       ((eq? sort-key 'customername)
+                        (lambda (a b)
+                          (strcmp (gncOwnerGetName (car a)) (gncOwnerGetName (car b)))))
+                       ((eq? sort-key 'profit)
+                        (lambda (a b)
+                          (cmp (gnc-numeric-compare (cadr a) (cadr b)) 0)))
+                       ((eq? sort-key 'markup)
+                        (lambda (a b)
+                          (cmp (list-ref a 2) (list-ref b 2))))
+                       ((eq? sort-key 'sales)
+                        (lambda (a b)
+                          (cmp (gnc-numeric-compare (list-ref a 3) (list-ref b 3)) 0)))
+                       ((eq? sort-key 'expense)
+                        (lambda (a b)
+                          (cmp (gnc-numeric-compare (list-ref a 4) (list-ref b 4)) 0)))))))
 
             ;; The actual content
             (for-each
              (lambda (row)
-               (if
-                (eq? (length row) 5)
-                (let ((owner (list-ref row 0))
-                      (profit (list-ref row 1))
-                      (markupfloat (list-ref row 2))
-                      (sales (list-ref row 3))
-                      (expense (list-ref row 4)))
-                  (set! total-profit (gnc-numeric-add-fixed total-profit profit))
-                  (set! total-sales (gnc-numeric-add-fixed total-sales sales))
-                  (set! total-expense (gnc-numeric-add-fixed total-expense expense))
-                  (if (or show-zero-lines?
-                          (not (and (gnc-numeric-zero-p profit) (gnc-numeric-zero-p sales))))
-                      (let ((row-content
-                             (list
-                              (gncOwnerGetName owner)
-                              (gnc:make-gnc-monetary currency profit)
-                              ;;(format #f (if (< (abs markupfloat) 10) "~2.1f%%" "%2.0f%%") markupfloat)
-                              (format #f  "~2,0f%" markupfloat)
-                              (gnc:make-gnc-monetary currency sales))))
-                        (if show-column-expense?
-                            (set!
-                             row-content
-                             (append row-content
-                                     (list
-                                      (gnc:make-gnc-monetary currency (gnc-numeric-neg expense))))))
-                        (gnc:html-table-append-row!
-                         table row-content)))
-                  )
-                (gnc:warn "Oops, encountered a row with wrong length=" (length row))))
+               (if (eq? (length row) 5)
+                   (let ((owner (list-ref row 0))
+                         (profit (list-ref row 1))
+                         (markupfloat (list-ref row 2))
+                         (sales (list-ref row 3))
+                         (expense (list-ref row 4)))
+                     (set! total-profit (gnc-numeric-add-fixed total-profit profit))
+                     (set! total-sales (gnc-numeric-add-fixed total-sales sales))
+                     (set! total-expense (gnc-numeric-add-fixed total-expense expense))
+                     (if (or show-zero-lines?
+                             (not (and (gnc-numeric-zero-p profit) (gnc-numeric-zero-p sales))))
+                         (let ((row-content (list
+                                             (gncOwnerGetName owner)
+                                             (gnc:make-gnc-monetary currency profit)
+                                             ;;(format #f (if (< (abs markupfloat) 10) "~2.1f%%" "%2.0f%%") markupfloat)
+                                             (format #f  "~2,0f%" markupfloat)
+                                             (gnc:make-gnc-monetary currency sales))))
+                           (if show-column-expense?
+                               (set! row-content
+                                 (append row-content
+                                         (list
+                                          (gnc:make-gnc-monetary currency (gnc-numeric-neg expense))))))
+                           (gnc:html-table-append-row!
+                            table row-content))))
+                   (gnc:warn "Oops, encountered a row with wrong length=" (length row))))
              resulttable) ;; END for-each row
 
             ;; The "No Customer" line
@@ -548,11 +533,10 @@
                      (format #f  "~2,0f%" markupfloat)
                      (gnc:make-gnc-monetary currency other-sales))))
               (if show-column-expense?
-                  (set!
-                   row-content
-                   (append row-content
-                           (list
-                            (gnc:make-gnc-monetary currency (gnc-numeric-neg other-expense))))))
+                  (set! row-content
+                    (append row-content
+                            (list
+                             (gnc:make-gnc-monetary currency (gnc-numeric-neg other-expense))))))
               (if (or show-zero-lines?
                       (not (and (gnc-numeric-zero-p other-profit) (gnc-numeric-zero-p other-sales))))
 
@@ -576,18 +560,15 @@
                     (list
                      (_ "Total")
                      (gnc:make-gnc-monetary currency total-profit)
-                     ;;(format #f (if (< (abs markupfloat) 10) "~2,1f%" "~2,0f%") markupfloat)
                      (format #f  "~2,0f%" markupfloat)
                      (gnc:make-gnc-monetary currency toplevel-total-income))))
               (if show-column-expense?
-                  (set!
-                   row-content
-                   (append row-content
-                           (list
-                            (gnc:make-gnc-monetary currency (gnc-numeric-neg toplevel-total-expense))))))
+                  (set! row-content
+                    (append row-content
+                            (list
+                             (gnc:make-gnc-monetary currency (gnc-numeric-neg toplevel-total-expense))))))
               (gnc:html-table-append-row!
-               table
-               row-content))
+               table row-content))
 
             ;; Set the formatting styles
             (gnc:html-table-set-style!
@@ -607,31 +588,21 @@
 
             ;; And add the table to the document
             (gnc:html-document-add-object!
-             document table)
-            )
-
-          ) ;; END let resulttable
-
-        ) ;; END if null? income-accounts
+             document table))))
 
     (if any-valid-owner?
         ;; Report contains valid data
-        (let ((headline 
-               (format
-                #f (_ "~a ~a - ~a")
-                report-title
-                (qof-print-date start-date)
-                (qof-print-date end-date))))
-          (gnc:html-document-set-title!
-           document headline)
+        (let ((headline (format #f (_ "~a ~a - ~a")
+                                report-title
+                                (qof-print-date start-date)
+                                (qof-print-date end-date))))
+          (gnc:html-document-set-title! document headline)
 
           ;; Check the settings for taking invoice/payment lines into
           ;; account and print the ch
           (make-break! document)
           (gnc:html-document-add-object!
-           document
-           (gnc:make-html-text notification-str))
-          )
+           document (gnc:make-html-text notification-str)))
 
         ;; else....
         (gnc:html-document-add-object!

--- a/gnucash/report/business-reports/owner-report.scm
+++ b/gnucash/report/business-reports/owner-report.scm
@@ -242,7 +242,7 @@
        (let* ((bal (gnc-lot-get-balance lot))
           (invoice (gncInvoiceGetInvoiceFromLot lot))
               (date (if (eq? date-type 'postdate)
-               (gncInvoiceGetDatePostedTT invoice) 
+               (gncInvoiceGetDatePosted invoice)
                (gncInvoiceGetDateDue invoice)))
               )
          

--- a/gnucash/report/report-system/html-table.scm
+++ b/gnucash/report/report-system/html-table.scm
@@ -569,11 +569,13 @@
           (cons 
            (cons (cons current-new current-existing) (car rest-result))
            (cdr rest-result)))))
+  (issue-deprecation-warning "gnc:html-table-prepend-column! is unused.")
   (let* ((existing-data (reverse (gnc:html-table-data table)))
 	 (existing-length (length existing-data))
 	 (newcol-length (length newcol)))
     (if (<= newcol-length existing-length)
-        (gnc:html-table-set-data! 
+        (gnc:html-table-set-data!
+         table
          (reverse (car (prepend-to-element 
                         newcol
                         existing-data

--- a/gnucash/report/report-system/report-utilities.scm
+++ b/gnucash/report/report-system/report-utilities.scm
@@ -264,6 +264,8 @@ construct gnc:make-gnc-monetary and use gnc:monetary->string instead.")
 ;;
 ;; New Example: But now USD is a <gnc:commodity*> and 123.4 a
 ;; <gnc:numeric>, so there is no simple example anymore.
+;
+;; Note amounts are rounded to the commodity's SCU.
 ;;
 ;; The functions:
 ;;   'add <commodity> <amount>: Add the given amount to the 
@@ -283,36 +285,33 @@ construct gnc:make-gnc-monetary and use gnc:monetary->string instead.")
 ;;       (even the fact that any commodity showed up at all).
 ;;   'getpair <commodity> signreverse?: Returns the two-element-list
 ;;       with the <commodity> and its corresponding balance. If
-;;       <commodity> doesn't exist, the balance will be
-;;       (gnc-numeric-zero). If signreverse? is true, the result's
-;;       sign will be reversed.
-;;   (internal) 'list #f #f: get the association list of 
-;;       commodity->numeric-collector
+;;       <commodity> doesn't exist, the balance will be 0. If
+;;       signreverse? is true, the result's sign will be reversed.
+;;   'getmonetary <commodity> signreverse?: Returns a gnc-monetary
+;;       of the <commodity> and its corresponding balance. If
+;;       <commodity> doesn't exist, the balance will be 0. If
+;;       signreverse? is true, the result's sign will be reversed.
+;;   (internal) 'list #f #f: get the list of
+;;       (cons commodity numeric-collector)
 
 (define (gnc:make-commodity-collector)
-  (let 
-      ;; the association list of (commodity -> value-collector) pairs.
-      ((commoditylist '()))
+  ;; the association list of (commodity . value-collector) pairs.
+  (let ((commoditylist '()))
     
-    ;; helper function to add a commodity->value pair to our list. 
+    ;; helper function to add a (commodity . value) pair to our list.
     ;; If no pair with this commodity exists, we will create one.
     (define (add-commodity-value commodity value)
-      ;; lookup the corresponding pair
       (let ((pair (assoc commodity commoditylist))
             (rvalue (gnc-numeric-convert
                      value
                      (gnc-commodity-get-fraction commodity) GNC-RND-ROUND)))
-	(if (not pair)
-	    (begin
-	      ;; create a new pair, using the gnc:value-collector
-	      (set! pair (list commodity (gnc:make-value-collector)))
-	      ;; and add it to the alist
-	      (set! commoditylist (cons pair commoditylist))))
-	;; add the value
+	(unless pair
+	  (set! pair (list commodity (gnc:make-value-collector)))
+	  (set! commoditylist (cons pair commoditylist)))
 	((cadr pair) 'add rvalue)))
     
     ;; helper function to walk an association list, adding each
-    ;; (commodity -> collector) pair to our list at the appropriate 
+    ;; (commodity . collector) pair to our list at the appropriate
     ;; place
     (define (add-commodity-clist clist)
       (cond ((null? clist) '())
@@ -331,25 +330,24 @@ construct gnc:make-gnc-monetary and use gnc:monetary->string instead.")
     ;; helper function walk the association list doing a callback on
     ;; each key-value pair.
     (define (process-commodity-list fn clist)
-      (map 
-       (lambda (pair) (fn (car pair) 
-			  ((cadr pair) 'total #f)))
+      (map
+       (lambda (pair)
+         (fn (car pair) ((cadr pair) 'total #f)))
        clist))
 
-    ;; helper function which is given a commodity and returns, if
-    ;; existing, a list (gnc:commodity gnc:numeric).
+    ;; helper function which is given a commodity and returns a list
+    ;; (list gnc:commodity number).
     (define (getpair c sign?)
       (let* ((pair (assoc c commoditylist))
-             (total (and pair ((cadr pair) 'total #f))))
-	(list c (if pair (if sign? (- total) total) 0))))
+             (total (if pair ((cadr pair) 'total #f) 0)))
+	(list c (if sign? (- total) total))))
 
-    ;; helper function which is given a commodity and returns, if
-    ;; existing, a <gnc:monetary> value.
+    ;; helper function which is given a commodity and returns a
+    ;; <gnc:monetary> value, whose amount may be 0.
     (define (getmonetary c sign?)
       (let* ((pair (assoc c commoditylist))
-             (total (and pair ((cadr pair) 'total #f))))
-	(gnc:make-gnc-monetary
-         c (if pair (if sign? (- total) total) 0))))
+             (total (if pair ((cadr pair) 'total #f) 0)))
+	(gnc:make-gnc-monetary c (if sign? (- total) total))))
     
     ;; Dispatch function
     (lambda (action commodity amount)
@@ -380,9 +378,7 @@ construct gnc:make-gnc-monetary and use gnc:monetary->string instead.")
 
 ;; Returns zero if all entries in this collector are zero.
 (define (gnc-commodity-collector-allzero? collector)
-  (every zero?
-         (map gnc:gnc-monetary-amount
-              (collector 'format gnc:make-gnc-monetary #f))))
+  (every zero? (map cdr (collector 'format cons #f))))
 
 ;; add any number of gnc-monetary objects into a commodity-collector
 ;; usage: (gnc:monetaries-add monetary1 monetary2 ...)


### PR DESCRIPTION
This line of work starts from fixing customer-summary.scm -- has issues, too numerous to mention
* counts all monetary amounts irrespective of currency
* can't handle multiple customer currencies
* formatting
* now has URL to owner-report.
* hidden useless options removed -- this report hardwired for customers; not much benefit creating parallel reports for vendors/employees/jobs. (saved-report trying to set a removed option does not cause a crash).

owner-report.scm also slightly upgraded
* running Report > Account Report (single transaction) will now run owner-report and find the appropriate APAR account according to owner's currency.
* other small srfi-1 refactoring
* timepair->t64 fix too

I'll leave this here a small while, I do not think these changes are uncontroversial, nor unsafe.