### PR TITLE
General UI - improve consistency of menu actions

### DIFF
--- a/gnucash/gnome-utils/dialog-dup-trans.c
+++ b/gnucash/gnome-utils/dialog-dup-trans.c
@@ -183,7 +183,8 @@ gnc_dup_trans_dialog_create (GtkWidget * parent, DupTransDialog *dt_dialog,
 }
 
 static gboolean
-gnc_dup_trans_dialog_internal (GtkWidget * parent, const char* title,
+gnc_dup_trans_dialog_internal (GtkWidget * parent,
+                               const char* window_title, const char* title,
                                gboolean show_date, time64 *date_p,
                                GDate *gdate_p, const char *num, char **out_num,
                                const char *tnum, char **out_tnum,
@@ -217,6 +218,9 @@ gnc_dup_trans_dialog_internal (GtkWidget * parent, const char* title,
         entry = gde->date_entry;
         gtk_widget_grab_focus (entry);
     }
+
+    if (window_title)
+        gtk_window_set_title (GTK_WINDOW (dt_dialog->dialog), window_title);
 
     if (title)
     {
@@ -296,7 +300,7 @@ gnc_dup_trans_dialog (GtkWidget * parent, const char* title, gboolean show_date,
                       const char *tnum, char **out_tnum,
                       const char *tassoc, char **out_tassoc)
 {
-    return gnc_dup_trans_dialog_internal(parent, title, show_date, date_p, NULL,
+    return gnc_dup_trans_dialog_internal(parent, NULL, title, show_date, date_p, NULL,
                                          num, out_num, tnum, out_tnum, tassoc, out_tassoc);
 }
 
@@ -308,8 +312,16 @@ gnc_dup_trans_dialog_gdate (GtkWidget * parent, GDate *gdate_p,
     g_assert(gdate_p);
 
     tmp_time = gdate_to_time64 (*gdate_p);
-    return gnc_dup_trans_dialog_internal(parent, NULL, TRUE, &tmp_time, gdate_p,
+    return gnc_dup_trans_dialog_internal(parent, NULL, NULL, TRUE, &tmp_time, gdate_p,
                                          num, out_num, NULL, NULL, NULL, NULL);
+}
+
+gboolean
+gnc_dup_time64_dialog (GtkWidget * parent, const char *window_title,
+                       const char* title, time64 *date)
+{
+    return gnc_dup_trans_dialog_internal(parent, window_title, title, TRUE, date, NULL,
+                                         NULL, NULL, NULL, NULL, NULL, NULL);
 }
 
 gboolean
@@ -319,6 +331,7 @@ gnc_dup_date_dialog (GtkWidget * parent, const char* title, GDate *gdate_p)
     g_assert(gdate_p);
 
     tmp_time = gdate_to_time64(*gdate_p);
-    return gnc_dup_trans_dialog_internal(parent, title, TRUE, &tmp_time, gdate_p,
+    return gnc_dup_trans_dialog_internal(parent, NULL, title, TRUE, &tmp_time, gdate_p,
                                          NULL, NULL, NULL, NULL, NULL, NULL);
 }
+

--- a/gnucash/gnome-utils/dialog-dup-trans.h
+++ b/gnucash/gnome-utils/dialog-dup-trans.h
@@ -73,4 +73,19 @@ gnc_dup_trans_dialog_gdate (GtkWidget * parent, GDate *gdate_p,
 gboolean
 gnc_dup_date_dialog (GtkWidget * parent, const char* title, GDate *date);
 
+/**
+ * Opens up a window to ask for a date for the duplicated element
+ *
+ * \param parent The parent of the window to be created
+ * \param window_title The title of the dialog window
+ * \param title The text of the title label
+ * \param date  The initial time64 date to use, and the output
+ *                   parameter for the new date. Must not be NULL.
+ *
+ * \return TRUE if user closes dialog with 'OK', otherwise FALSE
+ */
+gboolean
+gnc_dup_time64_dialog (GtkWidget * parent, const char *window_title,
+                       const char* title, time64 *date);
+
 #endif // DIALOGDUPTRANS_H

--- a/gnucash/gnome/gnc-plugin-budget.c
+++ b/gnucash/gnome/gnc-plugin-budget.c
@@ -54,6 +54,8 @@ static void gnc_plugin_budget_cmd_open_budget (GtkAction *action,
         GncMainWindowActionData *data);
 static void gnc_plugin_budget_cmd_copy_budget (GtkAction *action,
         GncMainWindowActionData *data);
+static void gnc_plugin_budget_cmd_delete_budget (GtkAction *action,
+        GncMainWindowActionData *data);
 
 static GtkActionEntry gnc_plugin_actions [] =
 {
@@ -74,6 +76,12 @@ static GtkActionEntry gnc_plugin_actions [] =
         N_("Copy an existing Budget"),
         G_CALLBACK(gnc_plugin_budget_cmd_copy_budget)
     },
+    {
+        "DeleteBudgetAction", NULL, N_("Delete Budget"), NULL,
+        N_("Deletes an existing Budget"),
+        G_CALLBACK(gnc_plugin_budget_cmd_delete_budget)
+    },
+
 };
 static guint gnc_plugin_n_actions = G_N_ELEMENTS (gnc_plugin_actions);
 
@@ -231,6 +239,26 @@ gnc_plugin_budget_cmd_copy_budget (GtkAction *action,
     }
     else     /* if no budgets exist yet, just open a new budget */
         gnc_plugin_budget_cmd_new_budget (action, user_data);
+}
+
+/* user selects budget to delete */
+static void
+gnc_plugin_budget_cmd_delete_budget (GtkAction *action,
+                                     GncMainWindowActionData *user_data)
+{
+    GncBudget *bgt;
+    QofBook *book;
+
+    g_return_if_fail (user_data != NULL);
+
+    book = gnc_get_current_book ();
+    if (qof_collection_count (qof_book_get_collection (book, GNC_ID_BUDGET)) == 0)
+        return;
+
+    bgt = gnc_budget_gui_select_budget (GTK_WINDOW(user_data->window), book);
+    if (!bgt) return;
+
+    gnc_budget_gui_delete_budget (bgt);
 }
 
 /************************************************************

--- a/gnucash/ui/gnc-plugin-budget-ui.xml
+++ b/gnucash/ui/gnc-plugin-budget-ui.xml
@@ -6,6 +6,7 @@
           <menuitem name="BudgetNewBudget" action="NewBudgetAction"/>
           <menuitem name="BudgetOpenBudget" action="OpenBudgetAction"/>
           <menuitem name="BudgetCopyBudget" action="CopyBudgetAction"/>
+          <menuitem name="BudgetDeleteBudget" action="DeleteBudgetAction"/>
         </menu>
       </placeholder>
     </menu>


### PR DESCRIPTION
Adds UI to get reversed transaction date. Current code acts immediately and doesn't jump to new split. This commit offers a chance to cancel.

This code also tries to jump to the reversing transaction, but fails. Not sure why this jump doesn't actually work.