### PR TITLE
Bug797236 Reconciliation - Retain visibility of current split

### DIFF
--- a/gnucash/gnome/reconcile-view.c
+++ b/gnucash/gnome/reconcile-view.c
@@ -901,12 +901,26 @@ void
 gnc_reconcile_view_refresh (GNCReconcileView *view)
 {
     GNCQueryView *qview;
+    GtkTreeSelection *selection;
+    GList *path_list, *node;
 
     g_return_if_fail (view != NULL);
     g_return_if_fail (GNC_IS_RECONCILE_VIEW (view));
 
     qview = GNC_QUERY_VIEW (view);
     gnc_query_view_refresh (qview);
+
+    /* Ensure last selected split, if any, can be seen */
+    selection = gtk_tree_view_get_selection (GTK_TREE_VIEW (qview));
+    path_list = gtk_tree_selection_get_selected_rows (selection, NULL);
+    node = g_list_last(path_list);
+    if (node)
+    {
+        GtkTreePath *tree_path = node->data;
+        gtk_tree_view_scroll_to_cell (GTK_TREE_VIEW (qview),
+                                      tree_path, NULL, FALSE, 0.0, 0.0);
+    }
+    g_list_free_full (path_list, (GDestroyNotify) gtk_tree_path_free);
 
     /* Now verify that everything in the reconcile hash is still in qview */
     if (view->reconciled)

--- a/gnucash/gnome/window-reconcile.c
+++ b/gnucash/gnome/window-reconcile.c
@@ -659,7 +659,7 @@ gnc_save_reconcile_interval(Account *account, time64 statement_date)
 
     /*
      * See if we need to remember days(weeks) or months.  The only trick
-     * value is 28 days which could be wither 4 weeks or 1 month.
+     * value is 28 days which could be either 4 weeks or 1 month.
      */
     if (days == 28)
     {
@@ -2144,7 +2144,7 @@ use Find Transactions to find them, unreconcile, and re-reconcile."));
 
 
 /********************************************************************\
- * gnc_ui_reconile_window_raise                                     *
+ * gnc_ui_reconcile_window_raise                                     *
  *   shows and raises an account editing window                     *
  *                                                                  *
  * Args:   editAccData - the edit window structure                  *


### PR DESCRIPTION
Ensure current split (or last selected), is visible after all
operations.
After a deletion, select next split so can delete multiple trans using
just the Delete button. If no next split, select previous.
