### PR TITLE
Bug 797636 - Incorrect Online account matches cannot be deleted

### DIFF
--- a/gnucash/import-export/aqb/assistant-ab-initial.c
+++ b/gnucash/import-export/aqb/assistant-ab-initial.c
@@ -89,6 +89,7 @@ gboolean aai_key_press_event_cb(GtkWidget *widget, GdkEventKey *event, gpointer 
 
 void aai_wizard_page_prepare (GtkAssistant *assistant, gpointer user_data);
 void aai_wizard_button_clicked_cb(GtkButton *button, gpointer user_data);
+void aai_match_delete_button_clicked_cb(GtkButton *button, gpointer user_data);
 
 #ifdef AQBANKING6
 static guint aai_ab_account_hash(gconstpointer v);
@@ -106,6 +107,8 @@ static gboolean find_gnc_acc_cb(gpointer key, gpointer value, gpointer user_data
 static gboolean clear_line_cb(GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, gpointer user_data);
 static void account_list_clicked_cb (GtkTreeView *view, GtkTreePath *path,
                                      GtkTreeViewColumn  *col, gpointer user_data);
+static void delete_account_match(ABInitialInfo *info, RevLookupData *data);
+static void delete_selected_match_cb(gpointer data, gpointer user_data);
 static void insert_acc_into_revhash_cb(gpointer ab_acc, gpointer gnc_acc, gpointer revhash);
 static void remove_acc_from_revhash_cb(gpointer ab_acc, gpointer gnc_acc, gpointer revhash);
 static void clear_kvp_acc_cb(gpointer key, gpointer value, gpointer user_data);
@@ -303,6 +306,66 @@ aai_wizard_button_clicked_cb(GtkButton *button, gpointer user_data)
         gtk_assistant_set_page_complete (GTK_ASSISTANT(info->window), page, FALSE);
 
     LEAVE(" ");
+}
+
+static void delete_account_match(ABInitialInfo *info, RevLookupData *data)
+{
+    g_return_if_fail(info && info->gnc_hash &&
+        info->account_view && data && data->ab_acc);
+
+    g_hash_table_remove(info->gnc_hash, data->ab_acc);
+    gtk_tree_model_foreach(
+        GTK_TREE_MODEL(info->account_store),
+        (GtkTreeModelForeachFunc) clear_line_cb,
+        data);
+}
+
+static void
+delete_selected_match_cb(gpointer data, gpointer user_data)
+{
+    GNC_AB_ACCOUNT_SPEC *ab_acc = NULL;
+    GtkTreeIter iter;
+    GtkTreeModel *model = NULL;
+    RevLookupData revLookupData = {NULL, NULL};
+
+    GtkTreePath *path = (GtkTreePath *) data;
+    ABInitialInfo *info = (ABInitialInfo *) user_data;
+    g_return_if_fail(path && info && info->account_view);
+
+    model = gtk_tree_view_get_model(info->account_view);
+    g_return_if_fail(model);
+
+    if (gtk_tree_model_get_iter(model, &iter, path))
+    {
+        gtk_tree_model_get(model, &iter, ACCOUNT_LIST_COL_AB_ACCT, &revLookupData.ab_acc, -1);
+        if (revLookupData.ab_acc)
+            delete_account_match(info, &revLookupData);
+    }
+}
+
+void
+aai_match_delete_button_clicked_cb(GtkButton *button, gpointer user_data)
+{
+    GList *selected_matches = NULL;
+    GtkTreeSelection *selection = NULL;
+    ABInitialInfo *info = (ABInitialInfo *) user_data;
+
+    g_return_if_fail(info && info->api && info->account_view && info->gnc_hash);
+
+    PINFO("Selected account matches are deleted");
+
+    selection = gtk_tree_view_get_selection (info->account_view);
+    if (selection)
+    {
+        selected_matches = gtk_tree_selection_get_selected_rows (selection, NULL);
+        if (selected_matches)
+        {
+            g_list_foreach (selected_matches, delete_selected_match_cb, info);
+            g_list_free_full (
+                selected_matches,
+                (GDestroyNotify) gtk_tree_path_free);
+        }
+    }
 }
 
 #ifdef AQBANKING6
@@ -648,13 +711,7 @@ account_list_clicked_cb (GtkTreeView *view, GtkTreePath *path,
                 g_hash_table_find(info->gnc_hash, (GHRFunc) find_gnc_acc_cb,
                                   &data);
                 if (data.ab_acc)
-                {
-                    g_hash_table_remove(info->gnc_hash, data.ab_acc);
-                    gtk_tree_model_foreach(
-                        GTK_TREE_MODEL(info->account_store),
-                        (GtkTreeModelForeachFunc) clear_line_cb,
-                        &data);
-                }
+                    delete_account_match(info, &data);
 
                 /* Map ab_acc to gnc_acc */
                 g_hash_table_insert(info->gnc_hash, ab_acc, gnc_acc);
@@ -800,7 +857,7 @@ gnc_ab_initial_assistant_new(void)
     gtk_tree_view_append_column(info->account_view, column);
 
     selection = gtk_tree_view_get_selection(info->account_view);
-    gtk_tree_selection_set_mode (selection, GTK_SELECTION_SINGLE);
+    gtk_tree_selection_set_mode (selection, GTK_SELECTION_MULTIPLE);
 
     gnc_restore_window_size (GNC_PREFS_GROUP,
                              GTK_WINDOW(info->window), gnc_ui_get_main_window(NULL));

--- a/gnucash/import-export/aqb/assistant-ab-initial.glade
+++ b/gnucash/import-export/aqb/assistant-ab-initial.glade
@@ -126,6 +126,19 @@ Click on "Next" to proceed or "Cancel" to Abort Import.</property>
         <property name="orientation">vertical</property>
         <property name="spacing">12</property>
         <child>
+          <object class="GtkLabel" id="account_label">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">Double Click on the line of an Online Banking account name if you want to match it to a GnuCash account or select incorrect matches and click "Delete selected matches". Click "Next" when all desired accounts are matching.</property>
+            <property name="wrap">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkScrolledWindow" id="account_scrolledwindow">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
@@ -143,20 +156,34 @@ Click on "Next" to proceed or "Cancel" to Abort Import.</property>
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="position">0</property>
+            <property name="position">1</property>
           </packing>
         </child>
         <child>
-          <object class="GtkLabel" id="account_label">
+          <object class="GtkBox" id="button_box">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="label" translatable="yes">Double Click on the line of an Online Banking account name if you want to match it to a GnuCash account. Click "Next" when all desired accounts are matching.</property>
-            <property name="wrap">True</property>
+            <child>
+              <object class="GtkButton" id="ab_match_delete_button">
+                <property name="label" translatable="yes">_Delete selected matches</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="halign">start</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="aai_match_delete_button_clicked_cb" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>


### PR DESCRIPTION
A push button with text "Delete selected matches" is added to the
"Match Online accounts with GnuCash accounts" page of the "Online
Banking Setup" tool.
Additionally, the underlying tree view is set to multiple selection
mode from single selection mode.
Pushing the button will remove the matched GnuCash account from
all selected AqBanking (Online) accounts.