### PR TITLE
Bug797275

### DIFF
--- a/gnucash/gtkbuilder/dialog-import.glade
+++ b/gnucash/gtkbuilder/dialog-import.glade
@@ -740,6 +740,9 @@
       <action-widget response="-5">ok_button1</action-widget>
     </action-widgets>
   </object>
+  <object class="GtkTextBuffer" id="textbuffer1">
+    <property name="text" translatable="yes">Multiple transaction rows may be selected and a transfer account assigned to all selected rows. Use Ctrl Left Click or Shift-Click to select multiple rows and then Right Click to select a transfer account. Only rows with "A" checked can be added to a selection.</property>
+  </object>
   <object class="GtkTextBuffer" id="textbuffer2">
     <property name="text" translatable="yes">This transaction probably requires your intervention or it will be imported unbalanced.</property>
   </object>
@@ -1096,6 +1099,35 @@
               </packing>
             </child>
             <child>
+              <object class="GtkScrolledWindow" id="scrolledwindow 36">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="hscrollbar_policy">never</property>
+                <property name="vscrollbar_policy">never</property>
+                <property name="shadow_type">in</property>
+                <child>
+                  <object class="GtkTextView" id="textview6">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="pixels_above_lines">5</property>
+                    <property name="pixels_below_lines">5</property>
+                    <property name="editable">False</property>
+                    <property name="wrap_mode">word</property>
+                    <property name="left_margin">5</property>
+                    <property name="right_margin">5</property>
+                    <property name="cursor_visible">False</property>
+                    <property name="buffer">textbuffer1</property>
+                    <property name="accepts_tab">False</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">11</property>
+                <property name="width">2</property>
+              </packing>
+            </child>
+            <child>
               <placeholder/>
             </child>
             <child>
@@ -1257,9 +1289,9 @@
       </object>
     </child>
     <action-widgets>
-      <action-widget response="-11">matcher__help</action-widget>
       <action-widget response="-6">matcher_cancel</action-widget>
       <action-widget response="-5">matcher_ok</action-widget>
+      <action-widget response="-11">matcher__help</action-widget>
     </action-widgets>
   </object>
 </interface>

--- a/gnucash/import-export/import-main-matcher.c
+++ b/gnucash/import-export/import-main-matcher.c
@@ -54,6 +54,7 @@
 
 #define GNC_PREFS_GROUP "dialogs.import.generic.transaction-list"
 
+
 struct _main_matcher_info
 {
     GtkWidget *main_widget;
@@ -65,6 +66,7 @@ struct _main_matcher_info
     gpointer user_data;
     GNCImportPendingMatches *pending_matches;
     GtkTreeViewColumn *account_column;
+    gboolean add_toggled;   // flag to indicate that add has been toggled to stop selection
 };
 
 enum downloaded_cols
@@ -90,7 +92,10 @@ enum downloaded_cols
 #define CSS_INT_PROB_REQUIRED_CLASS "intervention-probably-required"
 #define CSS_INT_NOT_REQUIRED_CLASS  "intervention-not-required"
 
-static QofLogModule log_module = GNC_MOD_IMPORT;
+/* Define log domain for extended debugging of matcher */
+#define G_MOD_IMPORT_MATCHER "gnc.import.main-matcher"
+/*static QofLogModule log_module = GNC_MOD_IMPORT;*/
+static QofLogModule log_module = G_MOD_IMPORT_MATCHER;
 
 void on_matcher_ok_clicked (GtkButton *button, GNCImportMainMatcher *info);
 void on_matcher_cancel_clicked (GtkButton *button, gpointer user_data);
@@ -117,6 +122,11 @@ static gboolean gnc_gen_trans_onButtonPressed_cb (GtkTreeView *treeview,
 static gboolean gnc_gen_trans_onPopupMenu_cb (GtkTreeView *treeview,
                                               GdkEvent *event,
                                               GNCImportMainMatcher *info);
+static gboolean view_selection_function (GtkTreeSelection *selection,
+                         GtkTreeModel *model,
+                         GtkTreePath *path,
+                         gboolean path_currently_selected,
+                         gpointer data);
 static void refresh_model_row (GNCImportMainMatcher *gui, GtkTreeModel *model,
                                GtkTreeIter *iter, GNCImportTransInfo *info);
 /* end local prototypes */
@@ -306,6 +316,7 @@ gnc_gen_trans_add_toggled_cb (GtkCellRendererToggle *cell_renderer,
     GtkTreeIter iter;
     GNCImportTransInfo *trans_info;
 
+    ENTER("");
     model = gtk_tree_view_get_model (gui->view);
     if (!gtk_tree_model_get_iter_from_string (model, &iter, path))
         return;
@@ -319,8 +330,10 @@ gnc_gen_trans_add_toggled_cb (GtkCellRendererToggle *cell_renderer,
     else
     {
         gnc_import_TransInfo_set_action (trans_info, GNCImport_ADD);
+        gui->add_toggled =TRUE;  //flag A(dd) has just been toggled to view_selection_function
     }
     refresh_model_row (gui, model, &iter, trans_info);
+    LEAVE("");
 }
 
 static void
@@ -331,8 +344,10 @@ gnc_gen_trans_clear_toggled_cb (GtkCellRendererToggle *cell_renderer,
     GtkTreeModel *model;
     GtkTreeIter iter;
     GNCImportTransInfo *trans_info;
-
+    
+    ENTER("");
     model = gtk_tree_view_get_model (gui->view);
+    
     if (!gtk_tree_model_get_iter_from_string (model, &iter, path))
         return;
     gtk_tree_model_get (model, &iter, DOWNLOADED_COL_DATA, &trans_info, -1);
@@ -347,6 +362,7 @@ gnc_gen_trans_clear_toggled_cb (GtkCellRendererToggle *cell_renderer,
         gnc_import_TransInfo_set_action (trans_info, GNCImport_CLEAR);
     }
     refresh_model_row (gui, model, &iter, trans_info);
+    LEAVE("");
 }
 
 static void
@@ -357,8 +373,10 @@ gnc_gen_trans_update_toggled_cb (GtkCellRendererToggle *cell_renderer,
     GtkTreeModel *model;
     GtkTreeIter iter;
     GNCImportTransInfo *trans_info;
-
+    
+    ENTER("");
     model = gtk_tree_view_get_model (gui->view);
+    
     if (!gtk_tree_model_get_iter_from_string (model, &iter, path))
         return;
     gtk_tree_model_get (model, &iter, DOWNLOADED_COL_DATA, &trans_info, -1);
@@ -373,6 +391,7 @@ gnc_gen_trans_update_toggled_cb (GtkCellRendererToggle *cell_renderer,
         gnc_import_TransInfo_set_action (trans_info, GNCImport_UPDATE);
     }
     refresh_model_row (gui, model, &iter, trans_info);
+    LEAVE("");
 }
 
 static void
@@ -457,7 +476,7 @@ gnc_gen_trans_assign_transfer_account_to_selection_cb (GtkMenuItem *menuitem,
     GList *selected_rows, *l;
     gboolean first, is_selection;
 
-    ENTER("");
+    ENTER("assign_transfer_account_to_selection_cb");
     treeview = GTK_TREE_VIEW(info->view);
     model = gtk_tree_view_get_model (treeview);
     selection = gtk_tree_view_get_selection (treeview);
@@ -481,7 +500,7 @@ gnc_gen_trans_assign_transfer_account_to_selection_cb (GtkMenuItem *menuitem,
             DEBUG("passing account value = %s",
                         gnc_account_get_full_name (assigned_account));
             gnc_gen_trans_assign_transfer_account (treeview,
-                           &first, is_selection, l->data, &assigned_account, info);
+                &first, is_selection, l->data, &assigned_account, info);
             DEBUG("returned value of account = %s",
                         gnc_account_get_full_name (assigned_account));
             DEBUG("returned value of first = %s", first ? "true" : "false");
@@ -614,14 +633,16 @@ gnc_gen_trans_onPopupMenu_cb (GtkTreeView *treeview,
                               GNCImportMainMatcher *info)
 {
     GtkTreeSelection *selection;
-    ENTER("");
+    ENTER("onPopupMenu_cb");
     /* respond to Shift-F10 popup menu hotkey */
     selection = gtk_tree_view_get_selection (treeview);
     if (gtk_tree_selection_count_selected_rows (selection) > 0)
     {
       gnc_gen_trans_view_popup_menu (treeview, NULL, info);
+      LEAVE ("TRUE");
+      return TRUE;
     }
-    LEAVE ("");
+    LEAVE ("FALSE");
     return TRUE;
 }
 
@@ -750,8 +771,21 @@ gnc_gen_trans_init_view (GNCImportMainMatcher *info,
     gtk_tree_sortable_set_sort_column_id (GTK_TREE_SORTABLE(store),
                                           DOWNLOADED_COL_DATE_INT64,
                                           GTK_SORT_ASCENDING);
-
     selection = gtk_tree_view_get_selection (info->view);
+    
+    /* set a selection function which will block selection of rows which are not 
+      flagged to be imported into Gnucash */
+    gtk_tree_selection_set_select_function
+                               (selection,
+                                view_selection_function,
+                                info,
+                                NULL);
+    /* clear the flag which indicates that A(dd) has been toggled so that the 
+      view_selection_function can block selection of a row when the 
+      view_selection_function is called immediately after A(dd) is toggled 
+      on that row */
+    info->add_toggled = FALSE;
+                                
     g_signal_connect (info->view, "row-activated",
                       G_CALLBACK(gnc_gen_trans_row_activated_cb), info);
     g_signal_connect (selection, "changed",
@@ -761,6 +795,73 @@ gnc_gen_trans_init_view (GNCImportMainMatcher *info,
                       G_CALLBACK(gnc_gen_trans_onButtonPressed_cb), info);
     g_signal_connect (view, "popup-menu",
                       G_CALLBACK(gnc_gen_trans_onPopupMenu_cb), info);
+}
+
+static gboolean
+view_selection_function (GtkTreeSelection *selection,
+                         GtkTreeModel *model,
+                         GtkTreePath *path,
+                         gboolean path_currently_selected,
+                         gpointer data)
+{
+    GtkTreeIter iter;
+    GNCImportTransInfo *trans_info;
+    GNCImportAction action;
+    GNCImportMainMatcher *info = data;
+  
+    ENTER("view_selection_function");
+    if (gtk_tree_model_get_iter(model, &iter, path))
+    {
+        gtk_tree_model_get (model, &iter, DOWNLOADED_COL_DATA, &trans_info, -1);
+        switch (gnc_import_TransInfo_get_action (trans_info))
+        {
+            case GNCImport_ADD:
+                DEBUG("Import action = ADD row selected");
+                if (info->add_toggled)
+                {
+                  DEBUG("Add just toggled- do not select the row.");
+                  info->add_toggled = FALSE;
+                  LEAVE("FALSE");
+                  return FALSE;
+                }
+                else
+                {
+                  DEBUG("Add has not been toggled - select the row");
+                  LEAVE("TRUE");
+                  return TRUE;
+                }
+            case GNCImport_UPDATE:
+                DEBUG("Import action = UPDATE row not selected");
+                LEAVE("FALSE");
+                return FALSE;
+            case GNCImport_CLEAR:
+                DEBUG("Import action = CLEAR row not selected");
+                LEAVE("FALSE");
+                return FALSE;
+            case GNCImport_SKIP:
+                DEBUG("Import action = SKIP row not selected");
+                LEAVE("FALSE");
+                return FALSE;
+            case GNCImport_LAST_ACTION:
+                DEBUG("Import action = LAST_ACTION row not selected");
+                LEAVE("FALSE");
+                return FALSE;
+            case GNCImport_INVALID_ACTION: 
+                DEBUG("Import action = LAST_ACTION row not selected"); 
+                LEAVE("FALSE");
+                return FALSE;    
+            default:
+                DEBUG("Import action = UNDEFINED -cannot select");
+                LEAVE("FALSE");
+                return FALSE;
+        }    
+    }
+    else
+    {
+        DEBUG("path to selected row undefined");
+        LEAVE("FALSE");
+        return FALSE;
+    } 
 }
 
 static void

--- a/gnucash/import-export/import-main-matcher.c
+++ b/gnucash/import-export/import-main-matcher.c
@@ -104,31 +104,32 @@ void on_matcher_help_close_clicked (GtkButton *button, gpointer user_data);
 
 /* Local prototypes */
 static void gnc_gen_trans_assign_transfer_account (
-                                                GtkTreeView *treeview,
-                                                gboolean *first,
-                                                gboolean is_selection,
-                                                GtkTreePath *path,
-                                                Account **new_acc,
-                                                GNCImportMainMatcher *info);
+                    GtkTreeView *treeview,
+                    gboolean *first,
+                    gboolean is_selection,
+                    GtkTreePath *path,
+                    Account **new_acc,
+                    GNCImportMainMatcher *info);
 static void gnc_gen_trans_assign_transfer_account_to_selection_cb (
-                                          GtkMenuItem *menuitem,
-                                          GNCImportMainMatcher *info);
-static void gnc_gen_trans_view_popup_menu (GtkTreeView *treeview,
-                                          GdkEvent *event,
-                                          GNCImportMainMatcher *info);
-static gboolean gnc_gen_trans_onButtonPressed_cb (GtkTreeView *treeview,
-                                                  GdkEvent *event,
-                                                  GNCImportMainMatcher *info);
-static gboolean gnc_gen_trans_onPopupMenu_cb (GtkTreeView *treeview,
-                                              GdkEvent *event,
-                                              GNCImportMainMatcher *info);
-static gboolean view_selection_function (GtkTreeSelection *selection,
-                         GtkTreeModel *model,
-                         GtkTreePath *path,
-                         gboolean path_currently_selected,
-                         gpointer data);
-static void refresh_model_row (GNCImportMainMatcher *gui, GtkTreeModel *model,
-                               GtkTreeIter *iter, GNCImportTransInfo *info);
+                    GtkMenuItem *menuitem,
+                    GNCImportMainMatcher *info);
+static void gnc_gen_trans_view_popup_menu (
+                    GtkTreeView *treeview,
+                    GdkEvent *event,
+                    GNCImportMainMatcher *info);
+static gboolean gnc_gen_trans_onButtonPressed_cb (
+                    GtkTreeView *treeview,
+                    GdkEvent *event,
+                    GNCImportMainMatcher *info);
+static gboolean gnc_gen_trans_onPopupMenu_cb (
+                    GtkTreeView *treeview,
+                    GdkEvent *event,
+                    GNCImportMainMatcher *info);
+static void refresh_model_row (
+                    GNCImportMainMatcher *gui,
+                    GtkTreeModel *model,
+                    GtkTreeIter *iter,
+                    GNCImportTransInfo *info);
 /* end local prototypes */
 
 void gnc_gen_trans_list_delete (GNCImportMainMatcher *info)
@@ -243,6 +244,7 @@ on_matcher_help_clicked (GtkButton *button, gpointer user_data)
     gnc_builder_add_from_file (builder, "dialog-import.glade", "textbuffer3");
     gnc_builder_add_from_file (builder, "dialog-import.glade", "textbuffer4");
     gnc_builder_add_from_file (builder, "dialog-import.glade", "textbuffer5");
+    gnc_builder_add_from_file (builder, "dialog-import.glade", "textbuffer1");
     gnc_builder_add_from_file (builder, "dialog-import.glade", "matcher_help_dialog");
 
     if (info->dark_theme == TRUE)
@@ -287,14 +289,15 @@ run_account_picker_dialog (GNCImportMainMatcher *info,
     g_assert (trans_info);
     old_acc = gnc_import_TransInfo_get_destacc (trans_info);
 
-    new_acc = gnc_import_select_account (info->main_widget,
-                                         NULL,
-                                         TRUE,
-                                         _("Destination account for the auto-balance split."),
-                                         xaccTransGetCurrency (gnc_import_TransInfo_get_trans (trans_info)),
-                                         ACCT_TYPE_NONE,
-                                         old_acc,
-                                         &ok_pressed);
+    new_acc = gnc_import_select_account (
+            info->main_widget,
+             NULL,
+             TRUE,
+             _("Destination account for the auto-balance split."),
+             xaccTransGetCurrency (gnc_import_TransInfo_get_trans (trans_info)),
+             ACCT_TYPE_NONE,
+             old_acc,
+             &ok_pressed);
     if (ok_pressed)
         gnc_import_TransInfo_set_destacc (trans_info, new_acc, TRUE);
 }
@@ -464,8 +467,9 @@ gnc_gen_trans_assign_transfer_account (GtkTreeView *treeview,
 }
 
 static void
-gnc_gen_trans_assign_transfer_account_to_selection_cb (GtkMenuItem *menuitem,
-                                                       GNCImportMainMatcher *info)
+gnc_gen_trans_assign_transfer_account_to_selection_cb (
+            GtkMenuItem *menuitem,
+            GNCImportMainMatcher *info)
 {
     GtkTreeView *treeview;
     GtkTreeSelection *selection;
@@ -494,13 +498,15 @@ gnc_gen_trans_assign_transfer_account_to_selection_cb (GtkMenuItem *menuitem,
         {
             gchar *path_str = gtk_tree_path_to_string (l->data);
             DEBUG("passing first = %s", first ? "true" : "false");
-            DEBUG("passing is_selection = %s", is_selection ? "true" : "false");
+            DEBUG("passing is_selection = %s",
+                        is_selection ? "true" : "false");
             DEBUG("passing path = %s", path_str);
             g_free (path_str);
             DEBUG("passing account value = %s",
                         gnc_account_get_full_name (assigned_account));
             gnc_gen_trans_assign_transfer_account (treeview,
-                &first, is_selection, l->data, &assigned_account, info);
+                        &first, is_selection, l->data,
+                        &assigned_account, info);
             DEBUG("returned value of account = %s",
                         gnc_account_get_full_name (assigned_account));
             DEBUG("returned value of first = %s", first ? "true" : "false");
@@ -575,7 +581,8 @@ gnc_gen_trans_view_popup_menu (GtkTreeView *treeview,
 
     ENTER ("");
     menu = gtk_menu_new();
-    menuitem = gtk_menu_item_new_with_label (_("Assign a transfer account."));
+    menuitem = gtk_menu_item_new_with_label (
+            _("Assign a transfer account to the selection."));
     g_signal_connect (menuitem, "activate",
                       G_CALLBACK(
                       gnc_gen_trans_assign_transfer_account_to_selection_cb),
@@ -617,7 +624,7 @@ gnc_gen_trans_onButtonPressed_cb (GtkTreeView *treeview,
             selection = gtk_tree_view_get_selection (treeview);
             if (gtk_tree_selection_count_selected_rows (selection) > 0)
             {
-              gnc_gen_trans_view_popup_menu (treeview, event, info);
+                gnc_gen_trans_view_popup_menu (treeview, event, info);
             }
             LEAVE("return TRUE");
             return TRUE;
@@ -645,7 +652,6 @@ gnc_gen_trans_onPopupMenu_cb (GtkTreeView *treeview,
     LEAVE ("FALSE");
     return TRUE;
 }
-
 
 static GtkTreeViewColumn *
 add_text_column(GtkTreeView *view, const gchar *title, int col_num)

--- a/gnucash/import-export/import-main-matcher.c
+++ b/gnucash/import-export/import-main-matcher.c
@@ -130,6 +130,11 @@ static void refresh_model_row (
                     GtkTreeModel *model,
                     GtkTreeIter *iter,
                     GNCImportTransInfo *info);
+static gboolean view_selection_function (GtkTreeSelection *selection,
+                         GtkTreeModel *model,
+                         GtkTreePath *path,
+                         gboolean path_currently_selected,
+                         gpointer data);
 /* end local prototypes */
 
 void gnc_gen_trans_list_delete (GNCImportMainMatcher *info)
@@ -347,10 +352,10 @@ gnc_gen_trans_clear_toggled_cb (GtkCellRendererToggle *cell_renderer,
     GtkTreeModel *model;
     GtkTreeIter iter;
     GNCImportTransInfo *trans_info;
-    
+
     ENTER("");
     model = gtk_tree_view_get_model (gui->view);
-    
+
     if (!gtk_tree_model_get_iter_from_string (model, &iter, path))
         return;
     gtk_tree_model_get (model, &iter, DOWNLOADED_COL_DATA, &trans_info, -1);
@@ -376,10 +381,10 @@ gnc_gen_trans_update_toggled_cb (GtkCellRendererToggle *cell_renderer,
     GtkTreeModel *model;
     GtkTreeIter iter;
     GNCImportTransInfo *trans_info;
-    
+
     ENTER("");
     model = gtk_tree_view_get_model (gui->view);
-    
+
     if (!gtk_tree_model_get_iter_from_string (model, &iter, path))
         return;
     gtk_tree_model_get (model, &iter, DOWNLOADED_COL_DATA, &trans_info, -1);
@@ -778,20 +783,20 @@ gnc_gen_trans_init_view (GNCImportMainMatcher *info,
                                           DOWNLOADED_COL_DATE_INT64,
                                           GTK_SORT_ASCENDING);
     selection = gtk_tree_view_get_selection (info->view);
-    
-    /* set a selection function which will block selection of rows which are not 
+
+    /* set a selection function which will block selection of rows which are not
       flagged to be imported into Gnucash */
     gtk_tree_selection_set_select_function
                                (selection,
                                 view_selection_function,
                                 info,
                                 NULL);
-    /* clear the flag which indicates that A(dd) has been toggled so that the 
-      view_selection_function can block selection of a row when the 
-      view_selection_function is called immediately after A(dd) is toggled 
+    /* clear the flag which indicates that A(dd) has been toggled so that the
+      view_selection_function can block selection of a row when the
+      view_selection_function is called immediately after A(dd) is toggled
       on that row */
     info->add_toggled = FALSE;
-                                
+
     g_signal_connect (info->view, "row-activated",
                       G_CALLBACK(gnc_gen_trans_row_activated_cb), info);
     g_signal_connect (selection, "changed",
@@ -814,7 +819,7 @@ view_selection_function (GtkTreeSelection *selection,
     GNCImportTransInfo *trans_info;
     GNCImportAction action;
     GNCImportMainMatcher *info = data;
-  
+
     ENTER("view_selection_function");
     if (gtk_tree_model_get_iter(model, &iter, path))
     {
@@ -852,22 +857,22 @@ view_selection_function (GtkTreeSelection *selection,
                 DEBUG("Import action = LAST_ACTION row not selected");
                 LEAVE("FALSE");
                 return FALSE;
-            case GNCImport_INVALID_ACTION: 
-                DEBUG("Import action = LAST_ACTION row not selected"); 
+            case GNCImport_INVALID_ACTION:
+                DEBUG("Import action = LAST_ACTION row not selected");
                 LEAVE("FALSE");
-                return FALSE;    
+                return FALSE;
             default:
                 DEBUG("Import action = UNDEFINED -cannot select");
                 LEAVE("FALSE");
                 return FALSE;
-        }    
+        }
     }
     else
     {
         DEBUG("path to selected row undefined");
         LEAVE("FALSE");
         return FALSE;
-    } 
+    }
 }
 
 static void


### PR DESCRIPTION
Fix to the multiple selection to only allow multiple selection of rows with the Add checkbox set and to correct the blocking of the running of the match_dialog by implementing a view_selection_function to enforce this action. This also corrects a problem with  toggling a row marked U+rR or R to A which left the row selected such that if it was then toggled back to U+R or R without deselecting the row which then left it in a state where it could not be unselected and blocked selecting other rows. This was occurring because the treeview selection was activated at the same time as the row was toggled adding the toggled row to the selection. This now unselects the row immediately after it is toggled to the A stateby creating a flag which is set in the add_toggled_cb and cleared in the view_selection_function after blocking selection of the row.