### PR TITLE
Bug 797355 - General Journal report seems to be off balance

### DIFF
--- a/gnucash/report/standard-reports/register.scm
+++ b/gnucash/report/standard-reports/register.scm
@@ -163,17 +163,6 @@
         (addto! heading-list (_ "Balance")))
     (reverse heading-list)))
 
-(define (gnc:split-get-balance-display split-info? split)
-  (let* ((account (xaccSplitGetAccount split))
-         (balance
-          (if split-info?
-              (xaccSplitGetBalance split)
-              (xaccTransGetAccountBalance
-               (xaccSplitGetParent split) account))))
-    (if (and (not (null? account)) (gnc-reverse-balance account))
-        (- balance)
-        balance)))
-
 (define (add-split-row table split column-vector row-style transaction-info?
                        split-info? action-for-num? ledger-type? double? memo?
                        description? total-collector)
@@ -360,10 +349,6 @@
                                                    (reverse row-contents))))))
     split-value))
 
-(define (lookup-sort-key sort-option)
-  (vector-ref (cdr (assq sort-option comp-funcs-assoc-list)) 0))
-(define (lookup-subtotal-pred sort-option)
-  (vector-ref (cdr (assq sort-option comp-funcs-assoc-list)) 1))
 
 (define (options-generator)
 

--- a/gnucash/report/standard-reports/register.scm
+++ b/gnucash/report/standard-reports/register.scm
@@ -610,20 +610,15 @@
           ;; ----------------------------------------------
           ;; update totals, but don't add them to the table
           ;; ----------------------------------------------
-          (if multi-rows?
-              (for-each
-               (lambda (split)
-                 (if (equal? (xaccSplitGetAccount current)
-                             (xaccSplitGetAccount split))
-                     (accumulate-totals split
-                                        total-collector total-value
-                                        debit-collector debit-value
-                                        credit-collector credit-value)))
-               (xaccTransGetSplitList (xaccSplitGetParent current)))
-              (accumulate-totals current
-                                 total-collector total-value
-                                 debit-collector debit-value
-                                 credit-collector credit-value))
+          (for-each
+           (lambda (split)
+             (accumulate-totals split
+                                total-collector total-value
+                                debit-collector debit-value
+                                credit-collector credit-value))
+           (if multi-rows?
+               (xaccTransGetSplitList (xaccSplitGetParent current))
+               (list current)))
           ;; ----------------------------------
           ;; add the splits to the table
           ;; ----------------------------------

--- a/gnucash/report/standard-reports/register.scm
+++ b/gnucash/report/standard-reports/register.scm
@@ -228,16 +228,15 @@
         (addto! row-contents
                 (gnc:make-html-table-cell/markup
                  "text-cell"
-                 (if split-info?
-                     (if transaction-info?
-                         (let ((other-split
-                                (xaccSplitGetOtherSplit split)))
-                           (if (not (null? other-split))
-                               (gnc-account-get-full-name
-                                (xaccSplitGetAccount other-split))
-                               (_ "-- Split Transaction --")))
-                         (gnc-account-get-full-name account))
-                     " "))))
+                 (cond
+                  ((not split-info?) #f)
+                  ((not transaction-info?) (gnc-account-get-full-name account))
+                  (else (case (xaccTransCountSplits (xaccSplitGetParent split))
+                          ((2) (gnc-account-get-full-name
+                                (xaccSplitGetAccount
+                                 (xaccSplitGetOtherSplit split))))
+                          ((1) (_ "None"))
+                          (else (_ "-- Split Transaction --"))))))))
     (if (shares-col column-vector)
         (addto! row-contents
                 (gnc:make-html-table-cell/markup

--- a/gnucash/report/standard-reports/test/test-register.scm
+++ b/gnucash/report/standard-reports/test/test-register.scm
@@ -64,6 +64,10 @@
          (account-alist (create-test-data))
          (bank (cdr (assoc "Bank" account-alist))))
 
+    (gnc-commodity-set-user-symbol
+     (xaccAccountGetCommodity (assoc-ref account-alist "GBP Bank"))
+     "#")
+
     (let ((query (qof-query-create-for-splits)))
       (qof-query-set-book query (gnc-get-current-book))
       (xaccQueryAddAccountMatch query (list bank)
@@ -75,61 +79,93 @@
         231
         (length (sxml->table-row-col sxml 1 #f #f)))
 
-      (test-equal "total debit = 2587"
+      (test-equal "total debit = $2587"
         '("Total Debits" "$2,587.00")
         (sxml->table-row-col sxml 1 -3 #f))
 
-      (test-equal "total credits = 401"
+      (test-equal "total credits = $401"
         '("Total Credits" "$401.00")
         (sxml->table-row-col sxml 1 -1 #f)))
 
     (set-option options "__reg" "journal" #t)
     (let ((sxml (options->sxml options "journal")))
-      (test-equal "table has 333 cells"
-        333
+      (test-equal "table has 337 cells"
+        337
         (length (sxml->table-row-col sxml 1 #f #f)))
 
-      (test-equal "total debit = 2587"
-        '("Total Debits" "$2,587.00")
-        (sxml->table-row-col sxml 1 -3 #f))
+      (test-equal "total debit = #6"
+        '("Total Debits" "#6.00")
+        (sxml->table-row-col sxml 1 135 #f))
 
-      (test-equal "total credits = 401"
-        '("Total Credits" "$401.00")
-        (sxml->table-row-col sxml 1 -1 #f)))
+      (test-equal "total debit = $2979"
+        '("Total Debits" "$2,979.00")
+        (sxml->table-row-col sxml 1 136 #f))
+
+      (test-equal "total credits = #10"
+        '("Total Credits" "#10.00")
+        (sxml->table-row-col sxml 1 138 #f))
+
+      (test-equal "total credits = 2974"
+        '("Total Credits" "$2,974.00")
+        (sxml->table-row-col sxml 1 139 #f)))
 
     (set-option options "__reg" "ledger-type" #t)
     (let ((sxml (options->sxml options "ledger-type")))
-      (test-equal "table has 335 cells"
-        335
+      (test-equal "table has 341 cells"
+        341
         (length (sxml->table-row-col sxml 1 #f #f)))
 
-      (test-equal "total debit = 2587"
-        '("Total Debits" "$2,587.00")
-        (sxml->table-row-col sxml 1 -5 #f))
+      (test-equal "total debit = #6"
+        '("Total Debits" "#6.00")
+        (sxml->table-row-col sxml 1 135 #f))
 
-      (test-equal "total credits = 401"
-        '("Total Credits" "$401.00")
-        (sxml->table-row-col sxml 1 -3 #f))
+      (test-equal "total debit = $2979"
+        '("Total Debits" "$2,979.00")
+        (sxml->table-row-col sxml 1 136 #f))
 
-      (test-equal "net change = 401"
-        '("Net Change" "$2,186.00")
-        (sxml->table-row-col sxml 1 -1 #f)))
+      (test-equal "total credits = #10"
+        '("Total Credits" "#10.00")
+        (sxml->table-row-col sxml 1 138 #f))
+
+      (test-equal "total credits = $2974"
+        '("Total Credits" "$2,974.00")
+        (sxml->table-row-col sxml 1 139 #f))
+
+      (test-equal "net change = #4"
+        '("Net Change" "#4.00")
+        (sxml->table-row-col sxml 1 141 #f))
+
+      (test-equal "net change = $5"
+        '("Net Change" "$5.00")
+        (sxml->table-row-col sxml 1 142 #f)))
 
     (set-option options "__reg" "double" #t)
     (let ((sxml (options->sxml options "double")))
-      (test-equal "table has 339 cells"
-        339
+      (test-equal "table has 345 cells"
+        345
         (length (sxml->table-row-col sxml 1 #f #f)))
 
-      (test-equal "total debit = 2587"
-        '("Total Debits" "$2,587.00")
-        (sxml->table-row-col sxml 1 -5 #f))
+      (test-equal "total debit = #6"
+        '("Total Debits" "#6.00")
+        (sxml->table-row-col sxml 1 179 #f))
 
-      (test-equal "total credits = 401"
-        '("Total Credits" "$401.00")
-        (sxml->table-row-col sxml 1 -3 #f))
+      (test-equal "total debit = $2979"
+        '("Total Debits" "$2,979.00")
+        (sxml->table-row-col sxml 1 180 #f))
 
-      (test-equal "net change = 401"
-        '("Net Change" "$2,186.00")
-        (sxml->table-row-col sxml 1 -1 #f)))
+      (test-equal "total credits = #10"
+        '("Total Credits" "#10.00")
+        (sxml->table-row-col sxml 1 182 #f))
+
+      (test-equal "total credits = $2974"
+        '("Total Credits" "$2,974.00")
+        (sxml->table-row-col sxml 1 183 #f))
+
+      (test-equal "net change = #4"
+        '("Net Change" "#4.00")
+        (sxml->table-row-col sxml 1 185 #f))
+
+      (test-equal "net change = $5"
+        '("Net Change" "$5.00")
+        (sxml->table-row-col sxml 1 186 #f)))
     ))


### PR DESCRIPTION
Previously, for general-journal, each split was being analyzed, and only the source split was counted for totals. This change will means the source split *and* its peers were used in the debit/credit totals. From my testing it's a good fix, and I've amended test suite to accommodate.