### PR TITLE
Remove not needed semicolons in Python bindings

### DIFF
--- a/bindings/python/example_scripts/rest-api/gnucash_simple.py
+++ b/bindings/python/example_scripts/rest-api/gnucash_simple.py
@@ -34,14 +34,14 @@ def addressToDict(address):
         return None
     else:
         simple_address = {}
-        simple_address['name'] = address.GetName();
-        simple_address['line_1'] = address.GetAddr1();
-        simple_address['line_2'] = address.GetAddr2();
-        simple_address['line_3'] = address.GetAddr3();
-        simple_address['line_4'] = address.GetAddr4();
-        simple_address['phone'] = address.GetPhone();
-        simple_address['fax'] = address.GetFax();
-        simple_address['email'] = address.GetEmail();
+        simple_address['name'] = address.GetName()
+        simple_address['line_1'] = address.GetAddr1()
+        simple_address['line_2'] = address.GetAddr2()
+        simple_address['line_3'] = address.GetAddr3()
+        simple_address['line_4'] = address.GetAddr4()
+        simple_address['phone'] = address.GetPhone()
+        simple_address['fax'] = address.GetFax()
+        simple_address['email'] = address.GetEmail()
 
         return simple_address
 

--- a/bindings/python/gnucash_core.py
+++ b/bindings/python/gnucash_core.py
@@ -619,7 +619,7 @@ methods_return_instance(GncLot, gnclot_dict)
 
 # Transaction
 Transaction.add_methods_with_prefix('xaccTrans')
-Transaction.add_method('gncTransGetGUID', 'GetGUID');
+Transaction.add_method('gncTransGetGUID', 'GetGUID')
 
 Transaction.add_method('xaccTransGetDescription', 'GetDescription')
 Transaction.add_method('xaccTransDestroy', 'Destroy')
@@ -648,7 +648,7 @@ Transaction.decorate_functions(
 
 # Split
 Split.add_methods_with_prefix('xaccSplit')
-Split.add_method('gncSplitGetGUID', 'GetGUID');
+Split.add_method('gncSplitGetGUID', 'GetGUID')
 Split.add_method('xaccSplitDestroy', 'Destroy')
 
 split_dict =    {
@@ -677,7 +677,7 @@ Split.parent = property( Split.GetParent, Split.SetParent )
 # Account
 Account.add_methods_with_prefix('xaccAccount')
 Account.add_methods_with_prefix('gnc_account_')
-Account.add_method('gncAccountGetGUID', 'GetGUID');
+Account.add_method('gncAccountGetGUID', 'GetGUID')
 Account.add_method('xaccAccountGetPlaceholder', 'GetPlaceholder')
 
 account_dict =  {


### PR DESCRIPTION
Python syntax fix - remove not needed semicolons.