### PR TITLE
Maint 797279 - fixes for RTL languages and better i18n

### DIFF
--- a/gnucash/report/business-reports/balsheet-eg.css
+++ b/gnucash/report/business-reports/balsheet-eg.css
@@ -26,11 +26,9 @@
     width: 1em;
   }
   td.accname {
-    text-align: left;
     vertical-align: top;
   }
   td.accnametotal {
-    text-align: left;
     vertical-align: top;
     font-weight: bold;
   }

--- a/gnucash/report/business-reports/balsheet-eg.eguile.scm
+++ b/gnucash/report/business-reports/balsheet-eg.eguile.scm
@@ -125,7 +125,7 @@
 ?>
 
 <!-- The HTML starts here... -->
-<html>
+<html dir='auto'>
 <head>
 <meta http-equiv="content-type" content="text-html; charset=utf-8">
 <title><?scm:d coyname ?> <?scm:d opt-report-title ?> <?scm:d (qof-print-date opt-date) ?></title>

--- a/gnucash/report/business-reports/receipt.eguile.scm
+++ b/gnucash/report/business-reports/receipt.eguile.scm
@@ -103,7 +103,7 @@
 
 <!-- ====================================================================== -->
 <!-- The HTML for the invoice starts here -->
-<html>
+<html dir='auto'>
 <head>
 <meta http-equiv="Content-Type" content="text/html;charset=utf-8" >
 <title><?scm:d (_ "Invoice") ?> <?scm:d invoiceid ?></title>

--- a/gnucash/report/business-reports/taxinvoice.eguile.scm
+++ b/gnucash/report/business-reports/taxinvoice.eguile.scm
@@ -125,7 +125,7 @@
 
 <!-- ====================================================================== -->
 <!-- The HTML for the invoice starts here -->
-<html>
+<html dir='auto'>
 <head>
 <meta http-equiv="Content-Type" content="text/html;charset=utf-8" >
 <title><?scm:d (_ "Invoice") ?> <?scm:d invoiceid ?></title>

--- a/gnucash/report/report-system/html-document.scm
+++ b/gnucash/report/report-system/html-document.scm
@@ -150,7 +150,7 @@
             ;;./share/gnucash/scm/gnucash/report/taxinvoice.eguile.scm:<html>
             ;;./share/gnucash/scm/gnucash/report/balsheet-eg.eguile.scm:<html>
 
-            (push "<html>\n")
+            (push "<html dir='auto'>\n")
             (push "<head>\n")
             (push "<meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\" />\n")
             (if style-text

--- a/gnucash/report/report-system/html-fonts.scm
+++ b/gnucash/report/report-system/html-fonts.scm
@@ -140,7 +140,7 @@
             (string-append
                 "h3 { " title-font-info " }\n"
                 "a { " account-link-font-info " }\n"
-                "body, p, table, tr, td { text-align: left; vertical-align: top; " text-cell-font-info " }\n"
+                "body, p, table, tr, td { vertical-align: top; " text-cell-font-info " }\n"
                 "tr.alternate-row { background: " alternate-row-color " }\n"
                 "tr { page-break-inside: avoid !important;}\n"
                 "th.column-heading-left { text-align: left; " number-header-font-info " }\n"

--- a/gnucash/report/report-system/test/test-report-html.scm
+++ b/gnucash/report/report-system/test/test-report-html.scm
@@ -45,7 +45,7 @@
 )
 
 (define html-doc-header-no-title
-"<html>\n\
+"<html dir='auto'>\n\
 <head>\n\
 <meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\" />\n\
 </head><body>")
@@ -87,7 +87,7 @@
 
     (gnc:html-document-set-title! test-doc "HTML Document Title")
     (test-equal "HTML Document - Render with title"
-"<html>\n\
+"<html dir='auto'>\n\
 <head>\n\
 <meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\" />\n\
 <title>\n\

--- a/gnucash/report/standard-reports/balsheet-pnl.scm
+++ b/gnucash/report/standard-reports/balsheet-pnl.scm
@@ -879,10 +879,10 @@ also show overall period profit & loss."))
            (lambda ()
              (display report-title)
              (display " ")
-             (when (or incr (eq? report-type 'pnl))
-               (display (qof-print-date startdate))
-               (display (_ " to ")))
-             (display (qof-print-date enddate)))))
+             (if (or incr (eq? report-type 'pnl))
+                 (format #t (_ "~a to ~a")
+                         (qof-print-date startdate) (qof-print-date enddate))
+                 (qof-print-date enddate)))))
 
     (if (eq? (get-option gnc:pagename-general optname-options-summary) 'always)
         (gnc:html-document-add-object!
@@ -1057,9 +1057,9 @@ also show overall period profit & loss."))
          multicol-table-right (_ "Equity")
          (append equity-accounts
                  (list
-                  (vector "Unrealized Gains"
+                  (vector (_ "Unrealized Gains")
                           unrealized-gain-fn)
-                  (vector "Retained Earnings"
+                  (vector (_ "Retained Earnings")
                           retained-earnings-fn)))
          #:negate-amounts? #t)
 
@@ -1074,7 +1074,7 @@ also show overall period profit & loss."))
             (gnc:html-document-add-object!
              doc
              (gnc:make-html-text
-              (gnc:html-markup-anchor chart "Barchart"))))))
+              (gnc:html-markup-anchor chart (_ "Barchart")))))))
 
      ((eq? report-type 'pnl)
       (let* ((closing-str (get-option pagename-entries optname-closing-pattern))

--- a/libgnucash/scm/utilities.scm
+++ b/libgnucash/scm/utilities.scm
@@ -194,3 +194,53 @@
      ((null? (cdr lst)) (reverse (cons (car lst) result)))
      ((= (car lst) (cadr lst)) (lp (cdr lst) result))
      (else (lp (cdr lst) (cons (car lst) result))))))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; compatibility hack for fixing guile-2.0 string handling. this code
+;; may be removed when minimum guile is 2.2 or later. see
+;; https://lists.gnu.org/archive/html/guile-user/2019-04/msg00012.html
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(when (string=? (effective-version) "2.0")
+  ;; When using Guile 2.0.x, use monkey patching to change the
+  ;; behavior of string ports to use UTF-8 as the internal encoding.
+  ;; Note that this is the default behavior in Guile 2.2 or later.
+  (let* ((mod                     (resolve-module '(guile)))
+         (orig-open-input-string  (module-ref mod 'open-input-string))
+         (orig-open-output-string (module-ref mod 'open-output-string))
+         (orig-object->string     (module-ref mod 'object->string))
+         (orig-simple-format      (module-ref mod 'simple-format)))
+
+    (define (open-input-string str)
+      (with-fluids ((%default-port-encoding "UTF-8"))
+        (orig-open-input-string str)))
+
+    (define (open-output-string)
+      (with-fluids ((%default-port-encoding "UTF-8"))
+        (orig-open-output-string)))
+
+    (define (object->string . args)
+      (with-fluids ((%default-port-encoding "UTF-8"))
+        (apply orig-object->string args)))
+
+    (define (simple-format . args)
+      (with-fluids ((%default-port-encoding "UTF-8"))
+        (apply orig-simple-format args)))
+
+    (define (call-with-input-string str proc)
+      (proc (open-input-string str)))
+
+    (define (call-with-output-string proc)
+      (let ((port (open-output-string)))
+        (proc port)
+        (get-output-string port)))
+
+    (module-set! mod 'open-input-string       open-input-string)
+    (module-set! mod 'open-output-string      open-output-string)
+    (module-set! mod 'object->string          object->string)
+    (module-set! mod 'simple-format           simple-format)
+    (module-set! mod 'call-with-input-string  call-with-input-string)
+    (module-set! mod 'call-with-output-string call-with-output-string)
+
+    (when (eqv? (module-ref mod 'format) orig-simple-format)
+      (module-set! mod 'format simple-format))))


### PR DESCRIPTION
* Enable autodetect for rtl
* Fix guile-2.0 string-ports handling
* Better strings handling in balsheet-pnl -- I figure `~a to ~a` is better than `(display x) (display (_ " to ")) (display y)`
* Fix some i18n strings in balsheet-pnl