### PR TITLE
[maint] budget code handles both natural and reversed amounts

### DIFF
--- a/gnucash/gnome/gnc-plugin-page-budget.c
+++ b/gnucash/gnome/gnc-plugin-page-budget.c
@@ -902,7 +902,7 @@ estimate_budget_helper(GtkTreeModel *model, GtkTreePath *path,
                               GNC_HOW_DENOM_SIGFIGS(priv->sigFigs) | 
                               GNC_HOW_RND_ROUND_HALF_UP);
 
-        if (gnc_reverse_balance(acct))
+        if (gnc_reverse_budget_balance(acct, FALSE))
             num = gnc_numeric_neg(num);
 
         for (i = 0; i < num_periods; i++)
@@ -920,7 +920,7 @@ estimate_budget_helper(GtkTreeModel *model, GtkTreePath *path,
 
             if (!gnc_numeric_check(num))
             {
-                if (gnc_reverse_balance(acct))
+                if (gnc_reverse_budget_balance(acct, FALSE))
                     num = gnc_numeric_neg(num);
 
                 num = gnc_numeric_convert(num, GNC_DENOM_AUTO,
@@ -1020,7 +1020,7 @@ allperiods_budget_helper(GtkTreeModel *model, GtkTreePath *path,
 {
     Account *acct;
     guint num_periods, i;
-    gnc_numeric num;
+    gnc_numeric num, allvalue;
     GncPluginPageBudgetPrivate *priv;
     GncPluginPageBudget *page = data;
 
@@ -1028,7 +1028,9 @@ allperiods_budget_helper(GtkTreeModel *model, GtkTreePath *path,
     priv = GNC_PLUGIN_PAGE_BUDGET_GET_PRIVATE(page);
     acct = gnc_budget_view_get_account_from_path(priv->budget_view, path);
     num_periods = gnc_budget_get_num_periods(priv->budget);
-    num = priv->allValue;
+    allvalue = priv->allValue;
+    if (gnc_reverse_budget_balance(acct, TRUE))
+        allvalue = gnc_numeric_neg(allvalue);
 
     for (i = 0; i < num_periods; i++)
     {
@@ -1036,7 +1038,7 @@ allperiods_budget_helper(GtkTreeModel *model, GtkTreePath *path,
         {
         case ADD:
             num = gnc_budget_get_account_period_value(priv->budget, acct, i);
-            num = gnc_numeric_add(num, priv->allValue, GNC_DENOM_AUTO,
+            num = gnc_numeric_add(num, allvalue, GNC_DENOM_AUTO,
                                   GNC_HOW_DENOM_SIGFIGS(priv->sigFigs) |
                                   GNC_HOW_RND_ROUND_HALF_UP);
             gnc_budget_set_account_period_value(priv->budget, acct, i, num);
@@ -1053,7 +1055,7 @@ allperiods_budget_helper(GtkTreeModel *model, GtkTreePath *path,
             break;
         default:
             gnc_budget_set_account_period_value(priv->budget, acct, i,
-                                                priv->allValue);
+                                                allvalue);
             break;
         }
     }

--- a/gnucash/report/standard-reports/budget-balance-sheet.scm
+++ b/gnucash/report/standard-reports/budget-balance-sheet.scm
@@ -256,7 +256,8 @@
       (gnc:report-options report-obj) pagename optname)))
 
   (define (get-budget-account-budget-balance budget account)
-    (gnc:budget-account-get-net budget account #f #f))
+    (let ((bal (gnc:budget-account-get-net budget account #f #f)))
+      (if (gnc-reverse-budget-balance account #t) (gnc:collector- bal) bal)))
 
   (define (get-budget-account-initial-balance budget account)
     (gnc:budget-account-get-initial-balance budget account))

--- a/gnucash/report/standard-reports/budget-income-statement.scm
+++ b/gnucash/report/standard-reports/budget-income-statement.scm
@@ -308,7 +308,8 @@
                    (get-balance-fn budget account period-start period-end))))
 
   (define (get-budget-account-budget-balance budget account period-start period-end)
-    (gnc:budget-account-get-net budget account period-start period-end))
+    (let ((bal (gnc:budget-account-get-net budget account period-start period-end)))
+      (if (gnc-reverse-budget-balance account #t) (gnc:collector- bal) bal)))
 
   (gnc:report-starting reportname)
   

--- a/libgnucash/app-utils/app-utils.i
+++ b/libgnucash/app-utils/app-utils.i
@@ -116,6 +116,8 @@ const char * xaccPrintAmount (gnc_numeric val, GNCPrintAmountInfo info);
 gchar *number_to_words(gdouble val, gint64 denom);
 const gchar *printable_value (gdouble val, gint denom);
 
+gboolean gnc_using_unreversed_budgets (QofBook* book);
+gboolean gnc_reverse_budget_balance (const Account *account, gboolean unreversed);
 gboolean gnc_reverse_balance (const Account *account);
 
 gboolean gnc_is_euro_currency(const gnc_commodity * currency);

--- a/libgnucash/app-utils/gnc-ui-util.c
+++ b/libgnucash/app-utils/gnc-ui-util.c
@@ -179,6 +179,23 @@ gnc_reverse_balance (const Account *account)
     return reverse_type[type];
 }
 
+gboolean gnc_using_unreversed_budgets (QofBook* book)
+{
+    return gnc_features_check_used (book, GNC_FEATURE_BUDGET_UNREVERSED);
+}
+
+/* similar to gnc_reverse_balance but also accepts a gboolean
+   unreversed which specifies the reversal strategy - FALSE = pre-4.x
+   always-assume-credit-accounts, TRUE = all amounts unreversed */
+gboolean
+gnc_reverse_budget_balance (const Account *account, gboolean unreversed)
+{
+    if (unreversed == gnc_using_unreversed_budgets(gnc_account_get_book(account)))
+        return gnc_reverse_balance (account);
+
+    return FALSE;
+}
+
 
 gchar *
 gnc_get_default_directory (const gchar *section)

--- a/libgnucash/app-utils/gnc-ui-util.h
+++ b/libgnucash/app-utils/gnc-ui-util.h
@@ -46,6 +46,16 @@ typedef QofSession * (*QofSessionCB) (void);
 gchar *gnc_normalize_account_separator (const gchar* separator);
 gboolean gnc_reverse_balance(const Account *account);
 
+/* Backward compatibility *******************************************
+ * Return book's UNREVERSED_BUDGET feature check. */
+gboolean gnc_using_unreversed_budgets (QofBook* book);
+
+/* Backward compatibility *******************************************
+ * Compare book's UNREVERSED_BUDGET with unreverse_check. If they
+ * match, return account reversal according to global pref. If they
+ * don't match, return FALSE. */
+gboolean gnc_reverse_budget_balance (const Account *account, gboolean unreversed);
+
 /* Default directory sections ***************************************/
 #define GNC_PREFS_GROUP_OPEN_SAVE    "dialogs.open-save"
 #define GNC_PREFS_GROUP_EXPORT       "dialogs.export-accounts"

--- a/libgnucash/engine/gnc-features.c
+++ b/libgnucash/engine/gnc-features.c
@@ -49,6 +49,7 @@ static gncFeature known_features[] =
     { GNC_FEATURE_GUID_FLAT_BAYESIAN, "Use account GUID as key for bayesian data and store KVP flat (requires at least Gnucash 2.6.19)" },
     { GNC_FEATURE_SQLITE3_ISO_DATES, "Use ISO formatted date-time strings in SQLite3 databases (requires at least GnuCash 2.6.20)"},
     { GNC_FEATURE_REG_SORT_FILTER, "Store the register sort and filter settings in .gcm metadata file (requires at least GnuCash 3.3)"},
+    { GNC_FEATURE_BUDGET_UNREVERSED, "Store budget amounts unreversed (i.e. natural) signs (requires at least Gnucash 3.8)"},
     { NULL },
 };
 

--- a/libgnucash/engine/gnc-features.h
+++ b/libgnucash/engine/gnc-features.h
@@ -53,6 +53,7 @@ extern "C" {
 #define GNC_FEATURE_GUID_FLAT_BAYESIAN "Account GUID based bayesian with flat KVP"
 #define GNC_FEATURE_SQLITE3_ISO_DATES "ISO-8601 formatted date strings in SQLite3 databases."
 #define GNC_FEATURE_REG_SORT_FILTER "Register sort and filter settings stored in .gcm file"
+#define GNC_FEATURE_BUDGET_UNREVERSED "Use natural signs in budget amounts"
 
 /** @} */
 


### PR DESCRIPTION
I guess this branch will be merged into maint, then merge maint to master, then merge #585 scrubbing function.

Modify maint branch to handle both reversed & unreversed budgets.

Scrubbing existing budget data is not done until master.

Draft. Not sure I've handled all possibilities. But I think this is safe.