### PR TITLE
[master] Remove "Report Title", use "Report name" instead

### DIFF
--- a/gnucash/report/reports/standard/account-summary.scm
+++ b/gnucash/report/reports/standard/account-summary.scm
@@ -69,9 +69,6 @@
 (define accsum-reportname (N_ "Account Summary"))
 (define fsts-reportname (N_ "Future Scheduled Transactions Summary"))
 
-(define optname-report-title (N_ "Report Title"))
-(define opthelp-report-title (N_ "Title for this report."))
-
 (define optname-party-name (N_ "Company name"))
 (define opthelp-party-name (N_ "Name of company/individual."))
 
@@ -142,10 +139,6 @@
           (lambda (new-option)
             (gnc:register-option options new-option))))
 
-    (add-option
-     (gnc:make-string-option
-      gnc:pagename-general optname-report-title
-      "a" opthelp-report-title (_ reportname)))
     (add-option
      (gnc:make-string-option
       gnc:pagename-general optname-party-name
@@ -278,7 +271,7 @@
 
   (gnc:report-starting reportname)
 
-  (let* ((report-title (get-option gnc:pagename-general optname-report-title))
+  (let* ((report-title (get-option gnc:pagename-general gnc:optname-reportname))
          (company-name (get-option gnc:pagename-general optname-party-name))
          (from-date (and sx?
                          (gnc:time64-start-day-time

--- a/gnucash/report/reports/standard/balance-sheet.scm
+++ b/gnucash/report/reports/standard/balance-sheet.scm
@@ -73,8 +73,6 @@
 
 ;; define all option's names and help text so that they are properly
 ;; defined in *one* place.
-(define optname-report-title (N_ "Report Title"))
-(define opthelp-report-title (N_ "Title for this report."))
 
 (define optname-party-name (N_ "Company name"))
 (define opthelp-party-name (N_ "Name of company/individual."))
@@ -150,11 +148,7 @@
          (add-option 
           (lambda (new-option)
             (gnc:register-option options new-option))))
-    
-    (add-option
-      (gnc:make-string-option
-      gnc:pagename-general optname-report-title
-      "a" opthelp-report-title (_ reportname)))
+
     (add-option
       (gnc:make-string-option
       gnc:pagename-general optname-party-name
@@ -290,8 +284,7 @@
   (gnc:report-starting reportname)
 
   ;; get all option's values
-  (let* (
-         (report-title (get-option gnc:pagename-general optname-report-title))
+  (let* ((report-title (get-option gnc:pagename-general gnc:optname-reportname))
          (company-name (get-option gnc:pagename-general optname-party-name))
          (reportdate (gnc:time64-end-day-time
                       (gnc:date-option-absolute-time

--- a/gnucash/report/reports/standard/balsheet-eg.scm
+++ b/gnucash/report/reports/standard/balsheet-eg.scm
@@ -176,8 +176,6 @@
 
 ;; define all option's names and help text so that they are properly
 ;; defined in *one* place.
-(define optname-report-title (N_ "Report Title"))
-(define opthelp-report-title (N_ "Title for this report."))
 
 (define optname-date    (N_ "Balance Sheet Date"))
 (define optname-columns (N_ "1- or 2-column report"))
@@ -282,8 +280,6 @@
                                         opthelp-css-file "balsheet-eg.css"))
 
     ;; General options
-    (add-option (gnc:make-string-option general-page optname-report-title
-                                        "a" opthelp-report-title reportname))
     (gnc:options-add-report-date!  options general-page optname-date "b")
 
     ;; Notes options

--- a/gnucash/report/reports/standard/budget-balance-sheet.scm
+++ b/gnucash/report/reports/standard/budget-balance-sheet.scm
@@ -39,8 +39,6 @@
 
 ;; define all option's names and help text so that they are properly
 ;; defined in *one* place.
-(define optname-report-title (N_ "Report Title"))
-(define opthelp-report-title (N_ "Title for this report."))
 
 (define optname-party-name (N_ "Company name"))
 (define opthelp-party-name (N_ "Name of company/individual."))
@@ -118,11 +116,7 @@
          (add-option 
           (lambda (new-option)
             (gnc:register-option options new-option))))
-    
-    (add-option
-      (gnc:make-string-option
-      gnc:pagename-general optname-report-title
-      "a" opthelp-report-title (_ reportname)))
+
     (add-option
       (gnc:make-string-option
       gnc:pagename-general optname-party-name
@@ -283,8 +277,7 @@
   (gnc:report-starting reportname)
   
   ;; get all option's values
-  (let* (
-	 (report-title (get-option gnc:pagename-general optname-report-title))
+  (let* ((report-title (get-option gnc:pagename-general gnc:optname-reportname))
 	 (company-name (get-option gnc:pagename-general optname-party-name))
          (budget (get-option gnc:pagename-general optname-budget))
          (budget-valid? (and budget (not (null? budget))))

--- a/gnucash/report/reports/standard/budget-income-statement.scm
+++ b/gnucash/report/reports/standard/budget-income-statement.scm
@@ -49,8 +49,6 @@
 
 ;; define all option's names and help text so that they are properly
 ;; defined in *one* place.
-(define optname-report-title (N_ "Report Title"))
-(define opthelp-report-title (N_ "Title for this report."))
 
 (define optname-party-name (N_ "Company name"))
 (define opthelp-party-name (N_ "Name of company/individual."))
@@ -137,11 +135,7 @@
          (add-option 
           (lambda (new-option)
             (gnc:register-option options new-option))))
-    
-    (add-option
-      (gnc:make-string-option
-      gnc:pagename-general optname-report-title
-      "a" opthelp-report-title (_ reportname)))
+
     (add-option
       (gnc:make-string-option
       gnc:pagename-general optname-party-name
@@ -314,8 +308,7 @@
   (gnc:report-starting reportname)
   
   ;; get all option's values
-  (let* (
-	 (report-title (get-option gnc:pagename-general optname-report-title))
+  (let* ((report-title (get-option gnc:pagename-general gnc:optname-reportname))
 	 (company-name (get-option gnc:pagename-general optname-party-name))
          (budget (get-option gnc:pagename-general optname-budget))
          (budget-valid? (and budget (not (null? budget))))

--- a/gnucash/report/reports/standard/equity-statement.scm
+++ b/gnucash/report/reports/standard/equity-statement.scm
@@ -56,8 +56,6 @@
 
 ;; define all option's names and help text so that they are properly
 ;; defined in *one* place.
-(define optname-report-title (N_ "Report Title"))
-(define opthelp-report-title (N_ "Title for this report."))
 
 (define optname-party-name (N_ "Company name"))
 (define opthelp-party-name (N_ "Name of company/individual."))
@@ -102,11 +100,7 @@
          (add-option 
           (lambda (new-option)
             (gnc:register-option options new-option))))
-    
-    (add-option
-      (gnc:make-string-option
-      (N_ "General") optname-report-title
-      "a" opthelp-report-title (_ reportname)))
+
     (add-option
       (gnc:make-string-option
       (N_ "General") optname-party-name
@@ -215,8 +209,7 @@
   (gnc:report-starting reportname)
   
   ;; get all option's values
-  (let* (
-	 (report-title (get-option gnc:pagename-general optname-report-title))
+  (let* ((report-title (get-option gnc:pagename-general gnc:optname-reportname))
 	 (company-name (get-option gnc:pagename-general optname-party-name))
 	 ;; this code makes the assumption that you want your equity
 	 ;; statement to no more than daily resolution

--- a/gnucash/report/reports/standard/income-statement.scm
+++ b/gnucash/report/reports/standard/income-statement.scm
@@ -50,8 +50,6 @@
 
 ;; define all option's names and help text so that they are properly
 ;; defined in *one* place.
-(define optname-report-title (N_ "Report Title"))
-(define opthelp-report-title (N_ "Title for this report."))
 
 (define optname-party-name (N_ "Company name"))
 (define opthelp-party-name (N_ "Name of company/individual."))
@@ -142,11 +140,7 @@
          (add-option 
           (lambda (new-option)
             (gnc:register-option options new-option))))
-    
-    (add-option
-      (gnc:make-string-option
-      gnc:pagename-general optname-report-title
-      "a" opthelp-report-title (_ reportname)))
+
     (add-option
       (gnc:make-string-option
       gnc:pagename-general optname-party-name
@@ -294,8 +288,7 @@
   (gnc:report-starting reportname)
   
   ;; get all option's values
-  (let* (
-	 (report-title (get-option gnc:pagename-general optname-report-title))
+  (let* ((report-title (get-option gnc:pagename-general gnc:optname-reportname))
 	 (company-name (get-option gnc:pagename-general optname-party-name))
          (start-date-printable (gnc:date-option-absolute-time
 				(get-option gnc:pagename-general

--- a/gnucash/report/reports/standard/register.scm
+++ b/gnucash/report/reports/standard/register.scm
@@ -371,12 +371,6 @@
    (gnc:make-internal-option "__reg" "credit-string" (_ "Credit")))
 
   (gnc:register-reg-option
-   (gnc:make-string-option
-    (N_ "General") (N_ "Title")
-    "a" (N_ "The title of the report.")
-    (N_ "Register Report")))
-
-  (gnc:register-reg-option
    (gnc:make-simple-boolean-option
     (N_ "Display") (N_ "Date")
     "b" (N_ "Display the date?") #t))
@@ -651,7 +645,7 @@
          (journal? (opt-val "__reg" "journal"))
          (debit-string (opt-val "__reg" "debit-string"))
          (credit-string (opt-val "__reg" "credit-string"))
-         (title (opt-val "General" "Title"))
+         (title (opt-val "General" gnc:optname-reportname))
          (query (gnc-scm2query query-scm)))
 
     (qof-query-set-book query (gnc-get-current-book))
@@ -693,7 +687,7 @@
          (journal-op (gnc:lookup-option options "__reg" "journal"))
          (ledger-type-op (gnc:lookup-option options "__reg" "ledger-type"))
          (double-op (gnc:lookup-option options "__reg" "double"))
-         (title-op (gnc:lookup-option options "General" "Title"))
+         (title-op (gnc:lookup-option options "General" gnc:optname-reportname))
          (debit-op (gnc:lookup-option options "__reg" "debit-string"))
          (credit-op (gnc:lookup-option options "__reg" "credit-string"))
          (account-op (gnc:lookup-option options "Display" "Account")))

--- a/gnucash/report/reports/standard/trial-balance.scm
+++ b/gnucash/report/reports/standard/trial-balance.scm
@@ -62,8 +62,6 @@
 
 ;; define all option's names and help text so that they are properly
 ;; defined in *one* place.
-(define optname-report-title (N_ "Report Title"))
-(define opthelp-report-title (N_ "Title for this report."))
 
 (define optname-party-name (N_ "Company name"))
 (define opthelp-party-name (N_ "Name of company/individual."))
@@ -180,10 +178,6 @@
           (lambda (new-option)
             (gnc:register-option options new-option))))
 
-    (add-option
-     (gnc:make-string-option
-      (N_ "General") optname-report-title
-      "a" opthelp-report-title (_ reportname)))
     (add-option
      (gnc:make-string-option
       (N_ "General") optname-party-name
@@ -331,7 +325,7 @@
   (gnc:report-starting reportname)
 
   ;; get all option's values
-  (let* ((report-title (get-option gnc:pagename-general optname-report-title))
+  (let* ((report-title (get-option gnc:pagename-general gnc:optname-reportname))
          (company-name (get-option gnc:pagename-general optname-party-name))
          (start-date-printable
           (gnc:date-option-absolute-time

--- a/libgnucash/app-utils/options.scm
+++ b/libgnucash/app-utils/options.scm
@@ -1682,6 +1682,9 @@ the option '~a'."))
       ("Account Substring" "Filter" "Account Name Filter")
       ;; invoice.scm, renamed November 2018
       ("Individual Taxes" #f "Use Detailed Tax Summary")
+      ;; Title/Report Title -> Report name, renamed Aug 2019
+      ("Title" #f "Report name")
+      ("Report Title" #f "Report name")
       ))
 
   (define (lookup-option section name)


### PR DESCRIPTION
Premise: *ALL* reports have, as a minimum, a reportname and a stylesheet. Most reports will use this reportname for the document `<title>` tag or for the chart heading. 10 reports however also define a "Report Title" (or "Title") option, which is then used to populate the `<title>` tag.

Proposal: remove Report Title, and reuse reportname to set document title. No compatibility issues are expected moving forward.

A backward-compatibility path is inserted in `options.scm` to ensure saved-reports pick up the new option-name. Will this file continue to exist in master?