### PR TITLE
Refactor aging report

### DIFF
--- a/gnucash/report/business-reports/aging.scm
+++ b/gnucash/report/business-reports/aging.scm
@@ -26,6 +26,9 @@
 
 (define-module (gnucash report aging))
 
+(use-modules (srfi srfi-1))
+(use-modules (srfi srfi-9))             ;record
+(use-modules (ice-9 receive))
 (use-modules (gnucash utilities))
 (use-modules (gnucash gnc-module))
 (use-modules (gnucash gettext))
@@ -40,7 +43,6 @@
 (define optname-sort-order (N_ "Sort Order"))
 (define optname-report-currency (N_ "Report's currency"))
 (define optname-price-source (N_ "Price Source"))
-(define optname-multicurrency-totals (N_ "Show Multi-currency Totals"))
 (define optname-show-zeros (N_ "Show zero balance items"))
 (define optname-date-driver (N_ "Due or Post Date"))
 
@@ -58,281 +60,12 @@
 
 (export optname-show-zeros)
 
-;; The idea is:  have a hash with the key being the contact name
-;; (In future this might be GUID'ed, but for now it's a string
-;; from the description or the split memo.
-;; The value is a record which contains the currency that contact
-;; is stored in (you can only owe a particular contact one
-;; currency, it just gets far too difficult otherwise), and a list
-;; of buckets containing the money owed for each interval,
-;; oldest first.
-;; overpayment is just that - it stores the current overpayment,
-;; if any.  Any bills get taken out of the overpayment before
-;; incurring debt.
-
-(define company-info
-  (make-record-type
-   "ComanyInfo"
-   '(currency bucket-vector overpayment owner-obj)))
-
 (define num-buckets 5)
-(define (new-bucket-vector)
-  (make-vector num-buckets (gnc-numeric-zero)))
 
-(define make-company-private
-  (record-constructor company-info '(currency bucket-vector overpayment owner-obj)))
-
-(define (make-company currency owner-obj)
-  (make-company-private currency (new-bucket-vector) (gnc-numeric-zero) owner-obj))
-
-(define company-get-currency
-  (record-accessor company-info 'currency))
-
-(define company-get-owner-obj
-  (record-accessor company-info 'owner-obj))
-
-(define company-set-owner-obj!
-  (record-modifier company-info 'owner-obj))
-
-(define company-get-buckets
-  (record-accessor company-info 'bucket-vector))
-
-(define company-set-buckets
-  (record-modifier company-info 'bucket-vector))
-
-(define company-get-overpayment
-  (record-accessor company-info 'overpayment))
-
-(define company-set-overpayment
-  (record-modifier company-info 'overpayment))
-
-;; Put an invoice in the appropriate bucket
-
-(define (process-invoice company amount bucket-intervals date)
-  (define (in-interval this-date current-bucket)
-    (< this-date current-bucket))
-
-  (define (find-bucket current-bucket bucket-intervals date)
-    (gnc:debug "looking for bucket for date: " date)
-    (begin
-      (gnc:debug "current bucket: " current-bucket)
-      (gnc:debug "bucket-intervals: " bucket-intervals)
-      (if (> current-bucket (vector-length bucket-intervals))
-          (gnc:error "sanity check failed in find-bucket")
-          (if (in-interval date (vector-ref bucket-intervals current-bucket))
-              (begin
-                (gnc:debug "found bucket")
-                current-bucket)
-              (find-bucket (+ current-bucket 1) bucket-intervals date)))))
-
-  (define (calculate-adjusted-values amount overpayment)
-    (if (>= (gnc-numeric-compare amount overpayment) 0)
-        (cons (gnc-numeric-sub-fixed amount overpayment)
-              (gnc-numeric-zero))
-        (cons (gnc-numeric-zero)
-              (gnc-numeric-sub-fixed overpayment amount))))
-
-  (let* ((current-overpayment (company-get-overpayment company))
-         (adjusted-values (calculate-adjusted-values amount current-overpayment))
-         (adjusted-amount (car adjusted-values))
-         (adjusted-overpayment (cdr adjusted-values))
-         (bucket-index (find-bucket 0 bucket-intervals date))
-         (buckets (company-get-buckets company))
-         (new-bucket-value
-          (gnc-numeric-add-fixed adjusted-amount (vector-ref buckets bucket-index))))
-    (vector-set! buckets bucket-index new-bucket-value)
-    (company-set-buckets company buckets)
-    (company-set-overpayment company adjusted-overpayment)))
-
-;; NOTE: We assume that bill payments occur in a FIFO manner - ie
-;; any payment to a company goes towards the *oldest* bill first
-
-(define (process-payment company amount)
-  (define (process-payment-driver amount buckets current-bucket-index)
-    (if (>= current-bucket-index (vector-length buckets))
-        amount
-        (let ((current-bucket-amt (vector-ref buckets current-bucket-index)))
-          (if (>= (gnc-numeric-compare current-bucket-amt amount) 0)
-              (begin
-                (vector-set! buckets current-bucket-index (gnc-numeric-sub-fixed
-                                                           current-bucket-amt amount))
-                (gnc-numeric-zero))
-              (begin
-                (vector-set! buckets current-bucket-index (gnc-numeric-zero))
-                (process-payment-driver
-                 (gnc-numeric-sub-fixed amount current-bucket-amt)
-                 buckets
-                 (+ current-bucket-index 1)))))))
-
-  (let ((overpayment (company-get-overpayment company)))
-    ;; if there's already an overpayment, make it bigger
-    (gnc:debug "processing payment of " amount)
-    (gnc:debug "overpayment was " overpayment)
-
-    (if (gnc-numeric-positive-p overpayment)
-        (company-set-overpayment company (gnc-numeric-add-fixed overpayment amount))
-
-        (let ((result (process-payment-driver amount (company-get-buckets company) 0)))
-          (gnc:debug "payment-driver processed.  new overpayment: " result)
-          (company-set-overpayment company result)))))
-
-;; determine date function to use
-(define (get-selected-date-from-txn transaction date-type)
-  (if (eq? date-type 'postdate)
-      (xaccTransGetDate transaction)
-      (xaccTransRetDateDue transaction)))
-
-;; deal with a transaction - figure out if we've seen the company before
-;; if so, either process it as a bill or a payment, if not, create
-;; a new company record in the hash
-
-(define (update-company-hash hash split bucket-intervals
-                             reverse? show-zeros date-type)
-
-  (define (do-update value)
-    (let* ((transaction (xaccSplitGetParent split))
-           (temp-owner (gncOwnerNew))
-           (owner (gnc:owner-from-split split temp-owner)))
-
-      (if (not (null? owner))
-          (let* ((guid (gncOwnerReturnGUID owner))
-                 (this-currency (xaccTransGetCurrency transaction))
-                 (this-date (get-selected-date-from-txn transaction date-type))
-                 (company-info (hash-ref hash guid)))
-
-            (gnc:debug "update-company-hash called")
-            (gnc:debug "owner: " owner ", guid: " guid)
-            (gnc:debug "split-value: " value)
-            (if reverse? (set! value (gnc-numeric-neg value)))
-            (if company-info
-                ;; if it's an existing company, destroy the temp owner and
-                ;; then make sure the currencies match
-                (begin
-                  (if (not (gnc-commodity-equiv
-                            this-currency
-                            (company-get-currency company-info)))
-                      (let ((error-str
-                             (string-append
-                              "IGNORING TRANSACTION!\n"
-                              "Invoice Owner: " (gncOwnerGetName owner)
-                              "\nTransaction GUID:" (gncTransGetGuid transaction)
-                              "\nTransaction Currency"
-                              (gnc-commodity-get-mnemonic this-currency)
-                              "\nClient Currency"
-                              (gnc-ommodity-get-mnemonic
-                               (company-get-currency company-info)))))
-                        (gnc-error-dialog '() error-str)
-                        (gnc:error error-str)
-                        (cons #f
-                              (format #f (_ "Transactions relating to '~a' contain \
-more than one currency. This report is not designed to cope with this possibility.")
-                                      (gncOwnerGetName owner))))
-                      (begin
-                        (gnc:debug "it's an old company")
-                        (if (gnc-numeric-negative-p value)
-                            (process-invoice company-info (gnc-numeric-neg value)
-                                             bucket-intervals this-date)
-                            (process-payment company-info value))
-                        (hash-set! hash guid company-info)
-                        (cons #t guid)))
-                  (gncOwnerFree temp-owner))
-
-                ;; if it's a new company
-                (begin
-                  (gnc:debug "value" value)
-                  (let ((new-company (make-company this-currency owner)))
-                    (if (gnc-numeric-negative-p value)
-                        (process-invoice new-company
-                                         (gnc-numeric-neg value)
-                                         bucket-intervals this-date)
-                        (process-payment new-company value))
-                    (hash-set! hash guid new-company))
-                  (cons #t guid))))
-          ;; else (no owner)
-          (gncOwnerFree temp-owner))))
-
-  ;; figure out if this split is part of a closed lot
-  ;; also save the split value...
-  (let* ((lot (xaccSplitGetLot split))
-         (value (xaccSplitGetValue split))
-         (is-paid? (if (null? lot) #f (gnc-lot-is-closed lot))))
-
-    ;; if it's closed, then ignore it because it doesn't matter.
-    ;; XXX: we _could_ just set the value to 0 in order to list
-    ;;      the company.  I'm not sure what to do.  Perhaps add an
-    ;;      option?
-    (if (or (not is-paid?) show-zeros)
-        (do-update value))))
-
-;; get the total debt from the buckets
-(define (buckets-get-total buckets)
-  (let ((running-total (gnc-numeric-zero))
-        (buckets-list (vector->list buckets)))
-    (for-each (lambda (bucket)
-                (set! running-total
-                  (gnc-numeric-add-fixed bucket running-total)))
-              buckets-list)
-    running-total))
-
-
-;; compare by the total in the buckets
-(define (safe-strcmp a b)
-  (if (and a b)
-      (cond
-       ((string<? a b) -1)
-       ((string>? a b) 1)
-       (else 0))
-      (cond
-       (a 1)
-       (b -1)
-       (else 0))))
-
-(define (compare-total litem-a litem-b)
-  (let*  ((company-a (cdr litem-a))
-          (bucket-a (company-get-buckets company-a))
-          (company-b (cdr litem-b))
-          (bucket-b (company-get-buckets company-b))
-          (total-a (buckets-get-total bucket-a))
-          (total-b (buckets-get-total bucket-b))
-          (difference-sign (gnc-numeric-compare
-                            (gnc-numeric-sub-fixed total-a total-b)
-                            (gnc-numeric-zero))))
-    ;; if same totals, compare by name
-    (if (= difference-sign 0)
-        (safe-strcmp (car litem-a) (car litem-b))
-        difference-sign)))
-
-;; compare by buckets, oldest first.
-
-(define (compare-buckets litem-a litem-b)
-  (define (driver buckets-a buckets-b)
-    (if (null? buckets-a)
-        0
-        (let ((diff (gnc-numeric-compare
-                     (gnc-numeric-sub-fixed
-                      (car buckets-a)
-                      (car buckets-b))
-                     (gnc-numeric-zero))))
-          (if (= diff 0)
-              (driver (cdr buckets-a) (cdr buckets-b))
-              diff))))
-
-  (let*  ((company-a (cdr litem-a))
-          (bucket-a (vector->list (company-get-buckets company-a)))
-          (company-b (cdr litem-b))
-          (bucket-b (vector->list (company-get-buckets company-b)))
-
-          (difference (driver bucket-a bucket-b)))
-    ;; if same totals, compare by name
-    (if (= difference 0)
-        (safe-strcmp (car litem-a) (car litem-b))
-        difference)))
-
-;; set up the query to get the splits in the chosen account
-(define (setup-query query account date)
+(define (setup-query query accounts date)
   (qof-query-set-book query (gnc-get-current-book))
   (gnc:query-set-match-non-voids-only! query (gnc-get-current-book))
-  (xaccQueryAddSingleAccountMatch query account QOF-QUERY-AND)
+  (xaccQueryAddAccountMatch query accounts QOF-GUID-MATCH-ANY QOF-QUERY-AND)
   (xaccQueryAddDateMatchTT query #f 0 #t date QOF-QUERY-AND)
   (qof-query-set-sort-order query (list SPLIT-TRANS TRANS-DATE-POSTED) '() '())
   (qof-query-set-sort-increasing query #t #t #t))
@@ -350,15 +83,6 @@ more than one currency. This report is not designed to cope with this possibilit
     (gnc:option-set-default-value
      (gnc:lookup-option options gnc:pagename-general optname-to-date)
      (cons 'relative 'today))
-
-    ;; all about currencies
-    (gnc:options-add-currency!
-     options gnc:pagename-general
-     optname-report-currency "b")
-
-    (gnc:options-add-price-source!
-     options gnc:pagename-general
-     optname-price-source "c" 'weighted-average)
 
     (add-option
      (gnc:make-multichoice-option
@@ -388,15 +112,6 @@ more than one currency. This report is not designed to cope with this possibilit
       (list
        (vector 'increasing (N_ "Increasing") (N_ "0 -> $999,999.99, A->Z."))
        (vector 'decreasing (N_ "Decreasing") (N_ "$999,999.99 -> $0, Z->A.")))))
-
-    (add-option
-     (gnc:make-simple-boolean-option
-      gnc:pagename-general
-      optname-multicurrency-totals
-      "i"
-      (N_ "Show multi-currency totals. If not selected, convert all \
-totals to report currency.")
-      #f))
 
     (add-option
      (gnc:make-simple-boolean-option
@@ -513,58 +228,25 @@ copying this report to a spreadsheet for use in a mail merge.")
 
 ;; Have make-list create a stepped list, then add a date in the future for the "current" bucket
 (define (make-extended-interval-list to-date)
-  (define dayforcurrent (incdate to-date YearDelta)) ;; MAGIC CONSTANT
-  (define oldintervalreversed (reverse (make-interval-list to-date)))
-  (reverse (cons dayforcurrent oldintervalreversed)))
+  (append (make-interval-list to-date)
+          (list +inf.0)))
+
+(define (txn-is-invoice? txn)
+  (eqv? (xaccTransGetTxnType txn) TXN-TYPE-INVOICE))
+
+(define (txn-is-payment? txn)
+  (eqv? (xaccTransGetTxnType txn) TXN-TYPE-PAYMENT))
+
+;; this is required because (equal? owner-a owner-b) doesn't always
+;; return #t if owner-a and owner-b refer to the same owner
+(define (gnc-owner-equal? a b)
+  (string=? (gncOwnerReturnGUID a) (gncOwnerReturnGUID b)))
 
 (define (aging-renderer report-obj reportname account reverse?)
-
-  (define receivable #t)     ;; receivable=#t payable=#f
-
-  (define (get-name a)
-    (let* ((owner (company-get-owner-obj (cdr a))))
-      (gncOwnerGetName owner)))
-
-  ;; Predicates for sorting the companys once the data has been collected
-
-  ;; Format: (cons 'sort-key (cons 'increasing-pred 'decreasing-pred))
-  (define sort-preds
-    (list
-     (cons 'name (cons (lambda (a b)
-                         (string<? (get-name a) (get-name b)))
-                       (lambda (a b)
-                         (string>? (get-name a) (get-name b)))))
-     (cons 'total (cons (lambda (a b)
-                          (< (compare-total a b) 0))
-                        (lambda (a b)
-                          (> (compare-total a b) 0))))
-     (cons 'oldest-bracket (cons
-                            (lambda (a b)
-                              (< (compare-buckets a b) 0))
-                            (lambda (a b)
-                              (> (compare-buckets a b) 0))))))
-
-
-  (define (get-sort-pred sort-criterion sort-order)
-    (let ((choice (assq-ref sort-preds sort-criterion)))
-      (gnc:debug "sort-criterion" sort-criterion)
-      (gnc:debug "sort-order" sort-order)
-      (gnc:debug "choice: " choice)
-      (if choice
-          (if (eq? sort-order 'increasing)
-              (car choice)
-              (cdr choice))
-          (begin
-            (gnc:warn "internal sorting option errorin aging.scm")
-            (lambda (a b)
-              (string<? (car a) (car b)))))))
-
   (define (get-op section name)
     (gnc:lookup-option (gnc:report-options report-obj) section name))
-
   (define (op-value section name)
     (gnc:option-value (get-op section name)))
-
 
   ;; XXX: This is a hack - will be fixed when we move to a
   ;; more general interval scheme in this report
@@ -578,111 +260,21 @@ copying this report to a spreadsheet for use in a mail merge.")
      (_ "91+ days")
      (_ "Total")))
 
-  ;; following cols are optional
-  ;;    (_ "Address Name")
-  ;;    (_ "Address 1")
-  ;;    (_ "Address 2")
-  ;;    (_ "Address 3")
-  ;;    (_ "Address 4")
-  ;;    (_ "Phone")
-  ;;    (_ "Fax")
-  ;;    (_ "Email")
-  ;;    (_ "Active")
-
-  ;;  Make a list of commodity collectors for column totals
-
-  (define (make-collector-list)
-    (define (make-collector-driver done total)
-      (if (< done total)
-          (cons
-           (gnc:make-commodity-collector)
-           (make-collector-driver (+ done 1) total))
-          '()))
-    (make-collector-driver 0 (+ num-buckets 1)))
-
-  ;; update the column totals
-
-  (define (add-to-column-totals column-totals monetary-list)
-    (begin
-      (gnc:debug "column-totals" column-totals)
-      (gnc:debug "monetary-list" monetary-list)
-      (map (lambda (amount collector)
-             (begin
-               (gnc:debug "amount" amount)
-               (gnc:debug "collector" collector)
-               (collector 'add
-                          (gnc:gnc-monetary-commodity amount)
-                          (gnc:gnc-monetary-amount amount))))
-           monetary-list
-           column-totals)))
-
-  ;; convert the buckets in the header data structure
-  (define (convert-to-monetary-list bucket-list currency overpayment)
-    (let* ((running-total (gnc-numeric-neg overpayment))
-           (monetised-buckets
-            (map (lambda (bucket-list-entry)
-                   (begin
-                     (set! running-total
-                       (gnc-numeric-add-fixed running-total bucket-list-entry))
-                     (gnc:make-gnc-monetary currency bucket-list-entry)))
-                 (vector->list bucket-list))))
-      (append (reverse monetised-buckets)
-              (list (gnc:make-gnc-monetary currency running-total)))))
-
-  ;; convert the collectors to the right output format
-
-  (define (convert-collectors collector-list report-currency
-                              exchange-fn
-                              multi-currencies-p)
-    (define (fmt-one-currency collector)
-      (let ((monetary (gnc:sum-collector-commodity
-                       collector report-currency exchange-fn)))
-        (if monetary
-            monetary
-            (begin
-              (gnc:warn "Exchange-lookup failed in fmt-one-currency")
-              #f))))
-
-    (define (fmt-multiple-currencies collector)
-      (let ((mini-table (gnc:make-html-table)))
-        (collector 'format
-                   (lambda (commodity amount)
-                     (gnc:html-table-append-row!
-                      mini-table
-                      (list (gnc:make-gnc-monetary
-                             commodity amount))))
-                   #f)
-        mini-table))
-
-    (let ((fmt-function
-           (if multi-currencies-p
-               fmt-multiple-currencies
-               fmt-one-currency)))
-      (map fmt-function collector-list)))
-
-  ;; return pointer to either billing or shipping address
-  ;;  note customers have a shipping address but not vendors
-
-  (define (get-addr owner disp-addr-source)
-    (if (and receivable (eq? disp-addr-source 'shipping))
-        (gncCustomerGetShipAddr (gncOwnerGetCustomer owner)) ;; shipping
-        (gncOwnerGetAddr owner)))                            ;; billing
-
-  (set! receivable (eq? (op-value "__hidden" "receivable-or-payable") 'R))
   (gnc:report-starting reportname)
-  (let* ((companys (make-hash-table 23))
+  (let* ((accounts (filter (compose xaccAccountIsAPARType xaccAccountGetType)
+                           (gnc-account-get-descendants-sorted
+                            (gnc-get-current-root-account))))
+         (companys (make-hash-table 23))
+         (receivable (eq? (op-value "__hidden" "receivable-or-payable") 'R))
          (report-title (op-value gnc:pagename-general gnc:optname-reportname))
          ;; document will be the HTML document that we return.
          (report-date (gnc:time64-end-day-time
                        (gnc:date-option-absolute-time
                         (op-value gnc:pagename-general optname-to-date))))
          (interval-vec (list->vector (make-extended-interval-list report-date)))
-         (sort-pred (get-sort-pred
-                     (op-value gnc:pagename-general optname-sort-by)
-                     (op-value gnc:pagename-general optname-sort-order)))
-         (report-currency (op-value gnc:pagename-general optname-report-currency))
-         (price-source (op-value gnc:pagename-general optname-price-source))
-         (multi-totals-p (op-value gnc:pagename-general optname-multicurrency-totals))
+         ;; (sort-pred (get-sort-pred
+         ;;             (op-value gnc:pagename-general optname-sort-by)
+         ;;             (op-value gnc:pagename-general optname-sort-order)))
          (show-zeros (op-value gnc:pagename-general optname-show-zeros))
          (date-type (op-value gnc:pagename-general optname-date-driver))
          (disp-addr-source (if receivable
@@ -697,184 +289,96 @@ copying this report to a spreadsheet for use in a mail merge.")
          (disp-addr-fax (op-value gnc:pagename-display optname-disp-addr-fax))
          (disp-addr-email (op-value gnc:pagename-display optname-disp-addr-email))
          (disp-active (op-value gnc:pagename-display optname-disp-active))
-         (heading-list make-heading-list)
-         (exchange-fn (gnc:case-exchange-fn price-source report-currency report-date))
-         (total-collector-list (make-collector-list))
-         (table (gnc:make-html-table))
          (query (qof-query-create-for-splits))
-         (company-list '())
-         (work-done 0)
-         (work-to-do 0)
          (document (gnc:make-html-document)))
-    ;; (gnc:debug "Account: " account)
 
-    ;; add optional column headings
-    (if disp-addr-name
-        (set! heading-list (append heading-list (list (_ "Address Name")))))
-    (if disp-addr1
-        (set! heading-list (append heading-list (list (_ "Address 1")))))
-    (if disp-addr2
-        (set! heading-list (append heading-list (list (_ "Address 2")))))
-    (if disp-addr3
-        (set! heading-list (append heading-list (list (_ "Address 3")))))
-    (if disp-addr4
-        (set! heading-list (append heading-list (list (_ "Address 4")))))
-    (if disp-addr-phone
-        (set! heading-list (append heading-list (list (_ "Phone")))))
-    (if disp-addr-fax
-        (set! heading-list (append heading-list (list (_ "Fax")))))
-    (if disp-addr-email
-        (set! heading-list (append heading-list (list (_ "Email")))))
-    (if disp-active
-        (set! heading-list (append heading-list (list (_ "Active")))))
+    
+    ;; return pointer to either billing or shipping address
+    ;;  note customers have a shipping address but not vendors
+    (define (get-addr owner disp-addr-source)
+      (if (and receivable (eq? disp-addr-source 'shipping))
+          (gncCustomerGetShipAddr (gncOwnerGetCustomer owner)) ;; shipping
+          (gncOwnerGetAddr owner)))                            ;; billing
 
+    
+    
     ;; set default title
     (gnc:html-document-set-title! document report-title)
-    ;; maybe redefine better...
-    (if (and account (not (null? account)))
-        (begin
-          (gnc:html-document-set-title!
-           document (string-append report-title ": " (xaccAccountGetName account)))
-          (gnc:html-document-set-headline!
-           document (gnc:html-markup
-                     "!" report-title ": "
-                     (gnc:html-markup-anchor
-                      (gnc:account-anchor-text account)
-                      (xaccAccountGetName account))))))
 
-    (gnc:html-table-set-col-headers! table heading-list)
+    (cond
+     ((null? accounts)
+      (gnc:html-document-add-object!
+       document
+       (gnc:make-html-text
+        (_ "No valid account selected. Click on the Options button and select the account to use."))))
 
-    (if (and account (not (null? account)))
-        (begin
-          (setup-query query account report-date)
-          ;; get the appropriate splits
-          (let ((splits (qof-query-run query)))
-            ;; (gnc:debug "splits" splits)
+     (else
+      (setup-query query accounts report-date)
+      (let* ((splits (qof-query-run query))
+             (accounts (delete-duplicates (map xaccSplitGetAccount splits)))
+             (table (gnc:make-html-table))
+             (heading-list make-heading-list))
 
-            ;; build the table
-            (set! work-to-do (length splits))
-            ;; work-done is already zero
-            (for-each
-             (lambda (split)
-               (gnc:report-percent-done (* 50 (/ work-done work-to-do)))
-               (set! work-done (+ 1 work-done))
-               (update-company-hash companys split interval-vec
-                                    reverse? show-zeros date-type))
-             splits)
-            ;; (gnc:debug "companys" companys)
-            ;; turn the hash into a list
-            (hash-for-each
-             (lambda (key value)
-               (set! company-list
-                 (cons (cons key value) company-list)))
-             companys)
-            ;; (gnc:debug "company list" company-list)
-
-            (set! company-list (sort-list! company-list sort-pred))
-
-            ;; build the table
-            (set! work-to-do (length company-list))
-            (set! work-done 0)
-            (for-each
-             (lambda (company-list-entry)
-               (gnc:report-percent-done (+ 50 (* 50 (/ work-done work-to-do))))
-               (set! work-done (+ 1 work-done))
-               (let* ((monetary-list (convert-to-monetary-list
-                                      (company-get-buckets
-                                       (cdr company-list-entry))
-                                      (company-get-currency
-                                       (cdr company-list-entry))
-                                      (company-get-overpayment
-                                       (cdr company-list-entry))))
-                      (owner (company-get-owner-obj
-                              (cdr company-list-entry)))
-                      (company-name (gncOwnerGetName owner))
-                      (addr (get-addr owner disp-addr-source))
-                      (addr-name  (gncAddressGetName  addr))
-                      (addr-addr1 (gncAddressGetAddr1 addr))
-                      (addr-addr2 (gncAddressGetAddr2 addr))
-                      (addr-addr3 (gncAddressGetAddr3 addr))
-                      (addr-addr4 (gncAddressGetAddr4 addr))
-                      (addr-phone (gncAddressGetPhone addr))
-                      (addr-fax   (gncAddressGetFax   addr))
-                      (addr-email (gncAddressGetEmail addr))
-                      (company-active (if (gncOwnerGetActive owner)
-                                          (_ "Y") (_ "N")))
-                      (opt-fld-list '()))
-                 ;; (gnc:debug "aging-renderer: disp-addr-source="
-                 ;;            disp-addr-source
-                 ;;            " owner=" owner
-                 ;;            " gncOwnerGetID=" (gncOwnerGetID owner)
-                 ;;            " gncCustomerGetShipAddr="
-                 ;;            (gncCustomerGetShipAddr
-                 ;;             (gncOwnerGetCustomer owner)))
-                 (if disp-addr-name
-                     (set! opt-fld-list
-                       (append opt-fld-list (list addr-name))))
-                 (if disp-addr1
-                     (set! opt-fld-list
-                       (append opt-fld-list (list addr-addr1))))
-                 (if disp-addr2
-                     (set! opt-fld-list
-                       (append opt-fld-list (list addr-addr2))))
-                 (if disp-addr3
-                     (set! opt-fld-list
-                       (append opt-fld-list (list addr-addr3))))
-                 (if disp-addr4
-                     (set! opt-fld-list
-                       (append opt-fld-list (list addr-addr4))))
-                 (if disp-addr-phone
-                     (set! opt-fld-list
-                       (append opt-fld-list (list addr-phone))))
-                 (if disp-addr-fax
-                     (set! opt-fld-list
-                       (append opt-fld-list (list addr-fax))))
-                 (if disp-addr-email
-                     (set! opt-fld-list
-                       (append opt-fld-list (list addr-email))))
-                 (if disp-active
-                     (set! opt-fld-list
-                       (append opt-fld-list (list company-active))))
-                 (add-to-column-totals total-collector-list
-                                       monetary-list)
-
-                 (let* ((ml (reverse monetary-list))
-                        (total (car ml))
-                        (rest (cdr ml)))
-
-                   (set! monetary-list
-                     (reverse
-                      (cons
+        (let loop ((accounts accounts))
+          (unless (null? accounts)
+            (let* ((account (car accounts))
+                   (account-buckets (make-vector num-buckets 0))
+                   (acc-splits
+                    (filter
+                     (lambda (split)
+                       (and (equal? account (xaccSplitGetAccount split))
+                            (or (txn-is-invoice? (xaccSplitGetParent split))
+                                (txn-is-payment? (xaccSplitGetParent split)))))
+                     splits))
+                   (owners
+                    (delete-duplicates
+                     (map
+                      (compose gncOwnerGetEndOwner gncInvoiceGetOwner
+                               gncInvoiceGetInvoiceFromTxn xaccSplitGetParent)
+                      (filter (compose txn-is-invoice? xaccSplitGetParent)
+                              acc-splits))
+                     gnc-owner-equal?)))
+              (gnc:pk 'account account 'splits:)
+              (for-each gnc:pk acc-splits)
+              (gnc:pk 'owners)
+              (gnc:html-table-append-row!
+               table
+               (list
+                (gnc:make-html-table-cell
+                 (xaccAccountGetName (car accounts)))))
+              (let lp ((owners owners)
+                       (rest-splits acc-splits))
+                (unless (null? owners)
+                  (receive (owner-splits rest)
+                      (partition
+                       (lambda (split)
+                         (string=? (gncOwnerReturnGUID (car owners))
+                                   (gncOwnerReturnGUID
+                                    (gncOwnerGetEndOwner
+                                     (gncInvoiceGetOwner
+                                      (gncInvoiceGetInvoiceFromLot
+                                       (xaccSplitGetLot
+                                        (gnc-lot-get-earliest-split
+                                         (xaccSplitGetLot split)))))))))
+                       rest-splits)
+                    (gnc:html-table-append-row!
+                     table
+                     (append
+                      (list #f)
+                      (list
                        (gnc:make-html-text
                         (gnc:html-markup-anchor
-                         (gnc:owner-report-text owner account)
-                         total))
-                       rest))))
+                         (gnc:owner-anchor-text (car owners))
+                         (gncOwnerGetName (car owners))))
+                       (apply + (cons 0 (map xaccSplitGetAmount owner-splits))))
+                      (list)
+                      (list)))
+                    (lp (cdr owners)
+                        rest))
+                  )))
+            (loop (cdr accounts))))
 
-                 (gnc:html-table-append-row! table
-                                             (append
-                                              (cons
-                                               (gnc:make-html-text
-                                                (gnc:html-markup-anchor
-                                                 (gnc:owner-anchor-text owner)
-                                                 company-name))
-                                               monetary-list)
-                                              opt-fld-list))
-                 (gncOwnerFree owner)))
-             company-list)
-
-            ;; add the totals
-            (gnc:html-table-append-row!
-             table
-             (cons (_ "Total")
-                   (convert-collectors
-                    total-collector-list report-currency exchange-fn multi-totals-p)))
-
-            (gnc:html-document-add-object! document table)))
-        (gnc:html-document-add-object!
-         document
-         (gnc:make-html-text
-          (_ "No valid account selected. Click on the Options button and select the account to use."))))
+        (gnc:html-document-add-object! document table))))
     (qof-query-destroy query)
     (gnc:report-finished)
     document))

--- a/gnucash/report/business-reports/aging.scm
+++ b/gnucash/report/business-reports/aging.scm
@@ -347,7 +347,7 @@ more than one currency. This report is not designed to cope with this possibilit
      optname-to-date "a")
 
     ;; Use a default report date of 'today'
-    (gnc:option-set-value
+    (gnc:option-set-default-value
      (gnc:lookup-option options gnc:pagename-general optname-to-date)
      (cons 'relative 'today))
 

--- a/gnucash/report/business-reports/aging.scm
+++ b/gnucash/report/business-reports/aging.scm
@@ -66,15 +66,14 @@
 ;; currency, it just gets far too difficult otherwise), and a list
 ;; of buckets containing the money owed for each interval,
 ;; oldest first.
-;; overpayment is just that - it stores the current overpayment, 
+;; overpayment is just that - it stores the current overpayment,
 ;; if any.  Any bills get taken out of the overpayment before
 ;; incurring debt.
 
-(define company-info (make-record-type "ComanyInfo" 
-				       '(currency
-					 bucket-vector
-					 overpayment
-					 owner-obj)))
+(define company-info
+  (make-record-type
+   "ComanyInfo"
+   '(currency bucket-vector overpayment owner-obj)))
 
 (define num-buckets 5)
 (define (new-bucket-vector)
@@ -113,159 +112,166 @@
   (define (in-interval this-date current-bucket)
     (< this-date current-bucket))
 
-  (define (find-bucket current-bucket bucket-intervals date)  
+  (define (find-bucket current-bucket bucket-intervals date)
     (gnc:debug "looking for bucket for date: " date)
     (begin
       (gnc:debug "current bucket: " current-bucket)
       (gnc:debug "bucket-intervals: " bucket-intervals)
       (if (> current-bucket (vector-length bucket-intervals))
-	  (gnc:error "sanity check failed in find-bucket")
-	  (if (in-interval date (vector-ref bucket-intervals current-bucket))
-	      (begin
-		(gnc:debug "found bucket")
-		current-bucket)
-	      (find-bucket (+ current-bucket 1) bucket-intervals date)))))
+          (gnc:error "sanity check failed in find-bucket")
+          (if (in-interval date (vector-ref bucket-intervals current-bucket))
+              (begin
+                (gnc:debug "found bucket")
+                current-bucket)
+              (find-bucket (+ current-bucket 1) bucket-intervals date)))))
 
   (define (calculate-adjusted-values amount overpayment)
     (if (>= (gnc-numeric-compare amount overpayment) 0)
-	(cons (gnc-numeric-sub-fixed amount overpayment)
-	      (gnc-numeric-zero))
-	(cons (gnc-numeric-zero)
-	      (gnc-numeric-sub-fixed overpayment amount))))
+        (cons (gnc-numeric-sub-fixed amount overpayment)
+              (gnc-numeric-zero))
+        (cons (gnc-numeric-zero)
+              (gnc-numeric-sub-fixed overpayment amount))))
 
   (let* ((current-overpayment (company-get-overpayment company))
-	 (adjusted-values (calculate-adjusted-values amount current-overpayment))
-	 (adjusted-amount (car adjusted-values))
-	 (adjusted-overpayment (cdr adjusted-values))
-	 (bucket-index (find-bucket 0 bucket-intervals date))
-	 (buckets (company-get-buckets company))
-	 (new-bucket-value 
-	  (gnc-numeric-add-fixed adjusted-amount (vector-ref buckets bucket-index))))
+         (adjusted-values (calculate-adjusted-values amount current-overpayment))
+         (adjusted-amount (car adjusted-values))
+         (adjusted-overpayment (cdr adjusted-values))
+         (bucket-index (find-bucket 0 bucket-intervals date))
+         (buckets (company-get-buckets company))
+         (new-bucket-value
+          (gnc-numeric-add-fixed adjusted-amount (vector-ref buckets bucket-index))))
     (vector-set! buckets bucket-index new-bucket-value)
     (company-set-buckets company buckets)
     (company-set-overpayment company adjusted-overpayment)))
 
-
 ;; NOTE: We assume that bill payments occur in a FIFO manner - ie
 ;; any payment to a company goes towards the *oldest* bill first
-
 
 (define (process-payment company amount)
   (define (process-payment-driver amount buckets current-bucket-index)
     (if (>= current-bucket-index (vector-length buckets))
-	amount
-	(let ((current-bucket-amt (vector-ref buckets current-bucket-index)))
-	  (if (>= (gnc-numeric-compare current-bucket-amt amount) 0)
-	      (begin
-		(vector-set! buckets current-bucket-index (gnc-numeric-sub-fixed
-							   current-bucket-amt amount))
-		(gnc-numeric-zero))
-	      (begin
-		(vector-set! buckets current-bucket-index (gnc-numeric-zero))
-		(process-payment-driver 
-		 (gnc-numeric-sub-fixed amount current-bucket-amt)
-		 buckets
-		 (+ current-bucket-index 1)))))))
+        amount
+        (let ((current-bucket-amt (vector-ref buckets current-bucket-index)))
+          (if (>= (gnc-numeric-compare current-bucket-amt amount) 0)
+              (begin
+                (vector-set! buckets current-bucket-index (gnc-numeric-sub-fixed
+                                                           current-bucket-amt amount))
+                (gnc-numeric-zero))
+              (begin
+                (vector-set! buckets current-bucket-index (gnc-numeric-zero))
+                (process-payment-driver
+                 (gnc-numeric-sub-fixed amount current-bucket-amt)
+                 buckets
+                 (+ current-bucket-index 1)))))))
 
   (let ((overpayment (company-get-overpayment company)))
-	;; if there's already an overpayment, make it bigger
+    ;; if there's already an overpayment, make it bigger
     (gnc:debug "processing payment of " amount)
     (gnc:debug "overpayment was " overpayment)
 
-	(if (gnc-numeric-positive-p overpayment)
-	    (company-set-overpayment company (gnc-numeric-add-fixed overpayment amount))
+    (if (gnc-numeric-positive-p overpayment)
+        (company-set-overpayment company (gnc-numeric-add-fixed overpayment amount))
 
-	    (let ((result (process-payment-driver amount (company-get-buckets company) 0)))
-	      (gnc:debug "payment-driver processed.  new overpayment: " result)
-	      (company-set-overpayment company result)))))
+        (let ((result (process-payment-driver amount (company-get-buckets company) 0)))
+          (gnc:debug "payment-driver processed.  new overpayment: " result)
+          (company-set-overpayment company result)))))
 
-;; determine date function to use 
+;; determine date function to use
 (define (get-selected-date-from-txn transaction date-type)
   (if (eq? date-type 'postdate)
       (xaccTransGetDate transaction)
       (xaccTransRetDateDue transaction)))
-  
+
 ;; deal with a transaction - figure out if we've seen the company before
 ;; if so, either process it as a bill or a payment, if not, create
 ;; a new company record in the hash
 
 (define (update-company-hash hash split bucket-intervals
-			     reverse? show-zeros date-type)
+                             reverse? show-zeros date-type)
 
   (define (do-update value)
     (let* ((transaction (xaccSplitGetParent split))
-	   (temp-owner (gncOwnerNew))
-	   (owner (gnc:owner-from-split split temp-owner)))
+           (temp-owner (gncOwnerNew))
+           (owner (gnc:owner-from-split split temp-owner)))
 
       (if (not (null? owner))
-       (let* ((guid (gncOwnerReturnGUID owner))
-	      (this-currency (xaccTransGetCurrency transaction))
-	      (this-date (get-selected-date-from-txn transaction date-type))
-	      (company-info (hash-ref hash guid)))
+          (let* ((guid (gncOwnerReturnGUID owner))
+                 (this-currency (xaccTransGetCurrency transaction))
+                 (this-date (get-selected-date-from-txn transaction date-type))
+                 (company-info (hash-ref hash guid)))
 
-	 (gnc:debug "update-company-hash called")
-	 (gnc:debug "owner: " owner ", guid: " guid)
-	 (gnc:debug "split-value: " value)
-	 (if reverse? (set! value (gnc-numeric-neg value)))
-	 (if company-info
-	     ;; if it's an existing company, destroy the temp owner and
-	     ;; then make sure the currencies match
-	     (begin
-	       (if (not (gnc-commodity-equiv
-			 this-currency
-			 (company-get-currency company-info)))
-		   (let ((error-str
-			  (string-append "IGNORING TRANSACTION!\n" "Invoice Owner: " (gncOwnerGetName owner)
-					 "\nTransaction GUID:" (gncTransGetGuid transaction)
-					 "\nTransaction Currency" (gnc-commodity-get-mnemonic this-currency)
-					 "\nClient Currency" (gnc-ommodity-get-mnemonic(company-get-currency company-info)))))
-		     (gnc-error-dialog '() error-str)
-		     (gnc:error error-str)
-		     (cons #f (format
-			       (_ "Transactions relating to '~a' contain \
-more than one currency. This report is not designed to cope with this possibility.")  (gncOwnerGetName owner))))
-		   (begin
-		     (gnc:debug "it's an old company")
-		     (if (gnc-numeric-negative-p value)
-			 (process-invoice company-info (gnc-numeric-neg value) bucket-intervals this-date)
-			 (process-payment company-info value))
-		     (hash-set! hash guid company-info)
-		     (cons #t guid)))
-	       (gncOwnerFree temp-owner))
+            (gnc:debug "update-company-hash called")
+            (gnc:debug "owner: " owner ", guid: " guid)
+            (gnc:debug "split-value: " value)
+            (if reverse? (set! value (gnc-numeric-neg value)))
+            (if company-info
+                ;; if it's an existing company, destroy the temp owner and
+                ;; then make sure the currencies match
+                (begin
+                  (if (not (gnc-commodity-equiv
+                            this-currency
+                            (company-get-currency company-info)))
+                      (let ((error-str
+                             (string-append
+                              "IGNORING TRANSACTION!\n"
+                              "Invoice Owner: " (gncOwnerGetName owner)
+                              "\nTransaction GUID:" (gncTransGetGuid transaction)
+                              "\nTransaction Currency"
+                              (gnc-commodity-get-mnemonic this-currency)
+                              "\nClient Currency"
+                              (gnc-ommodity-get-mnemonic
+                               (company-get-currency company-info)))))
+                        (gnc-error-dialog '() error-str)
+                        (gnc:error error-str)
+                        (cons #f
+                              (format #f (_ "Transactions relating to '~a' contain \
+more than one currency. This report is not designed to cope with this possibility.")
+                                      (gncOwnerGetName owner))))
+                      (begin
+                        (gnc:debug "it's an old company")
+                        (if (gnc-numeric-negative-p value)
+                            (process-invoice company-info (gnc-numeric-neg value)
+                                             bucket-intervals this-date)
+                            (process-payment company-info value))
+                        (hash-set! hash guid company-info)
+                        (cons #t guid)))
+                  (gncOwnerFree temp-owner))
 
-	     ;; if it's a new company
-	     (begin
-	       (gnc:debug "value" value)
-	       (let ((new-company (make-company this-currency owner)))
-		 (if (gnc-numeric-negative-p value)
-		     (process-invoice new-company (gnc-numeric-neg value) bucket-intervals this-date)
-		     (process-payment new-company value))
-		 (hash-set! hash guid new-company))
-	       (cons #t guid))))
-       ; else (no owner)
-       (gncOwnerFree temp-owner))))
+                ;; if it's a new company
+                (begin
+                  (gnc:debug "value" value)
+                  (let ((new-company (make-company this-currency owner)))
+                    (if (gnc-numeric-negative-p value)
+                        (process-invoice new-company
+                                         (gnc-numeric-neg value)
+                                         bucket-intervals this-date)
+                        (process-payment new-company value))
+                    (hash-set! hash guid new-company))
+                  (cons #t guid))))
+          ;; else (no owner)
+          (gncOwnerFree temp-owner))))
 
   ;; figure out if this split is part of a closed lot
   ;; also save the split value...
   (let* ((lot (xaccSplitGetLot split))
-	 (value (xaccSplitGetValue split))
-	 (is-paid? (if (null? lot) #f (gnc-lot-is-closed lot))))
+         (value (xaccSplitGetValue split))
+         (is-paid? (if (null? lot) #f (gnc-lot-is-closed lot))))
 
     ;; if it's closed, then ignore it because it doesn't matter.
     ;; XXX: we _could_ just set the value to 0 in order to list
     ;;      the company.  I'm not sure what to do.  Perhaps add an
     ;;      option?
     (if (or (not is-paid?) show-zeros)
-	(do-update value))))
+        (do-update value))))
 
 ;; get the total debt from the buckets
 (define (buckets-get-total buckets)
   (let ((running-total (gnc-numeric-zero))
-	(buckets-list (vector->list buckets)))
+        (buckets-list (vector->list buckets)))
     (for-each (lambda (bucket)
-		(set! running-total
-		      (gnc-numeric-add-fixed bucket running-total)))
-	      buckets-list)
+                (set! running-total
+                  (gnc-numeric-add-fixed bucket running-total)))
+              buckets-list)
     running-total))
 
 
@@ -283,43 +289,44 @@ more than one currency. This report is not designed to cope with this possibilit
 
 (define (compare-total litem-a litem-b)
   (let*  ((company-a (cdr litem-a))
-	 (bucket-a (company-get-buckets company-a))
-	 (company-b (cdr litem-b))
-	 (bucket-b (company-get-buckets company-b))
-	 (total-a (buckets-get-total bucket-a))
-	 (total-b (buckets-get-total bucket-b))
-	 (difference-sign (gnc-numeric-compare (gnc-numeric-sub-fixed total-a total-b) (gnc-numeric-zero))))
-	 ;; if same totals, compare by name
-	 (if (= difference-sign 0)
-	     (safe-strcmp (car litem-a) (car litem-b))
-	     difference-sign)))
+          (bucket-a (company-get-buckets company-a))
+          (company-b (cdr litem-b))
+          (bucket-b (company-get-buckets company-b))
+          (total-a (buckets-get-total bucket-a))
+          (total-b (buckets-get-total bucket-b))
+          (difference-sign (gnc-numeric-compare
+                            (gnc-numeric-sub-fixed total-a total-b)
+                            (gnc-numeric-zero))))
+    ;; if same totals, compare by name
+    (if (= difference-sign 0)
+        (safe-strcmp (car litem-a) (car litem-b))
+        difference-sign)))
 
 ;; compare by buckets, oldest first.
 
 (define (compare-buckets litem-a litem-b)
   (define (driver buckets-a buckets-b)
     (if (null? buckets-a)
-	0
-	(let ((diff (gnc-numeric-compare
-		     (gnc-numeric-sub-fixed
-		      (car buckets-a) 
-		      (car buckets-b)) 
-		     (gnc-numeric-zero))))
-	  (if (= diff 0)
-	      (driver (cdr buckets-a) (cdr buckets-b))
-	      diff))))
+        0
+        (let ((diff (gnc-numeric-compare
+                     (gnc-numeric-sub-fixed
+                      (car buckets-a)
+                      (car buckets-b))
+                     (gnc-numeric-zero))))
+          (if (= diff 0)
+              (driver (cdr buckets-a) (cdr buckets-b))
+              diff))))
 
   (let*  ((company-a (cdr litem-a))
-	 (bucket-a (vector->list (company-get-buckets company-a)))
-	 (company-b (cdr litem-b))
-	 (bucket-b (vector->list (company-get-buckets company-b)))
+          (bucket-a (vector->list (company-get-buckets company-a)))
+          (company-b (cdr litem-b))
+          (bucket-b (vector->list (company-get-buckets company-b)))
 
-	 (difference (driver bucket-a bucket-b)))
-	 ;; if same totals, compare by name
-	 (if (= difference 0)
-	     (safe-strcmp (car litem-a) (car litem-b))
-	     difference)))
-
+          (difference (driver bucket-a bucket-b)))
+    ;; if same totals, compare by name
+    (if (= difference 0)
+        (safe-strcmp (car litem-a) (car litem-b))
+        difference)))
 
 ;; set up the query to get the splits in the chosen account
 (define (setup-query query account date)
@@ -327,32 +334,29 @@ more than one currency. This report is not designed to cope with this possibilit
   (gnc:query-set-match-non-voids-only! query (gnc-get-current-book))
   (xaccQueryAddSingleAccountMatch query account QOF-QUERY-AND)
   (xaccQueryAddDateMatchTT query #f 0 #t date QOF-QUERY-AND)
-  (qof-query-set-sort-order query
-                            (list SPLIT-TRANS TRANS-DATE-POSTED)
-                            '() '())
+  (qof-query-set-sort-order query (list SPLIT-TRANS TRANS-DATE-POSTED) '() '())
   (qof-query-set-sort-increasing query #t #t #t))
 
 (define (aging-options-generator options)
-  (let* ((add-option 
+  (let* ((add-option
           (lambda (new-option)
             (gnc:register-option options new-option))))
-
 
     (gnc:options-add-report-date!
      options gnc:pagename-general
      optname-to-date "a")
-    ;; Use a default report date of 'today'
-    (gnc:option-set-value (gnc:lookup-option options
-                                             gnc:pagename-general
-                                             optname-to-date)
-                          (cons 'relative 'today))
 
- ;; all about currencies
+    ;; Use a default report date of 'today'
+    (gnc:option-set-value
+     (gnc:lookup-option options gnc:pagename-general optname-to-date)
+     (cons 'relative 'today))
+
+    ;; all about currencies
     (gnc:options-add-currency!
      options gnc:pagename-general
      optname-report-currency "b")
 
-    (gnc:options-add-price-source! 
+    (gnc:options-add-price-source!
      options gnc:pagename-general
      optname-price-source "c" 'weighted-average)
 
@@ -363,21 +367,27 @@ more than one currency. This report is not designed to cope with this possibilit
       "i"
       (N_ "Sort companies by.")
       'name
-      (list 
-       (vector 'name (N_ "Name") (N_ "Name of the company."))
-       (vector 'total (N_ "Total Owed") (N_ "Total amount owed to/from Company."))
-       (vector 'oldest-bracket (N_ "Bracket Total Owed") (N_ "Amount owed in oldest bracket - if same go to next oldest.")))))
+      (list
+       (vector 'name
+               (N_ "Name")
+               (N_ "Name of the company."))
+       (vector 'total
+               (N_ "Total Owed")
+               (N_ "Total amount owed to/from Company."))
+       (vector 'oldest-bracket
+               (N_ "Bracket Total Owed")
+               (N_ "Amount owed in oldest bracket - if same go to next oldest.")))))
 
-    (add-option 
+    (add-option
      (gnc:make-multichoice-option
       gnc:pagename-general
-       optname-sort-order
-       "ia"
-       (N_ "Sort order.")
-       'increasing
-       (list
-	(vector 'increasing (N_ "Increasing") (N_ "0 -> $999,999.99, A->Z."))
-	(vector 'decreasing (N_ "Decreasing") (N_ "$999,999.99 -> $0, Z->A.")))))
+      optname-sort-order
+      "ia"
+      (N_ "Sort order.")
+      'increasing
+      (list
+       (vector 'increasing (N_ "Increasing") (N_ "0 -> $999,999.99, A->Z."))
+       (vector 'decreasing (N_ "Decreasing") (N_ "$999,999.99 -> $0, Z->A.")))))
 
     (add-option
      (gnc:make-simple-boolean-option
@@ -397,17 +407,23 @@ totals to report currency.")
       #f))
 
     (add-option
-      (gnc:make-multichoice-option
-       gnc:pagename-general
-       optname-date-driver
-       "k"
-       (N_ "Leading date.")
-       'duedate
-       (list
-         (vector 'duedate (N_ "Due Date") (N_ "Due date is leading.")) ;; Should be using standard label for due date?
-         (vector 'postdate (N_ "Post Date") (N_ "Post date is leading."))))) ;; Should be using standard label for post date?
+     (gnc:make-multichoice-option
+      gnc:pagename-general
+      optname-date-driver
+      "k"
+      (N_ "Leading date.")
+      'duedate
+      (list
+       ;; Should be using standard label for due date?
+       (vector 'duedate
+               (N_ "Due Date")
+               (N_ "Due date is leading.")) 
+       ;; Should be using standard label for post date?
+       (vector 'postdate
+               (N_ "Post Date")
+               (N_ "Post date is leading.")))))
 
-	  ;; display tab options
+    ;; display tab options
 
     ;; option optname-addr-source is added in receivables.scm
     ;; as cannot access the value of an option in aging-options-generator
@@ -497,8 +513,8 @@ copying this report to a spreadsheet for use in a mail merge.")
 
 ;; Have make-list create a stepped list, then add a date in the future for the "current" bucket
 (define (make-extended-interval-list to-date)
-    (define dayforcurrent (incdate to-date YearDelta)) ;; MAGIC CONSTANT
-    (define oldintervalreversed (reverse (make-interval-list to-date)))		
+  (define dayforcurrent (incdate to-date YearDelta)) ;; MAGIC CONSTANT
+  (define oldintervalreversed (reverse (make-interval-list to-date)))
   (reverse (cons dayforcurrent oldintervalreversed)))
 
 (define (aging-renderer report-obj reportname account reverse?)
@@ -513,20 +529,20 @@ copying this report to a spreadsheet for use in a mail merge.")
 
   ;; Format: (cons 'sort-key (cons 'increasing-pred 'decreasing-pred))
   (define sort-preds
-    (list 
+    (list
      (cons 'name (cons (lambda (a b)
-			 (string<? (get-name a) (get-name b)))
-		       (lambda (a b)
-			 (string>? (get-name a) (get-name b)))))
+                         (string<? (get-name a) (get-name b)))
+                       (lambda (a b)
+                         (string>? (get-name a) (get-name b)))))
      (cons 'total (cons (lambda (a b)
-			  (< (compare-total a b) 0))
-			(lambda (a b)
-			  (> (compare-total a b) 0))))
-     (cons 'oldest-bracket (cons 
-			    (lambda (a b) 
-			     (< (compare-buckets a b) 0))
-			    (lambda (a b)
-			      (> (compare-buckets a b) 0))))))
+                          (< (compare-total a b) 0))
+                        (lambda (a b)
+                          (> (compare-total a b) 0))))
+     (cons 'oldest-bracket (cons
+                            (lambda (a b)
+                              (< (compare-buckets a b) 0))
+                            (lambda (a b)
+                              (> (compare-buckets a b) 0))))))
 
 
   (define (get-sort-pred sort-criterion sort-order)
@@ -535,13 +551,13 @@ copying this report to a spreadsheet for use in a mail merge.")
       (gnc:debug "sort-order" sort-order)
       (gnc:debug "choice: " choice)
       (if choice
-	  (if (eq? sort-order 'increasing)
-	      (car choice)
-	      (cdr choice))
-	  (begin
-	    (gnc:warn "internal sorting option errorin aging.scm")
-	    (lambda (a b)
-	      (string<? (car a) (car b)))))))
+          (if (eq? sort-order 'increasing)
+              (car choice)
+              (cdr choice))
+          (begin
+            (gnc:warn "internal sorting option errorin aging.scm")
+            (lambda (a b)
+              (string<? (car a) (car b)))))))
 
   (define (get-op section name)
     (gnc:lookup-option (gnc:report-options report-obj) section name))
@@ -553,165 +569,164 @@ copying this report to a spreadsheet for use in a mail merge.")
   ;; XXX: This is a hack - will be fixed when we move to a
   ;; more general interval scheme in this report
   (define make-heading-list
-    (list 
-      (_ "Company")
-      (_ "Current")
-      (_ "0-30 days")
-      (_ "31-60 days")
-      (_ "61-90 days")
-      (_ "91+ days")
-      (_ "Total")))
-     
-;; following cols are optional 
-;;    (_ "Address Name")
-;;    (_ "Address 1")
-;;    (_ "Address 2")
-;;    (_ "Address 3")
-;;    (_ "Address 4")
-;;    (_ "Phone")
-;;    (_ "Fax")
-;;    (_ "Email")
-;;    (_ "Active")
+    (list
+     (_ "Company")
+     (_ "Current")
+     (_ "0-30 days")
+     (_ "31-60 days")
+     (_ "61-90 days")
+     (_ "91+ days")
+     (_ "Total")))
 
+  ;; following cols are optional
+  ;;    (_ "Address Name")
+  ;;    (_ "Address 1")
+  ;;    (_ "Address 2")
+  ;;    (_ "Address 3")
+  ;;    (_ "Address 4")
+  ;;    (_ "Phone")
+  ;;    (_ "Fax")
+  ;;    (_ "Email")
+  ;;    (_ "Active")
 
   ;;  Make a list of commodity collectors for column totals
 
   (define (make-collector-list)
     (define (make-collector-driver done total)
-      (if (< done total) 
-	  (cons 
-	   (gnc:make-commodity-collector)
-	   (make-collector-driver (+ done 1) total))
-	  '()))
+      (if (< done total)
+          (cons
+           (gnc:make-commodity-collector)
+           (make-collector-driver (+ done 1) total))
+          '()))
     (make-collector-driver 0 (+ num-buckets 1)))
-	  
 
-  ;; update the column totals 
+  ;; update the column totals
 
   (define (add-to-column-totals column-totals monetary-list)
     (begin
       (gnc:debug "column-totals" column-totals)
       (gnc:debug "monetary-list" monetary-list)
       (map (lambda (amount collector)
-	   (begin
-	     (gnc:debug "amount" amount)
-	     (gnc:debug "collector" collector)
-	     (collector 'add 
-			(gnc:gnc-monetary-commodity amount)
-			(gnc:gnc-monetary-amount amount))))
-	 monetary-list
-	 column-totals)))
+             (begin
+               (gnc:debug "amount" amount)
+               (gnc:debug "collector" collector)
+               (collector 'add
+                          (gnc:gnc-monetary-commodity amount)
+                          (gnc:gnc-monetary-amount amount))))
+           monetary-list
+           column-totals)))
 
-  ;; convert the buckets in the header data structure 
+  ;; convert the buckets in the header data structure
   (define (convert-to-monetary-list bucket-list currency overpayment)
     (let* ((running-total (gnc-numeric-neg overpayment))
-	   (monetised-buckets
-	   (map (lambda (bucket-list-entry)
-		  (begin
-		    (set! running-total 
-			  (gnc-numeric-add-fixed running-total bucket-list-entry))
-		  (gnc:make-gnc-monetary currency bucket-list-entry)))
-		(vector->list bucket-list))))
-      (append (reverse monetised-buckets) 
-	      (list (gnc:make-gnc-monetary currency running-total)))))
+           (monetised-buckets
+            (map (lambda (bucket-list-entry)
+                   (begin
+                     (set! running-total
+                       (gnc-numeric-add-fixed running-total bucket-list-entry))
+                     (gnc:make-gnc-monetary currency bucket-list-entry)))
+                 (vector->list bucket-list))))
+      (append (reverse monetised-buckets)
+              (list (gnc:make-gnc-monetary currency running-total)))))
 
-  ;; convert the collectors to the right output format 
+  ;; convert the collectors to the right output format
 
-  (define (convert-collectors collector-list report-currency 
-			      exchange-fn
-			      multi-currencies-p)
+  (define (convert-collectors collector-list report-currency
+                              exchange-fn
+                              multi-currencies-p)
     (define (fmt-one-currency collector)
-      (let ((monetary (gnc:sum-collector-commodity collector report-currency exchange-fn)))
-	(if monetary
-	    monetary
-	    (begin
-	      (gnc:warn "Exchange-lookup failed in fmt-one-currency")
-	      #f))))
+      (let ((monetary (gnc:sum-collector-commodity
+                       collector report-currency exchange-fn)))
+        (if monetary
+            monetary
+            (begin
+              (gnc:warn "Exchange-lookup failed in fmt-one-currency")
+              #f))))
 
     (define (fmt-multiple-currencies collector)
       (let ((mini-table (gnc:make-html-table)))
-	(collector 'format 
-		   (lambda (commodity amount)
-		   (gnc:html-table-append-row!
-		    mini-table
-		    (list (gnc:make-gnc-monetary 
-			   commodity amount))))
-		   #f)
-	mini-table))
-			
-    (let ((fmt-function 
-	   (if multi-currencies-p
-	       fmt-multiple-currencies
-	       fmt-one-currency)))
+        (collector 'format
+                   (lambda (commodity amount)
+                     (gnc:html-table-append-row!
+                      mini-table
+                      (list (gnc:make-gnc-monetary
+                             commodity amount))))
+                   #f)
+        mini-table))
+
+    (let ((fmt-function
+           (if multi-currencies-p
+               fmt-multiple-currencies
+               fmt-one-currency)))
       (map fmt-function collector-list)))
-  
+
   ;; return pointer to either billing or shipping address
   ;;  note customers have a shipping address but not vendors
-  
+
   (define (get-addr owner disp-addr-source)
     (if (and receivable (eq? disp-addr-source 'shipping))
-      (gncCustomerGetShipAddr (gncOwnerGetCustomer owner)) ;; shipping
-      (gncOwnerGetAddr owner)))                            ;; billing
+        (gncCustomerGetShipAddr (gncOwnerGetCustomer owner)) ;; shipping
+        (gncOwnerGetAddr owner)))                            ;; billing
 
   (set! receivable (eq? (op-value "__hidden" "receivable-or-payable") 'R))
   (gnc:report-starting reportname)
   (let* ((companys (make-hash-table 23))
-	 (report-title (op-value gnc:pagename-general gnc:optname-reportname))
-        ;; document will be the HTML document that we return.
-	(report-date (gnc:time64-end-day-time 
-		      (gnc:date-option-absolute-time
-		       (op-value gnc:pagename-general optname-to-date))))
-	(interval-vec (list->vector (make-extended-interval-list report-date)))
-	(sort-pred (get-sort-pred 
-		    (op-value gnc:pagename-general optname-sort-by)
-		    (op-value gnc:pagename-general optname-sort-order)))
-	(report-currency (op-value gnc:pagename-general optname-report-currency))
-	(price-source (op-value gnc:pagename-general optname-price-source))
-	(multi-totals-p (op-value gnc:pagename-general optname-multicurrency-totals))
-	(show-zeros (op-value gnc:pagename-general optname-show-zeros))
-    (date-type (op-value gnc:pagename-general optname-date-driver)) 
-    (disp-addr-source (if receivable
-      (op-value gnc:pagename-display optname-addr-source)
-      'billing))
-    (disp-addr-name (op-value gnc:pagename-display optname-disp-addr-name))
-    (disp-addr1 (op-value gnc:pagename-display optname-disp-addr1))
-    (disp-addr2 (op-value gnc:pagename-display optname-disp-addr2))
-    (disp-addr3 (op-value gnc:pagename-display optname-disp-addr3))
-    (disp-addr4 (op-value gnc:pagename-display optname-disp-addr4))
-    (disp-addr-phone (op-value gnc:pagename-display optname-disp-addr-phone))
-    (disp-addr-fax (op-value gnc:pagename-display optname-disp-addr-fax))
-    (disp-addr-email (op-value gnc:pagename-display optname-disp-addr-email))
-    (disp-active (op-value gnc:pagename-display optname-disp-active))
-	(heading-list make-heading-list)
-	(exchange-fn (gnc:case-exchange-fn price-source report-currency report-date))
-	(total-collector-list (make-collector-list))
-	(table (gnc:make-html-table))
-	(query (qof-query-create-for-splits))
-	(company-list '())
-	(work-done 0)
-	(work-to-do 0)
-        (document (gnc:make-html-document)))
-;    (gnc:debug "Account: " account)
+         (report-title (op-value gnc:pagename-general gnc:optname-reportname))
+         ;; document will be the HTML document that we return.
+         (report-date (gnc:time64-end-day-time
+                       (gnc:date-option-absolute-time
+                        (op-value gnc:pagename-general optname-to-date))))
+         (interval-vec (list->vector (make-extended-interval-list report-date)))
+         (sort-pred (get-sort-pred
+                     (op-value gnc:pagename-general optname-sort-by)
+                     (op-value gnc:pagename-general optname-sort-order)))
+         (report-currency (op-value gnc:pagename-general optname-report-currency))
+         (price-source (op-value gnc:pagename-general optname-price-source))
+         (multi-totals-p (op-value gnc:pagename-general optname-multicurrency-totals))
+         (show-zeros (op-value gnc:pagename-general optname-show-zeros))
+         (date-type (op-value gnc:pagename-general optname-date-driver))
+         (disp-addr-source (if receivable
+                               (op-value gnc:pagename-display optname-addr-source)
+                               'billing))
+         (disp-addr-name (op-value gnc:pagename-display optname-disp-addr-name))
+         (disp-addr1 (op-value gnc:pagename-display optname-disp-addr1))
+         (disp-addr2 (op-value gnc:pagename-display optname-disp-addr2))
+         (disp-addr3 (op-value gnc:pagename-display optname-disp-addr3))
+         (disp-addr4 (op-value gnc:pagename-display optname-disp-addr4))
+         (disp-addr-phone (op-value gnc:pagename-display optname-disp-addr-phone))
+         (disp-addr-fax (op-value gnc:pagename-display optname-disp-addr-fax))
+         (disp-addr-email (op-value gnc:pagename-display optname-disp-addr-email))
+         (disp-active (op-value gnc:pagename-display optname-disp-active))
+         (heading-list make-heading-list)
+         (exchange-fn (gnc:case-exchange-fn price-source report-currency report-date))
+         (total-collector-list (make-collector-list))
+         (table (gnc:make-html-table))
+         (query (qof-query-create-for-splits))
+         (company-list '())
+         (work-done 0)
+         (work-to-do 0)
+         (document (gnc:make-html-document)))
+    ;; (gnc:debug "Account: " account)
 
     ;; add optional column headings
     (if disp-addr-name
-      (set! heading-list (append heading-list (list (_ "Address Name")))))
+        (set! heading-list (append heading-list (list (_ "Address Name")))))
     (if disp-addr1
-      (set! heading-list (append heading-list (list (_ "Address 1")))))
+        (set! heading-list (append heading-list (list (_ "Address 1")))))
     (if disp-addr2
-      (set! heading-list (append heading-list (list (_ "Address 2")))))
+        (set! heading-list (append heading-list (list (_ "Address 2")))))
     (if disp-addr3
-      (set! heading-list (append heading-list (list (_ "Address 3")))))
+        (set! heading-list (append heading-list (list (_ "Address 3")))))
     (if disp-addr4
-      (set! heading-list (append heading-list (list (_ "Address 4")))))
+        (set! heading-list (append heading-list (list (_ "Address 4")))))
     (if disp-addr-phone
-      (set! heading-list (append heading-list (list (_ "Phone")))))
+        (set! heading-list (append heading-list (list (_ "Phone")))))
     (if disp-addr-fax
-      (set! heading-list (append heading-list (list (_ "Fax")))))
+        (set! heading-list (append heading-list (list (_ "Fax")))))
     (if disp-addr-email
-      (set! heading-list (append heading-list (list (_ "Email")))))
+        (set! heading-list (append heading-list (list (_ "Email")))))
     (if disp-active
-      (set! heading-list (append heading-list (list (_ "Active")))))
+        (set! heading-list (append heading-list (list (_ "Active")))))
 
     ;; set default title
     (gnc:html-document-set-title! document report-title)
@@ -720,141 +735,146 @@ copying this report to a spreadsheet for use in a mail merge.")
         (begin
           (gnc:html-document-set-title!
            document (string-append report-title ": " (xaccAccountGetName account)))
-          (gnc:html-document-set-headline! document
-                                           (gnc:html-markup
-                                            "!" 
-                                            report-title
-                                            ": "
-                                            (gnc:html-markup-anchor
-                                             (gnc:account-anchor-text account)
-                                             (xaccAccountGetName account))))))
+          (gnc:html-document-set-headline!
+           document (gnc:html-markup
+                     "!" report-title ": "
+                     (gnc:html-markup-anchor
+                      (gnc:account-anchor-text account)
+                      (xaccAccountGetName account))))))
 
     (gnc:html-table-set-col-headers! table heading-list)
-				     
+
     (if (and account (not (null? account)))
-	(begin
-	  (setup-query query account report-date)
-	  ;; get the appropriate splits
-	  (let ((splits (qof-query-run query)))
-;	    (gnc:debug "splits" splits)
+        (begin
+          (setup-query query account report-date)
+          ;; get the appropriate splits
+          (let ((splits (qof-query-run query)))
+            ;; (gnc:debug "splits" splits)
 
-	    ;; build the table
-	    (set! work-to-do (length splits))
-	    ;; work-done is already zero
-	    (for-each (lambda (split)
-			(gnc:report-percent-done (* 50 (/ work-done work-to-do)))
-			(set! work-done (+ 1 work-done))
-			(update-company-hash companys 
-					      split 
-					      interval-vec 
-					      reverse? show-zeros
-                                              date-type))
-			splits)
-;	    (gnc:debug "companys" companys)
-	    ;; turn the hash into a list
-	    (hash-for-each (lambda (key value)
-			     (set! company-list
-				   (cons (cons key value) company-list)))
-			   companys)
-;	    (gnc:debug "company list" company-list)
-	   
-	    (set! company-list (sort-list! company-list
-					    sort-pred))
+            ;; build the table
+            (set! work-to-do (length splits))
+            ;; work-done is already zero
+            (for-each
+             (lambda (split)
+               (gnc:report-percent-done (* 50 (/ work-done work-to-do)))
+               (set! work-done (+ 1 work-done))
+               (update-company-hash companys split interval-vec
+                                    reverse? show-zeros date-type))
+             splits)
+            ;; (gnc:debug "companys" companys)
+            ;; turn the hash into a list
+            (hash-for-each
+             (lambda (key value)
+               (set! company-list
+                 (cons (cons key value) company-list)))
+             companys)
+            ;; (gnc:debug "company list" company-list)
 
-	    ;; build the table
-	    (set! work-to-do (length company-list))
-	    (set! work-done 0)
-	    (for-each (lambda (company-list-entry)
-			(gnc:report-percent-done (+ 50 (* 50 (/ work-done work-to-do))))
-			(set! work-done (+ 1 work-done))
-			(let* ((monetary-list (convert-to-monetary-list
-					       (company-get-buckets
-						(cdr company-list-entry))
-					       (company-get-currency
-						(cdr company-list-entry))
-					       (company-get-overpayment
-						(cdr company-list-entry))))
-			       (owner (company-get-owner-obj
-				       (cdr company-list-entry)))
-			       (company-name (gncOwnerGetName owner))
-			       (addr (get-addr owner disp-addr-source))
-			       (addr-name  (gncAddressGetName  addr))
-			       (addr-addr1 (gncAddressGetAddr1 addr))
-			       (addr-addr2 (gncAddressGetAddr2 addr))
-			       (addr-addr3 (gncAddressGetAddr3 addr))
-			       (addr-addr4 (gncAddressGetAddr4 addr))
-			       (addr-phone (gncAddressGetPhone addr))
-			       (addr-fax   (gncAddressGetFax   addr))
-			       (addr-email (gncAddressGetEmail addr))
-			       (company-active (if (gncOwnerGetActive owner)
-			         (_ "Y") (_ "N")))
-			       (opt-fld-list '())
-			      )
-;;            (gnc:debug "aging-renderer: disp-addr-source=" disp-addr-source
-;;              " owner=" owner
-;;              " gncOwnerGetID="  (gncOwnerGetID owner)	;; cust no
-;;              " gncCustomerGetShipAddr="                  
-;;                (gncCustomerGetShipAddr (gncOwnerGetCustomer owner)))
-			  (if disp-addr-name
-			    (set! opt-fld-list (append opt-fld-list (list addr-name))))
-			  (if disp-addr1
-                (set! opt-fld-list (append opt-fld-list (list addr-addr1))))
-			  (if disp-addr2
-                (set! opt-fld-list (append opt-fld-list (list addr-addr2))))
-			  (if disp-addr3
-                (set! opt-fld-list (append opt-fld-list (list addr-addr3))))
-			  (if disp-addr4
-                (set! opt-fld-list (append opt-fld-list (list addr-addr4))))
-			  (if disp-addr-phone
-                (set! opt-fld-list (append opt-fld-list (list addr-phone))))
-			  (if disp-addr-fax
-                (set! opt-fld-list (append opt-fld-list (list addr-fax))))
-			  (if disp-addr-email
-                (set! opt-fld-list (append opt-fld-list (list addr-email))))
-			  (if disp-active
-                (set! opt-fld-list (append opt-fld-list (list company-active))))
-			  (add-to-column-totals total-collector-list
-						monetary-list)
+            (set! company-list (sort-list! company-list sort-pred))
 
-			  (let* ((ml (reverse monetary-list))
-				 (total (car ml))
-				 (rest (cdr ml)))
+            ;; build the table
+            (set! work-to-do (length company-list))
+            (set! work-done 0)
+            (for-each
+             (lambda (company-list-entry)
+               (gnc:report-percent-done (+ 50 (* 50 (/ work-done work-to-do))))
+               (set! work-done (+ 1 work-done))
+               (let* ((monetary-list (convert-to-monetary-list
+                                      (company-get-buckets
+                                       (cdr company-list-entry))
+                                      (company-get-currency
+                                       (cdr company-list-entry))
+                                      (company-get-overpayment
+                                       (cdr company-list-entry))))
+                      (owner (company-get-owner-obj
+                              (cdr company-list-entry)))
+                      (company-name (gncOwnerGetName owner))
+                      (addr (get-addr owner disp-addr-source))
+                      (addr-name  (gncAddressGetName  addr))
+                      (addr-addr1 (gncAddressGetAddr1 addr))
+                      (addr-addr2 (gncAddressGetAddr2 addr))
+                      (addr-addr3 (gncAddressGetAddr3 addr))
+                      (addr-addr4 (gncAddressGetAddr4 addr))
+                      (addr-phone (gncAddressGetPhone addr))
+                      (addr-fax   (gncAddressGetFax   addr))
+                      (addr-email (gncAddressGetEmail addr))
+                      (company-active (if (gncOwnerGetActive owner)
+                                          (_ "Y") (_ "N")))
+                      (opt-fld-list '()))
+                 ;; (gnc:debug "aging-renderer: disp-addr-source="
+                 ;;            disp-addr-source
+                 ;;            " owner=" owner
+                 ;;            " gncOwnerGetID=" (gncOwnerGetID owner)
+                 ;;            " gncCustomerGetShipAddr="
+                 ;;            (gncCustomerGetShipAddr
+                 ;;             (gncOwnerGetCustomer owner)))
+                 (if disp-addr-name
+                     (set! opt-fld-list
+                       (append opt-fld-list (list addr-name))))
+                 (if disp-addr1
+                     (set! opt-fld-list
+                       (append opt-fld-list (list addr-addr1))))
+                 (if disp-addr2
+                     (set! opt-fld-list
+                       (append opt-fld-list (list addr-addr2))))
+                 (if disp-addr3
+                     (set! opt-fld-list
+                       (append opt-fld-list (list addr-addr3))))
+                 (if disp-addr4
+                     (set! opt-fld-list
+                       (append opt-fld-list (list addr-addr4))))
+                 (if disp-addr-phone
+                     (set! opt-fld-list
+                       (append opt-fld-list (list addr-phone))))
+                 (if disp-addr-fax
+                     (set! opt-fld-list
+                       (append opt-fld-list (list addr-fax))))
+                 (if disp-addr-email
+                     (set! opt-fld-list
+                       (append opt-fld-list (list addr-email))))
+                 (if disp-active
+                     (set! opt-fld-list
+                       (append opt-fld-list (list company-active))))
+                 (add-to-column-totals total-collector-list
+                                       monetary-list)
 
-			    (set! monetary-list
-				  (reverse
-				   (cons
-				    (gnc:make-html-text
-				     (gnc:html-markup-anchor
-				      (gnc:owner-report-text owner account)
-				      total))
-				    rest))))
+                 (let* ((ml (reverse monetary-list))
+                        (total (car ml))
+                        (rest (cdr ml)))
 
-			  (gnc:html-table-append-row! table
-			  	(append
-			  	  (cons
-				    (gnc:make-html-text
-				      (gnc:html-markup-anchor
-				        (gnc:owner-anchor-text owner)
-				        company-name))
-				    monetary-list)
-				  opt-fld-list))
-			  (gncOwnerFree owner)))
-		      company-list)
+                   (set! monetary-list
+                     (reverse
+                      (cons
+                       (gnc:make-html-text
+                        (gnc:html-markup-anchor
+                         (gnc:owner-report-text owner account)
+                         total))
+                       rest))))
 
-	    ;; add the totals
-	    (gnc:html-table-append-row!
-	     table 
-	     (cons (_ "Total") (convert-collectors total-collector-list 
-						   report-currency
-						   exchange-fn
-						   multi-totals-p)))
-	     
-	    (gnc:html-document-add-object!
-	     document table)))
-	(gnc:html-document-add-object!
-	 document
-	 (gnc:make-html-text
-	  (_ "No valid account selected. Click on the Options button and select the account to use."))))
+                 (gnc:html-table-append-row! table
+                                             (append
+                                              (cons
+                                               (gnc:make-html-text
+                                                (gnc:html-markup-anchor
+                                                 (gnc:owner-anchor-text owner)
+                                                 company-name))
+                                               monetary-list)
+                                              opt-fld-list))
+                 (gncOwnerFree owner)))
+             company-list)
+
+            ;; add the totals
+            (gnc:html-table-append-row!
+             table
+             (cons (_ "Total")
+                   (convert-collectors
+                    total-collector-list report-currency exchange-fn multi-totals-p)))
+
+            (gnc:html-document-add-object! document table)))
+        (gnc:html-document-add-object!
+         document
+         (gnc:make-html-text
+          (_ "No valid account selected. Click on the Options button and select the account to use."))))
     (qof-query-destroy query)
     (gnc:report-finished)
     document))

--- a/gnucash/report/business-reports/aging.scm
+++ b/gnucash/report/business-reports/aging.scm
@@ -375,18 +375,16 @@ copying this report to a spreadsheet for use in a mail merge.")
                   (gnc:make-html-table-cell/size
                    1 (+ 2 num-buckets)
                    (xaccAccountGetName account))))
-                (let ((acc-owners
-                       (delete-duplicates
-                        (sort
-                         (map
-                          (compose gncOwnerGetEndOwner gncInvoiceGetOwner
-                                   gncInvoiceGetInvoiceFromTxn xaccSplitGetParent)
-                          (filter (compose txn-is-invoice? xaccSplitGetParent)
-                                  acc-splits))
+                (let* ((acc-owners
+                        (sort-and-delete-duplicates
+                         (map (compose gncOwnerGetEndOwner gncInvoiceGetOwner
+                                       gncInvoiceGetInvoiceFromTxn xaccSplitGetParent)
+                              (filter (compose txn-is-invoice? xaccSplitGetParent)
+                                      acc-splits))
                          (lambda (a b)
                            ((if (eq? sort-order 'increasing) string<? string>?)
-                            (gncOwnerGetName a) (gncOwnerGetName b))))
-                        gnc-owner-equal?)))
+                            (gncOwnerGetName a) (gncOwnerGetName b)))
+                         gnc-owner-equal?)))
                   (gnc:debug 'owners acc-owners)
                   (let lp ((acc-owners acc-owners)
                            (acc-splits acc-splits)

--- a/gnucash/report/business-reports/aging.scm
+++ b/gnucash/report/business-reports/aging.scm
@@ -419,37 +419,37 @@ copying this report to a spreadsheet for use in a mail merge.")
                                (aging (owner-splits->aging-list
                                        owner-splits report-date date-type reverse?))
                                (aging-total (apply + aging)))
-                          (gnc:html-table-append-row!
-                           table
-                           (append
-                            (list #f)
-                            (cons
-                             (gnc:make-html-text
-                              (gnc:html-markup-anchor
-                               (gnc:owner-anchor-text owner)
-                               (gncOwnerGetName owner)))
-                             (map
-                              (lambda (amt)
-                                (gnc:make-html-table-cell/markup
-                                 "number-cell"
-				 (gnc:make-gnc-monetary
-                                  (xaccAccountGetCommodity account)
-                                  amt)))
-                              (reverse aging)))
-                            (list
-                             (gnc:make-html-table-cell/markup
-                              "number-cell"
-                              (gnc:make-html-text
-                               (gnc:html-markup-anchor
-			        (gnc:owner-report-text owner account)
-			        (gnc:make-gnc-monetary
-                                 (xaccAccountGetCommodity account)
-                                 aging-total)))))
-                            (list)))
+                          (when (or show-zeros (not (every zero? aging)))
+                            (gnc:html-table-append-row!
+                             table
+                             (append
+                              (list #f)
+                              (cons
+                               (gnc:make-html-text
+                                (gnc:html-markup-anchor
+                                 (gnc:owner-anchor-text owner)
+                                 (gncOwnerGetName owner)))
+                               (map
+                                (lambda (amt)
+                                  (gnc:make-html-table-cell/markup
+                                   "number-cell"
+				   (gnc:make-gnc-monetary
+                                    (xaccAccountGetCommodity account)
+                                    amt)))
+                                (reverse aging)))
+                              (list
+                               (gnc:make-html-table-cell/markup
+                                "number-cell"
+                                (gnc:make-html-text
+                                 (gnc:html-markup-anchor
+			          (gnc:owner-report-text owner account)
+			          (gnc:make-gnc-monetary
+                                   (xaccAccountGetCommodity account)
+                                   aging-total)))))
+                              (list))))
                           (lp (cdr acc-owners)
                               not-owner-splits
-                              (map +
-                                   acc-totals
+                              (map + acc-totals
                                    (reverse (cons aging-total aging))))))))))))))))))
     (gnc:report-finished)
     document))

--- a/gnucash/report/business-reports/aging.scm
+++ b/gnucash/report/business-reports/aging.scm
@@ -363,11 +363,11 @@ copying this report to a spreadsheet for use in a mail merge.")
                  table)))
            (else
             (let ((account (car accounts)))
-              (receive (acc-splits not-acc-splits)
-                  (partition
-                   (lambda (split)
-                     (equal? account (xaccSplitGetAccount split)))
-                   splits)
+              (let-values (((acc-splits other-acc-splits)
+                            (partition
+                             (lambda (split)
+                               (equal? account (xaccSplitGetAccount split)))
+                             splits)))
                 (gnc:debug 'account account)
                 (gnc:html-table-append-row!
                  table
@@ -407,14 +407,14 @@ copying this report to a spreadsheet for use in a mail merge.")
                                                  amt)))
                          acc-totals)))
                       (loop (cdr accounts)
-                            not-acc-splits))
+                            other-acc-splits))
                      (else
-                      (receive (owner-splits not-owner-splits)
-                          (partition
-                           (lambda (split)
-                             (string=? (gncOwnerReturnGUID (car acc-owners))
-                                       (gncOwnerReturnGUID (split->owner split))))
-                           acc-splits)
+                      (let-values (((owner-splits other-owner-splits)
+                                    (partition
+                                     (lambda (split)
+                                       (gnc-owner-equal? (car acc-owners)
+                                                         (split->owner split)))
+                                     acc-splits)))
                         (let* ((owner (car acc-owners))
                                (aging (owner-splits->aging-list
                                        owner-splits report-date date-type reverse?))
@@ -448,7 +448,7 @@ copying this report to a spreadsheet for use in a mail merge.")
                                    aging-total)))))
                               (list))))
                           (lp (cdr acc-owners)
-                              not-owner-splits
+                              other-owner-splits
                               (map + acc-totals
                                    (reverse (cons aging-total aging))))))))))))))))))
     (gnc:report-finished)

--- a/gnucash/report/business-reports/payables.scm
+++ b/gnucash/report/business-reports/payables.scm
@@ -36,19 +36,12 @@
 (use-modules (gnucash report business-reports))
 
 (define acc-page gnc:pagename-general)
-(define this-acc (N_ "Payable Account"))
 
 (define (options-generator)    
   (let* ((options (gnc:new-options)) 
          (add-option 
           (lambda (new-option)
             (gnc:register-option options new-option))))
-
-    (add-option
-     (gnc:make-account-sel-limited-option
-      acc-page this-acc
-      "w" (N_ "The payable account you wish to examine.") 
-      #f #f (list ACCT-TYPE-PAYABLE)))
 
     ;; As aging.scm functions are used by both receivables.scm and payables.scm
     ;;  add option "receivable" on hidden page "__hidden" with default value 'P
@@ -66,9 +59,7 @@
     (gnc:option-value
      (gnc:lookup-option (gnc:report-options report-obj) section name)))
 
-  (let ((payables-account (opt-val acc-page this-acc)))
-    (gnc:debug "payables-account" payables-account)
-    (aging-renderer report-obj this-acc payables-account #f)))
+  (aging-renderer report-obj #f #f #f))
 
 (define payables-aging-guid "e57770f2dbca46619d6dac4ac5469b50")
 

--- a/gnucash/report/business-reports/receivables.scm
+++ b/gnucash/report/business-reports/receivables.scm
@@ -36,7 +36,6 @@
 (use-modules (gnucash report business-reports))
 
 (define acc-page gnc:pagename-general)
-(define this-acc (N_ "Receivables Account"))
 (define optname-addr-source (N_ "Address Source")) ;; Billing or Shipping addresses
 
 (define (options-generator)    
@@ -44,12 +43,6 @@
          (add-option 
           (lambda (new-option)
             (gnc:register-option options new-option))))
-
-    (add-option
-     (gnc:make-account-sel-limited-option
-      acc-page this-acc
-      "w" (N_ "The receivables account you wish to examine.") 
-      #f #f (list ACCT-TYPE-RECEIVABLE)))
 
     ;; As aging.scm functions are used by both receivables.scm and payables.scm
     ;;  add option "receivable" on hidden page "__hidden" with default value 'R
@@ -78,10 +71,7 @@
     (gnc:option-value
      (gnc:lookup-option (gnc:report-options report-obj) section name)))
 
-  (let* ((receivables-account (op-value acc-page this-acc)))
-    (gnc:debug "receivables-account" receivables-account)
-
-    (aging-renderer report-obj this-acc receivables-account #t)))
+  (aging-renderer report-obj #f #f #t))
 
 (define receivables-aging-guid "9cf76bed17f14401b8e3e22d0079cb98")
 


### PR DESCRIPTION
Rebuild aging report from the ground up. Much easier using srfi-1. I can further break out larger functions for greater clarity. Some tricks:
* one query for the whole AP/AR query all splits, filtered for txn-type-invoice/payment types only
* all above analysed to obtain list of owners
* for-each owner, whole splitlist is `partition`ed into splits-belonging-to-owner and other-splits
  * owner-splits are analysed via lots to create aging-table
  * other-splits are then recycled to scan the next owner.
* all AP or AR accounts are scanned, which creates report with subtotals with all their currencies.

Removed features
* APAR-account selection
* sorting now works on account-name only; removed sort by aging-table or amount
* "show multicurrency subtotals" which had never worked properly.
* printing of owner address

Pending
* [ ] Clarification on overpayments & credit-notes -- how should overpayments be shown on aging-table? Should credit-notes automatically be applied to reduce invoices?
* Reinstate printing of owner address -- is this important?

Result
![image](https://user-images.githubusercontent.com/1975870/61539513-36ba3780-aa2b-11e9-89d8-c1c35d945a04.png)
