### PR TITLE
cli-reports: must load saved-reports

### DIFF
--- a/gnucash/gnucash-cli.cpp
+++ b/gnucash/gnucash-cli.cpp
@@ -50,6 +50,7 @@ namespace Gnucash {
     {
     public:
         GnucashCli (const char* app_name);
+        void load_configs (void);
         void parse_command_line (int argc, char **argv);
         int start (int argc, char **argv);
     private:
@@ -139,8 +140,11 @@ Gnucash::GnucashCli::start ([[maybe_unused]] int argc, [[maybe_unused]] char **a
             return 1;
         }
         else
+        {
+            Gnucash::CoreApp::load_configs ();
             return Gnucash::run_report(m_file_to_load, m_run_report,
                                        m_export_type, m_output_file);
+        }
     }
     return 1;
 }

--- a/gnucash/gnucash-commands.cpp
+++ b/gnucash/gnucash-commands.cpp
@@ -141,9 +141,6 @@ scm_run_report (void *data,
     scm_c_use_module ("gnucash report");
     scm_c_use_module ("gnucash reports");
 
-    // gnc_report_init ();
-    // load_system_config();
-    // load_user_config();
     gnc_prefs_init ();
     qof_event_suspend ();
     datafile = args->file_to_load.c_str();

--- a/gnucash/gnucash-core-app.cpp
+++ b/gnucash/gnucash-core-app.cpp
@@ -566,6 +566,14 @@ Gnucash::CoreApp::CoreApp (const char* app_name)
 }
 
 
+void
+Gnucash::CoreApp::load_configs (void)
+{
+    gnc_report_init ();
+    load_system_config ();
+    load_user_config ();
+}
+
 /* Parse command line options, using GOption interface.
  * We can't let gtk_init_with_args do it because it fails
  * before parsing any arguments if the GUI can't be initialized.

--- a/gnucash/gnucash-core-app.hpp
+++ b/gnucash/gnucash-core-app.hpp
@@ -38,6 +38,7 @@ public:
     CoreApp ();
     CoreApp (const char* app_name);
 
+    void load_configs (void);
     void parse_command_line (int argc, char **argv);
     void start (void);
 


### PR DESCRIPTION
From #723 still unfinished. `saved-reports` isn't loaded. Unfortunately `load_user_config` and `load_system_config` are not exported from `gnc-core-app.cpp` and must be loaded from `gnucash-cli.cpp`. This branch illustrates, but has a segfault in the guile module definition.

As a consequence, currently master:
* cannot load and run saved-reports
* can run reports but without stylesheet therefore `gnc-monetary` are rendered as `<gnc-monetary> #<<gnc-monetary> commodity: #<swig-pointer gnc_commodity * 55b45ec10110> amount: -5038/25>`
etc