### PR TITLE
fix master maint merge and reports

### DIFF
--- a/gnucash/report/reports/reports.scm
+++ b/gnucash/report/reports/reports.scm
@@ -26,6 +26,7 @@
 
 (define-module (gnucash reports))
 (use-modules (srfi srfi-13))
+(use-modules (srfi srfi-8))
 (use-modules (gnucash app-utils))
 (use-modules (gnucash core-utils))
 (use-modules (gnucash report))
@@ -88,8 +89,8 @@
   (receivables-report-create-internal account title show-zeros?))
 
 (use-modules (gnucash reports standard owner-report))
-(define (gnc:owner-report-create owner account)
+(define* (gnc:owner-report-create owner account #:key currency)
   ; Figure out an account to use if nothing exists here.
   (if (null? account)
-      (set! account (find-first-account-for-owner owner)))
+      (set! account (find-first-account-for-owner owner #:currency currency)))
   (owner-report-create owner account))

--- a/gnucash/report/reports/standard/customer-summary.scm
+++ b/gnucash/report/reports/standard/customer-summary.scm
@@ -32,6 +32,7 @@
 (use-modules (gnucash gnc-module))
 (use-modules (gnucash utilities))                ; for gnc:debug
 (use-modules (gnucash gettext))
+(use-modules (gnucash reports))
 
 (gnc:module-load "gnucash/report" 0)
 

--- a/gnucash/report/reports/standard/owner-report.scm
+++ b/gnucash/report/reports/standard/owner-report.scm
@@ -32,6 +32,7 @@
 (use-modules (gnucash gnc-module))
 (use-modules (gnucash utilities))        ; for gnc:debug
 (use-modules (gnucash gettext))
+(use-modules (gnucash reports))
 
 (gnc:module-load "gnucash/report" 0)
 


### PR DESCRIPTION
a couple mishaps during recent work

@gjanssens is the intention that reports need to `(use-modules (gnucash reports))`? without this line, customer-summary and owner-report crash. i'm not sure why other reports don't need it.