### PR TITLE
Bug 797351 - General ledger register transaction becomes "zombie" aft…

### DIFF
--- a/gnucash/register/ledger-core/gnc-ledger-display2.c
+++ b/gnucash/register/ledger-core/gnc-ledger-display2.c
@@ -809,7 +809,6 @@ gnc_ledger_display2_internal (Account *lead_account, Query *q,
 
     ld->use_double_line_default = use_double_line;
 
-    // JEAN: add mismatched_commodities
     ld->model = gnc_tree_model_split_reg_new (reg_type, style, use_double_line, is_template, mismatched_commodities);
 
     gnc_tree_model_split_reg_set_data (ld->model, ld, gnc_ledger_display2_parent);

--- a/gnucash/register/ledger-core/split-register.c
+++ b/gnucash/register/ledger-core/split-register.c
@@ -1223,6 +1223,7 @@ gnc_split_register_delete_current_trans (SplitRegister* reg)
         xaccTransCommitEdit (trans);
     }
     gnc_resume_gui_refresh();
+    gnc_split_register_redraw (reg);
     LEAVE (" ");
 }
 


### PR DESCRIPTION
…er deletion

This issue arises every time a pending transaction is deleted (it does not arise if blank splits are deleted). This PR fixes the issue by calling gnc_split_register_redraw() once the pending transaction has be deleted.