### PR TITLE
[Master] Invalid Imap mapping dialog

### DIFF
--- a/gnucash/gnome/dialog-imap-editor.c
+++ b/gnucash/gnome/dialog-imap-editor.c
@@ -58,6 +58,13 @@ typedef enum
 
 typedef struct
 {
+    guint inv_dialog_shown_bayes : 1;
+    guint inv_dialog_shown_nbayes : 1;
+    guint inv_dialog_shown_online : 1;
+}GncInvFlags;
+
+typedef struct
+{
     GtkWidget    *dialog;
     QofSession   *session;
     GtkWidget    *view;
@@ -80,6 +87,7 @@ typedef struct
     GtkWidget    *expand_button;
     GtkWidget    *collapse_button;
     GtkWidget    *remove_button;
+    GncInvFlags   inv_dialog_shown;
 }ImapDialog;
 
 
@@ -371,11 +379,36 @@ gnc_imap_invalid_maps_dialog (ImapDialog *imap_dialog)
         else
         {
             gtk_widget_show (imap_dialog->remove_button);
+
+            if (imap_dialog->type == BAYES)
+                imap_dialog->inv_dialog_shown.inv_dialog_shown_bayes = TRUE;
+            if (imap_dialog->type == NBAYES)
+                imap_dialog->inv_dialog_shown.inv_dialog_shown_nbayes = TRUE;
+            if (imap_dialog->type == ONLINE)
+                imap_dialog->inv_dialog_shown.inv_dialog_shown_online = TRUE;
         }
         g_free (message);
         g_free (message2);
         g_free (text);
     }
+}
+
+static void
+gnc_imap_invalid_maps (ImapDialog *imap_dialog)
+{
+    gboolean inv_dialog_shown = FALSE;
+
+    if ((imap_dialog->type == BAYES) && (imap_dialog->inv_dialog_shown.inv_dialog_shown_bayes))
+        inv_dialog_shown = TRUE;
+
+    if ((imap_dialog->type == NBAYES) && (imap_dialog->inv_dialog_shown.inv_dialog_shown_nbayes))
+        inv_dialog_shown = TRUE;
+
+    if ((imap_dialog->type == ONLINE) && (imap_dialog->inv_dialog_shown.inv_dialog_shown_online))
+        inv_dialog_shown = TRUE;
+
+    if (!inv_dialog_shown)
+        gnc_imap_invalid_maps_dialog (imap_dialog);
 }
 
 void
@@ -519,9 +552,22 @@ list_type_selected_cb (GtkToggleButton* button, ImapDialog *imap_dialog)
     // Lets do this only on change of list type
     if (type != imap_dialog->type)
     {
+        gboolean inv_dialog_shown = FALSE;
+
         imap_dialog->type = type;
         get_account_info (imap_dialog);
-        gnc_imap_invalid_maps_dialog (imap_dialog);
+
+        if ((imap_dialog->type == BAYES) && (imap_dialog->inv_dialog_shown.inv_dialog_shown_bayes))
+            inv_dialog_shown = TRUE;
+
+        if ((imap_dialog->type == NBAYES) && (imap_dialog->inv_dialog_shown.inv_dialog_shown_nbayes))
+            inv_dialog_shown = TRUE;
+
+        if ((imap_dialog->type == ONLINE) && (imap_dialog->inv_dialog_shown.inv_dialog_shown_online))
+            inv_dialog_shown = TRUE;
+
+        if (!inv_dialog_shown)
+            gnc_imap_invalid_maps_dialog (imap_dialog);
     }
 }
 

--- a/gnucash/gtkbuilder/dialog-imap-editor.glade
+++ b/gnucash/gtkbuilder/dialog-imap-editor.glade
@@ -51,6 +51,20 @@
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
+              <object class="GtkButton" id="remove_button">
+                <property name="label" translatable="yes">_Remove Invalid Mappings</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="no_show_all">True</property>
+                <property name="use_underline">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkButton" id="delete_button">
                 <property name="label" translatable="yes">_Delete</property>
                 <property name="visible">True</property>
@@ -61,7 +75,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
-                <property name="position">0</property>
+                <property name="position">1</property>
               </packing>
             </child>
             <child>
@@ -77,7 +91,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
-                <property name="position">1</property>
+                <property name="position">2</property>
               </packing>
             </child>
           </object>
@@ -85,7 +99,7 @@
             <property name="expand">False</property>
             <property name="fill">False</property>
             <property name="pack_type">end</property>
-            <property name="position">0</property>
+            <property name="position">3</property>
           </packing>
         </child>
         <child>
@@ -98,7 +112,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">False</property>
-            <property name="position">1</property>
+            <property name="position">0</property>
           </packing>
         </child>
         <child>
@@ -161,7 +175,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">False</property>
-            <property name="position">2</property>
+            <property name="position">1</property>
           </packing>
         </child>
         <child>
@@ -251,6 +265,22 @@
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="total_entries_label">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">start</property>
+            <property name="margin_left">6</property>
+            <property name="margin_right">6</property>
+            <property name="margin_top">3</property>
+            <property name="margin_bottom">3</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
             <property name="position">3</property>
           </packing>
         </child>
@@ -261,6 +291,9 @@
             <property name="margin_top">5</property>
             <property name="margin_bottom">5</property>
             <property name="label" translatable="yes">Filter will be applied to 'Match String' and 'Mapped to Account Name' fields, case sensitive.</property>
+            <style>
+              <class name="gnc-class-highlight"/>
+            </style>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -327,7 +360,7 @@
             </child>
             <child>
               <object class="GtkButton" id="collapse-button">
-                <property name="label" translatable="yes">_Collapse All</property>
+                <property name="label" translatable="yes">Collapse _All</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
@@ -374,6 +407,7 @@
       </object>
     </child>
     <action-widgets>
+      <action-widget response="-2">remove_button</action-widget>
       <action-widget response="-10">delete_button</action-widget>
       <action-widget response="-6">close_button</action-widget>
     </action-widgets>


### PR DESCRIPTION
This PR takes over from #647 in presenting a dialog when the 'Import Map Editor' starts if it finds any invalid account mappings. The dialog asks the user if they would like to remove them now, if not a button is added to the editor so they can remove them later.

@christopherlam I think this does what you wanted but would be interested in feedback and any text changes.