### PR TITLE
[budget] upgrade to show YTD values

### DIFF
--- a/gnucash/report/standard-reports/budget.scm
+++ b/gnucash/report/standard-reports/budget.scm
@@ -48,9 +48,6 @@
 (define optname-show-subaccounts (N_ "Always show sub-accounts"))
 (define optname-accounts (N_ "Account"))
 
-(define optname-price-source (N_ "Price Source"))
-(define optname-show-rates (N_ "Show Exchange Rates"))
-(define optname-show-full-names (N_ "Show Full Account Names"))
 (define optname-select-columns (N_ "Select Columns"))
 (define optname-show-budget (N_ "Show Budget"))
 (define opthelp-show-budget (N_ "Display a column for the budget values."))
@@ -137,15 +134,6 @@
      (gnc:make-budget-option
       gnc:pagename-general optname-budget
       "a" (N_ "Budget to use.")))
-
-    (gnc:options-add-price-source!
-     options gnc:pagename-general optname-price-source "c" 'pricedb-nearest)
-
-    (gnc:register-option
-     options
-     (gnc:make-simple-boolean-option
-      gnc:pagename-general optname-show-full-names
-      "e" (N_ "Show full account names (including parent accounts).") #t))
 
     (add-option
      (gnc:make-complex-boolean-option
@@ -638,8 +626,6 @@
          (include-collapse-after? (and use-ranges?
                                        (get-option gnc:pagename-general
                                                    optname-period-collapse-after)))
-         (show-full-names? (get-option gnc:pagename-general
-                                       optname-show-full-names))
          (doc (gnc:make-html-document))
          (accounts (append accounts
                            (filter (lambda (acc) (not (member acc accounts)))

--- a/gnucash/report/standard-reports/budget.scm
+++ b/gnucash/report/standard-reports/budget.scm
@@ -137,38 +137,29 @@
 
     (add-option
      (gnc:make-complex-boolean-option
-      gnc:pagename-general
-      optname-use-budget-period-range
-      "f"
-      opthelp-use-budget-period-range
-      #f
-      #f
-      ;; Make period only option widgets
-      ;; selectable only when we are running the report for a budget period
-      ;; range.
+      gnc:pagename-general optname-use-budget-period-range
+      "f" opthelp-use-budget-period-range #f #f
       (lambda (value)
-        (let ((enabler (lambda (target-opt enabled)
-                         (set-option-enabled
-                          options gnc:pagename-general target-opt enabled))))
-          (for-each
-           (lambda (target-opt)
-             (enabler target-opt value))
-           (list optname-budget-period-start optname-budget-period-end
-                 optname-period-collapse-before optname-period-collapse-after))
-          (enabler optname-budget-period-start-exact
-                   (and value
-                        (eq? 'manual ui-start-period-type)))
-          (enabler optname-budget-period-end-exact
-                   (and value
-                        (eq? 'manual ui-end-period-type)))
-          (set! ui-use-periods value)))))
+        (for-each
+         (lambda (opt)
+           (set-option-enabled options gnc:pagename-general opt value))
+         (list optname-budget-period-start optname-budget-period-end
+               optname-period-collapse-before optname-period-collapse-after))
+
+        (set-option-enabled options gnc:pagename-general
+                            optname-budget-period-start-exact
+                            (and value (eq? 'manual ui-start-period-type)))
+
+        (set-option-enabled options gnc:pagename-general
+                            optname-budget-period-end-exact
+                            (and value (eq? 'manual ui-end-period-type)))
+
+        (set! ui-use-periods value))))
 
     (add-option
      (gnc:make-multichoice-callback-option
       gnc:pagename-general optname-budget-period-start
-      "g1.1" opthelp-budget-period-start 'current
-      period-options
-      #f
+      "g1.1" opthelp-budget-period-start 'current period-options #f
       (lambda (new-val)
         (set-option-enabled options gnc:pagename-general
                             optname-budget-period-start-exact
@@ -187,9 +178,7 @@
     (add-option
      (gnc:make-multichoice-callback-option
       gnc:pagename-general optname-budget-period-end
-      "g2.1" opthelp-budget-period-end 'next
-      period-options
-      #f
+      "g2.1" opthelp-budget-period-end 'next period-options #f
       (lambda (new-val)
         (set-option-enabled options gnc:pagename-general
                             optname-budget-period-end-exact
@@ -217,15 +206,15 @@
       "g4" opthelp-period-collapse-after #t))
 
     (gnc:options-add-account-selection!
-     options gnc:pagename-accounts
-     optname-display-depth optname-show-subaccounts
-     optname-accounts "a" 2
+     options gnc:pagename-accounts optname-display-depth
+     optname-show-subaccounts optname-accounts "a" 2
      (lambda ()
        (gnc:filter-accountlist-type
         (list ACCT-TYPE-ASSET ACCT-TYPE-LIABILITY ACCT-TYPE-INCOME
               ACCT-TYPE-EXPENSE)
         (gnc-account-get-descendants-sorted (gnc-get-current-root-account))))
      #f)
+
     (add-option
      (gnc:make-simple-boolean-option
       gnc:pagename-accounts optname-bottom-behavior

--- a/gnucash/report/standard-reports/test/test-budget.scm
+++ b/gnucash/report/standard-reports/test/test-budget.scm
@@ -165,4 +165,11 @@
         '("Bank" "$40.00" "-$20.00" "$60.00" "." "$67.00" "-$67.00"
           "$60.00" "$77.00" "-$17.00" "$100.00" "$124.00" "-$24.00")
         (sxml->table-row-col sxml 1 5 #f)))
+
+    (set-option options "General" "Use envelope budgeting" #t)
+    (let ((sxml (options->sxml options "envelope budgeting")))
+      (test-equal "envelope budgeting"
+        '("Bank" "$60.00" "$15.00" "$45.00" "$60.00" "$82.00" "-$22.00"
+          "$120.00" "$159.00" "-$39.00" "$120.00" "$159.00" "-$39.00")
+        (sxml->table-row-col sxml 1 5 #f)))
     ))


### PR DESCRIPTION
Merges ideas from Phil Longstaff's ytd-budget.scm report

Copied from #532 which had become messy.

- [ ] awaiting feedback on budget-period headers -- it's rather crowded; at most it will print bgt / act / diff / bgt(ytd) / act(ytd) values

Screenshot:
![image](https://user-images.githubusercontent.com/1975870/60660731-e302f800-9e47-11e9-8707-9ac70179b12d.png)
