### PR TITLE
[Master] Css changes

### DIFF
--- a/doc/gtk-3.0.css
+++ b/doc/gtk-3.0.css
@@ -19,78 +19,254 @@
   the widget type can be configured unless they are named in code.
 */
 
-/* Register sheet font setting */
-.sheet {
-  font: 18px arial, sans-serif;
-}
 
-.sheet calendar {
+/* Application wide font setting */
+* {
   font: 12px arial, sans-serif;
 }
 
 
-/* Register User Colors */
-.header-color {
+/* Scollbar size */
+scrollbar slider {
+    /* Size of the slider */
+    min-width: 20px;
+    min-height: 20px;
+    border-radius: 22px;
+
+    /* Padding around the slider */
+    border: 5px solid transparent;
+}
+
+
+/* Register sheet font setting, use .gnc-class-sheet < gtk3.20 */
+gnc-id-sheet {
+  font: 10px arial, sans-serif;
+}
+
+
+/* Register header font setting, use .gnc-class-header < gtk3.20 */
+gnc-id-header {
+  background-color: pink;
+  color:blue;
+}
+
+
+/* Register cursor font setting, use .gnc-class-cursor < gtk3.20 */
+gnc-id-cursor {
+  background-color: #BDB76B;
+  color: white;
+}
+
+xgnc-id-cursor entry {
+  background-color: pink;
+
+  margin: 2px 5px 2px 5px;
+  padding: 0px 2px 0px 2px;
+
+/*  border-color: green;
+  color: white; */
+}
+
+gnc-id-cursor button {
+  border-width: 1px;
+  border-color: green;
+}
+
+
+/* Register sheet calendar */
+gnc-id-sheet calendar {
+  font: 13px arial, sans-serif;
+  background-color:lightgreen;
+  border-color: green;
+  border-width: 1px;
+}
+
+
+/* Register User Colors, remove 'user' for builtin register values */
+.gnc-class-user-register-header {
   background-color: seagreen;
   color: white;
 }
 
-.primary-color {
+.gnc-class-user-register-primary {
   background-color: pink;
 }
 
-.primary-color:disabled {
+.gnc-class-user-register-primary:disabled {
   background-color: plum;
 }
 
-.secondary-color {
+.gnc-class-user-register-secondary {
   background-color: lightgreen;
 }
 
-.secondary-color:disabled {
+.gnc-class-user-register-secondary:disabled {
   background-color: plum;
 }
 
-.split-color {
+.gnc-class-user-register-split {
   background-color: lightblue;
 }
 
-.split-color:disabled {
+.gnc-class-user-register-split:disabled {
   background-color: plum;
 }
 
-.cursor-color {
+.gnc-class-user-register-cursor {
   background-color: #00BFFF;
   color: white;
-}
-
-cursor entry {
-  background-color: #00BFFF;
-  color: white;
+  border-radius: 0px;
 }
 
 
-/* Dense Calendar Settings */
-.calendar {
-  border-color: white;
+/* Toolbar Button size and spacing */
+toolbar {
+  background-color: darkgrey;
 }
 
-.calendar.header {
+/* Toolbar font size, 0 to remove text */
+toolbar toolbutton label {
+  font-size: 0px;
+}
+
+toolbar toolbutton button {
+  padding-left: 4px;
+  padding-right: 4px;
+}
+
+toolbar toolbutton label {
+  padding-left: 4px;
+  padding-right: 4px;
+}
+
+
+/* Negative number color */
+.gnc-class-negative-numbers {
+  color: orange;
+}
+
+
+/* Gnucash Main Window, reduce size */
+#gnc-id-main-window notebook tab {
+  min-height: 0px;
+  min-width: 0px;
+  padding-top: 3px;
+  padding-bottom: 3px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+  border-top: 0px;
+  border-bottom: 0px;
+}
+
+#gnc-id-main-window notebook label {
+  font: 14px arial, sans-serif;
+}
+
+#gnc-id-main-window notebook tab button {
+  min-height: 0;
+  min-width: 0;
+  padding: 0px;
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+
+/* Dense Calendar Settings, use widget name gnc-id-dense-calendar
+ * or gtk css name calendar which would also apply to other calendar
+ * widgets */
+#gnc-id-dense-calendar .frame {
+  border-color: blue;
+  border-width: 1px;
+}
+
+calendar .frame {
+  border-color: blue;
+  border-width: 1px;
+}
+
+#gnc-id-dense-calendar .header {
  background-color: lightgreen;
 }
 
-.calendar.primary {
+calendar .header {
+ background-color: lightgreen;
+}
+
+#gnc-id-dense-calendar .primary {
   background-color: darksalmon;
 }
 
-.calendar.secondary {
+#gnc-id-dense-calendar .secondary {
   background-color: darkseagreen;
 }
 
-.calendar.markers {
+#gnc-id-dense-calendar .markers {
   background-color: indianred;
 }
 
-#dense-cal-popup treeview {
+#gnc-id-dense-calendar-popup {
+  background-color: darksalmon;
+  color: black;
+}
+
+#gnc-id-dense-calendar-popup treeview {
   background-color: lightcoral;
+}
+
+
+/* Progress bar */
+progressbar progress {
+  background-color: lime;
+}
+
+
+/* Status Bar */
+statusbar frame {
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+statusbar label {
+  font-size: 12px;
+  color: red;
+}
+
+
+/* Reconcile Window */
+#gnc-id-reconcile-totals * {
+  background-color: darkgrey;
+}
+
+.gnc-class-credits treeview {
+  background-color: pink;
+}
+
+.gnc-class-credits treeview:selected {
+  background-color: cornflowerblue;
+  color: white;
+}
+
+.gnc-class-debits treeview {
+  background-color: lightblue;
+}
+
+.gnc-class-debits treeview:selected {
+  background-color: cornflowerblue;
+  color: white;
+}
+
+
+/* Highlight Text */
+.gnc-class-highlight {
+  color: blue;
+}
+
+
+/* Summary bar */
+#gnc-id-summarybar {
+  background-color:lightblue;
+}
+
+#gnc-id-summarybar .gnc-class-highlight {
+  color: red;
 }

--- a/gnucash/gnome-search/dialog-search.c
+++ b/gnucash/gnome-search/dialog-search.c
@@ -1127,8 +1127,9 @@ gnc_search_dialog_init_widgets (GNCSearchWindow *sw, const gchar *title)
     gtk_window_set_title(GTK_WINDOW(sw->dialog), title);
     g_object_set_data (G_OBJECT (sw->dialog), "dialog-info", sw);
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(sw->dialog), "GncSearchDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(sw->dialog), "gnc-id-search");
+    gnc_widget_style_context_add_class (GTK_WIDGET(sw->dialog), "gnc-class-search");
 
     /* Grab the result hbox */
     sw->result_hbox = GTK_WIDGET(gtk_builder_get_object (builder, "result_hbox"));
@@ -1328,11 +1329,9 @@ gnc_search_dialog_create (GtkWindow *parent,
                                                 gtk_widget_get_allocated_height (
                                                 GTK_WIDGET(sw->grouping_combo)) * 1.5);
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    if (style_class == NULL)
-        gnc_widget_set_style_context (GTK_WIDGET(sw->dialog), "GncSearchDialog");
-    else
-        gnc_widget_set_style_context (GTK_WIDGET(sw->dialog), style_class);
+    // Add a style context for this dialog so it can be easily manipulated with css
+    if (style_class != NULL)
+        gnc_widget_style_context_add_class (GTK_WIDGET(sw->dialog), style_class);
 
     /* Maybe display the original query results? */
     if (callbacks && show_start_query)

--- a/gnucash/gnome-utils/assistant-xml-encoding.c
+++ b/gnucash/gnome-utils/assistant-xml-encoding.c
@@ -1189,9 +1189,8 @@ gxi_edit_encodings_clicked_cb (GtkButton *button, GncXmlImportData *data)
     dialog = GTK_WIDGET(gtk_builder_get_object (builder, "encodings_dialog"));
     data->encodings_dialog = dialog;
 
-
-    // Set the style context for this assistant so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(dialog), "GncAssistXmlEncoding");
+    // Set the name for this assistant so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(dialog), "gnc-id-assistant-xml-encoding");
 
     gtk_builder_connect_signals_full (builder, gnc_builder_connect_full_func, data);
 

--- a/gnucash/gnome-utils/dialog-account.c
+++ b/gnucash/gnome-utils/dialog-account.c
@@ -677,7 +677,7 @@ verify_children_compatible (AccountWindow *aw)
     gnc_label_set_alignment (label, 0.0, 0.0);
 
     /* make label large */
-    gnc_widget_set_style_context (GTK_WIDGET(label), "emphasize-label");
+    gnc_widget_style_context_add_class (GTK_WIDGET(label), "gnc-class-emphasize-label");
 
     gtk_box_pack_start (GTK_BOX (vbox), label, FALSE, FALSE, 0);
 
@@ -1327,8 +1327,10 @@ gnc_account_window_create(GtkWindow *parent, AccountWindow *aw)
     if (parent)
         gtk_window_set_transient_for (GTK_WINDOW (aw->dialog), parent);
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(aw->dialog), "GncAccountDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(aw->dialog), "gnc-id-account");
+    gnc_widget_style_context_add_class (GTK_WIDGET(aw->dialog), "gnc-class-account");
+
 
     g_object_set_data (awo, "dialog_info", aw);
 

--- a/gnucash/gnome-utils/dialog-book-close.c
+++ b/gnucash/gnome-utils/dialog-book-close.c
@@ -333,8 +333,8 @@ void gnc_ui_close_book (QofBook* book, GtkWindow *parent)
     gnc_builder_add_from_file (builder, "dialog-book-close.glade", "close_book_dialog");
     cbw->dialog = GTK_WIDGET(gtk_builder_get_object (builder,  "close_book_dialog"));
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(cbw->dialog), "GncBookCloseDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(cbw->dialog), "gnc-id-book-close");
 
     /* parent */
     if (parent != NULL)

--- a/gnucash/gnome-utils/dialog-commodity.c
+++ b/gnucash/gnome-utils/dialog-commodity.c
@@ -266,8 +266,9 @@ gnc_ui_select_commodity_create(const gnc_commodity * orig_sel,
     retval->ok_button = GTK_WIDGET(gtk_builder_get_object (builder, "ss_ok_button"));
     label = GTK_WIDGET(gtk_builder_get_object (builder, "item_label"));
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(retval->dialog), "GncSecurityDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(retval->dialog), "gnc-id-security-select");
+    gnc_widget_style_context_add_class (GTK_WIDGET(retval->dialog), "gnc-class-securities");
 
     gnc_cbwe_require_list_item(GTK_COMBO_BOX(retval->namespace_combo));
     gnc_cbwe_require_list_item(GTK_COMBO_BOX(retval->commodity_combo));
@@ -910,8 +911,9 @@ gnc_ui_build_commodity_dialog(const char * selected_namespace,
 
     retval->dialog = GTK_WIDGET(gtk_builder_get_object (builder, "security_dialog"));
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(retval->dialog), "GncSecurityDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(retval->dialog), "gnc-id-security");
+    gnc_widget_style_context_add_class (GTK_WIDGET(retval->dialog), "gnc-class-securities");
 
     if (parent != NULL)
         gtk_window_set_transient_for (GTK_WINDOW (retval->dialog), GTK_WINDOW (parent));

--- a/gnucash/gnome-utils/dialog-dup-trans.c
+++ b/gnucash/gnome-utils/dialog-dup-trans.c
@@ -110,8 +110,9 @@ gnc_dup_trans_dialog_create (GtkWidget * parent, DupTransDialog *dt_dialog,
     dialog = GTK_WIDGET(gtk_builder_get_object (builder, "duplicate_transaction_dialog"));
     dt_dialog->dialog = dialog;
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(dialog), "GncDupTransDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(dialog), "gnc-id-duplicate-transaction");
+    gnc_widget_style_context_add_class (GTK_WIDGET(dialog), "gnc-class-transactions");
 
     /* parent */
     if (parent != NULL)

--- a/gnucash/gnome-utils/dialog-file-access.c
+++ b/gnucash/gnome-utils/dialog-file-access.c
@@ -282,8 +282,8 @@ gnc_ui_file_access (GtkWindow *parent, int type)
     gtk_window_set_transient_for (GTK_WINDOW (faw->dialog), parent);
     g_object_set_data_full( G_OBJECT(faw->dialog), "FileAccessWindow", faw, g_free );
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(faw->dialog), "GncFileAccessDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(faw->dialog), "gnc-id-file-access");
 
     faw->frame_file = GTK_WIDGET(gtk_builder_get_object (builder, "frame_file" ));
     faw->frame_database = GTK_WIDGET(gtk_builder_get_object (builder, "frame_database" ));

--- a/gnucash/gnome-utils/dialog-object-references.c
+++ b/gnucash/gnome-utils/dialog-object-references.c
@@ -54,8 +54,8 @@ gnc_ui_object_references_show( const gchar* explanation_text, GList* objlist )
     gnc_builder_add_from_file (builder, "dialog-object-references.glade", "object_references_dialog" );
     dialog = GTK_WIDGET(gtk_builder_get_object (builder, "object_references_dialog" ));
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(dialog), "GncObjectRefDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(dialog), "gnc-id-object-reference");
 
     explanation = GTK_LABEL(gtk_builder_get_object (builder, "lbl_explanation" ));
     gtk_label_set_text( explanation, explanation_text );

--- a/gnucash/gnome-utils/dialog-options.c
+++ b/gnucash/gnome-utils/dialog-options.c
@@ -2227,8 +2227,8 @@ gnc_options_dialog_new_modal(gboolean modal, gchar *title,
     retval->window = GTK_WIDGET(gtk_builder_get_object (builder, "gnucash_options_window"));
     retval->page_list = GTK_WIDGET(gtk_builder_get_object (builder, "page_list_scroll"));
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(retval->window), "GncOptionsDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(retval->window), "gnc-id-options");
 
     /* Page List */
     {

--- a/gnucash/gnome-utils/dialog-preferences.c
+++ b/gnucash/gnome-utils/dialog-preferences.c
@@ -1254,8 +1254,8 @@ gnc_preferences_dialog_create(GtkWindow *parent)
 
     dialog = GTK_WIDGET(gtk_builder_get_object (builder, "gnucash_preferences_dialog"));
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(dialog), "GncPreferenceDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(dialog), "gnc-id-preferences");
 
     /* parent */
     gtk_window_set_transient_for (GTK_WINDOW(dialog), GTK_WINDOW(parent));

--- a/gnucash/gnome-utils/dialog-query-view.c
+++ b/gnucash/gnome-utils/dialog-query-view.c
@@ -193,8 +193,8 @@ gnc_dialog_query_view_new (GtkWindow *parent, GList *param_list, Query *q)
     g_object_set_data (G_OBJECT (dqv->dialog), "dialog-info", dqv);
     gtk_window_set_transient_for(GTK_WINDOW(dqv->dialog), parent);
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(dqv->dialog), "GncQueryViewDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(dqv->dialog), "gnc-id-query-view");
 
     /* grab the widgets */
     dqv->label = GTK_WIDGET(gtk_builder_get_object (builder, "dialog_label"));

--- a/gnucash/gnome-utils/dialog-reset-warnings.c
+++ b/gnucash/gnome-utils/dialog-reset-warnings.c
@@ -379,8 +379,8 @@ gnc_reset_warnings_dialog (GtkWindow *parent)
     gnc_builder_add_from_file (builder, "dialog-reset-warnings.glade", "reset_warnings_dialog");
     dialog = GTK_WIDGET(gtk_builder_get_object (builder, "reset_warnings_dialog"));
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(dialog), "GncResetWarningsDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(dialog), "gnc-id-reset-warnings");
 
     gtk_window_set_transient_for(GTK_WINDOW (dialog), parent);
 

--- a/gnucash/gnome-utils/dialog-tax-table.c
+++ b/gnucash/gnome-utils/dialog-tax-table.c
@@ -235,8 +235,9 @@ new_tax_table_dialog (TaxTableWindow *ttw, gboolean new_table,
 
     ntt->dialog = GTK_WIDGET(gtk_builder_get_object (builder, "new_tax_table_dialog"));
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(ntt->dialog), "GncTaxTableDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(ntt->dialog), "gnc-id-tax-table");
+    gnc_widget_style_context_add_class (GTK_WIDGET(ntt->dialog), "gnc-class-taxes");
 
     ntt->name_entry = GTK_WIDGET(gtk_builder_get_object (builder, "name_entry"));
     if (name)
@@ -813,8 +814,9 @@ gnc_ui_tax_table_window_new (GtkWindow *parent, QofBook *book)
 
     gtk_window_set_transient_for (GTK_WINDOW (ttw->dialog), parent);
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(ttw->dialog), "GncTaxTableDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(ttw->dialog), "gnc-id-new-tax-table");
+    gnc_widget_style_context_add_class (GTK_WIDGET(ttw->dialog), "gnc-class-taxes");
 
     /* Create the tax tables view */
     view = GTK_TREE_VIEW(ttw->names_view);

--- a/gnucash/gnome-utils/dialog-totd.c
+++ b/gnucash/gnome-utils/dialog-totd.c
@@ -345,8 +345,8 @@ gnc_totd_dialog (GtkWindow *parent, gboolean startup)
     dialog  = GTK_WIDGET(gtk_builder_get_object (builder, "totd_dialog"));
     gtk_window_set_transient_for(GTK_WINDOW (dialog), parent);
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(dialog), "GncTotdDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(dialog), "gnc-id-tip-of-the-day");
 
     totd_dialog = g_new0 (TotdDialog, 1);
     totd_dialog->dialog = dialog;

--- a/gnucash/gnome-utils/dialog-transfer.c
+++ b/gnucash/gnome-utils/dialog-transfer.c
@@ -1879,8 +1879,9 @@ gnc_xfer_dialog_create(GtkWidget *parent, XferDialog *xferData)
     xferData->dialog = GTK_WIDGET(gtk_builder_get_object (builder, "transfer_dialog"));
     g_object_set_data_full (G_OBJECT (xferData->dialog), "builder", builder, g_object_unref);
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(xferData->dialog), "GncTransferDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(xferData->dialog), "gnc-id-transfer");
+    gnc_widget_style_context_add_class (GTK_WIDGET(xferData->dialog), "gnc-class-securities");
 
     /* parent */
     if (parent != NULL)

--- a/gnucash/gnome-utils/dialog-userpass.c
+++ b/gnucash/gnome-utils/dialog-userpass.c
@@ -51,8 +51,8 @@ gnc_get_username_password (GtkWidget *parent,
 
     dialog = GTK_WIDGET(gtk_builder_get_object (builder, "username_password_dialog"));
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(dialog), "GncUserPassDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(dialog), "gnc-id-user-password");
 
     if (parent)
         gtk_window_set_transient_for (GTK_WINDOW (dialog), GTK_WINDOW (parent));

--- a/gnucash/gnome-utils/dialog-utils.c
+++ b/gnucash/gnome-utils/dialog-utils.c
@@ -363,12 +363,6 @@ gnc_tree_view_get_grid_lines_pref (void)
  * Returns:  nothing                                                *
 \********************************************************************/
 void
-gnc_widget_set_style_context (GtkWidget *widget, const char *gnc_class)
-{
-    gnc_widget_style_context_add_class (widget, gnc_class);
-}
-
-void
 gnc_widget_style_context_add_class (GtkWidget *widget, const char *gnc_class)
 {
     GtkStyleContext *context = gtk_widget_get_style_context (widget);

--- a/gnucash/gnome-utils/dialog-utils.h
+++ b/gnucash/gnome-utils/dialog-utils.h
@@ -89,7 +89,6 @@ GtkTreeViewGridLines gnc_tree_view_get_grid_lines_pref (void);
  *       gnc_class - character string for css class name            *
  * Returns:  nothing                                                *
 \********************************************************************/
-void gnc_widget_set_style_context (GtkWidget *widget, const char *gnc_class);
 void gnc_widget_style_context_add_class (GtkWidget *widget, const char *gnc_class);
 
 /********************************************************************\

--- a/gnucash/gnome-utils/gnc-account-sel.c
+++ b/gnucash/gnome-utils/gnc-account-sel.c
@@ -161,8 +161,8 @@ gnc_account_sel_init (GNCAccountSel *gas)
 
     g_object_set(gas, "spacing", 2, (gchar*)NULL);
 
-    // Set the style context for this widget so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(gas), "GncAccountSel");
+    // Set the name for this widget so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(gas), "gnc-id-account-select");
 
     gas->store = gtk_list_store_new(NUM_ACCT_COLS, G_TYPE_STRING, G_TYPE_POINTER);
     widget = gtk_combo_box_new_with_model_and_entry(GTK_TREE_MODEL(gas->store));

--- a/gnucash/gnome-utils/gnc-amount-edit.c
+++ b/gnucash/gnome-utils/gnc-amount-edit.c
@@ -140,8 +140,8 @@ gnc_amount_edit_init (GNCAmountEdit *gae)
     gae->fraction = 0;
     gae->evaluate_on_enter = FALSE;
 
-    // Set the style context for this widget so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(gae), "GncAmountEdit");
+    // Set the name for this widget so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(gae), "gnc-id-amount-edit");
 
     g_signal_connect (G_OBJECT (gae), "changed",
                       G_CALLBACK (gnc_amount_edit_changed), NULL);

--- a/gnucash/gnome-utils/gnc-autosave.c
+++ b/gnucash/gnome-utils/gnc-autosave.c
@@ -98,8 +98,8 @@ static gboolean autosave_confirm(GtkWidget *toplevel)
                                "%s",
                                _("Save file automatically?"));
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(dialog), "GncAutoSaveDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(dialog), "gnc-id-auto-save");
 
     gtk_message_dialog_format_secondary_text
     (GTK_MESSAGE_DIALOG(dialog),

--- a/gnucash/gnome-utils/gnc-combott.c
+++ b/gnucash/gnome-utils/gnc-combott.c
@@ -190,8 +190,8 @@ gnc_combott_init (GncCombott *combott)
 
     gtk_orientable_set_orientation (GTK_ORIENTABLE(combott), GTK_ORIENTATION_HORIZONTAL);
 
-    // Set the style context for this widget so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(combott), "GncCombott");
+    // Set the name for this widget so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(combott), "gnc-id-combo-tooltip");
 
     priv->active = 0;
     priv->text_col = 0;

--- a/gnucash/gnome-utils/gnc-currency-edit.c
+++ b/gnucash/gnome-utils/gnc-currency-edit.c
@@ -193,8 +193,8 @@ gnc_currency_edit_class_init (GNCCurrencyEditClass *klass)
 static void
 gnc_currency_edit_init (GNCCurrencyEdit *gce)
 {
-    // Set the style context for this widget so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(gce), "GncCurrencyEdit");
+    // Set the name for this widget so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(gce), "gnc-id-currency-edit");
 
     g_signal_connect (gce, "notify::mnemonic",
                       G_CALLBACK (gnc_currency_edit_mnemonic_changed), gce);

--- a/gnucash/gnome-utils/gnc-date-delta.c
+++ b/gnucash/gnome-utils/gnc-date-delta.c
@@ -162,8 +162,8 @@ gnc_date_delta_init (GNCDateDelta *gdd)
 {
     gtk_orientable_set_orientation (GTK_ORIENTABLE(gdd), GTK_ORIENTATION_HORIZONTAL);
 
-    // Set the style context for this widget so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(gdd), "GncDateDelta");
+    // Set the name for this widget so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(gdd), "gnc-id-date-delta");
 
     gdd->value_spin = NULL;
     gdd->units_combo = NULL;

--- a/gnucash/gnome-utils/gnc-date-edit.c
+++ b/gnucash/gnome-utils/gnc-date-edit.c
@@ -698,8 +698,8 @@ gnc_date_edit_init (GNCDateEdit *gde)
 {
     gtk_orientable_set_orientation (GTK_ORIENTABLE(gde), GTK_ORIENTATION_HORIZONTAL);
 
-    // Set the style context for this widget so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(gde), "GncDateEdit");
+    // Set the name for this widget so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(gde), "gnc-id-date-edit");
 
     gde->disposed = FALSE;
     gde->popup_in_progress = FALSE;

--- a/gnucash/gnome-utils/gnc-date-format.c
+++ b/gnucash/gnome-utils/gnc-date-format.c
@@ -126,8 +126,8 @@ gnc_date_format_init (GNCDateFormat *gdf)
 
     gtk_orientable_set_orientation (GTK_ORIENTABLE(gdf), GTK_ORIENTATION_HORIZONTAL);
 
-    // Set the style context for this widget so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(gdf), "GncDateFormat");
+    // Set the name for this widget so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(gdf), "gnc-id-date-format");
 
     /* Open up the Glade and set the signals */
     builder = gtk_builder_new();

--- a/gnucash/gnome-utils/gnc-dense-cal.c
+++ b/gnucash/gnome-utils/gnc-dense-cal.c
@@ -414,8 +414,8 @@ gnc_dense_cal_init(GncDenseCal *dcal)
 
     dcal->numMonths = 12;
     dcal->monthsPerCol = 3;
-    dcal->leftPadding = 2;
-    dcal->topPadding = 2;
+    dcal->leftPadding = 4;
+    dcal->topPadding = 4;
 
     {
     GDate now;
@@ -1011,15 +1011,16 @@ gnc_dense_cal_draw_to_buffer(GncDenseCal *dcal)
                 center_y = (y1 + y2 ) / 2;
                 radius = MIN((x2 - x1), (y2 - y1)) * .75;
 
-                // try to compensate for row height being odd or even
-                if (((y2 -y1) % 2) == 0)
-                    gtk_render_background (stylectxt, cr,
-                                           center_x - radius - 2, center_y - radius - 1,
-                                            (radius * 2) + 4, radius * 2);
-                else
-                    gtk_render_background (stylectxt, cr,
-                                           center_x - radius - 2, center_y - radius,
-                                            (radius * 2) + 4, (radius * 2) + 1);
+                // try to compensate for row height/width being odd or even
+                if (((y2 - y1) % 2) != 0)
+                    center_y = center_y + 1;
+
+                if (((x2 - x1) % 2) != 0)
+                    center_x = center_x + 1;
+
+                gtk_render_background (stylectxt, cr,
+                                       center_x - (radius + 2), center_y - radius,
+                                        (radius * 2) + 4, radius * 2);
             }
         }
         gtk_style_context_restore (stylectxt);
@@ -1037,7 +1038,7 @@ gnc_dense_cal_draw_to_buffer(GncDenseCal *dcal)
 
         x = dcal->leftPadding
             + (i * (col_width(dcal) + COL_BORDER_SIZE))
-            + dcal->label_width;
+            + dcal->label_height + 1;
         y = dcal->topPadding + dcal->dayLabelHeight;
         w = col_width(dcal) - COL_BORDER_SIZE - dcal->label_width;
         h = col_height(dcal);
@@ -1111,7 +1112,7 @@ gnc_dense_cal_draw_to_buffer(GncDenseCal *dcal)
     /* Month labels. */
     {
         gint i;
-        gint x_offset = dcal->label_height - (dcal->leftPadding * 2);
+        gint x_offset = dcal->leftPadding;
 
         gtk_style_context_save (stylectxt);
         gtk_style_context_add_class (stylectxt, GTK_STYLE_CLASS_HEADER);
@@ -1121,8 +1122,8 @@ gnc_dense_cal_draw_to_buffer(GncDenseCal *dcal)
             if (dcal->monthPositions[i].x == -1)
                 break;
 
-            gtk_render_background (stylectxt, cr, dcal->monthPositions[i].x + x_offset + 1, dcal->topPadding,
-                                   dcal->dayLabelHeight, col_height(dcal) + dcal->dayLabelHeight + 1);
+            gtk_render_background (stylectxt, cr, dcal->monthPositions[i].x + x_offset, dcal->topPadding,
+                                   dcal->dayLabelHeight + 1, col_height(dcal) + dcal->dayLabelHeight + 1);
         }
 
         for (i = 0; i < 12; i++)
@@ -1584,7 +1585,7 @@ month_coords(GncDenseCal *dcal, int monthOfCal, GList **outList)
         rect->x = dcal->leftPadding
                   + MINOR_BORDER_SIZE
                   + (colNum * (col_width(dcal) + COL_BORDER_SIZE))
-                  + dcal->label_width
+                  + dcal->label_height
                   + (start * day_width(dcal));
         rect->y = dcal->topPadding
                   + dcal->dayLabelHeight
@@ -1611,7 +1612,7 @@ month_coords(GncDenseCal *dcal, int monthOfCal, GList **outList)
             rect = g_new0(GdkRectangle, 1);
             rect->x = dcal->leftPadding
                       + MINOR_BORDER_SIZE
-                      + dcal->label_width
+                      + dcal->label_height
                       + (colNum * (col_width(dcal) + COL_BORDER_SIZE));
             rect->y = dcal->topPadding
                       + dcal->dayLabelHeight
@@ -1638,7 +1639,7 @@ month_coords(GncDenseCal *dcal, int monthOfCal, GList **outList)
         rect = g_new0(GdkRectangle, 1);
         rect->x = dcal->leftPadding
                   + MINOR_BORDER_SIZE
-                  + dcal->label_width
+                  + dcal->label_height
                   + (colNum * (col_width(dcal) + COL_BORDER_SIZE));
         rect->y = dcal->topPadding
                   + MINOR_BORDER_SIZE
@@ -1704,7 +1705,7 @@ doc_coords(GncDenseCal *dcal, int dayOfCal,
      * which it shouldn't. */
     *x1 = dcal->leftPadding
           + MINOR_BORDER_SIZE
-          + dcal->label_width
+          + dcal->label_height
           + (colNum * (col_width(dcal) + COL_BORDER_SIZE))
           + (dayCol * day_width(dcal))
           + (day_width(dcal) / 4);

--- a/gnucash/gnome-utils/gnc-dense-cal.c
+++ b/gnucash/gnome-utils/gnc-dense-cal.c
@@ -267,9 +267,10 @@ gnc_dense_cal_init(GncDenseCal *dcal)
     gtk_orientable_set_orientation (GTK_ORIENTABLE(dcal), GTK_ORIENTATION_VERTICAL);
 
     // Set the style context for this widget so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(dcal), "calendar");
+    gnc_widget_style_context_add_class (GTK_WIDGET(dcal), "calendar");
 
-    gtk_widget_set_name (GTK_WIDGET(dcal), "dense-cal");
+    // Set the name of this widget so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(dcal), "gnc-id-dense-calendar");
 
     gtk_style_context_add_class (context, GTK_STYLE_CLASS_CALENDAR);
     {
@@ -331,7 +332,7 @@ gnc_dense_cal_init(GncDenseCal *dcal)
         hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
         gtk_box_set_homogeneous (GTK_BOX (hbox), FALSE);
 
-        gtk_widget_set_name (GTK_WIDGET(dcal->transPopup), "dense-cal-popup");
+        gtk_widget_set_name (GTK_WIDGET(dcal->transPopup), "gnc-id-dense-calendar-popup");
 
         l = gtk_label_new(_("Date: "));
         gtk_widget_set_margin_start (l, 5);

--- a/gnucash/gnome-utils/gnc-embedded-window.c
+++ b/gnucash/gnome-utils/gnc-embedded-window.c
@@ -231,8 +231,8 @@ gnc_embedded_window_init (GncEmbeddedWindow *window, void *data)
 
     gtk_orientable_set_orientation (GTK_ORIENTABLE(window), GTK_ORIENTATION_VERTICAL);
 
-    // Set the style context for this widget so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(window), "GncEmbeddedWindow");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(window), "gnc-id-embedded-window");
 
     gnc_embedded_window_setup_window (window);
 

--- a/gnucash/gnome-utils/gnc-file.c
+++ b/gnucash/gnome-utils/gnc-file.c
@@ -169,8 +169,8 @@ gnc_file_dialog (GtkWindow *parent,
 
     response = gtk_dialog_run(GTK_DIALOG(file_box));
 
-    // Set the style context for this widget so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(file_box), "GncFileDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(file_box), "gnc-id-file");
 
     if (response == GTK_RESPONSE_ACCEPT)
     {

--- a/gnucash/gnome-utils/gnc-frequency.c
+++ b/gnucash/gnome-utils/gnc-frequency.c
@@ -203,8 +203,8 @@ gnc_frequency_init(GncFrequency *gf)
 
     gtk_orientable_set_orientation (GTK_ORIENTABLE(gf), GTK_ORIENTATION_VERTICAL);
 
-    // Set the style context for this widget so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(gf), "GncFrequency");
+    // Set the name for this widget so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(gf), "gnc-id-frequency");
 
     builder = gtk_builder_new();
     gnc_builder_add_from_file  (builder , "gnc-frequency.glade", "adjustment1");

--- a/gnucash/gnome-utils/gnc-general-select.c
+++ b/gnucash/gnome-utils/gnc-general-select.c
@@ -145,8 +145,8 @@ gnc_general_select_init (GNCGeneralSelect *gsl)
 {
     gtk_orientable_set_orientation (GTK_ORIENTABLE(gsl), GTK_ORIENTATION_HORIZONTAL);
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(gsl), "GncGeneralSelect");
+    // Set the name for this widget so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(gsl), "gnc-id-general-select");
 
     gsl->disposed = FALSE;
     gsl->selected_item = NULL;

--- a/gnucash/gnome-utils/gnc-main-window.c
+++ b/gnucash/gnome-utils/gnc-main-window.c
@@ -2570,8 +2570,8 @@ gnc_main_window_init (GncMainWindow *window, void *data)
     priv->merged_actions_table =
         g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
 
-    // Set the style context for this widget so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(window), "GncMainWindow");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(window), "gnc-id-main-window");
 
     priv->event_handler_id =
         qof_event_register_handler(gnc_main_window_event_handler, window);
@@ -3008,6 +3008,10 @@ gnc_main_window_open_page (GncMainWindow *window,
     gtk_widget_show (label);
 
     tab_hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 6);
+
+    if (g_strcmp0 (gnc_plugin_page_get_plugin_name (page), "GncPluginPageAccountTree") == 0)
+        gtk_widget_set_name (GTK_WIDGET(tab_hbox), "gnc-id-account-page-tab-box");
+
     gtk_box_set_homogeneous (GTK_BOX (tab_hbox), FALSE);
     gtk_widget_show (tab_hbox);
 

--- a/gnucash/gnome-utils/gnc-period-select.c
+++ b/gnucash/gnome-utils/gnc-period-select.c
@@ -577,8 +577,8 @@ gnc_period_select_init (GncPeriodSelect *period)
 
     gtk_orientable_set_orientation (GTK_ORIENTABLE(period), GTK_ORIENTATION_HORIZONTAL);
 
-    // Set the style context for this widget so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(period), "GncPeriodSelect");
+    // Set the name for this widget so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(period), "gnc-id-period-select");
 
     priv = GNC_PERIOD_SELECT_GET_PRIVATE(period);
     priv->start = TRUE;

--- a/gnucash/gnome-utils/gnc-query-view.c
+++ b/gnucash/gnome-utils/gnc-query-view.c
@@ -191,8 +191,8 @@ gnc_query_view_init (GNCQueryView *qview)
 {
     GNCQueryViewPrivate *priv;
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(qview), "GncQueryView");
+    // Set the name for this widget so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(qview), "gnc-id-query-view");
 
     qview->query = NULL;
 

--- a/gnucash/gnome-utils/gnc-recurrence.c
+++ b/gnucash/gnome-utils/gnc-recurrence.c
@@ -189,8 +189,8 @@ gnc_recurrence_init( GncRecurrence *gr )
 
     recurrenceSet(&gr->recurrence, 1, PERIOD_MONTH, NULL, WEEKEND_ADJ_NONE);
 
-    // Set the style context for this widget so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(gr), "GncRecurrence");
+    // Set the name for this widget so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(gr), "gnc-id-recurrence");
 
     /* Open up the builder file */
     builder = gtk_builder_new();

--- a/gnucash/gnome-utils/gnc-splash.c
+++ b/gnucash/gnome-utils/gnc-splash.c
@@ -69,8 +69,8 @@ gnc_show_splash_screen (void)
     gtk_window_set_decorated(GTK_WINDOW (splash), FALSE);
     gtk_window_set_skip_taskbar_hint (GTK_WINDOW (splash), TRUE);
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(splash), "GncSplash");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(splash), "gnc-id-splash");
 
     g_signal_connect (splash, "destroy",
                       G_CALLBACK (splash_destroy_cb), NULL);

--- a/gnucash/gnome-utils/gnc-tree-view-account.c
+++ b/gnucash/gnome-utils/gnc-tree-view-account.c
@@ -746,7 +746,7 @@ gnc_tree_view_account_new_with_root (Account *root, gboolean show_root)
     ENTER(" ");
     /* Create our view */
     view = g_object_new (GNC_TYPE_TREE_VIEW_ACCOUNT,
-                         "name", "account_tree", NULL);
+                         "name", "gnc-id-account-tree", NULL);
 
     priv = GNC_TREE_VIEW_ACCOUNT_GET_PRIVATE(GNC_TREE_VIEW_ACCOUNT (view));
 

--- a/gnucash/gnome-utils/gnc-tree-view-commodity.c
+++ b/gnucash/gnome-utils/gnc-tree-view-commodity.c
@@ -342,7 +342,7 @@ gnc_tree_view_commodity_new (QofBook *book,
 
     /* Create our view */
     view = g_object_new (GNC_TYPE_TREE_VIEW_COMMODITY,
-                         "name", "commodity_tree", NULL);
+                         "name", "gnc-id-commodity-tree", NULL);
     gtk_tree_view_set_model (GTK_TREE_VIEW (view), s_model);
     g_object_unref(G_OBJECT(s_model));
 

--- a/gnucash/gnome-utils/gnc-tree-view-owner.c
+++ b/gnucash/gnome-utils/gnc-tree-view-owner.c
@@ -367,7 +367,7 @@ gnc_tree_view_owner_new (GncOwnerType owner_type)
     }
     /* Create our view */
     view = g_object_new (GNC_TYPE_TREE_VIEW_OWNER,
-                         "name", "owner_tree", NULL);
+                         "name", "gnc-id-owner-tree", NULL);
 
     priv = GNC_TREE_VIEW_OWNER_GET_PRIVATE(GNC_TREE_VIEW_OWNER (view));
 

--- a/gnucash/gnome-utils/gnc-tree-view-price.c
+++ b/gnucash/gnome-utils/gnc-tree-view-price.c
@@ -382,7 +382,7 @@ gnc_tree_view_price_new (QofBook *book,
 
     /* Create our view */
     view = g_object_new (GNC_TYPE_TREE_VIEW_PRICE,
-                         "name", "price_tree", NULL);
+                         "name", "gnc-id-price-tree", NULL);
     gtk_tree_view_set_model (GTK_TREE_VIEW (view), s_model);
     g_object_unref(G_OBJECT(s_model));
 

--- a/gnucash/gnome-utils/gnc-tree-view-split-reg.c
+++ b/gnucash/gnome-utils/gnc-tree-view-split-reg.c
@@ -989,7 +989,7 @@ gnc_tree_view_split_reg_new_with_model (GncTreeModelSplitReg *model)
     view->help_text = g_strdup ("Help Text");
 
     /* Set the grid lines to be solid */
-    gnc_widget_set_style_context (GTK_WIDGET(view), "register2_grid_lines");
+    gnc_widget_style_context_add_class (GTK_WIDGET(view), "gnc-class-register2-grid-lines");
 
     /* TreeView Grid lines */
     if (view->priv->use_horizontal_lines)

--- a/gnucash/gnome-utils/gnc-tree-view-split-reg.c
+++ b/gnucash/gnome-utils/gnc-tree-view-split-reg.c
@@ -979,7 +979,7 @@ gnc_tree_view_split_reg_new_with_model (GncTreeModelSplitReg *model)
     GtkTreeSelection    *selection;
 
     view = g_object_new (gnc_tree_view_split_reg_get_type(), NULL);
-    g_object_set (view, "name", "split_reg_tree", NULL);
+    g_object_set (view, "name", "gnc-id-split-reg-tree", NULL);
 
     view->priv->anchor = gnc_tree_model_split_reg_get_anchor (model);
     view->priv->reg_comm = xaccAccountGetCommodity (view->priv->anchor);

--- a/gnucash/gnome-utils/gnc-tree-view-sx-list.c
+++ b/gnucash/gnome-utils/gnc-tree-view-sx-list.c
@@ -125,7 +125,7 @@ gnc_tree_view_sx_list_new(GncSxInstanceModel *sx_instances)
     GncTreeViewSxListPrivate *priv;
 
     view = (GncTreeView*)g_object_new(GNC_TYPE_TREE_VIEW_SX_LIST, NULL);
-    g_object_set(view, "name", "sx_list_tree", NULL);
+    g_object_set(view, "name", "gnc-id-sx-list-tree", NULL);
 
     priv = GNC_TREE_VIEW_SX_LIST_GET_PRIVATE(view);
 

--- a/gnucash/gnome-utils/gnc-tree-view.c
+++ b/gnucash/gnome-utils/gnc-tree-view.c
@@ -256,8 +256,8 @@ gnc_tree_view_init (GncTreeView *view, void *data)
     priv->sort_column_changed_cb_id = 0;
     priv->size_allocate_cb_id = 0;
 
-    // Set the style context for this page so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(view), "GncTreeView");
+    // Set the name for this widget so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(view), "gnc-id-tree-view");
 
     /* Handle column drag and drop */
     gtk_tree_view_set_column_drag_function (GTK_TREE_VIEW(view),

--- a/gnucash/gnome-utils/window-main-summarybar.c
+++ b/gnucash/gnome-utils/window-main-summarybar.c
@@ -634,8 +634,8 @@ gnc_main_window_summary_new (void)
     retval->hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
     gtk_box_set_homogeneous (GTK_BOX (retval->hbox), FALSE);
 
-    // Set the style context for this widget so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(retval->hbox), "summary-bar");
+    // Set the name for this wodget so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(retval->hbox), "gnc-id-account-summary-bar");
 
     retval->totals_combo = gtk_combo_box_new_with_model (GTK_TREE_MODEL (retval->datamodel));
     g_object_unref (retval->datamodel);

--- a/gnucash/gnome/assistant-acct-period.c
+++ b/gnucash/gnome/assistant-acct-period.c
@@ -542,8 +542,8 @@ ap_assistant_create (AcctPeriodInfo *info)
     window = GTK_WIDGET(gtk_builder_get_object (builder, "account_period_assistant"));
     info->window = window;
 
-    // Set the style context for this assistant so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(window), "GncAssistAccountPeriod");
+    // Set the name for this assistant so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(window), "gnc-id-assistant-account-period");
 
     /* Enable all pages except menu page. */
     gtk_assistant_set_page_complete (GTK_ASSISTANT (window),

--- a/gnucash/gnome/assistant-hierarchy.c
+++ b/gnucash/gnome/assistant-hierarchy.c
@@ -1576,8 +1576,8 @@ gnc_create_hierarchy_assistant (gboolean use_defaults, GncHierarchyAssistantFini
     dialog = GTK_WIDGET(gtk_builder_get_object (builder, "hierarchy_assistant"));
     data->dialog = dialog;
 
-    // Set the style context for this assistant so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(dialog), "GncAssistAccountHierarchy");
+    // Set the name for this assistant so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(dialog), "gnc-id-assistant-account-hierarchy");
 
     /* Enable buttons on first and last page. */
     gtk_assistant_set_page_complete (GTK_ASSISTANT (dialog),

--- a/gnucash/gnome/assistant-loan.cpp
+++ b/gnucash/gnome/assistant-loan.cpp
@@ -477,8 +477,8 @@ gnc_loan_assistant_create( LoanAssistantData *ldd )
     window = GTK_WIDGET(gtk_builder_get_object (builder, "loan_mortgage_assistant"));
     ldd->window = window;
 
-    // Set the style context for this assistant so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(window), "GncAssistLoan");
+    // Set the name for this assistant so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(window), "gnc-id-assistant-loan");
 
     /* Enable buttons on complete pages. */
     gtk_assistant_set_page_complete (GTK_ASSISTANT (window),

--- a/gnucash/gnome/assistant-stock-split.c
+++ b/gnucash/gnome/assistant-stock-split.c
@@ -532,8 +532,8 @@ gnc_stock_split_assistant_create (StockSplitInfo *info)
     window = GTK_WIDGET(gtk_builder_get_object (builder, "stock_split_assistant"));
     info->window = window;
 
-    // Set the style context for this assistant so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(window), "GncAssistStockSplit");
+    // Set the name for this assistant so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(window), "gnc-id-assistant-stock-split");
 
     /* Enable buttons on first, second, fourth and last page. */
     gtk_assistant_set_page_complete (GTK_ASSISTANT (window),

--- a/gnucash/gnome/dialog-billterms.c
+++ b/gnucash/gnome/dialog-billterms.c
@@ -135,8 +135,9 @@ init_notebook_widgets (BillTermNB *notebook, gboolean read_only,
     notebook->notebook = GTK_WIDGET(gtk_builder_get_object (builder, "term_notebook"));
     parent = GTK_WIDGET(gtk_builder_get_object (builder, "terms_notebook_window"));
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(notebook->notebook), "GncBillTermsDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(notebook->notebook), "gnc-id-bill-term");
+    gnc_widget_style_context_add_class (GTK_WIDGET(notebook->notebook), "gnc-class-bill-terms");
 
     /* load the "days" widgets */
     notebook->days_due_days = read_widget (builder, "days:due_days", read_only);
@@ -435,8 +436,9 @@ new_billterm_dialog (BillTermsWindow *btw, GncBillTerm *term,
     nbt->name_entry = GTK_WIDGET(gtk_builder_get_object (builder, "name_entry"));
     nbt->desc_entry = GTK_WIDGET(gtk_builder_get_object (builder, dialog_desc));
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(nbt->dialog), "GncBillTermsDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(nbt->dialog), "gnc-id-new-bill-terms");
+    gnc_widget_style_context_add_class (GTK_WIDGET(nbt->dialog), "gnc-class-bill-terms");
 
     if (name)
         gtk_entry_set_text (GTK_ENTRY (nbt->name_entry), name);
@@ -775,8 +777,9 @@ gnc_ui_billterms_window_new (GtkWindow *parent, QofBook *book)
     btw->type_label = GTK_WIDGET(gtk_builder_get_object (builder, "type_label"));
     btw->term_vbox = GTK_WIDGET(gtk_builder_get_object (builder, "term_vbox"));
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(btw->dialog), "GncBillTermsDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(btw->dialog), "gnc-id-bill-terms");
+    gnc_widget_style_context_add_class (GTK_WIDGET(btw->dialog), "gnc-class-bill-terms");
 
     gtk_window_set_transient_for (GTK_WINDOW (btw->dialog), parent);
 

--- a/gnucash/gnome/dialog-choose-owner.c
+++ b/gnucash/gnome/dialog-choose-owner.c
@@ -66,8 +66,8 @@ gcoi_create_dialog(Split* split)
     dco->dialog = GTK_WIDGET(gtk_builder_get_object (builder, "choose_owner_dialog"));
     g_assert(dco->dialog);
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(dco->dialog), "GncChooseOwnerDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(dco->dialog), "gnc-id-owner");
 
     /* Get the title widget and set the title */
     widget = GTK_WIDGET(gtk_builder_get_object (builder, "title_label"));

--- a/gnucash/gnome/dialog-commodities.c
+++ b/gnucash/gnome/dialog-commodities.c
@@ -321,8 +321,9 @@ gnc_commodities_dialog_create (GtkWidget * parent, CommoditiesDialog *cd)
     cd->book = qof_session_get_book(cd->session);
     cd->show_currencies = gnc_prefs_get_bool(GNC_PREFS_GROUP, GNC_PREF_INCL_ISO);
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(cd->window), "GncCommoditiesDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(cd->window), "gnc-id-commodity");
+    gnc_widget_style_context_add_class (GTK_WIDGET(cd->window), "gnc-class-securities");
 
     /* buttons */
     cd->remove_button = GTK_WIDGET(gtk_builder_get_object (builder, "remove_button"));

--- a/gnucash/gnome/dialog-custom-report.c
+++ b/gnucash/gnome/dialog-custom-report.c
@@ -530,8 +530,8 @@ gnc_ui_custom_report_internal(GncMainWindow * window)
 
     gtk_window_set_transient_for (GTK_WINDOW (crd->dialog), GTK_WINDOW(window));
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(crd->dialog), "GncCustomReportDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(crd->dialog), "gnc-id-custom-report");
 
     gnc_restore_window_size (GNC_PREFS_GROUP_REPORT_SAVED_CONFIGS,
                              GTK_WINDOW(crd->dialog), GTK_WINDOW(window));

--- a/gnucash/gnome/dialog-customer.c
+++ b/gnucash/gnome/dialog-customer.c
@@ -577,8 +577,9 @@ gnc_customer_new_window (GtkWindow *parent, QofBook *bookp, GncCustomer *cust)
     cw->dialog = GTK_WIDGET (gtk_builder_get_object (builder, "customer_dialog"));
     gtk_window_set_transient_for (GTK_WINDOW(cw->dialog), parent);
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(cw->dialog), "GncCustomerDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(cw->dialog), "gnc-id-customer");
+    gnc_widget_style_context_add_class (GTK_WIDGET(cw->dialog), "gnc-class-customers");
 
     g_object_set_data (G_OBJECT (cw->dialog), "dialog_info", cw);
 

--- a/gnucash/gnome/dialog-customer.c
+++ b/gnucash/gnome/dialog-customer.c
@@ -963,7 +963,7 @@ gnc_customer_search (GtkWindow *parent, GncCustomer *start, QofBook *book)
                                      params, columns, q, q2, buttons, NULL,
                                      new_customer_cb, sw, free_userdata_cb,
                                      GNC_PREFS_GROUP_SEARCH, NULL,
-                                     "GncFindCustomerDialog");
+                                     "gnc-class-customers");
 }
 
 GNCSearchWindow *

--- a/gnucash/gnome/dialog-date-close.c
+++ b/gnucash/gnome/dialog-date-close.c
@@ -140,8 +140,8 @@ gnc_dialog_date_close_parented (GtkWidget *parent, const char *message,
     gnc_builder_add_from_file (builder, "dialog-date-close.glade", "date_close_dialog");
     ddc->dialog = GTK_WIDGET(gtk_builder_get_object (builder, "date_close_dialog"));
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(ddc->dialog), "GncDateCloseDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(ddc->dialog), "gnc-id-date-close");
 
     date_box = GTK_WIDGET(gtk_builder_get_object (builder, "date_box"));
     ddc->date = gnc_date_edit_new (time(NULL), FALSE, FALSE);
@@ -234,8 +234,8 @@ gnc_dialog_dates_acct_question_parented (GtkWidget *parent, const char *message,
     ddc->dialog = GTK_WIDGET(gtk_builder_get_object (builder, "date_account_dialog"));
     ddc->memo_entry = GTK_WIDGET(gtk_builder_get_object (builder, "memo_entry"));
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(ddc->dialog), "GncDateCloseDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(ddc->dialog), "gnc-id-date-close");
 
     acct_box = GTK_WIDGET(gtk_builder_get_object (builder, "acct_hbox"));
     ddc->acct_combo = gnc_account_sel_new();
@@ -353,8 +353,8 @@ gnc_dialog_date_acct_parented (GtkWidget *parent, const char *message,
     gnc_builder_add_from_file (builder, "dialog-date-close.glade", "date_account_dialog");
     ddc->dialog = GTK_WIDGET(gtk_builder_get_object (builder, "date_account_dialog"));
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(ddc->dialog), "GncDateCloseDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(ddc->dialog), "gnc-id-date-close");
 
     acct_box = GTK_WIDGET(gtk_builder_get_object (builder, "acct_hbox"));
     ddc->acct_combo = gnc_account_sel_new();

--- a/gnucash/gnome/dialog-employee.c
+++ b/gnucash/gnome/dialog-employee.c
@@ -741,7 +741,7 @@ gnc_employee_search (GtkWindow *parent, GncEmployee *start, QofBook *book)
                                      buttons, NULL, new_employee_cb,
                                      sw, free_employee_cb,
                                      GNC_PREFS_GROUP_SEARCH, NULL,
-                                     "GncFindEmployeeDialog");
+                                     "gnc-class-employees");
 }
 
 GNCSearchWindow *

--- a/gnucash/gnome/dialog-employee.c
+++ b/gnucash/gnome/dialog-employee.c
@@ -415,8 +415,9 @@ gnc_employee_new_window (GtkWindow *parent,
     ew->dialog = GTK_WIDGET(gtk_builder_get_object (builder, "employee_dialog"));
     gtk_window_set_transient_for (GTK_WINDOW(ew->dialog), parent);
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(ew->dialog), "GncEmployeeDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(ew->dialog), "gnc-id-employee");
+    gnc_widget_style_context_add_class (GTK_WIDGET(ew->dialog), "gnc-class-employees");
 
     g_object_set_data (G_OBJECT (ew->dialog), "dialog_info", ew);
 

--- a/gnucash/gnome/dialog-fincalc.c
+++ b/gnucash/gnome/dialog-fincalc.c
@@ -581,8 +581,8 @@ gnc_ui_fincalc_dialog_create(GtkWindow *parent)
 
     fcd->dialog = GTK_WIDGET(gtk_builder_get_object (builder, "financial_calculator_dialog"));
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(fcd->dialog), "GncFinCalcDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(fcd->dialog), "gnc-id-financial-calc");
 
     /* parent */
     if (parent != NULL)

--- a/gnucash/gnome/dialog-find-account.c
+++ b/gnucash/gnome/dialog-find-account.c
@@ -334,8 +334,9 @@ gnc_find_account_dialog_create (GtkWidget *parent, FindAccountDialog *facc_dialo
     window = GTK_WIDGET(gtk_builder_get_object (builder, "find_account_window"));
     facc_dialog->window = window;
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(window), "GncFindAccountDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(window), "gnc-id-find-account");
+    gnc_widget_style_context_add_class (GTK_WIDGET(window), "gnc-class-account");
 
     facc_dialog->session = gnc_get_current_session();
     facc_dialog->parent = parent;

--- a/gnucash/gnome/dialog-find-transactions.c
+++ b/gnucash/gnome/dialog-find-transactions.c
@@ -228,7 +228,7 @@ gnc_ui_find_transactions_dialog_create(GtkWindow *parent, GNCLedgerDisplay * ori
                                         params, NULL, start_q, show_q,
                                         NULL, do_find_cb, NULL,
                                         ftd, free_ftd_cb, GNC_PREFS_GROUP_SEARCH, NULL,
-                                        "GncFindTransDialog");
+                                        "gnc-class-transactions");
     if (!ftd->sw)
     {
         free_ftd_cb (ftd);

--- a/gnucash/gnome/dialog-find-transactions2.c
+++ b/gnucash/gnome/dialog-find-transactions2.c
@@ -230,7 +230,7 @@ gnc_ui_find_transactions_dialog_create2 (GNCLedgerDisplay2 * orig_ledg)
                                         params, NULL, start_q, show_q,
                                         NULL, do_find_cb, NULL,
                                         ftd, free_ftd_cb, GNC_PREFS_GROUP_SEARCH, NULL,
-                                        "GncFindTransDialog");
+                                        "gnc-class-transactions");
     if (!ftd->sw)
     {
         free_ftd_cb (ftd);

--- a/gnucash/gnome/dialog-invoice.c
+++ b/gnucash/gnome/dialog-invoice.c
@@ -3331,21 +3331,21 @@ gnc_invoice_search (GtkWindow *parent, GncInvoice *start, GncOwner *owner, QofBo
     case GNC_OWNER_VENDOR:
         title = _("Find Bill");
         label = _("Bill");
-        style_class = "GncFindBillDialog";
+        style_class = "gnc-class-bills";
         params = bill_params;
         buttons = bill_buttons;
         break;
     case GNC_OWNER_EMPLOYEE:
         title = _("Find Expense Voucher");
         label = _("Expense Voucher");
-        style_class = "GncFindExpenseVoucherDialog";
+        style_class = "gnc-class-vouchers";
         params = emp_params;
         buttons = emp_buttons;
         break;
     default:
         title = _("Find Invoice");
         label = _("Invoice");
-        style_class = "GncFindInvoiceDialog";
+        style_class = "gnc-class-invoices";
         params = inv_params;
         buttons = inv_buttons;
         break;

--- a/gnucash/gnome/dialog-invoice.c
+++ b/gnucash/gnome/dialog-invoice.c
@@ -257,14 +257,29 @@ iw_ask_unpost (InvoiceWindow *iw)
     GtkToggleButton *toggle;
     GtkBuilder *builder;
     gint response;
+    const gchar *style_label = NULL;
+    GncOwnerType owner_type = gncOwnerGetType (&iw->owner);
+
 
     builder = gtk_builder_new();
     gnc_builder_add_from_file (builder, "dialog-invoice.glade", "unpost_message_dialog");
     dialog = GTK_WIDGET (gtk_builder_get_object (builder, "unpost_message_dialog"));
     toggle = GTK_TOGGLE_BUTTON(gtk_builder_get_object (builder, "yes_tt_reset"));
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(dialog), "GncInvoiceDialog");
+    switch (owner_type)
+    {
+        case GNC_OWNER_VENDOR:
+            style_label = "gnc-class-vendors";
+            break;
+        case GNC_OWNER_EMPLOYEE:
+            style_label = "gnc-class-employees";
+            break;
+        default:
+            style_label = "gnc-class-customers";
+            break;
+    }
+    // Set a secondary style context for this page so it can be easily manipulated with css
+    gnc_widget_style_context_add_class (GTK_WIDGET(dialog), style_label);
 
     gtk_window_set_transient_for (GTK_WINDOW(dialog),
                                   GTK_WINDOW(iw_get_window(iw)));
@@ -1261,6 +1276,7 @@ gnc_invoice_window_create_summary_bar (InvoiceWindow *iw)
 
     summarybar = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 4);
     gtk_box_set_homogeneous (GTK_BOX (summarybar), FALSE);
+    gtk_widget_set_name (summarybar, "gnc-id-summarybar");
 
     iw->total_label           = add_summary_label (summarybar, _("Total:"));
 
@@ -2306,6 +2322,7 @@ gnc_invoice_create_page (InvoiceWindow *iw, gpointer page)
     GncEntryLedgerType ledger_type;
     const gchar *prefs_group = NULL;
     gboolean is_credit_note = FALSE;
+    const gchar *style_label = NULL;
 
     invoice = gncInvoiceLookup (iw->book, &iw->invoice_guid);
     is_credit_note = gncInvoiceGetIsCreditNote (invoice);
@@ -2317,9 +2334,6 @@ gnc_invoice_create_page (InvoiceWindow *iw, gpointer page)
     gnc_builder_add_from_file (builder, "dialog-invoice.glade", "terms_store");
     gnc_builder_add_from_file (builder, "dialog-invoice.glade", "invoice_entry_vbox");
     dialog = GTK_WIDGET (gtk_builder_get_object (builder, "invoice_entry_vbox"));
-
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(dialog), "GncInvoiceDialog");
 
     /* Autoconnect all the signals */
     gtk_builder_connect_signals_full (builder, gnc_builder_connect_full_func, iw);
@@ -2339,7 +2353,7 @@ gnc_invoice_create_page (InvoiceWindow *iw, gpointer page)
     iw->job_box = GTK_WIDGET (gtk_builder_get_object (builder, "page_job_hbox"));
     iw->paid_label = GTK_WIDGET (gtk_builder_get_object (builder, "paid_label"));
 
-    // Set the style context for this label so it can be easily manipulated with css
+    // Add a style context for this label so it can be easily manipulated with css
     gnc_widget_style_context_add_class (GTK_WIDGET(iw->paid_label), "gnc-class-highlight");
 
     /* grab the project widgets */
@@ -2442,19 +2456,25 @@ gnc_invoice_create_page (InvoiceWindow *iw, gpointer page)
     }
     /* Default labels are for invoices, change them if they are anything else. */
     switch (owner_type)
-        {
+    {
         case GNC_OWNER_VENDOR:
             gtk_label_set_text (GTK_LABEL(iw->info_label),  _("Bill Information"));
             gtk_label_set_text (GTK_LABEL(iw->type_label),  _("Bill"));
             gtk_label_set_text (GTK_LABEL(iw->id_label),  _("Bill ID"));
+            style_label = "gnc-class-vendors";
             break;
         case GNC_OWNER_EMPLOYEE:
             gtk_label_set_text (GTK_LABEL(iw->info_label),  _("Voucher Information"));
             gtk_label_set_text (GTK_LABEL(iw->type_label),  _("Voucher"));
             gtk_label_set_text (GTK_LABEL(iw->id_label),  _("Voucher ID"));
-        default:
+            style_label = "gnc-class-employees";
             break;
-        }
+        default:
+            style_label = "gnc-class-customers";
+            break;
+    }
+    // Set a secondary style context for this page so it can be easily manipulated with css
+    gnc_widget_style_context_add_class (GTK_WIDGET(dialog), style_label);
 
     entry_ledger = gnc_entry_ledger_new (iw->book, ledger_type);
 
@@ -2526,6 +2546,7 @@ gnc_invoice_window_new_invoice (GtkWindow *parent, InvoiceDialogType dialog_type
     const GncOwner *start_owner;
     GncBillTerm *owner_terms = NULL;
     GncOwnerType owner_type;
+    const gchar *style_label = NULL;
 
     g_assert (dialog_type == NEW_INVOICE || dialog_type == MOD_INVOICE || dialog_type == DUP_INVOICE);
 
@@ -2604,8 +2625,8 @@ gnc_invoice_window_new_invoice (GtkWindow *parent, InvoiceDialogType dialog_type
     iw->dialog = GTK_WIDGET (gtk_builder_get_object (builder, "new_invoice_dialog"));
     gtk_window_set_transient_for (GTK_WINDOW(iw->dialog), parent);
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(iw->dialog), "GncInvoiceDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(iw->dialog), "gnc-id-invoice");
 
     g_object_set_data (G_OBJECT (iw->dialog), "dialog_info", iw);
 
@@ -2628,16 +2649,21 @@ gnc_invoice_window_new_invoice (GtkWindow *parent, InvoiceDialogType dialog_type
             gtk_label_set_text (GTK_LABEL(iw->type_label),  _("Bill"));
             gtk_button_set_label (GTK_BUTTON(invoice_radio),  _("Bill"));
             gtk_label_set_text (GTK_LABEL(iw->id_label),  _("Bill ID"));
-
+            style_label = "gnc-class-vendors";
             break;
         case GNC_OWNER_EMPLOYEE:
             gtk_label_set_text (GTK_LABEL(iw->info_label),  _("Voucher Information"));
             gtk_label_set_text (GTK_LABEL(iw->type_label),  _("Voucher"));
             gtk_button_set_label (GTK_BUTTON(invoice_radio),  _("Voucher"));
             gtk_label_set_text (GTK_LABEL(iw->id_label),  _("Voucher ID"));
+            style_label = "gnc-class-employees";
+            break;
         default:
+            style_label = "gnc-class-customers";
         break;
     }
+    // Set a secondary style context for this page so it can be easily manipulated with css
+    gnc_widget_style_context_add_class (GTK_WIDGET(iw->dialog), style_label);
 
     /* configure the type related widgets based on dialog type and invoice type */
     switch (dialog_type)

--- a/gnucash/gnome/dialog-job.c
+++ b/gnucash/gnome/dialog-job.c
@@ -342,8 +342,9 @@ gnc_job_new_window (GtkWindow *parent, QofBook *bookp, GncOwner *owner, GncJob *
     jw->dialog = GTK_WIDGET(gtk_builder_get_object (builder, "job_dialog"));
     gtk_window_set_transient_for (GTK_WINDOW(jw->dialog), parent);
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(jw->dialog), "GncJobDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(jw->dialog), "gnc-id-job");
+    gnc_widget_style_context_add_class (GTK_WIDGET(jw->dialog), "gnc-class-jobs");
 
     /* Get entry points */
     jw->id_entry  = GTK_WIDGET(gtk_builder_get_object (builder, "id_entry"));

--- a/gnucash/gnome/dialog-job.c
+++ b/gnucash/gnome/dialog-job.c
@@ -644,7 +644,7 @@ gnc_job_search (GtkWindow *parent, GncJob *start, GncOwner *owner, QofBook *book
                                      params, columns, q, q2, buttons, NULL,
                                      new_job_cb, sw, free_userdata_cb,
                                      GNC_PREFS_GROUP_SEARCH, NULL,
-                                     "GncFindJobDialog");
+                                     "gnc-class-jobs");
 }
 
 /* Functions for widgets for job selection */

--- a/gnucash/gnome/dialog-lot-viewer.c
+++ b/gnucash/gnome/dialog-lot-viewer.c
@@ -990,8 +990,8 @@ lv_create (GNCLotViewer *lv, GtkWindow *parent)
 
     gtk_window_set_transient_for (GTK_WINDOW (lv->window), parent);
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(lv->window), "GncLotViewerDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(lv->window), "gnc-id-lot-viewer");
 
     win_title = g_strdup_printf (_("Lots in Account %s"),
                                  xaccAccountGetName(lv->account));

--- a/gnucash/gnome/dialog-new-user.c
+++ b/gnucash/gnome/dialog-new-user.c
@@ -150,8 +150,8 @@ gnc_ui_new_user_dialog_create (GNCNewUserDialog *new_user)
 
     gtk_window_set_keep_above (GTK_WINDOW(new_user->window), TRUE);
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(new_user->window), "GncNewUserDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(new_user->window), "gnc-id-new-user");
 
     new_user->new_accounts_button = GTK_WIDGET(gtk_builder_get_object (builder, "new_accounts_button"));
     new_user->import_qif_button = GTK_WIDGET(gtk_builder_get_object (builder, "import_qif_button"));

--- a/gnucash/gnome/dialog-order.c
+++ b/gnucash/gnome/dialog-order.c
@@ -590,8 +590,9 @@ gnc_order_new_window (GtkWindow *parent, QofBook *bookp, OrderDialogType type,
     ow->dialog = GTK_WIDGET(gtk_builder_get_object (builder, "order_entry_dialog"));
     gtk_window_set_transient_for (GTK_WINDOW(ow->dialog), parent);
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(ow->dialog), "GncOrderDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(ow->dialog), "gnc-id-order");
+    gnc_widget_style_context_add_class (GTK_WIDGET(ow->dialog), "gnc-class-orders");
 
     /* Grab the widgets */
     ow->id_entry = GTK_WIDGET(gtk_builder_get_object (builder, "id_entry"));
@@ -704,8 +705,9 @@ gnc_order_window_new_order (GtkWindow *parent, QofBook *bookp, GncOwner *owner)
     ow->dialog = GTK_WIDGET(gtk_builder_get_object (builder, "new_order_dialog"));
     gtk_window_set_transient_for (GTK_WINDOW(ow->dialog), parent);
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(ow->dialog), "GncOrderDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(ow->dialog), "gnc-id-new-order");
+    gnc_widget_style_context_add_class (GTK_WIDGET(ow->dialog), "gnc-class-orders");
 
     g_object_set_data (G_OBJECT (ow->dialog), "dialog_info", ow);
 

--- a/gnucash/gnome/dialog-order.c
+++ b/gnucash/gnome/dialog-order.c
@@ -948,7 +948,7 @@ gnc_order_search (GtkWindow *parent, GncOrder *start, GncOwner *owner, QofBook *
                                      params, columns, q, q2,
                                      buttons, NULL, new_order_cb,
                                      sw, free_order_cb, GNC_PREFS_GROUP_SEARCH,
-                                     NULL, "GncFindOrderDialog");
+                                     NULL, "gnc-class-orders");
 }
 
 GNCSearchWindow *

--- a/gnucash/gnome/dialog-payment.c
+++ b/gnucash/gnome/dialog-payment.c
@@ -725,6 +725,39 @@ gnc_payment_set_owner (PaymentWindow *pw, GncOwner *owner)
     gnc_payment_dialog_owner_changed(pw);
 }
 
+static void
+gnc_payment_update_style_classes (PaymentWindow *pw)
+{
+    GtkStyleContext *stylectxt = gtk_widget_get_style_context (GTK_WIDGET(pw->dialog));
+    const gchar *style_label = NULL;
+
+    if (gtk_style_context_has_class (stylectxt, "gnc-class-customers"))
+        gtk_style_context_remove_class (stylectxt, "gnc-class-customers");
+
+    if (gtk_style_context_has_class (stylectxt, "gnc-class-vendors"))
+        gtk_style_context_remove_class (stylectxt, "gnc-class-vendors");
+
+    if (gtk_style_context_has_class (stylectxt, "gnc-class-employees"))
+        gtk_style_context_remove_class (stylectxt, "gnc-class-employees");
+
+    switch (pw->owner_type)
+    {
+        case GNC_OWNER_CUSTOMER:
+            style_label = "gnc-class-customers";
+            break;
+        case GNC_OWNER_VENDOR:
+            style_label = "gnc-class-vendors";
+            break;
+        case GNC_OWNER_EMPLOYEE:
+            style_label = "gnc-class-employees";
+            break;
+        default:
+            style_label = "gnc-class-unknown";
+            break;
+    }
+    // Set a secondary style context for this page so it can be easily manipulated with css
+    gtk_style_context_add_class (stylectxt, style_label);
+}
 
 static void
 gnc_payment_set_owner_type (PaymentWindow *pw, GncOwnerType owner_type)
@@ -757,6 +790,7 @@ gnc_payment_set_owner_type (PaymentWindow *pw, GncOwnerType owner_type)
         }
         valid = gtk_tree_model_iter_next (store, &iter);
     }
+    gnc_payment_update_style_classes (pw);
 
     gnc_payment_dialog_owner_type_changed (pw);
 }
@@ -1188,8 +1222,8 @@ new_payment_window (GtkWindow *parent, QofBook *book, InitialPaymentInfo *tx_inf
     pw->dialog = GTK_WIDGET (gtk_builder_get_object (builder, "payment_dialog"));
     gtk_window_set_transient_for (GTK_WINDOW(pw->dialog), parent);
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(pw->dialog), "GncPaymentDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(pw->dialog), "gnc-id-payment");
 
     /* Grab the widgets and build the dialog */
     pw->payment_warning = GTK_WIDGET (gtk_builder_get_object (builder, "payment_warning"));

--- a/gnucash/gnome/dialog-price-edit-db.c
+++ b/gnucash/gnome/dialog-price-edit-db.c
@@ -705,8 +705,9 @@ gnc_prices_dialog_create (GtkWidget * parent, PricesDialog *pdb_dialog)
     window = GTK_WIDGET(gtk_builder_get_object (builder, "prices_window"));
     pdb_dialog->window = window;
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(window), "GncPriceEditDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(window), "gnc-id-price-edit");
+    gnc_widget_style_context_add_class (GTK_WIDGET(window), "gnc-class-securities");
 
     pdb_dialog->session = gnc_get_current_session();
     pdb_dialog->book = qof_session_get_book(pdb_dialog->session);

--- a/gnucash/gnome/dialog-print-check.c
+++ b/gnucash/gnome/dialog-print-check.c
@@ -1651,8 +1651,8 @@ gnc_ui_print_check_dialog_create(GtkWidget *parent,
     pcd->builder = builder;
     pcd->dialog = GTK_WIDGET(gtk_builder_get_object (builder, "print_check_dialog"));
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(pcd->dialog), "GncPrintCheckDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(pcd->dialog), "gnc-id-print-check");
 
     /* now pick out the relevant child widgets */
     pcd->format_combobox = GTK_WIDGET(gtk_builder_get_object (builder, "check_format_combobox"));

--- a/gnucash/gnome/dialog-progress.c
+++ b/gnucash/gnome/dialog-progress.c
@@ -207,8 +207,8 @@ gnc_progress_dialog_create(GtkWidget * parent, GNCProgressDialog *progress)
     dialog = GTK_WIDGET(gtk_builder_get_object (builder, "progress_dialog"));
     progress->dialog = dialog;
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(dialog), "GncProgressDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(dialog), "gnc-id-progress");
 
     /* parent */
     if (parent != NULL)

--- a/gnucash/gnome/dialog-report-style-sheet.c
+++ b/gnucash/gnome/dialog-report-style-sheet.c
@@ -213,8 +213,9 @@ gnc_style_sheet_new (StyleSheetDialog * ssd)
     template_combo = GTK_WIDGET(gtk_builder_get_object (builder, "template_combobox"));
     name_entry     = GTK_WIDGET(gtk_builder_get_object (builder, "name_entry"));
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(dlg), "GncStyleSheetDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(dlg), "gnc-id-style-sheet-new");
+    gnc_widget_style_context_add_class (GTK_WIDGET(dlg), "gnc-class-style-sheets");
 
     g_assert(ssd);
 
@@ -431,8 +432,9 @@ gnc_style_sheet_select_dialog_create(GtkWindow *parent)
 
     gtk_window_set_transient_for (GTK_WINDOW (ss->toplevel), GTK_WINDOW(parent));
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(ss->toplevel), "GncStyleSheetDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(ss->toplevel), "gnc-id-style-sheet-select");
+    gnc_widget_style_context_add_class (GTK_WIDGET(ss->toplevel), "gnc-class-style-sheets");
 
     ss->list_view  = GTK_TREE_VIEW(gtk_builder_get_object (builder, "style_sheet_list_view"));
     ss->list_store = gtk_list_store_new (N_COLUMNS, G_TYPE_STRING, G_TYPE_POINTER, G_TYPE_POINTER);

--- a/gnucash/gnome/dialog-sx-editor.c
+++ b/gnucash/gnome/dialog-sx-editor.c
@@ -1191,9 +1191,10 @@ gnc_ui_scheduled_xaction_editor_dialog_create (GtkWindow *parent,
     sxed->endCountSpin = GTK_ENTRY(gtk_builder_get_object (builder, "end_spin"));
     sxed->endRemainSpin = GTK_ENTRY(gtk_builder_get_object (builder, "remain_spin"));
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(sxed->dialog), "GncSxEditorDialog");
-    
+    // Set the name of this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(sxed->dialog), "gnc-id-sx-editor");
+    gnc_widget_style_context_add_class (GTK_WIDGET(sxed->dialog), "gnc-class-sx");
+   
     gtk_window_set_transient_for (GTK_WINDOW (sxed->dialog), parent);
 
     /* Setup the end-date GNC widget */

--- a/gnucash/gnome/dialog-sx-editor2.c
+++ b/gnucash/gnome/dialog-sx-editor2.c
@@ -1162,8 +1162,9 @@ gnc_ui_scheduled_xaction_editor_dialog_create2 (GtkWindow *parent,
     sxed->endCountSpin = GTK_ENTRY (gtk_builder_get_object (builder, "end_spin"));
     sxed->endRemainSpin = GTK_ENTRY (gtk_builder_get_object (builder, "remain_spin"));
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(sxed->dialog), "GncSxEditorDialog");
+    // Set the name of this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(sxed->dialog), "gnc-id-sx2-editor");
+    gnc_widget_style_context_add_class (GTK_WIDGET(sxed->dialog), "gnc-class-sx");
 
     gtk_window_set_transient_for (GTK_WINDOW (sxed->dialog), parent);
 

--- a/gnucash/gnome/dialog-sx-from-trans.c
+++ b/gnucash/gnome/dialog-sx-from-trans.c
@@ -769,8 +769,9 @@ gnc_sx_create_from_trans( GtkWindow *parent, Transaction *trans )
     gnc_builder_add_from_file  (builder , "dialog-sx.glade", "sx_from_real_trans_dialog");
     dialog = GTK_WIDGET(gtk_builder_get_object (builder, "sx_from_real_trans_dialog"));
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(dialog), "GncSxFromTransDialog");
+    // Set the name of this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(dialog), "gnc-id-sx-from-trans");
+    gnc_widget_style_context_add_class (GTK_WIDGET(dialog), "gnc-class-sx");
 
     gtk_window_set_transient_for (GTK_WINDOW (dialog), parent);
 

--- a/gnucash/gnome/dialog-sx-since-last-run.c
+++ b/gnucash/gnome/dialog-sx-since-last-run.c
@@ -973,8 +973,9 @@ gnc_ui_sx_since_last_run_dialog (GtkWindow *parent, GncSxInstanceModel *sx_insta
     dialog->dialog = GTK_WIDGET(gtk_builder_get_object (builder, "since_last_run_dialog"));
     gtk_window_set_transient_for (GTK_WINDOW (dialog->dialog), parent);
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(dialog->dialog), "GncSxSinceLastRunDialog");
+    // Set the name of this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(dialog->dialog), "gnc-id-sx-since-last-run");
+    gnc_widget_style_context_add_class (GTK_WIDGET(dialog->dialog), "gnc-class-sx");
 
     dialog->editing_model = gnc_sx_slr_tree_model_adapter_new(sx_instances);
     dialog->review_created_txns_toggle = GTK_TOGGLE_BUTTON(gtk_builder_get_object (builder, "review_txn_toggle"));

--- a/gnucash/gnome/dialog-tax-info.c
+++ b/gnucash/gnome/dialog-tax-info.c
@@ -1292,8 +1292,9 @@ gnc_tax_info_dialog_create (GtkWidget * parent, TaxInfoDialog *ti_dialog)
     dialog = GTK_WIDGET(gtk_builder_get_object (builder, "tax_information_dialog"));
     ti_dialog->dialog = dialog;
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(dialog), "GncTaxInfoDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(dialog), "gnc-id-tax-information");
+    gnc_widget_style_context_add_class (GTK_WIDGET(dialog), "gnc-class-taxes");
 
     initialize_getters ();
 

--- a/gnucash/gnome/dialog-trans-assoc.c
+++ b/gnucash/gnome/dialog-trans-assoc.c
@@ -481,8 +481,8 @@ gnc_assoc_dialog_create (GtkWindow *parent, AssocDialog *assoc_dialog)
 
     gtk_window_set_title (GTK_WINDOW(assoc_dialog->window), _("Transaction Associations"));
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(window), "GncTransAssocDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(window), "gnc-id-transaction-associations");
 
     assoc_dialog->view = GTK_WIDGET(gtk_builder_get_object (builder, "treeview"));
     path_head = GTK_WIDGET(gtk_builder_get_object (builder, "path-head"));

--- a/gnucash/gnome/dialog-vendor.c
+++ b/gnucash/gnome/dialog-vendor.c
@@ -443,8 +443,9 @@ gnc_vendor_new_window (GtkWindow *parent, QofBook *bookp, GncVendor *vendor)
     vw->dialog = GTK_WIDGET (gtk_builder_get_object (builder, "vendor_dialog"));
     gtk_window_set_transient_for (GTK_WINDOW(vw->dialog), parent);
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(vw->dialog), "GncVendorDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(vw->dialog), "gnc-id-vendor");
+    gnc_widget_style_context_add_class (GTK_WIDGET(vw->dialog), "gnc-class-vendors");
 
     /* Get entry points */
     vw->id_entry = GTK_WIDGET (gtk_builder_get_object (builder, "id_entry"));

--- a/gnucash/gnome/dialog-vendor.c
+++ b/gnucash/gnome/dialog-vendor.c
@@ -765,7 +765,7 @@ gnc_vendor_search (GtkWindow *parent, GncVendor *start, QofBook *book)
                                      params, columns, q, q2, buttons, NULL,
                                      new_vendor_cb, sw, free_vendor_cb,
                                      GNC_PREFS_GROUP_SEARCH, NULL,
-                                     "GncFindVendorDialog");
+                                     "gnc-class-vendors");
 }
 
 GNCSearchWindow *

--- a/gnucash/gnome/gnc-budget-view.c
+++ b/gnucash/gnome/gnc-budget-view.c
@@ -419,8 +419,8 @@ gbv_create_widget (GncBudgetView *budget_view)
     priv = GNC_BUDGET_VIEW_GET_PRIVATE(budget_view);
     vbox = GTK_BOX(budget_view);
 
-    // Set the style context for this page so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(vbox), "GncBudgetPage");
+    // Set the name for this widget so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(vbox), "gnc-id-budget-page");
 
     // Accounts scroll window
     scrolled_window = gtk_scrolled_window_new (NULL, NULL);

--- a/gnucash/gnome/gnc-plugin-page-account-tree.c
+++ b/gnucash/gnome/gnc-plugin-page-account-tree.c
@@ -665,8 +665,8 @@ gnc_plugin_page_account_tree_create_widget (GncPluginPage *plugin_page)
     gtk_box_set_homogeneous (GTK_BOX (priv->widget), FALSE);
     gtk_widget_show (priv->widget);
 
-    // Set the style context for this page so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(priv->widget), "GncAccountPage");
+    // Set the name for this widget so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(priv->widget), "gnc-id-account-page");
 
     scrolled_window = gtk_scrolled_window_new (NULL, NULL);
     gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (scrolled_window),

--- a/gnucash/gnome/gnc-plugin-page-invoice.c
+++ b/gnucash/gnome/gnc-plugin-page-invoice.c
@@ -631,8 +631,8 @@ gnc_plugin_page_invoice_create_widget (GncPluginPage *plugin_page)
     priv->widget = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
     gtk_box_set_homogeneous (GTK_BOX (priv->widget), FALSE);
 
-    // Set the style context for this page so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(priv->widget), "GncInvoicePage");
+    // Set the name for this widget so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(priv->widget), "gnc-id-invoice-page");
 
     gtk_widget_show (priv->widget);
 

--- a/gnucash/gnome/gnc-plugin-page-owner-tree.c
+++ b/gnucash/gnome/gnc-plugin-page-owner-tree.c
@@ -576,8 +576,8 @@ gnc_plugin_page_owner_tree_create_widget (GncPluginPage *plugin_page)
     gtk_box_set_homogeneous (GTK_BOX (priv->widget), FALSE);
     gtk_widget_show (priv->widget);
 
-    // Set the style context for this page so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(priv->widget), "GncBusinessPage");
+    // Set the name for this widget so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(priv->widget), "gnc-id-owner-page");
 
     scrolled_window = gtk_scrolled_window_new (NULL, NULL);
     gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (scrolled_window),
@@ -609,32 +609,32 @@ gnc_plugin_page_owner_tree_create_widget (GncPluginPage *plugin_page)
     case GNC_OWNER_UNDEFINED :
         PWARN("missing owner_type");
         label = _("Unknown");
-        style_label = "GncUnknown";
+        style_label = "gnc-class-unknown";
         break;
     case GNC_OWNER_CUSTOMER :
         label = _("Customers");
         state_section = "Customers Overview";
-        style_label = "GncCustomers";
+        style_label = "gnc-class-customers";
         break;
     case GNC_OWNER_JOB :
         label = _("Jobs");
         state_section = "Jobs Overview";
-        style_label = "GncJobs";
+        style_label = "gnc-class-jobs";
         break;
     case GNC_OWNER_VENDOR :
         label = _("Vendors");
         state_section = "Vendors Overview";
-        style_label = "GncVendors";
+        style_label = "gnc-class-vendors";
         break;
     case GNC_OWNER_EMPLOYEE :
         label = _("Employees");
         state_section = "Employees Overview";
-        style_label = "GncEmployees";
+        style_label = "gnc-class-employees";
         break;
     }
 
     // Set a secondary style context for this page so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(priv->widget), style_label);
+    gnc_widget_style_context_add_class (GTK_WIDGET(priv->widget), style_label);
 
     g_object_set(G_OBJECT(tree_view), "state-section", state_section,
                                       "show-column-menu", TRUE,

--- a/gnucash/gnome/gnc-plugin-page-register.c
+++ b/gnucash/gnome/gnc-plugin-page-register.c
@@ -1220,8 +1220,8 @@ gnc_plugin_page_register_create_widget (GncPluginPage *plugin_page)
     gtk_box_set_homogeneous (GTK_BOX (priv->widget), FALSE);
     gtk_widget_show (priv->widget);
 
-    // Set the style context for this page so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(priv->widget), "GncRegisterPage");
+    // Set the name for this widget so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(priv->widget), "gnc-id-register-page");
 
     numRows = priv->lines_default;
     numRows = MIN(numRows, DEFAULT_LINES_AMOUNT);

--- a/gnucash/gnome/gnc-plugin-page-register2.c
+++ b/gnucash/gnome/gnc-plugin-page-register2.c
@@ -1061,8 +1061,8 @@ gnc_plugin_page_register2_create_widget (GncPluginPage *plugin_page)
     gtk_box_set_homogeneous (GTK_BOX (priv->widget), FALSE);
     gtk_widget_show (priv->widget);
 
-    // Set the style context for this page so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(priv->widget), "GncRegisterPage");
+    // Set the name for this widget so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(priv->widget), "gnc-id-register2-page");
 
     numRows = priv->lines_default;
     numRows = MIN (numRows, DEFAULT_LINES_AMOUNT);

--- a/gnucash/gnome/gnc-plugin-page-report.c
+++ b/gnucash/gnome/gnc-plugin-page-report.c
@@ -429,8 +429,8 @@ gnc_plugin_page_report_create_widget( GncPluginPage *page )
     priv->container = GTK_CONTAINER(gtk_frame_new(NULL));
     gtk_frame_set_shadow_type(GTK_FRAME(priv->container), GTK_SHADOW_NONE);
 
-    // Set the style context for this page so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(priv->container), "GncReportPage");
+    // Set the name for this widget so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(priv->container), "gnc-id-report-page");
 
     gtk_container_add(GTK_CONTAINER(priv->container),
                       gnc_html_get_widget(priv->html));

--- a/gnucash/gnome/gnc-plugin-page-sx-list.c
+++ b/gnucash/gnome/gnc-plugin-page-sx-list.c
@@ -373,8 +373,8 @@ gnc_plugin_page_sx_list_create_widget (GncPluginPage *plugin_page)
     priv->widget = widget;
     gtk_widget_show (priv->widget);
 
-    // Set the style context for this page so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(priv->widget), "GncSxPage");
+    // Set the name for this widget so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(priv->widget), "gnc-id-sx-page");
 
     /* Add vbox and label */
     vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);

--- a/gnucash/gnome/window-autoclear.c
+++ b/gnucash/gnome/window-autoclear.c
@@ -313,8 +313,8 @@ autoClearWindow (GtkWidget *parent, Account *account)
     gtk_window_set_title(GTK_WINDOW(data->window), title);
     g_free (title);
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(data->window), "GncAutoClearDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(data->window), "gnc-id-auto-clear");
 
     /* Add amount edit box */
     data->end_value = GNC_AMOUNT_EDIT(gnc_amount_edit_new());

--- a/gnucash/gnome/window-reconcile.c
+++ b/gnucash/gnome/window-reconcile.c
@@ -735,8 +735,8 @@ startRecnWindow(GtkWidget *parent, Account *account,
 
     dialog = GTK_WIDGET(gtk_builder_get_object (builder, "reconcile_start_dialog"));
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(dialog), "GncReconcileDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(dialog), "gnc-id-reconcile-start");
 
     title = gnc_recn_make_window_name (account);
     gtk_window_set_title(GTK_WINDOW(dialog), title);
@@ -1725,6 +1725,9 @@ recnWindowWithBalance (GtkWidget *parent, Account *account, gnc_numeric new_endi
     gtk_box_set_homogeneous (GTK_BOX (vbox), FALSE);
     gtk_container_add(GTK_CONTAINER(recnData->window), vbox);
 
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(recnData->window), "gnc-id-reconcile");
+
     dock = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
     gtk_box_set_homogeneous (GTK_BOX (dock), FALSE);
     gtk_widget_show(dock);
@@ -1811,9 +1814,15 @@ recnWindowWithBalance (GtkWidget *parent, Account *account, gnc_numeric new_endi
                      (account, RECLIST_DEBIT, recnData,
                       &recnData->debit, &recnData->total_debit);
 
+        // Add a style context for this widget so it can be easily manipulated with css
+        gnc_widget_style_context_add_class (GTK_WIDGET(debits_box), "gnc-class-debits");
+
         credits_box = gnc_reconcile_window_create_view_box
                       (account, RECLIST_CREDIT, recnData,
                        &recnData->credit, &recnData->total_credit);
+
+        // Add a style context for this widget so it can be easily manipulated with css
+        gnc_widget_style_context_add_class (GTK_WIDGET(credits_box), "gnc-class-credits");
 
         GNC_RECONCILE_VIEW(recnData->debit)->sibling = GNC_RECONCILE_VIEW(recnData->credit);
         GNC_RECONCILE_VIEW(recnData->credit)->sibling = GNC_RECONCILE_VIEW(recnData->debit);
@@ -1846,6 +1855,9 @@ recnWindowWithBalance (GtkWidget *parent, Account *account, gnc_numeric new_endi
             /* frame to hold totals */
             frame = gtk_frame_new(NULL);
             gtk_box_pack_end(GTK_BOX(hbox), frame, FALSE, FALSE, 0);
+
+            // Set the name for this widget so it can be easily manipulated with css
+            gtk_widget_set_name (GTK_WIDGET(frame), "gnc-id-reconcile-totals");
 
             /* hbox to hold title/value vboxes */
             totals_hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 3);

--- a/gnucash/gnome/window-reconcile2.c
+++ b/gnucash/gnome/window-reconcile2.c
@@ -693,8 +693,8 @@ startRecnWindow (GtkWidget *parent, Account *account,
 
     dialog = GTK_WIDGET(gtk_builder_get_object (builder, "reconcile_start_dialog"));
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(dialog), "GncReconcileDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(dialog), "gnc-id-reconcile2-start");
 
     title = gnc_recn_make_window_name (account);
     gtk_window_set_title (GTK_WINDOW (dialog), title);
@@ -1665,6 +1665,9 @@ recnWindow2WithBalance (GtkWidget *parent, Account *account,
     gtk_box_set_homogeneous (GTK_BOX (vbox), FALSE);
     gtk_container_add (GTK_CONTAINER(recnData->window), vbox);
 
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(recnData->window), "gnc-id-reconcile2");
+
     dock = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
     gtk_box_set_homogeneous (GTK_BOX (dock), FALSE);
     gtk_widget_show (dock);
@@ -1751,9 +1754,15 @@ recnWindow2WithBalance (GtkWidget *parent, Account *account,
                      (account, RECLIST_DEBIT, recnData,
                       &recnData->debit, &recnData->total_debit);
 
+        // Add a style context for this widget so it can be easily manipulated with css
+        gnc_widget_style_context_add_class (GTK_WIDGET(debits_box), "gnc-class-debits");
+
         credits_box = gnc_reconcile_window_create_view_box
                       (account, RECLIST_CREDIT, recnData,
                        &recnData->credit, &recnData->total_credit);
+
+        // Add a style context for this widget so it can be easily manipulated with css
+        gnc_widget_style_context_add_class (GTK_WIDGET(credits_box), "gnc-class-credits");
 
         GNC_RECONCILE_VIEW (recnData->debit)->sibling = GNC_RECONCILE_VIEW (recnData->credit);
         GNC_RECONCILE_VIEW (recnData->credit)->sibling = GNC_RECONCILE_VIEW (recnData->debit);
@@ -1786,6 +1795,9 @@ recnWindow2WithBalance (GtkWidget *parent, Account *account,
             /* frame to hold totals */
             frame = gtk_frame_new (NULL);
             gtk_box_pack_end (GTK_BOX (hbox), frame, FALSE, FALSE, 0);
+
+            // Set the name for this dialog so it can be easily manipulated with css
+            gtk_widget_set_name (GTK_WIDGET(frame), "gnc-id-reconcile-totals");
 
             /* hbox to hold title/value vboxes */
             totals_hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 3);

--- a/gnucash/gnucash-310.css
+++ b/gnucash/gnucash-310.css
@@ -13,12 +13,12 @@
 }
 
 /* Register Cursor settings, top, right, bottom, left */
-.cursor .entry {
+.gnc-class-cursor .entry {
   margin: 2px 5px 2px 5px;  /* this only works by doing it in code, yellow area */
   padding: 2px 2px 2px 2px; /* all work with different values, around the text blue area */
 }
 
-.cursor .button {
+.gnc-class-cursor .button {
   margin: 1px 1px 1px 1px; /* does not work, not used, here for completeness */
 }
 
@@ -30,52 +30,52 @@
 @define-color register_cursor_bg_color #FFEF98;
 @define-color register_fg_color black;
 
-*.register-foreground {
+*.gnc-class-register-foreground {
   color: @register_fg_color;
 }
 
-*.register-header {
+*.gnc-class-register-header {
   background-color: @register_header_bg_color;
 }
 
-*.register-primary {
+*.gnc-class-register-primary {
   background-color: @register_primary_bg_color;
 }
 
-*.register-primary:insensitive {
+*.gnc-class-register-primary:insensitive {
   background-color: mix (@register_primary_bg_color, grey, 0.2);
 }
 
-*.register-secondary {
+*.gnc-class-register-secondary {
   background-color: @register_secondary_bg_color;
 }
 
-*.register-secondary:insensitive {
+*.gnc-class-register-secondary:insensitive {
   background-color: mix (@register_secondary_bg_color, grey, 0.2);
 }
 
-*.register-split {
+*.gnc-class-register-split {
   background-color: @register_split_bg_color;
 }
 
-*.register-split:insensitive {
+*.gnc-class-register-split:insensitive {
   background-color: mix (@register_split_bg_color, grey, 0.2);
 }
 
-*.register-cursor {
+*.gnc-class-register-cursor {
   background-color: @register_cursor_bg_color;
 }
 
-*.register-cursor:insensitive {
+*.gnc-class-register-cursor:insensitive {
   background-color: mix (@register_cursor_bg_color, grey, 0.2);
 }
 
 /* Change font color by mixing with grey */
-.lighter-grey-mix {
+.gnc-class-lighter-grey-mix {
   color: mix (currentColor, grey, 0.8);
 }
 
-.darker-grey-mix {
+.gnc-class-darker-grey-mix {
   color: mix (currentColor, grey, 0.2);
 }
 

--- a/gnucash/gnucash-320.css
+++ b/gnucash/gnucash-320.css
@@ -13,12 +13,12 @@
 }
 
 /* Register Cursor settings, top, right, bottom, left */
-cursor entry {
+gnc-id-cursor entry {
   margin: 2px 5px 2px 5px;
   padding: 0px 2px 0px 2px;
 }
 
-cursor button {
+gnc-id-cursor button {
   margin: 1px 1px 1px 1px;
 }
 
@@ -30,52 +30,52 @@ cursor button {
 @define-color register_cursor_bg_color #FFEF98;
 @define-color register_fg_color black;
 
-*.register-foreground {
+*.gnc-class-register-foreground {
   color: @register_fg_color;
 }
 
-*.register-header {
+*.gnc-class-register-header {
   background-color: @register_header_bg_color;
 }
 
-*.register-primary {
+*.gnc-class-register-primary {
   background-color: @register_primary_bg_color;
 }
 
-*.register-primary:disabled {
+*.gnc-class-register-primary:disabled {
   background-color: mix (@register_primary_bg_color, grey, 0.2);
 }
 
-*.register-secondary {
+*.gnc-class-register-secondary {
   background-color: @register_secondary_bg_color;
 }
 
-*.register-secondary:disabled {
+*.gnc-class-register-secondary:disabled {
   background-color: mix (@register_secondary_bg_color, grey, 0.2);
 }
 
-*.register-split {
+*.gnc-class-register-split {
   background-color: @register_split_bg_color;
 }
 
-*.register-split:disabled {
+*.gnc-class-register-split:disabled {
   background-color: mix (@register_split_bg_color, grey, 0.2);
 }
 
-*.register-cursor {
+*.gnc-class-register-cursor {
   background-color: @register_cursor_bg_color;
 }
 
-*.register-cursor:disabled {
+*.gnc-class-register-cursor:disabled {
   background-color: mix (@register_cursor_bg_color, grey, 0.2);
 }
 
 /* Change font color by mixing with grey */
-.lighter-grey-mix {
+.gnc-class-lighter-grey-mix {
   color: mix (currentColor, grey, 0.8);
 }
 
-.darker-grey-mix {
+.gnc-class-darker-grey-mix {
   color: mix (currentColor, grey, 0.2);
 }
 

--- a/gnucash/gnucash-fallback-310.css
+++ b/gnucash/gnucash-fallback-310.css
@@ -42,7 +42,7 @@
 }
 
 /* Make label more important */
-.emphasize-label {
+.gnc-class-emphasize-label {
   font-size: large;
   font-weight: bold;
 }

--- a/gnucash/gnucash-fallback-310.css
+++ b/gnucash/gnucash-fallback-310.css
@@ -37,7 +37,7 @@
 @define-color negative-numbers rgb(75%, 0%, 0%);
 
 /* Register2 grid lines color */
-.register2_grid_lines {
+.gnc-class-register2-grid-lines {
   border-color: black;
 }
 

--- a/gnucash/gnucash-fallback-310.css
+++ b/gnucash/gnucash-fallback-310.css
@@ -8,27 +8,27 @@
 @define-color intervention-probably-required_bg_color gold;
 @define-color intervention-not-required_bg_color DarkSeaGreen1;
 
-.intervention-required {
+.gnc-class-intervention-required {
   background-color: @intervention-required_bg_color;
 }
 
-.intervention-probably-required {
+.gnc-class-intervention-probably-required {
   background-color: @intervention-probably-required_bg_color;
 }
 
-.intervention-not-required {
+.gnc-class-intervention-not-required {
   background-color: @intervention-not-required_bg_color;
 }
 
-.intervention-required-dark {
+.gnc-class-intervention-required-dark {
   background-color: shade (@intervention-required_bg_color, 0.7);
 }
 
-.intervention-probably-required-dark {
+.gnc-class-intervention-probably-required-dark {
   background-color: shade (@intervention-probably-required_bg_color, 0.8);
 }
 
-.intervention-not-required-dark {
+.gnc-class-intervention-not-required-dark {
   background-color: shade (@intervention-not-required_bg_color, 0.3);
 }
 

--- a/gnucash/gtkbuilder/dialog-account.glade
+++ b/gnucash/gtkbuilder/dialog-account.glade
@@ -388,6 +388,9 @@
       <action-widget response="-6">cancelbutton3</action-widget>
       <action-widget response="-5">okbutton3</action-widget>
     </action-widgets>
+    <style>
+      <class name="gnc-class-account"/>
+    </style>
   </object>
   <object class="GtkDialog" id="account_delete_dialog">
     <property name="can_focus">False</property>
@@ -822,6 +825,9 @@
       <action-widget response="-6">cancelbutton</action-widget>
       <action-widget response="-3">deletebutton</action-widget>
     </action-widgets>
+    <style>
+      <class name="gnc-class-account"/>
+    </style>
   </object>
   <object class="GtkDialog" id="account_filter_by_dialog">
     <property name="can_focus">False</property>
@@ -1077,6 +1083,9 @@
       <action-widget response="-6">cancelbutton1</action-widget>
       <action-widget response="-5">okbutton1</action-widget>
     </action-widgets>
+    <style>
+      <class name="gnc-class-account"/>
+    </style>
   </object>
   <object class="GtkListStore" id="fraction_liststore">
     <columns>
@@ -1669,6 +1678,9 @@
                     <property name="position">1</property>
                   </packing>
                 </child>
+                <style>
+                  <class name="gnc-class-account"/>
+                </style>
               </object>
               <packing>
                 <property name="tab_expand">True</property>
@@ -1855,6 +1867,9 @@
                     <property name="position">0</property>
                   </packing>
                 </child>
+                <style>
+                  <class name="gnc-class-account"/>
+                </style>
               </object>
               <packing>
                 <property name="position">1</property>
@@ -1872,6 +1887,9 @@
                 <property name="tab_fill">False</property>
               </packing>
             </child>
+            <style>
+              <class name="gnc-class-account"/>
+            </style>
           </object>
           <packing>
             <property name="expand">True</property>
@@ -1879,6 +1897,9 @@
             <property name="position">1</property>
           </packing>
         </child>
+        <style>
+          <class name="gnc-class-account"/>
+        </style>
       </object>
     </child>
     <action-widgets>
@@ -1886,6 +1907,9 @@
       <action-widget response="-6">cancel_button</action-widget>
       <action-widget response="-5">ok_button</action-widget>
     </action-widgets>
+    <style>
+      <class name="gnc-class-account"/>
+    </style>
   </object>
   <object class="GtkAdjustment" id="interval_adjustment">
     <property name="lower">1</property>
@@ -2096,5 +2120,8 @@
       <action-widget response="-6">cancelbutton2</action-widget>
       <action-widget response="-5">okbutton2</action-widget>
     </action-widgets>
+    <style>
+      <class name="gnc-class-account"/>
+    </style>
   </object>
 </interface>

--- a/gnucash/import-export/bi-import/dialog-bi-import-gui.c
+++ b/gnucash/import-export/bi-import/dialog-bi-import-gui.c
@@ -118,8 +118,9 @@ gnc_plugin_bi_import_showGUI (GtkWindow *parent)
     gui->tree_view = GTK_WIDGET(gtk_builder_get_object (builder, "treeview1"));
     gui->entryFilename = GTK_WIDGET(gtk_builder_get_object (builder, "entryFilename"));
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(gui->dialog), "GncBillImportDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(gui->dialog), "gnc-id-bill-import");
+    gnc_widget_style_context_add_class (GTK_WIDGET(gui->dialog), "gnc-class-imports");
 
     gtk_window_set_transient_for (GTK_WINDOW (gui->dialog), parent);
 

--- a/gnucash/import-export/csv-exp/assistant-csv-export.c
+++ b/gnucash/import-export/csv-exp/assistant-csv-export.c
@@ -855,8 +855,9 @@ csv_export_assistant_create (CsvExportInfo *info)
     gnc_builder_add_from_file  (builder , "assistant-csv-export.glade", "csv_export_assistant");
     info->assistant = GTK_WIDGET(gtk_builder_get_object (builder, "csv_export_assistant"));
 
-    // Set the style context for this assistant so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(info->assistant), "GncAssistExport");
+    // Set the name for this assistant so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(info->assistant), "gnc-id-assistant-csv-export");
+    gnc_widget_style_context_add_class (GTK_WIDGET(info->assistant), "gnc-class-exports");
 
     /* Load default settings */
     load_settings (info);

--- a/gnucash/import-export/csv-imp/assistant-csv-account-import.c
+++ b/gnucash/import-export/csv-imp/assistant-csv-account-import.c
@@ -641,8 +641,9 @@ csv_import_assistant_create (CsvImportInfo *info)
     gnc_builder_add_from_file  (builder, "assistant-csv-account-import.glade", "csv_account_import_assistant");
     info->assistant = GTK_WIDGET(gtk_builder_get_object (builder, "csv_account_import_assistant"));
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(info->assistant), "GncAssistAccountImport");
+    // Set the name for this assistant so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(info->assistant), "gnc-id-assistant-csv-account-import");
+    gnc_widget_style_context_add_class (GTK_WIDGET(info->assistant), "gnc-class-imports");
 
     /* Load default settings */
     load_settings (info);

--- a/gnucash/import-export/csv-imp/assistant-csv-price-import.cpp
+++ b/gnucash/import-export/csv-imp/assistant-csv-price-import.cpp
@@ -524,6 +524,10 @@ CsvImpPriceAssist::CsvImpPriceAssist ()
     gnc_builder_add_from_file  (builder , "assistant-csv-price-import.glade", "CSV Price Assistant");
     csv_imp_asst = GTK_ASSISTANT(gtk_builder_get_object (builder, "CSV Price Assistant"));
 
+    // Set the name for this assistant so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(csv_imp_asst), "gnc-id-assistant-csv-price-import");
+    gnc_widget_style_context_add_class (GTK_WIDGET(csv_imp_asst), "gnc-class-imports");
+
     /* Enable buttons on all page. */
     gtk_assistant_set_page_complete (csv_imp_asst,
                                      GTK_WIDGET(gtk_builder_get_object (builder, "start_page")),

--- a/gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp
+++ b/gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp
@@ -459,8 +459,9 @@ CsvImpTransAssist::CsvImpTransAssist ()
     gnc_builder_add_from_file  (builder , "assistant-csv-trans-import.glade", "csv_transaction_assistant");
     csv_imp_asst = GTK_ASSISTANT(gtk_builder_get_object (builder, "csv_transaction_assistant"));
 
-    // Set the style context for this assistant so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(csv_imp_asst), "GncAssistTransImport");
+    // Set the name for this assistant so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(csv_imp_asst), "gnc-id-assistant-csv-transaction-import");
+    gnc_widget_style_context_add_class (GTK_WIDGET(csv_imp_asst), "gnc-class-imports");
 
     /* Enable buttons on all page. */
     gtk_assistant_set_page_complete (csv_imp_asst,

--- a/gnucash/import-export/customer-import/dialog-customer-import-gui.c
+++ b/gnucash/import-export/customer-import/dialog-customer-import-gui.c
@@ -104,8 +104,9 @@ gnc_plugin_customer_import_showGUI(GtkWindow *parent)
     gui->entryFilename = GTK_WIDGET(gtk_builder_get_object (builder, "entryFilename"));
     gui->type = "CUSTOMER"; // Set a default type to import
 
-    // Set the style context for this dialog so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(gui->dialog), "GncCustomerImportDialog");
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(gui->dialog), "gnc-id-customer-import");
+    gnc_widget_style_context_add_class (GTK_WIDGET(gui->dialog), "gnc-class-imports");
 
     gtk_window_set_transient_for (GTK_WINDOW (gui->dialog), parent);
 

--- a/gnucash/import-export/import-main-matcher.c
+++ b/gnucash/import-export/import-main-matcher.c
@@ -91,9 +91,9 @@ enum downloaded_cols
     NUM_DOWNLOADED_COLS
 };
 
-#define CSS_INT_REQUIRED_CLASS      "intervention-required"
-#define CSS_INT_PROB_REQUIRED_CLASS "intervention-probably-required"
-#define CSS_INT_NOT_REQUIRED_CLASS  "intervention-not-required"
+#define CSS_INT_REQUIRED_CLASS      "gnc-class-intervention-required"
+#define CSS_INT_PROB_REQUIRED_CLASS "gnc-class-intervention-probably-required"
+#define CSS_INT_NOT_REQUIRED_CLASS  "gnc-class-intervention-not-required"
 
 /* Define log domain for extended debugging of matcher */
 #define G_MOD_IMPORT_MATCHER "gnc.import.main-matcher"
@@ -291,13 +291,13 @@ on_matcher_help_clicked (GtkButton *button, gpointer user_data)
     int_not_required_class = g_strconcat (CSS_INT_NOT_REQUIRED_CLASS, class_extension, NULL);
 
     box = GTK_WIDGET(gtk_builder_get_object (builder, "intervention_required_box"));
-    gnc_widget_set_style_context (GTK_WIDGET(box), int_required_class);
+    gnc_widget_style_context_add_class (GTK_WIDGET(box), int_required_class);
 
     box = GTK_WIDGET(gtk_builder_get_object (builder, "intervention_probably_required_box"));
-    gnc_widget_set_style_context (GTK_WIDGET(box), int_prob_required_class);
+    gnc_widget_style_context_add_class (GTK_WIDGET(box), int_prob_required_class);
 
     box = GTK_WIDGET(gtk_builder_get_object (builder, "intervention_not_required_box"));
-    gnc_widget_set_style_context (GTK_WIDGET(box), int_not_required_class);
+    gnc_widget_style_context_add_class (GTK_WIDGET(box), int_not_required_class);
 
     help_dialog = GTK_WIDGET(gtk_builder_get_object (builder, "matcher_help_dialog"));
     gtk_window_set_transient_for (GTK_WINDOW(help_dialog), GTK_WINDOW(info->main_widget));

--- a/gnucash/import-export/qif-imp/assistant-qif-import.c
+++ b/gnucash/import-export/qif-imp/assistant-qif-import.c
@@ -3616,8 +3616,9 @@ get_assistant_widgets (QIFImportWindow *wind, GtkBuilder *builder)
                                    GTK_TEXT_VIEW(wind->convert_log));
     wind->summary_text       = GTK_WIDGET(gtk_builder_get_object (builder, "summary_page"));
 
-    // Set the style context for this assistant so it can be easily manipulated with css
-    gnc_widget_set_style_context (GTK_WIDGET(wind->window), "GncAssistQifImport");
+    // Set the name for this assistant so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(wind->window), "gnc-id-assistant-qif-import");
+    gnc_widget_style_context_add_class (GTK_WIDGET(wind->window), "gnc-class-imports");
 
     wind->new_transaction_view =
         GTK_WIDGET(gtk_builder_get_object (builder, "new_transaction_view"));

--- a/gnucash/register/register-gnome/gnucash-header.c
+++ b/gnucash/register/register-gnome/gnucash-header.c
@@ -74,7 +74,7 @@ gnc_header_draw_offscreen (GncHeader *header)
 
     // Get the color type and apply the css class
     color_type = gnc_table_get_color (table, virt_loc, NULL);
-    gnucash_get_style_classes (header->sheet, stylectxt, color_type);
+    gnucash_get_style_classes (header->sheet, stylectxt, color_type, FALSE);
 
     if (header->surface)
         cairo_surface_destroy (header->surface);
@@ -596,7 +596,7 @@ gnc_header_init (GncHeader *header)
     header->style = NULL;
 
     // This sets a style class for when Gtk+ version is less than 3.20
-    gnc_widget_set_css_name (GTK_WIDGET(header), "header");
+    gnc_widget_add_style_class (GTK_WIDGET(header), "gnc-class-header");
 
     gtk_widget_add_events(GTK_WIDGET(header), (GDK_EXPOSURE_MASK
                           | GDK_BUTTON_PRESS_MASK
@@ -617,7 +617,7 @@ gnc_header_class_init (GncHeaderClass *header_class)
     GtkWidgetClass *item_class = GTK_WIDGET_CLASS (header_class);
 
 #if GTK_CHECK_VERSION(3,20,0)
-    gtk_widget_class_set_css_name (GTK_WIDGET_CLASS(header_class), "header");
+    gtk_widget_class_set_css_name (GTK_WIDGET_CLASS(header_class), "gnc-id-header");
 #endif
 
     parent_class = g_type_class_peek_parent (header_class);

--- a/gnucash/register/register-gnome/gnucash-item-edit.c
+++ b/gnucash/register/register-gnome/gnucash-item-edit.c
@@ -209,7 +209,7 @@ gnc_item_edit_tb_new (GnucashSheet *sheet)
                            NULL);
 
     // This sets a style class for when Gtk+ version is less than 3.20
-    gnc_widget_set_css_name (GTK_WIDGET(item_edit_tb), "button");
+    gnc_widget_add_style_class (GTK_WIDGET(item_edit_tb), "button");
 
     context = gtk_widget_get_style_context (GTK_WIDGET(item_edit_tb));
     gtk_style_context_add_class (context, GTK_STYLE_CLASS_BUTTON);
@@ -498,7 +498,7 @@ draw_background_cb (GtkWidget *widget, cairo_t *cr, gpointer user_data)
 
     // Get the color type and apply the css class
     color_type = gnc_table_get_color (item_edit->sheet->table, item_edit->virt_loc, NULL);
-    gnucash_get_style_classes (item_edit->sheet, stylectxt, color_type);
+    gnucash_get_style_classes (item_edit->sheet, stylectxt, color_type, FALSE);
 
     gtk_render_background (stylectxt, cr, 0, 1, width, height - 2);
 
@@ -711,7 +711,7 @@ gnc_item_edit_class_init (GncItemEditClass *gnc_item_edit_class)
     GtkWidgetClass *widget_class;
 
 #if GTK_CHECK_VERSION(3,20,0)
-    gtk_widget_class_set_css_name (GTK_WIDGET_CLASS(gnc_item_edit_class), "cursor");
+    gtk_widget_class_set_css_name (GTK_WIDGET_CLASS(gnc_item_edit_class), "gnc-id-cursor");
 #endif
 
     gnc_item_edit_parent_class = g_type_class_peek_parent (gnc_item_edit_class);
@@ -866,7 +866,7 @@ gnc_item_edit_new (GnucashSheet *sheet)
     gtk_layout_put (GTK_LAYOUT(sheet), GTK_WIDGET(item_edit), 0, 0);
 
     // This sets a style class for when Gtk+ version is less than 3.20
-    gnc_widget_set_css_name (GTK_WIDGET(item_edit), "cursor");
+    gnc_widget_add_style_class (GTK_WIDGET(item_edit), "gnc-class-cursor");
 
     /* Create the text entry */
     item_edit->editor = gtk_entry_new();
@@ -876,7 +876,7 @@ gnc_item_edit_new (GnucashSheet *sheet)
 
     // Get the CSS space settings for the entry
     stylectxt = gtk_widget_get_style_context (GTK_WIDGET(item_edit->editor));
-    gtk_style_context_add_class (stylectxt, "register-foreground");
+    gtk_style_context_add_class (stylectxt, "gnc-class-register-foreground");
     gtk_style_context_get_padding (stylectxt, GTK_STATE_FLAG_NORMAL, &padding);
     gtk_style_context_get_margin (stylectxt, GTK_STATE_FLAG_NORMAL, &margin);
     gtk_style_context_get_border (stylectxt, GTK_STATE_FLAG_NORMAL, &border);

--- a/gnucash/register/register-gnome/gnucash-register.c
+++ b/gnucash/register/register-gnome/gnucash-register.c
@@ -318,7 +318,7 @@ gnucash_register_class_init (GnucashRegisterClass *klass)
     gobject_class = G_OBJECT_CLASS (klass);
 
 #if GTK_CHECK_VERSION(3,20,0)
-    gtk_widget_class_set_css_name (GTK_WIDGET_CLASS(klass), "register");
+    gtk_widget_class_set_css_name (GTK_WIDGET_CLASS(klass), "gnc-id-register");
 #endif
 
     register_parent_class = g_type_class_peek_parent (klass);
@@ -379,7 +379,7 @@ gnucash_register_init (GnucashRegister *g_reg)
     gtk_widget_set_can_default (GTK_WIDGET(table), FALSE);
 
     // This sets a style class for when Gtk+ version is less than 3.20
-    gnc_widget_set_css_name (GTK_WIDGET(g_reg), "register");
+    gnc_widget_add_style_class (GTK_WIDGET(g_reg), "gnc-class-register");
 
     gtk_grid_set_row_homogeneous (GTK_GRID(table), FALSE);
     gtk_grid_set_column_homogeneous (GTK_GRID(table), FALSE);

--- a/gnucash/register/register-gnome/gnucash-sheet-private.c
+++ b/gnucash/register/register-gnome/gnucash-sheet-private.c
@@ -396,12 +396,19 @@ draw_cell (GnucashSheet *sheet,
     int x_offset;
     GtkStyleContext *stylectxt = gtk_widget_get_style_context (GTK_WIDGET(sheet));
     GdkRGBA color;
+    gboolean use_neg_class = TRUE;
 
     gtk_style_context_save (stylectxt);
 
+    text = gnc_table_get_entry (table, virt_loc);
+
+    // test for any text, if no text we do not want to add gnc-class-negative-numbers
+    if (!text || *text == '\0')
+        use_neg_class = FALSE;
+
     // Get the color type and apply the css class
     color_type = gnc_table_get_color (table, virt_loc, &hatching);
-    gnucash_get_style_classes (sheet, stylectxt, color_type);
+    gnucash_get_style_classes (sheet, stylectxt, color_type, use_neg_class);
 
     // Are we in a read-only row? Then make the background color somewhat more grey.
     if ((virt_loc.phys_row_offset < block->style->nrows)
@@ -477,8 +484,6 @@ draw_cell (GnucashSheet *sheet,
                            table->model->dividing_row_lower, block->style->nrows,
                            fg_color, x, y, width, height);
 
-    text = gnc_table_get_entry (table, virt_loc);
-
     layout = gtk_widget_create_pango_layout (GTK_WIDGET (sheet), text);
 
     if (gtk_style_context_has_class (stylectxt, GTK_STYLE_CLASS_VIEW))
@@ -496,7 +501,7 @@ draw_cell (GnucashSheet *sheet,
             && (virt_loc.vcell_loc.virt_row < table->model->dividing_row_upper))
     {
         // Make text color greyed
-        gtk_style_context_add_class (stylectxt, "lighter-grey-mix");
+        gtk_style_context_add_class (stylectxt, "gnc-class-lighter-grey-mix");
     }
 #endif
 
@@ -511,7 +516,7 @@ draw_cell (GnucashSheet *sheet,
             goto exit;
 
         // Make text color greyed
-        gtk_style_context_add_class (stylectxt, "lighter-grey-mix");
+        gtk_style_context_add_class (stylectxt, "gnc-class-lighter-grey-mix");
 
         pango_layout_set_text (layout, text, strlen (text));
         pango_font_description_set_style (font, PANGO_STYLE_ITALIC);
@@ -699,7 +704,7 @@ gnucash_sheet_draw_cursor (GnucashCursor *cursor, cairo_t *cr)
 }
 
 void
-gnc_widget_set_css_name (GtkWidget *widget, const char *name)
+gnc_widget_add_style_class (GtkWidget *widget, const char *name)
 {
 #if !GTK_CHECK_VERSION(3,20,0)
     GtkStyleContext *context = gtk_widget_get_style_context (widget);

--- a/gnucash/register/register-gnome/gnucash-sheet.c
+++ b/gnucash/register/register-gnome/gnucash-sheet.c
@@ -2519,19 +2519,20 @@ gnucash_sheet_table_load (GnucashSheet *sheet, gboolean do_scroll)
 /** Map a cell color type to a css style class. */
 void
 gnucash_get_style_classes (GnucashSheet *sheet, GtkStyleContext *stylectxt,
-                           RegisterColor field_type)
+                           RegisterColor field_type, gboolean use_neg_class)
 {
     gchar *full_class, *style_class = NULL;
 
     if (field_type >= COLOR_NEGATIVE) // Require a Negative fg color
     {
-        gtk_style_context_add_class (stylectxt, "gnc-class-negative-numbers");
+        if (use_neg_class)
+            gtk_style_context_add_class (stylectxt, "gnc-class-negative-numbers");
         field_type -= COLOR_NEGATIVE;
     }
     else
     {
         if (sheet->use_gnc_color_theme) // only add this class if builtin colors used
-            gtk_style_context_add_class (stylectxt, "register-foreground");
+            gtk_style_context_add_class (stylectxt, "gnc-class-register-foreground");
     }
 
     switch (field_type)
@@ -2566,11 +2567,11 @@ gnucash_get_style_classes (GnucashSheet *sheet, GtkStyleContext *stylectxt,
     }
 
     if (sheet->use_gnc_color_theme)
-        full_class = g_strconcat ("register-", style_class, NULL);
+        full_class = g_strconcat ("gnc-class-register-", style_class, NULL);
     else
     {
         gtk_style_context_add_class (stylectxt, GTK_STYLE_CLASS_VIEW);
-        full_class = g_strconcat (style_class, "-color", NULL);
+        full_class = g_strconcat ("gnc-class-user-register-", style_class, NULL);
     }
 
     gtk_style_context_add_class (stylectxt, full_class);
@@ -2590,7 +2591,7 @@ gnucash_sheet_class_init (GnucashSheetClass *klass)
     widget_class = GTK_WIDGET_CLASS (klass);
 
 #if GTK_CHECK_VERSION(3,20,0)
-    gtk_widget_class_set_css_name (GTK_WIDGET_CLASS(klass), "sheet");
+    gtk_widget_class_set_css_name (GTK_WIDGET_CLASS(klass), "gnc-id-sheet");
 #endif
 
     sheet_parent_class = g_type_class_peek_parent (klass);
@@ -2620,7 +2621,7 @@ gnucash_sheet_init (GnucashSheet *sheet)
     gtk_widget_set_can_default (GTK_WIDGET(sheet), TRUE);
 
     // This sets a style class for when Gtk+ version is less than 3.20
-    gnc_widget_set_css_name (GTK_WIDGET(sheet), "sheet");
+    gnc_widget_add_style_class (GTK_WIDGET(sheet), "gnc-class-sheet");
 
     sheet->num_visible_blocks = 1;
     sheet->num_visible_phys_rows = 1;

--- a/gnucash/register/register-gnome/gnucash-sheet.h
+++ b/gnucash/register/register-gnome/gnucash-sheet.h
@@ -102,7 +102,7 @@ void gnucash_sheet_update_adjustments (GnucashSheet *sheet);
 void gnucash_sheet_set_window (GnucashSheet *sheet, GtkWidget *window);
 
 void gnucash_get_style_classes (GnucashSheet *sheet, GtkStyleContext *stylectxt,
-                                RegisterColor field_type);
+                                RegisterColor field_type, gboolean use_neg_class);
 
 void gnucash_sheet_set_text_bounds (GnucashSheet *sheet, GdkRectangle *rect,
                                     gint x, gint y, gint width, gint height);

--- a/gnucash/register/register-gnome/gnucash-sheetP.h
+++ b/gnucash/register/register-gnome/gnucash-sheetP.h
@@ -139,7 +139,7 @@ gboolean gnucash_sheet_draw_internal (GnucashSheet *sheet, cairo_t *cr,
                                       GtkAllocation *alloc);
 void gnucash_sheet_draw_cursor (GnucashCursor *cursor, cairo_t *cr);
 
-void gnc_widget_set_css_name (GtkWidget *widget, const char *name);
+void gnc_widget_add_style_class (GtkWidget *widget, const char *name);
 
 /** @} */
 #endif


### PR DESCRIPTION
This PR is mostly about correcting some style classes that I added at the start of version 3.x
Instead of adding widget names I added style contexts based on appropriate structure naming which was wrong. An email awhile ago decided on widget names starting 'gnc-id-' and classes would start 'gnc-class-' followed by some friendly text. 
This PR makes those corrections and also adds some classes where I thought may be useful like 'gnc-class-highlight' which would allow appropriate text to be changed.

As a result of these changes, there will be some disruption when released as the setting in users gtk-3.0.css files will be wrong, mostly it will be just a matter of adding the prefixes above but not always. I have updated the example file with the new entries which I think is liked from the wiki.

It is possible to extract these id's and classes with the following bash file run from the source directory I cobbled together...

#/bin/bash
grep -IrF \"gnc-id- | sed 's/\"name\"/blank/g' > /tmp/id.txt
sed -i 's/[^"]*"\([^"]*\).*/\1/' /tmp/id.txt
grep -IrF \"gnc-class- | sed 's/[^"]*"\([^"]*\).*/\1/' > /tmp/class.txt
sort -u /tmp/class.txt > /tmp/out.txt
sort -u /tmp/id.txt >> /tmp/out.txt
cp /tmp/out.txt class-and-id-list.txt

