### PR TITLE
Speeds up the import of ofx files by only doing one query at the end.

### DIFF
--- a/gnucash/import-export/import-backend.c
+++ b/gnucash/import-export/import-backend.c
@@ -607,7 +607,7 @@ matchmap_store_destination (GncImportMatchMap *matchmap,
 
 /** @brief The transaction matching heuristics are here.
  */
-static void split_find_match (GNCImportTransInfo * trans_info,
+void split_find_match (GNCImportTransInfo * trans_info,
                               Split * split,
                               gint display_threshold,
                               double fuzzy_amount_difference)
@@ -820,66 +820,6 @@ static void split_find_match (GNCImportTransInfo * trans_info,
                            match_info);
     }
 }/* end split_find_match */
-
-
-/** /brief Iterate through all splits of the originating account of the given
-   transaction, and find all matching splits there. */
-void gnc_import_find_split_matches(GNCImportTransInfo *trans_info,
-                                   gint process_threshold,
-                                   double fuzzy_amount_difference,
-                                   gint match_date_hardlimit)
-{
-    GList * list_element;
-    Query *query = qof_query_create_for(GNC_ID_SPLIT);
-    g_assert (trans_info);
-
-    /* Get list of splits of the originating account. */
-    {
-        /* We used to traverse *all* splits of the account by using
-           xaccAccountGetSplitList, which is a bad idea because 90% of these
-           splits are outside the date range that is interesting. We should
-           rather use a query according to the date region, which is
-           implemented here.
-        */
-        Account *importaccount =
-            xaccSplitGetAccount (gnc_import_TransInfo_get_fsplit (trans_info));
-        time64 download_time = xaccTransGetDate (gnc_import_TransInfo_get_trans (trans_info));
-
-        qof_query_set_book (query, gnc_get_current_book());
-        xaccQueryAddSingleAccountMatch (query, importaccount,
-                                        QOF_QUERY_AND);
-        xaccQueryAddDateMatchTT (query,
-                                 TRUE, download_time - match_date_hardlimit * 86400,
-                                 TRUE, download_time + match_date_hardlimit * 86400,
-                                 QOF_QUERY_AND);
-        list_element = qof_query_run (query);
-        /* Sigh. Doesn't help too much. We still create and run one query
-           for each imported transaction. Maybe it would improve
-           performance further if there is one single (master-)query at
-           the beginning, matching the full date range and all accounts in
-           question. However, this doesn't quite work because this function
-           here is called from each gnc_gen_trans_list_add_trans(), which
-           is called one at a time. Therefore the whole importer would
-           have to change its behaviour: Accept the imported txns via
-           gnc_gen_trans_list_add_trans(), and only when
-           gnc_gen_trans_list_run() is called, then calculate all the
-           different match candidates. That's too much work for now.
-        */
-    }
-
-    /* Traverse that list, calling split_find_match on each one. Note
-       that xaccAccountForEachSplit is declared in Account.h but
-       implemented nowhere :-( */
-    while (list_element != NULL)
-    {
-        split_find_match (trans_info, list_element->data,
-                          process_threshold, fuzzy_amount_difference);
-        list_element = g_list_next (list_element);
-    }
-
-    qof_query_destroy (query);
-}
-
 
 /***********************************************************************
  */
@@ -1221,13 +1161,6 @@ gnc_import_TransInfo_init_matches (GNCImportTransInfo *trans_info,
 {
     GNCImportMatchInfo * best_match = NULL;
     g_assert (trans_info);
-
-
-    /* Find all split matches in originating account. */
-    gnc_import_find_split_matches(trans_info,
-                                  gnc_import_Settings_get_display_threshold (settings),
-                                  gnc_import_Settings_get_fuzzy_amount (settings),
-                                  gnc_import_Settings_get_match_date_hardlimit (settings));
 
     if (trans_info->match_list != NULL)
     {

--- a/gnucash/import-export/import-backend.h
+++ b/gnucash/import-export/import-backend.h
@@ -66,34 +66,20 @@ typedef enum _action
  * online_id. */
 gboolean gnc_import_exists_online_id (Transaction *trans);
 
-/** Iterate through all splits of the originating account of the given
- * transaction, find all matching splits there, and store them in the
- * GNCImportTransInfo structure.
+/** Evaluates the match between trans_info and split using the provided parameters.
  *
- * @param trans_info The TransInfo for which the corresponding
- * matching existing transactions should be found.
+ * @param trans_info The TransInfo for the imported transaction
  *
- * @param process_threshold Each match whose heuristics are smaller
- * than this value is totally ignored.
+ * @param split The register split that should be evaluated for a match.
  *
- * @param fuzzy_amount_difference For fuzzy amount matching, a certain
- * fuzzyness in the matching amount is allowed up to this value. May
- * be e.g. 3.00 dollars for ATM fees, or 0.0 if you only want to allow
- * exact matches.
+ * @param display_threshold Minimum match score to include split in the list of matches.
  *
- * @param match_date_hardlimit The number of days that a matching
- * split may differ from the given transaction before it is discarded
- * immediately. In other words, any split that is more distant from
- * the given transaction than this match_date_hardlimit days will be
- * ignored altogether. For use cases without paper checks (e.g. HBCI),
- * values like 14 (days) might be appropriate, whereas for use cases
- * with paper checks (e.g. OFX, QIF), values like 42 (days) seem more
- * appropriate.
+ * @param fuzzy_amount_difference Maximum amount difference to consider the match good.
  */
-void gnc_import_find_split_matches(GNCImportTransInfo *trans_info,
-                                   gint process_threshold,
-                                   double fuzzy_amount_difference,
-                                   gint match_date_hardlimit);
+void split_find_match (GNCImportTransInfo * trans_info,
+                       Split * split,
+                       gint display_threshold,
+                       double fuzzy_amount_difference);
 
 /** Iterates through all splits of the originating account of
  * trans_info. Sorts the resulting list and sets the selected_match

--- a/gnucash/import-export/import-backend.h
+++ b/gnucash/import-export/import-backend.h
@@ -64,7 +64,7 @@ typedef enum _action
  *
  * @param trans The transaction for which to check for an existing
  * online_id. */
-gboolean gnc_import_exists_online_id (Transaction *trans);
+gboolean gnc_import_exists_online_id (Transaction *trans, GHashTable* Foo);
 
 /** Evaluates the match between trans_info and split using the provided parameters.
  *

--- a/gnucash/import-export/import-backend.h
+++ b/gnucash/import-export/import-backend.h
@@ -64,7 +64,7 @@ typedef enum _action
  *
  * @param trans The transaction for which to check for an existing
  * online_id. */
-gboolean gnc_import_exists_online_id (Transaction *trans, GHashTable* id_hash);
+gboolean gnc_import_exists_online_id (Transaction *trans, GHashTable* acct_id_hash);
 
 /** Evaluates the match between trans_info and split using the provided parameters.
  *

--- a/gnucash/import-export/import-backend.h
+++ b/gnucash/import-export/import-backend.h
@@ -64,7 +64,7 @@ typedef enum _action
  *
  * @param trans The transaction for which to check for an existing
  * online_id. */
-gboolean gnc_import_exists_online_id (Transaction *trans, GHashTable* Foo);
+gboolean gnc_import_exists_online_id (Transaction *trans, GHashTable* id_hash);
 
 /** Evaluates the match between trans_info and split using the provided parameters.
  *

--- a/gnucash/import-export/test/gtest-import-backend.cpp
+++ b/gnucash/import-export/test/gtest-import-backend.cpp
@@ -120,6 +120,8 @@ protected:
         m_dest_acc   = new MockAccount();
         m_trans      = new MockTransaction();
         m_split      = new MockSplit();
+        m_splitList  = NULL;
+        m_splitList  = g_list_prepend (m_splitList, m_split);
 
         using namespace testing;
 
@@ -141,6 +143,7 @@ protected:
     MockAccount*      m_dest_acc;
     MockTransaction*  m_trans;
     MockSplit*        m_split;
+    GList*            m_splitList;
 };
 
 
@@ -160,6 +163,8 @@ TEST_F(ImportBackendTest, CreateTransInfo)
     // Define first split
     ON_CALL(*m_trans, getSplit(0))
         .WillByDefault(Return(m_split));
+    ON_CALL(*m_trans, getSplitList())
+        .WillByDefault(Return(m_splitList));
     // define description of the transaction
     ON_CALL(*m_trans, getDescription())
         .WillByDefault(Return("This is the description"));
@@ -228,6 +233,8 @@ TEST_F(ImportBackendBayesTest, CreateTransInfo)
     // Define first split
     ON_CALL(*m_trans, getSplit(0))
         .WillByDefault(Return(m_split));
+    ON_CALL(*m_trans, getSplitList())
+        .WillByDefault(Return(m_splitList));
     // Transaction has no further splits
     ON_CALL(*m_trans, getSplit(Gt(0)))
         .WillByDefault(Return(nullptr));

--- a/libgnucash/engine/Account.cpp
+++ b/libgnucash/engine/Account.cpp
@@ -1859,6 +1859,29 @@ gnc_account_set_balance_dirty (Account *acc)
     priv->balance_dirty = TRUE;
 }
 
+void gnc_account_set_defer_bal_computation (Account *acc, gboolean defer)
+{
+    AccountPrivate *priv;
+    
+    g_return_if_fail (GNC_IS_ACCOUNT (acc));
+    
+    if (qof_instance_get_destroying (acc))
+        return;
+    
+    priv = GET_PRIVATE (acc);
+    priv->defer_bal_computation = defer;
+}
+
+gboolean gnc_account_get_defer_bal_computation (Account *acc)
+{
+    AccountPrivate *priv;
+    if (!acc)
+        return false;
+    priv = GET_PRIVATE (acc);
+    return priv->defer_bal_computation;
+}
+
+
 /********************************************************************\
 \********************************************************************/
 
@@ -2214,7 +2237,7 @@ xaccAccountRecomputeBalance (Account * acc)
 
     priv = GET_PRIVATE(acc);
     if (qof_instance_get_editlevel(acc) > 0) return;
-    if (!priv->balance_dirty) return;
+    if (!priv->balance_dirty || priv->defer_bal_computation) return;
     if (qof_instance_get_destroying(acc)) return;
     if (qof_book_shutting_down(qof_instance_get_book(acc))) return;
 

--- a/libgnucash/engine/Account.h
+++ b/libgnucash/engine/Account.h
@@ -360,7 +360,18 @@ void gnc_account_set_balance_dirty (Account *acc);
  *
  *  @param acc Set the flag on this account. */
 void gnc_account_set_sort_dirty (Account *acc);
-
+    
+/** Set the defer balance flag. If defer is true, the account balance
+ * is not automatically computed, which can save a lot of time if
+ * multiple operations have to be done on the same account. If
+ * defer is false, further operations on account will cause the
+ * balance to be recomputed as normal.
+ *
+ *  @param acc Set the flag on this account.
+ *
+ *  @param defer New value for the flag. */
+void gnc_account_set_defer_bal_computation (Account *acc, gboolean defer);
+    
 /** Insert the given split from an account.
  *
  *  @param acc The account to which the split should be added.
@@ -403,6 +414,8 @@ const char * xaccAccountGetNotes (const Account *account);
 const char * xaccAccountGetLastNum (const Account *account);
 /** Get the account's lot order policy */
 GNCPolicy *gnc_account_get_policy (Account *account);
+/** Get the account's flag for deferred balance computation */
+gboolean gnc_account_get_defer_bal_computation (Account *acc);
 
 /** The following recompute the partial balances (stored with the
  *  transaction) and the total balance, for this account

--- a/libgnucash/engine/AccountP.h
+++ b/libgnucash/engine/AccountP.h
@@ -126,6 +126,7 @@ typedef struct AccountPrivate
      * in any way desired.  Handy for specialty traversals of the
      * account tree. */
     short mark;
+    gboolean defer_bal_computation;
 } AccountPrivate;
 
 struct account_s

--- a/libgnucash/engine/mocks/gmock-Transaction.cpp
+++ b/libgnucash/engine/mocks/gmock-Transaction.cpp
@@ -46,6 +46,13 @@ xaccTransGetSplit (const Transaction *trans, int i)
     return ((MockTransaction*)trans)->getSplit(i);
 }
 
+SplitList *
+xaccTransGetSplitList (const Transaction *trans)
+{
+    g_return_val_if_fail(GNC_IS_MOCK_TRANSACTION(trans), NULL);
+    return trans ? ((MockTransaction*)trans)->getSplitList() : NULL;
+}
+
 Split *
 xaccTransFindSplitByAccount(const Transaction *trans, const Account *acc)
 {

--- a/libgnucash/engine/mocks/gmock-Transaction.h
+++ b/libgnucash/engine/mocks/gmock-Transaction.h
@@ -52,6 +52,7 @@ public:
     MOCK_METHOD0(beginEdit, void());
     MOCK_METHOD0(commitEdit, void());
     MOCK_METHOD1(getSplit, Split *(int));
+    MOCK_METHOD0(getSplitList, SplitList *());
     MOCK_METHOD1(findSplitByAccount, Split *(const Account*));
     MOCK_METHOD0(getDate, time64());
     MOCK_METHOD1(setDatePostedSecsNormalized, void(time64));


### PR DESCRIPTION

The previous ofx import code performed one query for each imported transaction, which
was quite slow. The change consists of gathering all ofx transactions before doing the
query. The query must be wider to search for all matching accounts (in case the imported
transactions come from different accounts) and an enlarged date range (according to the
earliest and latest imported transaction). The rest of the code is identical to what was
done before. The final query is performed just before the matching dialog is displayed.