### PR TITLE
[master] add API, budget-estimator can ignore closing entries

### DIFF
--- a/gnucash/gnome/gnc-plugin-page-budget.c
+++ b/gnucash/gnome/gnc-plugin-page-budget.c
@@ -240,6 +240,7 @@ typedef struct GncPluginPageBudgetPrivate
     Recurrence r;
     gint sigFigs;
     gboolean useAvg;
+    gboolean ignClos;
 
     /* For the allPeriods value dialog */
     gnc_numeric allValue;
@@ -351,6 +352,7 @@ gnc_plugin_page_budget_init (GncPluginPageBudget *plugin_page)
 
     priv->sigFigs = 1;
     priv->useAvg = FALSE;
+    priv->ignClos = TRUE;
     recurrenceSet(&priv->r, 1, PERIOD_MONTH, NULL, WEEKEND_ADJ_NONE);
 
     LEAVE("page %p, priv %p, action group %p",
@@ -883,7 +885,6 @@ gnc_budget_gui_delete_budget(GncBudget *budget)
     }
 }
 
-
 static void
 estimate_budget_helper(GtkTreeModel *model, GtkTreePath *path,
                        GtkTreeIter *iter, gpointer data)
@@ -903,9 +904,15 @@ estimate_budget_helper(GtkTreeModel *model, GtkTreePath *path,
 
     if (priv->useAvg && num_periods)
     {
-        num = xaccAccountGetBalanceChangeForPeriod(acct, 
-                recurrenceGetPeriodTime(&priv->r, 0, FALSE),
-                recurrenceGetPeriodTime(&priv->r, num_periods - 1, TRUE), TRUE);
+        if (priv->ignClos)
+            num = xaccAccountGetNoclosingBalanceChangeForPeriod
+              (acct, recurrenceGetPeriodTime(&priv->r, 0, FALSE),
+               recurrenceGetPeriodTime(&priv->r, num_periods - 1, TRUE), TRUE);
+        else
+            num = xaccAccountGetBalanceChangeForPeriod
+              (acct, recurrenceGetPeriodTime(&priv->r, 0, FALSE),
+               recurrenceGetPeriodTime(&priv->r, num_periods - 1, TRUE), TRUE);
+
         num = gnc_numeric_div(num, 
                               gnc_numeric_create(num_periods, 1), 
                               GNC_DENOM_AUTO,
@@ -924,7 +931,15 @@ estimate_budget_helper(GtkTreeModel *model, GtkTreePath *path,
     {
         for (i = 0; i < num_periods; i++)
         {
-            num = recurrenceGetAccountPeriodValue(&priv->r, acct, i);
+            if (priv->ignClos)
+                num = xaccAccountGetNoclosingBalanceChangeForPeriod
+                  (acct, recurrenceGetPeriodTime(&priv->r, i, FALSE),
+                   recurrenceGetPeriodTime(&priv->r, i, TRUE), TRUE);
+            else
+                num = xaccAccountGetBalanceChangeForPeriod
+                  (acct, recurrenceGetPeriodTime(&priv->r, i, FALSE),
+                   recurrenceGetPeriodTime(&priv->r, i, TRUE), TRUE);
+
             if (!gnc_numeric_check(num))
             {
                 if (gnc_reverse_balance(acct))
@@ -949,7 +964,7 @@ gnc_plugin_page_budget_cmd_estimate_budget(GtkAction *action,
 {
     GncPluginPageBudgetPrivate *priv;
     GtkTreeSelection *sel;
-    GtkWidget *dialog, *gde, *dtr, *hb, *avg;
+    GtkWidget *dialog, *gde, *dtr, *hb, *avg, *ignclos;
     gint result;
     GDate date;
     const Recurrence *r;
@@ -996,6 +1011,9 @@ gnc_plugin_page_budget_cmd_estimate_budget(GtkAction *action,
     avg = GTK_WIDGET(gtk_builder_get_object(builder, "UseAverage"));
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(avg), priv->useAvg);
 
+    ignclos = GTK_WIDGET(gtk_builder_get_object(builder, "IgnClosing"));
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(ignclos), priv->ignClos);
+
     gtk_widget_show_all (dialog);
     result = gtk_dialog_run(GTK_DIALOG(dialog));
     switch (result)
@@ -1011,7 +1029,8 @@ gnc_plugin_page_budget_cmd_estimate_budget(GtkAction *action,
             gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(dtr));
 
         priv->useAvg = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(avg));
-        
+        priv->ignClos = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(ignclos));
+
         gtk_tree_selection_selected_foreach(sel, estimate_budget_helper, page);
         break;
     default:

--- a/gnucash/gtkbuilder/gnc-plugin-page-budget.glade
+++ b/gnucash/gtkbuilder/gnc-plugin-page-budget.glade
@@ -399,23 +399,6 @@
               </packing>
             </child>
             <child>
-              <object class="GtkCheckButton" id="IgnClosing">
-                <property name="label" translatable="yes" comments="Estimate budget for transactions and exclude closing transactions">Exclude Closing Transactions</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="tooltip_text" translatable="yes">While estimating budget values from existing transactions, exclude closing transactions.</property>
-                <property name="draw_indicator">True</property>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">3</property>
-              </packing>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
               <placeholder/>
             </child>
           </object>

--- a/gnucash/gtkbuilder/gnc-plugin-page-budget.glade
+++ b/gnucash/gtkbuilder/gnc-plugin-page-budget.glade
@@ -399,6 +399,23 @@
               </packing>
             </child>
             <child>
+              <object class="GtkCheckButton" id="IgnClosing">
+                <property name="label" translatable="yes" comments="Estimate budget for transactions and exclude closing transactions">Exclude Closing Transactions</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="tooltip_text" translatable="yes">While estimating budget values from existing transactions, exclude closing transactions.</property>
+                <property name="draw_indicator">True</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">3</property>
+              </packing>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
               <placeholder/>
             </child>
           </object>

--- a/libgnucash/engine/Account.h
+++ b/libgnucash/engine/Account.h
@@ -329,6 +329,16 @@ gboolean xaccAccountIsPriced(const Account *acc);
 void gnc_account_set_start_balance (Account *acc,
                                     const gnc_numeric start_baln);
 
+/** This function will set the starting noclosing commodity balance for
+ *  this account.  This routine is intended for use with backends that
+ *  do not return the complete list of splits for an account, but
+ *  rather return a partial list.  In such a case, the backend will
+ *  typically return all of the splits after some certain date, and
+ *  the 'starting balance' will represent the summation of the splits
+ *  up to that date. */
+void gnc_account_set_start_noclosing_balance (Account *acc,
+                                            const gnc_numeric start_baln);
+
 /** This function will set the starting cleared commodity balance for
  *  this account.  This routine is intended for use with backends that
  *  do not return the complete list of splits for an account, but
@@ -546,6 +556,8 @@ gboolean  xaccAccountGetNonStdSCU (const Account *account);
 /** Get the current balance of the account, which may include future
     splits */
 gnc_numeric xaccAccountGetBalance (const Account *account);
+/** Get the current balance of the account, excluding closing transactions */
+gnc_numeric xaccAccountGetNoclosingBalance (const Account *account);
 /** Get the current balance of the account, only including cleared
     transactions */
 gnc_numeric xaccAccountGetClearedBalance (const Account *account);
@@ -582,6 +594,9 @@ gnc_numeric xaccAccountConvertBalanceToCurrencyAsOfDate(
 gnc_numeric xaccAccountGetBalanceInCurrency (
     const Account *account, const gnc_commodity *report_commodity,
     gboolean include_children);
+gnc_numeric xaccAccountGetNoclosingBalanceInCurrency (
+    const Account *account, const gnc_commodity *report_commodity,
+    gboolean include_children);
 gnc_numeric xaccAccountGetClearedBalanceInCurrency (
     const Account *account, const gnc_commodity *report_commodity,
     gboolean include_children);
@@ -597,10 +612,15 @@ gnc_numeric xaccAccountGetProjectedMinimumBalanceInCurrency (
 
 /* This function gets the balance as of the given date in the desired
    commodity. */
+gnc_numeric xaccAccountGetNoclosingBalanceAsOfDateInCurrency(
+    Account *acc, time64 date, gnc_commodity *report_commodity,
+    gboolean include_children);
 gnc_numeric xaccAccountGetBalanceAsOfDateInCurrency(
     Account *account, time64 date, gnc_commodity *report_commodity,
     gboolean include_children);
 
+gnc_numeric xaccAccountGetNoclosingBalanceChangeForPeriod (
+    Account *acc, time64 date1, time64 date2, gboolean recurse);
 gnc_numeric xaccAccountGetBalanceChangeForPeriod (
     Account *acc, time64 date1, time64 date2, gboolean recurse);
 
@@ -1504,6 +1524,7 @@ const char * dxaccAccountGetQuoteTZ (const Account *account);
 #define ACCOUNT_SORT_REVERSED_ "sort-reversed"
 #define ACCOUNT_NOTES_		"notes"
 #define ACCOUNT_BALANCE_	"balance"
+#define ACCOUNT_NOCLOSING_	"noclosing"
 #define ACCOUNT_CLEARED_	"cleared"
 #define ACCOUNT_RECONCILED_	"reconciled"
 #define ACCOUNT_PRESENT_	"present"

--- a/libgnucash/engine/Account.h
+++ b/libgnucash/engine/Account.h
@@ -329,16 +329,6 @@ gboolean xaccAccountIsPriced(const Account *acc);
 void gnc_account_set_start_balance (Account *acc,
                                     const gnc_numeric start_baln);
 
-/** This function will set the starting noclosing commodity balance for
- *  this account.  This routine is intended for use with backends that
- *  do not return the complete list of splits for an account, but
- *  rather return a partial list.  In such a case, the backend will
- *  typically return all of the splits after some certain date, and
- *  the 'starting balance' will represent the summation of the splits
- *  up to that date. */
-void gnc_account_set_start_noclosing_balance (Account *acc,
-                                            const gnc_numeric start_baln);
-
 /** This function will set the starting cleared commodity balance for
  *  this account.  This routine is intended for use with backends that
  *  do not return the complete list of splits for an account, but
@@ -556,8 +546,6 @@ gboolean  xaccAccountGetNonStdSCU (const Account *account);
 /** Get the current balance of the account, which may include future
     splits */
 gnc_numeric xaccAccountGetBalance (const Account *account);
-/** Get the current balance of the account, excluding closing transactions */
-gnc_numeric xaccAccountGetNoclosingBalance (const Account *account);
 /** Get the current balance of the account, only including cleared
     transactions */
 gnc_numeric xaccAccountGetClearedBalance (const Account *account);
@@ -594,9 +582,6 @@ gnc_numeric xaccAccountConvertBalanceToCurrencyAsOfDate(
 gnc_numeric xaccAccountGetBalanceInCurrency (
     const Account *account, const gnc_commodity *report_commodity,
     gboolean include_children);
-gnc_numeric xaccAccountGetNoclosingBalanceInCurrency (
-    const Account *account, const gnc_commodity *report_commodity,
-    gboolean include_children);
 gnc_numeric xaccAccountGetClearedBalanceInCurrency (
     const Account *account, const gnc_commodity *report_commodity,
     gboolean include_children);
@@ -610,11 +595,13 @@ gnc_numeric xaccAccountGetProjectedMinimumBalanceInCurrency (
     const Account *account, const gnc_commodity *report_commodity,
     gboolean include_children);
 
-/* This function gets the balance as of the given date in the desired
-   commodity. */
+/* This function gets the balance as of the given date, ignoring
+   closing entries, in the desired commodity. */
 gnc_numeric xaccAccountGetNoclosingBalanceAsOfDateInCurrency(
     Account *acc, time64 date, gnc_commodity *report_commodity,
     gboolean include_children);
+/* This function gets the balance as of the given date in the desired
+   commodity. */
 gnc_numeric xaccAccountGetBalanceAsOfDateInCurrency(
     Account *account, time64 date, gnc_commodity *report_commodity,
     gboolean include_children);

--- a/libgnucash/engine/AccountP.h
+++ b/libgnucash/engine/AccountP.h
@@ -104,11 +104,13 @@ typedef struct AccountPrivate
 
     /* protected data - should only be set by backends */
     gnc_numeric starting_balance;
+    gnc_numeric starting_noclosing_balance;
     gnc_numeric starting_cleared_balance;
     gnc_numeric starting_reconciled_balance;
 
     /* cached parameters */
     gnc_numeric balance;
+    gnc_numeric noclosing_balance;
     gnc_numeric cleared_balance;
     gnc_numeric reconciled_balance;
 

--- a/libgnucash/engine/Split.c
+++ b/libgnucash/engine/Split.c
@@ -120,6 +120,7 @@ gnc_split_init(Split* split)
     split->balance             = gnc_numeric_zero();
     split->cleared_balance     = gnc_numeric_zero();
     split->reconciled_balance  = gnc_numeric_zero();
+    split->noclosing_balance   = gnc_numeric_zero();
 
     split->gains = GAINS_STATUS_UNKNOWN;
     split->gains_split = NULL;
@@ -513,6 +514,7 @@ xaccSplitReinit(Split * split)
     split->balance             = gnc_numeric_zero();
     split->cleared_balance     = gnc_numeric_zero();
     split->reconciled_balance  = gnc_numeric_zero();
+    split->noclosing_balance   = gnc_numeric_zero();
 
     qof_instance_set_idata(split, 0);
 
@@ -597,6 +599,7 @@ xaccSplitCloneNoKvp (const Split *s)
     split->balance             = s->balance;
     split->cleared_balance     = s->cleared_balance;
     split->reconciled_balance  = s->reconciled_balance;
+    split->noclosing_balance   = s->noclosing_balance;
 
     split->gains = GAINS_STATUS_UNKNOWN;
     split->gains_split = NULL;
@@ -679,6 +682,7 @@ xaccSplitDump (const Split *split, const char *tag)
     printf("    CBalance: %s\n", gnc_numeric_to_string(split->cleared_balance));
     printf("    RBalance: %s\n",
            gnc_numeric_to_string(split->reconciled_balance));
+    printf("    NoClose:  %s\n", gnc_numeric_to_string(split->noclosing_balance));
     printf("    idata:    %x\n", qof_instance_get_idata(split));
 }
 #endif
@@ -867,6 +871,9 @@ xaccSplitEqual(const Split *sa, const Split *sb,
             return FALSE;
         if (!xaccSplitEqualCheckBal ("reconciled ", sa->reconciled_balance,
                                      sb->reconciled_balance))
+            return FALSE;
+        if (!xaccSplitEqualCheckBal ("noclosing ", sa->noclosing_balance,
+                                     sb->noclosing_balance))
             return FALSE;
     }
 

--- a/libgnucash/engine/Split.c
+++ b/libgnucash/engine/Split.c
@@ -1273,6 +1273,12 @@ xaccSplitGetBalance (const Split *s)
 }
 
 gnc_numeric
+xaccSplitGetNoclosingBalance (const Split *s)
+{
+    return s ? s->noclosing_balance : gnc_numeric_zero();
+}
+
+gnc_numeric
 xaccSplitGetClearedBalance (const Split *s)
 {
     return s ? s->cleared_balance : gnc_numeric_zero();

--- a/libgnucash/engine/Split.h
+++ b/libgnucash/engine/Split.h
@@ -297,6 +297,15 @@ gnc_numeric xaccSplitGetBaseValue (const Split *split,
 gnc_numeric xaccSplitGetBalance (const Split *split);
 
 /**
+ * The noclosing-balance is the currency-denominated balance of all
+ * transactions except 'closing' transactions. It is correctly
+ * adjusted for price fluctuations.
+ *
+ * Returns the running balance up to & including the indicated split.
+ */
+gnc_numeric xaccSplitGetNoclosingBalance (const Split *split);
+
+/**
  * The cleared-balance is the currency-denominated balance
  * of all transactions that have been marked as cleared or reconciled.
  * It is correctly adjusted for price fluctuations.

--- a/libgnucash/engine/SplitP.h
+++ b/libgnucash/engine/SplitP.h
@@ -123,6 +123,7 @@ struct split_s
      * These balances apply to a sorting order by date posted
      * (not by date entered). */
     gnc_numeric  balance;
+    gnc_numeric  noclosing_balance;
     gnc_numeric  cleared_balance;
     gnc_numeric  reconciled_balance;
 };

--- a/libgnucash/engine/test/utest-Transaction.cpp
+++ b/libgnucash/engine/test/utest-Transaction.cpp
@@ -936,6 +936,8 @@ test_xaccTransEqual (Fixture *fixture, gconstpointer pData)
 
         split10->balance = split00->balance;
         split11->balance = split01->balance;
+        split10->noclosing_balance = split00->noclosing_balance;
+        split11->noclosing_balance = split01->noclosing_balance;
         g_assert (xaccTransEqual (txn1, txn0, TRUE, TRUE, TRUE, TRUE));
     }
     g_free (check3->msg);


### PR DESCRIPTION
1. A few new API calls:
`gnc_account_set_start_noclosing_balance`, `xaccAccountGetNoclosingBalance`, `xaccAccountGetNoclosingBalanceInCurrency`, `xaccAccountGetNoclosingBalanceAsOfDateInCurrency`, `xaccAccountGetNoclosingBalanceChangeForPeriod`, `xaccSplitGetNoclosingBalance`.

2. Fix for bug 797326 by querying above.

Tested via live UI use only. Works fine. No utest writing skills.