### PR TITLE
Scrub Import Map Editor

### DIFF
--- a/gnucash/gnome/dialog-imap-editor.c
+++ b/gnucash/gnome/dialog-imap-editor.c
@@ -181,27 +181,27 @@ delete_selected_row (GtkTreeModel *model, GtkTreeIter *iter, ImapDialog *imap_di
         g_free (full_source_account);
 }
 
-static void
+static gboolean
 gnc_delete_nomapping (GtkTreeModel *model, GtkTreePath *path,
                       GtkTreeIter *iter, gpointer data)
 {
     Account     *source_account = NULL;
     Account     *map_account = NULL;
     gchar       *head;
-    GtkTreePath *tree_path;
     gint         depth;
 
     gtk_tree_model_get (model, iter, SOURCE_ACCOUNT, &source_account,
                         MAP_ACCOUNT, &map_account, HEAD, &head, -1);
-    tree_path = gtk_tree_model_get_path (model, iter);
-    depth = gtk_tree_path_get_depth (tree_path);
+    depth = gtk_tree_path_get_depth (path);
     gtk_tree_path_free (tree_path);
 
-    if ((source_account == NULL) || (map_account != NULL) || (depth == 1))
-        return;
-
-    PWARN ("Delete map: Acc=%s, head=%s", xaccAccountGetName(source_account), head);
-    gnc_account_delete_map_entry (source_account, head, NULL, NULL, FALSE);
+    if (!((source_account == NULL) || (map_account != NULL) || (depth == 1)))
+    {
+        PWARN ("Delete map: Acc=%s, head=%s", xaccAccountGetName(source_account), head);
+        gnc_account_delete_map_entry (source_account, head, NULL, NULL, FALSE);
+    }
+    g_free(head);
+    return FALSE;
 }
 
 static void

--- a/gnucash/gtkbuilder/dialog-imap-editor.glade
+++ b/gnucash/gtkbuilder/dialog-imap-editor.glade
@@ -51,6 +51,20 @@
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
+              <object class="GtkButton" id="scrub_button">
+                <property name="label" translatable="yes">_Scrub</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="use_underline">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkButton" id="delete_button">
                 <property name="label" translatable="yes">_Delete</property>
                 <property name="visible">True</property>
@@ -61,7 +75,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
-                <property name="position">0</property>
+                <property name="position">1</property>
               </packing>
             </child>
             <child>
@@ -77,7 +91,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
-                <property name="position">1</property>
+                <property name="position">2</property>
               </packing>
             </child>
           </object>
@@ -374,6 +388,7 @@
       </object>
     </child>
     <action-widgets>
+      <action-widget response="4">scrub_button</action-widget>
       <action-widget response="-10">delete_button</action-widget>
       <action-widget response="-6">close_button</action-widget>
     </action-widgets>


### PR DESCRIPTION
Creates a `Scrub` button in Import Map Editor. It scans all gtk_list rows, finds mapping entries whereby map_account is NULL, and deletes them.

* probably missed g_free ()
* gui doesn't immediately refresh, need to close and reopen dialog to see the nomapping entries removed.