### PR TITLE
Fix bug 743943

### DIFF
--- a/gnucash/gnome-utils/gnc-plugin.h
+++ b/gnucash/gnome-utils/gnc-plugin.h
@@ -277,7 +277,7 @@ void gnc_plugin_set_important_actions (GtkActionGroup *action_group,
  *  contained in this group.
  *
  *  @param action_names A NULL terminated list of actions names that
- *  should modified.
+ *  should be modified.
  *
  *  @param property_name The property name to be changed on the
  *  specified actions. The only two GtkAction properties that it makes

--- a/gnucash/gnome/dialog-invoice.c
+++ b/gnucash/gnome/dialog-invoice.c
@@ -162,7 +162,7 @@ struct _invoice_window
     GtkWidget  * posted_date;
     GtkWidget  * active_check;
     GtkWidget  * paid_label;
-    
+
     GtkWidget  * owner_box;
     GtkWidget  * owner_label;
     GtkWidget  * owner_choice;
@@ -1941,11 +1941,37 @@ gnc_invoice_update_window (InvoiceWindow *iw, GtkWidget *widget)
         gtk_label_set_text(GTK_LABEL(iw->paid_label),  _("PAID"));
     else
         gtk_label_set_text(GTK_LABEL(iw->paid_label),  _("UNPAID"));
-    
+
     if (widget)
         gtk_widget_show (widget);
     else
         gtk_widget_show (iw_get_window(iw));
+}
+
+GncInvoiceType
+gnc_invoice_get_type_from_window (InvoiceWindow *iw)
+{
+    /* uses the same approach as gnc_invoice_get_title
+       not called gnc_invoice_get_type because of name collisions
+    */
+    switch (gncOwnerGetType(&iw->owner))
+    {
+    case GNC_OWNER_CUSTOMER:
+        return iw->is_credit_note ? GNC_INVOICE_CUST_CREDIT_NOTE
+                                  : GNC_INVOICE_CUST_INVOICE;
+        break;
+    case GNC_OWNER_VENDOR:
+        return iw->is_credit_note ? GNC_INVOICE_VEND_CREDIT_NOTE
+                                  : GNC_INVOICE_VEND_INVOICE;
+        break;
+    case GNC_OWNER_EMPLOYEE:
+        return iw->is_credit_note ? GNC_INVOICE_EMPL_CREDIT_NOTE
+                                  : GNC_INVOICE_EMPL_INVOICE;
+        break;
+    default:
+        return GNC_INVOICE_UNDEFINED;
+        break;
+    }
 }
 
 gchar *

--- a/gnucash/gnome/dialog-invoice.h
+++ b/gnucash/gnome/dialog-invoice.h
@@ -77,6 +77,8 @@ gchar *gnc_invoice_get_help (InvoiceWindow *iw);
 
 gchar *gnc_invoice_get_title (InvoiceWindow *iw);
 
+GncInvoiceType gnc_invoice_get_type_from_window(InvoiceWindow *iw);
+
 #ifdef __GNC_PLUGIN_PAGE_H
 #include "gnc-main-window.h"
 GncPluginPage *gnc_invoice_recreate_page (GncMainWindow *window, GKeyFile *key_file, const gchar *group_name);

--- a/gnucash/gnome/gnc-plugin-page-invoice.c
+++ b/gnucash/gnome/gnc-plugin-page-invoice.c
@@ -139,12 +139,12 @@ static GtkActionEntry gnc_plugin_page_invoice_actions [] =
     },
     {
         "EditPostInvoiceAction", GNC_ICON_INVOICE_POST, N_("_Post Invoice"), NULL,
-        N_("Post this Invoice to your Chart of Accounts"),
+        N_("Post this invoice to your Chart of Accounts"),
         G_CALLBACK (gnc_plugin_page_invoice_cmd_post)
     },
     {
         "EditUnpostInvoiceAction", GNC_ICON_INVOICE_UNPOST, N_("_Unpost Invoice"), NULL,
-        N_("Unpost this Invoice and make it editable"),
+        N_("Unpost this invoice and make it editable"),
         G_CALLBACK (gnc_plugin_page_invoice_cmd_unpost)
     },
 
@@ -195,19 +195,19 @@ static GtkActionEntry gnc_plugin_page_invoice_actions [] =
     /* Business menu */
     {
         "BusinessNewInvoiceAction", GNC_ICON_INVOICE_NEW, N_("New _Invoice"), "",
-        N_("Create a new Invoice for the same owner as the current one"),
+        N_("Create a new invoice for the same owner as the current one"),
         G_CALLBACK (gnc_plugin_page_invoice_cmd_new_invoice)
     },
     {
         "ToolsProcessPaymentAction", GNC_ICON_INVOICE_PAY, N_("_Pay Invoice"), NULL,
-        N_("Enter a payment for the owner of this Invoice"),
+        N_("Enter a payment for the owner of this invoice"),
         G_CALLBACK (gnc_plugin_page_invoice_cmd_pay_invoice)
     },
 
     /* Reports menu */
     {
         "ReportsCompanyReportAction", NULL, N_("_Company Report"), NULL,
-        N_("Open a company report window for the owner of this Invoice"),
+        N_("Open a company report window for the owner of this invoice"),
         G_CALLBACK (gnc_plugin_page_invoice_cmd_company_report)
     },
 };
@@ -310,12 +310,12 @@ static action_toolbar_labels invoice_action_tooltips[] = {
     {"FilePrintAction", N_("Make a printable invoice")},
     {"EditEditInvoiceAction", N_("Edit this invoice")},
     {"EditDuplicateInvoiceAction", N_("Create a new invoice as a duplicate of the current one")},
-    {"EditPostInvoiceAction", N_("Post this Invoice to your Chart of Accounts")},
-    {"EditUnpostInvoiceAction", N_("Unpost this Invoice and make it editable")},
-    {"BusinessNewInvoiceAction", N_("Create a new Invoice for the same owner as the current one")},
-    {"BlankEntryAction", N_("Move to the blank entry at the bottom of the Invoice")},
-    {"ToolsProcessPaymentAction", N_("Enter a payment for the owner of this Invoice") },
-    {"ReportsCompanyReportAction", N_("Open a company report window for the owner of this Invoice") }
+    {"EditPostInvoiceAction", N_("Post this invoice to your Chart of Accounts")},
+    {"EditUnpostInvoiceAction", N_("Unpost this invoice and make it editable")},
+    {"BusinessNewInvoiceAction", N_("Create a new invoice for the same owner as the current one")},
+    {"BlankEntryAction", N_("Move to the blank entry at the bottom of the invoice")},
+    {"ToolsProcessPaymentAction", N_("Enter a payment for the owner of this invoice") },
+    {"ReportsCompanyReportAction", N_("Open a company report window for the owner of this invoice") }
 };
 
 static action_toolbar_labels bill_action_tooltips[] = {
@@ -331,15 +331,15 @@ static action_toolbar_labels bill_action_tooltips[] = {
 };
 
 static action_toolbar_labels voucher_action_tooltips[] = {
-    {"FilePrintAction", N_("Make a printable Voucher")},
-    {"EditEditInvoiceAction", N_("Edit this Voucher")},
-    {"EditDuplicateInvoiceAction", N_("Create a new Voucher as a duplicate of the current one")},
-    {"EditPostInvoiceAction", N_("Post this Voucher to your Chart of Accounts")},
-    {"EditUnpostInvoiceAction", N_("Unpost this Voucher and make it editable")},
-    {"BusinessNewInvoiceAction", N_("Create a new Voucher for the same owner as the current one")},
-    {"BlankEntryAction", N_("Move to the blank entry at the bottom of the Voucher")},
-    {"ToolsProcessPaymentAction", N_("Enter a payment for the owner of this Voucher") },
-    {"ReportsCompanyReportAction", N_("Open a company report window for the owner of this Voucher") }
+    {"FilePrintAction", N_("Make a printable voucher")},
+    {"EditEditInvoiceAction", N_("Edit this voucher")},
+    {"EditDuplicateInvoiceAction", N_("Create a new voucher as a duplicate of the current one")},
+    {"EditPostInvoiceAction", N_("Post this voucher to your Chart of Accounts")},
+    {"EditUnpostInvoiceAction", N_("Unpost this voucher and make it editable")},
+    {"BusinessNewInvoiceAction", N_("Create a new voucher for the same owner as the current one")},
+    {"BlankEntryAction", N_("Move to the blank entry at the bottom of the voucher")},
+    {"ToolsProcessPaymentAction", N_("Enter a payment for the owner of this voucher") },
+    {"ReportsCompanyReportAction", N_("Open a company report window for the owner of this voucher") }
 };
 
 static action_toolbar_labels creditnote_action_tooltips[] = {

--- a/gnucash/gnome/gnc-plugin-page-invoice.c
+++ b/gnucash/gnome/gnc-plugin-page-invoice.c
@@ -92,7 +92,6 @@ static void gnc_plugin_page_invoice_cmd_entryDown (GtkAction *action, GncPluginP
 /************************************************************
  *                          Actions                         *
  ************************************************************/
-// FIXME:  The texts are wrong if we have a Bill or Expence Voucher.
 static GtkActionEntry gnc_plugin_page_invoice_actions [] =
 {
     /* Toplevel */
@@ -106,7 +105,7 @@ static GtkActionEntry gnc_plugin_page_invoice_actions [] =
         G_CALLBACK (gnc_plugin_page_invoice_cmd_new_account)
     },
     {
-        "FilePrintAction", "document-print", N_("Print Invoice"), "<primary>p",
+        "FilePrintAction", "document-print", N_("_Print Invoice"), "<primary>p",
         N_("Make a printable invoice"),
         G_CALLBACK (gnc_plugin_page_invoice_cmd_print)
     },
@@ -195,7 +194,7 @@ static GtkActionEntry gnc_plugin_page_invoice_actions [] =
     /* Business menu */
     {
         "BusinessNewInvoiceAction", GNC_ICON_INVOICE_NEW, N_("New _Invoice"), "",
-        N_("Create a new invoice for the same owner as the current one"),
+        N_("Create a new Invoice for the same owner as the current one"),
         G_CALLBACK (gnc_plugin_page_invoice_cmd_new_invoice)
     },
     {
@@ -261,22 +260,113 @@ static const gchar *can_unpost_actions[] =
     NULL
 };
 
-/** Short labels for use on the toolbar buttons. */
-static action_toolbar_labels toolbar_labels[] =
+static action_toolbar_labels invoice_action_labels[] =
 {
-    { "RecordEntryAction",    N_("Enter") },
-    { "CancelEntryAction",    N_("Cancel") },
-    { "DeleteEntryAction",    N_("Delete") },
-    { "DuplicateEntryAction", N_("Duplicate") },
-    { "EntryUpAction",        N_("Up") },
-    { "EntryDownAction",      N_("Down") },
-    { "BlankEntryAction",           N_("Blank") },
-    { "EditPostInvoiceAction",      N_("Post") },
-    { "EditUnpostInvoiceAction",    N_("Unpost") },
-    { "ToolsProcessPaymentAction",    N_("Pay") },
-    { NULL, NULL },
+    {"FilePrintAction", N_("_Print Invoice")},
+    {"EditEditInvoiceAction", N_("_Edit Invoice")},
+    {"EditDuplicateInvoiceAction", N_("_Duplicate Invoice")},
+    {"EditPostInvoiceAction", N_("_Post Invoice")},
+    {"EditUnpostInvoiceAction", N_("_Unpost Invoice")},
+    {"BusinessNewInvoiceAction", N_("New _Invoice")},
+    {"ToolsProcessPaymentAction", N_("_Pay Invoice")}
 };
 
+static action_toolbar_labels bill_action_labels[] =
+{
+    {"FilePrintAction", N_("_Print Bill")},
+    {"EditEditInvoiceAction", N_("_Edit Bill")},
+    {"EditDuplicateInvoiceAction", N_("_Duplicate Bill")},
+    {"EditPostInvoiceAction", N_("_Post Bill")},
+    {"EditUnpostInvoiceAction", N_("_Unpost Bill")},
+    {"BusinessNewInvoiceAction", N_("New _Bill")},
+    {"ToolsProcessPaymentAction", N_("_Pay Bill")}
+};
+
+static action_toolbar_labels voucher_action_labels[] =
+{
+    {"FilePrintAction", N_("_Print Voucher")},
+    {"EditEditInvoiceAction", N_("_Edit Voucher")},
+    {"EditDuplicateInvoiceAction", N_("_Duplicate Voucher")},
+    {"EditPostInvoiceAction", N_("_Post Voucher")},
+    {"EditUnpostInvoiceAction", N_("_Unpost Voucher")},
+    {"BusinessNewInvoiceAction", N_("New _Voucher")},
+    {"ToolsProcessPaymentAction", N_("_Pay Voucher")}
+};
+
+static action_toolbar_labels creditnote_action_labels[] =
+{
+    {"FilePrintAction", N_("_Print Credit Note")},
+    {"EditEditInvoiceAction", N_("_Edit Credit Note")},
+    {"EditDuplicateInvoiceAction", N_("_Duplicate Credit Note")},
+    {"EditPostInvoiceAction", N_("_Post Credit Note")},
+    {"EditUnpostInvoiceAction", N_("_Unpost Credit Note")},
+    {"BusinessNewInvoiceAction", N_("New _Credit Note")},
+    {"ToolsProcessPaymentAction", N_("_Pay Credit Note")}
+};
+
+
+static action_toolbar_labels invoice_action_tooltips[] = {
+    {"FilePrintAction", N_("Make a printable invoice")},
+    {"EditEditInvoiceAction", N_("Edit this invoice")},
+    {"EditDuplicateInvoiceAction", N_("Create a new invoice as a duplicate of the current one")},
+    {"EditPostInvoiceAction", N_("Post this Invoice to your Chart of Accounts")},
+    {"EditUnpostInvoiceAction", N_("Unpost this Invoice and make it editable")},
+    {"BusinessNewInvoiceAction", N_("Create a new Invoice for the same owner as the current one")},
+    {"BlankEntryAction", N_("Move to the blank entry at the bottom of the Invoice")},
+    {"ToolsProcessPaymentAction", N_("Enter a payment for the owner of this Invoice") },
+    {"ReportsCompanyReportAction", N_("Open a company report window for the owner of this Invoice") }
+};
+
+static action_toolbar_labels bill_action_tooltips[] = {
+    {"FilePrintAction", N_("Make a printable bill")},
+    {"EditEditInvoiceAction", N_("Edit this bill")},
+    {"EditDuplicateInvoiceAction", N_("Create a new bill as a duplicate of the current one")},
+    {"EditPostInvoiceAction", N_("Post this bill to your Chart of Accounts")},
+    {"EditUnpostInvoiceAction", N_("Unpost this bill and make it editable")},
+    {"BusinessNewInvoiceAction", N_("Create a new bill for the same owner as the current one")},
+    {"BlankEntryAction", N_("Move to the blank entry at the bottom of the bill")},
+    {"ToolsProcessPaymentAction", N_("Enter a payment for the owner of this bill") },
+    {"ReportsCompanyReportAction", N_("Open a company report window for the owner of this bill") }
+};
+
+static action_toolbar_labels voucher_action_tooltips[] = {
+    {"FilePrintAction", N_("Make a printable Voucher")},
+    {"EditEditInvoiceAction", N_("Edit this Voucher")},
+    {"EditDuplicateInvoiceAction", N_("Create a new Voucher as a duplicate of the current one")},
+    {"EditPostInvoiceAction", N_("Post this Voucher to your Chart of Accounts")},
+    {"EditUnpostInvoiceAction", N_("Unpost this Voucher and make it editable")},
+    {"BusinessNewInvoiceAction", N_("Create a new Voucher for the same owner as the current one")},
+    {"BlankEntryAction", N_("Move to the blank entry at the bottom of the Voucher")},
+    {"ToolsProcessPaymentAction", N_("Enter a payment for the owner of this Voucher") },
+    {"ReportsCompanyReportAction", N_("Open a company report window for the owner of this Voucher") }
+};
+
+static action_toolbar_labels creditnote_action_tooltips[] = {
+    {"FilePrintAction", N_("Make a printable credit note")},
+    {"EditEditInvoiceAction", N_("Edit this credit note")},
+    {"EditDuplicateInvoiceAction", N_("Create a new credit note as a duplicate of the current one")},
+    {"EditPostInvoiceAction", N_("Post this credit note to your Chart of Accounts")},
+    {"EditUnpostInvoiceAction", N_("Unpost this credit note and make it editable")},
+    {"BusinessNewInvoiceAction", N_("Create a new credit note for the same owner as the current one")},
+    {"BlankEntryAction", N_("Move to the blank entry at the bottom of the credit note")},
+    {"ToolsProcessPaymentAction", N_("Enter a payment for the owner of this credit note") },
+    {"ReportsCompanyReportAction", N_("Open a company report window for the owner of this credit note") }
+};
+
+/** Short labels for use on the toolbar buttons. */
+static action_toolbar_labels toolbar_labels[] = {
+    {"RecordEntryAction", N_("Enter")},
+    {"CancelEntryAction", N_("Cancel")},
+    {"DeleteEntryAction", N_("Delete")},
+    {"DuplicateEntryAction", N_("Duplicate")},
+    {"EntryUpAction", N_("Up")},
+    {"EntryDownAction", N_("Down")},
+    {"BlankEntryAction", N_("Blank")},
+    {"EditPostInvoiceAction", N_("Post")},
+    {"EditUnpostInvoiceAction", N_("Unpost")},
+    {"ToolsProcessPaymentAction", N_("Pay")},
+    {NULL, NULL},
+};
 
 /************************************************************/
 /*                      Data Structures                     */
@@ -401,7 +491,40 @@ void
 gnc_plugin_page_invoice_update_menus (GncPluginPage *page, gboolean is_posted, gboolean can_unpost)
 {
     GtkActionGroup *action_group;
+    GncPluginPageInvoicePrivate *priv;
+    GncInvoiceType invoice_type;
+    GtkAction *action;
+    gint i, j;
+    action_toolbar_labels *label_list;
+    action_toolbar_labels *tooltip_list;
+
     gboolean is_readonly = qof_book_is_readonly(gnc_get_current_book());
+    priv = GNC_PLUGIN_PAGE_INVOICE_GET_PRIVATE(page);
+    invoice_type = gnc_invoice_get_type_from_window(priv->iw);
+
+    switch (invoice_type) {
+        case GNC_INVOICE_CUST_INVOICE:
+            label_list = invoice_action_labels;
+            tooltip_list = invoice_action_tooltips;
+            break;
+        case GNC_INVOICE_VEND_INVOICE:
+            label_list = bill_action_labels;
+            tooltip_list = bill_action_tooltips;
+            break;
+        case GNC_INVOICE_EMPL_INVOICE:
+            label_list = voucher_action_labels;
+            tooltip_list = voucher_action_tooltips;
+            break;
+        case GNC_INVOICE_CUST_CREDIT_NOTE:  // fallthrough
+        case GNC_INVOICE_VEND_CREDIT_NOTE:  // fallthrough
+        case GNC_INVOICE_EMPL_CREDIT_NOTE:  // fallthrough
+            label_list = creditnote_action_labels;
+            tooltip_list = creditnote_action_tooltips;
+            break;
+        default: // catches GNC_INVOICE_UNDEFINED, use invoice by default
+            label_list = invoice_action_labels;
+            tooltip_list = invoice_action_tooltips;
+    }
 
     g_return_if_fail(GNC_IS_PLUGIN_PAGE_INVOICE(page));
 
@@ -421,6 +544,22 @@ gnc_plugin_page_invoice_update_menus (GncPluginPage *page, gboolean is_posted, g
                                "sensitive", can_unpost);
     gnc_plugin_update_actions (action_group, invoice_book_readwrite_actions,
                                "sensitive", !is_readonly);
+
+    for (i = 0; label_list[i].action_name; i++)
+    {
+        /* update the action labels */
+        action = gtk_action_group_get_action(action_group,
+                                             label_list[i].action_name);
+        gtk_action_set_label(action, _(label_list[i].label));
+    }
+
+    for (i = 0; tooltip_list[i].action_name; i++)
+    {
+        /* update the action tooltips */
+        action = gtk_action_group_get_action(action_group,
+                                             tooltip_list[i].action_name);
+        gtk_action_set_tooltip(action, _(tooltip_list[i].label));
+    }
 }
 
 

--- a/gnucash/gnome/gnc-plugin-page-invoice.c
+++ b/gnucash/gnome/gnc-plugin-page-invoice.c
@@ -42,6 +42,7 @@
 #include "gnc-ui-util.h"
 #include "gnc-window.h"
 #include "dialog-utils.h"
+#include "gncInvoice.h"
 
 /* This static indicates the debugging module that this .o belongs to.  */
 static QofLogModule log_module = GNC_MOD_GUI;

--- a/gnucash/gnome/gnc-plugin-page-invoice.c
+++ b/gnucash/gnome/gnc-plugin-page-invoice.c
@@ -106,8 +106,8 @@ static GtkActionEntry gnc_plugin_page_invoice_actions [] =
         G_CALLBACK (gnc_plugin_page_invoice_cmd_new_account)
     },
     {
-        "FilePrintAction", "document-print", N_("_Print Invoice"), "<primary>p",
-        N_("Make a printable invoice"),
+        "FilePrintAction", "document-print", "_Print Invoice", "<primary>p",
+        "Make a printable invoice",
         G_CALLBACK (gnc_plugin_page_invoice_cmd_print)
     },
 
@@ -128,23 +128,23 @@ static GtkActionEntry gnc_plugin_page_invoice_actions [] =
         G_CALLBACK (gnc_plugin_page_invoice_cmd_paste)
     },
     {
-        "EditEditInvoiceAction", GNC_ICON_INVOICE_EDIT, N_("_Edit Invoice"), NULL,
-        N_("Edit this invoice"),
+        "EditEditInvoiceAction", GNC_ICON_INVOICE_EDIT, "_Edit Invoice", NULL,
+        "Edit this invoice",
         G_CALLBACK (gnc_plugin_page_invoice_cmd_edit)
     },
     {
-        "EditDuplicateInvoiceAction", GNC_ICON_INVOICE_DUPLICATE, N_("_Duplicate Invoice"),
-        NULL, N_("Create a new invoice as a duplicate of the current one"),
+        "EditDuplicateInvoiceAction", GNC_ICON_INVOICE_DUPLICATE, "_Duplicate Invoice",
+        NULL, "Create a new invoice as a duplicate of the current one",
         G_CALLBACK (gnc_plugin_page_invoice_cmd_duplicateInvoice)
     },
     {
-        "EditPostInvoiceAction", GNC_ICON_INVOICE_POST, N_("_Post Invoice"), NULL,
-        N_("Post this invoice to your Chart of Accounts"),
+        "EditPostInvoiceAction", GNC_ICON_INVOICE_POST, "_Post Invoice", NULL,
+        "Post this invoice to your Chart of Accounts",
         G_CALLBACK (gnc_plugin_page_invoice_cmd_post)
     },
     {
-        "EditUnpostInvoiceAction", GNC_ICON_INVOICE_UNPOST, N_("_Unpost Invoice"), NULL,
-        N_("Unpost this invoice and make it editable"),
+        "EditUnpostInvoiceAction", GNC_ICON_INVOICE_UNPOST, "_Unpost Invoice", NULL,
+        "Unpost this invoice and make it editable",
         G_CALLBACK (gnc_plugin_page_invoice_cmd_unpost)
     },
 
@@ -173,7 +173,7 @@ static GtkActionEntry gnc_plugin_page_invoice_actions [] =
     },
     {
         "BlankEntryAction", "go-bottom", N_("_Blank"), NULL,
-        N_("Move to the blank entry at the bottom of the Invoice"),
+        "Move to the blank entry at the bottom of the Invoice",
         G_CALLBACK (gnc_plugin_page_invoice_cmd_blank)
     },
     {
@@ -194,20 +194,20 @@ static GtkActionEntry gnc_plugin_page_invoice_actions [] =
 
     /* Business menu */
     {
-        "BusinessNewInvoiceAction", GNC_ICON_INVOICE_NEW, N_("New _Invoice"), "",
-        N_("Create a new invoice for the same owner as the current one"),
+        "BusinessNewInvoiceAction", GNC_ICON_INVOICE_NEW, "New _Invoice", "",
+        "Create a new invoice for the same owner as the current one",
         G_CALLBACK (gnc_plugin_page_invoice_cmd_new_invoice)
     },
     {
-        "ToolsProcessPaymentAction", GNC_ICON_INVOICE_PAY, N_("_Pay Invoice"), NULL,
-        N_("Enter a payment for the owner of this invoice"),
+        "ToolsProcessPaymentAction", GNC_ICON_INVOICE_PAY, "_Pay Invoice", NULL,
+        "Enter a payment for the owner of this invoice",
         G_CALLBACK (gnc_plugin_page_invoice_cmd_pay_invoice)
     },
 
     /* Reports menu */
     {
         "ReportsCompanyReportAction", NULL, N_("_Company Report"), NULL,
-        N_("Open a company report window for the owner of this invoice"),
+        "Open a company report window for the owner of this invoice",
         G_CALLBACK (gnc_plugin_page_invoice_cmd_company_report)
     },
 };
@@ -269,7 +269,8 @@ static action_toolbar_labels invoice_action_labels[] =
     {"EditPostInvoiceAction", N_("_Post Invoice")},
     {"EditUnpostInvoiceAction", N_("_Unpost Invoice")},
     {"BusinessNewInvoiceAction", N_("New _Invoice")},
-    {"ToolsProcessPaymentAction", N_("_Pay Invoice")}
+    {"ToolsProcessPaymentAction", N_("_Pay Invoice")},
+    {NULL, NULL},
 };
 
 static action_toolbar_labels bill_action_labels[] =
@@ -280,7 +281,8 @@ static action_toolbar_labels bill_action_labels[] =
     {"EditPostInvoiceAction", N_("_Post Bill")},
     {"EditUnpostInvoiceAction", N_("_Unpost Bill")},
     {"BusinessNewInvoiceAction", N_("New _Bill")},
-    {"ToolsProcessPaymentAction", N_("_Pay Bill")}
+    {"ToolsProcessPaymentAction", N_("_Pay Bill")},
+    {NULL, NULL},
 };
 
 static action_toolbar_labels voucher_action_labels[] =
@@ -291,7 +293,8 @@ static action_toolbar_labels voucher_action_labels[] =
     {"EditPostInvoiceAction", N_("_Post Voucher")},
     {"EditUnpostInvoiceAction", N_("_Unpost Voucher")},
     {"BusinessNewInvoiceAction", N_("New _Voucher")},
-    {"ToolsProcessPaymentAction", N_("_Pay Voucher")}
+    {"ToolsProcessPaymentAction", N_("_Pay Voucher")},
+    {NULL, NULL},
 };
 
 static action_toolbar_labels creditnote_action_labels[] =
@@ -302,7 +305,8 @@ static action_toolbar_labels creditnote_action_labels[] =
     {"EditPostInvoiceAction", N_("_Post Credit Note")},
     {"EditUnpostInvoiceAction", N_("_Unpost Credit Note")},
     {"BusinessNewInvoiceAction", N_("New _Credit Note")},
-    {"ToolsProcessPaymentAction", N_("_Pay Credit Note")}
+    {"ToolsProcessPaymentAction", N_("_Pay Credit Note")},
+    {NULL, NULL},
 };
 
 
@@ -315,7 +319,8 @@ static action_toolbar_labels invoice_action_tooltips[] = {
     {"BusinessNewInvoiceAction", N_("Create a new invoice for the same owner as the current one")},
     {"BlankEntryAction", N_("Move to the blank entry at the bottom of the invoice")},
     {"ToolsProcessPaymentAction", N_("Enter a payment for the owner of this invoice") },
-    {"ReportsCompanyReportAction", N_("Open a company report window for the owner of this invoice") }
+    {"ReportsCompanyReportAction", N_("Open a company report window for the owner of this invoice") },
+    {NULL, NULL},
 };
 
 static action_toolbar_labels bill_action_tooltips[] = {
@@ -327,7 +332,8 @@ static action_toolbar_labels bill_action_tooltips[] = {
     {"BusinessNewInvoiceAction", N_("Create a new bill for the same owner as the current one")},
     {"BlankEntryAction", N_("Move to the blank entry at the bottom of the bill")},
     {"ToolsProcessPaymentAction", N_("Enter a payment for the owner of this bill") },
-    {"ReportsCompanyReportAction", N_("Open a company report window for the owner of this bill") }
+    {"ReportsCompanyReportAction", N_("Open a company report window for the owner of this bill") },
+    {NULL, NULL},
 };
 
 static action_toolbar_labels voucher_action_tooltips[] = {
@@ -339,7 +345,8 @@ static action_toolbar_labels voucher_action_tooltips[] = {
     {"BusinessNewInvoiceAction", N_("Create a new voucher for the same owner as the current one")},
     {"BlankEntryAction", N_("Move to the blank entry at the bottom of the voucher")},
     {"ToolsProcessPaymentAction", N_("Enter a payment for the owner of this voucher") },
-    {"ReportsCompanyReportAction", N_("Open a company report window for the owner of this voucher") }
+    {"ReportsCompanyReportAction", N_("Open a company report window for the owner of this voucher") },
+    {NULL, NULL},
 };
 
 static action_toolbar_labels creditnote_action_tooltips[] = {
@@ -351,7 +358,8 @@ static action_toolbar_labels creditnote_action_tooltips[] = {
     {"BusinessNewInvoiceAction", N_("Create a new credit note for the same owner as the current one")},
     {"BlankEntryAction", N_("Move to the blank entry at the bottom of the credit note")},
     {"ToolsProcessPaymentAction", N_("Enter a payment for the owner of this credit note") },
-    {"ReportsCompanyReportAction", N_("Open a company report window for the owner of this credit note") }
+    {"ReportsCompanyReportAction", N_("Open a company report window for the owner of this credit note") },
+    {NULL, NULL},
 };
 
 /** Short labels for use on the toolbar buttons. */


### PR DESCRIPTION
An attempt at fixing Gnucash#743943. The approach taken is to define parametrized strings and perform the actual translation depending on the invoice type and update of the actions on every call to `gnc_plugin_page_invoice_update_menus` accordingly.
The PR also include one tiny edit in the documentation to add a word I noticed was missing.