### PR TITLE
POC SplitListNode for gnc:account-accumulate-at-dates

### DIFF
--- a/gnucash/report/report-system/report-utilities.scm
+++ b/gnucash/report/report-system/report-utilities.scm
@@ -498,7 +498,7 @@ flawed. see report-utilities.scm. please update reports.")
           (nosplit->elt #f)
           (split->date (compose xaccTransGetDate xaccSplitGetParent))
           (split->elt xaccSplitGetBalance))
-  (let lp ((splits (xaccAccountGetSplitList acc))
+  (let lp ((splits (gnc-account-get-splits acc))
            (dates (sort dates <))
            (result '())
            (last-result nosplit->elt))
@@ -516,9 +516,9 @@ flawed. see report-utilities.scm. please update reports.")
          (lp '() rest (cons last-result result) last-result))
 
         (else
-         (let* ((head (car splits))
-                (tail (cdr splits))
-                (next (and (not (null? tail)) (car tail))))
+         (let* ((head (SplitListNode-split-get splits))
+                (tail (SplitListNode-next-get splits))
+                (next (and (not (null? tail)) (SplitListNode-split-get tail))))
            (cond
 
             ;; the next split is still before date.

--- a/gnucash/report/report-system/report-utilities.scm
+++ b/gnucash/report/report-system/report-utilities.scm
@@ -508,28 +508,31 @@ flawed. see report-utilities.scm. please update reports.")
       (() (reverse result))
 
       ((date . rest)
-       (match splits
+       (cond
 
-         ;; end of splits, but still has dates. pad with last-result
-         ;; until end of dates.
-         (() (lp '() rest (cons last-result result) last-result))
+        ;; end of splits, but still has dates. pad with last-result
+        ;; until end of dates.
+        ((null? splits)
+         (lp '() rest (cons last-result result) last-result))
 
-         ((head . tail)
-          (let ((next (and (pair? tail) (car tail))))
-            (cond
+        (else
+         (let* ((head (car splits))
+                (tail (cdr splits))
+                (next (and (not (null? tail)) (car tail))))
+           (cond
 
-             ;; the next split is still before date.
-             ((and next (< (split->date next) date))
-              (lp tail dates result (split->elt head)))
+            ;; the next split is still before date.
+            ((and next (< (split->date next) date))
+             (lp tail dates result (split->elt head)))
 
-             ;; head split after date, accumulate previous result
-             ((< date (split->date head))
-              (lp splits rest (cons last-result result) last-result))
+            ;; head split after date, accumulate previous result
+            ((< date (split->date head))
+             (lp splits rest (cons last-result result) last-result))
 
-             ;; head split before date, next split after date, or end.
-             (else
-              (let ((head-result (split->elt head)))
-                (lp tail rest (cons head-result result) head-result)))))))))))
+            ;; head split before date, next split after date, or end.
+            (else
+             (let ((head-result (split->elt head)))
+               (lp tail rest (cons head-result result) head-result)))))))))))
 
 ;; This works similar as above but returns a commodity-collector, 
 ;; thus takes care of children accounts with different currencies.

--- a/gnucash/report/report-system/report.scm
+++ b/gnucash/report/report-system/report.scm
@@ -23,6 +23,7 @@
 (use-modules (gnucash utilities))
 (use-modules (gnucash app-utils))
 (use-modules (gnucash gettext))
+(use-modules (statprof))
 (eval-when (compile load eval expand)
   (load-extension "libgncmod-report-system" "scm_init_sw_report_system_module"))
 (use-modules (sw_report_system))
@@ -753,7 +754,9 @@ not found.")))
         (and template
              (let* ((renderer (gnc:report-template-renderer template))
                     (stylesheet (gnc:report-stylesheet report))
-                    (doc (renderer report))
+                    (doc (statprof
+                          (lambda ()
+                            (renderer report))))
                     (html (cond
                            ((string? doc) doc)
                            (else

--- a/libgnucash/engine/engine-common.i
+++ b/libgnucash/engine/engine-common.i
@@ -36,6 +36,20 @@ static const GncGUID * gncAccountGetGUID(Account *x)
 
 %include <Split.h>
 
+%inline %{
+//typedef struct splitlist_s SplitListNode;
+typedef struct
+{
+    Split *split;
+    struct SplitListNode *next;
+    struct SplitListNode *prev;
+} SplitListNode;
+static SplitListNode *gnc_account_get_splits (const Account *account)
+{
+    return (SplitListNode*) xaccAccountGetSplitList (account);
+}
+%}
+
 AccountList * gnc_account_get_children (const Account *account);
 AccountList * gnc_account_get_children_sorted (const Account *account);
 AccountList * gnc_account_get_descendants (const Account *account);

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -513,6 +513,7 @@ libgnucash/app-utils/calculation/fin.c
 libgnucash/app-utils/c-interface.scm
 libgnucash/app-utils/date-utilities.scm
 libgnucash/app-utils/file-utils.c
+libgnucash/app-utils/fin.c
 libgnucash/app-utils/fin.scm
 libgnucash/app-utils/gettext.scm
 libgnucash/app-utils/gfec.c


### PR DESCRIPTION
also upgrades `gnc:account-get-balances-at-dates`. These are used by `category-barchart`, `net-charts`, experimental multicolumn reports

note sure if this speeds it up significantly. after all the GList traversal takes place only *once* per account per report. times in seconds. the best test would involve an account north of 10,000 splits. from guile, `,time (define x (iota 10000000))` to create 10E7 list runs in 0.22s.

old GList: 0.612, 0.553, 0.50 0.50 0.523
new SplitListNode: 0.58 0.55 0.50 0.51 0.52