### PR TITLE
Remove colon and trailing spaces

### DIFF
--- a/gnucash/gnome-utils/dialog-account.c
+++ b/gnucash/gnome-utils/dialog-account.c
@@ -2153,7 +2153,7 @@ gnc_account_cascade_color_dialog (GtkWidget *window, Account *account)
                       G_CALLBACK(default_color_button_cb), (gpointer)color_button);
 
     string = g_strdup_printf(_( "Set the account color for account '%s' "
-                                "including all sub-accounts to the selected color:"),
+                                "including all sub-accounts to the selected color"),
                              gnc_account_get_full_name(account));
     gtk_label_set_text (GTK_LABEL(color_label), string);
     g_free (string);

--- a/gnucash/gnome-utils/dialog-commodity.c
+++ b/gnucash/gnome-utils/dialog-commodity.c
@@ -171,7 +171,7 @@ gnc_ui_select_commodity_modal_full(gnc_commodity * orig_sel,
     if (user_message != NULL)
         initial = user_message;
     else if ((cusip != NULL) || (fullname != NULL) || (mnemonic != NULL))
-        initial = _("\nPlease select a commodity to match:");
+        initial = _("\nPlease select a commodity to match");
     else
         initial = "";
 
@@ -285,17 +285,17 @@ gnc_ui_select_commodity_create(const gnc_commodity * orig_sel,
     {
     case DIAG_COMM_ALL:
         title = _("Select security/currency");
-        text = _("_Security/currency:");
+        text = _("_Security/currency");
         break;
     case DIAG_COMM_NON_CURRENCY:
     case DIAG_COMM_NON_CURRENCY_SELECT:
         title = _("Select security");
-        text = _("_Security:");
+        text = _("_Security");
         break;
     case DIAG_COMM_CURRENCY:
     default:
         title = _("Select currency");
-        text = _("Cu_rrency:");
+        text = _("Cu_rrency");
         button = GTK_WIDGET(gtk_builder_get_object (builder, "ss_new_button"));
         gtk_widget_destroy(button);
         break;

--- a/gnucash/gnome-utils/dialog-dup-trans.c
+++ b/gnucash/gnome-utils/dialog-dup-trans.c
@@ -242,7 +242,7 @@ gnc_dup_trans_dialog_internal (GtkWidget * parent, const char* title,
     if (!show_date && !tnum)
     {
         // The "date" and the "tnum" fields aren't being asked for, this is a split copy
-        gtk_label_set_markup(GTK_LABEL (dt_dialog->num_label), _("Action/Number:"));
+        gtk_label_set_markup(GTK_LABEL (dt_dialog->num_label), _("Action/Number"));
     }
 
     if (tnum)

--- a/gnucash/gnome-utils/dialog-options.c
+++ b/gnucash/gnome-utils/dialog-options.c
@@ -1286,7 +1286,7 @@ gnc_option_create_currency_accounting_widget (char *name, GNCOption *option)
             gtk_grid_set_column_spacing (GTK_GRID (book_currency_data->book_currency_table), 6);
 
             tip = gnc_currency_accounting_option_currency_documentation(option);
-            widget_label = gtk_label_new( _("Book currency:") );
+            widget_label = gtk_label_new( _("Book currency") );
             gtk_widget_set_tooltip_text(book_currency_data->book_currency_table,
                         tip && *tip ? _(tip) : "");
 
@@ -1315,7 +1315,7 @@ gnc_option_create_currency_accounting_widget (char *name, GNCOption *option)
             gtk_grid_set_column_spacing (GTK_GRID (policy_table), 6);
 
             tip = gnc_currency_accounting_option_policy_documentation(option);
-            widget_label = gtk_label_new( _("Default lot tracking policy:") );
+            widget_label = gtk_label_new( _("Default lot tracking policy") );
             gtk_widget_set_tooltip_text(policy_table, tip && *tip ? _(tip) : "");
 
             gtk_widget_set_halign (GTK_WIDGET(widget_label), GTK_ALIGN_START);
@@ -1343,7 +1343,7 @@ gnc_option_create_currency_accounting_widget (char *name, GNCOption *option)
             gtk_grid_set_column_spacing (GTK_GRID (book_currency_data->gain_loss_account_table), 6);
 
             tip = gnc_currency_accounting_option_gain_loss_account_documentation(option);
-            widget_label = gtk_label_new( _("Default gain/loss account:") );
+            widget_label = gtk_label_new( _("Default gain/loss account") );
             gnc_label_set_alignment (GTK_WIDGET(widget_label), 0.0, 0.5);
 
             gtk_widget_set_tooltip_text(book_currency_data->gain_loss_account_table,
@@ -2451,12 +2451,9 @@ gnc_option_set_ui_widget_string (GNCOption *option, GtkBox *page_box,
 {
     GtkWidget *value;
     GtkWidget *label;
-    gchar *colon_name;
 
-    colon_name = g_strconcat(name, ":", NULL);
-    label = gtk_label_new(colon_name);
+    label = gtk_label_new(name);
     gnc_label_set_alignment(label, 1.0, 0.5);
-    g_free(colon_name);
 
     *enclosing = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
     gtk_box_set_homogeneous (GTK_BOX (*enclosing), FALSE);
@@ -2523,12 +2520,9 @@ gnc_option_set_ui_widget_currency (GNCOption *option, GtkBox *page_box,
 {
     GtkWidget *value;
     GtkWidget *label;
-    gchar *colon_name;
 
-    colon_name = g_strconcat(name, ":", NULL);
-    label = gtk_label_new(colon_name);
+    label = gtk_label_new(name);
     gnc_label_set_alignment(label, 1.0, 0.5);
-    g_free(colon_name);
 
     *enclosing = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
     gtk_box_set_homogeneous (GTK_BOX (*enclosing), FALSE);
@@ -2554,12 +2548,9 @@ gnc_option_set_ui_widget_commodity (GNCOption *option, GtkBox *page_box,
 {
     GtkWidget *value;
     GtkWidget *label;
-    gchar *colon_name;
 
-    colon_name = g_strconcat(name, ":", NULL);
-    label = gtk_label_new(colon_name);
+    label = gtk_label_new(name);
     gnc_label_set_alignment(label, 1.0, 0.5);
-    g_free(colon_name);
 
     *enclosing = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
     gtk_box_set_homogeneous (GTK_BOX (*enclosing), FALSE);
@@ -2592,12 +2583,9 @@ gnc_option_set_ui_widget_multichoice (GNCOption *option, GtkBox *page_box,
 {
     GtkWidget *value;
     GtkWidget *label;
-    gchar *colon_name;
 
-    colon_name = g_strconcat(name, ":", NULL);
-    label = gtk_label_new(colon_name);
+    label = gtk_label_new(name);
     gnc_label_set_alignment(label, 1.0, 0.5);
-    g_free(colon_name);
 
     *enclosing = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
     gtk_box_set_homogeneous (GTK_BOX (*enclosing), FALSE);
@@ -2623,10 +2611,8 @@ gnc_option_set_ui_widget_date (GNCOption *option, GtkBox *page_box,
     gchar *colon_name;
     GtkWidget *eventbox;
 
-    colon_name = g_strconcat(name, ":", NULL);
-    label = gtk_label_new(colon_name);
+    label = gtk_label_new(name);
     gnc_label_set_alignment(label, 1.0, 0.5);
-    g_free(colon_name);
 
     *enclosing = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
     gtk_box_set_homogeneous (GTK_BOX (*enclosing), FALSE);
@@ -2692,12 +2678,9 @@ gnc_option_set_ui_widget_account_sel (GNCOption *option, GtkBox *page_box,
     GtkWidget *value;
     GtkWidget *label;
     GList *acct_type_list;
-    gchar *colon_name;
 
-    colon_name = g_strconcat(name, ":", NULL);
-    label = gtk_label_new(colon_name);
+    label = gtk_label_new(name);
     gnc_label_set_alignment(label, 1.0, 0.5);
-    g_free(colon_name);
 
     acct_type_list = gnc_option_get_account_type_list(option);
     value = gnc_account_sel_new();
@@ -2752,17 +2735,14 @@ gnc_option_set_ui_widget_number_range (GNCOption *option, GtkBox *page_box,
 {
     GtkWidget *value;
     GtkWidget *label;
-    gchar *colon_name;
     GtkAdjustment *adj;
     gdouble lower_bound = G_MINDOUBLE;
     gdouble upper_bound = G_MAXDOUBLE;
     gdouble step_size = 1.0;
     int num_decimals = 0;
 
-    colon_name = g_strconcat(name, ":", NULL);
-    label = gtk_label_new(colon_name);
+    label = gtk_label_new(name);
     gnc_label_set_alignment(label, 1.0, 0.5);
-    g_free(colon_name);
 
     *enclosing = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
     gtk_box_set_homogeneous (GTK_BOX (*enclosing), FALSE);
@@ -2818,13 +2798,10 @@ gnc_option_set_ui_widget_color (GNCOption *option, GtkBox *page_box,
 {
     GtkWidget *value;
     GtkWidget *label;
-    gchar *colon_name;
     gboolean use_alpha;
 
-    colon_name = g_strconcat(name, ":", NULL);
-    label = gtk_label_new(colon_name);
+    label = gtk_label_new(name);
     gnc_label_set_alignment(label, 1.0, 0.5);
-    g_free(colon_name);
 
     *enclosing = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
     gtk_box_set_homogeneous (GTK_BOX (*enclosing), FALSE);
@@ -2855,12 +2832,9 @@ gnc_option_set_ui_widget_font (GNCOption *option, GtkBox *page_box,
 {
     GtkWidget *value;
     GtkWidget *label;
-    gchar *colon_name;
 
-    colon_name = g_strconcat(name, ":", NULL);
-    label = gtk_label_new(colon_name);
+    label = gtk_label_new(name);
     gnc_label_set_alignment(label, 1.0, 0.5);
-    g_free(colon_name);
 
     *enclosing = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
     gtk_box_set_homogeneous (GTK_BOX (*enclosing), FALSE);
@@ -2893,13 +2867,10 @@ gnc_option_set_ui_widget_pixmap (GNCOption *option, GtkBox *page_box,
     GtkWidget *value;
     GtkWidget *label;
     GtkWidget *button;
-    gchar *colon_name;
 
     ENTER("option %p(%s), name %s", option, gnc_option_name(option), name);
-    colon_name = g_strconcat(name, ":", NULL);
-    label = gtk_label_new(colon_name);
+    label = gtk_label_new(name);
     gnc_label_set_alignment(label, 1.0, 0.5);
-    g_free(colon_name);
 
     *enclosing = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
     gtk_box_set_homogeneous (GTK_BOX (*enclosing), FALSE);
@@ -3029,17 +3000,14 @@ gnc_option_set_ui_widget_plot_size (GNCOption *option, GtkBox *page_box,
     GtkWidget *label;
     GtkWidget *px_butt, *p_butt;
     GtkWidget *hbox;
-    gchar *colon_name;
     GtkAdjustment *adj_px, *adj_percent;
     gdouble lower_bound = G_MINDOUBLE;
     gdouble upper_bound = G_MAXDOUBLE;
     gdouble step_size = 1.0;
     int num_decimals = 0;
 
-    colon_name = g_strconcat(name, ":", NULL);
-    label = gtk_label_new(colon_name);
+    label = gtk_label_new(name);
     gnc_label_set_alignment(label, 1.0, 0.5);
-    g_free(colon_name);
 
     hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
     gtk_box_set_homogeneous (GTK_BOX (hbox), FALSE);
@@ -3125,12 +3093,9 @@ gnc_option_set_ui_widget_budget (GNCOption *option, GtkBox *page_box,
 {
     GtkWidget *value;
     GtkWidget *label;
-    gchar *colon_name;
 
-    colon_name = g_strconcat(name, ":", NULL);
-    label = gtk_label_new(colon_name);
+    label = gtk_label_new(name);
     gnc_label_set_alignment(label, 1.0, 0.5);
-    g_free(colon_name);
 
     *enclosing = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
     gtk_box_set_homogeneous (GTK_BOX (*enclosing), FALSE);

--- a/gnucash/gnome-utils/dialog-transfer.c
+++ b/gnucash/gnome-utils/dialog-transfer.c
@@ -2039,12 +2039,12 @@ gnc_xfer_dialog_create(GtkWidget *parent, XferDialog *xferData)
         if (use_accounting_labels)
         {
             gtk_label_set_text(GTK_LABEL(gtk_bin_get_child (GTK_BIN(xferData->amount_radio))),
-                               _("Debit Amount:"));
+                               _("Debit Amount"));
         }
         else
         {
             gtk_label_set_text(GTK_LABEL(gtk_bin_get_child (GTK_BIN(xferData->amount_radio))),
-                               _("To Amount:"));
+                               _("To Amount"));
         }
     }
 

--- a/gnucash/gnome-utils/gnc-dense-cal.c
+++ b/gnucash/gnome-utils/gnc-dense-cal.c
@@ -288,7 +288,7 @@ gnc_dense_cal_init(GncDenseCal *dcal)
 
     {
         GtkWidget *hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
-        GtkWidget *label = gtk_label_new (_("View:"));
+        GtkWidget *label = gtk_label_new (_("View"));
 
         gtk_box_set_homogeneous (GTK_BOX (hbox), FALSE);
         gtk_widget_set_halign (label, GTK_ALIGN_END);

--- a/gnucash/gnome-utils/gnc-frequency.h
+++ b/gnucash/gnome-utils/gnc-frequency.h
@@ -91,13 +91,13 @@ void gnc_frequency_save_to_recurrence(GncFrequency *gf, GList **recurrences, GDa
 
 /**
  * Set the label text for the frequency option menu.  In the current
- * implementation, the default label text is "Frequency:"
+ * implementation, the default label text is "Frequency"
  */
 void gnc_frequency_set_frequency_label_text (GncFrequency *gf, const gchar *txt);
 
 /**
  * Set the label text for the date entry widget. In the current
- * impelmentation, the default label text is "Start Date:"
+ * impelmentation, the default label text is "Start Date"
  */
 void gnc_frequency_set_date_label_text (GncFrequency *gf, const gchar *txt);
 

--- a/gnucash/gnome/assistant-acct-period.c
+++ b/gnucash/gnome/assistant-acct-period.c
@@ -586,8 +586,8 @@ ap_assistant_create (AcctPeriodInfo *info)
                             gnc_frequency_new_from_recurrence(info->period, &info->closing_date));
 
     /* Change the text so that its more mainingful for this assistant */
-    gnc_frequency_set_frequency_label_text(info->period_menu, _("Period:"));
-    gnc_frequency_set_date_label_text(info->period_menu, _("Closing Date:"));
+    gnc_frequency_set_frequency_label_text(info->period_menu, _("Period"));
+    gnc_frequency_set_date_label_text(info->period_menu, _("Closing Date"));
 
     /* Reparent to the correct location */
 

--- a/gnucash/gnome/business-options-gnome.c
+++ b/gnucash/gnome/business-options-gnome.c
@@ -80,13 +80,8 @@ create_owner_widget (GNCOption *option, GncOwnerType type, GtkWidget *hbox)
 static GtkWidget *
 make_name_label (char *name)
 {
-    GtkWidget *label;
-    gchar *colon_name;
-
-    colon_name = g_strconcat (name, ":", (char *)NULL);
-    label = gtk_label_new (colon_name);
+    GtkWidget *label = gtk_label_new (name);
     gnc_label_set_alignment (label, 1.0, 0.5);
-    g_free (colon_name);
 
     return label;
 }

--- a/gnucash/gnome/gnc-split-reg.c
+++ b/gnucash/gnome/gnc-split-reg.c
@@ -1353,11 +1353,11 @@ gsr_default_associate_handler_location (GNCSplitReg *gsr, Transaction *trans, gb
     // add a label and set entry text if required
     if (have_uri)
     {
-        label = gtk_label_new (_("Amend URL:"));
+        label = gtk_label_new (_("Amend URL"));
         gtk_entry_set_text (GTK_ENTRY (entry), xaccTransGetAssociation (trans));
     }
     else
-        label = gtk_label_new (_("Enter URL like https://www.gnucash.org:"));
+        label = gtk_label_new (_("Enter URL like https://www.gnucash.org"));
 
     // pack label and entry to content area
     gnc_label_set_alignment (label, 0.0, 0.5);
@@ -2482,7 +2482,7 @@ gsr_create_summary_bar( GNCSplitReg *gsr )
 
     gsr->filter_label = add_summary_label (summarybar, FALSE, "", NULL);
     gsr->sort_arrow = gtk_image_new_from_icon_name ("image-missing", GTK_ICON_SIZE_SMALL_TOOLBAR);
-    gsr->sort_label = add_summary_label (summarybar, FALSE, _("Sort By: "), gsr->sort_arrow);
+    gsr->sort_label = add_summary_label (summarybar, FALSE, _("Sort By:"), gsr->sort_arrow);
 
     gnc_widget_style_context_add_class (GTK_WIDGET(gsr->filter_label), "gnc-class-highlight");
     gnc_widget_style_context_add_class (GTK_WIDGET(gsr->sort_arrow), "gnc-class-highlight");

--- a/gnucash/gnome/window-reconcile.c
+++ b/gnucash/gnome/window-reconcile.c
@@ -1195,7 +1195,7 @@ gnc_reconcile_window_create_view_box(Account *account,
     gtk_box_set_homogeneous (GTK_BOX (hbox), FALSE);
     gtk_box_pack_start(GTK_BOX(vbox), hbox, FALSE, FALSE, 0);
 
-    label = gtk_label_new(_("Total:"));
+    label = gtk_label_new(_("Total"));
     gnc_label_set_alignment(label, 1.0, 0.5);
     gtk_box_pack_start(GTK_BOX(hbox), label, TRUE, TRUE, 0);
 
@@ -1886,7 +1886,7 @@ recnWindowWithBalance (GtkWidget *parent, Account *account, gnc_numeric new_endi
             gtk_box_pack_start(GTK_BOX(totals_hbox), value_vbox, TRUE, TRUE, 0);
 
             /* statement date title/value */
-            title = gtk_label_new(_("Statement Date:"));
+            title = gtk_label_new(_("Statement Date"));
             gnc_label_set_alignment(title, 1.0, 0.5);
             gtk_box_pack_start(GTK_BOX(title_vbox), title, FALSE, FALSE, 0);
 
@@ -1896,7 +1896,7 @@ recnWindowWithBalance (GtkWidget *parent, Account *account, gnc_numeric new_endi
             gtk_box_pack_start(GTK_BOX(value_vbox), value, FALSE, FALSE, 0);
 
             /* starting balance title/value */
-            title = gtk_label_new(_("Starting Balance:"));
+            title = gtk_label_new(_("Starting Balance"));
             gnc_label_set_alignment(title, 1.0, 0.5);
             gtk_box_pack_start(GTK_BOX(title_vbox), title, FALSE, FALSE, 3);
 
@@ -1906,7 +1906,7 @@ recnWindowWithBalance (GtkWidget *parent, Account *account, gnc_numeric new_endi
             gtk_box_pack_start(GTK_BOX(value_vbox), value, FALSE, FALSE, 3);
 
             /* ending balance title/value */
-            title = gtk_label_new(_("Ending Balance:"));
+            title = gtk_label_new(_("Ending Balance"));
             gnc_label_set_alignment(title, 1.0, 0.5);
             gtk_box_pack_start(GTK_BOX(title_vbox), title, FALSE, FALSE, 0);
 
@@ -1916,7 +1916,7 @@ recnWindowWithBalance (GtkWidget *parent, Account *account, gnc_numeric new_endi
             gtk_box_pack_start(GTK_BOX(value_vbox), value, FALSE, FALSE, 0);
 
             /* reconciled balance title/value */
-            title = gtk_label_new(_("Reconciled Balance:"));
+            title = gtk_label_new(_("Reconciled Balance"));
             gnc_label_set_alignment(title, 1.0, 0.5);
             gtk_box_pack_start(GTK_BOX(title_vbox), title, FALSE, FALSE, 0);
 
@@ -1926,7 +1926,7 @@ recnWindowWithBalance (GtkWidget *parent, Account *account, gnc_numeric new_endi
             gtk_box_pack_start(GTK_BOX(value_vbox), value, FALSE, FALSE, 0);
 
             /* difference title/value */
-            title = gtk_label_new(_("Difference:"));
+            title = gtk_label_new(_("Difference"));
             gnc_label_set_alignment(title, 1.0, 0.5);
             gtk_box_pack_start(GTK_BOX(title_vbox), title, FALSE, FALSE, 0);
 

--- a/gnucash/gnome/window-reconcile2.c
+++ b/gnucash/gnome/window-reconcile2.c
@@ -1145,7 +1145,7 @@ gnc_reconcile_window_create_view_box (Account *account,
     gtk_box_set_homogeneous (GTK_BOX (hbox), FALSE);
     gtk_box_pack_start (GTK_BOX (vbox), hbox, FALSE, FALSE, 0);
 
-    label = gtk_label_new (_("Total:"));
+    label = gtk_label_new (_("Total"));
     gnc_label_set_alignment (label, 1.0, 0.5);
     gtk_box_pack_start (GTK_BOX (hbox), label, TRUE, TRUE, 0);
 
@@ -1826,7 +1826,7 @@ recnWindow2WithBalance (GtkWidget *parent, Account *account,
             gtk_box_pack_start (GTK_BOX (totals_hbox), value_vbox, TRUE, TRUE, 0);
 
             /* statement date title/value */
-            title = gtk_label_new (_("Statement Date:"));
+            title = gtk_label_new (_("Statement Date"));
             gnc_label_set_alignment (title, 1.0, 0.5);
             gtk_box_pack_start (GTK_BOX (title_vbox), title, FALSE, FALSE, 0);
 
@@ -1836,7 +1836,7 @@ recnWindow2WithBalance (GtkWidget *parent, Account *account,
             gtk_box_pack_start (GTK_BOX (value_vbox), value, FALSE, FALSE, 0);
 
             /* starting balance title/value */
-            title = gtk_label_new(_("Starting Balance:"));
+            title = gtk_label_new(_("Starting Balance"));
             gnc_label_set_alignment (title, 1.0, 0.5);
             gtk_box_pack_start (GTK_BOX (title_vbox), title, FALSE, FALSE, 3);
 
@@ -1846,7 +1846,7 @@ recnWindow2WithBalance (GtkWidget *parent, Account *account,
             gtk_box_pack_start (GTK_BOX (value_vbox), value, FALSE, FALSE, 3);
 
             /* ending balance title/value */
-            title = gtk_label_new (_("Ending Balance:"));
+            title = gtk_label_new (_("Ending Balance"));
             gnc_label_set_alignment (title, 1.0, 0.5);
             gtk_box_pack_start (GTK_BOX (title_vbox), title, FALSE, FALSE, 0);
 
@@ -1856,7 +1856,7 @@ recnWindow2WithBalance (GtkWidget *parent, Account *account,
             gtk_box_pack_start (GTK_BOX (value_vbox), value, FALSE, FALSE, 0);
 
             /* reconciled balance title/value */
-            title = gtk_label_new (_("Reconciled Balance:"));
+            title = gtk_label_new (_("Reconciled Balance"));
             gnc_label_set_alignment (title, 1.0, 0.5);
             gtk_box_pack_start (GTK_BOX (title_vbox), title, FALSE, FALSE, 0);
 
@@ -1866,7 +1866,7 @@ recnWindow2WithBalance (GtkWidget *parent, Account *account,
             gtk_box_pack_start (GTK_BOX (value_vbox), value, FALSE, FALSE, 0);
 
             /* difference title/value */
-            title = gtk_label_new (_("Difference:"));
+            title = gtk_label_new (_("Difference"));
             gnc_label_set_alignment (title, 1.0, 0.5);
             gtk_box_pack_start (GTK_BOX (title_vbox), title, FALSE, FALSE, 0);
 

--- a/gnucash/gtkbuilder/assistant-acct-period.glade
+++ b/gnucash/gtkbuilder/assistant-acct-period.glade
@@ -124,12 +124,13 @@ Books will be closed at midnight on the selected date.</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="border_width">12</property>
+            <property name="column_spacing">6</property>
             <child>
               <object class="GtkLabel" id="book_title">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="hexpand">False</property>
-                <property name="label" translatable="yes">Title:</property>
+                <property name="label" translatable="yes">Title</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
@@ -140,7 +141,7 @@ Books will be closed at midnight on the selected date.</property>
               <object class="GtkLabel" id="book_notes">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Notes:</property>
+                <property name="label" translatable="yes">Notes</property>
                 <property name="wrap">True</property>
               </object>
               <packing>

--- a/gnucash/gtkbuilder/assistant-csv-export.glade
+++ b/gnucash/gtkbuilder/assistant-csv-export.glade
@@ -468,7 +468,7 @@ Select the type of Export required and the separator that will be used.
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="show_range">
-                    <property name="label" translatable="yes">Select _Range:</property>
+                    <property name="label" translatable="yes">Select _Range</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
@@ -493,7 +493,7 @@ Select the type of Export required and the separator that will be used.
                       <object class="GtkLabel" id="label847682">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Start:</property>
+                        <property name="label" translatable="yes">Start</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -519,7 +519,7 @@ Select the type of Export required and the separator that will be used.
                     </child>
                     <child>
                       <object class="GtkRadioButton" id="end_date_choose">
-                        <property name="label" translatable="yes">Cho_ose Date:</property>
+                        <property name="label" translatable="yes">Cho_ose Date</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
@@ -582,7 +582,7 @@ Select the type of Export required and the separator that will be used.
                       <object class="GtkLabel" id="label847684">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">End:</property>
+                        <property name="label" translatable="yes">End</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -591,7 +591,7 @@ Select the type of Export required and the separator that will be used.
                     </child>
                     <child>
                       <object class="GtkRadioButton" id="start_date_choose">
-                        <property name="label" translatable="yes">C_hoose Date:</property>
+                        <property name="label" translatable="yes">C_hoose Date</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>

--- a/gnucash/gtkbuilder/assistant-loan.glade
+++ b/gnucash/gtkbuilder/assistant-loan.glade
@@ -148,7 +148,7 @@ If you make a mistake or want to make changes later, you can edit the created Sc
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
-                <property name="label" translatable="yes">Interest Rate:</property>
+                <property name="label" translatable="yes">Interest Rate</property>
                 <property name="justify">center</property>
               </object>
               <packing>
@@ -161,7 +161,7 @@ If you make a mistake or want to make changes later, you can edit the created Sc
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
-                <property name="label" translatable="yes">Start Date:</property>
+                <property name="label" translatable="yes">Start Date</property>
                 <property name="justify">center</property>
               </object>
               <packing>
@@ -174,7 +174,7 @@ If you make a mistake or want to make changes later, you can edit the created Sc
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
-                <property name="label" translatable="yes">Length:</property>
+                <property name="label" translatable="yes">Length</property>
                 <property name="justify">center</property>
               </object>
               <packing>
@@ -187,7 +187,7 @@ If you make a mistake or want to make changes later, you can edit the created Sc
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
-                <property name="label" translatable="yes">Amount:</property>
+                <property name="label" translatable="yes">Amount</property>
                 <property name="justify">right</property>
               </object>
               <packing>
@@ -200,7 +200,7 @@ If you make a mistake or want to make changes later, you can edit the created Sc
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
-                <property name="label" translatable="yes">Loan Account:</property>
+                <property name="label" translatable="yes">Loan Account</property>
                 <property name="justify">center</property>
               </object>
               <packing>
@@ -351,7 +351,7 @@ If you make a mistake or want to make changes later, you can edit the created Sc
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
-                <property name="label" translatable="yes">Type:</property>
+                <property name="label" translatable="yes">Type</property>
                 <property name="justify">center</property>
               </object>
               <packing>
@@ -364,7 +364,7 @@ If you make a mistake or want to make changes later, you can edit the created Sc
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
-                <property name="label" translatable="yes">Months Remaining:</property>
+                <property name="label" translatable="yes">Months Remaining</property>
                 <property name="justify">center</property>
                 <property name="ellipsize">end</property>
               </object>
@@ -519,7 +519,7 @@ Do you utilise an escrow account, if so an account must be specified...</propert
                       <object class="GtkLabel" id="label847963">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Escrow Account:</property>
+                        <property name="label" translatable="yes">Escrow Account</property>
                         <property name="justify">center</property>
                       </object>
                       <packing>
@@ -594,7 +594,7 @@ All accounts must have valid entries to continue.
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
-                <property name="label" translatable="yes">Payment From:</property>
+                <property name="label" translatable="yes">Payment From</property>
                 <property name="justify">right</property>
               </object>
               <packing>
@@ -607,7 +607,7 @@ All accounts must have valid entries to continue.
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
-                <property name="label" translatable="yes">Principal To:</property>
+                <property name="label" translatable="yes">Principal To</property>
                 <property name="justify">right</property>
               </object>
               <packing>
@@ -620,7 +620,7 @@ All accounts must have valid entries to continue.
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
-                <property name="label" translatable="yes">Name:</property>
+                <property name="label" translatable="yes">Name</property>
                 <property name="justify">right</property>
               </object>
               <packing>
@@ -633,7 +633,7 @@ All accounts must have valid entries to continue.
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
-                <property name="label" translatable="yes">Amount:</property>
+                <property name="label" translatable="yes">Amount</property>
                 <property name="justify">right</property>
               </object>
               <packing>
@@ -646,7 +646,7 @@ All accounts must have valid entries to continue.
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
-                <property name="label" translatable="yes">Interest To:</property>
+                <property name="label" translatable="yes">Interest To</property>
                 <property name="justify">right</property>
               </object>
               <packing>
@@ -801,7 +801,7 @@ All enabled option pages must contain valid entries to continue.
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">end</property>
-                        <property name="label" translatable="yes">Amount:</property>
+                        <property name="label" translatable="yes">Amount</property>
                         <property name="justify">center</property>
                       </object>
                       <packing>
@@ -814,7 +814,7 @@ All enabled option pages must contain valid entries to continue.
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">end</property>
-                        <property name="label" translatable="yes">Payment From:</property>
+                        <property name="label" translatable="yes">Payment From</property>
                         <property name="justify">center</property>
                       </object>
                       <packing>
@@ -827,7 +827,7 @@ All enabled option pages must contain valid entries to continue.
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">end</property>
-                        <property name="label" translatable="yes">Name:</property>
+                        <property name="label" translatable="yes">Name</property>
                         <property name="justify">center</property>
                       </object>
                       <packing>
@@ -840,7 +840,7 @@ All enabled option pages must contain valid entries to continue.
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">end</property>
-                        <property name="label" translatable="yes">Payment To (Escrow):</property>
+                        <property name="label" translatable="yes">Payment To (Escrow)</property>
                         <property name="justify">right</property>
                       </object>
                       <packing>
@@ -895,7 +895,7 @@ All enabled option pages must contain valid entries to continue.
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">end</property>
-                        <property name="label" translatable="yes">Payment From (Escrow):</property>
+                        <property name="label" translatable="yes">Payment From (Escrow)</property>
                         <property name="justify">center</property>
                       </object>
                       <packing>
@@ -908,7 +908,7 @@ All enabled option pages must contain valid entries to continue.
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">end</property>
-                        <property name="label" translatable="yes">Payment To:</property>
+                        <property name="label" translatable="yes">Payment To</property>
                         <property name="justify">center</property>
                       </object>
                       <packing>
@@ -1170,7 +1170,7 @@ Review the details below and if correct press Apply to create the schedule.</pro
                       <object class="GtkLabel" id="label847973">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Range: </property>
+                        <property name="label" translatable="yes">Range</property>
                         <property name="justify">center</property>
                       </object>
                       <packing>
@@ -1233,7 +1233,7 @@ Review the details below and if correct press Apply to create the schedule.</pro
                           <object class="GtkLabel" id="label847971">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Start Date:</property>
+                            <property name="label" translatable="yes">Start Date</property>
                             <property name="justify">center</property>
                           </object>
                           <packing>
@@ -1245,7 +1245,7 @@ Review the details below and if correct press Apply to create the schedule.</pro
                           <object class="GtkLabel" id="label847972">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">End Date:</property>
+                            <property name="label" translatable="yes">End Date</property>
                             <property name="justify">center</property>
                           </object>
                           <packing>

--- a/gnucash/gtkbuilder/assistant-qif-import.glade
+++ b/gnucash/gtkbuilder/assistant-qif-import.glade
@@ -363,7 +363,7 @@ Please enter a name for the account. If the file was exported from another accou
               <object class="GtkLabel" id="label824">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Account name:</property>
+                <property name="label" translatable="yes">Account name</property>
                 <property name="justify">center</property>
               </object>
               <packing>
@@ -550,7 +550,7 @@ Note that GnuCash will be creating many accounts that did not exist on your othe
           <object class="GtkLabel" id="label7609">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="label" translatable="yes">_Select the matchings you want to change:</property>
+            <property name="label" translatable="yes">_Select the matchings you want to change</property>
             <property name="use_underline">True</property>
             <property name="mnemonic_widget">account_page_view</property>
           </object>
@@ -591,7 +591,7 @@ Note that GnuCash will be creating many accounts that did not exist on your othe
               <object class="GtkLabel" id="label7610">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Matchings selected:</property>
+                <property name="label" translatable="yes">Matchings selected</property>
                 <property name="wrap">True</property>
               </object>
               <packing>
@@ -682,7 +682,7 @@ If you change your mind later, you can reorganize the account structure safely w
           <object class="GtkLabel" id="label7611">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="label" translatable="yes">_Select the matchings you want to change:</property>
+            <property name="label" translatable="yes">_Select the matchings you want to change</property>
             <property name="use_underline">True</property>
             <property name="mnemonic_widget">category_page_view</property>
           </object>
@@ -723,7 +723,7 @@ If you change your mind later, you can reorganize the account structure safely w
               <object class="GtkLabel" id="label7613">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Matchings selected:</property>
+                <property name="label" translatable="yes">Matchings selected</property>
                 <property name="wrap">True</property>
               </object>
               <packing>
@@ -812,7 +812,7 @@ In the following page, you will see the text that appears in the Payee and Memo 
           <object class="GtkLabel" id="label7614">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="label" translatable="yes">_Select the matchings you want to change:</property>
+            <property name="label" translatable="yes">_Select the matchings you want to change</property>
             <property name="use_underline">True</property>
             <property name="mnemonic_widget">memo_page_view</property>
           </object>
@@ -853,7 +853,7 @@ In the following page, you will see the text that appears in the Payee and Memo 
               <object class="GtkLabel" id="label7616">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Matchings selected:</property>
+                <property name="label" translatable="yes">Matchings selected</property>
                 <property name="wrap">True</property>
               </object>
               <packing>
@@ -1281,7 +1281,7 @@ Click "Next" to review the possible matches.</property>
                   <object class="GtkLabel" id="label847716">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">_Imported transactions needing review:</property>
+                    <property name="label" translatable="yes">_Imported transactions needing review</property>
                     <property name="use_underline">True</property>
                     <property name="mnemonic_widget">new_transaction_view</property>
                   </object>
@@ -1320,7 +1320,7 @@ Click "Next" to review the possible matches.</property>
                   <object class="GtkLabel" id="label847717">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">_Possible matches for the selected transaction:</property>
+                    <property name="label" translatable="yes">_Possible matches for the selected transaction</property>
                     <property name="use_underline">True</property>
                     <property name="mnemonic_widget">old_transaction_view</property>
                   </object>

--- a/gnucash/gtkbuilder/assistant-stock-split.glade
+++ b/gnucash/gtkbuilder/assistant-stock-split.glade
@@ -107,7 +107,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">_Date:</property>
+                <property name="label" translatable="yes">_Date</property>
                 <property name="use_underline">True</property>
                 <property name="justify">center</property>
               </object>
@@ -121,7 +121,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">_Shares:</property>
+                <property name="label" translatable="yes">_Shares</property>
                 <property name="use_underline">True</property>
                 <property name="justify">center</property>
               </object>
@@ -135,7 +135,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">Desc_ription:</property>
+                <property name="label" translatable="yes">Desc_ription</property>
                 <property name="use_underline">True</property>
                 <property name="justify">center</property>
                 <property name="mnemonic_widget">description_entry</property>
@@ -188,7 +188,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">New _Price:</property>
+                <property name="label" translatable="yes">New _Price</property>
                 <property name="use_underline">True</property>
                 <property name="justify">center</property>
               </object>
@@ -202,7 +202,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">Currenc_y:</property>
+                <property name="label" translatable="yes">Currenc_y</property>
                 <property name="use_underline">True</property>
                 <property name="justify">center</property>
               </object>
@@ -267,7 +267,7 @@
               <object class="GtkLabel" id="cash_label">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">_Amount:</property>
+                <property name="label" translatable="yes">_Amount</property>
                 <property name="use_underline">True</property>
                 <property name="justify">center</property>
               </object>
@@ -280,7 +280,7 @@
               <object class="GtkLabel" id="memo_label">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">_Memo:</property>
+                <property name="label" translatable="yes">_Memo</property>
                 <property name="use_underline">True</property>
                 <property name="justify">center</property>
                 <property name="mnemonic_widget">memo_entry</property>

--- a/gnucash/gtkbuilder/assistant-xml-encoding.glade
+++ b/gnucash/gtkbuilder/assistant-xml-encoding.glade
@@ -67,7 +67,7 @@
                       <object class="GtkLabel" id="label12">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Default encoding:</property>
+                        <property name="label" translatable="yes">Default encoding</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>

--- a/gnucash/gtkbuilder/business-prefs.glade
+++ b/gnucash/gtkbuilder/business-prefs.glade
@@ -167,7 +167,7 @@
             <property name="can_focus">False</property>
             <property name="halign">start</property>
             <property name="margin_left">12</property>
-            <property name="label" translatable="yes">Report for printing:</property>
+            <property name="label" translatable="yes">Report for printing</property>
           </object>
           <packing>
             <property name="left_attach">0</property>
@@ -296,7 +296,7 @@
           <object class="GtkLabel">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="label" translatable="yes">Days in ad_vance:</property>
+            <property name="label" translatable="yes">Days in ad_vance</property>
             <property name="use_underline">True</property>
             <property name="mnemonic_widget">pref/dialogs.business.bill/days-in-advance</property>
           </object>
@@ -361,7 +361,7 @@
           <object class="GtkLabel">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="label" translatable="yes">_Days in advance:</property>
+            <property name="label" translatable="yes">_Days in advance</property>
             <property name="use_underline">True</property>
             <property name="mnemonic_widget">pref/dialogs.business.invoice/days-in-advance</property>
           </object>

--- a/gnucash/gtkbuilder/dialog-account.glade
+++ b/gnucash/gtkbuilder/dialog-account.glade
@@ -274,7 +274,7 @@
                     </child>
                     <child>
                       <object class="GtkRadioButton" id="sa_mrb">
-                        <property name="label" translatable="yes">_Move to:</property>
+                        <property name="label" translatable="yes">_Move to</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
@@ -366,7 +366,7 @@
                     <property name="column_spacing">12</property>
                     <child>
                       <object class="GtkRadioButton" id="trans_mrb">
-                        <property name="label" translatable="yes">M_ove to:</property>
+                        <property name="label" translatable="yes">M_ove to</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
@@ -487,7 +487,7 @@
                     <property name="column_spacing">12</property>
                     <child>
                       <object class="GtkRadioButton" id="sa_trans_mrb">
-                        <property name="label" translatable="yes">M_ove to:</property>
+                        <property name="label" translatable="yes">M_ove to</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
@@ -783,25 +783,6 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkCheckButton" id="show_unused">
-                    <property name="label" translatable="yes">Show _unused accounts</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Show accounts which do not have any transactions.</property>
-                    <property name="halign">start</property>
-                    <property name="margin_left">12</property>
-                    <property name="use_underline">True</property>
-                    <property name="draw_indicator">True</property>
-                    <signal name="toggled" handler="gppat_filter_show_unused_toggled_cb" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-                <child>
                   <object class="GtkCheckButton" id="show_zero">
                     <property name="label" translatable="yes">Show _zero total accounts</property>
                     <property name="visible">True</property>
@@ -813,6 +794,25 @@
                     <property name="use_underline">True</property>
                     <property name="draw_indicator">True</property>
                     <signal name="toggled" handler="gppat_filter_show_zero_toggled_cb" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="show_unused">
+                    <property name="label" translatable="yes">Show _unused accounts</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">Show accounts which do not have any transactions.</property>
+                    <property name="halign">start</property>
+                    <property name="margin_left">12</property>
+                    <property name="use_underline">True</property>
+                    <property name="draw_indicator">True</property>
+                    <signal name="toggled" handler="gppat_filter_show_unused_toggled_cb" swapped="no"/>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -1012,7 +1012,7 @@
                             <property name="can_focus">False</property>
                             <property name="halign">start</property>
                             <property name="margin_left">12</property>
-                            <property name="label" translatable="yes">Account _name:</property>
+                            <property name="label" translatable="yes">Account _name</property>
                             <property name="use_underline">True</property>
                             <property name="mnemonic_widget">name_entry</property>
                             <property name="ellipsize">middle</property>
@@ -1028,7 +1028,7 @@
                             <property name="can_focus">False</property>
                             <property name="halign">start</property>
                             <property name="margin_left">12</property>
-                            <property name="label" translatable="yes">_Account code:</property>
+                            <property name="label" translatable="yes">_Account code</property>
                             <property name="use_underline">True</property>
                             <property name="mnemonic_widget">code_entry</property>
                           </object>
@@ -1043,7 +1043,7 @@
                             <property name="can_focus">False</property>
                             <property name="halign">start</property>
                             <property name="margin_left">12</property>
-                            <property name="label" translatable="yes">_Description:</property>
+                            <property name="label" translatable="yes">_Description</property>
                             <property name="use_underline">True</property>
                             <property name="mnemonic_widget">description_entry</property>
                           </object>
@@ -1058,7 +1058,7 @@
                             <property name="can_focus">False</property>
                             <property name="halign">start</property>
                             <property name="margin_left">12</property>
-                            <property name="label" translatable="yes">_Security/currency:</property>
+                            <property name="label" translatable="yes">_Security/currency</property>
                             <property name="use_underline">True</property>
                           </object>
                           <packing>
@@ -1085,7 +1085,7 @@
                             <property name="can_focus">False</property>
                             <property name="halign">start</property>
                             <property name="margin_left">12</property>
-                            <property name="label" translatable="yes">Smallest _fraction:</property>
+                            <property name="label" translatable="yes">Smallest _fraction</property>
                             <property name="use_underline">True</property>
                             <property name="mnemonic_widget">account_scu</property>
                           </object>
@@ -1100,7 +1100,7 @@
                             <property name="can_focus">False</property>
                             <property name="halign">start</property>
                             <property name="margin_left">12</property>
-                            <property name="label" translatable="yes">Account _Color:</property>
+                            <property name="label" translatable="yes">Account _Color</property>
                             <property name="use_underline">True</property>
                           </object>
                           <packing>
@@ -1153,7 +1153,7 @@
                             <property name="halign">start</property>
                             <property name="valign">start</property>
                             <property name="margin_left">12</property>
-                            <property name="label" translatable="yes">No_tes:</property>
+                            <property name="label" translatable="yes">No_tes</property>
                             <property name="use_underline">True</property>
                             <property name="mnemonic_widget">notes_text</property>
                           </object>
@@ -1507,7 +1507,7 @@
                         <property name="can_focus">False</property>
                         <property name="halign">start</property>
                         <property name="margin_left">12</property>
-                        <property name="label" translatable="yes">_Balance:</property>
+                        <property name="label" translatable="yes">_Balance</property>
                         <property name="use_underline">True</property>
                         <property name="justify">right</property>
                       </object>
@@ -1522,7 +1522,7 @@
                         <property name="can_focus">False</property>
                         <property name="halign">start</property>
                         <property name="margin_left">12</property>
-                        <property name="label" translatable="yes">_Date:</property>
+                        <property name="label" translatable="yes">_Date</property>
                         <property name="use_underline">True</property>
                         <property name="justify">right</property>
                       </object>
@@ -1702,7 +1702,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">Prefix:</property>
+                <property name="label" translatable="yes">Prefix</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
@@ -1738,7 +1738,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">Examples:</property>
+                <property name="label" translatable="yes">Examples</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
@@ -1761,7 +1761,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">Interval:</property>
+                <property name="label" translatable="yes">Interval</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>

--- a/gnucash/gtkbuilder/dialog-billterms.glade
+++ b/gnucash/gtkbuilder/dialog-billterms.glade
@@ -64,6 +64,7 @@
               <object class="GtkBox" id="hbox9">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="spacing">6</property>
                 <child>
                   <object class="GtkBox" id="vbox7">
                     <property name="visible">True</property>
@@ -75,7 +76,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">end</property>
-                        <property name="label" translatable="yes">Due Days: </property>
+                        <property name="label" translatable="yes">Due Days</property>
                         <property name="justify">right</property>
                       </object>
                       <packing>
@@ -89,7 +90,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">end</property>
-                        <property name="label" translatable="yes">Discount Days: </property>
+                        <property name="label" translatable="yes">Discount Days</property>
                         <property name="justify">right</property>
                       </object>
                       <packing>
@@ -103,7 +104,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">end</property>
-                        <property name="label" translatable="yes">Discount %: </property>
+                        <property name="label" translatable="yes">Discount %</property>
                         <property name="justify">right</property>
                       </object>
                       <packing>
@@ -651,7 +652,7 @@
                           <object class="GtkLabel" id="label16">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">De_scription:</property>
+                            <property name="label" translatable="yes">De_scription</property>
                             <property name="use_underline">True</property>
                             <property name="justify">right</property>
                             <property name="mnemonic_widget">desc_entry</property>
@@ -665,7 +666,7 @@
                           <object class="GtkLabel" id="label9">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">_Type:</property>
+                            <property name="label" translatable="yes">_Type</property>
                             <property name="use_underline">True</property>
                             <property name="justify">right</property>
                           </object>
@@ -893,7 +894,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">De_scription:</property>
+                    <property name="label" translatable="yes">De_scription</property>
                     <property name="use_underline">True</property>
                     <property name="justify">right</property>
                     <property name="mnemonic_widget">entry_desc</property>
@@ -934,7 +935,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">_Type:</property>
+                    <property name="label" translatable="yes">_Type</property>
                     <property name="use_underline">True</property>
                     <property name="justify">right</property>
                     <property name="mnemonic_widget">type_combo</property>
@@ -1161,7 +1162,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">_Name:</property>
+                    <property name="label" translatable="yes">_Name</property>
                     <property name="use_underline">True</property>
                     <property name="justify">right</property>
                     <property name="mnemonic_widget">name_entry</property>
@@ -1184,7 +1185,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">De_scription:</property>
+                    <property name="label" translatable="yes">De_scription</property>
                     <property name="use_underline">True</property>
                     <property name="justify">right</property>
                     <property name="mnemonic_widget">description_entry</property>
@@ -1207,7 +1208,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">_Type:</property>
+                    <property name="label" translatable="yes">_Type</property>
                     <property name="use_underline">True</property>
                     <property name="justify">right</property>
                     <property name="mnemonic_widget">type_combobox</property>

--- a/gnucash/gtkbuilder/dialog-book-close.glade
+++ b/gnucash/gtkbuilder/dialog-book-close.glade
@@ -77,12 +77,13 @@
           <object class="GtkGrid" id="table1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="column_spacing">6</property>
             <child>
               <object class="GtkLabel" id="label1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">Closing Date:</property>
+                <property name="label" translatable="yes">Closing Date</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
@@ -94,7 +95,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">Income Total:</property>
+                <property name="label" translatable="yes">Income Total</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
@@ -106,7 +107,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">Expense Total:</property>
+                <property name="label" translatable="yes">Expense Total</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
@@ -157,7 +158,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">Description:</property>
+                <property name="label" translatable="yes">Description</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>

--- a/gnucash/gtkbuilder/dialog-commodity.glade
+++ b/gnucash/gtkbuilder/dialog-commodity.glade
@@ -306,7 +306,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">Type of quote source:</property>
+                    <property name="label" translatable="yes">Type of quote source</property>
                     <property name="justify">right</property>
                   </object>
                 </child>
@@ -326,7 +326,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">_Full name:</property>
+                    <property name="label" translatable="yes">_Full name</property>
                     <property name="use_underline">True</property>
                     <property name="justify">center</property>
                     <property name="mnemonic_widget">fullname_entry</property>
@@ -348,7 +348,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">_Symbol/abbreviation:</property>
+                    <property name="label" translatable="yes">_Symbol/abbreviation</property>
                     <property name="use_underline">True</property>
                     <property name="justify">center</property>
                     <property name="mnemonic_widget">mnemonic_entry</property>
@@ -370,7 +370,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">_Type:</property>
+                    <property name="label" translatable="yes">_Type</property>
                     <property name="use_underline">True</property>
                     <property name="justify">center</property>
                   </object>
@@ -391,7 +391,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">ISIN, CUSI_P or other code:</property>
+                    <property name="label" translatable="yes">ISIN, CUSI_P or other code</property>
                     <property name="use_underline">True</property>
                     <property name="justify">center</property>
                     <property name="mnemonic_widget">code_entry</property>
@@ -413,7 +413,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">F_raction traded:</property>
+                    <property name="label" translatable="yes">F_raction traded</property>
                     <property name="use_underline">True</property>
                     <property name="justify">center</property>
                   </object>
@@ -509,7 +509,7 @@
                 <property name="left_padding">24</property>
                 <child>
                   <object class="GtkRadioButton" id="single_source_button">
-                    <property name="label" translatable="yes">Si_ngle:</property>
+                    <property name="label" translatable="yes">Si_ngle</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
@@ -536,7 +536,7 @@
                 <property name="left_padding">24</property>
                 <child>
                   <object class="GtkRadioButton" id="multi_source_button">
-                    <property name="label" translatable="yes">_Multiple:</property>
+                    <property name="label" translatable="yes">_Multiple</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
@@ -563,7 +563,7 @@
                 <property name="left_padding">24</property>
                 <child>
                   <object class="GtkRadioButton" id="unknown_source_button">
-                    <property name="label" translatable="yes">_Unknown:</property>
+                    <property name="label" translatable="yes">_Unknown</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
@@ -593,7 +593,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">Time_zone:</property>
+                    <property name="label" translatable="yes">Time_zone</property>
                     <property name="use_underline">True</property>
                     <property name="justify">right</property>
                   </object>
@@ -702,9 +702,9 @@
       </object>
     </child>
     <action-widgets>
-      <action-widget response="-11">help_button</action-widget>
       <action-widget response="-6">cancel_button</action-widget>
       <action-widget response="-5">ok_button</action-widget>
+      <action-widget response="-11">help_button</action-widget>
     </action-widgets>
   </object>
   <object class="GtkDialog" id="security_selector_dialog">
@@ -810,7 +810,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">_Type:</property>
+                    <property name="label" translatable="yes">_Type</property>
                     <property name="use_underline">True</property>
                     <property name="justify">center</property>
                   </object>
@@ -831,7 +831,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label">_Security/currency:</property>
+                    <property name="label">_Security/currency</property>
                     <property name="use_underline">True</property>
                     <property name="justify">center</property>
                   </object>

--- a/gnucash/gtkbuilder/dialog-customer.glade
+++ b/gnucash/gtkbuilder/dialog-customer.glade
@@ -126,6 +126,7 @@
                         <property name="margin_top">5</property>
                         <property name="margin_bottom">5</property>
                         <property name="border_width">2</property>
+                        <property name="spacing">6</property>
                         <child>
                           <object class="GtkBox" id="vbox11">
                             <property name="visible">True</property>
@@ -137,7 +138,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Customer Number: </property>
+                                <property name="label" translatable="yes">Customer Number</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -151,7 +152,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Company Name: </property>
+                                <property name="label" translatable="yes">Company Name</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -279,7 +280,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Name: </property>
+                                <property name="label" translatable="yes">Name</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -293,7 +294,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Address: </property>
+                                <property name="label" translatable="yes">Address</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -343,7 +344,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Phone: </property>
+                                <property name="label" translatable="yes">Phone</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -357,7 +358,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Fax: </property>
+                                <property name="label" translatable="yes">Fax</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -371,7 +372,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Email: </property>
+                                <property name="label" translatable="yes">Email</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -595,6 +596,7 @@
                         <property name="margin_right">5</property>
                         <property name="margin_top">5</property>
                         <property name="margin_bottom">5</property>
+                        <property name="spacing">6</property>
                         <child>
                           <object class="GtkBox" id="vbox7">
                             <property name="visible">True</property>
@@ -606,7 +608,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Currency: </property>
+                                <property name="label" translatable="yes">Currency</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -620,7 +622,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Terms: </property>
+                                <property name="label" translatable="yes">Terms</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -634,7 +636,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Discount: </property>
+                                <property name="label" translatable="yes">Discount</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -648,7 +650,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Credit Limit: </property>
+                                <property name="label" translatable="yes">Credit Limit</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -662,7 +664,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Tax Included: </property>
+                                <property name="label" translatable="yes">Tax Included</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -676,7 +678,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Tax Table: </property>
+                                <property name="label" translatable="yes">Tax Table</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -901,7 +903,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Name: </property>
+                                <property name="label" translatable="yes">Name</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -915,7 +917,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Address: </property>
+                                <property name="label" translatable="yes">Address</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -965,7 +967,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Phone: </property>
+                                <property name="label" translatable="yes">Phone</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -979,7 +981,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Fax: </property>
+                                <property name="label" translatable="yes">Fax</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -993,7 +995,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Email: </property>
+                                <property name="label" translatable="yes">Email</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>

--- a/gnucash/gtkbuilder/dialog-employee.glade
+++ b/gnucash/gtkbuilder/dialog-employee.glade
@@ -102,6 +102,7 @@
                         <property name="margin_top">5</property>
                         <property name="margin_bottom">5</property>
                         <property name="border_width">2</property>
+                        <property name="spacing">6</property>
                         <child>
                           <object class="GtkBox" id="vbox11">
                             <property name="visible">True</property>
@@ -113,7 +114,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Employee Number: </property>
+                                <property name="label" translatable="yes">Employee Number</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -127,7 +128,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Username: </property>
+                                <property name="label" translatable="yes">Username</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -262,7 +263,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Name: </property>
+                                <property name="label" translatable="yes">Name</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -276,7 +277,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Address: </property>
+                                <property name="label" translatable="yes">Address</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -326,7 +327,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Phone: </property>
+                                <property name="label" translatable="yes">Phone</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -340,7 +341,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Fax: </property>
+                                <property name="label" translatable="yes">Fax</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -354,7 +355,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Email: </property>
+                                <property name="label" translatable="yes">Email</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -541,12 +542,13 @@
                             <property name="margin_top">5</property>
                             <property name="margin_bottom">5</property>
                             <property name="border_width">2</property>
+                            <property name="spacing">6</property>
                             <child>
                               <object class="GtkLabel" id="label34">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Language: </property>
+                                <property name="label" translatable="yes">Language</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -634,11 +636,12 @@
                           <object class="GtkBox" id="hbox8">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
+                            <property name="spacing">6</property>
                             <child>
                               <object class="GtkLabel" id="label35">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Default Hours per Day: </property>
+                                <property name="label" translatable="yes">Default Hours per Day</property>
                                 <property name="justify">center</property>
                               </object>
                               <packing>
@@ -673,11 +676,12 @@
                           <object class="GtkBox" id="hbox9">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
+                            <property name="spacing">6</property>
                             <child>
                               <object class="GtkLabel" id="label36">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Default Rate: </property>
+                                <property name="label" translatable="yes">Default Rate</property>
                                 <property name="justify">center</property>
                               </object>
                               <packing>
@@ -712,11 +716,12 @@
                           <object class="GtkBox" id="hbox10">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
+                            <property name="spacing">6</property>
                             <child>
                               <object class="GtkLabel" id="label37">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Currency: </property>
+                                <property name="label" translatable="yes">Currency</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -750,6 +755,7 @@
                           <object class="GtkBox" id="hbox11">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
+                            <property name="spacing">6</property>
                             <child>
                               <object class="GtkLabel" id="label39">
                                 <property name="visible">True</property>

--- a/gnucash/gtkbuilder/dialog-file-access.glade
+++ b/gnucash/gtkbuilder/dialog-file-access.glade
@@ -71,7 +71,7 @@
               <object class="GtkLabel" id="uri_type_label">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">&lt;b&gt;Data Format:&lt;/b&gt;</property>
+                <property name="label" translatable="yes">&lt;b&gt;Data Format&lt;/b&gt;</property>
                 <property name="use_markup">True</property>
               </object>
               <packing>

--- a/gnucash/gtkbuilder/dialog-fincalc.glade
+++ b/gnucash/gtkbuilder/dialog-fincalc.glade
@@ -601,7 +601,7 @@
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="halign">start</property>
-                            <property name="label" translatable="yes">Payment Total:</property>
+                            <property name="label" translatable="yes">Payment Total</property>
                             <property name="justify">center</property>
                           </object>
                           <packing>
@@ -685,7 +685,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">start</property>
-                                <property name="label" translatable="yes">Type:</property>
+                                <property name="label" translatable="yes">Type</property>
                               </object>
                             </child>
                           </object>
@@ -704,7 +704,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">start</property>
-                                <property name="label" translatable="yes">Frequency:</property>
+                                <property name="label" translatable="yes">Frequency</property>
                                 <property name="use_underline">True</property>
                               </object>
                             </child>
@@ -724,7 +724,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">start</property>
-                                <property name="label" translatable="yes">Frequency:</property>
+                                <property name="label" translatable="yes">Frequency</property>
                                 <property name="use_underline">True</property>
                               </object>
                             </child>
@@ -744,7 +744,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">start</property>
-                                <property name="label" translatable="yes">When paid:</property>
+                                <property name="label" translatable="yes">When paid</property>
                               </object>
                             </child>
                           </object>

--- a/gnucash/gtkbuilder/dialog-import.glade
+++ b/gnucash/gtkbuilder/dialog-import.glade
@@ -260,12 +260,12 @@
                   <object class="GtkBox" id="hbox1">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="spacing">3</property>
+                    <property name="spacing">6</property>
                     <child>
                       <object class="GtkLabel" id="label847775">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Format:</property>
+                        <property name="label" translatable="yes">Format</property>
                         <property name="justify">right</property>
                       </object>
                       <packing>
@@ -659,7 +659,7 @@
               <object class="GtkLabel" id="label847772">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes" comments="Dialog Select matching transactions">Imported transaction's first split:</property>
+                <property name="label" translatable="yes" comments="Dialog Select matching transactions">Imported transaction's first split</property>
                 <property name="justify">center</property>
               </object>
               <packing>
@@ -694,7 +694,7 @@
               <object class="GtkLabel" id="label847766">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes" comments="Dialog Select matching transactions">Potential splits matching the selected transaction: </property>
+                <property name="label" translatable="yes" comments="Dialog Select matching transactions">Potential splits matching the selected transaction</property>
                 <property name="justify">center</property>
               </object>
               <packing>
@@ -1153,7 +1153,7 @@
       <object class="GtkLabel" id="heading_label">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="label" translatable="yes">List of downloaded transactions (source split shown):</property>
+        <property name="label" translatable="yes">List of downloaded transactions (source split shown)</property>
         <property name="justify">center</property>
       </object>
       <packing>

--- a/gnucash/gtkbuilder/dialog-invoice.glade
+++ b/gnucash/gtkbuilder/dialog-invoice.glade
@@ -412,12 +412,12 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="border_width">3</property>
-                <property name="spacing">2</property>
+                <property name="spacing">6</property>
                 <child>
                   <object class="GtkLabel" id="label5">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Customer: </property>
+                    <property name="label" translatable="yes">Customer</property>
                     <property name="justify">right</property>
                   </object>
                   <packing>
@@ -444,7 +444,7 @@
                   <object class="GtkLabel" id="label6">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Job: </property>
+                    <property name="label" translatable="yes">Job</property>
                     <property name="justify">right</property>
                   </object>
                   <packing>
@@ -495,12 +495,12 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="border_width">3</property>
-                <property name="spacing">2</property>
+                <property name="spacing">6</property>
                 <child>
                   <object class="GtkLabel" id="label31">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Additional to Card:</property>
+                    <property name="label" translatable="yes">Additional to Card</property>
                     <property name="justify">right</property>
                   </object>
                   <packing>

--- a/gnucash/gtkbuilder/dialog-preferences.glade
+++ b/gnucash/gtkbuilder/dialog-preferences.glade
@@ -247,7 +247,7 @@
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="pref/window.pages.account-tree.summary/start-choice-relative">
-                    <property name="label" translatable="yes">_Relative:</property>
+                    <property name="label" translatable="yes">_Relative</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
@@ -267,7 +267,7 @@
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="pref/window.pages.account-tree.summary/start-choice-absolute">
-                    <property name="label" translatable="yes">_Absolute:</property>
+                    <property name="label" translatable="yes">_Absolute</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
@@ -287,7 +287,7 @@
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="pref/window.pages.account-tree.summary/end-choice-relative">
-                    <property name="label" translatable="yes">Re_lative:</property>
+                    <property name="label" translatable="yes">Re_lative</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
@@ -307,7 +307,7 @@
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="pref/window.pages.account-tree.summary/end-choice-absolute">
-                    <property name="label" translatable="yes">Ab_solute:</property>
+                    <property name="label" translatable="yes">Ab_solute</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
@@ -616,7 +616,7 @@
                     <property name="can_focus">False</property>
                     <child>
                       <object class="GtkRadioButton" id="pref/general/currency-choice-other">
-                        <property name="label" translatable="yes">Ch_oose:</property>
+                        <property name="label" translatable="yes">Ch_oose</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
@@ -653,7 +653,7 @@
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
                     <property name="margin_left">12</property>
-                    <property name="label" translatable="yes">Character:</property>
+                    <property name="label" translatable="yes">Character</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
@@ -666,7 +666,7 @@
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
                     <property name="margin_left">12</property>
-                    <property name="label" translatable="yes">Sample:</property>
+                    <property name="label" translatable="yes">Sample</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
@@ -753,7 +753,7 @@
                     <property name="can_focus">False</property>
                     <child>
                       <object class="GtkRadioButton" id="pref/general/currency-choice-locale">
-                        <property name="label" translatable="yes">Loc_ale:</property>
+                        <property name="label" translatable="yes">Loc_ale</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
@@ -1428,7 +1428,7 @@ many months before the current month:</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
                     <property name="margin_left">12</property>
-                    <property name="label" translatable="yes">New search _limit:</property>
+                    <property name="label" translatable="yes">New search _limit</property>
                     <property name="use_underline">True</property>
                     <property name="mnemonic_widget">pref/dialogs.search/new-search-limit</property>
                   </object>
@@ -1480,7 +1480,7 @@ many months before the current month:</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
                     <property name="margin_left">12</property>
-                    <property name="label" translatable="yes">Auto-save time _interval:</property>
+                    <property name="label" translatable="yes">Auto-save time _interval</property>
                     <property name="use_underline">True</property>
                     <property name="mnemonic_widget">pref/general/autosave-interval-minutes</property>
                   </object>
@@ -1581,7 +1581,7 @@ many months before the current month:</property>
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="pref/general/retain-type-days">
-                    <property name="label" translatable="yes">For:</property>
+                    <property name="label" translatable="yes">For</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
@@ -1641,7 +1641,7 @@ many months before the current month:</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
                     <property name="margin_left">12</property>
-                    <property name="label" translatable="yes">Time to _wait for answer:</property>
+                    <property name="label" translatable="yes">Time to _wait for answer</property>
                     <property name="use_underline">True</property>
                     <property name="mnemonic_widget">pref/general/autosave-interval-minutes</property>
                   </object>
@@ -1926,7 +1926,7 @@ many months before the current month:</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">start</property>
-                        <property name="label" translatable="yes">Default _font:</property>
+                        <property name="label" translatable="yes">Default _font</property>
                         <property name="use_markup">True</property>
                         <property name="use_underline">True</property>
                         <property name="mnemonic_widget">pref/dialogs.checkprinting/default-font</property>
@@ -2444,7 +2444,7 @@ many months before the current month:</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
                     <property name="margin_left">12</property>
-                    <property name="label" translatable="yes">Number of _transactions:</property>
+                    <property name="label" translatable="yes">Number of _transactions</property>
                     <property name="use_underline">True</property>
                     <property name="mnemonic_widget">pref/general.register/max-transactions</property>
                   </object>
@@ -2537,7 +2537,7 @@ many months before the current month:</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
                     <property name="margin_left">12</property>
-                    <property name="label" translatable="yes" comments="Register2 feature">Number of _characters for auto complete:</property>
+                    <property name="label" translatable="yes" comments="Register2 feature">Number of _characters for auto complete</property>
                     <property name="use_underline">True</property>
                     <property name="mnemonic_widget">pref/general.register/key-length</property>
                   </object>
@@ -2715,7 +2715,7 @@ many months before the current month:</property>
                     <property name="left_padding">12</property>
                     <child>
                       <object class="GtkRadioButton" id="pref/general.report/currency-choice-other">
-                        <property name="label" translatable="yes">Ch_oose:</property>
+                        <property name="label" translatable="yes">Ch_oose</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
@@ -2741,7 +2741,7 @@ many months before the current month:</property>
                     <property name="left_padding">12</property>
                     <child>
                       <object class="GtkRadioButton" id="pref/general.report/currency-choice-locale">
-                        <property name="label" translatable="yes">Loc_ale:</property>
+                        <property name="label" translatable="yes">Loc_ale</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
@@ -3193,7 +3193,7 @@ many months before the current month:</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">start</property>
-                        <property name="label" translatable="yes">_Width:</property>
+                        <property name="label" translatable="yes">_Width</property>
                         <property name="use_underline">True</property>
                         <property name="ellipsize">middle</property>
                       </object>

--- a/gnucash/gtkbuilder/dialog-price.glade
+++ b/gnucash/gtkbuilder/dialog-price.glade
@@ -131,7 +131,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">_Namespace:</property>
+                <property name="label" translatable="yes">_Namespace</property>
                 <property name="use_underline">True</property>
                 <property name="justify">center</property>
                 <property name="mnemonic_widget">namespace_cbwe</property>
@@ -146,7 +146,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">_Security:</property>
+                <property name="label" translatable="yes">_Security</property>
                 <property name="use_underline">True</property>
                 <property name="justify">center</property>
                 <property name="mnemonic_widget">commodity_cbwe</property>
@@ -161,7 +161,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">Cu_rrency:</property>
+                <property name="label" translatable="yes">Cu_rrency</property>
                 <property name="use_underline">True</property>
                 <property name="justify">center</property>
               </object>
@@ -175,7 +175,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">_Date:</property>
+                <property name="label" translatable="yes">_Date</property>
                 <property name="use_underline">True</property>
                 <property name="justify">center</property>
               </object>
@@ -188,7 +188,7 @@
               <object class="GtkLabel" id="source_label">
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">S_ource:</property>
+                <property name="label" translatable="yes">S_ource</property>
                 <property name="use_underline">True</property>
                 <property name="justify">center</property>
                 <property name="mnemonic_widget">source_entry</property>
@@ -203,7 +203,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">_Type:</property>
+                <property name="label" translatable="yes">_Type</property>
                 <property name="use_underline">True</property>
                 <property name="justify">center</property>
                 <property name="mnemonic_widget">type_combobox</property>
@@ -218,7 +218,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">_Price:</property>
+                <property name="label" translatable="yes">_Price</property>
                 <property name="use_underline">True</property>
                 <property name="justify">center</property>
               </object>
@@ -615,7 +615,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">From these Commodities:</property>
+                <property name="label" translatable="yes">From these Commodities</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
@@ -628,7 +628,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">Keeping the last available price for option:</property>
+                <property name="label" translatable="yes">Keeping the last available price for option</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
@@ -643,7 +643,7 @@
                 <property name="halign">start</property>
                 <property name="valign">start</property>
                 <property name="hexpand">False</property>
-                <property name="label" translatable="yes">Source:</property>
+                <property name="label" translatable="yes">Source</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
@@ -747,7 +747,7 @@ These prices were added so that there's always a "nearest in time" price for eve
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">Before _Date:</property>
+                <property name="label" translatable="yes">Before _Date</property>
                 <property name="use_underline">True</property>
               </object>
               <packing>

--- a/gnucash/gtkbuilder/dialog-print-check.glade
+++ b/gnucash/gtkbuilder/dialog-print-check.glade
@@ -367,7 +367,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">Check _format:</property>
+                    <property name="label" translatable="yes">Check _format</property>
                     <property name="use_underline">True</property>
                     <property name="justify">center</property>
                     <property name="mnemonic_widget">check_format_combobox</property>
@@ -382,7 +382,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">Check po_sition:</property>
+                    <property name="label" translatable="yes">Check po_sition</property>
                     <property name="use_underline">True</property>
                     <property name="justify">center</property>
                     <property name="mnemonic_widget">check_position_combobox</property>
@@ -398,7 +398,7 @@
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
                     <property name="valign">start</property>
-                    <property name="label" translatable="yes">_Date format:</property>
+                    <property name="label" translatable="yes">_Date format</property>
                     <property name="use_underline">True</property>
                     <property name="justify">center</property>
                   </object>
@@ -541,7 +541,7 @@ to print an address on the check.</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">Checks on first _page:</property>
+                    <property name="label" translatable="yes">Checks on first _page</property>
                     <property name="use_underline">True</property>
                     <property name="mnemonic_widget">first_page_count_entry</property>
                   </object>
@@ -662,7 +662,7 @@ to print an address on the check.</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">Pa_yee:</property>
+                    <property name="label" translatable="yes">Pa_yee</property>
                     <property name="use_underline">True</property>
                     <property name="justify">center</property>
                     <property name="mnemonic_widget">payee_x_entry</property>
@@ -677,7 +677,7 @@ to print an address on the check.</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">_Date:</property>
+                    <property name="label" translatable="yes">_Date</property>
                     <property name="use_underline">True</property>
                     <property name="justify">center</property>
                     <property name="mnemonic_widget">date_x_entry</property>
@@ -692,7 +692,7 @@ to print an address on the check.</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">Amount (_words):</property>
+                    <property name="label" translatable="yes">Amount (_words)</property>
                     <property name="use_underline">True</property>
                     <property name="justify">center</property>
                     <property name="mnemonic_widget">amount_words_x_entry</property>
@@ -707,7 +707,7 @@ to print an address on the check.</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">Amount (_numbers):</property>
+                    <property name="label" translatable="yes">Amount (_numbers)</property>
                     <property name="use_underline">True</property>
                     <property name="justify">center</property>
                     <property name="mnemonic_widget">amount_numbers_x_entry</property>
@@ -722,7 +722,7 @@ to print an address on the check.</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">_Notes:</property>
+                    <property name="label" translatable="yes">_Notes</property>
                     <property name="use_underline">True</property>
                     <property name="justify">center</property>
                     <property name="mnemonic_widget">notes_x_entry</property>
@@ -915,7 +915,7 @@ to print an address on the check.</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">_Units:</property>
+                    <property name="label" translatable="yes">_Units</property>
                     <property name="use_underline">True</property>
                     <property name="justify">center</property>
                     <property name="mnemonic_widget">units_combobox</property>
@@ -946,7 +946,7 @@ to print an address on the check.</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">_Translation:</property>
+                    <property name="label" translatable="yes">_Translation</property>
                     <property name="use_underline">True</property>
                     <property name="justify">center</property>
                     <property name="mnemonic_widget">translation_x_entry</property>
@@ -1060,7 +1060,7 @@ to print an address on the check.</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">_Address:</property>
+                    <property name="label" translatable="yes">_Address</property>
                     <property name="use_underline">True</property>
                   </object>
                   <packing>
@@ -1105,7 +1105,7 @@ to print an address on the check.</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">_Memo:</property>
+                    <property name="label" translatable="yes">_Memo</property>
                     <property name="use_underline">True</property>
                     <property name="justify">center</property>
                     <property name="mnemonic_widget">memo_x_entry</property>

--- a/gnucash/gtkbuilder/dialog-report.glade
+++ b/gnucash/gtkbuilder/dialog-report.glade
@@ -548,7 +548,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">_Row span:</property>
+                <property name="label" translatable="yes">_Row span</property>
                 <property name="use_underline">True</property>
                 <property name="justify">center</property>
                 <property name="mnemonic_widget">row_spin</property>
@@ -563,7 +563,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">_Column span:</property>
+                <property name="label" translatable="yes">_Column span</property>
                 <property name="use_underline">True</property>
                 <property name="justify">center</property>
                 <property name="mnemonic_widget">col_spin</property>
@@ -799,7 +799,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">_Name:</property>
+                <property name="label" translatable="yes">_Name</property>
                 <property name="use_underline">True</property>
                 <property name="justify">center</property>
                 <property name="mnemonic_widget">name_entry</property>
@@ -814,7 +814,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">_Template:</property>
+                <property name="label" translatable="yes">_Template</property>
                 <property name="use_underline">True</property>
                 <property name="justify">center</property>
                 <property name="mnemonic_widget">template_combobox</property>

--- a/gnucash/gtkbuilder/dialog-sx.glade
+++ b/gnucash/gtkbuilder/dialog-sx.glade
@@ -228,13 +228,13 @@
                   <object class="GtkGrid" id="param_table">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="column_spacing">5</property>
+                    <property name="column_spacing">6</property>
                     <child>
                       <object class="GtkLabel" id="label847842">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">end</property>
-                        <property name="label" translatable="yes">Name:</property>
+                        <property name="label" translatable="yes">Name</property>
                         <property name="justify">center</property>
                       </object>
                       <packing>
@@ -247,7 +247,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">end</property>
-                        <property name="label" translatable="yes">Frequency:</property>
+                        <property name="label" translatable="yes">Frequency</property>
                         <property name="justify">center</property>
                       </object>
                       <packing>
@@ -260,7 +260,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">end</property>
-                        <property name="label" translatable="yes">Start Date:</property>
+                        <property name="label" translatable="yes">Start Date</property>
                         <property name="justify">center</property>
                       </object>
                       <packing>
@@ -332,7 +332,7 @@
                                 <property name="can_focus">False</property>
                                 <child>
                                   <object class="GtkRadioButton" id="end_on_date_button">
-                                    <property name="label" translatable="yes">End Date:</property>
+                                    <property name="label" translatable="yes">End Date</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">False</property>
@@ -363,7 +363,7 @@
                                 <property name="can_focus">False</property>
                                 <child>
                                   <object class="GtkRadioButton" id="n_occurrences_button">
-                                    <property name="label" translatable="yes">Number of Occurrences:</property>
+                                    <property name="label" translatable="yes">Number of Occurrences</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">False</property>
@@ -421,7 +421,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">end</property>
-                        <property name="label" translatable="yes">End: </property>
+                        <property name="label" translatable="yes">End</property>
                         <property name="use_markup">True</property>
                       </object>
                       <packing>
@@ -603,7 +603,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
                 <property name="margin_left">12</property>
-                <property name="label" translatable="yes">Crea_te in advance:</property>
+                <property name="label" translatable="yes">Crea_te in advance</property>
                 <property name="use_underline">True</property>
                 <property name="mnemonic_widget">pref/dialogs.sxs.transaction-editor/create-days</property>
               </object>
@@ -625,7 +625,7 @@
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
                 <property name="margin_left">12</property>
-                <property name="label" translatable="yes">R_emind in advance:</property>
+                <property name="label" translatable="yes">R_emind in advance</property>
                 <property name="use_underline">True</property>
                 <property name="mnemonic_widget">pref/dialogs.sxs.transaction-editor/remind-days</property>
               </object>
@@ -836,6 +836,7 @@
               <object class="GtkBox" id="hbox96">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="spacing">6</property>
                 <child>
                   <object class="GtkLabel" id="label847707">
                     <property name="visible">True</property>
@@ -930,7 +931,7 @@
                             <property name="column_spacing">6</property>
                             <child>
                               <object class="GtkCheckButton" id="advance_opt">
-                                <property name="label" translatable="yes">Create in advance:</property>
+                                <property name="label" translatable="yes">Create in advance</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
@@ -945,7 +946,7 @@
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="remind_opt">
-                                <property name="label" translatable="yes">Remind in advance:</property>
+                                <property name="label" translatable="yes">Remind in advance</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
@@ -1228,7 +1229,7 @@
                                     </child>
                                     <child>
                                       <object class="GtkRadioButton" id="rb_enddate">
-                                        <property name="label" translatable="yes">Until:</property>
+                                        <property name="label" translatable="yes">Until</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>
@@ -1244,7 +1245,7 @@
                                     </child>
                                     <child>
                                       <object class="GtkRadioButton" id="rb_num_occur">
-                                        <property name="label" translatable="yes">For:</property>
+                                        <property name="label" translatable="yes">For</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">False</property>

--- a/gnucash/gtkbuilder/dialog-tax-info.glade
+++ b/gnucash/gtkbuilder/dialog-tax-info.glade
@@ -116,7 +116,7 @@
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="halign">start</property>
-                            <property name="label" translatable="yes">Name:</property>
+                            <property name="label" translatable="yes">Name</property>
                             <property name="use_markup">True</property>
                             <property name="use_underline">True</property>
                             <property name="justify">right</property>
@@ -139,7 +139,7 @@
                           <object class="GtkLabel" id="label847742">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Type:</property>
+                            <property name="label" translatable="yes">Type</property>
                             <property name="use_markup">True</property>
                             <property name="use_underline">True</property>
                             <property name="justify">right</property>

--- a/gnucash/gtkbuilder/dialog-tax-table.glade
+++ b/gnucash/gtkbuilder/dialog-tax-table.glade
@@ -451,7 +451,7 @@
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
                     <property name="valign">start</property>
-                    <property name="label" translatable="yes">_Account:</property>
+                    <property name="label" translatable="yes">_Account</property>
                     <property name="use_underline">True</property>
                   </object>
                 </child>
@@ -471,7 +471,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">_Value: </property>
+                    <property name="label" translatable="yes">_Value</property>
                     <property name="use_underline">True</property>
                     <property name="justify">right</property>
                   </object>
@@ -492,7 +492,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">_Type: </property>
+                    <property name="label" translatable="yes">_Type</property>
                     <property name="use_underline">True</property>
                     <property name="justify">right</property>
                     <property name="mnemonic_widget">type_combobox</property>
@@ -543,7 +543,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">_Name: </property>
+                    <property name="label" translatable="yes">_Name</property>
                     <property name="use_underline">True</property>
                     <property name="justify">right</property>
                     <property name="mnemonic_widget">name_entry</property>

--- a/gnucash/gtkbuilder/dialog-totd.glade
+++ b/gnucash/gtkbuilder/dialog-totd.glade
@@ -95,7 +95,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">&lt;b&gt;Tip of the Day:&lt;/b&gt;</property>
+                    <property name="label" translatable="yes">&lt;b&gt;Tip of the Day&lt;/b&gt;</property>
                     <property name="use_markup">True</property>
                     <property name="use_underline">True</property>
                   </object>

--- a/gnucash/gtkbuilder/dialog-transfer.glade
+++ b/gnucash/gtkbuilder/dialog-transfer.glade
@@ -112,7 +112,7 @@
                         <property name="can_focus">False</property>
                         <property name="halign">start</property>
                         <property name="margin_left">12</property>
-                        <property name="label" translatable="yes">Amount:</property>
+                        <property name="label" translatable="yes">Amount</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -139,7 +139,7 @@
                         <property name="can_focus">False</property>
                         <property name="halign">start</property>
                         <property name="margin_left">12</property>
-                        <property name="label" translatable="yes">Date:</property>
+                        <property name="label" translatable="yes">Date</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -167,7 +167,7 @@
                         <property name="can_focus">False</property>
                         <property name="halign">start</property>
                         <property name="margin_left">12</property>
-                        <property name="label" translatable="yes">Num:</property>
+                        <property name="label" translatable="yes">Num</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -192,7 +192,7 @@
                         <property name="can_focus">False</property>
                         <property name="halign">start</property>
                         <property name="margin_left">12</property>
-                        <property name="label" translatable="yes">Description:</property>
+                        <property name="label" translatable="yes">Description</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -219,7 +219,7 @@
                         <property name="can_focus">False</property>
                         <property name="halign">start</property>
                         <property name="margin_left">12</property>
-                        <property name="label" translatable="yes">Memo:</property>
+                        <property name="label" translatable="yes">Memo</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -281,7 +281,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">start</property>
-                        <property name="label" translatable="yes">Currency:</property>
+                        <property name="label" translatable="yes">Currency</property>
                         <property name="justify">center</property>
                       </object>
                       <packing>
@@ -369,7 +369,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">start</property>
-                        <property name="label" translatable="yes">Currency:</property>
+                        <property name="label" translatable="yes">Currency</property>
                         <property name="justify">center</property>
                       </object>
                       <packing>
@@ -512,7 +512,7 @@
                     <property name="column_spacing">12</property>
                     <child>
                       <object class="GtkRadioButton" id="price_radio">
-                        <property name="label" translatable="yes">Exchange Rate:</property>
+                        <property name="label" translatable="yes">Exchange Rate</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
@@ -552,7 +552,7 @@
                     </child>
                     <child>
                       <object class="GtkRadioButton" id="amount_radio">
-                        <property name="label" translatable="yes">To Amount:</property>
+                        <property name="label" translatable="yes">To Amount</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>

--- a/gnucash/gtkbuilder/dialog-userpass.glade
+++ b/gnucash/gtkbuilder/dialog-userpass.glade
@@ -83,7 +83,7 @@
               <object class="GtkLabel" id="label847713">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">_Username:</property>
+                <property name="label" translatable="yes">_Username</property>
                 <property name="use_underline">True</property>
                 <property name="justify">center</property>
                 <property name="mnemonic_widget">username_entry</property>
@@ -97,7 +97,7 @@
               <object class="GtkLabel" id="label847714">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">_Password:</property>
+                <property name="label" translatable="yes">_Password</property>
                 <property name="use_underline">True</property>
                 <property name="justify">center</property>
                 <property name="mnemonic_widget">password_entry</property>

--- a/gnucash/gtkbuilder/dialog-vendor.glade
+++ b/gnucash/gtkbuilder/dialog-vendor.glade
@@ -127,6 +127,7 @@
                         <property name="margin_top">5</property>
                         <property name="margin_bottom">5</property>
                         <property name="border_width">2</property>
+                        <property name="spacing">6</property>
                         <child>
                           <object class="GtkBox" id="vbox11">
                             <property name="visible">True</property>
@@ -138,7 +139,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Vendor Number: </property>
+                                <property name="label" translatable="yes">Vendor Number</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -152,7 +153,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Company Name: </property>
+                                <property name="label" translatable="yes">Company Name</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -280,7 +281,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Name: </property>
+                                <property name="label" translatable="yes">Name</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -294,7 +295,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Address: </property>
+                                <property name="label" translatable="yes">Address</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -344,7 +345,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Phone: </property>
+                                <property name="label" translatable="yes">Phone</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -358,7 +359,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Fax: </property>
+                                <property name="label" translatable="yes">Fax</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -372,7 +373,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Email: </property>
+                                <property name="label" translatable="yes">Email</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -590,6 +591,7 @@
                         <property name="margin_right">5</property>
                         <property name="margin_top">5</property>
                         <property name="margin_bottom">5</property>
+                        <property name="spacing">6</property>
                         <child>
                           <object class="GtkBox" id="vbox7">
                             <property name="visible">True</property>
@@ -601,7 +603,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Currency: </property>
+                                <property name="label" translatable="yes">Currency</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -615,7 +617,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Terms: </property>
+                                <property name="label" translatable="yes">Terms</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -629,7 +631,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Tax Included:</property>
+                                <property name="label" translatable="yes">Tax Included</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -643,7 +645,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Tax Table:</property>
+                                <property name="label" translatable="yes">Tax Table</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>

--- a/gnucash/gtkbuilder/gnc-date-format.glade
+++ b/gnucash/gtkbuilder/gnc-date-format.glade
@@ -166,7 +166,7 @@
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="halign">start</property>
-            <property name="label" translatable="yes">Months:</property>
+            <property name="label" translatable="yes">Months</property>
           </object>
           <packing>
             <property name="left_attach">1</property>
@@ -178,7 +178,7 @@
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="halign">start</property>
-            <property name="label" translatable="yes">Years:</property>
+            <property name="label" translatable="yes">Years</property>
           </object>
           <packing>
             <property name="left_attach">1</property>
@@ -190,7 +190,7 @@
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="halign">start</property>
-            <property name="label" translatable="yes">Format:</property>
+            <property name="label" translatable="yes">Format</property>
           </object>
           <packing>
             <property name="left_attach">1</property>
@@ -203,7 +203,7 @@
             <property name="can_focus">False</property>
             <property name="halign">start</property>
             <property name="margin_right">5</property>
-            <property name="label" translatable="yes">Sample:</property>
+            <property name="label" translatable="yes">Sample</property>
           </object>
           <packing>
             <property name="left_attach">1</property>
@@ -221,7 +221,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">Date format:</property>
+                <property name="label" translatable="yes">Date format</property>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/gnucash/gtkbuilder/gnc-frequency.glade
+++ b/gnucash/gtkbuilder/gnc-frequency.glade
@@ -585,12 +585,13 @@
               <object class="GtkGrid" id="gncfreq_table">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="column_spacing">6</property>
                 <child>
                   <object class="GtkLabel" id="freq_label">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="margin_right">12</property>
-                    <property name="label" translatable="yes">Frequency:</property>
+                    <property name="label" translatable="yes">Frequency</property>
                     <property name="justify">right</property>
                   </object>
                   <packing>
@@ -603,7 +604,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="margin_right">12</property>
-                    <property name="label" translatable="yes">Start Date:</property>
+                    <property name="label" translatable="yes">Start Date</property>
                     <property name="justify">center</property>
                   </object>
                   <packing>
@@ -1090,13 +1091,14 @@
                           <object class="GtkBox" id="hbox127">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
+                            <property name="spacing">6</property>
                             <child>
                               <object class="GtkLabel" id="label847759">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">start</property>
                                 <property name="margin_right">12</property>
-                                <property name="label" translatable="yes">First on the:</property>
+                                <property name="label" translatable="yes">First on the</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -1131,7 +1133,7 @@
                                 <property name="can_focus">False</property>
                                 <property name="halign">start</property>
                                 <property name="margin_right">12</property>
-                                <property name="label" translatable="yes">except on weekends:</property>
+                                <property name="label" translatable="yes">except on weekends</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -1169,13 +1171,14 @@
                           <object class="GtkBox" id="hbox128">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
+                            <property name="spacing">6</property>
                             <child>
                               <object class="GtkLabel" id="label847760">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">start</property>
                                 <property name="margin_right">12</property>
-                                <property name="label" translatable="yes">then on the:</property>
+                                <property name="label" translatable="yes">then on the</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -1210,7 +1213,7 @@
                                 <property name="can_focus">False</property>
                                 <property name="halign">start</property>
                                 <property name="margin_right">12</property>
-                                <property name="label" translatable="yes">except on weekends:</property>
+                                <property name="label" translatable="yes">except on weekends</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>
@@ -1341,12 +1344,12 @@
                           <object class="GtkBox" id="hbox125">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
+                            <property name="spacing">6</property>
                             <child>
                               <object class="GtkLabel" id="label847756">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">start</property>
-                                <property name="margin_right">12</property>
                                 <property name="label" translatable="yes">On the</property>
                                 <property name="justify">right</property>
                               </object>
@@ -1361,7 +1364,6 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">start</property>
-                                <property name="margin_right">12</property>
                                 <property name="model">liststore4</property>
                                 <child>
                                   <object class="GtkCellRendererText" id="cellrenderertext4"/>
@@ -1382,8 +1384,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">start</property>
-                                <property name="margin_right">12</property>
-                                <property name="label" translatable="yes">except on weekends:</property>
+                                <property name="label" translatable="yes">except on weekends</property>
                                 <property name="justify">right</property>
                               </object>
                               <packing>

--- a/gnucash/gtkbuilder/gnc-plugin-page-budget.glade
+++ b/gnucash/gtkbuilder/gnc-plugin-page-budget.glade
@@ -99,12 +99,13 @@
           <object class="GtkGrid" id="table1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="column_spacing">6</property>
             <child>
               <object class="GtkLabel" id="label3">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">Value:</property>
+                <property name="label" translatable="yes">Value</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
@@ -126,6 +127,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="halign">start</property>
                 <property name="label" translatable="yes">Action</property>
               </object>
               <packing>
@@ -145,6 +147,7 @@
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
                     <property name="tooltip_text" translatable="yes">Replace the budget for all periods with new 'value'. Use empty value to unset budget for the accounts.</property>
+                    <property name="halign">start</property>
                     <property name="active">True</property>
                     <property name="draw_indicator">True</property>
                   </object>
@@ -161,6 +164,7 @@
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
                     <property name="tooltip_text" translatable="yes">Add 'value' to current budget for each period</property>
+                    <property name="halign">start</property>
                     <property name="active">True</property>
                     <property name="draw_indicator">True</property>
                     <property name="group">RB_Replace</property>
@@ -178,6 +182,7 @@
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
                     <property name="tooltip_text" translatable="yes">Multiply current budget for each period by 'value'</property>
+                    <property name="halign">start</property>
                     <property name="active">True</property>
                     <property name="draw_indicator">True</property>
                     <property name="group">RB_Replace</property>
@@ -218,7 +223,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">Significant Digits:</property>
+                <property name="label" translatable="yes">Significant Digits</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
@@ -329,12 +334,13 @@
           <object class="GtkGrid" id="table6">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="column_spacing">6</property>
             <child>
               <object class="GtkLabel" id="label96">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">Start Date:</property>
+                <property name="label" translatable="yes">Start Date</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
@@ -346,7 +352,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">Significant Digits:</property>
+                <property name="label" translatable="yes">Significant Digits</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
@@ -391,6 +397,7 @@
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
                 <property name="tooltip_text" translatable="yes">Use the average value over all actual periods for all projected periods</property>
+                <property name="halign">start</property>
                 <property name="draw_indicator">True</property>
               </object>
               <packing>
@@ -492,14 +499,14 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="row_spacing">3</property>
-                <property name="column_spacing">3</property>
+                <property name="column_spacing">6</property>
                 <child>
                   <object class="GtkLabel" id="label85">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
                     <property name="margin_left">5</property>
-                    <property name="label" translatable="yes">Budget Name:</property>
+                    <property name="label" translatable="yes">Budget Name</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
@@ -526,7 +533,7 @@
                     <property name="halign">start</property>
                     <property name="valign">start</property>
                     <property name="margin_left">5</property>
-                    <property name="label" translatable="yes">Notes:</property>
+                    <property name="label" translatable="yes">Notes</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
@@ -575,7 +582,7 @@
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
                     <property name="margin_left">5</property>
-                    <property name="label" translatable="yes">Number of Periods:</property>
+                    <property name="label" translatable="yes">Number of Periods</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
@@ -604,7 +611,7 @@
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
                     <property name="margin_left">5</property>
-                    <property name="label" translatable="yes">Budget Period:</property>
+                    <property name="label" translatable="yes">Budget Period</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>

--- a/gnucash/gtkbuilder/gnc-plugin-page-register.glade
+++ b/gnucash/gtkbuilder/gnc-plugin-page-register.glade
@@ -141,7 +141,7 @@ If 0, all previous days included</property>
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="filter_show_range">
-                    <property name="label" translatable="yes">Select _Range:</property>
+                    <property name="label" translatable="yes">Select _Range</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
@@ -166,7 +166,7 @@ If 0, all previous days included</property>
                       <object class="GtkLabel" id="label847682">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes" comments="Filter By Dialog, Date Tab, Start section">Start:</property>
+                        <property name="label" translatable="yes" comments="Filter By Dialog, Date Tab, Start section">Start</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -191,7 +191,7 @@ If 0, all previous days included</property>
                     </child>
                     <child>
                       <object class="GtkRadioButton" id="end_date_choose">
-                        <property name="label" translatable="yes">Choo_se Date:</property>
+                        <property name="label" translatable="yes">Choo_se Date</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
@@ -253,7 +253,7 @@ If 0, all previous days included</property>
                       <object class="GtkLabel" id="label847684">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes" comments="Filter By Dialog, Date Tab, End section">End:</property>
+                        <property name="label" translatable="yes" comments="Filter By Dialog, Date Tab, End section">End</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -262,7 +262,7 @@ If 0, all previous days included</property>
                     </child>
                     <child>
                       <object class="GtkRadioButton" id="start_date_choose">
-                        <property name="label" translatable="yes">C_hoose Date:</property>
+                        <property name="label" translatable="yes">C_hoose Date</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
@@ -1007,7 +1007,7 @@ If 0, all previous days included</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">_Date:</property>
+                    <property name="label" translatable="yes">_Date</property>
                     <property name="use_underline">True</property>
                     <property name="justify">center</property>
                   </object>
@@ -1021,7 +1021,7 @@ If 0, all previous days included</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">_Number:</property>
+                    <property name="label" translatable="yes">_Number</property>
                     <property name="use_underline">True</property>
                     <property name="justify">center</property>
                     <property name="mnemonic_widget">num_spin</property>
@@ -1064,7 +1064,7 @@ If 0, all previous days included</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">_Transaction Number:</property>
+                    <property name="label" translatable="yes">_Transaction Number</property>
                     <property name="use_underline">True</property>
                     <property name="justify">center</property>
                     <property name="mnemonic_widget">tnum_spin</property>
@@ -1215,7 +1215,7 @@ If 0, all previous days included</property>
               <object class="GtkLabel" id="label847671">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Reason for voiding transaction:</property>
+                <property name="label" translatable="yes">Reason for voiding transaction</property>
                 <property name="justify">center</property>
               </object>
               <packing>

--- a/gnucash/gtkbuilder/gnc-plugin-page-register2.glade
+++ b/gnucash/gtkbuilder/gnc-plugin-page-register2.glade
@@ -97,7 +97,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">_Date:</property>
+                    <property name="label" translatable="yes">_Date</property>
                     <property name="use_underline">True</property>
                     <property name="justify">center</property>
                   </object>
@@ -111,7 +111,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="label" translatable="yes">_Number:</property>
+                    <property name="label" translatable="yes">_Number</property>
                     <property name="use_underline">True</property>
                     <property name="justify">center</property>
                     <property name="mnemonic_widget">num_spin</property>
@@ -291,7 +291,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">start</property>
-                        <property name="label" translatable="yes">Start:</property>
+                        <property name="label" translatable="yes">Start</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -316,7 +316,7 @@
                     </child>
                     <child>
                       <object class="GtkRadioButton" id="end_date_choose">
-                        <property name="label" translatable="yes">Choo_se Date:</property>
+                        <property name="label" translatable="yes">Choo_se Date</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
@@ -379,7 +379,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">start</property>
-                        <property name="label" translatable="yes">End:</property>
+                        <property name="label" translatable="yes">End</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -388,7 +388,7 @@
                     </child>
                     <child>
                       <object class="GtkRadioButton" id="start_date_choose">
-                        <property name="label" translatable="yes">C_hoose Date:</property>
+                        <property name="label" translatable="yes">C_hoose Date</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
@@ -750,7 +750,7 @@
               <object class="GtkLabel" id="label847671">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Reason for voiding transaction:</property>
+                <property name="label" translatable="yes">Reason for voiding transaction</property>
                 <property name="justify">center</property>
               </object>
               <packing>

--- a/gnucash/gtkbuilder/gnc-recurrence.glade
+++ b/gnucash/gtkbuilder/gnc-recurrence.glade
@@ -103,11 +103,12 @@
           <object class="GtkBox" id="hbox219">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="spacing">6</property>
             <child>
               <object class="GtkLabel" id="label89">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">beginning on: </property>
+                <property name="label" translatable="yes">beginning on</property>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/gnucash/gtkbuilder/window-autoclear.glade
+++ b/gnucash/gtkbuilder/window-autoclear.glade
@@ -91,13 +91,13 @@
                     <property name="can_focus">False</property>
                     <property name="border_width">10</property>
                     <property name="row_spacing">6</property>
-                    <property name="column_spacing">4</property>
+                    <property name="column_spacing">6</property>
                     <child>
                       <object class="GtkLabel" id="end_label">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">start</property>
-                        <property name="label" translatable="yes">_Ending Balance:</property>
+                        <property name="label" translatable="yes">_Ending Balance</property>
                         <property name="use_underline">True</property>
                       </object>
                       <packing>

--- a/gnucash/gtkbuilder/window-reconcile.glade
+++ b/gnucash/gtkbuilder/window-reconcile.glade
@@ -90,7 +90,7 @@
                     <property name="can_focus">False</property>
                     <property name="border_width">10</property>
                     <property name="row_spacing">6</property>
-                    <property name="column_spacing">4</property>
+                    <property name="column_spacing">6</property>
                     <child>
                       <object class="GtkLabel" id="start_value">
                         <property name="visible">True</property>
@@ -107,7 +107,7 @@
                       <object class="GtkLabel" id="date_label">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Statement _Date:</property>
+                        <property name="label" translatable="yes">Statement _Date</property>
                         <property name="use_underline">True</property>
                       </object>
                       <packing>
@@ -119,7 +119,7 @@
                       <object class="GtkLabel" id="start_label">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Starting Balance:</property>
+                        <property name="label" translatable="yes">Starting Balance</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -130,7 +130,7 @@
                       <object class="GtkLabel" id="end_label">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">_Ending Balance:</property>
+                        <property name="label" translatable="yes">_Ending Balance</property>
                         <property name="use_underline">True</property>
                       </object>
                       <packing>

--- a/gnucash/import-export/qif-imp/assistant-qif-import.c
+++ b/gnucash/import-export/qif-imp/assistant-qif-import.c
@@ -903,7 +903,7 @@ new_security_notebook_page (SCM security_hash_key, gnc_commodity *comm, QIFImpor
     comm_nb_page->name_entry = gtk_entry_new ();
     gtk_entry_set_text (GTK_ENTRY(comm_nb_page->name_entry),
                         gnc_commodity_get_fullname (comm));
-    label = gtk_label_new_with_mnemonic (_("_Name or description:"));
+    label = gtk_label_new_with_mnemonic (_("_Name or description"));
     gtk_label_set_mnemonic_widget (GTK_LABEL(label), comm_nb_page->name_entry);
     gnc_label_set_alignment (label, 0, 0.5);
 
@@ -927,7 +927,7 @@ new_security_notebook_page (SCM security_hash_key, gnc_commodity *comm, QIFImpor
     gtk_entry_set_text (GTK_ENTRY(comm_nb_page->mnemonic_entry),
                        gnc_commodity_get_mnemonic (comm));
     label = gtk_label_new_with_mnemonic (
-                _("_Ticker symbol or other abbreviation:"));
+                _("_Ticker symbol or other abbreviation"));
     gtk_label_set_mnemonic_widget (GTK_LABEL(label), comm_nb_page->mnemonic_entry);
     gnc_label_set_alignment (label, 0, 0.5);
 
@@ -961,7 +961,7 @@ new_security_notebook_page (SCM security_hash_key, gnc_commodity *comm, QIFImpor
 
     gnc_cbwe_add_completion (GTK_COMBO_BOX(comm_nb_page->namespace_combo));
     label = gtk_label_new_with_mnemonic (
-                _("_Exchange or abbreviation type:"));
+                _("_Exchange or abbreviation type"));
     gtk_label_set_mnemonic_widget (GTK_LABEL(label), comm_nb_page->namespace_combo);
     gnc_label_set_alignment (label, 0, 0.5);
 


### PR DESCRIPTION
This PR removes the trailing colon from dialogue labels to make all labels of the same format, it also removes some trailing spaces that were added as a spacer which have been replaced with the use of padding and margins. The status bars have been left as is. 

I think I have identified all of them but if I come across them on master when I change some widgets to grids I will change them then.

This obviously will require updated translations and may be ultimately some reduction if the labels are consistent and it was expressed that it should be done on maint.

If no one has any concerns, I will push this on Friday and hopefully merge this to master once I worked out how to do that and then I can change some dialogues to use grids instead of boxes and also change the label alignment to the right.