### PR TITLE
 Bug 797730 - Transaction matching can match multiple imported transa…

### DIFF
--- a/gnucash/import-export/import-backend.c
+++ b/gnucash/import-export/import-backend.c
@@ -113,6 +113,22 @@ gnc_import_TransInfo_get_match_list (const GNCImportTransInfo *info)
     return info->match_list;
 }
 
+void
+gnc_import_TransInfo_set_match_list (GNCImportTransInfo *info, GList* match_list)
+{
+    g_assert (info);
+    info->match_list = match_list;
+    if (match_list)
+    {
+        info->selected_match_info.selected_match = match_list->data;
+    }
+    else
+    {
+        info->selected_match_info.selected_match = NULL;
+        gnc_import_TransInfo_set_action (info, GNCImport_ADD);
+    }
+}
+
 Transaction *
 gnc_import_TransInfo_get_trans (const GNCImportTransInfo *info)
 {

--- a/gnucash/import-export/import-backend.h
+++ b/gnucash/import-export/import-backend.h
@@ -176,6 +176,9 @@ void gnc_import_TransInfo_delete (GNCImportTransInfo *info);
 /** Returns the stored list of possible matches. */
 GList *gnc_import_TransInfo_get_match_list (const GNCImportTransInfo *info);
 
+/** Assigns the list of possible matches. */
+void gnc_import_TransInfo_set_match_list (GNCImportTransInfo *info, GList* match_list);
+
 /** Returns the transaction of this TransInfo. */
 Transaction *gnc_import_TransInfo_get_trans (const GNCImportTransInfo *info);
 


### PR DESCRIPTION
…ctions to the same existing one

This is a simple solution to the conflict problem. It does not guarantee an optimal match (i.e. a match with the best combined match score) but it removes conflicts and finds an acceptable solution. The idea is simple:
- Start with the first imported transaction,
- Find all other imported transations that conflict with it (i.e., want to match the same register transaction).
- Of all these conflicting transactions, find the one with the best match to the register transaction
and set it as the winner: it keeps its match, and all other transactions go to their next favorite match.
- If any conflict happened, start back from the top as new conflicts can arise when imported transactions lose their top match and go to their second best one (if any).

This loop is guaranteed to terminate because every time we go to the top, we remove at least one match from the sum of all matches.