### PR TITLE
aging speedup

### DIFF
--- a/gnucash/report/business-reports/new-aging.scm
+++ b/gnucash/report/business-reports/new-aging.scm
@@ -193,7 +193,7 @@ exist but have no suitable transactions."))
 ;; simpler version of gnc:owner-from-split. must be gncOwnerFree after
 ;; use! see split-has-owner? above...
 (define (split->owner split)
-  (let* ((lot (xaccSplitGetLot (gnc-lot-get-earliest-split (xaccSplitGetLot split))))
+  (let* ((lot (xaccSplitGetLot split))
          (owner (gncOwnerNew))
          (use-lot-owner? (gncOwnerGetOwnerFromLot lot owner)))
     (unless use-lot-owner?


### PR DESCRIPTION
Speeds up new-aging.scm

There were several splits loops that are reduced: (1) to find valid/invalid owners (2) to find unique owners (3) process each owner sequentially. Changed to (1) find next split's owner; if invalid then skip; process owner splits.

Will request @gjanssens to test with unusual APAR transactions. 