### PR TITLE
Bug 797115 - Can't 're-activate' an expired SX Fix 3 problems with th…

### DIFF
--- a/gnucash/gnome-utils/gnc-dense-cal.c
+++ b/gnucash/gnome-utils/gnc-dense-cal.c
@@ -1939,10 +1939,13 @@ gdc_model_added_cb(GncDenseCalModel *model, guint added_tag, gpointer user_data)
 static void
 gdc_model_update_cb(GncDenseCalModel *model, guint update_tag, gpointer user_data)
 {
-    GncDenseCal *cal = GNC_DENSE_CAL(user_data);
-    g_debug("gdc_model_update_cb update for tag [%d]\n", update_tag);
-    gdc_mark_remove(cal, update_tag, FALSE);
-    gdc_add_tag_markings(cal, update_tag);
+    GncDenseCal *cal = GNC_DENSE_CAL (user_data);
+    gint num_marks = 0;
+    g_debug ("gdc_model_update_cb update for tag [%d]\n", update_tag);
+    num_marks = gnc_dense_cal_model_get_instance_count (cal->model, update_tag);
+    // We need to redraw if there are no mark, to ensure they're all erased.
+    gdc_mark_remove (cal, update_tag, num_marks==0);
+    gdc_add_tag_markings (cal, update_tag);
 
 }
 

--- a/gnucash/gnome/dialog-sx-editor.c
+++ b/gnucash/gnome/dialog-sx-editor.c
@@ -1594,7 +1594,6 @@ gnc_sxed_update_cal(GncSxEditorDialog *sxed)
     g_date_clear(&start_date, 1);
 
     gnc_frequency_save_to_recurrence(sxed->gncfreq, &recurrences, &start_date);
-    g_date_subtract_days(&start_date, 1);
     recurrenceListNextInstance(recurrences, &start_date, &first_date);
 
     /* Deal with the fact that this SX may have been run before [the
@@ -1605,10 +1604,10 @@ gnc_sxed_update_cal(GncSxEditorDialog *sxed)
         last_sx_inst = xaccSchedXactionGetLastOccurDate(sxed->sx);
         if (g_date_valid(last_sx_inst)
             && g_date_valid(&first_date)
-            && g_date_compare(last_sx_inst, &first_date) != 0)
+            && g_date_compare(last_sx_inst, &first_date) > 0)
         {
             /* last occurrence will be passed as initial date to update store
-             * later on as well */
+             * later on as well, but only if it's past first_date */
             start_date = *last_sx_inst;
             recurrenceListNextInstance(recurrences, &start_date, &first_date);
         }

--- a/gnucash/register/ledger-core/gnc-ledger-display2.c
+++ b/gnucash/register/ledger-core/gnc-ledger-display2.c
@@ -809,7 +809,6 @@ gnc_ledger_display2_internal (Account *lead_account, Query *q,
 
     ld->use_double_line_default = use_double_line;
 
-    // JEAN: add mismatched_commodities
     ld->model = gnc_tree_model_split_reg_new (reg_type, style, use_double_line, is_template, mismatched_commodities);
 
     gnc_tree_model_split_reg_set_data (ld->model, ld, gnc_ledger_display2_parent);

--- a/libgnucash/engine/SchedXaction.c
+++ b/libgnucash/engine/SchedXaction.c
@@ -931,13 +931,13 @@ xaccSchedXactionGetNextInstance (const SchedXaction *sx, SXTmpStateData *tsd)
      * we're at the beginning. We want to pretend prev_occur is the day before
      * the start_date in case the start_date is today so that the SX will fire
      * today. If start_date isn't valid either then the SX will fire anyway, no
-     * harm done.
+     * harm done. prev_occur cannot be before start_date either.
      */
-    if (! g_date_valid( &prev_occur ) && g_date_valid(&sx->start_date))
+    if (g_date_valid (&sx->start_date) && (!g_date_valid ( &prev_occur ) || g_date_compare (&prev_occur, &sx->start_date)<0))
     {
         /* We must be at the beginning. */
         prev_occur = sx->start_date;
-        g_date_subtract_days( &prev_occur, 1 );
+        g_date_subtract_days (&prev_occur, 1 );
     }
 
     recurrenceListNextInstance(sx->schedule, &prev_occur, &next_occur);


### PR DESCRIPTION
…e scheduled transactions calculations
While reproducing the bug I found quite a few problems with the scheduled transactions: inconsistencies between what's displayed in the main dialog and in the edit dialog, mistakes by 1 day in the calculation of the first instance, lack of removal of marks in the calendar in cases where no instances can possibly occur.
These were mostly corner cases (playing with the start date, the previous occurrence date, the end date, etc), but things seem to be working well now.
I haven't run the tests, I'll check later to ensure they all pass.