### PR TITLE
Fix typos for several directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -616,7 +616,7 @@ endif()
 set(BUILD_SHARED_LIBS ON)
 
 # Most libraries are installed to lib/gnucash, so set that as the default.
-# For the handful that are installed to lib, we override the properies below
+# For the handful that are installed to lib, we override the properties below
 # (after the targets have been read in).
 
 

--- a/HACKING
+++ b/HACKING
@@ -129,9 +129,9 @@ or unit tests with Electric Fence.
 It should probably be relatively straightforward to add this as all it
 needs is to link with libefence.so (-lefence).
 
-Fedora 27 ships an ElectricFence package containing that libary and also
-an exectuable 'ef' to run an arbitrary program with Electric Fence
-guarding enabled. I have given it a quick spin on gnucash but it immediatly
+Fedora 27 ships an ElectricFence package containing that library and also
+an executable 'ef' to run an arbitrary program with Electric Fence
+guarding enabled. I have given it a quick spin on gnucash but it immediately
 crashes. I haven't investigated whether this is because I should first have
 linked gnucash with -lefence or because a real problem in GnuCash code.
 

--- a/README.dependencies
+++ b/README.dependencies
@@ -71,7 +71,7 @@ Libraries/Deps
                                                 doesn't include all file types
                                                 when building gnucash.pot.
   libxslt, including xsltproc
-  ICU                                           International Compnents for
+  ICU                                           International Components for
                                                 Unicode
   boost			1.50.0                  locale and regex libs must be
                                                 built with ICU support.

--- a/bindings/python/example_scripts/account_analysis.py
+++ b/bindings/python/example_scripts/account_analysis.py
@@ -83,7 +83,7 @@ def gnc_numeric_to_python_Decimal(numeric):
     copy = GncNumeric(numeric.num(), numeric.denom())
     result = copy.to_decimal(None)
     if not result:
-        raise Exception("gnc numeric value %s can't be converted to deciaml" %
+        raise Exception("gnc numeric value %s can't be converted to decimal" %
                         copy.to_string() )
     digit_tuple = tuple( int(char)
                          for char in str(copy.num())

--- a/bindings/python/example_scripts/new_book_with_opening_balances.py
+++ b/bindings/python/example_scripts/new_book_with_opening_balances.py
@@ -42,7 +42,7 @@ from datetime import date
 
 # This script takes a gnucash url
 # and creates a new file/db at a second url that has the same
-# account tree and an equivilent opening balance on all the simple balance
+# account tree and an equivalent opening balance on all the simple balance
 # sheet accounts (not for income and expense accounts)
 #
 # This is done a per currency basis, one opening balance account for each
@@ -122,7 +122,7 @@ ACCOUNT_TYPES_TO_OPEN = ACCOUNT_TYPES_TO_OPEN.difference( set((
             )) )
 
 # this script isn't capable of properly setting up the transactions for
-# ACCT_TYPE_TRADING, you'll have to create opening balances for them mannually;
+# ACCT_TYPE_TRADING, you'll have to create opening balances for them manually;
 # so, they are not included in the set of accounts used for opening balances
 ACCOUNT_TYPES_TO_OPEN.remove(ACCT_TYPE_TRADING)
 

--- a/bindings/python/example_scripts/rest-api/gnucash_rest.py
+++ b/bindings/python/example_scripts/rest-api/gnucash_rest.py
@@ -1141,7 +1141,7 @@ def payBill(book, id, posted_account_guid, transfer_account_guid, payment_date,
 
     xfer_acc = account_guid.AccountLookup(session.book)
 
-    # We pay the negitive total as the bill as this seemed to cause issues
+    # We pay the negative total as the bill as this seemed to cause issues
     # with the split not being set correctly and not being marked as paid
     bill.ApplyPayment(None, xfer_acc, bill.GetTotal().neg(), GncNumeric(0),
         datetime.datetime.strptime(payment_date, '%Y-%m-%d'), memo, num)

--- a/bindings/python/example_scripts/simple_business_create.py
+++ b/bindings/python/example_scripts/simple_business_create.py
@@ -27,7 +27,7 @@
 # gnucash-env python simple_business_create.py \
 #                       sqlite3:///home/blah/blah.gnucash
 #
-# Specificically, this sets up a simple tree, creates a customer, job,
+# Specifically, this sets up a simple tree, creates a customer, job,
 # employee and vendor, creates an unposted invoice for each,
 # and posts the customer invoice with a few entries and a tax table.
 #

--- a/bindings/python/function_class.py
+++ b/bindings/python/function_class.py
@@ -48,7 +48,7 @@ class ClassFromFunctions(object):
     add_method and add_methods_with_prefix.
     """
     def __new__(cls, *args, **kargs):
-        # why reimpliment __new__? Because later on we're going to
+        # why reimplement __new__? Because later on we're going to
         # use new to avoid creating new instances when existing instances
         # already exist with the same __instance value, or equivalent __instance
         # values, where this is desirable...

--- a/bindings/python/gnucash_core.i
+++ b/bindings/python/gnucash_core.i
@@ -93,7 +93,7 @@
 
 %include <qofbackend.h>
 
-// this function is defined in qofsession.h, but isnt found in the libraries,
+// this function is defined in qofsession.h, but isn't found in the libraries,
 // ignored because SWIG attempts to link against (to create language bindings)
 %ignore qof_session_not_saved;
 %include <qofsession.h>

--- a/bindings/python/time64.i
+++ b/bindings/python/time64.i
@@ -58,7 +58,7 @@
 // receiving this pointer is going to make a copy of the data. After the
 // function call, the memory for the time64 used to perform this conversion
 // is going to be lost, so make damn sure that the recipient of this pointer
-// is NOT going dereference it sometime after this function call takes place.
+// is NOT going to dereference it sometime after this function call takes place.
 //
 // As far as I know, the xaccTransSetDate[Posted|Entered|Due]TS functions
 // from Transaction.h are the only functions with time64 * that we re
@@ -71,7 +71,7 @@
 //
 // Mark Jenkins <mark@parit.ca>
 //
-// as far as I can see all occurences of pointers to time64 are now covered
+// as far as I can see all occurrences of pointers to time64 are now covered
 // by the named typemaps below (2019-04)
 //
 // Christoph Holtermann <mail@c-holtermann.net>

--- a/borrowed/libc/strptime.c
+++ b/borrowed/libc/strptime.c
@@ -460,7 +460,7 @@ int era_cnt;
         }
 
         /* Any character but `%' must be matched by the same character
-        	 in the iput string.  */
+        	 in the input string.  */
         if (*fmt != '%')
         {
             match_char (*fmt++, *rp++);

--- a/common/gnc-test-env.pl
+++ b/common/gnc-test-env.pl
@@ -10,9 +10,9 @@ my @gnc_module_dirs=();
 my @guile_load_dirs=();
 my @library_dirs=();
 GetOptions ("exports!"       => \$define_exports,  # flag
-            "gnc-module-dir=s" => \@gnc_module_dirs, # arry of strings
-            "guile-load-dir=s" => \@guile_load_dirs, # arry of strings
-            "library-dir=s"    => \@library_dirs,    # arry of strings
+            "gnc-module-dir=s" => \@gnc_module_dirs, # array of strings
+            "guile-load-dir=s" => \@guile_load_dirs, # array of strings
+            "library-dir=s"    => \@library_dirs,    # array of strings
             "verbose" => \$verbose) # flag
 or die(
 "Usage: gnc-test-env.pl [ --exports | --noexports ]\n" .

--- a/doc/README.OFX
+++ b/doc/README.OFX
@@ -197,12 +197,12 @@ output of the ofxdump utility on your file.
 (1) GnuCash simply hangs when importing an OFX file
 
 This is probably bug https://bugs.gnucash.org/show_bug.cgi?id=101738
-Unfortunately the main developpers are unable to reproduce.  So far, this bug
+Unfortunately the main developers are unable to reproduce.  So far, this bug
 only occurs with OpenSP 1.5.  It does not occur for anyone with OpenSP 1.3.x,
 which is shipped on most Linux distro as part of openjade, so you may want to
 downgrade. (Please note that OpenSP 1.3.x has several other issues however)
 
-This bug is beleived to be a threading issue, and may be a problem in GnuCash,
+This bug is believed to be a threading issue, and may be a problem in GnuCash,
 LibOFX, OpenSP, or some versions of the Linux kernel.  If you have any useful 
 info,please add a comment to the bug above (even if only to say you encountered 
 the bug,and your version of the previously mentioned packages).

--- a/doc/TRANSLATION_HOWTO
+++ b/doc/TRANSLATION_HOWTO
@@ -100,7 +100,7 @@ email address.
 4) Building, Installing and running GnuCash
 
 Before starting to work on your translations, it is suggested that you 
-buiild the gnucash source code.  This way you can get your system set up 
+build the gnucash source code.  This way you can get your system set up 
 correctly with all the development packages you need.  It is a good idea
 to actually run gnucash with your new translations because it is quite 
 helpful to see the phrases in the context of the running program.
@@ -157,7 +157,7 @@ Now, open your language's glossary file and translate it completely.
 ==============================================================================
 6) Initial processing of the translation file
 
-Before you begin actualy translation work, you should update the gnucash.pot 
+Before you begin actual translation work, you should update the gnucash.pot 
 file and use this to update your .po file.  This process will insure that 
 you have the latest translatable strings.
 
@@ -174,7 +174,7 @@ If your language file does exist, update it using the msgmerge program:
 
 /usr/bin/msgmerge -o XXXX.po XXXX.po gnucash.pot
 
-The top of the .po file should be editted somewhat.  The comments at the 
+The top of the .po file should be edited somewhat.  The comments at the 
 top of the file should be changed to be current:
 
 # Messages in Deutsch f�r GnuCash
@@ -191,7 +191,7 @@ Make sure that the header of your .po file contains this line:
 
 Finally.  You are ready to do some translating!
 
-There are many transaltion editors, KBabel, for example, works well for 
+There are many translation editors, KBabel, for example, works well for 
 GnuCash.  Some Editors are noted here:
 https://translationproject.org/html/software.html
 
@@ -256,13 +256,13 @@ Notice that the comment "c-format" was not removed.  That is correct, you
 should leave that.
 
 When you see the comment "c-format", it means that the format codes in the 
-tranlatable string are referring to C formatting codes.  So, '%s' means text, 
+translatable string are referring to C formatting codes.  So, '%s' means text, 
 '%d' means an integer, etc...
 
 ==============================================================================
 8) Testing and submitting your translations
 
-You must check that your new translations are programatically correct (ie: 
+You must check that your new translations are programmatically correct (ie: 
 that there are no unclosed quotes, etc).  To do this, use the msgfmt program
 
 /usr/bin/msgfmt -c --statistics XXXX.po

--- a/doc/examples/iif/README
+++ b/doc/examples/iif/README
@@ -1,5 +1,5 @@
 This directory contains sample data files in the 'iif'
-Intuit Interchange Format files.   Most of thise files
+Intuit Interchange Format files.   Most of these files
 have only one transaction in them, with only one or two 
 splits.  
 

--- a/doc/examples/taxreport.gnucash
+++ b/doc/examples/taxreport.gnucash
@@ -502,7 +502,7 @@
     <cmdty:id>USD</cmdty:id>
   </act:commodity>
   <act:commodity-scu>100</act:commodity-scu>
-  <act:description>Company 50% match of S&amp;S, to 7% of salery.</act:description>
+  <act:description>Company 50% match of S&amp;S, to 7% of salary.</act:description>
   <act:slots>
     <slot>
       <slot:key>tax-US</slot:key>
@@ -1993,7 +1993,7 @@
   <act:parent type="guid">ce8a0ff9cfc2c79c99e6c65d5e258a55</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
-  <act:name>HomeMaintainance</act:name>
+  <act:name>HomeMaintenance</act:name>
   <act:id type="guid">2f46699ef618ac2e88c9a5201d4bff2d</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
@@ -2004,7 +2004,7 @@
   <act:parent type="guid">ce8a0ff9cfc2c79c99e6c65d5e258a55</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
-  <act:name>IRA Contribution, Non Deductable</act:name>
+  <act:name>IRA Contribution, Non Deductible</act:name>
   <act:id type="guid">911b7f106931fb26917aa2aa6662e70e</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
@@ -2081,7 +2081,7 @@
   <act:parent type="guid">ce8a0ff9cfc2c79c99e6c65d5e258a55</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
-  <act:name>Morgage</act:name>
+  <act:name>Mortgage</act:name>
   <act:id type="guid">8d172831a7cee627802966332dc04411</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
@@ -2139,7 +2139,7 @@
   <act:parent type="guid">ce8a0ff9cfc2c79c99e6c65d5e258a55</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
-  <act:name>Restarant</act:name>
+  <act:name>Restaurant</act:name>
   <act:id type="guid">ab78940fcbc8e25834c57c92a0dadd0e</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
@@ -2162,7 +2162,7 @@
   <act:parent type="guid">ce8a0ff9cfc2c79c99e6c65d5e258a55</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
-  <act:name>Tax Deductable</act:name>
+  <act:name>Tax Deductible</act:name>
   <act:id type="guid">d7bfc2020fd8cb91e46a6cda6bdb6efd</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
@@ -2392,7 +2392,7 @@
   <act:parent type="guid">d7bfc2020fd8cb91e46a6cda6bdb6efd</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
-  <act:name>Non Deductable</act:name>
+  <act:name>Non Deductible</act:name>
   <act:id type="guid">82119f5617cc4cbaf7f882a0883fd7df</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
@@ -2512,7 +2512,7 @@
   <act:parent type="guid">babd20035ed6cd6415d878a31675210c</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
-  <act:name>IRA mangement fee</act:name>
+  <act:name>IRA management fee</act:name>
   <act:id type="guid">380635c3d759d34529e0422ced08628c</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
@@ -4008,7 +4008,7 @@ Witholding</act:name>
   <trn:date-entered>
     <ts:date>2000-10-21 16:41:40 +0200</ts:date>
   </trn:date-entered>
-  <trn:description>IRA Contrib, non Deductable</trn:description>
+  <trn:description>IRA Contrib, non Deductible</trn:description>
   <trn:splits>
     <trn:split>
       <split:id type="guid">d6d30e081d5da4f33d5248e8a6aae3c2</split:id>

--- a/doc/gtk-3.0.css
+++ b/doc/gtk-3.0.css
@@ -1,5 +1,5 @@
 /* This is an example GTK CSS file that can be used with Gnucash.
-   Simply copy this file to the loaction specified below according
+   Simply copy this file to the location specified below according
    to your platform and then restart gnucash.
 
   - Windows: CSIDL_APPDATA/GnuCash

--- a/doc/projects.html
+++ b/doc/projects.html
@@ -248,7 +248,7 @@
 
     <h2>A Web Browser for Financial Data</h2>
 
-    <p>More and more finacial data is moving onto the web.  
+    <p>More and more financial data is moving onto the web.  
     People shop on-line. They pay bills on-line.  There are
     even some promising e-wallet systems (such as 
     <a href="https://www.webfunds.org">WebFunds</a>).  For GnuCash
@@ -338,7 +338,7 @@
     <dl>
     <dt><b>E-Wallet</b></dt>
     <dd>An e-wallet, just like a real wallet, stores cash.  You
-        can use that cash to pay freinds or businesses.  Just
+        can use that cash to pay friends or businesses.  Just
 	like a real wallet, an e-wallet should not charge you 
 	monthly fees.  It should provide you with some measure
 	of anonymity and privacy.  An e-wallet should also do 
@@ -428,7 +428,7 @@
       <li>Basic Audit features.  There's a problem with blindly
           allowing on-line data (prices, transactions) to enter
 	  GnuCash.  It may not be clear where it came from,
-	  and even if the source is beleived to be 'reputable',
+	  and even if the source is believed to be 'reputable',
 	  there still may be factual errors in the data.  Thus,
 	  there must be a way of audting newly-arrived (or even old)
 	  on-line data, and mark it as 'reconciled', i.e. 
@@ -1215,7 +1215,7 @@
             do you own jewelry? appraised value? etc.)
             In particular, show how appreciation
             and depreciation should be treated.
-            See the section <a href="#arrangments">Arrangements</a> for
+            See the section <a href="#arrangements">Arrangements</a> for
             a discussion of the customization issues.
             </p>
           </li>
@@ -1272,7 +1272,7 @@
             menu. It would be nice to be able to examine different
             account types (Asset, Liability, Income, Expense,
             Payables, Receivables, Inventory) by selecting a tab
-            folder. This is maybe a bs. request that shoudn't 
+            folder. This is maybe a bs. request that shouldn't 
 	    be implemented.</p>
           </li>
 
@@ -1417,7 +1417,7 @@
             <p><b>Print Register Window</b>. Output register window to
                printer.
                <b>Status:</b> Done: there is a register report which
-	       is printable, there is botton on register. Done in 1.6.0
+	       is printable, there is a button on register. Done in 1.6.0
             </p>
           </li>
           <li>
@@ -1536,7 +1536,7 @@
         complex tasks, such as new user setup, account creation, 
         QIF import, budget prep, obscure functional corners.
 	<p>
-	Wizards are great, but lets not thow away the denser GUI's.
+	Wizards are great, but lets not throw away the denser GUI's.
 	For 8-hour-a-day users, the wizards can be irritating. 
 	A single, dense screen can be more efficient and nicer.
 	So when adding wizards, don't dump GUI's !! (instead,
@@ -1583,7 +1583,7 @@
         <p></p>
 
 
-      <dt><a name="arrangements"><b>Arrangments</b></a></dt>
+      <dt><a name="arrangements"><b>Arrangements</b></a></dt>
 
       <dd>
         An "application arrangement" is the defining look-n-feel of an application.
@@ -1622,9 +1622,9 @@
         their own preferred arrangement.   It can also simplify the code base: 
         instead of having two products, a home-user application, and a small-business 
         application, each with a different code base and #defines and what not, instead,
-        we have one code base, and different arrangments for each.
-        However, most importantly, the arrangments should be easy to share between users.
-        They should be such that users are encouraged to trade and use arrangments,
+        we have one code base, and different arrangements for each.
+        However, most importantly, the arrangements should be easy to share between users.
+        They should be such that users are encouraged to trade and use arrangements,
         and to create new ones that suit their needs.
         </p>
         <p>
@@ -1638,7 +1638,7 @@
 	Not started. Individually, all these cusomizable things exist
 	here and there in gnucash, but they cannot be shared between
 	users: a gnucash user cannot mail her favorite 'arrangement'
-	to her freind.
+	to her friend.
 	</p>
 
 
@@ -1767,7 +1767,7 @@
         dates, ISP contract expiration date :-). These may or may
         not be associated with transactions. Memo's should be
         possible. Pop-ups should happen when dates get close.
-        Technology: best bet is the Ximian Evolution Calander
+        Technology: best bet is the Ximian Evolution Calendar
 	component.</p>
 
         <p><b>Design Notes:</b> Most alerts &amp; data storage
@@ -2365,7 +2365,7 @@ next due date mm/dd/yy
 &gt;&gt;  - Export retrieved account data to CBB, Xfinans and QIF files
 &gt;&gt;
 &gt;&gt; With a simple click to an icon on my desktop, ZKA4BTX logs into
-&gt;&gt; T-Online, gets all my account datas from several banks, and writes
+&gt;&gt; T-Online, gets all my account data from several banks, and writes
 &gt;&gt; (adds) it to my CBB, Xfinans or GnuCash (QIF) files.
 &gt;&gt;
 &gt;&gt; Another very important thing is that I can do all my transfers

--- a/gnucash/gnome-search/search-string.c
+++ b/gnucash/gnome-search/search-string.c
@@ -175,7 +175,7 @@ gncs_validate (GNCSearchCoreType *fe)
     if (fi->how == SEARCH_STRING_MATCHES_REGEX ||
             fi->how == SEARCH_STRING_NOT_MATCHES_REGEX)
     {
-        regex_t regexpat;        /* regex patern */
+        regex_t regexpat;        /* regex pattern */
         gint regerr;
         int flags = REG_EXTENDED;
 

--- a/gnucash/gnome-utils/assistant-xml-encoding.c
+++ b/gnucash/gnome-utils/assistant-xml-encoding.c
@@ -174,7 +174,7 @@ void gxi_add_custom_enc_clicked_cb (GtkButton *button, GncXmlImportData *data);
 void gxi_selected_enc_activated_cb (GtkTreeView *view, GtkTreePath *path, GtkTreeViewColumn *column, GncXmlImportData *data);
 void gxi_remove_enc_clicked_cb (GtkButton *button, GncXmlImportData *data);
 
-/* Translators: Run the assistent in your language to see GTK's translation of the button labels. */
+/* Translators: Run the assistant in your language to see GTK's translation of the button labels. */
 static const gchar *encodings_doc_string = N_(
             "\nThe file you are trying to load is from an older version of "
             "GnuCash. The file format in the older versions was missing the "

--- a/gnucash/gnome-utils/dialog-account.c
+++ b/gnucash/gnome-utils/dialog-account.c
@@ -2134,7 +2134,7 @@ gnc_account_cascade_color_dialog (GtkWidget *window, Account *account)
     GdkRGBA color;
     gint response;
 
-    // check if we actualy do have sub accounts
+    // check if we actually do have sub accounts
     g_return_if_fail (gnc_account_n_children (account) > 0);
 
     builder = gtk_builder_new();

--- a/gnucash/gnome-utils/dialog-account.h
+++ b/gnucash/gnome-utils/dialog-account.h
@@ -43,7 +43,7 @@
 /** @name Non-Modal
  @{ */
 
-/** Disply a window for editing the attributes of an existing account.
+/** Display a window for editing the attributes of an existing account.
  *
  *  @param parent The widget on which to parent the dialog.
  *
@@ -53,7 +53,7 @@
 void gnc_ui_edit_account_window (GtkWindow *parent, Account *account);
 
 
-/** Disply a window for creating a new account.  This function will
+/** Display a window for creating a new account.  This function will
  *  also initially set the parent account of the new account to what
  *  the caller specified.  The user is free, however, to choose any
  *  parent account they wish.
@@ -71,7 +71,7 @@ void gnc_ui_new_account_window (GtkWindow *parent,
                                 QofBook *book, Account *parent_acct);
 
 
-/** Disply a window for creating a new account.  This function will
+/** Display a window for creating a new account.  This function will
  *  restrict the available account type values to the list specified
  *  by the caller.
  *
@@ -93,7 +93,7 @@ void gnc_ui_new_account_with_types (GtkWindow *parent, QofBook *book,
 /** @name Modal
  @{ */
 
-/** Disply a modal window for creating a new account
+/** Display a modal window for creating a new account
  *
  *  @param parent The widget on which to parent the dialog.
  *
@@ -103,7 +103,7 @@ void gnc_ui_new_account_with_types (GtkWindow *parent, QofBook *book,
 Account * gnc_ui_new_accounts_from_name_window (GtkWindow *parent,
                                                 const char *name);
 
-/** Disply a modal window for creating a new account.  This function
+/** Display a modal window for creating a new account.  This function
  *  will restrict the available account type values to the list
  *  specified by the caller.
  *
@@ -151,7 +151,7 @@ Account * gnc_ui_new_accounts_from_name_with_defaults (GtkWindow *parent,
                                         Account * parent_acct);
 
 /*
- * register a callback that get's called when the account has changed
+ * register a callback that gets called when the account has changed
  * so significantly that you need to destroy yourself.  In particular
  * this is used by the ledger display to destroy ledgers when the
  * account type has changed.

--- a/gnucash/gnome-utils/dialog-options.c
+++ b/gnucash/gnome-utils/dialog-options.c
@@ -1209,7 +1209,7 @@ gnc_option_create_currency_accounting_widget (char *name, GNCOption *option)
     gtk_widget_set_halign (GTK_WIDGET(frame), GTK_ALIGN_FILL);
     gtk_widget_set_hexpand (GTK_WIDGET(frame), TRUE);
 
-    /* Create the verticle button box */
+    /* Create the vertical button box */
     vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 5);
     gtk_box_set_homogeneous (GTK_BOX (vbox), FALSE);
     gtk_container_add (GTK_CONTAINER (frame), vbox);

--- a/gnucash/gnome-utils/dialog-utils.c
+++ b/gnucash/gnome-utils/dialog-utils.c
@@ -149,7 +149,7 @@ gnc_restore_window_size(const char *group, GtkWindow *window, GtkWindow *parent)
             if (wpos[1] - monitor_size.y + wsize[1] > monitor_size.y + monitor_size.height)
                 wpos[1] = monitor_size.y + monitor_size.height - wsize[1];
 
-            /* make sure the cordinates have not left the monitor */
+            /* make sure the coordinates have not left the monitor */
             if (wpos[0] < monitor_size.x)
                 wpos[0] = monitor_size.x;
 
@@ -292,7 +292,7 @@ gnc_window_adjust_for_screen(GtkWindow * window)
     if (wpos[1] - monitor_size.y + height > monitor_size.y + monitor_size.height)
         wpos[1] = monitor_size.y + monitor_size.height - height;
 
-    /* make sure the cordinates have not left the monitor */
+    /* make sure the coordinates have not left the monitor */
     if (wpos[0] < monitor_size.x)
         wpos[0] = monitor_size.x;
 

--- a/gnucash/gnome-utils/gnc-gnome-utils.h
+++ b/gnucash/gnome-utils/gnc-gnome-utils.h
@@ -39,7 +39,7 @@
 #include "dialog-options.h"
 
 /** Load a gtk resource configuration file to customize gtk
- *  appearance and behviour.
+ *  appearance and behaviour.
  */
 void gnc_add_css_file (void);
 

--- a/gnucash/gnome-utils/gnc-keyring.h
+++ b/gnucash/gnome-utils/gnc-keyring.h
@@ -100,7 +100,7 @@ void gnc_keyring_set_password ( const gchar *access_method,
  *  @return       a boolean indicating whether or not a valid password
  *                has been retrieved. The function will return FALSE
  *                when the user explicitly cancels the password dialog or
- *                if it wasn't called properly. Otherwise it wil return
+ *                if it wasn't called properly. Otherwise it will return
  *                TRUE.
  *
  *  access_method, server, port, service and user will be the parameters

--- a/gnucash/gnome-utils/gnc-main-window.h
+++ b/gnucash/gnome-utils/gnc-main-window.h
@@ -362,7 +362,7 @@ void gnc_main_window_restore_default_state(GncMainWindow *window);
  *  If any page returns a failure indication, then the function stops
  *  walking pages and immediately returns a failure.
  *
- *  @param window Whe window whose pages should be checked.
+ *  @param window When window whose pages should be checked.
  *
  *  @return FALSE if any page could not or would not comply, which
  *  should cancel the pending operation.  TRUE otherwise */
@@ -391,7 +391,7 @@ void gnc_main_window_all_action_set_sensitive (const gchar *action_name, gboolea
 
 /** Find action in main window.
  *
- *  @param window Whe window which should be checked for the action.
+ *  @param window When window which should be checked for the action.
  *
  *  @param name The name of the command to be retrieved.
  *

--- a/gnucash/gnome-utils/gnc-tree-model-owner.c
+++ b/gnucash/gnome-utils/gnc-tree-model-owner.c
@@ -731,7 +731,7 @@ gnc_tree_model_owner_iter_n_children (GtkTreeModel *tree_model,
 
     /* Owner lists don't have children, so always return 0, except for
      * the special case this request comes for the special "root" iter
-     * (NULL). For that exception we return the size of the ower list.
+     * (NULL). For that exception we return the size of the owner list.
      */
     if (iter == NULL)
         return (gint) g_list_length (priv->owner_list);

--- a/gnucash/gnome-utils/gnc-tree-model-split-reg.c
+++ b/gnucash/gnome-utils/gnc-tree-model-split-reg.c
@@ -166,7 +166,7 @@ struct GncTreeModelSplitRegPrivate
 */
 
 /*FIXME I thought this would work, it does not ????????? */
-/* Do we need to test for a valid iter every where, is it enougth to test on make iter ? */
+/* Do we need to test for a valid iter every where, is it enough to test on make iter ? */
 #define VALID_ITER (model, iter) \
  (GNC_IS_TREE_MODEL_SPLIT_REG (model) && \
  ((iter).user_data != NULL) && ((iter).user_data2 != NULL) && (model->stamp == (gint)(iter).stamp) && \
@@ -687,7 +687,7 @@ gnc_tree_model_split_reg_move (GncTreeModelSplitReg *model, GncTreeModelSplitReg
 
     priv = model->priv;
 
-    // if list is not long enougth, return
+    // if list is not long enough, return
     if (g_list_length (priv->full_tlist) < NUM_OF_TRANS*3)
         return;
 
@@ -958,7 +958,7 @@ gnc_tree_model_split_reg_set_data (GncTreeModelSplitReg *model, gpointer user_da
 {
     GncTreeModelSplitRegPrivate *priv;
 
-/*FIXME This is used to get the parent window, mabe move to view */
+/*FIXME This is used to get the parent window, maybe move to view */
     priv = model->priv;
 
     priv->user_data = user_data;
@@ -1374,7 +1374,7 @@ gnc_tree_model_split_reg_get_path (GtkTreeModel *tree_model, GtkTreeIter *iter)
         else if (tnode && snode)
         {
             /* Can not use snode position directly as slist length does not follow
-               number of splits exactly, especailly if you delete a split */
+               number of splits exactly, especially if you delete a split */
             spos = xaccTransGetSplitIndex (tnode->data, snode->data);
         }
 

--- a/gnucash/gnome-utils/gnc-tree-view-commodity.h
+++ b/gnucash/gnome-utils/gnc-tree-view-commodity.h
@@ -96,7 +96,7 @@ GtkTreeView *gnc_tree_view_commodity_new (QofBook *book,
 
 /** Configure (by name) the set of visible columns in an commodity tree
  *  view.  By default, only the commodity name column is show.  The
- *  avalible list of columns can be found in the file
+ *  available list of columns can be found in the file
  *  gnc-tree-view-commodity.c
  *
  *  @param view A pointer to an commodity tree view.
@@ -136,7 +136,7 @@ typedef gboolean (*gnc_tree_view_commodity_cm_filter_func)(gnc_commodity*, gpoin
  *  thinks should possibly show.  The filter may perform any actions
  *  necessary on the commodity to decide whether it should be shown or
  *  not.  (I.E. Check type, placeholder status, etc.)  If the filter
- *  returns TRUE then the commodity wil be displayed.
+ *  returns TRUE then the commodity will be displayed.
  *
  *  @param view A pointer to an commodity tree view.
  *

--- a/gnucash/gnome-utils/gnc-tree-view-price.h
+++ b/gnucash/gnome-utils/gnc-tree-view-price.h
@@ -121,7 +121,7 @@ void gnc_tree_view_price_add_kvp_column (GncTreeViewPrice *view,
  *  thinks should possibly show.  The filter may perform any actions
  *  necessary on the price to decide whether it should be shown or
  *  not.  (I.E. Check type, placeholder status, etc.)  If the filter
- *  returns TRUE then the price wil be displayed.
+ *  returns TRUE then the price will be displayed.
  *
  *  @param price_view A pointer to an price tree view.
  *

--- a/gnucash/gnome-utils/gnc-tree-view-split-reg.c
+++ b/gnucash/gnome-utils/gnc-tree-view-split-reg.c
@@ -865,7 +865,7 @@ gnc_tree_view_split_reg_set_format (GncTreeViewSplitReg *view)
 
             priv->expanded = FALSE;
 
-            LEAVE("#### Single line foramt ####");
+            LEAVE("#### Single line format ####");
         }
 
         if (model->use_double_line)
@@ -929,7 +929,7 @@ gnc_tree_view_split_reg_format_trans (GncTreeViewSplitReg *view, Transaction *tr
     {
         gtk_tree_view_collapse_row (GTK_TREE_VIEW (view), spath);
         priv->expanded = FALSE;
-        LEAVE("#### Single line transaction foramt ####");
+        LEAVE("#### Single line transaction format ####");
     }
 
     if ((model->use_double_line) && (model->style != REG2_STYLE_JOURNAL))
@@ -1498,7 +1498,7 @@ gtv_sr_cdf0 (GtkTreeViewColumn *col, GtkCellRenderer *cell, GtkTreeModel *s_mode
 
         editable = (read_only == TRUE) ? FALSE : editable;
 
-        /* This will remove the calander buttons if FALSE */
+        /* This will remove the calendar buttons if FALSE */
         g_object_set (cell, "use_buttons", view->priv->show_calendar_buttons, NULL );
         g_object_set (cell, "text", datebuff, "editable", editable, NULL);
         break;
@@ -4491,7 +4491,7 @@ gtv_sr_edited_normal_cb (GtkCellRendererText *cell, const gchar *path_string,
             // Set the split parent trans
             xaccSplitSetParent (split, trans);
 
-            // If we are at trasaction level, column is value, split level is amount
+            // If we are at transaction level, column is value, split level is amount
             if (viewcol == COL_AMTVAL)
             {
                 gnc_tree_util_set_number_for_input (view, trans, split, input, COL_AMTVAL);

--- a/gnucash/gnome-utils/gnc-tree-view.h
+++ b/gnucash/gnome-utils/gnc-tree-view.h
@@ -449,18 +449,18 @@ void
 gnc_tree_view_keynav (GncTreeView *view, GtkTreeViewColumn **col,
                       GtkTreePath *path, GdkEventKey *event);
 
-/* Returns TRUE if path is a vaid path for the treeview */
+/* Returns TRUE if path is a valid path for the treeview */
 gboolean
 gnc_tree_view_path_is_valid (GncTreeView *view, GtkTreePath *path);
 
-/** Setup a callback for when the user starts editing so appropiate actions can be taken
+/** Setup a callback for when the user starts editing so appropriate actions can be taken
  *  like disable the actions delete menu option.
  */
 void
 gnc_tree_view_set_editing_started_cb (GncTreeView *view,
                      GFunc editing_started_cb, gpointer editing_cb_data);
 
-/** Setup a callback for when the user finishes editing so appropiate actions can be taken
+/** Setup a callback for when the user finishes editing so appropriate actions can be taken
  *  like enable the actions delete menu option.
  */
 void

--- a/gnucash/gnome/assistant-acct-period.c
+++ b/gnucash/gnome/assistant-acct-period.c
@@ -1,5 +1,5 @@
 /********************************************************************\
- * assistant-acct-period.c - accouting period assistant for GnuCash *
+ * assistant-acct-period.c - accounting period assistant for GnuCash*
  * Copyright (C) 2001 Gnumatic, Inc.                                *
  * Copyright (C) 2001 Dave Peticolas <dave@krondo.com>              *
  * Copyright (C) 2003 Linas Vepstas <linas@linas.org>               *
@@ -365,7 +365,7 @@ ap_assistant_book_prepare (GtkAssistant *assistant, gpointer user_data)
     /* Display the book info */
 
     period_text =
-	/* Translators: Run the assistent in your language to see GTK's translation of the button labels. */
+	/* Translators: Run the assistant in your language to see GTK's translation of the button labels. */
         _("You have asked for a book to be created. This book "
           "will contain all transactions up to midnight %s "
           "(for a total of %d transactions spread over %d accounts).\n\n "

--- a/gnucash/gnome/assistant-loan.cpp
+++ b/gnucash/gnome/assistant-loan.cpp
@@ -597,7 +597,7 @@ gnc_loan_assistant_create( LoanAssistantData *ldd )
                 GList *allowableAccounts;
             } gas_data[] =
             {
-                /* These ints are the GtkGrid boundries */
+                /* These ints are the GtkGrid boundaries */
                 { &ldd->prmAccountGAS,     ldd->prmTable, TRUE,  1, 0, 1, 1, liabilityAcct },
                 { &ldd->repAssetsFromGAS,  ldd->repTable, TRUE,  1, 2, 1, 1, paymentFromAccts },
                 { &ldd->repPrincToGAS,     ldd->repTable, TRUE,  1, 3, 1, 1, paymentToAccts  },
@@ -656,7 +656,7 @@ gnc_loan_assistant_create( LoanAssistantData *ldd )
                 int left, top, width, height;
             } gde_data[] =
             {
-                /* These ints are the GtkGrid boundries */
+                /* These ints are the GtkGrid boundaries */
                 { &ldd->prmStartDateGDE, ldd->prmTable, 1, 4, 1, 1 },
                 { &ldd->revStartDate,    ldd->revTable, 1, 0, 1, 1 },
                 { &ldd->revEndDate,      ldd->revTable, 1, 1, 1, 1 },

--- a/gnucash/gnome/business-gnome-utils.c
+++ b/gnucash/gnome/business-gnome-utils.c
@@ -520,7 +520,7 @@ gnc_simple_combo_make (GtkComboBox *cbox, QofBook *book,
 
 /* Use a list available billing terms to fill the model of
  * the combobox passed in.  If none_ok is true, then add "none" as a
- * choice (with data set to NULL)..  If inital_choice is non-NULL,
+ * choice (with data set to NULL)..  If initial_choice is non-NULL,
  * then that will be the default option setting when the menu is
  * created.
  */

--- a/gnucash/gnome/business-gnome-utils.h
+++ b/gnucash/gnome/business-gnome-utils.h
@@ -71,7 +71,7 @@ Account * gnc_account_select_combo_get_active (GtkWidget *combo);
 
 /* Create a combo box of available billing terms based on
  * the combo box If none_ok is true, then add "none" as a
- * choice (with data set to NULL).  If inital_choice is non-NULL,
+ * choice (with data set to NULL).  If initial_choice is non-NULL,
  * then that will be the default option setting when the menu is
  * created.
  *

--- a/gnucash/gnome/dialog-invoice.c
+++ b/gnucash/gnome/dialog-invoice.c
@@ -2591,7 +2591,7 @@ gnc_invoice_window_new_invoice (GtkWindow *parent, InvoiceDialogType dialog_type
     iw->type_hbox = GTK_WIDGET (gtk_builder_get_object (builder, "dialog_type_choice_hbox"));
     iw->type_choice = GTK_WIDGET (gtk_builder_get_object (builder, "dialog_type_invoice"));
 
-    /* The default GUI lables are for invoices, so change them if it isn't. */
+    /* The default GUI labels are for invoices, so change them if it isn't. */
     owner_type = gncOwnerGetType (&iw->owner);
     switch(owner_type)
     {

--- a/gnucash/gnome/dialog-sx-editor.c
+++ b/gnucash/gnome/dialog-sx-editor.c
@@ -962,7 +962,7 @@ gnc_sxed_save_sx( GncSxEditorDialog *sxed )
 
         autocreateState = gtk_toggle_button_get_active( sxed->autocreateOpt );
         notifyState = gtk_toggle_button_get_active( sxed->notifyOpt );
-        /* "Notify" only makes sense if AutoCreate is actived;
+        /* "Notify" only makes sense if AutoCreate is activated;
          * enforce that here. */
         xaccSchedXactionSetAutoCreate( sxed->sx,
                                        autocreateState,

--- a/gnucash/gnome/dialog-sx-editor2.c
+++ b/gnucash/gnome/dialog-sx-editor2.c
@@ -933,7 +933,7 @@ gnc_sxed_save_sx (GncSxEditorDialog2 *sxed )
 
         autocreateState = gtk_toggle_button_get_active (sxed->autocreateOpt);
         notifyState = gtk_toggle_button_get_active (sxed->notifyOpt);
-        /* "Notify" only makes sense if AutoCreate is actived;
+        /* "Notify" only makes sense if AutoCreate is activated;
          * enforce that here. */
         xaccSchedXactionSetAutoCreate (sxed->sx,
                                        autocreateState,
@@ -1773,7 +1773,7 @@ gnc_ui_sx_initialize2 (void) //FIXME need to remove the 2 when live
     gnc_hook_add_dangler (HOOK_BOOK_OPENED,
                          (GFunc)gnc_sx_sxsincelast_book_opened, NULL);
 
-    /* Add page to preferences page for Sheduled Transactions */
+    /* Add page to preferences page for Scheduled Transactions */
     /* The parameters are; glade file, items to add from glade file - last being the dialog, preference tab name */
     gnc_preferences_add_page ("dialog-sx.glade",
                               "create_days_adj,remind_days_adj,sx_prefs",

--- a/gnucash/gnome/dialog-tax-info.c
+++ b/gnucash/gnome/dialog-tax-info.c
@@ -929,7 +929,7 @@ gnc_tax_info_account_changed_cb (GtkTreeSelection *selection,
     case 1:
         /* Get the account. This view is set for multiple selection, so we
            can only get a list of accounts. 1-25-19: The dialog does not work
-           for multipe accounts so it was changed to single selection */
+           for multiple accounts so it was changed to single selection */
         view = GNC_TREE_VIEW_ACCOUNT(ti_dialog->account_treeview);
         accounts = gnc_tree_view_account_get_selected_accounts (view);
         if (accounts == NULL)

--- a/gnucash/gnome/gnc-budget-view.c
+++ b/gnucash/gnome/gnc-budget-view.c
@@ -880,7 +880,7 @@ budget_accum_helper(Account* account, gpointer data)
 
 /** \brief Function to calculate the accumulated budget amount in a given account at a specified period number.
 
-This function uses the \ref budget_accum_helper to calculate the accumulated budget amount in a given budget account for a specified period number. If the acocunt does not have children, then it simply returns the balance of the account.
+This function uses the \ref budget_accum_helper to calculate the accumulated budget amount in a given budget account for a specified period number. If the account does not have children, then it simply returns the balance of the account.
 */
 static gnc_numeric
 gbv_get_accumulated_budget_amount(GncBudget* budget, Account* account, guint period_num)

--- a/gnucash/gnome/gnc-plugin-page-account-tree.c
+++ b/gnucash/gnome/gnc-plugin-page-account-tree.c
@@ -1408,7 +1408,7 @@ gnc_plugin_page_account_tree_cmd_delete_account (GtkAction *action, GncPluginPag
         g_object_set_data(G_OBJECT(dialog), DELETE_DIALOG_FILTER, filter);
         g_object_set_data(G_OBJECT(dialog), DELETE_DIALOG_ACCOUNT, account);
 
-        // Add the account selectors and enable sections as appropiate
+        // Add the account selectors and enable sections as appropriate
         // setup transactions selector
         trans_mas = gppat_setup_account_selector (builder, dialog, "trans_mas_hbox", DELETE_DIALOG_TRANS_MAS);
 

--- a/gnucash/gnome/gnc-plugin-page-register.c
+++ b/gnucash/gnome/gnc-plugin-page-register.c
@@ -1294,7 +1294,7 @@ gnc_plugin_page_register_create_widget (GncPluginPage *plugin_page)
     gnc_ppr_update_status_query (page);
     gnc_ppr_update_date_query (page);
 
-    /* Now do the refresh if this is a new page instaed of restore */
+    /* Now do the refresh if this is a new page instead of restore */
     if (create_new_page)
     {
         priv->enable_refresh = TRUE;
@@ -2774,7 +2774,7 @@ get_filter_times(GncPluginPageRegister *page)
  *  function is responsible for setting the sensitivity of the widgets
  *  controlled by each radio button choice and updating the time
  *  limitation on the register query. This is handled by a helper
- *  function as potentialy all widgets will need to be examined.
+ *  function as potentially all widgets will need to be examined.
  *
  *  @param button A pointer to the "select range" radio button.
  *
@@ -2825,7 +2825,7 @@ gnc_plugin_page_register_filter_select_range_cb (GtkRadioButton *button,
 /** This function is called when the "number of days" spin button is
  *  changed which is then saved and updates the time limitation on
  *  the register query. This is handled by a helper function as
- *  potentialy all widgets will need to be examined.
+ *  potentially all widgets will need to be examined.
  *
  *  @param button A pointer to the "number of days" spin button.
  *
@@ -3837,7 +3837,7 @@ gnc_plugin_page_register_cmd_view_sort_by (GtkAction *action,
     if (priv->sd.save_order == TRUE)
         gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), TRUE);
 
-    // hide the save button if appropiate
+    // hide the save button if appropriate
     gtk_widget_set_visible (GTK_WIDGET(button),
         gnc_plugin_page_register_show_fs_save (page));
 
@@ -3922,7 +3922,7 @@ gnc_plugin_page_register_cmd_view_filter_by (GtkAction *action,
     if (priv->fd.save_filter == TRUE)
         gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), TRUE);
 
-    // hide the save button if appropiate
+    // hide the save button if appropriate
     gtk_widget_set_visible (GTK_WIDGET(button),
         gnc_plugin_page_register_show_fs_save (page));
 
@@ -4789,7 +4789,7 @@ gnc_plugin_page_register_close_cb (gpointer user_data)
 
 /** This function is called when an account has been edited and an
  *  "extreme" change has been made to it.  (E.G. Changing from a
- *  credit card account to an expense account.  This rouine is
+ *  credit card account to an expense account.  This routine is
  *  responsible for finding all open registers containing the account
  *  and closing them.
  *

--- a/gnucash/gnome/gnc-plugin-page-register2.c
+++ b/gnucash/gnome/gnc-plugin-page-register2.c
@@ -3929,7 +3929,7 @@ gnc_plugin_page_register2_close_cb (gpointer user_data)
 
 /** This function is called when an account has been edited and an
  *  "extreme" change has been made to it.  (E.G. Changing from a
- *  credit card account to an expense account.  This rouine is
+ *  credit card account to an expense account.  This routine is
  *  responsible for finding all open registers containing the account
  *  and closing them.
  *

--- a/gnucash/gtkbuilder/assistant-csv-account-import.glade
+++ b/gnucash/gtkbuilder/assistant-csv-account-import.glade
@@ -30,7 +30,7 @@
           <object class="GtkLabel" id="start_label">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="label" translatable="yes" comments="Run the assistent in your language to see GTK's translation of the button labels.">
+            <property name="label" translatable="yes" comments="Run the assistant in your language to see GTK's translation of the button labels.">
 This assistant will help you import Accounts from a file.
 
 The file must be in the same format as that exported as this is a fixed format import which can be seen by looking at a file created by using the "Export Account Tree to CSV" export menu option.

--- a/gnucash/gtkbuilder/assistant-csv-price-import.glade
+++ b/gnucash/gtkbuilder/assistant-csv-price-import.glade
@@ -62,7 +62,7 @@ There is an option for specifying the start row, end row and an option to skip a
 
 Lastly, for repeated imports the preview page has buttons to Load and Save the settings. To save the settings, tweak the settings to your preferences (optionally starting from an existing preset), then (optionally change the settings name and press the Save Settings button. Note you can't save to built-in presets.
 
-This operation is not reversable, so make sure you have a working backup.
+This operation is not reversible, so make sure you have a working backup.
 
 Click on "Next" to proceed or "Cancel" to Abort Import.</property>
         <property name="wrap">True</property>

--- a/gnucash/gtkbuilder/assistant-qif-import.glade
+++ b/gnucash/gtkbuilder/assistant-qif-import.glade
@@ -39,7 +39,7 @@
       <object class="GtkLabel" id="start_page">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="label" translatable="yes" comments="Run the assistent in your language to see GTK's translation of the button labels.">GnuCash can import financial data from QIF (Quicken Interchange Format) files written by Quicken/QuickBooks, MS Money, Moneydance, and many other programs. 
+        <property name="label" translatable="yes" comments="Run the assistant in your language to see GTK's translation of the button labels.">GnuCash can import financial data from QIF (Quicken Interchange Format) files written by Quicken/QuickBooks, MS Money, Moneydance, and many other programs. 
 
 The import process has several steps. Your GnuCash accounts will not be changed until you click "Apply" at the end of the process. 
 
@@ -63,7 +63,7 @@ Click "Next" to start loading your QIF data, or "Cancel" to abort the process. <
           <object class="GtkLabel" id="label822">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="label" translatable="yes" comments="Run the assistent in your language to see GTK's translation of the button labels.">Please select a file to load. When you click "Next", the file will be loaded and analyzed. You may need to answer some questions about the account(s) in the file.
+            <property name="label" translatable="yes" comments="Run the assistant in your language to see GTK's translation of the button labels.">Please select a file to load. When you click "Next", the file will be loaded and analyzed. You may need to answer some questions about the account(s) in the file.
 
 You will have the opportunity to load as many files as you wish, so don't worry if your data is in multiple files. 
 </property>
@@ -451,7 +451,7 @@ Please enter a name for the account. If the file was exported from another accou
           <object class="GtkLabel" id="label816">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="label" translatable="yes" comments="Run the assistent in your language to see GTK's translation of the button labels.">Click "Load another file" if you have more data to import at this time. Do this if you have saved your accounts to separate QIF files.
+            <property name="label" translatable="yes" comments="Run the assistant in your language to see GTK's translation of the button labels.">Click "Load another file" if you have more data to import at this time. Do this if you have saved your accounts to separate QIF files.
 
 Click "Next" to finish loading files and move to the next step of the QIF import process. </property>
             <property name="wrap">True</property>
@@ -1222,7 +1222,7 @@ If you don't see your exchange listed, or none of the available choices are appr
           <object class="GtkLabel" id="label847694">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="label" translatable="yes" comments="Run the assistent in your language to see GTK's translation of the button labels.">
+            <property name="label" translatable="yes" comments="Run the assistant in your language to see GTK's translation of the button labels.">
 If you are importing a QIF file from a bank or other financial institution, some of the transactions may already exist in your GnuCash accounts. To avoid duplication, GnuCash has tried to identify matches and needs your help to review them.
 
 On the next page you will be shown a list of imported transactions. As you select each one, a list of possible matches will be shown below it. If you find a correct match, click on it. Your selection will be confirmed by a check mark in the "Match?" column.

--- a/gnucash/gtkbuilder/dialog-account-picker.glade
+++ b/gnucash/gtkbuilder/dialog-account-picker.glade
@@ -107,7 +107,7 @@
           </packing>
         </child>
         <child>
-          <object class="GtkLabel" id="qif_default_transation_status">
+          <object class="GtkLabel" id="qif_default_transaction_status">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="halign">start</property>

--- a/gnucash/import-export/aqb/assistant-ab-initial.glade
+++ b/gnucash/import-export/aqb/assistant-ab-initial.glade
@@ -53,7 +53,7 @@ Press "Cancel" if you do not wish to setup any Online Banking connection now.
 
 Lastly, for repeated imports the preview page has buttons to Load and Save the settings. To save the settings, tweak the settings to your preferences (optionally starting from an existing preset), then (optionally change the settings name and press the Save Settings button. Note you can't save to built-in presets.
 
-This operation is not reversable, so make sure you have a working backup.
+This operation is not reversible, so make sure you have a working backup.
 
 Click on "Next" to proceed or "Cancel" to Abort Import.</property>
             <property name="wrap">True</property>

--- a/gnucash/import-export/aqb/gnc-ab-utils.c
+++ b/gnucash/import-export/aqb/gnc-ab-utils.c
@@ -1240,7 +1240,7 @@ gnc_ab_import_context(AB_IMEXPORTER_CONTEXT *context,
 #ifdef AQBANKING6
             bankmsg = AB_Message_List_Next(bankmsg);
 #else
-            bankmsg = AB_ImExporterContext_GetNextMessage(context); // The interator is incremented within aqbanking
+            bankmsg = AB_ImExporterContext_GetNextMessage(context); // The iterator is incremented within aqbanking
 #endif
         }
     }

--- a/gnucash/import-export/aqb/gnc-gwen-gui.c
+++ b/gnucash/import-export/aqb/gnc-gwen-gui.c
@@ -881,7 +881,7 @@ hide_progress(GncGWENGui *gui, Progress *progress)
             }
             else
             {
-                /* Last other progress to be hided */
+                /* Last other progress to be hidden */
                 gtk_grid_remove_row (GTK_GRID(gui->entries_grid),
                                      OTHER_ENTRIES_ROW_OFFSET);
                 gtk_widget_destroy(box);

--- a/gnucash/import-export/bi-import/README
+++ b/gnucash/import-export/bi-import/README
@@ -1,6 +1,6 @@
 Things and thoughts AKA the TODO and README pages.
 
-BAD THINGS BAOUT THE IMPORTER
+BAD THINGS ABOUT THE IMPORTER
 The importer should be limited to a single invoice per file, perhaps creating a new invoice number each time.
 Too many fields, and too inflexible field format.
 

--- a/gnucash/import-export/csv-exp/assistant-csv-export.c
+++ b/gnucash/import-export/csv-exp/assistant-csv-export.c
@@ -199,7 +199,7 @@ csv_export_file_chooser_selection_changed_cb (GtkFileChooser *chooser,
 /*******************************************************
  * csv_export_sep_cb
  *
- * call back for type of separartor required
+ * call back for type of separator required
  *******************************************************/
 void
 csv_export_sep_cb (GtkWidget *radio, gpointer user_data)

--- a/gnucash/import-export/csv-exp/csv-tree-export.c
+++ b/gnucash/import-export/csv-exp/csv-tree-export.c
@@ -89,7 +89,7 @@ gchar *csv_test_field_string (CsvExportInfo *info, const gchar *string_in)
     g_strfreev (parts);
 
     /* Check for separator string and \n and " in field,
-       if so quote field if not allready quoted */
+       if so quote field if not already quoted */
     if (g_strrstr (string_parts, info->separator_str) != NULL)
         need_quote = TRUE;
     if (g_strrstr (string_parts, "\n") != NULL)

--- a/gnucash/import-export/csv-imp/assistant-csv-account-import.c
+++ b/gnucash/import-export/csv-imp/assistant-csv-account-import.c
@@ -273,7 +273,7 @@ static void csv_import_assistant_enable_account_forward (CsvImportInfo *info)
 /*******************************************************
  * csv_import_sep_cb
  *
- * call back for type of separartor required
+ * call back for type of separator required
  *******************************************************/
 void csv_import_sep_cb (GtkWidget *radio, gpointer user_data)
 {

--- a/gnucash/import-export/csv-imp/assistant-csv-price-import.cpp
+++ b/gnucash/import-export/csv-imp/assistant-csv-price-import.cpp
@@ -66,7 +66,7 @@ static QofLogModule log_module = GNC_MOD_ASSISTANT;
 
 /* Note on memory management
  *
- * The same notes as for assistant-csv-trans-import.cpp appy to
+ * The same notes as for assistant-csv-trans-import.cpp apply to
  * this assistant as well. Please read the note at the top of that
  * file to understand important details about the use of several
  * memory management models in one file.

--- a/gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp
+++ b/gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp
@@ -672,7 +672,7 @@ CsvImpTransAssist::~CsvImpTransAssist ()
     /* This function is safe to call on a null pointer */
     gnc_gen_trans_list_delete (gnc_csv_importer_gui);
     /* The call above frees gnc_csv_importer_gui but can't nullify it.
-     * Do it here so noone accidentally can access it still */
+     * Do it here so no one accidentally can access it still */
     gnc_csv_importer_gui = nullptr;
     gtk_widget_destroy (GTK_WIDGET(csv_imp_asst));
 }

--- a/gnucash/import-export/csv-imp/assistant-csv-trans-import.h
+++ b/gnucash/import-export/csv-imp/assistant-csv-trans-import.h
@@ -29,7 +29,7 @@
 #define GNC_ASSISTANT_CSV_IMPORT_TRANS_H
 
 
-/** The gnc_file_csv_trans_import() will let the user import thte
+/** The gnc_file_csv_trans_import() will let the user import the
  *  account tree or transactions to a delimited file.
  */
 void gnc_file_csv_trans_import (void);

--- a/gnucash/import-export/csv-imp/gnc-import-tx.hpp
+++ b/gnucash/import-export/csv-imp/gnc-import-tx.hpp
@@ -79,7 +79,7 @@ enum parse_line_cols {
 };
 
 /** Tuple to hold all internal state for one parsed line. The contents of each
- * colummn is described by the parse_line_cols enum. This enum should be used
+ * column is described by the parse_line_cols enum. This enum should be used
  * with std::get to access the columns. */
 using parse_line_t = std::tuple<StrVec,
                                 std::string,

--- a/gnucash/import-export/csv-imp/gnc-tokenizer-csv.cpp
+++ b/gnucash/import-export/csv-imp/gnc-tokenizer-csv.cpp
@@ -89,7 +89,7 @@ int GncCsvTokenizer::tokenize()
                 // is by checking whether the character in front or after are either
                 // a field separator or the beginning or end of of the string.
                 if (!(((bs_pos == 0) ||                                          // quotes are at start of line
-                       (m_sep_str.find (line[bs_pos-1]) != std::string::npos))    // quotes preceeded by field separator
+                       (m_sep_str.find (line[bs_pos-1]) != std::string::npos))    // quotes preceded by field separator
                       &&
                       ((bs_pos + 2 >= line.length()) ||                          // quotes are at end of line
                        (m_sep_str.find (line[bs_pos+2]) != std::string::npos))))   // quotes followed by field separator

--- a/gnucash/import-export/generic-import-design.txt
+++ b/gnucash/import-export/generic-import-design.txt
@@ -40,7 +40,7 @@ In split_to_match's parent account; for each split where date >= split_to_match.
 	if amount match
 		if transaction_online_id exists but doesn't match
 			add to matches using UNLIKELY (not IMPOSSIBLE, could be protocol change or prior error)
-		eles if memo match and date within 4 days
+		else if memo match and date within 4 days
 			add to matches using PROBABLE
 		else if date within 24 hours
 			add to matches using LIKELY

--- a/gnucash/import-export/import-account-matcher.c
+++ b/gnucash/import-export/import-account-matcher.c
@@ -100,7 +100,7 @@ static gpointer test_acct_online_id_match(Account *acct, gpointer param_online_i
 /***********************************************************
  * build_acct_tree
  *
- * build the account tree with the custome column, online_id
+ * build the account tree with the custom column, online_id
  ************************************************************/
 static void
 build_acct_tree(AccountPickerDialog *picker)

--- a/gnucash/import-export/import-commodity-matcher.c
+++ b/gnucash/import-export/import-commodity-matcher.c
@@ -127,7 +127,7 @@ gnc_commodity * gnc_import_select_commodity(const char * cusip,
        it does not get overwritten - which is not consistent with the
        message - so Im adding it to do this.  Looks like this is all
        that was needed to fix the cash value used as stock units problem
-       for pre-defined commodities which didnt have the cusip defined! */
+       for pre-defined commodities which didn't have the cusip defined! */
     if (retval != NULL &&
             gnc_commodity_get_cusip(retval) != NULL &&
             cusip != NULL &&

--- a/gnucash/import-export/import-parse.c
+++ b/gnucash/import-export/import-parse.c
@@ -270,7 +270,7 @@ gnc_import_parse_numeric(const char* str, GncImportFormat fmt, gnc_numeric *val)
 static int
 fix_year(int y)
 {
-    /* two-digit numbers less than "70"  are interpretted to be post-2000. */
+    /* two-digit numbers less than "70"  are interpreted to be post-2000. */
     if (y < 70)
         return (y + 2000);
 

--- a/gnucash/import-export/ofx/gnc-ofx-import.c
+++ b/gnucash/import-export/ofx/gnc-ofx-import.c
@@ -538,7 +538,7 @@ int ofx_proc_transaction_cb(struct OfxTransactionData data, void *user_data)
         g_free(tmp);
     }
 
-    //PERR("WRITEME: GnuCash ofx_proc_transaction():Add PAYEE and ADRESS here once supported by libofx! Notes=%s\n", notes);
+    //PERR("WRITEME: GnuCash ofx_proc_transaction():Add PAYEE and ADDRESS here once supported by libofx! Notes=%s\n", notes);
 
     /* Ideally, gnucash should process the corrected transactions */
     if (data.fi_id_corrected_valid)

--- a/gnucash/import-export/qif-imp/assistant-qif-import.c
+++ b/gnucash/import-export/qif-imp/assistant-qif-import.c
@@ -282,7 +282,7 @@ void gnc_ui_qif_import_summary_page_prepare (GtkAssistant *assistant, gpointer u
  * generalizes the code shared whenever any QIF -> GNC mapper is
  * updating it's LIST STORE.  It asks the Scheme side to guess some account
  * translations and then shows the account name and suggested
- * translation in the Accounts page view (acount picker list).
+ * translation in the Accounts page view (account picker list).
  ****************************************************************/
 static void
 update_account_picker_page (QIFImportWindow * wind, SCM make_display,
@@ -347,7 +347,7 @@ update_account_picker_page (QIFImportWindow * wind, SCM make_display,
 
     gtk_tree_selection_select_path (selection, path);
 
-    /* scroll the tree view so the selection is visable if there are rows */
+    /* scroll the tree view so the selection is visible if there are rows */
     if (gtk_tree_model_iter_n_children (GTK_TREE_MODEL(store), NULL) > 0)
         gtk_tree_view_scroll_to_cell (GTK_TREE_VIEW(view), path, NULL, TRUE, 0.5, 0.0);
     gtk_tree_path_free (path);
@@ -2449,7 +2449,7 @@ gnc_ui_qif_import_account_rematch_cb (GtkButton *button, gpointer user_data)
 
 
 /*******************************************
- * Page 8 - Catagory Doc. Page Procedures
+ * Page 8 - Category Doc. Page Procedures
  *******************************************/
 
 /********************************************************************
@@ -2485,7 +2485,7 @@ gnc_ui_qif_import_catagory_doc_prepare (GtkAssistant *assistant,
 
 
 /******************************************
- * Page 9 - Catagory Match Page Procedures
+ * Page 9 - Category Match Page Procedures
  ******************************************/
 
 /****************************************************************
@@ -3510,12 +3510,12 @@ void gnc_ui_qif_import_prepare_cb (GtkAssistant  *assistant, GtkWidget *page,
     }
     else if (!g_strcmp0 (pagename, "category_doc_page"))
     {
-        /* Current page is Catagory Doc. page */
+        /* Current page is Category Doc. page */
         gnc_ui_qif_import_catagory_doc_prepare (assistant, user_data);
     }
     else if (!g_strcmp0 (pagename, "category_match_page"))
     {
-        /* Current page is Catagory Match page */
+        /* Current page is Category Match page */
         gnc_ui_qif_import_catagory_match_prepare (assistant, user_data);
     }
     else if (!g_strcmp0 (pagename, "memo_doc_page"))

--- a/gnucash/import-export/test/test-import-pending-matches.cpp
+++ b/gnucash/import-export/test/test-import-pending-matches.cpp
@@ -51,7 +51,7 @@ teardown (Fixture *fixture, gconstpointer pData)
     test_clear_error_list();
 }
 
-/* The exluded tests all rely on g_assert_true wich was only introduced
+/* The excluded tests all rely on g_assert_true which was only introduced
  * in glib 2.38 */
 #ifdef HAVE_GLIB_2_38
 static void
@@ -125,7 +125,7 @@ main (int argc, char *argv[])
     qof_init();
     g_test_init (&argc, &argv, NULL);
 
-    /* The exluded tests all rely on g_assert_true wich was only introduced
+    /* The excluded tests all rely on g_assert_true which was only introduced
      * in glib 2.38 */
 #ifdef HAVE_GLIB_2_38
     GNC_TEST_ADD (suitename, "match_types", Fixture, NULL, setup,

--- a/gnucash/python/gncmod-python.c
+++ b/gnucash/python/gncmod-python.c
@@ -80,7 +80,7 @@ libgncmod_python_gnc_module_init(int refcount)
 #endif
     Py_Initialize();
     PySys_SetArgv(0, &argv);
-    // I dont quite understand why these are loaded here
+    // I don't quite understand why these are loaded here
     // - these are python modules so should be able to just import them
     // in init.py
 #if PY_VERSION_HEX >= 0x03000000

--- a/gnucash/python/pycons/shell.py
+++ b/gnucash/python/pycons/shell.py
@@ -55,10 +55,10 @@ class Shell:
         return self.globals
 
     def is_balanced (self, line):
-        """ Checks line balance for brace, bracket, parenthese and string quote
+        """ Checks line balance for brace, bracket, parentheses and string quote
 
         This helper function checks for the balance of brace, bracket,
-        parenthese and string quote. Any unbalanced line means to wait until
+        parentheses and string quote. Any unbalanced line means to wait until
         some other lines are fed to the console.
         """
         

--- a/gnucash/register/ledger-core/gncEntryLedger.c
+++ b/gnucash/register/ledger-core/gncEntryLedger.c
@@ -736,7 +736,7 @@ gnc_entry_ledger_compute_value (GncEntryLedger *ledger,
     disc_type = gnc_entry_ledger_get_type (ledger, ENTRY_DISTYPE_CELL);
     disc_how = gnc_entry_ledger_get_type (ledger, ENTRY_DISHOW_CELL);
 
-    /* Bills and exp-vouchers dont have discounts */
+    /* Bills and exp-vouchers don't have discounts */
     if (ledger->type == GNCENTRY_BILL_ENTRY ||
             ledger->type == GNCENTRY_BILL_VIEWER ||
             ledger->type == GNCENTRY_EXPVOUCHER_ENTRY ||

--- a/gnucash/register/ledger-core/split-register.c
+++ b/gnucash/register/ledger-core/split-register.c
@@ -1769,7 +1769,7 @@ gnc_split_register_save (SplitRegister *reg, gboolean do_commit)
         // transaction ever not be the current trans?
         if (xaccTransIsOpen (pending_trans))
         {
-            g_warning("Impossible? commiting pending %p", pending_trans);
+            g_warning("Impossible? committing pending %p", pending_trans);
             xaccTransCommitEdit (pending_trans);
         }
         else if (pending_trans)
@@ -1950,7 +1950,7 @@ gnc_split_register_get_account_by_name (SplitRegister *reg, BasicCell * bcell,
         account = gnc_account_lookup_by_code(gnc_get_current_root_account(), name);
 
     /* if gnc_ui_new_accounts_from_name_window is used, there is a call to
-     * refresh which subsequently calls this function again, thats the
+     * refresh which subsequently calls this function again, that's the
      * reason for static creating_account. */
 
     if (!account && !creating_account)

--- a/gnucash/register/ledger-core/split-register.h
+++ b/gnucash/register/ledger-core/split-register.h
@@ -467,7 +467,7 @@ void gnc_split_register_void_current_trans (SplitRegister *reg,
  *    non-NULL. */
 void gnc_split_register_unvoid_current_trans (SplitRegister *reg);
 
-/** Deletes the non-transaction splits associated wih the current
+/** Deletes the non-transaction splits associated with the current
  *    cursor, if both are non-NULL. */
 void gnc_split_register_empty_current_trans_except_split  (SplitRegister *reg, Split *split);
 void gnc_split_register_empty_current_trans  (SplitRegister *reg);

--- a/gnucash/register/register-core/combocell.h
+++ b/gnucash/register/register-core/combocell.h
@@ -29,7 +29,7 @@
  *
  * On output, the currently selected menu item is displayed.
  * On input, the user can select from a list in the pull-down menu,
- * or use the keyboard to slect a menu entry by typing the first
+ * or use the keyboard to select a menu entry by typing the first
  * few menu characters.
  *
  * @author Created Jan 1998 Linas Vepstas

--- a/gnucash/register/register-core/datecell.h
+++ b/gnucash/register/register-core/datecell.h
@@ -30,7 +30,7 @@
  * keys.
  *
  * On output, this cell will display a date as mm/dd/yy
- * The actual date formate is compile-time configurable.
+ * The actual date format is compile-time configurable.
  *
  * hack alert -- make the display format run-time configurable, and
  * appropriately internationalized.

--- a/gnucash/register/register-core/quickfillcell.c
+++ b/gnucash/register/register-core/quickfillcell.c
@@ -129,7 +129,7 @@ utf8_caseequal_len (const char *s1, const char *s2, guint len)
     s2_bytes_len = s2_offset - s2;
 
     /* Test whether the number of characters might be too small anyway
-       (dont need to examine more than bytes_len bytes to check that) */
+       (don't need to examine more than bytes_len bytes to check that) */
     s1chars = g_utf8_strlen (s1, s1_bytes_len);
     s2chars = g_utf8_strlen (s2, s2_bytes_len);
     if ( (s1chars < len) || (s2chars < len) )

--- a/gnucash/register/register-gnome/gnucash-cursor.c
+++ b/gnucash/register/register-gnome/gnucash-cursor.c
@@ -310,7 +310,7 @@ gnucash_cursor_get_type (void)
             NULL,		/* class_data */
             sizeof (GnucashCursor),
             0,		/* n_preallocs */
-            NULL        /* instance intialization */
+            NULL        /* instance initialization */
         };
 
         gnucash_cursor_type =

--- a/gnucash/register/register-gnome/gnucash-item-edit.c
+++ b/gnucash/register/register-gnome/gnucash-item-edit.c
@@ -898,7 +898,7 @@ gnc_item_edit_new (GnucashSheet *sheet)
                       item_edit->popup_toggle.tbutton);
 
     /* The button needs to be packed into a vertical box so that the height and position
-     * can be controlled in ealier than Gtk3.20 versions */
+     * can be controlled in earlier than Gtk3.20 versions */
     gtk_box_pack_start (GTK_BOX(vb), item_edit->popup_toggle.ebox,
                         FALSE, FALSE, 0);
 

--- a/gnucash/register/register-gnome/gnucash-register.c
+++ b/gnucash/register/register-gnome/gnucash-register.c
@@ -300,7 +300,7 @@ gnucash_register_update_hadjustment (GtkAdjustment *adj,
             gtk_widget_hide(reg->hscrollbar);
             reg->hscrollbar_visible = FALSE;
             // When sheet first loaded and the scrollbar is hidden, the space left
-            // is not always automaticly taken up by the sheet so queue a resize
+            // is not always automatically taken up by the sheet so queue a resize
             // when all is idle
             g_idle_add ((GSourceFunc) gnucash_register_sheet_resize, reg);
         }

--- a/gnucash/register/register-gnome/gnucash-sheet-private.c
+++ b/gnucash/register/register-gnome/gnucash-sheet-private.c
@@ -245,7 +245,7 @@ static guint8 inc_intensity_byte(guint8 input, int numerator, int denominator)
 }
 
 /** For a given RGB value, increase the color intensity for each of the three
-colors indentically by 10 percent (i.e. make them "less black" and "more gray")
+colors identically by 10 percent (i.e. make them "less black" and "more gray")
 and return this changed RGB value. */
 static guint32 inc_intensity_10percent(guint32 argb)
 {
@@ -269,7 +269,7 @@ static guint8 dec_intensity_byte(guint8 input, int numerator, int denominator)
 }
 
 /** For a given RGB value, decrease the color intensity for each of the three
-colors indentically by 10 percent and return this changed RGB value. */
+colors identically by 10 percent and return this changed RGB value. */
 static guint32 dec_intensity_10percent(guint32 argb)
 {
     // Multiply each single byte by 9/10 i.e. by 0.9 which decreases the

--- a/gnucash/register/register-gnome/gnucash-sheet.c
+++ b/gnucash/register/register-gnome/gnucash-sheet.c
@@ -1709,7 +1709,7 @@ gnucash_sheet_key_press_event_internal (GtkWidget *widget, GdkEventKey *event)
     new_virt_loc = cur_virt_loc;
 
     /* Don't process any keystrokes where a modifier key (Alt,
-     * Meta, etc.) is being held down.  This should't include
+     * Meta, etc.) is being held down.  This shouldn't include
          * MOD2, aka NUM LOCK. */
     if (event->state & modifiers & (GDK_MODIFIER_INTENT_DEFAULT_MOD_MASK))
         pass_on = TRUE;

--- a/gnucash/report/jqplot/excanvas.js
+++ b/gnucash/report/jqplot/excanvas.js
@@ -54,7 +54,7 @@ if (!document.createElement('canvas').getContext) {
   var IE_VERSION = +navigator.userAgent.match(/MSIE ([\d.]+)?/)[1];
 
   /**
-   * This funtion is assigned to the <canvas> elements as element.getContext().
+   * This function is assigned to the <canvas> elements as element.getContext().
    * @this {HTMLElement}
    * @return {CanvasRenderingContext2D_}
    */
@@ -665,7 +665,7 @@ if (!document.createElement('canvas').getContext) {
     bezierCurveTo(this, cp1, cp2, p);
   };
 
-  // Helper function that takes the already fixed cordinates.
+  // Helper function that takes the already fixed coordinates.
   function bezierCurveTo(self, cp1, cp2, p) {
     self.currentPath_.push({
       type: 'bezierCurveTo',
@@ -791,7 +791,7 @@ if (!document.createElement('canvas').getContext) {
   contextPrototype.drawImage = function(image, var_args) {
     var dx, dy, dw, dh, sx, sy, sw, sh;
 
-    // to find the original width we overide the width and height
+    // to find the original width we override the width and height
     var oldRuntimeWidth = image.runtimeStyle.width;
     var oldRuntimeHeight = image.runtimeStyle.height;
     image.runtimeStyle.width = 'auto';
@@ -801,7 +801,7 @@ if (!document.createElement('canvas').getContext) {
     var w = image.width;
     var h = image.height;
 
-    // and remove overides
+    // and remove overrides
     image.runtimeStyle.width = oldRuntimeWidth;
     image.runtimeStyle.height = oldRuntimeHeight;
 

--- a/gnucash/report/jqplot/jqPlotOptions.txt
+++ b/gnucash/report/jqplot/jqPlotOptions.txt
@@ -1,7 +1,7 @@
 Title: jqPlot Options
 
 **This document is out of date.  While the options described here should still be 
-relavent and valid, it has not been updated for many new options.  Sorry for
+relevant and valid, it has not been updated for many new options.  Sorry for
 this inconvenience.**
 
 This document describes the options available to jqPlot.  These are set with the 
@@ -37,7 +37,7 @@ options =
     },
 
     axesDefaults: {
-        show: false,    // wether or not to renderer the axis.  Determined automatically.
+        show: false,    // whether or not to renderer the axis.  Determined automatically.
         min: null,      // minimum numerical value of the axis.  Determined automatically.
         max: null,      // maximum numverical value of the axis.  Determined automatically.
         pad: 1.2,       // a factor multiplied by the data range on the axis to give the 
@@ -52,15 +52,15 @@ options =
             mark: 'outside',    // Where to put the tick mark on the axis
                                 // 'outside', 'inside' or 'cross',
             showMark: true,
-            showGridline: true, // wether to draw a gridline (across the whole grid) at this tick,
+            showGridline: true, // whether to draw a gridline (across the whole grid) at this tick,
             markSize: 4,        // length the tick will extend beyond the grid in pixels.  For
                                 // 'cross', length will be added above and below the grid boundary,
-            show: true,         // wether to show the tick (mark and label),
-            showLabel: true,    // wether to show the text label at the tick,
+            show: true,         // whether to show the tick (mark and label),
+            showLabel: true,    // whether to show the text label at the tick,
             formatString: '',   // format string to use with the axis tick formatter
         }
-        showTicks: true,        // wether or not to show the tick labels,
-        showTickMarks: true,    // wether or not to show the tick marks
+        showTicks: true,        // whether or not to show the tick labels,
+        showTickMarks: true,    // whether or not to show the tick marks
     },
     
     axes: {
@@ -79,7 +79,7 @@ options =
     },
     
     seriesDefaults: {
-        show: true,     // wether to render the series.
+        show: true,     // whether to render the series.
         xaxis: 'xaxis', // either 'xaxis' or 'x2axis'.
         yaxis: 'yaxis', // either 'yaxis' or 'y2axis'.
         label: '',      // label to use in the legend for this line.
@@ -102,13 +102,13 @@ options =
         markerRenderer: $.jqplot.MarkerRenderer,    // renderer to use to draw the data 
                                                     // point markers.
         markerOptions: { 
-            show: true,             // wether to show data point markers.
+            show: true,             // whether to show data point markers.
             style: 'filledCircle',  // circle, diamond, square, filledCircle.
                                     // filledDiamond or filledSquare.
             lineWidth: 2,       // width of the stroke drawing the marker.
             size: 9,            // size (diameter, edge length, etc.) of the marker.
             color: '#666666'    // color of marker, set to color of line by default.
-            shadow: true,       // wether to draw shadow on marker or not.
+            shadow: true,       // whether to draw shadow on marker or not.
             shadowAngle: 45,    // angle of the shadow.  Clockwise from x axis.
             shadowOffset: 1,    // offset from the line of the shadow,
             shadowDepth: 3,     // Number of strokes to make when drawing shadow.  Each stroke 
@@ -130,7 +130,7 @@ options =
     },
     
     grid: {
-        drawGridLines: true,        // wether to draw lines across the grid or not.
+        drawGridLines: true,        // whether to draw lines across the grid or not.
         gridLineColor: '#cccccc'    // **Color of the grid lines.
         background: '#fffdf6',      // CSS color spec for background color of grid.
         borderColor: '#999999',     // CSS color spec for border around grid.
@@ -162,7 +162,7 @@ options =
             barDirection: 'vertical', // vertical or horizontal.
             barWidth: null,     // width of the bars.  null to calculate automatically.
             shadowOffset: 2,    // offset from the bar edge to stroke the shadow.
-            shadowDepth: 5,     // nuber of strokes to make for the shadow.
+            shadowDepth: 5,     // number of strokes to make for the shadow.
             shadowAlpha: 0.8,   // transparency of the shadow.
         }
     },
@@ -176,7 +176,7 @@ options =
                                 // cursor to when over plot.
         show: true, 
         showTooltip: true,      // show a tooltip showing cursor position.
-        followMouse: false,     // wether tooltip should follow the mouse or be stationary.
+        followMouse: false,     // whether tooltip should follow the mouse or be stationary.
         tooltipLocation: 'se',  // location of the tooltip either relative to the mouse 
                                 // (followMouse=true) or relative to the plot.  One of
                                 // the compass directions, n, ne, e, se, etc.
@@ -186,7 +186,7 @@ options =
         showTooltipUnitPosition: true,      // show the coordinates in data units of the mouse 
                                             // in the tooltip.
         tooltipFormatString: '%.4P',    // sprintf style format string for tooltip values.
-        useAxesFormatters: true,        // wether to use the same formatter and formatStrings
+        useAxesFormatters: true,        // whether to use the same formatter and formatStrings
                                         // as used by the axes, or to use the formatString
                                         // specified on the cursor with sprintf.
         tooltipAxesGroups: [],  // show only specified axes groups in tooltip.  Would specify like:

--- a/gnucash/report/jqplot/jquery.jqplot.css
+++ b/gnucash/report/jqplot/jquery.jqplot.css
@@ -39,7 +39,7 @@
 
 .jqplot-xaxis-tick {
     top: 0px;
-    /* initial position untill tick is drawn in proper place */
+    /* initial position until tick is drawn in proper place */
     left: 15px;
 /*    padding-top: 10px;*/
     vertical-align: top;
@@ -47,7 +47,7 @@
 
 .jqplot-x2axis-tick {
     bottom: 0px;
-    /* initial position untill tick is drawn in proper place */
+    /* initial position until tick is drawn in proper place */
     left: 15px;
 /*    padding-bottom: 10px;*/
     vertical-align: bottom;
@@ -55,7 +55,7 @@
 
 .jqplot-yaxis-tick {
     right: 0px;
-    /* initial position untill tick is drawn in proper place */
+    /* initial position until tick is drawn in proper place */
     top: 15px;
 /*    padding-right: 10px;*/
     text-align: right;
@@ -72,7 +72,7 @@
 
 .jqplot-y2axis-tick, .jqplot-y3axis-tick, .jqplot-y4axis-tick, .jqplot-y5axis-tick, .jqplot-y6axis-tick, .jqplot-y7axis-tick, .jqplot-y8axis-tick, .jqplot-y9axis-tick {
     left: 0px;
-    /* initial position untill tick is drawn in proper place */
+    /* initial position until tick is drawn in proper place */
     top: 15px;
 /*    padding-left: 10px;*/
 /*    padding-right: 15px;*/

--- a/gnucash/report/jqplot/jquery.jqplot.js
+++ b/gnucash/report/jqplot/jquery.jqplot.js
@@ -62,7 +62,7 @@
  * > dataArray = [34,12,43,55,77];
  * > chart = $.jqplot('targetElemId', [dataArray, ...], {title:'My Plot', axes:{yaxis:{min:20, max:100}}});
  * 
- * For more inforrmation, see <jqPlot Usage>.
+ * For more information, see <jqPlot Usage>.
  * 
  * About: Usage
  * 
@@ -70,7 +70,7 @@
  * 
  * About: Available Options 
  * 
- * See <jqPlot Options> for a list of options available thorugh the options object (not complete yet!)
+ * See <jqPlot Options> for a list of options available through the options object (not complete yet!)
  * 
  * About: Options Usage
  * 
@@ -289,7 +289,7 @@
             return canvas;
         };
         
-        // this method has to be used after settings the dimesions
+        // this method has to be used after settings the dimensions
         // on the element returned by getCanvas()
         this.initCanvas = function(canvas) {
             if ($.jqplot.use_excanvas) {
@@ -315,7 +315,7 @@
                 var canvas = $.jqplot.CanvasManager.canvases[idx];
                 canvas.getContext('2d').clearRect(0, 0, canvas.width, canvas.height);
                 $(canvas).unbind().removeAttr('class').removeAttr('style');
-                // Style attributes seemed to be still hanging around.  wierd.  Some ticks
+                // Style attributes seemed to be still hanging around.  weird.  Some ticks
                 // still retained a left: 0px attribute after reusing a canvas.
                 $(canvas).css({left: '', top: '', position: ''});
                 // setting size to 0 may save memory of unused canvases?
@@ -328,7 +328,7 @@
     };
 
             
-    // Convienence function that won't hang IE or FF without FireBug.
+    // Convenience function that won't hang IE or FF without FireBug.
     $.jqplot.log = function() {
         if (window.console) {
             window.console.log.apply(window.console, arguments);
@@ -511,7 +511,7 @@
     /**
      * Class: Axis
      * An individual axis object.  Cannot be instantiated directly, but created
-     * by the Plot oject.  Axis properties can be set or overriden by the 
+     * by the Plot object.  Axis properties can be set or overridden by the 
      * options passed in from the user.
      * 
      */
@@ -534,7 +534,7 @@
         this.name = name;
         this._series = [];
         // prop: show
-        // Wether to display the axis on the graph.
+        // Whether to display the axis on the graph.
         this.show = false;
         // prop: tickRenderer
         // A class of a rendering engine for creating the ticks labels displayed on the plot, 
@@ -598,15 +598,15 @@
         // renderer specific options.  See <$.jqplot.LinearAxisRenderer> for options.
         this.rendererOptions = {};
         // prop: showTicks
-        // Wether to show the ticks (both marks and labels) or not.
+        // Whether to show the ticks (both marks and labels) or not.
         // Will not override showMark and showLabel options if specified on the ticks themselves.
         this.showTicks = true;
         // prop: showTickMarks
-        // Wether to show the tick marks (line crossing grid) or not.
+        // Whether to show the tick marks (line crossing grid) or not.
         // Overridden by showTicks and showMark option of tick itself.
         this.showTickMarks = true;
         // prop: showMinorTicks
-        // Wether or not to show minor ticks.  This is renderer dependent.
+        // Whether or not to show minor ticks.  This is renderer dependent.
         this.showMinorTicks = true;
         // prop: drawMajorGridlines
         // True to draw gridlines for major axis ticks.
@@ -848,7 +848,7 @@
     /**
      * Class: Legend
      * Legend object.  Cannot be instantiated directly, but created
-     * by the Plot oject.  Legend properties can be set or overriden by the 
+     * by the Plot object.  Legend properties can be set or overridden by the 
      * options passed in from the user.
      */
     function Legend(options) {
@@ -856,7 +856,7 @@
         // Group: Properties
         
         // prop: show
-        // Wether to display the legend on the graph.
+        // Whether to display the legend on the graph.
         this.show = false;
         // prop: location
         // Placement of the legend.  one of the compass directions: nw, n, ne, e, se, s, sw, w
@@ -874,9 +874,9 @@
         // prop: placement
         // "insideGrid" places legend inside the grid area of the plot.
         // "outsideGrid" places the legend outside the grid but inside the plot container, 
-        // shrinking the grid to accomodate the legend.
+        // shrinking the grid to accommodate the legend.
         // "inside" synonym for "insideGrid", 
-        // "outside" places the legend ouside the grid area, but does not shrink the grid which
+        // "outside" places the legend outside the grid area, but does not shrink the grid which
         // can cause the legend to overflow the plot container.
         this.placement = "insideGrid";
         // prop: xoffset
@@ -913,7 +913,7 @@
         // renderer specific options passed to the renderer.
         this.rendererOptions = {};
         // prop: predraw
-        // Wether to draw the legend before the series or not.
+        // Whether to draw the legend before the series or not.
         // Used with series specific legend renderers for pie, donut, mekko charts, etc.
         this.preDraw = false;
         // prop: marginTop
@@ -1077,7 +1077,7 @@
     /**
      * Class: Title
      * Plot Title object.  Cannot be instantiated directly, but created
-     * by the Plot oject.  Title properties can be set or overriden by the 
+     * by the Plot object.  Title properties can be set or overridden by the 
      * options passed in from the user.
      * 
      * Parameters:
@@ -1091,7 +1091,7 @@
         // text of the title;
         this.text = text;
         // prop: show
-        // wether or not to show the title
+        // whether or not to show the title
         this.show = true;
         // prop: fontFamily
         // css font-family spec for the text.
@@ -1140,7 +1140,7 @@
     /**
      * Class: Series
      * An individual data series object.  Cannot be instantiated directly, but created
-     * by the Plot oject.  Series properties can be set or overriden by the 
+     * by the Plot object.  Series properties can be set or overridden by the 
      * options passed in from the user.
      */
     function Series(options) {
@@ -1159,7 +1159,7 @@
         // > }
 
         // prop: show
-        // wether or not to draw the series.
+        // whether or not to draw the series.
         this.show = true;
         // prop: xaxis
         // which x axis to use with this series, either 'xaxis' or 'x2axis'.
@@ -1221,7 +1221,7 @@
         // Alpha channel transparency of shadow.  0 = transparent.
         this.shadowAlpha = '0.1';
         // prop: breakOnNull
-        // Wether line segments should be broken at null value.
+        // Whether line segments should be broken at null value.
         // False will join point on either side of line.
         this.breakOnNull = false;
         // prop: markerRenderer
@@ -1233,16 +1233,16 @@
         // see <$.jqplot.MarkerRenderer>.
         this.markerOptions = {};
         // prop: showLine
-        // wether to actually draw the line or not.  Series will still be renderered, even if no line is drawn.
+        // whether to actually draw the line or not.  Series will still be renderered, even if no line is drawn.
         this.showLine = true;
         // prop: showMarker
-        // wether or not to show the markers at the data points.
+        // whether or not to show the markers at the data points.
         this.showMarker = true;
         // prop: index
         // 0 based index of this series in the plot series array.
         this.index;
         // prop: fill
-        // true or false, wether to fill under lines or in bars.
+        // true or false, whether to fill under lines or in bars.
         // May not be implemented in all renderers.
         this.fill = false;
         // prop: fillColor
@@ -1524,15 +1524,15 @@
      * Object representing the grid on which the plot is drawn.  The grid in this
      * context is the area bounded by the axes, the area which will contain the series.
      * Note, the series are drawn on their own canvas.
-     * The Grid object cannot be instantiated directly, but is created by the Plot oject.  
-     * Grid properties can be set or overriden by the options passed in from the user.
+     * The Grid object cannot be instantiated directly, but is created by the Plot object.  
+     * Grid properties can be set or overridden by the options passed in from the user.
      */
     function Grid() {
         $.jqplot.ElemContainer.call(this);
         // Group: Properties
         
         // prop: drawGridlines
-        // wether to draw the gridlines on the plot.
+        // whether to draw the gridlines on the plot.
         this.drawGridlines = true;
         // prop: gridLineColor
         // color of the grid lines.
@@ -1553,7 +1553,7 @@
         // True to draw border around grid.
         this.drawBorder = true;
         // prop: shadow
-        // wether to show a shadow behind the grid.
+        // whether to show a shadow behind the grid.
         this.shadow = true;
         // prop: shadowAngle
         // shadow angle in degrees
@@ -1751,7 +1751,7 @@
         // prop: data
         // user's data.  Data should *NOT* be specified in the options object,
         // but be passed in as the second argument to the $.jqplot() function.
-        // The data property is described here soley for reference. 
+        // The data property is described here solely for reference. 
         // The data should be in the form of an array of 2D or 1D arrays like
         // > [ [[x1, y1], [x2, y2],...], [y1, y2, ...] ].
         this.data = [];
@@ -1785,7 +1785,7 @@
         // prop: drawIfHidden
         // True to execute the draw method even if the plot target is hidden.
         // Generally, this should be false.  Most plot elements will not be sized/
-        // positioned correclty if renderered into a hidden container.  To render into
+        // positioned correctly if renderered into a hidden container.  To render into
         // a hidden container, call the replot method when the container is shown.
         this.drawIfHidden = false;
         this.eventCanvas = new $.jqplot.GenericCanvas();
@@ -1839,7 +1839,7 @@
                 }
             }
         };
-        // container to hold all of the merged options.  Convienence for plugins.
+        // container to hold all of the merged options.  Convenience for plugins.
         this.options = {};
         this.previousSeriesStack = [];
         // Namespece to hold plugins.  Generally non-renderer plugins add themselves to here.
@@ -1848,7 +1848,7 @@
         // Array of series object options.
         // see <Series> for series specific options.
         this.series = [];
-        // array of series indicies. Keep track of order
+        // array of series indices. Keep track of order
         // which series canvases are displayed, lowest
         // to highest, back to front.
         this.seriesStack = [];
@@ -1884,7 +1884,7 @@
         // and this will create a new title object with the specified text.
         this.title = new Title();
         // Count how many times the draw method has been called while the plot is visible.
-        // Mostly used to test if plot has never been dran (=0), has been successfully drawn
+        // Mostly used to test if plot has never been drawn (=0), has been successfully drawn
         // into a visible container once (=1) or draw more than once into a visible container.
         // Can use this in tests to see if plot has been visibly drawn at least one time.
         // After plot has been visibly drawn once, it generally doesn't need redrawn if its
@@ -1895,7 +1895,7 @@
         this._sumy = 0;
         this._sumx = 0;
         // array to hold the cumulative stacked series data.
-        // used to ajust the individual series data, which won't have access to other
+        // used to adjust the individual series data, which won't have access to other
         // series data.
         this._stackData = [];
         // array that holds the data to be plotted. This will be the series data
@@ -2514,7 +2514,7 @@
                                 // only need to sum up the stack axis column of data
                                 // and only sum if it is of same sign.
                                 // if previous series isn't same sign, keep looking
-                                // at earlier series untill we find one of same sign.
+                                // at earlier series until we find one of same sign.
                                 if (temp * prevval >= 0) {
                                     this._plotData[index][k][sidx] += prevval;
                                     this._stackData[index][k][sidx] += prevval;
@@ -2727,7 +2727,7 @@
                 for (var j=0; j<this.preParseSeriesOptionsHooks.hooks.length; j++) {
                     this.preParseSeriesOptionsHooks.hooks[j].call(temp, this.options.seriesDefaults, this.options.series[i]);
                 }
-                // Now go back and apply the options to the series.  Really should just do this during initializaiton, but don't want to
+                // Now go back and apply the options to the series.  Really should just do this during initialization, but don't want to
                 // mess up preParseSeriesOptionsHooks at this point.
                 $.extend(true, temp, sopts);
                 var dir = 'vertical';
@@ -2889,7 +2889,7 @@
             if (clear) {
                 this.canvasManager.freeAllCanvases();
                 this.eventCanvas._elem.unbind();
-                // Dont think I bind any events to the target, this shouldn't be necessary.
+                // Don't think I bind any events to the target, this shouldn't be necessary.
                 // It will remove user's events.
                 // this.target.unbind();
                 this.target.empty();
@@ -4090,7 +4090,7 @@
         // name of the axis associated with this tick
         this.axis;
         // prop: show
-        // wether or not to show the tick (mark and label).
+        // whether or not to show the tick (mark and label).
         this.show = true;
         // prop: label
         // The text or html for the label.
@@ -4159,29 +4159,29 @@
         // name of the axis associated with this tick
         this.axis;
         // prop: showMark
-        // wether or not to show the mark on the axis.
+        // whether or not to show the mark on the axis.
         this.showMark = true;
         // prop: showGridline
-        // wether or not to draw the gridline on the grid at this tick.
+        // whether or not to draw the gridline on the grid at this tick.
         this.showGridline = true;
         // prop: isMinorTick
         // if this is a minor tick.
         this.isMinorTick = false;
         // prop: size
         // Length of the tick beyond the grid in pixels.
-        // DEPRECATED: This has been superceeded by markSize
+        // DEPRECATED: This has been superseded by markSize
         this.size = 4;
         // prop:  markSize
         // Length of the tick marks in pixels.  For 'cross' style, length
         // will be stoked above and below axis, so total length will be twice this.
         this.markSize = 6;
         // prop: show
-        // wether or not to show the tick (mark and label).
+        // whether or not to show the tick (mark and label).
         // Setting this to false requires more testing.  It is recommended
         // to set showLabel and showMark to false instead.
         this.show = true;
         // prop: showLabel
-        // wether or not to show the label.
+        // whether or not to show the label.
         this.showLabel = true;
         this.label = null;
         this.value = null;
@@ -4967,12 +4967,12 @@
 
         this.renderer.options = options;
 
-        // if we are given some band data, and bands aren't explicity set to false in options, turn them on.
+        // if we are given some band data, and bands aren't explicitly set to false in options, turn them on.
         if (this.renderer.bandData.length > 1 && (!options.bands || options.bands.show == null)) {
             this.renderer.bands.show = true;
         }
 
-        // if we are given an interval, and bands aren't explicity set to false in options, turn them on.
+        // if we are given an interval, and bands aren't explicitly set to false in options, turn them on.
         else if (options.bands && options.bands.show == null && options.bands.interval != null) {
             this.renderer.bands.show = true;
         }
@@ -6822,7 +6822,7 @@
         }
         
         this._offsets = offsets;
-        // pixellength will be + for x axes and - for y axes becasue pixels always measured from top left.
+        // pixellength will be + for x axes and - for y axes because pixels always measured from top left.
         var pixellength = offmax - offmin;
         var unitlength = max - min;
         
@@ -7099,7 +7099,7 @@
         }
     };
 
-    // Given a fixed minimum and maximum and a target number ot ticks
+    // Given a fixed minimum and maximum and a target number of ticks
     // figure out the best interval and 
     // return min, max, number ticks, format string and tick interval
     function bestConstrainedInterval(min, max, nttarget) {
@@ -7129,7 +7129,7 @@
                 bestPrec = sd.digitsRight;
             }
             else if (temp === badness) {
-                // let nicer ticks trump number ot ticks
+                // let nicer ticks trump number of ticks
                 if (sd.digitsRight < bestPrec) {
                     bestNT = currentNT;
                     bestPrec = sd.digitsRight;
@@ -7151,7 +7151,7 @@
     }
 
     // This will return an interval of form 2 * 10^n, 5 * 10^n or 10 * 10^n
-    // it is based soley on the range and number of ticks.  So if user specifies
+    // it is based solely on the range and number of ticks.  So if user specifies
     // number of ticks, use this.
     function bestInterval(range, numberTicks) {
         numberTicks = numberTicks || 7;
@@ -7202,7 +7202,7 @@
     }
 
     // This will return an interval of form 2 * 10^n, 5 * 10^n or 10 * 10^n
-    // it is based soley on the range of data, number of ticks must be computed later.
+    // it is based solely on the range of data, number of ticks must be computed later.
     function bestLinearInterval(range, scalefact) {
         scalefact = scalefact || 1;
         var expv = Math.floor(Math.log(range)/Math.LN10);
@@ -7313,7 +7313,7 @@
 
             // Figure out the axis min, max and number of ticks
             // the min and max will be some multiple of the tick interval,
-            // 1*10^n, 2*10^n or 5*10^n.  This gaurantees that, if the
+            // 1*10^n, 2*10^n or 5*10^n.  This guarantees that, if the
             // axis min is negative, 0 will be a tick.
             if (!keepMin && !keepMax) {
                 r[0] = Math.floor(axis_min / ss) * ss;  // min
@@ -7359,7 +7359,7 @@
 
             // Figure out the axis min, max and number of ticks
             // the min and max will be some multiple of the tick interval,
-            // 1*10^n, 2*10^n or 5*10^n.  This gaurantees that, if the
+            // 1*10^n, 2*10^n or 5*10^n.  This guarantees that, if the
             // axis min is negative, 0 will be a tick.
             tempr[0] = Math.floor(axis_min / ss) * ss;  // min
             tempr[1] = Math.ceil(axis_max / ss) * ss;   // max
@@ -7399,7 +7399,7 @@
         // Group: Properties
         
         // prop: show
-        // wether or not to show the marker.
+        // whether or not to show the marker.
         this.show = true;
         // prop: style
         // One of diamond, circle, square, x, plus, dash, filledDiamond, filledCircle, filledSquare
@@ -7414,7 +7414,7 @@
         // color of marker.  Will be set to color of series by default on init.
         this.color = '#666666';
         // prop: shadow
-        // wether or not to draw a shadow on the line
+        // whether or not to draw a shadow on the line
         this.shadow = true;
         // prop: shadowAngle
         // Shadow angle in degrees
@@ -7625,7 +7625,7 @@
         this.depth = 3;
         this.strokeStyle = 'rgba(0,0,0,0.1)';
         // prop: isarc
-        // wether the shadow is an arc or not.
+        // whether the shadow is an arc or not.
         this.isarc = false;
         
         $.extend(true, this, options);
@@ -7727,7 +7727,7 @@
         // whether to fill the shape.
         this.fill = false;
         // prop: isarc
-        // wether the shadow is an arc or not.
+        // whether the shadow is an arc or not.
         this.isarc = false;
         // prop: fillRect
         // true to draw shape as a filled rectangle.
@@ -8129,7 +8129,7 @@
 
     /**
      * Class: $.jqplot.ThemeEngine
-     * Theme Engine provides a programatic way to change some of the  more
+     * Theme Engine provides a programmatic way to change some of the  more
      * common jqplot styling options such as fonts, colors and grid options.
      * A theme engine instance is created with each plot.  The theme engine
      * manages a collection of themes which can be modified, added to, or 
@@ -9283,7 +9283,7 @@
         return str;
     };
 
-    // Not gauranteed to work, even on canvas supporting browsers due to 
+    // Not guaranteed to work, even on canvas supporting browsers due to 
     // limitations with location.href and browser support.
     $.fn.jqplotSaveImage = function() {
         var imgData = $(this).jqplotToImageStr({});
@@ -9293,7 +9293,7 @@
 
     };
 
-    // Not gauranteed to work, even on canvas supporting browsers due to
+    // Not guaranteed to work, even on canvas supporting browsers due to
     // limitations with window.open and arbitrary data.
     $.fn.jqplotViewImage = function() {
         var imgStr = $(this).jqplotToImageElemStr({});
@@ -9527,9 +9527,9 @@
     };
     
     /**
-     * Get the Day of week 1 (Monday) thru 7 (Sunday)
+     * Get the Day of week 1 (Monday) through 7 (Sunday)
      * 
-     * @returns {Integer} Day of week 1 (Monday) thru 7 (Sunday)
+     * @returns {Integer} Day of week 1 (Monday) through 7 (Sunday)
      */
     jsDate.prototype.getDayOfWeek = function() { 
         var dow = this.proxy.getDay(); 
@@ -10069,7 +10069,7 @@
             add: function(d, number) {
                 // add any years needed (increments of 12)
                 multipliers.year.add(d, Math[number > 0 ? 'floor' : 'ceil'](number / 12));
-                // ensure that we properly wrap betwen December and January
+                // ensure that we properly wrap between December and January
                 // 11 % 12 = 11
                 // 12 % 12 = 0
                 var prevMonth = d.getMonth() + (number % 12);
@@ -10419,7 +10419,7 @@
      * === Time ===                     
      * %H      00 through 23             Two digit representation of the hour in 24-hour format
      * %I      01 through 12             Two digit representation of the hour in 12-hour format
-     * %l      1 through 12              Hour in 12-hour format, with a space preceeding single digits
+     * %l      1 through 12              Hour in 12-hour format, with a space preceding single digits
      * %M      00 through 59             Two digit representation of the minute
      * %p      AM/PM                     UPPER-CASE 'AM' or 'PM' based on the given time
      * %P      am/pm                     lower-case 'am' or 'pm' based on the given time
@@ -10638,7 +10638,7 @@
      * @returns {Integer} Number of days in the month.
     */
     //
-    // handy utility method Borrowed right from Ken Snyder's Date Instance Mehtods.
+    // handy utility method Borrowed right from Ken Snyder's Date Instance Methods.
     // 
     jsDate.daysInMonth = function(year, month) {
         if (month == 2) {
@@ -11293,7 +11293,7 @@
                     }
                 }
 
-                // if the element is hiddden and mode is hide,
+                // if the element is hidden and mode is hide,
                 // or element is visible and mode is show
                 if ( elem.is( ":hidden" ) ? mode === "hide" : mode === "show" ) {
                     done();

--- a/gnucash/report/jqplot/jquery.js
+++ b/gnucash/report/jqplot/jquery.js
@@ -4186,7 +4186,7 @@ setDocument = Sizzle.setDocument = function( node ) {
 		// Regex strategy adopted from Diego Perini
 		assert(function( div ) {
 			// Select is set to empty string on purpose
-			// This is to test IE's treatment of not explictly
+			// This is to test IE's treatment of not explicitly
 			// setting a boolean content attribute,
 			// since its presence should be enough
 			// http://bugs.jquery.com/ticket/12359
@@ -6836,7 +6836,7 @@ jQuery.extend({
 				value += "px";
 			}
 
-			// Fixes #8908, it can be done more correctly by specifing setters in cssHooks,
+			// Fixes #8908, it can be done more correctly by specifying setters in cssHooks,
 			// but it would mean to define eight (for every problematic property) identical functions
 			if ( !jQuery.support.clearCloneStyle && value === "" && name.indexOf("background") === 0 ) {
 				style[ name ] = "inherit";

--- a/gnucash/report/jqplot/optionsTutorial.txt
+++ b/gnucash/report/jqplot/optionsTutorial.txt
@@ -127,7 +127,7 @@ and
 
 > optionsObj = {title:"My Plot"}
 
-Where things need more explaination is with renderers, plugins and
+Where things need more explanation is with renderers, plugins and
 their options.  Briefly, what's  renderer, what's a plugin.
 
 A renderer is an object that is used to draw something and gets
@@ -138,7 +138,7 @@ cursor, provide event driven functionality, etc.  I consider renderers
 plugins, but plugins don't have to be renderers.
 
 So, how do you use renderers, plugins, and specify their options?
-Some common renderes are for bar charts and category axes.  If you
+Some common renderers are for bar charts and category axes.  If you
 want to render your series as a bar chart with each set of bars
 showing up in a category on the x axis, you do:
 

--- a/gnucash/report/jqplot/plugins/jqplot.BezierCurveRenderer.js
+++ b/gnucash/report/jqplot/plugins/jqplot.BezierCurveRenderer.js
@@ -32,7 +32,7 @@
     // Class: $.jqplot.BezierCurveRenderer.js
     // Renderer which draws lines as stacked bezier curves.
     // Data for the line will not be specified as an array of
-    // [x, y] data point values, but as a an array of [start piont, bezier curve]
+    // [x, y] data point values, but as a an array of [start point, bezier curve]
     // So, the line is specified as: [[xstart, ystart], [cp1x, cp1y, cp2x, cp2y, xend, yend]].
     $.jqplot.BezierCurveRenderer = function(){
         $.jqplot.LineRenderer.call(this);

--- a/gnucash/report/jqplot/plugins/jqplot.barRenderer.js
+++ b/gnucash/report/jqplot/plugins/jqplot.barRenderer.js
@@ -59,7 +59,7 @@
         this.barWidth = null;
         // prop: shadowOffset
         // offset of the shadow from the slice and offset of 
-        // each succesive stroke of the shadow from the last.
+        // each successive stroke of the shadow from the last.
         this.shadowOffset = 2;
         // prop: shadowDepth
         // number of strokes to apply to the shadow, 
@@ -97,7 +97,7 @@
         // NOT IMPLEMENTED YET.  True if this is a horizontal bar plot and 
         // x and y values are "transposed".  Tranposed, or "swapped", data is 
         // required prior to rev. 894 builds of jqPlot with horizontal bars. 
-        // Allows backward compatability of bar renderer horizontal bars with 
+        // Allows backward compatibility of bar renderer horizontal bars with 
         // old style data sets.
         this.transposedData = true;
         this.renderer.animation = {
@@ -115,7 +115,7 @@
         
         //////
         // This is probably wrong here.
-        // After going back and forth on wether renderer should be the thing
+        // After going back and forth on whether renderer should be the thing
         // or extend the thing, it seems that it is best if it is a property
         // on the thing.  This should be something that is commonized 
         // among series renderers in the future.
@@ -148,7 +148,7 @@
             this._stackAxis = 'x';
             this.fillAxis = 'x';
         }
-        // index of the currenty highlighted point, if any
+        // index of the currently highlighted point, if any
         this._highlightedPoint = null;
         // total number of values for all bar series, total number of bar series, and position of this series
         this._plotSeriesInfo = null;
@@ -233,7 +233,7 @@
             }
             // is the series rendered as a bar?
             if (series.renderer.constructor == $.jqplot.BarRenderer) {
-                // gridData may not be computed yet, use data length insted
+                // gridData may not be computed yet, use data length instead
                 nvals += series.data.length;
                 nseries += 1;
             }

--- a/gnucash/report/jqplot/plugins/jqplot.blockRenderer.js
+++ b/gnucash/report/jqplot/plugins/jqplot.blockRenderer.js
@@ -36,7 +36,7 @@
      * 
      * > [[x1, y1, "label 1", {css}], [x2, y2, "label 2", {css}], ...]
      * 
-     * The label and css object are optional.  If the label is ommitted, the
+     * The label and css object are optional.  If the label is omitted, the
      * box will collapse unless a css height and/or width is specified.
      * 
      * The css object is an object specifying css properties 

--- a/gnucash/report/jqplot/plugins/jqplot.bubbleRenderer.js
+++ b/gnucash/report/jqplot/plugins/jqplot.bubbleRenderer.js
@@ -139,7 +139,7 @@
         // largest points below smaller points.
         this.radii = [];
         this.maxRadius = 0;
-        // index of the currenty highlighted point, if any
+        // index of the currently highlighted point, if any
         this._highlightedPoint = null;
         // array of jQuery labels.
         this.labels = [];
@@ -162,7 +162,7 @@
         
         this.autoscaleMultiplier = this.autoscaleMultiplier * Math.pow(this.data.length, this.autoscalePointsFactor);
         
-        // index of the currenty highlighted point, if any
+        // index of the currently highlighted point, if any
         this._highlightedPoint = null;
         
         // adjust the series colors for options colors passed in with data or for alpha.
@@ -327,7 +327,7 @@
             // color = (this.varyBubbleColors) ? this.colorGenerator.get(idx) : this.color;
             color = this.colorGenerator.get(idx);
             
-            // If we're drawing a shadow, expand the canvas dimensions to accomodate.
+            // If we're drawing a shadow, expand the canvas dimensions to accommodate.
             var canvasRadius = gd[2];
             var offset, depth;
             if (this.shadow) {
@@ -422,7 +422,7 @@
     $.jqplot.BubbleCanvas.prototype = new $.jqplot.ElemContainer();
     $.jqplot.BubbleCanvas.prototype.constructor = $.jqplot.BubbleCanvas;
     
-    // initialize with the x,y pont of bubble center and the bubble radius.
+    // initialize with the x,y point of bubble center and the bubble radius.
     $.jqplot.BubbleCanvas.prototype.createElement = function(x, y, r) {     
         var klass = 'jqplot-bubble-point';
 

--- a/gnucash/report/jqplot/plugins/jqplot.canvasAxisLabelRenderer.js
+++ b/gnucash/report/jqplot/plugins/jqplot.canvasAxisLabelRenderer.js
@@ -34,7 +34,7 @@
     * Renderer to draw axis labels with a canvas element to support advanced
     * featrues such as rotated text.  This renderer uses a separate rendering engine
     * to draw the text on the canvas.  Two modes of rendering the text are available.
-    * If the browser has native font support for canvas fonts (currently Mozila 3.5
+    * If the browser has native font support for canvas fonts (currently Mozilla 3.5
     * and Safari 4), you can enable text rendering with the canvas fillText method.
     * You do so by setting the "enableFontSupport" option to true. 
     * 
@@ -52,10 +52,10 @@
         // name of the axis associated with this tick
         this.axis;
         // prop: show
-        // wether or not to show the tick (mark and label).
+        // whether or not to show the tick (mark and label).
         this.show = true;
         // prop: showLabel
-        // wether or not to show the label.
+        // whether or not to show the label.
         this.showLabel = true;
         // prop: label
         // label for the axis.
@@ -88,7 +88,7 @@
         // around a label.  The labels text renderer has a default setting of 1.4, which 
         // should be suitable for most fonts.  Leave as null to use default.  If tops of
         // letters appear clipped, increase this.  If bounding box seems too big, decrease.
-        // This is an issue only with the native font renderering capabilities of Mozilla
+        // This is an issue only with the native font rendering capabilities of Mozilla
         // 3.5 and Safari 4 since they do not provide a method to determine the font height.
         this.pt2px = null;
         
@@ -174,8 +174,8 @@
               this._elem = null;
           }
 
-        // create a canvas here, but can't draw on it untill it is appended
-        // to dom for IE compatability.
+        // create a canvas here, but can't draw on it until it is appended
+        // to dom for IE compatibility.
         var elem = plot.canvasManager.getCanvas();
 
         this._textRenderer.setText(this.label, ctx);

--- a/gnucash/report/jqplot/plugins/jqplot.canvasAxisTickRenderer.js
+++ b/gnucash/report/jqplot/plugins/jqplot.canvasAxisTickRenderer.js
@@ -34,7 +34,7 @@
     * Renderer to draw axis ticks with a canvas element to support advanced
     * featrues such as rotated text.  This renderer uses a separate rendering engine
     * to draw the text on the canvas.  Two modes of rendering the text are available.
-    * If the browser has native font support for canvas fonts (currently Mozila 3.5
+    * If the browser has native font support for canvas fonts (currently Mozilla 3.5
     * and Safari 4), you can enable text rendering with the canvas fillText method.
     * You do so by setting the "enableFontSupport" option to true. 
     * 
@@ -49,10 +49,10 @@
         // tick mark on the axis.  One of 'inside', 'outside', 'cross', '' or null.
         this.mark = 'outside';
         // prop: showMark
-        // wether or not to show the mark on the axis.
+        // whether or not to show the mark on the axis.
         this.showMark = true;
         // prop: showGridline
-        // wether or not to draw the gridline on the grid at this tick.
+        // whether or not to draw the gridline on the grid at this tick.
         this.showGridline = true;
         // prop: isMinorTick
         // if this is a minor tick.
@@ -65,10 +65,10 @@
         // will be stoked above and below axis, so total length will be twice this.
         this.markSize = 4;
         // prop: show
-        // wether or not to show the tick (mark and label).
+        // whether or not to show the tick (mark and label).
         this.show = true;
         // prop: showLabel
-        // wether or not to show the label.
+        // whether or not to show the label.
         this.showLabel = true;
         // prop: labelPosition
         // 'auto', 'start', 'middle' or 'end'.
@@ -115,7 +115,7 @@
         // around a label.  The labels text renderer has a default setting of 1.4, which 
         // should be suitable for most fonts.  Leave as null to use default.  If tops of
         // letters appear clipped, increase this.  If bounding box seems too big, decrease.
-        // This is an issue only with the native font renderering capabilities of Mozilla
+        // This is an issue only with the native font rendering capabilities of Mozilla
         // 3.5 and Safari 4 since they do not provide a method to determine the font height.
         this.pt2px = null;
         
@@ -210,15 +210,15 @@
             this._elem = null;
         }
 
-        // create a canvas here, but can't draw on it untill it is appended
-        // to dom for IE compatability.
+        // create a canvas here, but can't draw on it until it is appended
+        // to dom for IE compatibility.
 
         var elem = plot.canvasManager.getCanvas();
 
         this._textRenderer.setText(this.label, ctx);
         var w = this.getWidth(ctx);
         var h = this.getHeight(ctx);
-        // canvases seem to need to have width and heigh attributes directly set.
+        // canvases seem to need to have width and height attributes directly set.
         elem.width = w;
         elem.height = h;
         elem.style.width = w;

--- a/gnucash/report/jqplot/plugins/jqplot.canvasOverlay.js
+++ b/gnucash/report/jqplot/plugins/jqplot.canvasOverlay.js
@@ -107,7 +107,7 @@
             // color of the line
             color: '#666666',
             // prop: shadow
-            // wether or not to draw a shadow on the line
+            // whether or not to draw a shadow on the line
             shadow: true,
             // prop: shadowAngle
             // Shadow angle in degrees

--- a/gnucash/report/jqplot/plugins/jqplot.canvasTextRenderer.js
+++ b/gnucash/report/jqplot/plugins/jqplot.canvasTextRenderer.js
@@ -170,7 +170,7 @@
     };
     
     // w - height in pt
-    // set heigh in px
+    // set height in px
     $.jqplot.CanvasTextRenderer.prototype.setHeight = function(w) {
         if (!w) {
             //height = this.fontSize /0.75;

--- a/gnucash/report/jqplot/plugins/jqplot.categoryAxisRenderer.js
+++ b/gnucash/report/jqplot/plugins/jqplot.categoryAxisRenderer.js
@@ -217,7 +217,7 @@
             // keep a reference to these tick labels to use for redrawing plot (see bug #57)
             this.ticks = labels;
             
-            // now bin the data values to the right lables.
+            // now bin the data values to the right labels.
             for (var i=0; i<this._series.length; i++) {
                 var s = this._series[i];
                 for (var j=0; j<s.data.length; j++) {
@@ -438,7 +438,7 @@
         }
         
         this._offsets = offsets;
-        // pixellength will be + for x axes and - for y axes becasue pixels always measured from top left.
+        // pixellength will be + for x axes and - for y axes because pixels always measured from top left.
         var pixellength = offmax - offmin;
         var unitlength = max - min;
         

--- a/gnucash/report/jqplot/plugins/jqplot.cursor.js
+++ b/gnucash/report/jqplot/plugins/jqplot.cursor.js
@@ -42,7 +42,7 @@
         this.style = 'crosshair';
         this.previousCursor = 'auto';
         // prop: show
-        // wether to show the cursor or not.
+        // whether to show the cursor or not.
         this.show = $.jqplot.config.enablePlugins;
         // prop: showTooltip
         // show a cursor position tooltip.  Location of the tooltip
@@ -59,7 +59,7 @@
         // One of 'n', 'ne', 'e', 'se', 's', 'sw', 'w', 'nw'
         this.tooltipLocation = 'se';
         // prop: tooltipOffset
-        // Pixel offset of tooltip from the grid boudaries or cursor center.
+        // Pixel offset of tooltip from the grid boundaries or cursor center.
         this.tooltipOffset = 6;
         // prop: showTooltipGridPosition
         // show the grid pixel coordinates of the mouse.

--- a/gnucash/report/jqplot/plugins/jqplot.dateAxisRenderer.js
+++ b/gnucash/report/jqplot/plugins/jqplot.dateAxisRenderer.js
@@ -459,7 +459,7 @@
             }
 
             // If tickInterval is specified, we'll try to honor it.
-            // Not gauranteed to get this interval, but we'll get as close as
+            // Not guaranteed to get this interval, but we'll get as close as
             // we can.
             // tickInterval will be used before numberTicks, that is if
             // both are specified, numberTicks will be ignored.
@@ -468,7 +468,7 @@
             }
 
             // if numberTicks specified, try to honor it.
-            // Not gauranteed, but will try to get close.
+            // Not guaranteed, but will try to get close.
             else if (this.numberTicks) {
                 nttarget = this.numberTicks;
                 titarget = (max - min) / (nttarget - 1);

--- a/gnucash/report/jqplot/plugins/jqplot.donutRenderer.js
+++ b/gnucash/report/jqplot/plugins/jqplot.donutRenderer.js
@@ -65,7 +65,7 @@
      * 'jqplotDataUnhighlight' - triggered when a user moves the mouse out of
      * a highlighted slice.
      * 'jqplotDataClick' - triggered when the user clicks on a slice.
-     * 'jqplotDataRightClick' - tiggered when the user right clicks on a slice if
+     * 'jqplotDataRightClick' - triggered when the user right clicks on a slice if
      * the "captureRightClick" option is set to true on the plot.
      */
     $.jqplot.DonutRenderer = function(){
@@ -101,11 +101,11 @@
         // null will compute ringMargin based on sliceMargin.
         this.ringMargin = null;
         // prop: fill
-        // true or false, wether to fil the slices.
+        // true or false, whether to fill the slices.
         this.fill = true;
         // prop: shadowOffset
         // offset of the shadow from the slice and offset of 
-        // each succesive stroke of the shadow from the last.
+        // each successive stroke of the shadow from the last.
         this.shadowOffset = 2;
         // prop: shadowAlpha
         // transparency of the shadow (0 = transparent, 1 = opaque)
@@ -136,7 +136,7 @@
         // Format string for data labels.  If none, '%s' is used for "label" and for arrays, '%d' for value and '%d%%' for percentage.
         this.dataLabelFormatString = null;
         // prop: dataLabelThreshold
-        // Threshhold in percentage (0 - 100) of pie area, below which no label will be displayed.
+        // Threshold in percentage (0 - 100) of pie area, below which no label will be displayed.
         // This applies to all label types, not just to percentage labels.
         this.dataLabelThreshold = 3;
         // prop: dataLabelPositionFactor
@@ -151,7 +151,7 @@
         // According to orientation of canvas coordinate system:
         // 0 = on the positive x axis
         // -90 = on the positive y axis.
-        // 90 = on the negaive y axis.
+        // 90 = on the negative y axis.
         // 180 or - 180 = on the negative x axis.
         this.startAngle = 0;
         this.tickRenderer = $.jqplot.DonutTickRenderer;
@@ -179,7 +179,7 @@
         this._numberSeries = 1;
         // array of [start,end] angles arrays, one for each slice.  In radians.
         this._sliceAngles = [];
-        // index of the currenty highlighted point, if any
+        // index of the currently highlighted point, if any
         this._highlightedPoint = null;
         
         // set highlight colors if none provided
@@ -471,7 +471,7 @@
         // I don't think I'm going to need _dataBounds here.
         // have to go Axis scaling in a way to fit chart onto plot area
         // and provide u2p and p2u functionality for mouse cursor, etc.
-        // for convienence set _dataBounds to 0 and 100 and
+        // for convenience set _dataBounds to 0 and 100 and
         // set min/max to 0 and 100.
         this._dataBounds = {min:0, max:100};
         this.min = 0;

--- a/gnucash/report/jqplot/plugins/jqplot.enhancedLegendRenderer.js
+++ b/gnucash/report/jqplot/plugins/jqplot.enhancedLegendRenderer.js
@@ -271,7 +271,7 @@
 
                 if (s.canvas._elem.is(':hidden') || !s.show) {
                     // Not sure if there is a better way to check for showSwatches and showLabels === true.
-                    // Test for "undefined" since default values for both showSwatches and showLables is true.
+                    // Test for "undefined" since default values for both showSwatches and showLabels is true.
                     if (typeof plot.options.legend.showSwatches === 'undefined' || plot.options.legend.showSwatches === true) {
                         plot.legend._elem.find('td').eq(sidx * 2).addClass('jqplot-series-hidden');
                     }

--- a/gnucash/report/jqplot/plugins/jqplot.funnelRenderer.js
+++ b/gnucash/report/jqplot/plugins/jqplot.funnelRenderer.js
@@ -72,7 +72,7 @@
      * A funnel plot will trigger events on the plot target
      * according to user interaction.  All events return the event object,
      * the series index, the point (section) index, and the point data for 
-     * the appropriate section. *Note* the point index will referr to the ordered
+     * the appropriate section. *Note* the point index will refer to the ordered
      * data, not the original unordered data.
      * 
      * 'jqplotDataMouseOver' - triggered when mousing over a section.
@@ -81,7 +81,7 @@
      * 'jqplotDataUnhighlight' - triggered when a user moves the mouse out of
      * a highlighted section.
      * 'jqplotDataClick' - triggered when the user clicks on a section.
-     * 'jqplotDataRightClick' - tiggered when the user right clicks on a section if
+     * 'jqplotDataRightClick' - triggered when the user right clicks on a section if
      * the "captureRightClick" option is set to true on the plot.
      */
     $.jqplot.FunnelRenderer = function(){
@@ -102,11 +102,11 @@
         // spacing between funnel sections in pixels.
         this.sectionMargin = 6;
         // prop: fill
-        // true or false, wether to fill the areas.
+        // true or false, whether to fill the areas.
         this.fill = true;
         // prop: shadowOffset
         // offset of the shadow from the area and offset of 
-        // each succesive stroke of the shadow from the last.
+        // each successive stroke of the shadow from the last.
         this.shadowOffset = 2;
         // prop: shadowAlpha
         // transparency of the shadow (0 = transparent, 1 = opaque)
@@ -144,7 +144,7 @@
         // Format string for data labels.  If none, '%s' is used for "label" and for arrays, '%d' for value and '%d%%' for percentage.
         this.dataLabelFormatString = null;
         // prop: dataLabelThreshold
-        // Threshhold in percentage (0 - 100) of pie area, below which no label will be displayed.
+        // Threshold in percentage (0 - 100) of pie area, below which no label will be displayed.
         // This applies to all label types, not just to percentage labels.
         this.dataLabelThreshold = 3;
         this._type = 'funnel';
@@ -158,7 +158,7 @@
         
         $.extend(true, this, options);
         
-        // index of the currenty highlighted point, if any
+        // index of the currently highlighted point, if any
         this._highlightedPoint = null;
         
         // lengths of bases, or horizontal sides of areas of trapezoid.
@@ -511,7 +511,7 @@
         // I don't think I'm going to need _dataBounds here.
         // have to go Axis scaling in a way to fit chart onto plot area
         // and provide u2p and p2u functionality for mouse cursor, etc.
-        // for convienence set _dataBounds to 0 and 100 and
+        // for convenience set _dataBounds to 0 and 100 and
         // set min/max to 0 and 100.
         this._dataBounds = {min:0, max:100};
         this.min = 0;

--- a/gnucash/report/jqplot/plugins/jqplot.highlighter.js
+++ b/gnucash/report/jqplot/plugins/jqplot.highlighter.js
@@ -44,7 +44,7 @@
      * To disable the tooltip, set "showTooltip" to false.
      * 
      * You can control what data is displayed in the tooltip with various
-     * options.  The "tooltipAxes" option controls wether the x, y or both
+     * options.  The "tooltipAxes" option controls whether the x, y or both
      * data values are displayed.
      * 
      * Some chart types (e.g. hi-low-close) have more than one y value per

--- a/gnucash/report/jqplot/plugins/jqplot.json2.js
+++ b/gnucash/report/jqplot/plugins/jqplot.json2.js
@@ -4,7 +4,7 @@
     Slightly modified version of the original json2.js to put JSON
     functions under the $.jqplot namespace.
     
-    licensing and orignal comments follow:
+    licensing and original comments follow:
     
     http://www.JSON.org/json2.js
     2010-08-25

--- a/gnucash/report/jqplot/plugins/jqplot.logAxisRenderer.js
+++ b/gnucash/report/jqplot/plugins/jqplot.logAxisRenderer.js
@@ -379,7 +379,7 @@
         }
         
         this._offsets = offsets;
-        // pixellength will be + for x axes and - for y axes becasue pixels always measured from top left.
+        // pixellength will be + for x axes and - for y axes because pixels always measured from top left.
         var pixellength = offmax - offmin;
         var unitlength = max - min;
         

--- a/gnucash/report/jqplot/plugins/jqplot.mekkoAxisRenderer.js
+++ b/gnucash/report/jqplot/plugins/jqplot.mekkoAxisRenderer.js
@@ -359,7 +359,7 @@
                 }
             }
             
-            // for x axes, have number ot ticks equal to number of series and ticks placed
+            // for x axes, have number of ticks equal to number of series and ticks placed
             // at sum of y values for each series.
             else if (this.tickMode == 'bar') {
                 this.min = 0;
@@ -450,7 +450,7 @@
         }
         
         this._offsets = offsets;
-        // pixellength will be + for x axes and - for y axes becasue pixels always measured from top left.
+        // pixellength will be + for x axes and - for y axes because pixels always measured from top left.
         var pixellength = offmax - offmin;
         var unitlength = max - min;
         

--- a/gnucash/report/jqplot/plugins/jqplot.meterGaugeRenderer.js
+++ b/gnucash/report/jqplot/plugins/jqplot.meterGaugeRenderer.js
@@ -75,7 +75,7 @@
         this.padding = null;
         // prop: shadowOffset
         // offset of the shadow from the gauge ring and offset of 
-        // each succesive stroke of the shadow from the last.
+        // each successive stroke of the shadow from the last.
         this.shadowOffset = 2;
         // prop: shadowAlpha
         // transparency of the shadow (0 = transparent, 1 = opaque)
@@ -223,7 +223,7 @@
             this.numberTicks = this.ticks.length;
             this.tickInterval = this.ticks[1][0] - this.ticks[0][0];
             this.tickFactor = Math.floor(parseFloat((Math.log(this.tickInterval)/Math.log(10)).toFixed(11)));
-            // use the first interal to calculate minor ticks;
+            // use the first internal to calculate minor ticks;
             this.numberMinorTicks = getnmt(this.tickPositions, this.tickInterval, this.tickFactor);
             if (!this.numberMinorTicks) {
                 this.numberMinorTicks = getnmt(this.tickPositions, this.tickInterval, this.tickFactor-1);
@@ -494,7 +494,7 @@
                     tmax += ti;
                     nt += 1;
                 }
-                // now tmax should always be mroe than dataMax
+                // now tmax should always be more than dataMax
                 if (tmax - max < 0.23*ti) { 
                     tmax += ti;
                     nt += 1;
@@ -841,7 +841,7 @@
         // I don't think I'm going to need _dataBounds here.
         // have to go Axis scaling in a way to fit chart onto plot area
         // and provide u2p and p2u functionality for mouse cursor, etc.
-        // for convienence set _dataBounds to 0 and 100 and
+        // for convenience set _dataBounds to 0 and 100 and
         // set min/max to 0 and 100.
         this._dataBounds = {min:0, max:100};
         this.min = 0;

--- a/gnucash/report/jqplot/plugins/jqplot.ohlcRenderer.js
+++ b/gnucash/report/jqplot/plugins/jqplot.ohlcRenderer.js
@@ -87,7 +87,7 @@
         // color of the close price tick mark.  Default is series color.
         this.closeColor = null;
         // prop: wickColor
-        // color of the hi-lo line thorugh the candlestick body.
+        // color of the hi-lo line through the candlestick body.
         // Default is the series color.
         this.wickColor = null;
         // prop: fillUpBody

--- a/gnucash/report/jqplot/plugins/jqplot.pieRenderer.js
+++ b/gnucash/report/jqplot/plugins/jqplot.pieRenderer.js
@@ -64,7 +64,7 @@
      * 'jqplotDataUnhighlight' - triggered when a user moves the mouse out of
      * a highlighted slice.
      * 'jqplotDataClick' - triggered when the user clicks on a slice.
-     * 'jqplotDataRightClick' - tiggered when the user right clicks on a slice if
+     * 'jqplotDataRightClick' - triggered when the user right clicks on a slice if
      * the "captureRightClick" option is set to true on the plot.
      */
     $.jqplot.PieRenderer = function(){
@@ -88,11 +88,11 @@
         // angular spacing between pie slices in degrees.
         this.sliceMargin = 0;
         // prop: fill
-        // true or false, wether to fil the slices.
+        // true or false, whether to fill the slices.
         this.fill = true;
         // prop: shadowOffset
         // offset of the shadow from the slice and offset of 
-        // each succesive stroke of the shadow from the last.
+        // each successive stroke of the shadow from the last.
         this.shadowOffset = 2;
         // prop: shadowAlpha
         // transparency of the shadow (0 = transparent, 1 = opaque)
@@ -123,7 +123,7 @@
         // Format string for data labels.  If none, '%s' is used for "label" and for arrays, '%d' for value and '%d%%' for percentage.
         this.dataLabelFormatString = null;
         // prop: dataLabelThreshold
-        // Threshhold in percentage (0-100) of pie area, below which no label will be displayed.
+        // Threshold in percentage (0-100) of pie area, below which no label will be displayed.
         // This applies to all label types, not just to percentage labels.
         this.dataLabelThreshold = 3;
         // prop: dataLabelPositionFactor
@@ -142,7 +142,7 @@
         // According to orientation of canvas coordinate system:
         // 0 = on the positive x axis
         // -90 = on the positive y axis.
-        // 90 = on the negaive y axis.
+        // 90 = on the negative y axis.
         // 180 or - 180 = on the negative x axis.
         this.startAngle = 0;
         this.tickRenderer = $.jqplot.PieTickRenderer;
@@ -165,7 +165,7 @@
         this._radius = null;
         // array of [start,end] angles arrays, one for each slice.  In radians.
         this._sliceAngles = [];
-        // index of the currenty highlighted point, if any
+        // index of the currently highlighted point, if any
         this._highlightedPoint = null;
         
         // set highlight colors if none provided
@@ -417,7 +417,7 @@
         var ang, ang1, ang2, shadowColor;
         var sa = this.startAngle / 180 * Math.PI;
 
-        // have to pre-draw shadows, so loop throgh here and calculate some values also.
+        // have to pre-draw shadows, so loop through here and calculate some values also.
         for (var i=0, l=gd.length; i<l; i++) {
             ang1 = (i == 0) ? sa : gd[i-1][1] + sa;
             ang2 = gd[i][1] + sa;
@@ -519,7 +519,7 @@
         // I don't think I'm going to need _dataBounds here.
         // have to go Axis scaling in a way to fit chart onto plot area
         // and provide u2p and p2u functionality for mouse cursor, etc.
-        // for convienence set _dataBounds to 0 and 100 and
+        // for convenience set _dataBounds to 0 and 100 and
         // set min/max to 0 and 100.
         this._dataBounds = {min:0, max:100};
         this.min = 0;

--- a/gnucash/report/jqplot/plugins/jqplot.pointLabels.js
+++ b/gnucash/report/jqplot/plugins/jqplot.pointLabels.js
@@ -65,7 +65,7 @@
      * >    }
      * > }]
      * 
-     * A custom labels array in the options takes precendence over any labels
+     * A custom labels array in the options takes precedence over any labels
      * in the series data.  If you have a custom labels array in the options,
      * but still want to use values from the series array as labels, set the
      * "labelsFromSeries" option to true.

--- a/gnucash/report/jqplot/plugins/jqplot.pyramidAxisRenderer.js
+++ b/gnucash/report/jqplot/plugins/jqplot.pyramidAxisRenderer.js
@@ -332,7 +332,7 @@
         else {
             if (this.name.charAt(0) === 'x') {
                 dim = this._plotDimensions.width;
-                // make sure x axis is symetric about 0.
+                // make sure x axis is symmetric about 0.
                 var tempmax = Math.max(db.max, Math.abs(db.min));
                 var tempmin = Math.min(db.min, -tempmax);
                 // min = ((this.min != null) ? this.min : tempmin);
@@ -428,7 +428,7 @@
                 t.label = t.prefix + t.formatter(t.formatString, labelval);
 
                 this._ticks.push(t);
-                // for x axis, if y axis is in middle, add a symetrical 0 tick
+                // for x axis, if y axis is in middle, add a symmetrical 0 tick
                 if (this.name.charAt(0) === 'x' && plot.axes.yMidAxis.show && this.tickOptions.value === 0) {
                     this._splitAxis = true;
                     this._splitLength = plot.axes.yMidAxis.getWidth();
@@ -537,7 +537,7 @@
         }
         
         this._offsets = offsets;
-        // pixellength will be + for x axes and - for y axes becasue pixels always measured from top left.
+        // pixellength will be + for x axes and - for y axes because pixels always measured from top left.
         var pixellength = offmax - offmin;
         var unitlength = max - min;
         var sl = this._splitLength;

--- a/gnucash/report/jqplot/plugins/jqplot.pyramidRenderer.js
+++ b/gnucash/report/jqplot/plugins/jqplot.pyramidRenderer.js
@@ -117,7 +117,7 @@
         }
         
         this.renderer.options = options;
-        // index of the currenty highlighted point, if any
+        // index of the currently highlighted point, if any
         this._highlightedPoint = null;
         // Array of actual data colors used for each data point.
         this._dataColors = [];
@@ -507,7 +507,7 @@
         }
     }
 
-    // Have to add hook here, becuase it needs called before series is inited.
+    // Have to add hook here, because it needs to be called before series is init'ed.
     $.jqplot.preInitHooks.push(preInit);
     
 

--- a/gnucash/report/jqplot/plugins/jqplot.trendline.js
+++ b/gnucash/report/jqplot/plugins/jqplot.trendline.js
@@ -38,11 +38,11 @@
         // Group: Properties
         
         // prop: show
-        // Wether or not to show the trend line.
+        // Whether or not to show the trend line.
         this.show = $.jqplot.config.enablePlugins;
         // prop: color
         // CSS color spec for the trend line.
-        // By default this wil be the same color as the primary line.
+        // By default this will be the same color as the primary line.
         this.color = '#666666';
         // prop: renderer
         // Renderer to use to draw the trend line.
@@ -60,7 +60,7 @@
         // Either 'exponential', 'exp', or 'linear'.
         this.type = 'linear';
         // prop: shadow
-        // true or false, wether or not to show the shadow.
+        // true or false, whether or not to show the shadow.
         this.shadow = true;
         // prop: markerRenderer
         // Renderer to use to draw markers on the line.
@@ -89,7 +89,7 @@
     $.jqplot.postDrawSeriesHooks.push(drawTrendline);
     $.jqplot.addLegendRowHooks.push(addTrendlineLegend);
     
-    // called witin scope of the legend object
+    // called within scope of the legend object
     // current series passed in
     // must return null or an object {label:label, color:color}
     function addTrendlineLegend(series) {

--- a/gnucash/report/locale-specific/us/taxtxf-de_DE.scm
+++ b/gnucash/report/locale-specific/us/taxtxf-de_DE.scm
@@ -450,7 +450,7 @@
             end-cells))
           (if (= level 1) (make-header-row table max-level))))))
 
-;; Recursivly validate children if parent is not a tax account.
+;; Recursively validate children if parent is not a tax account.
 ;; Don't check children if parent is valid.
 ;; Returns the Parent if a child or grandchild is valid.
 (define (validate accounts)

--- a/gnucash/report/locale-specific/us/taxtxf.scm
+++ b/gnucash/report/locale-specific/us/taxtxf.scm
@@ -1657,7 +1657,7 @@
   ) ;;end of let*
 )
 
-;; Recursivly validate children if parent is not a tax account.
+;; Recursively validate children if parent is not a tax account.
 ;; Don't check children if parent is valid.
 ;; Returns the Parent if a child or grandchild is valid.
 (define (validate accounts)

--- a/gnucash/report/report-system/commodity-utilities.scm
+++ b/gnucash/report/report-system/commodity-utilities.scm
@@ -919,7 +919,7 @@ construct with gnc:make-gnc-monetary and gnc:monetary->string instead.")
 ;; CAS: Previously, the exchange-fn was not optional -- we would crash
 ;; if it was invalid.  I've changed this so that when exchange-fn is
 ;; #f, #f is returned.  Since #f is already returned when foreign is
-;; #f, and since any previous dependance on some behavior for the case
+;; #f, and since any previous dependence on some behavior for the case
 ;; where exchange-fn was #f would've crashed, I think this change is
 ;; safe.
 ;;

--- a/gnucash/report/report-system/doc/report-html.txt
+++ b/gnucash/report/report-system/doc/report-html.txt
@@ -387,7 +387,7 @@ We have three different kinds of style control information available:
    
            ;; if you want to set default markup and data styles for
            ;; documents using this stylesheet, do it here.  This 
-           ;; style element dosn't do anything, it's just there 
+           ;; style element doesn't do anything, it's just there 
            ;; as an example:
            (gnc:html-document-set-style! ssdoc "p" 'tag "p")
 

--- a/gnucash/report/report-system/html-acct-table.scm
+++ b/gnucash/report/report-system/html-acct-table.scm
@@ -126,7 +126,7 @@
 ;;         the order in which they will be displayed.  the function
 ;;         must take two Account arguments and represent a total
 ;;         ordering on Account-space.  #t means to use the default
-;;         sorting function.  #f means to preform no sorting.  the
+;;         sorting function.  #f means to perform no sorting.  the
 ;;         default sorting function is gnc:account-code-less-p.
 ;; 
 ;;     start-date: time64
@@ -134,17 +134,17 @@
 ;;         the starting date of the reporting period over which to
 ;;         report balances for this account.  if start-date is #f,
 ;;         will be no limit on how early a counted transaction may
-;;         ocurr.
+;;         occur.
 ;; 
 ;;     end-date: time64
 ;; 
 ;;         the ending date of the reporting period over which to
 ;;         report balances for this account.  if end-date is #f, there
 ;;         will be no limit on how late a counted transaction may
-;;         ocurr. note: i do not know if GnuCash, right now, supports
+;;         occur. note: i do not know if GnuCash, right now, supports
 ;;         transactions in the future. so be prepared for the
 ;;         possibility that this may match transactions which haven't
-;;         ocurred, yet. [CAS: I don't think end-date of #f works.
+;;         occurred, yet. [CAS: I don't think end-date of #f works.
 ;;         It bombs.]
 ;; 
 ;;     report-commodity: commodity
@@ -338,7 +338,7 @@
 ;;         account-depth when depth-limit-behavior is 'flatten.
 ;;         unlike in gnc:html-build-acct-table, the first level of
 ;;         accounts is level 0. this means that display-depth is also
-;;         the number of empty cells which should preced the account
+;;         the number of empty cells which should precede the account
 ;;         name in the gnc:html-table being generated.
 ;; 
 ;;     indented-depth: integer
@@ -1062,7 +1062,7 @@
   ;; balance and its respective report balance.  note that this
   ;; shows report-commodity amounts twice: first as a commodity
   ;; and second in the report commodity.  though this may arguably
-  ;; be a bit redundant, i beleive that it makes the report more
+  ;; be a bit redundant, i believe that it makes the report more
   ;; readable.
   (let* ((table (gnc:make-html-table))
          (spacer (gnc:make-html-table-cell))

--- a/gnucash/report/report-system/report.scm
+++ b/gnucash/report/report-system/report.scm
@@ -176,7 +176,7 @@ not found.")))
           (hash-set! *gnc:_report-templates_* report-guid report-rec)))
 
        (else
-        ;;there is no parent found -> this is an inital faulty report definition
+        ;;there is no parent found -> this is an initial faulty report definition
         (gui-error (string-append rpterr-guid1 report-name rpterr-guid2))))))))
 
 (define gnc:report-template-version
@@ -668,7 +668,7 @@ not found.")))
 ;; These condititions are:
 ;; 1. the report is an instance of an existing custom report template
 ;;    (ie a template that is stored in the savefile already)
-;; 2. an overwrite is requestes by setting overwrite? to #t
+;; 2. an overwrite is requested by setting overwrite? to #t
 (define (gnc:report-to-template report overwrite?)
   ;; This implements the Save Report Configuration tasks
   (let* ((custom-template-id (gnc:report-custom-template report))

--- a/gnucash/report/report-system/test/test-commodity-utils.scm
+++ b/gnucash/report/report-system/test/test-commodity-utils.scm
@@ -564,7 +564,7 @@
                    (cadr (assoc (gnc-dmy2time64-neutral 15 01 2012)
                                 report-list)))
 ;; Astute observers will notice that the totals include the
-;; capital gain split but not the acutal sell split on the day because the
+;; capital gain split but not the actual sell split on the day because the
 ;; capital gain price is first in the list so that's the one (assoc) finds. See
 ;; the comment at the gnc:get-commodity-totalavg-prices definition for more
 ;; about the prices from this function.

--- a/gnucash/report/standard-reports/account-piecharts.scm
+++ b/gnucash/report/standard-reports/account-piecharts.scm
@@ -80,7 +80,7 @@ balance at a given time"))
 (define optname-averaging (N_ "Show Average"))
 (define opthelp-averaging (N_ "Select whether the amounts should be shown over the full time period or rather as the average e.g. per month."))
 
-;; The option-generator. The only dependance on the type of piechart
+;; The option-generator. The only dependence on the type of piechart
 ;; is the list of account types that the account selection option
 ;; accepts.
 (define (options-generator account-types reverse-balance? do-intervals? depth-based?)

--- a/gnucash/report/standard-reports/budget-barchart.scm
+++ b/gnucash/report/standard-reports/budget-barchart.scm
@@ -169,7 +169,7 @@
       )
     )
 
-    ;; Prepair vars for running sums, and to loop though periods
+    ;; Prepare vars for running sums, and to loop though periods
     (let* (
         (num-periods (gnc-budget-get-num-periods budget))
         (period 0)

--- a/gnucash/report/standard-reports/budget-flow.scm
+++ b/gnucash/report/standard-reports/budget-flow.scm
@@ -201,7 +201,7 @@
             (gnc:html-table-add-budget-accounts!
              html-table value budget period exchange-fn report-currency)))))
      acct-table)
-    ;; Reutrn assoc list
+    ;; Return assoc list
     accounts-totals))
 
 ;; Displays type-totals

--- a/gnucash/report/standard-reports/budget.scm
+++ b/gnucash/report/standard-reports/budget.scm
@@ -328,7 +328,7 @@
                    (loop rest (append (loop elt '()) result))
                    (loop rest (cons elt result))))))))
 
-    ;; Adds a line to tbe budget report.
+    ;; Adds a line to the budget report.
     ;;
     ;; Parameters:
     ;;   html-table - html table being created

--- a/gnucash/report/standard-reports/daily-reports.scm
+++ b/gnucash/report/standard-reports/daily-reports.scm
@@ -65,7 +65,7 @@
 (define optname-plot-height (N_ "Plot Height"))
 (define optname-sort-method (N_ "Sort Method"))
 
-;; The option-generator. The only dependance on the type of piechart
+;; The option-generator. The only dependence on the type of piechart
 ;; is the list of account types that the account selection option
 ;; accepts.
 (define (options-generator account-types)

--- a/gnucash/report/standard-reports/equity-statement.scm
+++ b/gnucash/report/standard-reports/equity-statement.scm
@@ -491,7 +491,7 @@
 	  
 	  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 	  ;; 
-	  ;; beleive it or not, i think this part is right...
+	  ;; believe it or not, i think this part is right...
 	  ;; 
 	  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 	  

--- a/gnucash/report/standard-reports/test/test-transaction.scm
+++ b/gnucash/report/standard-reports/test/test-transaction.scm
@@ -15,8 +15,8 @@
 
 ;; Guide to the test-transaction.scm
 
-;; This test-transation will implement regression testing for most
-;; features from transction.scm as of March 2018. It requires SRFI-64
+;; This test-transaction will implement regression testing for most
+;; features from transaction.scm as of March 2018. It requires SRFI-64
 ;; (present in guile-2.0.10 or later), SXML, and VM.  SRFI-64 and SXML
 ;; are mandatory and has tremendously eased creation of tests. The VM
 ;; modules are only required to perform coverage analysis of this test

--- a/test-templates/test-suite.c
+++ b/test-templates/test-suite.c
@@ -80,7 +80,7 @@ static void
 test_performance_function( void )
 {
     /* A slow function that measures performance of some critical
-     * routine. Note g_test_timer functions for simple perfomance
+     * routine. Note g_test_timer functions for simple performance
      * measurements. */
 }
 

--- a/util/elegant-sort.pl
+++ b/util/elegant-sort.pl
@@ -2,7 +2,7 @@
 # -*- perl -*-
 #
 # Sort filenames in POTFILES.in in a consistent way
-# This reduces the amount of clutter in our version manangement system
+# This reduces the amount of clutter in our version management system
 # The files will be sorted
 # * per directory
 # * case-insensitive


### PR DESCRIPTION
Typos found via `codespell -q 3 -D ~/Projects/codespell/codespell_lib/data/dictionary.txt -S *.po,./po,*.min.js,./ChangeLog*,./NEWS,./doc/README*,./AUTHORS,./libgnucash/tax/us/txf-de*,./data/accounts -L ans,cas,dragable,gae,iff,iif,mut,nd,numer,startd,stoll`