### PR TITLE
Bug 797357 - Negative amounts are not displayed in red in some reports

### DIFF
--- a/gnucash/report/report-system/test/test-report-html.scm
+++ b/gnucash/report/report-system/test/test-report-html.scm
@@ -798,6 +798,31 @@ HTML Document Title</title></head><body></body>\n\
       )
     (test-end "HTML Table - Table Rendering")
 
+    (test-begin "html-table-cell renderers")
+    (let ((doc (gnc:make-html-document))
+          (cell (gnc:make-html-table-cell 4)))
+      (test-equal "html-table-cell renders correctly"
+        "<td rowspan=\"1\" colspan=\"1\"><number> 4</td>\n"
+        (string-concatenate
+         (gnc:html-document-tree-collapse
+          (gnc:html-table-cell-render cell doc)))))
+
+    ;; the following is tailor-made to test bug 797357. if the report
+    ;; system is refactored, this test will probably need fixing. it
+    ;; aims to ensure the table-cell class eg 'number-cell'
+    ;; 'total-number-cell' is augmented with a '-neg', and the
+    ;; resulting renderer renders as <td class='number-cell neg' ...>
+    (let* ((doc (gnc:make-html-document))
+           (comm-table (gnc-commodity-table-get-table (gnc-get-current-book)))
+           (USD (gnc-commodity-table-lookup comm-table "CURRENCY" "USD"))
+           (cell (gnc:make-html-table-cell (gnc:make-gnc-monetary USD -10))))
+      (test-equal "html-table-cell negative-monetary -> tag gets -neg appended"
+        "td-neg"
+        (cadr
+         (gnc:html-document-tree-collapse
+          (gnc:html-table-cell-render cell doc)))))
+    (test-end "html-table-cell renderers")
+
   (test-end "HTML Tables - without style sheets")
 )
 

--- a/gnucash/report/standard-reports/budget.scm
+++ b/gnucash/report/standard-reports/budget.scm
@@ -350,25 +350,24 @@
         ;;   col - next column
         (define (disp-cols style-tag col0
                            bgt-val act-val dif-val)
-          (let* ((style-tag-neg (string-append style-tag "-neg"))
-                 (col1 (+ col0 (if show-budget? 1 0)))
+          (let* ((col1 (+ col0 (if show-budget? 1 0)))
                  (col2 (+ col1 (if show-actual? 1 0)))
                  (col3 (+ col2 (if show-diff? 1 0))))
             (if show-budget?
                 (gnc:html-table-set-cell/tag!
                  html-table rownum col0
-                 (if (negative? bgt-val) style-tag-neg style-tag)
+                 style-tag
                  (if (zero? bgt-val) "."
                      (gnc:make-gnc-monetary comm bgt-val))))
             (if show-actual?
                 (gnc:html-table-set-cell/tag!
                  html-table rownum col1
-                 (if (negative? act-val) style-tag-neg style-tag)
+                 style-tag
                  (gnc:make-gnc-monetary comm act-val)))
             (if show-diff?
                 (gnc:html-table-set-cell/tag!
                  html-table rownum col2
-                 (if (negative? dif-val) style-tag-neg style-tag)
+                 style-tag
                  (if (and (zero? bgt-val) (zero? act-val)) "."
                      (gnc:make-gnc-monetary comm dif-val))))
             col3))


### PR DESCRIPTION
Fixes display of negative monetary-amounts so that they are rendered according to style-sheet option.

This commit fixes via the `<td>` renderer -- if it has a single datum, and has a negative monetary amount, then its tag (e.g. `number-cell`) gets `-neg` appended to become `number-cell-neg`. Some internal function ensures the resulting html becomes `<td class="number-cell neg" ...>`

![image](https://user-images.githubusercontent.com/1975870/66311086-2bc1c580-e8fd-11e9-8f33-61207c4928bc.png)
