### PR TITLE
Add & verify balance assertions

### DIFF
--- a/bindings/engine.i
+++ b/bindings/engine.i
@@ -71,6 +71,23 @@ GLIST_HELPER_INOUT(PriceList, SWIGTYPE_p_GNCPrice);
 GLIST_HELPER_INOUT(CommodityList, SWIGTYPE_p_gnc_commodity);
 
 %typemap(newfree) gchar * "g_free($1);"
+%typemap(newfree) DatesList * "g_list_free_full($1, g_free);"
+
+%typemap(out) DatesList *
+{
+    SCM lst = SCM_EOL;
+    for (GList* node = $1; node; node = node->next)
+    {
+        time64 *date = node->data;
+        lst = scm_cons (scm_from_int64 (*date), lst);
+    }
+    $result = scm_reverse (lst);
+}
+
+%typemap(out) gnc_numeric *
+{
+    $result = ($1) ? gnc_numeric_to_scm(*($1)) : SCM_BOOL_F;
+}
 
 /* These need to be here so that they are *before* the function
 declarations in the header files, some of which are included by

--- a/gnucash/gnome/window-reconcile.c
+++ b/gnucash/gnome/window-reconcile.c
@@ -2246,6 +2246,8 @@ recnFinishCB (GtkAction *action, RecnWindow *recnData)
     xaccAccountClearReconcilePostpone (account);
     xaccAccountSetReconcileLastDate (account, date);
 
+    xaccAccountSetBalanceAssertionAtDate (account, date, recnData->new_ending);
+
     if (auto_payment &&
             (xaccAccountGetType (account) == ACCT_TYPE_CREDIT) &&
             (gnc_numeric_negative_p (recnData->new_ending)))

--- a/gnucash/report/reports/CMakeLists.txt
+++ b/gnucash/report/reports/CMakeLists.txt
@@ -23,6 +23,7 @@ set (reports_standard_SCHEME
     standard/account-piecharts.scm
     standard/account-summary.scm
     standard/advanced-portfolio.scm
+    standard/balance-assertion-report.scm
     standard/balance-sheet.scm
     standard/balance-forecast.scm
     standard/balsheet-pnl.scm

--- a/gnucash/report/reports/standard/balance-assertion-report.scm
+++ b/gnucash/report/reports/standard/balance-assertion-report.scm
@@ -1,0 +1,175 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Balance Assertion Report
+;;
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation; either version 2 of
+;; the License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program; if not, contact:
+;;
+;; Free Software Foundation           Voice:  +1-617-542-5942
+;; 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652
+;; Boston, MA  02110-1301,  USA       gnu@gnu.org
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define-module (gnucash reports standard balance-assertion-report))
+(use-modules (ice-9 match))
+(use-modules (srfi srfi-1))
+(use-modules (srfi srfi-8))
+(use-modules (srfi srfi-26))
+
+(use-modules (gnucash core-utils))
+(use-modules (gnucash gnc-module))
+(use-modules (gnucash engine))
+(use-modules (gnucash app-utils))
+(use-modules (gnucash report))
+
+(define optname-verbose (N_ "Verbose report"))
+(define opthelp-verbose (N_ "Verbose report"))
+
+(define (reconcile-report-options-generator)
+  (define options (gnc:new-options))
+  (define add-option (cut gnc:register-option options <>))
+
+  (add-option
+   (gnc:make-account-list-option
+    gnc:pagename-accounts "Accounts"
+    "a" (G_ "Report on these accounts.")
+    (const '()) #f #t))
+
+  (add-option
+   (gnc:make-simple-boolean-option
+    gnc:pagename-general optname-verbose
+    "a" opthelp-verbose #f))
+
+  (gnc:options-set-default-section options gnc:pagename-general)
+  options)
+
+(define (reconcile-audit-report-renderer report-obj)
+  (define (get-option section name)
+    (gnc:option-value
+     (gnc:lookup-option (gnc:report-options report-obj) section name)))
+
+  (define (split->reconciled-date split)
+    (if (eqv? (xaccSplitGetReconcile split) #\y)
+        (xaccSplitGetDateReconciled split)
+        +inf.0))
+
+  (let* ((report-title (get-option gnc:pagename-general gnc:optname-reportname))
+         (accounts-option (get-option gnc:pagename-accounts "Accounts"))
+         (accounts (if (null? accounts-option)
+                       (gnc-account-get-descendants (gnc-get-current-root-account))
+                       accounts-option))
+         (verbose? (get-option gnc:pagename-general optname-verbose))
+         (document (gnc:make-html-document)))
+
+    (gnc:report-starting report-title)
+
+    (let lp ((accounts accounts) (has-data? #f))
+      (match accounts
+
+        (()
+         (unless has-data?
+           (gnc:html-document-add-object!
+            document
+            (gnc:html-make-empty-data-warning
+             report-title (gnc:report-id report-obj))))
+
+         (gnc:report-finished)
+
+         document)
+
+        ((account . rest-accounts)
+         (define table (gnc:make-html-table))
+         (define assertion-dates (xaccAccountGetBalanceAssertionDates account))
+         (define has-assertions? (pair? assertion-dates))
+         (define split->elt
+           (let ((bal 0))
+             (lambda (s)
+               (set! bal (+ bal (xaccSplitGetAmount s)))
+               bal)))
+
+         (let lp1 ((assertion-dates assertion-dates)
+                   (acc-balances (gnc:account-accumulate-at-dates
+                                  account assertion-dates
+                                  #:split->date split->reconciled-date
+                                  #:split->elt split->elt))
+                   (splits (xaccAccountGetSplitList account))
+                   (has-data? has-data?))
+
+           (match assertion-dates
+             (()
+              (let ((assertions-valid? (gnc-account-assertions-are-valid account)))
+                (when (or verbose? has-assertions?)
+                  (gnc:html-document-add-object!
+                   document
+                   (gnc:make-html-text
+                    (gnc:html-markup-h3
+                     "Account "
+                     (gnc:html-markup-i (gnc-account-get-full-name account))
+                     (if assertions-valid? "PASS" "FAIL"))))
+
+                  (gnc:html-table-set-col-headers!
+                   table (list "Reconcile Date" "Post Date"
+                               "Description" "Amount" "Reconciled Balance"))
+
+                  (gnc:html-document-add-object! document table))
+
+                (lp rest-accounts (or has-data? has-assertions?))))
+
+             ((assertion-date . rest-dates)
+              (let* ((acc-balance (car acc-balances))
+                     (assertion-bal (xaccAccountGetBalanceAssertionAtDate
+                                     account assertion-date)))
+
+                (define (in-date? s)
+                  (<= (xaccSplitGetDateReconciled s) assertion-date))
+
+                (define (add-split-row s)
+                  (define t (xaccSplitGetParent s))
+                  (gnc:html-table-append-row!
+                   table
+                   (append
+                    (list (qof-print-date (xaccSplitGetDateReconciled s))
+                          (qof-print-date (xaccTransGetDate t))
+                          (xaccTransGetDescription t))
+                    (map (cut gnc:make-html-table-cell/markup "number-cell" <>)
+                         (list (xaccSplitGetAmount s)
+                               (xaccSplitGetReconciledBalance s))))))
+
+                (receive (acc-splits rest-splits) (partition in-date? splits)
+                  (when (or verbose? (not (equal? acc-balance assertion-bal)))
+                    (for-each add-split-row acc-splits))
+
+                  (gnc:html-table-append-row!
+                   table
+                   (append
+                    (map (cut gnc:make-html-table-cell/markup "total-label-cell" <>)
+                         (list (qof-print-date assertion-date) #f #f #f))
+                    (map (cut gnc:make-html-table-cell/markup "total-number-cell" <>)
+                         (list acc-balance
+                               (if (equal? acc-balance assertion-bal) "PASS"
+                                   (format #f "FAIL (expected bal = ~a)"
+                                           (gnc:monetary->string
+                                            (gnc:make-gnc-monetary
+                                             (xaccAccountGetCommodity account)
+                                             assertion-bal))))))))
+
+                  (lp1 (cdr assertion-dates) (cdr acc-balances) rest-splits
+                       #t)))))))))))
+
+(gnc:define-report
+ 'version 1
+ 'name (G_ "Balance Assertion Audit Report")
+ 'report-guid "63e4a56c0e86478482dc6fcf515e9228"
+ 'options-generator reconcile-report-options-generator
+ 'renderer reconcile-audit-report-renderer)
+

--- a/gnucash/ui/gnc-plugin-page-account-tree-ui.xml
+++ b/gnucash/ui/gnc-plugin-page-account-tree-ui.xml
@@ -28,6 +28,7 @@
           <menuitem name="Scrub" action="ScrubAction"/>
           <menuitem name="ScrubSub" action="ScrubSubAction"/>
           <menuitem name="ScrubAll" action="ScrubAllAction"/>
+          <menuitem name="RegenReconcile" action="RegenerateReconciledBalancesAction"/>
         </menu>
       </placeholder>
     </menu>
@@ -67,6 +68,7 @@
         <menuitem name="Scrub" action="ScrubAction"/>
         <menuitem name="ScrubSub" action="ScrubSubAction"/>
         <menuitem name="ScrubAll" action="ScrubAllAction"/>
+        <menuitem name="RegenReconcile" action="RegenerateReconciledBalancesAction"/>
       </menu>
     </placeholder>
   </popup>

--- a/libgnucash/engine/Account.h
+++ b/libgnucash/engine/Account.h
@@ -423,6 +423,8 @@ GNCPolicy *gnc_account_get_policy (Account *account);
 /** Get the account's flag for deferred balance computation */
 gboolean gnc_account_get_defer_bal_computation (Account *acc);
 
+gboolean gnc_account_assertions_are_valid (Account *acc);
+
 /** The following recompute the partial balances (stored with the
  *  transaction) and the total balance, for this account
  */
@@ -1145,6 +1147,64 @@ gboolean xaccAccountGetReconcileLastDate (const Account *account,
         time64 *last_date);
 /** DOCUMENT ME! */
 void xaccAccountSetReconcileLastDate (Account *account, time64 last_date);
+
+/** The xaccAccountSetBalanceAssertionAtDate() method will
+ *  register the statment date and reconciled balance for this
+ *  account.  This is performed at the end of reconciliation. It can
+ *  function as a 'soft' balance assertion and may be useful for
+ *  hunting errant splits.
+ *
+ * @param acc the account to set reconcile info
+ *
+ * @param statement_date a time64 for statement date
+ *
+ * @param ending_balance a gnc_numeric specifying reconciled balance
+ */
+void xaccAccountSetBalanceAssertionAtDate (Account *acc,
+                                           time64 statement_date,
+                                           gnc_numeric ending_balance);
+
+/** The xaccAccountClearBalanceAssertions() method clears all
+ *  account reconciled statement date and reconciled balance info.
+ *
+ * @param acc the account to set reconcile info
+ */
+void xaccAccountClearBalanceAssertions (Account *acc);
+
+/** The xaccAccountGetBalanceAssertionDates() routine returns a
+ *   GList of time64 dates which have reconciled_balances
+ *   attached. This list is sorted.
+ *
+ * @param acc the account to set reconcile info
+ *
+ * @return a GList of time64 dates, or nullptr
+ */
+DatesList * xaccAccountGetBalanceAssertionDates (Account *acc);
+
+/** The xaccAccountDeleteBalanceAssertionBalanceAtDate() routine
+ * deletes the statement_date -> reconciled_balance KVP pair. If the
+ * statement_date does not exist, it returns.
+ *
+ * @param acc the account to set reconcile info
+ *
+ * @param statement_date a time64
+ */
+void xaccAccountDeleteBalanceAssertionAtDate (const Account *acc,
+                                              time64 statement_date);
+
+/** The xaccAccountGetBalanceAssertionBalanceAtDate() routine
+ *   retrieves a pointer to gnc_numeric if the account has a
+ *   reconciled_balance stored for statement_date.
+ *
+ * @param acc the account to set reconcile info
+ *
+ * @param statement_date a time64
+ *
+ * @return a gnc_numeric* reconciled_balance, or nullptr
+ */
+gnc_numeric *
+xaccAccountGetBalanceAssertionAtDate (const Account *acc,
+                                      time64 statement_date);
 
 /** DOCUMENT ME! */
 gboolean xaccAccountGetReconcileLastInterval (const Account *account,

--- a/libgnucash/engine/gnc-engine.h
+++ b/libgnucash/engine/gnc-engine.h
@@ -211,6 +211,8 @@ typedef GList                  TransList;
 typedef GList                  AccountGUIDList;
 /** GList of GUIDs of a QofBook */
 typedef GList                  BookGUIDList;
+/** GList of time64 */
+typedef GList                  DatesList;
 
 typedef void (*EngineCommitErrorCallback)( gpointer data, QofBackendError errcode );
 

--- a/libgnucash/engine/kvp-frame.hpp
+++ b/libgnucash/engine/kvp-frame.hpp
@@ -226,10 +226,11 @@ struct KvpFrameImpl
     bool empty() const noexcept { return m_valuemap.empty(); }
     friend int compare(const KvpFrameImpl&, const KvpFrameImpl&) noexcept;
 
+    KvpFrame * get_child_frame_or_nullptr (Path const &) noexcept;
+
     private:
     map_type m_valuemap;
 
-    KvpFrame * get_child_frame_or_nullptr (Path const &) noexcept;
     KvpFrame * get_child_frame_or_create (Path const &) noexcept;
     void flatten_kvp_impl(std::vector <std::string>, std::vector <KvpEntry> &) const noexcept;
     KvpValue * set_impl (std::string const &, KvpValue *) noexcept;


### PR DESCRIPTION
Add account API to store reconciliation pairs of `statement_date` and `ending_balance`
Upon reconciliation complete, add into account's kvp. Overwrite any previous reconciliation pair.
There's off-by-one error somewhere. Buggy. No `g_free` at all yet. 
Assistance would be nice.
I'll follow on with tools to actually use it and possibly augment the reconciliation report to find errant transactions.