### PR TITLE
make (parts of) gnucash logging accessible from python modules

### DIFF
--- a/bindings/python/gnucash_core.i
+++ b/bindings/python/gnucash_core.i
@@ -215,6 +215,8 @@ static const GncGUID * gncEntryGetGUID(GncEntry *x);
 %include <cap-gains.h>
 %include <Scrub3.h>
 
+%include <qoflog.h>
+
 %init %{
 gnc_environment_setup();
 qof_log_init();


### PR DESCRIPTION
Small change, big effect. This makes (parts of) logging accessible to python bindings.

With this it's possible to go

```
gnucash.gnucash_core_c.qof_log_set_level("", gnucash.gnucash_core_c.QOF_LOG_DEBUG)
gnucash.gnucash_core_c.qof_log_set_level("gnc", gnucash.gnucash_core_c.QOF_LOG_DEBUG)
gnucash.gnucash_core_c.qof_log_set_level("qof", gnucash.gnucash_core_c.QOF_LOG_DEBUG)
```

and see all the debug information when calling the c/c++ code. Very helpful for coding/debugging python.

It could be worth a try
* enable code using python modules to read the logging config file as done in gnucash bin gnc_log_init()
  * it would be nice to be able to just call gnc_log_init() but there's no header file for that as that is in gnucash-bin.c - could that be put into a separate file to make it accessible from python? Otherwise mimic it
* use the gnucash logging functions to write out python info