### PR TITLE
Bug 797613  Due Invoices Reminder shows Job Name instead of Company Name

### DIFF
--- a/gnucash/gnome/dialog-invoice.c
+++ b/gnucash/gnome/dialog-invoice.c
@@ -3387,7 +3387,7 @@ gnc_invoice_show_docs_due (GtkWindow *parent, QofBook *book, double days_in_adva
         param_list = gnc_search_param_prepend (param_list, _("Amount"), NULL, type,
                                                INVOICE_POST_LOT, LOT_BALANCE, NULL);
         param_list = gnc_search_param_prepend (param_list, _("Company"), NULL, type,
-                                               INVOICE_OWNER, OWNER_NAME, NULL);
+                                               INVOICE_OWNER, OWNER_PARENT, OWNER_NAME, NULL);
         param_list = gnc_search_param_prepend (param_list, _("Due"), NULL, type,
                                                INVOICE_DUE, NULL);
     }


### PR DESCRIPTION
In the invoices due dialog, the column 'Company' should show the name of the customer/vendor of an invoice/bill.
Currently the content is set to the owner name, but if a job is assigned to the invoice, that will show the job name.
This change changes the content to the name of the owner parent, which is always  the customer/vendor name.