### PR TITLE
gnc-fq-dump Err msg if AlphaVantage API Key is needed but missing

### DIFF
--- a/gnucash/price-quotes.scm
+++ b/gnucash/price-quotes.scm
@@ -128,6 +128,9 @@
            (catch #t
              (lambda ()
                (gnc:debug "handling-request: " request)
+               (and (member (car request) '("currency" "alphavantage" "vanguard"))
+                    (not (getenv "ALPHAVANTAGE_API_KEY"))
+                    (throw 'need-alphavantage-key))
                ;; we need to display the first element (the method,
                ;; so it won't be quoted) and then write the rest
                (with-output-to-port (fdes->outport (gnc-process-get-fd quoter 0))
@@ -446,6 +449,11 @@
       (set! keep-going? #f)
       (show-error (N_ "You are missing some needed Perl libraries.
 Run 'gnc-fq-update' as root to install them.")))
+
+     ((memq 'need-alphavantage-key fq-results)
+      (set! keep-going? #f)
+      (show-error (N_ "ERROR: ALPHAVANTAGE_API_KEY must be set for currency \
++ quotes; see https://wiki.gnucash.org/wiki/Online_Quotes#Source_Alphavantage.2C_US")))
 
      ((memq 'system-error fq-results)
       (set! keep-going? #f)

--- a/libgnucash/quotes/gnc-fq-dump.in
+++ b/libgnucash/quotes/gnc-fq-dump.in
@@ -113,13 +113,13 @@ sub report {
 
   # Dump gnucash recognized fields
   printf "Finance::Quote fields Gnucash uses:\n";
-  printf "    symbol: %-20s <=== required\n",	  $symbol;
+  printf "    symbol: %-20s <=== required\n",     $symbol;
   printf "      date: %-20s <=== recommended\n",  $date;
-  printf "  currency: %-20s <=== required\n", 	  $currency;
-  printf "      last: %-20s <=\\       \n",    	  $last;
+  printf "  currency: %-20s <=== required\n",     $currency;
+  printf "      last: %-20s <=\\       \n",       $last;
   printf "       nav: %-20s <=== one of these\n", $nav;
-  printf "     price: %-20s <=/        \n", 	  $price;
-  printf "  timezone: %-20s <=== optional\n", 	  $timezone;
+  printf "     price: %-20s <=/        \n",       $price;
+  printf "  timezone: %-20s <=== optional\n",     $timezone;
 
   # Report failure
   if ($gccanuse == 0) {
@@ -197,15 +197,20 @@ if ($exchange eq "currency") {
 
 =head1 NAME
 
-gnc-fq-dump	- Print out data from the F::Q module
+gnc-fq-dump - Print out data from the F::Q module
 
 =head1 SYNOPSIS
 
-    gnc-fq-dump alphavantage CSCO JNPR
-    gnc-fq-dump alphavantage BAESY.PK
-    gnc-fq-dump europe 48406.PA 13000.PA
-    gnc-fq-dump vwd 632034
-    gnc-fq-dump ftportfolios FKYGTX
+  Currency Exchange Rates
+    gnc-fq-dump currency USD AUD
+    gnc-fq-dump [-v] yahoo_json USDEUR=X
+  Stock Quotes    
+    gnc-fq-dump [-v] alphavantage CSCO JNPR
+    gnc-fq-dump [-v] alphavantage BAESY.PK
+    gnc-fq-dump [-v] yahoo_json CBA.AX
+    gnc-fq-dump [-v] europe 48406.PA 13000.PA
+    gnc-fq-dump [-v] vwd 632034
+    gnc-fq-dump [-v] ftportfolios FKYGTX
 
 =head1 DESCRIPTION
 

--- a/libgnucash/quotes/gnc-fq-dump.in
+++ b/libgnucash/quotes/gnc-fq-dump.in
@@ -141,6 +141,25 @@ sub report {
   }
 }
 
+sub chk_api_key {
+  my $exch = $_[0];
+  my $url = " https://wiki.gnucash.org/wiki/Online_Quotes#Source_Alphavantage.2C_US\n";
+  if (($exch eq "currency") || ($exch eq "alphavantage")
+  ||  ($exch eq "vanguard")) {
+    die "ERROR: ALPHAVANTAGE_API_KEY *must* be set for currency quotes and \n" .
+        " stock quotes with source 'alphavantage' or 'vanguard'; see\n" . $url
+      unless (defined ($ENV{'ALPHAVANTAGE_API_KEY'}));
+  }
+  if (($exch eq "canada") || ($exch eq "nasdaq")
+  ||  ($exch eq "nyse")   || ($exch eq "usa")) {
+    printf("WARNING: Multiple Source '%s' will not be able to use alphavantage " .
+        "unless ALPHAVANTAGE_API_KEY is set; see\n%s", $exch, $url)
+      unless (defined ($ENV{'ALPHAVANTAGE_API_KEY'}));
+    }
+}
+
+############## end of functions - start mainline #########################
+
 # Check for and load non-standard modules
 check_modules ();
 
@@ -162,6 +181,7 @@ if ($ARGV[0] eq "-v") {
 }
 
 my $exchange = shift;
+chk_api_key ($exchange);
 if ($exchange eq "currency") {
   my $from = shift;
   while ($#ARGV >= 0) {


### PR DESCRIPTION
As mentioned in Bug 796993.
Note Finance::Quote will also give an err msg but it will only show when gnc-fq-dump is run with -v for a stock quote.

Christopher Lam has also contributed scheme code, which I have included here, to give an error message during Get Quotes processing in Price Database if a currency quote or a stock quote for source 'alphavantage' or 'vanguard' is detected and the API key is missing. No warning message is given from 'Get Quotes' for the 'multiple source' sources that include alphavantage (canada,nyse,nasdaq + usa) as one of the other sources may work. Unlike previously, if a missing api key is detected, no further sources will be processed. I don't think this will be a problem as it is easy to get an api key.