### PR TITLE
[Master] Fix issue when editing the account tree view notes field

### DIFF
--- a/gnucash/gnome-utils/CMakeLists.txt
+++ b/gnucash/gnome-utils/CMakeLists.txt
@@ -51,6 +51,8 @@ set (gnome_utils_SOURCES
   gnc-cell-renderer-popup.c
   gnc-cell-renderer-popup-entry.c
   gnc-cell-renderer-text-flag.c
+  gnc-cell-renderer-text-view.c
+  gnc-cell-view.c
   gnc-combott.c
   gnc-commodity-edit.c
   gnc-component-manager.c
@@ -140,6 +142,8 @@ set (gnome_utils_HEADERS
   gnc-cell-renderer-popup.h
   gnc-cell-renderer-popup-entry.h
   gnc-cell-renderer-text-flag.h
+  gnc-cell-renderer-text-view.h
+  gnc-cell-view.h
   gnc-combott.h
   gnc-commodity-edit.h
   gnc-component-manager.h

--- a/gnucash/gnome-utils/gnc-cell-renderer-text-view.c
+++ b/gnucash/gnome-utils/gnc-cell-renderer-text-view.c
@@ -1,0 +1,160 @@
+/*************************************************************************
+ * The following code implements a text view in a custom GtkCellRenderer.
+ *
+ * Copyright (C) 2020 Robert Fewell
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *************************************************************************/
+#include <config.h>
+
+#include <gtk/gtk.h>
+#include <glib/gi18n.h>
+#include <gdk/gdkkeysyms.h>
+
+#include "gnc-cell-renderer-text-view.h"
+#include "gnc-cell-view.h"
+
+static void      gnc_cell_renderer_text_view_init       (GncCellRendererTextView      *self);
+static void      gnc_cell_renderer_text_view_class_init (GncCellRendererTextViewClass *klass);
+
+static GtkCellEditable *gcrtv_start_editing (GtkCellRenderer          *cell,
+                                             GdkEvent                 *event,
+                                             GtkWidget                *widget,
+                                             const gchar              *path,
+                                             const GdkRectangle       *background_area,
+                                             const GdkRectangle       *cell_area,
+                                             GtkCellRendererState      flags);
+
+#define GNC_CELL_RENDERER_TEXT_VIEW_PATH "gnc-cell-renderer-text-view-path"
+
+G_DEFINE_TYPE (GncCellRendererTextView, gnc_cell_renderer_text_view, GTK_TYPE_CELL_RENDERER_TEXT)
+
+static void
+gnc_cell_renderer_text_view_init (GncCellRendererTextView *self)
+{
+}
+
+static void
+gnc_cell_renderer_text_view_finalize (GObject *object)
+{
+    G_OBJECT_CLASS (gnc_cell_renderer_text_view_parent_class)->finalize (object);
+}
+
+static void
+gnc_cell_renderer_text_view_class_init (GncCellRendererTextViewClass *klass)
+{
+    GObjectClass         *gobject_class = G_OBJECT_CLASS(klass);
+    GtkCellRendererClass *cell_class = GTK_CELL_RENDERER_CLASS(klass);
+
+    gobject_class->finalize = gnc_cell_renderer_text_view_finalize;
+
+    cell_class->start_editing = gcrtv_start_editing;
+}
+
+static void
+gcrtv_editing_done (GtkCellEditable         *editable,
+                    GncCellRendererTextView *cell_tv)
+{
+    gchar       *path;
+    const gchar *new_text;
+
+    if (GNC_CELL_VIEW (editable)->focus_out_id > 0)
+    {
+        g_signal_handler_disconnect (GNC_CELL_VIEW(editable)->text_view,
+                                     GNC_CELL_VIEW(editable)->focus_out_id);
+        GNC_CELL_VIEW(editable)->focus_out_id = 0;
+    }
+
+    if (GNC_CELL_VIEW(editable)->editing_canceled)
+    {
+        gtk_cell_renderer_stop_editing (GTK_CELL_RENDERER(cell_tv), TRUE);
+        return;
+    }
+
+    path = g_object_get_data (G_OBJECT(editable), 
+                              GNC_CELL_RENDERER_TEXT_VIEW_PATH);
+
+    new_text = gnc_cell_view_get_text (GNC_CELL_VIEW(editable));
+
+    g_signal_emit_by_name (cell_tv, "edited", path, new_text);
+}
+
+static gboolean
+gcrtv_button_press_event (GtkWidget      *widget,
+                          GdkEventButton *event,
+                          gpointer        user_data)
+{
+    // allows mouse clicks in text view
+    return TRUE;
+}
+
+static GtkCellEditable *
+gcrtv_start_editing (GtkCellRenderer      *cell,
+                     GdkEvent             *event,
+                     GtkWidget            *widget,
+                     const gchar          *path,
+                     const GdkRectangle   *background_area,
+                     const GdkRectangle   *cell_area,
+                     GtkCellRendererState  flags)
+{
+    GncCellRendererTextView *cell_tv = GNC_CELL_RENDERER_TEXT_VIEW(cell);
+    GtkWidget                *editable;
+    gchar                    *text = NULL;
+    gboolean                  iseditable;
+
+    g_object_get (G_OBJECT(cell_tv), "editable", &iseditable, NULL);
+
+    /* If the cell isn't editable we return NULL. */
+    if (iseditable == FALSE) {
+        return NULL;
+    }
+
+    editable = g_object_new (GNC_TYPE_CELL_VIEW, NULL);
+
+    g_signal_connect (editable, "button-press-event",
+                      G_CALLBACK(gcrtv_button_press_event),
+                      NULL);
+
+    g_object_get (G_OBJECT(cell), "text", &text, NULL);
+
+    gnc_cell_view_set_text (GNC_CELL_VIEW(editable), text);
+
+    g_free (text);
+
+    gtk_widget_grab_focus (GTK_WIDGET(editable));
+
+    g_object_set_data_full (G_OBJECT(editable),
+                            GNC_CELL_RENDERER_TEXT_VIEW_PATH,
+                            g_strdup (path),
+                            g_free);
+
+    gtk_widget_show (editable);
+
+    g_signal_connect (editable, "editing-done", G_CALLBACK(gcrtv_editing_done), cell_tv);
+
+    cell_tv->editable = editable;
+
+    g_object_add_weak_pointer (G_OBJECT(cell_tv->editable),
+                               (gpointer) &cell_tv->editable);
+
+    return GTK_CELL_EDITABLE(editable);
+}
+
+GtkCellRenderer *
+gnc_cell_renderer_text_view_new (void)
+{
+    return g_object_new (GNC_TYPE_CELL_RENDERER_TEXT_VIEW, NULL);
+}

--- a/gnucash/gnome-utils/gnc-cell-renderer-text-view.h
+++ b/gnucash/gnome-utils/gnc-cell-renderer-text-view.h
@@ -1,0 +1,57 @@
+/*************************************************************************
+ * The following code implements a text view in a custom GtkCellRenderer.
+ *
+ * Copyright (C) 2020 Robert Fewell
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *************************************************************************/
+
+#ifndef __GNC_CELL_RENDERER_TEXT_VIEW_H__
+#define __GNC_CELL_RENDERER_TEXT_VIEW_H__
+
+#include <pango/pango.h>
+#include <gtk/gtk.h>
+
+#define GNC_TYPE_CELL_RENDERER_TEXT_VIEW            (gnc_cell_renderer_text_view_get_type ())
+#define GNC_CELL_RENDERER_TEXT_VIEW(obj)            (G_TYPE_CHECK_INSTANCE_CAST ((obj), GNC_TYPE_CELL_RENDERER_TEXT_VIEW, GncCellRendererTextView))
+#define GNC_CELL_RENDERER_TEXT_VIEW_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST ((klass), GNC_TYPE_CELL_RENDERER_TEXT_VIEW, GncCellRendererTextViewClass))
+#define GNC_IS_CELL_RENDERER_TEXT_VIEW(obj)         (G_TYPE_CHECK_INSTANCE_TYPE ((obj), GNC_TYPE_CELL_RENDERER_TEXT_VIEW))
+#define GNC_IS_CELL_RENDERER_TEXT_VIEW_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE ((obj), GNC_TYPE_CELL_RENDERER_TEXT_VIEW))
+#define GNC_CELL_RENDERER_TEXT_VIEW_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS ((obj), GNC_TYPE_CELL_RENDERER_TEXT_VIEW, GncCellRendererTextViewClass))
+
+
+typedef struct _GncCellRendererTextView      GncCellRendererTextView;
+typedef struct _GncCellRendererTextViewClass GncCellRendererTextViewClass;
+
+struct _GncCellRendererTextView
+{
+    GtkCellRendererText  parent;
+
+    /* The editable entry. */
+    GtkWidget *editable;
+};
+
+struct _GncCellRendererTextViewClass
+{
+    GtkCellRendererTextClass parent_class;
+};
+
+GType            gnc_cell_renderer_text_view_get_type (void) G_GNUC_CONST;
+
+GtkCellRenderer *gnc_cell_renderer_text_view_new (void);
+
+
+#endif /* __GNC_CELL_RENDERER_TEXT_VIEW_H__ */

--- a/gnucash/gnome-utils/gnc-cell-view.c
+++ b/gnucash/gnome-utils/gnc-cell-view.c
@@ -1,0 +1,243 @@
+/*************************************************************************
+ * The following code implements a text view in a custom GtkCellRenderer.
+ *
+ * Copyright (C) 2020 Robert Fewell
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *************************************************************************/
+#include <config.h>
+
+#include <gtk/gtk.h>
+#include <glib/gi18n.h>
+#include <gdk/gdkkeysyms.h>
+#include <string.h>
+
+#include "gnc-cell-view.h"
+
+static void     gnc_cell_view_init          (GncCellView          *cv);
+static void     gnc_cell_view_class_init    (GncCellViewClass     *klass);
+static void     gnc_cell_view_editable_init (GtkCellEditableIface *iface);
+static gboolean gcv_key_press_event         (GtkWidget            *box,
+                                             GdkEventKey          *key_event);
+
+static void     gnc_cell_view_set_property  (GObject              *object,
+                                             guint                 param_id,
+                                             const GValue         *value,
+                                             GParamSpec           *pspec);
+
+static void     gnc_cell_view_get_property  (GObject              *object,
+                                             guint                 param_id,
+                                             GValue               *value,
+                                             GParamSpec           *pspec);
+
+enum {
+    PROP_0,
+    PROP_EDITING_CANCELED,
+};
+
+G_DEFINE_TYPE_WITH_CODE (GncCellView, gnc_cell_view, GTK_TYPE_EVENT_BOX,
+                         G_IMPLEMENT_INTERFACE (GTK_TYPE_CELL_EDITABLE,
+                         gnc_cell_view_editable_init))
+
+static void
+gnc_cell_view_finalize (GObject *gobject)
+{
+    G_OBJECT_CLASS (gnc_cell_view_parent_class)->finalize (gobject);
+}
+
+static void
+gnc_cell_view_init (GncCellView *cv)
+{
+    cv->editing_canceled = FALSE;
+
+    cv->text_view = g_object_new (GTK_TYPE_TEXT_VIEW, "accepts-tab", FALSE, NULL);
+    cv->buffer = gtk_text_view_get_buffer (GTK_TEXT_VIEW(cv->text_view));
+
+    gtk_text_view_set_left_margin (GTK_TEXT_VIEW(cv->text_view), 2);
+    gtk_text_view_set_right_margin (GTK_TEXT_VIEW(cv->text_view), 2);
+
+    gtk_widget_set_tooltip_text (GTK_WIDGET(cv->text_view),
+            _("Use Shift combined with Return or Keypad Enter to finish editing"));
+
+    gtk_container_add (GTK_CONTAINER(cv), GTK_WIDGET(cv->text_view));
+    gtk_widget_show (cv->text_view);
+
+    gtk_widget_set_can_focus (GTK_WIDGET(cv->text_view), TRUE);
+    gtk_widget_add_events (GTK_WIDGET(cv), GDK_KEY_PRESS_MASK);
+    gtk_widget_add_events (GTK_WIDGET(cv), GDK_KEY_RELEASE_MASK);
+}
+
+static void
+gnc_cell_view_class_init (GncCellViewClass *klass)
+{
+    GObjectClass  *gobject_class = G_OBJECT_CLASS(klass);
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS(klass);
+
+    gobject_class->finalize = gnc_cell_view_finalize;
+
+    gobject_class->set_property = gnc_cell_view_set_property;
+    gobject_class->get_property = gnc_cell_view_get_property;
+
+    g_object_class_override_property (gobject_class,
+                                      PROP_EDITING_CANCELED,
+                                      "editing-canceled");
+}
+
+static void
+gnc_cell_view_set_property (GObject      *object,
+                            guint         param_id,
+                            const GValue *value,
+                            GParamSpec   *pspec)
+{
+    GncCellView *cv = GNC_CELL_VIEW(object);
+
+    switch (param_id)
+    {
+        case PROP_EDITING_CANCELED:
+            cv->editing_canceled = g_value_get_boolean (value);
+            break;
+
+        default:
+            G_OBJECT_WARN_INVALID_PROPERTY_ID(object, param_id, pspec);
+            break;
+    }
+}
+
+static void
+gnc_cell_view_get_property (GObject    *object,
+                            guint       param_id,
+                            GValue     *value,
+                            GParamSpec *pspec)
+{
+    GncCellView *cv = GNC_CELL_VIEW(object);
+
+    switch (param_id)
+    {
+        case PROP_EDITING_CANCELED:
+            g_value_set_boolean (value, cv->editing_canceled);
+            break;
+
+        default:
+            G_OBJECT_WARN_INVALID_PROPERTY_ID(object, param_id, pspec);
+            break;
+    }
+}
+
+static gboolean
+gtk_cell_editable_key_press_event (GtkTextView   *text_view,
+                                   GdkEventKey   *key_event,
+                                   GncCellView   *cv)
+{
+    if (key_event->keyval == GDK_KEY_Escape)
+    {
+        cv->editing_canceled = TRUE;
+        gtk_cell_editable_editing_done (GTK_CELL_EDITABLE(cv));
+
+        if (GTK_IS_CELL_EDITABLE(cv))
+            gtk_cell_editable_remove_widget (GTK_CELL_EDITABLE(cv));
+
+        return TRUE;
+    }
+
+    if ((key_event->keyval == GDK_KEY_Return || key_event->keyval == GDK_KEY_KP_Enter)
+         && (key_event->state & GDK_SHIFT_MASK))
+    {
+        gtk_cell_editable_editing_done (GTK_CELL_EDITABLE(cv));
+
+        if (GTK_IS_CELL_EDITABLE(cv))
+            gtk_cell_editable_remove_widget (GTK_CELL_EDITABLE(cv));
+
+        return TRUE;
+    }
+    return FALSE;
+}
+
+static gboolean
+gcv_focus_out_event (GtkWidget *widget, GdkEvent *event, GncCellView *cv)
+{
+    cv->editing_canceled = TRUE;
+
+    if (cv->focus_out_id > 0)
+    {
+        g_signal_handler_disconnect (cv->text_view, cv->focus_out_id);
+        cv->focus_out_id = 0;
+    }
+    gtk_cell_editable_editing_done (GTK_CELL_EDITABLE(cv));
+    gtk_cell_editable_remove_widget (GTK_CELL_EDITABLE(cv));
+
+    return FALSE;
+}
+
+static gboolean
+gcv_remove_tooltip (GncCellView *cv)
+{
+    if (GTK_IS_WIDGET(cv->text_view))
+        gtk_widget_set_tooltip_text (GTK_WIDGET(cv->text_view), NULL);
+    return FALSE;
+}
+
+static void
+gcv_start_editing (GtkCellEditable *cell_editable,
+                   GdkEvent        *event)
+{
+    GncCellView *cv = GNC_CELL_VIEW(cell_editable);
+    GtkTextIter siter, eiter;
+
+    // Remove the text_view tooltip after 5secs
+    g_timeout_add (5000, (GSourceFunc) gcv_remove_tooltip, cv);
+
+    gtk_text_buffer_get_bounds (cv->buffer, &siter, &eiter);
+    gtk_text_buffer_select_range (cv->buffer, &eiter, &siter);
+
+    gtk_text_view_set_cursor_visible (GTK_TEXT_VIEW(cv->text_view), TRUE);
+
+    gtk_widget_grab_focus (GTK_WIDGET(cv->text_view));
+
+    g_signal_connect (G_OBJECT(cv->text_view), "key_press_event",
+                      G_CALLBACK(gtk_cell_editable_key_press_event), cv);
+
+    cv->focus_out_id = g_signal_connect (G_OBJECT(cv->text_view),
+                                         "focus-out-event",
+                                         G_CALLBACK(gcv_focus_out_event), cv);
+}
+
+static void
+gnc_cell_view_editable_init (GtkCellEditableIface *iface)
+{
+    iface->start_editing = gcv_start_editing;
+}
+
+void
+gnc_cell_view_set_text (GncCellView *cv, const gchar *text)
+{
+    g_return_if_fail (GNC_IS_CELL_VIEW(cv));
+
+    gtk_text_buffer_set_text (cv->buffer,
+                              text ? text : "",
+                              -1);
+}
+
+const gchar *
+gnc_cell_view_get_text (GncCellView *cv)
+{
+    GtkTextIter siter, eiter;
+
+    g_return_val_if_fail (GNC_IS_CELL_VIEW(cv), NULL);
+
+    gtk_text_buffer_get_bounds (cv->buffer, &siter, &eiter);
+
+    return gtk_text_buffer_get_text (cv->buffer, &siter, &eiter, TRUE);
+}

--- a/gnucash/gnome-utils/gnc-cell-view.h
+++ b/gnucash/gnome-utils/gnc-cell-view.h
@@ -1,0 +1,62 @@
+/*************************************************************************
+ * The following code implements a text view in a custom GtkCellRenderer.
+ *
+ * Copyright (C) 2020 Robert Fewell
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *************************************************************************/
+
+#ifndef __GNC_CELL_VIEW_H__
+#define __GNC_CELL_VIEW_H__
+
+#include <pango/pango.h>
+#include <gtk/gtk.h>
+
+#define GNC_TYPE_CELL_VIEW            (gnc_cell_view_get_type ())
+#define GNC_CELL_VIEW(obj)            (G_TYPE_CHECK_INSTANCE_CAST ((obj), GNC_TYPE_CELL_VIEW, GncCellView))
+#define GNC_CELL_VIEW_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST ((klass), GNC_TYPE_CELL_VIEW, GncCellViewClass))
+#define GNC_IS_CELL_VIEW(obj)         (G_TYPE_CHECK_INSTANCE_TYPE ((obj), GNC_TYPE_CELL_VIEW))
+#define GNC_IS_CELL_VIEW_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE ((obj), GNC_TYPE_CELL_VIEW))
+#define GNC_CELL_VIEW_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS ((obj), GNC_TYPE_CELL_VIEW, GncCellViewClass))
+
+typedef struct _GncCellView      GncCellView;
+typedef struct _GncCellViewClass GncCellViewClass;
+
+struct _GncCellView
+{
+    GtkEventBox    parent;
+
+    GtkWidget     *text_view;
+    GtkTextBuffer *buffer;
+
+    gulong         focus_out_id;
+    gboolean       editing_canceled;
+};
+
+struct _GncCellViewClass
+{
+    GtkEventBoxClass parent_class;
+};
+
+GType        gnc_cell_view_get_type (void) G_GNUC_CONST;
+
+GtkWidget   *gnc_cell_view_new (void);
+
+void         gnc_cell_view_set_text (GncCellView *cv, const gchar *text);
+
+const gchar *gnc_cell_view_get_text (GncCellView *cv);
+
+#endif /* __GNC_CELL_VIEW_H__ */

--- a/gnucash/gnome-utils/gnc-tree-view-account.c
+++ b/gnucash/gnome-utils/gnc-tree-view-account.c
@@ -931,11 +931,12 @@ gnc_tree_view_account_new_with_root (Account *root, gboolean show_root)
                            g_strdup(_("Account Color")), g_free);
 
     priv->notes_column
-        = gnc_tree_view_add_text_column(view, _("Notes"), "notes", NULL,
+        = gnc_tree_view_add_text_view_column(view, _("Notes"), "notes", NULL,
                                         "Sample account notes.",
                                         GNC_TREE_MODEL_ACCOUNT_COL_NOTES,
                                         GNC_TREE_VIEW_COLUMN_VISIBLE_ALWAYS,
                                         sort_by_string);
+
     tax_info_column
         = gnc_tree_view_add_text_column(view, _("Tax Info"), "tax-info", NULL,
                                         "Sample tax info.",

--- a/gnucash/gnome-utils/gnc-tree-view.c
+++ b/gnucash/gnome-utils/gnc-tree-view.c
@@ -43,6 +43,7 @@
 #include "gnc-gnome-utils.h"
 #include "gnc-gobject-utils.h"
 #include "gnc-cell-renderer-date.h"
+#include "gnc-cell-renderer-text-view.h"
 #include "gnc-state.h"
 #include "gnc-prefs.h"
 #include "dialog-utils.h"
@@ -1830,26 +1831,18 @@ renderer_edited_cb (GtkCellRendererText *renderer, gchar *path,
         (priv->editing_finished_cb)(view, priv->editing_cb_data);
 }
 
-/** This function adds a new text column to a GncTreeView base view.
- *  It takes all the parameters necessary to hook a GtkTreeModel
- *  column to a GtkTreeViewColumn.  If the tree has a state section
- *  associated with it, this function also wires up the column so that
- *  its visibility and width are remembered.
- *
- *  Parameters are defined in gnc-tree-view.h
- */
-GtkTreeViewColumn *
-gnc_tree_view_add_text_column (GncTreeView *view,
-                               const gchar *column_title,
-                               const gchar *pref_name,
-                               const gchar *icon_name,
-                               const gchar *sizing_text,
-                               gint model_data_column,
-                               gint model_visibility_column,
-                               GtkTreeIterCompareFunc column_sort_fn)
+
+static GtkTreeViewColumn *
+add_text_column_variant (GncTreeView *view, GtkCellRenderer *renderer,
+                         const gchar *column_title,
+                         const gchar *pref_name,
+                         const gchar *icon_name,
+                         const gchar *sizing_text,
+                         gint model_data_column,
+                         gint model_visibility_column,
+                         GtkTreeIterCompareFunc column_sort_fn)
 {
     GtkTreeViewColumn *column;
-    GtkCellRenderer *renderer;
     PangoLayout* layout;
     int default_width, title_width;
 
@@ -1861,13 +1854,12 @@ gnc_tree_view_add_text_column (GncTreeView *view,
     /* Set up an icon renderer if requested */
     if (icon_name)
     {
-        renderer = gtk_cell_renderer_pixbuf_new ();
-        g_object_set (renderer, "icon-name", icon_name, NULL);
-        gtk_tree_view_column_pack_start (column, renderer, FALSE);
+        GtkCellRenderer *renderer_pix = gtk_cell_renderer_pixbuf_new ();
+        g_object_set (renderer_pix, "icon-name", icon_name, NULL);
+        gtk_tree_view_column_pack_start (column, renderer_pix, FALSE);
     }
 
     /* Set up a text renderer and attributes */
-    renderer = gtk_cell_renderer_text_new ();
     gtk_tree_view_column_pack_start (column, renderer, TRUE);
 
     /* Set up the callbacks for when editing */
@@ -1905,6 +1897,70 @@ gnc_tree_view_add_text_column (GncTreeView *view,
     return column;
 }
 
+
+/** This function adds a new text column to a GncTreeView base view.
+ *  It takes all the parameters necessary to hook a GtkTreeModel
+ *  column to a GtkTreeViewColumn.  If the tree has a state section
+ *  associated with it, this function also wires up the column so that
+ *  its visibility and width are remembered.
+ *
+ *  Parameters are defined in gnc-tree-view.h
+ */
+GtkTreeViewColumn *
+gnc_tree_view_add_text_column (GncTreeView *view,
+                               const gchar *column_title,
+                               const gchar *pref_name,
+                               const gchar *icon_name,
+                               const gchar *sizing_text,
+                               gint model_data_column,
+                               gint model_visibility_column,
+                               GtkTreeIterCompareFunc column_sort_fn)
+{
+    GtkCellRenderer *renderer;
+
+    g_return_val_if_fail (GNC_IS_TREE_VIEW(view), NULL);
+
+    renderer = gtk_cell_renderer_text_new ();
+
+    return add_text_column_variant (view, renderer,
+                                    column_title, pref_name,
+                                    icon_name, sizing_text,
+                                    model_data_column,
+                                    model_visibility_column,
+                                    column_sort_fn);
+}
+
+/** This function adds a new text view column to a GncTreeView base view.
+ *  It takes all the parameters necessary to hook a GtkTreeModel
+ *  column to a GtkTreeViewColumn.  If the tree has a state section
+ *  associated with it, this function also wires up the column so that
+ *  its visibility and width are remembered.
+ *
+ *  Parameters are defined in gnc-tree-view.h
+ */
+GtkTreeViewColumn *
+gnc_tree_view_add_text_view_column (GncTreeView *view,
+                                    const gchar *column_title,
+                                    const gchar *pref_name,
+                                    const gchar *icon_name,
+                                    const gchar *sizing_text,
+                                    gint model_data_column,
+                                    gint model_visibility_column,
+                                    GtkTreeIterCompareFunc column_sort_fn)
+{
+    GtkCellRenderer *renderer;
+
+    g_return_val_if_fail (GNC_IS_TREE_VIEW(view), NULL);
+
+    renderer = gnc_cell_renderer_text_view_new ();
+
+    return add_text_column_variant (view, renderer,
+                                    column_title, pref_name,
+                                    icon_name, sizing_text,
+                                    model_data_column,
+                                    model_visibility_column,
+                                    column_sort_fn);
+}
 
 
 /** This function adds a new date column to a GncTreeView base view.

--- a/gnucash/gnome-utils/gnc-tree-view.h
+++ b/gnucash/gnome-utils/gnc-tree-view.h
@@ -199,6 +199,53 @@ gnc_tree_view_add_text_column (GncTreeView *view,
                                gint model_visibility_column,
                                GtkTreeIterCompareFunc column_sort_fn);
 
+/** This function adds a new text view column to a GncTreeView base view.
+ *  It takes all the parameters necessary to hook a GtkTreeModel
+ *  column to a GtkTreeViewColumn.
+ *
+ *  @param view A pointer to a generic GncTreeView.
+ *
+ *  @param column_title The title for this column.
+ *
+ *  @param pref_name The internal name of this column.  This name is
+ *  used in several functions to look up the column, and it is also
+ *  used when saving/restoring the view's state.
+ *
+ *  @param icon_name The name of the icon to display to
+ *  the left of the text in this column.  Used for adding icons like
+ *  the "account" icon to a view.  This must be a registered icon,
+ *  not a filename.
+ *
+ *  @param sizing_text A string used to compute the default width of
+ *  the column.  This text is never displayed.
+ *
+ *  @param model_data_column The index of the GtkTreeModel data column
+ *  used to determine the data that will be displayed in this column
+ *  for each row in the view.  Use GNC_TREE_VIEW_COLUMN_DATA_NONE if
+ *  you plan on using a non-model data source for this column.  This
+ *  index is connected to the "text" attribute of the cell renderer.
+ *
+ *  @param model_visibility_column The index of the GtkTreeModel data
+ *  column used to determine whether or not a checkbox for each row
+ *  will be displayed at all.  Use GNC_TREE_VIEW_COLUMN_VISIBLE_ALWAYS
+ *  if the checkbox should be displayed in all rows.
+ *
+ *  @param column_sort_fn The function that GtkTreeModelSort
+ *  will call to compare two rows to determine their displayed
+ *  order.
+ *
+ *  @return The newly created GtkTreeViewColumn.
+ */
+GtkTreeViewColumn *
+gnc_tree_view_add_text_view_column (GncTreeView *view,
+                               const gchar *column_title,
+                               const gchar *pref_name,
+                               const gchar *icon_name,
+                               const gchar *sizing_text,
+                               gint model_data_column,
+                               gint model_visibility_column,
+                               GtkTreeIterCompareFunc column_sort_fn);
+
 /** This function adds a new combobox column to a GncTreeView base
  *  view.  The parameters it takes in common with
  *  gnc_tree_view_add_text_column() behave the same as there.  In


### PR DESCRIPTION
I think this is correct and works OK but just a question.
This fix adds a new cell renderer based on a text view to fix editing the notes field on the account tree view. As part of this, when editing the notes field I am using the return key to add new lines and then to complete the edit I am using 'shift and return/keypad enter', Should this be the other way round or some other key combinations?

I have also added gnc_tree_view_add_text_view_column but there is really only one line different to that of gnc_tree_view_add_text so extracted common code to be called from these functions.
