### PR TITLE
Bug 797737 - Import matching can match an imported transaction to an …

### DIFF
--- a/gnucash/import-export/import-backend.c
+++ b/gnucash/import-export/import-backend.c
@@ -627,6 +627,10 @@ static void split_find_match (GNCImportTransInfo * trans_info,
         Transaction *new_trans = gnc_import_TransInfo_get_trans (trans_info);
         Split *new_trans_fsplit = gnc_import_TransInfo_get_fsplit (trans_info);
 
+        // Do not consider transactions that have been previously matched.
+        if (gnc_import_split_has_online_id (split))
+            return;
+
         /* Matching heuristics */
 
         /* Amount heuristics */


### PR DESCRIPTION
…existing, previously matched transaction

A simple fix that skips transactions that have an online_id in the matching process.
This fixes the issue, and also speeds up the import.