### PR TITLE
Remove the deprecated sudo tag from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 # Test
-sudo: required
 language: c++
 compiler: gcc
 env:


### PR DESCRIPTION
As discussed in #545, [Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).  Mention  of the __sudo:__ tag has been removed from all Travis docs because the sudo command is now _always_ available and there is no way to turn it off.