### PR TITLE
Speed up lot->owner by caching it

### DIFF
--- a/libgnucash/engine/gnc-lot.c
+++ b/libgnucash/engine/gnc-lot.c
@@ -87,7 +87,7 @@ typedef struct GNCLotPrivate
     SplitList *splits;
 
     GncInvoice *cached_invoice;
-    GncGUID *cached_owner;
+    GncOwner *cached_owner;
 
     /* Handy cached value to indicate if lot is closed. */
     /* If value is negative, then the cache is invalid. */
@@ -302,7 +302,7 @@ gnc_lot_free(GNCLot* lot)
     priv->is_closed = TRUE;
 
     if (priv->cached_owner)
-        guid_free (priv->cached_owner);
+        gncOwnerFree (priv->cached_owner);
 
     /* qof_instance_release (&lot->inst); */
     g_object_unref (lot);
@@ -394,7 +394,7 @@ GncInvoice * gnc_lot_get_cached_invoice (const GNCLot *lot)
     return GET_PRIVATE(lot)->cached_invoice;
 }
 
-GncGUID * gnc_lot_get_cached_owner (const GNCLot *lot)
+GncOwner * gnc_lot_get_cached_owner (const GNCLot *lot)
 {
     if (!lot) return NULL;
     return GET_PRIVATE(lot)->cached_owner;
@@ -402,10 +402,17 @@ GncGUID * gnc_lot_get_cached_owner (const GNCLot *lot)
 
 
 void
-gnc_lot_set_cached_owner (GNCLot* lot, const GncGUID *owner)
+gnc_lot_set_cached_owner (GNCLot* lot, const GncOwner *owner)
 {
+    GncOwner *cached_owner;
     if (!lot) return;
-    GET_PRIVATE(lot)->cached_owner = guid_copy (owner);
+
+    if (GET_PRIVATE(lot)->cached_owner)
+        gncOwnerFree (GET_PRIVATE(lot)->cached_owner);
+
+    cached_owner = gncOwnerNew ();
+    gncOwnerCopy (owner, cached_owner);
+    GET_PRIVATE(lot)->cached_owner = cached_owner;
 }
 
 void

--- a/libgnucash/engine/gnc-lot.c
+++ b/libgnucash/engine/gnc-lot.c
@@ -87,6 +87,8 @@ typedef struct GNCLotPrivate
     SplitList *splits;
 
     GncInvoice *cached_invoice;
+    GncGUID *cached_owner;
+
     /* Handy cached value to indicate if lot is closed. */
     /* If value is negative, then the cache is invalid. */
     signed char is_closed;
@@ -115,6 +117,7 @@ gnc_lot_init(GNCLot* lot)
     priv->account = NULL;
     priv->splits = NULL;
     priv->cached_invoice = NULL;
+    priv->cached_owner = NULL;
     priv->is_closed = LOT_CLOSED_UNKNOWN;
     priv->marker = 0;
 }
@@ -297,6 +300,10 @@ gnc_lot_free(GNCLot* lot)
 
     priv->account = NULL;
     priv->is_closed = TRUE;
+
+    if (priv->cached_owner)
+        guid_free (priv->cached_owner);
+
     /* qof_instance_release (&lot->inst); */
     g_object_unref (lot);
 
@@ -385,6 +392,20 @@ GncInvoice * gnc_lot_get_cached_invoice (const GNCLot *lot)
 {
     if (!lot) return NULL;
     return GET_PRIVATE(lot)->cached_invoice;
+}
+
+GncGUID * gnc_lot_get_cached_owner (const GNCLot *lot)
+{
+    if (!lot) return NULL;
+    return GET_PRIVATE(lot)->cached_owner;
+}
+
+
+void
+gnc_lot_set_cached_owner (GNCLot* lot, const GncGUID *owner)
+{
+    if (!lot) return;
+    GET_PRIVATE(lot)->cached_owner = guid_copy (owner);
 }
 
 void

--- a/libgnucash/engine/gnc-lot.h
+++ b/libgnucash/engine/gnc-lot.h
@@ -137,8 +137,8 @@ void gnc_lot_set_cached_invoice(GNCLot* lot, GncInvoice *invoice);
 /** The gnc_lot_get_cached_owner() routine returns the owner guid with
  *    which this lot is associated. */
 /*@ dependent @*/
-GncGUID * gnc_lot_get_cached_owner (const GNCLot *lot);
-void gnc_lot_set_cached_owner (GNCLot* lot, const GncGUID *owner);
+GncOwner * gnc_lot_get_cached_owner (const GNCLot *lot);
+void gnc_lot_set_cached_owner (GNCLot* lot, const GncOwner *owner);
 
 /** The gnc_lot_get_balance() routine returns the balance of the lot.
  *    The commodity in which this balance is expressed is the commodity

--- a/libgnucash/engine/gnc-lot.h
+++ b/libgnucash/engine/gnc-lot.h
@@ -134,6 +134,12 @@ void gnc_lot_set_account(GNCLot*, Account*);
 GncInvoice * gnc_lot_get_cached_invoice (const GNCLot *lot);
 void gnc_lot_set_cached_invoice(GNCLot* lot, GncInvoice *invoice);
 
+/** The gnc_lot_get_cached_owner() routine returns the owner guid with
+ *    which this lot is associated. */
+/*@ dependent @*/
+GncGUID * gnc_lot_get_cached_owner (const GNCLot *lot);
+void gnc_lot_set_cached_owner (GNCLot* lot, const GncGUID *owner);
+
 /** The gnc_lot_get_balance() routine returns the balance of the lot.
  *    The commodity in which this balance is expressed is the commodity
  *    of the account. */

--- a/libgnucash/engine/gncOwner.c
+++ b/libgnucash/engine/gncOwner.c
@@ -627,7 +627,7 @@ void gncOwnerAttachToLot (const GncOwner *owner, GNCLot *lot)
 
     gnc_lot_begin_edit (lot);
 
-    gnc_lot_set_cached_owner (lot, gncOwnerGetGUID (owner));
+    gnc_lot_set_cached_owner (lot, owner);
 
     qof_instance_set (QOF_INSTANCE (lot),
 		      GNC_OWNER_TYPE, (gint64)gncOwnerGetType (owner),
@@ -642,21 +642,23 @@ gboolean gncOwnerGetOwnerFromLot (GNCLot *lot, GncOwner *owner)
     QofBook *book;
     GncOwnerType type = GNC_OWNER_NONE;
     guint64 type64 = 0;
+    GncOwner *cached_owner;
 
     if (!lot || !owner) return FALSE;
 
     book = gnc_lot_get_book (lot);
-    guid = gnc_lot_get_cached_owner (lot);
+    cached_owner = gnc_lot_get_cached_owner (lot);
 
-    if (!guid)
+    if (cached_owner)
     {
-        qof_instance_get (QOF_INSTANCE (lot),
-                          GNC_OWNER_TYPE, &type64,
-                          GNC_OWNER_GUID, &guid,
-                          NULL);
-
-        gnc_lot_set_cached_owner (lot, guid);
+        gncOwnerCopy (cached_owner, owner);
+        return (owner->owner.undefined != NULL);
     }
+
+    qof_instance_get (QOF_INSTANCE (lot),
+                      GNC_OWNER_TYPE, &type64,
+                      GNC_OWNER_GUID, &guid,
+                      NULL);
 
     type = (GncOwnerType) type64;
     switch (type)
@@ -679,6 +681,7 @@ gboolean gncOwnerGetOwnerFromLot (GNCLot *lot, GncOwner *owner)
     }
 
     guid_free (guid);
+    gnc_lot_set_cached_owner (lot, owner);
     return (owner->owner.undefined != NULL);
 }
 

--- a/libgnucash/engine/gncOwner.c
+++ b/libgnucash/engine/gncOwner.c
@@ -627,6 +627,8 @@ void gncOwnerAttachToLot (const GncOwner *owner, GNCLot *lot)
 
     gnc_lot_begin_edit (lot);
 
+    gnc_lot_set_cached_owner (lot, gncOwnerGetGUID (owner));
+
     qof_instance_set (QOF_INSTANCE (lot),
 		      GNC_OWNER_TYPE, (gint64)gncOwnerGetType (owner),
 		      GNC_OWNER_GUID, gncOwnerGetGUID (owner),
@@ -644,10 +646,18 @@ gboolean gncOwnerGetOwnerFromLot (GNCLot *lot, GncOwner *owner)
     if (!lot || !owner) return FALSE;
 
     book = gnc_lot_get_book (lot);
-    qof_instance_get (QOF_INSTANCE (lot),
-		      GNC_OWNER_TYPE, &type64,
-		      GNC_OWNER_GUID, &guid,
-		      NULL);
+    guid = gnc_lot_get_cached_owner (lot);
+
+    if (!guid)
+    {
+        qof_instance_get (QOF_INSTANCE (lot),
+                          GNC_OWNER_TYPE, &type64,
+                          GNC_OWNER_GUID, &guid,
+                          NULL);
+
+        gnc_lot_set_cached_owner (lot, guid);
+    }
+
     type = (GncOwnerType) type64;
     switch (type)
     {


### PR DESCRIPTION
Offshoot from #638 caching lot's owner. First attempt caches the guid only; second attempt caches the whole gncOwner. In the second approach, a gncOwner object copying is done for every cache hit.