### PR TITLE
add instance argument to Session constructor

### DIFF
--- a/bindings/python/function_class.py
+++ b/bindings/python/function_class.py
@@ -59,12 +59,15 @@ class ClassFromFunctions(object):
         self._module[self._new_instance] or using existing instance
         data. (specified with the keyword argument, instance)
 
+        if instance argument is None it will be ignored and the
+        constructor will be called to get a new instance
+
         Pass the arguments that should be passed on to
-        self._module[self._new_instance] . Any arguments of that
+        self._module[self._new_instance]. Any arguments of that
         are instances of ClassFromFunctions will be switched with the instance
         data. (by calling the .instance property)
         """
-        if INSTANCE_ARGUMENT in kargs:
+        if INSTANCE_ARGUMENT in kargs and kargs[INSTANCE_ARGUMENT] is not None:
             self.__instance = kargs[INSTANCE_ARGUMENT]
         else:
             self.__instance = getattr(self._module, self._new_instance)(

--- a/bindings/python/gnucash_core.py
+++ b/bindings/python/gnucash_core.py
@@ -75,7 +75,7 @@ class Session(GnuCashCoreClass):
     """
 
     def __init__(self, book_uri=None, ignore_lock=False, is_new=False,
-                 force_new= False):
+                 force_new=False, instance=None):
         """A convenient constructor that allows you to specify a book URI,
         begin the session, and load the book.
 
@@ -95,13 +95,15 @@ class Session(GnuCashCoreClass):
         ignore_lock is passed to qof_session_begin's argument of the
         same name and is used to break an existing lock on a dataset.
 
+        instance argument can be passed if new Session is used as a
+        wrapper for an existing session instance
 
 
         This function can raise a GnuCashBackendException. If it does,
         you don't need to cleanup and call end() and destroy(), that is handled
         for you, and the exception is raised.
         """
-        GnuCashCoreClass.__init__(self)
+        GnuCashCoreClass.__init__(self, instance=instance)
         if book_uri is not None:
             try:
                 self.begin(book_uri, ignore_lock, is_new, force_new)

--- a/bindings/python/tests/runTests.py.in
+++ b/bindings/python/tests/runTests.py.in
@@ -5,6 +5,7 @@ import os
 
 os.environ["GNC_UNINSTALLED"] = "1"
 
+from test_session import TestSession
 from test_book import TestBook
 from test_account import TestAccount
 from test_split import TestSplit

--- a/bindings/python/tests/test_account.py
+++ b/bindings/python/tests/test_account.py
@@ -5,12 +5,12 @@ from gnucash import Book, Account, Split, GncCommodity, GncNumeric, \
 
 from test_book import BookSession
 
-class AccountSession( BookSession ):
+class AccountSession(BookSession):
     def setUp(self):
         BookSession.setUp(self)
         self.account = Account(self.book)
 
-class TestAccount( AccountSession ):
+class TestAccount(AccountSession):
     def test_name(self):
         NAME = "Money"
         self.assertEqual( '', self.account.GetName() )

--- a/bindings/python/tests/test_book.py
+++ b/bindings/python/tests/test_book.py
@@ -2,14 +2,14 @@ from unittest import TestCase, main
 
 from gnucash import Session
 
-class BookSession( TestCase ):
+class BookSession(TestCase):
     def setUp(self):
         self.ses = Session()
         self.book = self.ses.get_book()
         self.table = self.book.get_table()
         self.currency = self.table.lookup('CURRENCY', 'EUR')
 
-class TestBook( BookSession ):
+class TestBook(BookSession):
     def test_markclosed(self):
         self.ses.end()
 

--- a/bindings/python/tests/test_business.py
+++ b/bindings/python/tests/test_business.py
@@ -9,7 +9,7 @@ from gnucash.gnucash_business import Vendor, Employee, Customer, Job, Invoice, E
 
 from test_book import BookSession
 
-class BusinessSession( BookSession ):
+class BusinessSession(BookSession):
     def setUp(self):
         BookSession.setUp(self)
 
@@ -43,7 +43,7 @@ class BusinessSession( BookSession ):
         self.invoice.PostToAccount(self.receivable,
             self.today, self.today, "", True, False)
 
-class TestBusiness( BusinessSession ):
+class TestBusiness(BusinessSession):
     def test_equal(self):
         self.assertTrue( self.vendor.Equal( self.vendor.GetVendor() ) )
         self.assertTrue( self.customer.Equal( self.job.GetOwner() ) )

--- a/bindings/python/tests/test_commodity.py
+++ b/bindings/python/tests/test_commodity.py
@@ -2,7 +2,7 @@ from unittest import TestCase, main
 
 from gnucash import Session
 
-class CommoditySession( TestCase ):
+class CommoditySession(TestCase):
     def setUp(self):
         self.ses = Session()
         self.book = self.ses.get_book()
@@ -11,12 +11,12 @@ class CommoditySession( TestCase ):
     def tearDown(self):
         self.ses.end()
 
-class TestCommodity( CommoditySession ):
+class TestCommodity(CommoditySession):
     def test_iso_currency(self):
         eur = self.table.lookup('CURRENCY', 'EUR')
         self.assertIsNotNone(eur)
 
-class TestCommodityNamespace( CommoditySession ):
+class TestCommodityNamespace(CommoditySession):
     def test_namespaces(self):
         #print(self.table.__class__)
         namespace_names = self.table.get_namespaces()

--- a/bindings/python/tests/test_numeric.py
+++ b/bindings/python/tests/test_numeric.py
@@ -3,7 +3,7 @@ from unittest import TestCase, main
 from gnucash import GncNumeric, GNC_DENOM_AUTO, GNC_HOW_DENOM_FIXED, \
     GNC_HOW_RND_NEVER, GNC_HOW_RND_FLOOR, GNC_HOW_RND_CEIL
 
-class TestGncNumeric( TestCase ):
+class TestGncNumeric(TestCase):
     def test_defaut(self):
         num = GncNumeric()
         self.assertEqual(str(num), "0/1")

--- a/bindings/python/tests/test_session.py
+++ b/bindings/python/tests/test_session.py
@@ -1,0 +1,34 @@
+# test cases for Session wrapper object
+#
+# test for get_book may belong in test_book but it makes sense here
+# to see if get_current_session works
+# test for app_utils on the other hand could go to a subfolder of
+# /libgnucash/app-utils
+#
+# @date 2020-04-03
+# @author Christoph Holtermann <mail@c-holtermann.net>
+
+from unittest import TestCase, main
+
+from gnucash import Session
+
+class TestSession(TestCase):
+    def test_create_empty_session(self):
+        self.ses = Session()
+
+    def test_app_utils_get_current_session(self):
+        from gnucash import _sw_app_utils
+        self.ses_instance = _sw_app_utils.gnc_get_current_session()
+        self.ses = Session(instance = self.ses_instance)
+        self.assertIsInstance(obj = self.ses, cls = Session)
+
+    def test_get_book_from_current_session(self):
+        from gnucash import _sw_app_utils
+        from gnucash import Book
+        self.ses_instance = _sw_app_utils.gnc_get_current_session()
+        self.ses = Session(instance = self.ses_instance)
+        self.book = self.ses.get_book()
+        self.assertIsInstance(obj = self.book, cls = Book)
+
+if __name__ == '__main__':
+    main()

--- a/bindings/python/tests/test_split.py
+++ b/bindings/python/tests/test_split.py
@@ -5,7 +5,7 @@ from unittest_support import *
 
 from test_book import BookSession
 
-class SplitSession( BookSession ):
+class SplitSession(BookSession):
     def setUp(self):
 
         BookSession.setUp(self)
@@ -14,7 +14,7 @@ class SplitSession( BookSession ):
     def tearDown(self):
         pass
 
-class TestSplit( SplitSession ):
+class TestSplit(SplitSession):
     def test_memo(self):
         MEMO = "cookie monster"
         self.assertEqual( '', self.split.GetMemo() )

--- a/bindings/python/tests/test_transaction.py
+++ b/bindings/python/tests/test_transaction.py
@@ -5,7 +5,7 @@ from unittest_support import *
 
 from test_book import BookSession
 
-class TransactionSession( BookSession ):
+class TransactionSession(BookSession):
     def setUp(self):
         self.domain1 = "gnc.engine"
         self.domain2 = "gnc.engine.scrub"
@@ -40,7 +40,7 @@ class TransactionSession( BookSession ):
         g_log_remove_handler(self.domain2, self.hdlr2)
         test_clear_error_list ()
 
-class TestTransaction( TransactionSession ):
+class TestTransaction(TransactionSession):
     def test_equal(self):
         TRANS = self.trans
         self.assertTrue( TRANS.Equal(self.trans, True, False, False, False) )

--- a/common/cmake_modules/GncAddSwigCommand.cmake
+++ b/common/cmake_modules/GncAddSwigCommand.cmake
@@ -84,7 +84,8 @@ macro (gnc_add_swig_python_command _target _out_var _py_out_var _output _py_outp
             ${CMAKE_SOURCE_DIR}/common
             ${CMAKE_SOURCE_DIR}/libgnucash/engine
             ${CMAKE_SOURCE_DIR}/libgnucash/app-utils
-        )
+       	    ${CMAKE_SOURCE_DIR}/bindings/python
+	)
 
         set (PYTHON_SWIG_FLAGS ${DEFAULT_SWIG_PYTHON_FLAGS})
         foreach (dir ${DEFAULT_SWIG_PYTHON_C_INCLUDES})

--- a/libgnucash/app-utils/app-utils.i
+++ b/libgnucash/app-utils/app-utils.i
@@ -56,6 +56,7 @@ void
 #endif
 SWIG_init (void);
 %}
+%import <gnucash_core.i>
 #endif
 
 %import "base-typemaps.i"


### PR DESCRIPTION
if Session is used only as a wrapper for an existing session instance
its necessary to be able to pass this instance as an argument

Session(instance=gnucash._sw_app_utils.gnc_get_current_session()) is impossible otherwise as can be used in the python shell