### PR TITLE
Improve price quotes to be more responsive

### DIFF
--- a/gnucash/gnome-utils/gnc-window.c
+++ b/gnucash/gnome-utils/gnc-window.c
@@ -161,6 +161,26 @@ gnc_window_get_progressbar_window (void)
     return progress_bar_hack_window;
 }
 
+void
+gnc_window_set_title (GtkWindow *window, const char *message)
+{
+  if (window == NULL)
+      return;
+
+  gtk_window_set_title (window, message);
+
+  while (gtk_events_pending ())
+    gtk_main_iteration ();
+}
+
+const char *
+gnc_window_get_title (GtkWindow *window)
+{
+  if (window == NULL)
+      return "";
+
+  return gtk_window_get_title (window);
+}
 
 void
 gnc_window_show_progress (const char *message, double percentage)

--- a/gnucash/gnome-utils/gnc-window.h
+++ b/gnucash/gnome-utils/gnc-window.h
@@ -78,6 +78,8 @@ void           gnc_window_set_progressbar_window (GncWindow *window);
 GncWindow     *gnc_window_get_progressbar_window (void);
 GtkWidget     *gnc_window_get_progressbar (GncWindow *window);
 void           gnc_window_show_progress (const char *message, double percentage);
+void           gnc_window_set_title (GtkWindow *window, const char *message);
+const char *   gnc_window_get_title (GtkWindow *window);
 
 G_END_DECLS
 

--- a/gnucash/gnome-utils/gnome-utils.i
+++ b/gnucash/gnome-utils/gnome-utils.i
@@ -75,6 +75,8 @@ void gnc_add_scm_extension (SCM extension);
 void gnc_set_busy_cursor (GtkWidget *w, gboolean update_now);
 void gnc_unset_busy_cursor (GtkWidget *w);
 void gnc_window_show_progress (const char *message, double percentage);
+void gnc_window_set_title (GtkWindow *window, const char *message);
+const char *   gnc_window_get_title (GtkWindow *window);
 
 gboolean gnucash_ui_is_running(void);
 


### PR DESCRIPTION
Calling C aficionados.

This is the outcome. See window-title. It shows current F::Q job, and restores the window title when completed.
![image](https://user-images.githubusercontent.com/1975870/62817881-99d05300-bb2d-11e9-97eb-875046d8b8a2.png)

The implementation is, I'm sure, not ideal.

In particular, GtkWindow vs GncWindow. The correct file to add my window-title getter/setters. Alternatively, a multiline GtkTextBox to add the progress notes will also be useful, but I don't know how to do this. Any C style mistakes.

Otherwise, price-quotes.scm is cleaned up a bit.