### PR TITLE
Maint multirow table headers

### DIFF
--- a/gnucash/report/business-reports/new-owner-report.scm
+++ b/gnucash/report/business-reports/new-owner-report.scm
@@ -367,13 +367,13 @@
                      (and due-date (qof-print-date due-date)))
               (addif (ref-col column-vector)    ref)
               (addif (type-col column-vector)   type-str)
-              (addif (desc-col column-vector)   desc)
-              (addif (sale-col column-vector)   (cell sale))
-              (addif (tax-col column-vector)    (cell tax))))
+              (addif (desc-col column-vector)   desc)))
             (map
              (lambda (cell)
                (gnc:make-html-table-cell/size/markup nrows 1 "number-cell" cell))
              (append
+              (addif (sale-col column-vector)    (cell sale))
+              (addif (tax-col column-vector)     (cell tax))
               (addif (credit-col column-vector)  (cell-anchor credit))
               (addif (debit-col column-vector)   (cell-anchor (and debit (- debit))))
               (addif (bal-col column-vector)     (cell amt))))

--- a/gnucash/report/report-system/report-system.scm
+++ b/gnucash/report/report-system/report-system.scm
@@ -586,6 +586,8 @@
 (export gnc:html-table-set-caption!)
 (export gnc:html-table-col-headers)
 (export gnc:html-table-set-col-headers!)
+(export gnc:html-table-multirow-col-headers)
+(export gnc:html-table-set-multirow-col-headers!)
 (export gnc:html-table-row-headers)
 (export gnc:html-table-set-row-headers!)
 (export gnc:html-table-style)


### PR DESCRIPTION
I think this is good to go.

Upgrade to html-chart. `html-chart` record property `col-headers` is repurposed to contain a list-of-list-of-th-elements, instead of previous list-of-th-elements. new-owner-report can show double th row. 2 new API functions, and backward compatibility is maintained.

![image](https://user-images.githubusercontent.com/1975870/71641199-6f736380-2c8f-11ea-9609-efd6fad6c55b.png)
