### PR TITLE
Make pycons/ishell.py compatible with Python 3 and current IPython

### DIFF
--- a/gnucash/python/pycons/ishell.py
+++ b/gnucash/python/pycons/ishell.py
@@ -16,12 +16,11 @@
 import os
 import sys
 import re
-from StringIO import StringIO
+from io import StringIO
 try:
     import IPython
-    from IPython import ipapi
-except Exception,e:
-    raise "Error importing IPython (%s)" % str(e)
+except Exception as e:
+    raise Exception("Error importing IPython (%s)" % str(e))
 
 
 # ------------------------------------------------------------------ class Shell
@@ -54,11 +53,11 @@ class Shell:
                                                 header='IPython system call: ',
                                                 verbose=self.IP.rc.system_verbose)
         # Get a hold of the public IPython API object and use it
-        self.ip = ipapi.get()
+        self.ip = IPython.core.getipython.get_ipython()
         self.ip.magic('colors LightBG')                
         sys.excepthook = excepthook
         self.iter_more = 0
-        self.complete_sep =  re.compile('[\s\{\}\[\]\(\)]')
+        self.complete_sep =  re.compile(r'[\s\{\}\[\]\(\)]')
 
 
     def namespace(self):


### PR DESCRIPTION
I've only tested this with python -Wd and not actually used it.

ipapi.get() has been deprecated since 0.11 (2011) apparently:
https://stackoverflow.com/questions/13864126/no-module-named-ipapi#comment19164908_13864322
