### PR TITLE
Bug797301

### DIFF
--- a/gnucash/gnome/gnc-plugin-page-account-tree.c
+++ b/gnucash/gnome/gnc-plugin-page-account-tree.c
@@ -146,6 +146,7 @@ static void gnc_plugin_page_account_tree_cmd_delete_account (GtkAction *action, 
 static void gnc_plugin_page_account_tree_cmd_renumber_accounts (GtkAction *action, GncPluginPageAccountTree *page);
 static void gnc_plugin_page_account_tree_cmd_view_filter_by (GtkAction *action, GncPluginPageAccountTree *plugin_page);
 static void gnc_plugin_page_account_tree_cmd_reconcile (GtkAction *action, GncPluginPageAccountTree *page);
+static void gnc_plugin_page_account_tree_cmd_refresh (GtkAction *action, GncPluginPageAccountTree *page);
 static void gnc_plugin_page_account_tree_cmd_autoclear (GtkAction *action, GncPluginPageAccountTree *page);
 static void gnc_plugin_page_account_tree_cmd_transfer (GtkAction *action, GncPluginPageAccountTree *page);
 static void gnc_plugin_page_account_tree_cmd_stock_split (GtkAction *action, GncPluginPageAccountTree *page);
@@ -252,6 +253,11 @@ static GtkActionEntry gnc_plugin_page_account_tree_actions [] =
     {
         "ViewFilterByAction", NULL, N_("_Filter By..."), NULL, NULL,
         G_CALLBACK (gnc_plugin_page_account_tree_cmd_view_filter_by)
+    },
+    {
+        "ViewRefreshAction", "view-refresh", N_("_Refresh"), "<primary>r",
+        N_("Refresh this window"),
+        G_CALLBACK (gnc_plugin_page_account_tree_cmd_refresh)
     },
 
     /* Actions menu */
@@ -1654,6 +1660,18 @@ gnc_plugin_page_account_tree_cmd_renumber_accounts (GtkAction *action,
         return;
 
     gnc_account_renumber_create_dialog(window, account);
+}
+
+static void
+gnc_plugin_page_account_tree_cmd_refresh (GtkAction *action,
+        GncPluginPageAccountTree *page)
+{
+    GncPluginPageAccountTreePrivate *priv;
+
+    g_return_if_fail(GNC_IS_PLUGIN_PAGE_ACCOUNT_TREE(page));
+
+    priv = GNC_PLUGIN_PAGE_ACCOUNT_TREE_GET_PRIVATE(page);
+    gtk_widget_queue_draw (priv->widget);
 }
 
 /*********************/

--- a/gnucash/gnome/gnc-plugin-page-budget.c
+++ b/gnucash/gnome/gnc-plugin-page-budget.c
@@ -117,6 +117,8 @@ static void gnc_plugin_page_budget_cmd_estimate_budget(
     GtkAction *action, GncPluginPageBudget *page);
 static void gnc_plugin_page_budget_cmd_allperiods_budget(
     GtkAction *action, GncPluginPageBudget *page);
+static void gnc_plugin_page_budget_cmd_refresh (
+    GtkAction *action, GncPluginPageBudget *page);
 
 static GtkActionEntry gnc_plugin_page_budget_actions [] =
 {
@@ -164,6 +166,11 @@ static GtkActionEntry gnc_plugin_page_budget_actions [] =
     {
         "ViewFilterByAction", NULL, N_("_Filter By..."), NULL, NULL,
         G_CALLBACK (gnc_plugin_page_budget_cmd_view_filter_by)
+    },
+    {
+        "ViewRefreshAction", "view-refresh", N_("_Refresh"), "<primary>r",
+        N_("Refresh this window"),
+        G_CALLBACK (gnc_plugin_page_budget_cmd_refresh)
     },
 
 };
@@ -1143,5 +1150,20 @@ gnc_plugin_page_budget_cmd_view_filter_by (GtkAction *action,
     priv = GNC_PLUGIN_PAGE_BUDGET_GET_PRIVATE(page);
     account_filter_dialog_create(&priv->fd, GNC_PLUGIN_PAGE(page));
 
+    LEAVE(" ");
+}
+
+static void
+gnc_plugin_page_budget_cmd_refresh (GtkAction *action,
+        GncPluginPageBudget *page)
+{
+    GncPluginPageBudgetPrivate *priv;
+
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_BUDGET(page));
+    ENTER("(action %p, page %p)", action, page);
+
+    priv = GNC_PLUGIN_PAGE_BUDGET_GET_PRIVATE(page);
+
+    gnc_budget_view_refresh (priv->budget_view);
     LEAVE(" ");
 }

--- a/gnucash/gnome/gnc-plugin-page-invoice.c
+++ b/gnucash/gnome/gnc-plugin-page-invoice.c
@@ -69,6 +69,7 @@ static void gnc_plugin_page_invoice_cmd_edit (GtkAction *action, GncPluginPageIn
 static void gnc_plugin_page_invoice_cmd_duplicateInvoice (GtkAction *action, GncPluginPageInvoice *plugin_page);
 static void gnc_plugin_page_invoice_cmd_post (GtkAction *action, GncPluginPageInvoice *plugin_page);
 static void gnc_plugin_page_invoice_cmd_unpost (GtkAction *action, GncPluginPageInvoice *plugin_page);
+static void gnc_plugin_page_invoice_cmd_refresh (GtkAction *action, GncPluginPageInvoice *plugin_page);
 
 static void gnc_plugin_page_invoice_cmd_sort_changed (GtkAction *action,
         GtkRadioAction *current,
@@ -145,6 +146,13 @@ static GtkActionEntry gnc_plugin_page_invoice_actions [] =
         "EditUnpostInvoiceAction", GNC_ICON_INVOICE_UNPOST, N_("_Unpost Invoice"), NULL,
         N_("Unpost this Invoice and make it editable"),
         G_CALLBACK (gnc_plugin_page_invoice_cmd_unpost)
+    },
+
+    /* View menu */
+    {
+        "ViewRefreshAction", "view-refresh", N_("_Refresh"), "<primary>r",
+        N_("Refresh this window"),
+        G_CALLBACK (gnc_plugin_page_invoice_cmd_refresh)
     },
 
     /* Actions menu */
@@ -853,6 +861,20 @@ gnc_plugin_page_invoice_cmd_sort_changed (GtkAction *action,
     LEAVE(" ");
 }
 
+static void
+gnc_plugin_page_invoice_cmd_refresh (GtkAction *action,
+                                     GncPluginPageInvoice *plugin_page)
+{
+    GncPluginPageInvoicePrivate *priv;
+
+    g_return_if_fail(GNC_IS_PLUGIN_PAGE_INVOICE(plugin_page));
+
+    ENTER("(action %p, plugin_page %p)", action, plugin_page);
+    priv = GNC_PLUGIN_PAGE_INVOICE_GET_PRIVATE(plugin_page);
+
+    gtk_widget_queue_draw (priv->widget);
+    LEAVE(" ");
+}
 
 static void
 gnc_plugin_page_invoice_cmd_enter (GtkAction *action,

--- a/gnucash/gnome/gnc-plugin-page-owner-tree.c
+++ b/gnucash/gnome/gnc-plugin-page-owner-tree.c
@@ -123,6 +123,7 @@ static void gnc_plugin_page_owner_tree_cmd_edit_owner (GtkAction *action, GncPlu
 static void gnc_plugin_page_owner_tree_cmd_delete_owner (GtkAction *action, GncPluginPageOwnerTree *page);
 #endif
 static void gnc_plugin_page_owner_tree_cmd_view_filter_by (GtkAction *action, GncPluginPageOwnerTree *page);
+static void gnc_plugin_page_owner_tree_cmd_refresh (GtkAction *action, GncPluginPageOwnerTree *page);
 static void gnc_plugin_page_owner_tree_cmd_new_invoice (GtkAction *action, GncPluginPageOwnerTree *page);
 static void gnc_plugin_page_owner_tree_cmd_owners_report (GtkAction *action, GncPluginPageOwnerTree *plugin_page);
 static void gnc_plugin_page_owner_tree_cmd_owner_report (GtkAction *action, GncPluginPageOwnerTree *plugin_page);
@@ -180,6 +181,11 @@ static GtkActionEntry gnc_plugin_page_owner_tree_actions [] =
     {
         "ViewFilterByAction", NULL, N_("_Filter By..."), NULL, NULL,
         G_CALLBACK (gnc_plugin_page_owner_tree_cmd_view_filter_by)
+    },
+    {
+        "ViewRefreshAction", "view-refresh", N_("_Refresh"), "<primary>r",
+        N_("Refresh this window"),
+        G_CALLBACK (gnc_plugin_page_owner_tree_cmd_refresh)
     },
 
     /* Business menu */
@@ -1150,6 +1156,17 @@ gnc_plugin_page_owner_tree_cmd_view_filter_by (GtkAction *action,
     LEAVE(" ");
 }
 
+static void
+gnc_plugin_page_owner_tree_cmd_refresh (GtkAction *action,
+        GncPluginPageOwnerTree *page)
+{
+    GncPluginPageOwnerTreePrivate *priv;
+
+    g_return_if_fail(GNC_IS_PLUGIN_PAGE_OWNER_TREE(page));
+
+    priv = GNC_PLUGIN_PAGE_OWNER_TREE_GET_PRIVATE(page);
+    gtk_widget_queue_draw (priv->widget);
+}
 
 static void
 gnc_plugin_page_owner_tree_cmd_new_invoice (GtkAction *action,

--- a/gnucash/gnome/gnc-plugin-page-register.c
+++ b/gnucash/gnome/gnc-plugin-page-register.c
@@ -175,6 +175,7 @@ static void gnc_plugin_page_register_cmd_reinitialize_transaction (GtkAction *ac
 static void gnc_plugin_page_register_cmd_expand_transaction (GtkToggleAction *action, GncPluginPageRegister *plugin_page);
 static void gnc_plugin_page_register_cmd_exchange_rate (GtkAction *action, GncPluginPageRegister *plugin_page);
 static void gnc_plugin_page_register_cmd_jump (GtkAction *action, GncPluginPageRegister *plugin_page);
+static void gnc_plugin_page_register_cmd_reload (GtkAction *action, GncPluginPageRegister *plugin_page);
 static void gnc_plugin_page_register_cmd_schedule (GtkAction *action, GncPluginPageRegister *plugin_page);
 static void gnc_plugin_page_register_cmd_scrub_all (GtkAction *action, GncPluginPageRegister *plugin_page);
 static void gnc_plugin_page_register_cmd_scrub_current (GtkAction *action, GncPluginPageRegister *plugin_page);
@@ -348,6 +349,11 @@ static GtkActionEntry gnc_plugin_page_register_actions [] =
     {
         "ViewFilterByAction", NULL, N_("_Filter By..."), NULL, NULL,
         G_CALLBACK (gnc_plugin_page_register_cmd_view_filter_by)
+    },
+    {
+        "ViewRefreshAction", "view-refresh", N_("_Refresh"), "<primary>r",
+        N_("Refresh this window"),
+        G_CALLBACK (gnc_plugin_page_register_cmd_reload)
     },
 
     /* Actions menu */
@@ -4040,6 +4046,29 @@ gnc_plugin_page_register_cmd_view_filter_by (GtkAction *action,
     /* Show it */
     gtk_widget_show(dialog);
     g_object_unref(G_OBJECT(builder));
+    LEAVE(" ");
+}
+
+static void
+gnc_plugin_page_register_cmd_reload (GtkAction *action, GncPluginPageRegister *plugin_page)
+{
+    GncPluginPageRegisterPrivate *priv;
+    SplitRegister *reg;
+
+    ENTER("(action %p, page %p)", action, plugin_page);
+
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page));
+
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
+    reg = gnc_ledger_display_get_split_register (priv->ledger);
+
+    /* Check for trans being edited */
+    if (gnc_split_register_changed (reg))
+    {
+        LEAVE("register has pending edits");
+        return;
+    }
+    gnc_ledger_display_refresh (priv->ledger);
     LEAVE(" ");
 }
 

--- a/gnucash/gnome/gnc-plugin-page-sx-list.c
+++ b/gnucash/gnome/gnc-plugin-page-sx-list.c
@@ -127,6 +127,7 @@ static void gnc_plugin_page_sx_list_cmd_edit2(GtkAction *action, GncPluginPageSx
 /*################## Added for Reg2 #################*/
 #endif
 static void gnc_plugin_page_sx_list_cmd_delete(GtkAction *action, GncPluginPageSxList *page);
+static void gnc_plugin_page_sx_list_cmd_refresh (GtkAction *action, GncPluginPageSxList *page);
 
 /* Command callbacks */
 static GtkActionEntry gnc_plugin_page_sx_list_actions [] =
@@ -159,6 +160,13 @@ static GtkActionEntry gnc_plugin_page_sx_list_actions [] =
     {
         "SxListDeleteAction", GNC_ICON_DELETE_ACCOUNT, N_("_Delete"), NULL,
         N_("Delete the selected scheduled transaction"), G_CALLBACK(gnc_plugin_page_sx_list_cmd_delete)
+    },
+
+    /* View menu */
+
+    {
+        "ViewRefreshAction", "view-refresh", N_("_Refresh"), "<primary>r",
+        N_("Refresh this window"), G_CALLBACK (gnc_plugin_page_sx_list_cmd_refresh)
     },
 };
 /** The number of actions provided by this plugin. */
@@ -658,6 +666,17 @@ gnc_plugin_page_sx_list_cmd_new2 (GtkAction *action, GncPluginPageSxList *page)
 }
 /*################## Added for Reg2 #################*/
 #endif
+
+static void
+gnc_plugin_page_sx_list_cmd_refresh (GtkAction *action, GncPluginPageSxList *page)
+{
+    GncPluginPageSxListPrivate *priv;
+
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_SX_LIST(page));
+
+    priv = GNC_PLUGIN_PAGE_SX_LIST_GET_PRIVATE(page);
+    gtk_widget_queue_draw (priv->widget);
+}
 
 static void
 _edit_sx(gpointer data, gpointer user_data)

--- a/gnucash/gtkbuilder/dialog-import.glade
+++ b/gnucash/gtkbuilder/dialog-import.glade
@@ -79,7 +79,7 @@
             <property name="expand">False</property>
             <property name="fill">False</property>
             <property name="pack_type">end</property>
-            <property name="position">0</property>
+            <property name="position">4</property>
           </packing>
         </child>
         <child>
@@ -106,6 +106,20 @@
             <property name="expand">False</property>
             <property name="fill">False</property>
             <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkScrolledWindow" id="account_tree_sw">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
           </packing>
         </child>
         <child>
@@ -143,22 +157,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="pack_type">end</property>
-            <property name="position">2</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkScrolledWindow" id="account_tree_sw">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <child>
-              <placeholder/>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">4</property>
+            <property name="position">3</property>
           </packing>
         </child>
       </object>
@@ -1282,9 +1281,6 @@
             <property name="pack_type">end</property>
             <property name="position">0</property>
           </packing>
-        </child>
-        <child>
-          <placeholder/>
         </child>
       </object>
     </child>

--- a/gnucash/register/ledger-core/split-register.c
+++ b/gnucash/register/ledger-core/split-register.c
@@ -1969,7 +1969,7 @@ gnc_split_register_get_account_by_name (SplitRegister *reg, BasicCell * bcell,
     g_free (account_name);
 
     /* See if the account (either old or new) is a placeholder. */
-    if (xaccAccountGetPlaceholder (account))
+    if (account && xaccAccountGetPlaceholder (account))
     {
         gnc_error_dialog (GTK_WINDOW (gnc_split_register_get_parent (reg)),
                           placeholder, name);

--- a/gnucash/register/register-gnome/gnucash-sheet.c
+++ b/gnucash/register/register-gnome/gnucash-sheet.c
@@ -1855,7 +1855,12 @@ gnucash_sheet_key_press_event_internal (GtkWidget *widget, GdkEventKey *event)
 
     /* If that would leave the register, abort */
     if (abort_move)
+    {
+        // Make sure the sheet is the focus
+        if (!gtk_widget_has_focus(GTK_WIDGET (sheet)))
+            gtk_widget_grab_focus (GTK_WIDGET (sheet));
         return TRUE;
+    }
 
     /* Clear the saved selection for the new cell. */
     sheet->end_sel = sheet->start_sel;


### PR DESCRIPTION
This is a two part fix, the first commit adds a fix for the menu View->refresh that only worked on the report pages, the other pages did not connect to the menu item so for the register and budget they are reloaded and for other pages a GTK queue draw is requested.
The second fixes when in a sub-account register and you create another account which is also a sub-account but the register does not update. To fix this the number of sub-accounts is tracked and if it is different on the refresh the query is recreated as opposed to just rerun.

The error cancelling commit fixes when you are asked whether you want to create a new account in the register, possibly due to a typo and you answer no, the same dialogue will appear another three times before resetting the account cell to the original value. This change eliminate that by returning you back to the cell with the invalid entry so that you can amend / cancel or use the dialogue again to create a new account based on an amended entry. It also fixes if you create a placeholder account, which brings up a warning dialogue but currently will still allow the transaction to be added to the placeholder.

I have tried this on Linux and Windows and I think it works as expected but would appreciate if some else gave it a spin before I push it.