### PR TITLE
Bug 797388 - Add watch for each subacct of the acct to be reconciled

### DIFF
--- a/gnucash/gnome/window-reconcile.c
+++ b/gnucash/gnome/window-reconcile.c
@@ -1543,6 +1543,12 @@ recn_set_watches_one_account (gpointer data, gpointer user_data)
     RecnWindow *recnData = (RecnWindow *)user_data;
     GList *node;
 
+    /* add a watch on the account */
+    gnc_gui_component_watch_entity (recnData->component_id,
+                                    xaccAccountGetGUID (account),
+                                    QOF_EVENT_MODIFY | QOF_EVENT_DESTROY);
+
+    /* add a watch on each unreconciled or cleared split for the account */
     for (node = xaccAccountGetSplitList (account); node; node = node->next)
     {
         Split *split = node->data;
@@ -1578,10 +1584,6 @@ recn_set_watches (RecnWindow *recnData)
     GList *accounts = NULL;
 
     gnc_gui_component_clear_watches (recnData->component_id);
-
-    gnc_gui_component_watch_entity (recnData->component_id,
-                                    &recnData->account,
-                                    QOF_EVENT_MODIFY | QOF_EVENT_DESTROY);
 
     account = recn_get_account (recnData);
 


### PR DESCRIPTION
Enable the Reconcile window debit & credit unreconciled split
lists to be automatically updated when transactions for
subaccounts of the account to be reconciled are added, modified or
deleted. This already occurs for the reconciliation account.
