### PR TITLE
scheme progress

### DIFF
--- a/gnucash/report/business-reports/invoice.scm
+++ b/gnucash/report/business-reports/invoice.scm
@@ -729,6 +729,7 @@ for styling the invoice. Please see the exported report for the CSS class names.
          (fax (gnc:company-info book gnc:*company-fax*))
          (email (gnc:company-info book gnc:*company-email*))
          (url (gnc:company-info book gnc:*company-url*))
+         (taxnr (gnc:option-get-value book gnc:*tax-label* gnc:*tax-nr-label*))
          (taxid (gnc:company-info book gnc:*company-id*)))
 
     (if (and name (not (string-null? name)))
@@ -765,6 +766,11 @@ for styling the invoice. Please see the exported report for the CSS class names.
         (gnc:html-table-append-row! table (list
                                            (gnc:make-html-div/markup
                                             "maybe-align-right company-tax-id" taxid))))
+
+    (if (and taxnr (not (string-null? taxnr)))
+        (gnc:html-table-append-row!
+         table (list (gnc:make-html-div/markup
+                      "maybe-align-right company-tax-nr" taxnr))))
 
     table))
 

--- a/gnucash/report/business-reports/owner-report.scm
+++ b/gnucash/report/business-reports/owner-report.scm
@@ -748,8 +748,8 @@
      (end-date (gnc:time64-end-day-time 
                (gnc:date-option-absolute-time
                (opt-val gnc:pagename-general optname-to-date))))
-     (book (gnc-account-get-book account))
-     (date-format (if (not (null? book)) (gnc:options-fancy-date book)))
+     (book (gnc-get-current-book))
+     (date-format (gnc:options-fancy-date book))
      (type (opt-val "__reg" "owner-type"))
      (owner-descr (owner-string type))
      (date-type (opt-val gnc:pagename-general optname-date-driver))

--- a/gnucash/report/locale-specific/us/taxtxf-de_DE.scm
+++ b/gnucash/report/locale-specific/us/taxtxf-de_DE.scm
@@ -505,11 +505,7 @@
                                 (validate (reverse 
                                            (gnc-account-get-children-sorted
                                             (gnc-get-current-root-account))))))
-         (book (if selected-accounts
-                   (gnc-account-get-book (if (pair? selected-accounts)
-                                             (car selected-accounts)
-                                             selected-accounts))
-                   #f))
+         (book (gnc-get-current-book))
          (generations (if (pair? selected-accounts)
                           (apply max (map (lambda (x) (num-generations x 1))
                                           selected-accounts))

--- a/gnucash/report/locale-specific/us/taxtxf-de_DE.scm
+++ b/gnucash/report/locale-specific/us/taxtxf-de_DE.scm
@@ -768,12 +768,7 @@
 	  (to-year    (gnc-print-time64 to-value "%Y"))
           (today-date (gnc-print-time64 (time64CanonicalDayTime (current-time))
                                         "%d.%m.%Y"))
-	  (tax-nr (unless book
-                      (or
-                       (gnc:option-get-value book gnc:*tax-label* gnc:*tax-nr-label*)
-                       "")
-                      ""))
-	  )
+	  (tax-nr (gnc:option-get-value book gnc:*tax-label* gnc:*tax-nr-label*)))
 
       ;; Now, the main body
       ;; Reset all the balance collectors

--- a/libgnucash/app-utils/app-utils.scm
+++ b/libgnucash/app-utils/app-utils.scm
@@ -300,6 +300,8 @@
 (define gnc:*company-contact* (N_ "Company Contact Person"))
 (define gnc:*fancy-date-label* (N_ "Fancy Date Format"))
 (define gnc:*fancy-date-format* (N_ "custom"))
+(define gnc:*tax-label* (N_ "Tax"))
+(define gnc:*tax-nr-label* (N_ "Tax Number"))
 
 (define (gnc:company-info book key)
   ;; Access company info from key-value pairs for current book
@@ -328,6 +330,7 @@
         gnc:*option-name-currency-accounting* gnc:*option-name-book-currency*
         gnc:*option-name-default-gains-policy*
         gnc:*option-name-default-gain-loss-account*
+        gnc:*tax-label* gnc:*tax-nr-label*
         gnc:*option-name-auto-readonly-days* gnc:*option-name-num-field-source*)
 
 (define gnc:*option-section-budgeting* OPTION-SECTION-BUDGETING)

--- a/libgnucash/app-utils/business-prefs.scm
+++ b/libgnucash/app-utils/business-prefs.scm
@@ -157,6 +157,12 @@
     gnc:*option-section-budgeting* gnc:*option-name-default-budget*
     "a" (N_ "Budget to be used when none has been otherwise specified.")))
 
+  ;; Tax Tab
+  (reg-option
+   (gnc:make-string-option
+    gnc:*tax-label* gnc:*tax-nr-label*
+    "a" (N_ "The electronic tax number of your business") ""))
+
   ;; Counters Tab
   (for-each
    (lambda (vals)

--- a/libgnucash/tax/us/de_DE.scm
+++ b/libgnucash/tax/us/de_DE.scm
@@ -49,10 +49,5 @@
 (export txf-asset-categories)
 (export txf-liab-eq-categories)
 
-(define gnc:*tax-label* (N_ "Tax"))
-(define gnc:*tax-nr-label* (N_ "Tax Number"))
-
-(export gnc:*tax-label* gnc:*tax-nr-label*)
-
 (load-from-path "txf-de_DE")
 (load-from-path "txf-help-de_DE")

--- a/libgnucash/tax/us/txf-de_DE.scm
+++ b/libgnucash/tax/us/txf-de_DE.scm
@@ -312,16 +312,3 @@ Fehlermeldungen + Dankschreiben an: stoll@bomhardt.de"))
    )
   )
 ))
-
-;;; Register global options in this book
-(define (book-options-generator options)
-  (define (reg-option new-option)
-    (gnc:register-option options new-option))
-
-  (reg-option
-   (gnc:make-string-option
-    gnc:*tax-label* gnc:*tax-nr-label*
-    "a" (N_ "The electronic tax number of your business") ""))
-  )
-
-(gnc-register-kvp-option-generator QOF-ID-BOOK-SCM book-options-generator)


### PR DESCRIPTION
A few cleanup possibilities.

1. bugfix when account can return #f
2. move de_DE-specific global option "Tax"/"Tax Number" option to be included in *all* locales.
3. use it in invoice.scm.

Mainly wish to confirm the option upgrade is acceptable.
I'm not sure why taxtxf-de_DE did not reuse company-id for its use, so, there are now two tax-number type fields. The other option is to remove Tax/Tax Number and redirect to company-id.