### PR TITLE
TaxTable ref count on entries

### DIFF
--- a/gnucash/register/ledger-core/gncEntryLedgerControl.c
+++ b/gnucash/register/ledger-core/gncEntryLedgerControl.c
@@ -93,6 +93,8 @@ gnc_entry_ledger_save (GncEntryLedger *ledger, gboolean do_commit)
         time64 time = gnc_time (NULL);
         gncEntrySetDateEntered (blank_entry, time);
 
+        gncEntrySetBlankEntry (blank_entry, FALSE);
+
         switch (ledger->type)
         {
         case GNCENTRY_ORDER_ENTRY:
@@ -100,6 +102,9 @@ gnc_entry_ledger_save (GncEntryLedger *ledger, gboolean do_commit)
             break;
         case GNCENTRY_INVOICE_ENTRY:
         case GNCENTRY_CUST_CREDIT_NOTE_ENTRY:
+            /* saving blank entry so increase the tax table ref if present */
+            if (gncEntryGetInvTaxable (blank_entry))
+                gncTaxTableIncRef (gncEntryGetInvTaxTable (blank_entry));
             /* Anything entered on an invoice entry must be part of the invoice! */
             gncInvoiceAddEntry (ledger->invoice, blank_entry);
             break;
@@ -107,6 +112,9 @@ gnc_entry_ledger_save (GncEntryLedger *ledger, gboolean do_commit)
         case GNCENTRY_EXPVOUCHER_ENTRY:
         case GNCENTRY_VEND_CREDIT_NOTE_ENTRY:
         case GNCENTRY_EMPL_CREDIT_NOTE_ENTRY:
+            /* saving blank entry so increase the tax table ref if present */
+            if (gncEntryGetBillTaxable (blank_entry))
+                gncTaxTableIncRef (gncEntryGetBillTaxTable (blank_entry));
             /* Anything entered on an invoice entry must be part of the invoice! */
             gncBillAddEntry (ledger->invoice, blank_entry);
             break;

--- a/gnucash/register/ledger-core/gncEntryLedgerLoad.c
+++ b/gnucash/register/ledger-core/gncEntryLedgerLoad.c
@@ -364,6 +364,9 @@ void gnc_entry_ledger_load (GncEntryLedger *ledger, GList *entry_list)
             gnc_suspend_gui_refresh ();
 
             blank_entry = gncEntryCreate (ledger->book);
+
+            gncEntrySetBlankEntry (blank_entry, TRUE);
+
             gncEntrySetDateGDate (blank_entry, &ledger->last_date_entered);
             ledger->blank_entry_guid = *gncEntryGetGUID (blank_entry);
 

--- a/gnucash/register/ledger-core/gncEntryLedgerLoad.c
+++ b/gnucash/register/ledger-core/gncEntryLedgerLoad.c
@@ -365,6 +365,8 @@ void gnc_entry_ledger_load (GncEntryLedger *ledger, GList *entry_list)
 
             blank_entry = gncEntryCreate (ledger->book);
 
+            gncEntryBeginEdit (blank_entry);
+
             gncEntrySetBlankEntry (blank_entry, TRUE);
 
             gncEntrySetDateGDate (blank_entry, &ledger->last_date_entered);

--- a/libgnucash/backend/xml/gnc-entry-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-entry-xml-v2.cpp
@@ -796,8 +796,13 @@ entry_sixtp_parser_create (void)
 static void
 do_count (QofInstance* entry_p, gpointer count_p)
 {
-    int* count = static_cast<decltype (count)> (count_p);
-    (*count)++;
+    GncEntry* entry = (GncEntry*) entry_p;
+
+    if (!gncEntryIsBlankEntry(entry))
+    {
+        int* count = static_cast<decltype (count)> (count_p);
+        (*count)++;
+    }
 }
 
 static int

--- a/libgnucash/engine/gncEntry.h
+++ b/libgnucash/engine/gncEntry.h
@@ -121,6 +121,12 @@ void gncEntrySetQuantity (GncEntry *entry, gnc_numeric quantity);
  *  actual credit note (and hence how the ledger and reports show it
  *  to the user). */
 void gncEntrySetDocQuantity (GncEntry *entry, gnc_numeric quantity, gboolean is_cn);
+/** Set the entry is_blank_entry depending on is_blank
+ */
+void gncEntrySetBlankEntry (GncEntry *entry, gboolean is_blank);
+/** Get the is_blank_entry for the entry
+ */
+gboolean gncEntryIsBlankEntry (const GncEntry *entry);
 /** @} */
 
 /** @name Customer Invoices


### PR DESCRIPTION
I was getting this in my trace file with an xml Gnucash file...
 * 11:58:50  WARN <gnc.io> [taxtable_reset_refcount()] Fixing refcount on
taxtable 2dca815fad04436cbb5497517803cc79 (2 -> 1)

after some investigation it was due to the tax table on the blank entry being counted if it was still open when GnuCash is closed. I fixed this by adding a gboolean to the GncEntry indicating whether it was the blank entry and so could be counted or not which also fixed the total entries count.

I will push this at the weekend if no one sees a problem with it.