### PR TITLE
Fix rounding precision when importing commodity prices from CSV

### DIFF
--- a/gnucash/import-export/csv-imp/gnc-imp-props-price.cpp
+++ b/gnucash/import-export/csv-imp/gnc-imp-props-price.cpp
@@ -332,7 +332,9 @@ Result GncImportPrice::create_price (QofBook* book, GNCPriceDB *pdb, bool over)
         gnc_price_set_commodity (price, *m_from_commodity);
         gnc_price_set_currency (price, *m_to_currency);
 
-        auto amount_conv = amount.convert<RoundType::half_up>(CURRENCY_DENOM);
+        int scu = gnc_commodity_get_fraction (*m_to_currency);
+        auto amount_conv = amount.convert<RoundType::half_up>(scu * COMMODITY_DENOM_MULT);
+
         gnc_price_set_value (price, static_cast<gnc_numeric>(amount_conv));
 
         gnc_price_set_time64 (price, date);


### PR DESCRIPTION
I've noticed that in the `round_price` function, in `gnucash/gnome-utils/dialog-transfer.c:200`, commodity prices are rounded according to the following policy:

>  If both commodities are currencies, round to a fixed denominator.            
>  If only one is a currency, round to the currency's scu * a fixed factor.     
>  The fixed values are defined in gnc-pricedb.h                                

However, when importing the commodity prices from a CSV, the rounding applied is computed in a different way.

This patch amends this by making the CSV import assistant approximate commodity prices as it's done in the transfer dialog.

*_For reference, the actual code of the `round_price` function is the following:_

```
static gnc_numeric                                                              
round_price(gnc_commodity *from, gnc_commodity *to, gnc_numeric value)          
{                                                                               
    if (gnc_commodity_is_currency(from) && gnc_commodity_is_currency(to))       
        value = gnc_numeric_convert(value, CURRENCY_DENOM,                      
                                    GNC_HOW_RND_ROUND_HALF_UP);                 
    else if (gnc_commodity_is_currency(to))                                     
    {                                                                           
        int scu = gnc_commodity_get_fraction (to);                              
        value = gnc_numeric_convert(value, scu * COMMODITY_DENOM_MULT,          
                                    GNC_HOW_RND_ROUND_HALF_UP);                 
    }                                                                           
    else if (gnc_commodity_is_currency(from))                                   
    {                                                                           
        int scu = gnc_commodity_get_fraction (from);                            
        value = gnc_numeric_convert(value, scu * COMMODITY_DENOM_MULT,          
                                    GNC_HOW_RND_ROUND_HALF_UP);                 
    }                                                                           
    return value;                                                               
}                                                                               
```