### PR TITLE
Bug 797640 - The Reconciliation Window starting balance calculator needs to ignore splits after statement date

### DIFF
--- a/gnucash/gnome/window-reconcile.c
+++ b/gnucash/gnome/window-reconcile.c
@@ -281,7 +281,8 @@ recnRecalculateBalance (RecnWindow *recnData)
 
     /* update the starting balance */
     include_children = xaccAccountGetReconcileChildrenStatus(account);
-    starting = gnc_ui_account_get_reconciled_balance(account, include_children);
+    starting = gnc_ui_account_get_reconciled_balance_as_of_date
+        (account, recnData->statement_date, include_children);
     print_info = gnc_account_print_info (account, TRUE);
 
     /*

--- a/libgnucash/app-utils/gnc-ui-balances.h
+++ b/libgnucash/app-utils/gnc-ui-balances.h
@@ -110,6 +110,10 @@ gnc_ui_account_get_print_report_balance (xaccGetBalanceInCurrencyFn fn,
 gnc_numeric gnc_ui_account_get_balance_as_of_date (Account *account,
 						   time64 date,
 						   gboolean include_children);
+gnc_numeric
+gnc_ui_account_get_reconciled_balance_as_of_date (Account *account,
+                                                  time64 date,
+                                                  gboolean include_children);
 
 /********************************************************************
  * Balance calculations related to owners

--- a/libgnucash/engine/Account.cpp
+++ b/libgnucash/engine/Account.cpp
@@ -3428,6 +3428,24 @@ xaccAccountGetNoclosingBalanceAsOfDate (Account *acc, time64 date)
     return GetBalanceAsOfDate (acc, date, TRUE);
 }
 
+gnc_numeric
+xaccAccountGetReconciledBalanceAsOfDate (Account *acc, time64 date)
+{
+    gnc_numeric balance = gnc_numeric_zero();
+
+    g_return_val_if_fail(GNC_IS_ACCOUNT(acc), gnc_numeric_zero());
+
+    for (GList *node = GET_PRIVATE(acc)->splits; node; node = node->next)
+    {
+        Split *split = (Split*) node->data;
+        if ((xaccSplitGetReconcile (split) == YREC) &&
+            (xaccSplitGetDateReconciled (split) <= date))
+            balance = gnc_numeric_add_fixed (balance, xaccSplitGetAmount (split));
+    };
+
+    return balance;
+}
+
 /*
  * Originally gsr_account_present_balance in gnc-split-reg.c
  *

--- a/libgnucash/engine/Account.h
+++ b/libgnucash/engine/Account.h
@@ -558,6 +558,9 @@ gnc_numeric xaccAccountGetProjectedMinimumBalance (const Account *account);
 gnc_numeric xaccAccountGetBalanceAsOfDate (Account *account,
         time64 date);
 
+/** Get the reconciled balance of the account as of the date specified */
+gnc_numeric xaccAccountGetReconciledBalanceAsOfDate (Account *account, time64 date);
+
 /* These two functions convert a given balance from one commodity to
    another.  The account argument is only used to get the Book, and
    may have nothing to do with the supplied balance.  Likewise, the


### PR DESCRIPTION
adds a couple helper functions in account.cpp and gnc-ui-balances.c