### PR TITLE
Optimize glist by avoiding g_list_nth_data

### DIFF
--- a/common/base-typemaps.i
+++ b/common/base-typemaps.i
@@ -268,12 +268,12 @@ typedef char gchar;
 
 %typemap(out) GList *, CommodityList *, SplitList *, AccountList *, LotList *,
     MonetaryList *, PriceList *, EntryList * {
-    guint i;
     gpointer data;
+    GList *l;
     PyObject *list = PyList_New(0);
-    for (i = 0; i < g_list_length($1); i++)
+    for (l = $1; l != NULL; l = l->next)
     {
-        data = g_list_nth_data($1, i);
+        data = l->data;
         if (GNC_IS_ACCOUNT(data))
             PyList_Append(list, SWIG_NewPointerObj(data, SWIGTYPE_p_Account, 0));
         else if (GNC_IS_SPLIT(data))

--- a/libgnucash/engine/Transaction.c
+++ b/libgnucash/engine/Transaction.c
@@ -676,15 +676,25 @@ Transaction *
 xaccTransClone (const Transaction *from)
 {
     Transaction *to = xaccTransCloneNoKvp (from);
-    int i = 0;
-    int length = g_list_length (from->splits);
+    GList *lfrom, *lto;
 
     xaccTransBeginEdit (to);
     qof_instance_copy_kvp (QOF_INSTANCE (to), QOF_INSTANCE (from));
-    g_assert (g_list_length (to->splits) == length);
-    for (i = 0; i < length; ++i)
-	xaccSplitCopyKvp (g_list_nth_data (from->splits, i),
-			    g_list_nth_data (to->splits, i));
+    g_return_val_if_fail (g_list_length (to->splits) == g_list_length (from->splits),
+                          NULL);
+
+    lfrom = from->splits;
+    lto = to->splits;
+
+    /* lfrom and lto are known to be of equal length via above
+       g_return_val_if_fail */
+    while (lfrom != NULL)
+    {
+        xaccSplitCopyKvp (lfrom->data, lto->data);
+        lfrom = lfrom->next;
+        lto = lto->next;
+    }
+
     xaccTransCommitEdit (to);
     return to;
 }


### PR DESCRIPTION
While exploring alternatives to xaccAccountGetSplitList (gets slow e.g. account has 1000s of splits) I found `g_list_nth_data` being used in a few places which is known to be inefficient.

https://developer.gnome.org/programming-guidelines/stable/glist.html.en

My aim was to traverse an account splitlist by pointer dereferences rather than creating a GList to be converted to SCM list. I am now sure how to do yet. Creating calls to xaccAccountGetFirstSplit, xaccSplitGetNextSplit does not seem currently possible.

But these two optimisations seem very safe and correct.