### PR TITLE
[maint] qif-import-map stores account guids instead of account-full-name

### DIFF
--- a/gnucash/import-export/qif-imp/qif-file.scm
+++ b/gnucash/import-export/qif-imp/qif-file.scm
@@ -35,8 +35,7 @@
   (make-regexp "^\\.\\.\\."))
 
 (define (not-bad-numeric-string? input)
-  (let ((match (regexp-exec qif-bad-numeric-rexp input)))
-    (if match #f #t)))
+  (not (regexp-exec qif-bad-numeric-rexp input)))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1046,12 +1045,4 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (qif-file:parse-fields-results results type)
-  (define (test-results results)
-    (if (null? results) #f
-        (let* ((this-res (car results))
-               (this-type (car this-res)))
-          (if (eq? this-type type)
-              (cdr this-res)
-              (test-results (cdr results))))))
-
-  (if results (test-results results) #f))
+  (and results (assq-ref results type)))

--- a/gnucash/import-export/qif-imp/qif-to-gnc.scm
+++ b/gnucash/import-export/qif-imp/qif-to-gnc.scm
@@ -51,14 +51,11 @@
     (define (compatible? account)
       (let ((acc-type (xaccAccountGetType account))
             (acc-commodity (xaccAccountGetCommodity account)))
-        (and
-         (if check-types?
-             (and (list? allowed-types)
-                  (memv acc-type allowed-types))
-             #t)
-	 (if check-commodity?
-	     (gnc-commodity-equiv acc-commodity commodity)
-	     #t))))
+        (and (or (not check-types?)
+                 (and (list? allowed-types)
+                      (memv acc-type allowed-types)))
+	     (or (not check-commodity?)
+	         (gnc-commodity-equiv acc-commodity commodity)))))
 
     (define (make-unique-name-variant long-name short-name)
       (if (not (null? (gnc-account-lookup-by-full-name old-root long-name)))
@@ -1240,10 +1237,10 @@
 ;;  NOTE: Any new commodities should be destroyed by the druid.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (define (qif-import:qif-to-gnc-undo root)
-  (if root
+  (when root
     (let ((txns (gnc:account-tree-get-transactions root)))
       ;; Destroy all the transactions and their splits.
-      (for-each (lambda (elt) (xaccTransDestroy elt)) txns)
+      (for-each xaccTransDestroy txns)
 
       ;; Destroy the accounts
       (xaccAccountBeginEdit root)


### PR DESCRIPTION
This wip branch will contain refactoring commits for `qif/*.scm`
The main purpose will be to figure out what the various parsers do, document and use modern scheme style.
The parsers are compacted and functionally unchanged; e.g. the number parser will successfully parse `$-3000` --> `3000` (integer), `$-$5.99+` --> `-5.99` (decimal), `$5'123.456,99-` --> `-5123456.99` (comma).