### PR TITLE
Prevent crash by skipping unnecessary sanity checks

### DIFF
--- a/gnucash/gnome/gnc-plugin-page-invoice.c
+++ b/gnucash/gnome/gnc-plugin-page-invoice.c
@@ -609,8 +609,7 @@ gnc_plugin_page_invoice_main_window_page_changed (GncMainWindow *window,
                                                   GncPluginPage *invoice_plugin_page)
 {
     // We continue only if the plugin_page is a valid
-    if (!current_plugin_page || !GNC_IS_PLUGIN_PAGE_INVOICE(current_plugin_page) ||
-        !invoice_plugin_page || !GNC_IS_PLUGIN_PAGE_INVOICE(invoice_plugin_page))
+    if (!current_plugin_page || !invoice_plugin_page)
         return;
 
     if (current_plugin_page == invoice_plugin_page)


### PR DESCRIPTION
Occasional crash. I think it's safe to remove these unnecessary sanity checks? The next `if` will take care of any invalid `current_plugin_page` or `invoice_plugin_page`.

```log
Thread 1 "gnucash" received signal SIGSEGV, Segmentation fault.
0x00007ffff7f3ec2c in gnc_plugin_page_invoice_main_window_page_changed (window=0x555555982310, current_plugin_page=0x555557031d80, invoice_plugin_page=0x5555573e1580)
    at /home/chris/sources/code/gnucash/gnucash/gnome/gnc-plugin-page-invoice.c:613
613	        !invoice_plugin_page || !GNC_IS_PLUGIN_PAGE_INVOICE(invoice_plugin_page))
(gdb) bt
#0  0x00007ffff7f3ec2c in gnc_plugin_page_invoice_main_window_page_changed (window=0x555555982310, current_plugin_page=0x555557031d80, invoice_plugin_page=0x5555573e1580)
    at /home/chris/sources/code/gnucash/gnucash/gnome/gnc-plugin-page-invoice.c:613
#1  0x00007ffff6d086e2 in g_closure_invoke () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#2  0x00007ffff6d1c544 in  () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#3  0x00007ffff6d25327 in g_signal_emit_valist () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#4  0x00007ffff6d25fa9 in g_signal_emit_by_name () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#5  0x00007ffff7b593a5 in gnc_main_window_generate_title (window=0x555555982310) at /home/chris/sources/code/gnucash/gnucash/gnome-utils/gnc-main-window.c:1558
#6  0x00007ffff7b593df in gnc_main_window_update_title (window=0x555555982310) at /home/chris/sources/code/gnucash/gnucash/gnome-utils/gnc-main-window.c:1580
#7  0x00007ffff7b5fd3a in gnc_main_window_switch_page (notebook=0x555555986290, notebook_page=0x555557009750, pos=3, window=0x555555982310)
    at /home/chris/sources/code/gnucash/gnucash/gnome-utils/gnc-main-window.c:3886
#8  0x00007ffff6d086e2 in g_closure_invoke () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#9  0x00007ffff6d1c544 in  () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#10 0x00007ffff6d25327 in g_signal_emit_valist () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#11 0x00007ffff6d259b3 in g_signal_emit () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#12 0x00007ffff71a1cc3 in  () at /lib/x86_64-linux-gnu/libgtk-3.so.0
```