### PR TITLE
Fix white text on white background

### DIFF
--- a/gnucash/report/report-system/html-fonts.scm
+++ b/gnucash/report/report-system/html-fonts.scm
@@ -132,6 +132,7 @@
     (gnc:html-document-set-style-text!
      ssdoc
      (string-append
+      "@media (prefers-color-scheme: dark) {body {color: #000; background-color: #fff;}}\n"
       "h3 { " title-info " }\n"
       "a { " account-link-info " }\n"
       "body, p, table, tr, td { vertical-align: top; " text-cell-info " }\n"


### PR DESCRIPTION
When dark theme is active in Gnome Shell it sets text colour to white, combined with background colour set in default style to white lead to unreadable reports.