### PR TITLE
show backtrace in report error

### DIFF
--- a/gnucash/report/report-gnome/window-report.c
+++ b/gnucash/report/report-gnome/window-report.c
@@ -274,10 +274,16 @@ gnc_html_report_stream_cb (const char *location, char ** data, int *len)
 
     if (!ok)
     {
+        SCM captured = scm_c_eval_string ("gnc:last-captured-error");
+        gchar *captured_str = gnc_scm_to_utf8_string(captured);
+
         *data = g_strdup_printf ("<html><body><h3>%s</h3>"
-                                 "<p>%s</p></body></html>",
+                                 "<p>%s</p><pre>%s</pre></body></html>",
                                  _("Report error"),
-                                 _("An error occurred while running the report."));
+                                 _("An error occurred while running the report."),
+                                 captured_str);
+
+        g_free (captured_str);
 
         /* Make sure the progress bar is finished, which will also
            make the GUI sensitive again. Easier to do this via guile

--- a/gnucash/report/report-system/html-utilities.scm
+++ b/gnucash/report/report-system/html-utilities.scm
@@ -870,18 +870,5 @@
           "<link rel=\"stylesheet\" type=\"text/css\" href=\"file:///~a\" />\n"
           (gnc-path-find-localized-html-file file)))
 
-;; function to sanitize strings prior to sending to html
-(define (gnc:html-string-sanitize str)
-  (with-output-to-string
-    (lambda ()
-      (string-for-each
-       (lambda (c)
-         (display
-          (case c
-            ((#\&) "&amp;")
-            ((#\<) "&lt;")
-            ((#\>) "&gt;")
-            (else c))))
-       str))))
 
 

--- a/gnucash/report/report-system/report-system.scm
+++ b/gnucash/report/report-system/report-system.scm
@@ -122,7 +122,6 @@
 (export gnc:html-make-options-link)
 (export gnc:html-js-include)
 (export gnc:html-css-include)
-(export gnc:html-string-sanitize)
 
 ;; report.scm
 (export gnc:menuname-reports)

--- a/gnucash/report/report-system/test/test-html-utilities-srfi64.scm
+++ b/gnucash/report/report-system/test/test-html-utilities-srfi64.scm
@@ -12,43 +12,8 @@
 (define (run-test)
   (test-runner-factory gnc:test-runner)
   (test-begin "test-html-utilities-srfi64.scm")
-  (test-gnc:html-string-sanitize)
   (test-gnc:assign-colors)
   (test-end "test-html-utilities-srfi64.scm"))
-
-(define (test-gnc:html-string-sanitize)
-  (test-begin "gnc:html-string-sanitize")
-  (test-equal "null test"
-              "abc"
-              (gnc:html-string-sanitize "abc"))
-
-  (test-equal "sanitize &copy;"
-              "&amp;copy;"
-              (gnc:html-string-sanitize "&copy;"))
-
-  (if (not (string=? (with-output-to-string (lambda () (display "🎃"))) "🎃"))
-      (test-skip 2))
-  (test-equal "emoji unchanged"
-              "🎃"
-              (gnc:html-string-sanitize "🎃"))
-
-  (test-equal "complex string"
-              "Smiley:\"🙂\" something"
-              (gnc:html-string-sanitize "Smiley:\"🙂\" something"))
-
-  (test-equal "sanitize <b>bold tags</b>"
-              "&lt;b&gt;bold tags&lt;/b&gt;"
-              (gnc:html-string-sanitize "<b>bold tags</b>"))
-
-  (test-equal "quotes are unchanged for html"
-              "\""
-              (gnc:html-string-sanitize "\""))
-
-  (test-equal "backslash is unchanged for html"
-              "\\"
-              (gnc:html-string-sanitize "\\"))
-
-  (test-end "gnc:html-string-sanitize"))
 
 (define (test-gnc:assign-colors)
   (test-begin "test-gnc:assign-colors")

--- a/libgnucash/app-utils/c-interface.scm
+++ b/libgnucash/app-utils/c-interface.scm
@@ -63,13 +63,16 @@
 (define (gnc:backtrace-if-exception proc . args)
   (let* ((apply-result (gnc:apply-with-error-handling proc args))
          (result (car apply-result))
-         (error (cadr apply-result)))
+         (captured-error (cadr apply-result)))
     (cond
-     (error
-      (display error (current-error-port))
+     (captured-error
+      (display captured-error (current-error-port))
+      (set! gnc:last-captured-error (gnc:html-string-sanitize captured-error))
       (when (defined? 'gnc:warn)
-        (gnc:warn error)))
+        (gnc:warn captured-error)))
      (else result))))
+
+(define-public gnc:last-captured-error "")
 
 ;; This database can be used to store and retrieve translatable
 ;; strings. Strings that are returned by the lookup function are

--- a/libgnucash/scm/test/test-libgnucash-scm-utilities.scm
+++ b/libgnucash/scm/test/test-libgnucash-scm-utilities.scm
@@ -10,6 +10,7 @@
   (test-traverse-vec)
   (test-substring-replace)
   (test-sort-and-delete-duplicates)
+  (test-gnc:html-string-sanitize)
   (test-gnc:list-flatten)
   (test-begin "test-libgnucash-scm-utilities.scm"))
 
@@ -88,6 +89,40 @@
     '(1 2 3)
     (sort-and-delete-duplicates '(3 1 2) <))
   (test-end "sort-and-delete-duplicates"))
+
+(define (test-gnc:html-string-sanitize)
+  (test-begin "gnc:html-string-sanitize")
+  (test-equal "null test"
+              "abc"
+              (gnc:html-string-sanitize "abc"))
+
+  (test-equal "sanitize &copy;"
+              "&amp;copy;"
+              (gnc:html-string-sanitize "&copy;"))
+
+  (if (not (string=? (with-output-to-string (lambda () (display "🎃"))) "🎃"))
+      (test-skip 2))
+  (test-equal "emoji unchanged"
+              "🎃"
+              (gnc:html-string-sanitize "🎃"))
+
+  (test-equal "complex string"
+              "Smiley:\"🙂\" something"
+              (gnc:html-string-sanitize "Smiley:\"🙂\" something"))
+
+  (test-equal "sanitize <b>bold tags</b>"
+              "&lt;b&gt;bold tags&lt;/b&gt;"
+              (gnc:html-string-sanitize "<b>bold tags</b>"))
+
+  (test-equal "quotes are unchanged for html"
+              "\""
+              (gnc:html-string-sanitize "\""))
+
+  (test-equal "backslash is unchanged for html"
+              "\\"
+              (gnc:html-string-sanitize "\\"))
+
+  (test-end "gnc:html-string-sanitize"))
 
 (define (test-gnc:list-flatten)
   (test-equal "gnc:list-flatten null"

--- a/libgnucash/scm/utilities.scm
+++ b/libgnucash/scm/utilities.scm
@@ -173,6 +173,23 @@
    (and (positive? end-after) (+ (max 0 (1- start)) (1- end-after)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; function to sanitize strings. the resulting string can be safely
+;; added to html.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(define-public (gnc:html-string-sanitize str)
+  (with-output-to-string
+    (lambda ()
+      (string-for-each
+       (lambda (c)
+         (display
+          (case c
+            ((#\&) "&amp;")
+            ((#\<) "&lt;")
+            ((#\>) "&gt;")
+            (else c))))
+       str))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; avoid using strftime, still broken in guile-2.2. see explanation at
 ;; https://lists.gnu.org/archive/html/bug-guile/2019-05/msg00003.html
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Couple commits to show backtrace in report crash.

* exposes a SCM string `gnc:last-captured-error` containing last backtrace
* when rendering report-crash window, include it in `<pre>` block
* we *do* need to upgrade `gnc:html-string-sanitize` to `libgnucash` to neutralize the captured-error -- otherwise if backtrace contains `</pre>` it will prematurely end the block and mess up the error. Or even worse, backtrace could contain a `<script>` block :)
* note this snippet is not thread-safe -- `gnc:last-captured-error` could be modified in another thread and the errorpage gets the wrong string, but we'll leave it for another decade...

![image](https://user-images.githubusercontent.com/1975870/65388655-70fec880-dd3d-11e9-8366-a712b618c71a.png)
