### PR TITLE
A functional gncOwnerFromLot

### DIFF
--- a/libgnucash/engine/business-core.i
+++ b/libgnucash/engine/business-core.i
@@ -112,6 +112,7 @@ GLIST_HELPER_INOUT(OwnerList, SWIGTYPE_p__gncOwner);
 
   $result = scm_reverse(list);
 }
+%typemap(newfree) GncOwner * "gncOwnerFree($1);"
 #endif
 
 

--- a/libgnucash/engine/gncOwner.c
+++ b/libgnucash/engine/gncOwner.c
@@ -1559,6 +1559,23 @@ owner_from_lot (GNCLot *lot)
     return NULL;
 }
 
+GncOwner* gncOwnerFromLot (GNCLot *lot)
+{
+    GncOwner* owner, ownercopy;
+
+    if (!lot) return NULL;
+    owner = owner_from_lot (lot);
+
+    if (owner)
+    {
+        GncOwner *ownercopy = gncOwnerNew ();
+        gncOwnerCopy (owner, ownercopy);
+        return ownercopy;
+    }
+    else
+        return NULL;
+}
+
 static void
 reg_lot (void)
 {

--- a/libgnucash/engine/gncOwner.h
+++ b/libgnucash/engine/gncOwner.h
@@ -206,6 +206,11 @@ gboolean gncOwnerGetOwnerFromLot (GNCLot *lot, GncOwner *owner);
  */
 gboolean gncOwnerGetOwnerFromTxn (Transaction *txn, GncOwner *owner);
 
+/** From lot, get owner. The resulting owner must be freed with
+ *  gncOwnerFree when not needed anymore.
+ */
+GncOwner* gncOwnerFromLot (GNCLot *lot);
+
 gboolean gncOwnerGetOwnerFromTypeGuid (QofBook *book, GncOwner *owner, QofIdType type, GncGUID *guid);
 
 /**


### PR DESCRIPTION
Convenience wrapper around `owner_from_lot` and the resulting `*owner` is freed automatically in SWIG.