### PR TITLE
[dialog-import] connect delete_event to gnc_gen_trans_list_delete

### DIFF
--- a/gnucash/gtkbuilder/dialog-import.glade
+++ b/gnucash/gtkbuilder/dialog-import.glade
@@ -1212,6 +1212,7 @@
     <property name="default_height">400</property>
     <property name="type_hint">dialog</property>
     <signal name="close" handler="on_matcher_cancel_clicked" swapped="no"/>
+    <signal name="delete-event" handler="on_matcher_delete_event" swapped="no"/>
     <child>
       <placeholder/>
     </child>

--- a/gnucash/import-export/import-main-matcher.c
+++ b/gnucash/import-export/import-main-matcher.c
@@ -99,6 +99,7 @@ static QofLogModule log_module = G_MOD_IMPORT_MATCHER;
 
 void on_matcher_ok_clicked (GtkButton *button, GNCImportMainMatcher *info);
 void on_matcher_cancel_clicked (GtkButton *button, gpointer user_data);
+gboolean on_matcher_delete_event (GtkWidget *widget, GdkEvent *event, gpointer data);
 void on_matcher_help_clicked (GtkButton *button, gpointer user_data);
 void on_matcher_help_close_clicked (GtkButton *button, gpointer user_data);
 
@@ -225,6 +226,14 @@ on_matcher_cancel_clicked (GtkButton *button, gpointer user_data)
 {
     GNCImportMainMatcher *info = user_data;
     gnc_gen_trans_list_delete (info);
+}
+
+gboolean
+on_matcher_delete_event (GtkWidget *widget, GdkEvent *event, gpointer data)
+{
+    GNCImportMainMatcher *info = data;
+    gnc_gen_trans_list_delete (info);
+    return FALSE;
 }
 
 void


### PR DESCRIPTION
Connect signal so that Alt-F4 will properly delete partially imported transactions. From #565 