### PR TITLE
[Master] State file changes

### DIFF
--- a/gnucash/gnome-utils/gnc-tree-view-account.c
+++ b/gnucash/gnome-utils/gnc-tree-view-account.c
@@ -2486,10 +2486,6 @@ gnc_tree_view_account_save_filter (GncTreeViewAccount *view,
                            fd->show_zero_total);
     g_key_file_set_boolean (key_file, group_name, SHOW_UNUSED_ACCOUNTS,
                            fd->show_unused);
-
-    g_key_file_set_comment (key_file, group_name, ACCOUNT_TYPES,
-                            "Account Filter Section below, four lines", NULL);
-
     LEAVE("");
 }
 

--- a/gnucash/gnome/dialog-invoice.c
+++ b/gnucash/gnome/dialog-invoice.c
@@ -518,19 +518,19 @@ gnc_invoice_window_help_cb (GtkWidget *widget, gpointer data)
     gnc_gnome_help(HF_HELP, HL_USAGE_INVOICE);
 }
 
-static gchar *
+static const gchar *
 gnc_invoice_window_get_state_group (InvoiceWindow *iw)
 {
     switch (gncOwnerGetType (gncOwnerGetEndOwner (&iw->owner)))
     {
         case GNC_OWNER_VENDOR:
-            return g_strdup ("Vendor documents");
+            return "Vendor documents";
             break;
         case GNC_OWNER_EMPLOYEE:
-            return g_strdup ("Employee documents");
+            return "Employee documents";
             break;
         default:
-            return g_strdup ("Customer documents");
+            return "Customer documents";
             break;
     }
 }
@@ -542,10 +542,9 @@ void
 gnc_invoice_window_save_document_layout_to_user_state (InvoiceWindow *iw)
 {
     Table *table = gnc_entry_ledger_get_table (iw->ledger);
-    gchar *group = gnc_invoice_window_get_state_group (iw);
+    const gchar *group = gnc_invoice_window_get_state_group (iw);
 
     gnc_table_save_state (table, group, NULL);
-    g_free (group);
 }
 
 /* Removes the user state layout information for Invoice/Bill/Voucher
@@ -555,11 +554,10 @@ void
 gnc_invoice_window_reset_document_layout_and_clear_user_state (InvoiceWindow *iw)
 {
     GnucashRegister *reg = iw->reg;
-    gchar *group = gnc_invoice_window_get_state_group (iw);
+    const gchar *group = gnc_invoice_window_get_state_group (iw);
 
     gnucash_register_reset_sheet_layout (reg);
     gnc_state_drop_sections_for (group);
-    g_free (group);
 }
 
 /* Checks to see if there is user state layout information for
@@ -570,10 +568,8 @@ gboolean
 gnc_invoice_window_document_has_user_state (InvoiceWindow *iw)
 {
     GKeyFile *state_file = gnc_state_get_current ();
-    gchar *group = gnc_invoice_window_get_state_group (iw);
-    gboolean has_group = g_key_file_has_group (state_file, group);
-    g_free (group);
-    return has_group;
+    const gchar *group = gnc_invoice_window_get_state_group (iw);
+    return g_key_file_has_group (state_file, group);
 }
 
 void
@@ -2351,7 +2347,6 @@ gnc_invoice_save_page (InvoiceWindow *iw,
                        const gchar *group_name)
 {
     Table *table = gnc_entry_ledger_get_table (iw->ledger);
-    gchar *group = g_strdup (group_name);
     gchar guidstr[GUID_ENCODING_LENGTH+1];
     guid_to_string_buff(&iw->invoice_guid, guidstr);
     g_key_file_set_string(key_file, group_name, KEY_INVOICE_TYPE,
@@ -2373,8 +2368,7 @@ gnc_invoice_save_page (InvoiceWindow *iw,
         g_key_file_set_string(key_file, group_name, KEY_OWNER_GUID, guidstr);
     }
     // save the open table layout
-    gnc_table_save_state (table, group, NULL);
-    g_free (group);
+    gnc_table_save_state (table, group_name, NULL);
 }
 
 GtkWidget *
@@ -2568,21 +2562,20 @@ gnc_invoice_create_page (InvoiceWindow *iw, gpointer page)
     /* Create the register */
     {
         GtkWidget *regWidget, *frame, *window;
-        gchar *default_group = gnc_invoice_window_get_state_group (iw);
-        gchar *group;
+        const gchar *default_group = gnc_invoice_window_get_state_group (iw);
+        const gchar *group;
 
         // if this is from a page recreate, use those settings
         if (iw->page_state_name)
-            group = g_strdup (iw->page_state_name);
+            group = iw->page_state_name;
         else
-            group = g_strdup (default_group);
+            group = default_group;
 
         /* Watch the order of operations, here... */
         regWidget = gnucash_register_new (gnc_entry_ledger_get_table
                                           (entry_ledger), group);
         gtk_widget_show(regWidget);
-        g_free (default_group);
-        g_free (group);
+
         frame = GTK_WIDGET (gtk_builder_get_object (builder, "ledger_frame"));
         gtk_container_add (GTK_CONTAINER (frame), regWidget);
 

--- a/gnucash/gnome/dialog-invoice.c
+++ b/gnucash/gnome/dialog-invoice.c
@@ -544,7 +544,7 @@ gnc_invoice_window_save_document_layout_to_user_state (InvoiceWindow *iw)
     Table *table = gnc_entry_ledger_get_table (iw->ledger);
     const gchar *group = gnc_invoice_window_get_state_group (iw);
 
-    gnc_table_save_state (table, group, NULL);
+    gnc_table_save_state (table, group);
 }
 
 /* Removes the user state layout information for Invoice/Bill/Voucher
@@ -2368,7 +2368,7 @@ gnc_invoice_save_page (InvoiceWindow *iw,
         g_key_file_set_string(key_file, group_name, KEY_OWNER_GUID, guidstr);
     }
     // save the open table layout
-    gnc_table_save_state (table, group_name, NULL);
+    gnc_table_save_state (table, group_name);
 }
 
 GtkWidget *

--- a/gnucash/gnome/dialog-invoice.h
+++ b/gnucash/gnome/dialog-invoice.h
@@ -110,6 +110,10 @@ void gnc_invoice_window_duplicateCB (GtkWidget *widget, gpointer data);
 void gnc_invoice_window_payment_cb (GtkWindow *parent, gpointer data);
 void gnc_invoice_window_report_owner_cb (GtkWindow *parent, gpointer data);
 
+void gnc_invoice_window_save_document_layout_to_user_state (InvoiceWindow *iw);
+void gnc_invoice_window_reset_document_layout_and_clear_user_state (InvoiceWindow *iw);
+gboolean gnc_invoice_window_document_has_user_state (InvoiceWindow *iw);
+
 void gnc_invoice_window_entryUpCB (GtkWidget *widget, gpointer data);
 void gnc_invoice_window_entryDownCB (GtkWidget *widget, gpointer data);
 

--- a/gnucash/gnome/gnc-plugin-page-register.c
+++ b/gnucash/gnome/gnc-plugin-page-register.c
@@ -1739,7 +1739,7 @@ gnc_plugin_page_register_save_page (GncPluginPage* plugin_page,
                             reg->use_double_line);
 
     // save the open table layout
-    gnc_table_save_state (reg->table, group_name, NULL);
+    gnc_table_save_state (reg->table, group_name);
 
     LEAVE(" ");
 }

--- a/gnucash/gnome/gnc-split-reg.c
+++ b/gnucash/gnome/gnc-split-reg.c
@@ -508,7 +508,7 @@ gsr_create_table( GNCSplitReg *gsr )
     if (g_key_file_has_group (gnc_state_get_current (), register_state_section))
     {
         if (!gnc_split_reg_register_has_user_state (gsr))
-             gnc_table_save_state (sr->table, default_state_section, NULL);
+             gnc_table_save_state (sr->table, default_state_section);
         // drop the register state
         gnc_state_drop_sections_for (register_state_section);
     }
@@ -2008,7 +2008,7 @@ gnc_split_reg_save_register_layout_to_user_state (GNCSplitReg *gsr)
     SplitRegister *split_reg = gnc_ledger_display_get_split_register (gsr->ledger);
     const gchar *group = gnc_split_reg_get_register_state_group (gsr);
 
-    gnc_table_save_state (split_reg->table, group, NULL);
+    gnc_table_save_state (split_reg->table, group);
 }
 
 /* Removes the user state layout information for the register group

--- a/gnucash/gnome/gnc-split-reg.c
+++ b/gnucash/gnome/gnc-split-reg.c
@@ -412,7 +412,7 @@ gsr_create_table( GNCSplitReg *gsr )
     Account * account = gnc_ledger_display_leader(gsr->ledger);
     const GncGUID * guid = xaccAccountGetGUID(account);
     gchar guidstr[GUID_ENCODING_LENGTH+1];
-    gchar *state_section = NULL;
+    const gchar *state_section = NULL;
     guid_to_string_buff(guid, guidstr);
     state_section = g_strconcat (STATE_SECTION_REG_PREFIX, " ", guidstr, NULL);
 
@@ -427,7 +427,7 @@ gsr_create_table( GNCSplitReg *gsr )
     sr = gnc_ledger_display_get_split_register( gsr->ledger );
     register_widget = gnucash_register_new( sr->table, state_section );
     gsr->reg = GNUCASH_REGISTER( register_widget );
-    g_free (state_section);
+
     gtk_box_pack_start (GTK_BOX (gsr), GTK_WIDGET(gsr->reg), TRUE, TRUE, 0);
     gnucash_sheet_set_window (gnucash_register_get_sheet (gsr->reg), gsr->window);
     gtk_widget_show ( GTK_WIDGET(gsr->reg) );

--- a/gnucash/gnome/gnc-split-reg.h
+++ b/gnucash/gnome/gnc-split-reg.h
@@ -85,6 +85,8 @@ struct _GNCSplitReg
     /** The actual gnucash register widget. **/
     GnucashRegister *reg;
 
+    const gchar *page_state_name; /* Used for loading open state information */
+
     gint numRows;
 
     guint    sort_type;
@@ -179,11 +181,13 @@ GType gnc_split_reg_get_type(void);
  * @param parent        The containing window.
  * @param numberOfLines The initial number of lines for the register.
  * @param read_only      If the contained register should be setup read-only.
+ * @param group_name     The group name of the page state section for this page
  **/
 GtkWidget* gnc_split_reg_new( GNCLedgerDisplay *ld,
                               GtkWindow *parent,
                               gint numberOfLines,
-                              gboolean read_only );
+                              gboolean read_only,
+                              const gchar *group_name );
 
 /**
  * Returns the GnucashRegister in effect for this GNCSplitReg.
@@ -249,6 +253,14 @@ void gnc_split_reg_jump_to_split_amount(GNCSplitReg *gsr, Split *split);
  **/
 void gnc_split_reg_focus_on_sheet (GNCSplitReg *gsr);
 void gnc_split_reg_set_sheet_focus (GNCSplitReg *gsr, gboolean has_focus);
+
+/**
+ * Save/Reset/Has functions used for the user default register layouts.
+ **/
+void gnc_split_reg_save_register_layout_to_user_state (GNCSplitReg *gsr);
+void gnc_split_reg_reset_register_layout_and_clear_user_state (GNCSplitReg *gsr);
+gboolean gnc_split_reg_register_has_user_state (GNCSplitReg *gsr);
+const gchar *gnc_split_reg_get_register_state_group (GNCSplitReg *gsr);
 
 /*
  * Create a transaction entry with given amount and date. One account is

--- a/gnucash/gnome/gnc-split-reg.h
+++ b/gnucash/gnome/gnc-split-reg.h
@@ -37,6 +37,9 @@
 #define IS_GNC_SPLIT_REG(obj)      G_TYPE_CHECK_INSTANCE_TYPE( obj, gnc_split_reg_get_type() )
 
 #define STATE_SECTION_REG_PREFIX "Register"
+#define KEY_PAGE_SORT            "register_order"
+#define KEY_PAGE_SORT_REV        "register_reversed"
+#define KEY_PAGE_FILTER          "register_filter"
 
 typedef struct _GNCSplitReg GNCSplitReg;
 typedef struct _GNCSplitRegClass GNCSplitRegClass;

--- a/gnucash/register/ledger-core/split-register-layout.c
+++ b/gnucash/register/ledger-core/split-register-layout.c
@@ -83,17 +83,9 @@ gnc_split_register_set_cells (SplitRegister* reg, TableLayout* layout)
     CellBlock* curs;
     CellBlock* curs_last;
 
-    switch (reg->type)
+    switch (gnc_split_register_get_register_group (reg))
     {
-    case BANK_REGISTER:
-    case CASH_REGISTER:
-    case ASSET_REGISTER:
-    case CREDIT_REGISTER:
-    case LIABILITY_REGISTER:
-    case INCOME_REGISTER:
-    case EXPENSE_REGISTER:
-    case EQUITY_REGISTER:
-    case TRADING_REGISTER:
+    case REG_TYPE_GROUP_CURRENCY:
     {
         curs = gnc_table_layout_get_cursor (layout,
                                             CURSOR_SINGLE_LEDGER);
@@ -191,8 +183,7 @@ gnc_split_register_set_cells (SplitRegister* reg, TableLayout* layout)
     }
     /* --------------------------------------------------------- */
 
-    case PAYABLE_REGISTER:
-    case RECEIVABLE_REGISTER:
+    case REG_TYPE_GROUP_APAR:
     {
         curs = gnc_table_layout_get_cursor (layout,
                                             CURSOR_SINGLE_LEDGER);
@@ -269,9 +260,7 @@ gnc_split_register_set_cells (SplitRegister* reg, TableLayout* layout)
     }
 
     /* --------------------------------------------------------- */
-    case INCOME_LEDGER:
-    case GENERAL_JOURNAL:
-    case SEARCH_LEDGER:
+    case REG_TYPE_GROUP_JOURNAL:
     {
         curs = gnc_table_layout_get_cursor (layout,
                                             CURSOR_SINGLE_LEDGER);
@@ -391,8 +380,7 @@ gnc_split_register_set_cells (SplitRegister* reg, TableLayout* layout)
     }
 
     /* --------------------------------------------------------- */
-    case STOCK_REGISTER:
-    case CURRENCY_REGISTER:
+    case REG_TYPE_GROUP_STOCK:
     {
         curs = gnc_table_layout_get_cursor (layout,
                                             CURSOR_SINGLE_LEDGER);
@@ -476,7 +464,7 @@ gnc_split_register_set_cells (SplitRegister* reg, TableLayout* layout)
     }
 
     /* --------------------------------------------------------- */
-    case PORTFOLIO_LEDGER:
+    case REG_TYPE_GROUP_PORTFOLIO:
     {
         curs = gnc_table_layout_get_cursor (layout,
                                             CURSOR_SINGLE_LEDGER);
@@ -559,7 +547,7 @@ gnc_split_register_set_cells (SplitRegister* reg, TableLayout* layout)
 
     /* --------------------------------------------------------- */
     default:
-        PERR ("unknown register type %d \n", reg->type);
+        PERR ("unknown register group type for %d \n", reg->type);
         break;
     }
 }

--- a/gnucash/register/ledger-core/split-register.c
+++ b/gnucash/register/ledger-core/split-register.c
@@ -3183,3 +3183,52 @@ gnc_split_register_set_read_only (SplitRegister* reg, gboolean read_only)
 {
     gnc_table_model_set_read_only (reg->table->model, read_only);
 }
+
+SplitRegisterTypeGroup
+gnc_split_register_get_register_group (SplitRegister *reg)
+{
+    switch (reg->type)
+    {
+        case BANK_REGISTER:
+        case CASH_REGISTER:
+        case ASSET_REGISTER:
+        case CREDIT_REGISTER:
+        case LIABILITY_REGISTER:
+        case INCOME_REGISTER:
+        case EXPENSE_REGISTER:
+        case EQUITY_REGISTER:
+        case TRADING_REGISTER:
+        {
+            return REG_TYPE_GROUP_CURRENCY;
+            break;
+        }
+        case PAYABLE_REGISTER:
+        case RECEIVABLE_REGISTER:
+        {
+            return REG_TYPE_GROUP_APAR;
+            break;
+        }
+        case INCOME_LEDGER:
+        case GENERAL_JOURNAL:
+        case SEARCH_LEDGER:
+        {
+            return REG_TYPE_GROUP_JOURNAL;
+            break;
+        }
+        case STOCK_REGISTER:
+        case CURRENCY_REGISTER:
+        {
+            return REG_TYPE_GROUP_STOCK;
+            break;
+        }
+        case PORTFOLIO_LEDGER:
+        {
+            return REG_TYPE_GROUP_PORTFOLIO;
+            break;
+        }
+        default:
+            return REG_TYPE_GROUP_UNKNOWN;
+            PERR ("unknown register type %d \n", reg->type);
+        break;
+    }
+}

--- a/gnucash/register/ledger-core/split-register.h
+++ b/gnucash/register/ledger-core/split-register.h
@@ -167,6 +167,19 @@ typedef enum
     NUM_REGISTER_TYPES
 } SplitRegisterType;
 
+/** @brief Register group types
+ *
+ * used for grouping registers that have the same layout */
+typedef enum
+{
+    REG_TYPE_GROUP_UNKNOWN,
+    REG_TYPE_GROUP_CURRENCY,
+    REG_TYPE_GROUP_APAR,
+    REG_TYPE_GROUP_STOCK,
+    REG_TYPE_GROUP_JOURNAL,
+    REG_TYPE_GROUP_PORTFOLIO,
+} SplitRegisterTypeGroup;
+
 /** Register styles */
 typedef enum
 {
@@ -327,6 +340,12 @@ void gnc_split_register_set_auto_complete (SplitRegister* reg,
  */
 void gnc_split_register_set_read_only (SplitRegister* reg, gboolean read_only);
 
+/** Group registers for common layouts.
+ *  @param reg a ::SplitRegister
+ *
+ *  @return the ::SplitRegisterTypeGroup that groups registers together
+ */
+SplitRegisterTypeGroup gnc_split_register_get_register_group (SplitRegister *reg);
 
 /** Set the template account for use in a template register.
  *

--- a/gnucash/register/register-core/table-allgui.h
+++ b/gnucash/register/register-core/table-allgui.h
@@ -201,7 +201,7 @@ Table *     gnc_table_new (TableLayout *layout,
                            TableControl *control);
 void        gnc_virtual_location_init (VirtualLocation *vloc);
 
-void        gnc_table_save_state (Table *table, gchar *state_section, gchar *account_fullname);
+void        gnc_table_save_state (Table *table, const gchar *state_section, gchar *account_fullname);
 void        gnc_table_destroy (Table *table);
 
 

--- a/gnucash/register/register-core/table-allgui.h
+++ b/gnucash/register/register-core/table-allgui.h
@@ -201,7 +201,7 @@ Table *     gnc_table_new (TableLayout *layout,
                            TableControl *control);
 void        gnc_virtual_location_init (VirtualLocation *vloc);
 
-void        gnc_table_save_state (Table *table, const gchar *state_section, gchar *account_fullname);
+void        gnc_table_save_state (Table *table, const gchar *state_section);
 void        gnc_table_destroy (Table *table);
 
 

--- a/gnucash/register/register-gnome/gnucash-register.c
+++ b/gnucash/register/register-gnome/gnucash-register.c
@@ -182,6 +182,37 @@ gnucash_register_refresh_from_prefs (GnucashRegister *reg)
     gnc_header_request_redraw (GNC_HEADER(sheet->header_item));
 }
 
+void
+gnucash_register_reset_sheet_layout (GnucashRegister *reg)
+{
+    GNCHeaderWidths widths;
+    Table *table;
+    GList *node;
+    gchar *key;
+    guint value;
+    GnucashSheet *sheet;
+    gint current_width;
+
+    g_return_if_fail (reg != NULL);
+
+    sheet = GNUCASH_SHEET(reg->sheet);
+
+    g_return_if_fail (sheet != NULL);
+    g_return_if_fail (GNUCASH_IS_SHEET (sheet));
+
+    current_width = sheet->window_width - 1;
+
+    widths = gnc_header_widths_new ();
+    gnucash_sheet_set_header_widths (sheet, widths);
+
+    gnucash_sheet_styles_set_dimensions (sheet, current_width);
+
+    gnucash_sheet_compile_styles (sheet);
+    gnucash_sheet_table_load (sheet, TRUE);
+    gnucash_sheet_cursor_set_from_table (sheet, TRUE);
+    gnucash_sheet_redraw_all (sheet);
+    gnc_header_widths_destroy (widths);
+}
 
 void
 gnucash_register_goto_virt_cell (GnucashRegister *reg,

--- a/gnucash/register/register-gnome/gnucash-register.c
+++ b/gnucash/register/register-gnome/gnucash-register.c
@@ -186,10 +186,6 @@ void
 gnucash_register_reset_sheet_layout (GnucashRegister *reg)
 {
     GNCHeaderWidths widths;
-    Table *table;
-    GList *node;
-    gchar *key;
-    guint value;
     GnucashSheet *sheet;
     gint current_width;
 

--- a/gnucash/register/register-gnome/gnucash-register.c
+++ b/gnucash/register/register-gnome/gnucash-register.c
@@ -486,7 +486,7 @@ gnucash_register_attach_popup (GnucashRegister *reg,
  *  to pass NULL as second parameter. */
 
 static void
-gnucash_register_configure (GnucashSheet *sheet, gchar * state_section)
+gnucash_register_configure (GnucashSheet *sheet, const gchar * state_section)
 {
     GNCHeaderWidths widths;
     Table *table;
@@ -644,7 +644,7 @@ gnucash_register_create_widget (Table *table)
 
 
 GtkWidget *
-gnucash_register_new (Table *table, gchar *state_section)
+gnucash_register_new (Table *table, const gchar *state_section)
 {
     GnucashRegister *reg;
     GtkWidget *widget;

--- a/gnucash/register/register-gnome/gnucash-register.h
+++ b/gnucash/register/register-gnome/gnucash-register.h
@@ -83,5 +83,6 @@ void gnucash_register_set_moved_cb (GnucashRegister *reg,
                                     GFunc cb, gpointer cb_data);
 
 GnucashSheet *gnucash_register_get_sheet (GnucashRegister *reg);
+void gnucash_register_reset_sheet_layout (GnucashRegister *reg);
 /** @} */
 #endif

--- a/gnucash/register/register-gnome/gnucash-register.h
+++ b/gnucash/register/register-gnome/gnucash-register.h
@@ -54,7 +54,7 @@ GType gnucash_register_get_type (void);
 void gnucash_register_add_cell_types (void);
 
 /** this already has scrollbars attached */
-GtkWidget *gnucash_register_new (Table *table, gchar *state_section);
+GtkWidget *gnucash_register_new (Table *table, const gchar *state_section);
 
 void gnucash_register_goto_virt_cell (GnucashRegister *reg,
                                       VirtualCellLocation vcell_loc);

--- a/gnucash/register/register-gnome/table-gnome.c
+++ b/gnucash/register/register-gnome/table-gnome.c
@@ -108,10 +108,12 @@ gnc_table_save_state (Table *table, gchar * state_section, gchar * account_fulln
             g_key_file_remove_key (state_file, state_section, key, NULL);
         g_free (key);
     }
-    key = g_strdup_printf ("Register state for \"%s\"", account_fullname);
-    g_key_file_set_comment (state_file, state_section, NULL, key, NULL);
-    g_free (key);
-
+    if (account_fullname)
+    {
+        key = g_strdup_printf ("Register state for \"%s\"", account_fullname);
+        g_key_file_set_comment (state_file, state_section, NULL, key, NULL);
+        g_free (key);
+    }
     gnc_header_widths_destroy (widths);
 }
 

--- a/gnucash/register/register-gnome/table-gnome.c
+++ b/gnucash/register/register-gnome/table-gnome.c
@@ -68,7 +68,7 @@ static QofLogModule UNUSED_VAR log_module = GNC_MOD_REGISTER;
 /** Implementation *****************************************************/
 
 void
-gnc_table_save_state (Table *table, gchar * state_section, gchar * account_fullname)
+gnc_table_save_state (Table *table, const gchar * state_section, gchar * account_fullname)
 {
     GnucashSheet *sheet;
     GNCHeaderWidths widths;

--- a/gnucash/register/register-gnome/table-gnome.c
+++ b/gnucash/register/register-gnome/table-gnome.c
@@ -68,7 +68,7 @@ static QofLogModule UNUSED_VAR log_module = GNC_MOD_REGISTER;
 /** Implementation *****************************************************/
 
 void
-gnc_table_save_state (Table *table, const gchar * state_section, gchar * account_fullname)
+gnc_table_save_state (Table *table, const gchar * state_section)
 {
     GnucashSheet *sheet;
     GNCHeaderWidths widths;
@@ -106,12 +106,6 @@ gnc_table_save_state (Table *table, const gchar * state_section, gchar * account
         }
         else if (g_key_file_has_key (state_file, state_section, key, NULL))
             g_key_file_remove_key (state_file, state_section, key, NULL);
-        g_free (key);
-    }
-    if (account_fullname)
-    {
-        key = g_strdup_printf ("Register state for \"%s\"", account_fullname);
-        g_key_file_set_comment (state_file, state_section, NULL, key, NULL);
         g_free (key);
     }
     gnc_header_widths_destroy (widths);

--- a/gnucash/ui/gnc-plugin-page-invoice-ui.xml
+++ b/gnucash/ui/gnc-plugin-page-invoice-ui.xml
@@ -49,6 +49,14 @@
         <menuitem name="ReportsCompanyReport"   action="ReportsCompanyReportAction"/>
       </placeholder>
     </menu>
+    
+    <menu name="Windows" action="WindowsAction">
+      <placeholder name="WindowsLayoutPlaceholder">
+        <menuitem name="WindowsSaveLayout"         action="WindowsSaveLayoutAction"/>
+        <menuitem name="WindowsResetLayout"        action="WindowsResetLayoutAction"/>
+       </placeholder>
+    </menu>
+    
   </menubar>
 
   <toolbar name="DefaultToolbar">

--- a/gnucash/ui/gnc-plugin-page-register-ui.xml
+++ b/gnucash/ui/gnc-plugin-page-register-ui.xml
@@ -66,6 +66,13 @@
         <menuitem name="ReportsAcctTransReport"    action="ReportsAcctTransReportAction"/>
       </placeholder>
     </menu>
+
+    <menu name="Windows" action="WindowsAction">
+      <placeholder name="WindowsLayoutPlaceholder">
+        <menuitem name="WindowsSaveLayout"         action="WindowsSaveLayoutAction"/>
+        <menuitem name="WindowsResetLayout"        action="WindowsResetLayoutAction"/>
+       </placeholder>
+    </menu>
   </menubar>
 
   <toolbar name="DefaultToolbar">

--- a/gnucash/ui/gnc-windows-menu-ui.xml
+++ b/gnucash/ui/gnc-windows-menu-ui.xml
@@ -5,6 +5,8 @@
     <menu name="Windows" action="WindowsAction">
       <menuitem name="WindowNew"      action="WindowNewAction"/>
       <menuitem name="WindowMovePage" action="WindowMovePageAction"/>
+      <separator name="ViewSep5"/>
+      <placeholder name="WindowsLayoutPlaceholder"/>
       <separator name="ViewSep4"/>
       <menuitem name="Window0"        action="Window0Action"/>
       <menuitem name="Window1"        action="Window1Action"/>


### PR DESCRIPTION
Currently the comments, which I think are useful as the group entries are based on guid's, used in the state file are only saved for the open registers as on load all comments are removed. Tried to use G_KEY_FILE_KEEP_COMMENTS but that still did not work in the way wanted even if you deleted the group.
So the first commit changes saving a comment to using a dummy key and add the comment there along with also adding it to the budget groups which are also based on guid's.

Invoice/Bill/Vouchers never saved there sheet layouts so have added that as a separate commit. This works OK but a bit tedious having to change each layout so have added an option to save a layout for each as a default layout. As there maybe many, once an invoice/bill/voucher is paid the saved layout is dropped and the default one used if present.

As I was in the area, I think there was mention of a register reset layout option so have added that also.

If there are no issues with this I aim to push this at the weekend.