### PR TITLE
Bug 605602 - precision of Financial Calculator seems to depend on locale

### DIFF
--- a/gnucash/gtkbuilder/dialog-fincalc.glade
+++ b/gnucash/gtkbuilder/dialog-fincalc.glade
@@ -216,11 +216,8 @@
                                 <property name="can_focus">False</property>
                                 <property name="spacing">6</property>
                                 <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
                                   <object class="GtkButton" id="payment_periods_clear_button">
-                                    <property name="label" translatable="yes">_Clear</property>
+                                    <property name="label" translatable="yes">Clear</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">False</property>
@@ -273,11 +270,8 @@
                                 <property name="can_focus">False</property>
                                 <property name="spacing">6</property>
                                 <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
                                   <object class="GtkButton" id="interest_rate_clear_button">
-                                    <property name="label" translatable="yes">_Clear</property>
+                                    <property name="label" translatable="yes">Clear</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">False</property>
@@ -330,11 +324,8 @@
                                 <property name="can_focus">False</property>
                                 <property name="spacing">6</property>
                                 <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
                                   <object class="GtkButton" id="present_value_clear_button">
-                                    <property name="label" translatable="yes">_Clear</property>
+                                    <property name="label" translatable="yes">Clear</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">False</property>
@@ -387,11 +378,8 @@
                                 <property name="can_focus">False</property>
                                 <property name="spacing">6</property>
                                 <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
                                   <object class="GtkButton" id="periodic_payment_clear_button">
-                                    <property name="label" translatable="yes">_Clear</property>
+                                    <property name="label" translatable="yes">Clear</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">False</property>
@@ -444,11 +432,8 @@
                                 <property name="can_focus">False</property>
                                 <property name="spacing">6</property>
                                 <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
                                   <object class="GtkButton" id="future_value_clear_button">
-                                    <property name="label" translatable="yes">_Clear</property>
+                                    <property name="label" translatable="yes">Clear</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">False</property>
@@ -634,6 +619,7 @@
                           <packing>
                             <property name="left_attach">1</property>
                             <property name="top_attach">12</property>
+                            <property name="width">2</property>
                           </packing>
                         </child>
                         <child>
@@ -902,9 +888,6 @@
                             <property name="left_attach">0</property>
                             <property name="top_attach">11</property>
                           </packing>
-                        </child>
-                        <child>
-                          <placeholder/>
                         </child>
                         <child>
                           <placeholder/>

--- a/gnucash/gtkbuilder/dialog-fincalc.glade
+++ b/gnucash/gtkbuilder/dialog-fincalc.glade
@@ -478,6 +478,46 @@
                           </packing>
                         </child>
                         <child>
+                          <object class="GtkBox" id="vbox83">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <object class="GtkLabel" id="label803">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Precision</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSpinButton" id="precision_spin">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="input_purpose">number</property>
+                                <property name="climb_rate">1</property>
+                                <property name="numeric">True</property>
+                                <property name="value">1</property>
+                                <signal name="value-changed" handler="fincalc_precision_spin_value_changed_cb" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">5</property>
+                          </packing>
+                        </child>
+                        <child>
                           <object class="GtkAlignment" id="alignment31">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
@@ -509,7 +549,7 @@
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">True</property>
-                            <property name="position">5</property>
+                            <property name="position">6</property>
                           </packing>
                         </child>
                       </object>


### PR DESCRIPTION
Attempt. Probably stinky code.

* the calc_clicked_cb had mechanism to abort if no fields were empty. disable it.

* to convert gnc_numeric to string, the only suitable print_info is `gnc_share_print_info_places` which takes decimal and outputs suitable print_info. Not very suitable, but works.