### PR TITLE
[Master] Change dialog-options to use a two column GtkGrid

### DIFF
--- a/gnucash/gnome-utils/dialog-options.h
+++ b/gnucash/gnome-utils/dialog-options.h
@@ -84,8 +84,8 @@ void gnc_options_dialog_set_scm_callbacks (GNCOptionWin *win,
 
 /* Function to set the UI widget based upon the option */
 typedef GtkWidget *
-(*GNCOptionUISetWidget) (GNCOption *option, GtkBox *page_box,
-                         char *name, char *documentation,
+(*GNCOptionUISetWidget) (GNCOption *option, GtkGrid *page_box,
+                         GtkLabel *name_label, char *documentation,
                          /* Return values */
                          GtkWidget **enclosing, gboolean *packed);
 

--- a/gnucash/gnome/business-options-gnome.c
+++ b/gnucash/gnome/business-options-gnome.c
@@ -102,19 +102,15 @@ get_owner_type_from_option (GNCOption *option)
 
 /* Function to set the UI widget based upon the option */
 static GtkWidget *
-owner_set_widget (GNCOption *option, GtkBox *page_box,
-                  char *name, char *documentation,
+owner_set_widget (GNCOption *option, GtkGrid *page_box,
+                  GtkLabel *name_label, char *documentation,
                   /* Return values */
                   GtkWidget **enclosing, gboolean *packed)
 {
     GtkWidget *value;
-    GtkWidget *label;
 
     *enclosing = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
     gtk_box_set_homogeneous (GTK_BOX (*enclosing), FALSE);
-
-    label = make_name_label (name);
-    gtk_box_pack_start (GTK_BOX (*enclosing), label, FALSE, FALSE, 0);
 
     value = create_owner_widget (option, get_owner_type_from_option (option),
                                  *enclosing);
@@ -173,19 +169,15 @@ owner_get_value (GNCOption *option, GtkWidget *widget)
 
 /* Function to set the UI widget based upon the option */
 static GtkWidget *
-customer_set_widget (GNCOption *option, GtkBox *page_box,
-                     char *name, char *documentation,
+customer_set_widget (GNCOption *option, GtkGrid *page_box,
+                     GtkLabel *name_label, char *documentation,
                      /* Return values */
                      GtkWidget **enclosing, gboolean *packed)
 {
     GtkWidget *value;
-    GtkWidget *label;
 
     *enclosing = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
     gtk_box_set_homogeneous (GTK_BOX (*enclosing), FALSE);
-
-    label = make_name_label (name);
-    gtk_box_pack_start (GTK_BOX (*enclosing), label, FALSE, FALSE, 0);
 
     value = create_owner_widget (option, GNC_OWNER_CUSTOMER, *enclosing);
 
@@ -233,19 +225,15 @@ customer_get_value (GNCOption *option, GtkWidget *widget)
 
 /* Function to set the UI widget based upon the option */
 static GtkWidget *
-vendor_set_widget (GNCOption *option, GtkBox *page_box,
-                   char *name, char *documentation,
+vendor_set_widget (GNCOption *option, GtkGrid *page_box,
+                   GtkLabel *name_label, char *documentation,
                    /* Return values */
                    GtkWidget **enclosing, gboolean *packed)
 {
     GtkWidget *value;
-    GtkWidget *label;
 
     *enclosing = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
     gtk_box_set_homogeneous (GTK_BOX (*enclosing), FALSE);
-
-    label = make_name_label (name);
-    gtk_box_pack_start (GTK_BOX (*enclosing), label, FALSE, FALSE, 0);
 
     value = create_owner_widget (option, GNC_OWNER_VENDOR, *enclosing);
 
@@ -292,19 +280,15 @@ vendor_get_value (GNCOption *option, GtkWidget *widget)
 
 /* Function to set the UI widget based upon the option */
 static GtkWidget *
-employee_set_widget (GNCOption *option, GtkBox *page_box,
-                     char *name, char *documentation,
+employee_set_widget (GNCOption *option, GtkGrid *page_box,
+                     GtkLabel *name_label, char *documentation,
                      /* Return values */
                      GtkWidget **enclosing, gboolean *packed)
 {
     GtkWidget *value;
-    GtkWidget *label;
 
     *enclosing = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
     gtk_box_set_homogeneous (GTK_BOX (*enclosing), FALSE);
-
-    label = make_name_label (name);
-    gtk_box_pack_start (GTK_BOX (*enclosing), label, FALSE, FALSE, 0);
 
     value = create_owner_widget (option, GNC_OWNER_EMPLOYEE, *enclosing);
 
@@ -368,19 +352,15 @@ create_invoice_widget (GNCOption *option, GtkWidget *hbox)
 
 /* Function to set the UI widget based upon the option */
 static GtkWidget *
-invoice_set_widget (GNCOption *option, GtkBox *page_box,
-                    char *name, char *documentation,
+invoice_set_widget (GNCOption *option, GtkGrid *page_box,
+                    GtkLabel *name_label, char *documentation,
                     /* Return values */
                     GtkWidget **enclosing, gboolean *packed)
 {
     GtkWidget *value;
-    GtkWidget *label;
 
     *enclosing = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
     gtk_box_set_homogeneous (GTK_BOX (*enclosing), FALSE);
-
-    label = make_name_label (name);
-    gtk_box_pack_start (GTK_BOX (*enclosing), label, FALSE, FALSE, 0);
 
     value = create_invoice_widget (option, *enclosing);
 
@@ -448,19 +428,15 @@ create_taxtable_widget (GNCOption *option, GtkWidget *hbox)
 
 /* Function to set the UI widget based upon the option */
 static GtkWidget *
-taxtable_set_widget (GNCOption *option, GtkBox *page_box,
-                     char *name, char *documentation,
+taxtable_set_widget (GNCOption *option, GtkGrid *page_box,
+                     GtkLabel *name_label, char *documentation,
                      /* Return values */
                      GtkWidget **enclosing, gboolean *packed)
 {
     GtkWidget *value;
-    GtkWidget *label;
 
     *enclosing = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
     gtk_box_set_homogeneous (GTK_BOX (*enclosing), FALSE);
-
-    label = make_name_label (name);
-    gtk_box_pack_start (GTK_BOX (*enclosing), label, FALSE, FALSE, 0);
 
     value = create_taxtable_widget (option, *enclosing);
 

--- a/gnucash/report/reports/example/hello-world.scm
+++ b/gnucash/report/reports/example/hello-world.scm
@@ -206,7 +206,22 @@
 Your reports probably shouldn't have an \
 option like this.") 
       #f))
-    
+
+    ;; This is a Radio Button option. The user can only select one 
+    ;; value from the list of buttons.
+    (add-option
+     (gnc:make-radiobutton-option
+      (N_ "Hello Again") "A Radio Button option" "z" (N_ "This is a Radio Button option.") 'good
+      (list (vector 'good
+                    (N_ "The Good")
+                    (N_ "Good option."))
+            (vector 'bad
+                    (N_ "The Bad")
+                    (N_ "Bad option."))
+            (vector 'ugly
+                    (N_ "The Ugly")
+                    (N_ "Ugly option.")))))
+
     (gnc:options-set-default-section options "Hello, World!")      
     options))
 
@@ -242,6 +257,7 @@ option like this.")
         (bg-color-op  (get-op   "Hello, World!" "Background Color"))
         (accounts     (op-value "Hello Again"   "An account list option"))
         (list-val     (op-value "Hello Again"   "A list option"))
+        (radio-val    (op-value "Hello Again"   "A Radio Button option"))
         (crash-val    (op-value "Testing"       "Crash the report"))
         
         ;; document will be the HTML document that we return.
@@ -348,6 +364,11 @@ new, totally cool report, consult the mailing list ~a.")
 
         (gnc:html-markup-p
          (gnc:html-markup/format
+          (_ "The radio button option is ~a.")
+          (gnc:html-markup-b radio-val)))
+
+        (gnc:html-markup-p
+         (gnc:html-markup/format
           (_ "The multi-choice option is ~a.")
           (gnc:html-markup-b (symbol->string mult-val))))
 
@@ -407,6 +428,8 @@ new, totally cool report, consult the mailing list ~a.")
           (let ((table (gnc:make-html-table)))
             (gnc:html-table-append-column! 
              table (map symbol->string list-val))
+            (gnc:html-table-set-style! table "table"
+             'attribute (list "style" "width:200px"))
             (gnc:html-table-set-caption! table 
                                          (_ "List items selected"))
             (gnc:html-document-add-object! document table))
@@ -439,11 +462,11 @@ new, totally cool report, consult the mailing list ~a.")
              (map 
               (lambda (acct)
                 (gnc:html-markup-anchor 
-		 (gnc-build-url URL-TYPE-REGISTER
-				     (string-append "account=" 
-						    (gnc-account-get-full-name
-						     acct))
-				     "")
+                 (gnc-build-url URL-TYPE-REGISTER
+                   (string-append "account=" 
+                     (gnc-account-get-full-name
+                        acct))
+                     "")
                  (xaccAccountGetName acct)))
               accounts))))
           (gnc:html-document-add-object!


### PR DESCRIPTION
Change the dialogue options to use a two column grid and setup to be the same as other dialogues. In the first column there is the 'name' of the option and the right column the option widget. There are two options that do not conform to this and they are the 'account-select' and 'list' options that have frames with the 'name' contained and so these two options use both columns.

This is a follow on from PR614 but was not sure if this would affect John's work so created separate PR, @jralls this can wait if this would interfere with your changes.

I have tested all the options and all looks good apart from radiobutton-option and currency-accounting-option-... which I can find being used.
@christopherlam Have I missed them, would it be possible to add a radiobutton example to Hello, World' and maybe fix the list option?