### PR TITLE
Maint

### DIFF
--- a/gnucash/report/business-reports/new-owner-report.scm
+++ b/gnucash/report/business-reports/new-owner-report.scm
@@ -395,10 +395,12 @@
           (gnc:invoice-anchor-text invoice)
           (gncInvoiceGetTypeString invoice))))
        ((txn-is-payment? txn)
-        (gnc:make-html-text
-         (gnc:html-markup-anchor
-          (gnc:split-anchor-text split)
-          (_ "Payment"))))
+        (apply gnc:make-html-text
+               (map (lambda (pmt-split)
+                      (gnc:html-markup-anchor
+                       (gnc:split-anchor-text pmt-split)
+                       (_ "Payment")))
+                    (xaccTransGetPaymentAcctSplitList txn))))
        (else (_ "Unknown")))))
 
   (define (invoice->sale invoice)

--- a/gnucash/report/report-system/report-utilities.scm
+++ b/gnucash/report/report-system/report-utilities.scm
@@ -1147,14 +1147,14 @@ flawed. see report-utilities.scm. please update reports.")
               TXN-TYPE-PAYMENT)
         (let* ((txn (xaccSplitGetParent (car splits)))
                (payment (apply + (map xaccSplitGetAmount
-                                      (xaccTransGetPaymentAcctSplitList txn))))
+                                      (xaccTransGetAPARAcctSplitList txn #f))))
                (overpayment
                 (fold
                  (lambda (inv-and-splits payment-left)
                    (if (member txn (map xaccSplitGetParent (cdr inv-and-splits)))
                        (- payment-left (gncInvoiceGetTotal (car inv-and-splits)))
                        payment-left))
-                 (if receivable? payment (- payment)) invoices-and-splits)))
+                 (if receivable? (- payment) payment) invoices-and-splits)))
           (gnc:pk 'payment (car splits) payment "->" overpayment)
           (when (positive? overpayment)
             (addbucket! (1- num-buckets) (- overpayment)))


### PR DESCRIPTION
Some subjectively better changes.

Consider main table = owner-report, and invoice->payments and payment->invoices table = link-table. Changes in this series are:

1. main table 'payment' links to transfer account split **instead** of APAR split.
2. link table invoice->payments show **full** payment amount for multi-invoice payments instead of *partial* payment.
3. link table invoice->payments show **transfer account currency** instead of APAR currency whereby payments were made in another currency.

![image](https://user-images.githubusercontent.com/1975870/68655689-60dabc80-0528-11ea-9eb9-e51602367f9c.png)
