### PR TITLE
[Master] Remove preference callbacks on quit / window close

### DIFF
--- a/gnucash/gnome-utils/account-quickfill.c
+++ b/gnucash/gnome-utils/account-quickfill.c
@@ -65,7 +65,7 @@ static void
 shared_quickfill_destroy (QofBook *book, gpointer key, gpointer user_data)
 {
     QFB *qfb = user_data;
-    gnc_prefs_remove_cb_by_func (GNC_PREFS_GROUP_GENERAL_REGISTER,
+    gnc_prefs_remove_cb_by_func (GNC_PREFS_GROUP_GENERAL,
                                  GNC_PREF_ACCOUNT_SEPARATOR,
                                  shared_quickfill_pref_changed,
                                  qfb);

--- a/gnucash/gnome-utils/gnc-gnome-utils.c
+++ b/gnucash/gnome-utils/gnc-gnome-utils.c
@@ -748,6 +748,31 @@ gnc_gui_destroy (void)
     if (!gnome_is_initialized)
         return;
 
+    if (gnc_prefs_is_set_up())
+    {
+        gnc_prefs_remove_cb_by_func (GNC_PREFS_GROUP_GENERAL,
+                                     GNC_PREF_DATE_FORMAT,
+                                     gnc_configure_date_format,
+                                     NULL);
+        gnc_prefs_remove_cb_by_func (GNC_PREFS_GROUP_GENERAL,
+                                     GNC_PREF_DATE_COMPL_THISYEAR,
+                                     gnc_configure_date_completion,
+                                     NULL);
+        gnc_prefs_remove_cb_by_func (GNC_PREFS_GROUP_GENERAL,
+                                     GNC_PREF_DATE_COMPL_SLIDING,
+                                     gnc_configure_date_completion,
+                                     NULL);
+        gnc_prefs_remove_cb_by_func (GNC_PREFS_GROUP_GENERAL,
+                                     GNC_PREF_DATE_BACKMONTHS,
+                                     gnc_configure_date_completion,
+                                     NULL);
+        gnc_prefs_remove_group_cb_by_func (GNC_PREFS_GROUP_GENERAL,
+                                           gnc_gui_refresh_all,
+                                           NULL);
+
+        gnc_ui_util_remove_registered_prefs ();
+        gnc_prefs_remove_registered ();
+    }
     gnc_extensions_shutdown ();
 }
 

--- a/gnucash/gnome-utils/gnc-main-window.c
+++ b/gnucash/gnome-utils/gnc-main-window.c
@@ -1385,6 +1385,7 @@ gnc_main_window_quit(GncMainWindow *window)
     if (do_shutdown)
     {
         /* remove the preference callbacks from the main window */
+        window->window_quitting = TRUE;
         gnc_main_window_remove_prefs (window);
         g_timeout_add(250, gnc_main_window_timed_quit, NULL);
         return TRUE;
@@ -2654,7 +2655,7 @@ gnc_main_window_remove_prefs (GncMainWindow *window)
                                  window);
 
     // remove the registered negative color preference callback.
-    if (gnc_prefs_get_reg_negative_color_pref_id() > 0)
+    if (gnc_prefs_get_reg_negative_color_pref_id() > 0 && window->window_quitting)
     {
         gnc_prefs_remove_cb_by_id (GNC_PREFS_GROUP_GENERAL,
                                    gnc_prefs_get_reg_negative_color_pref_id());
@@ -2662,7 +2663,7 @@ gnc_main_window_remove_prefs (GncMainWindow *window)
     }
 
     // remove the registered auto_raise_lists preference callback.
-    if (gnc_prefs_get_reg_auto_raise_lists_id() > 0)
+    if (gnc_prefs_get_reg_auto_raise_lists_id() > 0 && window->window_quitting)
     {
         gnc_prefs_remove_cb_by_id (GNC_PREFS_GROUP_GENERAL_REGISTER,
                                    gnc_prefs_get_reg_auto_raise_lists_id());
@@ -2745,6 +2746,7 @@ gnc_main_window_new (void)
     }
     active_windows = g_list_append (active_windows, window);
     gnc_main_window_update_title(window);
+    window->window_quitting = FALSE;
 #ifdef MAC_INTEGRATION
     gnc_quartz_set_menu(window);
 #else

--- a/gnucash/gnome-utils/gnc-main-window.c
+++ b/gnucash/gnome-utils/gnc-main-window.c
@@ -2652,6 +2652,22 @@ gnc_main_window_remove_prefs (GncMainWindow *window)
                                  GNC_PREF_TAB_POSITION_RIGHT,
                                  gnc_main_window_update_tab_position,
                                  window);
+
+    // remove the registered negative color preference callback.
+    if (gnc_prefs_get_reg_negative_color_pref_id() > 0)
+    {
+        gnc_prefs_remove_cb_by_id (GNC_PREFS_GROUP_GENERAL,
+                                   gnc_prefs_get_reg_negative_color_pref_id());
+        gnc_prefs_set_reg_negative_color_pref_id (0);
+    }
+
+    // remove the registered auto_raise_lists preference callback.
+    if (gnc_prefs_get_reg_auto_raise_lists_id() > 0)
+    {
+        gnc_prefs_remove_cb_by_id (GNC_PREFS_GROUP_GENERAL_REGISTER,
+                                   gnc_prefs_get_reg_auto_raise_lists_id());
+        gnc_prefs_set_reg_auto_raise_lists_id (0);
+    }
 }
 
 

--- a/gnucash/gnome-utils/gnc-main-window.c
+++ b/gnucash/gnome-utils/gnc-main-window.c
@@ -2747,6 +2747,7 @@ gnc_main_window_new (void)
     active_windows = g_list_append (active_windows, window);
     gnc_main_window_update_title(window);
     window->window_quitting = FALSE;
+    window->just_plugin_prefs = FALSE;
 #ifdef MAC_INTEGRATION
     gnc_quartz_set_menu(window);
 #else
@@ -3115,6 +3116,15 @@ gnc_main_window_close_page (GncPluginPage *page)
     priv = GNC_MAIN_WINDOW_GET_PRIVATE(window);
     if (priv->installed_pages == NULL)
     {
+        GncPluginManager *manager = gnc_plugin_manager_get ();
+        GList *plugins = gnc_plugin_manager_get_plugins (manager);
+
+        /* remove only the preference callbacks from the window plugins */
+        window->just_plugin_prefs = TRUE;
+        g_list_foreach (plugins, gnc_main_window_remove_plugin, window);
+        window->just_plugin_prefs = FALSE;
+        g_list_free (plugins);
+
         /* remove the preference callbacks from the main window */
         gnc_main_window_remove_prefs (window);
 

--- a/gnucash/gnome-utils/gnc-main-window.h
+++ b/gnucash/gnome-utils/gnc-main-window.h
@@ -58,6 +58,7 @@ typedef struct GncMainWindow
     GtkUIManager *ui_merge; /**< A pointer to the UI Manager data
                                  structure for the whole window. */
     gboolean window_quitting; /**< Set to TRUE when quitting from this window. */
+    gboolean just_plugin_prefs; /**< Just remove preferences only from plugins */
 } GncMainWindow;
 
 /** The class data structure for a main window object. */

--- a/gnucash/gnome-utils/gnc-main-window.h
+++ b/gnucash/gnome-utils/gnc-main-window.h
@@ -56,7 +56,8 @@ typedef struct GncMainWindow
 {
     GtkWindow gtk_window;	/**< The parent object for a main window. */
     GtkUIManager *ui_merge; /**< A pointer to the UI Manager data
-				   structure for the whole window. */
+                                 structure for the whole window. */
+    gboolean window_quitting; /**< Set to TRUE when quitting from this window. */
 } GncMainWindow;
 
 /** The class data structure for a main window object. */

--- a/gnucash/gnome-utils/gnc-plugin-manager.c
+++ b/gnucash/gnome-utils/gnc-plugin-manager.c
@@ -66,7 +66,7 @@ gnc_plugin_manager_get (void)
     {
         singleton = g_object_new (GNC_TYPE_PLUGIN_MANAGER,
                                   NULL);
-        gnc_hook_add_dangler (HOOK_UI_SHUTDOWN,
+        gnc_hook_add_dangler (HOOK_SHUTDOWN,
                               gnc_plugin_manager_shutdown, NULL);
     }
 

--- a/gnucash/gnome-utils/gnc-plugin-menu-additions.c
+++ b/gnucash/gnome-utils/gnc-plugin-menu-additions.c
@@ -474,7 +474,8 @@ gnc_plugin_menu_additions_remove_from_window (GncPlugin *plugin,
     /* Have to remove our actions manually. Its only automatic if the
      * actions name is installed into the plugin class. */
     group = gnc_main_window_get_action_group(window, PLUGIN_ACTIONS_NAME);
-    if (group)
+
+    if (group && !window->just_plugin_prefs)
         gtk_ui_manager_remove_action_group(window->ui_merge, group);
 
     /* Note: This code does not clean up the per-callback data structures

--- a/gnucash/gnome-utils/gnc-plugin.c
+++ b/gnucash/gnome-utils/gnc-plugin.c
@@ -201,7 +201,7 @@ gnc_plugin_remove_from_window (GncPlugin *plugin,
     /*
      * Update window to remove UI items
      */
-    if (klass->actions_name)
+    if (klass->actions_name && !window->just_plugin_prefs)
     {
         DEBUG ("%s: %d actions to unmerge",
                klass->actions_name, (klass->n_actions + klass->n_toggle_actions));

--- a/gnucash/register/ledger-core/split-register-model.c
+++ b/gnucash/register/ledger-core/split-register-model.c
@@ -2459,9 +2459,13 @@ gnc_split_register_colorize_negative (gpointer gsettings, gchar *key, gpointer u
 static gpointer
 gnc_split_register_model_add_hooks (gpointer unused)
 {
-    gnc_prefs_register_cb(GNC_PREFS_GROUP_GENERAL, GNC_PREF_NEGATIVE_IN_RED,
-                          gnc_split_register_colorize_negative,
-                          NULL);
+    gulong id = gnc_prefs_register_cb (GNC_PREFS_GROUP_GENERAL,
+                                       GNC_PREF_NEGATIVE_IN_RED,
+                                       gnc_split_register_colorize_negative,
+                                       NULL);
+
+    gnc_prefs_set_reg_negative_color_pref_id (id);
+
     /* Get the initial value */
     use_red_for_negative = gnc_prefs_get_bool(GNC_PREFS_GROUP_GENERAL,
                                               GNC_PREF_NEGATIVE_IN_RED);

--- a/gnucash/register/register-gnome/combocell-gnome.c
+++ b/gnucash/register/register-gnome/combocell-gnome.c
@@ -99,13 +99,16 @@ gnc_combo_cell_set_autopop (gpointer prefs, gchar *pref, gpointer user_data)
 static gpointer
 gnc_combo_cell_autopop_init (gpointer unused)
 {
+    gulong id;
     auto_pop_combos = gnc_prefs_get_bool (GNC_PREFS_GROUP_GENERAL_REGISTER,
                                           GNC_PREF_AUTO_RAISE_LISTS);
 
-    gnc_prefs_register_cb (GNC_PREFS_GROUP_GENERAL_REGISTER,
-                           GNC_PREF_AUTO_RAISE_LISTS,
-                           gnc_combo_cell_set_autopop,
-                           NULL);
+    id = gnc_prefs_register_cb (GNC_PREFS_GROUP_GENERAL_REGISTER,
+                                GNC_PREF_AUTO_RAISE_LISTS,
+                                gnc_combo_cell_set_autopop,
+                                NULL);
+
+    gnc_prefs_set_reg_auto_raise_lists_id (id);
     return NULL;
 }
 

--- a/libgnucash/app-utils/gnc-gsettings.c
+++ b/libgnucash/app-utils/gnc-gsettings.c
@@ -296,6 +296,13 @@ gnc_gsettings_remove_cb_by_id (const gchar *schema,
     // remove the handlerid from the registerered_handlers_hash
     g_hash_table_remove (registered_handlers_hash, GINT_TO_POINTER(handlerid));
 
+    // destroy hash table if size is 0
+    if (g_hash_table_size (registered_handlers_hash) == 0)
+    {
+        g_hash_table_destroy (registered_handlers_hash);
+        PINFO ("All registered preference callbacks removed");
+    }
+
     LEAVE ("Schema: %s, handlerid: %d, hashtable size: %d - removed for handler",
             schema, handlerid, g_hash_table_size (registered_handlers_hash));
 }

--- a/libgnucash/app-utils/gnc-prefs-utils.c
+++ b/libgnucash/app-utils/gnc-prefs-utils.c
@@ -124,3 +124,19 @@ void gnc_prefs_init (void)
                            file_compression_changed_cb, NULL);
 
 }
+
+void
+gnc_prefs_remove_registered (void)
+{
+    // remove the registered pref call backs above
+    gnc_prefs_remove_cb_by_func (GNC_PREFS_GROUP_GENERAL, GNC_PREF_RETAIN_DAYS,
+                           file_retain_changed_cb, NULL);
+    gnc_prefs_remove_cb_by_func (GNC_PREFS_GROUP_GENERAL, GNC_PREF_RETAIN_TYPE_NEVER,
+                           file_retain_type_changed_cb, NULL);
+    gnc_prefs_remove_cb_by_func (GNC_PREFS_GROUP_GENERAL, GNC_PREF_RETAIN_TYPE_DAYS,
+                           file_retain_type_changed_cb, NULL);
+    gnc_prefs_remove_cb_by_func (GNC_PREFS_GROUP_GENERAL, GNC_PREF_RETAIN_TYPE_FOREVER,
+                           file_retain_type_changed_cb, NULL);
+    gnc_prefs_remove_cb_by_func (GNC_PREFS_GROUP_GENERAL, GNC_PREF_FILE_COMPRESSION,
+                           file_compression_changed_cb, NULL);
+}

--- a/libgnucash/app-utils/gnc-prefs-utils.h
+++ b/libgnucash/app-utils/gnc-prefs-utils.h
@@ -47,6 +47,11 @@
  */
 void gnc_prefs_init (void);
 
+/** This function is called to remove the registered preference
+ *  call backs setup in this file
+ */
+void gnc_prefs_remove_registered (void);
+
 #endif /* GNC_PREFS_UTILS_H_ */
 /** @} */
 /** @} */

--- a/libgnucash/app-utils/gnc-ui-util.c
+++ b/libgnucash/app-utils/gnc-ui-util.c
@@ -1511,7 +1511,7 @@ gnc_default_price_print_info (const gnc_commodity *curr)
     info.use_symbol = 0;
     info.use_locale = 1;
     info.monetary = 1;
-    
+
     info.force_fit = force;
     info.round = force;
     return info;
@@ -2674,4 +2674,46 @@ gnc_ui_util_init (void)
     gnc_prefs_register_cb(GNC_PREFS_GROUP_GENERAL, GNC_PREF_AUTO_DECIMAL_PLACES,
                           gnc_set_auto_decimal_places, NULL);
 
+}
+
+void
+gnc_ui_util_remove_registered_prefs (void)
+{
+    // remove the registered pref call backs above
+    gnc_prefs_remove_cb_by_func (GNC_PREFS_GROUP_GENERAL,
+                                 GNC_PREF_ACCOUNT_SEPARATOR,
+                                 gnc_configure_account_separator, NULL);
+    gnc_prefs_remove_cb_by_func (GNC_PREFS_GROUP_GENERAL,
+                                 GNC_PREF_REVERSED_ACCTS_NONE,
+                                 gnc_configure_reverse_balance, NULL);
+    gnc_prefs_remove_cb_by_func (GNC_PREFS_GROUP_GENERAL,
+                                 GNC_PREF_REVERSED_ACCTS_CREDIT,
+                                 gnc_configure_reverse_balance, NULL);
+    gnc_prefs_remove_cb_by_func (GNC_PREFS_GROUP_GENERAL,
+                                 GNC_PREF_REVERSED_ACCTS_INC_EXP,
+                                 gnc_configure_reverse_balance, NULL);
+    gnc_prefs_remove_cb_by_func (GNC_PREFS_GROUP_GENERAL,
+                                 GNC_PREF_CURRENCY_CHOICE_LOCALE,
+                                 gnc_currency_changed_cb, NULL);
+    gnc_prefs_remove_cb_by_func (GNC_PREFS_GROUP_GENERAL,
+                                 GNC_PREF_CURRENCY_CHOICE_OTHER,
+                                 gnc_currency_changed_cb, NULL);
+    gnc_prefs_remove_cb_by_func (GNC_PREFS_GROUP_GENERAL,
+                                 GNC_PREF_CURRENCY_OTHER,
+                                 gnc_currency_changed_cb, NULL);
+    gnc_prefs_remove_cb_by_func (GNC_PREFS_GROUP_GENERAL_REPORT,
+                                 GNC_PREF_CURRENCY_CHOICE_LOCALE,
+                                 gnc_currency_changed_cb, NULL);
+    gnc_prefs_remove_cb_by_func (GNC_PREFS_GROUP_GENERAL_REPORT,
+                                 GNC_PREF_CURRENCY_CHOICE_OTHER,
+                                 gnc_currency_changed_cb, NULL);
+    gnc_prefs_remove_cb_by_func (GNC_PREFS_GROUP_GENERAL_REPORT,
+                                 GNC_PREF_CURRENCY_OTHER,
+                                 gnc_currency_changed_cb, NULL);
+    gnc_prefs_remove_cb_by_func (GNC_PREFS_GROUP_GENERAL,
+                                 GNC_PREF_AUTO_DECIMAL_POINT,
+                                 gnc_set_auto_decimal_enabled, NULL);
+    gnc_prefs_remove_cb_by_func (GNC_PREFS_GROUP_GENERAL,
+                                 GNC_PREF_AUTO_DECIMAL_PLACES,
+                                 gnc_set_auto_decimal_places, NULL);
 }

--- a/libgnucash/app-utils/gnc-ui-util.h
+++ b/libgnucash/app-utils/gnc-ui-util.h
@@ -355,6 +355,10 @@ xaccParseAmountExtended (const char * in_str, gboolean monetary,
 
 void gnc_ui_util_init (void);
 
+/* Remove callback preferences **************************************/
+
+void gnc_ui_util_remove_registered_prefs (void);
+
 #endif
 /** @} */
 /** @} */

--- a/libgnucash/core-utils/gnc-prefs.c
+++ b/libgnucash/core-utils/gnc-prefs.c
@@ -35,6 +35,12 @@ static gboolean use_compression   = TRUE; // This is also the default in the pre
 static gint file_retention_policy = 1;    // 1 = "days", the default in the prefs backend
 static gint file_retention_days   = 30;   // This is also the default in the prefs backend
 
+
+/* Global variables used to remove the preference registered callbacks
+ * that were setup via a g_once. */
+static gulong reg_auto_raise_lists_id;
+static gulong reg_negative_color_pref_id;
+
 PrefsBackend *prefsbackend = NULL;
 
 const gchar *
@@ -379,3 +385,24 @@ void gnc_prefs_unblock_all (void)
     if (prefsbackend && prefsbackend->unblock_all)
         (prefsbackend->unblock_all) ();
 }
+
+gulong gnc_prefs_get_reg_auto_raise_lists_id (void)
+{
+    return reg_auto_raise_lists_id;
+}
+
+void gnc_prefs_set_reg_auto_raise_lists_id (gulong id)
+{
+    reg_auto_raise_lists_id = id;
+}
+
+gulong gnc_prefs_get_reg_negative_color_pref_id (void)
+{
+    return reg_negative_color_pref_id;
+}
+
+void gnc_prefs_set_reg_negative_color_pref_id (gulong id)
+{
+    reg_negative_color_pref_id = id;
+}
+

--- a/libgnucash/core-utils/gnc-prefs.h
+++ b/libgnucash/core-utils/gnc-prefs.h
@@ -553,6 +553,16 @@ void gnc_prefs_reset (const gchar *group,
  */
 void gnc_prefs_reset_group (const gchar *group);
 
+/** Get and Set registered preference id for register auto_raise_lists
+ */
+gulong gnc_prefs_get_reg_auto_raise_lists_id (void);
+void gnc_prefs_set_reg_auto_raise_lists_id (gulong id);
+
+/** Get and Set registered preference id for register negative_color_pref
+ */
+gulong gnc_prefs_get_reg_negative_color_pref_id (void);
+void gnc_prefs_set_reg_negative_color_pref_id (gulong id);
+
 /** @} */
 
 


### PR DESCRIPTION
This is a follow up for the blocking of registered preference callbacks to remove the callbacks on GncWindow close and quit.
The first few commits are straightforward adding functions to remove the preference callbacks setup in various source files.
There are two 'register' preference callbacks that are setup with a 'g_once' that are used till quit so the easiest way to remove them was to save the preference id and use that on quit.
With these changes it took the remaining callbacks from about 50 to 3 on quit.
These last few are setup via plugins so there is a couple of commits dealing with that with the final commit destroying the hash table when there are no callbacks left.

I have tested this by quitting with multiple windows open and closing windows in different orders and all preference callbacks are removed. Will leave here for feedback and push end of week if all OK.