### PR TITLE
Use the proper UTF8 strip function.

### DIFF
--- a/gnucash/import-export/aqb/gnc-ab-utils.c
+++ b/gnucash/import-export/aqb/gnc-ab-utils.c
@@ -331,7 +331,7 @@ join_ab_strings_cb(const gchar *str, gpointer user_data)
  
     tmp = g_strdup(str);
     g_strstrip(tmp);
-    gnc_utf8_strip_invalid(tmp);
+    gnc_utf8_strip_invalid_and_controls(tmp);
 
     if (*acc)
     {


### PR DESCRIPTION
Fixes #797473