### PR TITLE
Follow up to previous commit 94cb965 / Bug 797522

### DIFF
--- a/gnucash/gnome-utils/gnc-main-window.c
+++ b/gnucash/gnome-utils/gnc-main-window.c
@@ -2795,6 +2795,9 @@ gnc_main_window_disconnect (GncMainWindow *window,
     g_signal_handlers_disconnect_by_func(G_OBJECT(page->notebook_page),
                                          G_CALLBACK(gnc_main_window_button_press_cb), page);
 
+    // Remove the page_changed signal callback
+    gnc_plugin_page_disconnect_page_changed (GNC_PLUGIN_PAGE(page));
+
     /* Disconnect the page and summarybar from the window */
     priv = GNC_MAIN_WINDOW_GET_PRIVATE(window);
     if (priv->current_page == page)
@@ -3712,7 +3715,7 @@ gnc_quartz_shutdown (GtkosxApplication *theApp, gpointer data)
     /* Do Nothing. It's too late. */
 }
 /* Should quit responds to NSApplicationBlockTermination; returning
- * TRUE means "don't terminate", FALSE means "do terminate". 
+ * TRUE means "don't terminate", FALSE means "do terminate".
  */
 static gboolean
 gnc_quartz_should_quit (GtkosxApplication *theApp, GncMainWindow *window)
@@ -4324,6 +4327,9 @@ gnc_main_window_cmd_window_move_page (GtkAction *action, GncMainWindow *window)
     notebook = GTK_NOTEBOOK (priv->notebook);
     tab_widget = gtk_notebook_get_tab_label (notebook, page->notebook_page);
     menu_widget = gtk_notebook_get_menu_label (notebook, page->notebook_page);
+
+    // Remove the page_changed signal callback
+    gnc_plugin_page_disconnect_page_changed (GNC_PLUGIN_PAGE(page));
 
     /* Ref the page components, then remove it from its old window */
     g_object_ref(page);

--- a/gnucash/gnome-utils/gnc-plugin-page.h
+++ b/gnucash/gnome-utils/gnc-plugin-page.h
@@ -156,6 +156,21 @@ typedef struct
      *  @param window The window where the page was added. */
     void (* window_changed) (GncPluginPage *plugin_page, GtkWidget *window);
 
+    /** Perform plugin specific actions to set the focus.
+     *
+     *  @param page The page that was added to a window.
+     *
+     *  @param on_current_pgae Whether this page is the currentone. */
+    void (* focus_page) (GncPluginPage *plugin_page, gboolean on_current_page);
+
+    /** This function performs specific actions to set the focus on a specific
+     *  widget.
+     *
+     *  @param page The page that was added to a window.
+     *
+     *  @param on_current_pgae Whether this page is the currentone. */
+    gboolean (* focus_page_function) (GncPluginPage *plugin_page);
+
     /** This function vector allows page specific actions to occur
      *  when the page name is changed.
      *
@@ -393,10 +408,28 @@ const gchar *gnc_plugin_page_get_page_color (GncPluginPage *page);
  *
  *  @param page The page whose name should be retrieved.
  *
- *  @return The color for this page.  This string is owned by the page and
+ *  @param The color for this page.  This string is owned by the page and
  *  should not be freed by the caller.
  */
 void gnc_plugin_page_set_page_color (GncPluginPage *page, const char *color);
+
+
+/** Set up the page_changed callback for when the current page is changed.
+ *  This will store a pointer to the page focus funtion passed as a parameter
+ *  so that it can be used in setting up the g_idle_add
+ *
+ *  @param page The page the callback is setup for.
+ *
+ *  @param user_data The page focus function
+ */
+void gnc_plugin_page_inserted_cb (GncPluginPage *page, gpointer user_data);
+
+
+/** Disconnect the page_changed_id signal callback.
+ *
+ *  @param page The page whose name should be retrieved.
+ */
+void gnc_plugin_page_disconnect_page_changed (GncPluginPage *page);
 
 
 /** Retrieve the Uniform Resource Identifier for this page.

--- a/gnucash/gnome/gnc-plugin-page-account-tree.h
+++ b/gnucash/gnome/gnc-plugin-page-account-tree.h
@@ -95,15 +95,6 @@ GncPluginPage *gnc_plugin_page_account_tree_new  (void);
 Account * gnc_plugin_page_account_tree_get_current_account (GncPluginPageAccountTree *page);
 
 
-/** Given a pointer to an account tree plugin page, set the focus to
- *  the GtkTreeView. This is used in a g_idle_add so return FALSE.
- *
- *  @param page The "account tree" page.
- * 
- *  @return FALSE;
- */
-gboolean gnc_plugin_page_account_tree_focus (GncPluginPageAccountTree *page);
-
 /** Given a pointer to an account, the account tree will open
  *  and the account will be selected (if any).
  *

--- a/gnucash/gnome/gnc-plugin-page-budget.c
+++ b/gnucash/gnome/gnc-plugin-page-budget.c
@@ -58,6 +58,7 @@
 #include "gnc-tree-view-account.h"
 #include "gnc-ui.h"
 #include "gnc-ui-util.h"
+#include "gnc-window.h"
 #include "option-util.h"
 #include "gnc-main-window.h"
 #include "gnc-component-manager.h"
@@ -85,6 +86,7 @@ static void gnc_plugin_page_budget_finalize (GObject *object);
 
 static GtkWidget *
 gnc_plugin_page_budget_create_widget (GncPluginPage *plugin_page);
+static gboolean gnc_plugin_page_budget_focus_widget (GncPluginPage *plugin_page);
 static void gnc_plugin_page_budget_destroy_widget (GncPluginPage *plugin_page);
 static void gnc_plugin_page_budget_save_page (GncPluginPage *plugin_page,
                                               GKeyFile *file,
@@ -299,6 +301,7 @@ gnc_plugin_page_budget_class_init (GncPluginPageBudgetClass *klass)
     gnc_plugin_class->destroy_widget  = gnc_plugin_page_budget_destroy_widget;
     gnc_plugin_class->save_page       = gnc_plugin_page_budget_save_page;
     gnc_plugin_class->recreate_page   = gnc_plugin_page_budget_recreate_page;
+    gnc_plugin_class->focus_page_function = gnc_plugin_page_budget_focus_widget;
 }
 
 
@@ -372,12 +375,16 @@ gnc_plugin_page_budget_close_cb (gpointer user_data)
 }
 
 
-gboolean
-gnc_plugin_page_budget_focus (GncPluginPageBudget *page)
+/**
+ * Whenever the current page is changed, if a budget page is
+ * the current page, set focus on the budget tree view.
+ */
+static gboolean
+gnc_plugin_page_budget_focus_widget (GncPluginPage *budget_plugin_page)
 {
-    if (GNC_IS_PLUGIN_PAGE_BUDGET(page))
+    if (GNC_IS_PLUGIN_PAGE_BUDGET(budget_plugin_page))
     {
-        GncPluginPageBudgetPrivate *priv = GNC_PLUGIN_PAGE_BUDGET_GET_PRIVATE(page);
+        GncPluginPageBudgetPrivate *priv = GNC_PLUGIN_PAGE_BUDGET_GET_PRIVATE(budget_plugin_page);
         GncBudgetView *budget_view = priv->budget_view;
         GtkWidget *account_view = gnc_budget_view_get_account_tree_view (budget_view);
 
@@ -423,27 +430,6 @@ gnc_plugin_page_budget_refresh_cb (GHashTable *changes, gpointer user_data)
 }
 
 
-static void
-gnc_plugin_budget_main_window_page_changed (GncMainWindow *window,
-                                            GncPluginPage *current_plugin_page,
-                                            GncPluginPage *budget_plugin_page)
-{
-    // We continue only if the plugin_page is a valid
-    if (!current_plugin_page || !GNC_IS_PLUGIN_PAGE_BUDGET(current_plugin_page) ||
-        !budget_plugin_page || !GNC_IS_PLUGIN_PAGE_BUDGET(budget_plugin_page))
-        return;
-
-    if (current_plugin_page == budget_plugin_page)
-    {
-        // The page changed signal is emitted multiple times so we need
-        // to use an idle_add to change the focus to the tree view
-        g_idle_remove_by_data (GNC_PLUGIN_PAGE_BUDGET(budget_plugin_page));
-        g_idle_add ((GSourceFunc)gnc_plugin_page_budget_focus,
-                      GNC_PLUGIN_PAGE_BUDGET(budget_plugin_page));
-    }
-}
-
-
 /****************************
  * GncPluginPage Functions  *
  ***************************/
@@ -452,7 +438,6 @@ gnc_plugin_page_budget_create_widget (GncPluginPage *plugin_page)
 {
     GncPluginPageBudget *page;
     GncPluginPageBudgetPrivate *priv;
-    GncMainWindow *window;
 
     ENTER("page %p", plugin_page);
     page = GNC_PLUGIN_PAGE_BUDGET(plugin_page);
@@ -487,10 +472,9 @@ gnc_plugin_page_budget_create_widget (GncPluginPage *plugin_page)
                                     gnc_budget_get_guid (priv->budget),
                                     QOF_EVENT_DESTROY | QOF_EVENT_MODIFY);
 
-    window = GNC_MAIN_WINDOW(GNC_PLUGIN_PAGE(page)->window);
-    g_signal_connect (window, "page_changed",
-                      G_CALLBACK(gnc_plugin_budget_main_window_page_changed),
-                      plugin_page);
+    g_signal_connect (G_OBJECT(plugin_page), "inserted",
+                      G_CALLBACK(gnc_plugin_page_inserted_cb),
+                      NULL);
 
     LEAVE("widget = %p", priv->budget_view);
     return GTK_WIDGET(priv->budget_view);
@@ -505,8 +489,11 @@ gnc_plugin_page_budget_destroy_widget (GncPluginPage *plugin_page)
     ENTER("page %p", plugin_page);
     priv = GNC_PLUGIN_PAGE_BUDGET_GET_PRIVATE(plugin_page);
 
+    // Remove the page_changed signal callback
+    gnc_plugin_page_disconnect_page_changed (GNC_PLUGIN_PAGE(plugin_page));
+
     // Remove the page focus idle function if present
-    g_idle_remove_by_data (GNC_PLUGIN_PAGE_BUDGET(plugin_page));
+    g_idle_remove_by_data (plugin_page);
 
     if (priv->budget_view)
     {

--- a/gnucash/gnome/gnc-plugin-page-budget.h
+++ b/gnucash/gnome/gnc-plugin-page-budget.h
@@ -70,16 +70,6 @@ GncPluginPage *gnc_plugin_page_budget_new (GncBudget *budget);
 
 void gnc_budget_gui_delete_budget (GncBudget *budget);
 
-/** Given a pointer to a budget plugin page, set the focus to
- *  the Account GtkTreeView. This is used in a g_idle_add so
- *  return FALSE.
- *
- *  @param page The "budget" page.
- *
- *  @return FALSE
- */
-gboolean gnc_plugin_page_budget_focus (GncPluginPageBudget *page);
-
 G_END_DECLS
 
 #endif /* __GNC_PLUGIN_PAGE_BUDGET_H */

--- a/gnucash/gnome/gnc-plugin-page-owner-tree.c
+++ b/gnucash/gnome/gnc-plugin-page-owner-tree.c
@@ -58,6 +58,7 @@
 #include "gnc-tree-view-owner.h"
 #include "gnc-ui.h"
 #include "gnc-ui-util.h"
+#include "gnc-window.h"
 #include "guile-mappings.h"
 #include "dialog-lot-viewer.h"
 #include "dialog-object-references.h"
@@ -365,43 +366,25 @@ gnc_plugin_page_owner_tree_new (GncOwnerType owner_type)
     return GNC_PLUGIN_PAGE(plugin_page);
 }
 
-
-static gboolean
-gnc_plugin_page_owner_focus (GtkTreeView *tree_view)
-{
-    if (GTK_IS_TREE_VIEW(tree_view))
-    {
-        if (!gtk_widget_is_focus (GTK_WIDGET(tree_view)))
-            gtk_widget_grab_focus (GTK_WIDGET(tree_view));
-    }
-    return FALSE;
-}
-
-
 /**
  * Whenever the current page is changed, if an owner page is
- * the current page, set focus on the treeview.
+ * the current page, set focus on the tree view.
  */
-static void
-gnc_plugin_page_owner_main_window_page_changed (GncMainWindow *window,
-                                                GncPluginPage *current_plugin_page,
-                                                GncPluginPage *owner_plugin_page)
+static gboolean
+gnc_plugin_page_owner_focus_widget (GncPluginPage *owner_plugin_page)
 {
-    // We continue only if the plugin_page is a valid
-    if (!current_plugin_page || !GNC_IS_PLUGIN_PAGE_OWNER_TREE(current_plugin_page) ||
-        !owner_plugin_page || !GNC_IS_PLUGIN_PAGE_OWNER_TREE(owner_plugin_page))
-        return;
-
-    if (current_plugin_page == owner_plugin_page)
+    if (GNC_IS_PLUGIN_PAGE_OWNER_TREE(owner_plugin_page))
     {
         GncPluginPageOwnerTreePrivate *priv = GNC_PLUGIN_PAGE_OWNER_TREE_GET_PRIVATE(owner_plugin_page);
+        GtkTreeView *tree_view = priv->tree_view;
 
-        // The page changed signal is emitted multiple times so we need
-        // to use an idle_add to change the focus to the tree view
-        g_idle_remove_by_data (GTK_TREE_VIEW (priv->tree_view));
-        g_idle_add ((GSourceFunc)gnc_plugin_page_owner_focus,
-                      GTK_TREE_VIEW (priv->tree_view));
+        if (GTK_IS_TREE_VIEW(tree_view))
+        {
+            if (!gtk_widget_is_focus (GTK_WIDGET(tree_view)))
+                gtk_widget_grab_focus (GTK_WIDGET(tree_view));
+        }
     }
+    return FALSE;
 }
 
 G_DEFINE_TYPE_WITH_PRIVATE(GncPluginPageOwnerTree, gnc_plugin_page_owner_tree, GNC_TYPE_PLUGIN_PAGE)
@@ -422,6 +405,7 @@ gnc_plugin_page_owner_tree_class_init (GncPluginPageOwnerTreeClass *klass)
     gnc_plugin_class->destroy_widget  = gnc_plugin_page_owner_tree_destroy_widget;
     gnc_plugin_class->save_page       = gnc_plugin_page_owner_tree_save_page;
     gnc_plugin_class->recreate_page   = gnc_plugin_page_owner_tree_recreate_page;
+    gnc_plugin_class->focus_page_function = gnc_plugin_page_owner_focus_widget;
 
     plugin_page_signals[OWNER_SELECTED] =
         g_signal_new ("owner_selected",
@@ -571,7 +555,6 @@ gnc_plugin_page_owner_tree_create_widget (GncPluginPage *plugin_page)
 {
     GncPluginPageOwnerTree *page;
     GncPluginPageOwnerTreePrivate *priv;
-    GncMainWindow  *window;
     GtkTreeSelection *selection;
     GtkTreeView *tree_view;
     GtkWidget *scrolled_window;
@@ -686,10 +669,9 @@ gnc_plugin_page_owner_tree_create_widget (GncPluginPage *plugin_page)
     gnc_gui_component_set_session (priv->component_id,
                                    gnc_get_current_session());
 
-    window = GNC_MAIN_WINDOW(GNC_PLUGIN_PAGE(plugin_page)->window);
-    g_signal_connect(window, "page_changed",
-                     G_CALLBACK(gnc_plugin_page_owner_main_window_page_changed),
-                     plugin_page);
+    g_signal_connect (G_OBJECT(plugin_page), "inserted",
+                      G_CALLBACK(gnc_plugin_page_inserted_cb),
+                      NULL);
 
     LEAVE("widget = %p", priv->widget);
     return priv->widget;
@@ -705,8 +687,11 @@ gnc_plugin_page_owner_tree_destroy_widget (GncPluginPage *plugin_page)
     page = GNC_PLUGIN_PAGE_OWNER_TREE (plugin_page);
     priv = GNC_PLUGIN_PAGE_OWNER_TREE_GET_PRIVATE(page);
 
+    // Remove the page_changed signal callback
+    gnc_plugin_page_disconnect_page_changed (GNC_PLUGIN_PAGE(plugin_page));
+
     // Remove the page focus idle function if present
-    g_idle_remove_by_data (GTK_TREE_VIEW (priv->tree_view));
+    g_idle_remove_by_data (plugin_page);
 
     if (priv->widget)
     {

--- a/gnucash/gnome/gnc-plugin-page-register.h
+++ b/gnucash/gnome/gnc-plugin-page-register.h
@@ -163,16 +163,6 @@ gnc_plugin_page_register_get_account (GncPluginPageRegister *page);
 Transaction *
 gnc_plugin_page_register_get_current_txn (GncPluginPageRegister *page);
 
-/** Given a pointer to a register plugin page, set the focus to
- *  the sheet. This is used in a g_idle_add so return FALSE.
- *
- *  @param page The "register" page.
- *
- *  @return FALSE
- */
-gboolean
-gnc_plugin_page_register_focus (GncPluginPageRegister *page);
-
 G_END_DECLS
 /** @} */
 /** @} */


### PR DESCRIPTION
This commit moves the setting up of the page changed signal callback to when the plugin page is inserted and also records the id used. The call back functions have been changed to reflect the signal spec and cast to the correct types. The id is used to disconnect this callback when the page is moved to a different window with the gnc_main_window_cmd_window_move_page function so it gets disconnected as early as possible before pages start changing. It is also used when the page is destroyed.