### PR TITLE
Maint 796952 797332

### DIFF
--- a/gnucash/report/report-system/html-acct-table.scm
+++ b/gnucash/report/report-system/html-acct-table.scm
@@ -1166,7 +1166,6 @@
 			params))
 		  (acct (get-val env 'account))
 		  (children (get-val env 'account-children))
-		  (children-displayed? (get-val env 'children-displayed?))
 		  (label (get-val env 'account-label))
 		  (acct-name (get-val env 'account-name)) ;; for diagnostics...
 		  (report-commodity  (get-val env 'report-commodity))
@@ -1293,18 +1292,6 @@
 	      amount
 	      (+ account-cols (- 0 1)
 		 (- logical-cols display-depth)
-		 ;; account for 'immediate-bal parents displaying children
-		 ;; NOTE: before you go mucking with this, BE ABSOLUTELY
-		 ;; SURE you know what you're doing... i spent A LOT of
-		 ;; time trying to make sure this is right. i know, in
-		 ;; some reports, the output might look incorrect. but,
-		 ;; if you think long and hard about it, i think you'll
-		 ;; find the current treatment correct... i think. -DM-
-		 (- 0 (if (if (not children-displayed?)
-			      #f
-			      (equal? bal-method 'immediate-bal))
-			  1 0)
-		    )
 		 (if (equal? subtotal-mode 'canonically-tabbed) 1 0)
 		 )                          ;; amount-depth
 	      1                             ;; amount-colspan

--- a/gnucash/report/standard-reports/account-summary.scm
+++ b/gnucash/report/standard-reports/account-summary.scm
@@ -457,23 +457,25 @@
 		)
           (if show-account-bals?
               (gnc:html-table-set-cell/tag!
-               build-table 0 (1+ cur-col) "number-header"
+               build-table 0 (+ cur-col account-cols) "number-header"
 	       (_ "Balance"))
               )
-          (let ((row 0))
-            (while (< row table-rows)
-              (let ((col 1))
-                (gnc:html-table-set-cell! build-table (1+ row) cur-col
-                                          (gnc:html-table-get-cell hold-table row 0))
-                (if show-account-bals?
-                    (while (< col hold-table-width)
-                      (if (gnc:html-table-get-cell hold-table row col)
-                          (gnc:html-table-set-cell!
-                           build-table (1+ row) (1+ cur-col)
-                           (gnc:html-table-get-cell hold-table row col)))
-                      (set! col (1+ col)))))
-              (set! row (1+ row))))
-          (set! cur-col (+ cur-col (if show-account-bals? 2 1)))
+	  (let ((row 0))
+	    (while (< row table-rows)
+		   (gnc:html-table-set-row-markup! build-table (+ row 1)
+						   (gnc:html-table-row-markup hold-table row))
+		   (let ((col 0))
+		     (while (< col hold-table-width)
+			    (gnc:html-table-set-cell!
+			     build-table (+ row 1) (+ cur-col col)
+			     (gnc:html-table-get-cell hold-table row col)
+			     )
+			    (set! col (+ col 1))
+			    )
+		     )
+		   (set! row (+ row 1))
+		   )
+	    )
 	  (set! cur-col (+ cur-col hold-table-width))
 	  (if show-account-notes?
 	      (begin

--- a/gnucash/report/standard-reports/test/test-balsheet-pnl.scm
+++ b/gnucash/report/standard-reports/test/test-balsheet-pnl.scm
@@ -216,13 +216,13 @@
       (let ((sxml (options->sxml balance-sheet-uuid balance-sheet-options "balsheet-multilevel")))
         (test-equal "multilevel. root = $0.00"
           (list "$0.00")
-          (sxml->table-row-col sxml 1 3 5))
+          (sxml->table-row-col sxml 1 3 6))
         (test-equal "multilevel. assets = $0.00"
           (list "$0.00")
-          (sxml->table-row-col sxml 1 4 4))
+          (sxml->table-row-col sxml 1 4 5))
         (test-equal "multilevel. bank1 = $0.00"
           (list "$0.00")
-          (sxml->table-row-col sxml 1 5 3))
+          (sxml->table-row-col sxml 1 5 4))
         (test-equal "multilevel. bonds = $2,000.00"
           (list "$2,000.00")
           (sxml->table-row-col sxml 1 6 3))
@@ -240,7 +240,7 @@
           (sxml->table-row-col sxml 1 10 4))
         (test-equal "multilevel. broker = $2,000.00"
           (list "$2,000.00")
-          (sxml->table-row-col sxml 1 11 3))
+          (sxml->table-row-col sxml 1 11 4))
         (test-equal "multilevel. funds = $15,000.00"
           (list "30 FUNDS" "$15,000.00" "$15,000.00")
           (sxml->table-row-col sxml 1 12 3))
@@ -249,7 +249,7 @@
           (sxml->table-row-col sxml 1 13 4))
         (test-equal "multilevel. foreign = $0.00"
           (list "$0.00")
-          (sxml->table-row-col sxml 1 14 3))
+          (sxml->table-row-col sxml 1 14 4))
         (test-equal "multilevel. foreignsavings = #200.00 = $340"
           (list "#200.00" "$340.00" "$340.00")
           (sxml->table-row-col sxml 1 15 3))
@@ -352,7 +352,7 @@
       (let ((sxml (options->sxml balance-sheet-uuid balance-sheet-options "balsheet-incl-zb-accts=#t omit-zb-bals=#f")))
         (test-equal "omit-zb-bals=#f"
           (list "$0.00")
-          (sxml->table-row-col sxml 1 3 5))
+          (sxml->table-row-col sxml 1 3 6))
         (test-equal "incl-zb-accts=#t"
           '("Empty" "$0.00")
           (sxml->table-row-col sxml 1 8 #f)))
@@ -362,35 +362,41 @@
     (let* ((pnl-options (default-pnl-testing-options))
            (sxml (options->sxml pnl-uuid pnl-options "pnl-default")))
       (test-equal "total revenue  = $1,270.00"
-        (list "$1,270.00" "$1,270.00")
-        (sxml->table-row-col sxml 1 5 6))
+        (list "$1,270.00")
+        ((sxpath '(// table // (tr 1) // table // (tr 5) // (td 6) // *text*))
+         sxml))
       (test-equal "total expenses  = $0.00"
-        (list "$0.00" "$0.00")
-        (sxml->table-row-col sxml 1 3 6))
+        (list "$0.00")
+        ((sxpath '(// table // (tr 2) // table // (tr 3) // (td 6) // *text*))
+         sxml))
 
       (set-option! pnl-options "Commodities" "Price Source" 'weighted-average)
       (let ((sxml (options->sxml pnl-uuid pnl-options "pnl-weighted-average")))
         (test-equal "weighted average revenue = $1160.36"
-          (list "$1,160.36" "$1,160.36")
-          (sxml->table-row-col sxml 1 5 6)))
+          (list "$1,160.36")
+          ((sxpath '(// table // (tr 1) // table // (tr 5) // (td 6) // *text*))
+           sxml)))
 
       (set-option! pnl-options "Commodities" "Price Source" 'average-cost)
       (let ((sxml (options->sxml pnl-uuid pnl-options "pnl-average-cost")))
         (test-equal "average-cost revenue = $976"
-          (list "$976.00" "$976.00")
-          (sxml->table-row-col sxml 1 5 6)))
+          (list "$976.00")
+          ((sxpath '(// table // (tr 1) // table // (tr 5) // (td 6) // *text*))
+           sxml)))
 
       (set-option! pnl-options "Commodities" "Price Source" 'pricedb-nearest)
       (let ((sxml (options->sxml pnl-uuid pnl-options "pnl-pricedb-nearest")))
         (test-equal "pricedb-nearest revenue = $1270"
-          (list "$1,270.00" "$1,270.00")
-          (sxml->table-row-col sxml 1 5 6)))
+          (list "$1,270.00")
+          ((sxpath '(// table // (tr 1) // table // (tr 5) // (td 6) // *text*))
+           sxml)))
 
       (set-option! pnl-options "Commodities" "Price Source" 'pricedb-latest)
       (let ((sxml (options->sxml pnl-uuid pnl-options "pnl-pricedb-latest")))
         (test-equal "pricedb-latest revenue = $1270"
-          (list "$1,270.00" "$1,270.00")
-          (sxml->table-row-col sxml 1 5 6)))
+          (list "$1,270.00")
+          ((sxpath '(// table // (tr 1) // table // (tr 5) // (td 6) // *text*))
+           sxml)))
 
       ;; set multilevel subtotal style
       ;; verifies amount in EVERY line of the report.
@@ -398,23 +404,29 @@
       (set-option! pnl-options "Display" "Parent account subtotals" 't)
       (let ((sxml (options->sxml pnl-uuid pnl-options "pnl-multilevel")))
         (test-equal "multilevel. income = -$250.00"
-          (list "-$250.00" "-$250.00")
-          (sxml->table-row-col sxml 1 3 5))
-        (test-equal "multilevel. income-GBP = $0.00"
-          (list "-#600.00" "-$1,020.00" "-#600.00" "-$1,020.00")
-          (sxml->table-row-col sxml 1 4 5))
+          (list "-$250.00")
+          ((sxpath '(// table // (tr 1) // table // (tr 3) // (td 6) // *text*))
+           sxml))
+        (test-equal "multilevel. income-GBP = -#600"
+          (list "-#600.00" "-$1,020.00")
+          ((sxpath '(// table // (tr 1) // table // (tr 4) // (td 5) // *text*))
+           sxml))
         (test-equal "multilevel. total income = -$1,270.00"
-          (list "-$1,270.00" "-$1,270.00")
-          (sxml->table-row-col sxml 1 5 6))
+          (list "-$1,270.00")
+          ((sxpath '(// table // (tr 1) // table // (tr 5) // (td 6) // *text*))
+           sxml))
         (test-equal "multilevel. total revenue = $1,270.00"
-          (list "$1,270.00" "$1,270.00")
-          (sxml->table-row-col sxml 1 6 6))
+          (list "$1,270.00")
+          ((sxpath '(// table // (tr 1) // table // (tr 6) // (td 6) // *text*))
+           sxml))
         (test-equal "multilevel. expenses = $0.00"
-          (list "$0.00" "$0.00")
-          (sxml->table-row-col sxml 1 3 6))
+          (list "$0.00")
+          ((sxpath '(// table // (tr 2) // table // (tr 3) // (td 6) // *text*))
+           sxml))
         (test-equal "multilevel. net-income = $1,270"
-          (list "$1,270.00" "$1,270.00")
-          (sxml->table-row-col sxml 1 4 6)))
+          (list "$1,270.00")
+          ((sxpath '(// table // (tr 2) // table // (tr 4) // (td 6) // *text*))
+           sxml)))
 
       ;; set recursive-subtotal subtotal style
       (set-option! pnl-options "Display" "Parent account balances" 'recursive-bal)


### PR DESCRIPTION
1. restore amount indenting in account-summary.scm for bug 797332
2. remove the "has-children && immediate-bal" conditional to artificially reduce the amount indent-level for reports using html-acct-table. This causes confusing indenting for account-trees whereby the account-depth varies across accounts.