### PR TITLE
Better UI Refinements

### DIFF
--- a/gnucash/gnome/dialog-payment.c
+++ b/gnucash/gnome/dialog-payment.c
@@ -81,6 +81,7 @@ struct _payment_window
     GtkWidget   * dialog;
 
     GtkWidget   * payment_warning;
+    GtkWidget   * conflict_message;
     GtkWidget   * ok_button;
     GtkWidget   * num_entry;
     GtkWidget   * memo_entry;
@@ -288,7 +289,7 @@ update_cleanup:
         gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON(pw->print_check), pw->print_check_state);
 
     /* Check if there are issues preventing a successful payment */
-    gtk_widget_set_tooltip_text (pw->payment_warning, conflict_msg);
+    gtk_label_set_text (GTK_LABEL(pw->conflict_message), conflict_msg);
     gtk_widget_set_sensitive (pw->ok_button, allow_payment);
     if (conflict_msg)
     {
@@ -1192,6 +1193,7 @@ new_payment_window (GtkWindow *parent, QofBook *book, InitialPaymentInfo *tx_inf
 
     /* Grab the widgets and build the dialog */
     pw->payment_warning = GTK_WIDGET (gtk_builder_get_object (builder, "payment_warning"));
+    pw->conflict_message = GTK_WIDGET (gtk_builder_get_object (builder, "conflict_message"));
     pw->ok_button = GTK_WIDGET (gtk_builder_get_object (builder, "okbutton"));
     pw->num_entry = GTK_WIDGET (gtk_builder_get_object (builder, "num_entry"));
     pw->memo_entry = GTK_WIDGET (gtk_builder_get_object (builder, "memo_entry"));

--- a/gnucash/gnome/gnc-plugin-page-register.c
+++ b/gnucash/gnome/gnc-plugin-page-register.c
@@ -199,7 +199,7 @@ static void gnc_plugin_page_register_event_handler (QofInstance *entity,
         GncPluginPageRegister *page,
         GncEventData *ed);
 
-static GncInvoice * invoice_from_trans (Transaction *trans);
+static GncInvoice * invoice_from_split (Split *split);
 
 /************************************************************/
 /*                          Actions                         */
@@ -1025,7 +1025,7 @@ gnc_plugin_page_register_ui_update (gpointer various, GncPluginPageRegister *pag
     gtk_action_set_sensitive (GTK_ACTION(action), (uri && *uri));
 
     /* Set 'ExecAssociatedInvoice' */
-    inv = invoice_from_trans(trans);
+    inv = invoice_from_split (gnc_split_register_get_current_split (reg));
     action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE(page),
                                          "JumpAssociatedInvoiceAction");
     gtk_action_set_sensitive (GTK_ACTION(action), inv != NULL);
@@ -4328,37 +4328,23 @@ gnc_plugin_page_register_cmd_execassociated_transaction (GtkAction *action,
 
 }
 
-static GncInvoice * invoice_from_trans (Transaction *trans)
+static GncInvoice * invoice_from_split (Split *split)
 {
     GncInvoice *invoice;
-    SplitList *splits;
+    GNCLot *lot;
 
-    g_return_val_if_fail (GNC_IS_TRANSACTION(trans), NULL);
-    invoice = gncInvoiceGetInvoiceFromTxn(trans);
+    if (!split)
+        return NULL;
 
-    if (invoice)
-        return invoice;
+    lot = xaccSplitGetLot (split);
+    if (!lot)
+        return NULL;
 
-    for (splits = xaccTransGetSplitList (trans); splits; splits = splits->next)
-    {
-        Split *split = splits->data;
-        GNCLot *lot;
+    invoice = gncInvoiceGetInvoiceFromLot (lot);
+    if (!invoice)
+        return NULL;
 
-        if (!split)
-            continue;
-
-        lot = xaccSplitGetLot (split);
-        if (!lot)
-            continue;
-
-        invoice = gncInvoiceGetInvoiceFromLot (lot);
-        if (!invoice)
-            continue;
-
-        return invoice;
-    }
-
-    return NULL;
+    return invoice;
 }
 
 static void
@@ -4374,8 +4360,7 @@ gnc_plugin_page_register_cmd_jump_associated_invoice (GtkAction *action,
     g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(plugin_page));
     priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
     reg = gnc_ledger_display_get_split_register (priv->gsr->ledger);
-    invoice = invoice_from_trans (xaccSplitGetParent
-                                  (gnc_split_register_get_current_split (reg)));
+    invoice = invoice_from_split (gnc_split_register_get_current_split (reg));
     if (invoice)
         gnc_ui_invoice_edit (NULL, invoice);
 

--- a/gnucash/gtkbuilder/dialog-payment.glade
+++ b/gnucash/gtkbuilder/dialog-payment.glade
@@ -108,18 +108,6 @@
                 <property name="position">1</property>
               </packing>
             </child>
-            <child>
-              <object class="GtkImage" id="payment_warning">
-                <property name="can_focus">False</property>
-                <property name="icon_name">dialog-warning</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">2</property>
-                <property name="secondary">True</property>
-              </packing>
-            </child>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -754,6 +742,38 @@ In case of an over-payment or if no invoice was selected, GnuCash will automatic
                     </attributes>
                   </object>
                 </child>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkGrid" id="table4">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="column_spacing">5</property>
+            <child>
+              <object class="GtkImage" id="payment_warning">
+                <property name="can_focus">False</property>
+                <property name="icon_name">dialog-warning</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="conflict_message">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
               </object>
               <packing>
                 <property name="left_attach">1</property>


### PR DESCRIPTION
A better #599 - Show warning if no documents were assigned to payment, and show warnings in gtklabel instead of a tooltip. Warning icon is still shown/hidden appropriately.
![status-msg](https://user-images.githubusercontent.com/1975870/68093426-3b491580-fe8d-11e9-801e-86572e69e918.png)
