### PR TITLE
[gnc-lot.c] speed up gncInvoiceGetInvoiceFromLot by caching invoice

### DIFF
--- a/libgnucash/engine/gnc-lot.c
+++ b/libgnucash/engine/gnc-lot.c
@@ -52,6 +52,7 @@
 #include "cap-gains.h"
 #include "Transaction.h"
 #include "TransactionP.h"
+#include "gncInvoice.h"
 
 /* This static indicates the debugging module that this .o belongs to.  */
 static QofLogModule log_module = GNC_MOD_LOT;
@@ -85,6 +86,7 @@ typedef struct GNCLotPrivate
     /* List of splits that belong to this lot. */
     SplitList *splits;
 
+    GncInvoice *cached_invoice;
     /* Handy cached value to indicate if lot is closed. */
     /* If value is negative, then the cache is invalid. */
     signed char is_closed;
@@ -112,6 +114,7 @@ gnc_lot_init(GNCLot* lot)
     priv = GET_PRIVATE(lot);
     priv->account = NULL;
     priv->splits = NULL;
+    priv->cached_invoice = NULL;
     priv->is_closed = LOT_CLOSED_UNKNOWN;
     priv->marker = 0;
 }
@@ -376,6 +379,19 @@ gnc_lot_get_account (const GNCLot *lot)
     if (!lot) return NULL;
     priv = GET_PRIVATE(lot);
     return priv->account;
+}
+
+GncInvoice * gnc_lot_get_cached_invoice (const GNCLot *lot)
+{
+    if (!lot) return NULL;
+    return GET_PRIVATE(lot)->cached_invoice;
+}
+
+void
+gnc_lot_set_cached_invoice(GNCLot* lot, GncInvoice *invoice)
+{
+    if (!lot) return;
+    GET_PRIVATE(lot)->cached_invoice = invoice;
 }
 
 void

--- a/libgnucash/engine/gnc-lot.h
+++ b/libgnucash/engine/gnc-lot.h
@@ -64,6 +64,7 @@
 #include "qof.h"
 #include "gnc-engine.h"
 /*#include "gnc-lot-p.h"*/
+#include "gncInvoice.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -126,6 +127,12 @@ gint gnc_lot_count_splits (const GNCLot *);
 /*@ dependent @*/
 Account * gnc_lot_get_account (const GNCLot *);
 void gnc_lot_set_account(GNCLot*, Account*);
+
+/** The gnc_lot_get_cached_invoice() routine returns the invoice with
+ *    which this lot is associated. */
+/*@ dependent @*/
+GncInvoice * gnc_lot_get_cached_invoice (const GNCLot *lot);
+void gnc_lot_set_cached_invoice(GNCLot* lot, GncInvoice *invoice);
 
 /** The gnc_lot_get_balance() routine returns the balance of the lot.
  *    The commodity in which this balance is expressed is the commodity

--- a/libgnucash/engine/gncInvoice.c
+++ b/libgnucash/engine/gncInvoice.c
@@ -1228,6 +1228,7 @@ gncInvoiceDetachFromLot (GNCLot *lot)
     gnc_lot_begin_edit (lot);
     qof_instance_set (QOF_INSTANCE (lot), "invoice", NULL, NULL);
     gnc_lot_commit_edit (lot);
+    gnc_lot_set_cached_invoice (lot, NULL);
 }
 
 void
@@ -1242,6 +1243,7 @@ gncInvoiceAttachToLot (GncInvoice *invoice, GNCLot *lot)
     gnc_lot_begin_edit (lot);
     qof_instance_set (QOF_INSTANCE (lot), "invoice", guid, NULL);
     gnc_lot_commit_edit (lot);
+    gnc_lot_set_cached_invoice (lot, invoice);
     gncInvoiceSetPostedLot (invoice, lot);
 }
 
@@ -1253,10 +1255,16 @@ GncInvoice * gncInvoiceGetInvoiceFromLot (GNCLot *lot)
 
     if (!lot) return NULL;
 
-    book = gnc_lot_get_book (lot);
-    qof_instance_get (QOF_INSTANCE (lot), "invoice", &guid, NULL);
-    invoice = gncInvoiceLookup(book, guid);
-    guid_free (guid);
+    invoice = gnc_lot_get_cached_invoice (lot);
+    if (!invoice)
+    {
+        book = gnc_lot_get_book (lot);
+        qof_instance_get (QOF_INSTANCE (lot), "invoice", &guid, NULL);
+        invoice = gncInvoiceLookup(book, guid);
+        guid_free (guid);
+        gnc_lot_set_cached_invoice (lot, invoice);
+    }
+
     return invoice;
 }
 


### PR DESCRIPTION
I'd hope this does not add debt. `cached_invoice` only used/set in gncInvoice API