### PR TITLE
Fix for bug in string_to_gnc_numeric where negative decimal fractions…

### DIFF
--- a/libgnucash/engine/gnc-numeric.cpp
+++ b/libgnucash/engine/gnc-numeric.cpp
@@ -178,7 +178,8 @@ GncNumeric::GncNumeric(const std::string& str, bool autoround)
         GncInt128 high(stoll(m[1].str()));
         GncInt128 low(stoll(m[2].str()));
         int64_t d = powten(m[2].str().length());
-        GncInt128 n = high * d + (high >= 0 ? low : -low);
+        GncInt128 n = high * d + ( ( (0<m[1].str().length()) && ('-'!=m[1].str().at(0)) ) ? low : -low);
+
         if (!autoround && n.isBig())
         {
             std::ostringstream errmsg;

--- a/libgnucash/engine/test/gtest-gnc-numeric.cpp
+++ b/libgnucash/engine/test/gtest-gnc-numeric.cpp
@@ -179,6 +179,9 @@ TEST(gncnumeric_constructors, test_string_constructor)
                  std::out_of_range);
     EXPECT_THROW(GncNumeric bad_string("Four score and seven"),
                  std::invalid_argument);
+    GncNumeric neg_decimal("-0.12345");
+    EXPECT_EQ(-12345, neg_decimal.num());
+    EXPECT_EQ(100000, neg_decimal.denom());
 }
 
 TEST(gncnumeric_output, string_output)


### PR DESCRIPTION
… did not parse as negative (e.g. -0.1 would parse as 0.1)

For some reason I cannot run `make check` - my test-gnc-numeric always fails, even before my patch. So please check that for me :)