### PR TITLE
Remove unwanted space from xmlns sodipodi URI.

### DIFF
--- a/data/pixmaps/hicolor/scalable/apps/gnucash-icon.svg
+++ b/data/pixmaps/hicolor/scalable/apps/gnucash-icon.svg
@@ -7,7 +7,7 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://inkscape.sourceforge.net/DTD/s odipodi-0.dtd"
+   xmlns:sodipodi="http://inkscape.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="48px"
    height="48px"


### PR DESCRIPTION
SVG icon doesn't open with latest librsvg (2.48) due to bad URI.

XML parse error: error code=99 (3) in (null):10:72: xmlns:sodipodi: 'http://inkscape.sourceforge.net/DTD/s odipodi-0.dtd' is not a valid URI