### PR TITLE
Bug 797648 Redo - Reconciliation - Treat each split independently

### DIFF
--- a/gnucash/gnome/reconcile-view.c
+++ b/gnucash/gnome/reconcile-view.c
@@ -524,17 +524,18 @@ gnc_reconcile_view_toggle_split (GNCReconcileView *view, Split *split)
 }
 
 
-/** Insert or remove a split from the list of splits to be reconciled
- *   (view->reconciled) so that all other splits in the same transaction
- *   for the account being reconciled (including children), are the same
- *   reconciliation state as the split that has been toggled.
- *
- *  @param view The view to use.
- *
- *  @param split The split to be inserted or removed
- *
- *  @param reconcile TRUE=insert, FALSE=remove
- */
+/*****************************************************************************\
+ * gnc_reconcile_view_rec_or_unrec_split                                     *
+ *   insert or remove a child split from the list of splits to be reconciled *
+ *   (view->reconciled) so that all other splits in the same transaction     *
+ *   for the account being reconciled (including children), are the same     *
+ *   reconciliation state as the split that has  been toggled                *
+ *                                                                           *
+ * Args: view           - the view to use                                    *
+ *       split          - the split to be inserted or removed                *
+ *       reconcile      - TRUE=insert, FALSE=remove                          *
+ * Returns: void                                                             *
+\*****************************************************************************/
 static void
 gnc_reconcile_view_rec_or_unrec_split (GNCReconcileView *view, Split *split, gboolean reconcile)
 {


### PR DESCRIPTION
The previous change under this bug which propagated the status
change (reconcile or unreconcile) of any split for the account to
be reconciled (and its subaccounts) in a transaction, to all
splits for the account to be reconciled (and its subaccounts) in
the transaction, is incorrect. Each split needs to be able to be
checked or unchecked independently of any other split in the
transaction.
For instance, if an order delivery was split into 2 parts delivered and billed in different statement periods, the 2 splits need to be reconciled independently.

If anyone needs to reconcile or unreconcile multiple splits in a transaction, they can still do a multi-split selection, then use either the 'Reconcile Selection' or 'Unreconcile Selection' buttons. This is slightly more work, but we need the ability to reconcile splits independently.

See discussion under previous PR https://github.com/Gnucash/gnucash/pull/670