### PR TITLE
U+R and R changed to U+C and C

### DIFF
--- a/gnucash/gtkbuilder/dialog-import.glade
+++ b/gnucash/gtkbuilder/dialog-import.glade
@@ -939,7 +939,7 @@
               <object class="GtkLabel" id="label847797">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">"U+R"</property>
+                <property name="label" translatable="yes">"U+C"</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
@@ -950,7 +950,7 @@
               <object class="GtkLabel" id="label847798">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">"R"</property>
+                <property name="label" translatable="yes">"C"</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
@@ -974,7 +974,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">Select "U+R" to update and reconcile a matching transaction.</property>
+                <property name="label" translatable="yes">Select "U+C" to update and clear ('c") a matching transaction.</property>
               </object>
               <packing>
                 <property name="left_attach">1</property>
@@ -986,7 +986,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">Select "R" to reconcile a matching transaction.</property>
+                <property name="label" translatable="yes">Select "C" to set the reconcile status of a matching transaction to "c".</property>
               </object>
               <packing>
                 <property name="left_attach">1</property>

--- a/gnucash/import-export/import-main-matcher.c
+++ b/gnucash/import-export/import-main-matcher.c
@@ -775,13 +775,13 @@ gnc_gen_trans_init_view (GNCImportMainMatcher *info,
                        _("A"), DOWNLOADED_COL_ACTION_ADD,
                        G_CALLBACK(gnc_gen_trans_add_toggled_cb), info);
     column = add_toggle_column (view,
-            /* toggle column: update existing transaction & mark it reconciled */
-            _("U+R"), DOWNLOADED_COL_ACTION_UPDATE,
+            /* toggle column: update existing transaction & mark it cleared */
+            _("U+C"), DOWNLOADED_COL_ACTION_UPDATE,
                                G_CALLBACK(gnc_gen_trans_update_toggled_cb), info);
     gtk_tree_view_column_set_visible (column, show_update);
     add_toggle_column (view,
-            /* toggle column: mark existing transaction reconciled */
-            _("R"), DOWNLOADED_COL_ACTION_CLEAR,
+            /* toggle column: mark existing transaction cleared */
+            _("C"), DOWNLOADED_COL_ACTION_CLEAR,
                       G_CALLBACK(gnc_gen_trans_clear_toggled_cb), info);
 
     /* The last column has multiple renderers */


### PR DESCRIPTION
The labels in the import matcher dialog and message s in the code imply that a transaction split to an account is reconciled when its status is actually only set to cleared 'c'. The labels and reference in the code are changed to U+C and C to better reflect the actual actions on import.

These are changes to the codse so it now matches the documentation in the Help manual