### PR TITLE
Bug 797670 - scheduled transaction editor can remain open when switch…

### DIFF
--- a/gnucash/gnome/dialog-sx-editor.c
+++ b/gnucash/gnome/dialog-sx-editor.c
@@ -62,6 +62,7 @@
 #include "gnc-ui.h"
 #include "gnc-ui-util.h"
 #include "gnucash-sheet.h"
+#include "gnc-session.h"
 
 #include "gnc-split-reg.h"
 
@@ -1123,6 +1124,7 @@ gnc_ui_scheduled_xaction_editor_dialog_create (GtkWindow *parent,
     GtkBuilder *builder;
     GtkWidget *button;
     int i;
+    gint id;
     GList *dlgExists = NULL;
 
     static struct widgetSignalCallback
@@ -1208,10 +1210,12 @@ gnc_ui_scheduled_xaction_editor_dialog_create (GtkWindow *parent,
                             TRUE, TRUE, 0 );
     }
 
-    gnc_register_gui_component( DIALOG_SCHEDXACTION_EDITOR_CM_CLASS,
+    id = gnc_register_gui_component( DIALOG_SCHEDXACTION_EDITOR_CM_CLASS,
                                 NULL, /* no refresh handler */
                                 sxed_close_handler,
                                 sxed );
+    // This ensure this dialog is closed when the session is closed.
+    gnc_gui_component_set_session (id,gnc_get_current_session());
 
     g_signal_connect( sxed->dialog, "delete_event",
                       G_CALLBACK(sxed_delete_event), sxed );

--- a/gnucash/gnome/dialog-sx-editor.c
+++ b/gnucash/gnome/dialog-sx-editor.c
@@ -1124,7 +1124,7 @@ gnc_ui_scheduled_xaction_editor_dialog_create (GtkWindow *parent,
     GtkBuilder *builder;
     GtkWidget *button;
     int i;
-    gint id;
+    int id;
     GList *dlgExists = NULL;
 
     static struct widgetSignalCallback
@@ -1211,11 +1211,11 @@ gnc_ui_scheduled_xaction_editor_dialog_create (GtkWindow *parent,
     }
 
     id = gnc_register_gui_component( DIALOG_SCHEDXACTION_EDITOR_CM_CLASS,
-                                NULL, /* no refresh handler */
-                                sxed_close_handler,
-                                sxed );
+                                     NULL, /* no refresh handler */
+                                     sxed_close_handler,
+                                     sxed );
     // This ensure this dialog is closed when the session is closed.
-    gnc_gui_component_set_session (id,gnc_get_current_session());
+    gnc_gui_component_set_session (id, gnc_get_current_session());
 
     g_signal_connect( sxed->dialog, "delete_event",
                       G_CALLBACK(sxed_delete_event), sxed );

--- a/gnucash/import-export/import-main-matcher.c
+++ b/gnucash/import-export/import-main-matcher.c
@@ -51,9 +51,10 @@
 #include "import-pending-matches.h"
 #include "gnc-component-manager.h"
 #include "guid.h"
+#include "gnc-session.h"
 
 #define GNC_PREFS_GROUP "dialogs.import.generic.transaction-list"
-
+#define IMPORT_MAIN_MATCHER_CM_CLASS "transaction-matcher-dialog"
 
 struct _main_matcher_info
 {
@@ -923,6 +924,7 @@ GNCImportMainMatcher *gnc_gen_trans_list_new (GtkWidget *parent,
     GtkStyleContext *stylectxt;
     GdkRGBA color;
     GtkWidget *button;
+    gint id;
 
     info = g_new0 (GNCImportMainMatcher, 1);
     info->pending_matches = gnc_import_PendingMatches_new();
@@ -977,7 +979,14 @@ GNCImportMainMatcher *gnc_gen_trans_list_new (GtkWidget *parent,
     gtk_builder_connect_signals_full (builder, gnc_builder_connect_full_func, info);
 
     g_object_unref (G_OBJECT(builder));
-
+    
+    // Register this UI, it needs to be closed when the session is closed.
+    id = gnc_register_gui_component (IMPORT_MAIN_MATCHER_CM_CLASS,
+                                    NULL, /* no refresh handler */
+                                    (GNCComponentCloseHandler)gnc_gen_trans_list_delete,
+                                    info);
+    // This ensure this dialog is closed when the session is closed.
+    gnc_gui_component_set_session (id, gnc_get_current_session());
     return info;
 }
 


### PR DESCRIPTION
…ing file, which causes seg fault when later closed

The solution was to add a missing call to gnc_gui_component_set_session()