### PR TITLE
[gnc-exp-parser] don't crash when gnc:fn returns non-number

### DIFF
--- a/libgnucash/app-utils/gnc-exp-parser.c
+++ b/libgnucash/app-utils/gnc-exp-parser.c
@@ -339,6 +339,12 @@ func_op(const char *fname, int argc, void **argv)
         return NULL;
     }
 
+    if (!scm_is_number (scmTmp))
+    {
+        PERR("function gnc:%s does not return a number", fname);
+        return NULL;
+    }
+
     result = g_new0( gnc_numeric, 1 );
     *result = double_to_gnc_numeric( scm_to_double(scmTmp),
                                      GNC_DENOM_AUTO,


### PR DESCRIPTION
If gnc:fn returns anything other than a finite real number, abort rather than crash. Precursor to #691

test by modifying `fin.scm`:

```scheme
(define (gnc:foobar val) (and (positive? val) val))
```

and in SX formula try both `foobar(20)` and `foobar(-20)` -- now gnc:function can return anything, and will only be processed if it returns a number.