### PR TITLE
Allow edit of some fields for posted invoice

### DIFF
--- a/gnucash/gnome/dialog-invoice.c
+++ b/gnucash/gnome/dialog-invoice.c
@@ -1918,13 +1918,13 @@ gnc_invoice_update_window (InvoiceWindow *iw, GtkWidget *widget)
 
         /* Setup viewer for read-only access */
         gtk_widget_set_sensitive (acct_entry, FALSE);
-        gtk_widget_set_sensitive (iw->id_entry, FALSE);
+        gtk_widget_set_sensitive (iw->id_entry, FALSE); /* XXX: why set FALSE and then TRUE? */
         gtk_widget_set_sensitive (iw->id_entry, TRUE);
         gtk_widget_set_sensitive (iw->terms_menu, FALSE);
-        gtk_widget_set_sensitive (iw->owner_box, FALSE);
-        gtk_widget_set_sensitive (iw->job_box, FALSE);
+        gtk_widget_set_sensitive (iw->owner_box, TRUE);
+        gtk_widget_set_sensitive (iw->job_box, TRUE);
         gtk_widget_set_sensitive (iw->billing_id_entry, FALSE);
-        gtk_widget_set_sensitive (iw->notes_text, FALSE); /* XXX: should notes remain writable?*/
+        gtk_widget_set_sensitive (iw->notes_text, TRUE);
     }
     else           /* ! posted */
     {


### PR DESCRIPTION
Allow editing of some fields for posted invoice.

For reasons, see bug report:
https://bugs.gnucash.org/show_bug.cgi?id=797400

Reverts some changes done to fix:
https://bugs.gnucash.org/show_bug.cgi?id=797168