### PR TITLE
Bug 797006 - Balance is misleading in open subaccounts when different…

### DIFF
--- a/gnucash/gnome-utils/gnc-tree-model-split-reg.c
+++ b/gnucash/gnome-utils/gnc-tree-model-split-reg.c
@@ -451,7 +451,7 @@ gnc_tree_model_split_reg_dispose (GObject *object)
 /* Create a new tree model */
 GncTreeModelSplitReg *
 gnc_tree_model_split_reg_new (SplitRegisterType2 reg_type, SplitRegisterStyle2 style,
-                        gboolean use_double_line, gboolean is_template)
+                        gboolean use_double_line, gboolean is_template, gboolean mismatched_commodities)
 {
     GncTreeModelSplitReg *model;
     GncTreeModelSplitRegPrivate *priv;
@@ -469,6 +469,7 @@ gnc_tree_model_split_reg_new (SplitRegisterType2 reg_type, SplitRegisterStyle2 s
     model->style = style;
     model->use_double_line = use_double_line;
     model->is_template = is_template;
+    model->mismatched_commodities = mismatched_commodities;
 
     model->sort_col = 1;
     model->sort_depth = 1;

--- a/gnucash/gnome-utils/gnc-tree-model-split-reg.h
+++ b/gnucash/gnome-utils/gnc-tree-model-split-reg.h
@@ -144,6 +144,7 @@ typedef struct
     gboolean                     use_double_line;       /**<FIXME ? As above, whether to use two lines per transaction */
 
     gboolean                     is_template;           /**< Are we using a template */
+    gboolean                     mismatched_commodities; /**< Are there different commodities */
 
     gint                         sort_depth;            /**< This is the row the sort direction is based on. */
     gint                         sort_col;              /**< This is the column the sort direction is based on. */
@@ -201,7 +202,7 @@ GType gnc_tree_model_split_reg_get_type (void);
 /** Create new model and set options for register. */
 GncTreeModelSplitReg *
 gnc_tree_model_split_reg_new (SplitRegisterType2 reg_type, SplitRegisterStyle2 style,
-                        gboolean use_double_line, gboolean is_template);
+                        gboolean use_double_line, gboolean is_template, gboolean mismatched_commodities);
 
 /** Load the model from a slist and set default account for register. */
 void gnc_tree_model_split_reg_load (GncTreeModelSplitReg *model, GList * slist, Account *default_account);

--- a/gnucash/gnome/gnc-plugin-page-register.c
+++ b/gnucash/gnome/gnc-plugin-page-register.c
@@ -93,115 +93,191 @@ static QofLogModule log_module = GNC_MOD_GUI;
 #define DEFAULT_LINES_AMOUNT         50
 #define DEFAULT_FILTER_NUM_DAYS_GL  "30"
 
-static void gnc_plugin_page_register_class_init (GncPluginPageRegisterClass *klass);
-static void gnc_plugin_page_register_init (GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_finalize (GObject *object);
+static void gnc_plugin_page_register_class_init (GncPluginPageRegisterClass*
+                                                 klass);
+static void gnc_plugin_page_register_init (GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_finalize (GObject* object);
 
 /* static Account *gnc_plugin_page_register_get_current_account (GncPluginPageRegister *page); */
 
-static GtkWidget *gnc_plugin_page_register_create_widget (GncPluginPage *plugin_page);
-static void gnc_plugin_page_register_destroy_widget (GncPluginPage *plugin_page);
-static void gnc_plugin_page_register_window_changed (GncPluginPage *plugin_page, GtkWidget *window);
-static gboolean gnc_plugin_page_register_focus_widget (GncPluginPage *plugin_page);
-static void gnc_plugin_page_register_focus (GncPluginPage *plugin_page, gboolean current_page);
-static void gnc_plugin_page_register_save_page (GncPluginPage *plugin_page, GKeyFile *file, const gchar *group);
-static GncPluginPage *gnc_plugin_page_register_recreate_page (GtkWidget *window, GKeyFile *file, const gchar *group);
-static void gnc_plugin_page_register_update_edit_menu (GncPluginPage *page, gboolean hide);
-static gboolean gnc_plugin_page_register_finish_pending (GncPluginPage *page);
+static GtkWidget* gnc_plugin_page_register_create_widget (
+    GncPluginPage* plugin_page);
+static void gnc_plugin_page_register_destroy_widget (GncPluginPage*
+                                                     plugin_page);
+static void gnc_plugin_page_register_window_changed (GncPluginPage*
+                                                     plugin_page, GtkWidget* window);
+static gboolean gnc_plugin_page_register_focus_widget (GncPluginPage*
+                                                       plugin_page);
+static void gnc_plugin_page_register_focus (GncPluginPage* plugin_page,
+                                            gboolean current_page);
+static void gnc_plugin_page_register_save_page (GncPluginPage* plugin_page,
+                                                GKeyFile* file, const gchar* group);
+static GncPluginPage* gnc_plugin_page_register_recreate_page (
+    GtkWidget* window, GKeyFile* file, const gchar* group);
+static void gnc_plugin_page_register_update_edit_menu (GncPluginPage* page,
+                                                       gboolean hide);
+static gboolean gnc_plugin_page_register_finish_pending (GncPluginPage* page);
 
-static gchar *gnc_plugin_page_register_get_tab_name (GncPluginPage *plugin_page);
-static gchar *gnc_plugin_page_register_get_tab_color (GncPluginPage *plugin_page);
-static gchar *gnc_plugin_page_register_get_long_name (GncPluginPage *plugin_page);
+static gchar* gnc_plugin_page_register_get_tab_name (GncPluginPage*
+                                                     plugin_page);
+static gchar* gnc_plugin_page_register_get_tab_color (GncPluginPage*
+                                                      plugin_page);
+static gchar* gnc_plugin_page_register_get_long_name (GncPluginPage*
+                                                      plugin_page);
 
-static void gnc_plugin_page_register_summarybar_position_changed(gpointer prefs, gchar* pref, gpointer user_data);
+static void gnc_plugin_page_register_summarybar_position_changed (
+    gpointer prefs, gchar* pref, gpointer user_data);
 
 /* Callbacks for the "Sort By" dialog */
-void gnc_plugin_page_register_sort_button_cb(GtkToggleButton *button, GncPluginPageRegister *page);
-void gnc_plugin_page_register_sort_response_cb(GtkDialog *dialog, gint response, GncPluginPageRegister *plugin_page);
-void gnc_plugin_page_register_sort_order_save_cb(GtkToggleButton *button, GncPluginPageRegister *page);
-void gnc_plugin_page_register_sort_order_reverse_cb(GtkToggleButton *button, GncPluginPageRegister *page);
+void gnc_plugin_page_register_sort_button_cb (GtkToggleButton* button,
+                                              GncPluginPageRegister* page);
+void gnc_plugin_page_register_sort_response_cb (GtkDialog* dialog,
+                                                gint response, GncPluginPageRegister* plugin_page);
+void gnc_plugin_page_register_sort_order_save_cb (GtkToggleButton* button,
+                                                  GncPluginPageRegister* page);
+void gnc_plugin_page_register_sort_order_reverse_cb (GtkToggleButton* button,
+                                                     GncPluginPageRegister* page);
 
-static gchar *gnc_plugin_page_register_get_sort_order (GncPluginPage *plugin_page);
-void gnc_plugin_page_register_set_sort_order (GncPluginPage *plugin_page, const gchar *sort_order);
-static gboolean gnc_plugin_page_register_get_sort_reversed (GncPluginPage *plugin_page);
-void gnc_plugin_page_register_set_sort_reversed (GncPluginPage *plugin_page, gboolean reverse_order);
+static gchar* gnc_plugin_page_register_get_sort_order (GncPluginPage*
+                                                       plugin_page);
+void gnc_plugin_page_register_set_sort_order (GncPluginPage* plugin_page,
+                                              const gchar* sort_order);
+static gboolean gnc_plugin_page_register_get_sort_reversed (
+    GncPluginPage* plugin_page);
+void gnc_plugin_page_register_set_sort_reversed (GncPluginPage* plugin_page,
+                                                 gboolean reverse_order);
 
 /* Callbacks for the "Filter By" dialog */
-void gnc_plugin_page_register_filter_select_range_cb(GtkRadioButton *button, GncPluginPageRegister *page);
-void gnc_plugin_page_register_filter_start_cb(GtkWidget *radio, GncPluginPageRegister *page);
-void gnc_plugin_page_register_filter_end_cb(GtkWidget *radio, GncPluginPageRegister *page);
-void gnc_plugin_page_register_filter_response_cb(GtkDialog *dialog, gint response, GncPluginPageRegister *plugin_page);
-void gnc_plugin_page_register_filter_status_all_cb(GtkButton *button, GncPluginPageRegister *plugin_page);
-void gnc_plugin_page_register_filter_status_one_cb(GtkToggleButton *button, GncPluginPageRegister *page);
-void gnc_plugin_page_register_filter_save_cb(GtkToggleButton *button, GncPluginPageRegister *page);
-void gnc_plugin_page_register_filter_days_changed_cb (GtkSpinButton *button, GncPluginPageRegister *page);
+void gnc_plugin_page_register_filter_select_range_cb (GtkRadioButton* button,
+                                                      GncPluginPageRegister* page);
+void gnc_plugin_page_register_filter_start_cb (GtkWidget* radio,
+                                               GncPluginPageRegister* page);
+void gnc_plugin_page_register_filter_end_cb (GtkWidget* radio,
+                                             GncPluginPageRegister* page);
+void gnc_plugin_page_register_filter_response_cb (GtkDialog* dialog,
+                                                  gint response, GncPluginPageRegister* plugin_page);
+void gnc_plugin_page_register_filter_status_all_cb (GtkButton* button,
+                                                    GncPluginPageRegister* plugin_page);
+void gnc_plugin_page_register_filter_status_one_cb (GtkToggleButton* button,
+                                                    GncPluginPageRegister* page);
+void gnc_plugin_page_register_filter_save_cb (GtkToggleButton* button,
+                                              GncPluginPageRegister* page);
+void gnc_plugin_page_register_filter_days_changed_cb (GtkSpinButton* button,
+                                                      GncPluginPageRegister* page);
 
-static time64 gnc_plugin_page_register_filter_dmy2time (char *date_string);
-static gchar *gnc_plugin_page_register_filter_time2dmy (time64 raw_time);
-static gchar *gnc_plugin_page_register_get_filter (GncPluginPage *plugin_page);
-void gnc_plugin_page_register_set_filter (GncPluginPage *plugin_page, const gchar *filter);
-static void gnc_plugin_page_register_set_filter_tooltip (GncPluginPageRegister *page);
+static time64 gnc_plugin_page_register_filter_dmy2time (char* date_string);
+static gchar* gnc_plugin_page_register_filter_time2dmy (time64 raw_time);
+static gchar* gnc_plugin_page_register_get_filter (GncPluginPage* plugin_page);
+void gnc_plugin_page_register_set_filter (GncPluginPage* plugin_page,
+                                          const gchar* filter);
+static void gnc_plugin_page_register_set_filter_tooltip (
+    GncPluginPageRegister* page);
 
-static void gnc_ppr_update_status_query (GncPluginPageRegister *page);
-static void gnc_ppr_update_date_query (GncPluginPageRegister *page);
+static void gnc_ppr_update_status_query (GncPluginPageRegister* page);
+static void gnc_ppr_update_date_query (GncPluginPageRegister* page);
 
 /* Command callbacks */
-static void gnc_plugin_page_register_cmd_print_check (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_cut (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_copy (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_paste (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_edit_account (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_find_account (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_find_transactions (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_cut_transaction (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_copy_transaction (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_paste_transaction (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_void_transaction (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_unvoid_transaction (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_reverse_transaction (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_view_sort_by (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_view_filter_by (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_style_changed (GtkAction *action, GtkRadioAction *current, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_style_double_line (GtkToggleAction *action, GncPluginPageRegister *plugin_page);
+static void gnc_plugin_page_register_cmd_print_check (GtkAction* action,
+                                                      GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_cut (GtkAction* action,
+                                              GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_copy (GtkAction* action,
+                                               GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_paste (GtkAction* action,
+                                                GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_edit_account (GtkAction* action,
+                                                       GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_find_account (GtkAction* action,
+                                                       GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_find_transactions (GtkAction* action,
+                                                            GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_cut_transaction (GtkAction* action,
+                                                          GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_copy_transaction (GtkAction* action,
+                                                           GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_paste_transaction (GtkAction* action,
+                                                            GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_void_transaction (GtkAction* action,
+                                                           GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_unvoid_transaction (GtkAction* action,
+        GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_reverse_transaction (
+    GtkAction* action, GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_view_sort_by (GtkAction* action,
+                                                       GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_view_filter_by (GtkAction* action,
+                                                         GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_style_changed (GtkAction* action,
+                                                        GtkRadioAction* current, GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_style_double_line (
+    GtkToggleAction* action, GncPluginPageRegister* plugin_page);
 
-static void gnc_plugin_page_register_cmd_reconcile (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_autoclear (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_transfer (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_stock_split (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_lots (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_enter_transaction (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_cancel_transaction (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_delete_transaction (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_blank_transaction (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_duplicate_transaction (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_reinitialize_transaction (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_expand_transaction (GtkToggleAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_exchange_rate (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_jump (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_reload (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_schedule (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_scrub_all (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_scrub_current (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_account_report (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_transaction_report (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_associate_file_transaction (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_associate_location_transaction (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_execassociated_transaction (GtkAction *action, GncPluginPageRegister *plugin_page);
-static void gnc_plugin_page_register_cmd_jump_associated_invoice (GtkAction *action, GncPluginPageRegister *plugin_page);
+static void gnc_plugin_page_register_cmd_reconcile (GtkAction* action,
+                                                    GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_autoclear (GtkAction* action,
+                                                    GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_transfer (GtkAction* action,
+                                                   GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_stock_split (GtkAction* action,
+                                                      GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_lots (GtkAction* action,
+                                               GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_enter_transaction (GtkAction* action,
+                                                            GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_cancel_transaction (GtkAction* action,
+        GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_delete_transaction (GtkAction* action,
+        GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_blank_transaction (GtkAction* action,
+                                                            GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_duplicate_transaction (
+    GtkAction* action, GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_reinitialize_transaction (
+    GtkAction* action, GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_expand_transaction (
+    GtkToggleAction* action, GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_exchange_rate (GtkAction* action,
+                                                        GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_jump (GtkAction* action,
+                                               GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_reload (GtkAction* action,
+                                                 GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_schedule (GtkAction* action,
+                                                   GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_scrub_all (GtkAction* action,
+                                                    GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_scrub_current (GtkAction* action,
+                                                        GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_account_report (GtkAction* action,
+                                                         GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_transaction_report (GtkAction* action,
+        GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_associate_file_transaction (
+    GtkAction* action, GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_associate_location_transaction (
+    GtkAction* action, GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_execassociated_transaction (
+    GtkAction* action, GncPluginPageRegister* plugin_page);
+static void gnc_plugin_page_register_cmd_jump_associated_invoice (
+    GtkAction* action, GncPluginPageRegister* plugin_page);
 
-static void gnc_plugin_page_help_changed_cb( GNCSplitReg *gsr, GncPluginPageRegister *register_page );
-static void gnc_plugin_page_popup_menu_cb( GNCSplitReg *gsr, GncPluginPageRegister *register_page );
-static void gnc_plugin_page_register_refresh_cb (GHashTable *changes, gpointer user_data);
+static void gnc_plugin_page_help_changed_cb (GNCSplitReg* gsr,
+                                             GncPluginPageRegister* register_page);
+static void gnc_plugin_page_popup_menu_cb (GNCSplitReg* gsr,
+                                           GncPluginPageRegister* register_page);
+static void gnc_plugin_page_register_refresh_cb (GHashTable* changes,
+                                                 gpointer user_data);
 static void gnc_plugin_page_register_close_cb (gpointer user_data);
 
-static void gnc_plugin_page_register_ui_update (gpointer various, GncPluginPageRegister *page);
-static void gppr_account_destroy_cb (Account *account);
-static void gnc_plugin_page_register_event_handler (QofInstance *entity,
-        QofEventId event_type,
-        GncPluginPageRegister *page,
-        GncEventData *ed);
+static void gnc_plugin_page_register_ui_update (gpointer various,
+                                                GncPluginPageRegister* page);
+static void gppr_account_destroy_cb (Account* account);
+static void gnc_plugin_page_register_event_handler (QofInstance* entity,
+                                                    QofEventId event_type,
+                                                    GncPluginPageRegister* page,
+                                                    GncEventData* ed);
 
-static GncInvoice * invoice_from_split (Split *split);
+static GncInvoice* invoice_from_split (Split* split);
 
 /************************************************************/
 /*                          Actions                         */
@@ -241,40 +317,40 @@ static GtkActionEntry gnc_plugin_page_register_actions [] =
     /* File menu */
 
     {
-        "FilePrintAction", "document-print", N_("_Print Checks..."), "<primary>p", NULL,
+        "FilePrintAction", "document-print", N_ ("_Print Checks..."), "<primary>p", NULL,
         G_CALLBACK (gnc_plugin_page_register_cmd_print_check)
     },
 
     /* Edit menu */
 
     {
-        "EditCutAction", "edit-cut", N_("Cu_t"), "<primary>X",
-        N_("Cut the current selection and copy it to clipboard"),
+        "EditCutAction", "edit-cut", N_ ("Cu_t"), "<primary>X",
+        N_ ("Cut the current selection and copy it to clipboard"),
         G_CALLBACK (gnc_plugin_page_register_cmd_cut)
     },
     {
-        "EditCopyAction", "edit-copy", N_("_Copy"), "<primary>C",
-        N_("Copy the current selection to clipboard"),
+        "EditCopyAction", "edit-copy", N_ ("_Copy"), "<primary>C",
+        N_ ("Copy the current selection to clipboard"),
         G_CALLBACK (gnc_plugin_page_register_cmd_copy)
     },
     {
-        "EditPasteAction", "edit-paste", N_("_Paste"), "<primary>V",
-        N_("Paste the clipboard content at the cursor position"),
+        "EditPasteAction", "edit-paste", N_ ("_Paste"), "<primary>V",
+        N_ ("Paste the clipboard content at the cursor position"),
         G_CALLBACK (gnc_plugin_page_register_cmd_paste)
     },
     {
-        "EditEditAccountAction", GNC_ICON_EDIT_ACCOUNT, N_("Edit _Account"), "<primary>e",
-        N_("Edit the selected account"),
+        "EditEditAccountAction", GNC_ICON_EDIT_ACCOUNT, N_ ("Edit _Account"), "<primary>e",
+        N_ ("Edit the selected account"),
         G_CALLBACK (gnc_plugin_page_register_cmd_edit_account)
     },
     {
-        "EditFindAccountAction", "edit-find", N_("F_ind Account"), "<primary>i",
-        N_("Find an account"),
+        "EditFindAccountAction", "edit-find", N_ ("F_ind Account"), "<primary>i",
+        N_ ("Find an account"),
         G_CALLBACK (gnc_plugin_page_register_cmd_find_account)
     },
     {
-        "EditFindTransactionsAction", "edit-find", N_("_Find..."), "<primary>f",
-        N_("Find transactions with a search"),
+        "EditFindTransactionsAction", "edit-find", N_ ("_Find..."), "<primary>f",
+        N_ ("Find transactions with a search"),
         G_CALLBACK (gnc_plugin_page_register_cmd_find_transactions)
     },
 
@@ -306,30 +382,30 @@ static GtkActionEntry gnc_plugin_page_register_actions [] =
         G_CALLBACK (gnc_plugin_page_register_cmd_delete_transaction)
     },
     {
-        "RemoveTransactionSplitsAction", "edit-clear", N_("Remo_ve Other Splits"), NULL,
-        N_("Remove all splits in the current transaction"),
+        "RemoveTransactionSplitsAction", "edit-clear", N_ ("Remo_ve Other Splits"), NULL,
+        N_ ("Remove all splits in the current transaction"),
         G_CALLBACK (gnc_plugin_page_register_cmd_reinitialize_transaction)
     },
     {
-        "RecordTransactionAction", "list-add", N_("_Enter Transaction"), NULL,
-        N_("Record the current transaction"),
+        "RecordTransactionAction", "list-add", N_ ("_Enter Transaction"), NULL,
+        N_ ("Record the current transaction"),
         G_CALLBACK (gnc_plugin_page_register_cmd_enter_transaction)
     },
     {
-        "CancelTransactionAction", "process-stop", N_("Ca_ncel Transaction"), NULL,
-        N_("Cancel the current transaction"),
+        "CancelTransactionAction", "process-stop", N_ ("Ca_ncel Transaction"), NULL,
+        N_ ("Cancel the current transaction"),
         G_CALLBACK (gnc_plugin_page_register_cmd_cancel_transaction)
     },
     {
-        "VoidTransactionAction", NULL, N_("_Void Transaction"), NULL, NULL,
+        "VoidTransactionAction", NULL, N_ ("_Void Transaction"), NULL, NULL,
         G_CALLBACK (gnc_plugin_page_register_cmd_void_transaction)
     },
     {
-        "UnvoidTransactionAction", NULL, N_("_Unvoid Transaction"), NULL, NULL,
+        "UnvoidTransactionAction", NULL, N_ ("_Unvoid Transaction"), NULL, NULL,
         G_CALLBACK (gnc_plugin_page_register_cmd_unvoid_transaction)
     },
     {
-        "ReverseTransactionAction", NULL, N_("Add _Reversing Transaction"), NULL, NULL,
+        "ReverseTransactionAction", NULL, N_ ("Add _Reversing Transaction"), NULL, NULL,
         G_CALLBACK (gnc_plugin_page_register_cmd_reverse_transaction)
     },
     {
@@ -356,104 +432,105 @@ static GtkActionEntry gnc_plugin_page_register_actions [] =
     /* View menu */
 
     {
-        "ViewSortByAction", NULL, N_("_Sort By..."), NULL, NULL,
+        "ViewSortByAction", NULL, N_ ("_Sort By..."), NULL, NULL,
         G_CALLBACK (gnc_plugin_page_register_cmd_view_sort_by)
     },
     {
-        "ViewFilterByAction", NULL, N_("_Filter By..."), NULL, NULL,
+        "ViewFilterByAction", NULL, N_ ("_Filter By..."), NULL, NULL,
         G_CALLBACK (gnc_plugin_page_register_cmd_view_filter_by)
     },
     {
-        "ViewRefreshAction", "view-refresh", N_("_Refresh"), "<primary>r",
-        N_("Refresh this window"),
+        "ViewRefreshAction", "view-refresh", N_ ("_Refresh"), "<primary>r",
+        N_ ("Refresh this window"),
         G_CALLBACK (gnc_plugin_page_register_cmd_reload)
     },
 
     /* Actions menu */
 
     {
-        "ActionsTransferAction", GNC_ICON_TRANSFER, N_("_Transfer..."), "<primary>t",
-        N_("Transfer funds from one account to another"),
+        "ActionsTransferAction", GNC_ICON_TRANSFER, N_ ("_Transfer..."), "<primary>t",
+        N_ ("Transfer funds from one account to another"),
         G_CALLBACK (gnc_plugin_page_register_cmd_transfer)
     },
     {
-        "ActionsReconcileAction", "edit-select-all", N_("_Reconcile..."), NULL,
-        N_("Reconcile the selected account"),
+        "ActionsReconcileAction", "edit-select-all", N_ ("_Reconcile..."), NULL,
+        N_ ("Reconcile the selected account"),
         G_CALLBACK (gnc_plugin_page_register_cmd_reconcile)
     },
     {
-        "ActionsAutoClearAction", "edit-select-all", N_("_Auto-clear..."), NULL,
-        N_("Automatically clear individual transactions, so as to reach a certain cleared amount"),
+        "ActionsAutoClearAction", "edit-select-all", N_ ("_Auto-clear..."), NULL,
+        N_ ("Automatically clear individual transactions, so as to reach a certain cleared amount"),
         G_CALLBACK (gnc_plugin_page_register_cmd_autoclear)
     },
     {
-        "ActionsStockSplitAction", NULL, N_("Stoc_k Split..."), NULL,
-        N_("Record a stock split or a stock merger"),
+        "ActionsStockSplitAction", NULL, N_ ("Stoc_k Split..."), NULL,
+        N_ ("Record a stock split or a stock merger"),
         G_CALLBACK (gnc_plugin_page_register_cmd_stock_split)
     },
     {
-        "ActionsLotsAction", NULL, N_("View _Lots..."), NULL,
-        N_("Bring up the lot viewer/editor window"),
+        "ActionsLotsAction", NULL, N_ ("View _Lots..."), NULL,
+        N_ ("Bring up the lot viewer/editor window"),
         G_CALLBACK (gnc_plugin_page_register_cmd_lots)
     },
     {
-        "BlankTransactionAction", "go-bottom", N_("_Blank Transaction"), "<primary>Page_Down",
-        N_("Move to the blank transaction at the bottom of the register"),
+        "BlankTransactionAction", "go-bottom", N_ ("_Blank Transaction"), "<primary>Page_Down",
+        N_ ("Move to the blank transaction at the bottom of the register"),
         G_CALLBACK (gnc_plugin_page_register_cmd_blank_transaction)
     },
     {
-        "EditExchangeRateAction", NULL, N_("Edit E_xchange Rate"), NULL,
-        N_("Edit the exchange rate for the current transaction"),
+        "EditExchangeRateAction", NULL, N_ ("Edit E_xchange Rate"), NULL,
+        N_ ("Edit the exchange rate for the current transaction"),
         G_CALLBACK (gnc_plugin_page_register_cmd_exchange_rate)
     },
     {
-        "JumpTransactionAction", GNC_ICON_JUMP_TO, N_("_Jump"), NULL,
-        N_("Jump to the corresponding transaction in the other account"),
+        "JumpTransactionAction", GNC_ICON_JUMP_TO, N_ ("_Jump"), NULL,
+        N_ ("Jump to the corresponding transaction in the other account"),
         G_CALLBACK (gnc_plugin_page_register_cmd_jump)
     },
     {
-        "ScheduleTransactionAction", GNC_ICON_SCHEDULE, N_("Sche_dule..."), NULL,
-        N_("Create a Scheduled Transaction with the current transaction as a template"),
+        "ScheduleTransactionAction", GNC_ICON_SCHEDULE, N_ ("Sche_dule..."), NULL,
+        N_ ("Create a Scheduled Transaction with the current transaction as a template"),
         G_CALLBACK (gnc_plugin_page_register_cmd_schedule)
     },
     {
         "ScrubAllAction", NULL,
         /* Translators: The following 2 are Scrub actions in register view */
-        N_("_All transactions"), NULL, NULL,
+        N_ ("_All transactions"), NULL, NULL,
         G_CALLBACK (gnc_plugin_page_register_cmd_scrub_all)
     },
     {
-        "ScrubCurrentAction", NULL, N_("_This transaction"), NULL, NULL,
+        "ScrubCurrentAction", NULL, N_ ("_This transaction"), NULL, NULL,
         G_CALLBACK (gnc_plugin_page_register_cmd_scrub_current)
     },
 
     /* Reports menu */
 
     {
-        "ReportsAccountReportAction", NULL, N_("Account Report"), NULL,
-        N_("Open a register report for this Account"),
+        "ReportsAccountReportAction", NULL, N_ ("Account Report"), NULL,
+        N_ ("Open a register report for this Account"),
         G_CALLBACK (gnc_plugin_page_register_cmd_account_report)
     },
     {
-        "ReportsAcctTransReportAction", NULL, N_("Account Report - Single Transaction"), NULL,
-        N_("Open a register report for the selected Transaction"),
+        "ReportsAcctTransReportAction", NULL, N_ ("Account Report - Single Transaction"), NULL,
+        N_ ("Open a register report for the selected Transaction"),
         G_CALLBACK (gnc_plugin_page_register_cmd_transaction_report)
     },
 };
 
-static guint gnc_plugin_page_register_n_actions = G_N_ELEMENTS (gnc_plugin_page_register_actions);
+static guint gnc_plugin_page_register_n_actions = G_N_ELEMENTS (
+                                                      gnc_plugin_page_register_actions);
 
 static GtkToggleActionEntry toggle_entries[] =
 {
     {
-        "ViewStyleDoubleLineAction", NULL, N_("_Double Line"), NULL,
-        N_("Show two lines of information for each transaction"),
+        "ViewStyleDoubleLineAction", NULL, N_ ("_Double Line"), NULL,
+        N_ ("Show two lines of information for each transaction"),
         G_CALLBACK (gnc_plugin_page_register_cmd_style_double_line), FALSE
     },
 
     {
-        "SplitTransactionAction", GNC_ICON_SPLIT_TRANS, N_("S_plit Transaction"), NULL,
-        N_("Show all splits in the current transaction"),
+        "SplitTransactionAction", GNC_ICON_SPLIT_TRANS, N_ ("S_plit Transaction"), NULL,
+        N_ ("Show all splits in the current transaction"),
         G_CALLBACK (gnc_plugin_page_register_cmd_expand_transaction), FALSE
     },
 };
@@ -464,18 +541,18 @@ static GtkRadioActionEntry radio_entries_2 [] =
 {
     /* Translators: This is a menu item in the View menu */
     {
-        "ViewStyleBasicAction", NULL, N_("_Basic Ledger"), NULL,
-        N_("Show transactions on one or two lines"), REG_STYLE_LEDGER
+        "ViewStyleBasicAction", NULL, N_ ("_Basic Ledger"), NULL,
+        N_ ("Show transactions on one or two lines"), REG_STYLE_LEDGER
     },
     /* Translators: This is a menu item in the View menu */
     {
-        "ViewStyleAutoSplitAction", NULL, N_("_Auto-Split Ledger"), NULL,
-        N_("Show transactions on one or two lines and expand the current transaction"), REG_STYLE_AUTO_LEDGER
+        "ViewStyleAutoSplitAction", NULL, N_ ("_Auto-Split Ledger"), NULL,
+        N_ ("Show transactions on one or two lines and expand the current transaction"), REG_STYLE_AUTO_LEDGER
     },
     /* Translators: This is a menu item in the View menu */
     {
-        "ViewStyleJournalAction", NULL, N_("Transaction _Journal"), NULL,
-        N_("Show expanded transactions with all splits"), REG_STYLE_JOURNAL
+        "ViewStyleJournalAction", NULL, N_ ("Transaction _Journal"), NULL,
+        N_ ("Show expanded transactions with all splits"), REG_STYLE_JOURNAL
     }
 };
 
@@ -484,7 +561,7 @@ static guint n_radio_entries_2 = G_N_ELEMENTS (radio_entries_2);
 /** These are the "important" actions provided by the register page.
  *  Their labels will appear when the toolbar is set to "Icons and
  *  important text" (e.g. GTK_TOOLBAR_BOTH_HORIZ) mode. */
-static const gchar *important_actions[] =
+static const gchar* important_actions[] =
 {
     "SplitTransactionAction",
     NULL,
@@ -492,7 +569,7 @@ static const gchar *important_actions[] =
 
 /** Actions that require an account to be selected before they are
  *  enabled. */
-static const gchar *actions_requiring_account[] =
+static const gchar* actions_requiring_account[] =
 {
     "EditEditAccountAction",
     "ActionsReconcileAction",
@@ -502,7 +579,7 @@ static const gchar *actions_requiring_account[] =
 };
 
 /** View Style actions */
-static const gchar *view_style_actions[] =
+static const gchar* view_style_actions[] =
 {
     "ViewStyleBasicAction",
     "ViewStyleAutoSplitAction",
@@ -513,28 +590,28 @@ static const gchar *view_style_actions[] =
 /** Short labels for use on the toolbar buttons. */
 static action_toolbar_labels toolbar_labels[] =
 {
-    { "ActionsTransferAction",              N_("Transfer") },
-    { "RecordTransactionAction",            N_("Enter") },
-    { "CancelTransactionAction",            N_("Cancel") },
-    { "DeleteTransactionAction",            N_("Delete") },
-    { "DuplicateTransactionAction",         N_("Duplicate") },
-    { "SplitTransactionAction",             N_("Split") },
-    { "ScheduleTransactionAction",          N_("Schedule") },
-    { "BlankTransactionAction",             N_("Blank") },
-    { "ActionsReconcileAction",             N_("Reconcile") },
-    { "ActionsAutoClearAction",             N_("Auto-clear") },
-    { "AssociateTransactionFileAction",     N_("Associate File") },
-    { "AssociateTransactionLocationAction", N_("Associate Location") },
-    { "ExecAssociatedTransactionAction",    N_("Open File/Location") },
-    { "JumpAssociatedInvoiceAction",        N_("Open Invoice") },
+    { "ActionsTransferAction",              N_ ("Transfer") },
+    { "RecordTransactionAction",            N_ ("Enter") },
+    { "CancelTransactionAction",            N_ ("Cancel") },
+    { "DeleteTransactionAction",            N_ ("Delete") },
+    { "DuplicateTransactionAction",         N_ ("Duplicate") },
+    { "SplitTransactionAction",             N_ ("Split") },
+    { "ScheduleTransactionAction",          N_ ("Schedule") },
+    { "BlankTransactionAction",             N_ ("Blank") },
+    { "ActionsReconcileAction",             N_ ("Reconcile") },
+    { "ActionsAutoClearAction",             N_ ("Auto-clear") },
+    { "AssociateTransactionFileAction",     N_ ("Associate File") },
+    { "AssociateTransactionLocationAction", N_ ("Associate Location") },
+    { "ExecAssociatedTransactionAction",    N_ ("Open File/Location") },
+    { "JumpAssociatedInvoiceAction",        N_ ("Open Invoice") },
     { NULL, NULL },
 };
 
 struct status_action
 {
-    const char *action_name;
+    const char* action_name;
     int value;
-    GtkWidget *widget;
+    GtkWidget* widget;
 };
 
 static struct status_action status_actions[] =
@@ -557,10 +634,10 @@ static struct status_action status_actions[] =
 
 typedef struct GncPluginPageRegisterPrivate
 {
-    GNCLedgerDisplay *ledger;
-    GNCSplitReg *gsr;
+    GNCLedgerDisplay* ledger;
+    GNCSplitReg* gsr;
 
-    GtkWidget *widget;
+    GtkWidget* widget;
 
     gint event_handler_id;
     gint component_manager_id;
@@ -570,14 +647,14 @@ typedef struct GncPluginPageRegisterPrivate
     gboolean read_only;
     gboolean page_focus;
     gboolean enable_refresh; // used to reduce ledger display refreshes
-    Query *search_query;     // saved search query for comparison
-    Query *filter_query;     // saved filter query for comparison
+    Query* search_query;     // saved search query for comparison
+    Query* filter_query;     // saved filter query for comparison
 
     struct
     {
-        GtkWidget *dialog;
-        GtkWidget *num_radio;
-        GtkWidget *act_radio;
+        GtkWidget* dialog;
+        GtkWidget* num_radio;
+        GtkWidget* act_radio;
         SortType original_sort_type;
         gboolean original_save_order;
         gboolean save_order;
@@ -587,15 +664,15 @@ typedef struct GncPluginPageRegisterPrivate
 
     struct
     {
-        GtkWidget *dialog;
-        GtkWidget *table;
-        GtkWidget *start_date_choose;
-        GtkWidget *start_date_today;
-        GtkWidget *start_date;
-        GtkWidget *end_date_choose;
-        GtkWidget *end_date_today;
-        GtkWidget *end_date;
-        GtkWidget *num_days;
+        GtkWidget* dialog;
+        GtkWidget* table;
+        GtkWidget* start_date_choose;
+        GtkWidget* start_date_today;
+        GtkWidget* start_date;
+        GtkWidget* end_date_choose;
+        GtkWidget* end_date_today;
+        GtkWidget* end_date;
+        GtkWidget* num_days;
         cleared_match_t original_cleared_match;
         cleared_match_t cleared_match;
         time64 original_start_time;
@@ -609,66 +686,67 @@ typedef struct GncPluginPageRegisterPrivate
     } fd;
 } GncPluginPageRegisterPrivate;
 
-G_DEFINE_TYPE_WITH_PRIVATE(GncPluginPageRegister, gnc_plugin_page_register, GNC_TYPE_PLUGIN_PAGE)
+G_DEFINE_TYPE_WITH_PRIVATE (GncPluginPageRegister, gnc_plugin_page_register,
+                            GNC_TYPE_PLUGIN_PAGE)
 
 #define GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(o)  \
    ((GncPluginPageRegisterPrivate*)g_type_instance_get_private((GTypeInstance*)o, GNC_TYPE_PLUGIN_PAGE_REGISTER))
 
-static GObjectClass *parent_class = NULL;
+static GObjectClass* parent_class = NULL;
 
 /************************************************************/
 /*                      Implementation                      */
 /************************************************************/
 
-static GncPluginPage *
-gnc_plugin_page_register_new_common (GNCLedgerDisplay *ledger)
+static GncPluginPage*
+gnc_plugin_page_register_new_common (GNCLedgerDisplay* ledger)
 {
-    GncPluginPageRegister *register_page;
-    GncPluginPageRegisterPrivate *priv;
-    GncPluginPage *plugin_page;
-    GNCSplitReg *gsr;
-    const GList *item;
-    GList *book_list;
-    gchar *label;
-    gchar *label_color;
-    QofQuery *q;
+    GncPluginPageRegister* register_page;
+    GncPluginPageRegisterPrivate* priv;
+    GncPluginPage* plugin_page;
+    GNCSplitReg* gsr;
+    const GList* item;
+    GList* book_list;
+    gchar* label;
+    gchar* label_color;
+    QofQuery* q;
 
     /* Is there an existing page? */
     gsr = gnc_ledger_display_get_user_data (ledger);
     if (gsr)
     {
-        item = gnc_gobject_tracking_get_list(GNC_PLUGIN_PAGE_REGISTER_NAME);
-        for ( ; item; item = g_list_next(item))
+        item = gnc_gobject_tracking_get_list (GNC_PLUGIN_PAGE_REGISTER_NAME);
+        for (; item; item = g_list_next (item))
         {
-            register_page = (GncPluginPageRegister *)item->data;
-            priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(register_page);
+            register_page = (GncPluginPageRegister*)item->data;
+            priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (register_page);
             if (priv->gsr == gsr)
-                return GNC_PLUGIN_PAGE(register_page);
+                return GNC_PLUGIN_PAGE (register_page);
         }
     }
 
     register_page = g_object_new (GNC_TYPE_PLUGIN_PAGE_REGISTER, NULL);
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(register_page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (register_page);
     priv->ledger = ledger;
     priv->key = *guid_null();
 
-    plugin_page = GNC_PLUGIN_PAGE(register_page);
-    label = gnc_plugin_page_register_get_tab_name(plugin_page);
-    gnc_plugin_page_set_page_name(plugin_page, label);
-    g_free(label);
+    plugin_page = GNC_PLUGIN_PAGE (register_page);
+    label = gnc_plugin_page_register_get_tab_name (plugin_page);
+    gnc_plugin_page_set_page_name (plugin_page, label);
+    g_free (label);
 
-    label_color = gnc_plugin_page_register_get_tab_color(plugin_page);
-    gnc_plugin_page_set_page_color(plugin_page, label_color);
-    g_free(label_color);
+    label_color = gnc_plugin_page_register_get_tab_color (plugin_page);
+    gnc_plugin_page_set_page_color (plugin_page, label_color);
+    g_free (label_color);
 
-    label = gnc_plugin_page_register_get_long_name(plugin_page);
-    gnc_plugin_page_set_page_long_name(plugin_page, label);
-    g_free(label);
+    label = gnc_plugin_page_register_get_long_name (plugin_page);
+    gnc_plugin_page_set_page_long_name (plugin_page, label);
+    g_free (label);
 
     q = gnc_ledger_display_get_query (ledger);
     book_list = qof_query_get_books (q);
-    for (item = book_list; item; item = g_list_next(item))
-        gnc_plugin_page_add_book (plugin_page, (QofBook *)item->data);
+    for (item = book_list; item; item = g_list_next (item))
+        gnc_plugin_page_add_book (plugin_page, (QofBook*)item->data);
     // Do not free the list. It is owned by the query.
 
     priv->component_manager_id = 0;
@@ -676,92 +754,97 @@ gnc_plugin_page_register_new_common (GNCLedgerDisplay *ledger)
 }
 
 static gpointer
-gnc_plug_page_register_check_commodity(Account *account, void* usr_data)
+gnc_plug_page_register_check_commodity (Account* account, void* usr_data)
 {
     // Check that account's commodity matches the commodity in usr_data
     gnc_commodity* com0 = (gnc_commodity*) usr_data;
-    gnc_commodity* com1 = xaccAccountGetCommodity(account);
-    return gnc_commodity_equal(com1, com0) ? NULL : com1;
+    gnc_commodity* com1 = xaccAccountGetCommodity (account);
+    return gnc_commodity_equal (com1, com0) ? NULL : com1;
 }
 
-GncPluginPage *
-gnc_plugin_page_register_new (Account *account, gboolean subaccounts)
+GncPluginPage*
+gnc_plugin_page_register_new (Account* account, gboolean subaccounts)
 {
-    GNCLedgerDisplay *ledger;
-    GncPluginPage *page;
-    GncPluginPageRegisterPrivate *priv;
+    GNCLedgerDisplay* ledger;
+    GncPluginPage* page;
+    GncPluginPageRegisterPrivate* priv;
     gnc_commodity* com0;
     gnc_commodity* com1;
 
-/*################## Added for Reg2 #################*/
-    const GList *item;
-    GncPluginPageRegister2  *new_register_page;
-/*################## Added for Reg2 #################*/
+    /*################## Added for Reg2 #################*/
+    const GList* item;
+    GncPluginPageRegister2*  new_register_page;
+    /*################## Added for Reg2 #################*/
 
-    ENTER("account=%p, subaccounts=%s", account,
-          subaccounts ? "TRUE" : "FALSE");
+    ENTER ("account=%p, subaccounts=%s", account,
+           subaccounts ? "TRUE" : "FALSE");
 
-/*################## Added for Reg2 #################*/
+    /*################## Added for Reg2 #################*/
     // We test for the new register being open here, ie matching account guids
     item = gnc_gobject_tracking_get_list (GNC_PLUGIN_PAGE_REGISTER2_NAME);
-    for ( ; item; item = g_list_next (item))
+    for (; item; item = g_list_next (item))
     {
-        Account *new_account;
-        new_register_page = (GncPluginPageRegister2 *)item->data;
+        Account* new_account;
+        new_register_page = (GncPluginPageRegister2*)item->data;
         new_account = gnc_plugin_page_register2_get_account (new_register_page);
 
-        if (guid_equal (xaccAccountGetGUID (account), xaccAccountGetGUID (new_account)))
+        if (guid_equal (xaccAccountGetGUID (account),
+                        xaccAccountGetGUID (new_account)))
         {
-            GtkWindow *window = GTK_WINDOW (gnc_plugin_page_get_window (GNC_PLUGIN_PAGE (new_register_page)));
+            GtkWindow* window = GTK_WINDOW (gnc_plugin_page_get_window (GNC_PLUGIN_PAGE (
+                    new_register_page)));
             gnc_error_dialog (window, "%s",
-                         _("You have tried to open an account in the old register while it is open in the new register."));
+                              _ ("You have tried to open an account in the old register while it is open in the new register."));
             return NULL;
         }
     }
-/*################## Added for Reg2 #################*/
-    com0 = gnc_account_get_currency_or_parent(account);
-    com1 = gnc_account_foreach_descendant_until(account,gnc_plug_page_register_check_commodity,com0);
-    if(0 && com1 != NULL)
+    /*################## Added for Reg2 #################*/
+    com0 = gnc_account_get_currency_or_parent (account);
+    com1 = gnc_account_foreach_descendant_until (account,
+                                                 gnc_plug_page_register_check_commodity, com0);
+    if (0 && com1 != NULL)
     {
-        const gchar* com0_str = gnc_commodity_get_fullname(com0);
-        const gchar* com1_str = gnc_commodity_get_fullname(com1);
-        gnc_info_dialog(NULL,_("Cannot open sub-accounts because sub-accounts and parent account have different commodities or currencies\nFound:\n%s\n%s\n(There may be more mismatches)"),com0_str,com1_str);
+        const gchar* com0_str = gnc_commodity_get_fullname (com0);
+        const gchar* com1_str = gnc_commodity_get_fullname (com1);
+        gnc_info_dialog (NULL,
+                         _ ("Cannot open sub-accounts because sub-accounts and parent account have different commodities or currencies\nFound:\n%s\n%s\n(There may be more mismatches)"),
+                         com0_str, com1_str);
         return NULL;
     }
 
     if (subaccounts)
-        ledger = gnc_ledger_display_subaccounts (account,com1 != NULL);
+        ledger = gnc_ledger_display_subaccounts (account, com1 != NULL);
     else
         ledger = gnc_ledger_display_simple (account);
 
-    page = gnc_plugin_page_register_new_common(ledger);
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
-    priv->key = *xaccAccountGetGUID(account);
+    page = gnc_plugin_page_register_new_common (ledger);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
+    priv->key = *xaccAccountGetGUID (account);
 
-    LEAVE("%p", page);
+    LEAVE ("%p", page);
     return page;
 }
 
-GncPluginPage *
+GncPluginPage*
 gnc_plugin_page_register_new_gl (void)
 {
-    GNCLedgerDisplay *ledger;
+    GNCLedgerDisplay* ledger;
 
-    ledger = gnc_ledger_display_gl ();
-    return gnc_plugin_page_register_new_common(ledger);
+    ledger = gnc_ledger_display_gl();
+    return gnc_plugin_page_register_new_common (ledger);
 }
 
-GncPluginPage *
-gnc_plugin_page_register_new_ledger (GNCLedgerDisplay *ledger)
+GncPluginPage*
+gnc_plugin_page_register_new_ledger (GNCLedgerDisplay* ledger)
 {
-    return gnc_plugin_page_register_new_common(ledger);
+    return gnc_plugin_page_register_new_common (ledger);
 }
 
 static void
-gnc_plugin_page_register_class_init (GncPluginPageRegisterClass *klass)
+gnc_plugin_page_register_class_init (GncPluginPageRegisterClass* klass)
 {
-    GObjectClass *object_class = G_OBJECT_CLASS (klass);
-    GncPluginPageClass *gnc_plugin_class = GNC_PLUGIN_PAGE_CLASS(klass);
+    GObjectClass* object_class = G_OBJECT_CLASS (klass);
+    GncPluginPageClass* gnc_plugin_class = GNC_PLUGIN_PAGE_CLASS (klass);
 
     parent_class = g_type_class_peek_parent (klass);
 
@@ -775,7 +858,8 @@ gnc_plugin_page_register_class_init (GncPluginPageRegisterClass *klass)
     gnc_plugin_class->focus_page      = gnc_plugin_page_register_focus;
     gnc_plugin_class->save_page       = gnc_plugin_page_register_save_page;
     gnc_plugin_class->recreate_page   = gnc_plugin_page_register_recreate_page;
-    gnc_plugin_class->update_edit_menu_actions = gnc_plugin_page_register_update_edit_menu;
+    gnc_plugin_class->update_edit_menu_actions =
+        gnc_plugin_page_register_update_edit_menu;
     gnc_plugin_class->finish_pending  = gnc_plugin_page_register_finish_pending;
     gnc_plugin_class->focus_page_function = gnc_plugin_page_register_focus_widget;
 
@@ -783,29 +867,30 @@ gnc_plugin_page_register_class_init (GncPluginPageRegisterClass *klass)
 }
 
 static void
-gnc_plugin_page_register_init (GncPluginPageRegister *plugin_page)
+gnc_plugin_page_register_init (GncPluginPageRegister* plugin_page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    GncPluginPage *parent;
-    GtkActionGroup *action_group;
+    GncPluginPageRegisterPrivate* priv;
+    GncPluginPage* parent;
+    GtkActionGroup* action_group;
     gboolean use_new;
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
 
     /* Init parent declared variables */
-    parent = GNC_PLUGIN_PAGE(plugin_page);
-    use_new = gnc_prefs_get_bool(GNC_PREFS_GROUP_GENERAL_REGISTER, GNC_PREF_USE_NEW);
-    g_object_set(G_OBJECT(plugin_page),
-                 "page-name",      _("General Journal"),
-                 "page-uri",       "default:",
-                 "ui-description", "gnc-plugin-page-register-ui.xml",
-                 "use-new-window", use_new,
-                 NULL);
+    parent = GNC_PLUGIN_PAGE (plugin_page);
+    use_new = gnc_prefs_get_bool (GNC_PREFS_GROUP_GENERAL_REGISTER,
+                                  GNC_PREF_USE_NEW);
+    g_object_set (G_OBJECT (plugin_page),
+                  "page-name",      _ ("General Journal"),
+                  "page-uri",       "default:",
+                  "ui-description", "gnc-plugin-page-register-ui.xml",
+                  "use-new-window", use_new,
+                  NULL);
 
     /* Create menu and toolbar information */
     action_group =
-        gnc_plugin_page_create_action_group(parent,
-                                            "GncPluginPageRegisterActions");
+        gnc_plugin_page_create_action_group (parent,
+                                             "GncPluginPageRegisterActions");
     gtk_action_group_add_actions (action_group, gnc_plugin_page_register_actions,
                                   gnc_plugin_page_register_n_actions, plugin_page);
     gtk_action_group_add_toggle_actions (action_group,
@@ -814,7 +899,7 @@ gnc_plugin_page_register_init (GncPluginPageRegister *plugin_page)
     gtk_action_group_add_radio_actions (action_group,
                                         radio_entries_2, n_radio_entries_2,
                                         REG_STYLE_LEDGER,
-                                        G_CALLBACK(gnc_plugin_page_register_cmd_style_changed),
+                                        G_CALLBACK (gnc_plugin_page_register_cmd_style_changed),
                                         plugin_page);
 
     gnc_plugin_init_short_names (action_group, toolbar_labels);
@@ -830,24 +915,24 @@ gnc_plugin_page_register_init (GncPluginPageRegister *plugin_page)
 }
 
 static void
-gnc_plugin_page_register_finalize (GObject *object)
+gnc_plugin_page_register_finalize (GObject* object)
 {
     g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (object));
 
-    ENTER("object %p", object);
+    ENTER ("object %p", object);
 
     G_OBJECT_CLASS (parent_class)->finalize (object);
-    LEAVE(" ");
+    LEAVE (" ");
 }
 
-Account *
-gnc_plugin_page_register_get_account (GncPluginPageRegister *page)
+Account*
+gnc_plugin_page_register_get_account (GncPluginPageRegister* page)
 {
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegisterPrivate* priv;
     GNCLedgerDisplayType ledger_type;
-    Account *leader;
+    Account* leader;
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
     ledger_type = gnc_ledger_display_type (priv->ledger);
     leader = gnc_ledger_display_leader (priv->ledger);
 
@@ -856,15 +941,15 @@ gnc_plugin_page_register_get_account (GncPluginPageRegister *page)
     return NULL;
 }
 
-Transaction *
-gnc_plugin_page_register_get_current_txn (GncPluginPageRegister *page)
+Transaction*
+gnc_plugin_page_register_get_current_txn (GncPluginPageRegister* page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    SplitRegister *reg;
+    GncPluginPageRegisterPrivate* priv;
+    SplitRegister* reg;
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
-    reg = gnc_ledger_display_get_split_register(priv->ledger);
-    return gnc_split_register_get_current_trans(reg);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
+    reg = gnc_ledger_display_get_split_register (priv->ledger);
+    return gnc_split_register_get_current_trans (reg);
 }
 
 /**
@@ -872,11 +957,12 @@ gnc_plugin_page_register_get_current_txn (GncPluginPageRegister *page)
  * the current page, set focus on the sheet.
  */
 static gboolean
-gnc_plugin_page_register_focus_widget (GncPluginPage *register_plugin_page)
+gnc_plugin_page_register_focus_widget (GncPluginPage* register_plugin_page)
 {
-    if (GNC_IS_PLUGIN_PAGE_REGISTER(register_plugin_page))
+    if (GNC_IS_PLUGIN_PAGE_REGISTER (register_plugin_page))
     {
-        GNCSplitReg *gsr = gnc_plugin_page_register_get_gsr(GNC_PLUGIN_PAGE(register_plugin_page));
+        GNCSplitReg* gsr = gnc_plugin_page_register_get_gsr (GNC_PLUGIN_PAGE (
+                                                                 register_plugin_page));
         gnc_split_reg_focus_on_sheet (gsr);
     }
     return FALSE;
@@ -973,28 +1059,29 @@ static const char* split_action_tips[] =
 };
 
 static void
-gnc_plugin_page_register_ui_update (gpointer various, GncPluginPageRegister *page)
+gnc_plugin_page_register_ui_update (gpointer various,
+                                    GncPluginPageRegister* page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    SplitRegister *reg;
-    GtkAction *action;
+    GncPluginPageRegisterPrivate* priv;
+    SplitRegister* reg;
+    GtkAction* action;
     gboolean expanded, voided, read_only = FALSE;
-    Transaction *trans;
-    GncInvoice *inv;
+    Transaction* trans;
+    GncInvoice* inv;
     CursorClass cursor_class;
-    const char *uri;
+    const char* uri;
 
     /* Set 'Split Transaction' */
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
-    reg = gnc_ledger_display_get_split_register(priv->ledger);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
+    reg = gnc_ledger_display_get_split_register (priv->ledger);
     cursor_class = gnc_split_register_get_current_cursor_class (reg);
-    expanded = gnc_split_register_current_trans_expanded(reg);
-    action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE(page),
+    expanded = gnc_split_register_current_trans_expanded (reg);
+    action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page),
                                          "SplitTransactionAction");
     gtk_action_set_sensitive (action, reg->style == REG_STYLE_LEDGER);
     g_signal_handlers_block_by_func
     (action, gnc_plugin_page_register_cmd_expand_transaction, page);
-    gtk_toggle_action_set_active (GTK_TOGGLE_ACTION(action), expanded);
+    gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action), expanded);
     g_signal_handlers_unblock_by_func
     (action, gnc_plugin_page_register_cmd_expand_transaction, page);
 
@@ -1003,84 +1090,84 @@ gnc_plugin_page_register_ui_update (gpointer various, GncPluginPageRegister *pag
 
     if (trans)
         read_only = xaccTransIsReadonlyByPostedDate (trans);
-    voided = xaccTransHasSplitsInState(trans, VREC);
+    voided = xaccTransHasSplitsInState (trans, VREC);
 
-    action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE(page),
+    action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page),
                                          "CutTransactionAction");
-    gtk_action_set_sensitive (GTK_ACTION(action), !read_only & !voided);
+    gtk_action_set_sensitive (GTK_ACTION (action), !read_only & !voided);
 
-    action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE(page),
+    action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page),
                                          "PasteTransactionAction");
-    gtk_action_set_sensitive (GTK_ACTION(action), !read_only & !voided);
+    gtk_action_set_sensitive (GTK_ACTION (action), !read_only & !voided);
 
-    action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE(page),
+    action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page),
                                          "DeleteTransactionAction");
-    gtk_action_set_sensitive (GTK_ACTION(action), !read_only & !voided);
+    gtk_action_set_sensitive (GTK_ACTION (action), !read_only & !voided);
 
-    action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE(page),
+    action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page),
                                          "DuplicateTransactionAction");
-    gtk_action_set_sensitive (GTK_ACTION(action), TRUE);
+    gtk_action_set_sensitive (GTK_ACTION (action), TRUE);
 
     if (cursor_class == CURSOR_CLASS_SPLIT)
     {
-        action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE(page),
+        action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page),
                                              "DuplicateTransactionAction");
-        gtk_action_set_sensitive (GTK_ACTION(action), !read_only & !voided);
+        gtk_action_set_sensitive (GTK_ACTION (action), !read_only & !voided);
     }
 
-    action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE(page),
+    action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page),
                                          "RemoveTransactionSplitsAction");
-    gtk_action_set_sensitive (GTK_ACTION(action), !read_only & !voided);
+    gtk_action_set_sensitive (GTK_ACTION (action), !read_only & !voided);
 
     /* Set 'Void' and 'Unvoid' */
     if (read_only)
         voided = TRUE;
 
-    action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE(page),
+    action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page),
                                          "VoidTransactionAction");
-    gtk_action_set_sensitive (GTK_ACTION(action), !voided);
+    gtk_action_set_sensitive (GTK_ACTION (action), !voided);
 
     if (read_only)
         voided = FALSE;
 
-    action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE(page),
+    action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page),
                                          "UnvoidTransactionAction");
-    gtk_action_set_sensitive (GTK_ACTION(action), voided);
+    gtk_action_set_sensitive (GTK_ACTION (action), voided);
 
     /* Set 'ExecAssociated' */
-    uri = xaccTransGetAssociation(trans);
-    action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE(page),
+    uri = xaccTransGetAssociation (trans);
+    action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page),
                                          "ExecAssociatedTransactionAction");
-    gtk_action_set_sensitive (GTK_ACTION(action), (uri && *uri));
+    gtk_action_set_sensitive (GTK_ACTION (action), (uri && *uri));
 
     /* Set 'ExecAssociatedInvoice' */
     inv = invoice_from_split (gnc_split_register_get_current_split (reg));
-    action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE(page),
+    action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page),
                                          "JumpAssociatedInvoiceAction");
-    gtk_action_set_sensitive (GTK_ACTION(action), inv != NULL);
+    gtk_action_set_sensitive (GTK_ACTION (action), inv != NULL);
 
-    gnc_plugin_business_split_reg_ui_update (GNC_PLUGIN_PAGE(page));
+    gnc_plugin_business_split_reg_ui_update (GNC_PLUGIN_PAGE (page));
 
     /* If we are in a readonly book, make any modifying action inactive */
-    if (qof_book_is_readonly(gnc_get_current_book()))
+    if (qof_book_is_readonly (gnc_get_current_book()))
     {
-        const char **iter;
+        const char** iter;
         for (iter = readonly_inactive_actions; *iter; ++iter)
         {
             /* Set the action's sensitivity */
-            GtkAction *action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE(page), *iter);
-            gtk_action_set_sensitive(action, FALSE);
+            GtkAction* action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page), *iter);
+            gtk_action_set_sensitive (action, FALSE);
         }
     }
 
     /* Modifying action descriptions based on cursor class */
     {
-        const char **iter, **label_iter, **tooltip_iter;
+        const char** iter, **label_iter, **tooltip_iter;
         gboolean curr_label_trans = FALSE;
         iter = tran_vs_split_actions;
-        action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE(page), *iter);
+        action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page), *iter);
         label_iter = tran_action_labels;
-        if (g_strcmp0 (gtk_action_get_label(action), _(*label_iter)) == 0)
+        if (g_strcmp0 (gtk_action_get_label (action), _ (*label_iter)) == 0)
             curr_label_trans = TRUE;
         if ((cursor_class == CURSOR_CLASS_SPLIT) && curr_label_trans)
         {
@@ -1089,9 +1176,9 @@ gnc_plugin_page_register_ui_update (gpointer various, GncPluginPageRegister *pag
             for (iter = tran_vs_split_actions; *iter; ++iter)
             {
                 /* Adjust the action's label and tooltip */
-                action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE(page), *iter);
-                gtk_action_set_label(action, _(*label_iter));
-                gtk_action_set_tooltip(action, _(*tooltip_iter));
+                action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page), *iter);
+                gtk_action_set_label (action, _ (*label_iter));
+                gtk_action_set_tooltip (action, _ (*tooltip_iter));
                 ++label_iter;
                 ++tooltip_iter;
             }
@@ -1103,9 +1190,9 @@ gnc_plugin_page_register_ui_update (gpointer various, GncPluginPageRegister *pag
             for (iter = tran_vs_split_actions; *iter; ++iter)
             {
                 /* Adjust the action's label and tooltip */
-                action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE(page), *iter);
-                gtk_action_set_label(action, _(*label_iter));
-                gtk_action_set_tooltip(action, _(*tooltip_iter));
+                action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page), *iter);
+                gtk_action_set_label (action, _ (*label_iter));
+                gtk_action_set_tooltip (action, _ (*tooltip_iter));
                 ++label_iter;
                 ++tooltip_iter;
             }
@@ -1114,57 +1201,62 @@ gnc_plugin_page_register_ui_update (gpointer various, GncPluginPageRegister *pag
 }
 
 static void
-gnc_plugin_page_register_ui_initial_state (GncPluginPageRegister *page)
+gnc_plugin_page_register_ui_initial_state (GncPluginPageRegister* page)
 {
-    GncPluginPageRegisterPrivate *priv ;
-    GtkActionGroup *action_group;
-    GtkAction *action;
-    Account *account;
-    SplitRegister *reg;
+    GncPluginPageRegisterPrivate* priv ;
+    GtkActionGroup* action_group;
+    GtkAction* action;
+    Account* account;
+    SplitRegister* reg;
     GNCLedgerDisplayType ledger_type;
     int i;
-    gboolean is_readwrite = !qof_book_is_readonly(gnc_get_current_book());
+    gboolean is_readwrite = !qof_book_is_readonly (gnc_get_current_book());
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
     account = gnc_plugin_page_register_get_account (page);
-    action_group = gnc_plugin_page_get_action_group(GNC_PLUGIN_PAGE(page));
-    gnc_plugin_update_actions(action_group, actions_requiring_account,
-                              "sensitive", is_readwrite && account != NULL);
+    action_group = gnc_plugin_page_get_action_group (GNC_PLUGIN_PAGE (page));
+    gnc_plugin_update_actions (action_group, actions_requiring_account,
+                               "sensitive", is_readwrite && account != NULL);
 
     /* Set "style" radio button */
-    ledger_type = gnc_ledger_display_type(priv->ledger);
-    gnc_plugin_update_actions(action_group, view_style_actions,
-                              "sensitive", ledger_type == LD_SINGLE);
+    ledger_type = gnc_ledger_display_type (priv->ledger);
+    gnc_plugin_update_actions (action_group, view_style_actions,
+                               "sensitive", ledger_type == LD_SINGLE);
 
-    reg = gnc_ledger_display_get_split_register(priv->ledger);
+    reg = gnc_ledger_display_get_split_register (priv->ledger);
     for (i = n_radio_entries_2 - 1; i > 0; i--)
     {
-        DEBUG(" index %d: comparing %x to %x", i, radio_entries_2[i].value,
-              reg->style);
+        DEBUG (" index %d: comparing %x to %x", i, radio_entries_2[i].value,
+               reg->style);
         if (radio_entries_2[i].value == reg->style)
         {
-            DEBUG("match");
+            DEBUG ("match");
             break;
         }
     }
 
     /* Either a match was found, or fell out with i = 0 */
-    action = gtk_action_group_get_action(action_group, radio_entries_2[i].name);
-    g_signal_handlers_block_by_func(action, gnc_plugin_page_register_cmd_style_changed, page);
-    gtk_toggle_action_set_active(GTK_TOGGLE_ACTION(action), TRUE);
-    g_signal_handlers_unblock_by_func(action, gnc_plugin_page_register_cmd_style_changed, page);
+    action = gtk_action_group_get_action (action_group, radio_entries_2[i].name);
+    g_signal_handlers_block_by_func (action,
+                                     gnc_plugin_page_register_cmd_style_changed, page);
+    gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action), TRUE);
+    g_signal_handlers_unblock_by_func (action,
+                                       gnc_plugin_page_register_cmd_style_changed, page);
 
     /* Set "double line" toggle button */
     action = gtk_action_group_get_action (action_group,
                                           "ViewStyleDoubleLineAction");
-    g_signal_handlers_block_by_func(action, gnc_plugin_page_register_cmd_style_double_line, page);
-    gtk_toggle_action_set_active (GTK_TOGGLE_ACTION(action), reg->use_double_line);
-    g_signal_handlers_unblock_by_func(action, gnc_plugin_page_register_cmd_style_double_line, page);
+    g_signal_handlers_block_by_func (action,
+                                     gnc_plugin_page_register_cmd_style_double_line, page);
+    gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action),
+                                  reg->use_double_line);
+    g_signal_handlers_unblock_by_func (action,
+                                       gnc_plugin_page_register_cmd_style_double_line, page);
 }
 
 /* Virtual Functions */
 
-static const gchar *
+static const gchar*
 get_filter_default_num_of_days (GNCLedgerDisplayType ledger_type)
 {
     if (ledger_type == LD_GL)
@@ -1179,27 +1271,27 @@ get_filter_default_num_of_days (GNCLedgerDisplayType ledger_type)
  * of the sheet focus only when the page is the current one.
  */
 static void
-gnc_plugin_page_register_focus (GncPluginPage *plugin_page,
+gnc_plugin_page_register_focus (GncPluginPage* plugin_page,
                                 gboolean on_current_page)
 {
-    GncPluginPageRegister *page;
-    GncPluginPageRegisterPrivate *priv;
-    GNCSplitReg *gsr;
+    GncPluginPageRegister* page;
+    GncPluginPageRegisterPrivate* priv;
+    GNCSplitReg* gsr;
 
     g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page));
 
-    page = GNC_PLUGIN_PAGE_REGISTER(plugin_page);
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
+    page = GNC_PLUGIN_PAGE_REGISTER (plugin_page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
 
-    gsr = gnc_plugin_page_register_get_gsr (GNC_PLUGIN_PAGE(plugin_page));
+    gsr = gnc_plugin_page_register_get_gsr (GNC_PLUGIN_PAGE (plugin_page));
 
     if (on_current_page)
     {
         priv->page_focus = TRUE;
 
-       // Chain up to use parent version of 'focus_page' which will
-       // use an idle_add as the page changed signal is emitted multiple times.
-       GNC_PLUGIN_PAGE_CLASS(parent_class)->focus_page (plugin_page, TRUE);
+        // Chain up to use parent version of 'focus_page' which will
+        // use an idle_add as the page changed signal is emitted multiple times.
+        GNC_PLUGIN_PAGE_CLASS (parent_class)->focus_page (plugin_page, TRUE);
     }
     else
         priv->page_focus = FALSE;
@@ -1208,29 +1300,29 @@ gnc_plugin_page_register_focus (GncPluginPage *plugin_page,
     gnc_split_reg_set_sheet_focus (gsr, priv->page_focus);
 }
 
-static GtkWidget *
-gnc_plugin_page_register_create_widget (GncPluginPage *plugin_page)
+static GtkWidget*
+gnc_plugin_page_register_create_widget (GncPluginPage* plugin_page)
 {
-    GncPluginPageRegister *page;
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegister* page;
+    GncPluginPageRegisterPrivate* priv;
     GNCLedgerDisplayType ledger_type;
-    GncWindow *gnc_window;
+    GncWindow* gnc_window;
     guint numRows;
-    GtkWidget *gsr;
-    SplitRegister *reg;
-    Account *acct;
-    gchar **filter;
-    gchar *order;
+    GtkWidget* gsr;
+    SplitRegister* reg;
+    Account* acct;
+    gchar** filter;
+    gchar* order;
     int filter_changed = 0;
     gboolean create_new_page = FALSE;
 
-    ENTER("page %p", plugin_page);
+    ENTER ("page %p", plugin_page);
     page = GNC_PLUGIN_PAGE_REGISTER (plugin_page);
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
 
     if (priv->widget != NULL)
     {
-        LEAVE("existing widget %p", priv->widget);
+        LEAVE ("existing widget %p", priv->widget);
         return priv->widget;
     }
     // on create, the page will be the current page so set the focus flag
@@ -1241,30 +1333,30 @@ gnc_plugin_page_register_create_widget (GncPluginPage *plugin_page)
     gtk_widget_show (priv->widget);
 
     // Set the style context for this page so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(priv->widget), "GncRegisterPage");
+    gnc_widget_set_style_context (GTK_WIDGET (priv->widget), "GncRegisterPage");
 
     numRows = priv->lines_default;
-    numRows = MIN(numRows, DEFAULT_LINES_AMOUNT);
+    numRows = MIN (numRows, DEFAULT_LINES_AMOUNT);
 
-    gnc_window = GNC_WINDOW(GNC_PLUGIN_PAGE(page)->window);
-    gsr = gnc_split_reg_new(priv->ledger,
-                            gnc_window_get_gtk_window(gnc_window),
-                            numRows, priv->read_only);
-    priv->gsr = (GNCSplitReg *)gsr;
+    gnc_window = GNC_WINDOW (GNC_PLUGIN_PAGE (page)->window);
+    gsr = gnc_split_reg_new (priv->ledger,
+                             gnc_window_get_gtk_window (gnc_window),
+                             numRows, priv->read_only);
+    priv->gsr = (GNCSplitReg*)gsr;
     gtk_widget_show (gsr);
     gtk_box_pack_start (GTK_BOX (priv->widget), gsr, TRUE, TRUE, 0);
 
     g_signal_connect (G_OBJECT (gsr), "help-changed",
-                      G_CALLBACK ( gnc_plugin_page_help_changed_cb ),
-                      page );
+                      G_CALLBACK (gnc_plugin_page_help_changed_cb),
+                      page);
 
     g_signal_connect (G_OBJECT (gsr), "show-popup-menu",
-                      G_CALLBACK ( gnc_plugin_page_popup_menu_cb ),
-                      page );
+                      G_CALLBACK (gnc_plugin_page_popup_menu_cb),
+                      page);
 
-    reg = gnc_ledger_display_get_split_register(priv->ledger);
-    gnc_split_register_config(reg, reg->type, reg->style,
-                              reg->use_double_line);
+    reg = gnc_ledger_display_get_split_register (priv->ledger);
+    gnc_split_register_config (reg, reg->type, reg->style,
+                               reg->use_double_line);
 
     gnc_plugin_page_register_ui_initial_state (page);
     gnc_plugin_page_register_ui_update (NULL, page);
@@ -1274,20 +1366,21 @@ gnc_plugin_page_register_create_widget (GncPluginPage *plugin_page)
     {
         /* Set the sort order for the split register and status of save order button */
         priv->sd.save_order = FALSE;
-        order = gnc_plugin_page_register_get_sort_order(plugin_page);
+        order = gnc_plugin_page_register_get_sort_order (plugin_page);
 
-        PINFO("Loaded Sort order is %s", order);
+        PINFO ("Loaded Sort order is %s", order);
 
-        gnc_split_reg_set_sort_type(priv->gsr, SortTypefromString(order));
+        gnc_split_reg_set_sort_type (priv->gsr, SortTypefromString (order));
 
         if (order && (g_strcmp0 (order, DEFAULT_SORT_ORDER) != 0))
             priv->sd.save_order = TRUE;
 
         priv->sd.original_save_order = priv->sd.save_order;
-        g_free(order);
+        g_free (order);
 
-        priv->sd.reverse_order = gnc_plugin_page_register_get_sort_reversed(plugin_page);
-        gnc_split_reg_set_sort_reversed(priv->gsr, priv->sd.reverse_order, FALSE);
+        priv->sd.reverse_order = gnc_plugin_page_register_get_sort_reversed (
+                                     plugin_page);
+        gnc_split_reg_set_sort_reversed (priv->gsr, priv->sd.reverse_order, FALSE);
         if (priv->sd.reverse_order)
             priv->sd.save_order = TRUE;
 
@@ -1296,42 +1389,44 @@ gnc_plugin_page_register_create_widget (GncPluginPage *plugin_page)
         /* Set the filter for the split register and status of save filter button */
         priv->fd.save_filter = FALSE;
 
-        filter = g_strsplit(gnc_plugin_page_register_get_filter(plugin_page), ",", -1);
+        filter = g_strsplit (gnc_plugin_page_register_get_filter (plugin_page), ",",
+                             -1);
 
-        PINFO("Loaded Filter Status is %s", filter[0]);
+        PINFO ("Loaded Filter Status is %s", filter[0]);
 
-        priv->fd.cleared_match = (gint)g_ascii_strtoll( filter[0], NULL, 16 );
+        priv->fd.cleared_match = (gint)g_ascii_strtoll (filter[0], NULL, 16);
 
         if (filter[0] && (g_strcmp0 (filter[0], DEFAULT_FILTER) != 0))
             filter_changed = filter_changed + 1;
 
-        if (filter[1] && (g_strcmp0 (filter[1], "0") != 0 ))
+        if (filter[1] && (g_strcmp0 (filter[1], "0") != 0))
         {
-            PINFO("Loaded Filter Start Date is %s", filter[1]);
+            PINFO ("Loaded Filter Start Date is %s", filter[1]);
 
-            priv->fd.start_time = gnc_plugin_page_register_filter_dmy2time (filter[1] );
-            priv->fd.start_time = gnc_time64_get_day_start(priv->fd.start_time);
+            priv->fd.start_time = gnc_plugin_page_register_filter_dmy2time (filter[1]);
+            priv->fd.start_time = gnc_time64_get_day_start (priv->fd.start_time);
             filter_changed = filter_changed + 1;
         }
 
-        if (filter[2] && (g_strcmp0 (filter[2], "0") != 0 ))
+        if (filter[2] && (g_strcmp0 (filter[2], "0") != 0))
         {
-            PINFO("Loaded Filter End Date is %s", filter[2]);
+            PINFO ("Loaded Filter End Date is %s", filter[2]);
 
-            priv->fd.end_time = gnc_plugin_page_register_filter_dmy2time (filter[2] );
-            priv->fd.end_time = gnc_time64_get_day_end(priv->fd.end_time);
+            priv->fd.end_time = gnc_plugin_page_register_filter_dmy2time (filter[2]);
+            priv->fd.end_time = gnc_time64_get_day_end (priv->fd.end_time);
             filter_changed = filter_changed + 1;
         }
 
         // set the default for the number of days
         priv->fd.days = (gint)g_ascii_strtoll (
-                                    get_filter_default_num_of_days (ledger_type), NULL, 10);
+                            get_filter_default_num_of_days (ledger_type), NULL, 10);
 
-        if (filter[3] && (g_strcmp0 (filter[3], get_filter_default_num_of_days (ledger_type)) != 0 ))
+        if (filter[3] &&
+            (g_strcmp0 (filter[3], get_filter_default_num_of_days (ledger_type)) != 0))
         {
-            PINFO("Loaded Filter Days is %s", filter[3]);
+            PINFO ("Loaded Filter Days is %s", filter[3]);
 
-            priv->fd.days = (gint)g_ascii_strtoll(filter[3], NULL, 10);
+            priv->fd.days = (gint)g_ascii_strtoll (filter[3], NULL, 10);
             filter_changed = filter_changed + 1;
         }
 
@@ -1339,7 +1434,7 @@ gnc_plugin_page_register_create_widget (GncPluginPage *plugin_page)
             priv->fd.save_filter = TRUE;
 
         priv->fd.original_save_filter = priv->fd.save_filter;
-        g_strfreev(filter);
+        g_strfreev (filter);
     }
 
     if (ledger_type == LD_GL)
@@ -1355,7 +1450,8 @@ gnc_plugin_page_register_create_widget (GncPluginPage *plugin_page)
         {
             priv->fd.days = 0;
             priv->fd.cleared_match = (gint)g_ascii_strtoll (DEFAULT_FILTER, NULL, 16);
-            gnc_split_reg_set_sort_type (priv->gsr, SortTypefromString (DEFAULT_SORT_ORDER));
+            gnc_split_reg_set_sort_type (priv->gsr,
+                                         SortTypefromString (DEFAULT_SORT_ORDER));
             priv->sd.reverse_order = FALSE;
             priv->fd.save_filter = FALSE;
             priv->sd.save_order = FALSE;
@@ -1391,12 +1487,12 @@ gnc_plugin_page_register_create_widget (GncPluginPage *plugin_page)
     // Set filter tooltip for summary bar
     gnc_plugin_page_register_set_filter_tooltip (page);
 
-    plugin_page->summarybar = gsr_create_summary_bar(priv->gsr);
+    plugin_page->summarybar = gsr_create_summary_bar (priv->gsr);
     if (plugin_page->summarybar)
     {
-        gtk_widget_show_all(plugin_page->summarybar);
-        gtk_box_pack_start(GTK_BOX (priv->widget), plugin_page->summarybar,
-                           FALSE, FALSE, 0);
+        gtk_widget_show_all (plugin_page->summarybar);
+        gtk_box_pack_start (GTK_BOX (priv->widget), plugin_page->summarybar,
+                            FALSE, FALSE, 0);
 
         gnc_plugin_page_register_summarybar_position_changed (NULL, NULL, page);
         gnc_prefs_register_cb (GNC_PREFS_GROUP_GENERAL,
@@ -1412,39 +1508,39 @@ gnc_plugin_page_register_create_widget (GncPluginPage *plugin_page)
     priv->event_handler_id = qof_event_register_handler
                              ((QofEventHandler)gnc_plugin_page_register_event_handler, page);
     priv->component_manager_id =
-        gnc_register_gui_component(GNC_PLUGIN_PAGE_REGISTER_NAME,
-                                   gnc_plugin_page_register_refresh_cb,
-                                   gnc_plugin_page_register_close_cb,
-                                   page);
+        gnc_register_gui_component (GNC_PLUGIN_PAGE_REGISTER_NAME,
+                                    gnc_plugin_page_register_refresh_cb,
+                                    gnc_plugin_page_register_close_cb,
+                                    page);
     gnc_gui_component_set_session (priv->component_manager_id,
                                    gnc_get_current_session());
-    acct = gnc_plugin_page_register_get_account(page);
+    acct = gnc_plugin_page_register_get_account (page);
     if (acct)
         gnc_gui_component_watch_entity (
-            priv->component_manager_id, xaccAccountGetGUID(acct),
+            priv->component_manager_id, xaccAccountGetGUID (acct),
             QOF_EVENT_DESTROY | QOF_EVENT_MODIFY);
 
     gnc_split_reg_set_moved_cb
     (priv->gsr, (GFunc)gnc_plugin_page_register_ui_update, page);
 
-    g_signal_connect (G_OBJECT(plugin_page), "inserted",
-                      G_CALLBACK(gnc_plugin_page_inserted_cb),
+    g_signal_connect (G_OBJECT (plugin_page), "inserted",
+                      G_CALLBACK (gnc_plugin_page_inserted_cb),
                       NULL);
 
     /* DRH - Probably lots of other stuff from regWindowLedger should end up here. */
-    LEAVE(" ");
+    LEAVE (" ");
     return priv->widget;
 }
 
 static void
-gnc_plugin_page_register_destroy_widget (GncPluginPage *plugin_page)
+gnc_plugin_page_register_destroy_widget (GncPluginPage* plugin_page)
 {
-    GncPluginPageRegister *page;
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegister* page;
+    GncPluginPageRegisterPrivate* priv;
 
-    ENTER("page %p", plugin_page);
+    ENTER ("page %p", plugin_page);
     page = GNC_PLUGIN_PAGE_REGISTER (plugin_page);
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
 
     gnc_prefs_remove_cb_by_func (GNC_PREFS_GROUP_GENERAL,
                                  GNC_PREF_SUMMARYBAR_POSITION_TOP,
@@ -1456,7 +1552,7 @@ gnc_plugin_page_register_destroy_widget (GncPluginPage *plugin_page)
                                  page);
 
     // Remove the page_changed signal callback
-    gnc_plugin_page_disconnect_page_changed (GNC_PLUGIN_PAGE(plugin_page));
+    gnc_plugin_page_disconnect_page_changed (GNC_PLUGIN_PAGE (plugin_page));
 
     // Remove the page focus idle function if present
     g_idle_remove_by_data (GNC_PLUGIN_PAGE_REGISTER (plugin_page));
@@ -1466,53 +1562,53 @@ gnc_plugin_page_register_destroy_widget (GncPluginPage *plugin_page)
 
     if (priv->component_manager_id)
     {
-        gnc_unregister_gui_component(priv->component_manager_id);
+        gnc_unregister_gui_component (priv->component_manager_id);
         priv->component_manager_id = 0;
     }
 
     if (priv->event_handler_id)
     {
-        qof_event_unregister_handler(priv->event_handler_id);
+        qof_event_unregister_handler (priv->event_handler_id);
         priv->event_handler_id = 0;
     }
 
     if (priv->sd.dialog)
     {
-        gtk_widget_destroy(priv->sd.dialog);
-        memset(&priv->sd, 0, sizeof(priv->sd));
+        gtk_widget_destroy (priv->sd.dialog);
+        memset (&priv->sd, 0, sizeof (priv->sd));
     }
 
     if (priv->fd.dialog)
     {
-        gtk_widget_destroy(priv->fd.dialog);
-        memset(&priv->fd, 0, sizeof(priv->fd));
+        gtk_widget_destroy (priv->fd.dialog);
+        memset (&priv->fd, 0, sizeof (priv->fd));
     }
 
     qof_query_destroy (priv->search_query);
     qof_query_destroy (priv->filter_query);
 
-    gtk_widget_hide(priv->widget);
+    gtk_widget_hide (priv->widget);
     gnc_ledger_display_close (priv->ledger);
     priv->ledger = NULL;
-    LEAVE(" ");
+    LEAVE (" ");
 }
 
 static void
-gnc_plugin_page_register_window_changed (GncPluginPage *plugin_page,
-                                         GtkWidget *window)
+gnc_plugin_page_register_window_changed (GncPluginPage* plugin_page,
+                                         GtkWidget* window)
 {
-    GncPluginPageRegister *page;
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegister* page;
+    GncPluginPageRegisterPrivate* priv;
 
     g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page));
 
-    page = GNC_PLUGIN_PAGE_REGISTER(plugin_page);
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
+    page = GNC_PLUGIN_PAGE_REGISTER (plugin_page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
     priv->gsr->window =
-        GTK_WIDGET(gnc_window_get_gtk_window(GNC_WINDOW(window)));
+        GTK_WIDGET (gnc_window_get_gtk_window (GNC_WINDOW (window)));
 }
 
-static const gchar *style_names[] =
+static const gchar* style_names[] =
 {
     "Ledger",
     "Auto Ledger",
@@ -1546,69 +1642,69 @@ static const gchar *style_names[] =
  *
  *  @param group_name The group name to use when saving data. */
 static void
-gnc_plugin_page_register_save_page (GncPluginPage *plugin_page,
-                                    GKeyFile *key_file,
-                                    const gchar *group_name)
+gnc_plugin_page_register_save_page (GncPluginPage* plugin_page,
+                                    GKeyFile* key_file,
+                                    const gchar* group_name)
 {
-    GncPluginPageRegister *page;
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegister* page;
+    GncPluginPageRegisterPrivate* priv;
     GNCLedgerDisplayType ledger_type;
-    SplitRegister *reg;
-    Account *leader;
+    SplitRegister* reg;
+    Account* leader;
 
-    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER(plugin_page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page));
     g_return_if_fail (key_file != NULL);
     g_return_if_fail (group_name != NULL);
 
-    ENTER("page %p, key_file %p, group_name %s", plugin_page, key_file,
-          group_name);
+    ENTER ("page %p, key_file %p, group_name %s", plugin_page, key_file,
+           group_name);
 
-    page = GNC_PLUGIN_PAGE_REGISTER(plugin_page);
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
+    page = GNC_PLUGIN_PAGE_REGISTER (plugin_page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
 
-    reg = gnc_ledger_display_get_split_register(priv->ledger);
-    ledger_type = gnc_ledger_display_type(priv->ledger);
+    reg = gnc_ledger_display_get_split_register (priv->ledger);
+    ledger_type = gnc_ledger_display_type (priv->ledger);
     if (ledger_type > LD_GL)
     {
-        LEAVE("Unsupported ledger type");
+        LEAVE ("Unsupported ledger type");
         return;
     }
     if ((ledger_type == LD_SINGLE) || (ledger_type == LD_SUBACCOUNT))
     {
-        const gchar *label;
+        const gchar* label;
         gchar* name;
         gchar acct_guid[GUID_ENCODING_LENGTH + 1];
         label = (ledger_type == LD_SINGLE) ? LABEL_ACCOUNT : LABEL_SUBACCOUNT;
-        leader = gnc_ledger_display_leader(priv->ledger);
-        g_key_file_set_string(key_file, group_name, KEY_REGISTER_TYPE, label);
-        name = gnc_account_get_full_name(leader);
-        g_key_file_set_string(key_file, group_name, KEY_ACCOUNT_NAME, name);
-        g_free(name);
+        leader = gnc_ledger_display_leader (priv->ledger);
+        g_key_file_set_string (key_file, group_name, KEY_REGISTER_TYPE, label);
+        name = gnc_account_get_full_name (leader);
+        g_key_file_set_string (key_file, group_name, KEY_ACCOUNT_NAME, name);
+        g_free (name);
         guid_to_string_buff (xaccAccountGetGUID (leader), acct_guid);
-        g_key_file_set_string(key_file, group_name, KEY_ACCOUNT_GUID, acct_guid);
+        g_key_file_set_string (key_file, group_name, KEY_ACCOUNT_GUID, acct_guid);
     }
     else if (reg->type == GENERAL_JOURNAL)
     {
-        g_key_file_set_string(key_file, group_name, KEY_REGISTER_TYPE,
-                              LABEL_GL);
+        g_key_file_set_string (key_file, group_name, KEY_REGISTER_TYPE,
+                               LABEL_GL);
     }
     else if (reg->type == SEARCH_LEDGER)
     {
-        g_key_file_set_string(key_file, group_name, KEY_REGISTER_TYPE,
-                              LABEL_SEARCH);
+        g_key_file_set_string (key_file, group_name, KEY_REGISTER_TYPE,
+                               LABEL_SEARCH);
     }
     else
     {
-        LEAVE("Unsupported register type");
+        LEAVE ("Unsupported register type");
         return;
     }
 
-    g_key_file_set_string(key_file, group_name, KEY_REGISTER_STYLE,
-                          style_names[reg->style]);
-    g_key_file_set_boolean(key_file, group_name, KEY_DOUBLE_LINE,
-                           reg->use_double_line);
+    g_key_file_set_string (key_file, group_name, KEY_REGISTER_STYLE,
+                           style_names[reg->style]);
+    g_key_file_set_boolean (key_file, group_name, KEY_DOUBLE_LINE,
+                            reg->use_double_line);
 
-    LEAVE(" ");
+    LEAVE (" ");
 }
 
 
@@ -1625,47 +1721,47 @@ gnc_plugin_page_register_save_page (GncPluginPage *plugin_page,
  *
  *  @param group_name The group name to use when restoring data. */
 static void
-gnc_plugin_page_register_restore_edit_menu (GncPluginPage *page,
-        GKeyFile *key_file,
-        const gchar *group_name)
+gnc_plugin_page_register_restore_edit_menu (GncPluginPage* page,
+                                            GKeyFile* key_file,
+                                            const gchar* group_name)
 {
-    GtkAction *action;
-    GError *error = NULL;
-    gchar *style_name;
+    GtkAction* action;
+    GError* error = NULL;
+    gchar* style_name;
     gint i;
     gboolean use_double_line;
 
-    ENTER(" ");
+    ENTER (" ");
 
     /* Convert the style name to an index */
-    style_name = g_key_file_get_string(key_file, group_name,
-                                       KEY_REGISTER_STYLE, &error);
+    style_name = g_key_file_get_string (key_file, group_name,
+                                        KEY_REGISTER_STYLE, &error);
     for (i = 0 ; style_names[i]; i++)
     {
-        if (g_ascii_strcasecmp(style_name, style_names[i]) == 0)
+        if (g_ascii_strcasecmp (style_name, style_names[i]) == 0)
         {
-            DEBUG("Found match for style name: %s", style_name);
+            DEBUG ("Found match for style name: %s", style_name);
             break;
         }
     }
-    g_free(style_name);
+    g_free (style_name);
 
     /* Update the style menu action for this page */
     if (i <= REG_STYLE_JOURNAL)
     {
-        DEBUG("Setting style: %d", i);
-        action = gnc_plugin_page_get_action(page, radio_entries_2[i].name);
-        gtk_toggle_action_set_active(GTK_TOGGLE_ACTION(action), TRUE);
+        DEBUG ("Setting style: %d", i);
+        action = gnc_plugin_page_get_action (page, radio_entries_2[i].name);
+        gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action), TRUE);
     }
 
     /* Update the  double line action on this page */
     use_double_line =
-        g_key_file_get_boolean(key_file, group_name, KEY_DOUBLE_LINE, &error);
-    DEBUG("Setting double_line_mode: %d", use_double_line);
-    action = gnc_plugin_page_get_action(page, "ViewStyleDoubleLineAction");
-    gtk_toggle_action_set_active(GTK_TOGGLE_ACTION(action), use_double_line);
+        g_key_file_get_boolean (key_file, group_name, KEY_DOUBLE_LINE, &error);
+    DEBUG ("Setting double_line_mode: %d", use_double_line);
+    action = gnc_plugin_page_get_action (page, "ViewStyleDoubleLineAction");
+    gtk_toggle_action_set_active (GTK_TOGGLE_ACTION (action), use_double_line);
 
-    LEAVE(" ");
+    LEAVE (" ");
 }
 
 
@@ -1678,87 +1774,87 @@ gnc_plugin_page_register_restore_edit_menu (GncPluginPage *page,
  *  page information should be read.
  *
  *  @param group_name The group name to use when restoring data. */
-static GncPluginPage *
-gnc_plugin_page_register_recreate_page (GtkWidget *window,
-                                        GKeyFile *key_file,
-                                        const gchar *group_name)
+static GncPluginPage*
+gnc_plugin_page_register_recreate_page (GtkWidget* window,
+                                        GKeyFile* key_file,
+                                        const gchar* group_name)
 {
-    GncPluginPageRegisterPrivate *priv;
-    GncPluginPage *page;
-    GError *error = NULL;
-    gchar *reg_type, *acct_guid;
+    GncPluginPageRegisterPrivate* priv;
+    GncPluginPage* page;
+    GError* error = NULL;
+    gchar* reg_type, *acct_guid;
     GncGUID guid;
-    Account *account = NULL;
-    QofBook *book;
+    Account* account = NULL;
+    QofBook* book;
     gboolean include_subs;
 
-    g_return_val_if_fail(key_file, NULL);
-    g_return_val_if_fail(group_name, NULL);
-    ENTER("key_file %p, group_name %s", key_file, group_name);
+    g_return_val_if_fail (key_file, NULL);
+    g_return_val_if_fail (group_name, NULL);
+    ENTER ("key_file %p, group_name %s", key_file, group_name);
 
     /* Create the new page. */
-    reg_type = g_key_file_get_string(key_file, group_name,
-                                     KEY_REGISTER_TYPE, &error);
-    DEBUG("Page type: %s", reg_type);
-    if ((g_ascii_strcasecmp(reg_type, LABEL_ACCOUNT) == 0) ||
-            (g_ascii_strcasecmp(reg_type, LABEL_SUBACCOUNT) == 0))
+    reg_type = g_key_file_get_string (key_file, group_name,
+                                      KEY_REGISTER_TYPE, &error);
+    DEBUG ("Page type: %s", reg_type);
+    if ((g_ascii_strcasecmp (reg_type, LABEL_ACCOUNT) == 0) ||
+        (g_ascii_strcasecmp (reg_type, LABEL_SUBACCOUNT) == 0))
     {
-        include_subs = (g_ascii_strcasecmp(reg_type, LABEL_SUBACCOUNT) == 0);
-        DEBUG("Include subs: %d", include_subs);
-        book = qof_session_get_book(gnc_get_current_session());
-        acct_guid = g_key_file_get_string(key_file, group_name,
-                                          KEY_ACCOUNT_GUID, &error);
+        include_subs = (g_ascii_strcasecmp (reg_type, LABEL_SUBACCOUNT) == 0);
+        DEBUG ("Include subs: %d", include_subs);
+        book = qof_session_get_book (gnc_get_current_session());
+        acct_guid = g_key_file_get_string (key_file, group_name,
+                                           KEY_ACCOUNT_GUID, &error);
         if (string_to_guid (acct_guid, &guid)) //find account by guid
         {
             account = xaccAccountLookup (&guid, book);
-            g_free(acct_guid);
+            g_free (acct_guid);
         }
         if (account == NULL) //find account by full name
         {
-            gchar *acct_name = g_key_file_get_string(key_file, group_name,
-                                              KEY_ACCOUNT_NAME, &error);
-            account = gnc_account_lookup_by_full_name(gnc_book_get_root_account(book),
-                      acct_name);
-            g_free(acct_name);
+            gchar* acct_name = g_key_file_get_string (key_file, group_name,
+                                                      KEY_ACCOUNT_NAME, &error);
+            account = gnc_account_lookup_by_full_name (gnc_book_get_root_account (book),
+                                                       acct_name);
+            g_free (acct_name);
         }
         if (account == NULL)
         {
-            LEAVE("Bad account name");
-            g_free(reg_type);
+            LEAVE ("Bad account name");
+            g_free (reg_type);
             return NULL;
         }
         page = gnc_plugin_page_register_new (account, include_subs);
     }
-    else if (g_ascii_strcasecmp(reg_type, LABEL_GL) == 0)
+    else if (g_ascii_strcasecmp (reg_type, LABEL_GL) == 0)
     {
         page = gnc_plugin_page_register_new_gl();
     }
     else
     {
-        LEAVE("Bad ledger type");
-        g_free(reg_type);
+        LEAVE ("Bad ledger type");
+        g_free (reg_type);
         return NULL;
     }
-    g_free(reg_type);
+    g_free (reg_type);
 
     /* disable the refresh of the display ledger, this is for
      * sort/filter updates and double line/style changes */
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
     priv->enable_refresh = FALSE;
 
     /* Recreate page in given window */
-    gnc_plugin_page_set_use_new_window(page, FALSE);
+    gnc_plugin_page_set_use_new_window (page, FALSE);
 
     /* Install it now so we can them manipulate the created widget */
-    gnc_main_window_open_page(GNC_MAIN_WINDOW(window), page);
+    gnc_main_window_open_page (GNC_MAIN_WINDOW (window), page);
 
     /* Now update the page to the last state it was in */
-    gnc_plugin_page_register_restore_edit_menu(page, key_file, group_name);
+    gnc_plugin_page_register_restore_edit_menu (page, key_file, group_name);
 
     /* enable the refresh */
     priv->enable_refresh = TRUE;
     gnc_ledger_display_refresh (priv->ledger);
-    LEAVE(" ");
+    LEAVE (" ");
     return page;
 }
 
@@ -1767,17 +1863,17 @@ gnc_plugin_page_register_recreate_page (GtkWidget *window,
  * Based on code from Epiphany (src/ephy-window.c)
  */
 static void
-gnc_plugin_page_register_update_edit_menu (GncPluginPage *page, gboolean hide)
+gnc_plugin_page_register_update_edit_menu (GncPluginPage* page, gboolean hide)
 {
-    GncPluginPageRegisterPrivate *priv;
-    GncPluginPageRegister *reg_page;
-    GtkAction *action;
+    GncPluginPageRegisterPrivate* priv;
+    GncPluginPageRegister* reg_page;
+    GtkAction* action;
     gboolean can_copy = FALSE, can_cut = FALSE, can_paste = FALSE;
     gboolean has_selection;
-    gboolean is_readwrite = !qof_book_is_readonly(gnc_get_current_book());
+    gboolean is_readwrite = !qof_book_is_readonly (gnc_get_current_book());
 
-    reg_page = GNC_PLUGIN_PAGE_REGISTER(page);
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(reg_page);
+    reg_page = GNC_PLUGIN_PAGE_REGISTER (page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (reg_page);
     has_selection = gnucash_register_has_selection (priv->gsr->reg);
 
     can_copy = has_selection;
@@ -1797,55 +1893,55 @@ gnc_plugin_page_register_update_edit_menu (GncPluginPage *page, gboolean hide)
 
 
 static gboolean
-gnc_plugin_page_register_finish_pending (GncPluginPage *page)
+gnc_plugin_page_register_finish_pending (GncPluginPage* page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    GncPluginPageRegister *reg_page;
-    SplitRegister *reg;
-    GtkWidget *dialog, *window;
-    const gchar *name;
+    GncPluginPageRegisterPrivate* priv;
+    GncPluginPageRegister* reg_page;
+    SplitRegister* reg;
+    GtkWidget* dialog, *window;
+    const gchar* name;
     gint response;
 
-    reg_page = GNC_PLUGIN_PAGE_REGISTER(page);
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(reg_page);
-    reg = gnc_ledger_display_get_split_register(priv->ledger);
+    reg_page = GNC_PLUGIN_PAGE_REGISTER (page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (reg_page);
+    reg = gnc_ledger_display_get_split_register (priv->ledger);
 
-    if (!reg || !gnc_split_register_changed(reg))
+    if (!reg || !gnc_split_register_changed (reg))
         return TRUE;
 
-    name = gnc_plugin_page_register_get_tab_name(page);
+    name = gnc_plugin_page_register_get_tab_name (page);
     window = gnc_plugin_page_get_window (page);
-    dialog = gtk_message_dialog_new(GTK_WINDOW(window),
-                                    GTK_DIALOG_DESTROY_WITH_PARENT,
-                                    GTK_MESSAGE_WARNING,
-                                    GTK_BUTTONS_NONE,
-                                    /* Translators: %s is the name
-                                       of the tab page */
-                                    _("Save changes to %s?"), name);
+    dialog = gtk_message_dialog_new (GTK_WINDOW (window),
+                                     GTK_DIALOG_DESTROY_WITH_PARENT,
+                                     GTK_MESSAGE_WARNING,
+                                     GTK_BUTTONS_NONE,
+                                     /* Translators: %s is the name
+                                        of the tab page */
+                                     _ ("Save changes to %s?"), name);
     gtk_message_dialog_format_secondary_text
-    (GTK_MESSAGE_DIALOG(dialog),
+    (GTK_MESSAGE_DIALOG (dialog),
      "%s",
-     _("This register has pending changes to a transaction. "
-       "Would you like to save the changes to this transaction, "
-       "discard the transaction, or cancel the operation?"));
-    gnc_gtk_dialog_add_button(dialog, _("_Discard Transaction"),
-                              "edit-delete", GTK_RESPONSE_REJECT);
-    gtk_dialog_add_button(GTK_DIALOG(dialog),
-                          _("_Cancel"), GTK_RESPONSE_CANCEL);
-    gnc_gtk_dialog_add_button(dialog, _("_Save Transaction"),
-                              "document-save", GTK_RESPONSE_ACCEPT);
+     _ ("This register has pending changes to a transaction. "
+        "Would you like to save the changes to this transaction, "
+        "discard the transaction, or cancel the operation?"));
+    gnc_gtk_dialog_add_button (dialog, _ ("_Discard Transaction"),
+                               "edit-delete", GTK_RESPONSE_REJECT);
+    gtk_dialog_add_button (GTK_DIALOG (dialog),
+                           _ ("_Cancel"), GTK_RESPONSE_CANCEL);
+    gnc_gtk_dialog_add_button (dialog, _ ("_Save Transaction"),
+                               "document-save", GTK_RESPONSE_ACCEPT);
 
-    response = gtk_dialog_run(GTK_DIALOG(dialog));
-    gtk_widget_destroy(dialog);
+    response = gtk_dialog_run (GTK_DIALOG (dialog));
+    gtk_widget_destroy (dialog);
 
     switch (response)
     {
     case GTK_RESPONSE_ACCEPT:
-        gnc_split_register_save(reg, TRUE);
+        gnc_split_register_save (reg, TRUE);
         return TRUE;
 
     case GTK_RESPONSE_REJECT:
-        gnc_split_register_cancel_cursor_trans_changes(reg);
+        gnc_split_register_cancel_cursor_trans_changes (reg);
         gnc_split_register_save (reg, TRUE);
         return TRUE;
 
@@ -1855,18 +1951,19 @@ gnc_plugin_page_register_finish_pending (GncPluginPage *page)
 }
 
 
-static gchar *
-gnc_plugin_page_register_get_tab_name (GncPluginPage *plugin_page)
+static gchar*
+gnc_plugin_page_register_get_tab_name (GncPluginPage* plugin_page)
 {
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegisterPrivate* priv;
     GNCLedgerDisplayType ledger_type;
-    GNCLedgerDisplay *ld;
-    SplitRegister *reg;
-    Account *leader;
+    GNCLedgerDisplay* ld;
+    SplitRegister* reg;
+    Account* leader;
 
-    g_return_val_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page), _("unknown"));
+    g_return_val_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page),
+                          _ ("unknown"));
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
     ld = priv->ledger;
     reg = gnc_ledger_display_get_split_register (ld);
     ledger_type = gnc_ledger_display_type (ld);
@@ -1875,21 +1972,21 @@ gnc_plugin_page_register_get_tab_name (GncPluginPage *plugin_page)
     switch (ledger_type)
     {
     case LD_SINGLE:
-        return g_strdup(xaccAccountGetName (leader));
+        return g_strdup (xaccAccountGetName (leader));
 
     case LD_SUBACCOUNT:
-        return g_strdup_printf("%s+", xaccAccountGetName (leader));
+        return g_strdup_printf ("%s+", xaccAccountGetName (leader));
 
     case LD_GL:
         switch (reg->type)
         {
         case GENERAL_JOURNAL:
         case INCOME_LEDGER:
-            return g_strdup(_("General Journal"));
+            return g_strdup (_ ("General Journal"));
         case PORTFOLIO_LEDGER:
-            return g_strdup(_("Portfolio"));
+            return g_strdup (_ ("Portfolio"));
         case SEARCH_LEDGER:
-            return g_strdup(_("Search Results"));
+            return g_strdup (_ ("Search Results"));
         default:
             break;
         }
@@ -1899,21 +1996,22 @@ gnc_plugin_page_register_get_tab_name (GncPluginPage *plugin_page)
         break;
     }
 
-    return g_strdup(_("unknown"));
+    return g_strdup (_ ("unknown"));
 }
 
-static gchar *
-gnc_plugin_page_register_get_tab_color (GncPluginPage *plugin_page)
+static gchar*
+gnc_plugin_page_register_get_tab_color (GncPluginPage* plugin_page)
 {
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegisterPrivate* priv;
     GNCLedgerDisplayType ledger_type;
-    GNCLedgerDisplay *ld;
-    Account *leader;
+    GNCLedgerDisplay* ld;
+    Account* leader;
     const char* color;
 
-    g_return_val_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page), _("unknown"));
+    g_return_val_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page),
+                          _ ("unknown"));
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
     ld = priv->ledger;
     ledger_type = gnc_ledger_display_type (ld);
     leader = gnc_ledger_display_leader (ld);
@@ -1922,23 +2020,24 @@ gnc_plugin_page_register_get_tab_color (GncPluginPage *plugin_page)
     if ((ledger_type == LD_SINGLE) || (ledger_type == LD_SUBACCOUNT))
         color = xaccAccountGetColor (leader);
 
-    return g_strdup(color ? color : "Not Set");
+    return g_strdup (color ? color : "Not Set");
 }
 
-static const gchar *
-gnc_plugin_page_register_get_filter_gcm (Account *leader)
+static const gchar*
+gnc_plugin_page_register_get_filter_gcm (Account* leader)
 {
-    GKeyFile *state_file = gnc_state_get_current();
-    gchar *state_section;
-    gchar *filter_text;
+    GKeyFile* state_file = gnc_state_get_current();
+    gchar* state_section;
+    gchar* filter_text;
     gchar acct_guid[GUID_ENCODING_LENGTH + 1];
-    GError *error = NULL;
+    GError* error = NULL;
     const char* filter = NULL;
 
     // get the filter from the .gcm file
     guid_to_string_buff (xaccAccountGetGUID (leader), acct_guid);
     state_section = g_strconcat (STATE_SECTION_REG_PREFIX, " ", acct_guid, NULL);
-    filter_text = g_key_file_get_string (state_file, state_section, KEY_PAGE_FILTER, &error);
+    filter_text = g_key_file_get_string (state_file, state_section,
+                                         KEY_PAGE_FILTER, &error);
 
     if (error)
         g_clear_error (&error);
@@ -1952,25 +2051,26 @@ gnc_plugin_page_register_get_filter_gcm (Account *leader)
     return filter;
 }
 
-static gchar *
-gnc_plugin_page_register_get_filter (GncPluginPage *plugin_page)
+static gchar*
+gnc_plugin_page_register_get_filter (GncPluginPage* plugin_page)
 {
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegisterPrivate* priv;
     GNCLedgerDisplayType ledger_type;
-    GNCLedgerDisplay *ld;
-    Account *leader;
+    GNCLedgerDisplay* ld;
+    Account* leader;
     const char* filter = NULL;
 
-    g_return_val_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page), _("unknown"));
+    g_return_val_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page),
+                          _ ("unknown"));
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
     ld = priv->ledger;
     ledger_type = gnc_ledger_display_type (ld);
     leader = gnc_ledger_display_leader (ld);
 
     // load from gcm file for LD_GL or when feature is set
     if (ledger_type == LD_GL ||
-        gnc_features_check_used (gnc_get_current_book (), GNC_FEATURE_REG_SORT_FILTER))
+        gnc_features_check_used (gnc_get_current_book(), GNC_FEATURE_REG_SORT_FILTER))
         filter = gnc_plugin_page_register_get_filter_gcm (leader);
     else // load from kvp
     {
@@ -1978,16 +2078,18 @@ gnc_plugin_page_register_get_filter (GncPluginPage *plugin_page)
             filter = xaccAccountGetFilter (leader);
     }
 
-    return filter ? g_strdup(filter) : g_strdup_printf("%s,%s,%s,%s", DEFAULT_FILTER,
-                                       "0", "0", get_filter_default_num_of_days (ledger_type));
+    return filter ? g_strdup (filter) : g_strdup_printf ("%s,%s,%s,%s",
+                                                         DEFAULT_FILTER,
+                                                         "0", "0", get_filter_default_num_of_days (ledger_type));
 }
 
 static void
-gnc_plugin_page_register_set_filter_gcm (Account *leader, const gchar *filter, gchar *default_filter)
+gnc_plugin_page_register_set_filter_gcm (Account* leader, const gchar* filter,
+                                         gchar* default_filter)
 {
-    GKeyFile *state_file = gnc_state_get_current();
-    gchar *state_section;
-    gchar *filter_text;
+    GKeyFile* state_file = gnc_state_get_current();
+    gchar* state_section;
+    gchar* filter_text;
     gchar acct_guid[GUID_ENCODING_LENGTH + 1];
 
     // save the filter to the .gcm file also
@@ -2001,33 +2103,36 @@ gnc_plugin_page_register_set_filter_gcm (Account *leader, const gchar *filter, g
     else
     {
         filter_text = g_strdup (filter);
-        filter_text = g_strdelimit (filter_text, ",", ';'); // make it conform to .gcm file list
-        g_key_file_set_string (state_file, state_section, KEY_PAGE_FILTER, filter_text);
+        filter_text = g_strdelimit (filter_text, ",",
+                                    ';'); // make it conform to .gcm file list
+        g_key_file_set_string (state_file, state_section, KEY_PAGE_FILTER,
+                               filter_text);
         g_free (filter_text);
     }
     g_free (state_section);
 }
 
 void
-gnc_plugin_page_register_set_filter (GncPluginPage *plugin_page, const gchar *filter )
+gnc_plugin_page_register_set_filter (GncPluginPage* plugin_page,
+                                     const gchar* filter)
 {
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegisterPrivate* priv;
     GNCLedgerDisplayType ledger_type;
-    GNCLedgerDisplay *ld;
-    Account *leader;
-    gchar *default_filter;
+    GNCLedgerDisplay* ld;
+    Account* leader;
+    gchar* default_filter;
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
     ld = priv->ledger;
     ledger_type = gnc_ledger_display_type (ld);
     leader = gnc_ledger_display_leader (ld);
 
-    default_filter = g_strdup_printf("%s,%s,%s,%s", DEFAULT_FILTER,
+    default_filter = g_strdup_printf ("%s,%s,%s,%s", DEFAULT_FILTER,
                                       "0", "0", get_filter_default_num_of_days (ledger_type));
 
     // save to gcm file for LD_GL or when feature is set
     if (ledger_type == LD_GL ||
-        gnc_features_check_used (gnc_get_current_book (), GNC_FEATURE_REG_SORT_FILTER))
+        gnc_features_check_used (gnc_get_current_book(), GNC_FEATURE_REG_SORT_FILTER))
         gnc_plugin_page_register_set_filter_gcm (leader, filter, default_filter);
     else // save to kvp
     {
@@ -2043,20 +2148,21 @@ gnc_plugin_page_register_set_filter (GncPluginPage *plugin_page, const gchar *fi
     return;
 }
 
-static const gchar *
-gnc_plugin_page_register_get_sort_order_gcm (Account *leader)
+static const gchar*
+gnc_plugin_page_register_get_sort_order_gcm (Account* leader)
 {
-    GKeyFile *state_file = gnc_state_get_current();
-    gchar *state_section;
-    gchar *sort_text;
+    GKeyFile* state_file = gnc_state_get_current();
+    gchar* state_section;
+    gchar* sort_text;
     gchar acct_guid[GUID_ENCODING_LENGTH + 1];
-    GError *error = NULL;
+    GError* error = NULL;
     const char* sort_order = NULL;
 
     // get the sort_order from the .gcm file
     guid_to_string_buff (xaccAccountGetGUID (leader), acct_guid);
     state_section = g_strconcat (STATE_SECTION_REG_PREFIX, " ", acct_guid, NULL);
-    sort_text = g_key_file_get_string (state_file, state_section, KEY_PAGE_SORT, &error);
+    sort_text = g_key_file_get_string (state_file, state_section, KEY_PAGE_SORT,
+                                       &error);
 
     if (error)
         g_clear_error (&error);
@@ -2069,39 +2175,41 @@ gnc_plugin_page_register_get_sort_order_gcm (Account *leader)
     return sort_order;
 }
 
-static gchar *
-gnc_plugin_page_register_get_sort_order (GncPluginPage *plugin_page)
+static gchar*
+gnc_plugin_page_register_get_sort_order (GncPluginPage* plugin_page)
 {
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegisterPrivate* priv;
     GNCLedgerDisplayType ledger_type;
-    GNCLedgerDisplay *ld;
-    Account *leader;
+    GNCLedgerDisplay* ld;
+    Account* leader;
     const char* sort_order = NULL;
 
-    g_return_val_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page), _("unknown"));
+    g_return_val_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page),
+                          _ ("unknown"));
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
     ld = priv->ledger;
     ledger_type = gnc_ledger_display_type (ld);
     leader = gnc_ledger_display_leader (ld);
 
     // load from gcm file for LD_GL or when feature is set
     if (ledger_type == LD_GL ||
-        gnc_features_check_used (gnc_get_current_book (), GNC_FEATURE_REG_SORT_FILTER))
+        gnc_features_check_used (gnc_get_current_book(), GNC_FEATURE_REG_SORT_FILTER))
         sort_order = gnc_plugin_page_register_get_sort_order_gcm (leader);
     else // load from kvp
     {
         if ((ledger_type == LD_SINGLE) || (ledger_type == LD_SUBACCOUNT))
             sort_order = xaccAccountGetSortOrder (leader);
     }
-    return g_strdup(sort_order ? sort_order : DEFAULT_SORT_ORDER);
+    return g_strdup (sort_order ? sort_order : DEFAULT_SORT_ORDER);
 }
 
 static void
-gnc_plugin_page_register_set_sort_order_gcm (Account *leader, const gchar *sort_order )
+gnc_plugin_page_register_set_sort_order_gcm (Account* leader,
+                                             const gchar* sort_order)
 {
-    GKeyFile *state_file = gnc_state_get_current();
-    gchar *state_section;
+    GKeyFile* state_file = gnc_state_get_current();
+    gchar* state_section;
     gchar acct_guid[GUID_ENCODING_LENGTH + 1];
 
     // save sort_order to the .gcm file also
@@ -2118,21 +2226,22 @@ gnc_plugin_page_register_set_sort_order_gcm (Account *leader, const gchar *sort_
     g_free (state_section);
 }
 void
-gnc_plugin_page_register_set_sort_order (GncPluginPage *plugin_page, const gchar *sort_order )
+gnc_plugin_page_register_set_sort_order (GncPluginPage* plugin_page,
+                                         const gchar* sort_order)
 {
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegisterPrivate* priv;
     GNCLedgerDisplayType ledger_type;
-    GNCLedgerDisplay *ld;
-    Account *leader;
+    GNCLedgerDisplay* ld;
+    Account* leader;
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
     ld = priv->ledger;
     ledger_type = gnc_ledger_display_type (ld);
     leader = gnc_ledger_display_leader (ld);
 
     // save to gcm file for LD_GL or when feature is set
     if (ledger_type == LD_GL ||
-        gnc_features_check_used (gnc_get_current_book (), GNC_FEATURE_REG_SORT_FILTER))
+        gnc_features_check_used (gnc_get_current_book(), GNC_FEATURE_REG_SORT_FILTER))
         gnc_plugin_page_register_set_sort_order_gcm (leader, sort_order);
     else // save to kvp
     {
@@ -2148,18 +2257,19 @@ gnc_plugin_page_register_set_sort_order (GncPluginPage *plugin_page, const gchar
 }
 
 static gboolean
-gnc_plugin_page_register_get_sort_reversed_gcm (Account *leader)
+gnc_plugin_page_register_get_sort_reversed_gcm (Account* leader)
 {
-    GKeyFile *state_file = gnc_state_get_current();
-    gchar *state_section;
+    GKeyFile* state_file = gnc_state_get_current();
+    gchar* state_section;
     gchar acct_guid[GUID_ENCODING_LENGTH + 1];
-    GError *error = NULL;
+    GError* error = NULL;
     gboolean sort_reversed = FALSE;
 
     // get the sort_reversed from the .gcm file
     guid_to_string_buff (xaccAccountGetGUID (leader), acct_guid);
     state_section = g_strconcat (STATE_SECTION_REG_PREFIX, " ", acct_guid, NULL);
-    sort_reversed = g_key_file_get_boolean (state_file, state_section, KEY_PAGE_SORT_REV, &error);
+    sort_reversed = g_key_file_get_boolean (state_file, state_section,
+                                            KEY_PAGE_SORT_REV, &error);
 
     if (error)
         g_clear_error (&error);
@@ -2169,24 +2279,24 @@ gnc_plugin_page_register_get_sort_reversed_gcm (Account *leader)
 }
 
 static gboolean
-gnc_plugin_page_register_get_sort_reversed (GncPluginPage *plugin_page)
+gnc_plugin_page_register_get_sort_reversed (GncPluginPage* plugin_page)
 {
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegisterPrivate* priv;
     GNCLedgerDisplayType ledger_type;
-    GNCLedgerDisplay *ld;
-    Account *leader;
+    GNCLedgerDisplay* ld;
+    Account* leader;
     gboolean sort_reversed = FALSE;
 
     g_return_val_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page), FALSE);
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
     ld = priv->ledger;
     ledger_type = gnc_ledger_display_type (ld);
     leader = gnc_ledger_display_leader (ld);
 
     // load from gcm file for LD_GL or when feature is set
     if (ledger_type == LD_GL ||
-        gnc_features_check_used (gnc_get_current_book (), GNC_FEATURE_REG_SORT_FILTER))
+        gnc_features_check_used (gnc_get_current_book(), GNC_FEATURE_REG_SORT_FILTER))
         sort_reversed = gnc_plugin_page_register_get_sort_reversed_gcm (leader);
     else // load from kvp
     {
@@ -2197,10 +2307,11 @@ gnc_plugin_page_register_get_sort_reversed (GncPluginPage *plugin_page)
 }
 
 static void
-gnc_plugin_page_register_set_sort_reversed_gcm (Account *leader, gboolean reverse_order)
+gnc_plugin_page_register_set_sort_reversed_gcm (Account* leader,
+                                                gboolean reverse_order)
 {
-    GKeyFile *state_file = gnc_state_get_current();
-    gchar *state_section;
+    GKeyFile* state_file = gnc_state_get_current();
+    gchar* state_section;
     gchar acct_guid[GUID_ENCODING_LENGTH + 1];
 
     // save reverse_order to the .gcm file also
@@ -2212,27 +2323,29 @@ gnc_plugin_page_register_set_sort_reversed_gcm (Account *leader, gboolean revers
             g_key_file_remove_key (state_file, state_section, KEY_PAGE_SORT_REV, NULL);
     }
     else
-        g_key_file_set_boolean (state_file, state_section, KEY_PAGE_SORT_REV, reverse_order);
+        g_key_file_set_boolean (state_file, state_section, KEY_PAGE_SORT_REV,
+                                reverse_order);
 
     g_free (state_section);
 }
 
 void
-gnc_plugin_page_register_set_sort_reversed (GncPluginPage *plugin_page, gboolean reverse_order)
+gnc_plugin_page_register_set_sort_reversed (GncPluginPage* plugin_page,
+                                            gboolean reverse_order)
 {
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegisterPrivate* priv;
     GNCLedgerDisplayType ledger_type;
-    GNCLedgerDisplay *ld;
-    Account *leader;
+    GNCLedgerDisplay* ld;
+    Account* leader;
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
     ld = priv->ledger;
     ledger_type = gnc_ledger_display_type (ld);
     leader = gnc_ledger_display_leader (ld);
 
     // save to gcm file for LD_GL or when feature is set
     if (ledger_type == LD_GL ||
-        gnc_features_check_used (gnc_get_current_book (), GNC_FEATURE_REG_SORT_FILTER))
+        gnc_features_check_used (gnc_get_current_book(), GNC_FEATURE_REG_SORT_FILTER))
         gnc_plugin_page_register_set_sort_reversed_gcm (leader, reverse_order);
     else // save to kvp
     {
@@ -2242,17 +2355,18 @@ gnc_plugin_page_register_set_sort_reversed (GncPluginPage *plugin_page, gboolean
     return;
 }
 
-static gchar *
-gnc_plugin_page_register_get_long_name (GncPluginPage *plugin_page)
+static gchar*
+gnc_plugin_page_register_get_long_name (GncPluginPage* plugin_page)
 {
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegisterPrivate* priv;
     GNCLedgerDisplayType ledger_type;
-    GNCLedgerDisplay *ld;
-    Account *leader;
+    GNCLedgerDisplay* ld;
+    Account* leader;
 
-    g_return_val_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page), _("unknown"));
+    g_return_val_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page),
+                          _ ("unknown"));
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
     ld = priv->ledger;
     ledger_type = gnc_ledger_display_type (ld);
     leader = gnc_ledger_display_leader (ld);
@@ -2264,9 +2378,9 @@ gnc_plugin_page_register_get_long_name (GncPluginPage *plugin_page)
 
     case LD_SUBACCOUNT:
     {
-        gchar *account_full_name = gnc_account_get_full_name (leader);
-        gchar *return_string = g_strdup_printf("%s+", account_full_name);
-        g_free ((gpointer *) account_full_name);
+        gchar* account_full_name = gnc_account_get_full_name (leader);
+        gchar* return_string = g_strdup_printf ("%s+", account_full_name);
+        g_free ((gpointer*) account_full_name);
         return return_string;
     }
 
@@ -2278,11 +2392,12 @@ gnc_plugin_page_register_get_long_name (GncPluginPage *plugin_page)
 }
 
 static void
-gnc_plugin_page_register_summarybar_position_changed (gpointer prefs, gchar* pref, gpointer user_data)
+gnc_plugin_page_register_summarybar_position_changed (gpointer prefs,
+                                                      gchar* pref, gpointer user_data)
 {
-    GncPluginPage *plugin_page;
-    GncPluginPageRegister *page;
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPage* plugin_page;
+    GncPluginPageRegister* page;
+    GncPluginPageRegisterPrivate* priv;
     GtkPositionType position = GTK_POS_BOTTOM;
 
     g_return_if_fail (user_data != NULL);
@@ -2295,14 +2410,15 @@ gnc_plugin_page_register_summarybar_position_changed (gpointer prefs, gchar* pre
     priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
 
     if (priv == NULL)
-       return;
+        return;
 
-    if (gnc_prefs_get_bool (GNC_PREFS_GROUP_GENERAL, GNC_PREF_SUMMARYBAR_POSITION_TOP))
+    if (gnc_prefs_get_bool (GNC_PREFS_GROUP_GENERAL,
+                            GNC_PREF_SUMMARYBAR_POSITION_TOP))
         position = GTK_POS_TOP;
 
     gtk_box_reorder_child (GTK_BOX (priv->widget),
-                          plugin_page->summarybar,
-                          (position == GTK_POS_TOP ? 0 : -1) );
+                           plugin_page->summarybar,
+                           (position == GTK_POS_TOP ? 0 : -1));
 }
 
 /** This function is called to get the query associated with this
@@ -2310,16 +2426,16 @@ gnc_plugin_page_register_summarybar_position_changed (gpointer prefs, gchar* pre
  *
  *  @param page A pointer to the GncPluginPage.
  */
-Query *
-gnc_plugin_page_register_get_query (GncPluginPage *plugin_page)
+Query*
+gnc_plugin_page_register_get_query (GncPluginPage* plugin_page)
 {
-    GncPluginPageRegister *page;
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegister* page;
+    GncPluginPageRegisterPrivate* priv;
 
-    g_return_val_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(plugin_page), NULL);
+    g_return_val_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page), NULL);
 
     page = GNC_PLUGIN_PAGE_REGISTER (plugin_page);
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
     return gnc_ledger_display_get_query (priv->ledger);
 }
 
@@ -2339,24 +2455,25 @@ gnc_plugin_page_register_get_query (GncPluginPage *plugin_page)
  */
 static void
 gnc_plugin_page_register_sort_book_option_changed (gpointer new_val,
-                                                    gpointer user_data)
+                                                   gpointer user_data)
 {
-    GncPluginPageRegisterPrivate *priv;
-    GncPluginPageRegister *page = user_data;
-    gboolean *new_data = (gboolean*)new_val;
+    GncPluginPageRegisterPrivate* priv;
+    GncPluginPageRegister* page = user_data;
+    gboolean* new_data = (gboolean*)new_val;
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
     if (*new_data)
     {
-        gtk_button_set_label(GTK_BUTTON (priv->sd.num_radio), _("Transaction Number"));
-        gtk_button_set_label(GTK_BUTTON (priv->sd.act_radio), _("Number/Action"));
+        gtk_button_set_label (GTK_BUTTON (priv->sd.num_radio),
+                              _ ("Transaction Number"));
+        gtk_button_set_label (GTK_BUTTON (priv->sd.act_radio), _ ("Number/Action"));
     }
     else
     {
-        gtk_button_set_label(GTK_BUTTON (priv->sd.num_radio), _("Number"));
-        gtk_button_set_label(GTK_BUTTON (priv->sd.act_radio), _("Action"));
+        gtk_button_set_label (GTK_BUTTON (priv->sd.num_radio), _ ("Number"));
+        gtk_button_set_label (GTK_BUTTON (priv->sd.act_radio), _ ("Action"));
     }
     gnc_split_reg_set_sort_type_force (priv->gsr, priv->gsr->sort_type, TRUE);
 }
@@ -2373,28 +2490,29 @@ gnc_plugin_page_register_sort_book_option_changed (gpointer new_val,
  *  this dialog box.
  */
 void
-gnc_plugin_page_register_sort_response_cb (GtkDialog *dialog,
-        gint response,
-        GncPluginPageRegister *page)
+gnc_plugin_page_register_sort_response_cb (GtkDialog* dialog,
+                                           gint response,
+                                           GncPluginPageRegister* page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    GncPluginPage *plugin_page;
+    GncPluginPageRegisterPrivate* priv;
+    GncPluginPage* plugin_page;
     SortType type;
-    const gchar *order;
+    const gchar* order;
 
-    g_return_if_fail(GTK_IS_DIALOG(dialog));
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
+    g_return_if_fail (GTK_IS_DIALOG (dialog));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
 
-    ENTER(" ");
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
-    plugin_page = GNC_PLUGIN_PAGE(page);
+    ENTER (" ");
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
+    plugin_page = GNC_PLUGIN_PAGE (page);
 
     if (response != GTK_RESPONSE_OK)
     {
         /* Restore the original sort order */
-        gnc_split_reg_set_sort_reversed(priv->gsr, priv->sd.original_reverse_order, TRUE);
+        gnc_split_reg_set_sort_reversed (priv->gsr, priv->sd.original_reverse_order,
+                                         TRUE);
         priv->sd.reverse_order = priv->sd.original_reverse_order;
-        gnc_split_reg_set_sort_type(priv->gsr, priv->sd.original_sort_type);
+        gnc_split_reg_set_sort_type (priv->gsr, priv->sd.original_sort_type);
         priv->sd.save_order = priv->sd.original_save_order;
     }
     else
@@ -2409,20 +2527,21 @@ gnc_plugin_page_register_sort_response_cb (GtkDialog *dialog,
 
         if (priv->sd.save_order)
         {
-            type = gnc_split_reg_get_sort_type(priv->gsr);
-            order = SortTypeasString(type);
+            type = gnc_split_reg_get_sort_type (priv->gsr);
+            order = SortTypeasString (type);
             gnc_plugin_page_register_set_sort_order (plugin_page, order);
-            gnc_plugin_page_register_set_sort_reversed (plugin_page, priv->sd.reverse_order);
+            gnc_plugin_page_register_set_sort_reversed (plugin_page,
+                                                        priv->sd.reverse_order);
         }
     }
-    gnc_book_option_remove_cb(OPTION_NAME_NUM_FIELD_SOURCE,
-                                gnc_plugin_page_register_sort_book_option_changed,
-                                page);
+    gnc_book_option_remove_cb (OPTION_NAME_NUM_FIELD_SOURCE,
+                               gnc_plugin_page_register_sort_book_option_changed,
+                               page);
     priv->sd.dialog = NULL;
     priv->sd.num_radio = NULL;
     priv->sd.act_radio = NULL;
-    gtk_widget_destroy(GTK_WIDGET(dialog));
-    LEAVE(" ");
+    gtk_widget_destroy (GTK_WIDGET (dialog));
+    LEAVE (" ");
 }
 
 
@@ -2435,22 +2554,22 @@ gnc_plugin_page_register_sort_response_cb (GtkDialog *dialog,
  *  this dialog box.
  */
 void
-gnc_plugin_page_register_sort_button_cb (GtkToggleButton *button,
-        GncPluginPageRegister *page)
+gnc_plugin_page_register_sort_button_cb (GtkToggleButton* button,
+                                         GncPluginPageRegister* page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    const gchar *name;
+    GncPluginPageRegisterPrivate* priv;
+    const gchar* name;
     SortType type;
 
-    g_return_if_fail(GTK_IS_TOGGLE_BUTTON(button));
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
+    g_return_if_fail (GTK_IS_TOGGLE_BUTTON (button));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
-    name = gtk_buildable_get_name(GTK_BUILDABLE(button));
-    ENTER("button %s(%p), page %p", name, button, page);
-    type = SortTypefromString(name);
-    gnc_split_reg_set_sort_type(priv->gsr, type);
-    LEAVE(" ");
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
+    name = gtk_buildable_get_name (GTK_BUILDABLE (button));
+    ENTER ("button %s(%p), page %p", name, button, page);
+    type = SortTypefromString (name);
+    gnc_split_reg_set_sort_type (priv->gsr, type);
+    LEAVE (" ");
 }
 
 
@@ -2463,24 +2582,24 @@ gnc_plugin_page_register_sort_button_cb (GtkToggleButton *button,
  *  associated with this sort order dialog.
  */
 void
-gnc_plugin_page_register_sort_order_save_cb (GtkToggleButton *button,
-        GncPluginPageRegister *page)
+gnc_plugin_page_register_sort_order_save_cb (GtkToggleButton* button,
+                                             GncPluginPageRegister* page)
 {
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegisterPrivate* priv;
 
-    g_return_if_fail(GTK_IS_CHECK_BUTTON(button));
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
+    g_return_if_fail (GTK_IS_CHECK_BUTTON (button));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
 
-    ENTER("Save toggle button (%p), plugin_page %p", button, page);
+    ENTER ("Save toggle button (%p), plugin_page %p", button, page);
 
     /* Compute the new save sort order */
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
 
-    if (gtk_toggle_button_get_active(button))
+    if (gtk_toggle_button_get_active (button))
         priv->sd.save_order = TRUE;
     else
         priv->sd.save_order = FALSE;
-    LEAVE(" ");
+    LEAVE (" ");
 }
 
 /** This function is called whenever the reverse sort order is checked
@@ -2492,23 +2611,23 @@ gnc_plugin_page_register_sort_order_save_cb (GtkToggleButton *button,
  *  associated with this sort order dialog.
  */
 void
-gnc_plugin_page_register_sort_order_reverse_cb (GtkToggleButton *button,
-        GncPluginPageRegister *page)
+gnc_plugin_page_register_sort_order_reverse_cb (GtkToggleButton* button,
+                                                GncPluginPageRegister* page)
 
 {
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegisterPrivate* priv;
 
-    g_return_if_fail(GTK_IS_CHECK_BUTTON(button));
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
+    g_return_if_fail (GTK_IS_CHECK_BUTTON (button));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
 
-    ENTER("Reverse toggle button (%p), plugin_page %p", button, page);
+    ENTER ("Reverse toggle button (%p), plugin_page %p", button, page);
 
     /* Compute the new save sort order */
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
 
-    priv->sd.reverse_order = gtk_toggle_button_get_active(button);
-    gnc_split_reg_set_sort_reversed(priv->gsr, priv->sd.reverse_order, TRUE);
-    LEAVE(" ");
+    priv->sd.reverse_order = gtk_toggle_button_get_active (button);
+    gnc_split_reg_set_sort_reversed (priv->gsr, priv->sd.reverse_order, TRUE);
+    LEAVE (" ");
 }
 
 /************************************************************/
@@ -2516,23 +2635,23 @@ gnc_plugin_page_register_sort_order_reverse_cb (GtkToggleButton *button,
 /************************************************************/
 
 static void
-gnc_ppr_update_for_search_query (GncPluginPageRegister *page)
+gnc_ppr_update_for_search_query (GncPluginPageRegister* page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    SplitRegister *reg;
+    GncPluginPageRegisterPrivate* priv;
+    SplitRegister* reg;
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
     reg = gnc_ledger_display_get_split_register (priv->ledger);
 
     if (reg->type == SEARCH_LEDGER)
     {
-        Query *query_tmp = gnc_ledger_display_get_query (priv->ledger);
+        Query* query_tmp = gnc_ledger_display_get_query (priv->ledger);
 
         // if filter_query is NULL, then the dialogue find has been run
         // before coming here. if query_tmp does not equal filter_query
         // then the dialogue find has been run again before coming here
         if ((priv->filter_query == NULL) ||
-           (!qof_query_equal (query_tmp, priv->filter_query)))
+            (!qof_query_equal (query_tmp, priv->filter_query)))
         {
             qof_query_destroy (priv->search_query);
             priv->search_query = qof_query_copy (query_tmp);
@@ -2555,27 +2674,27 @@ gnc_ppr_update_for_search_query (GncPluginPageRegister *page)
  *  associated with this filter dialog.
  */
 static void
-gnc_ppr_update_status_query (GncPluginPageRegister *page)
+gnc_ppr_update_status_query (GncPluginPageRegister* page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    GSList *param_list;
-    Query *query;
-    SplitRegister *reg;
+    GncPluginPageRegisterPrivate* priv;
+    GSList* param_list;
+    Query* query;
+    SplitRegister* reg;
 
-    ENTER(" ");
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
+    ENTER (" ");
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
     if (!priv->ledger)
     {
-        LEAVE("no ledger");
+        LEAVE ("no ledger");
         return;
     }
     // check if this a search register and save query
     gnc_ppr_update_for_search_query (page);
 
-    query = gnc_ledger_display_get_query( priv->ledger );
+    query = gnc_ledger_display_get_query (priv->ledger);
     if (!query)
     {
-        LEAVE("no query found");
+        LEAVE ("no query found");
         return;
     }
 
@@ -2586,12 +2705,12 @@ gnc_ppr_update_status_query (GncPluginPageRegister *page)
     if (param_list && (reg->type != SEARCH_LEDGER))
     {
         qof_query_purge_terms (query, param_list);
-        g_slist_free(param_list);
+        g_slist_free (param_list);
     }
 
     /* Install the new status match */
     if (priv->fd.cleared_match != CLEARED_ALL)
-        xaccQueryAddClearedMatch(query, priv->fd.cleared_match, QOF_QUERY_AND);
+        xaccQueryAddClearedMatch (query, priv->fd.cleared_match, QOF_QUERY_AND);
 
     // Set filter tooltip for summary bar
     gnc_plugin_page_register_set_filter_tooltip (page);
@@ -2602,7 +2721,7 @@ gnc_ppr_update_status_query (GncPluginPageRegister *page)
 
     if (priv->enable_refresh)
         gnc_ledger_display_refresh (priv->ledger);
-    LEAVE(" ");
+    LEAVE (" ");
 }
 
 
@@ -2619,18 +2738,18 @@ gnc_ppr_update_status_query (GncPluginPageRegister *page)
  *  associated with this filter dialog.
  */
 static void
-gnc_ppr_update_date_query (GncPluginPageRegister *page)
+gnc_ppr_update_date_query (GncPluginPageRegister* page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    GSList *param_list;
-    Query *query;
-    SplitRegister *reg;
+    GncPluginPageRegisterPrivate* priv;
+    GSList* param_list;
+    Query* query;
+    SplitRegister* reg;
 
-    ENTER(" ");
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
+    ENTER (" ");
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
     if (!priv->ledger)
     {
-        LEAVE("no ledger");
+        LEAVE ("no ledger");
         return;
     }
     // check if this a search register and save query
@@ -2640,27 +2759,27 @@ gnc_ppr_update_date_query (GncPluginPageRegister *page)
 
     if (!query)
     {
-        LEAVE("no query");
+        LEAVE ("no query");
         return;
     }
 
     reg = gnc_ledger_display_get_split_register (priv->ledger);
 
     /* Delete any existing old date spec. */
-    param_list = qof_query_build_param_list(SPLIT_TRANS, TRANS_DATE_POSTED, NULL);
+    param_list = qof_query_build_param_list (SPLIT_TRANS, TRANS_DATE_POSTED, NULL);
     if (param_list && (reg->type != SEARCH_LEDGER))
     {
         qof_query_purge_terms (query, param_list);
-        g_slist_free(param_list);
+        g_slist_free (param_list);
     }
 
     if (priv->fd.start_time || priv->fd.end_time)
     {
         /* Build a new spec */
-        xaccQueryAddDateMatchTT(query,
-                                priv->fd.start_time != 0, priv->fd.start_time,
-                                priv->fd.end_time != 0,   priv->fd.end_time,
-                                QOF_QUERY_AND);
+        xaccQueryAddDateMatchTT (query,
+                                 priv->fd.start_time != 0, priv->fd.start_time,
+                                 priv->fd.end_time != 0,   priv->fd.end_time,
+                                 QOF_QUERY_AND);
     }
 
     if (priv->fd.days > 0)
@@ -2668,7 +2787,7 @@ gnc_ppr_update_date_query (GncPluginPageRegister *page)
         time64 start;
         struct tm tm;
 
-        gnc_tm_get_today_start(&tm);
+        gnc_tm_get_today_start (&tm);
 
         tm.tm_mday = tm.tm_mday - priv->fd.days;
         start = gnc_mktime (&tm);
@@ -2684,37 +2803,37 @@ gnc_ppr_update_date_query (GncPluginPageRegister *page)
 
     if (priv->enable_refresh)
         gnc_ledger_display_refresh (priv->ledger);
-    LEAVE(" ");
+    LEAVE (" ");
 }
 
 
 /* This function converts a time64 value date to a string */
-static gchar *
-gnc_plugin_page_register_filter_time2dmy ( time64 raw_time)
+static gchar*
+gnc_plugin_page_register_filter_time2dmy (time64 raw_time)
 {
-    struct tm * timeinfo;
+    struct tm* timeinfo;
     gchar date_string[11];
 
     timeinfo = gnc_localtime (&raw_time);
     strftime (date_string, 11, "%d-%m-%Y", timeinfo);
-    PINFO("Date string is %s", date_string);
+    PINFO ("Date string is %s", date_string);
     gnc_tm_free (timeinfo);
 
-    return g_strdup(date_string);
+    return g_strdup (date_string);
 }
 
 
 /* This function converts a string date to a time64 value */
 static time64
-gnc_plugin_page_register_filter_dmy2time (char *date_string)
+gnc_plugin_page_register_filter_dmy2time (char* date_string)
 {
     struct tm when;
 
-    PINFO("Date string is %s", date_string);
-        memset (&when, 0, sizeof (when));
+    PINFO ("Date string is %s", date_string);
+    memset (&when, 0, sizeof (when));
 
     sscanf (date_string, "%d-%d-%d", &when.tm_mday,
-        &when.tm_mon, &when.tm_year);
+            &when.tm_mon, &when.tm_year);
 
     when.tm_mon -= 1;
     when.tm_year -= 1900;
@@ -2734,24 +2853,24 @@ gnc_plugin_page_register_filter_dmy2time (char *date_string)
  *  associated with this filter dialog.
  */
 void
-gnc_plugin_page_register_filter_status_one_cb (GtkToggleButton *button,
-        GncPluginPageRegister *page)
+gnc_plugin_page_register_filter_status_one_cb (GtkToggleButton* button,
+                                               GncPluginPageRegister* page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    const gchar *name;
+    GncPluginPageRegisterPrivate* priv;
+    const gchar* name;
     gint i, value;
 
-    g_return_if_fail(GTK_IS_CHECK_BUTTON(button));
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
+    g_return_if_fail (GTK_IS_CHECK_BUTTON (button));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
 
-    name = gtk_buildable_get_name(GTK_BUILDABLE(button));
-    ENTER("toggle button %s (%p), plugin_page %p", name, button, page);
+    name = gtk_buildable_get_name (GTK_BUILDABLE (button));
+    ENTER ("toggle button %s (%p), plugin_page %p", name, button, page);
 
     /* Determine what status bit to change */
     value = CLEARED_NONE;
     for (i = 0; status_actions[i].action_name; i++)
     {
-        if (g_strcmp0(name, status_actions[i].action_name) == 0)
+        if (g_strcmp0 (name, status_actions[i].action_name) == 0)
         {
             value = status_actions[i].value;
             break;
@@ -2759,13 +2878,13 @@ gnc_plugin_page_register_filter_status_one_cb (GtkToggleButton *button,
     }
 
     /* Compute the new match status */
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
-    if (gtk_toggle_button_get_active(button))
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
+    if (gtk_toggle_button_get_active (button))
         priv->fd.cleared_match |= value;
     else
         priv->fd.cleared_match &= ~value;
-    gnc_ppr_update_status_query(page);
-    LEAVE(" ");
+    gnc_ppr_update_status_query (page);
+    LEAVE (" ");
 }
 
 
@@ -2779,32 +2898,34 @@ gnc_plugin_page_register_filter_status_one_cb (GtkToggleButton *button,
  *  associated with this filter dialog.
  */
 void
-gnc_plugin_page_register_filter_status_all_cb (GtkButton *button,
-        GncPluginPageRegister *page)
+gnc_plugin_page_register_filter_status_all_cb (GtkButton* button,
+                                               GncPluginPageRegister* page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    GtkWidget *widget;
+    GncPluginPageRegisterPrivate* priv;
+    GtkWidget* widget;
     gint i;
 
-    g_return_if_fail(GTK_IS_BUTTON(button));
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
+    g_return_if_fail (GTK_IS_BUTTON (button));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
 
-    ENTER("(button %p, page %p)", button, page);
+    ENTER ("(button %p, page %p)", button, page);
 
     /* Turn on all the check menu items */
     for (i = 0; status_actions[i].action_name; i++)
     {
         widget = status_actions[i].widget;
-        g_signal_handlers_block_by_func(widget, gnc_plugin_page_register_filter_status_one_cb, page);
-        gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON(widget), TRUE);
-        g_signal_handlers_unblock_by_func(widget, gnc_plugin_page_register_filter_status_one_cb, page);
+        g_signal_handlers_block_by_func (widget,
+                                         gnc_plugin_page_register_filter_status_one_cb, page);
+        gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (widget), TRUE);
+        g_signal_handlers_unblock_by_func (widget,
+                                           gnc_plugin_page_register_filter_status_one_cb, page);
     }
 
     /* Set the requested status */
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
     priv->fd.cleared_match = CLEARED_ALL;
-    gnc_ppr_update_status_query(page);
-    LEAVE(" ");
+    gnc_ppr_update_status_query (page);
+    LEAVE (" ");
 }
 
 
@@ -2820,21 +2941,23 @@ gnc_plugin_page_register_filter_status_all_cb (GtkButton *button,
  *  associated with this filter dialog.
  */
 static void
-get_filter_times(GncPluginPageRegister *page)
+get_filter_times (GncPluginPageRegister* page)
 {
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegisterPrivate* priv;
     time64 time_val;
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
-    if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(priv->fd.start_date_choose)))
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
+    if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (
+                                          priv->fd.start_date_choose)))
     {
-        time_val = gnc_date_edit_get_date(GNC_DATE_EDIT(priv->fd.start_date));
-        time_val = gnc_time64_get_day_start(time_val);
+        time_val = gnc_date_edit_get_date (GNC_DATE_EDIT (priv->fd.start_date));
+        time_val = gnc_time64_get_day_start (time_val);
         priv->fd.start_time = time_val;
     }
     else
     {
-        if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(priv->fd.start_date_today)))
+        if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (
+                                              priv->fd.start_date_today)))
         {
             priv->fd.start_time = gnc_time64_get_today_start();
         }
@@ -2844,15 +2967,17 @@ get_filter_times(GncPluginPageRegister *page)
         }
     }
 
-    if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(priv->fd.end_date_choose)))
+    if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (
+                                          priv->fd.end_date_choose)))
     {
-        time_val = gnc_date_edit_get_date(GNC_DATE_EDIT(priv->fd.end_date));
-        time_val = gnc_time64_get_day_end(time_val);
+        time_val = gnc_date_edit_get_date (GNC_DATE_EDIT (priv->fd.end_date));
+        time_val = gnc_time64_get_day_end (time_val);
         priv->fd.end_time = time_val;
     }
     else
     {
-        if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(priv->fd.start_date_today)))
+        if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (
+                                              priv->fd.start_date_today)))
         {
             priv->fd.end_time = gnc_time64_get_today_end();
         }
@@ -2876,43 +3001,43 @@ get_filter_times(GncPluginPageRegister *page)
  *  associated with this filter dialog.
  */
 void
-gnc_plugin_page_register_filter_select_range_cb (GtkRadioButton *button,
-        GncPluginPageRegister *page)
+gnc_plugin_page_register_filter_select_range_cb (GtkRadioButton* button,
+                                                 GncPluginPageRegister* page)
 {
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegisterPrivate* priv;
     gboolean active;
-    const gchar *name;
+    const gchar* name;
 
-    g_return_if_fail(GTK_IS_RADIO_BUTTON(button));
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
+    g_return_if_fail (GTK_IS_RADIO_BUTTON (button));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
 
-    ENTER("(button %p, page %p)", button, page);
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
-    name = gtk_buildable_get_name(GTK_BUILDABLE(button));
-    active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(button));
+    ENTER ("(button %p, page %p)", button, page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
+    name = gtk_buildable_get_name (GTK_BUILDABLE (button));
+    active = gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (button));
 
-    if (active && g_strcmp0(name, "filter_show_range") == 0)
+    if (active && g_strcmp0 (name, "filter_show_range") == 0)
     {
-        gtk_widget_set_sensitive(priv->fd.table, active);
-        gtk_widget_set_sensitive(priv->fd.num_days, !active);
-        get_filter_times(page);
+        gtk_widget_set_sensitive (priv->fd.table, active);
+        gtk_widget_set_sensitive (priv->fd.num_days, !active);
+        get_filter_times (page);
     }
-    else if (active && g_strcmp0(name, "filter_show_days") == 0)
+    else if (active && g_strcmp0 (name, "filter_show_days") == 0)
     {
-        gtk_widget_set_sensitive(priv->fd.table, !active);
-        gtk_widget_set_sensitive(priv->fd.num_days, active);
-        gtk_spin_button_set_value(GTK_SPIN_BUTTON(priv->fd.num_days), priv->fd.days);
+        gtk_widget_set_sensitive (priv->fd.table, !active);
+        gtk_widget_set_sensitive (priv->fd.num_days, active);
+        gtk_spin_button_set_value (GTK_SPIN_BUTTON (priv->fd.num_days), priv->fd.days);
     }
     else
     {
-        gtk_widget_set_sensitive(priv->fd.table, FALSE);
-        gtk_widget_set_sensitive(priv->fd.num_days, FALSE);
+        gtk_widget_set_sensitive (priv->fd.table, FALSE);
+        gtk_widget_set_sensitive (priv->fd.num_days, FALSE);
         priv->fd.days = 0;
         priv->fd.start_time = 0;
         priv->fd.end_time = 0;
     }
-    gnc_ppr_update_date_query(page);
-    LEAVE(" ");
+    gnc_ppr_update_date_query (page);
+    LEAVE (" ");
 }
 
 
@@ -2927,20 +3052,20 @@ gnc_plugin_page_register_filter_select_range_cb (GtkRadioButton *button,
  *  associated with this filter dialog.
  */
 void
-gnc_plugin_page_register_filter_days_changed_cb (GtkSpinButton *button,
-        GncPluginPageRegister *page)
+gnc_plugin_page_register_filter_days_changed_cb (GtkSpinButton* button,
+                                                 GncPluginPageRegister* page)
 {
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegisterPrivate* priv;
 
-    g_return_if_fail(GTK_IS_SPIN_BUTTON(button));
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
+    g_return_if_fail (GTK_IS_SPIN_BUTTON (button));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
 
-    ENTER("(button %p, page %p)", button, page);
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
+    ENTER ("(button %p, page %p)", button, page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
 
-    priv->fd.days = gtk_spin_button_get_value(GTK_SPIN_BUTTON(button));
-    gnc_ppr_update_date_query(page);
-    LEAVE(" ");
+    priv->fd.days = gtk_spin_button_get_value (GTK_SPIN_BUTTON (button));
+    gnc_ppr_update_date_query (page);
+    LEAVE (" ");
 }
 
 
@@ -2955,15 +3080,16 @@ gnc_plugin_page_register_filter_days_changed_cb (GtkSpinButton *button,
  *  associated with this filter dialog.
  */
 static void
-gnc_plugin_page_register_filter_gde_changed_cb (GtkWidget *unused,
-        GncPluginPageRegister *page)
+gnc_plugin_page_register_filter_gde_changed_cb (GtkWidget* unused,
+                                                GncPluginPageRegister* page)
 {
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
 
-    ENTER("(widget %s(%p), page %p)", gtk_buildable_get_name(GTK_BUILDABLE(unused)), unused, page);
-    get_filter_times(page);
-    gnc_ppr_update_date_query(page);
-    LEAVE(" ");
+    ENTER ("(widget %s(%p), page %p)",
+           gtk_buildable_get_name (GTK_BUILDABLE (unused)), unused, page);
+    get_filter_times (page);
+    gnc_ppr_update_date_query (page);
+    LEAVE (" ");
 }
 
 
@@ -2987,30 +3113,31 @@ gnc_plugin_page_register_filter_gde_changed_cb (GtkWidget *unused,
  *  associated with this filter dialog.
  */
 void
-gnc_plugin_page_register_filter_start_cb (GtkWidget *radio,
-        GncPluginPageRegister *page)
+gnc_plugin_page_register_filter_start_cb (GtkWidget* radio,
+                                          GncPluginPageRegister* page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    const gchar *name;
+    GncPluginPageRegisterPrivate* priv;
+    const gchar* name;
     gboolean active;
 
-    g_return_if_fail(GTK_IS_RADIO_BUTTON(radio));
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
+    g_return_if_fail (GTK_IS_RADIO_BUTTON (radio));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
 
-    ENTER("(radio %s(%p), page %p)", gtk_buildable_get_name(GTK_BUILDABLE(radio)), radio, page);
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
-    if (!gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(radio)))
+    ENTER ("(radio %s(%p), page %p)",
+           gtk_buildable_get_name (GTK_BUILDABLE (radio)), radio, page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
+    if (!gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (radio)))
     {
-        LEAVE("1st callback of pair. Defer to 2nd callback.");
+        LEAVE ("1st callback of pair. Defer to 2nd callback.");
         return;
     }
 
-    name = gtk_buildable_get_name(GTK_BUILDABLE(radio));
-    active = ( g_strcmp0(name, g_strdup("start_date_choose")) == 0 ? 1 : 0 );
-    gtk_widget_set_sensitive(priv->fd.start_date, active);
-    get_filter_times(page);
-    gnc_ppr_update_date_query(page);
-    LEAVE(" ");
+    name = gtk_buildable_get_name (GTK_BUILDABLE (radio));
+    active = (g_strcmp0 (name, g_strdup ("start_date_choose")) == 0 ? 1 : 0);
+    gtk_widget_set_sensitive (priv->fd.start_date, active);
+    get_filter_times (page);
+    gnc_ppr_update_date_query (page);
+    LEAVE (" ");
 }
 
 
@@ -3034,30 +3161,31 @@ gnc_plugin_page_register_filter_start_cb (GtkWidget *radio,
  *  associated with this filter dialog.
  */
 void
-gnc_plugin_page_register_filter_end_cb (GtkWidget *radio,
-                                        GncPluginPageRegister *page)
+gnc_plugin_page_register_filter_end_cb (GtkWidget* radio,
+                                        GncPluginPageRegister* page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    const gchar *name;
+    GncPluginPageRegisterPrivate* priv;
+    const gchar* name;
     gboolean active;
 
-    g_return_if_fail(GTK_IS_RADIO_BUTTON(radio));
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
+    g_return_if_fail (GTK_IS_RADIO_BUTTON (radio));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
 
-    ENTER("(radio %s(%p), page %p)", gtk_buildable_get_name(GTK_BUILDABLE(radio)), radio, page);
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
-    if (!gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(radio)))
+    ENTER ("(radio %s(%p), page %p)",
+           gtk_buildable_get_name (GTK_BUILDABLE (radio)), radio, page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
+    if (!gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (radio)))
     {
-        LEAVE("1st callback of pair. Defer to 2nd callback.");
+        LEAVE ("1st callback of pair. Defer to 2nd callback.");
         return;
     }
 
-    name = gtk_buildable_get_name(GTK_BUILDABLE(radio));
-    active = ( g_strcmp0(name, g_strdup("end_date_choose")) == 0 ? 1 : 0 );
-    gtk_widget_set_sensitive(priv->fd.end_date, active);
-    get_filter_times(page);
-    gnc_ppr_update_date_query(page);
-    LEAVE(" ");
+    name = gtk_buildable_get_name (GTK_BUILDABLE (radio));
+    active = (g_strcmp0 (name, g_strdup ("end_date_choose")) == 0 ? 1 : 0);
+    gtk_widget_set_sensitive (priv->fd.end_date, active);
+    get_filter_times (page);
+    gnc_ppr_update_date_query (page);
+    LEAVE (" ");
 }
 
 
@@ -3070,23 +3198,23 @@ gnc_plugin_page_register_filter_end_cb (GtkWidget *radio,
  *  associated with this filter dialog.
  */
 void
-gnc_plugin_page_register_filter_save_cb (GtkToggleButton *button,
-        GncPluginPageRegister *page)
+gnc_plugin_page_register_filter_save_cb (GtkToggleButton* button,
+                                         GncPluginPageRegister* page)
 {
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegisterPrivate* priv;
 
-    g_return_if_fail(GTK_IS_CHECK_BUTTON(button));
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
+    g_return_if_fail (GTK_IS_CHECK_BUTTON (button));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
 
-    ENTER("Save toggle button (%p), plugin_page %p", button, page);
+    ENTER ("Save toggle button (%p), plugin_page %p", button, page);
 
     /* Compute the new save filter status */
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
-    if (gtk_toggle_button_get_active(button))
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
+    if (gtk_toggle_button_get_active (button))
         priv->fd.save_filter = TRUE;
     else
         priv->fd.save_filter = FALSE;
-    LEAVE(" ");
+    LEAVE (" ");
 }
 
 
@@ -3102,32 +3230,32 @@ gnc_plugin_page_register_filter_save_cb (GtkToggleButton *button,
  *  this dialog box.
  */
 void
-gnc_plugin_page_register_filter_response_cb (GtkDialog *dialog,
-        gint response,
-        GncPluginPageRegister *page)
+gnc_plugin_page_register_filter_response_cb (GtkDialog* dialog,
+                                             gint response,
+                                             GncPluginPageRegister* page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    GncPluginPage *plugin_page;
+    GncPluginPageRegisterPrivate* priv;
+    GncPluginPage* plugin_page;
 
-    g_return_if_fail(GTK_IS_DIALOG(dialog));
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
+    g_return_if_fail (GTK_IS_DIALOG (dialog));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
 
-    ENTER(" ");
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
-    plugin_page = GNC_PLUGIN_PAGE(page);
+    ENTER (" ");
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
+    plugin_page = GNC_PLUGIN_PAGE (page);
 
     if (response != GTK_RESPONSE_OK)
     {
         /* Remove the old status match */
         priv->fd.cleared_match = priv->fd.original_cleared_match;
         priv->enable_refresh = FALSE;
-        gnc_ppr_update_status_query(page);
+        gnc_ppr_update_status_query (page);
         priv->enable_refresh = TRUE;
         priv->fd.start_time = priv->fd.original_start_time;
         priv->fd.end_time = priv->fd.original_end_time;
         priv->fd.days = priv->fd.original_days;
         priv->fd.save_filter = priv->fd.original_save_filter;
-        gnc_ppr_update_date_query(page);
+        gnc_ppr_update_date_query (page);
     }
     else
     {
@@ -3139,13 +3267,16 @@ gnc_plugin_page_register_filter_response_cb (GtkDialog *dialog,
 
         if (priv->fd.save_filter)
         {
-            gchar* filter = g_strdup_printf("0x%04x", priv->fd.cleared_match); // cleared match
-            gchar *tmp = g_strdup (filter);
+            gchar* filter = g_strdup_printf ("0x%04x",
+                                             priv->fd.cleared_match); // cleared match
+            gchar* tmp = g_strdup (filter);
 
             // start time
-            if ( gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(priv->fd.start_date_choose)) && priv->fd.start_time != 0 )
+            if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (
+                                                  priv->fd.start_date_choose)) && priv->fd.start_time != 0)
             {
-                gchar *timeval = gnc_plugin_page_register_filter_time2dmy(priv->fd.start_time);
+                gchar* timeval = gnc_plugin_page_register_filter_time2dmy (
+                                     priv->fd.start_time);
                 filter = g_strconcat (tmp, ",", timeval, NULL);
                 g_free (timeval);
             }
@@ -3157,9 +3288,10 @@ gnc_plugin_page_register_filter_response_cb (GtkDialog *dialog,
             g_free (filter);
 
             // end time
-            if ( gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(priv->fd.end_date_choose)) && priv->fd.end_time != 0 )
+            if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (priv->fd.end_date_choose))
+                && priv->fd.end_time != 0)
             {
-                gchar *timeval = gnc_plugin_page_register_filter_time2dmy(priv->fd.end_time);
+                gchar* timeval = gnc_plugin_page_register_filter_time2dmy (priv->fd.end_time);
                 filter = g_strconcat (tmp, ",", timeval, NULL);
                 g_free (timeval);
             }
@@ -3178,19 +3310,19 @@ gnc_plugin_page_register_filter_response_cb (GtkDialog *dialog,
 
             g_free (tmp);
 
-            PINFO("The filter to save is %s", filter);
+            PINFO ("The filter to save is %s", filter);
             gnc_plugin_page_register_set_filter (plugin_page, filter);
             g_free (filter);
         }
     }
     priv->fd.dialog = NULL;
-    gtk_widget_destroy(GTK_WIDGET(dialog));
-    LEAVE(" ");
+    gtk_widget_destroy (GTK_WIDGET (dialog));
+    LEAVE (" ");
 }
 
 static void
 gpp_update_match_filter_text (cleared_match_t match, const guint mask,
-                              const gchar *filter_name, gchar **show, gchar **hide)
+                              const gchar* filter_name, gchar** show, gchar** hide)
 {
     if ((match & mask) == mask)
     {
@@ -3198,7 +3330,7 @@ gpp_update_match_filter_text (cleared_match_t match, const guint mask,
             *show = g_strdup (filter_name);
         else
         {
-            gchar *temp = g_strdup (*show);
+            gchar* temp = g_strdup (*show);
             g_free (*show);
             *show = g_strconcat (temp, ", ", filter_name, NULL);
         }
@@ -3209,7 +3341,7 @@ gpp_update_match_filter_text (cleared_match_t match, const guint mask,
             *hide = g_strdup (filter_name);
         else
         {
-            gchar *temp = g_strdup (*hide);
+            gchar* temp = g_strdup (*hide);
             g_free (*hide);
             *hide = g_strconcat (temp, ", ", filter_name, NULL);
         }
@@ -3217,57 +3349,64 @@ gpp_update_match_filter_text (cleared_match_t match, const guint mask,
 }
 
 static void
-gnc_plugin_page_register_set_filter_tooltip (GncPluginPageRegister *page)
+gnc_plugin_page_register_set_filter_tooltip (GncPluginPageRegister* page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    GncPluginPage *plugin_page;
-    gchar *text = NULL;
-    gchar *text_header = g_strdup_printf ("%s", _("Filter By:"));
-    gchar *text_start = NULL;
-    gchar *text_end = NULL;
-    gchar *text_cleared = NULL;
+    GncPluginPageRegisterPrivate* priv;
+    GncPluginPage* plugin_page;
+    gchar* text = NULL;
+    gchar* text_header = g_strdup_printf ("%s", _ ("Filter By:"));
+    gchar* text_start = NULL;
+    gchar* text_end = NULL;
+    gchar* text_cleared = NULL;
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
 
-    ENTER(" ");
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
+    ENTER (" ");
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
 
     // filtered start time
     if (priv->fd.start_time != 0)
     {
-        gchar *sdate = qof_print_date (priv->fd.start_time);
-        text_start = g_strdup_printf ("%s %s", _("Start Date:"), sdate);
+        gchar* sdate = qof_print_date (priv->fd.start_time);
+        text_start = g_strdup_printf ("%s %s", _ ("Start Date:"), sdate);
         g_free (sdate);
     }
 
     // filtered number of days
     if (priv->fd.days > 0)
-        text_start = g_strdup_printf ("%s %d", _("Show previous number of days:"), priv->fd.days);
+        text_start = g_strdup_printf ("%s %d", _ ("Show previous number of days:"),
+                                      priv->fd.days);
 
     // filtered end time
     if (priv->fd.end_time != 0)
     {
-        gchar *edate = qof_print_date (priv->fd.end_time);
-        text_end = g_strdup_printf ("%s %s", _("End Date:"), edate);
+        gchar* edate = qof_print_date (priv->fd.end_time);
+        text_end = g_strdup_printf ("%s %s", _ ("End Date:"), edate);
         g_free (edate);
     }
 
     // filtered match items
     if (priv->fd.cleared_match != 31)
     {
-        gchar *show = NULL;
-        gchar *hide = NULL;
+        gchar* show = NULL;
+        gchar* hide = NULL;
 
-        gpp_update_match_filter_text (priv->fd.cleared_match, 0x01, _("Unreconciled"), &show, &hide);
-        gpp_update_match_filter_text (priv->fd.cleared_match, 0x02, _("Cleared"), &show, &hide);
-        gpp_update_match_filter_text (priv->fd.cleared_match, 0x04, _("Reconciled"), &show, &hide);
-        gpp_update_match_filter_text (priv->fd.cleared_match, 0x08, _("Frozen"), &show, &hide);
-        gpp_update_match_filter_text (priv->fd.cleared_match, 0x10, _("Voided"), &show, &hide);
+        gpp_update_match_filter_text (priv->fd.cleared_match, 0x01, _ ("Unreconciled"),
+                                      &show, &hide);
+        gpp_update_match_filter_text (priv->fd.cleared_match, 0x02, _ ("Cleared"),
+                                      &show, &hide);
+        gpp_update_match_filter_text (priv->fd.cleared_match, 0x04, _ ("Reconciled"),
+                                      &show, &hide);
+        gpp_update_match_filter_text (priv->fd.cleared_match, 0x08, _ ("Frozen"),
+                                      &show, &hide);
+        gpp_update_match_filter_text (priv->fd.cleared_match, 0x10, _ ("Voided"),
+                                      &show, &hide);
 
         if (show == NULL)
-            text_cleared = g_strconcat (_("Hide:"), " ", hide, NULL);
+            text_cleared = g_strconcat (_ ("Hide:"), " ", hide, NULL);
         else
-            text_cleared = g_strconcat (_("Show:"), " ", show, "\n", _("Hide:"), " ", hide, NULL);
+            text_cleared = g_strconcat (_ ("Show:"), " ", show, "\n", _ ("Hide:"), " ",
+                                        hide, NULL);
 
         g_free (show);
         g_free (hide);
@@ -3284,7 +3423,7 @@ gnc_plugin_page_register_set_filter_tooltip (GncPluginPageRegister *page)
                 text = g_strconcat (text_header, "\n", text_end, NULL);
             else
             {
-                gchar *temp = g_strdup (text);
+                gchar* temp = g_strdup (text);
                 g_free (text);
                 text = g_strconcat (temp, "\n", text_end, NULL);
                 g_free (temp);
@@ -3297,7 +3436,7 @@ gnc_plugin_page_register_set_filter_tooltip (GncPluginPageRegister *page)
                 text = g_strconcat (text_header, "\n", text_cleared, NULL);
             else
             {
-                gchar *temp = g_strdup (text);
+                gchar* temp = g_strdup (text);
                 g_free (text);
                 text = g_strconcat (temp, "\n", text_cleared, NULL);
                 g_free (temp);
@@ -3320,21 +3459,21 @@ gnc_plugin_page_register_set_filter_tooltip (GncPluginPageRegister *page)
     g_free (text_header);
     g_free (text);
 
-    LEAVE(" ");
+    LEAVE (" ");
 }
 
 /************************************************************/
 /*                  Report Helper Functions                 */
 /************************************************************/
 
-static char *
-gnc_reg_get_name (GNCLedgerDisplay *ledger, gboolean for_window)
+static char*
+gnc_reg_get_name (GNCLedgerDisplay* ledger, gboolean for_window)
 {
-    Account *leader;
-    SplitRegister *reg;
-    gchar *account_name;
-    gchar *reg_name;
-    gchar *name;
+    Account* leader;
+    SplitRegister* reg;
+    gchar* account_name;
+    gchar* reg_name;
+    gchar* name;
     GNCLedgerDisplayType ledger_type;
 
     if (ledger == NULL)
@@ -3348,27 +3487,27 @@ gnc_reg_get_name (GNCLedgerDisplay *ledger, gboolean for_window)
     case GENERAL_JOURNAL:
     case INCOME_LEDGER:
         if (for_window)
-            reg_name = _("General Journal");
+            reg_name = _ ("General Journal");
         else
-            reg_name = _("Transaction Report");
+            reg_name = _ ("Transaction Report");
         break;
     case PORTFOLIO_LEDGER:
         if (for_window)
-            reg_name = _("Portfolio");
+            reg_name = _ ("Portfolio");
         else
-            reg_name = _("Portfolio Report");
+            reg_name = _ ("Portfolio Report");
         break;
     case SEARCH_LEDGER:
         if (for_window)
-            reg_name = _("Search Results");
+            reg_name = _ ("Search Results");
         else
-            reg_name = _("Search Results Report");
+            reg_name = _ ("Search Results Report");
         break;
     default:
         if (for_window)
-            reg_name = _("Register");
+            reg_name = _ ("Register");
         else
-            reg_name = _("Transaction Report");
+            reg_name = _ ("Transaction Report");
         break;
     }
 
@@ -3384,9 +3523,10 @@ gnc_reg_get_name (GNCLedgerDisplay *ledger, gboolean for_window)
         }
         else
         {
-            name = g_strconcat (account_name, " ", _("and subaccounts"), " - ", reg_name, NULL);
+            name = g_strconcat (account_name, " ", _ ("and subaccounts"), " - ", reg_name,
+                                NULL);
         }
-        g_free(account_name);
+        g_free (account_name);
     }
     else
         name = g_strdup (reg_name);
@@ -3395,13 +3535,13 @@ gnc_reg_get_name (GNCLedgerDisplay *ledger, gboolean for_window)
 }
 
 static int
-report_helper (GNCLedgerDisplay *ledger, Split *split, Query *query)
+report_helper (GNCLedgerDisplay* ledger, Split* split, Query* query)
 {
-    SplitRegister *reg = gnc_ledger_display_get_split_register (ledger);
-    Account *account;
-    char *str;
-    const char *tmp;
-    swig_type_info * qtype;
+    SplitRegister* reg = gnc_ledger_display_get_split_register (ledger);
+    Account* account;
+    char* str;
+    const char* tmp;
+    swig_type_info* qtype;
     SCM args;
     SCM func;
     SCM arg;
@@ -3412,11 +3552,11 @@ report_helper (GNCLedgerDisplay *ledger, Split *split, Query *query)
     g_return_val_if_fail (scm_is_procedure (func), -1);
 
     tmp = gnc_split_register_get_credit_string (reg);
-    arg = scm_from_utf8_string (tmp ? tmp : _("Credit"));
+    arg = scm_from_utf8_string (tmp ? tmp : _ ("Credit"));
     args = scm_cons (arg, args);
 
     tmp = gnc_split_register_get_debit_string (reg);
-    arg = scm_from_utf8_string (tmp ? tmp : _("Debit"));
+    arg = scm_from_utf8_string (tmp ? tmp : _ ("Debit"));
     args = scm_cons (arg, args);
 
     str = gnc_reg_get_name (ledger, FALSE);
@@ -3428,7 +3568,7 @@ report_helper (GNCLedgerDisplay *ledger, Split *split, Query *query)
     args = scm_cons (arg, args);
 
     arg = SCM_BOOL (reg->type == GENERAL_JOURNAL || reg->type == INCOME_LEDGER
-                                                || reg->type == SEARCH_LEDGER);
+                    || reg->type == SEARCH_LEDGER);
     args = scm_cons (arg, args);
 
     arg = SCM_BOOL (reg->style == REG_STYLE_JOURNAL);
@@ -3483,179 +3623,180 @@ report_helper (GNCLedgerDisplay *ledger, Split *split, Query *query)
 /************************************************************/
 
 static void
-gnc_plugin_page_register_cmd_print_check (GtkAction *action,
-        GncPluginPageRegister *plugin_page)
+gnc_plugin_page_register_cmd_print_check (GtkAction* action,
+                                          GncPluginPageRegister* plugin_page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    SplitRegister * reg;
-    Split         * split;
-    Transaction   * trans;
-    GList         * splits = NULL, *item;
+    GncPluginPageRegisterPrivate* priv;
+    SplitRegister* reg;
+    Split*          split;
+    Transaction*    trans;
+    GList*          splits = NULL, *item;
     GNCLedgerDisplayType ledger_type;
-    Account       * account;
-    GtkWidget     * window;
+    Account*        account;
+    GtkWidget*      window;
 
-    ENTER("(action %p, plugin_page %p)", action, plugin_page);
+    ENTER ("(action %p, plugin_page %p)", action, plugin_page);
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(plugin_page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page));
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
     reg = gnc_ledger_display_get_split_register (priv->ledger);
-    ledger_type = gnc_ledger_display_type(priv->ledger);
+    ledger_type = gnc_ledger_display_type (priv->ledger);
     window = gnc_plugin_page_get_window (GNC_PLUGIN_PAGE (plugin_page));
     if (ledger_type == LD_SINGLE || ledger_type == LD_SUBACCOUNT)
     {
         account  = gnc_plugin_page_register_get_account (plugin_page);
-        split    = gnc_split_register_get_current_split(reg);
-        trans    = xaccSplitGetParent(split);
+        split    = gnc_split_register_get_current_split (reg);
+        trans    = xaccSplitGetParent (split);
 
         if (split && trans)
         {
-            if (xaccSplitGetAccount(split) == account)
+            if (xaccSplitGetAccount (split) == account)
             {
-                splits = g_list_append(splits, split);
-                gnc_ui_print_check_dialog_create(window, splits);
-                g_list_free(splits);
+                splits = g_list_append (splits, split);
+                gnc_ui_print_check_dialog_create (window, splits);
+                g_list_free (splits);
             }
             else
             {
                 /* This split is not for the account shown in this register.  Get the
                    split that anchors the transaction to the registor */
-                split = gnc_split_register_get_current_trans_split(reg, NULL);
+                split = gnc_split_register_get_current_trans_split (reg, NULL);
                 if (split)
                 {
-                    splits = g_list_append(splits, split);
-                    gnc_ui_print_check_dialog_create(window, splits);
-                    g_list_free(splits);
+                    splits = g_list_append (splits, split);
+                    gnc_ui_print_check_dialog_create (window, splits);
+                    g_list_free (splits);
                 }
             }
         }
     }
     else if (ledger_type == LD_GL && reg->type == SEARCH_LEDGER)
     {
-        Account *common_acct = NULL;
-        splits = qof_query_run(gnc_ledger_display_get_query(priv->ledger));
+        Account* common_acct = NULL;
+        splits = qof_query_run (gnc_ledger_display_get_query (priv->ledger));
         /* Make sure each split is from the same account */
-        for (item = splits; item; item = g_list_next(item))
+        for (item = splits; item; item = g_list_next (item))
         {
-            split = (Split *) item->data;
+            split = (Split*) item->data;
             if (common_acct == NULL)
             {
-                common_acct = xaccSplitGetAccount(split);
+                common_acct = xaccSplitGetAccount (split);
             }
             else
             {
-                if (xaccSplitGetAccount(split) != common_acct)
+                if (xaccSplitGetAccount (split) != common_acct)
                 {
-                    GtkWidget *dialog;
+                    GtkWidget* dialog;
                     gint response;
-                    const gchar *title = _("Print checks from multiple accounts?");
-                    const gchar *message =
-                        _("This search result contains splits from more than one account. "
-                          "Do you want to print the checks even though they are not all "
-                          "from the same account?");
-                    dialog = gtk_message_dialog_new(GTK_WINDOW(window),
-                                                    GTK_DIALOG_DESTROY_WITH_PARENT,
-                                                    GTK_MESSAGE_WARNING,
-                                                    GTK_BUTTONS_CANCEL,
-                                                    "%s", title);
-                    gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog),
-                            "%s", message);
-                    gtk_dialog_add_button(GTK_DIALOG(dialog), _("_Print checks"),
-                                          GTK_RESPONSE_YES);
-                    response = gnc_dialog_run(GTK_DIALOG(dialog),
-                                              GNC_PREF_WARN_CHECKPRINTING_MULTI_ACCT);
-                    gtk_widget_destroy(dialog);
+                    const gchar* title = _ ("Print checks from multiple accounts?");
+                    const gchar* message =
+                        _ ("This search result contains splits from more than one account. "
+                           "Do you want to print the checks even though they are not all "
+                           "from the same account?");
+                    dialog = gtk_message_dialog_new (GTK_WINDOW (window),
+                                                     GTK_DIALOG_DESTROY_WITH_PARENT,
+                                                     GTK_MESSAGE_WARNING,
+                                                     GTK_BUTTONS_CANCEL,
+                                                     "%s", title);
+                    gtk_message_dialog_format_secondary_text (GTK_MESSAGE_DIALOG (dialog),
+                                                              "%s", message);
+                    gtk_dialog_add_button (GTK_DIALOG (dialog), _ ("_Print checks"),
+                                           GTK_RESPONSE_YES);
+                    response = gnc_dialog_run (GTK_DIALOG (dialog),
+                                               GNC_PREF_WARN_CHECKPRINTING_MULTI_ACCT);
+                    gtk_widget_destroy (dialog);
                     if (response != GTK_RESPONSE_YES)
                     {
-                        LEAVE("Multiple accounts");
+                        LEAVE ("Multiple accounts");
                         return;
                     }
                     break;
                 }
             }
         }
-        gnc_ui_print_check_dialog_create(window, splits);
+        gnc_ui_print_check_dialog_create (window, splits);
     }
     else
     {
-        gnc_error_dialog(GTK_WINDOW (window), "%s",
-                         _("You can only print checks from a bank account register or search results."));
-        LEAVE("Unsupported ledger type");
+        gnc_error_dialog (GTK_WINDOW (window), "%s",
+                          _ ("You can only print checks from a bank account register or search results."));
+        LEAVE ("Unsupported ledger type");
         return;
     }
-    LEAVE(" ");
+    LEAVE (" ");
 }
 
 
 static void
-gnc_plugin_page_register_cmd_cut (GtkAction *action,
-                                  GncPluginPageRegister *page)
+gnc_plugin_page_register_cmd_cut (GtkAction* action,
+                                  GncPluginPageRegister* page)
 {
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegisterPrivate* priv;
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
 
-    ENTER("(action %p, page %p)", action, page);
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
-    gnucash_register_cut_clipboard(priv->gsr->reg);
-    LEAVE("");
+    ENTER ("(action %p, page %p)", action, page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
+    gnucash_register_cut_clipboard (priv->gsr->reg);
+    LEAVE ("");
 }
 
 
 static void
-gnc_plugin_page_register_cmd_copy (GtkAction *action,
-                                   GncPluginPageRegister *page)
+gnc_plugin_page_register_cmd_copy (GtkAction* action,
+                                   GncPluginPageRegister* page)
 {
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegisterPrivate* priv;
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
 
-    ENTER("(action %p, page %p)", action, page);
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
-    gnucash_register_copy_clipboard(priv->gsr->reg);
-    LEAVE("");
+    ENTER ("(action %p, page %p)", action, page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
+    gnucash_register_copy_clipboard (priv->gsr->reg);
+    LEAVE ("");
 }
 
 
 static void
-gnc_plugin_page_register_cmd_paste (GtkAction *action,
-                                    GncPluginPageRegister *page)
+gnc_plugin_page_register_cmd_paste (GtkAction* action,
+                                    GncPluginPageRegister* page)
 {
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegisterPrivate* priv;
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
 
-    ENTER("(action %p, page %p)", action, page);
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
-    gnucash_register_paste_clipboard(priv->gsr->reg);
-    LEAVE("");
+    ENTER ("(action %p, page %p)", action, page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
+    gnucash_register_paste_clipboard (priv->gsr->reg);
+    LEAVE ("");
 }
 
 
 static void
-gnc_plugin_page_register_cmd_edit_account (GtkAction *action,
-        GncPluginPageRegister *page)
+gnc_plugin_page_register_cmd_edit_account (GtkAction* action,
+                                           GncPluginPageRegister* page)
 {
-    Account *account;
-    GtkWindow *parent = GTK_WINDOW (gnc_plugin_page_get_window (GNC_PLUGIN_PAGE (page)));
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
+    Account* account;
+    GtkWindow* parent = GTK_WINDOW (gnc_plugin_page_get_window (GNC_PLUGIN_PAGE (
+            page)));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
 
-    ENTER("(action %p, page %p)", action, page);
+    ENTER ("(action %p, page %p)", action, page);
     account = gnc_plugin_page_register_get_account (page);
     if (account)
         gnc_ui_edit_account_window (parent, account);
-    LEAVE(" ");
+    LEAVE (" ");
 }
 
 
 static void
-gnc_plugin_page_register_cmd_find_account (GtkAction *action,
-        GncPluginPageRegister *page)
+gnc_plugin_page_register_cmd_find_account (GtkAction* action,
+                                           GncPluginPageRegister* page)
 {
-    GtkWidget *window;
+    GtkWidget* window;
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
 
     window = gnc_plugin_page_get_window (GNC_PLUGIN_PAGE (page));
     gnc_find_account_dialog (window, NULL);
@@ -3664,184 +3805,190 @@ gnc_plugin_page_register_cmd_find_account (GtkAction *action,
 
 
 static void
-gnc_plugin_page_register_cmd_find_transactions (GtkAction *action,
-        GncPluginPageRegister *page)
+gnc_plugin_page_register_cmd_find_transactions (GtkAction* action,
+                                                GncPluginPageRegister* page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    GtkWindow *window;
+    GncPluginPageRegisterPrivate* priv;
+    GtkWindow* window;
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
 
-    ENTER("(action %p, page %p)", action, page);
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
-    window = GTK_WINDOW(gnc_plugin_page_get_window (GNC_PLUGIN_PAGE (page)));
+    ENTER ("(action %p, page %p)", action, page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
+    window = GTK_WINDOW (gnc_plugin_page_get_window (GNC_PLUGIN_PAGE (page)));
     gnc_ui_find_transactions_dialog_create (window, priv->ledger);
-    LEAVE(" ");
+    LEAVE (" ");
 }
 
 
 static void
-gnc_plugin_page_register_cmd_cut_transaction (GtkAction *action,
-        GncPluginPageRegister *plugin_page)
+gnc_plugin_page_register_cmd_cut_transaction (GtkAction* action,
+                                              GncPluginPageRegister* plugin_page)
 {
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegisterPrivate* priv;
 
-    ENTER("(action %p, plugin_page %p)", action, plugin_page);
+    ENTER ("(action %p, plugin_page %p)", action, plugin_page);
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(plugin_page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page));
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
     gsr_default_cut_txn_handler (priv->gsr, NULL);
-    LEAVE(" ");
+    LEAVE (" ");
 }
 
 
 static void
-gnc_plugin_page_register_cmd_copy_transaction (GtkAction *action,
-        GncPluginPageRegister *page)
+gnc_plugin_page_register_cmd_copy_transaction (GtkAction* action,
+                                               GncPluginPageRegister* page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    SplitRegister *reg;
+    GncPluginPageRegisterPrivate* priv;
+    SplitRegister* reg;
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
 
-    ENTER("(action %p, page %p)", action, page);
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
-    reg = gnc_ledger_display_get_split_register(priv->ledger);
-    gnc_split_register_copy_current(reg);
-    LEAVE(" ");
+    ENTER ("(action %p, page %p)", action, page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
+    reg = gnc_ledger_display_get_split_register (priv->ledger);
+    gnc_split_register_copy_current (reg);
+    LEAVE (" ");
 }
 
 
 static void
-gnc_plugin_page_register_cmd_paste_transaction (GtkAction *action,
-        GncPluginPageRegister *page)
+gnc_plugin_page_register_cmd_paste_transaction (GtkAction* action,
+                                                GncPluginPageRegister* page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    SplitRegister *reg;
+    GncPluginPageRegisterPrivate* priv;
+    SplitRegister* reg;
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
 
-    ENTER("(action %p, page %p)", action, page);
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
-    reg = gnc_ledger_display_get_split_register(priv->ledger);
-    gnc_split_register_paste_current(reg);
-    LEAVE(" ");
+    ENTER ("(action %p, page %p)", action, page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
+    reg = gnc_ledger_display_get_split_register (priv->ledger);
+    gnc_split_register_paste_current (reg);
+    LEAVE (" ");
 }
 
 
 static void
-gnc_plugin_page_register_cmd_void_transaction (GtkAction *action,
-        GncPluginPageRegister *page)
+gnc_plugin_page_register_cmd_void_transaction (GtkAction* action,
+                                               GncPluginPageRegister* page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    GtkWidget *dialog, *entry;
-    SplitRegister *reg;
-    Transaction *trans;
-    GtkBuilder *builder;
-    const char *reason;
+    GncPluginPageRegisterPrivate* priv;
+    GtkWidget* dialog, *entry;
+    SplitRegister* reg;
+    Transaction* trans;
+    GtkBuilder* builder;
+    const char* reason;
     gint result;
-    GtkWindow *window;
+    GtkWindow* window;
 
-    ENTER("(action %p, page %p)", action, page);
+    ENTER ("(action %p, page %p)", action, page);
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
 
     window = GTK_WINDOW (gnc_plugin_page_get_window (GNC_PLUGIN_PAGE (page)));
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
-    reg = gnc_ledger_display_get_split_register(priv->ledger);
-    trans = gnc_split_register_get_current_trans(reg);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
+    reg = gnc_ledger_display_get_split_register (priv->ledger);
+    trans = gnc_split_register_get_current_trans (reg);
     if (trans == NULL)
         return;
-    if (xaccTransHasSplitsInState(trans, VREC))
+    if (xaccTransHasSplitsInState (trans, VREC))
         return;
-    if (xaccTransHasReconciledSplits(trans) || xaccTransHasSplitsInState(trans, CREC))
+    if (xaccTransHasReconciledSplits (trans) ||
+        xaccTransHasSplitsInState (trans, CREC))
     {
-        gnc_error_dialog (window, "%s", _("You cannot void a transaction with reconciled or cleared splits."));
+        gnc_error_dialog (window, "%s",
+                          _ ("You cannot void a transaction with reconciled or cleared splits."));
         return;
     }
     reason = xaccTransGetReadOnly (trans);
     if (reason)
     {
-        gnc_error_dialog(window, _("This transaction is marked read-only with the comment: '%s'"), reason);
+        gnc_error_dialog (window,
+                          _ ("This transaction is marked read-only with the comment: '%s'"), reason);
         return;
     }
 
-    if (!gnc_plugin_page_register_finish_pending(GNC_PLUGIN_PAGE(page)))
+    if (!gnc_plugin_page_register_finish_pending (GNC_PLUGIN_PAGE (page)))
         return;
 
     builder = gtk_builder_new();
-    gnc_builder_add_from_file  (builder , "gnc-plugin-page-register.glade", "void_transaction_dialog");
-    dialog = GTK_WIDGET(gtk_builder_get_object (builder, "void_transaction_dialog"));
-    entry = GTK_WIDGET(gtk_builder_get_object (builder, "reason"));
+    gnc_builder_add_from_file (builder, "gnc-plugin-page-register.glade",
+                               "void_transaction_dialog");
+    dialog = GTK_WIDGET (gtk_builder_get_object (builder,
+                                                 "void_transaction_dialog"));
+    entry = GTK_WIDGET (gtk_builder_get_object (builder, "reason"));
 
     gtk_window_set_transient_for (GTK_WINDOW (dialog), window);
 
-    result = gtk_dialog_run(GTK_DIALOG(dialog));
+    result = gtk_dialog_run (GTK_DIALOG (dialog));
     if (result == GTK_RESPONSE_OK)
     {
-        reason = gtk_entry_get_text(GTK_ENTRY(entry));
+        reason = gtk_entry_get_text (GTK_ENTRY (entry));
         if (reason == NULL)
             reason = "";
-        gnc_split_register_void_current_trans(reg, reason);
+        gnc_split_register_void_current_trans (reg, reason);
     }
 
     /* All done. Get rid of it. */
-    gtk_widget_destroy(dialog);
-    g_object_unref(G_OBJECT(builder));
+    gtk_widget_destroy (dialog);
+    g_object_unref (G_OBJECT (builder));
 }
 
 
 static void
-gnc_plugin_page_register_cmd_unvoid_transaction (GtkAction *action,
-        GncPluginPageRegister *page)
+gnc_plugin_page_register_cmd_unvoid_transaction (GtkAction* action,
+                                                 GncPluginPageRegister* page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    SplitRegister *reg;
-    Transaction *trans;
+    GncPluginPageRegisterPrivate* priv;
+    SplitRegister* reg;
+    Transaction* trans;
 
-    ENTER("(action %p, page %p)", action, page);
+    ENTER ("(action %p, page %p)", action, page);
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
-    reg = gnc_ledger_display_get_split_register(priv->ledger);
-    trans = gnc_split_register_get_current_trans(reg);
-    if (!xaccTransHasSplitsInState(trans, VREC))
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
+    reg = gnc_ledger_display_get_split_register (priv->ledger);
+    trans = gnc_split_register_get_current_trans (reg);
+    if (!xaccTransHasSplitsInState (trans, VREC))
         return;
-    gnc_split_register_unvoid_current_trans(reg);
-    LEAVE(" ");
+    gnc_split_register_unvoid_current_trans (reg);
+    LEAVE (" ");
 }
 
 
 static void
-gnc_plugin_page_register_cmd_reverse_transaction (GtkAction *action,
-        GncPluginPageRegister *page)
+gnc_plugin_page_register_cmd_reverse_transaction (GtkAction* action,
+                                                  GncPluginPageRegister* page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    SplitRegister *reg;
-    GNCSplitReg *gsr;
-    Transaction *trans, *new_trans;
+    GncPluginPageRegisterPrivate* priv;
+    SplitRegister* reg;
+    GNCSplitReg* gsr;
+    Transaction* trans, *new_trans;
 
-    ENTER("(action %p, page %p)", action, page);
+    ENTER ("(action %p, page %p)", action, page);
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
-    reg = gnc_ledger_display_get_split_register(priv->ledger);
-    trans = gnc_split_register_get_current_trans(reg);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
+    reg = gnc_ledger_display_get_split_register (priv->ledger);
+    trans = gnc_split_register_get_current_trans (reg);
     if (trans == NULL)
         return;
 
-    if (xaccTransGetReversedBy(trans))
+    if (xaccTransGetReversedBy (trans))
     {
-        gnc_error_dialog(GTK_WINDOW (gnc_plugin_page_get_window (GNC_PLUGIN_PAGE (page))), "%s",
-                         _("A reversing entry has already been created for this transaction."));
+        gnc_error_dialog (GTK_WINDOW (gnc_plugin_page_get_window (GNC_PLUGIN_PAGE (
+                page))), "%s",
+                          _ ("A reversing entry has already been created for this transaction."));
         return;
     }
 
     qof_event_suspend();
-    new_trans = xaccTransReverse(trans);
+    new_trans = xaccTransReverse (trans);
 
     /* Clear transaction level info */
     xaccTransSetDatePostedSecsNormalized (new_trans, gnc_time (NULL));
@@ -3850,17 +3997,18 @@ gnc_plugin_page_register_cmd_reverse_transaction (GtkAction *action,
     qof_event_resume();
 
     /* Now jump to new trans */
-    gsr = gnc_plugin_page_register_get_gsr(GNC_PLUGIN_PAGE(page));
-    gnc_split_reg_jump_to_split(gsr, xaccTransGetSplit(new_trans, 0));
-    LEAVE(" ");
+    gsr = gnc_plugin_page_register_get_gsr (GNC_PLUGIN_PAGE (page));
+    gnc_split_reg_jump_to_split (gsr, xaccTransGetSplit (new_trans, 0));
+    LEAVE (" ");
 }
 
 static gboolean
-gnc_plugin_page_register_show_fs_save (GncPluginPageRegister *page)
+gnc_plugin_page_register_show_fs_save (GncPluginPageRegister* page)
 {
-    GncPluginPageRegisterPrivate *priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
+    GncPluginPageRegisterPrivate* priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (
+                                             page);
     GNCLedgerDisplayType ledger_type = gnc_ledger_display_type (priv->ledger);
-    SplitRegister *reg = gnc_ledger_display_get_split_register (priv->ledger);
+    SplitRegister* reg = gnc_ledger_display_get_split_register (priv->ledger);
 
     if (ledger_type == LD_SINGLE || ledger_type == LD_SUBACCOUNT)
         return TRUE;
@@ -3883,154 +4031,162 @@ gnc_plugin_page_register_show_fs_save (GncPluginPageRegister *page)
 }
 
 static void
-gnc_plugin_page_register_cmd_view_sort_by (GtkAction *action,
-        GncPluginPageRegister *page)
+gnc_plugin_page_register_cmd_view_sort_by (GtkAction* action,
+                                           GncPluginPageRegister* page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    SplitRegister *reg;
-    GtkWidget *dialog, *button;
-    GtkBuilder *builder;
+    GncPluginPageRegisterPrivate* priv;
+    SplitRegister* reg;
+    GtkWidget* dialog, *button;
+    GtkBuilder* builder;
     SortType sort;
-    const gchar *name;
-    gchar *title;
+    const gchar* name;
+    gchar* title;
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
-    ENTER("(action %p, page %p)", action, page);
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
+    ENTER ("(action %p, page %p)", action, page);
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
     if (priv->sd.dialog)
     {
-        gtk_window_present(GTK_WINDOW(priv->sd.dialog));
-        LEAVE("existing dialog");
+        gtk_window_present (GTK_WINDOW (priv->sd.dialog));
+        LEAVE ("existing dialog");
         return;
     }
 
     /* Create the dialog */
 
     builder = gtk_builder_new();
-    gnc_builder_add_from_file  (builder, "gnc-plugin-page-register.glade", "sort_by_dialog");
-    dialog = GTK_WIDGET(gtk_builder_get_object (builder, "sort_by_dialog"));
+    gnc_builder_add_from_file (builder, "gnc-plugin-page-register.glade",
+                               "sort_by_dialog");
+    dialog = GTK_WIDGET (gtk_builder_get_object (builder, "sort_by_dialog"));
     priv->sd.dialog = dialog;
-    gtk_window_set_transient_for(GTK_WINDOW(dialog),
-                                 gnc_window_get_gtk_window(GNC_WINDOW(GNC_PLUGIN_PAGE(page)->window)));
+    gtk_window_set_transient_for (GTK_WINDOW (dialog),
+                                  gnc_window_get_gtk_window (GNC_WINDOW (GNC_PLUGIN_PAGE (page)->window)));
     /* Translators: The %s is the name of the plugin page */
-    title = g_strdup_printf(_("Sort %s by..."),
-                            gnc_plugin_page_get_page_name(GNC_PLUGIN_PAGE(page)));
-    gtk_window_set_title(GTK_WINDOW(dialog), title);
-    g_free(title);
+    title = g_strdup_printf (_ ("Sort %s by..."),
+                             gnc_plugin_page_get_page_name (GNC_PLUGIN_PAGE (page)));
+    gtk_window_set_title (GTK_WINDOW (dialog), title);
+    g_free (title);
 
     /* Set the button for the current sort order */
-    sort = gnc_split_reg_get_sort_type(priv->gsr);
-    name = SortTypeasString(sort);
-    button = GTK_WIDGET(gtk_builder_get_object (builder, name));
-    DEBUG("current sort %d, button %s(%p)", sort, name, button);
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), TRUE);
+    sort = gnc_split_reg_get_sort_type (priv->gsr);
+    name = SortTypeasString (sort);
+    button = GTK_WIDGET (gtk_builder_get_object (builder, name));
+    DEBUG ("current sort %d, button %s(%p)", sort, name, button);
+    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (button), TRUE);
     priv->sd.original_sort_type = sort;
 
-    button = GTK_WIDGET(gtk_builder_get_object (builder, "sort_save"));
+    button = GTK_WIDGET (gtk_builder_get_object (builder, "sort_save"));
     if (priv->sd.save_order == TRUE)
-        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), TRUE);
+        gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (button), TRUE);
 
     // hide the save button if appropriate
-    gtk_widget_set_visible (GTK_WIDGET(button),
-        gnc_plugin_page_register_show_fs_save (page));
+    gtk_widget_set_visible (GTK_WIDGET (button),
+                            gnc_plugin_page_register_show_fs_save (page));
 
     /* Set the button for the current reverse_order order */
-    button = GTK_WIDGET(gtk_builder_get_object (builder, "sort_reverse"));
-    if(priv->sd.reverse_order == TRUE)
-       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), TRUE);
+    button = GTK_WIDGET (gtk_builder_get_object (builder, "sort_reverse"));
+    if (priv->sd.reverse_order == TRUE)
+        gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (button), TRUE);
     priv->sd.original_reverse_order = priv->sd.reverse_order;
 
-    priv->sd.num_radio = GTK_WIDGET(gtk_builder_get_object (builder, "BY_NUM"));
-    priv->sd.act_radio = GTK_WIDGET(gtk_builder_get_object (builder, "BY_ACTION"));
+    priv->sd.num_radio = GTK_WIDGET (gtk_builder_get_object (builder, "BY_NUM"));
+    priv->sd.act_radio = GTK_WIDGET (gtk_builder_get_object (builder,
+                                                             "BY_ACTION"));
     /* Adjust labels related to Num/Action radio buttons based on book option */
-    reg = gnc_ledger_display_get_split_register(priv->ledger);
+    reg = gnc_ledger_display_get_split_register (priv->ledger);
     if (reg && !reg->use_tran_num_for_num_field)
     {
-        gtk_button_set_label(GTK_BUTTON (priv->sd.num_radio), _("Transaction Number"));
-        gtk_button_set_label(GTK_BUTTON (priv->sd.act_radio), _("Number/Action"));
+        gtk_button_set_label (GTK_BUTTON (priv->sd.num_radio),
+                              _ ("Transaction Number"));
+        gtk_button_set_label (GTK_BUTTON (priv->sd.act_radio), _ ("Number/Action"));
     }
-    gnc_book_option_register_cb(OPTION_NAME_NUM_FIELD_SOURCE,
-                                gnc_plugin_page_register_sort_book_option_changed,
-                                page);
+    gnc_book_option_register_cb (OPTION_NAME_NUM_FIELD_SOURCE,
+                                 gnc_plugin_page_register_sort_book_option_changed,
+                                 page);
 
-     /* Wire it up */
-    gtk_builder_connect_signals_full (builder, gnc_builder_connect_full_func, page);
+    /* Wire it up */
+    gtk_builder_connect_signals_full (builder, gnc_builder_connect_full_func,
+                                      page);
 
     /* Show it */
-    gtk_widget_show(dialog);
-    g_object_unref(G_OBJECT(builder));
-    LEAVE(" ");
+    gtk_widget_show (dialog);
+    g_object_unref (G_OBJECT (builder));
+    LEAVE (" ");
 }
 
 static void
-gnc_plugin_page_register_cmd_view_filter_by (GtkAction *action,
-        GncPluginPageRegister *page)
+gnc_plugin_page_register_cmd_view_filter_by (GtkAction* action,
+                                             GncPluginPageRegister* page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    GtkWidget *dialog, *toggle, *button, *table, *hbox;
+    GncPluginPageRegisterPrivate* priv;
+    GtkWidget* dialog, *toggle, *button, *table, *hbox;
     time64 start_time, end_time, time_val;
-    GtkBuilder *builder;
+    GtkBuilder* builder;
     gboolean sensitive, value;
-    Query *query;
-    gchar *title;
+    Query* query;
+    gchar* title;
     int i;
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
-    ENTER("(action %p, page %p)", action, page);
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
+    ENTER ("(action %p, page %p)", action, page);
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
     if (priv->fd.dialog)
     {
-        gtk_window_present(GTK_WINDOW(priv->fd.dialog));
-        LEAVE("existing dialog");
+        gtk_window_present (GTK_WINDOW (priv->fd.dialog));
+        LEAVE ("existing dialog");
         return;
     }
 
     /* Create the dialog */
     builder = gtk_builder_new();
-    gnc_builder_add_from_file (builder, "gnc-plugin-page-register.glade", "days_adjustment");
-    gnc_builder_add_from_file (builder, "gnc-plugin-page-register.glade", "filter_by_dialog");
-    dialog = GTK_WIDGET(gtk_builder_get_object (builder, "filter_by_dialog"));
+    gnc_builder_add_from_file (builder, "gnc-plugin-page-register.glade",
+                               "days_adjustment");
+    gnc_builder_add_from_file (builder, "gnc-plugin-page-register.glade",
+                               "filter_by_dialog");
+    dialog = GTK_WIDGET (gtk_builder_get_object (builder, "filter_by_dialog"));
     priv->fd.dialog = dialog;
-    gtk_window_set_transient_for(GTK_WINDOW(dialog),
-                                 gnc_window_get_gtk_window(GNC_WINDOW(GNC_PLUGIN_PAGE(page)->window)));
+    gtk_window_set_transient_for (GTK_WINDOW (dialog),
+                                  gnc_window_get_gtk_window (GNC_WINDOW (GNC_PLUGIN_PAGE (page)->window)));
 
     /* Translators: The %s is the name of the plugin page */
-    title = g_strdup_printf(_("Filter %s by..."),
-                            gnc_plugin_page_get_page_name(GNC_PLUGIN_PAGE(page)));
-    gtk_window_set_title(GTK_WINDOW(dialog), title);
-    g_free(title);
+    title = g_strdup_printf (_ ("Filter %s by..."),
+                             gnc_plugin_page_get_page_name (GNC_PLUGIN_PAGE (page)));
+    gtk_window_set_title (GTK_WINDOW (dialog), title);
+    g_free (title);
 
     /* Set the check buttons for the current status */
     for (i = 0; status_actions[i].action_name; i++)
     {
-        toggle = GTK_WIDGET(gtk_builder_get_object (builder, status_actions[i].action_name));
+        toggle = GTK_WIDGET (gtk_builder_get_object (builder,
+                                                     status_actions[i].action_name));
         value = priv->fd.cleared_match & status_actions[i].value;
         status_actions[i].widget = toggle;
-        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(toggle), value);
+        gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (toggle), value);
     }
     priv->fd.original_cleared_match = priv->fd.cleared_match;
 
-    button = GTK_WIDGET(gtk_builder_get_object (builder, "filter_save"));
+    button = GTK_WIDGET (gtk_builder_get_object (builder, "filter_save"));
     if (priv->fd.save_filter == TRUE)
-        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), TRUE);
+        gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (button), TRUE);
 
     // hide the save button if appropriate
-    gtk_widget_set_visible (GTK_WIDGET(button),
-        gnc_plugin_page_register_show_fs_save (page));
+    gtk_widget_set_visible (GTK_WIDGET (button),
+                            gnc_plugin_page_register_show_fs_save (page));
 
     /* Set up number of days */
-    priv->fd.num_days = GTK_WIDGET(gtk_builder_get_object (builder, "filter_show_num_days"));
-    button = GTK_WIDGET(gtk_builder_get_object (builder, "filter_show_days"));
+    priv->fd.num_days = GTK_WIDGET (gtk_builder_get_object (builder,
+                                                            "filter_show_num_days"));
+    button = GTK_WIDGET (gtk_builder_get_object (builder, "filter_show_days"));
 
     query = gnc_ledger_display_get_query (priv->ledger);
 
     if (priv->fd.days > 0) // using number of days
     {
-        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), TRUE);
-        gtk_widget_set_sensitive(GTK_WIDGET(priv->fd.num_days), TRUE);
-        gtk_spin_button_set_value(GTK_SPIN_BUTTON(priv->fd.num_days), priv->fd.days);
+        gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (button), TRUE);
+        gtk_widget_set_sensitive (GTK_WIDGET (priv->fd.num_days), TRUE);
+        gtk_spin_button_set_value (GTK_SPIN_BUTTON (priv->fd.num_days), priv->fd.days);
         priv->fd.original_days = priv->fd.days;
 
         /* Set the start_time and end_time to 0 */
@@ -4039,12 +4195,12 @@ gnc_plugin_page_register_cmd_view_filter_by (GtkAction *action,
     }
     else
     {
-        gtk_widget_set_sensitive(GTK_WIDGET(priv->fd.num_days), FALSE);
+        gtk_widget_set_sensitive (GTK_WIDGET (priv->fd.num_days), FALSE);
         priv->fd.original_days = 0;
         priv->fd.days = 0;
 
         /* Get the start and end times */
-        xaccQueryGetDateMatchTT(query, &start_time, &end_time);
+        xaccQueryGetDateMatchTT (query, &start_time, &end_time);
     }
 
     /* Set the date info */
@@ -4053,22 +4209,27 @@ gnc_plugin_page_register_cmd_view_filter_by (GtkAction *action,
     priv->fd.original_end_time = end_time;
     priv->fd.end_time = end_time;
 
-    button = GTK_WIDGET(gtk_builder_get_object (builder, "filter_show_range"));
-    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), start_time || end_time);
-    table = GTK_WIDGET(gtk_builder_get_object (builder, "select_range_table"));
+    button = GTK_WIDGET (gtk_builder_get_object (builder, "filter_show_range"));
+    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (button), start_time ||
+                                  end_time);
+    table = GTK_WIDGET (gtk_builder_get_object (builder, "select_range_table"));
     priv->fd.table = table;
-    gtk_widget_set_sensitive(GTK_WIDGET(table), start_time || end_time);
+    gtk_widget_set_sensitive (GTK_WIDGET (table), start_time || end_time);
 
-    priv->fd.start_date_choose = GTK_WIDGET(gtk_builder_get_object (builder, "start_date_choose"));
-    priv->fd.start_date_today = GTK_WIDGET(gtk_builder_get_object (builder, "start_date_today"));
-    priv->fd.end_date_choose = GTK_WIDGET(gtk_builder_get_object (builder, "end_date_choose"));
-    priv->fd.end_date_today = GTK_WIDGET(gtk_builder_get_object (builder, "end_date_today"));
+    priv->fd.start_date_choose = GTK_WIDGET (gtk_builder_get_object (builder,
+                                             "start_date_choose"));
+    priv->fd.start_date_today = GTK_WIDGET (gtk_builder_get_object (builder,
+                                            "start_date_today"));
+    priv->fd.end_date_choose = GTK_WIDGET (gtk_builder_get_object (builder,
+                                           "end_date_choose"));
+    priv->fd.end_date_today = GTK_WIDGET (gtk_builder_get_object (builder,
+                                          "end_date_today"));
 
     {
         /* Start date info */
         if (start_time == 0)
         {
-            button = GTK_WIDGET(gtk_builder_get_object (builder, "start_date_earliest"));
+            button = GTK_WIDGET (gtk_builder_get_object (builder, "start_date_earliest"));
             time_val = xaccQueryGetEarliestDateFound (query);
             sensitive = FALSE;
         }
@@ -4076,7 +4237,7 @@ gnc_plugin_page_register_cmd_view_filter_by (GtkAction *action,
         {
             time_val = start_time;
             if ((start_time >= gnc_time64_get_today_start()) &&
-                    (start_time <= gnc_time64_get_today_end()))
+                (start_time <= gnc_time64_get_today_end()))
             {
                 button = priv->fd.start_date_today;
                 sensitive = FALSE;
@@ -4087,13 +4248,13 @@ gnc_plugin_page_register_cmd_view_filter_by (GtkAction *action,
                 sensitive = TRUE;
             }
         }
-        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), TRUE);
+        gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (button), TRUE);
         priv->fd.start_date = gnc_date_edit_new (gnc_time (NULL), FALSE, FALSE);
-        hbox = GTK_WIDGET(gtk_builder_get_object (builder, "start_date_hbox"));
+        hbox = GTK_WIDGET (gtk_builder_get_object (builder, "start_date_hbox"));
         gtk_box_pack_start (GTK_BOX (hbox), priv->fd.start_date, TRUE, TRUE, 0);
         gtk_widget_show (priv->fd.start_date);
-        gtk_widget_set_sensitive(GTK_WIDGET(priv->fd.start_date), sensitive);
-        gnc_date_edit_set_time (GNC_DATE_EDIT(priv->fd.start_date), time_val);
+        gtk_widget_set_sensitive (GTK_WIDGET (priv->fd.start_date), sensitive);
+        gnc_date_edit_set_time (GNC_DATE_EDIT (priv->fd.start_date), time_val);
         g_signal_connect (G_OBJECT (priv->fd.start_date), "date-changed",
                           G_CALLBACK (gnc_plugin_page_register_filter_gde_changed_cb),
                           page);
@@ -4103,7 +4264,7 @@ gnc_plugin_page_register_cmd_view_filter_by (GtkAction *action,
         /* End date info */
         if (end_time == 0)
         {
-            button = GTK_WIDGET(gtk_builder_get_object (builder, "end_date_latest"));
+            button = GTK_WIDGET (gtk_builder_get_object (builder, "end_date_latest"));
             time_val = xaccQueryGetLatestDateFound (query);
             sensitive = FALSE;
         }
@@ -4111,7 +4272,7 @@ gnc_plugin_page_register_cmd_view_filter_by (GtkAction *action,
         {
             time_val = end_time;
             if ((end_time >= gnc_time64_get_today_start()) &&
-                    (end_time <= gnc_time64_get_today_end()))
+                (end_time <= gnc_time64_get_today_end()))
             {
                 button = priv->fd.end_date_today;
                 sensitive = FALSE;
@@ -4122,34 +4283,36 @@ gnc_plugin_page_register_cmd_view_filter_by (GtkAction *action,
                 sensitive = TRUE;
             }
         }
-        gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(button), TRUE);
+        gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (button), TRUE);
         priv->fd.end_date = gnc_date_edit_new (gnc_time (NULL), FALSE, FALSE);
-        hbox = GTK_WIDGET(gtk_builder_get_object (builder, "end_date_hbox"));
+        hbox = GTK_WIDGET (gtk_builder_get_object (builder, "end_date_hbox"));
         gtk_box_pack_start (GTK_BOX (hbox), priv->fd.end_date, TRUE, TRUE, 0);
         gtk_widget_show (priv->fd.end_date);
-        gtk_widget_set_sensitive(GTK_WIDGET(priv->fd.end_date), sensitive);
-        gnc_date_edit_set_time (GNC_DATE_EDIT(priv->fd.end_date), time_val);
+        gtk_widget_set_sensitive (GTK_WIDGET (priv->fd.end_date), sensitive);
+        gnc_date_edit_set_time (GNC_DATE_EDIT (priv->fd.end_date), time_val);
         g_signal_connect (G_OBJECT (priv->fd.end_date), "date-changed",
                           G_CALLBACK (gnc_plugin_page_register_filter_gde_changed_cb),
                           page);
     }
 
     /* Wire it up */
-    gtk_builder_connect_signals_full (builder, gnc_builder_connect_full_func, page);
+    gtk_builder_connect_signals_full (builder, gnc_builder_connect_full_func,
+                                      page);
 
     /* Show it */
-    gtk_widget_show(dialog);
-    g_object_unref(G_OBJECT(builder));
-    LEAVE(" ");
+    gtk_widget_show (dialog);
+    g_object_unref (G_OBJECT (builder));
+    LEAVE (" ");
 }
 
 static void
-gnc_plugin_page_register_cmd_reload (GtkAction *action, GncPluginPageRegister *plugin_page)
+gnc_plugin_page_register_cmd_reload (GtkAction* action,
+                                     GncPluginPageRegister* plugin_page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    SplitRegister *reg;
+    GncPluginPageRegisterPrivate* priv;
+    SplitRegister* reg;
 
-    ENTER("(action %p, page %p)", action, plugin_page);
+    ENTER ("(action %p, page %p)", action, plugin_page);
 
     g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page));
 
@@ -4159,252 +4322,255 @@ gnc_plugin_page_register_cmd_reload (GtkAction *action, GncPluginPageRegister *p
     /* Check for trans being edited */
     if (gnc_split_register_changed (reg))
     {
-        LEAVE("register has pending edits");
+        LEAVE ("register has pending edits");
         return;
     }
     gnc_ledger_display_refresh (priv->ledger);
-    LEAVE(" ");
+    LEAVE (" ");
 }
 
 static void
-gnc_plugin_page_register_cmd_style_changed (GtkAction *action,
-        GtkRadioAction *current,
-        GncPluginPageRegister *plugin_page)
+gnc_plugin_page_register_cmd_style_changed (GtkAction* action,
+                                            GtkRadioAction* current,
+                                            GncPluginPageRegister* plugin_page)
 {
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegisterPrivate* priv;
     SplitRegisterStyle value;
 
-    ENTER("(action %p, radio action %p, plugin_page %p)",
-          action, current, plugin_page);
+    ENTER ("(action %p, radio action %p, plugin_page %p)",
+           action, current, plugin_page);
 
-    g_return_if_fail(GTK_IS_ACTION(action));
-    g_return_if_fail(GTK_IS_RADIO_ACTION(current));
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(plugin_page));
+    g_return_if_fail (GTK_IS_ACTION (action));
+    g_return_if_fail (GTK_IS_RADIO_ACTION (current));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page));
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
-    value = gtk_radio_action_get_current_value(current);
-    gnc_split_reg_change_style(priv->gsr, value, priv->enable_refresh);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
+    value = gtk_radio_action_get_current_value (current);
+    gnc_split_reg_change_style (priv->gsr, value, priv->enable_refresh);
 
     gnc_plugin_page_register_ui_update (NULL, plugin_page);
-    LEAVE(" ");
+    LEAVE (" ");
 }
 
 static void
-gnc_plugin_page_register_cmd_style_double_line (GtkToggleAction *action,
-        GncPluginPageRegister *plugin_page)
+gnc_plugin_page_register_cmd_style_double_line (GtkToggleAction* action,
+                                                GncPluginPageRegister* plugin_page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    SplitRegister *reg;
+    GncPluginPageRegisterPrivate* priv;
+    SplitRegister* reg;
     gboolean use_double_line;
 
-    ENTER("(action %p, plugin_page %p)", action, plugin_page);
+    ENTER ("(action %p, plugin_page %p)", action, plugin_page);
 
-    g_return_if_fail(GTK_IS_ACTION(action));
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(plugin_page));
+    g_return_if_fail (GTK_IS_ACTION (action));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page));
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
     reg = gnc_ledger_display_get_split_register (priv->ledger);
 
     use_double_line =  gtk_toggle_action_get_active (action);
     if (use_double_line != reg->use_double_line)
     {
-        gnc_split_register_config(reg, reg->type, reg->style, use_double_line);
+        gnc_split_register_config (reg, reg->type, reg->style, use_double_line);
         if (priv->enable_refresh)
-            gnc_ledger_display_refresh(priv->ledger);
+            gnc_ledger_display_refresh (priv->ledger);
     }
-    LEAVE(" ");
+    LEAVE (" ");
 }
 
 static void
-gnc_plugin_page_register_cmd_transfer (GtkAction *action,
-                                       GncPluginPageRegister *page)
+gnc_plugin_page_register_cmd_transfer (GtkAction* action,
+                                       GncPluginPageRegister* page)
 {
-    Account *account;
-    GncWindow *gnc_window;
-    GtkWidget *window;
+    Account* account;
+    GncWindow* gnc_window;
+    GtkWidget* window;
 
-    ENTER("(action %p, plugin_page %p)", action, page);
+    ENTER ("(action %p, plugin_page %p)", action, page);
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
 
     account = gnc_plugin_page_register_get_account (page);
-    gnc_window = GNC_WINDOW(GNC_PLUGIN_PAGE (page)->window);
-    window = GTK_WIDGET(gnc_window_get_gtk_window(gnc_window));
+    gnc_window = GNC_WINDOW (GNC_PLUGIN_PAGE (page)->window);
+    window = GTK_WIDGET (gnc_window_get_gtk_window (gnc_window));
     gnc_xfer_dialog (window, account);
-    LEAVE(" ");
+    LEAVE (" ");
 }
 
 static void
-gnc_plugin_page_register_cmd_reconcile (GtkAction *action,
-                                        GncPluginPageRegister *page)
+gnc_plugin_page_register_cmd_reconcile (GtkAction* action,
+                                        GncPluginPageRegister* page)
 {
-    Account *account;
-    GtkWindow *window;
-    RecnWindow * recnData;
+    Account* account;
+    GtkWindow* window;
+    RecnWindow* recnData;
 
-    ENTER("(action %p, plugin_page %p)", action, page);
+    ENTER ("(action %p, plugin_page %p)", action, page);
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
 
     account = gnc_plugin_page_register_get_account (page);
 
-    window = gnc_window_get_gtk_window(GNC_WINDOW(GNC_PLUGIN_PAGE (page)->window));
-    recnData = recnWindow (GTK_WIDGET(window), account);
+    window = gnc_window_get_gtk_window (GNC_WINDOW (GNC_PLUGIN_PAGE (
+                                                        page)->window));
+    recnData = recnWindow (GTK_WIDGET (window), account);
     gnc_ui_reconcile_window_raise (recnData);
-    LEAVE(" ");
+    LEAVE (" ");
 }
 
 static void
-gnc_plugin_page_register_cmd_autoclear (GtkAction *action,
-                                        GncPluginPageRegister *page)
+gnc_plugin_page_register_cmd_autoclear (GtkAction* action,
+                                        GncPluginPageRegister* page)
 {
-    Account *account;
-    GtkWindow *window;
-    AutoClearWindow * autoClearData;
+    Account* account;
+    GtkWindow* window;
+    AutoClearWindow* autoClearData;
 
-    ENTER("(action %p, plugin_page %p)", action, page);
+    ENTER ("(action %p, plugin_page %p)", action, page);
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
 
     account = gnc_plugin_page_register_get_account (page);
 
-    window = gnc_window_get_gtk_window(GNC_WINDOW(GNC_PLUGIN_PAGE (page)->window));
-    autoClearData = autoClearWindow (GTK_WIDGET(window), account);
+    window = gnc_window_get_gtk_window (GNC_WINDOW (GNC_PLUGIN_PAGE (
+                                                        page)->window));
+    autoClearData = autoClearWindow (GTK_WIDGET (window), account);
     gnc_ui_autoclear_window_raise (autoClearData);
-    LEAVE(" ");
+    LEAVE (" ");
 }
 
 static void
-gnc_plugin_page_register_cmd_stock_split (GtkAction *action,
-        GncPluginPageRegister *page)
+gnc_plugin_page_register_cmd_stock_split (GtkAction* action,
+                                          GncPluginPageRegister* page)
 {
-    Account *account;
+    Account* account;
 
-    ENTER("(action %p, plugin_page %p)", action, page);
+    ENTER ("(action %p, plugin_page %p)", action, page);
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
 
     account = gnc_plugin_page_register_get_account (page);
     gnc_stock_split_dialog (NULL, account);
-    LEAVE(" ");
+    LEAVE (" ");
 }
 
 static void
-gnc_plugin_page_register_cmd_lots (GtkAction *action,
-                                   GncPluginPageRegister *page)
+gnc_plugin_page_register_cmd_lots (GtkAction* action,
+                                   GncPluginPageRegister* page)
 {
-    GtkWindow *window;
-    Account *account;
+    GtkWindow* window;
+    Account* account;
 
-    ENTER("(action %p, plugin_page %p)", action, page);
+    ENTER ("(action %p, plugin_page %p)", action, page);
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
 
-    window = gnc_window_get_gtk_window(GNC_WINDOW(GNC_PLUGIN_PAGE (page)->window));
+    window = gnc_window_get_gtk_window (GNC_WINDOW (GNC_PLUGIN_PAGE (
+                                                        page)->window));
     account = gnc_plugin_page_register_get_account (page);
     gnc_lot_viewer_dialog (window, account);
-    LEAVE(" ");
+    LEAVE (" ");
 }
 
 static void
-gnc_plugin_page_register_cmd_enter_transaction (GtkAction *action,
-        GncPluginPageRegister *plugin_page)
+gnc_plugin_page_register_cmd_enter_transaction (GtkAction* action,
+                                                GncPluginPageRegister* plugin_page)
 {
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegisterPrivate* priv;
 
-    ENTER("(action %p, plugin_page %p)", action, plugin_page);
+    ENTER ("(action %p, plugin_page %p)", action, plugin_page);
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(plugin_page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page));
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
-    gnc_split_reg_enter(priv->gsr, FALSE);
-    LEAVE(" ");
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
+    gnc_split_reg_enter (priv->gsr, FALSE);
+    LEAVE (" ");
 }
 
 static void
-gnc_plugin_page_register_cmd_cancel_transaction (GtkAction *action,
-        GncPluginPageRegister *plugin_page)
+gnc_plugin_page_register_cmd_cancel_transaction (GtkAction* action,
+                                                 GncPluginPageRegister* plugin_page)
 {
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegisterPrivate* priv;
 
-    ENTER("(action %p, plugin_page %p)", action, plugin_page);
+    ENTER ("(action %p, plugin_page %p)", action, plugin_page);
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(plugin_page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page));
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
     gnc_split_register_cancel_cursor_trans_changes
-    (gnc_ledger_display_get_split_register(priv->ledger));
-    LEAVE(" ");
+    (gnc_ledger_display_get_split_register (priv->ledger));
+    LEAVE (" ");
 }
 
 static void
-gnc_plugin_page_register_cmd_delete_transaction (GtkAction *action,
-        GncPluginPageRegister *plugin_page)
+gnc_plugin_page_register_cmd_delete_transaction (GtkAction* action,
+                                                 GncPluginPageRegister* plugin_page)
 {
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegisterPrivate* priv;
 
-    ENTER("(action %p, plugin_page %p)", action, plugin_page);
+    ENTER ("(action %p, plugin_page %p)", action, plugin_page);
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(plugin_page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page));
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
-    gsr_default_delete_handler(priv->gsr, NULL);
-    LEAVE(" ");
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
+    gsr_default_delete_handler (priv->gsr, NULL);
+    LEAVE (" ");
 
 }
 
 static void
-gnc_plugin_page_register_cmd_associate_file_transaction (GtkAction *action,
-        GncPluginPageRegister *plugin_page)
+gnc_plugin_page_register_cmd_associate_file_transaction (GtkAction* action,
+                                                         GncPluginPageRegister* plugin_page)
 {
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegisterPrivate* priv;
 
-    ENTER("(action %p, plugin_page %p)", action, plugin_page);
+    ENTER ("(action %p, plugin_page %p)", action, plugin_page);
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(plugin_page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page));
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
     gsr_default_associate_handler (priv->gsr, TRUE);
     gnc_plugin_page_register_ui_update (NULL, plugin_page);
-    LEAVE(" ");
+    LEAVE (" ");
 }
 
 static void
-gnc_plugin_page_register_cmd_associate_location_transaction (GtkAction *action,
-        GncPluginPageRegister *plugin_page)
+gnc_plugin_page_register_cmd_associate_location_transaction (GtkAction* action,
+        GncPluginPageRegister* plugin_page)
 {
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegisterPrivate* priv;
 
-    ENTER("(action %p, plugin_page %p)", action, plugin_page);
+    ENTER ("(action %p, plugin_page %p)", action, plugin_page);
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(plugin_page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page));
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
     gsr_default_associate_handler (priv->gsr, FALSE);
     gnc_plugin_page_register_ui_update (NULL, plugin_page);
-    LEAVE(" ");
+    LEAVE (" ");
 }
 
 static void
-gnc_plugin_page_register_cmd_execassociated_transaction (GtkAction *action,
-        GncPluginPageRegister *plugin_page)
+gnc_plugin_page_register_cmd_execassociated_transaction (GtkAction* action,
+                                                         GncPluginPageRegister* plugin_page)
 {
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegisterPrivate* priv;
 
-    ENTER("(action %p, plugin_page %p)", action, plugin_page);
+    ENTER ("(action %p, plugin_page %p)", action, plugin_page);
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(plugin_page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page));
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
-    gsr_default_execassociated_handler(priv->gsr, NULL);
-    LEAVE(" ");
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
+    gsr_default_execassociated_handler (priv->gsr, NULL);
+    LEAVE (" ");
 
 }
 
-static GncInvoice * invoice_from_split (Split *split)
+static GncInvoice* invoice_from_split (Split* split)
 {
-    GncInvoice *invoice;
-    GNCLot *lot;
+    GncInvoice* invoice;
+    GNCLot* lot;
 
     if (!split)
         return NULL;
@@ -4421,139 +4587,139 @@ static GncInvoice * invoice_from_split (Split *split)
 }
 
 static void
-gnc_plugin_page_register_cmd_jump_associated_invoice (GtkAction *action,
-        GncPluginPageRegister *plugin_page)
+gnc_plugin_page_register_cmd_jump_associated_invoice (GtkAction* action,
+                                                      GncPluginPageRegister* plugin_page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    SplitRegister *reg;
-    GncInvoice *invoice;
+    GncPluginPageRegisterPrivate* priv;
+    SplitRegister* reg;
+    GncInvoice* invoice;
 
-    ENTER("(action %p, plugin_page %p)", action, plugin_page);
+    ENTER ("(action %p, plugin_page %p)", action, plugin_page);
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(plugin_page));
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page));
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
     reg = gnc_ledger_display_get_split_register (priv->gsr->ledger);
     invoice = invoice_from_split (gnc_split_register_get_current_split (reg));
     if (invoice)
         gnc_ui_invoice_edit (NULL, invoice);
 
-    LEAVE(" ");
+    LEAVE (" ");
 }
 
 static void
-gnc_plugin_page_register_cmd_blank_transaction (GtkAction *action,
-        GncPluginPageRegister *plugin_page)
+gnc_plugin_page_register_cmd_blank_transaction (GtkAction* action,
+                                                GncPluginPageRegister* plugin_page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    SplitRegister *reg;
+    GncPluginPageRegisterPrivate* priv;
+    SplitRegister* reg;
 
-    ENTER("(action %p, plugin_page %p)", action, plugin_page);
+    ENTER ("(action %p, plugin_page %p)", action, plugin_page);
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(plugin_page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page));
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
     reg = gnc_ledger_display_get_split_register (priv->ledger);
 
     if (gnc_split_register_save (reg, TRUE))
         gnc_split_register_redraw (reg);
 
     gnc_split_reg_jump_to_blank (priv->gsr);
-    LEAVE(" ");
+    LEAVE (" ");
 }
 
 static void
-gnc_plugin_page_register_cmd_duplicate_transaction (GtkAction *action,
-        GncPluginPageRegister *plugin_page)
+gnc_plugin_page_register_cmd_duplicate_transaction (GtkAction* action,
+                                                    GncPluginPageRegister* plugin_page)
 {
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegisterPrivate* priv;
 
-    ENTER("(action %p, plugin_page %p)", action, plugin_page);
+    ENTER ("(action %p, plugin_page %p)", action, plugin_page);
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(plugin_page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page));
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
     gnc_split_register_duplicate_current
-    (gnc_ledger_display_get_split_register(priv->ledger));
-    LEAVE(" ");
+    (gnc_ledger_display_get_split_register (priv->ledger));
+    LEAVE (" ");
 }
 
 static void
-gnc_plugin_page_register_cmd_reinitialize_transaction (GtkAction *action,
-        GncPluginPageRegister *plugin_page)
+gnc_plugin_page_register_cmd_reinitialize_transaction (GtkAction* action,
+                                                       GncPluginPageRegister* plugin_page)
 {
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegisterPrivate* priv;
 
-    ENTER("(action %p, plugin_page %p)", action, plugin_page);
+    ENTER ("(action %p, plugin_page %p)", action, plugin_page);
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(plugin_page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page));
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
-    gsr_default_reinit_handler(priv->gsr, NULL);
-    LEAVE(" ");
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
+    gsr_default_reinit_handler (priv->gsr, NULL);
+    LEAVE (" ");
 }
 
 static void
-gnc_plugin_page_register_cmd_expand_transaction (GtkToggleAction *action,
-        GncPluginPageRegister *plugin_page)
+gnc_plugin_page_register_cmd_expand_transaction (GtkToggleAction* action,
+                                                 GncPluginPageRegister* plugin_page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    SplitRegister *reg;
+    GncPluginPageRegisterPrivate* priv;
+    SplitRegister* reg;
     gboolean expand;
 
-    ENTER("(action %p, plugin_page %p)", action, plugin_page);
+    ENTER ("(action %p, plugin_page %p)", action, plugin_page);
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(plugin_page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page));
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
     reg = gnc_ledger_display_get_split_register (priv->ledger);
     expand = gtk_toggle_action_get_active (action);
     gnc_split_register_expand_current_trans (reg, expand);
-    LEAVE(" ");
+    LEAVE (" ");
 }
 
 /** Callback for "Edit Exchange Rate" menu item.
  */
 static void
-gnc_plugin_page_register_cmd_exchange_rate (GtkAction *action,
-        GncPluginPageRegister *plugin_page)
+gnc_plugin_page_register_cmd_exchange_rate (GtkAction* action,
+                                            GncPluginPageRegister* plugin_page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    SplitRegister *reg;
+    GncPluginPageRegisterPrivate* priv;
+    SplitRegister* reg;
 
-    ENTER("(action %p, plugin_page %p)", action, plugin_page);
+    ENTER ("(action %p, plugin_page %p)", action, plugin_page);
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(plugin_page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page));
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
     reg = gnc_ledger_display_get_split_register (priv->ledger);
 
     /* XXX Ignore the return value -- we don't care if this succeeds */
     (void)gnc_split_register_handle_exchange (reg, TRUE);
-    LEAVE(" ");
+    LEAVE (" ");
 }
 
 static void
-gnc_plugin_page_register_cmd_jump (GtkAction *action,
-                                   GncPluginPageRegister *plugin_page)
+gnc_plugin_page_register_cmd_jump (GtkAction* action,
+                                   GncPluginPageRegister* plugin_page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    GncPluginPage *new_page;
-    GtkWidget *window;
-    GNCSplitReg *gsr;
-    SplitRegister *reg;
-    Account *account;
-    Account *leader;
-    Split *split;
+    GncPluginPageRegisterPrivate* priv;
+    GncPluginPage* new_page;
+    GtkWidget* window;
+    GNCSplitReg* gsr;
+    SplitRegister* reg;
+    Account* account;
+    Account* leader;
+    Split* split;
 
-    ENTER("(action %p, plugin_page %p)", action, plugin_page);
+    ENTER ("(action %p, plugin_page %p)", action, plugin_page);
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(plugin_page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page));
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
     window = GNC_PLUGIN_PAGE (plugin_page)->window;
     if (window == NULL)
     {
-        LEAVE("no window");
+        LEAVE ("no window");
         return;
     }
 
@@ -4561,14 +4727,14 @@ gnc_plugin_page_register_cmd_jump (GtkAction *action,
     split = gnc_split_register_get_current_split (reg);
     if (split == NULL)
     {
-        LEAVE("no split (1)");
+        LEAVE ("no split (1)");
         return;
     }
 
     account = xaccSplitGetAccount (split);
     if (account == NULL)
     {
-        LEAVE("no account");
+        LEAVE ("no account");
         return;
     }
 
@@ -4578,20 +4744,20 @@ gnc_plugin_page_register_cmd_jump (GtkAction *action,
         split = xaccSplitGetOtherSplit (split);
         if (split == NULL)
         {
-            LEAVE("no split (2)");
+            LEAVE ("no split (2)");
             return;
         }
 
         account = xaccSplitGetAccount (split);
         if (account == NULL)
         {
-            LEAVE("no account (2)");
+            LEAVE ("no account (2)");
             return;
         }
 
         if (account == leader)
         {
-            LEAVE("register open for account");
+            LEAVE ("register open for account");
             return;
         }
     }
@@ -4599,206 +4765,209 @@ gnc_plugin_page_register_cmd_jump (GtkAction *action,
     new_page = gnc_plugin_page_register_new (account, FALSE);
     if (new_page == NULL)
     {
-        LEAVE("couldn't create new page");
+        LEAVE ("couldn't create new page");
         return;
     }
 
-    gnc_main_window_open_page (GNC_MAIN_WINDOW(window), new_page);
+    gnc_main_window_open_page (GNC_MAIN_WINDOW (window), new_page);
     gsr = gnc_plugin_page_register_get_gsr (new_page);
-    gnc_split_reg_jump_to_split(gsr, split);
-    LEAVE(" ");
+    gnc_split_reg_jump_to_split (gsr, split);
+    LEAVE (" ");
 }
 
 static void
-gnc_plugin_page_register_cmd_schedule (GtkAction *action,
-                                       GncPluginPageRegister *plugin_page)
+gnc_plugin_page_register_cmd_schedule (GtkAction* action,
+                                       GncPluginPageRegister* plugin_page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    GtkWindow *window;
+    GncPluginPageRegisterPrivate* priv;
+    GtkWindow* window;
 
-    ENTER("(action %p, plugin_page %p)", action, plugin_page);
+    ENTER ("(action %p, plugin_page %p)", action, plugin_page);
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(plugin_page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page));
 
-    window = GTK_WINDOW (gnc_plugin_page_get_window (GNC_PLUGIN_PAGE (plugin_page)));
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
-    gsr_default_schedule_handler(priv->gsr, window);
-    LEAVE(" ");
+    window = GTK_WINDOW (gnc_plugin_page_get_window (GNC_PLUGIN_PAGE (
+                                                         plugin_page)));
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
+    gsr_default_schedule_handler (priv->gsr, window);
+    LEAVE (" ");
 }
 
 static void
-gnc_plugin_page_register_cmd_scrub_current (GtkAction *action,
-        GncPluginPageRegister *plugin_page)
+gnc_plugin_page_register_cmd_scrub_current (GtkAction* action,
+                                            GncPluginPageRegister* plugin_page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    Query *query;
-    Account *root;
-    Transaction *trans;
-    Split *split;
-    GNCLot *lot;
-    SplitRegister *reg;
+    GncPluginPageRegisterPrivate* priv;
+    Query* query;
+    Account* root;
+    Transaction* trans;
+    Split* split;
+    GNCLot* lot;
+    SplitRegister* reg;
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(plugin_page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page));
 
-    ENTER("(action %p, plugin_page %p)", action, plugin_page);
+    ENTER ("(action %p, plugin_page %p)", action, plugin_page);
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
-    query = gnc_ledger_display_get_query( priv->ledger );
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
+    query = gnc_ledger_display_get_query (priv->ledger);
     if (query == NULL)
     {
-        LEAVE("no query found");
+        LEAVE ("no query found");
         return;
     }
 
-    reg = gnc_ledger_display_get_split_register(priv->ledger);
-    trans = gnc_split_register_get_current_trans(reg);
+    reg = gnc_ledger_display_get_split_register (priv->ledger);
+    trans = gnc_split_register_get_current_trans (reg);
     if (trans == NULL)
     {
-        LEAVE("no trans found");
+        LEAVE ("no trans found");
         return;
     }
 
     gnc_suspend_gui_refresh();
     root = gnc_get_current_root_account();
-    xaccTransScrubOrphans(trans);
-    xaccTransScrubImbalance(trans, root, NULL);
+    xaccTransScrubOrphans (trans);
+    xaccTransScrubImbalance (trans, root, NULL);
 
     split = gnc_split_register_get_current_split (reg);
     lot = xaccSplitGetLot (split);
-    if (lot && xaccAccountIsAPARType (xaccAccountGetType (xaccSplitGetAccount (split))))
+    if (lot &&
+        xaccAccountIsAPARType (xaccAccountGetType (xaccSplitGetAccount (split))))
     {
         gncScrubBusinessLot (lot);
         gncScrubBusinessSplit (split);
     }
     gnc_resume_gui_refresh();
-    LEAVE(" ");
+    LEAVE (" ");
 }
 
 static void
-gnc_plugin_page_register_cmd_scrub_all (GtkAction *action,
-                                        GncPluginPageRegister *plugin_page)
+gnc_plugin_page_register_cmd_scrub_all (GtkAction* action,
+                                        GncPluginPageRegister* plugin_page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    Query *query;
-    Account *root;
-    GncWindow *window;
-    GList *node, *splits;
+    GncPluginPageRegisterPrivate* priv;
+    Query* query;
+    Account* root;
+    GncWindow* window;
+    GList* node, *splits;
     gint split_count = 0, curr_split_no = 0;
-    const char *message = _( "Checking splits in current register: %u of %u");
+    const char* message = _ ("Checking splits in current register: %u of %u");
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(plugin_page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page));
 
-    ENTER("(action %p, plugin_page %p)", action, plugin_page);
+    ENTER ("(action %p, plugin_page %p)", action, plugin_page);
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
-    query = gnc_ledger_display_get_query( priv->ledger );
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
+    query = gnc_ledger_display_get_query (priv->ledger);
     if (!query)
     {
-        LEAVE("no query found");
+        LEAVE ("no query found");
         return;
     }
 
     gnc_suspend_gui_refresh();
-    window = GNC_WINDOW(GNC_PLUGIN_PAGE (plugin_page)->window);
+    window = GNC_WINDOW (GNC_PLUGIN_PAGE (plugin_page)->window);
     gnc_window_set_progressbar_window (window);
 
     root = gnc_get_current_root_account();
 
-    splits = qof_query_run(query);
+    splits = qof_query_run (query);
     split_count = g_list_length (splits);
     for (node = splits; node; node = node->next)
     {
-        GNCLot *lot;
-        Split *split = node->data;
-        Transaction *trans = xaccSplitGetParent(split);
+        GNCLot* lot;
+        Split* split = node->data;
+        Transaction* trans = xaccSplitGetParent (split);
 
         if (!split) continue;
 
-        PINFO("Start processing split %d of %d",
-              curr_split_no + 1, split_count);
+        PINFO ("Start processing split %d of %d",
+               curr_split_no + 1, split_count);
 
         if (curr_split_no % 100 == 0)
         {
-            char *progress_msg = g_strdup_printf (message, curr_split_no, split_count);
+            char* progress_msg = g_strdup_printf (message, curr_split_no, split_count);
             gnc_window_show_progress (progress_msg, (100 * curr_split_no) / split_count);
             g_free (progress_msg);
         }
 
-        xaccTransScrubOrphans(trans);
-        xaccTransScrubImbalance(trans, root, NULL);
+        xaccTransScrubOrphans (trans);
+        xaccTransScrubImbalance (trans, root, NULL);
 
         lot = xaccSplitGetLot (split);
-        if (lot && xaccAccountIsAPARType (xaccAccountGetType (xaccSplitGetAccount (split))))
+        if (lot &&
+            xaccAccountIsAPARType (xaccAccountGetType (xaccSplitGetAccount (split))))
         {
             gncScrubBusinessLot (lot);
             gncScrubBusinessSplit (split);
         }
 
-        PINFO("Finished processing split %d of %d",
-              curr_split_no + 1, split_count);
+        PINFO ("Finished processing split %d of %d",
+               curr_split_no + 1, split_count);
         curr_split_no++;
     }
 
     gnc_window_show_progress (NULL, -1.0);
     gnc_resume_gui_refresh();
-    LEAVE(" ");
+    LEAVE (" ");
 }
 
 static void
-gnc_plugin_page_register_cmd_account_report (GtkAction *action,
-        GncPluginPageRegister *plugin_page)
+gnc_plugin_page_register_cmd_account_report (GtkAction* action,
+                                             GncPluginPageRegister* plugin_page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    GncMainWindow *window;
+    GncPluginPageRegisterPrivate* priv;
+    GncMainWindow* window;
     int id;
 
-    ENTER("(action %p, plugin_page %p)", action, plugin_page);
+    ENTER ("(action %p, plugin_page %p)", action, plugin_page);
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(plugin_page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page));
 
-    window = GNC_MAIN_WINDOW(GNC_PLUGIN_PAGE(plugin_page)->window);
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
+    window = GNC_MAIN_WINDOW (GNC_PLUGIN_PAGE (plugin_page)->window);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
     id = report_helper (priv->ledger, NULL, NULL);
     if (id >= 0)
-        gnc_main_window_open_report(id, window);
-    LEAVE(" ");
+        gnc_main_window_open_report (id, window);
+    LEAVE (" ");
 }
 
 static void
-gnc_plugin_page_register_cmd_transaction_report (GtkAction *action,
-        GncPluginPageRegister *plugin_page)
+gnc_plugin_page_register_cmd_transaction_report (GtkAction* action,
+                                                 GncPluginPageRegister* plugin_page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    GncMainWindow *window;
-    SplitRegister *reg;
-    Split *split;
-    Query *query;
+    GncPluginPageRegisterPrivate* priv;
+    GncMainWindow* window;
+    SplitRegister* reg;
+    Split* split;
+    Query* query;
     int id;
 
 
-    ENTER("(action %p, plugin_page %p)", action, plugin_page);
+    ENTER ("(action %p, plugin_page %p)", action, plugin_page);
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(plugin_page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page));
 
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(plugin_page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
     reg = gnc_ledger_display_get_split_register (priv->ledger);
 
     split = gnc_split_register_get_current_split (reg);
     if (!split)
         return;
 
-    query = qof_query_create_for(GNC_ID_SPLIT);
+    query = qof_query_create_for (GNC_ID_SPLIT);
 
-    qof_query_set_book (query, gnc_get_current_book ());
+    qof_query_set_book (query, gnc_get_current_book());
 
     xaccQueryAddGUIDMatch (query, xaccSplitGetGUID (split),
                            GNC_ID_SPLIT, QOF_QUERY_AND);
 
-    window = GNC_MAIN_WINDOW(GNC_PLUGIN_PAGE(plugin_page)->window);
+    window = GNC_MAIN_WINDOW (GNC_PLUGIN_PAGE (plugin_page)->window);
     id = report_helper (priv->ledger, split, query);
     if (id >= 0)
-        gnc_main_window_open_report(id, window);
-    LEAVE(" ");
+        gnc_main_window_open_report (id, window);
+    LEAVE (" ");
 }
 
 /************************************************************/
@@ -4806,46 +4975,47 @@ gnc_plugin_page_register_cmd_transaction_report (GtkAction *action,
 /************************************************************/
 
 void
-gnc_plugin_page_register_set_options (GncPluginPage *plugin_page,
+gnc_plugin_page_register_set_options (GncPluginPage* plugin_page,
                                       gint lines_default,
                                       gboolean read_only)
 {
-    GncPluginPageRegister *page;
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegister* page;
+    GncPluginPageRegisterPrivate* priv;
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(plugin_page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page));
 
     page = GNC_PLUGIN_PAGE_REGISTER (plugin_page);
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
     priv->lines_default     = lines_default;
     priv->read_only         = read_only;
 }
 
-GNCSplitReg *
-gnc_plugin_page_register_get_gsr (GncPluginPage *plugin_page)
+GNCSplitReg*
+gnc_plugin_page_register_get_gsr (GncPluginPage* plugin_page)
 {
-    GncPluginPageRegister *page;
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegister* page;
+    GncPluginPageRegisterPrivate* priv;
 
-    g_return_val_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(plugin_page), NULL);
+    g_return_val_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page), NULL);
 
     page = GNC_PLUGIN_PAGE_REGISTER (plugin_page);
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
 
     return priv->gsr;
 }
 
 static void
-gnc_plugin_page_help_changed_cb (GNCSplitReg *gsr, GncPluginPageRegister *register_page)
+gnc_plugin_page_help_changed_cb (GNCSplitReg* gsr,
+                                 GncPluginPageRegister* register_page)
 {
-    GncPluginPageRegisterPrivate *priv;
-    SplitRegister *reg;
-    GncWindow *window;
-    char *help;
+    GncPluginPageRegisterPrivate* priv;
+    SplitRegister* reg;
+    GncWindow* window;
+    char* help;
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(register_page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (register_page));
 
-    window = GNC_WINDOW(GNC_PLUGIN_PAGE(register_page)->window);
+    window = GNC_WINDOW (GNC_PLUGIN_PAGE (register_page)->window);
     if (!window)
     {
         // This routine can be called before the page is added to a
@@ -4854,48 +5024,50 @@ gnc_plugin_page_help_changed_cb (GNCSplitReg *gsr, GncPluginPageRegister *regist
     }
 
     /* Get the text from the ledger */
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(register_page);
-    reg = gnc_ledger_display_get_split_register(priv->ledger);
-    help = gnc_table_get_help(reg->table);
-    gnc_window_set_status(window, GNC_PLUGIN_PAGE(register_page), help);
-    g_free(help);
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (register_page);
+    reg = gnc_ledger_display_get_split_register (priv->ledger);
+    help = gnc_table_get_help (reg->table);
+    gnc_window_set_status (window, GNC_PLUGIN_PAGE (register_page), help);
+    g_free (help);
 }
 
 static void
-gnc_plugin_page_popup_menu_cb (GNCSplitReg *gsr, GncPluginPageRegister *register_page)
+gnc_plugin_page_popup_menu_cb (GNCSplitReg* gsr,
+                               GncPluginPageRegister* register_page)
 {
-    GncWindow *window;
+    GncWindow* window;
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(register_page));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (register_page));
 
-    window = GNC_WINDOW(GNC_PLUGIN_PAGE(register_page)->window);
+    window = GNC_WINDOW (GNC_PLUGIN_PAGE (register_page)->window);
     if (!window)
     {
         // This routine can be called before the page is added to a
         // window.
         return;
     }
-    gnc_main_window_popup_menu_cb (GTK_WIDGET(window), GNC_PLUGIN_PAGE(register_page));
+    gnc_main_window_popup_menu_cb (GTK_WIDGET (window),
+                                   GNC_PLUGIN_PAGE (register_page));
 }
 
 static void
-gnc_plugin_page_register_refresh_cb (GHashTable *changes, gpointer user_data)
+gnc_plugin_page_register_refresh_cb (GHashTable* changes, gpointer user_data)
 {
-    GncPluginPageRegister *page = user_data;
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegister* page = user_data;
+    GncPluginPageRegisterPrivate* priv;
 
-    g_return_if_fail(GNC_IS_PLUGIN_PAGE_REGISTER(page));
-    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
 
     if (changes)
     {
         const EventInfo* ei;
-        ei = gnc_gui_get_entity_events(changes, &priv->key);
+        ei = gnc_gui_get_entity_events (changes, &priv->key);
         if (ei)
         {
             if (ei->event_mask & QOF_EVENT_DESTROY)
             {
-                gnc_main_window_close_page(GNC_PLUGIN_PAGE(page));
+                gnc_main_window_close_page (GNC_PLUGIN_PAGE (page));
                 return;
             }
             if (ei->event_mask & QOF_EVENT_MODIFY)
@@ -4906,17 +5078,17 @@ gnc_plugin_page_register_refresh_cb (GHashTable *changes, gpointer user_data)
     else
     {
         /* forced updates */
-        gnucash_register_refresh_from_prefs(priv->gsr->reg);
-        gtk_widget_queue_draw(priv->widget);
+        gnucash_register_refresh_from_prefs (priv->gsr->reg);
+        gtk_widget_queue_draw (priv->widget);
     }
 
-    gnc_plugin_page_register_ui_update(NULL, page);
+    gnc_plugin_page_register_ui_update (NULL, page);
 }
 
 static void
 gnc_plugin_page_register_close_cb (gpointer user_data)
 {
-    GncPluginPage *plugin_page = GNC_PLUGIN_PAGE(user_data);
+    GncPluginPage* plugin_page = GNC_PLUGIN_PAGE (user_data);
     gnc_main_window_close_page (plugin_page);
 }
 
@@ -4929,44 +5101,44 @@ gnc_plugin_page_register_close_cb (gpointer user_data)
  *  @param account A pointer to the account that was changed.
  */
 static void
-gppr_account_destroy_cb (Account *account)
+gppr_account_destroy_cb (Account* account)
 {
-    GncPluginPageRegister *page;
-    GncPluginPageRegisterPrivate *priv;
+    GncPluginPageRegister* page;
+    GncPluginPageRegisterPrivate* priv;
     GNCLedgerDisplayType ledger_type;
-    const GncGUID *acct_guid;
-    const GList *citem;
-    GList *item, *kill = NULL;
+    const GncGUID* acct_guid;
+    const GList* citem;
+    GList* item, *kill = NULL;
 
-    acct_guid = xaccAccountGetGUID(account);
+    acct_guid = xaccAccountGetGUID (account);
 
     /* Find all windows that need to be killed.  Don't kill them yet, as
      * that would affect the list being walked.*/
-    citem = gnc_gobject_tracking_get_list(GNC_PLUGIN_PAGE_REGISTER_NAME);
-    for ( ; citem; citem = g_list_next(citem))
+    citem = gnc_gobject_tracking_get_list (GNC_PLUGIN_PAGE_REGISTER_NAME);
+    for (; citem; citem = g_list_next (citem))
     {
-        page = (GncPluginPageRegister *)citem->data;
-        priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE(page);
+        page = (GncPluginPageRegister*)citem->data;
+        priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (page);
         ledger_type = gnc_ledger_display_type (priv->ledger);
         if (ledger_type == LD_GL)
         {
-            kill = g_list_append(kill, page);
+            kill = g_list_append (kill, page);
             /* kill it */
         }
         else if ((ledger_type == LD_SINGLE) || (ledger_type == LD_SUBACCOUNT))
         {
-            if (guid_compare(acct_guid, &priv->key) == 0)
+            if (guid_compare (acct_guid, &priv->key) == 0)
             {
-                kill = g_list_append(kill, page);
+                kill = g_list_append (kill, page);
             }
         }
     }
 
     /* Now kill them. */
-    for (item = kill; item; item = g_list_next(item))
+    for (item = kill; item; item = g_list_next (item))
     {
-        page = (GncPluginPageRegister *)item->data;
-        gnc_main_window_close_page(GNC_PLUGIN_PAGE(page));
+        page = (GncPluginPageRegister*)item->data;
+        gnc_main_window_close_page (GNC_PLUGIN_PAGE (page));
     }
 }
 
@@ -4985,66 +5157,66 @@ gppr_account_destroy_cb (Account *account)
  *  @param ed
  */
 static void
-gnc_plugin_page_register_event_handler (QofInstance *entity,
+gnc_plugin_page_register_event_handler (QofInstance* entity,
                                         QofEventId event_type,
-                                        GncPluginPageRegister *page,
-                                        GncEventData *ed)
+                                        GncPluginPageRegister* page,
+                                        GncEventData* ed)
 {
-    Transaction *trans;
-    QofBook *book;
-    GncPluginPage *visible_page;
-    GtkWidget *window;
-    gchar *label, *color;
+    Transaction* trans;
+    QofBook* book;
+    GncPluginPage* visible_page;
+    GtkWidget* window;
+    gchar* label, *color;
 
-    g_return_if_fail(page); /* Required */
-    if (!GNC_IS_TRANS(entity) && !GNC_IS_ACCOUNT(entity))
+    g_return_if_fail (page); /* Required */
+    if (!GNC_IS_TRANS (entity) && !GNC_IS_ACCOUNT (entity))
         return;
 
-    ENTER("entity %p of type %d, page %p, event data %p",
-          entity, event_type, page, ed);
+    ENTER ("entity %p of type %d, page %p, event data %p",
+           entity, event_type, page, ed);
 
     window = gnc_plugin_page_get_window (GNC_PLUGIN_PAGE (page));
 
-    if (GNC_IS_ACCOUNT(entity))
+    if (GNC_IS_ACCOUNT (entity))
     {
-        if (GNC_IS_MAIN_WINDOW(window))
+        if (GNC_IS_MAIN_WINDOW (window))
         {
-            label = gnc_plugin_page_register_get_tab_name(GNC_PLUGIN_PAGE(page));
-            main_window_update_page_name(GNC_PLUGIN_PAGE(page), label);
-            color = gnc_plugin_page_register_get_tab_color(GNC_PLUGIN_PAGE(page));
-            main_window_update_page_color(GNC_PLUGIN_PAGE(page), color);
-            g_free(color);
-            g_free(label);
+            label = gnc_plugin_page_register_get_tab_name (GNC_PLUGIN_PAGE (page));
+            main_window_update_page_name (GNC_PLUGIN_PAGE (page), label);
+            color = gnc_plugin_page_register_get_tab_color (GNC_PLUGIN_PAGE (page));
+            main_window_update_page_color (GNC_PLUGIN_PAGE (page), color);
+            g_free (color);
+            g_free (label);
         }
-        LEAVE("tab name updated");
+        LEAVE ("tab name updated");
         return;
     }
 
-    if (!(event_type & (QOF_EVENT_MODIFY | QOF_EVENT_DESTROY)))
+    if (! (event_type & (QOF_EVENT_MODIFY | QOF_EVENT_DESTROY)))
     {
-        LEAVE("not a modify");
+        LEAVE ("not a modify");
         return;
     }
-    trans = GNC_TRANS(entity);
-    book = qof_instance_get_book(QOF_INSTANCE(trans));
-    if (!gnc_plugin_page_has_book(GNC_PLUGIN_PAGE(page), book))
+    trans = GNC_TRANS (entity);
+    book = qof_instance_get_book (QOF_INSTANCE (trans));
+    if (!gnc_plugin_page_has_book (GNC_PLUGIN_PAGE (page), book))
     {
-        LEAVE("not in this book");
+        LEAVE ("not in this book");
         return;
     }
 
-    if (GNC_IS_MAIN_WINDOW(window))
+    if (GNC_IS_MAIN_WINDOW (window))
     {
-        visible_page = gnc_main_window_get_current_page(GNC_MAIN_WINDOW(window));
-        if (visible_page != GNC_PLUGIN_PAGE(page))
+        visible_page = gnc_main_window_get_current_page (GNC_MAIN_WINDOW (window));
+        if (visible_page != GNC_PLUGIN_PAGE (page))
         {
-            LEAVE("page not visible");
+            LEAVE ("page not visible");
             return;
         }
     }
 
-    gnc_plugin_page_register_ui_update(NULL, page);
-    LEAVE(" ");
+    gnc_plugin_page_register_ui_update (NULL, page);
+    LEAVE (" ");
     return;
 }
 

--- a/gnucash/gnome/gnc-plugin-page-register.c
+++ b/gnucash/gnome/gnc-plugin-page-register.c
@@ -802,15 +802,6 @@ gnc_plugin_page_register_new (Account* account, gboolean subaccounts)
     com0 = gnc_account_get_currency_or_parent (account);
     com1 = gnc_account_foreach_descendant_until (account,
                                                  gnc_plug_page_register_check_commodity, com0);
-    if (0 && com1 != NULL)
-    {
-        const gchar* com0_str = gnc_commodity_get_fullname (com0);
-        const gchar* com1_str = gnc_commodity_get_fullname (com1);
-        gnc_info_dialog (NULL,
-                         _ ("Cannot open sub-accounts because sub-accounts and parent account have different commodities or currencies\nFound:\n%s\n%s\n(There may be more mismatches)"),
-                         com0_str, com1_str);
-        return NULL;
-    }
 
     if (subaccounts)
         ledger = gnc_ledger_display_subaccounts (account, com1 != NULL);

--- a/gnucash/gnome/gnc-plugin-page-register2.c
+++ b/gnucash/gnome/gnc-plugin-page-register2.c
@@ -559,6 +559,15 @@ typedef struct GncPluginPageRegister2Private
 
 static GObjectClass *parent_class = NULL;
 
+static gpointer
+gnc_plug_page_register_check_commodity(Account *account, void* usr_data)
+{
+    // Check that account's commodity matches the commodity in usr_data
+    gnc_commodity* com0 = (gnc_commodity*) usr_data;
+    gnc_commodity* com1 = xaccAccountGetCommodity(account);
+    return gnc_commodity_equal(com1, com0) ? NULL : com1;
+}
+
 /************************************************************/
 /*                      Implementation                      */
 /************************************************************/
@@ -630,6 +639,8 @@ gnc_plugin_page_register2_new (Account *account, gboolean subaccounts)
     GNCLedgerDisplay2 *ledger;
     GncPluginPage *page;
     GncPluginPageRegister2Private *priv;
+    gnc_commodity* com0;
+    gnc_commodity* com1;
 
 /*################## Added for Reg2 #################*/
     const GList *item;
@@ -657,9 +668,10 @@ gnc_plugin_page_register2_new (Account *account, gboolean subaccounts)
         }
     }
 /*################## Added for Reg2 #################*/
-
+    com0 = gnc_account_get_currency_or_parent(account);
+    com1 = gnc_account_foreach_descendant_until(account,gnc_plug_page_register_check_commodity,com0);
     if (subaccounts)
-        ledger = gnc_ledger_display2_subaccounts (account);
+        ledger = gnc_ledger_display2_subaccounts (account,com1!=NULL);
     else
         ledger = gnc_ledger_display2_simple (account);
 

--- a/gnucash/gnome/gnc-split-reg.c
+++ b/gnucash/gnome/gnc-split-reg.c
@@ -2619,27 +2619,38 @@ gnc_split_reg_determine_read_only( GNCSplitReg *gsr )
     {
         dialog_args *args;
         char *string = NULL;
-        switch (gnc_split_reg_get_placeholder(gsr))
+        reg = gnc_ledger_display_get_split_register( gsr->ledger );
+        if(reg->mismatched_commodities)
         {
-        case PLACEHOLDER_NONE:
-            /* stay as false. */
-            return;
+            string = _("This account may not be edited because its"
+                       " subaccounts have mismatched commodities or currencies."
+                       "You need to open each account individually to "
+                       "edit transactions.");
+        }
+        else
+        {
+            switch (gnc_split_reg_get_placeholder(gsr))
+            {
+            case PLACEHOLDER_NONE:
+                /* stay as false. */
+                return;
 
-        case PLACEHOLDER_THIS:
-            string = _("This account may not be edited. If you want "
-                             "to edit transactions in this register, please "
-                             "open the account options and turn off the "
-                             "placeholder checkbox.");
-            break;
+            case PLACEHOLDER_THIS:
+                string = _("This account may not be edited. If you want "
+                                 "to edit transactions in this register, please "
+                                 "open the account options and turn off the "
+                                 "placeholder checkbox.");
+                break;
 
-        default:
-            string = _("One of the sub-accounts selected may not be "
-                             "edited. If you want to edit transactions in "
-                             "this register, please open the sub-account "
-                             "options and turn off the placeholder checkbox. "
-                             "You may also open an individual account instead "
-                             "of a set of accounts.");
-            break;
+            default:
+                string = _("One of the sub-accounts selected may not be "
+                                 "edited. If you want to edit transactions in "
+                                 "this register, please open the sub-account "
+                                 "options and turn off the placeholder checkbox. "
+                                 "You may also open an individual account instead "
+                                 "of a set of accounts.");
+                break;
+            }
         }
         gsr->read_only = TRUE;
         /* Put up a warning dialog */

--- a/gnucash/register/ledger-core/gnc-ledger-display.c
+++ b/gnucash/register/ledger-core/gnc-ledger-display.c
@@ -88,7 +88,8 @@ gnc_ledger_display_internal (Account *lead_account, Query *q,
                              SplitRegisterType reg_type,
                              SplitRegisterStyle style,
                              gboolean use_double_line,
-                             gboolean is_template);
+                             gboolean is_template,
+                             gboolean mismatched_commodities);
 
 static void gnc_ledger_display_refresh_internal (GNCLedgerDisplay *ld,
                              GList *splits);
@@ -370,7 +371,7 @@ gnc_ledger_display_simple (Account *account)
 
     ld = gnc_ledger_display_internal (account, NULL, LD_SINGLE, reg_type,
                                       gnc_get_default_register_style(acc_type),
-                                      use_double_line, FALSE);
+                                      use_double_line, FALSE, FALSE);
     LEAVE("%p", ld);
     return ld;
 }
@@ -378,7 +379,7 @@ gnc_ledger_display_simple (Account *account)
 /* Opens up a register window to display an account, and all of its
  *   children, in the same window */
 GNCLedgerDisplay *
-gnc_ledger_display_subaccounts (Account *account)
+gnc_ledger_display_subaccounts (Account *account,gboolean mismatched_commodities)
 {
     SplitRegisterType reg_type;
     GNCLedgerDisplay *ld;
@@ -389,7 +390,7 @@ gnc_ledger_display_subaccounts (Account *account)
 
     ld = gnc_ledger_display_internal (account, NULL, LD_SUBACCOUNT,
                                       reg_type, REG_STYLE_JOURNAL, FALSE,
-                                      FALSE);
+                                      FALSE,mismatched_commodities);
     LEAVE("%p", ld);
     return ld;
 }
@@ -439,7 +440,7 @@ gnc_ledger_display_gl (void)
                              QOF_QUERY_AND);
 
     ld = gnc_ledger_display_internal (NULL, query, LD_GL, GENERAL_JOURNAL,
-                                      REG_STYLE_JOURNAL, FALSE, FALSE);
+                                      REG_STYLE_JOURNAL, FALSE, FALSE, FALSE);
     LEAVE("%p", ld);
     return ld;
 }
@@ -484,7 +485,8 @@ gnc_ledger_display_template_gl (char *id)
                                       SEARCH_LEDGER,
                                       REG_STYLE_JOURNAL,
                                       FALSE,
-                                      isTemplateModeTrue);
+                                      isTemplateModeTrue,
+                                      FALSE);
 
     sr = gnc_ledger_display_get_split_register (ld);
     if ( acct )
@@ -526,7 +528,7 @@ gnc_ledger_display_set_watches (GNCLedgerDisplay *ld, GList *splits)
                                          GNC_ID_ACCOUNT,
                                          QOF_EVENT_MODIFY | QOF_EVENT_DESTROY
                                          | GNC_EVENT_ITEM_CHANGED);
-
+    
     for (node = splits; node; node = node->next)
     {
         Split *split = node->data;
@@ -697,7 +699,7 @@ gnc_ledger_display_query (Query *query, SplitRegisterType type,
     ENTER("query=%p", query);
 
     ld = gnc_ledger_display_internal (NULL, query, LD_GL, type, style,
-                                      FALSE, FALSE);
+                                      FALSE, FALSE, FALSE);
     LEAVE("%p", ld);
     return ld;
 }
@@ -708,7 +710,8 @@ gnc_ledger_display_internal (Account *lead_account, Query *q,
                              SplitRegisterType reg_type,
                              SplitRegisterStyle style,
                              gboolean use_double_line,
-                             gboolean is_template )
+                             gboolean is_template,
+                             gboolean mismatched_commodities)
 {
     GNCLedgerDisplay *ld;
     gint limit;
@@ -808,8 +811,9 @@ gnc_ledger_display_internal (Account *lead_account, Query *q,
     \******************************************************************/
 
     ld->use_double_line_default = use_double_line;
+
     ld->reg = gnc_split_register_new (reg_type, style, use_double_line,
-                                      is_template);
+                                      is_template,mismatched_commodities);
 
     gnc_split_register_set_data (ld->reg, ld, gnc_ledger_display_parent);
 

--- a/gnucash/register/ledger-core/gnc-ledger-display.c
+++ b/gnucash/register/ledger-core/gnc-ledger-display.c
@@ -57,11 +57,11 @@ struct gnc_ledger_display
 {
     GncGUID leader;
 
-    Query *query;
+    Query* query;
 
     GNCLedgerDisplayType ld_type;
 
-    SplitRegister *reg;
+    SplitRegister* reg;
 
     gboolean loading;
     gboolean use_double_line_default;
@@ -70,7 +70,7 @@ struct gnc_ledger_display
     GNCLedgerDisplayGetParent get_parent;
 
     gpointer user_data;
-    
+
     gint number_of_subaccounts;
 
     gint component_id;
@@ -82,8 +82,8 @@ static QofLogModule log_module = GNC_MOD_LEDGER;
 
 
 /** Declarations ****************************************************/
-static GNCLedgerDisplay *
-gnc_ledger_display_internal (Account *lead_account, Query *q,
+static GNCLedgerDisplay*
+gnc_ledger_display_internal (Account* lead_account, Query* q,
                              GNCLedgerDisplayType ld_type,
                              SplitRegisterType reg_type,
                              SplitRegisterStyle style,
@@ -91,26 +91,26 @@ gnc_ledger_display_internal (Account *lead_account, Query *q,
                              gboolean is_template,
                              gboolean mismatched_commodities);
 
-static void gnc_ledger_display_refresh_internal (GNCLedgerDisplay *ld,
-                             GList *splits);
+static void gnc_ledger_display_refresh_internal (GNCLedgerDisplay* ld,
+                                                 GList* splits);
 
-static void gnc_ledger_display_make_query (GNCLedgerDisplay *ld,
-                             gint limit,
-                             SplitRegisterType type);
+static void gnc_ledger_display_make_query (GNCLedgerDisplay* ld,
+                                           gint limit,
+                                           SplitRegisterType type);
 
 /** Implementations *************************************************/
 
-Account *
-gnc_ledger_display_leader (GNCLedgerDisplay *ld)
+Account*
+gnc_ledger_display_leader (GNCLedgerDisplay* ld)
 {
     if (!ld)
         return NULL;
 
-    return xaccAccountLookup (&ld->leader, gnc_get_current_book ());
+    return xaccAccountLookup (&ld->leader, gnc_get_current_book());
 }
 
 GNCLedgerDisplayType
-gnc_ledger_display_type (GNCLedgerDisplay *ld)
+gnc_ledger_display_type (GNCLedgerDisplay* ld)
 {
     if (!ld)
         return -1;
@@ -119,7 +119,7 @@ gnc_ledger_display_type (GNCLedgerDisplay *ld)
 }
 
 void
-gnc_ledger_display_set_user_data (GNCLedgerDisplay *ld, gpointer user_data)
+gnc_ledger_display_set_user_data (GNCLedgerDisplay* ld, gpointer user_data)
 {
     if (!ld)
         return;
@@ -128,7 +128,7 @@ gnc_ledger_display_set_user_data (GNCLedgerDisplay *ld, gpointer user_data)
 }
 
 gpointer
-gnc_ledger_display_get_user_data (GNCLedgerDisplay *ld)
+gnc_ledger_display_get_user_data (GNCLedgerDisplay* ld)
 {
     if (!ld)
         return NULL;
@@ -137,7 +137,7 @@ gnc_ledger_display_get_user_data (GNCLedgerDisplay *ld)
 }
 
 void
-gnc_ledger_display_set_handlers (GNCLedgerDisplay *ld,
+gnc_ledger_display_set_handlers (GNCLedgerDisplay* ld,
                                  GNCLedgerDisplayDestroy destroy,
                                  GNCLedgerDisplayGetParent get_parent)
 {
@@ -148,8 +148,8 @@ gnc_ledger_display_set_handlers (GNCLedgerDisplay *ld,
     ld->get_parent = get_parent;
 }
 
-SplitRegister *
-gnc_ledger_display_get_split_register (GNCLedgerDisplay *ld)
+SplitRegister*
+gnc_ledger_display_get_split_register (GNCLedgerDisplay* ld)
 {
     if (!ld)
         return NULL;
@@ -157,8 +157,8 @@ gnc_ledger_display_get_split_register (GNCLedgerDisplay *ld)
     return ld->reg;
 }
 
-Query *
-gnc_ledger_display_get_query (GNCLedgerDisplay *ld)
+Query*
+gnc_ledger_display_get_query (GNCLedgerDisplay* ld)
 {
     if (!ld)
         return NULL;
@@ -169,8 +169,8 @@ gnc_ledger_display_get_query (GNCLedgerDisplay *ld)
 static gboolean
 find_by_leader (gpointer find_data, gpointer user_data)
 {
-    Account *account = find_data;
-    GNCLedgerDisplay *ld = user_data;
+    Account* account = find_data;
+    GNCLedgerDisplay* ld = user_data;
 
     if (!account || !ld)
         return FALSE;
@@ -181,8 +181,8 @@ find_by_leader (gpointer find_data, gpointer user_data)
 static gboolean
 find_by_query (gpointer find_data, gpointer user_data)
 {
-    Query *q = find_data;
-    GNCLedgerDisplay *ld = user_data;
+    Query* q = find_data;
+    GNCLedgerDisplay* ld = user_data;
 
     if (!q || !ld)
         return FALSE;
@@ -193,8 +193,8 @@ find_by_query (gpointer find_data, gpointer user_data)
 static gboolean
 find_by_reg (gpointer find_data, gpointer user_data)
 {
-    SplitRegister *reg = find_data;
-    GNCLedgerDisplay *ld = user_data;
+    SplitRegister* reg = find_data;
+    GNCLedgerDisplay* ld = user_data;
 
     if (!reg || !ld)
         return FALSE;
@@ -218,13 +218,13 @@ gnc_get_default_register_style (GNCAccountType type)
 }
 
 static gpointer
-look_for_portfolio_cb (Account *account, gpointer data)
+look_for_portfolio_cb (Account* account, gpointer data)
 {
-    return xaccAccountIsPriced(account) ? (gpointer) PORTFOLIO_LEDGER : NULL;
+    return xaccAccountIsPriced (account) ? (gpointer) PORTFOLIO_LEDGER : NULL;
 }
 
 static SplitRegisterType
-gnc_get_reg_type (Account *leader, GNCLedgerDisplayType ld_type)
+gnc_get_reg_type (Account* leader, GNCLedgerDisplayType ld_type)
 {
     GNCAccountType account_type;
     SplitRegisterType reg_type;
@@ -306,7 +306,8 @@ gnc_get_reg_type (Account *leader, GNCLedgerDisplayType ld_type)
         gpointer ret;
         reg_type = GENERAL_JOURNAL;
 
-        ret = gnc_account_foreach_descendant_until(leader, look_for_portfolio_cb, NULL);
+        ret = gnc_account_foreach_descendant_until (leader, look_for_portfolio_cb,
+                                                    NULL);
         if (ret) reg_type = PORTFOLIO_LEDGER;
         break;
     }
@@ -339,22 +340,23 @@ gnc_get_reg_type (Account *leader, GNCLedgerDisplayType ld_type)
 /* Returns a boolean of whether this display should be single or double lined
  * mode by default */
 gboolean
-gnc_ledger_display_default_double_line (GNCLedgerDisplay *gld)
+gnc_ledger_display_default_double_line (GNCLedgerDisplay* gld)
 {
     return (gld->use_double_line_default ||
-            gnc_prefs_get_bool(GNC_PREFS_GROUP_GENERAL_REGISTER, GNC_PREF_DOUBLE_LINE_MODE));
+            gnc_prefs_get_bool (GNC_PREFS_GROUP_GENERAL_REGISTER,
+                                GNC_PREF_DOUBLE_LINE_MODE));
 }
 
 /* Opens up a register window to display a single account */
-GNCLedgerDisplay *
-gnc_ledger_display_simple (Account *account)
+GNCLedgerDisplay*
+gnc_ledger_display_simple (Account* account)
 {
     SplitRegisterType reg_type;
     GNCAccountType acc_type = xaccAccountGetType (account);
     gboolean use_double_line;
-    GNCLedgerDisplay *ld;
+    GNCLedgerDisplay* ld;
 
-    ENTER("account=%p", account);
+    ENTER ("account=%p", account);
 
     switch (acc_type)
     {
@@ -370,43 +372,44 @@ gnc_ledger_display_simple (Account *account)
     reg_type = gnc_get_reg_type (account, LD_SINGLE);
 
     ld = gnc_ledger_display_internal (account, NULL, LD_SINGLE, reg_type,
-                                      gnc_get_default_register_style(acc_type),
+                                      gnc_get_default_register_style (acc_type),
                                       use_double_line, FALSE, FALSE);
-    LEAVE("%p", ld);
+    LEAVE ("%p", ld);
     return ld;
 }
 
 /* Opens up a register window to display an account, and all of its
  *   children, in the same window */
-GNCLedgerDisplay *
-gnc_ledger_display_subaccounts (Account *account,gboolean mismatched_commodities)
+GNCLedgerDisplay*
+gnc_ledger_display_subaccounts (Account* account,
+                                gboolean mismatched_commodities)
 {
     SplitRegisterType reg_type;
-    GNCLedgerDisplay *ld;
+    GNCLedgerDisplay* ld;
 
-    ENTER("account=%p", account);
+    ENTER ("account=%p", account);
 
     reg_type = gnc_get_reg_type (account, LD_SUBACCOUNT);
 
     ld = gnc_ledger_display_internal (account, NULL, LD_SUBACCOUNT,
                                       reg_type, REG_STYLE_JOURNAL, FALSE,
-                                      FALSE,mismatched_commodities);
-    LEAVE("%p", ld);
+                                      FALSE, mismatched_commodities);
+    LEAVE ("%p", ld);
     return ld;
 }
 
 /* Opens up a general journal window. */
-GNCLedgerDisplay *
+GNCLedgerDisplay*
 gnc_ledger_display_gl (void)
 {
-    Query *query;
+    Query* query;
     time64 start;
     struct tm tm;
-    GNCLedgerDisplay *ld;
+    GNCLedgerDisplay* ld;
 
-    ENTER(" ");
+    ENTER (" ");
 
-    query = qof_query_create_for(GNC_ID_SPLIT);
+    query = qof_query_create_for (GNC_ID_SPLIT);
 
     qof_query_set_book (query, gnc_get_current_book());
 
@@ -417,21 +420,21 @@ gnc_ledger_display_gl (void)
      * See Gnome Bug 86302.
      *         -- jsled */
     {
-        Account *tRoot;
-        GList *al;
+        Account* tRoot;
+        GList* al;
 
-        tRoot = gnc_book_get_template_root( gnc_get_current_book() );
-        al = gnc_account_get_descendants( tRoot );
+        tRoot = gnc_book_get_template_root (gnc_get_current_book());
+        al = gnc_account_get_descendants (tRoot);
 
-        if (g_list_length(al) != 0)
-            xaccQueryAddAccountMatch( query, al, QOF_GUID_MATCH_NONE, QOF_QUERY_AND );
+        if (g_list_length (al) != 0)
+            xaccQueryAddAccountMatch (query, al, QOF_GUID_MATCH_NONE, QOF_QUERY_AND);
 
         g_list_free (al);
         al = NULL;
         tRoot = NULL;
     }
 
-    gnc_tm_get_today_start(&tm);
+    gnc_tm_get_today_start (&tm);
     tm.tm_mon--; /* Default the register to the last month's worth of transactions. */
     start = gnc_mktime (&tm);
     xaccQueryAddDateMatchTT (query,
@@ -441,7 +444,7 @@ gnc_ledger_display_gl (void)
 
     ld = gnc_ledger_display_internal (NULL, query, LD_GL, GENERAL_JOURNAL,
                                       REG_STYLE_JOURNAL, FALSE, FALSE, FALSE);
-    LEAVE("%p", ld);
+    LEAVE ("%p", ld);
     return ld;
 }
 
@@ -453,31 +456,31 @@ gnc_ledger_display_gl (void)
  * scheduled transaction.  That's right.  The stringified GncGUID of the SX is
  * the name of the SX'es template account.
  **/
-GNCLedgerDisplay *
-gnc_ledger_display_template_gl (char *id)
+GNCLedgerDisplay*
+gnc_ledger_display_template_gl (char* id)
 {
-    QofBook *book;
-    Query *q;
-    GNCLedgerDisplay *ld;
-    SplitRegister *sr;
-    Account *root, *acct;
+    QofBook* book;
+    Query* q;
+    GNCLedgerDisplay* ld;
+    SplitRegister* sr;
+    Account* root, *acct;
     gboolean isTemplateModeTrue;
 
-    ENTER("id=%s", id ? id : "(null)");
+    ENTER ("id=%s", id ? id : "(null)");
 
     acct = NULL;
     isTemplateModeTrue = TRUE;
 
-    q = qof_query_create_for(GNC_ID_SPLIT);
+    q = qof_query_create_for (GNC_ID_SPLIT);
 
-    book = gnc_get_current_book ();
+    book = gnc_get_current_book();
     qof_query_set_book (q, book);
 
-    if ( id != NULL )
+    if (id != NULL)
     {
         root = gnc_book_get_template_root (book);
-        acct = gnc_account_lookup_by_name(root, id);
-        g_assert( acct );
+        acct = gnc_account_lookup_by_name (root, id);
+        g_assert (acct);
         xaccQueryAddSingleAccountMatch (q, acct, QOF_QUERY_AND);
     }
 
@@ -489,38 +492,38 @@ gnc_ledger_display_template_gl (char *id)
                                       FALSE);
 
     sr = gnc_ledger_display_get_split_register (ld);
-    if ( acct )
+    if (acct)
     {
         gnc_split_register_set_template_account (sr, acct);
     }
 
-    LEAVE("%p", ld);
+    LEAVE ("%p", ld);
     return ld;
 }
 
-GtkWidget *
-gnc_ledger_display_get_parent( GNCLedgerDisplay *ld )
+GtkWidget*
+gnc_ledger_display_get_parent (GNCLedgerDisplay* ld)
 {
-    if ( ld == NULL )
+    if (ld == NULL)
         return NULL;
 
-    if ( ld->get_parent == NULL )
+    if (ld->get_parent == NULL)
         return NULL;
 
-    return ld->get_parent( ld );
+    return ld->get_parent (ld);
 }
 
-static GtkWidget *
-gnc_ledger_display_parent (void *user_data)
+static GtkWidget*
+gnc_ledger_display_parent (void* user_data)
 {
-    GNCLedgerDisplay *ld = user_data;
-    return gnc_ledger_display_get_parent( ld );
+    GNCLedgerDisplay* ld = user_data;
+    return gnc_ledger_display_get_parent (ld);
 }
 
 static void
-gnc_ledger_display_set_watches (GNCLedgerDisplay *ld, GList *splits)
+gnc_ledger_display_set_watches (GNCLedgerDisplay* ld, GList* splits)
 {
-    GList *node;
+    GList* node;
 
     gnc_gui_component_clear_watches (ld->component_id);
 
@@ -528,11 +531,11 @@ gnc_ledger_display_set_watches (GNCLedgerDisplay *ld, GList *splits)
                                          GNC_ID_ACCOUNT,
                                          QOF_EVENT_MODIFY | QOF_EVENT_DESTROY
                                          | GNC_EVENT_ITEM_CHANGED);
-    
+
     for (node = splits; node; node = node->next)
     {
-        Split *split = node->data;
-        Transaction *trans = xaccSplitGetParent (split);
+        Split* split = node->data;
+        Transaction* trans = xaccSplitGetParent (split);
 
         gnc_gui_component_watch_entity (ld->component_id,
                                         xaccTransGetGUID (trans),
@@ -541,18 +544,18 @@ gnc_ledger_display_set_watches (GNCLedgerDisplay *ld, GList *splits)
 }
 
 static void
-refresh_handler (GHashTable *changes, gpointer user_data)
+refresh_handler (GHashTable* changes, gpointer user_data)
 {
-    GNCLedgerDisplay *ld = user_data;
-    const EventInfo *info;
+    GNCLedgerDisplay* ld = user_data;
+    const EventInfo* info;
     gboolean has_leader;
-    GList *splits;
+    GList* splits;
 
-    ENTER("changes=%p, user_data=%p", changes, user_data);
+    ENTER ("changes=%p, user_data=%p", changes, user_data);
 
     if (ld->loading)
     {
-        LEAVE("already loading");
+        LEAVE ("already loading");
         return;
     }
 
@@ -560,11 +563,11 @@ refresh_handler (GHashTable *changes, gpointer user_data)
 
     if (has_leader)
     {
-        Account *leader = gnc_ledger_display_leader (ld);
+        Account* leader = gnc_ledger_display_leader (ld);
         if (!leader)
         {
             gnc_close_gui_component (ld->component_id);
-            LEAVE("no leader");
+            LEAVE ("no leader");
             return;
         }
     }
@@ -575,7 +578,7 @@ refresh_handler (GHashTable *changes, gpointer user_data)
         if (info && (info->event_mask & QOF_EVENT_DESTROY))
         {
             gnc_close_gui_component (ld->component_id);
-            LEAVE("destroy");
+            LEAVE ("destroy");
             return;
         }
     }
@@ -584,13 +587,13 @@ refresh_handler (GHashTable *changes, gpointer user_data)
      *  of subaccounts, if not recreate the query. */
     if (ld->ld_type == LD_SUBACCOUNT)
     {
-        Account *leader = gnc_ledger_display_leader (ld);
-        GList *accounts = gnc_account_get_descendants (leader);
+        Account* leader = gnc_ledger_display_leader (ld);
+        GList* accounts = gnc_account_get_descendants (leader);
 
         if (g_list_length (accounts) != ld->number_of_subaccounts)
             gnc_ledger_display_make_query (ld,
-                               gnc_prefs_get_float(GNC_PREFS_GROUP_GENERAL_REGISTER, GNC_PREF_MAX_TRANS),
-                               gnc_get_reg_type (leader, ld->ld_type));
+                                           gnc_prefs_get_float (GNC_PREFS_GROUP_GENERAL_REGISTER, GNC_PREF_MAX_TRANS),
+                                           gnc_get_reg_type (leader, ld->ld_type));
 
         g_list_free (accounts);
     }
@@ -605,13 +608,13 @@ refresh_handler (GHashTable *changes, gpointer user_data)
     gnc_ledger_display_set_watches (ld, splits);
 
     gnc_ledger_display_refresh_internal (ld, splits);
-    LEAVE(" ");
+    LEAVE (" ");
 }
 
 static void
 close_handler (gpointer user_data)
 {
-    GNCLedgerDisplay *ld = user_data;
+    GNCLedgerDisplay* ld = user_data;
 
     if (!ld)
         return;
@@ -632,12 +635,12 @@ close_handler (gpointer user_data)
 }
 
 static void
-gnc_ledger_display_make_query (GNCLedgerDisplay *ld,
+gnc_ledger_display_make_query (GNCLedgerDisplay* ld,
                                gint limit,
                                SplitRegisterType type)
 {
-    Account *leader;
-    GList *accounts;
+    Account* leader;
+    GList* accounts;
 
     if (!ld)
         return;
@@ -657,7 +660,7 @@ gnc_ledger_display_make_query (GNCLedgerDisplay *ld,
     }
 
     qof_query_destroy (ld->query);
-    ld->query = qof_query_create_for(GNC_ID_SPLIT);
+    ld->query = qof_query_create_for (GNC_ID_SPLIT);
 
     /* This is a bit of a hack. The number of splits should be
      * configurable, or maybe we should go back a time range instead
@@ -670,8 +673,8 @@ gnc_ledger_display_make_query (GNCLedgerDisplay *ld,
 
     leader = gnc_ledger_display_leader (ld);
 
-    /* if this is a subaccount ledger, record the number of 
-     * subaccounts so we can determine if the query needs 
+    /* if this is a subaccount ledger, record the number of
+     * subaccounts so we can determine if the query needs
      * recreating on a refresh. */
     if (ld->ld_type == LD_SUBACCOUNT)
     {
@@ -690,22 +693,22 @@ gnc_ledger_display_make_query (GNCLedgerDisplay *ld,
 }
 
 /* Opens up a ledger window for an arbitrary query. */
-GNCLedgerDisplay *
-gnc_ledger_display_query (Query *query, SplitRegisterType type,
+GNCLedgerDisplay*
+gnc_ledger_display_query (Query* query, SplitRegisterType type,
                           SplitRegisterStyle style)
 {
-    GNCLedgerDisplay *ld;
+    GNCLedgerDisplay* ld;
 
-    ENTER("query=%p", query);
+    ENTER ("query=%p", query);
 
     ld = gnc_ledger_display_internal (NULL, query, LD_GL, type, style,
                                       FALSE, FALSE, FALSE);
-    LEAVE("%p", ld);
+    LEAVE ("%p", ld);
     return ld;
 }
 
-static GNCLedgerDisplay *
-gnc_ledger_display_internal (Account *lead_account, Query *q,
+static GNCLedgerDisplay*
+gnc_ledger_display_internal (Account* lead_account, Query* q,
                              GNCLedgerDisplayType ld_type,
                              SplitRegisterType reg_type,
                              SplitRegisterStyle style,
@@ -713,10 +716,10 @@ gnc_ledger_display_internal (Account *lead_account, Query *q,
                              gboolean is_template,
                              gboolean mismatched_commodities)
 {
-    GNCLedgerDisplay *ld;
+    GNCLedgerDisplay* ld;
     gint limit;
-    const char *klass;
-    GList *splits;
+    const char* klass;
+    GList* splits;
 
     switch (ld_type)
     {
@@ -794,7 +797,8 @@ gnc_ledger_display_internal (Account *lead_account, Query *q,
     ld->get_parent = NULL;
     ld->user_data = NULL;
 
-    limit = gnc_prefs_get_float(GNC_PREFS_GROUP_GENERAL_REGISTER, GNC_PREF_MAX_TRANS);
+    limit = gnc_prefs_get_float (GNC_PREFS_GROUP_GENERAL_REGISTER,
+                                 GNC_PREF_MAX_TRANS);
 
     /* set up the query filter */
     if (q)
@@ -803,8 +807,8 @@ gnc_ledger_display_internal (Account *lead_account, Query *q,
         gnc_ledger_display_make_query (ld, limit, reg_type);
 
     ld->component_id = gnc_register_gui_component (klass,
-                       refresh_handler,
-                       close_handler, ld);
+                                                   refresh_handler,
+                                                   close_handler, ld);
 
     /******************************************************************\
      * The main register window itself                                *
@@ -813,7 +817,7 @@ gnc_ledger_display_internal (Account *lead_account, Query *q,
     ld->use_double_line_default = use_double_line;
 
     ld->reg = gnc_split_register_new (reg_type, style, use_double_line,
-                                      is_template,mismatched_commodities);
+                                      is_template, mismatched_commodities);
 
     gnc_split_register_set_data (ld->reg, ld, gnc_ledger_display_parent);
 
@@ -827,7 +831,7 @@ gnc_ledger_display_internal (Account *lead_account, Query *q,
 }
 
 void
-gnc_ledger_display_set_query (GNCLedgerDisplay *ledger_display, Query *q)
+gnc_ledger_display_set_query (GNCLedgerDisplay* ledger_display, Query* q)
 {
     if (!ledger_display || !q)
         return;
@@ -838,8 +842,8 @@ gnc_ledger_display_set_query (GNCLedgerDisplay *ledger_display, Query *q)
     ledger_display->query = qof_query_copy (q);
 }
 
-GNCLedgerDisplay *
-gnc_ledger_display_find_by_query (Query *q)
+GNCLedgerDisplay*
+gnc_ledger_display_find_by_query (Query* q)
 {
     if (!q)
         return NULL;
@@ -852,7 +856,7 @@ gnc_ledger_display_find_by_query (Query *q)
 \********************************************************************/
 
 static void
-gnc_ledger_display_refresh_internal (GNCLedgerDisplay *ld, GList *splits)
+gnc_ledger_display_refresh_internal (GNCLedgerDisplay* ld, GList* splits)
 {
     if (!ld || ld->loading)
         return;
@@ -869,30 +873,30 @@ gnc_ledger_display_refresh_internal (GNCLedgerDisplay *ld, GList *splits)
 }
 
 void
-gnc_ledger_display_refresh (GNCLedgerDisplay *ld)
+gnc_ledger_display_refresh (GNCLedgerDisplay* ld)
 {
-    ENTER("ld=%p", ld);
+    ENTER ("ld=%p", ld);
 
     if (!ld)
     {
-        LEAVE("no display");
+        LEAVE ("no display");
         return;
     }
 
     if (ld->loading)
     {
-        LEAVE("already loading");
+        LEAVE ("already loading");
         return;
     }
 
     gnc_ledger_display_refresh_internal (ld, qof_query_run (ld->query));
-    LEAVE(" ");
+    LEAVE (" ");
 }
 
 void
-gnc_ledger_display_refresh_by_split_register (SplitRegister *reg)
+gnc_ledger_display_refresh_by_split_register (SplitRegister* reg)
 {
-    GNCLedgerDisplay *ld;
+    GNCLedgerDisplay* ld;
 
     if (!reg)
         return;
@@ -922,7 +926,7 @@ gnc_ledger_display_refresh_by_split_register (SplitRegister *reg)
     }
 
     ld = gnc_find_first_gui_component (REGISTER_TEMPLATE_CM_CLASS,
-                                       find_by_reg, reg );
+                                       find_by_reg, reg);
     if (ld)
     {
         gnc_ledger_display_refresh (ld);
@@ -930,7 +934,7 @@ gnc_ledger_display_refresh_by_split_register (SplitRegister *reg)
 }
 
 void
-gnc_ledger_display_close (GNCLedgerDisplay *ld)
+gnc_ledger_display_close (GNCLedgerDisplay* ld)
 {
     if (!ld)
         return;

--- a/gnucash/register/ledger-core/gnc-ledger-display.h
+++ b/gnucash/register/ledger-core/gnc-ledger-display.h
@@ -46,10 +46,10 @@
  * displaying the results of a Query.  It also stores the Query.  */
 typedef struct gnc_ledger_display GNCLedgerDisplay;
 
-typedef void (*GNCLedgerDisplayDestroy) (GNCLedgerDisplay *ld);
-typedef GtkWidget *(*GNCLedgerDisplayGetParent) (GNCLedgerDisplay *ld);
-typedef void (*GNCLedgerDisplaySetHelp) (GNCLedgerDisplay *ld,
-        const char *help_str);
+typedef void (*GNCLedgerDisplayDestroy) (GNCLedgerDisplay* ld);
+typedef GtkWidget* (*GNCLedgerDisplayGetParent) (GNCLedgerDisplay* ld);
+typedef void (*GNCLedgerDisplaySetHelp) (GNCLedgerDisplay* ld,
+                                         const char* help_str);
 
 typedef enum
 {
@@ -60,35 +60,36 @@ typedef enum
 
 
 /** returns the 'lead' account of a ledger display, or NULL if none. */
-Account * gnc_ledger_display_leader (GNCLedgerDisplay *ld);
+Account* gnc_ledger_display_leader (GNCLedgerDisplay* ld);
 
-GNCLedgerDisplayType gnc_ledger_display_type (GNCLedgerDisplay *ld);
+GNCLedgerDisplayType gnc_ledger_display_type (GNCLedgerDisplay* ld);
 
 /** get and set the user data associated with the ledger */
-void gnc_ledger_display_set_user_data (GNCLedgerDisplay *ld,
+void gnc_ledger_display_set_user_data (GNCLedgerDisplay* ld,
                                        gpointer user_data);
-gpointer gnc_ledger_display_get_user_data (GNCLedgerDisplay *ld);
+gpointer gnc_ledger_display_get_user_data (GNCLedgerDisplay* ld);
 
 /** set the handlers used by the ledger display */
-void gnc_ledger_display_set_handlers (GNCLedgerDisplay *ld,
+void gnc_ledger_display_set_handlers (GNCLedgerDisplay* ld,
                                       GNCLedgerDisplayDestroy destroy,
                                       GNCLedgerDisplayGetParent get_parent);
 
 /** Returns the parent of a given ledger display */
-GtkWidget *gnc_ledger_display_get_parent( GNCLedgerDisplay *ld );
+GtkWidget* gnc_ledger_display_get_parent (GNCLedgerDisplay* ld);
 
 /** return the split register associated with a ledger display */
-SplitRegister * gnc_ledger_display_get_split_register (GNCLedgerDisplay *ld);
+SplitRegister* gnc_ledger_display_get_split_register (GNCLedgerDisplay* ld);
 
 /** opens up a register window to display a single account */
-GNCLedgerDisplay * gnc_ledger_display_simple (Account *account);
+GNCLedgerDisplay* gnc_ledger_display_simple (Account* account);
 
 /** opens up a register window to display the parent account and all of
  * its children. */
-GNCLedgerDisplay * gnc_ledger_display_subaccounts (Account *account, gboolean mismatched_commodities);
+GNCLedgerDisplay* gnc_ledger_display_subaccounts (Account* account,
+                                                  gboolean mismatched_commodities);
 
 /** opens up a general ledger window */
-GNCLedgerDisplay * gnc_ledger_display_gl (void);
+GNCLedgerDisplay* gnc_ledger_display_gl (void);
 
 /**
  * Displays a template ledger.
@@ -97,34 +98,34 @@ GNCLedgerDisplay * gnc_ledger_display_gl (void);
  * Really, requires a GList of scheduled transactions and kvp-frame
  * data.
  **/
-GNCLedgerDisplay * gnc_ledger_display_template_gl (char *id);
+GNCLedgerDisplay* gnc_ledger_display_template_gl (char* id);
 
 /** display a general ledger for an arbitrary query */
-GNCLedgerDisplay * gnc_ledger_display_query (Query *query,
-        SplitRegisterType type,
-        SplitRegisterStyle style);
+GNCLedgerDisplay* gnc_ledger_display_query (Query* query,
+                                            SplitRegisterType type,
+                                            SplitRegisterStyle style);
 
 /** Set the query used for a register. */
-void gnc_ledger_display_set_query (GNCLedgerDisplay *ledger_display,
-                                   Query *q);
+void gnc_ledger_display_set_query (GNCLedgerDisplay* ledger_display,
+                                   Query* q);
 
 /** return the query associated with a ledger */
-Query * gnc_ledger_display_get_query (GNCLedgerDisplay *ld);
+Query* gnc_ledger_display_get_query (GNCLedgerDisplay* ld);
 
 /** If the given ledger display still exists, return it. Otherwise,
  * return NULL */
-GNCLedgerDisplay * gnc_ledger_display_find_by_query (Query *q);
+GNCLedgerDisplay* gnc_ledger_display_find_by_query (Query* q);
 
 /** redisplay/redraw only the indicated window. Both routines do same
  * thing, they differ only by the argument they take. */
-void gnc_ledger_display_refresh (GNCLedgerDisplay * ledger_display);
-void gnc_ledger_display_refresh_by_split_register (SplitRegister *reg);
+void gnc_ledger_display_refresh (GNCLedgerDisplay* ledger_display);
+void gnc_ledger_display_refresh_by_split_register (SplitRegister* reg);
 
 /** close the window */
-void gnc_ledger_display_close (GNCLedgerDisplay * ledger_display);
+void gnc_ledger_display_close (GNCLedgerDisplay* ledger_display);
 
 /** Returns a boolean of whether this display should be single or double lined
  * mode by default */
-gboolean gnc_ledger_display_default_double_line (GNCLedgerDisplay *gld);
+gboolean gnc_ledger_display_default_double_line (GNCLedgerDisplay* gld);
 
 #endif

--- a/gnucash/register/ledger-core/gnc-ledger-display.h
+++ b/gnucash/register/ledger-core/gnc-ledger-display.h
@@ -85,7 +85,7 @@ GNCLedgerDisplay * gnc_ledger_display_simple (Account *account);
 
 /** opens up a register window to display the parent account and all of
  * its children. */
-GNCLedgerDisplay * gnc_ledger_display_subaccounts (Account *account);
+GNCLedgerDisplay * gnc_ledger_display_subaccounts (Account *account, gboolean mismatched_commodities);
 
 /** opens up a general ledger window */
 GNCLedgerDisplay * gnc_ledger_display_gl (void);

--- a/gnucash/register/ledger-core/gnc-ledger-display2.c
+++ b/gnucash/register/ledger-core/gnc-ledger-display2.c
@@ -93,7 +93,8 @@ gnc_ledger_display2_internal (Account *lead_account, Query *q,
                              SplitRegisterType2 reg_type,
                              SplitRegisterStyle2 style,
                              gboolean use_double_line,
-                             gboolean is_template);
+                             gboolean is_template,
+                             gboolean mismatched_commodities);
 
 static void gnc_ledger_display2_refresh_internal (GNCLedgerDisplay2 *ld, GList *splits);
 
@@ -373,7 +374,7 @@ gnc_ledger_display2_simple (Account *account)
 
     ld = gnc_ledger_display2_internal (account, NULL, LD2_SINGLE, reg_type,
                                       gnc_get_default_register_style(acc_type),
-                                      use_double_line, FALSE);
+                                      use_double_line, FALSE, FALSE);
     LEAVE("%p", ld);
     return ld;
 }
@@ -381,7 +382,7 @@ gnc_ledger_display2_simple (Account *account)
 /* Opens up a register window to display an account, and all of its
  *   children, in the same window */
 GNCLedgerDisplay2 *
-gnc_ledger_display2_subaccounts (Account *account)
+gnc_ledger_display2_subaccounts (Account *account, gboolean mismatched_commodities)
 {
     SplitRegisterType2 reg_type;
     GNCLedgerDisplay2 *ld;
@@ -392,7 +393,7 @@ gnc_ledger_display2_subaccounts (Account *account)
 
     ld = gnc_ledger_display2_internal (account, NULL, LD2_SUBACCOUNT,
                                       reg_type, REG2_STYLE_JOURNAL, FALSE,
-                                      FALSE);
+                                      FALSE,mismatched_commodities);
     LEAVE("%p", ld);
     return ld;
 }
@@ -442,7 +443,7 @@ gnc_ledger_display2_gl (void)
                              QOF_QUERY_AND);
 
     ld = gnc_ledger_display2_internal (NULL, query, LD2_GL, GENERAL_JOURNAL2,
-                                      REG2_STYLE_JOURNAL, FALSE, FALSE);
+                                      REG2_STYLE_JOURNAL, FALSE, FALSE, FALSE);
     LEAVE("%p", ld);
     return ld;
 }
@@ -487,7 +488,8 @@ gnc_ledger_display2_template_gl (char *id)
                                       SEARCH_LEDGER2,
                                       REG2_STYLE_JOURNAL,
                                       FALSE,
-                                      isTemplateModeTrue);
+                                      isTemplateModeTrue,
+                                       FALSE);
 
 
     model = gnc_ledger_display2_get_split_model_register (ld);
@@ -689,7 +691,7 @@ gnc_ledger_display2_query (Query *query, SplitRegisterType2 type,
     ENTER("query=%p", query);
 
     ld = gnc_ledger_display2_internal (NULL, query, LD2_GL, type, style,
-                                      FALSE, FALSE);
+                                      FALSE, FALSE, FALSE);
     LEAVE("%p", ld);
     return ld;
 }
@@ -700,7 +702,8 @@ gnc_ledger_display2_internal (Account *lead_account, Query *q,
                              SplitRegisterType2 reg_type,
                              SplitRegisterStyle2 style,
                              gboolean use_double_line,
-                             gboolean is_template )
+                              gboolean is_template,
+                              gboolean mismatched_commodities)
 {
     GNCLedgerDisplay2 *ld;
     gint limit;
@@ -806,7 +809,8 @@ gnc_ledger_display2_internal (Account *lead_account, Query *q,
 
     ld->use_double_line_default = use_double_line;
 
-    ld->model = gnc_tree_model_split_reg_new (reg_type, style, use_double_line, is_template);
+    // JEAN: add mismatched_commodities
+    ld->model = gnc_tree_model_split_reg_new (reg_type, style, use_double_line, is_template, mismatched_commodities);
 
     gnc_tree_model_split_reg_set_data (ld->model, ld, gnc_ledger_display2_parent);
     gnc_tree_model_split_reg_set_display (ld->model, display_subaccounts, is_gl);

--- a/gnucash/register/ledger-core/gnc-ledger-display2.h
+++ b/gnucash/register/ledger-core/gnc-ledger-display2.h
@@ -99,7 +99,7 @@ GNCLedgerDisplay2 * gnc_ledger_display2_simple (Account *account);
 
 /** opens up a register window to display the parent account and all of
  * its children. */
-GNCLedgerDisplay2 * gnc_ledger_display2_subaccounts (Account *account);
+GNCLedgerDisplay2 * gnc_ledger_display2_subaccounts (Account *account, gboolean mismatched_commodities);
 
 /** opens up a general ledger window */
 GNCLedgerDisplay2 * gnc_ledger_display2_gl (void);

--- a/gnucash/register/ledger-core/split-register-layout.c
+++ b/gnucash/register/ledger-core/split-register-layout.c
@@ -291,8 +291,16 @@ gnc_split_register_set_cells (SplitRegister *reg, TableLayout *layout)
         {
             gnc_table_layout_set_cell (layout, curs, DEBT_CELL,  0, 5);
             gnc_table_layout_set_cell (layout, curs, CRED_CELL,  0, 6);
-            gnc_table_layout_set_cell (layout, curs, RBALN_CELL, 0, 7);
-            gnc_table_layout_set_cell (layout, curs, RATE_CELL,  0, 8);
+            if(!reg->mismatched_commodities)
+            {
+                gnc_table_layout_set_cell (layout, curs, RBALN_CELL, 0, 7);
+                gnc_table_layout_set_cell (layout, curs, RATE_CELL,  0, 8);
+            }
+            else
+            {
+                // Don't display the balance if there are mismatched commodities
+                gnc_table_layout_set_cell (layout, curs, RATE_CELL,  0, 7);
+            }
         }
 
         curs_last = curs;
@@ -328,8 +336,16 @@ gnc_split_register_set_cells (SplitRegister *reg, TableLayout *layout)
             gnc_table_layout_set_cell (layout, curs, RATE_CELL,  0, 7);
         else
         {
-            gnc_table_layout_set_cell (layout, curs, RBALN_CELL, 0, 7);
-            gnc_table_layout_set_cell (layout, curs, RATE_CELL,  0, 8);
+            if(!reg->mismatched_commodities)
+            {
+                gnc_table_layout_set_cell (layout, curs, RBALN_CELL, 0, 7);
+                gnc_table_layout_set_cell (layout, curs, RATE_CELL,  0, 8);
+            }
+            else
+            {
+                // Don't display the balance if there are mismatched commodities
+                gnc_table_layout_set_cell (layout, curs, RATE_CELL,  0, 7);
+            }
         }
 
         curs_last = curs;
@@ -577,7 +593,7 @@ gnc_split_register_layout_add_cursors (SplitRegister *reg,
     case INCOME_LEDGER:
     case GENERAL_JOURNAL:
     case SEARCH_LEDGER:
-        if (reg->is_template)
+        if (reg->is_template || reg->mismatched_commodities)
             num_cols = 8;
         else
             num_cols = 9;

--- a/gnucash/register/ledger-core/split-register-layout.c
+++ b/gnucash/register/ledger-core/split-register-layout.c
@@ -35,15 +35,15 @@ static QofLogModule log_module = GNC_MOD_REGISTER;
 
 
 static void
-gnc_register_add_cell (TableLayout *layout,
-                       const char *cell_name,
-                       const char *cell_type_name,
-                       const char *sample_text,
+gnc_register_add_cell (TableLayout* layout,
+                       const char* cell_name,
+                       const char* cell_type_name,
+                       const char* sample_text,
                        CellAlignment alignment,
                        gboolean expandable,
                        gboolean span)
 {
-    BasicCell *cell;
+    BasicCell* cell;
 
     g_return_if_fail (layout != NULL);
     g_return_if_fail (cell_type_name != NULL);
@@ -61,13 +61,13 @@ gnc_register_add_cell (TableLayout *layout,
 }
 
 static void
-copy_cursor_row (TableLayout *layout, CellBlock *to, CellBlock *from, int row)
+copy_cursor_row (TableLayout* layout, CellBlock* to, CellBlock* from, int row)
 {
     int col;
 
     for (col = 0; col < from->num_cols; col++)
     {
-        BasicCell *cell;
+        BasicCell* cell;
 
         cell = gnc_cellblock_get_cell (from, row, col);
         if (!cell || !cell->cell_name)
@@ -78,10 +78,10 @@ copy_cursor_row (TableLayout *layout, CellBlock *to, CellBlock *from, int row)
 }
 
 static void
-gnc_split_register_set_cells (SplitRegister *reg, TableLayout *layout)
+gnc_split_register_set_cells (SplitRegister* reg, TableLayout* layout)
 {
-    CellBlock *curs;
-    CellBlock *curs_last;
+    CellBlock* curs;
+    CellBlock* curs_last;
 
     switch (reg->type)
     {
@@ -291,7 +291,7 @@ gnc_split_register_set_cells (SplitRegister *reg, TableLayout *layout)
         {
             gnc_table_layout_set_cell (layout, curs, DEBT_CELL,  0, 5);
             gnc_table_layout_set_cell (layout, curs, CRED_CELL,  0, 6);
-            if(!reg->mismatched_commodities)
+            if (!reg->mismatched_commodities)
             {
                 gnc_table_layout_set_cell (layout, curs, RBALN_CELL, 0, 7);
                 gnc_table_layout_set_cell (layout, curs, RATE_CELL,  0, 8);
@@ -336,7 +336,7 @@ gnc_split_register_set_cells (SplitRegister *reg, TableLayout *layout)
             gnc_table_layout_set_cell (layout, curs, RATE_CELL,  0, 7);
         else
         {
-            if(!reg->mismatched_commodities)
+            if (!reg->mismatched_commodities)
             {
                 gnc_table_layout_set_cell (layout, curs, RBALN_CELL, 0, 7);
                 gnc_table_layout_set_cell (layout, curs, RATE_CELL,  0, 8);
@@ -565,10 +565,10 @@ gnc_split_register_set_cells (SplitRegister *reg, TableLayout *layout)
 }
 
 static void
-gnc_split_register_layout_add_cursors (SplitRegister *reg,
-                                       TableLayout *layout)
+gnc_split_register_layout_add_cursors (SplitRegister* reg,
+                                       TableLayout* layout)
 {
-    CellBlock *cursor;
+    CellBlock* cursor;
     int num_cols;
 
     switch (reg->type)
@@ -609,7 +609,7 @@ gnc_split_register_layout_add_cursors (SplitRegister *reg,
         break;
 
     default:
-        PERR("Bad register type");
+        PERR ("Bad register type");
         g_assert (FALSE);
         return;
     }
@@ -644,8 +644,8 @@ gnc_split_register_layout_add_cursors (SplitRegister *reg,
 }
 
 static void
-gnc_split_register_layout_add_cells (SplitRegister *reg,
-                                     TableLayout *layout)
+gnc_split_register_layout_add_cells (SplitRegister* reg,
+                                     TableLayout* layout)
 {
     gnc_register_add_cell (layout,
                            DATE_CELL,
@@ -653,7 +653,7 @@ gnc_split_register_layout_add_cells (SplitRegister *reg,
                            /* Translators: The 'sample:' items are
                               strings which are not displayed, but only
                               used to estimate widths. */
-                           C_("sample", "22/02/2000"),
+                           C_ ("sample", "22/02/2000"),
                            CELL_ALIGN_RIGHT,
                            FALSE,
                            FALSE);
@@ -661,7 +661,7 @@ gnc_split_register_layout_add_cells (SplitRegister *reg,
     gnc_register_add_cell (layout,
                            DDUE_CELL,
                            DATE_CELL_TYPE_NAME,
-                           C_("sample", "22/02/2000"),
+                           C_ ("sample", "22/02/2000"),
                            CELL_ALIGN_RIGHT,
                            FALSE,
                            FALSE);
@@ -672,7 +672,7 @@ gnc_split_register_layout_add_cells (SplitRegister *reg,
                            /* Translators: The 'sample' items are
                               strings which are not displayed, but only
                               used to estimate widths. */
-                           C_("sample", "99999"),
+                           C_ ("sample", "99999"),
                            CELL_ALIGN_LEFT,
                            FALSE,
                            FALSE);
@@ -680,7 +680,7 @@ gnc_split_register_layout_add_cells (SplitRegister *reg,
     gnc_register_add_cell (layout,
                            TNUM_CELL,
                            BASIC_CELL_TYPE_NAME,
-                           C_("sample", "99999"),
+                           C_ ("sample", "99999"),
                            CELL_ALIGN_LEFT,
                            FALSE,
                            FALSE);
@@ -688,7 +688,7 @@ gnc_split_register_layout_add_cells (SplitRegister *reg,
     gnc_register_add_cell (layout,
                            DESC_CELL,
                            QUICKFILL_CELL_TYPE_NAME,
-                           C_("sample", "Description of a transaction"),
+                           C_ ("sample", "Description of a transaction"),
                            CELL_ALIGN_LEFT,
                            TRUE,
                            FALSE);
@@ -704,7 +704,7 @@ gnc_split_register_layout_add_cells (SplitRegister *reg,
     gnc_register_add_cell (layout,
                            RECN_CELL,
                            RECN_CELL_TYPE_NAME,
-	                   C_("Column header for 'Reconciled'", "R"),
+                           C_ ("Column header for 'Reconciled'", "R"),
                            CELL_ALIGN_CENTER,
                            FALSE,
                            FALSE);
@@ -712,7 +712,7 @@ gnc_split_register_layout_add_cells (SplitRegister *reg,
     gnc_register_add_cell (layout,
                            ASSOC_CELL,
                            RECN_CELL_TYPE_NAME,
-                           C_("Column header for 'Associate'", "A"),
+                           C_ ("Column header for 'Associate'", "A"),
                            CELL_ALIGN_CENTER,
                            FALSE,
                            FALSE);
@@ -720,7 +720,7 @@ gnc_split_register_layout_add_cells (SplitRegister *reg,
     gnc_register_add_cell (layout,
                            BALN_CELL,
                            PRICE_CELL_TYPE_NAME,
-                           C_("sample", "999,999.000"),
+                           C_ ("sample", "999,999.000"),
                            CELL_ALIGN_RIGHT,
                            FALSE,
                            FALSE);
@@ -728,7 +728,7 @@ gnc_split_register_layout_add_cells (SplitRegister *reg,
     gnc_register_add_cell (layout,
                            XFRM_CELL,
                            COMBO_CELL_TYPE_NAME,
-                           _("Transfer"),
+                           _ ("Transfer"),
                            CELL_ALIGN_RIGHT,
                            FALSE,
                            FALSE);
@@ -736,7 +736,7 @@ gnc_split_register_layout_add_cells (SplitRegister *reg,
     gnc_register_add_cell (layout,
                            MXFRM_CELL,
                            COMBO_CELL_TYPE_NAME,
-                           C_("sample", "Expenses:Automobile:Gasoline"),
+                           C_ ("sample", "Expenses:Automobile:Gasoline"),
                            CELL_ALIGN_RIGHT,
                            FALSE,
                            FALSE);
@@ -744,7 +744,7 @@ gnc_split_register_layout_add_cells (SplitRegister *reg,
     gnc_register_add_cell (layout,
                            ACTN_CELL,
                            COMBO_CELL_TYPE_NAME,
-                           C_("sample", "Expenses:Automobile:Gasoline"),
+                           C_ ("sample", "Expenses:Automobile:Gasoline"),
                            CELL_ALIGN_RIGHT,
                            FALSE,
                            FALSE);
@@ -752,7 +752,7 @@ gnc_split_register_layout_add_cells (SplitRegister *reg,
     gnc_register_add_cell (layout,
                            MEMO_CELL,
                            QUICKFILL_CELL_TYPE_NAME,
-                           C_("sample", "Memo field sample text string"),
+                           C_ ("sample", "Memo field sample text string"),
                            CELL_ALIGN_LEFT,
                            TRUE,
                            FALSE);
@@ -760,7 +760,7 @@ gnc_split_register_layout_add_cells (SplitRegister *reg,
     gnc_register_add_cell (layout,
                            DEBT_CELL,
                            PRICE_CELL_TYPE_NAME,
-                           C_("sample", "999,999.000"),
+                           C_ ("sample", "999,999.000"),
                            CELL_ALIGN_RIGHT,
                            FALSE,
                            FALSE);
@@ -768,7 +768,7 @@ gnc_split_register_layout_add_cells (SplitRegister *reg,
     gnc_register_add_cell (layout,
                            CRED_CELL,
                            PRICE_CELL_TYPE_NAME,
-                           C_("sample", "999,999.000"),
+                           C_ ("sample", "999,999.000"),
                            CELL_ALIGN_RIGHT,
                            FALSE,
                            FALSE);
@@ -776,7 +776,7 @@ gnc_split_register_layout_add_cells (SplitRegister *reg,
     gnc_register_add_cell (layout,
                            SHRS_CELL,
                            PRICE_CELL_TYPE_NAME,
-                           C_("sample", "999,999.000"),
+                           C_ ("sample", "999,999.000"),
                            CELL_ALIGN_RIGHT,
                            FALSE,
                            FALSE);
@@ -786,7 +786,7 @@ gnc_split_register_layout_add_cells (SplitRegister *reg,
     gnc_register_add_cell (layout,
                            PRIC_CELL,
                            PRICE_CELL_TYPE_NAME,
-                           C_("sample", "999,999.000"),
+                           C_ ("sample", "999,999.000"),
                            CELL_ALIGN_RIGHT,
                            FALSE,
                            FALSE);
@@ -794,7 +794,7 @@ gnc_split_register_layout_add_cells (SplitRegister *reg,
     gnc_register_add_cell (layout,
                            TDEBT_CELL,
                            PRICE_CELL_TYPE_NAME,
-                           C_("sample", "999,999.000"),
+                           C_ ("sample", "999,999.000"),
                            CELL_ALIGN_RIGHT,
                            FALSE,
                            FALSE);
@@ -802,7 +802,7 @@ gnc_split_register_layout_add_cells (SplitRegister *reg,
     gnc_register_add_cell (layout,
                            TCRED_CELL,
                            PRICE_CELL_TYPE_NAME,
-                           C_("sample", "999,999.000"),
+                           C_ ("sample", "999,999.000"),
                            CELL_ALIGN_RIGHT,
                            FALSE,
                            FALSE);
@@ -810,7 +810,7 @@ gnc_split_register_layout_add_cells (SplitRegister *reg,
     gnc_register_add_cell (layout,
                            TSHRS_CELL,
                            PRICE_CELL_TYPE_NAME,
-                           C_("sample", "999,999.000"),
+                           C_ ("sample", "999,999.000"),
                            CELL_ALIGN_RIGHT,
                            FALSE,
                            FALSE);
@@ -818,7 +818,7 @@ gnc_split_register_layout_add_cells (SplitRegister *reg,
     gnc_register_add_cell (layout,
                            TBALN_CELL,
                            PRICE_CELL_TYPE_NAME,
-                           C_("sample", "999,999.000"),
+                           C_ ("sample", "999,999.000"),
                            CELL_ALIGN_RIGHT,
                            FALSE,
                            FALSE);
@@ -826,7 +826,7 @@ gnc_split_register_layout_add_cells (SplitRegister *reg,
     gnc_register_add_cell (layout,
                            TYPE_CELL,
                            RECN_CELL_TYPE_NAME,
-	                   C_("Column header for 'Type'", "T"),
+                           C_ ("Column header for 'Type'", "T"),
                            CELL_ALIGN_CENTER,
                            FALSE,
                            FALSE);
@@ -834,7 +834,7 @@ gnc_split_register_layout_add_cells (SplitRegister *reg,
     gnc_register_add_cell (layout,
                            NOTES_CELL,
                            QUICKFILL_CELL_TYPE_NAME,
-                           C_("sample", "Notes field sample text string"),
+                           C_ ("sample", "Notes field sample text string"),
                            CELL_ALIGN_LEFT,
                            FALSE,
                            TRUE);
@@ -842,7 +842,7 @@ gnc_split_register_layout_add_cells (SplitRegister *reg,
     gnc_register_add_cell (layout,
                            VNOTES_CELL,
                            BASIC_CELL_TYPE_NAME,
-                           C_("sample", "No Particular Reason"),
+                           C_ ("sample", "No Particular Reason"),
                            CELL_ALIGN_RIGHT,
                            FALSE,
                            TRUE);
@@ -850,7 +850,7 @@ gnc_split_register_layout_add_cells (SplitRegister *reg,
     gnc_register_add_cell (layout,
                            FCRED_CELL,
                            FORMULA_CELL_TYPE_NAME,
-                           C_("sample", "(x + 0.33 * y + (x+y) )"),
+                           C_ ("sample", "(x + 0.33 * y + (x+y) )"),
                            CELL_ALIGN_LEFT,
                            FALSE,
                            FALSE);
@@ -858,7 +858,7 @@ gnc_split_register_layout_add_cells (SplitRegister *reg,
     gnc_register_add_cell (layout,
                            FDEBT_CELL,
                            FORMULA_CELL_TYPE_NAME,
-                           C_("sample", "(x + 0.33 * y + (x+y) )"),
+                           C_ ("sample", "(x + 0.33 * y + (x+y) )"),
                            CELL_ALIGN_LEFT,
                            FALSE,
                            FALSE);
@@ -866,19 +866,19 @@ gnc_split_register_layout_add_cells (SplitRegister *reg,
     gnc_register_add_cell (layout,
                            RBALN_CELL,
                            PRICE_CELL_TYPE_NAME,
-                           C_("sample", "999,999.000"),
+                           C_ ("sample", "999,999.000"),
                            CELL_ALIGN_RIGHT,
                            FALSE,
                            FALSE);
 
 }
 
-TableLayout *
-gnc_split_register_layout_new (SplitRegister *reg)
+TableLayout*
+gnc_split_register_layout_new (SplitRegister* reg)
 {
-    TableLayout *layout;
+    TableLayout* layout;
 
-    layout = gnc_table_layout_new ();
+    layout = gnc_table_layout_new();
 
     gnc_split_register_layout_add_cells (reg, layout);
     gnc_split_register_layout_add_cursors (reg, layout);

--- a/gnucash/register/ledger-core/split-register-model.c
+++ b/gnucash/register/ledger-core/split-register-model.c
@@ -52,16 +52,17 @@ static gboolean use_red_for_negative = TRUE;
  * If gboolean subaccounts is TRUE, then it will return the total balance of the parent account
  * and all its subaccounts. FALSE will return the balance of just the parent account of the register. */
 static gnc_numeric
-gnc_split_register_get_rbaln (VirtualLocation virt_loc, gpointer user_data, gboolean subaccounts)
+gnc_split_register_get_rbaln (VirtualLocation virt_loc, gpointer user_data,
+                              gboolean subaccounts)
 {
-    SplitRegister *reg = user_data;
-    Split *split;
-    SRInfo *info = gnc_split_register_get_info (reg);
+    SplitRegister* reg = user_data;
+    Split* split;
+    SRInfo* info = gnc_split_register_get_info (reg);
     gnc_numeric balance;
-    Account *account = NULL;
-    Transaction *trans;
-    GList *node, *child;
-    GList *children = NULL;
+    Account* account = NULL;
+    Transaction* trans;
+    GList* node, *child;
+    GList* children = NULL;
     int i, row;
 
     balance = gnc_numeric_zero();
@@ -69,7 +70,7 @@ gnc_split_register_get_rbaln (VirtualLocation virt_loc, gpointer user_data, gboo
     /* Return NULL if this is a blank transaction. */
     split = gnc_split_register_get_split (reg, virt_loc.vcell_loc);
     if (split == xaccSplitLookup (&info->blank_split_guid,
-                                  gnc_get_current_book ()))
+                                  gnc_get_current_book()))
         return gnc_numeric_zero();
 
     trans = xaccSplitGetParent (split);
@@ -77,7 +78,7 @@ gnc_split_register_get_rbaln (VirtualLocation virt_loc, gpointer user_data, gboo
         return gnc_numeric_zero();
 
     /* Get a list of accounts for matching */
-    account = gnc_split_register_get_default_account(reg);
+    account = gnc_split_register_get_default_account (reg);
     if (!account)
         /* Register has no account (perhaps general journal) so it has no
            well defined balance, return zero. */
@@ -85,15 +86,15 @@ gnc_split_register_get_rbaln (VirtualLocation virt_loc, gpointer user_data, gboo
 
     if (subaccounts)
     {
-        children = gnc_account_get_descendants(account);
-        children = g_list_append(children, account);
+        children = gnc_account_get_descendants (account);
+        children = g_list_append (children, account);
     }
 
     /* Get the row number we're on, then start with the first row. */
     row = virt_loc.vcell_loc.virt_row;
     virt_loc.vcell_loc.virt_row = 0;
 
-    while (virt_loc.vcell_loc.virt_row <= row )
+    while (virt_loc.vcell_loc.virt_row <= row)
     {
         /* Get new temporary split and its parent transaction */
         split = gnc_split_register_get_split (reg, virt_loc.vcell_loc);
@@ -102,7 +103,7 @@ gnc_split_register_get_rbaln (VirtualLocation virt_loc, gpointer user_data, gboo
         i = 1;
         for (node = xaccTransGetSplitList (trans); node; node = node->next)
         {
-            Split *secondary = node->data;
+            Split* secondary = node->data;
             i++;
 
             if (subaccounts)
@@ -115,40 +116,40 @@ gnc_split_register_get_rbaln (VirtualLocation virt_loc, gpointer user_data, gboo
                 {
                     if (account == child->data)
                     {
-                        balance = gnc_numeric_add_fixed(balance, xaccSplitGetAmount(secondary));
+                        balance = gnc_numeric_add_fixed (balance, xaccSplitGetAmount (secondary));
                         break;
                     }
                 }
             }
             else
             {
-                if ( account == xaccSplitGetAccount(secondary) )
-                    balance = gnc_numeric_add_fixed( balance, xaccSplitGetAmount(secondary) );
+                if (account == xaccSplitGetAccount (secondary))
+                    balance = gnc_numeric_add_fixed (balance, xaccSplitGetAmount (secondary));
             }
         }
         virt_loc.vcell_loc.virt_row += i;
     }
 
     if (subaccounts)
-        g_list_free(children);
+        g_list_free (children);
 
     return balance;
 }
 
-static gnc_commodity *
-gnc_split_register_get_split_commodity (SplitRegister *reg,
+static gnc_commodity*
+gnc_split_register_get_split_commodity (SplitRegister* reg,
                                         VirtualLocation virt_loc)
 {
     CursorClass cursor_class;
-    Account *account;
-    Split *split;
+    Account* account;
+    Split* split;
 
     split = gnc_split_register_get_split (reg, virt_loc.vcell_loc);
     if (!split)
         return NULL;
 
     cursor_class = gnc_split_register_get_cursor_class (reg,
-                   virt_loc.vcell_loc);
+                                                        virt_loc.vcell_loc);
     if (cursor_class != CURSOR_CLASS_SPLIT)
         return NULL;
 
@@ -156,12 +157,13 @@ gnc_split_register_get_split_commodity (SplitRegister *reg,
 
     if (virt_cell_loc_equal (virt_loc.vcell_loc,
                              reg->table->current_cursor_loc.vcell_loc) &&
-            gnc_table_layout_get_cell_changed (reg->table->layout, XFRM_CELL, FALSE))
+        gnc_table_layout_get_cell_changed (reg->table->layout, XFRM_CELL, FALSE))
     {
-        const char *name;
+        const char* name;
 
         name = gnc_table_layout_get_cell_value (reg->table->layout, XFRM_CELL);
-        account = gnc_account_lookup_for_register (gnc_get_current_root_account (), name);
+        account = gnc_account_lookup_for_register (gnc_get_current_root_account(),
+                                                   name);
     }
 
     if (!account)
@@ -170,23 +172,23 @@ gnc_split_register_get_split_commodity (SplitRegister *reg,
     if (!account)
         return NULL;
 
-    return xaccAccountGetCommodity(account);
+    return xaccAccountGetCommodity (account);
 }
 
 static gboolean
-gnc_split_register_use_security_cells (SplitRegister *reg,
+gnc_split_register_use_security_cells (SplitRegister* reg,
                                        VirtualLocation virt_loc)
 {
     CursorClass cursor_class;
-    Account *account;
-    Split *split;
+    Account* account;
+    Split* split;
 
     split = gnc_split_register_get_split (reg, virt_loc.vcell_loc);
     if (!split)
         return TRUE;
 
     cursor_class = gnc_split_register_get_cursor_class (reg,
-                   virt_loc.vcell_loc);
+                                                        virt_loc.vcell_loc);
     if (cursor_class != CURSOR_CLASS_SPLIT)
         return TRUE;
 
@@ -194,12 +196,13 @@ gnc_split_register_use_security_cells (SplitRegister *reg,
 
     if (virt_cell_loc_equal (virt_loc.vcell_loc,
                              reg->table->current_cursor_loc.vcell_loc) &&
-            gnc_table_layout_get_cell_changed (reg->table->layout, XFRM_CELL, FALSE))
+        gnc_table_layout_get_cell_changed (reg->table->layout, XFRM_CELL, FALSE))
     {
-        const char *name;
+        const char* name;
 
         name = gnc_table_layout_get_cell_value (reg->table->layout, XFRM_CELL);
-        account = gnc_account_lookup_for_register (gnc_get_current_root_account (), name);
+        account = gnc_account_lookup_for_register (gnc_get_current_root_account(),
+                                                   name);
     }
 
     if (!account)
@@ -210,312 +213,313 @@ gnc_split_register_use_security_cells (SplitRegister *reg,
 
     if (xaccTransUseTradingAccounts (xaccSplitGetParent (split)))
     {
-        gnc_commodity *commod = xaccAccountGetCommodity(account);
-        if (!gnc_commodity_is_iso(commod) ||
-            !gnc_commodity_equal(commod, xaccTransGetCurrency(xaccSplitGetParent(split))))
+        gnc_commodity* commod = xaccAccountGetCommodity (account);
+        if (!gnc_commodity_is_iso (commod) ||
+            !gnc_commodity_equal (commod,
+                                  xaccTransGetCurrency (xaccSplitGetParent (split))))
             return TRUE;
     }
 
-    return xaccAccountIsPriced(account);
+    return xaccAccountIsPriced (account);
 }
 
-static const char *
+static const char*
 gnc_split_register_get_date_label (VirtualLocation virt_loc,
                                    gpointer user_data)
 {
-    return _("Date");
+    return _ ("Date");
 }
 
-static const char *
+static const char*
 gnc_split_register_get_due_date_label (VirtualLocation virt_loc,
                                        gpointer user_data)
 {
-    return _("Due Date");
+    return _ ("Due Date");
 }
 
-static const char *
+static const char*
 gnc_split_register_get_num_label (VirtualLocation virt_loc,
                                   gpointer user_data)
 {
-    SplitRegister *reg = user_data;
+    SplitRegister* reg = user_data;
 
     switch (reg->type)
     {
     case RECEIVABLE_REGISTER:
     case PAYABLE_REGISTER:
         /* Column label for Invoice IDs in A/P & A/R accounts */
-        return _("Ref");
+        return _ ("Ref");
     default:
-        return _("Num");
+        return _ ("Num");
     }
 }
 
-static const char *
+static const char*
 gnc_split_register_get_tran_num_label (VirtualLocation virt_loc,
-                                  gpointer user_data)
+                                       gpointer user_data)
 {
-    SplitRegister *reg = user_data;
+    SplitRegister* reg = user_data;
 
     switch (reg->type)
     {
     case RECEIVABLE_REGISTER:
     case PAYABLE_REGISTER:
-        return _("T-Ref");
+        return _ ("T-Ref");
     case GENERAL_JOURNAL:
     case INCOME_LEDGER:
     case SEARCH_LEDGER:
     {
         if (reg->use_tran_num_for_num_field)
-            return _("Num");
+            return _ ("Num");
     }
     default:
-        return _("T-Num");
+        return _ ("T-Num");
     }
 }
 
-static const char *
+static const char*
 gnc_split_register_get_desc_label (VirtualLocation virt_loc,
                                    gpointer user_data)
 {
-    SplitRegister *reg = user_data;
+    SplitRegister* reg = user_data;
 
     switch (reg->type)
     {
     case RECEIVABLE_REGISTER:
-        return _("Customer");
+        return _ ("Customer");
     case PAYABLE_REGISTER:
-        return _("Vendor");
+        return _ ("Vendor");
     default:
-        return _("Description");
+        return _ ("Description");
     }
 }
 
-static const char *
+static const char*
 gnc_split_register_get_recn_label (VirtualLocation virt_loc,
                                    gpointer user_data)
 {
-    SplitRegister *reg = user_data;
+    SplitRegister* reg = user_data;
 
     switch (reg->type)
     {
     case RECEIVABLE_REGISTER:
     case PAYABLE_REGISTER:
-        return _("Paid");
+        return _ ("Paid");
 
     default:
-        return C_("Column header for 'Reconciled'", "R");
+        return C_ ("Column header for 'Reconciled'", "R");
     }
 }
 
-static const char *
+static const char*
 gnc_split_register_get_baln_label (VirtualLocation virt_loc,
                                    gpointer user_data)
 {
-    return _("Balance");
+    return _ ("Balance");
 }
 
-static const char *
+static const char*
 gnc_split_register_get_action_label (VirtualLocation virt_loc,
                                      gpointer user_data)
 {
-    return _("Action");
+    return _ ("Action");
 }
 
-static const char *
+static const char*
 gnc_split_register_get_associate_label (VirtualLocation virt_loc,
-                                   gpointer user_data)
+                                        gpointer user_data)
 {
-    return C_("Column header for 'Associate'", "A");
+    return C_ ("Column header for 'Associate'", "A");
 }
 
-static const char *
+static const char*
 gnc_split_register_get_xfrm_label (VirtualLocation virt_loc,
                                    gpointer user_data)
 {
-    return _("Account");
+    return _ ("Account");
 }
 
-static const char *
+static const char*
 gnc_split_register_get_mxfrm_label (VirtualLocation virt_loc,
                                     gpointer user_data)
 {
-    return _("Transfer");
+    return _ ("Transfer");
 }
 
-static const char *
+static const char*
 gnc_split_register_get_memo_label (VirtualLocation virt_loc,
                                    gpointer user_data)
 {
-    return _("Memo");
+    return _ ("Memo");
 }
 
-static const char *
+static const char*
 gnc_split_register_get_type_label (VirtualLocation virt_loc,
                                    gpointer user_data)
 {
-    return _("Type");
+    return _ ("Type");
 }
 
-static const char *
+static const char*
 gnc_split_register_get_rate_label (VirtualLocation virt_loc,
                                    gpointer user_data)
 {
-    return _("Rate");
+    return _ ("Rate");
 }
 
-static const char *
+static const char*
 gnc_split_register_get_debit_label (VirtualLocation virt_loc,
                                     gpointer user_data)
 {
-    SplitRegister *reg = user_data;
+    SplitRegister* reg = user_data;
 
     return gnc_split_register_get_debit_string (reg);
 }
 
-static const char *
+static const char*
 gnc_split_register_get_credit_label (VirtualLocation virt_loc,
                                      gpointer user_data)
 {
-    SplitRegister *reg = user_data;
+    SplitRegister* reg = user_data;
 
     return gnc_split_register_get_credit_string (reg);
 }
 
-static const char *
+static const char*
 gnc_split_register_get_price_label (VirtualLocation virt_loc,
                                     gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    gnc_commodity *commod;
+    SplitRegister* reg = user_data;
+    gnc_commodity* commod;
 
     if (!gnc_split_register_use_security_cells (reg, virt_loc))
         return NULL;
 
     commod = gnc_split_register_get_split_commodity (reg, virt_loc);
-    if (!commod || !gnc_commodity_is_iso(commod))
-        return _("Price");
+    if (!commod || !gnc_commodity_is_iso (commod))
+        return _ ("Price");
     else
-        return _("Exch. Rate");
+        return _ ("Exch. Rate");
 }
 
-static const char *
+static const char*
 gnc_split_register_get_shares_label (VirtualLocation virt_loc,
                                      gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    gnc_commodity *commod;
+    SplitRegister* reg = user_data;
+    gnc_commodity* commod;
 
     if (!gnc_split_register_use_security_cells (reg, virt_loc))
         return NULL;
 
     commod = gnc_split_register_get_split_commodity (reg, virt_loc);
-    if (!commod || !gnc_commodity_is_iso(commod))
-        return _("Shares");
+    if (!commod || !gnc_commodity_is_iso (commod))
+        return _ ("Shares");
     else
-        return _("Oth. Curr.");
+        return _ ("Oth. Curr.");
 }
 
-static const char *
+static const char*
 gnc_split_register_get_tcredit_label (VirtualLocation virt_loc,
                                       gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    SRInfo *info = gnc_split_register_get_info (reg);
+    SplitRegister* reg = user_data;
+    SRInfo* info = gnc_split_register_get_info (reg);
 
     if (info->tcredit_str)
         return info->tcredit_str;
 
     {
-        const char *string = gnc_split_register_get_credit_string (reg);
+        const char* string = gnc_split_register_get_credit_string (reg);
 
         if (string)
-            info->tcredit_str = g_strdup_printf (_("Tot %s"), string);
+            info->tcredit_str = g_strdup_printf (_ ("Tot %s"), string);
     }
 
     if (info->tcredit_str)
         return info->tcredit_str;
 
-    info->tcredit_str = g_strdup (_("Tot Credit"));
+    info->tcredit_str = g_strdup (_ ("Tot Credit"));
 
     return info->tcredit_str;
 }
 
-static const char *
+static const char*
 gnc_split_register_get_tdebit_label (VirtualLocation virt_loc,
                                      gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    SRInfo *info = gnc_split_register_get_info (reg);
+    SplitRegister* reg = user_data;
+    SRInfo* info = gnc_split_register_get_info (reg);
 
     if (info->tdebit_str)
         return info->tdebit_str;
 
     {
-        const char *string = gnc_split_register_get_debit_string (reg);
+        const char* string = gnc_split_register_get_debit_string (reg);
         if (string)
-            info->tdebit_str = g_strdup_printf (_("Tot %s"), string);
+            info->tdebit_str = g_strdup_printf (_ ("Tot %s"), string);
     }
 
     if (info->tdebit_str)
         return info->tdebit_str;
 
-    info->tdebit_str = g_strdup (_("Tot Debit"));
+    info->tdebit_str = g_strdup (_ ("Tot Debit"));
 
     return info->tdebit_str;
 }
 
-static const char *
+static const char*
 gnc_split_register_get_tshares_label (VirtualLocation virt_loc,
                                       gpointer user_data)
 {
-    return _("Tot Shares");
+    return _ ("Tot Shares");
 }
 
-static const char *
+static const char*
 gnc_split_register_get_tbalance_label (VirtualLocation virt_loc,
                                        gpointer user_data)
 {
-    return _("Balance");
+    return _ ("Balance");
 }
 
-static const char *
+static const char*
 gnc_split_register_get_notes_label (VirtualLocation virt_loc,
                                     gpointer user_data)
 {
-    return _("Notes");
+    return _ ("Notes");
 }
 
-static const char *
+static const char*
 gnc_split_register_get_fdebit_label (VirtualLocation virt_loc,
                                      gpointer user_data)
 {
-    return _("Debit Formula");
+    return _ ("Debit Formula");
 }
 
-static const char *
+static const char*
 gnc_split_register_get_fcredit_label (VirtualLocation virt_loc,
                                       gpointer user_data)
 {
-    return _("Credit Formula");
+    return _ ("Credit Formula");
 }
 
 
-static char *
+static char*
 gnc_split_register_get_default_tooltip (VirtualLocation virt_loc,
-                                     gpointer user_data)
+                                        gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    const char *tooltip = gnc_table_get_entry(reg->table, virt_loc);
+    SplitRegister* reg = user_data;
+    const char* tooltip = gnc_table_get_entry (reg->table, virt_loc);
 
     return g_strdup (tooltip);
 }
 
-static char *
+static char*
 gnc_split_register_get_recn_tooltip (VirtualLocation virt_loc,
                                      gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    Split *split;
+    SplitRegister* reg = user_data;
+    Split* split;
 
     split = gnc_split_register_get_split (reg, virt_loc.vcell_loc);
     if (!split)
@@ -525,26 +529,26 @@ gnc_split_register_get_recn_tooltip (VirtualLocation virt_loc,
     {
         char datebuff[MAX_DATE_LENGTH + 1];
         time64 time = xaccSplitGetDateReconciled (split);
-        memset (datebuff, 0, sizeof(datebuff));
+        memset (datebuff, 0, sizeof (datebuff));
         qof_print_date_buff (datebuff, MAX_DATE_LENGTH, time);
-        return g_strdup_printf (_("Reconciled on %s"), datebuff);
+        return g_strdup_printf (_ ("Reconciled on %s"), datebuff);
     }
     else if (xaccSplitGetReconcile (split) == VREC)
     {
-        Transaction *trans = xaccSplitGetParent (split);
+        Transaction* trans = xaccSplitGetParent (split);
         return g_strdup (xaccTransGetVoidReason (trans));
     }
     else
         return NULL;
 }
 
-static char *
+static char*
 gnc_split_register_get_associate_tooltip (VirtualLocation virt_loc,
                                           gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    Transaction *trans;
-    const char *uri;
+    SplitRegister* reg = user_data;
+    Transaction* trans;
+    const char* uri;
 
     trans = gnc_split_register_get_trans (reg, virt_loc.vcell_loc);
     if (!trans)
@@ -556,12 +560,13 @@ gnc_split_register_get_associate_tooltip (VirtualLocation virt_loc,
     // Check for uri is empty or NULL
     if (uri && *uri != '\0')
     {
-        gchar *scheme = gnc_uri_get_scheme (uri);
-        gchar *file_path = NULL;
+        gchar* scheme = gnc_uri_get_scheme (uri);
+        gchar* file_path = NULL;
 
         if (!scheme) // relative path
         {
-            gchar *path_head = gnc_prefs_get_string (GNC_PREFS_GROUP_GENERAL, "assoc-head");
+            gchar* path_head = gnc_prefs_get_string (GNC_PREFS_GROUP_GENERAL,
+                                                     "assoc-head");
 
             if (path_head && *path_head != '\0') // not default entry
                 file_path = gnc_file_path_absolute (gnc_uri_get_path (path_head), uri);
@@ -585,8 +590,8 @@ gnc_split_register_get_associate_tooltip (VirtualLocation virt_loc,
             return g_uri_unescape_string (uri, NULL);
         else
         {
-            gchar *file_uri_u = g_uri_unescape_string (file_path, NULL);
-            const gchar *filename = gnc_uri_get_path (file_uri_u);
+            gchar* file_uri_u = g_uri_unescape_string (file_path, NULL);
+            const gchar* filename = gnc_uri_get_path (file_uri_u);
             g_free (file_uri_u);
             g_free (file_path);
             return g_strdup (filename);
@@ -597,30 +602,30 @@ gnc_split_register_get_associate_tooltip (VirtualLocation virt_loc,
 }
 
 static gnc_numeric
-get_trans_total_amount (SplitRegister *reg, Transaction *trans)
+get_trans_total_amount (SplitRegister* reg, Transaction* trans)
 {
-    Account *account = gnc_split_register_get_default_account (reg);
-    return xaccTransGetAccountAmount(trans, account);
+    Account* account = gnc_split_register_get_default_account (reg);
+    return xaccTransGetAccountAmount (trans, account);
 }
 
 static gnc_numeric
-get_trans_total_balance (SplitRegister *reg, Transaction *trans)
+get_trans_total_balance (SplitRegister* reg, Transaction* trans)
 {
-    Account *account;
+    Account* account;
 
     account = gnc_split_register_get_default_account (reg);
     if (!trans || !account) return gnc_numeric_zero();
 
-    return xaccTransGetAccountBalance(trans, account);
+    return xaccTransGetAccountBalance (trans, account);
 }
 
 static gboolean
 gnc_split_register_use_negative_color (VirtualLocation virt_loc,
-                                       SplitRegister *reg)
+                                       SplitRegister* reg)
 {
-    const char * cell_name;
+    const char* cell_name;
     gnc_numeric value = gnc_numeric_zero();
-    Split *split;
+    Split* split;
 
     if (!use_red_for_negative)
         return FALSE;
@@ -636,10 +641,10 @@ gnc_split_register_use_negative_color (VirtualLocation virt_loc,
     else if (gnc_cell_name_equal (cell_name, SHRS_CELL))
     {
         if (virt_cell_loc_equal (reg->table->current_cursor_loc.vcell_loc,
-                                      virt_loc.vcell_loc))
+                                 virt_loc.vcell_loc))
             value = gnc_price_cell_get_value
-                     ((PriceCell *) gnc_table_layout_get_cell (reg->table->layout,
-                             SHRS_CELL));
+                    ((PriceCell*) gnc_table_layout_get_cell (reg->table->layout,
+                                                             SHRS_CELL));
         else
             value = xaccSplitGetAmount (split);
     }
@@ -651,13 +656,13 @@ gnc_split_register_use_negative_color (VirtualLocation virt_loc,
         value = get_trans_total_balance (reg, xaccSplitGetParent (split));
 
     if ((gnc_cell_name_equal (cell_name, BALN_CELL)) ||
-            (gnc_cell_name_equal (cell_name, RBALN_CELL)) ||
-            (gnc_cell_name_equal (cell_name, TBALN_CELL)))
-        {
-            Account *account = xaccSplitGetAccount (split);
-            if (gnc_reverse_balance (account))
-                value = gnc_numeric_neg (value);
-        }
+        (gnc_cell_name_equal (cell_name, RBALN_CELL)) ||
+        (gnc_cell_name_equal (cell_name, TBALN_CELL)))
+    {
+        Account* account = xaccSplitGetAccount (split);
+        if (gnc_reverse_balance (account))
+            value = gnc_numeric_neg (value);
+    }
 
     if (gnc_numeric_negative_p (value))
         return TRUE;
@@ -667,14 +672,14 @@ gnc_split_register_use_negative_color (VirtualLocation virt_loc,
 
 static guint32
 gnc_split_register_get_cell_color_internal (VirtualLocation virt_loc,
-                                            SplitRegister *reg)
+                                            SplitRegister* reg)
 {
-    const char *cursor_name;
-    VirtualCell *vcell;
+    const char* cursor_name;
+    VirtualCell* vcell;
     gboolean is_current;
     guint32 colorbase = 0;
 
-     /* a bit of enum arithmetic */
+    /* a bit of enum arithmetic */
 
     if (gnc_split_register_use_negative_color (virt_loc, reg))
         colorbase = COLOR_NEGATIVE; // Requires Negative fg color
@@ -690,7 +695,7 @@ gnc_split_register_get_cell_color_internal (VirtualLocation virt_loc,
         return (colorbase + COLOR_UNDEFINED);
 
     if ((virt_loc.phys_col_offset < vcell->cellblock->start_col) ||
-            (virt_loc.phys_col_offset > vcell->cellblock->stop_col))
+        (virt_loc.phys_col_offset > vcell->cellblock->stop_col))
         return (colorbase + COLOR_UNDEFINED);
 
     is_current = virt_cell_loc_equal (reg->table->current_cursor_loc.vcell_loc,
@@ -699,42 +704,42 @@ gnc_split_register_get_cell_color_internal (VirtualLocation virt_loc,
     cursor_name = vcell->cellblock->cursor_name;
 
     if (g_strcmp0 (cursor_name, CURSOR_SINGLE_JOURNAL) == 0 ||
-            g_strcmp0 (cursor_name, CURSOR_SINGLE_LEDGER) == 0)
+        g_strcmp0 (cursor_name, CURSOR_SINGLE_LEDGER) == 0)
     {
         if (is_current)
             return vcell->start_primary_color ?
-                    (colorbase + COLOR_PRIMARY_ACTIVE) :
-                    (colorbase + COLOR_SECONDARY_ACTIVE);
+                   (colorbase + COLOR_PRIMARY_ACTIVE) :
+                   (colorbase + COLOR_SECONDARY_ACTIVE);
 
         return vcell->start_primary_color ?
-                (colorbase + COLOR_PRIMARY) : (colorbase + COLOR_SECONDARY);
+               (colorbase + COLOR_PRIMARY) : (colorbase + COLOR_SECONDARY);
     }
 
     if (g_strcmp0 (cursor_name, CURSOR_DOUBLE_JOURNAL) == 0 ||
-            g_strcmp0 (cursor_name, CURSOR_DOUBLE_JOURNAL_NUM_ACTN) == 0 ||
-            g_strcmp0 (cursor_name, CURSOR_DOUBLE_LEDGER) == 0 ||
-            g_strcmp0 (cursor_name, CURSOR_DOUBLE_LEDGER_NUM_ACTN) == 0)
+        g_strcmp0 (cursor_name, CURSOR_DOUBLE_JOURNAL_NUM_ACTN) == 0 ||
+        g_strcmp0 (cursor_name, CURSOR_DOUBLE_LEDGER) == 0 ||
+        g_strcmp0 (cursor_name, CURSOR_DOUBLE_LEDGER_NUM_ACTN) == 0)
     {
         if (is_current)
         {
             if (reg->double_alt_color)
                 return vcell->start_primary_color ?
-                        (colorbase + COLOR_PRIMARY_ACTIVE) :
-                        (colorbase + COLOR_SECONDARY_ACTIVE);
+                       (colorbase + COLOR_PRIMARY_ACTIVE) :
+                       (colorbase + COLOR_SECONDARY_ACTIVE);
 
             return (virt_loc.phys_row_offset % 2 == 0) ?
-                    (colorbase + COLOR_PRIMARY_ACTIVE) :
-                    (colorbase + COLOR_SECONDARY_ACTIVE);
+                   (colorbase + COLOR_PRIMARY_ACTIVE) :
+                   (colorbase + COLOR_SECONDARY_ACTIVE);
         }
 
         if (reg->double_alt_color)
             return vcell->start_primary_color ?
-                    (colorbase + COLOR_PRIMARY) :
-                    (colorbase + COLOR_SECONDARY);
+                   (colorbase + COLOR_PRIMARY) :
+                   (colorbase + COLOR_SECONDARY);
 
         return (virt_loc.phys_row_offset % 2 == 0) ?
-                (colorbase + COLOR_PRIMARY) :
-                (colorbase + COLOR_SECONDARY);
+               (colorbase + COLOR_PRIMARY) :
+               (colorbase + COLOR_SECONDARY);
     }
 
     if (g_strcmp0 (cursor_name, CURSOR_SPLIT) == 0)
@@ -753,10 +758,10 @@ gnc_split_register_get_cell_color_internal (VirtualLocation virt_loc,
 // Get Color for non numeric cells, no hatching required
 static guint32
 gnc_split_register_get_cell_color (VirtualLocation virt_loc,
-        gboolean *hatching,
-        gpointer user_data)
+                                   gboolean* hatching,
+                                   gpointer user_data)
 {
-    SplitRegister *reg = user_data;
+    SplitRegister* reg = user_data;
 
     if (hatching)
         *hatching = FALSE;
@@ -767,14 +772,14 @@ gnc_split_register_get_cell_color (VirtualLocation virt_loc,
 // Get Color for numeric cells, update hatching
 static guint32
 gnc_split_register_get_debcred_color (VirtualLocation virt_loc,
-        gboolean *hatching,
-        gpointer user_data)
+                                      gboolean* hatching,
+                                      gpointer user_data)
 {
-    SplitRegister *reg = user_data;
+    SplitRegister* reg = user_data;
 
     if (hatching)
     {
-        Transaction *trans;
+        Transaction* trans;
 
         trans = gnc_split_register_get_trans (reg, virt_loc.vcell_loc);
 
@@ -788,19 +793,19 @@ gnc_split_register_get_debcred_color (VirtualLocation virt_loc,
 
 static void
 gnc_split_register_get_border (VirtualLocation virt_loc,
-                               PhysicalCellBorders *borders,
+                               PhysicalCellBorders* borders,
                                gpointer user_data)
 {
-    SplitRegister *reg = user_data;
+    SplitRegister* reg = user_data;
     CursorClass cursor_class;
-    VirtualCell *vcell;
+    VirtualCell* vcell;
 
     vcell = gnc_table_get_virtual_cell (reg->table, virt_loc.vcell_loc);
     if (!vcell || !vcell->cellblock)
         return;
 
     if (virt_loc.phys_col_offset < vcell->cellblock->start_col ||
-            virt_loc.phys_col_offset > vcell->cellblock->stop_col)
+        virt_loc.phys_col_offset > vcell->cellblock->stop_col)
     {
         borders->top    = CELL_BORDER_LINE_NONE;
         borders->bottom = CELL_BORDER_LINE_NONE;
@@ -826,17 +831,17 @@ gnc_split_register_get_border (VirtualLocation virt_loc,
     }
 }
 
-static const char *
+static const char*
 gnc_split_register_get_associate_entry (VirtualLocation virt_loc,
-                                   gboolean translate,
-                                   gboolean *conditionally_changed,
-                                   gpointer user_data)
+                                        gboolean translate,
+                                        gboolean* conditionally_changed,
+                                        gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    Transaction *trans;
+    SplitRegister* reg = user_data;
+    Transaction* trans;
     char associate;
     static char s[2];
-    const char *uri;
+    const char* uri;
 
     trans = gnc_split_register_get_trans (reg, virt_loc.vcell_loc);
     if (!trans)
@@ -848,7 +853,7 @@ gnc_split_register_get_associate_entry (VirtualLocation virt_loc,
     // Check for uri is empty or NULL
     if (uri && g_strcmp0 (uri, "") != 0)
     {
-        gchar *scheme = gnc_uri_get_scheme (uri);
+        gchar* scheme = gnc_uri_get_scheme (uri);
 
         if (!scheme || g_strcmp0 (scheme, "file") == 0)
             associate = 'f';
@@ -869,12 +874,12 @@ gnc_split_register_get_associate_entry (VirtualLocation virt_loc,
 #if 0
 // this code is not used yet
 static char
-gnc_split_register_get_associate_value (SplitRegister *reg,
-                                   VirtualLocation virt_loc)
+gnc_split_register_get_associate_value (SplitRegister* reg,
+                                        VirtualLocation virt_loc)
 {
-    RecnCell *cell;
+    RecnCell* cell;
 
-    cell = (RecnCell *)gnc_table_layout_get_cell (reg->table->layout, ASSOC_CELL);
+    cell = (RecnCell*)gnc_table_layout_get_cell (reg->table->layout, ASSOC_CELL);
     if (!cell)
         return '\0';
 
@@ -882,14 +887,14 @@ gnc_split_register_get_associate_value (SplitRegister *reg,
 }
 #endif
 
-static const char *
+static const char*
 gnc_split_register_get_type_entry (VirtualLocation virt_loc,
                                    gboolean translate,
-                                   gboolean *conditionally_changed,
+                                   gboolean* conditionally_changed,
                                    gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    Transaction *trans;
+    SplitRegister* reg = user_data;
+    Transaction* trans;
     char type;
     static char s[2];
 
@@ -909,27 +914,27 @@ gnc_split_register_get_type_entry (VirtualLocation virt_loc,
 }
 
 static char
-gnc_split_register_get_type_value (SplitRegister *reg,
+gnc_split_register_get_type_value (SplitRegister* reg,
                                    VirtualLocation virt_loc)
 {
-    RecnCell *cell;
+    RecnCell* cell;
 
-    cell = (RecnCell *)gnc_table_layout_get_cell (reg->table->layout, TYPE_CELL);
+    cell = (RecnCell*)gnc_table_layout_get_cell (reg->table->layout, TYPE_CELL);
     if (!cell)
         return '\0';
 
     return gnc_recn_cell_get_flag (cell);
 }
 
-static const char *
+static const char*
 gnc_split_register_get_due_date_entry (VirtualLocation virt_loc,
                                        gboolean translate,
-                                       gboolean *conditionally_changed,
+                                       gboolean* conditionally_changed,
                                        gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    Transaction *trans;
-    Split *split;
+    SplitRegister* reg = user_data;
+    Transaction* trans;
+    Split* split;
     gboolean is_current;
     char type;
 
@@ -942,7 +947,7 @@ gnc_split_register_get_due_date_entry (VirtualLocation virt_loc,
     }
     else
     {
-        const char *typestr =
+        const char* typestr =
             gnc_split_register_get_type_entry (virt_loc, translate,
                                                conditionally_changed, user_data);
         if (typestr != NULL)
@@ -971,15 +976,15 @@ gnc_split_register_get_due_date_entry (VirtualLocation virt_loc,
     return qof_print_date (xaccTransRetDateDue (trans));
 }
 
-static const char *
+static const char*
 gnc_split_register_get_date_entry (VirtualLocation virt_loc,
                                    gboolean translate,
-                                   gboolean *conditionally_changed,
+                                   gboolean* conditionally_changed,
                                    gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    Transaction *trans;
-    Split *split;
+    SplitRegister* reg = user_data;
+    Transaction* trans;
+    Split* split;
 
     split = gnc_split_register_get_split (reg, virt_loc.vcell_loc);
     trans = xaccSplitGetParent (split);
@@ -988,48 +993,48 @@ gnc_split_register_get_date_entry (VirtualLocation virt_loc,
     return qof_print_date (xaccTransRetDatePosted (trans));
 }
 
-static char *
+static char*
 gnc_split_register_get_date_help (VirtualLocation virt_loc,
                                   gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    BasicCell *cell;
-    const char *date_string;
+    SplitRegister* reg = user_data;
+    BasicCell* cell;
+    const char* date_string;
     time64 cell_time;
 
     cell = gnc_table_get_cell (reg->table, virt_loc);
     if (!cell || !cell->value || *cell->value == '\0')
         return NULL;
 
-    gnc_date_cell_get_date ((DateCell *) cell, &cell_time, FALSE);
+    gnc_date_cell_get_date ((DateCell*) cell, &cell_time, FALSE);
 
     /* Translators: This is a date format, see i.e.
        https://www.gnu.org/software/libc/manual/html_node/Formatting-Calendar-Time.html */
-    date_string = gnc_print_time64 (cell_time, _("%A %d %B %Y"));
+    date_string = gnc_print_time64 (cell_time, _ ("%A %d %B %Y"));
 
     return g_strdup (date_string);
 }
 
-static const char *
+static const char*
 gnc_split_register_get_inactive_date_entry (VirtualLocation virt_loc,
-        gboolean translate,
-        gboolean *conditionally_changed,
-        gpointer user_data)
+                                            gboolean translate,
+                                            gboolean* conditionally_changed,
+                                            gpointer user_data)
 {
     /* This seems to be the one that initially gets used, the InactiveDateCell
        is set to, and subsequently displayed. */
-    return _("Scheduled");
+    return _ ("Scheduled");
 }
 
-static const char *
+static const char*
 gnc_split_register_get_num_entry (VirtualLocation virt_loc,
                                   gboolean translate,
-                                  gboolean *conditionally_changed,
+                                  gboolean* conditionally_changed,
                                   gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    Transaction *trans;
-    Split *split;
+    SplitRegister* reg = user_data;
+    Transaction* trans;
+    Split* split;
 
     split = gnc_split_register_get_split (reg, virt_loc.vcell_loc);
     trans = xaccSplitGetParent (split);
@@ -1037,15 +1042,15 @@ gnc_split_register_get_num_entry (VirtualLocation virt_loc,
     return gnc_get_num_action (trans, split);
 }
 
-static const char *
+static const char*
 gnc_split_register_get_tran_num_entry (VirtualLocation virt_loc,
-                                  gboolean translate,
-                                  gboolean *conditionally_changed,
-                                  gpointer user_data)
+                                       gboolean translate,
+                                       gboolean* conditionally_changed,
+                                       gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    Transaction *trans;
-    Split *split;
+    SplitRegister* reg = user_data;
+    Transaction* trans;
+    Split* split;
 
     split = gnc_split_register_get_split (reg, virt_loc.vcell_loc);
     trans = xaccSplitGetParent (split);
@@ -1053,12 +1058,12 @@ gnc_split_register_get_tran_num_entry (VirtualLocation virt_loc,
     return gnc_get_num_action (trans, NULL);
 }
 
-static char *
+static char*
 gnc_split_register_get_num_help (VirtualLocation virt_loc,
                                  gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    const char *help;
+    SplitRegister* reg = user_data;
+    const char* help;
 
     help = gnc_table_get_entry (reg->table, virt_loc);
     if (!help || *help == '\0')
@@ -1067,29 +1072,29 @@ gnc_split_register_get_num_help (VirtualLocation virt_loc,
         case RECEIVABLE_REGISTER:
         case PAYABLE_REGISTER:
             help = reg->use_tran_num_for_num_field ?
-                    _("Enter a reference, such as an invoice or check number, "
-                        "common to all entry lines (splits)") :
-                    _("Enter a reference, such as an invoice or check number, "
-                        "unique to each entry line (split)");
+                   _ ("Enter a reference, such as an invoice or check number, "
+                      "common to all entry lines (splits)") :
+                   _ ("Enter a reference, such as an invoice or check number, "
+                      "unique to each entry line (split)");
             break;
         default:
             help = reg->use_tran_num_for_num_field ?
-                    _("Enter a reference, such as a check number, "
-                        "common to all entry lines (splits)") :
-                    _("Enter a reference, such as a check number, "
-                        "unique to each entry line (split)");
+                   _ ("Enter a reference, such as a check number, "
+                      "common to all entry lines (splits)") :
+                   _ ("Enter a reference, such as a check number, "
+                      "unique to each entry line (split)");
             break;
         }
 
     return g_strdup (help);
 }
 
-static char *
+static char*
 gnc_split_register_get_tran_num_help (VirtualLocation virt_loc,
-                                 gpointer user_data)
+                                      gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    const char *help;
+    SplitRegister* reg = user_data;
+    const char* help;
 
     help = gnc_table_get_entry (reg->table, virt_loc);
     if (!help || *help == '\0')
@@ -1097,27 +1102,27 @@ gnc_split_register_get_tran_num_help (VirtualLocation virt_loc,
         {
         case RECEIVABLE_REGISTER:
         case PAYABLE_REGISTER:
-            help = _("Enter a transaction reference, such as an invoice "
-                    "or check number, common to all entry lines (splits)");
+            help = _ ("Enter a transaction reference, such as an invoice "
+                      "or check number, common to all entry lines (splits)");
             break;
         default:
-            help = _("Enter a transaction reference "
-                    "that will be common to all entry lines (splits)");
+            help = _ ("Enter a transaction reference "
+                      "that will be common to all entry lines (splits)");
             break;
         }
 
     return g_strdup (help);
 }
 
-static const char *
+static const char*
 gnc_split_register_get_desc_entry (VirtualLocation virt_loc,
                                    gboolean translate,
-                                   gboolean *conditionally_changed,
+                                   gboolean* conditionally_changed,
                                    gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    Transaction *trans;
-    Split *split;
+    SplitRegister* reg = user_data;
+    Transaction* trans;
+    Split* split;
 
     split = gnc_split_register_get_split (reg, virt_loc.vcell_loc);
     trans = xaccSplitGetParent (split);
@@ -1125,39 +1130,39 @@ gnc_split_register_get_desc_entry (VirtualLocation virt_loc,
     return xaccTransGetDescription (trans);
 }
 
-static char *
+static char*
 gnc_split_register_get_desc_help (VirtualLocation virt_loc,
                                   gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    const char *help;
+    SplitRegister* reg = user_data;
+    const char* help;
 
     help = gnc_table_get_entry (reg->table, virt_loc);
     if (!help || *help == '\0')
         switch (reg->type)
         {
         case RECEIVABLE_REGISTER:
-            help = _("Enter the name of the Customer");
+            help = _ ("Enter the name of the Customer");
             break;
         case PAYABLE_REGISTER:
-            help = _("Enter the name of the Vendor");
+            help = _ ("Enter the name of the Vendor");
             break;
         default:
-            help = _("Enter a description of the transaction");
+            help = _ ("Enter a description of the transaction");
             break;
         }
     return g_strdup (help);
 }
 
-static const char *
+static const char*
 gnc_split_register_get_notes_entry (VirtualLocation virt_loc,
                                     gboolean translate,
-                                    gboolean *conditionally_changed,
+                                    gboolean* conditionally_changed,
                                     gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    Transaction *trans;
-    Split *split;
+    SplitRegister* reg = user_data;
+    Transaction* trans;
+    Split* split;
 
     split = gnc_split_register_get_split (reg, virt_loc.vcell_loc);
     trans = xaccSplitGetParent (split);
@@ -1165,65 +1170,65 @@ gnc_split_register_get_notes_entry (VirtualLocation virt_loc,
     return xaccTransGetNotes (trans);
 }
 
-static char *
+static char*
 gnc_split_register_get_notes_help (VirtualLocation virt_loc,
                                    gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    const char *help;
+    SplitRegister* reg = user_data;
+    const char* help;
 
     help = gnc_table_get_entry (reg->table, virt_loc);
     if (!help || *help == '\0')
-        help = _("Enter notes for the transaction");
+        help = _ ("Enter notes for the transaction");
 
     return g_strdup (help);
 }
 
-static const char *
+static const char*
 gnc_split_register_get_vnotes_entry (VirtualLocation virt_loc,
                                      gboolean translate,
-                                     gboolean *conditionally_changed,
+                                     gboolean* conditionally_changed,
                                      gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    Transaction *trans;
-    Split *split;
+    SplitRegister* reg = user_data;
+    Transaction* trans;
+    Split* split;
 
     split = gnc_split_register_get_split (reg, virt_loc.vcell_loc);
     trans = xaccSplitGetParent (split);
 
-    if(trans == NULL)
+    if (trans == NULL)
         return NULL;
     else
-        return xaccTransGetVoidReason(trans);
+        return xaccTransGetVoidReason (trans);
 }
 
-static char *
+static char*
 gnc_split_register_get_vnotes_help (VirtualLocation virt_loc,
                                     gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    const char *help;
+    SplitRegister* reg = user_data;
+    const char* help;
 
     help = gnc_table_get_entry (reg->table, virt_loc);
     if (!help || *help == '\0')
-        help = _("Reason the transaction was voided");
+        help = _ ("Reason the transaction was voided");
 
     return g_strdup (help);
 }
 
-static const char *
+static const char*
 gnc_split_register_get_rate_entry (VirtualLocation virt_loc,
                                    gboolean translate,
-                                   gboolean *conditionally_changed,
+                                   gboolean* conditionally_changed,
                                    gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    Split *split, *osplit;
-    Transaction *txn;
+    SplitRegister* reg = user_data;
+    Split* split, *osplit;
+    Transaction* txn;
     gnc_numeric amount, value, convrate;
-    gnc_commodity *curr;
-    SRInfo *info = gnc_split_register_get_info (reg);
+    gnc_commodity* curr;
+    SRInfo* info = gnc_split_register_get_info (reg);
 
     if (info->rate_reset == RATE_RESET_REQD && info->auto_complete)
         return "0";
@@ -1240,8 +1245,8 @@ gnc_split_register_get_rate_entry (VirtualLocation virt_loc,
     txn = gnc_split_register_get_trans (reg, virt_loc.vcell_loc);
     curr = xaccTransGetCurrency (xaccSplitGetParent (split));
     if (!gnc_split_register_current_trans_expanded (reg) && osplit &&
-            !gnc_split_register_needs_conv_rate(reg, txn,
-                    xaccSplitGetAccount(split)))
+        !gnc_split_register_needs_conv_rate (reg, txn,
+                                             xaccSplitGetAccount (split)))
     {
         split = osplit;
     }
@@ -1252,19 +1257,20 @@ gnc_split_register_get_rate_entry (VirtualLocation virt_loc,
     if (gnc_numeric_zero_p (value))
         return "0";
 
-    convrate = gnc_numeric_div (amount, value, GNC_DENOM_AUTO, GNC_HOW_DENOM_REDUCE);
+    convrate = gnc_numeric_div (amount, value, GNC_DENOM_AUTO,
+                                GNC_HOW_DENOM_REDUCE);
 
     return xaccPrintAmount (convrate, gnc_default_price_print_info (curr));
 }
 
-static const char *
+static const char*
 gnc_split_register_get_recn_entry (VirtualLocation virt_loc,
                                    gboolean translate,
-                                   gboolean *conditionally_changed,
+                                   gboolean* conditionally_changed,
                                    gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    Split *split;
+    SplitRegister* reg = user_data;
+    Split* split;
 
     split = gnc_split_register_get_split (reg, virt_loc.vcell_loc);
     if (!split)
@@ -1283,77 +1289,77 @@ gnc_split_register_get_recn_entry (VirtualLocation virt_loc,
     }
 }
 
-static const char *
+static const char*
 gnc_split_register_get_action_entry (VirtualLocation virt_loc,
                                      gboolean translate,
-                                     gboolean *conditionally_changed,
+                                     gboolean* conditionally_changed,
                                      gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    Split *split = gnc_split_register_get_split(reg, virt_loc.vcell_loc);
+    SplitRegister* reg = user_data;
+    Split* split = gnc_split_register_get_split (reg, virt_loc.vcell_loc);
 
     return gnc_get_num_action (NULL, split);
 }
 
-static char *
+static char*
 gnc_split_register_get_action_help (VirtualLocation virt_loc,
                                     gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    const char *help;
+    SplitRegister* reg = user_data;
+    const char* help;
 
     help = gnc_table_get_entry (reg->table, virt_loc);
     if (!help || *help == '\0')
         help = reg->use_tran_num_for_num_field ?
-        _("Enter an action type, or choose one from the list") :
-        _("Enter a reference number, such as the next check number, or choose an action type from the list");
+               _ ("Enter an action type, or choose one from the list") :
+               _ ("Enter a reference number, such as the next check number, or choose an action type from the list");
 
     return g_strdup (help);
 }
 
-static const char *
+static const char*
 gnc_split_register_get_memo_entry (VirtualLocation virt_loc,
                                    gboolean translate,
-                                   gboolean *conditionally_changed,
+                                   gboolean* conditionally_changed,
                                    gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    Split *split;
+    SplitRegister* reg = user_data;
+    Split* split;
 
     split = gnc_split_register_get_split (reg, virt_loc.vcell_loc);
 
     return xaccSplitGetMemo (split);
 }
 
-static char *
+static char*
 gnc_split_register_get_memo_help (VirtualLocation virt_loc,
                                   gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    const char *help;
+    SplitRegister* reg = user_data;
+    const char* help;
 
     help = gnc_table_get_entry (reg->table, virt_loc);
     if (!help || *help == '\0')
-        help = _("Enter a description of the split");
+        help = _ ("Enter a description of the split");
     return g_strdup (help);
 }
 
-static const char *
+static const char*
 gnc_split_register_get_balance_entry (VirtualLocation virt_loc,
                                       gboolean translate,
-                                      gboolean *conditionally_changed,
+                                      gboolean* conditionally_changed,
                                       gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    SRInfo *info = gnc_split_register_get_info (reg);
+    SplitRegister* reg = user_data;
+    SRInfo* info = gnc_split_register_get_info (reg);
     gnc_numeric balance;
     gboolean is_trans;
-    Split *split;
-    Account *account;
+    Split* split;
+    Account* account;
 
     split = gnc_split_register_get_split (reg, virt_loc.vcell_loc);
     if (split == xaccSplitLookup (&info->blank_split_guid,
-                                  gnc_get_current_book ()))
+                                  gnc_get_current_book()))
         return NULL;
 
     is_trans = gnc_cell_name_equal
@@ -1371,19 +1377,20 @@ gnc_split_register_get_balance_entry (VirtualLocation virt_loc,
     if (gnc_reverse_balance (account))
         balance = gnc_numeric_neg (balance);
 
-    return xaccPrintAmount (balance, gnc_account_print_info (account, reg->mismatched_commodities));
+    return xaccPrintAmount (balance, gnc_account_print_info (account,
+                                                             reg->mismatched_commodities));
 }
 
-static const char *
+static const char*
 gnc_split_register_get_price_entry (VirtualLocation virt_loc,
                                     gboolean translate,
-                                    gboolean *conditionally_changed,
+                                    gboolean* conditionally_changed,
                                     gpointer user_data)
 {
-    SplitRegister *reg = user_data;
+    SplitRegister* reg = user_data;
     gnc_numeric price;
-    gnc_commodity *curr;
-    Split *split;
+    gnc_commodity* curr;
+    Split* split;
 
     if (!gnc_split_register_use_security_cells (reg, virt_loc))
         return NULL;
@@ -1398,29 +1405,29 @@ gnc_split_register_get_price_entry (VirtualLocation virt_loc,
     return xaccPrintAmount (price, gnc_default_price_print_info (curr));
 }
 
-static char *
+static char*
 gnc_split_register_get_price_help (VirtualLocation virt_loc,
                                    gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    const char *help;
+    SplitRegister* reg = user_data;
+    const char* help;
 
     help = gnc_table_get_entry (reg->table, virt_loc);
     if (!help || *help == '\0')
-        help = _("Enter the effective share price");
+        help = _ ("Enter the effective share price");
 
     return g_strdup (help);
 }
 
-static const char *
+static const char*
 gnc_split_register_get_shares_entry (VirtualLocation virt_loc,
                                      gboolean translate,
-                                     gboolean *conditionally_changed,
+                                     gboolean* conditionally_changed,
                                      gpointer user_data)
 {
-    SplitRegister *reg = user_data;
+    SplitRegister* reg = user_data;
     gnc_numeric shares;
-    Split *split;
+    Split* split;
 
     if (!gnc_split_register_use_security_cells (reg, virt_loc))
         return NULL;
@@ -1434,29 +1441,29 @@ gnc_split_register_get_shares_entry (VirtualLocation virt_loc,
     return xaccPrintAmount (shares, gnc_split_amount_print_info (split, FALSE));
 }
 
-static char *
+static char*
 gnc_split_register_get_shares_help (VirtualLocation virt_loc,
                                     gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    const char *help;
+    SplitRegister* reg = user_data;
+    const char* help;
 
     help = gnc_table_get_entry (reg->table, virt_loc);
     if (!help || *help == '\0')
-        help = _("Enter the number of shares bought or sold");
+        help = _ ("Enter the number of shares bought or sold");
 
     return g_strdup (help);
 }
 
-static const char *
+static const char*
 gnc_split_register_get_tshares_entry (VirtualLocation virt_loc,
                                       gboolean translate,
-                                      gboolean *conditionally_changed,
+                                      gboolean* conditionally_changed,
                                       gpointer user_data)
 {
-    SplitRegister *reg = user_data;
+    SplitRegister* reg = user_data;
     gnc_numeric total;
-    Split *split;
+    Split* split;
 
     split = gnc_split_register_get_split (reg, virt_loc.vcell_loc);
 
@@ -1465,53 +1472,53 @@ gnc_split_register_get_tshares_entry (VirtualLocation virt_loc,
     return xaccPrintAmount (total, gnc_split_amount_print_info (split, FALSE));
 }
 
-static const char *
+static const char*
 gnc_split_register_get_xfrm_entry (VirtualLocation virt_loc,
                                    gboolean translate,
-                                   gboolean *conditionally_changed,
+                                   gboolean* conditionally_changed,
                                    gpointer user_data)
 {
-    static char *name = NULL;
+    static char* name = NULL;
 
-    SplitRegister *reg = user_data;
-    Split *split;
+    SplitRegister* reg = user_data;
+    Split* split;
 
     split = gnc_split_register_get_split (reg, virt_loc.vcell_loc);
 
     g_free (name);
 
     name = gnc_get_account_name_for_split_register (xaccSplitGetAccount (split),
-               reg->show_leaf_accounts);
+                                                    reg->show_leaf_accounts);
 
     return name;
 }
 
-static char *
+static char*
 gnc_split_register_get_xfrm_help (VirtualLocation virt_loc,
                                   gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    const char *help;
+    SplitRegister* reg = user_data;
+    const char* help;
 
     help = gnc_table_get_entry (reg->table, virt_loc);
     if (!help || *help == '\0')
-        help = _("Enter the account to transfer from, "
-                 "or choose one from the list");
+        help = _ ("Enter the account to transfer from, "
+                  "or choose one from the list");
 
     return g_strdup (help);
 }
 
-static const char *
+static const char*
 gnc_split_register_get_mxfrm_entry (VirtualLocation virt_loc,
                                     gboolean translate,
-                                    gboolean *conditionally_changed,
+                                    gboolean* conditionally_changed,
                                     gpointer user_data)
 {
-    static char *name = NULL;
+    static char* name = NULL;
 
-    SplitRegister *reg = user_data;
-    Split *split;
-    Split *s;
+    SplitRegister* reg = user_data;
+    Split* split;
+    Split* s;
 
     split = gnc_split_register_get_split (reg, virt_loc.vcell_loc);
     if (!split)
@@ -1523,12 +1530,12 @@ gnc_split_register_get_mxfrm_entry (VirtualLocation virt_loc,
 
     if (s)
         name = gnc_get_account_name_for_split_register (xaccSplitGetAccount (s),
-                   reg->show_leaf_accounts);
+                                                        reg->show_leaf_accounts);
     else
     {
         /* For multi-split transactions and stock splits,
          * use a special value. */
-        s = xaccTransGetSplit (xaccSplitGetParent(split), 1);
+        s = xaccTransGetSplit (xaccSplitGetParent (split), 1);
 
         if (s)
             name = g_strdup (SPLIT_TRANS_STR);
@@ -1541,15 +1548,15 @@ gnc_split_register_get_mxfrm_entry (VirtualLocation virt_loc,
     return name;
 }
 
-static char *
+static char*
 gnc_split_register_get_mxfrm_help (VirtualLocation virt_loc,
                                    gpointer user_data)
 {
-    const char *help;
+    const char* help;
 
-    SplitRegister *reg = user_data;
-    Split *split;
-    Split *s;
+    SplitRegister* reg = user_data;
+    Split* split;
+    Split* s;
 
     split = gnc_split_register_get_split (reg, virt_loc.vcell_loc);
     if (!split)
@@ -1560,23 +1567,23 @@ gnc_split_register_get_mxfrm_help (VirtualLocation virt_loc,
     if (s)
     {
         help = gnc_split_register_get_mxfrm_entry (virt_loc, FALSE,
-                NULL, user_data);
+                                                   NULL, user_data);
         if (!help || *help == '\0')
-            help = _("Enter the account to transfer from, "
-                     "or choose one from the list");
+            help = _ ("Enter the account to transfer from, "
+                      "or choose one from the list");
     }
     else
     {
         /* For multi-split transactions and stock splits,
          * use a special value. */
-        s = xaccTransGetSplit (xaccSplitGetParent(split), 1);
+        s = xaccTransGetSplit (xaccSplitGetParent (split), 1);
 
         if (s)
-            help = _("This transaction has multiple splits; "
-                     "press the Split button to see them all");
+            help = _ ("This transaction has multiple splits; "
+                      "press the Split button to see them all");
         else if (g_strcmp0 ("stock-split", xaccSplitGetType (split)) == 0)
-            help = _("This transaction is a stock split; "
-                     "press the Split button to see details");
+            help = _ ("This transaction is a stock split; "
+                      "press the Split button to see details");
         else
             help = "";
     }
@@ -1587,42 +1594,43 @@ gnc_split_register_get_mxfrm_help (VirtualLocation virt_loc,
 /* Return the total amount of the transaction for splits of default account
  * and all subaccounts of the register. */
 static gnc_numeric
-get_trans_total_amount_subaccounts (SplitRegister *reg, Transaction *trans)
+get_trans_total_amount_subaccounts (SplitRegister* reg, Transaction* trans)
 {
-    GList *children, *child;
-    Account *parent;
+    GList* children, *child;
+    Account* parent;
     gnc_numeric total = gnc_numeric_zero();
 
     /* Get a list of all subaccounts for matching */
-    parent = gnc_split_register_get_default_account(reg);
+    parent = gnc_split_register_get_default_account (reg);
     if (!parent)
         /* Register has no account, perhaps it's the general journal.  If it
            has no account then we have no way of picking out the desired splits,
            return zero. */
         return total;
-    children = gnc_account_get_descendants(parent);
-    children = g_list_append(children, parent);
+    children = gnc_account_get_descendants (parent);
+    children = g_list_append (children, parent);
 
     for (child = children; child; child = child->next)
     {
-        total = gnc_numeric_add_fixed(total, xaccTransGetAccountAmount(trans, child->data));
+        total = gnc_numeric_add_fixed (total, xaccTransGetAccountAmount (trans,
+                                       child->data));
     }
 
-    g_list_free(children);
+    g_list_free (children);
 
     return total;
 }
 
-static const char *
+static const char*
 gnc_split_register_get_tdebcred_entry (VirtualLocation virt_loc,
                                        gboolean translate,
-                                       gboolean *conditionally_changed,
+                                       gboolean* conditionally_changed,
                                        gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    const char * cell_name;
+    SplitRegister* reg = user_data;
+    const char* cell_name;
     gnc_numeric total;
-    Split *split;
+    Split* split;
 
     split = gnc_split_register_get_split (reg, virt_loc.vcell_loc);
     if (!split)
@@ -1645,16 +1653,17 @@ gnc_split_register_get_tdebcred_entry (VirtualLocation virt_loc,
         return NULL;
 
     if (gnc_numeric_negative_p (total) &&
-            gnc_cell_name_equal (cell_name, TDEBT_CELL))
+        gnc_cell_name_equal (cell_name, TDEBT_CELL))
         return NULL;
 
     if (gnc_numeric_positive_p (total) &&
-            gnc_cell_name_equal (cell_name, TCRED_CELL))
+        gnc_cell_name_equal (cell_name, TCRED_CELL))
         return NULL;
 
     total = gnc_numeric_abs (total);
 
-    return xaccPrintAmount (total, gnc_split_amount_print_info (split, reg->mismatched_commodities));
+    return xaccPrintAmount (total, gnc_split_amount_print_info (split,
+                                                                reg->mismatched_commodities));
 }
 
 /* return TRUE if we have a RATE_CELL; return FALSE if we do not.
@@ -1694,10 +1703,10 @@ gnc_split_reg_has_rate_cell (SplitRegisterType type)
  * split->value directly.
  */
 gboolean
-gnc_split_register_needs_conv_rate (SplitRegister *reg,
-                                    Transaction *txn, Account *acc)
+gnc_split_register_needs_conv_rate (SplitRegister* reg,
+                                    Transaction* txn, Account* acc)
 {
-    gnc_commodity *txn_cur, *acc_com;
+    gnc_commodity* txn_cur, *acc_com;
 
     /* If there is not a RATE_CELL, then don't do anything */
     if (!gnc_split_reg_has_rate_cell (reg->type))
@@ -1712,17 +1721,17 @@ gnc_split_register_needs_conv_rate (SplitRegister *reg,
     return TRUE;
 }
 
-static const char *
+static const char*
 gnc_split_register_get_debcred_entry (VirtualLocation virt_loc,
                                       gboolean translate,
-                                      gboolean *conditionally_changed,
+                                      gboolean* conditionally_changed,
                                       gpointer user_data)
 {
-    SplitRegister *reg = user_data;
+    SplitRegister* reg = user_data;
     gboolean is_debit;
-    Split *split;
-    Transaction *trans;
-    gnc_commodity *currency;
+    Split* split;
+    Transaction* trans;
+    gnc_commodity* currency;
 
     is_debit = gnc_cell_name_equal
                (gnc_table_get_cell_name (reg->table, virt_loc), DEBT_CELL);
@@ -1732,12 +1741,12 @@ gnc_split_register_get_debcred_entry (VirtualLocation virt_loc,
 
     currency = xaccTransGetCurrency (trans);
     if (!currency)
-        currency = gnc_default_currency ();
+        currency = gnc_default_currency();
 
     if (!split)
     {
         gnc_numeric imbalance;
-        Account *acc;
+        Account* acc;
 
         imbalance = xaccTransGetImbalanceValue (trans);
 
@@ -1746,8 +1755,8 @@ gnc_split_register_get_debcred_entry (VirtualLocation virt_loc,
 
         if (xaccTransUseTradingAccounts (trans))
         {
-            MonetaryList *imbal_list;
-            gnc_monetary *imbal_mon;
+            MonetaryList* imbal_list;
+            gnc_monetary* imbal_mon;
             imbal_list = xaccTransGetImbalance (trans);
 
             if (!imbal_list)
@@ -1759,27 +1768,27 @@ gnc_split_register_get_debcred_entry (VirtualLocation virt_loc,
             if (imbal_list->next)
             {
                 /* Multiple currency imbalance. */
-                gnc_monetary_list_free(imbal_list);
+                gnc_monetary_list_free (imbal_list);
                 return NULL;
             }
 
             imbal_mon = imbal_list->data;
-            if (!gnc_commodity_equal(gnc_monetary_commodity(*imbal_mon), currency))
+            if (!gnc_commodity_equal (gnc_monetary_commodity (*imbal_mon), currency))
             {
                 /* Imbalance is in wrong currency */
-                gnc_monetary_list_free(imbal_list);
+                gnc_monetary_list_free (imbal_list);
                 return NULL;
             }
 
-            if (!gnc_numeric_equal (gnc_monetary_value(*imbal_mon), imbalance))
+            if (!gnc_numeric_equal (gnc_monetary_value (*imbal_mon), imbalance))
             {
                 /* Value and commodity imbalances differ */
-                gnc_monetary_list_free(imbal_list);
+                gnc_monetary_list_free (imbal_list);
                 return NULL;
             }
 
             /* Done with the imbalance list */
-            gnc_monetary_list_free(imbal_list);
+            gnc_monetary_list_free (imbal_list);
         }
 
         imbalance = gnc_numeric_neg (imbalance);
@@ -1799,7 +1808,7 @@ gnc_split_register_get_debcred_entry (VirtualLocation virt_loc,
         if (gnc_split_register_needs_conv_rate (reg, trans, acc))
         {
             imbalance = gnc_numeric_mul (imbalance,
-                                         xaccTransGetAccountConvRate(trans, acc),
+                                         xaccTransGetAccountConvRate (trans, acc),
                                          gnc_commodity_get_fraction (currency),
                                          GNC_HOW_RND_ROUND_HALF_UP);
         }
@@ -1810,19 +1819,20 @@ gnc_split_register_get_debcred_entry (VirtualLocation virt_loc,
                                              GNC_HOW_RND_ROUND_HALF_UP);
         }
 
-        return xaccPrintAmount (imbalance, gnc_account_print_info (acc, reg->mismatched_commodities));
+        return xaccPrintAmount (imbalance, gnc_account_print_info (acc,
+                                                                   reg->mismatched_commodities));
     }
 
     {
         gnc_numeric amount;
-        gnc_commodity *split_commodity;
+        gnc_commodity* split_commodity;
         GNCPrintAmountInfo print_info;
-        Account *account;
-        gnc_commodity * commodity;
+        Account* account;
+        gnc_commodity* commodity;
 
         account = gnc_split_register_get_default_account (reg);
         commodity = xaccAccountGetCommodity (account);
-        split_commodity = xaccAccountGetCommodity(xaccSplitGetAccount(split));
+        split_commodity = xaccAccountGetCommodity (xaccSplitGetAccount (split));
 
         if (xaccTransUseTradingAccounts (trans))
         {
@@ -1831,40 +1841,40 @@ gnc_split_register_get_debcred_entry (VirtualLocation virt_loc,
                                               virt_loc.vcell_loc);
 
             if (reg->type == STOCK_REGISTER ||
-                    reg->type == CURRENCY_REGISTER ||
-                    reg->type == PORTFOLIO_LEDGER)
+                reg->type == CURRENCY_REGISTER ||
+                reg->type == PORTFOLIO_LEDGER)
             {
-                gnc_commodity *amount_commodity;
+                gnc_commodity* amount_commodity;
                 /* security register.  If this split has price and shares columns,
                    use the value, otherwise use the amount.  */
-                if (gnc_split_register_use_security_cells(reg, virt_loc))
+                if (gnc_split_register_use_security_cells (reg, virt_loc))
                 {
-                    amount = xaccSplitGetValue(split);
+                    amount = xaccSplitGetValue (split);
                     amount_commodity = currency;
                 }
                 else
                 {
-                    amount = xaccSplitGetAmount(split);
+                    amount = xaccSplitGetAmount (split);
                     amount_commodity = split_commodity;
                 }
                 /* Show the currency if it is not the default currency */
                 if (is_current ||
-                        gnc_commodity_equiv(amount_commodity, gnc_default_currency()))
+                    gnc_commodity_equiv (amount_commodity, gnc_default_currency()))
                     use_symbol = FALSE;
                 else
                     use_symbol = TRUE;
-                print_info = gnc_commodity_print_info(amount_commodity, use_symbol);
+                print_info = gnc_commodity_print_info (amount_commodity, use_symbol);
             }
             else
             {
                 /* non-security register, always use the split amount. */
-                amount = xaccSplitGetAmount(split);
+                amount = xaccSplitGetAmount (split);
                 if (is_current ||
-                        gnc_commodity_equiv(split_commodity, commodity))
+                    gnc_commodity_equiv (split_commodity, commodity))
                     use_symbol = FALSE;
                 else
                     use_symbol = TRUE;
-                print_info = gnc_commodity_print_info(split_commodity, use_symbol);
+                print_info = gnc_commodity_print_info (split_commodity, use_symbol);
             }
         }
         else
@@ -1908,25 +1918,25 @@ gnc_split_register_get_debcred_entry (VirtualLocation virt_loc,
 
 /* Calculates the register balance for each split at runtime.
  * This works regardless of the sort order. */
-static const char *
+static const char*
 gnc_split_register_get_rbaln_entry (VirtualLocation virt_loc,
                                     gboolean translate,
-                                    gboolean *conditionally_changed,
+                                    gboolean* conditionally_changed,
                                     gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    SRInfo *info = gnc_split_register_get_info (reg);
-    Split *split;
-    Transaction *trans;
+    SplitRegister* reg = user_data;
+    SRInfo* info = gnc_split_register_get_info (reg);
+    Split* split;
+    Transaction* trans;
     gnc_numeric balance;
-    Account *account;
+    Account* account;
 
     /* Return NULL if this is a blank transaction. */
     split = gnc_split_register_get_split (reg, virt_loc.vcell_loc);
     if (split == xaccSplitLookup (&info->blank_split_guid,
-                                  gnc_get_current_book ()))
+                                  gnc_get_current_book()))
         return NULL;
-    
+
     trans = xaccSplitGetParent (split);
     if (!trans)
         return NULL;
@@ -1947,9 +1957,9 @@ static gboolean
 gnc_split_register_cursor_is_readonly (VirtualLocation virt_loc,
                                        gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    Split *split;
-    Transaction *txn;
+    SplitRegister* reg = user_data;
+    Split* split;
+    Transaction* txn;
     char type;
 
     split = gnc_split_register_get_split (reg, virt_loc.vcell_loc);
@@ -1961,7 +1971,7 @@ gnc_split_register_cursor_is_readonly (VirtualLocation virt_loc,
         if (txn) // get the current trans and see if read_only required
         {
             if (xaccTransGetReadOnly (txn)
-                    || xaccTransIsReadonlyByPostedDate (txn))
+                || xaccTransIsReadonlyByPostedDate (txn))
                 return (TRUE);
         }
         return FALSE;
@@ -1970,9 +1980,9 @@ gnc_split_register_cursor_is_readonly (VirtualLocation virt_loc,
     txn = xaccSplitGetParent (split);
     if (!txn) return FALSE;
 
-    if (xaccTransGetReadOnly(txn)
-            || xaccTransIsReadonlyByPostedDate(txn))
-        return(TRUE);
+    if (xaccTransGetReadOnly (txn)
+        || xaccTransIsReadonlyByPostedDate (txn))
+        return (TRUE);
 
     type = xaccTransGetTxnType (txn);
     return (type == TXN_TYPE_INVOICE);
@@ -1980,7 +1990,7 @@ gnc_split_register_cursor_is_readonly (VirtualLocation virt_loc,
 
 static CellIOFlags
 gnc_split_register_get_inactive_io_flags (VirtualLocation virt_loc,
-        gpointer user_data)
+                                          gpointer user_data)
 {
     if (gnc_split_register_cursor_is_readonly (virt_loc, user_data))
         return XACC_CELL_ALLOW_READ_ONLY;
@@ -1990,7 +2000,7 @@ gnc_split_register_get_inactive_io_flags (VirtualLocation virt_loc,
 
 static CellIOFlags
 gnc_split_register_get_standard_io_flags (VirtualLocation virt_loc,
-        gpointer user_data)
+                                          gpointer user_data)
 {
     if (gnc_split_register_cursor_is_readonly (virt_loc, user_data))
         return XACC_CELL_ALLOW_READ_ONLY;
@@ -2012,7 +2022,7 @@ static CellIOFlags
 gnc_split_register_get_ddue_io_flags (VirtualLocation virt_loc,
                                       gpointer user_data)
 {
-    SplitRegister *reg = user_data;
+    SplitRegister* reg = user_data;
     char type;
 
     type = gnc_split_register_get_type_value (reg, virt_loc);
@@ -2035,10 +2045,10 @@ gnc_split_register_get_rate_io_flags (VirtualLocation virt_loc,
 
 static CellIOFlags
 gnc_split_register_get_debcred_io_flags (VirtualLocation virt_loc,
-        gpointer user_data)
+                                         gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    Split *split;
+    SplitRegister* reg = user_data;
+    Split* split;
 
     if (gnc_split_register_cursor_is_readonly (virt_loc, user_data))
         return XACC_CELL_ALLOW_READ_ONLY;
@@ -2053,9 +2063,9 @@ gnc_split_register_get_debcred_io_flags (VirtualLocation virt_loc,
 
 static CellIOFlags
 gnc_split_register_get_security_io_flags (VirtualLocation virt_loc,
-        gpointer user_data)
+                                          gpointer user_data)
 {
-    SplitRegister *reg = user_data;
+    SplitRegister* reg = user_data;
 
     if (gnc_split_register_cursor_is_readonly (virt_loc, user_data))
         return XACC_CELL_ALLOW_READ_ONLY;
@@ -2067,41 +2077,42 @@ gnc_split_register_get_security_io_flags (VirtualLocation virt_loc,
 }
 
 static gboolean
-xaccTransWarnReadOnly (GtkWidget *parent, Transaction *trans)
+xaccTransWarnReadOnly (GtkWidget* parent, Transaction* trans)
 {
-    GtkWidget *dialog;
-    const gchar *reason;
-    const gchar *format =
-        _("Cannot modify or delete this transaction. This transaction is "
-          "marked read-only because:\n\n'%s'");
+    GtkWidget* dialog;
+    const gchar* reason;
+    const gchar* format =
+        _ ("Cannot modify or delete this transaction. This transaction is "
+           "marked read-only because:\n\n'%s'");
 
     if (!trans) return FALSE;
 
     reason = xaccTransGetReadOnly (trans);
     if (reason)
     {
-        dialog = gtk_message_dialog_new(GTK_WINDOW(parent),
-                                        0,
-                                        GTK_MESSAGE_ERROR,
-                                        GTK_BUTTONS_OK,
-                                        format,
-                                        reason);
-        gtk_dialog_run(GTK_DIALOG(dialog));
-        gtk_widget_destroy(dialog);
+        dialog = gtk_message_dialog_new (GTK_WINDOW (parent),
+                                         0,
+                                         GTK_MESSAGE_ERROR,
+                                         GTK_BUTTONS_OK,
+                                         format,
+                                         reason);
+        gtk_dialog_run (GTK_DIALOG (dialog));
+        gtk_widget_destroy (dialog);
         return TRUE;
     }
     return FALSE;
 }
 
-static gboolean reg_trans_has_reconciled_splits (SplitRegister *reg, Transaction *trans)
+static gboolean reg_trans_has_reconciled_splits (SplitRegister* reg,
+                                                 Transaction* trans)
 {
-    GList *node;
+    GList* node;
 
     for (node = xaccTransGetSplitList (trans); node; node = node->next)
     {
-        Split *split = node->data;
+        Split* split = node->data;
 
-        if (!xaccTransStillHasSplit(trans, split))
+        if (!xaccTransStillHasSplit (trans, split))
             continue;
 
         if ((xaccSplitGetReconcile (split) == YREC) &&
@@ -2115,15 +2126,15 @@ static gboolean reg_trans_has_reconciled_splits (SplitRegister *reg, Transaction
 static gboolean
 gnc_split_register_confirm (VirtualLocation virt_loc, gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    SRInfo *info = gnc_split_register_get_info (reg);
-    Transaction *trans;
-    Split *split;
+    SplitRegister* reg = user_data;
+    SRInfo* info = gnc_split_register_get_info (reg);
+    Transaction* trans;
+    Split* split;
     char recn;
-    const char *cell_name;
+    const char* cell_name;
     gboolean protected_split_cell, protected_trans_cell;
-    const gchar *title = NULL;
-    const gchar *message = NULL;
+    const gchar* title = NULL;
+    const gchar* message = NULL;
 
     /* This assumes we reset the flag whenever we change splits.
      * This happens in gnc_split_register_move_cursor(). */
@@ -2135,7 +2146,7 @@ gnc_split_register_confirm (VirtualLocation virt_loc, gpointer user_data)
         return TRUE;
 
     trans = xaccSplitGetParent (split);
-    if (xaccTransWarnReadOnly(gnc_split_register_get_parent(reg), trans))
+    if (xaccTransWarnReadOnly (gnc_split_register_get_parent (reg), trans))
         return FALSE;
 
     if (!reg_trans_has_reconciled_splits (reg, trans))
@@ -2143,7 +2154,7 @@ gnc_split_register_confirm (VirtualLocation virt_loc, gpointer user_data)
 
     if (gnc_table_layout_get_cell_changed (reg->table->layout, RECN_CELL, FALSE))
         recn = gnc_recn_cell_get_flag
-               ((RecnCell *) gnc_table_layout_get_cell (reg->table->layout, RECN_CELL));
+               ((RecnCell*) gnc_table_layout_get_cell (reg->table->layout, RECN_CELL));
     else if (g_list_index (reg->unrecn_splits, split) != -1)
         recn = NREC;   /* A previous run of this function marked this split for unreconciling */
     else
@@ -2153,35 +2164,41 @@ gnc_split_register_confirm (VirtualLocation virt_loc, gpointer user_data)
     cell_name = gnc_table_get_cell_name (reg->table, virt_loc);
 
     /* if we change a transfer cell, we want the other split */
-    if (g_strcmp0(cell_name, "transfer") == 0)
+    if (g_strcmp0 (cell_name, "transfer") == 0)
         recn = xaccSplitGetReconcile (xaccSplitGetOtherSplit (split));
 
     /* These cells can not be changed */
-    protected_split_cell = (g_strcmp0(cell_name, "account") == 0) || (g_strcmp0(cell_name, "transfer") == 0) || (g_strcmp0(cell_name, "debit") == 0) || (g_strcmp0(cell_name, "credit") == 0);
-    protected_trans_cell = (g_strcmp0(cell_name, "date") == 0) || (g_strcmp0(cell_name, "num") == 0) || (g_strcmp0(cell_name, "description") == 0);
+    protected_split_cell = (g_strcmp0 (cell_name, "account") == 0) ||
+                           (g_strcmp0 (cell_name, "transfer") == 0) ||
+                           (g_strcmp0 (cell_name, "debit") == 0) ||
+                           (g_strcmp0 (cell_name, "credit") == 0);
+    protected_trans_cell = (g_strcmp0 (cell_name, "date") == 0) ||
+                           (g_strcmp0 (cell_name, "num") == 0) ||
+                           (g_strcmp0 (cell_name, "description") == 0);
 
-    PINFO ("Protected transaction cell %d, Protected split cell %d, Cell is %s", protected_trans_cell, protected_split_cell, cell_name);
+    PINFO ("Protected transaction cell %d, Protected split cell %d, Cell is %s",
+           protected_trans_cell, protected_split_cell, cell_name);
 
     if (protected_trans_cell)
     {
-        GList *node;
-        gchar *acc_list = NULL;
-        gchar *message_format;
+        GList* node;
+        gchar* acc_list = NULL;
+        gchar* message_format;
 
         for (node = xaccTransGetSplitList (trans); node; node = node->next)
         {
-            Split *split = node->data;
+            Split* split = node->data;
 
             if (xaccSplitGetReconcile (split) == YREC)
             {
-                Account *acc = xaccSplitGetAccount (split);
-                gchar *name = gnc_account_get_full_name (acc);
+                Account* acc = xaccSplitGetAccount (split);
+                gchar* name = gnc_account_get_full_name (acc);
 
                 if (acc_list == NULL)
                     acc_list = g_strconcat ("\n", name, NULL);
                 else
                 {
-                    gchar *acc_list_copy = g_strdup(acc_list);
+                    gchar* acc_list_copy = g_strdup (acc_list);
                     g_free (acc_list);
                     acc_list = g_strconcat (acc_list_copy, "\n", name, NULL);
                     g_free (acc_list_copy);
@@ -2189,10 +2206,10 @@ gnc_split_register_confirm (VirtualLocation virt_loc, gpointer user_data)
                 g_free (name);
             }
         }
-        title = _("Change transaction containing a reconciled split?");
+        title = _ ("Change transaction containing a reconciled split?");
         message_format =
-         _("The transaction you are about to change contains reconciled splits in the following accounts:\n%s"
-           "\n\nAre you sure you want to continue with this change ?");
+            _ ("The transaction you are about to change contains reconciled splits in the following accounts:\n%s"
+               "\n\nAre you sure you want to continue with this change ?");
 
         message = g_strdup_printf (message_format, acc_list);
         g_free (acc_list);
@@ -2200,37 +2217,38 @@ gnc_split_register_confirm (VirtualLocation virt_loc, gpointer user_data)
 
     if (protected_split_cell)
     {
-        title = _("Change reconciled split?");
+        title = _ ("Change reconciled split?");
         message =
-         _("You are about to change a protected field of a reconciled split. "
-           "If you continue editing this split it will be unreconciled. "
-           "This might make future reconciliation difficult! Continue with this change?");
+            _ ("You are about to change a protected field of a reconciled split. "
+               "If you continue editing this split it will be unreconciled. "
+               "This might make future reconciliation difficult! Continue with this change?");
     }
 
     if ((recn == YREC && protected_split_cell) || protected_trans_cell)
     {
-        GtkWidget *dialog, *window;
+        GtkWidget* dialog, *window;
         gint response;
 
         /* Does the user want to be warned? */
-        window = gnc_split_register_get_parent(reg);
+        window = gnc_split_register_get_parent (reg);
         dialog =
-            gtk_message_dialog_new(GTK_WINDOW(window),
-                                   GTK_DIALOG_DESTROY_WITH_PARENT,
-                                   GTK_MESSAGE_WARNING,
-                                   GTK_BUTTONS_CANCEL,
-                                   "%s", title);
-        gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog),
-                "%s", message);
+            gtk_message_dialog_new (GTK_WINDOW (window),
+                                    GTK_DIALOG_DESTROY_WITH_PARENT,
+                                    GTK_MESSAGE_WARNING,
+                                    GTK_BUTTONS_CANCEL,
+                                    "%s", title);
+        gtk_message_dialog_format_secondary_text (GTK_MESSAGE_DIALOG (dialog),
+                                                  "%s", message);
 
         if (protected_split_cell)
-            gtk_dialog_add_button(GTK_DIALOG(dialog), _("Chan_ge Split"),
-                              GTK_RESPONSE_YES);
+            gtk_dialog_add_button (GTK_DIALOG (dialog), _ ("Chan_ge Split"),
+                                   GTK_RESPONSE_YES);
         else
-            gtk_dialog_add_button(GTK_DIALOG(dialog), _("Chan_ge Transaction"),
-                              GTK_RESPONSE_YES);
-        response = gnc_dialog_run(GTK_DIALOG(dialog), GNC_PREF_WARN_REG_RECD_SPLIT_MOD);
-        gtk_widget_destroy(dialog);
+            gtk_dialog_add_button (GTK_DIALOG (dialog), _ ("Chan_ge Transaction"),
+                                   GTK_RESPONSE_YES);
+        response = gnc_dialog_run (GTK_DIALOG (dialog),
+                                   GNC_PREF_WARN_REG_RECD_SPLIT_MOD);
+        gtk_widget_destroy (dialog);
         if (response != GTK_RESPONSE_YES)
             return FALSE;
 
@@ -2241,12 +2259,13 @@ gnc_split_register_confirm (VirtualLocation virt_loc, gpointer user_data)
             {
                 reg->unrecn_splits = g_list_append (reg->unrecn_splits, split);
                 gnc_recn_cell_set_flag
-                    ((RecnCell *) gnc_table_layout_get_cell (reg->table->layout, RECN_CELL),
-                     NREC);
+                ((RecnCell*) gnc_table_layout_get_cell (reg->table->layout, RECN_CELL),
+                 NREC);
             }
         }
 
-        PINFO ("Unreconcile split list length is %d", g_list_length(reg->unrecn_splits));
+        PINFO ("Unreconcile split list length is %d",
+               g_list_length (reg->unrecn_splits));
         info->change_confirmed = TRUE;
     }
     return TRUE;
@@ -2255,27 +2274,27 @@ gnc_split_register_confirm (VirtualLocation virt_loc, gpointer user_data)
 static gpointer
 gnc_split_register_guid_malloc (void)
 {
-    GncGUID *guid;
+    GncGUID* guid;
 
-    guid = guid_malloc ();
+    guid = guid_malloc();
 
-    *guid = *guid_null ();
+    *guid = *guid_null();
 
     return guid;
 }
 
-static const char *
+static const char*
 gnc_template_register_get_xfrm_entry (VirtualLocation virt_loc,
                                       gboolean translate,
-                                      gboolean *conditionally_changed,
+                                      gboolean* conditionally_changed,
                                       gpointer user_data)
 {
-    static char *name = NULL;
+    static char* name = NULL;
 
-    SplitRegister *reg = user_data;
-    Split *split;
-    Account *account;
-    GncGUID *guid = NULL;
+    SplitRegister* reg = user_data;
+    Split* split;
+    Account* account;
+    GncGUID* guid = NULL;
 
     split = gnc_split_register_get_split (reg, virt_loc.vcell_loc);
     if (!split)
@@ -2286,88 +2305,88 @@ gnc_template_register_get_xfrm_entry (VirtualLocation virt_loc,
      */
     g_free (name);
     qof_instance_get (QOF_INSTANCE (split),
-              "sx-account", &guid,
-              NULL);
-    account = xaccAccountLookup (guid, gnc_get_current_book ());
+                      "sx-account", &guid,
+                      NULL);
+    account = xaccAccountLookup (guid, gnc_get_current_book());
     name = account ? gnc_get_account_name_for_split_register (account,
-                         reg->show_leaf_accounts) : NULL;
+                                                              reg->show_leaf_accounts) : NULL;
     return name;
 }
 
-static const char *
+static const char*
 gnc_template_register_get_fdebt_entry (VirtualLocation virt_loc,
                                        gboolean translate,
-                                       gboolean *conditionally_changed,
+                                       gboolean* conditionally_changed,
                                        gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    Split *split = gnc_split_register_get_split(reg, virt_loc.vcell_loc);
-    char *formula = NULL;
+    SplitRegister* reg = user_data;
+    Split* split = gnc_split_register_get_split (reg, virt_loc.vcell_loc);
+    char* formula = NULL;
 
     if (split)
     {
         qof_instance_get (QOF_INSTANCE (split),
-                  "sx-debit-formula", &formula,
-                  NULL);
+                          "sx-debit-formula", &formula,
+                          NULL);
     }
 
     return formula;
 }
 
-static char *
+static char*
 gnc_split_register_get_fdebt_help (VirtualLocation virt_loc,
                                    gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    const char *help;
+    SplitRegister* reg = user_data;
+    const char* help;
 
     help = gnc_table_get_entry (reg->table, virt_loc);
     if (!help || *help == '\0')
-        help = _("Enter debit formula for real transaction");
+        help = _ ("Enter debit formula for real transaction");
 
     return g_strdup (help);
 }
 
-static const char *
+static const char*
 gnc_template_register_get_fcred_entry (VirtualLocation virt_loc,
                                        gboolean translate,
-                                       gboolean *conditionally_changed,
+                                       gboolean* conditionally_changed,
                                        gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    Split *split = gnc_split_register_get_split(reg, virt_loc.vcell_loc);
-    char *formula = NULL;
+    SplitRegister* reg = user_data;
+    Split* split = gnc_split_register_get_split (reg, virt_loc.vcell_loc);
+    char* formula = NULL;
 
     if (split)
     {
         qof_instance_get (QOF_INSTANCE (split),
-                  "sx-credit-formula", &formula,
-                  NULL);
+                          "sx-credit-formula", &formula,
+                          NULL);
     }
 
     return formula;
 
 }
 
-static char *
+static char*
 gnc_split_register_get_fcred_help (VirtualLocation virt_loc,
                                    gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    const char *help = gnc_table_get_entry (reg->table, virt_loc);
+    SplitRegister* reg = user_data;
+    const char* help = gnc_table_get_entry (reg->table, virt_loc);
 
     if (!help || *help == '\0')
-        help = _("Enter credit formula for real transaction");
+        help = _ ("Enter credit formula for real transaction");
 
     return g_strdup (help);
 }
 
-static char *
+static char*
 gnc_split_register_get_default_help (VirtualLocation virt_loc,
                                      gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    const char *help = gnc_table_get_entry(reg->table, virt_loc);
+    SplitRegister* reg = user_data;
+    const char* help = gnc_table_get_entry (reg->table, virt_loc);
 
     return g_strdup (help);
 }
@@ -2380,23 +2399,23 @@ gnc_split_register_get_default_help (VirtualLocation virt_loc,
  * the split. I'm not sure that it's what was originally intended, but at least
  * it can do something now. <jralls, 8 June 2015>
  */
-static const char *
+static const char*
 gnc_template_register_get_debcred_entry (VirtualLocation virt_loc,
-        gboolean translate,
-        gboolean *conditionally_changed,
-        gpointer user_data)
+                                         gboolean translate,
+                                         gboolean* conditionally_changed,
+                                         gpointer user_data)
 {
-    SplitRegister *reg = user_data;
-    Split *split;
-    gnc_numeric *amount, amount2;
-    const char * cell_name;
+    SplitRegister* reg = user_data;
+    Split* split;
+    gnc_numeric* amount, amount2;
+    const char* cell_name;
 
     split = gnc_split_register_get_split (reg, virt_loc.vcell_loc);
     if (!split)
         return gnc_split_register_get_debcred_entry (virt_loc,
-                translate,
-                conditionally_changed,
-                user_data);
+                                                     translate,
+                                                     conditionally_changed,
+                                                     user_data);
 
     cell_name = gnc_table_get_cell_name (reg->table, virt_loc);
     if (gnc_cell_name_equal (cell_name, DEBT_CELL))
@@ -2418,7 +2437,8 @@ gnc_template_register_get_debcred_entry (VirtualLocation virt_loc,
 
     amount2 = gnc_numeric_abs (*amount);
     g_free (amount);
-    return xaccPrintAmount (amount2, gnc_default_print_info (reg->mismatched_commodities));
+    return xaccPrintAmount (amount2,
+                            gnc_default_print_info (reg->mismatched_commodities));
 }
 
 static void
@@ -2430,8 +2450,8 @@ gnc_split_register_guid_free (gpointer guid)
 static void
 gnc_split_register_guid_copy (gpointer p_to, gconstpointer p_from)
 {
-    GncGUID *to = p_to;
-    const GncGUID *from = p_from;
+    GncGUID* to = p_to;
+    const GncGUID* from = p_from;
 
     g_return_if_fail (to != NULL);
     *to = from ? *from : *guid_null();
@@ -2439,35 +2459,36 @@ gnc_split_register_guid_copy (gpointer p_to, gconstpointer p_from)
 
 
 static void
-gnc_split_register_colorize_negative (gpointer gsettings, gchar *key, gpointer unused)
+gnc_split_register_colorize_negative (gpointer gsettings, gchar* key,
+                                      gpointer unused)
 {
-    use_red_for_negative = gnc_prefs_get_bool(GNC_PREFS_GROUP_GENERAL,
-                                              GNC_PREF_NEGATIVE_IN_RED);
+    use_red_for_negative = gnc_prefs_get_bool (GNC_PREFS_GROUP_GENERAL,
+                                               GNC_PREF_NEGATIVE_IN_RED);
 }
 
 
 static gpointer
 gnc_split_register_model_add_hooks (gpointer unused)
 {
-    gnc_prefs_register_cb(GNC_PREFS_GROUP_GENERAL, GNC_PREF_NEGATIVE_IN_RED,
-                          gnc_split_register_colorize_negative,
-                          NULL);
+    gnc_prefs_register_cb (GNC_PREFS_GROUP_GENERAL, GNC_PREF_NEGATIVE_IN_RED,
+                           gnc_split_register_colorize_negative,
+                           NULL);
     /* Get the initial value */
-    use_red_for_negative = gnc_prefs_get_bool(GNC_PREFS_GROUP_GENERAL,
-                                              GNC_PREF_NEGATIVE_IN_RED);
+    use_red_for_negative = gnc_prefs_get_bool (GNC_PREFS_GROUP_GENERAL,
+                                               GNC_PREF_NEGATIVE_IN_RED);
     return NULL;
 }
 
 
-TableModel *
+TableModel*
 gnc_split_register_model_new (void)
 {
-    TableModel *model;
+    TableModel* model;
     static GOnce once = G_ONCE_INIT;
 
-    g_once(&once, gnc_split_register_model_add_hooks, NULL);
+    g_once (&once, gnc_split_register_model_add_hooks, NULL);
 
-    model = gnc_table_model_new ();
+    model = gnc_table_model_new();
 
     // entry handlers
     gnc_table_model_set_entry_handler (model,
@@ -2680,16 +2701,16 @@ gnc_split_register_model_new (void)
 //        model, gnc_split_register_get_default_tooltip);
 
     gnc_table_model_set_tooltip_handler (model,
-                                       gnc_split_register_get_recn_tooltip,
-                                       RECN_CELL);
+                                         gnc_split_register_get_recn_tooltip,
+                                         RECN_CELL);
 
     gnc_table_model_set_tooltip_handler (model,
-                                       gnc_split_register_get_associate_tooltip,
-                                       ASSOC_CELL);
+                                         gnc_split_register_get_associate_tooltip,
+                                         ASSOC_CELL);
 
 
     // help handlers
-    gnc_table_model_set_default_help_handler(
+    gnc_table_model_set_default_help_handler (
         model, gnc_split_register_get_default_help);
 
     gnc_table_model_set_help_handler (model,
@@ -2753,7 +2774,7 @@ gnc_split_register_model_new (void)
                                       FDEBT_CELL);
 
     // io flag handlers
-    gnc_table_model_set_io_flags_handler(
+    gnc_table_model_set_io_flags_handler (
         model, gnc_split_register_get_standard_io_flags, DATE_CELL);
 
     /* FIXME: We really only need a due date for 'invoices', not for
@@ -2761,88 +2782,88 @@ gnc_split_register_model_new (void)
      * due-date for transactions that credit the ACCT_TYPE_RECEIVABLE or
      * debit the ACCT_TYPE_PAYABLE account type.
      */
-    gnc_table_model_set_io_flags_handler(
+    gnc_table_model_set_io_flags_handler (
         model, gnc_split_register_get_rate_io_flags, RATE_CELL);
 
-    gnc_table_model_set_io_flags_handler(
+    gnc_table_model_set_io_flags_handler (
         model, gnc_split_register_get_ddue_io_flags, DDUE_CELL);
 
-    gnc_table_model_set_io_flags_handler(
+    gnc_table_model_set_io_flags_handler (
         model, gnc_split_register_get_standard_io_flags, NUM_CELL);
 
-    gnc_table_model_set_io_flags_handler(
+    gnc_table_model_set_io_flags_handler (
         model, gnc_split_register_get_standard_io_flags, TNUM_CELL);
 
-    gnc_table_model_set_io_flags_handler(
+    gnc_table_model_set_io_flags_handler (
         model, gnc_split_register_get_standard_io_flags, DESC_CELL);
 
-    gnc_table_model_set_io_flags_handler(
+    gnc_table_model_set_io_flags_handler (
         model, gnc_split_register_get_standard_io_flags, ACTN_CELL);
 
-    gnc_table_model_set_io_flags_handler(
+    gnc_table_model_set_io_flags_handler (
         model, gnc_split_register_get_standard_io_flags, XFRM_CELL);
 
-    gnc_table_model_set_io_flags_handler(
+    gnc_table_model_set_io_flags_handler (
         model, gnc_split_register_get_standard_io_flags, MEMO_CELL);
 
-    gnc_table_model_set_io_flags_handler(
+    gnc_table_model_set_io_flags_handler (
         model, gnc_split_register_get_standard_io_flags, MXFRM_CELL);
 
-    gnc_table_model_set_io_flags_handler(
+    gnc_table_model_set_io_flags_handler (
         model, gnc_split_register_get_standard_io_flags, NOTES_CELL);
 
-    gnc_table_model_set_io_flags_handler(
+    gnc_table_model_set_io_flags_handler (
         model, gnc_split_register_get_inactive_io_flags, VNOTES_CELL);
 
-    gnc_table_model_set_io_flags_handler(
+    gnc_table_model_set_io_flags_handler (
         model, gnc_split_register_get_debcred_io_flags, CRED_CELL);
 
-    gnc_table_model_set_io_flags_handler(
+    gnc_table_model_set_io_flags_handler (
         model, gnc_split_register_get_debcred_io_flags, DEBT_CELL);
 
-    gnc_table_model_set_io_flags_handler(
+    gnc_table_model_set_io_flags_handler (
         model, gnc_split_register_get_recn_io_flags, RECN_CELL);
 
-    gnc_table_model_set_io_flags_handler(
+    gnc_table_model_set_io_flags_handler (
         model, gnc_split_register_get_recn_io_flags, ASSOC_CELL);
 
-    gnc_table_model_set_io_flags_handler(
+    gnc_table_model_set_io_flags_handler (
         model, gnc_split_register_get_recn_io_flags, TYPE_CELL);
 
-    gnc_table_model_set_io_flags_handler(
+    gnc_table_model_set_io_flags_handler (
         model, gnc_split_register_get_security_io_flags, PRIC_CELL);
 
-    gnc_table_model_set_io_flags_handler(
+    gnc_table_model_set_io_flags_handler (
         model, gnc_split_register_get_security_io_flags, SHRS_CELL);
 
 
-    gnc_table_model_set_default_cell_color_handler(
+    gnc_table_model_set_default_cell_color_handler (
         model, gnc_split_register_get_cell_color);
 
-    gnc_table_model_set_cell_color_handler(
+    gnc_table_model_set_cell_color_handler (
         model, gnc_split_register_get_debcred_color, DEBT_CELL);
 
-    gnc_table_model_set_cell_color_handler(
+    gnc_table_model_set_cell_color_handler (
         model, gnc_split_register_get_debcred_color, CRED_CELL);
 
-    gnc_table_model_set_cell_color_handler(
+    gnc_table_model_set_cell_color_handler (
         model, gnc_split_register_get_debcred_color, TDEBT_CELL);
 
-    gnc_table_model_set_cell_color_handler(
+    gnc_table_model_set_cell_color_handler (
         model, gnc_split_register_get_debcred_color, TCRED_CELL);
 
-    gnc_table_model_set_cell_color_handler(
+    gnc_table_model_set_cell_color_handler (
         model, gnc_split_register_get_debcred_color, FCRED_CELL);
 
-    gnc_table_model_set_cell_color_handler(
+    gnc_table_model_set_cell_color_handler (
         model, gnc_split_register_get_debcred_color, FDEBT_CELL);
 
 
-    gnc_table_model_set_default_cell_border_handler(
+    gnc_table_model_set_default_cell_border_handler (
         model, gnc_split_register_get_border);
 
 
-    gnc_table_model_set_default_confirm_handler(
+    gnc_table_model_set_default_confirm_handler (
         model, gnc_split_register_confirm);
 
     model->cell_data_allocator   = gnc_split_register_guid_malloc;
@@ -2854,44 +2875,44 @@ gnc_split_register_model_new (void)
     return model;
 }
 
-TableModel *
+TableModel*
 gnc_template_register_model_new (void)
 {
-    TableModel *model;
+    TableModel* model;
 
-    model = gnc_split_register_model_new ();
+    model = gnc_split_register_model_new();
 
-    gnc_table_model_set_entry_handler(
-        model, gnc_split_register_get_inactive_date_entry, DATE_CELL );
+    gnc_table_model_set_entry_handler (
+        model, gnc_split_register_get_inactive_date_entry, DATE_CELL);
 
-    gnc_table_model_set_entry_handler(
-        model, gnc_split_register_get_inactive_date_entry, DDUE_CELL );
+    gnc_table_model_set_entry_handler (
+        model, gnc_split_register_get_inactive_date_entry, DDUE_CELL);
 
-    gnc_table_model_set_io_flags_handler(
-        model, gnc_split_register_get_inactive_io_flags, DATE_CELL );
+    gnc_table_model_set_io_flags_handler (
+        model, gnc_split_register_get_inactive_io_flags, DATE_CELL);
 
-    gnc_table_model_set_io_flags_handler(
-        model, gnc_split_register_get_inactive_io_flags, DDUE_CELL );
+    gnc_table_model_set_io_flags_handler (
+        model, gnc_split_register_get_inactive_io_flags, DDUE_CELL);
 
-    gnc_table_model_set_entry_handler(
+    gnc_table_model_set_entry_handler (
         model, gnc_template_register_get_xfrm_entry, XFRM_CELL);
 
-    gnc_table_model_set_entry_handler(
+    gnc_table_model_set_entry_handler (
         model, gnc_template_register_get_fdebt_entry, FDEBT_CELL);
 
-    gnc_table_model_set_entry_handler(
+    gnc_table_model_set_entry_handler (
         model, gnc_template_register_get_fcred_entry, FCRED_CELL);
 
-    gnc_table_model_set_entry_handler(
+    gnc_table_model_set_entry_handler (
         model, gnc_template_register_get_debcred_entry, DEBT_CELL);
 
-    gnc_table_model_set_entry_handler(
+    gnc_table_model_set_entry_handler (
         model, gnc_template_register_get_debcred_entry, CRED_CELL);
 
-    gnc_table_model_set_io_flags_handler(
+    gnc_table_model_set_io_flags_handler (
         model, gnc_split_register_get_standard_io_flags, FCRED_CELL);
 
-    gnc_table_model_set_io_flags_handler(
+    gnc_table_model_set_io_flags_handler (
         model, gnc_split_register_get_standard_io_flags, FDEBT_CELL);
 
     gnc_template_register_model_add_save_handlers (model);

--- a/gnucash/register/ledger-core/split-register.c
+++ b/gnucash/register/ledger-core/split-register.c
@@ -67,61 +67,61 @@ static SCM copied_item = SCM_UNDEFINED;
 static GncGUID copied_leader_guid;
 /** static prototypes *****************************************************/
 
-static gboolean gnc_split_register_save_to_scm (SplitRegister *reg,
-        SCM trans_scm, SCM split_scm,
-        gboolean use_cut_semantics);
-static gboolean gnc_split_register_auto_calc (SplitRegister *reg,
-        Split *split);
+static gboolean gnc_split_register_save_to_scm (SplitRegister* reg,
+                                                SCM trans_scm, SCM split_scm,
+                                                gboolean use_cut_semantics);
+static gboolean gnc_split_register_auto_calc (SplitRegister* reg,
+                                              Split* split);
 
 
 /** implementations *******************************************************/
 
 /* Uses the scheme split copying routines */
 static void
-gnc_copy_split_onto_split(Split *from, Split *to, gboolean use_cut_semantics)
+gnc_copy_split_onto_split (Split* from, Split* to, gboolean use_cut_semantics)
 {
     SCM split_scm;
 
     if ((from == NULL) || (to == NULL))
         return;
 
-    split_scm = gnc_copy_split(from, use_cut_semantics);
+    split_scm = gnc_copy_split (from, use_cut_semantics);
     if (split_scm == SCM_UNDEFINED)
         return;
 
-    gnc_copy_split_scm_onto_split(split_scm, to, gnc_get_current_book ());
+    gnc_copy_split_scm_onto_split (split_scm, to, gnc_get_current_book());
 }
 
 /* Uses the scheme transaction copying routines */
 void
-gnc_copy_trans_onto_trans(Transaction *from, Transaction *to,
-                          gboolean use_cut_semantics,
-                          gboolean do_commit)
+gnc_copy_trans_onto_trans (Transaction* from, Transaction* to,
+                           gboolean use_cut_semantics,
+                           gboolean do_commit)
 {
     SCM trans_scm;
 
     if ((from == NULL) || (to == NULL))
         return;
 
-    trans_scm = gnc_copy_trans(from, use_cut_semantics);
+    trans_scm = gnc_copy_trans (from, use_cut_semantics);
     if (trans_scm == SCM_UNDEFINED)
         return;
 
-    gnc_copy_trans_scm_onto_trans(trans_scm, to, do_commit,
-                                  gnc_get_current_book ());
+    gnc_copy_trans_scm_onto_trans (trans_scm, to, do_commit,
+                                   gnc_get_current_book());
 }
 
 static int
-gnc_split_get_value_denom (Split *split)
+gnc_split_get_value_denom (Split* split)
 {
-    gnc_commodity *currency;
+    gnc_commodity* currency;
     int denom;
 
     currency = xaccTransGetCurrency (xaccSplitGetParent (split));
     denom = gnc_commodity_get_fraction (currency);
     if (denom == 0)
     {
-        gnc_commodity *commodity = gnc_default_currency ();
+        gnc_commodity* commodity = gnc_default_currency();
         denom = gnc_commodity_get_fraction (commodity);
         if (denom == 0)
             denom = 100;
@@ -131,14 +131,14 @@ gnc_split_get_value_denom (Split *split)
 }
 
 static int
-gnc_split_get_amount_denom (Split *split)
+gnc_split_get_amount_denom (Split* split)
 {
     int denom;
 
     denom = xaccAccountGetCommoditySCU (xaccSplitGetAccount (split));
     if (denom == 0)
     {
-        gnc_commodity *commodity = gnc_default_currency ();
+        gnc_commodity* commodity = gnc_default_currency();
         denom = gnc_commodity_get_fraction (commodity);
         if (denom == 0)
             denom = 100;
@@ -149,61 +149,62 @@ gnc_split_get_amount_denom (Split *split)
 
 /* returns TRUE if begin_edit was aborted */
 gboolean
-gnc_split_register_begin_edit_or_warn(SRInfo *info, Transaction *trans)
+gnc_split_register_begin_edit_or_warn (SRInfo* info, Transaction* trans)
 {
-    ENTER("info=%p, trans=%p", info, trans);
+    ENTER ("info=%p, trans=%p", info, trans);
 
-    if (!xaccTransIsOpen(trans))
+    if (!xaccTransIsOpen (trans))
     {
-        xaccTransBeginEdit(trans);
+        xaccTransBeginEdit (trans);
         /* This is now the pending transaction */
-        info->pending_trans_guid = *xaccTransGetGUID(trans);
-        LEAVE("opened and marked pending");
+        info->pending_trans_guid = *xaccTransGetGUID (trans);
+        LEAVE ("opened and marked pending");
         return FALSE;
     }
     else
     {
-        Split       *blank_split = xaccSplitLookup (&info->blank_split_guid,
-                                   gnc_get_current_book ());
-        Transaction *blank_trans = xaccSplitGetParent (blank_split);
+        Split*       blank_split = xaccSplitLookup (&info->blank_split_guid,
+                                                    gnc_get_current_book());
+        Transaction* blank_trans = xaccSplitGetParent (blank_split);
 
         if (trans == blank_trans)
         {
             /* This is a brand-new transaction. It is already
              * open, so just mark it as pending. */
-            info->pending_trans_guid = *xaccTransGetGUID(trans);
-            LEAVE("already open, now pending.");
+            info->pending_trans_guid = *xaccTransGetGUID (trans);
+            LEAVE ("already open, now pending.");
             return FALSE;
         }
         else
         {
-            GtkWindow *parent = NULL;
+            GtkWindow* parent = NULL;
             if (info->get_parent)
                 parent = GTK_WINDOW (info->get_parent (info->user_data));
-            gnc_error_dialog(parent, "%s", _("This transaction is already being edited in another register. Please finish editing it there first."));
-            LEAVE("already editing");
+            gnc_error_dialog (parent, "%s",
+                              _ ("This transaction is already being edited in another register. Please finish editing it there first."));
+            LEAVE ("already editing");
             return TRUE;
         }
     }
-    LEAVE(" ");
+    LEAVE (" ");
     return FALSE;  /* to satisfy static code analysis */
 }
 
 void
-gnc_split_register_expand_current_trans (SplitRegister *reg, gboolean expand)
+gnc_split_register_expand_current_trans (SplitRegister* reg, gboolean expand)
 {
-    SRInfo *info = gnc_split_register_get_info (reg);
+    SRInfo* info = gnc_split_register_get_info (reg);
     VirtualLocation virt_loc;
 
     if (!reg)
         return;
 
     if (reg->style == REG_STYLE_AUTO_LEDGER ||
-            reg->style == REG_STYLE_JOURNAL)
+        reg->style == REG_STYLE_JOURNAL)
         return;
 
     /* ok, so I just wanted an excuse to use exclusive-or */
-    if (!(expand ^ info->trans_expanded))
+    if (! (expand ^ info->trans_expanded))
         return;
 
     if (!expand)
@@ -227,7 +228,7 @@ gnc_split_register_expand_current_trans (SplitRegister *reg, gboolean expand)
                                     reg->table->current_cursor_loc.vcell_loc,
                                     gnc_split_register_get_active_cursor (reg));
 
-    gnc_split_register_set_trans_visible(
+    gnc_split_register_set_trans_visible (
         reg, reg->table->current_cursor_loc.vcell_loc, expand, FALSE);
 
     virt_loc = reg->table->current_cursor_loc;
@@ -250,24 +251,24 @@ gnc_split_register_expand_current_trans (SplitRegister *reg, gboolean expand)
 }
 
 gboolean
-gnc_split_register_current_trans_expanded (SplitRegister *reg)
+gnc_split_register_current_trans_expanded (SplitRegister* reg)
 {
-    SRInfo *info = gnc_split_register_get_info (reg);
+    SRInfo* info = gnc_split_register_get_info (reg);
 
     if (!reg)
         return FALSE;
 
     if (reg->style == REG_STYLE_AUTO_LEDGER ||
-            reg->style == REG_STYLE_JOURNAL)
+        reg->style == REG_STYLE_JOURNAL)
         return TRUE;
 
     return info->trans_expanded;
 }
 
-Transaction *
-gnc_split_register_get_current_trans (SplitRegister *reg)
+Transaction*
+gnc_split_register_get_current_trans (SplitRegister* reg)
 {
-    Split *split;
+    Split* split;
     VirtualCellLocation vcell_loc;
 
     if (reg == NULL)
@@ -275,7 +276,7 @@ gnc_split_register_get_current_trans (SplitRegister *reg)
 
     split = gnc_split_register_get_current_split (reg);
     if (split != NULL)
-        return xaccSplitGetParent(split);
+        return xaccSplitGetParent (split);
 
     /* Split is blank. Assume it is the blank split of a multi-line
      * transaction. Go back one row to find a split in the transaction. */
@@ -288,31 +289,31 @@ gnc_split_register_get_current_trans (SplitRegister *reg)
     return xaccSplitGetParent (split);
 }
 
-Split *
-gnc_split_register_get_current_split (SplitRegister *reg)
+Split*
+gnc_split_register_get_current_split (SplitRegister* reg)
 {
     if (reg == NULL)
         return NULL;
 
-    return gnc_split_register_get_split(
+    return gnc_split_register_get_split (
                reg, reg->table->current_cursor_loc.vcell_loc);
 }
 
-Split *
-gnc_split_register_get_blank_split (SplitRegister *reg)
+Split*
+gnc_split_register_get_blank_split (SplitRegister* reg)
 {
-    SRInfo *info = gnc_split_register_get_info (reg);
+    SRInfo* info = gnc_split_register_get_info (reg);
 
     if (!reg) return NULL;
 
-    return xaccSplitLookup (&info->blank_split_guid, gnc_get_current_book ());
+    return xaccSplitLookup (&info->blank_split_guid, gnc_get_current_book());
 }
 
 gboolean
-gnc_split_register_get_split_virt_loc (SplitRegister *reg, Split *split,
-                                       VirtualCellLocation *vcell_loc)
+gnc_split_register_get_split_virt_loc (SplitRegister* reg, Split* split,
+                                       VirtualCellLocation* vcell_loc)
 {
-    Table *table;
+    Table* table;
     int v_row;
     int v_col;
 
@@ -327,14 +328,14 @@ gnc_split_register_get_split_virt_loc (SplitRegister *reg, Split *split,
         for (v_col = 0; v_col < table->num_virt_cols; v_col++)
         {
             VirtualCellLocation vc_loc = { v_row, v_col };
-            VirtualCell *vcell;
-            Split *s;
+            VirtualCell* vcell;
+            Split* s;
 
             vcell = gnc_table_get_virtual_cell (table, vc_loc);
             if (!vcell || !vcell->visible)
                 continue;
 
-            s = xaccSplitLookup (vcell->vcell_data, gnc_get_current_book ());
+            s = xaccSplitLookup (vcell->vcell_data, gnc_get_current_book());
 
             if (s == split)
             {
@@ -349,12 +350,12 @@ gnc_split_register_get_split_virt_loc (SplitRegister *reg, Split *split,
 }
 
 gboolean
-gnc_split_register_get_split_amount_virt_loc (SplitRegister *reg, Split *split,
-        VirtualLocation *virt_loc)
+gnc_split_register_get_split_amount_virt_loc (SplitRegister* reg, Split* split,
+                                              VirtualLocation* virt_loc)
 {
     VirtualLocation v_loc;
     CursorClass cursor_class;
-    const char *cell_name;
+    const char* cell_name;
     gnc_numeric value;
 
     if (!gnc_split_register_get_split_virt_loc (reg, split, &v_loc.vcell_loc))
@@ -386,22 +387,22 @@ gnc_split_register_get_split_amount_virt_loc (SplitRegister *reg, Split *split,
     return TRUE;
 }
 
-Split *
-gnc_split_register_duplicate_current (SplitRegister *reg)
+Split*
+gnc_split_register_duplicate_current (SplitRegister* reg)
 {
-    SRInfo *info = gnc_split_register_get_info(reg);
+    SRInfo* info = gnc_split_register_get_info (reg);
     CursorClass cursor_class;
-    Transaction *trans;
-    Split *return_split;
-    Split *trans_split;
-    Split *blank_split;
+    Transaction* trans;
+    Split* return_split;
+    Split* trans_split;
+    Split* blank_split;
     gboolean changed;
-    Split *split;
+    Split* split;
 
-    ENTER("reg=%p", reg);
+    ENTER ("reg=%p", reg);
 
-    blank_split = xaccSplitLookup(&info->blank_split_guid,
-                                  gnc_get_current_book ());
+    blank_split = xaccSplitLookup (&info->blank_split_guid,
+                                   gnc_get_current_book());
     split = gnc_split_register_get_current_split (reg);
     trans = gnc_split_register_get_current_trans (reg);
     trans_split = gnc_split_register_get_current_trans_split (reg, NULL);
@@ -409,7 +410,7 @@ gnc_split_register_duplicate_current (SplitRegister *reg)
     /* This shouldn't happen, but be paranoid. */
     if (trans == NULL)
     {
-        LEAVE("no transaction");
+        LEAVE ("no transaction");
         return NULL;
     }
 
@@ -418,14 +419,14 @@ gnc_split_register_duplicate_current (SplitRegister *reg)
     /* Can't do anything with this. */
     if (cursor_class == CURSOR_CLASS_NONE)
     {
-        LEAVE("no cursor class");
+        LEAVE ("no cursor class");
         return NULL;
     }
 
     /* This shouldn't happen, but be paranoid. */
     if ((split == NULL) && (cursor_class == CURSOR_CLASS_TRANS))
     {
-        LEAVE("no split with transaction class");
+        LEAVE ("no split with transaction class");
         return NULL;
     }
 
@@ -435,41 +436,41 @@ gnc_split_register_duplicate_current (SplitRegister *reg)
      * There's no point in doing that! */
     if (!changed && ((split == NULL) || (split == blank_split)))
     {
-        LEAVE("skip unchanged blank split");
+        LEAVE ("skip unchanged blank split");
         return NULL;
     }
 
-    gnc_suspend_gui_refresh ();
+    gnc_suspend_gui_refresh();
 
     /* If the cursor has been edited, we are going to have to commit
      * it before we can duplicate. Make sure the user wants to do that. */
     if (changed)
     {
-        GtkWidget *dialog, *window;
+        GtkWidget* dialog, *window;
         gint response;
-        const char *title = _("Save transaction before duplicating?");
-        const char *message =
-            _("The current transaction has been changed. Would you like to "
-              "record the changes before duplicating the transaction, or "
-              "cancel the duplication?");
+        const char* title = _ ("Save transaction before duplicating?");
+        const char* message =
+            _ ("The current transaction has been changed. Would you like to "
+               "record the changes before duplicating the transaction, or "
+               "cancel the duplication?");
 
         window = gnc_split_register_get_parent (reg);
-        dialog = gtk_message_dialog_new(GTK_WINDOW(window),
-                                        GTK_DIALOG_DESTROY_WITH_PARENT,
-                                        GTK_MESSAGE_QUESTION,
-                                        GTK_BUTTONS_CANCEL,
-                                        "%s", title);
-        gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog),
-                "%s", message);
-        gtk_dialog_add_button(GTK_DIALOG(dialog),
-                              _("_Record"), GTK_RESPONSE_ACCEPT);
-        response = gnc_dialog_run(GTK_DIALOG(dialog), GNC_PREF_WARN_REG_TRANS_DUP);
-        gtk_widget_destroy(dialog);
+        dialog = gtk_message_dialog_new (GTK_WINDOW (window),
+                                         GTK_DIALOG_DESTROY_WITH_PARENT,
+                                         GTK_MESSAGE_QUESTION,
+                                         GTK_BUTTONS_CANCEL,
+                                         "%s", title);
+        gtk_message_dialog_format_secondary_text (GTK_MESSAGE_DIALOG (dialog),
+                                                  "%s", message);
+        gtk_dialog_add_button (GTK_DIALOG (dialog),
+                               _ ("_Record"), GTK_RESPONSE_ACCEPT);
+        response = gnc_dialog_run (GTK_DIALOG (dialog), GNC_PREF_WARN_REG_TRANS_DUP);
+        gtk_widget_destroy (dialog);
 
         if (response != GTK_RESPONSE_ACCEPT)
         {
-            gnc_resume_gui_refresh ();
-            LEAVE("save cancelled");
+            gnc_resume_gui_refresh();
+            LEAVE ("save cancelled");
             return NULL;
         }
 
@@ -487,8 +488,8 @@ gnc_split_register_duplicate_current (SplitRegister *reg)
 
     if (cursor_class == CURSOR_CLASS_SPLIT)
     {
-        Split *new_split;
-        char *out_num;
+        Split* new_split;
+        char* out_num;
         gboolean new_act_num = FALSE;
 
         /* We are on a split in an expanded transaction.
@@ -501,9 +502,9 @@ gnc_split_register_duplicate_current (SplitRegister *reg)
         if (!reg->use_tran_num_for_num_field
             && gnc_strisnum (gnc_get_num_action (NULL, split)))
         {
-            Account *account = xaccSplitGetAccount (split);
-            const char *in_num = NULL;
-            const char* title = _("New Split Information");
+            Account* account = xaccSplitGetAccount (split);
+            const char* in_num = NULL;
+            const char* title = _ ("New Split Information");
             time64 date = info->last_date_entered;
 
             if (account)
@@ -512,17 +513,17 @@ gnc_split_register_duplicate_current (SplitRegister *reg)
                 in_num = gnc_get_num_action (NULL, split);
 
             if (!gnc_dup_trans_dialog (gnc_split_register_get_parent (reg),
-                                   title, FALSE, &date, in_num, &out_num,
-                                   NULL, NULL, NULL, NULL))
+                                       title, FALSE, &date, in_num, &out_num,
+                                       NULL, NULL, NULL, NULL))
             {
-                gnc_resume_gui_refresh ();
-                LEAVE("dup cancelled");
+                gnc_resume_gui_refresh();
+                LEAVE ("dup cancelled");
                 return NULL;
             }
             new_act_num = TRUE;
         }
 
-        new_split = xaccMallocSplit (gnc_get_current_book ());
+        new_split = xaccMallocSplit (gnc_get_current_book());
 
         xaccTransBeginEdit (trans);
         xaccSplitSetParent (new_split, trans);
@@ -534,16 +535,16 @@ gnc_split_register_duplicate_current (SplitRegister *reg)
 
         if (new_act_num && gnc_strisnum (out_num))
         {
-            Account *account = xaccSplitGetAccount (new_split);
+            Account* account = xaccSplitGetAccount (new_split);
 
             /* If current register is for account, set last num */
-            if (xaccAccountEqual(account,
-                                    gnc_split_register_get_default_account(reg),
-                                    TRUE))
+            if (xaccAccountEqual (account,
+                                  gnc_split_register_get_default_account (reg),
+                                  TRUE))
             {
-                NumCell *num_cell;
-                num_cell = (NumCell *) gnc_table_layout_get_cell (reg->table->layout,
-                       NUM_CELL);
+                NumCell* num_cell;
+                num_cell = (NumCell*) gnc_table_layout_get_cell (reg->table->layout,
+                                                                 NUM_CELL);
                 if (gnc_num_cell_set_last_num (num_cell, out_num))
                     gnc_split_register_set_last_num (reg, out_num);
             }
@@ -562,86 +563,88 @@ gnc_split_register_duplicate_current (SplitRegister *reg)
     }
     else
     {
-        NumCell *num_cell;
-        Transaction *new_trans;
+        NumCell* num_cell;
+        Transaction* new_trans;
         int trans_split_index;
         int split_index;
-        const char *in_num = NULL;
-        const char *in_tnum = NULL;
-        char *out_num = NULL;
-        char *out_tnum = NULL;
-        char *out_tassoc = NULL;
+        const char* in_num = NULL;
+        const char* in_tnum = NULL;
+        char* out_num = NULL;
+        char* out_tnum = NULL;
+        char* out_tassoc = NULL;
         time64 date;
-        gboolean use_autoreadonly = qof_book_uses_autoreadonly(gnc_get_current_book());
+        gboolean use_autoreadonly = qof_book_uses_autoreadonly (
+                                        gnc_get_current_book());
 
         /* We are on a transaction row. Copy the whole transaction. */
 
         date = info->last_date_entered;
         if (gnc_strisnum (gnc_get_num_action (trans, trans_split)))
         {
-            Account *account = gnc_split_register_get_default_account (reg);
+            Account* account = gnc_split_register_get_default_account (reg);
 
             if (account)
                 in_num = xaccAccountGetLastNum (account);
             else
                 in_num = gnc_get_num_action (trans, trans_split);
             in_tnum = (reg->use_tran_num_for_num_field
-                                        ? NULL
-                                        : gnc_get_num_action (trans, NULL));
+                       ? NULL
+                       : gnc_get_num_action (trans, NULL));
         }
 
         if (!gnc_dup_trans_dialog (gnc_split_register_get_parent (reg), NULL,
                                    TRUE, &date, in_num, &out_num, in_tnum, &out_tnum,
                                    xaccTransGetAssociation (trans), &out_tassoc))
         {
-            gnc_resume_gui_refresh ();
-            LEAVE("dup cancelled");
+            gnc_resume_gui_refresh();
+            LEAVE ("dup cancelled");
             return NULL;
         }
 
         if (use_autoreadonly)
         {
             GDate d;
-            GDate *readonly_threshold = qof_book_get_autoreadonly_gdate(gnc_get_current_book());
+            GDate* readonly_threshold = qof_book_get_autoreadonly_gdate (
+                                            gnc_get_current_book());
             gnc_gdate_set_time64 (&d, date);
-            if (g_date_compare(&d, readonly_threshold) < 0)
+            if (g_date_compare (&d, readonly_threshold) < 0)
             {
-                GtkWidget *dialog = gtk_message_dialog_new(NULL,
-                                    0,
-                                    GTK_MESSAGE_ERROR,
-                                    GTK_BUTTONS_OK,
-                                    "%s", _("Cannot store a transaction at this date"));
-                gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog),
-                        "%s", _("The entered date of the duplicated transaction is older than the \"Read-Only Threshold\" set for this book. "
-                                "This setting can be changed in File->Properties->Accounts."));
-                gtk_dialog_run(GTK_DIALOG(dialog));
-                gtk_widget_destroy(dialog);
+                GtkWidget* dialog = gtk_message_dialog_new (NULL,
+                                                            0,
+                                                            GTK_MESSAGE_ERROR,
+                                                            GTK_BUTTONS_OK,
+                                                            "%s", _ ("Cannot store a transaction at this date"));
+                gtk_message_dialog_format_secondary_text (GTK_MESSAGE_DIALOG (dialog),
+                                                          "%s", _ ("The entered date of the duplicated transaction is older than the \"Read-Only Threshold\" set for this book. "
+                                                                   "This setting can be changed in File->Properties->Accounts."));
+                gtk_dialog_run (GTK_DIALOG (dialog));
+                gtk_widget_destroy (dialog);
 
-                g_date_free(readonly_threshold);
+                g_date_free (readonly_threshold);
                 return NULL;
             }
-            g_date_free(readonly_threshold);
+            g_date_free (readonly_threshold);
         }
 
-        split_index = xaccTransGetSplitIndex(trans, split);
-        trans_split_index = xaccTransGetSplitIndex(trans, trans_split);
+        split_index = xaccTransGetSplitIndex (trans, split);
+        trans_split_index = xaccTransGetSplitIndex (trans, trans_split);
 
         /* we should *always* find the split, but be paranoid */
         if (split_index < 0)
         {
-            gnc_resume_gui_refresh ();
-            LEAVE("no split");
+            gnc_resume_gui_refresh();
+            LEAVE ("no split");
             return NULL;
         }
 
-        new_trans = xaccMallocTransaction (gnc_get_current_book ());
+        new_trans = xaccMallocTransaction (gnc_get_current_book());
 
         xaccTransBeginEdit (new_trans);
         gnc_copy_trans_onto_trans (trans, new_trans, FALSE, FALSE);
         xaccTransSetDatePostedSecsNormalized (new_trans, date);
         /* We also must set a new DateEntered on the new entry
          * because otherwise the ordering is not deterministic */
-        xaccTransSetDateEnteredSecs(new_trans, gnc_time(NULL));
+        xaccTransSetDateEnteredSecs (new_trans, gnc_time (NULL));
 
         /* clear the associated entry if returned value NULL */
         if (out_tassoc == NULL)
@@ -664,8 +667,8 @@ gnc_split_register_duplicate_current (SplitRegister *reg)
         }
         xaccTransCommitEdit (new_trans);
 
-        num_cell = (NumCell *) gnc_table_layout_get_cell (reg->table->layout,
-                   NUM_CELL);
+        num_cell = (NumCell*) gnc_table_layout_get_cell (reg->table->layout,
+                                                         NUM_CELL);
         if (gnc_num_cell_set_last_num (num_cell, out_num))
             gnc_split_register_set_last_num (reg, out_num);
 
@@ -689,37 +692,37 @@ gnc_split_register_duplicate_current (SplitRegister *reg)
     }
 
     /* Refresh the GUI. */
-    gnc_resume_gui_refresh ();
+    gnc_resume_gui_refresh();
 
-    LEAVE(" ");
+    LEAVE (" ");
     return return_split;
 }
 
 static void
-gnc_split_register_copy_current_internal (SplitRegister *reg,
-        gboolean use_cut_semantics)
+gnc_split_register_copy_current_internal (SplitRegister* reg,
+                                          gboolean use_cut_semantics)
 {
-    SRInfo *info = gnc_split_register_get_info(reg);
+    SRInfo* info = gnc_split_register_get_info (reg);
     CursorClass cursor_class;
-    Transaction *trans;
-    Split *blank_split;
+    Transaction* trans;
+    Split* blank_split;
     gboolean changed;
-    Split *split;
+    Split* split;
     SCM new_item;
 
-    g_return_if_fail(reg);
-    ENTER("reg=%p, use_cut_semantics=%s", reg,
-          use_cut_semantics ? "TRUE" : "FALSE");
+    g_return_if_fail (reg);
+    ENTER ("reg=%p, use_cut_semantics=%s", reg,
+           use_cut_semantics ? "TRUE" : "FALSE");
 
-    blank_split = xaccSplitLookup(&info->blank_split_guid,
-                                  gnc_get_current_book ());
+    blank_split = xaccSplitLookup (&info->blank_split_guid,
+                                   gnc_get_current_book());
     split = gnc_split_register_get_current_split (reg);
     trans = gnc_split_register_get_current_trans (reg);
 
     /* This shouldn't happen, but be paranoid. */
     if (trans == NULL)
     {
-        LEAVE("no trans");
+        LEAVE ("no trans");
         return;
     }
 
@@ -728,15 +731,15 @@ gnc_split_register_copy_current_internal (SplitRegister *reg,
     /* Can't do anything with this. */
     if (cursor_class == CURSOR_CLASS_NONE)
     {
-        LEAVE("no cursor class");
+        LEAVE ("no cursor class");
         return;
     }
 
     /* This shouldn't happen, but be paranoid. */
     if ((split == NULL) && (cursor_class == CURSOR_CLASS_TRANS))
     {
-        g_warning("BUG DETECTED: transaction cursor with no anchoring split!");
-        LEAVE("transaction cursor with no anchoring split");
+        g_warning ("BUG DETECTED: transaction cursor with no anchoring split!");
+        LEAVE ("transaction cursor with no anchoring split");
         return;
     }
 
@@ -752,7 +755,7 @@ gnc_split_register_copy_current_internal (SplitRegister *reg,
          *        back to the description, then ask for a copy, and this code will
          *        be reached. It forgets that you changed the row the first time
          *        you were there.  -Charles */
-        LEAVE("nothing to copy/cut");
+        LEAVE ("nothing to copy/cut");
         return;
     }
 
@@ -761,7 +764,7 @@ gnc_split_register_copy_current_internal (SplitRegister *reg,
     if (cursor_class == CURSOR_CLASS_SPLIT)
     {
         /* We are on a split in an expanded transaction. Just copy the split. */
-        new_item = gnc_copy_split(split, use_cut_semantics);
+        new_item = gnc_copy_split (split, use_cut_semantics);
 
         if (new_item != SCM_UNDEFINED)
         {
@@ -775,7 +778,7 @@ gnc_split_register_copy_current_internal (SplitRegister *reg,
     else
     {
         /* We are on a transaction row. Copy the whole transaction. */
-        new_item = gnc_copy_trans(trans, use_cut_semantics);
+        new_item = gnc_copy_trans (trans, use_cut_semantics);
 
         if (new_item != SCM_UNDEFINED)
         {
@@ -784,9 +787,9 @@ gnc_split_register_copy_current_internal (SplitRegister *reg,
                 int split_index;
                 SCM split_scm;
 
-                split_index = xaccTransGetSplitIndex(trans, split);
+                split_index = xaccTransGetSplitIndex (trans, split);
                 if (split_index >= 0)
-                    split_scm = gnc_trans_scm_get_split_scm(new_item, split_index);
+                    split_scm = gnc_trans_scm_get_split_scm (new_item, split_index);
                 else
                     split_scm = SCM_UNDEFINED;
 
@@ -800,41 +803,41 @@ gnc_split_register_copy_current_internal (SplitRegister *reg,
 
     if (new_item == SCM_UNDEFINED)
     {
-        g_warning("BUG DETECTED: copy failed");
-        LEAVE("copy failed");
+        g_warning ("BUG DETECTED: copy failed");
+        LEAVE ("copy failed");
         return;
     }
 
     /* unprotect the old object, if any */
     if (copied_item != SCM_UNDEFINED)
-        scm_gc_unprotect_object(copied_item);
+        scm_gc_unprotect_object (copied_item);
 
     copied_item = new_item;
-    scm_gc_protect_object(copied_item);
+    scm_gc_protect_object (copied_item);
 
     copied_class = cursor_class;
-    LEAVE("%s %s", use_cut_semantics ? "cut" : "copied",
-          cursor_class == CURSOR_CLASS_SPLIT ? "split" : "transaction");
+    LEAVE ("%s %s", use_cut_semantics ? "cut" : "copied",
+           cursor_class == CURSOR_CLASS_SPLIT ? "split" : "transaction");
 }
 
 void
-gnc_split_register_copy_current (SplitRegister *reg)
+gnc_split_register_copy_current (SplitRegister* reg)
 {
     gnc_split_register_copy_current_internal (reg, FALSE);
 }
 
 void
-gnc_split_register_cut_current (SplitRegister *reg)
+gnc_split_register_cut_current (SplitRegister* reg)
 {
-    SRInfo *info = gnc_split_register_get_info (reg);
+    SRInfo* info = gnc_split_register_get_info (reg);
     CursorClass cursor_class;
-    Transaction *trans;
-    Split *blank_split;
+    Transaction* trans;
+    Split* blank_split;
     gboolean changed;
-    Split *split;
+    Split* split;
 
     blank_split = xaccSplitLookup (&info->blank_split_guid,
-                                   gnc_get_current_book ());
+                                   gnc_get_current_book());
     split = gnc_split_register_get_current_split (reg);
     trans = gnc_split_register_get_current_trans (reg);
 
@@ -867,26 +870,26 @@ gnc_split_register_cut_current (SplitRegister *reg)
 }
 
 void
-gnc_split_register_paste_current (SplitRegister *reg)
+gnc_split_register_paste_current (SplitRegister* reg)
 {
-    SRInfo *info = gnc_split_register_get_info(reg);
+    SRInfo* info = gnc_split_register_get_info (reg);
     CursorClass cursor_class;
-    Transaction *trans;
-    Transaction *blank_trans;
-    Split *blank_split;
-    Split *trans_split;
-    Split *split;
+    Transaction* trans;
+    Transaction* blank_trans;
+    Split* blank_split;
+    Split* trans_split;
+    Split* split;
 
-    ENTER("reg=%p", reg);
+    ENTER ("reg=%p", reg);
 
     if (copied_class == CURSOR_CLASS_NONE)
     {
-        LEAVE("no copied cursor class");
+        LEAVE ("no copied cursor class");
         return;
     }
 
     blank_split = xaccSplitLookup (&info->blank_split_guid,
-                                   gnc_get_current_book ());
+                                   gnc_get_current_book());
     blank_trans = xaccSplitGetParent (blank_split);
     split = gnc_split_register_get_current_split (reg);
     trans = gnc_split_register_get_current_trans (reg);
@@ -896,7 +899,7 @@ gnc_split_register_paste_current (SplitRegister *reg)
     /* This shouldn't happen, but be paranoid. */
     if (trans == NULL)
     {
-        LEAVE("no transaction");
+        LEAVE ("no transaction");
         return;
     }
 
@@ -905,32 +908,32 @@ gnc_split_register_paste_current (SplitRegister *reg)
     /* Can't do anything with this. */
     if (cursor_class == CURSOR_CLASS_NONE)
     {
-        LEAVE("no current cursor class");
+        LEAVE ("no current cursor class");
         return;
     }
 
     /* This shouldn't happen, but be paranoid. */
     if ((split == NULL) && (cursor_class == CURSOR_CLASS_TRANS))
     {
-        g_warning("BUG DETECTED: transaction cursor with no anchoring split!");
-        LEAVE("transaction cursor with no anchoring split");
+        g_warning ("BUG DETECTED: transaction cursor with no anchoring split!");
+        LEAVE ("transaction cursor with no anchoring split");
         return;
     }
 
     if (cursor_class == CURSOR_CLASS_SPLIT)
     {
-        const char *message = _("You are about to overwrite an existing split. "
-                                "Are you sure you want to do that?");
-        const char *anchor_message = _("This is the split anchoring this transaction "
-                                       "to the register. You may not overwrite it from "
-                                       "this register window. You may overwrite it if "
-                                       "you navigate to a register that shows another "
-                                       "side of this same transaction.");
+        const char* message = _ ("You are about to overwrite an existing split. "
+                                 "Are you sure you want to do that?");
+        const char* anchor_message = _ ("This is the split anchoring this transaction "
+                                        "to the register. You may not overwrite it from "
+                                        "this register window. You may overwrite it if "
+                                        "you navigate to a register that shows another "
+                                        "side of this same transaction.");
 
         if (copied_class == CURSOR_CLASS_TRANS)
         {
             /* An entire transaction was copied, but we're just on a split. */
-            LEAVE("can't copy trans to split");
+            LEAVE ("can't copy trans to split");
             return;
         }
 
@@ -942,13 +945,13 @@ gnc_split_register_paste_current (SplitRegister *reg)
             {
                 gnc_warning_dialog (GTK_WINDOW (gnc_split_register_get_parent (reg)),
                                     "%s", anchor_message);
-                LEAVE("anchore split");
+                LEAVE ("anchore split");
                 return;
             }
             else if (!gnc_verify_dialog (GTK_WINDOW (gnc_split_register_get_parent (reg)),
                                          FALSE, "%s", message))
             {
-                LEAVE("user cancelled");
+                LEAVE ("user cancelled");
                 return;
             }
         }
@@ -956,89 +959,89 @@ gnc_split_register_paste_current (SplitRegister *reg)
         /* Open the transaction for editing. */
         if (gnc_split_register_begin_edit_or_warn (info, trans))
         {
-            LEAVE("can't begin editing");
+            LEAVE ("can't begin editing");
             return;
         }
 
-        gnc_suspend_gui_refresh ();
+        gnc_suspend_gui_refresh();
 
         if (split == NULL)
         {
             /* We are on a null split in an expanded transaction. */
-            split = xaccMallocSplit(gnc_get_current_book ());
-            xaccSplitSetParent(split, trans);
+            split = xaccMallocSplit (gnc_get_current_book());
+            xaccSplitSetParent (split, trans);
         }
 
-        gnc_copy_split_scm_onto_split(copied_item, split,
-                                      gnc_get_current_book ());
+        gnc_copy_split_scm_onto_split (copied_item, split,
+                                       gnc_get_current_book());
     }
     else
     {
-        const char *message = _("You are about to overwrite an existing "
-                                "transaction. "
-                                "Are you sure you want to do that?");
-        Account * copied_leader;
-        const GncGUID *new_guid;
+        const char* message = _ ("You are about to overwrite an existing "
+                                 "transaction. "
+                                 "Are you sure you want to do that?");
+        Account* copied_leader;
+        const GncGUID* new_guid;
         int trans_split_index;
         int split_index;
         int num_splits;
 
         if (copied_class == CURSOR_CLASS_SPLIT)
         {
-            LEAVE("can't copy split to transaction");
+            LEAVE ("can't copy split to transaction");
             return;
         }
 
         /* Ask before overwriting an existing transaction. */
         if (split != blank_split &&
-                !gnc_verify_dialog (GTK_WINDOW (gnc_split_register_get_parent (reg)),
-                                   FALSE, "%s", message))
+            !gnc_verify_dialog (GTK_WINDOW (gnc_split_register_get_parent (reg)),
+                                FALSE, "%s", message))
         {
-            LEAVE("user cancelled");
+            LEAVE ("user cancelled");
             return;
         }
 
         /* Open the transaction for editing. */
-        if (gnc_split_register_begin_edit_or_warn(info, trans))
+        if (gnc_split_register_begin_edit_or_warn (info, trans))
         {
-            LEAVE("can't begin editing");
+            LEAVE ("can't begin editing");
             return;
         }
 
-        gnc_suspend_gui_refresh ();
+        gnc_suspend_gui_refresh();
 
-        DEBUG("Pasting txn, trans=%p, split=%p, blank_trans=%p, blank_split=%p",
-              trans, split, blank_trans, blank_split);
+        DEBUG ("Pasting txn, trans=%p, split=%p, blank_trans=%p, blank_split=%p",
+               trans, split, blank_trans, blank_split);
 
-        split_index = xaccTransGetSplitIndex(trans, split);
-        trans_split_index = xaccTransGetSplitIndex(trans, trans_split);
+        split_index = xaccTransGetSplitIndex (trans, split);
+        trans_split_index = xaccTransGetSplitIndex (trans, trans_split);
 
-        copied_leader = xaccAccountLookup(&copied_leader_guid,
-                                          gnc_get_current_book());
-        if (copied_leader && (gnc_split_register_get_default_account(reg) != NULL))
+        copied_leader = xaccAccountLookup (&copied_leader_guid,
+                                           gnc_get_current_book());
+        if (copied_leader && (gnc_split_register_get_default_account (reg) != NULL))
         {
             new_guid = &info->default_account;
-            gnc_copy_trans_scm_onto_trans_swap_accounts(copied_item, trans,
-                    &copied_leader_guid,
-                    new_guid, FALSE,
-                    gnc_get_current_book ());
+            gnc_copy_trans_scm_onto_trans_swap_accounts (copied_item, trans,
+                                                         &copied_leader_guid,
+                                                         new_guid, FALSE,
+                                                         gnc_get_current_book());
         }
         else
-            gnc_copy_trans_scm_onto_trans(copied_item, trans, FALSE,
-                                          gnc_get_current_book ());
+            gnc_copy_trans_scm_onto_trans (copied_item, trans, FALSE,
+                                           gnc_get_current_book());
 
-        num_splits = xaccTransCountSplits(trans);
+        num_splits = xaccTransCountSplits (trans);
         if (split_index >= num_splits)
             split_index = 0;
 
         if (trans == blank_trans)
         {
             /* In pasting, the blank split is deleted. Pick a new one. */
-            blank_split = xaccTransGetSplit(trans, 0);
+            blank_split = xaccTransGetSplit (trans, 0);
             info->blank_split_guid = *xaccSplitGetGUID (blank_split);
             info->blank_split_edited = TRUE;
             info->auto_complete = FALSE;
-            DEBUG("replacement blank_split=%p", blank_split);
+            DEBUG ("replacement blank_split=%p", blank_split);
 
             /* NOTE: At this point, the blank transaction virtual cell is still
              *       anchored by the old, deleted blank split. The register will
@@ -1046,22 +1049,23 @@ gnc_split_register_paste_current (SplitRegister *reg)
         }
 
         info->cursor_hint_trans = trans;
-        info->cursor_hint_split = xaccTransGetSplit(trans, split_index);
-        info->cursor_hint_trans_split = xaccTransGetSplit(trans,
-                                        trans_split_index);
+        info->cursor_hint_split = xaccTransGetSplit (trans, split_index);
+        info->cursor_hint_trans_split = xaccTransGetSplit (trans,
+                                                           trans_split_index);
         info->cursor_hint_cursor_class = CURSOR_CLASS_TRANS;
     }
 
     /* Refresh the GUI. */
-    gnc_resume_gui_refresh ();
-    LEAVE(" ");
+    gnc_resume_gui_refresh();
+    LEAVE (" ");
 }
 
 gboolean
-gnc_split_register_is_blank_split (SplitRegister *reg, Split *split)
+gnc_split_register_is_blank_split (SplitRegister* reg, Split* split)
 {
-    SRInfo *info = gnc_split_register_get_info (reg);
-    Split *current_blank_split = xaccSplitLookup (&info->blank_split_guid, gnc_get_current_book ());
+    SRInfo* info = gnc_split_register_get_info (reg);
+    Split* current_blank_split = xaccSplitLookup (&info->blank_split_guid,
+                                                  gnc_get_current_book());
 
     if (split == current_blank_split)
         return TRUE;
@@ -1070,15 +1074,16 @@ gnc_split_register_is_blank_split (SplitRegister *reg, Split *split)
 }
 
 void
-gnc_split_register_change_blank_split_ref (SplitRegister *reg, Split *split)
+gnc_split_register_change_blank_split_ref (SplitRegister* reg, Split* split)
 {
-    SRInfo *info = gnc_split_register_get_info (reg);
-    Split *current_blank_split = xaccSplitLookup (&info->blank_split_guid, gnc_get_current_book ());
-    Split *pref_split = NULL; // has the same account as incoming split
-    Split *other_split = NULL; // other split
-    Split *s;
-    Account *blank_split_account = xaccSplitGetAccount (current_blank_split);
-    Transaction *trans = xaccSplitGetParent (split);
+    SRInfo* info = gnc_split_register_get_info (reg);
+    Split* current_blank_split = xaccSplitLookup (&info->blank_split_guid,
+                                                  gnc_get_current_book());
+    Split* pref_split = NULL; // has the same account as incoming split
+    Split* other_split = NULL; // other split
+    Split* s;
+    Account* blank_split_account = xaccSplitGetAccount (current_blank_split);
+    Transaction* trans = xaccSplitGetParent (split);
     int i = 0;
 
     // loop through splitlist looking for splits other than the blank_split
@@ -1101,21 +1106,21 @@ gnc_split_register_change_blank_split_ref (SplitRegister *reg, Split *split)
 }
 
 void
-gnc_split_register_delete_current_split (SplitRegister *reg)
+gnc_split_register_delete_current_split (SplitRegister* reg)
 {
-    SRInfo *info = gnc_split_register_get_info (reg);
-    Transaction *pending_trans;
-    Transaction *trans;
-    Split *blank_split;
-    Split *split;
+    SRInfo* info = gnc_split_register_get_info (reg);
+    Transaction* pending_trans;
+    Transaction* trans;
+    Split* blank_split;
+    Split* split;
 
     if (!reg) return;
 
     blank_split = xaccSplitLookup (&info->blank_split_guid,
-                                   gnc_get_current_book ());
+                                   gnc_get_current_book());
 
     pending_trans = xaccTransLookup (&info->pending_trans_guid,
-                                     gnc_get_current_book ());
+                                     gnc_get_current_book());
 
     /* get the current split based on cursor position */
     split = gnc_split_register_get_current_split (reg);
@@ -1131,69 +1136,69 @@ gnc_split_register_delete_current_split (SplitRegister *reg)
         return;
     }
 
-    gnc_suspend_gui_refresh ();
+    gnc_suspend_gui_refresh();
 
-    trans = xaccSplitGetParent(split);
+    trans = xaccSplitGetParent (split);
 
     /* Check pending transaction */
     if (trans == pending_trans)
     {
-        g_assert(xaccTransIsOpen(trans));
+        g_assert (xaccTransIsOpen (trans));
     }
     else
     {
-        g_assert(!pending_trans);
-        if (gnc_split_register_begin_edit_or_warn(info, trans))
+        g_assert (!pending_trans);
+        if (gnc_split_register_begin_edit_or_warn (info, trans))
         {
-            gnc_resume_gui_refresh ();
+            gnc_resume_gui_refresh();
             return;
         }
     }
     xaccSplitDestroy (split);
 
-    gnc_resume_gui_refresh ();
-    gnc_split_register_redraw(reg);
+    gnc_resume_gui_refresh();
+    gnc_split_register_redraw (reg);
 }
 
 void
-gnc_split_register_delete_current_trans (SplitRegister *reg)
+gnc_split_register_delete_current_trans (SplitRegister* reg)
 {
-    SRInfo *info = gnc_split_register_get_info (reg);
-    Transaction *pending_trans;
-    Transaction *trans;
-    Split *blank_split;
-    Split *split;
+    SRInfo* info = gnc_split_register_get_info (reg);
+    Transaction* pending_trans;
+    Transaction* trans;
+    Split* blank_split;
+    Split* split;
     gboolean was_open;
 
-    ENTER("reg=%p", reg);
+    ENTER ("reg=%p", reg);
     if (!reg)
     {
-        LEAVE("no register");
+        LEAVE ("no register");
         return;
     }
 
     blank_split = xaccSplitLookup (&info->blank_split_guid,
-                                   gnc_get_current_book ());
+                                   gnc_get_current_book());
     pending_trans = xaccTransLookup (&info->pending_trans_guid,
-                                     gnc_get_current_book ());
+                                     gnc_get_current_book());
 
     /* get the current split based on cursor position */
     split = gnc_split_register_get_current_split (reg);
     if (split == NULL)
     {
-        LEAVE("no split");
+        LEAVE ("no split");
         return;
     }
 
-    gnc_suspend_gui_refresh ();
-    trans = xaccSplitGetParent(split);
+    gnc_suspend_gui_refresh();
+    trans = xaccSplitGetParent (split);
 
     /* If we just deleted the blank split, clean up. The user is
      * allowed to delete the blank split as a method for discarding
      * any edits they may have made to it. */
     if (split == blank_split)
     {
-        DEBUG("deleting blank split");
+        DEBUG ("deleting blank split");
         info->blank_split_guid = *guid_null();
         info->auto_complete = FALSE;
     }
@@ -1205,37 +1210,37 @@ gnc_split_register_delete_current_trans (SplitRegister *reg)
     /* Check pending transaction */
     if (trans == pending_trans)
     {
-        DEBUG("clearing pending trans");
+        DEBUG ("clearing pending trans");
         info->pending_trans_guid = *guid_null();
         pending_trans = NULL;
     }
 
-    was_open = xaccTransIsOpen(trans);
-    xaccTransDestroy(trans);
+    was_open = xaccTransIsOpen (trans);
+    xaccTransDestroy (trans);
     if (was_open)
     {
-        DEBUG("committing");
-        xaccTransCommitEdit(trans);
+        DEBUG ("committing");
+        xaccTransCommitEdit (trans);
     }
-    gnc_resume_gui_refresh ();
-    LEAVE(" ");
+    gnc_resume_gui_refresh();
+    LEAVE (" ");
 }
 
 void
-gnc_split_register_void_current_trans (SplitRegister *reg, const char *reason)
+gnc_split_register_void_current_trans (SplitRegister* reg, const char* reason)
 {
-    SRInfo *info = gnc_split_register_get_info (reg);
-    Transaction *pending_trans;
-    Transaction *trans;
-    Split *blank_split;
-    Split *split;
+    SRInfo* info = gnc_split_register_get_info (reg);
+    Transaction* pending_trans;
+    Transaction* trans;
+    Split* blank_split;
+    Split* split;
 
     if (!reg) return;
 
     blank_split = xaccSplitLookup (&info->blank_split_guid,
-                                   gnc_get_current_book ());
+                                   gnc_get_current_book());
     pending_trans = xaccTransLookup (&info->pending_trans_guid,
-                                     gnc_get_current_book ());
+                                     gnc_get_current_book());
 
     /* get the current split based on cursor position */
     split = gnc_split_register_get_current_split (reg);
@@ -1252,10 +1257,10 @@ gnc_split_register_void_current_trans (SplitRegister *reg, const char *reason)
 
     info->trans_expanded = FALSE;
 
-    gnc_suspend_gui_refresh ();
+    gnc_suspend_gui_refresh();
 
-    trans = xaccSplitGetParent(split);
-    xaccTransVoid(trans, reason);
+    trans = xaccSplitGetParent (split);
+    xaccTransVoid (trans, reason);
 
     /* Check pending transaction */
     if (trans == pending_trans)
@@ -1263,29 +1268,29 @@ gnc_split_register_void_current_trans (SplitRegister *reg, const char *reason)
         info->pending_trans_guid = *guid_null();
         pending_trans = NULL;
     }
-    if (xaccTransIsOpen(trans))
+    if (xaccTransIsOpen (trans))
     {
-        PERR("We should not be voiding an open transaction.");
-        xaccTransCommitEdit(trans);
+        PERR ("We should not be voiding an open transaction.");
+        xaccTransCommitEdit (trans);
     }
-    gnc_resume_gui_refresh ();
+    gnc_resume_gui_refresh();
 }
 
 void
-gnc_split_register_unvoid_current_trans (SplitRegister *reg)
+gnc_split_register_unvoid_current_trans (SplitRegister* reg)
 {
-    SRInfo *info = gnc_split_register_get_info (reg);
-    Transaction *pending_trans;
-    Transaction *trans;
-    Split *blank_split;
-    Split *split;
+    SRInfo* info = gnc_split_register_get_info (reg);
+    Transaction* pending_trans;
+    Transaction* trans;
+    Split* blank_split;
+    Split* split;
 
     if (!reg) return;
 
     blank_split = xaccSplitLookup (&info->blank_split_guid,
-                                   gnc_get_current_book ());
+                                   gnc_get_current_book());
     pending_trans = xaccTransLookup (&info->pending_trans_guid,
-                                     gnc_get_current_book ());
+                                     gnc_get_current_book());
 
     /* get the current split based on cursor position */
     split = gnc_split_register_get_current_split (reg);
@@ -1302,11 +1307,11 @@ gnc_split_register_unvoid_current_trans (SplitRegister *reg)
 
     info->trans_expanded = FALSE;
 
-    gnc_suspend_gui_refresh ();
+    gnc_suspend_gui_refresh();
 
-    trans = xaccSplitGetParent(split);
+    trans = xaccSplitGetParent (split);
 
-    xaccTransUnvoid(trans);
+    xaccTransUnvoid (trans);
 
     /* Check pending transaction */
     if (trans == pending_trans)
@@ -1315,56 +1320,56 @@ gnc_split_register_unvoid_current_trans (SplitRegister *reg)
         pending_trans = NULL;
     }
 
-    gnc_resume_gui_refresh ();
+    gnc_resume_gui_refresh();
 }
 
 void
-gnc_split_register_empty_current_trans_except_split (SplitRegister *reg,
-        Split *split)
+gnc_split_register_empty_current_trans_except_split (SplitRegister* reg,
+                                                     Split* split)
 {
-    SRInfo *info;
-    Transaction *trans;
-    Transaction *pending;
+    SRInfo* info;
+    Transaction* trans;
+    Transaction* pending;
     int i = 0;
-    Split *s;
+    Split* s;
 
     if ((reg == NULL)  || (split == NULL))
         return;
 
-    gnc_suspend_gui_refresh ();
-    info = gnc_split_register_get_info(reg);
-    pending = xaccTransLookup(&info->pending_trans_guid, gnc_get_current_book());
+    gnc_suspend_gui_refresh();
+    info = gnc_split_register_get_info (reg);
+    pending = xaccTransLookup (&info->pending_trans_guid, gnc_get_current_book());
 
-    trans = xaccSplitGetParent(split);
+    trans = xaccSplitGetParent (split);
     if (!pending)
     {
-        if (gnc_split_register_begin_edit_or_warn(info, trans))
+        if (gnc_split_register_begin_edit_or_warn (info, trans))
         {
-            gnc_resume_gui_refresh ();
+            gnc_resume_gui_refresh();
             return;
         }
     }
     else if (pending == trans)
     {
-        g_assert(xaccTransIsOpen(trans));
+        g_assert (xaccTransIsOpen (trans));
     }
     else g_assert_not_reached();
 
-    while ((s = xaccTransGetSplit(trans, i)) != NULL)
+    while ((s = xaccTransGetSplit (trans, i)) != NULL)
     {
         if (s != split)
-            xaccSplitDestroy(s);
+            xaccSplitDestroy (s);
         else i++;
     }
 
-    gnc_resume_gui_refresh ();
-    gnc_split_register_redraw(reg);
+    gnc_resume_gui_refresh();
+    gnc_split_register_redraw (reg);
 }
 
 void
-gnc_split_register_empty_current_trans (SplitRegister *reg)
+gnc_split_register_empty_current_trans (SplitRegister* reg)
 {
-    Split *split;
+    Split* split;
 
     /* get the current split based on cursor position */
     split = gnc_split_register_get_current_split (reg);
@@ -1372,7 +1377,7 @@ gnc_split_register_empty_current_trans (SplitRegister *reg)
 }
 
 void
-gnc_split_register_cancel_cursor_split_changes (SplitRegister *reg)
+gnc_split_register_cancel_cursor_split_changes (SplitRegister* reg)
 {
     VirtualLocation virt_loc;
 
@@ -1395,14 +1400,14 @@ gnc_split_register_cancel_cursor_split_changes (SplitRegister *reg)
 }
 
 void
-gnc_split_register_cancel_cursor_trans_changes (SplitRegister *reg)
+gnc_split_register_cancel_cursor_trans_changes (SplitRegister* reg)
 {
-    SRInfo *info = gnc_split_register_get_info (reg);
-    Transaction *pending_trans, *blank_trans;
+    SRInfo* info = gnc_split_register_get_info (reg);
+    Transaction* pending_trans, *blank_trans;
     gboolean refresh_all = FALSE;
 
     pending_trans = xaccTransLookup (&info->pending_trans_guid,
-                                     gnc_get_current_book ());
+                                     gnc_get_current_book());
 
     blank_trans = xaccSplitGetParent (gnc_split_register_get_blank_split (reg));
 
@@ -1421,22 +1426,22 @@ gnc_split_register_cancel_cursor_trans_changes (SplitRegister *reg)
     if (!pending_trans)
         return;
 
-    gnc_suspend_gui_refresh ();
+    gnc_suspend_gui_refresh();
 
     xaccTransRollbackEdit (pending_trans);
 
-    info->pending_trans_guid = *guid_null ();
+    info->pending_trans_guid = *guid_null();
 
-    gnc_resume_gui_refresh ();
+    gnc_resume_gui_refresh();
 
     if (refresh_all)
-        gnc_gui_refresh_all (); // force a refresh of all registers
+        gnc_gui_refresh_all();  // force a refresh of all registers
     else
         gnc_split_register_redraw (reg);
 }
 
 void
-gnc_split_register_redraw (SplitRegister *reg)
+gnc_split_register_redraw (SplitRegister* reg)
 {
     gnc_ledger_display_refresh_by_split_register (reg);
 }
@@ -1444,12 +1449,12 @@ gnc_split_register_redraw (SplitRegister *reg)
 /* Copy from the register object to scheme. This needs to be
  * in sync with gnc_split_register_save and xaccSRSaveChangedCells. */
 static gboolean
-gnc_split_register_save_to_scm (SplitRegister *reg,
+gnc_split_register_save_to_scm (SplitRegister* reg,
                                 SCM trans_scm, SCM split_scm,
                                 gboolean use_cut_semantics)
 {
     SCM other_split_scm = SCM_UNDEFINED;
-    Transaction *trans;
+    Transaction* trans;
 
     /* use the changed flag to avoid heavy-weight updates
      * of the split & transaction fields. This will help
@@ -1465,38 +1470,38 @@ gnc_split_register_save_to_scm (SplitRegister *reg,
     /* copy the contents from the cursor to the split */
     if (gnc_table_layout_get_cell_changed (reg->table->layout, DATE_CELL, TRUE))
     {
-        BasicCell *cell;
+        BasicCell* cell;
         time64 time;
         cell = gnc_table_layout_get_cell (reg->table->layout, DATE_CELL);
-        gnc_date_cell_get_date ((DateCell *) cell, &time, TRUE);
-        xaccTransSetDatePostedSecsNormalized(trans, time);
+        gnc_date_cell_get_date ((DateCell*) cell, &time, TRUE);
+        xaccTransSetDatePostedSecsNormalized (trans, time);
     }
 
     if (gnc_table_layout_get_cell_changed (reg->table->layout, NUM_CELL, TRUE))
     {
-        const char *value;
+        const char* value;
 
         value = gnc_table_layout_get_cell_value (reg->table->layout, NUM_CELL);
         if (reg->use_tran_num_for_num_field)
             xaccTransSetNum (trans, value);
-     /* else this contains the same as ACTN_CELL which is already handled below *
-      * and the TNUM_CELL contains transaction number which is handled in next  *
-      * if statement. */
+        /* else this contains the same as ACTN_CELL which is already handled below *
+         * and the TNUM_CELL contains transaction number which is handled in next  *
+         * if statement. */
     }
 
     if (gnc_table_layout_get_cell_changed (reg->table->layout, TNUM_CELL, TRUE))
     {
-        const char *value;
+        const char* value;
 
         value = gnc_table_layout_get_cell_value (reg->table->layout, TNUM_CELL);
         if (!reg->use_tran_num_for_num_field)
             xaccTransSetNum (trans, value);
-     /* else this cell is not used */
+        /* else this cell is not used */
     }
 
     if (gnc_table_layout_get_cell_changed (reg->table->layout, DESC_CELL, TRUE))
     {
-        const char *value;
+        const char* value;
 
         value = gnc_table_layout_get_cell_value (reg->table->layout, DESC_CELL);
         xaccTransSetDescription (trans, value);
@@ -1504,7 +1509,7 @@ gnc_split_register_save_to_scm (SplitRegister *reg,
 
     if (gnc_table_layout_get_cell_changed (reg->table->layout, NOTES_CELL, TRUE))
     {
-        const char *value;
+        const char* value;
 
         value = gnc_table_layout_get_cell_value (reg->table->layout, NOTES_CELL);
         xaccTransSetNotes (trans, value);
@@ -1512,18 +1517,18 @@ gnc_split_register_save_to_scm (SplitRegister *reg,
 
     if (gnc_table_layout_get_cell_changed (reg->table->layout, RECN_CELL, TRUE))
     {
-        BasicCell *cell;
+        BasicCell* cell;
         char flag;
 
         cell = gnc_table_layout_get_cell (reg->table->layout, RECN_CELL);
-        flag = gnc_recn_cell_get_flag ((RecnCell *) cell);
+        flag = gnc_recn_cell_get_flag ((RecnCell*) cell);
 
-        gnc_split_scm_set_reconcile_state(split_scm, flag);
+        gnc_split_scm_set_reconcile_state (split_scm, flag);
     }
 
     if (gnc_table_layout_get_cell_changed (reg->table->layout, ACTN_CELL, TRUE))
     {
-        const char *value;
+        const char* value;
 
         value = gnc_table_layout_get_cell_value (reg->table->layout, ACTN_CELL);
         gnc_split_scm_set_action (split_scm, value);
@@ -1531,7 +1536,7 @@ gnc_split_register_save_to_scm (SplitRegister *reg,
 
     if (gnc_table_layout_get_cell_changed (reg->table->layout, MEMO_CELL, TRUE))
     {
-        const char *value;
+        const char* value;
 
         value = gnc_table_layout_get_cell_value (reg->table->layout, MEMO_CELL);
         gnc_split_scm_set_memo (split_scm, value);
@@ -1539,7 +1544,7 @@ gnc_split_register_save_to_scm (SplitRegister *reg,
 
     if (gnc_table_layout_get_cell_changed (reg->table->layout, XFRM_CELL, TRUE))
     {
-        Account *new_account;
+        Account* new_account;
 
         new_account = gnc_split_register_get_account (reg, XFRM_CELL);
 
@@ -1556,11 +1561,11 @@ gnc_split_register_save_to_scm (SplitRegister *reg,
 
         if (other_split_scm == SCM_UNDEFINED)
         {
-            if (gnc_trans_scm_get_num_splits(trans_scm) == 1)
+            if (gnc_trans_scm_get_num_splits (trans_scm) == 1)
             {
-                Split *temp_split;
+                Split* temp_split;
 
-                temp_split = xaccMallocSplit (gnc_get_current_book ());
+                temp_split = xaccMallocSplit (gnc_get_current_book());
                 other_split_scm = gnc_copy_split (temp_split, use_cut_semantics);
                 xaccSplitDestroy (temp_split);
 
@@ -1570,7 +1575,7 @@ gnc_split_register_save_to_scm (SplitRegister *reg,
 
         if (other_split_scm != SCM_UNDEFINED)
         {
-            Account *new_account;
+            Account* new_account;
 
             new_account = gnc_split_register_get_account (reg, MXFRM_CELL);
 
@@ -1581,19 +1586,19 @@ gnc_split_register_save_to_scm (SplitRegister *reg,
 
     if (gnc_table_layout_get_cell_changed (reg->table->layout,
                                            DEBT_CELL, TRUE) ||
-            gnc_table_layout_get_cell_changed (reg->table->layout,
-                    CRED_CELL, TRUE))
+        gnc_table_layout_get_cell_changed (reg->table->layout,
+                                           CRED_CELL, TRUE))
     {
-        BasicCell *cell;
+        BasicCell* cell;
         gnc_numeric new_value;
         gnc_numeric credit;
         gnc_numeric debit;
 
         cell = gnc_table_layout_get_cell (reg->table->layout, CRED_CELL);
-        credit = gnc_price_cell_get_value ((PriceCell *) cell);
+        credit = gnc_price_cell_get_value ((PriceCell*) cell);
 
         cell = gnc_table_layout_get_cell (reg->table->layout, DEBT_CELL);
-        debit = gnc_price_cell_get_value ((PriceCell *) cell);
+        debit = gnc_price_cell_get_value ((PriceCell*) cell);
 
         new_value = gnc_numeric_sub_fixed (debit, credit);
 
@@ -1607,24 +1612,24 @@ gnc_split_register_save_to_scm (SplitRegister *reg,
 
     if (gnc_table_layout_get_cell_changed (reg->table->layout, SHRS_CELL, TRUE))
     {
-        BasicCell *cell;
+        BasicCell* cell;
         gnc_numeric shares;
 
         cell = gnc_table_layout_get_cell (reg->table->layout, SHRS_CELL);
 
-        shares = gnc_price_cell_get_value ((PriceCell *) cell);
+        shares = gnc_price_cell_get_value ((PriceCell*) cell);
 
         gnc_split_scm_set_amount (split_scm, shares);
     }
 
     if (gnc_table_layout_get_cell_changed (reg->table->layout,
                                            DEBT_CELL, TRUE) ||
-            gnc_table_layout_get_cell_changed (reg->table->layout,
-                    CRED_CELL, TRUE) ||
-            gnc_table_layout_get_cell_changed (reg->table->layout,
-                    PRIC_CELL, TRUE) ||
-            gnc_table_layout_get_cell_changed (reg->table->layout,
-                    SHRS_CELL, TRUE))
+        gnc_table_layout_get_cell_changed (reg->table->layout,
+                                           CRED_CELL, TRUE) ||
+        gnc_table_layout_get_cell_changed (reg->table->layout,
+                                           PRIC_CELL, TRUE) ||
+        gnc_table_layout_get_cell_changed (reg->table->layout,
+                                           SHRS_CELL, TRUE))
     {
         if (other_split_scm != SCM_UNDEFINED)
         {
@@ -1642,31 +1647,31 @@ gnc_split_register_save_to_scm (SplitRegister *reg,
 }
 
 gboolean
-gnc_split_register_save (SplitRegister *reg, gboolean do_commit)
+gnc_split_register_save (SplitRegister* reg, gboolean do_commit)
 {
-    SRInfo *info = gnc_split_register_get_info (reg);
-    Transaction *pending_trans;
-    Transaction *blank_trans;
-    Transaction *trans;
-    Account *account;
-    Split *blank_split;
-    const char *memo;
-    const char *desc;
-    Split *split;
+    SRInfo* info = gnc_split_register_get_info (reg);
+    Transaction* pending_trans;
+    Transaction* blank_trans;
+    Transaction* trans;
+    Account* account;
+    Split* blank_split;
+    const char* memo;
+    const char* desc;
+    Split* split;
 
-    ENTER("reg=%p, do_commit=%s", reg, do_commit ? "TRUE" : "FALSE");
+    ENTER ("reg=%p, do_commit=%s", reg, do_commit ? "TRUE" : "FALSE");
 
     if (!reg)
     {
-        LEAVE("no register");
+        LEAVE ("no register");
         return FALSE;
     }
 
     blank_split = xaccSplitLookup (&info->blank_split_guid,
-                                   gnc_get_current_book ());
+                                   gnc_get_current_book());
 
     pending_trans = xaccTransLookup (&info->pending_trans_guid,
-                                     gnc_get_current_book ());
+                                     gnc_get_current_book());
 
     blank_trans = xaccSplitGetParent (blank_split);
 
@@ -1675,7 +1680,7 @@ gnc_split_register_save (SplitRegister *reg, gboolean do_commit)
     trans = gnc_split_register_get_current_trans (reg);
     if (trans == NULL)
     {
-        LEAVE("no transaction");
+        LEAVE ("no transaction");
         return FALSE;
     }
 
@@ -1686,29 +1691,29 @@ gnc_split_register_save (SplitRegister *reg, gboolean do_commit)
     {
         if (!do_commit)
         {
-            LEAVE("commit unnecessary");
+            LEAVE ("commit unnecessary");
             return FALSE;
         }
 
-        if (!xaccTransIsOpen(trans))
+        if (!xaccTransIsOpen (trans))
         {
-            LEAVE("transaction not open");
+            LEAVE ("transaction not open");
             return FALSE;
         }
 
         if (trans == pending_trans ||
-                (trans == blank_trans && info->blank_split_edited))
+            (trans == blank_trans && info->blank_split_edited))
         {
             /* We are going to commit. */
 
-            gnc_suspend_gui_refresh ();
+            gnc_suspend_gui_refresh();
 
             if (trans == blank_trans)
             {
                 /* We have to clear the blank split before the
                  * refresh or a new one won't be created. */
                 info->last_date_entered = xaccTransGetDate (trans);
-                info->blank_split_guid = *guid_null ();
+                info->blank_split_guid = *guid_null();
                 info->blank_split_edited = FALSE;
                 info->auto_complete = FALSE;
             }
@@ -1716,35 +1721,35 @@ gnc_split_register_save (SplitRegister *reg, gboolean do_commit)
             /* We have to clear the pending guid *before* committing the
              * trans, because the event handler will find it otherwise. */
             if (trans == pending_trans)
-                info->pending_trans_guid = *guid_null ();
+                info->pending_trans_guid = *guid_null();
 
-            PINFO("committing trans (%p)", trans);
-            xaccTransCommitEdit(trans);
+            PINFO ("committing trans (%p)", trans);
+            xaccTransCommitEdit (trans);
 
-            gnc_resume_gui_refresh ();
+            gnc_resume_gui_refresh();
         }
         else
-            DEBUG("leaving trans (%p) open", trans);
+            DEBUG ("leaving trans (%p) open", trans);
 
-        LEAVE("unchanged cursor");
+        LEAVE ("unchanged cursor");
         return TRUE;
     }
 
-    DEBUG("save split=%p", split);
-    DEBUG("blank_split=%p, blank_trans=%p, pending_trans=%p, trans=%p",
-          blank_split, blank_trans, pending_trans, trans);
+    DEBUG ("save split=%p", split);
+    DEBUG ("blank_split=%p, blank_trans=%p, pending_trans=%p, trans=%p",
+           blank_split, blank_trans, pending_trans, trans);
 
     /* Act on any changes to the current cell before the save. */
     if (!gnc_split_register_check_cell (reg,
-            gnc_table_get_current_cell_name (reg->table)))
+                                        gnc_table_get_current_cell_name (reg->table)))
     {
-        LEAVE("need another go at changing cell");
+        LEAVE ("need another go at changing cell");
         return FALSE;
     }
 
     if (!gnc_split_register_auto_calc (reg, split))
     {
-        LEAVE("auto calc failed");
+        LEAVE ("auto calc failed");
         return FALSE;
     }
 
@@ -1755,11 +1760,11 @@ gnc_split_register_save (SplitRegister *reg, gboolean do_commit)
     /* Maybe deal with exchange-rate transfers */
     if (gnc_split_register_handle_exchange (reg, FALSE))
     {
-        LEAVE("no exchange rate");
+        LEAVE ("no exchange rate");
         return TRUE;
     }
 
-    gnc_suspend_gui_refresh ();
+    gnc_suspend_gui_refresh();
 
     /* determine whether we should commit the pending transaction */
     if (pending_trans != trans)
@@ -1769,13 +1774,13 @@ gnc_split_register_save (SplitRegister *reg, gboolean do_commit)
         // transaction ever not be the current trans?
         if (xaccTransIsOpen (pending_trans))
         {
-            g_warning("Impossible? committing pending %p", pending_trans);
+            g_warning ("Impossible? committing pending %p", pending_trans);
             xaccTransCommitEdit (pending_trans);
         }
         else if (pending_trans)
         {
-            g_critical("BUG DETECTED! pending transaction (%p) not open",
-                       pending_trans);
+            g_critical ("BUG DETECTED! pending transaction (%p) not open",
+                        pending_trans);
             g_assert_not_reached();
         }
 
@@ -1783,23 +1788,23 @@ gnc_split_register_save (SplitRegister *reg, gboolean do_commit)
         {
             /* Don't begin editing the blank trans, because it's
                already open, but mark it pending now. */
-            g_assert(xaccTransIsOpen(blank_trans));
+            g_assert (xaccTransIsOpen (blank_trans));
             /* This is now the pending transaction */
-            info->pending_trans_guid = *xaccTransGetGUID(blank_trans);
+            info->pending_trans_guid = *xaccTransGetGUID (blank_trans);
         }
         else
         {
-            PINFO("beginning edit of trans %p", trans);
-            if (gnc_split_register_begin_edit_or_warn(info, trans))
+            PINFO ("beginning edit of trans %p", trans);
+            if (gnc_split_register_begin_edit_or_warn (info, trans))
             {
-                gnc_resume_gui_refresh ();
-                LEAVE("transaction opened elsewhere");
+                gnc_resume_gui_refresh();
+                LEAVE ("transaction opened elsewhere");
                 return FALSE;
             }
         }
         pending_trans = trans;
     }
-    g_assert(xaccTransIsOpen(trans));
+    g_assert (xaccTransIsOpen (trans));
 
     /* If we are saving a brand new transaction and the blank split hasn't
      * been edited, then we need to give it a default account. */
@@ -1815,10 +1820,10 @@ gnc_split_register_save (SplitRegister *reg, gboolean do_commit)
          * for an explanation - and the transaction has been edited (as evidenced
          * by the earlier check for a changed cursor.) Since the blank split
          * itself has not been edited, we'll have to assign a default account. */
-        account = gnc_split_register_get_default_account(reg);
+        account = gnc_split_register_get_default_account (reg);
         if (account)
-            xaccSplitSetAccount(blank_split, account);
-        xaccTransSetDateEnteredSecs(trans, gnc_time (NULL));
+            xaccSplitSetAccount (blank_split, account);
+        xaccTransSetDateEnteredSecs (trans, gnc_time (NULL));
     }
 
     if (split == NULL)
@@ -1831,30 +1836,30 @@ gnc_split_register_save (SplitRegister *reg, gboolean do_commit)
          * xaccSRGetCurrent will handle this case, too. We will create
          * a new split, copy the row contents to that split, and append
          * the split to the pre-existing transaction. */
-        Split *trans_split;
+        Split* trans_split;
 
-        split = xaccMallocSplit (gnc_get_current_book ());
+        split = xaccMallocSplit (gnc_get_current_book());
         xaccTransAppendSplit (trans, split);
 
         gnc_table_set_virt_cell_data (reg->table,
                                       reg->table->current_cursor_loc.vcell_loc,
                                       xaccSplitGetGUID (split));
-        DEBUG("assigned cell to new split=%p", split);
+        DEBUG ("assigned cell to new split=%p", split);
 
         trans_split = gnc_split_register_get_current_trans_split (reg, NULL);
         if ((info->cursor_hint_trans == trans) &&
-                (info->cursor_hint_trans_split == trans_split) &&
-                (info->cursor_hint_split == NULL))
+            (info->cursor_hint_trans_split == trans_split) &&
+            (info->cursor_hint_split == NULL))
         {
             info->cursor_hint_split = split;
             info->cursor_hint_cursor_class = CURSOR_CLASS_SPLIT;
         }
     }
 
-    DEBUG("updating trans=%p", trans);
+    DEBUG ("updating trans=%p", trans);
 
     {
-        SRSaveData *sd;
+        SRSaveData* sd;
 
         sd = gnc_split_register_save_data_new (
                  trans, split, (info->trans_expanded ||
@@ -1878,7 +1883,7 @@ gnc_split_register_save (SplitRegister *reg, gboolean do_commit)
     {
         if (do_commit)
         {
-            info->blank_split_guid = *guid_null ();
+            info->blank_split_guid = *guid_null();
             info->auto_complete = FALSE;
             blank_split = NULL;
             info->last_date_entered = xaccTransGetDate (trans);
@@ -1891,11 +1896,11 @@ gnc_split_register_save (SplitRegister *reg, gboolean do_commit)
      * transaction to NULL. */
     if (do_commit)
     {
-        g_assert(trans == blank_trans || trans == pending_trans);
+        g_assert (trans == blank_trans || trans == pending_trans);
         if (pending_trans == trans)
         {
             pending_trans = NULL;
-            info->pending_trans_guid = *guid_null ();
+            info->pending_trans_guid = *guid_null();
         }
         xaccTransCommitEdit (trans);
     }
@@ -1904,13 +1909,14 @@ gnc_split_register_save (SplitRegister *reg, gboolean do_commit)
      * we need to unreconcile them */
     if (do_commit && (reg->unrecn_splits != NULL))
     {
-        GList *node;
+        GList* node;
 
-        PINFO ("Unreconcile %d splits of reconciled transaction", g_list_length (reg->unrecn_splits));
+        PINFO ("Unreconcile %d splits of reconciled transaction",
+               g_list_length (reg->unrecn_splits));
 
         for (node = reg->unrecn_splits; node; node = node->next)
         {
-            Split *split = node->data;
+            Split* split = node->data;
 
             if (xaccSplitGetReconcile (split) == YREC)
                 xaccSplitSetReconcile (split, NREC);
@@ -1921,33 +1927,34 @@ gnc_split_register_save (SplitRegister *reg, gboolean do_commit)
 
     gnc_table_clear_current_cursor_changes (reg->table);
 
-    gnc_resume_gui_refresh ();
+    gnc_resume_gui_refresh();
 
-    LEAVE(" ");
+    LEAVE (" ");
     return TRUE;
 }
 
 
-Account *
-gnc_split_register_get_account_by_name (SplitRegister *reg, BasicCell * bcell,
-                                        const char *name)
+Account*
+gnc_split_register_get_account_by_name (SplitRegister* reg, BasicCell* bcell,
+                                        const char* name)
 {
-    const char *placeholder = _("The account %s does not allow transactions.");
-    const char *missing = _("The account %s does not exist. "
-                            "Would you like to create it?");
-    char *account_name;
-    ComboCell *cell = (ComboCell *) bcell;
-    Account *account;
+    const char* placeholder = _ ("The account %s does not allow transactions.");
+    const char* missing = _ ("The account %s does not exist. "
+                             "Would you like to create it?");
+    char* account_name;
+    ComboCell* cell = (ComboCell*) bcell;
+    Account* account;
     static gboolean creating_account = FALSE;
-    GtkWindow *parent = GTK_WINDOW (gnc_split_register_get_parent (reg));
+    GtkWindow* parent = GTK_WINDOW (gnc_split_register_get_parent (reg));
 
-    if (!name || (strlen(name) == 0))
+    if (!name || (strlen (name) == 0))
         return NULL;
 
     /* Find the account */
-    account = gnc_account_lookup_for_register (gnc_get_current_root_account (), name);
+    account = gnc_account_lookup_for_register (gnc_get_current_root_account(),
+                                               name);
     if (!account)
-        account = gnc_account_lookup_by_code(gnc_get_current_root_account(), name);
+        account = gnc_account_lookup_by_code (gnc_get_current_root_account(), name);
 
     /* if gnc_ui_new_accounts_from_name_window is used, there is a call to
      * refresh which subsequently calls this function again, that's the
@@ -1969,8 +1976,9 @@ gnc_split_register_get_account_by_name (SplitRegister *reg, BasicCell * bcell,
     if (!creating_account)
     {
         /* Now have the account. */
-        account_name = gnc_get_account_name_for_split_register (account, reg->show_leaf_accounts);
-        if (g_strcmp0(account_name, gnc_basic_cell_get_value(bcell)))
+        account_name = gnc_get_account_name_for_split_register (account,
+                                                                reg->show_leaf_accounts);
+        if (g_strcmp0 (account_name, gnc_basic_cell_get_value (bcell)))
         {
             /* The name has changed. Update the cell. */
             gnc_combo_cell_set_value (cell, account_name);
@@ -1981,7 +1989,7 @@ gnc_split_register_get_account_by_name (SplitRegister *reg, BasicCell * bcell,
         /* See if the account (either old or new) is a placeholder. */
         if (account && xaccAccountGetPlaceholder (account))
         {
-            gchar *fullname = gnc_account_get_full_name (account);
+            gchar* fullname = gnc_account_get_full_name (account);
             gnc_error_dialog (GTK_WINDOW (gnc_split_register_get_parent (reg)),
                               placeholder, fullname);
             g_free (fullname);
@@ -1993,11 +2001,11 @@ gnc_split_register_get_account_by_name (SplitRegister *reg, BasicCell * bcell,
     return account;
 }
 
-Account *
-gnc_split_register_get_account (SplitRegister *reg, const char * cell_name)
+Account*
+gnc_split_register_get_account (SplitRegister* reg, const char* cell_name)
 {
-    BasicCell *cell;
-    const char *name;
+    BasicCell* cell;
+    const char* name;
 
     if (!gnc_table_layout_get_cell_changed (reg->table->layout, cell_name, TRUE))
         return NULL;
@@ -2010,12 +2018,12 @@ gnc_split_register_get_account (SplitRegister *reg, const char * cell_name)
 }
 
 static gnc_numeric
-calculate_value (SplitRegister *reg)
+calculate_value (SplitRegister* reg)
 {
     gnc_numeric credit;
     gnc_numeric debit;
 
-    PriceCell *cell = (PriceCell*)gnc_table_layout_get_cell (reg->table->layout,
+    PriceCell* cell = (PriceCell*)gnc_table_layout_get_cell (reg->table->layout,
                                                              CRED_CELL);
     credit = gnc_price_cell_get_value (cell);
 
@@ -2028,49 +2036,49 @@ calculate_value (SplitRegister *reg)
 
 
 static int
-recalc_message_box (SplitRegister *reg, gboolean shares_changed,
+recalc_message_box (SplitRegister* reg, gboolean shares_changed,
                     gboolean price_changed, gboolean value_changed)
 {
     int choice;
     int default_value;
-    GList *node;
-    GList *radio_list = NULL;
-    const char *title = _("Recalculate Transaction");
-    const char *message = _("The values entered for this transaction "
-                            "are inconsistent. Which value would you "
-                            "like to have recalculated?");
+    GList* node;
+    GList* radio_list = NULL;
+    const char* title = _ ("Recalculate Transaction");
+    const char* message = _ ("The values entered for this transaction "
+                             "are inconsistent. Which value would you "
+                             "like to have recalculated?");
 
     if (shares_changed)
         radio_list = g_list_append (radio_list, g_strdup_printf ("%s (%s)",
-                                                                 _("_Shares"),
-                                                                 _("Changed")));
+                                                                 _ ("_Shares"),
+                                                                 _ ("Changed")));
     else
-        radio_list = g_list_append (radio_list, g_strdup (_("_Shares")));
+        radio_list = g_list_append (radio_list, g_strdup (_ ("_Shares")));
 
     if (price_changed)
         radio_list = g_list_append (radio_list, g_strdup_printf ("%s (%s)",
-                                                                 _("_Price"),
-                                                                 _("Changed")));
+                                                                 _ ("_Price"),
+                                                                 _ ("Changed")));
     else
-        radio_list = g_list_append (radio_list, g_strdup (_("_Price")));
+        radio_list = g_list_append (radio_list, g_strdup (_ ("_Price")));
 
     if (value_changed)
         radio_list = g_list_append (radio_list, g_strdup_printf ("%s (%s)",
-                                                                 _("_Value"),
-                                                                 _("Changed")));
+                                                                 _ ("_Value"),
+                                                                 _ ("Changed")));
     else
-        radio_list = g_list_append (radio_list, g_strdup (_("_Value")));
+        radio_list = g_list_append (radio_list, g_strdup (_ ("_Value")));
 
     if (price_changed) default_value = 2;  /* change the value */
     else  default_value = 1;  /* change the value */
 
     choice = gnc_choose_radio_option_dialog
-        (gnc_split_register_get_parent (reg),
-         title,
-         message,
-         _("_Recalculate"),
-         default_value,
-         radio_list);
+             (gnc_split_register_get_parent (reg),
+              title,
+              message,
+              _ ("_Recalculate"),
+              default_value,
+              radio_list);
 
     for (node = radio_list; node; node = node->next)
         g_free (node->data);
@@ -2081,15 +2089,15 @@ recalc_message_box (SplitRegister *reg, gboolean shares_changed,
 }
 
 static void
-recalculate_shares (Split* split, SplitRegister *reg,
-               gnc_numeric value, gnc_numeric price, gboolean value_changed)
+recalculate_shares (Split* split, SplitRegister* reg,
+                    gnc_numeric value, gnc_numeric price, gboolean value_changed)
 {
     gint64 denom = gnc_split_get_amount_denom (split);
     gnc_numeric amount = gnc_numeric_div (value, price, denom,
                                           GNC_HOW_RND_ROUND_HALF_UP);
 
-    BasicCell *cell = gnc_table_layout_get_cell (reg->table->layout, SHRS_CELL);
-    gnc_price_cell_set_value ((PriceCell *) cell, amount);
+    BasicCell* cell = gnc_table_layout_get_cell (reg->table->layout, SHRS_CELL);
+    gnc_price_cell_set_value ((PriceCell*) cell, amount);
     gnc_basic_cell_set_changed (cell, TRUE);
 
     if (value_changed)
@@ -2100,18 +2108,18 @@ recalculate_shares (Split* split, SplitRegister *reg,
 }
 
 static void
-recalculate_price (Split *split, SplitRegister *reg,
-              gnc_numeric value, gnc_numeric amount)
+recalculate_price (Split* split, SplitRegister* reg,
+                   gnc_numeric value, gnc_numeric amount)
 {
-    BasicCell *price_cell;
+    BasicCell* price_cell;
     gnc_numeric price = gnc_numeric_div (value, amount,
                                          GNC_DENOM_AUTO,
                                          GNC_HOW_DENOM_EXACT);
 
     if (gnc_numeric_negative_p (price))
     {
-        BasicCell *debit_cell;
-        BasicCell *credit_cell;
+        BasicCell* debit_cell;
+        BasicCell* credit_cell;
 
         debit_cell = gnc_table_layout_get_cell (reg->table->layout,
                                                 DEBT_CELL);
@@ -2121,8 +2129,8 @@ recalculate_price (Split *split, SplitRegister *reg,
 
         price = gnc_numeric_neg (price);
 
-        gnc_price_cell_set_debt_credit_value ((PriceCell *) debit_cell,
-                                              (PriceCell *) credit_cell,
+        gnc_price_cell_set_debt_credit_value ((PriceCell*) debit_cell,
+                                              (PriceCell*) credit_cell,
                                               gnc_numeric_neg (value));
 
         gnc_basic_cell_set_changed (debit_cell, TRUE);
@@ -2130,50 +2138,50 @@ recalculate_price (Split *split, SplitRegister *reg,
     }
 
     price_cell = gnc_table_layout_get_cell (reg->table->layout, PRIC_CELL);
-    gnc_price_cell_set_value ((PriceCell *) price_cell, price);
+    gnc_price_cell_set_value ((PriceCell*) price_cell, price);
     gnc_basic_cell_set_changed (price_cell, TRUE);
 }
 
 static void
-recalculate_value (Split *split, SplitRegister *reg,
-              gnc_numeric price, gnc_numeric amount, gboolean shares_changed)
+recalculate_value (Split* split, SplitRegister* reg,
+                   gnc_numeric price, gnc_numeric amount, gboolean shares_changed)
 {
-    BasicCell *debit_cell = gnc_table_layout_get_cell (reg->table->layout,
+    BasicCell* debit_cell = gnc_table_layout_get_cell (reg->table->layout,
                                                        DEBT_CELL);
-    BasicCell *credit_cell = gnc_table_layout_get_cell (reg->table->layout,
+    BasicCell* credit_cell = gnc_table_layout_get_cell (reg->table->layout,
                                                         CRED_CELL);
     gint64 denom = gnc_split_get_value_denom (split);
     gnc_numeric value = gnc_numeric_mul (price, amount, denom,
                                          GNC_HOW_RND_ROUND_HALF_UP);
 
-    gnc_price_cell_set_debt_credit_value ((PriceCell *) debit_cell,
-                                          (PriceCell *) credit_cell, value);
+    gnc_price_cell_set_debt_credit_value ((PriceCell*) debit_cell,
+                                          (PriceCell*) credit_cell, value);
 
     gnc_basic_cell_set_changed (debit_cell, TRUE);
     gnc_basic_cell_set_changed (credit_cell, TRUE);
 
     if (shares_changed)
     {
-        BasicCell *cell = gnc_table_layout_get_cell (reg->table->layout,
+        BasicCell* cell = gnc_table_layout_get_cell (reg->table->layout,
                                                      PRIC_CELL);
         gnc_basic_cell_set_changed (cell, FALSE);
     }
 }
 
 static void
-record_price (SplitRegister *reg, Account *account, gnc_numeric value,
+record_price (SplitRegister* reg, Account* account, gnc_numeric value,
               PriceSource source)
 {
-    Transaction *trans = gnc_split_register_get_current_trans (reg);
-    QofBook *book = qof_instance_get_book (QOF_INSTANCE (account));
-    GNCPriceDB *pricedb = gnc_pricedb_get_db (book);
-    gnc_commodity *comm = xaccAccountGetCommodity (account);
-    gnc_commodity *curr = xaccTransGetCurrency (trans);
-    GNCPrice *price;
+    Transaction* trans = gnc_split_register_get_current_trans (reg);
+    QofBook* book = qof_instance_get_book (QOF_INSTANCE (account));
+    GNCPriceDB* pricedb = gnc_pricedb_get_db (book);
+    gnc_commodity* comm = xaccAccountGetCommodity (account);
+    gnc_commodity* curr = xaccTransGetCurrency (trans);
+    GNCPrice* price;
     gnc_numeric price_value;
-    int scu = gnc_commodity_get_fraction(curr);
+    int scu = gnc_commodity_get_fraction (curr);
     time64 time;
-    BasicCell *cell = gnc_table_layout_get_cell (reg->table->layout, DATE_CELL);
+    BasicCell* cell = gnc_table_layout_get_cell (reg->table->layout, DATE_CELL);
     gboolean swap = FALSE;
 
     /* Only record the price for account types that don't have a
@@ -2185,30 +2193,30 @@ record_price (SplitRegister *reg, Account *account, gnc_numeric value,
     gnc_date_cell_get_date ((DateCell*)cell, &time, TRUE);
     price = gnc_pricedb_lookup_day_t64 (pricedb, comm, curr, time);
     if (gnc_commodity_equiv (comm, gnc_price_get_currency (price)))
-            swap = TRUE;
+        swap = TRUE;
 
     if (price)
     {
-        price_value = gnc_price_get_value(price);
-        if (gnc_numeric_equal(swap ? gnc_numeric_invert(value) : value,
-                              price_value))
+        price_value = gnc_price_get_value (price);
+        if (gnc_numeric_equal (swap ? gnc_numeric_invert (value) : value,
+                               price_value))
         {
             gnc_price_unref (price);
             return;
         }
-        if (gnc_price_get_source(price) < PRICE_SOURCE_XFER_DLG_VAL)
+        if (gnc_price_get_source (price) < PRICE_SOURCE_XFER_DLG_VAL)
         {
             /* Existing price is preferred over this one. */
-            gnc_price_unref(price);
+            gnc_price_unref (price);
             return;
         }
         if (swap)
         {
-            value = gnc_numeric_invert(value);
-            scu = gnc_commodity_get_fraction(comm);
+            value = gnc_numeric_invert (value);
+            scu = gnc_commodity_get_fraction (comm);
         }
-        value = gnc_numeric_convert(value, scu * COMMODITY_DENOM_MULT,
-                                    GNC_HOW_RND_ROUND_HALF_UP);
+        value = gnc_numeric_convert (value, scu * COMMODITY_DENOM_MULT,
+                                     GNC_HOW_RND_ROUND_HALF_UP);
         gnc_price_begin_edit (price);
         gnc_price_set_time64 (price, time);
         gnc_price_set_source (price, source);
@@ -2219,8 +2227,8 @@ record_price (SplitRegister *reg, Account *account, gnc_numeric value,
         return;
     }
 
-    value = gnc_numeric_convert(value, scu * COMMODITY_DENOM_MULT,
-                                GNC_HOW_RND_ROUND_HALF_UP);
+    value = gnc_numeric_convert (value, scu * COMMODITY_DENOM_MULT,
+                                 GNC_HOW_RND_ROUND_HALF_UP);
     price = gnc_price_create (book);
     gnc_price_begin_edit (price);
     gnc_price_set_commodity (price, comm);
@@ -2234,9 +2242,9 @@ record_price (SplitRegister *reg, Account *account, gnc_numeric value,
 }
 
 static gboolean
-gnc_split_register_auto_calc (SplitRegister *reg, Split *split)
+gnc_split_register_auto_calc (SplitRegister* reg, Split* split)
 {
-    PriceCell *cell = NULL;
+    PriceCell* cell = NULL;
     gboolean recalc_shares = FALSE;
     gboolean recalc_price = FALSE;
     gboolean recalc_value = FALSE;
@@ -2247,7 +2255,7 @@ gnc_split_register_auto_calc (SplitRegister *reg, Split *split)
     gnc_numeric value;
     gnc_numeric price;
     gnc_numeric amount;
-    Account *account;
+    Account* account;
     int denom;
     int choice;
     PriceSource source = PRICE_SOURCE_USER_PRICE;
@@ -2265,17 +2273,17 @@ gnc_split_register_auto_calc (SplitRegister *reg, Split *split)
     if (!account)
         account = gnc_split_register_get_default_account (reg);
 
-    if (!xaccAccountIsPriced(account))
+    if (!xaccAccountIsPriced (account))
         return TRUE;
 
     price_changed = gnc_table_layout_get_cell_changed (reg->table->layout,
-                    PRIC_CELL, TRUE);
+                                                       PRIC_CELL, TRUE);
     value_changed = (gnc_table_layout_get_cell_changed (reg->table->layout,
-                      DEBT_CELL, TRUE) ||
-                      gnc_table_layout_get_cell_changed (reg->table->layout,
-                              CRED_CELL, TRUE));
+                                                        DEBT_CELL, TRUE) ||
+                     gnc_table_layout_get_cell_changed (reg->table->layout,
+                                                        CRED_CELL, TRUE));
     shares_changed = gnc_table_layout_get_cell_changed (reg->table->layout,
-                     SHRS_CELL, TRUE);
+                                                        SHRS_CELL, TRUE);
 
     if (!price_changed && !value_changed && !shares_changed)
         return TRUE;
@@ -2284,17 +2292,17 @@ gnc_split_register_auto_calc (SplitRegister *reg, Split *split)
        not really be the value.  Punt if so. */
     if (xaccTransUseTradingAccounts (xaccSplitGetParent (split)))
     {
-        gnc_commodity *acc_commodity;
+        gnc_commodity* acc_commodity;
         acc_commodity = xaccAccountGetCommodity (account);
         if (! (xaccAccountIsPriced (account) ||
-                !gnc_commodity_is_iso (acc_commodity)))
+               !gnc_commodity_is_iso (acc_commodity)))
             return TRUE;
     }
 
     if (shares_changed)
     {
-        cell = (PriceCell *) gnc_table_layout_get_cell (reg->table->layout,
-                SHRS_CELL);
+        cell = (PriceCell*) gnc_table_layout_get_cell (reg->table->layout,
+                                                       SHRS_CELL);
         amount = gnc_price_cell_get_value (cell);
     }
     else
@@ -2302,8 +2310,8 @@ gnc_split_register_auto_calc (SplitRegister *reg, Split *split)
 
     if (price_changed)
     {
-        cell = (PriceCell *) gnc_table_layout_get_cell (reg->table->layout,
-                PRIC_CELL);
+        cell = (PriceCell*) gnc_table_layout_get_cell (reg->table->layout,
+                                                       PRIC_CELL);
         price = gnc_price_cell_get_value (cell);
     }
     else
@@ -2318,8 +2326,8 @@ gnc_split_register_auto_calc (SplitRegister *reg, Split *split)
     /* Check if shares and price are BOTH zero (and value is non-zero).
      * If so, we can assume that this is an income-correcting split
      */
-    if (gnc_numeric_zero_p(amount) && gnc_numeric_zero_p(price) &&
-            !gnc_numeric_zero_p(value))
+    if (gnc_numeric_zero_p (amount) && gnc_numeric_zero_p (price) &&
+        !gnc_numeric_zero_p (value))
     {
         return TRUE;
     }
@@ -2345,8 +2353,8 @@ gnc_split_register_auto_calc (SplitRegister *reg, Split *split)
      * which has 2 of the 3 values changed. */
 
     if ((!recalc_shares) &&
-            (!recalc_price)  &&
-            (!recalc_value))
+        (!recalc_price)  &&
+        (!recalc_value))
     {
         if (price_changed && value_changed)
         {
@@ -2373,9 +2381,9 @@ gnc_split_register_auto_calc (SplitRegister *reg, Split *split)
         !recalc_value &&
         !gnc_numeric_same (value, calc_value, denom, GNC_HOW_RND_ROUND_HALF_UP))
     {
-        choice = recalc_message_box(reg, shares_changed,
-                                    price_changed,
-                                    value_changed);
+        choice = recalc_message_box (reg, shares_changed,
+                                     price_changed,
+                                     value_changed);
         switch (choice)
         {
         case 0: /* Modify number of shares */
@@ -2406,11 +2414,11 @@ gnc_split_register_auto_calc (SplitRegister *reg, Split *split)
 
     if (price_changed)
     {
-        cell = (PriceCell *) gnc_table_layout_get_cell (reg->table->layout,
-                PRIC_CELL);
+        cell = (PriceCell*) gnc_table_layout_get_cell (reg->table->layout,
+                                                       PRIC_CELL);
         price = gnc_price_cell_get_value (cell);
-	if (gnc_numeric_positive_p(price))
-	    record_price (reg, account, price, source);
+        if (gnc_numeric_positive_p (price))
+            record_price (reg, account, price, source);
     }
     return TRUE;
 }
@@ -2457,10 +2465,10 @@ gnc_split_register_type_to_account_type (SplitRegisterType sr_type)
     }
 }
 
-const char *
-gnc_split_register_get_debit_string (SplitRegister *reg)
+const char*
+gnc_split_register_get_debit_string (SplitRegister* reg)
 {
-    SRInfo *info = gnc_split_register_get_info (reg);
+    SRInfo* info = gnc_split_register_get_info (reg);
 
     if (!reg)
         return NULL;
@@ -2475,15 +2483,15 @@ gnc_split_register_get_debit_string (SplitRegister *reg)
     if (info->debit_str)
         return info->debit_str;
 
-    info->debit_str = g_strdup (_("Debit"));
+    info->debit_str = g_strdup (_ ("Debit"));
 
     return info->debit_str;
 }
 
-const char *
-gnc_split_register_get_credit_string (SplitRegister *reg)
+const char*
+gnc_split_register_get_credit_string (SplitRegister* reg)
 {
-    SRInfo *info = gnc_split_register_get_info (reg);
+    SRInfo* info = gnc_split_register_get_info (reg);
 
     if (!reg)
         return NULL;
@@ -2498,48 +2506,48 @@ gnc_split_register_get_credit_string (SplitRegister *reg)
     if (info->credit_str)
         return info->credit_str;
 
-    info->credit_str = g_strdup (_("Credit"));
+    info->credit_str = g_strdup (_ ("Credit"));
 
     return info->credit_str;
 }
 
 gboolean
-gnc_split_register_changed (SplitRegister *reg)
+gnc_split_register_changed (SplitRegister* reg)
 {
-    SRInfo *info = gnc_split_register_get_info (reg);
-    Transaction *pending_trans;
+    SRInfo* info = gnc_split_register_get_info (reg);
+    Transaction* pending_trans;
 
-    ENTER("reg=%p", reg);
+    ENTER ("reg=%p", reg);
 
     if (reg == NULL)
     {
-        LEAVE("no register");
+        LEAVE ("no register");
         return FALSE;
     }
 
     if (gnc_table_current_cursor_changed (reg->table, FALSE))
     {
-        LEAVE("cursor changed");
+        LEAVE ("cursor changed");
         return TRUE;
     }
 
     pending_trans = xaccTransLookup (&info->pending_trans_guid,
-                                     gnc_get_current_book ());
+                                     gnc_get_current_book());
     if (xaccTransIsOpen (pending_trans))
     {
-        LEAVE("open and pending txn");
+        LEAVE ("open and pending txn");
         return TRUE;
     }
 
-    LEAVE("register unchanged");
+    LEAVE ("register unchanged");
     return FALSE;
 }
 
 void
-gnc_split_register_show_present_divider (SplitRegister *reg,
-        gboolean show_present)
+gnc_split_register_show_present_divider (SplitRegister* reg,
+                                         gboolean show_present)
 {
-    SRInfo *info = gnc_split_register_get_info (reg);
+    SRInfo* info = gnc_split_register_get_info (reg);
 
     if (reg == NULL)
         return;
@@ -2548,9 +2556,9 @@ gnc_split_register_show_present_divider (SplitRegister *reg,
 }
 
 gboolean
-gnc_split_register_full_refresh_ok (SplitRegister *reg)
+gnc_split_register_full_refresh_ok (SplitRegister* reg)
 {
-    SRInfo *info = gnc_split_register_get_info (reg);
+    SRInfo* info = gnc_split_register_get_info (reg);
 
     if (!info)
         return FALSE;
@@ -2561,173 +2569,173 @@ gnc_split_register_full_refresh_ok (SplitRegister *reg)
 /* configAction strings into the action cell */
 /* hack alert -- this stuff really, really should be in a config file ... */
 static void
-gnc_split_register_config_action (SplitRegister *reg)
+gnc_split_register_config_action (SplitRegister* reg)
 {
-    ComboCell *cell;
+    ComboCell* cell;
 
-    cell = (ComboCell *) gnc_table_layout_get_cell (reg->table->layout,
-            ACTN_CELL);
+    cell = (ComboCell*) gnc_table_layout_get_cell (reg->table->layout,
+                                                   ACTN_CELL);
 
     /* setup strings in the action pull-down */
     switch (reg->type)
     {
     case BANK_REGISTER:
-        /* broken ! FIXME bg */
+    /* broken ! FIXME bg */
     case SEARCH_LEDGER:
-        gnc_combo_cell_add_menu_item (cell, C_("Action Column", "Deposit"));
-        gnc_combo_cell_add_menu_item (cell, _("Withdraw"));
-        gnc_combo_cell_add_menu_item (cell, _("Check"));
-        gnc_combo_cell_add_menu_item (cell, _("Interest"));
-        gnc_combo_cell_add_menu_item (cell, _("ATM Deposit"));
-        gnc_combo_cell_add_menu_item (cell, _("ATM Draw"));
-        gnc_combo_cell_add_menu_item (cell, _("Teller"));
-        gnc_combo_cell_add_menu_item (cell, _("Charge"));
-        gnc_combo_cell_add_menu_item (cell, _("Payment"));
-        gnc_combo_cell_add_menu_item (cell, _("Receipt"));
-        gnc_combo_cell_add_menu_item (cell, _("Increase"));
-        gnc_combo_cell_add_menu_item (cell, _("Decrease"));
+        gnc_combo_cell_add_menu_item (cell, C_ ("Action Column", "Deposit"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Withdraw"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Check"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Interest"));
+        gnc_combo_cell_add_menu_item (cell, _ ("ATM Deposit"));
+        gnc_combo_cell_add_menu_item (cell, _ ("ATM Draw"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Teller"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Charge"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Payment"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Receipt"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Increase"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Decrease"));
         /* Action: Point Of Sale */
-        gnc_combo_cell_add_menu_item (cell, _("POS"));
-        gnc_combo_cell_add_menu_item (cell, _("Phone"));
-        gnc_combo_cell_add_menu_item (cell, _("Online"));
+        gnc_combo_cell_add_menu_item (cell, _ ("POS"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Phone"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Online"));
         /* Action: Automatic Deposit ?!? */
-        gnc_combo_cell_add_menu_item (cell, _("AutoDep"));
-        gnc_combo_cell_add_menu_item (cell, _("Wire"));
-        gnc_combo_cell_add_menu_item (cell, _("Credit"));
-        gnc_combo_cell_add_menu_item (cell, _("Direct Debit"));
-        gnc_combo_cell_add_menu_item (cell, _("Transfer"));
+        gnc_combo_cell_add_menu_item (cell, _ ("AutoDep"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Wire"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Credit"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Direct Debit"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Transfer"));
         break;
     case CASH_REGISTER:
-        gnc_combo_cell_add_menu_item (cell, _("Increase"));
-        gnc_combo_cell_add_menu_item (cell, _("Decrease"));
-        gnc_combo_cell_add_menu_item (cell, _("Buy"));
-        gnc_combo_cell_add_menu_item (cell, _("Sell"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Increase"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Decrease"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Buy"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Sell"));
         break;
     case ASSET_REGISTER:
-        gnc_combo_cell_add_menu_item (cell, _("Buy"));
-        gnc_combo_cell_add_menu_item (cell, _("Sell"));
-        gnc_combo_cell_add_menu_item (cell, _("Fee"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Buy"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Sell"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Fee"));
         break;
     case CREDIT_REGISTER:
-        gnc_combo_cell_add_menu_item (cell, _("ATM Deposit"));
-        gnc_combo_cell_add_menu_item (cell, _("ATM Draw"));
-        gnc_combo_cell_add_menu_item (cell, _("Buy"));
-        gnc_combo_cell_add_menu_item (cell, _("Credit"));
-        gnc_combo_cell_add_menu_item (cell, _("Fee"));
-        gnc_combo_cell_add_menu_item (cell, _("Interest"));
-        gnc_combo_cell_add_menu_item (cell, _("Online"));
-        gnc_combo_cell_add_menu_item (cell, _("Sell"));
+        gnc_combo_cell_add_menu_item (cell, _ ("ATM Deposit"));
+        gnc_combo_cell_add_menu_item (cell, _ ("ATM Draw"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Buy"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Credit"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Fee"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Interest"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Online"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Sell"));
         break;
     case LIABILITY_REGISTER:
-        gnc_combo_cell_add_menu_item (cell, _("Buy"));
-        gnc_combo_cell_add_menu_item (cell, _("Sell"));
-        gnc_combo_cell_add_menu_item (cell, _("Loan"));
-        gnc_combo_cell_add_menu_item (cell, _("Interest"));
-        gnc_combo_cell_add_menu_item (cell, _("Payment"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Buy"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Sell"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Loan"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Interest"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Payment"));
         break;
     case RECEIVABLE_REGISTER:
     case PAYABLE_REGISTER:
-        gnc_combo_cell_add_menu_item (cell, _("Invoice"));
-        gnc_combo_cell_add_menu_item (cell, _("Payment"));
-        gnc_combo_cell_add_menu_item (cell, _("Interest"));
-        gnc_combo_cell_add_menu_item (cell, _("Credit"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Invoice"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Payment"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Interest"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Credit"));
         break;
     case INCOME_LEDGER:
     case INCOME_REGISTER:
-        gnc_combo_cell_add_menu_item (cell, _("Increase"));
-        gnc_combo_cell_add_menu_item (cell, _("Decrease"));
-        gnc_combo_cell_add_menu_item (cell, _("Buy"));
-        gnc_combo_cell_add_menu_item (cell, _("Sell"));
-        gnc_combo_cell_add_menu_item (cell, _("Interest"));
-        gnc_combo_cell_add_menu_item (cell, _("Payment"));
-        gnc_combo_cell_add_menu_item (cell, _("Rebate"));
-        gnc_combo_cell_add_menu_item (cell, _("Paycheck"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Increase"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Decrease"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Buy"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Sell"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Interest"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Payment"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Rebate"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Paycheck"));
         break;
     case EXPENSE_REGISTER:
     case TRADING_REGISTER:
-        gnc_combo_cell_add_menu_item (cell, _("Increase"));
-        gnc_combo_cell_add_menu_item (cell, _("Decrease"));
-        gnc_combo_cell_add_menu_item (cell, _("Buy"));
-        gnc_combo_cell_add_menu_item (cell, _("Sell"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Increase"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Decrease"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Buy"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Sell"));
         break;
     case GENERAL_JOURNAL:
     case EQUITY_REGISTER:
-        gnc_combo_cell_add_menu_item (cell, _("Buy"));
-        gnc_combo_cell_add_menu_item (cell, _("Sell"));
-        gnc_combo_cell_add_menu_item (cell, _("Equity"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Buy"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Sell"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Equity"));
         break;
     case STOCK_REGISTER:
     case PORTFOLIO_LEDGER:
     case CURRENCY_REGISTER:
         gnc_combo_cell_add_menu_item (cell, ACTION_BUY_STR);
         gnc_combo_cell_add_menu_item (cell, ACTION_SELL_STR);
-        gnc_combo_cell_add_menu_item (cell, _("Price"));
-        gnc_combo_cell_add_menu_item (cell, _("Fee"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Price"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Fee"));
         /* Action: Dividend */
-        gnc_combo_cell_add_menu_item (cell, _("Dividend"));
-        gnc_combo_cell_add_menu_item (cell, _("Interest"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Dividend"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Interest"));
         /* Action: Long Term Capital Gains */
-        gnc_combo_cell_add_menu_item (cell, _("LTCG"));
+        gnc_combo_cell_add_menu_item (cell, _ ("LTCG"));
         /* Action: Short Term Capital Gains */
-        gnc_combo_cell_add_menu_item (cell, _("STCG"));
-        gnc_combo_cell_add_menu_item (cell, _("Income"));
+        gnc_combo_cell_add_menu_item (cell, _ ("STCG"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Income"));
         /* Action: Distribution */
-        gnc_combo_cell_add_menu_item (cell, _("Dist"));
-        gnc_combo_cell_add_menu_item (cell, C_("Action Column", "Split"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Dist"));
+        gnc_combo_cell_add_menu_item (cell, C_ ("Action Column", "Split"));
         break;
 
     default:
-        gnc_combo_cell_add_menu_item (cell, _("Increase"));
-        gnc_combo_cell_add_menu_item (cell, _("Decrease"));
-        gnc_combo_cell_add_menu_item (cell, _("Buy"));
-        gnc_combo_cell_add_menu_item (cell, _("Sell"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Increase"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Decrease"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Buy"));
+        gnc_combo_cell_add_menu_item (cell, _ ("Sell"));
         break;
     }
 }
 
 static void
-gnc_split_register_config_cells (SplitRegister *reg)
+gnc_split_register_config_cells (SplitRegister* reg)
 {
     gnc_combo_cell_add_ignore_string
-    ((ComboCell *)
+    ((ComboCell*)
      gnc_table_layout_get_cell (reg->table->layout, MXFRM_CELL),
      SPLIT_TRANS_STR);
 
     gnc_combo_cell_add_ignore_string
-    ((ComboCell *)
+    ((ComboCell*)
      gnc_table_layout_get_cell (reg->table->layout, MXFRM_CELL),
      STOCK_SPLIT_STR);
 
     /* the action cell */
     gnc_combo_cell_set_autosize
-    ((ComboCell *)
+    ((ComboCell*)
      gnc_table_layout_get_cell (reg->table->layout, ACTN_CELL), TRUE);
 
     /* Use GNC_COMMODITY_MAX_FRACTION for prices and "exchange rates"  */
     gnc_price_cell_set_fraction
-    ((PriceCell *)
+    ((PriceCell*)
      gnc_table_layout_get_cell (reg->table->layout, PRIC_CELL),
      GNC_COMMODITY_MAX_FRACTION);
 
     /* Initialize shares and share balance cells */
     gnc_price_cell_set_print_info
-    ((PriceCell *) gnc_table_layout_get_cell (reg->table->layout, SHRS_CELL),
-     gnc_default_share_print_info ());
+    ((PriceCell*) gnc_table_layout_get_cell (reg->table->layout, SHRS_CELL),
+     gnc_default_share_print_info());
 
     gnc_price_cell_set_print_info
-    ((PriceCell *) gnc_table_layout_get_cell (reg->table->layout, TSHRS_CELL),
-     gnc_default_share_print_info ());
+    ((PriceCell*) gnc_table_layout_get_cell (reg->table->layout, TSHRS_CELL),
+     gnc_default_share_print_info());
 
     /* Initialize the rate cell
      * use a share_print_info to make sure we don't have rounding errors
      */
     gnc_price_cell_set_print_info
-    ((PriceCell *) gnc_table_layout_get_cell (reg->table->layout, RATE_CELL),
+    ((PriceCell*) gnc_table_layout_get_cell (reg->table->layout, RATE_CELL),
      gnc_default_share_print_info());
 
     /* The action cell should accept strings not in the list */
     gnc_combo_cell_set_strict
-    ((ComboCell *)
+    ((ComboCell*)
      gnc_table_layout_get_cell (reg->table->layout, ACTN_CELL), FALSE);
 
     /* number format for share quantities in stock ledgers */
@@ -2737,9 +2745,9 @@ gnc_split_register_config_cells (SplitRegister *reg)
     case STOCK_REGISTER:
     case PORTFOLIO_LEDGER:
         gnc_price_cell_set_print_info
-        ((PriceCell *)
+        ((PriceCell*)
          gnc_table_layout_get_cell (reg->table->layout, PRIC_CELL),
-         gnc_default_price_print_info (gnc_default_currency ()));
+         gnc_default_price_print_info (gnc_default_currency()));
         break;
 
     default:
@@ -2751,12 +2759,12 @@ gnc_split_register_config_cells (SplitRegister *reg)
 }
 
 static void
-split_register_pref_changed (gpointer prefs, gchar *pref, gpointer user_data)
+split_register_pref_changed (gpointer prefs, gchar* pref, gpointer user_data)
 {
-    SplitRegister * reg = user_data;
-    SRInfo *info;
+    SplitRegister* reg = user_data;
+    SRInfo* info;
 
-    g_return_if_fail(pref);
+    g_return_if_fail (pref);
     if (reg == NULL)
         return;
 
@@ -2764,7 +2772,7 @@ split_register_pref_changed (gpointer prefs, gchar *pref, gpointer user_data)
     if (!info)
         return;
 
-    if (g_str_has_suffix(pref, GNC_PREF_ACCOUNTING_LABELS))
+    if (g_str_has_suffix (pref, GNC_PREF_ACCOUNTING_LABELS))
     {
         /* Release current strings. Will be reloaded at next reference. */
         g_free (info->debit_str);
@@ -2778,31 +2786,31 @@ split_register_pref_changed (gpointer prefs, gchar *pref, gpointer user_data)
         info->tcredit_str = NULL;
 
     }
-    else if (g_str_has_suffix(pref, GNC_PREF_ACCOUNT_SEPARATOR))
+    else if (g_str_has_suffix (pref, GNC_PREF_ACCOUNT_SEPARATOR))
     {
         info->separator_changed = TRUE;
     }
-    else if (g_str_has_suffix(pref, GNC_PREF_SHOW_LEAF_ACCT_NAMES))
+    else if (g_str_has_suffix (pref, GNC_PREF_SHOW_LEAF_ACCT_NAMES))
     {
-        reg->show_leaf_accounts = gnc_prefs_get_bool(GNC_PREFS_GROUP_GENERAL_REGISTER,
-                                            GNC_PREF_SHOW_LEAF_ACCT_NAMES);
+        reg->show_leaf_accounts = gnc_prefs_get_bool (GNC_PREFS_GROUP_GENERAL_REGISTER,
+                                                      GNC_PREF_SHOW_LEAF_ACCT_NAMES);
     }
-    else if (g_str_has_suffix(pref, GNC_PREF_ALT_COLOR_BY_TRANS))
+    else if (g_str_has_suffix (pref, GNC_PREF_ALT_COLOR_BY_TRANS))
     {
-        reg->double_alt_color = gnc_prefs_get_bool(GNC_PREFS_GROUP_GENERAL_REGISTER,
-                                            GNC_PREF_ALT_COLOR_BY_TRANS);
+        reg->double_alt_color = gnc_prefs_get_bool (GNC_PREFS_GROUP_GENERAL_REGISTER,
+                                                    GNC_PREF_ALT_COLOR_BY_TRANS);
     }
     else
     {
-        g_warning("split_register_pref_changed: Unknown preference %s", pref);
+        g_warning ("split_register_pref_changed: Unknown preference %s", pref);
     }
 }
 
 static void
 split_register_book_option_changed (gpointer new_val, gpointer user_data)
 {
-    SplitRegister * reg = user_data;
-    gboolean *new_data = (gboolean*)new_val;
+    SplitRegister* reg = user_data;
+    gboolean* new_data = (gboolean*)new_val;
 
     if (reg == NULL)
         return;
@@ -2811,7 +2819,7 @@ split_register_book_option_changed (gpointer new_val, gpointer user_data)
 }
 
 static void
-gnc_split_register_init (SplitRegister *reg,
+gnc_split_register_init (SplitRegister* reg,
                          SplitRegisterType type,
                          SplitRegisterStyle style,
                          gboolean use_double_line,
@@ -2819,9 +2827,9 @@ gnc_split_register_init (SplitRegister *reg,
                          gboolean is_template,
                          gboolean mismatched_commodities)
 {
-    TableLayout *layout;
-    TableModel *model;
-    TableControl *control;
+    TableLayout* layout;
+    TableModel* model;
+    TableControl* control;
 
     /* Register 'destroy' callback */
     gnc_prefs_register_cb (GNC_PREFS_GROUP_GENERAL,
@@ -2840,18 +2848,18 @@ gnc_split_register_init (SplitRegister *reg,
                            GNC_PREF_ALT_COLOR_BY_TRANS,
                            split_register_pref_changed,
                            reg);
-    gnc_book_option_register_cb(OPTION_NAME_NUM_FIELD_SOURCE,
-                                split_register_book_option_changed,
-                                reg);
+    gnc_book_option_register_cb (OPTION_NAME_NUM_FIELD_SOURCE,
+                                 split_register_book_option_changed,
+                                 reg);
 
     reg->sr_info = NULL;
 
     reg->unrecn_splits = NULL;
 
-    reg->show_leaf_accounts = gnc_prefs_get_bool(GNC_PREFS_GROUP_GENERAL_REGISTER,
-                                            GNC_PREF_SHOW_LEAF_ACCT_NAMES);
-    reg->double_alt_color = gnc_prefs_get_bool(GNC_PREFS_GROUP_GENERAL_REGISTER,
-                                            GNC_PREF_ALT_COLOR_BY_TRANS);
+    reg->show_leaf_accounts = gnc_prefs_get_bool (GNC_PREFS_GROUP_GENERAL_REGISTER,
+                                                  GNC_PREF_SHOW_LEAF_ACCT_NAMES);
+    reg->double_alt_color = gnc_prefs_get_bool (GNC_PREFS_GROUP_GENERAL_REGISTER,
+                                                GNC_PREF_ALT_COLOR_BY_TRANS);
 
     reg->type = type;
     reg->style = style;
@@ -2860,18 +2868,18 @@ gnc_split_register_init (SplitRegister *reg,
     reg->is_template = is_template;
     reg->mismatched_commodities = mismatched_commodities;
     reg->use_tran_num_for_num_field =
-                (qof_book_use_split_action_for_num_field(gnc_get_current_book())
-                    ? FALSE : TRUE);
+        (qof_book_use_split_action_for_num_field (gnc_get_current_book())
+         ? FALSE : TRUE);
 
     layout = gnc_split_register_layout_new (reg);
 
     if (is_template)
-        model = gnc_template_register_model_new ();
+        model = gnc_template_register_model_new();
     else
-        model = gnc_split_register_model_new ();
+        model = gnc_split_register_model_new();
     model->handler_user_data = reg;
 
-    control = gnc_split_register_control_new ();
+    control = gnc_split_register_control_new();
     control->user_data = reg;
 
     reg->table = gnc_table_new (layout, model, control);
@@ -2881,7 +2889,7 @@ gnc_split_register_init (SplitRegister *reg,
     /* Set up header */
     {
         VirtualCellLocation vcell_loc = { 0, 0 };
-        CellBlock *header;
+        CellBlock* header;
 
         header = gnc_table_layout_get_cursor (reg->table->layout, CURSOR_HEADER);
 
@@ -2891,7 +2899,7 @@ gnc_split_register_init (SplitRegister *reg,
     /* Set up first and only initial row */
     {
         VirtualLocation vloc;
-        CellBlock *cursor;
+        CellBlock* cursor;
 
         vloc.vcell_loc.virt_row = 1;
         vloc.vcell_loc.virt_col = 0;
@@ -2912,14 +2920,14 @@ gnc_split_register_init (SplitRegister *reg,
     }
 }
 
-SplitRegister *
+SplitRegister*
 gnc_split_register_new (SplitRegisterType type,
                         SplitRegisterStyle style,
                         gboolean use_double_line,
                         gboolean is_template,
                         gboolean mismatched_commodities)
 {
-    SplitRegister * reg;
+    SplitRegister* reg;
     gboolean default_do_auto_complete = TRUE;
 
     reg = g_new0 (SplitRegister, 1);
@@ -2939,7 +2947,7 @@ gnc_split_register_new (SplitRegisterType type,
 }
 
 void
-gnc_split_register_config (SplitRegister *reg,
+gnc_split_register_config (SplitRegister* reg,
                            SplitRegisterType newtype,
                            SplitRegisterStyle newstyle,
                            gboolean use_double_line)
@@ -2954,7 +2962,8 @@ gnc_split_register_config (SplitRegister *reg,
         {
             if (virt_loc.phys_row_offset)
             {
-                gnc_table_move_vertical_position (reg->table, &virt_loc, -virt_loc.phys_row_offset);
+                gnc_table_move_vertical_position (reg->table, &virt_loc,
+                                                  -virt_loc.phys_row_offset);
                 gnc_table_move_cursor_gui (reg->table, virt_loc);
             }
         }
@@ -2981,17 +2990,17 @@ gnc_split_register_config (SplitRegister *reg,
 }
 
 void
-gnc_split_register_set_auto_complete(SplitRegister *reg,
-                                     gboolean do_auto_complete)
+gnc_split_register_set_auto_complete (SplitRegister* reg,
+                                      gboolean do_auto_complete)
 {
-    g_return_if_fail(reg);
+    g_return_if_fail (reg);
     reg->do_auto_complete = do_auto_complete;
 }
 
 static void
-gnc_split_register_destroy_info (SplitRegister *reg)
+gnc_split_register_destroy_info (SplitRegister* reg)
 {
-    SRInfo *info;
+    SRInfo* info;
 
     if (reg == NULL)
         return;
@@ -3022,10 +3031,10 @@ gnc_split_register_destroy_info (SplitRegister *reg)
 }
 
 void
-gnc_split_register_set_data (SplitRegister *reg, void *user_data,
+gnc_split_register_set_data (SplitRegister* reg, void* user_data,
                              SRGetParentCallback get_parent)
 {
-    SRInfo *info = gnc_split_register_get_info (reg);
+    SRInfo* info = gnc_split_register_get_info (reg);
 
     g_return_if_fail (reg != NULL);
 
@@ -3034,22 +3043,22 @@ gnc_split_register_set_data (SplitRegister *reg, void *user_data,
 }
 
 static void
-gnc_split_register_cleanup (SplitRegister *reg)
+gnc_split_register_cleanup (SplitRegister* reg)
 {
-    SRInfo *info = gnc_split_register_get_info (reg);
-    Transaction *pending_trans;
-    Transaction *blank_trans = NULL;
-    Split *blank_split;
+    SRInfo* info = gnc_split_register_get_info (reg);
+    Transaction* pending_trans;
+    Transaction* blank_trans = NULL;
+    Split* blank_split;
 
-    ENTER("reg=%p", reg);
+    ENTER ("reg=%p", reg);
 
     blank_split = xaccSplitLookup (&info->blank_split_guid,
-                                   gnc_get_current_book ());
+                                   gnc_get_current_book());
 
     pending_trans = xaccTransLookup (&info->pending_trans_guid,
-                                     gnc_get_current_book ());
+                                     gnc_get_current_book());
 
-    gnc_suspend_gui_refresh ();
+    gnc_suspend_gui_refresh();
 
     /* Destroy the transaction containing the "blank split", which was only
      * created to support the area for entering a new transaction. Since the
@@ -3060,8 +3069,8 @@ gnc_split_register_cleanup (SplitRegister *reg)
 
         blank_trans = xaccSplitGetParent (blank_split);
 
-        DEBUG("blank_split=%p, blank_trans=%p, pending_trans=%p",
-              blank_split, blank_trans, pending_trans);
+        DEBUG ("blank_split=%p, blank_trans=%p, pending_trans=%p",
+               blank_split, blank_trans, pending_trans);
 
         /* Destroying the transaction will automatically remove its splits. */
         was_open = xaccTransIsOpen (blank_trans);
@@ -3072,10 +3081,10 @@ gnc_split_register_cleanup (SplitRegister *reg)
         /* Update the register info. */
         if (blank_trans == pending_trans)
         {
-            info->pending_trans_guid = *guid_null ();
+            info->pending_trans_guid = *guid_null();
             pending_trans = NULL;
         }
-        info->blank_split_guid = *guid_null ();
+        info->blank_split_guid = *guid_null();
         info->auto_complete = FALSE;
         blank_split = NULL;
     }
@@ -3083,10 +3092,10 @@ gnc_split_register_cleanup (SplitRegister *reg)
     /* be sure to take care of any open transactions */
     if (pending_trans != NULL)
     {
-        g_critical("BUG DETECTED: pending_trans=%p, blank_split=%p, blank_trans=%p",
-                   pending_trans, blank_split, blank_trans);
+        g_critical ("BUG DETECTED: pending_trans=%p, blank_split=%p, blank_trans=%p",
+                    pending_trans, blank_split, blank_trans);
         g_assert_not_reached();
-        info->pending_trans_guid = *guid_null ();
+        info->pending_trans_guid = *guid_null();
         /* CAS: It's not clear to me that we'd really want to commit
            here, rather than rollback. But, maybe this is just dead
            code. */
@@ -3099,17 +3108,17 @@ gnc_split_register_cleanup (SplitRegister *reg)
 
     gnc_split_register_destroy_info (reg);
 
-    gnc_resume_gui_refresh ();
+    gnc_resume_gui_refresh();
 
-    LEAVE(" ");
+    LEAVE (" ");
 }
 
 void
-gnc_split_register_destroy (SplitRegister *reg)
+gnc_split_register_destroy (SplitRegister* reg)
 {
-    g_return_if_fail(reg);
+    g_return_if_fail (reg);
 
-    ENTER("reg=%p", reg);
+    ENTER ("reg=%p", reg);
 
     gnc_prefs_remove_cb_by_func (GNC_PREFS_GROUP_GENERAL,
                                  GNC_PREF_ACCOUNTING_LABELS,
@@ -3128,8 +3137,8 @@ gnc_split_register_destroy (SplitRegister *reg)
                                  split_register_pref_changed,
                                  reg);
     gnc_book_option_remove_cb (OPTION_NAME_NUM_FIELD_SOURCE,
-                                 split_register_book_option_changed,
-                                 reg);
+                               split_register_book_option_changed,
+                               reg);
 
     gnc_split_register_cleanup (reg);
 
@@ -3138,11 +3147,11 @@ gnc_split_register_destroy (SplitRegister *reg)
 
     /* free the memory itself */
     g_free (reg);
-    LEAVE(" ");
+    LEAVE (" ");
 }
 
 void
-gnc_split_register_set_read_only (SplitRegister *reg, gboolean read_only)
+gnc_split_register_set_read_only (SplitRegister* reg, gboolean read_only)
 {
     gnc_table_model_set_read_only (reg->table->model, read_only);
 }

--- a/gnucash/register/ledger-core/split-register.c
+++ b/gnucash/register/ledger-core/split-register.c
@@ -2816,7 +2816,8 @@ gnc_split_register_init (SplitRegister *reg,
                          SplitRegisterStyle style,
                          gboolean use_double_line,
                          gboolean do_auto_complete,
-                         gboolean is_template)
+                         gboolean is_template,
+                         gboolean mismatched_commodities)
 {
     TableLayout *layout;
     TableModel *model;
@@ -2857,6 +2858,7 @@ gnc_split_register_init (SplitRegister *reg,
     reg->use_double_line = use_double_line;
     reg->do_auto_complete = do_auto_complete;
     reg->is_template = is_template;
+    reg->mismatched_commodities = mismatched_commodities;
     reg->use_tran_num_for_num_field =
                 (qof_book_use_split_action_for_num_field(gnc_get_current_book())
                     ? FALSE : TRUE);
@@ -2914,7 +2916,8 @@ SplitRegister *
 gnc_split_register_new (SplitRegisterType type,
                         SplitRegisterStyle style,
                         gboolean use_double_line,
-                        gboolean is_template)
+                        gboolean is_template,
+                        gboolean mismatched_commodities)
 {
     SplitRegister * reg;
     gboolean default_do_auto_complete = TRUE;
@@ -2929,7 +2932,8 @@ gnc_split_register_new (SplitRegisterType type,
                              style,
                              use_double_line,
                              default_do_auto_complete,
-                             is_template);
+                             is_template,
+                             mismatched_commodities);
 
     return reg;
 }

--- a/gnucash/register/ledger-core/split-register.h
+++ b/gnucash/register/ledger-core/split-register.h
@@ -240,7 +240,7 @@ typedef struct sr_info SRInfo;
 /** @brief The type, style and table for the register. */
 struct split_register
 {
-    Table * table;   /**< The table itself that implements the underlying GUI. */
+    Table* table;    /**< The table itself that implements the underlying GUI. */
 
     SplitRegisterType type;
     SplitRegisterStyle style;
@@ -257,13 +257,14 @@ struct split_register
     gboolean mismatched_commodities; /**< indicates the register includes transactions in
                                       mismatched commodities */
 
-    SplitList *unrecn_splits; /**< list of splits to unreconcile after transaction edit */
+    SplitList*
+    unrecn_splits; /**< list of splits to unreconcile after transaction edit */
 
-    SRInfo * sr_info;   /**< private data; outsiders should not access this */
+    SRInfo* sr_info;    /**< private data; outsiders should not access this */
 };
 
 /** Callback function type */
-typedef GtkWidget *(*SRGetParentCallback) (gpointer user_data);
+typedef GtkWidget* (*SRGetParentCallback) (gpointer user_data);
 
 
 /* Prototypes ******************************************************/
@@ -281,17 +282,17 @@ typedef GtkWidget *(*SRGetParentCallback) (gpointer user_data);
  *
  *  @return a newly created ::SplitRegister
  */
-SplitRegister * gnc_split_register_new (SplitRegisterType type,
-                                        SplitRegisterStyle style,
-                                        gboolean use_double_line,
-                                        gboolean is_template,
-                                        gboolean mismatched_commodities);
+SplitRegister* gnc_split_register_new (SplitRegisterType type,
+                                       SplitRegisterStyle style,
+                                       gboolean use_double_line,
+                                       gboolean is_template,
+                                       gboolean mismatched_commodities);
 
 /** Destroys a split register.
  *
  *  @param reg a ::SplitRegister
  */
-void gnc_split_register_destroy (SplitRegister *reg);
+void gnc_split_register_destroy (SplitRegister* reg);
 
 /** Sets a split register's type, style or line use.
  *
@@ -304,7 +305,7 @@ void gnc_split_register_destroy (SplitRegister *reg);
  *  @param use_double_line @c TRUE to show two lines for transactions,
  *  @c FALSE for one
  */
-void gnc_split_register_config (SplitRegister *reg,
+void gnc_split_register_config (SplitRegister* reg,
                                 SplitRegisterType type,
                                 SplitRegisterStyle style,
                                 gboolean use_double_line);
@@ -315,8 +316,8 @@ void gnc_split_register_config (SplitRegister *reg,
  *
  *  @param do_auto_complete @c TRUE to use auto-completion, @c FALSE otherwise
  */
-void gnc_split_register_set_auto_complete(SplitRegister *reg,
-        gboolean do_auto_complete);
+void gnc_split_register_set_auto_complete (SplitRegister* reg,
+                                           gboolean do_auto_complete);
 
 /** Sets whether a register window is "read only".
  *
@@ -324,7 +325,7 @@ void gnc_split_register_set_auto_complete(SplitRegister *reg,
  *
  *  @param read_only @c TRUE to use "read only" mode, @c FALSE otherwise
  */
-void gnc_split_register_set_read_only (SplitRegister *reg, gboolean read_only);
+void gnc_split_register_set_read_only (SplitRegister* reg, gboolean read_only);
 
 
 /** Set the template account for use in a template register.
@@ -333,11 +334,11 @@ void gnc_split_register_set_read_only (SplitRegister *reg, gboolean read_only);
  *
  *  @param template_account the account to use for the template
  */
-void gnc_split_register_set_template_account (SplitRegister *reg,
-        Account *template_account);
+void gnc_split_register_set_template_account (SplitRegister* reg,
+                                              Account* template_account);
 
 /** Sets the user data and callback hooks for the register. */
-void gnc_split_register_set_data (SplitRegister *reg, gpointer user_data,
+void gnc_split_register_set_data (SplitRegister* reg, gpointer user_data,
                                   SRGetParentCallback get_parent);
 
 /** Returns the class of a register's current cursor.
@@ -346,7 +347,7 @@ void gnc_split_register_set_data (SplitRegister *reg, gpointer user_data,
  *
  *  @return the ::CursorClass of the current cursor
  */
-CursorClass gnc_split_register_get_current_cursor_class (SplitRegister *reg);
+CursorClass gnc_split_register_get_current_cursor_class (SplitRegister* reg);
 
 /** Returns the class of the cursor at the given virtual cell location.
  *
@@ -357,7 +358,7 @@ CursorClass gnc_split_register_get_current_cursor_class (SplitRegister *reg);
  *  @return the ::CursorClass of the cursor at @a vcell_loc
  */
 CursorClass gnc_split_register_get_cursor_class
-(SplitRegister *reg,
+(SplitRegister* reg,
  VirtualCellLocation vcell_loc);
 
 /** Gets the transaction at the current cursor location, which may be on
@@ -367,7 +368,7 @@ CursorClass gnc_split_register_get_cursor_class
  *
  *  @return the ::Transaction at the cursor location, or @c NULL
  */
-Transaction * gnc_split_register_get_current_trans (SplitRegister *reg);
+Transaction* gnc_split_register_get_current_trans (SplitRegister* reg);
 
 /** Gets the anchoring split of the transaction at the current cursor location,
  *  which may be on the transaction itself or on any of its splits.
@@ -379,9 +380,9 @@ Transaction * gnc_split_register_get_current_trans (SplitRegister *reg);
  *
  *  @return the anchoring ::Split of the transaction
  */
-Split *
-gnc_split_register_get_current_trans_split (SplitRegister *reg,
-        VirtualCellLocation *vcell_loc);
+Split*
+gnc_split_register_get_current_trans_split (SplitRegister* reg,
+                                            VirtualCellLocation* vcell_loc);
 
 /** Returns the split at which the cursor is currently located.
  *
@@ -390,7 +391,7 @@ gnc_split_register_get_current_trans_split (SplitRegister *reg,
  *  @return the ::Split at the cursor location, or the anchoring split
  *  if the cursor is currently on a transaction
  */
-Split * gnc_split_register_get_current_split (SplitRegister *reg);
+Split* gnc_split_register_get_current_split (SplitRegister* reg);
 
 /** Gets the blank split for a register.
  *
@@ -399,7 +400,7 @@ Split * gnc_split_register_get_current_split (SplitRegister *reg);
  *  @return the ::Split used as the blank split, or @c NULL if
  *  there currently isn't one
  */
-Split * gnc_split_register_get_blank_split (SplitRegister *reg);
+Split* gnc_split_register_get_blank_split (SplitRegister* reg);
 
 /** Searches the split register for a given split.
  *  The search begins from the bottom row and works backwards. The location
@@ -416,8 +417,8 @@ Split * gnc_split_register_get_blank_split (SplitRegister *reg);
  *  at @a vcell_loc, @c FALSE otherwise
  */
 gboolean
-gnc_split_register_get_split_virt_loc (SplitRegister *reg, Split *split,
-                                       VirtualCellLocation *vcell_loc);
+gnc_split_register_get_split_virt_loc (SplitRegister* reg, Split* split,
+                                       VirtualCellLocation* vcell_loc);
 
 /** Searches the split register for the given split and determines the
  *  location of either its credit (if non-zero) or debit cell.
@@ -432,58 +433,59 @@ gnc_split_register_get_split_virt_loc (SplitRegister *reg, Split *split,
  *  at @a virt_loc, @c FALSE otherwise
  */
 gboolean
-gnc_split_register_get_split_amount_virt_loc (SplitRegister *reg, Split *split,
-        VirtualLocation *virt_loc);
+gnc_split_register_get_split_amount_virt_loc (SplitRegister* reg, Split* split,
+                                              VirtualLocation* virt_loc);
 
 /** Duplicates either the current transaction or the current split
  *    depending on the register mode and cursor position. Returns the
  *    split just created, or the 'main' split of the transaction just
  *    created, or NULL if nothing happened. */
-Split * gnc_split_register_duplicate_current (SplitRegister *reg);
+Split* gnc_split_register_duplicate_current (SplitRegister* reg);
 
 /** Makes a copy of the current entity, either a split or a
  *    transaction, so that it can be pasted later. */
-void gnc_split_register_copy_current (SplitRegister *reg);
+void gnc_split_register_copy_current (SplitRegister* reg);
 
 /** Equivalent to copying the current entity and the deleting it with
  *    the appropriate delete method. */
-void gnc_split_register_cut_current (SplitRegister *reg);
+void gnc_split_register_cut_current (SplitRegister* reg);
 
 /** Pastes a previous copied entity onto the current entity, but only
  *    if the copied and current entity have the same type. */
-void gnc_split_register_paste_current (SplitRegister *reg);
+void gnc_split_register_paste_current (SplitRegister* reg);
 
 /** Deletes the split associated with the current cursor, if both are
  *    non-NULL. Deleting the blank split just clears cursor values. */
-void gnc_split_register_delete_current_split (SplitRegister *reg);
+void gnc_split_register_delete_current_split (SplitRegister* reg);
 
 /** Deletes the transaction associated with the current cursor, if both
  *    are non-NULL. */
-void gnc_split_register_delete_current_trans (SplitRegister *reg);
+void gnc_split_register_delete_current_trans (SplitRegister* reg);
 
 /** Voids the transaction associated with the current cursor, if
  *    non-NULL. */
-void gnc_split_register_void_current_trans (SplitRegister *reg,
-        const char *reason);
+void gnc_split_register_void_current_trans (SplitRegister* reg,
+                                            const char* reason);
 
 /** Unvoids the transaction associated with the current cursor, if
  *    non-NULL. */
-void gnc_split_register_unvoid_current_trans (SplitRegister *reg);
+void gnc_split_register_unvoid_current_trans (SplitRegister* reg);
 
 /** Deletes the non-transaction splits associated with the current
  *    cursor, if both are non-NULL. */
-void gnc_split_register_empty_current_trans_except_split  (SplitRegister *reg, Split *split);
-void gnc_split_register_empty_current_trans  (SplitRegister *reg);
+void gnc_split_register_empty_current_trans_except_split (SplitRegister* reg,
+                                                          Split* split);
+void gnc_split_register_empty_current_trans (SplitRegister* reg);
 
 /** Cancels any changes made to the current cursor, reloads the cursor
  *    from the engine, reloads the table from the cursor, and updates
  *    the GUI. The change flags are cleared. */
-void gnc_split_register_cancel_cursor_split_changes (SplitRegister *reg);
+void gnc_split_register_cancel_cursor_split_changes (SplitRegister* reg);
 
 /** Cancels any changes made to the current pending transaction,
  *    reloads the table from the engine, and updates the GUI. The
  *    change flags are cleared. */
-void gnc_split_register_cancel_cursor_trans_changes (SplitRegister *reg);
+void gnc_split_register_cancel_cursor_trans_changes (SplitRegister* reg);
 
 /** Populates the rows of a register.
  *
@@ -502,8 +504,8 @@ void gnc_split_register_cancel_cursor_trans_changes (SplitRegister *reg);
  *
  *  @param default_account an account to provide defaults for the blank split
  */
-void gnc_split_register_load (SplitRegister *reg, GList * slist,
-                              Account *default_account);
+void gnc_split_register_load (SplitRegister* reg, GList* slist,
+                              Account* default_account);
 
 /** Copy the contents of the current cursor to a split. The split and
  *    transaction that are updated are the ones associated with the
@@ -512,44 +514,45 @@ void gnc_split_register_load (SplitRegister *reg, GList * slist,
  *    blank transaction, and the do_commit flag is set, a refresh will
  *    result in a new blank transaction.  The method returns TRUE if
  *    something was changed. */
-gboolean gnc_split_register_save (SplitRegister *reg, gboolean do_commit);
+gboolean gnc_split_register_save (SplitRegister* reg, gboolean do_commit);
 
 /** Causes a redraw of the register window associated with reg. */
-void gnc_split_register_redraw (SplitRegister *reg);
+void gnc_split_register_redraw (SplitRegister* reg);
 
 /** Returns TRUE if the register has changed cells. */
-gboolean gnc_split_register_changed (SplitRegister *reg);
+gboolean gnc_split_register_changed (SplitRegister* reg);
 
 /** If TRUE, visually indicate the demarcation between splits with post
  * dates prior to the present, and after. This will only make sense if
  * the splits are ordered primarily by post date. */
-void gnc_split_register_show_present_divider (SplitRegister *reg,
-        gboolean show_present);
+void gnc_split_register_show_present_divider (SplitRegister* reg,
+                                              gboolean show_present);
 
 /** Expand the current transaction if it is collapsed. */
-void gnc_split_register_expand_current_trans (SplitRegister *reg,
-        gboolean expand);
+void gnc_split_register_expand_current_trans (SplitRegister* reg,
+                                              gboolean expand);
 
 /** Mark the current transaction as collapsed, and do callbacks. */
-void gnc_split_register_collapse_current_trans (SplitRegister *reg);
+void gnc_split_register_collapse_current_trans (SplitRegister* reg);
 
 /** Return TRUE if current trans is expanded and style is REG_STYLE_LEDGER. */
-gboolean gnc_split_register_current_trans_expanded (SplitRegister *reg);
+gboolean gnc_split_register_current_trans_expanded (SplitRegister* reg);
 
 /** Return the debit string used in the register. */
-const char * gnc_split_register_get_debit_string (SplitRegister *reg);
+const char* gnc_split_register_get_debit_string (SplitRegister* reg);
 
 /** Return the credit string used in the register. */
-const char * gnc_split_register_get_credit_string (SplitRegister *reg);
+const char* gnc_split_register_get_credit_string (SplitRegister* reg);
 
 /** Return TRUE if split is the blank_split. */
-gboolean gnc_split_register_is_blank_split (SplitRegister *reg, Split *split);
+gboolean gnc_split_register_is_blank_split (SplitRegister* reg, Split* split);
 
 /** Change the blank_split reference from pointing to split to another
  *  split of the transaction. This is used when deleting a split after an
  *  autocomplete as the blank_split reference will be pointing to one of
  *  the splits so it does not cancel the whole transaction */
-void gnc_split_register_change_blank_split_ref (SplitRegister *reg, Split *split);
+void gnc_split_register_change_blank_split_ref (SplitRegister* reg,
+                                                Split* split);
 
 /** Pop up the exchange-rate dialog, maybe, for the current split.
  * If force_dialog is TRUE, the forces the dialog to be called.
@@ -557,11 +560,11 @@ void gnc_split_register_change_blank_split_ref (SplitRegister *reg, Split *split
  * Return FALSE in all other cases (meaning "move on")
  */
 gboolean
-gnc_split_register_handle_exchange (SplitRegister *reg, gboolean force_dialog);
+gnc_split_register_handle_exchange (SplitRegister* reg, gboolean force_dialog);
 
 /* returns TRUE if begin_edit was aborted */
 gboolean
-gnc_split_register_begin_edit_or_warn(SRInfo *info, Transaction *trans);
+gnc_split_register_begin_edit_or_warn (SRInfo* info, Transaction* trans);
 
 /** @} */
 /** @} */
@@ -569,10 +572,10 @@ gnc_split_register_begin_edit_or_warn(SRInfo *info, Transaction *trans);
 /* -------------------------------------------------------------- */
 
 /** Private function -- outsiders must not use this */
-gboolean gnc_split_register_full_refresh_ok (SplitRegister *reg);
+gboolean gnc_split_register_full_refresh_ok (SplitRegister* reg);
 
 /** Private function -- outsiders must not use this */
-void gnc_copy_trans_onto_trans (Transaction *from, Transaction *to,
+void gnc_copy_trans_onto_trans (Transaction* from, Transaction* to,
                                 gboolean use_cut_semantics,
                                 gboolean do_commit);
 

--- a/gnucash/register/ledger-core/split-register.h
+++ b/gnucash/register/ledger-core/split-register.h
@@ -254,6 +254,8 @@ struct split_register
 
     gboolean is_template;
     gboolean do_auto_complete; /**< whether to use auto-completion */
+    gboolean mismatched_commodities; /**< indicates the register includes transactions in
+                                      mismatched commodities */
 
     SplitList *unrecn_splits; /**< list of splits to unreconcile after transaction edit */
 
@@ -282,7 +284,8 @@ typedef GtkWidget *(*SRGetParentCallback) (gpointer user_data);
 SplitRegister * gnc_split_register_new (SplitRegisterType type,
                                         SplitRegisterStyle style,
                                         gboolean use_double_line,
-                                        gboolean is_template);
+                                        gboolean is_template,
+                                        gboolean mismatched_commodities);
 
 /** Destroys a split register.
  *


### PR DESCRIPTION
… currencies are involved
I implemented the solution suggested by John to prevent opening subaccounts if there is a currency / commodity mismatch.
I think a possibly better solution would be to open as read-only, and fix the display issue (i.e., mark each subaccount with its currency and remove the balance column).