### PR TITLE
drop emacs_trailer from xml files.

### DIFF
--- a/libgnucash/backend/xml/io-example-account.cpp
+++ b/libgnucash/backend/xml/io-example-account.cpp
@@ -425,8 +425,6 @@ gnc_write_example_account (GncExampleAccount* gea, const gchar* filename)
 
     fprintf (out, "</" GNC_ACCOUNT_STRING ">\n\n");
 
-    write_emacs_trailer (out);
-
     fclose (out);
 
     return TRUE;

--- a/libgnucash/backend/xml/io-gncxml-v2.cpp
+++ b/libgnucash/backend/xml/io-gncxml-v2.cpp
@@ -1601,8 +1601,7 @@ gnc_book_write_to_xml_file_v2 (
 
     /* Try to write as much as possible */
     if (!out
-        || !gnc_book_write_to_xml_filehandle_v2 (book, out)
-        || !write_emacs_trailer (out))
+        || !gnc_book_write_to_xml_filehandle_v2 (book, out))
         success = FALSE;
 
     /* Close the output stream */
@@ -1633,8 +1632,7 @@ gnc_book_write_accounts_to_xml_file_v2 (QofBackend* qof_be, QofBook* book,
 
     /* Try to write as much as possible */
     if (!out
-        || !gnc_book_write_accounts_to_xml_filehandle_v2 (qof_be, book, out)
-        || !write_emacs_trailer (out))
+        || !gnc_book_write_accounts_to_xml_filehandle_v2 (qof_be, book, out))
         success = FALSE;
 
     /* Close the output stream */
@@ -2153,7 +2151,7 @@ gnc_xml2_parse_with_subst (GncXmlBackend* xml_be, QofBook* book, GHashTable* sub
                   xml_be, book, (sixtp_push_handler) parse_with_subst_push_handler,
                   push_data, GNC_BOOK_XML2_FILE);
     g_free (push_data);
-    
+
     if (success)
         qof_instance_set_dirty (QOF_INSTANCE (book));
 

--- a/libgnucash/backend/xml/io-utils.cpp
+++ b/libgnucash/backend/xml/io-utils.cpp
@@ -33,23 +33,6 @@ extern "C"
 #include "gnc-xml.h"
 #include "io-utils.h"
 #include "sixtp.h"
-/*
-  <!-- Local variables: -->
-  <!-- mode: C          -->
-  <!-- End:             -->
-*/
-
-static const gchar* emacs_trailer =
-    "<!-- Local variables: -->\n"
-    "<!-- mode: xml        -->\n"
-    "<!-- End:             -->\n";
-
-
-gboolean
-write_emacs_trailer (FILE* out)
-{
-    return fprintf (out, "%s", emacs_trailer) >= 0;
-}
 
 static gboolean
 write_one_account (FILE* out,
@@ -66,7 +49,7 @@ write_one_account (FILE* out,
     xmlFreeNode (accnode);
 
     g_return_val_if_fail(gd, FALSE);
-    
+
     if (ferror (out) || fprintf (out, "\n") < 0)
         return FALSE;
 

--- a/libgnucash/backend/xml/io-utils.h
+++ b/libgnucash/backend/xml/io-utils.h
@@ -37,7 +37,5 @@ gboolean write_accounts (FILE* out, QofBook* book, sixtp_gdv2* gd);
 gboolean write_book_parts (FILE* out, QofBook* book);
 gboolean write_commodities (FILE* out, QofBook* book, sixtp_gdv2* gd);
 
-gboolean write_emacs_trailer (FILE* out);
-
 
 #endif /* IO_UTILS_H */


### PR DESCRIPTION
Modern versions of emacs know, how to behave on xml files.