### PR TITLE
Bug 797218 - Support QIF import with any encoding

### DIFF
--- a/gnucash/gtkbuilder/assistant-qif-import.glade
+++ b/gnucash/gtkbuilder/assistant-qif-import.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkListStore" id="currency_liststore">
@@ -32,9 +32,6 @@
     <signal name="cancel" handler="gnc_ui_qif_import_cancel_cb" swapped="no"/>
     <signal name="close" handler="gnc_ui_qif_import_close_cb" swapped="no"/>
     <signal name="prepare" handler="gnc_ui_qif_import_prepare_cb" swapped="no"/>
-    <child>
-      <placeholder/>
-    </child>
     <child>
       <object class="GtkLabel" id="start_page">
         <property name="visible">True</property>
@@ -121,6 +118,17 @@ You will have the opportunity to load as many files as you wish, so don't worry 
             <property name="expand">False</property>
             <property name="fill">False</property>
             <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="encoding_container">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>

--- a/gnucash/import-export/qif-imp/CMakeLists.txt
+++ b/gnucash/import-export/qif-imp/CMakeLists.txt
@@ -8,6 +8,18 @@ set (qif_import_SOURCES
     gnc-plugin-qif-import.c
 )
 
+set (qif_import_remote_HEADERS
+  ${CMAKE_SOURCE_DIR}/borrowed/goffice/go-charmap-sel.h
+  ${CMAKE_SOURCE_DIR}/borrowed/goffice/go-optionmenu.h
+  ${CMAKE_SOURCE_DIR}/borrowed/goffice/go-glib-extras.h
+  )
+
+set (qif_import_remote_SOURCES
+  ${CMAKE_SOURCE_DIR}/borrowed/goffice/go-charmap-sel.c
+  ${CMAKE_SOURCE_DIR}/borrowed/goffice/go-optionmenu.c
+  ${CMAKE_SOURCE_DIR}/borrowed/goffice/go-glib-extras.c
+  )
+
 # Add dependency on config.h
 set_source_files_properties (${qif_import_SOURCES} PROPERTIES OBJECT_DEPENDS ${CONFIG_H})
 
@@ -17,7 +29,13 @@ set (qif_import_noinst_HEADERS
     gnc-plugin-qif-import.h
 )
 
-add_library	(gnc-qif-import ${qif_import_SOURCES} ${qif_import_noinst_HEADERS})
+add_library (gnc-qif-import
+  ${qif_import_noinst_HEADERS}
+  ${qif_import_remote_HEADERS}
+  ${qif_import_HEADERS}
+  ${qif_import_remote_SOURCES}
+  ${qif_import_SOURCES}
+)
 
 target_link_libraries(gnc-qif-import
     gnc-app-utils
@@ -31,6 +49,10 @@ target_include_directories(gnc-qif-import
 )
 
 target_compile_definitions(gnc-qif-import PRIVATE -DG_LOG_DOMAIN=\"gnc.import.qif.import\")
+
+target_include_directories (gnc-qif-import PRIVATE
+  ${CMAKE_SOURCE_DIR}/borrowed/goffice
+  )
 
 if (APPLE)
   set_target_properties (gnc-qif-import PROPERTIES INSTALL_NAME_DIR "${CMAKE_INSTALL_FULL_LIBDIR}/gnucash")

--- a/gnucash/import-export/qif-imp/CMakeLists.txt
+++ b/gnucash/import-export/qif-imp/CMakeLists.txt
@@ -6,19 +6,10 @@ set (qif_import_SOURCES
     dialog-account-picker.c
     assistant-qif-import.c
     gnc-plugin-qif-import.c
+    ${CMAKE_SOURCE_DIR}/borrowed/goffice/go-charmap-sel.c
+    ${CMAKE_SOURCE_DIR}/borrowed/goffice/go-optionmenu.c
+    ${CMAKE_SOURCE_DIR}/borrowed/goffice/go-glib-extras.c
 )
-
-set (qif_import_remote_HEADERS
-  ${CMAKE_SOURCE_DIR}/borrowed/goffice/go-charmap-sel.h
-  ${CMAKE_SOURCE_DIR}/borrowed/goffice/go-optionmenu.h
-  ${CMAKE_SOURCE_DIR}/borrowed/goffice/go-glib-extras.h
-  )
-
-set (qif_import_remote_SOURCES
-  ${CMAKE_SOURCE_DIR}/borrowed/goffice/go-charmap-sel.c
-  ${CMAKE_SOURCE_DIR}/borrowed/goffice/go-optionmenu.c
-  ${CMAKE_SOURCE_DIR}/borrowed/goffice/go-glib-extras.c
-  )
 
 # Add dependency on config.h
 set_source_files_properties (${qif_import_SOURCES} PROPERTIES OBJECT_DEPENDS ${CONFIG_H})
@@ -27,15 +18,12 @@ set (qif_import_noinst_HEADERS
     dialog-account-picker.h
     assistant-qif-import.h
     gnc-plugin-qif-import.h
+    ${CMAKE_SOURCE_DIR}/borrowed/goffice/go-charmap-sel.h
+    ${CMAKE_SOURCE_DIR}/borrowed/goffice/go-optionmenu.h
+    ${CMAKE_SOURCE_DIR}/borrowed/goffice/go-glib-extras.h
 )
 
-add_library (gnc-qif-import
-  ${qif_import_noinst_HEADERS}
-  ${qif_import_remote_HEADERS}
-  ${qif_import_HEADERS}
-  ${qif_import_remote_SOURCES}
-  ${qif_import_SOURCES}
-)
+add_library	(gnc-qif-import ${qif_import_SOURCES} ${qif_import_noinst_HEADERS})
 
 target_link_libraries(gnc-qif-import
     gnc-app-utils

--- a/gnucash/import-export/qif-imp/assistant-qif-import.c
+++ b/gnucash/import-export/qif-imp/assistant-qif-import.c
@@ -1877,7 +1877,7 @@ gnc_ui_qif_import_load_progress_start_cb (GtkButton * button,
     gnc_progress_dialog_pop (wind->load_progress);
     wind->ask_date_format = FALSE;
     wind->date_format = NULL;
-    }
+
     if (parse_return == SCM_BOOL_T)
     {
         /* Canceled by the user. */
@@ -1992,6 +1992,7 @@ gnc_ui_qif_import_load_progress_start_cb (GtkButton * button,
 
     gtk_widget_set_sensitive (wind->load_pause, FALSE);
     wind->busy = FALSE;
+    }
 
     if (wind->load_stop == FALSE)
     {

--- a/gnucash/import-export/qif-imp/assistant-qif-import.c
+++ b/gnucash/import-export/qif-imp/assistant-qif-import.c
@@ -1590,7 +1590,7 @@ gnc_ui_qif_import_load_file_complete (GtkAssistant  *assistant,
 
         /* See if the file is already loaded. */
         if (scm_call_2 (qif_file_loaded,
-                        scm_from_locale_string (path_to_load ? path_to_load : ""),
+                        scm_from_utf8_string (path_to_load ? path_to_load : ""),
                         wind->imported_files) == SCM_BOOL_T)
             gnc_error_dialog (GTK_WINDOW(assistant), "%s",
                               _("That QIF file is already loaded. "
@@ -1802,7 +1802,7 @@ gnc_ui_qif_import_load_progress_start_cb (GtkButton * button,
     gnc_progress_dialog_push (wind->load_progress, 0.7);
     load_return = scm_call_5 (qif_file_load,
                               SCM_CAR(imported_files),
-                              scm_from_locale_string (path_to_load ? path_to_load : ""),
+                              scm_from_utf8_string (path_to_load ? path_to_load : ""),
                               wind->ticker_map,
                               progress,
                               scm_from_utf8_string (qif_encoding));
@@ -3572,6 +3572,14 @@ void gnc_ui_qif_import_prepare_cb (GtkAssistant  *assistant, GtkWidget *page,
     }
 }
 
+inline static GtkWidget*
+make_encoding_widget (GObject* container)
+{
+    GtkWidget* encoding_widget = go_charmap_sel_new (GO_CHARMAP_SEL_TO_UTF8);
+    gtk_container_add (GTK_CONTAINER (container), encoding_widget);
+    return encoding_widget;
+}
+
 
 /********************************************************************
  * get_assistant_widgets
@@ -3581,16 +3589,14 @@ void gnc_ui_qif_import_prepare_cb (GtkAssistant  *assistant, GtkWidget *page,
 static void
 get_assistant_widgets (QIFImportWindow *wind, GtkBuilder *builder)
 {
+    GtkWidget *enc_con = GTK_WIDGET (gtk_builder_get_object (builder, "encoding_container"));
+
     g_return_if_fail (wind);
     g_return_if_fail (builder);
 
     wind->window             = GTK_WIDGET(gtk_builder_get_object (builder, "qif_import_assistant"));
     wind->filename_entry     = GTK_WIDGET(gtk_builder_get_object (builder, "qif_filename_entry"));
-    {
-        GtkWidget *enc_con = GTK_WIDGET (gtk_builder_get_object (builder, "encoding_container"));
-        wind->qif_encoding = go_charmap_sel_new (GO_CHARMAP_SEL_TO_UTF8);
-        gtk_container_add (GTK_CONTAINER (enc_con), wind->qif_encoding);
-    }
+    wind->qif_encoding       = make_encoding_widget (gtk_builder_get_object (builder, "encoding_container"));
     wind->load_pause         = GTK_WIDGET(gtk_builder_get_object (builder, "load_progress_pause"));
     wind->load_start         = GTK_WIDGET(gtk_builder_get_object (builder, "load_progress_start"));
     wind->load_log           = GTK_WIDGET(gtk_builder_get_object (builder, "load_progress_log"));

--- a/gnucash/import-export/qif-imp/qif-file.scm
+++ b/gnucash/import-export/qif-imp/qif-file.scm
@@ -527,8 +527,9 @@
       (let ((msg (string-append
                   (case key
                     ((decoding-error)
-                     (format #f (_ "Invalid charset ~a specified.") encoding))
-                    ((system-error) (_ "I/O system error. Try again."))
+                     (format #f (G_ "The file contains characters that are not \
+part of charset ~a. Please choose a different one.") encoding))
+                    ((system-error) (G_ "I/O system error. Try again."))
                     (else (format #f "~a: ~s" key rest)))
                   "\n")))
         (gnc-progress-dialog-append-log progress-dialog msg)

--- a/gnucash/import-export/qif-imp/qif-file.scm
+++ b/gnucash/import-export/qif-imp/qif-file.scm
@@ -56,7 +56,7 @@
 ;;        errors and warnings rather than a single one.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define (qif-file:read-file self path ticker-map progress-dialog)
+(define (qif-file:read-file self path ticker-map progress-dialog encoding)
 
   ;; This procedure does all the work. We'll define it, then call it safely.
   (define (private-read)
@@ -146,24 +146,6 @@
                   ;; Pick the 1-char tag off from the remainder of the line.
                   (set! tag (string-ref line 0))
                   (set! value (substring line 1))
-
-                  ;; If the line doesn't conform to UTF-8, try a default
-                  ;; character set conversion based on the locale. If that
-                  ;; fails, remove any invalid characters.
-                  (if (not (gnc-utf8? value))
-                      (let ((converted-value (gnc-locale-to-utf8 value)))
-                        (if (or (string=? converted-value "")
-                                (not (gnc-utf8? converted-value)))
-                            (begin
-                              (set! value (gnc-utf8-strip-invalid-strdup value))
-                              (mywarn
-                               (G_ "Some characters have been discarded.")
-                               " " (G_"Converted to: ") value))
-                            (begin
-                              (mywarn
-                               (G_ "Some characters have been converted according to your locale.")
-                               " " (G_"Converted to: ") converted-value)
-                              (set! value converted-value)))))
 
                   (if (eq? tag #\!)
                       ;; The "!" tag has the highest precedence and is used
@@ -516,7 +498,7 @@
                 ;; ...and this is if we read a null or eof line.
                 (if (and (not abort-read)
                          (not (eof-object? line)))
-                    (line-loop))))) #:encoding "UTF-8")
+                    (line-loop))))) #:encoding encoding)
 
       ;; Reverse the transaction list so xtns are in the same order that
       ;; they appeared in the file.  This is important in a few cases.

--- a/gnucash/import-export/qif-imp/qif-import.scm
+++ b/gnucash/import-export/qif-imp/qif-import.scm
@@ -72,7 +72,7 @@
 (export qif-map-entry:qif-name)
 (export qif-map-entry:new-acct?)
 
-(export qif-file:read-file)
+(export qif-file:load)
 (export qif-file:parse-fields)
 (export qif-file:parse-fields-results)
 (export qif-file:check-from-acct)


### PR DESCRIPTION
Inputs the encoding as a string. Better to use a `GtkComboBox`, but choose an appropriate encoding and QIF can import.

![image](https://user-images.githubusercontent.com/1975870/81071584-74ae1c80-8ed4-11ea-9d80-48779dafdb3e.png)
![image](https://user-images.githubusercontent.com/1975870/81071626-81327500-8ed4-11ea-9b08-ede2168f1bc9.png)
