### PR TITLE
Wrapqoflog

### DIFF
--- a/libgnucash/engine/engine.i
+++ b/libgnucash/engine/engine.i
@@ -24,6 +24,7 @@
 #include <config.h>
 #include <glib.h>
 #include "qof.h"
+#include "qoflog.h"
 #include "Query.h"
 #include "gnc-budget.h"
 #include "gnc-commodity.h"
@@ -82,6 +83,7 @@ engine-common.i */
 
 %include "engine-common.i"
 %include "engine-deprecated.h"
+%include "qoflog.h"
 
 %inline %{
 static const GncGUID * gncPriceGetGUID(GNCPrice *x)
@@ -324,6 +326,8 @@ void qof_book_set_string_option(QofBook* book, const char* opt_name, const char*
     SET_ENUM("QOF-COMPARE-NEQ");
     SET_ENUM("QOF-COMPARE-CONTAINS");
     SET_ENUM("QOF-COMPARE-NCONTAINS");
+
+    SET_ENUM("QOF-LOG-DEBUG");  /* errors out */
 
     SET_ENUM("QOF-NUMERIC-MATCH-ANY");
     SET_ENUM("QOF-NUMERIC-MATCH-CREDIT");

--- a/libgnucash/engine/engine.i
+++ b/libgnucash/engine/engine.i
@@ -83,6 +83,19 @@ engine-common.i */
 
 %include "engine-common.i"
 %include "engine-deprecated.h"
+
+#if defined(SWIGGUILE)
+%ignore QofLogModule;
+%typemap(in) QofLogModule {
+     $1 = (const char *)SWIG_scm2str($input);
+ }
+
+%typemap(freearg) QofLogModule {
+    SWIG_free((char*)$1);
+ }
+
+#endif
+
 %include "qoflog.h"
 
 %inline %{
@@ -327,7 +340,12 @@ void qof_book_set_string_option(QofBook* book, const char* opt_name, const char*
     SET_ENUM("QOF-COMPARE-CONTAINS");
     SET_ENUM("QOF-COMPARE-NCONTAINS");
 
-    SET_ENUM("QOF-LOG-DEBUG");  /* errors out */
+    SET_ENUM("QOF-LOG-DEBUG");
+    SET_ENUM("QOF-LOG-FATAL");
+    SET_ENUM("QOF-LOG-ERROR");
+    SET_ENUM("QOF-LOG-WARNING");
+    SET_ENUM("QOF-LOG-MESSAGE");
+    SET_ENUM("QOF-LOG-INFO");
 
     SET_ENUM("QOF-NUMERIC-MATCH-ANY");
     SET_ENUM("QOF-NUMERIC-MATCH-CREDIT");

--- a/libgnucash/engine/qoflog.h
+++ b/libgnucash/engine/qoflog.h
@@ -104,7 +104,7 @@ extern "C"
   _(QOF_LOG_INFO,    = G_LOG_LEVEL_INFO)    \
   _(QOF_LOG_DEBUG,   = G_LOG_LEVEL_DEBUG)
 
-DEFINE_ENUM (QofLogLevel, LOG_LEVEL_LIST)
+DEFINE_ENUM (QofLogLevel, LOG_LEVEL_LIST);
 
 const char* qof_log_level_to_string(QofLogLevel lvl);
 QofLogLevel qof_log_level_from_string(const char *str);

--- a/libgnucash/engine/qoflog.h
+++ b/libgnucash/engine/qoflog.h
@@ -96,15 +96,15 @@ extern "C"
 
 #define QOF_MOD_ENGINE "qof.engine"
 
-#define LOG_LEVEL_LIST(_) \
-  _(QOF_LOG_FATAL,   = G_LOG_LEVEL_ERROR)   \
-  _(QOF_LOG_ERROR,   = G_LOG_LEVEL_CRITICAL)   \
-  _(QOF_LOG_WARNING, = G_LOG_LEVEL_WARNING) \
-  _(QOF_LOG_MESSAGE, = G_LOG_LEVEL_MESSAGE) \
-  _(QOF_LOG_INFO,    = G_LOG_LEVEL_INFO)    \
-  _(QOF_LOG_DEBUG,   = G_LOG_LEVEL_DEBUG)
-
-DEFINE_ENUM (QofLogLevel, LOG_LEVEL_LIST);
+typedef enum
+{
+    QOF_LOG_FATAL   = G_LOG_LEVEL_ERROR,
+    QOF_LOG_ERROR   = G_LOG_LEVEL_CRITICAL,
+    QOF_LOG_WARNING = G_LOG_LEVEL_WARNING,
+    QOF_LOG_MESSAGE = G_LOG_LEVEL_MESSAGE,
+    QOF_LOG_INFO    = G_LOG_LEVEL_INFO,
+    QOF_LOG_DEBUG   = G_LOG_LEVEL_DEBUG
+} QofLogLevel;
 
 const char* qof_log_level_to_string(QofLogLevel lvl);
 QofLogLevel qof_log_level_from_string(const char *str);

--- a/libgnucash/scm/CMakeLists.txt
+++ b/libgnucash/scm/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_subdirectory(test)
 
-set(GUILE_DEPENDS      scm-core-utils scm-gnc-module)
+set(GUILE_DEPENDS      scm-core-utils scm-gnc-module gncmod-engine)
 
 
 gnc_add_scheme_targets(scm-scm

--- a/libgnucash/scm/utilities.scm
+++ b/libgnucash/scm/utilities.scm
@@ -27,6 +27,10 @@
 
 (use-modules (gnucash core-utils))
 
+(eval-when (compile load eval expand)
+  (load-extension "libgncmod-engine" "scm_init_sw_engine_module"))
+(use-modules (sw_engine))
+
 ;; Load the srfis (eventually, we should see where these are needed
 ;; and only have the use-modules statements in those files).
 (use-modules (srfi srfi-1))
@@ -63,7 +67,8 @@
   (gnc-scm-log-msg (strify items)))
 
 (define (gnc:debug . items)
-  (gnc-scm-log-debug (strify items)))
+  (when (qof-log-check "gnc" G-LOG-LEVEL-DEBUG)
+    (gnc-scm-log-debug (strify items))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; the following functions are initialized to log message to tracefile

--- a/libgnucash/scm/utilities.scm
+++ b/libgnucash/scm/utilities.scm
@@ -66,9 +66,18 @@
 (define (gnc:msg . items)
   (gnc-scm-log-msg (strify items)))
 
-(define (gnc:debug . items)
-  (when (qof-log-check "gnc" G-LOG-LEVEL-DEBUG)
-    (gnc-scm-log-debug (strify items))))
+;; this definition of gnc:debug is different from others because we
+;; want to check loglevel is debug *once* at gnc:debug definition
+;; instead of every call to gnc:debug. if loglevel isn't debug then
+;; gnc:debug becomes a NOOP.
+(define gnc:debug
+  (cond
+   ((qof-log-check "gnc" QOF-LOG-DEBUG)
+    (display "debugging enabled\n")
+    (lambda items (gnc-scm-log-debug (strify items))))
+
+   (else
+    (lambda items #f))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; the following functions are initialized to log message to tracefile


### PR DESCRIPTION
Figuring out how to wrap qoflog.h

Still unsure how to check appropriate log domain is debug-enabled.

Checking "gnc" will be too noisy; checking "gnc.reports" means gnc:debug isn't working in libgnucash/scm