### PR TITLE
Couple of bug fixes

### DIFF
--- a/gnucash/gnome/gnc-plugin-account-tree.c
+++ b/gnucash/gnome/gnc-plugin-account-tree.c
@@ -44,8 +44,6 @@
 static void gnc_plugin_account_tree_class_init (GncPluginAccountTreeClass *klass);
 static void gnc_plugin_account_tree_init (GncPluginAccountTree *plugin);
 static void gnc_plugin_account_tree_finalize (GObject *object);
-static void gnc_plugin_account_tree_add_to_window (GncPlugin *plugin,
-                                                   GncMainWindow *window, GQuark type);
 
 /* Command callbacks */
 static void gnc_plugin_account_tree_cmd_new_account_tree (GtkAction *action, GncMainWindowActionData *data);
@@ -97,26 +95,6 @@ gnc_plugin_account_tree_new (void)
     return GNC_PLUGIN (plugin);
 }
 
-static void
-gnc_plugin_account_tree_main_window_page_changed (GncMainWindow *window,
-        GncPluginPage *plugin_page, gpointer user_data)
-{
-    // We continue only if the plugin_page is a valid
-    if (!plugin_page || !GNC_IS_PLUGIN_PAGE(plugin_page))
-        return;
-
-    if (gnc_main_window_get_current_page (window) == plugin_page)
-    {
-        if (!GNC_IS_PLUGIN_PAGE_ACCOUNT_TREE(plugin_page))
-            return;
-
-        // The page changed signal is emitted multiple times so we need
-        // to use an idle_add to change the focus to the tree view
-        g_idle_remove_by_data (GNC_PLUGIN_PAGE_ACCOUNT_TREE (plugin_page));
-        g_idle_add ((GSourceFunc)gnc_plugin_page_account_tree_focus,
-                      GNC_PLUGIN_PAGE_ACCOUNT_TREE (plugin_page));
-    }
-}
 
 /** Initialize the class for a new account tree plugin.  This will set
  *  up any function pointers that override functions in the parent
@@ -137,9 +115,6 @@ gnc_plugin_account_tree_class_init (GncPluginAccountTreeClass *klass)
 
     /* plugin info */
     plugin_class->plugin_name  = GNC_PLUGIN_ACCOUNT_TREE_NAME;
-
-    /* function overrides */
-    plugin_class->add_to_window = gnc_plugin_account_tree_add_to_window;
 
     /* widget addition/removal */
     plugin_class->actions_name = PLUGIN_ACTIONS_NAME;
@@ -176,20 +151,6 @@ gnc_plugin_account_tree_finalize (GObject *object)
     G_OBJECT_CLASS (parent_class)->finalize (object);
 }
 
-
-/**
- * Called when this plugin is added to a main window.  Connect a few callbacks
- * here to track page changes.
- *
- */
-static void gnc_plugin_account_tree_add_to_window (GncPlugin *plugin,
-        GncMainWindow *mainwindow,
-        GQuark type)
-{
-    g_signal_connect(mainwindow, "page_changed",
-                     G_CALLBACK(gnc_plugin_account_tree_main_window_page_changed),
-                     plugin);
-}
 /************************************************************
  *                    Command Callbacks                     *
  ************************************************************/

--- a/gnucash/gnome/gnc-plugin-budget.c
+++ b/gnucash/gnome/gnc-plugin-budget.c
@@ -101,28 +101,6 @@ GncPlugin * gnc_plugin_budget_new (void)
     return GNC_PLUGIN(plugin);
 }
 
-static void
-gnc_plugin_budget_main_window_page_changed (GncMainWindow *window,
-                                            GncPluginPage *plugin_page,
-                                            gpointer user_data)
-{
-    // We continue only if the plugin_page is a valid
-    if (!plugin_page || !GNC_IS_PLUGIN_PAGE(plugin_page))
-        return;
-
-    if (gnc_main_window_get_current_page (window) == plugin_page)
-    {
-        if (!GNC_IS_PLUGIN_PAGE_BUDGET(plugin_page))
-            return;
-
-        // The page changed signal is emitted multiple times so we need
-        // to use an idle_add to change the focus to the tree view
-        g_idle_remove_by_data (GNC_PLUGIN_PAGE_BUDGET(plugin_page));
-        g_idle_add ((GSourceFunc)gnc_plugin_page_budget_focus,
-                      GNC_PLUGIN_PAGE_BUDGET(plugin_page));
-    }
-}
-
 G_DEFINE_TYPE_WITH_PRIVATE(GncPluginBudget, gnc_plugin_budget, GNC_TYPE_PLUGIN)
 
 static void
@@ -134,9 +112,6 @@ gnc_plugin_budget_class_init (GncPluginBudgetClass *klass)
     ENTER (" ");
     parent_class = g_type_class_peek_parent (klass);
     object_class->finalize = gnc_plugin_budget_finalize;
-
-    /* function overrides */
-    plugin_class->add_to_window = gnc_plugin_budget_add_to_window;
 
     plugin_class->plugin_name  = GNC_PLUGIN_BUDGET_NAME;
     plugin_class->actions_name = PLUGIN_ACTIONS_NAME;
@@ -161,20 +136,6 @@ gnc_plugin_budget_finalize (GObject *object)
     (parent_class->finalize)(object);
     LEAVE(" ");
 
-}
-
-/**
- * Called when this plugin is added to a main window.  Connect a few callbacks
- * here to track page changes.
- *
- */
-static void gnc_plugin_budget_add_to_window (GncPlugin *plugin,
-                                             GncMainWindow *mainwindow,
-                                             GQuark type)
-{
-    g_signal_connect (mainwindow, "page_changed",
-                      G_CALLBACK(gnc_plugin_budget_main_window_page_changed),
-                      plugin);
 }
 
 /************************************************************

--- a/gnucash/gnome/gnc-plugin-page-invoice.c
+++ b/gnucash/gnome/gnc-plugin-page-invoice.c
@@ -605,22 +605,17 @@ gnc_plugin_page_invoice_focus (InvoiceWindow *iw)
  */
 static void
 gnc_plugin_page_invoice_main_window_page_changed (GncMainWindow *window,
-        GncPluginPage *plugin_page, gpointer user_data)
+                                                  GncPluginPage *current_plugin_page,
+                                                  GncPluginPage *invoice_plugin_page)
 {
     // We continue only if the plugin_page is a valid
-    if (!plugin_page || !GNC_IS_PLUGIN_PAGE(plugin_page))
+    if (!current_plugin_page || !GNC_IS_PLUGIN_PAGE_INVOICE(current_plugin_page) ||
+        !invoice_plugin_page || !GNC_IS_PLUGIN_PAGE_INVOICE(invoice_plugin_page))
         return;
 
-    if (gnc_main_window_get_current_page (window) == plugin_page)
+    if (current_plugin_page == invoice_plugin_page)
     {
-        GncPluginPageInvoice *page;
-        GncPluginPageInvoicePrivate *priv;
-
-        if (!GNC_IS_PLUGIN_PAGE_INVOICE(plugin_page))
-            return;
-
-        page = GNC_PLUGIN_PAGE_INVOICE(plugin_page);
-        priv = GNC_PLUGIN_PAGE_INVOICE_GET_PRIVATE(page);
+        GncPluginPageInvoicePrivate *priv = GNC_PLUGIN_PAGE_INVOICE_GET_PRIVATE(invoice_plugin_page);
 
         // The page changed signal is emitted multiple times so we need
         // to use an idle_add to change the focus to the sheet

--- a/gnucash/gnome/gnc-plugin-page-owner-tree.c
+++ b/gnucash/gnome/gnc-plugin-page-owner-tree.c
@@ -384,22 +384,17 @@ gnc_plugin_page_owner_focus (GtkTreeView *tree_view)
  */
 static void
 gnc_plugin_page_owner_main_window_page_changed (GncMainWindow *window,
-        GncPluginPage *plugin_page, gpointer user_data)
+                                                GncPluginPage *current_plugin_page,
+                                                GncPluginPage *owner_plugin_page)
 {
     // We continue only if the plugin_page is a valid
-    if (!plugin_page || !GNC_IS_PLUGIN_PAGE(plugin_page))
+    if (!current_plugin_page || !GNC_IS_PLUGIN_PAGE_OWNER_TREE(current_plugin_page) ||
+        !owner_plugin_page || !GNC_IS_PLUGIN_PAGE_OWNER_TREE(owner_plugin_page))
         return;
 
-    if (gnc_main_window_get_current_page (window) == plugin_page)
+    if (current_plugin_page == owner_plugin_page)
     {
-        GncPluginPageOwnerTree *page;
-        GncPluginPageOwnerTreePrivate *priv;
-
-        if (!GNC_IS_PLUGIN_PAGE_OWNER_TREE(plugin_page))
-            return;
-
-        page = GNC_PLUGIN_PAGE_OWNER_TREE(plugin_page);
-        priv = GNC_PLUGIN_PAGE_OWNER_TREE_GET_PRIVATE(page);
+        GncPluginPageOwnerTreePrivate *priv = GNC_PLUGIN_PAGE_OWNER_TREE_GET_PRIVATE(owner_plugin_page);
 
         // The page changed signal is emitted multiple times so we need
         // to use an idle_add to change the focus to the tree view

--- a/gnucash/gnome/gnc-plugin-page-sx-list.c
+++ b/gnucash/gnome/gnc-plugin-page-sx-list.c
@@ -205,22 +205,17 @@ gnc_plugin_page_sx_list_focus (GtkTreeView *tree_view)
  */
 static void
 gnc_plugin_page_sx_list_main_window_page_changed (GncMainWindow *window,
-        GncPluginPage *plugin_page, gpointer user_data)
+                                                  GncPluginPage *current_plugin_page,
+                                                  GncPluginPage *sx_plugin_page)
 {
     // We continue only if the plugin_page is a valid
-    if (!plugin_page || !GNC_IS_PLUGIN_PAGE(plugin_page))
+    if (!current_plugin_page || !GNC_IS_PLUGIN_PAGE_SX_LIST(current_plugin_page) ||
+        !sx_plugin_page || !GNC_IS_PLUGIN_PAGE_SX_LIST(sx_plugin_page))
         return;
 
-    if (gnc_main_window_get_current_page (window) == plugin_page)
+    if (current_plugin_page == sx_plugin_page)
     {
-        GncPluginPageSxList *page;
-        GncPluginPageSxListPrivate *priv;
-
-        if (!GNC_IS_PLUGIN_PAGE_SX_LIST(plugin_page))
-            return;
-
-        page = GNC_PLUGIN_PAGE_SX_LIST(plugin_page);
-        priv = GNC_PLUGIN_PAGE_SX_LIST_GET_PRIVATE(page);
+        GncPluginPageSxListPrivate *priv = GNC_PLUGIN_PAGE_SX_LIST_GET_PRIVATE(sx_plugin_page);
 
         // The page changed signal is emitted multiple times so we need
         // to use an idle_add to change the focus to the tree view

--- a/gnucash/gnome/gnc-plugin-register.c
+++ b/gnucash/gnome/gnc-plugin-register.c
@@ -121,27 +121,6 @@ gnc_plugin_register_new (void)
 }
 
 static void
-gnc_plugin_register_main_window_page_changed(GncMainWindow *window,
-        GncPluginPage *plugin_page, gpointer user_data)
-{
-    // We continue only if the plugin_page is a valid
-    if (!plugin_page || !GNC_IS_PLUGIN_PAGE(plugin_page))
-        return;
-
-    if (gnc_main_window_get_current_page (window) == plugin_page)
-    {
-        if (!GNC_IS_PLUGIN_PAGE_REGISTER(plugin_page))
-            return;
-
-        // The page changed signal is emitted multiple times so we need
-        // to use an idle_add to change the focus to the register
-        g_idle_remove_by_data (GNC_PLUGIN_PAGE_REGISTER (plugin_page));
-        g_idle_add ((GSourceFunc)gnc_plugin_page_register_focus,
-                      GNC_PLUGIN_PAGE_REGISTER (plugin_page));
-    }
-}
-
-static void
 gnc_plugin_register_class_init (GncPluginRegisterClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS (klass);
@@ -204,10 +183,6 @@ gnc_plugin_register_add_to_window (GncPlugin *plugin,
 {
     gnc_prefs_register_cb (GNC_PREFS_GROUP_GENERAL_REGISTER, NULL,
                            gnc_plugin_register_pref_changed, window);
-
-    g_signal_connect(window, "page_changed",
-                     G_CALLBACK(gnc_plugin_register_main_window_page_changed),
-                     plugin);
 }
 
 

--- a/gnucash/gnome/gnc-split-reg.c
+++ b/gnucash/gnome/gnc-split-reg.c
@@ -1931,6 +1931,14 @@ gnc_split_reg_focus_on_sheet (GNCSplitReg *gsr)
 }
 
 void
+gnc_split_reg_set_sheet_focus (GNCSplitReg *gsr, gboolean has_focus)
+{
+    GnucashRegister *reg = gsr->reg;
+    GnucashSheet *sheet = gnucash_register_get_sheet (reg);
+    gnucash_sheet_set_has_focus (sheet, has_focus);
+}
+
+void
 gnc_split_reg_balancing_entry(GNCSplitReg *gsr, Account *account,
                               time64 statement_date, gnc_numeric balancing_amount)
 {

--- a/gnucash/gnome/gnc-split-reg.h
+++ b/gnucash/gnome/gnc-split-reg.h
@@ -248,6 +248,7 @@ void gnc_split_reg_jump_to_split_amount(GNCSplitReg *gsr, Split *split);
  * Set the focus of the register to the sheet
  **/
 void gnc_split_reg_focus_on_sheet (GNCSplitReg *gsr);
+void gnc_split_reg_set_sheet_focus (GNCSplitReg *gsr, gboolean has_focus);
 
 /*
  * Create a transaction entry with given amount and date. One account is

--- a/gnucash/import-export/import-main-matcher.c
+++ b/gnucash/import-export/import-main-matcher.c
@@ -124,7 +124,6 @@ static gboolean gnc_gen_trans_onButtonPressed_cb (
                     GNCImportMainMatcher *info);
 static gboolean gnc_gen_trans_onPopupMenu_cb (
                     GtkTreeView *treeview,
-                    GdkEvent *event,
                     GNCImportMainMatcher *info);
 static void refresh_model_row (
                     GNCImportMainMatcher *gui,
@@ -651,7 +650,6 @@ gnc_gen_trans_onButtonPressed_cb (GtkTreeView *treeview,
 
 static gboolean
 gnc_gen_trans_onPopupMenu_cb (GtkTreeView *treeview,
-                              GdkEvent *event,
                               GNCImportMainMatcher *info)
 {
     GtkTreeSelection *selection;

--- a/gnucash/register/register-gnome/gnucash-sheet.c
+++ b/gnucash/register/register-gnome/gnucash-sheet.c
@@ -407,8 +407,10 @@ gnucash_sheet_activate_cursor_cell (GnucashSheet *sheet,
         sheet->direct_update_cell =
             gnucash_sheet_check_direct_update_cell (sheet, virt_loc);
     }
-
-    gtk_widget_grab_focus (GTK_WIDGET(sheet));
+    // when a gui refresh is called, we end up here so only grab the focus
+    // if the sheet is showing on the current plugin_page
+    if (sheet->sheet_has_focus)
+        gtk_widget_grab_focus (GTK_WIDGET(sheet));
 }
 
 
@@ -755,6 +757,12 @@ gnucash_sheet_is_read_only (GnucashSheet *sheet)
     g_return_val_if_fail (sheet != NULL, TRUE);
     g_return_val_if_fail (GNUCASH_IS_SHEET(sheet), TRUE);
     return gnc_table_model_read_only (sheet->table->model);
+}
+
+void
+gnucash_sheet_set_has_focus (GnucashSheet *sheet, gboolean has_focus)
+{
+    sheet->sheet_has_focus = has_focus;
 }
 
 static void
@@ -2763,6 +2771,9 @@ gnucash_sheet_new (Table *table)
     g_return_val_if_fail (table != NULL, NULL);
 
     sheet = gnucash_sheet_create (table);
+
+    /* on create, the sheet can grab the focus */
+    sheet->sheet_has_focus = TRUE;
 
     /* The cursor */
     sheet->cursor = gnucash_cursor_new (sheet);

--- a/gnucash/register/register-gnome/gnucash-sheet.h
+++ b/gnucash/register/register-gnome/gnucash-sheet.h
@@ -112,5 +112,7 @@ gint gnucash_sheet_get_text_offset (GnucashSheet *sheet, const VirtualLocation v
 
 gboolean gnucash_sheet_is_read_only (GnucashSheet *sheet);
 
+void gnucash_sheet_set_has_focus (GnucashSheet *sheet, gboolean has_focus);
+
 /** @} */
 #endif

--- a/gnucash/register/register-gnome/gnucash-sheetP.h
+++ b/gnucash/register/register-gnome/gnucash-sheetP.h
@@ -80,6 +80,8 @@ struct _GnucashSheet
 
     gint editing;
 
+    gboolean sheet_has_focus;
+
     guint button; /* mouse button being held down */
     gboolean grabbed; /* has the grab */
     gdouble button_x, button_y;

--- a/gnucash/report/report-gnome/gnc-plugin-page-report.c
+++ b/gnucash/report/report-gnome/gnc-plugin-page-report.c
@@ -250,24 +250,18 @@ gnc_plugin_page_report_focus (GtkWidget *widget)
  */
 static void
 gnc_plugin_page_report_main_window_page_changed (GncMainWindow *window,
-        GncPluginPage *plugin_page, gpointer user_data)
+                                                 GncPluginPage *current_plugin_page,
+                                                 GncPluginPage *report_plugin_page)
 {
     // We continue only if the plugin_page is a valid
-    if (!plugin_page || !GNC_IS_PLUGIN_PAGE(plugin_page))
+    if (!current_plugin_page || !GNC_IS_PLUGIN_PAGE_REPORT(current_plugin_page) ||
+        !report_plugin_page || !GNC_IS_PLUGIN_PAGE_REPORT(report_plugin_page))
         return;
 
-    if (gnc_main_window_get_current_page (window) == plugin_page)
+    if (current_plugin_page == report_plugin_page)
     {
-        GncPluginPageReport *report;
-        GncPluginPageReportPrivate *priv;
-        GtkWidget *widget;
-
-        if (!GNC_IS_PLUGIN_PAGE_REPORT(plugin_page))
-            return;
-
-        report = GNC_PLUGIN_PAGE_REPORT(plugin_page);
-        priv = GNC_PLUGIN_PAGE_REPORT_GET_PRIVATE(report);
-        widget = gnc_html_get_widget(priv->html);
+        GncPluginPageReportPrivate *priv = GNC_PLUGIN_PAGE_REPORT_GET_PRIVATE(report_plugin_page);
+        GtkWidget *widget = gnc_html_get_widget (priv->html);
 
         // The page changed signal is emitted multiple times so we need
         // to use an idle_add to change the focus to the webkit widget


### PR DESCRIPTION
Just some bug fixes and thought I would park them here for any comments.
The first one should be OK.
The second one fixes a misunderstanding I had when trying to fix the focus when pages were selected, the original was not specific enough, worked OK when there was only one plugin of a kind so this commit fixes that and all plugins now use the same approach.
The last commit builds on the previous commit for register plugin_pages in that it sets a flag on the register sheet to indicate whether it should grab keyboard focus. This fixes an issue when reconciling an account that when done the keyboard focus may be on an other register.
This can be seen by having a couple of registers open, choose one to reconcile, OK on the start window and then postpone it. Depending on the order the registers were opened, the keyboard focus may be on another register observed by typing with no visible result.

