### PR TITLE
Python app utils 2

### DIFF
--- a/bindings/python/__init__.py
+++ b/bindings/python/__init__.py
@@ -4,6 +4,7 @@
 # instead of
 # >>> from gnucash.gnucash_core import thingy
 from gnucash.gnucash_core import *
+from . import app_utils
 ##  @file
 #   @brief helper file for the importing of gnucash
 #   @author Mark Jenkins, ParIT Worker Co-operative <mark@parit.ca>

--- a/bindings/python/app_utils.py
+++ b/bindings/python/app_utils.py
@@ -4,13 +4,14 @@
 ## @file
 #  @brief High level python wrapper for app-utils
 #  @ingroup python_bindings 
+#
+# further functions in _sw_app_utils that have not been included:
+# _gnc_get_current_book is available through Session.get_book()
+# _gnc_get_current_root_account is available through Book.get_root_account()
+
 
 from gnucash import _sw_app_utils
 
 def gnc_get_current_session():
     from gnucash import Session
     return Session(instance=_sw_app_utils.gnc_get_current_session())
-
-# further functions in _sw_app_utils
-# _gnc_get_current_book is availabe through Session.get_book()
-# _gnc_get_current_root_account is available through Session.get_root_account()

--- a/gnucash/python/init.py
+++ b/gnucash/python/init.py
@@ -1,5 +1,4 @@
 import sys
-import gnucash._sw_app_utils as _sw_app_utils
 from gnucash import *
 from gnucash._sw_core_utils import gnc_prefs_is_extra_enabled, gnc_prefs_is_debugging_enabled
 from gi import require_version
@@ -23,9 +22,9 @@ signal.signal(signal.SIGTTOU, old_sigttou)
 if gnc_prefs_is_extra_enabled() and gnc_prefs_is_debugging_enabled():
     print("Hello from python!")
     print("test", sys.modules.keys())
-    print("test2", dir(_sw_app_utils))
 
-   #root = _sw_app_utils.gnc_get_current_root_account()
+    #session = app_utils.gnc_get_current_session()
+    #root account can later on be accessed by session.get_book().get_root_account()
 
    #print("test", dir(root), root.__class__)
     print("test3", dir(gnucash_core_c))


### PR DESCRIPTION
An import statement was missing to actually utilize the app_utils wrapper. Modify python shell to use this wrapper.