### PR TITLE
Python c++ QofSessionImpl (draft)

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -3,7 +3,9 @@ add_subdirectory(tests)
 
 set(PYEXEC_FILES  __init__.py function_class.py gnucash_business.py gnucash_core.py app_utils.py)
 
-set(SWIG_FILES ${CMAKE_CURRENT_SOURCE_DIR}/gnucash_core.i ${CMAKE_CURRENT_SOURCE_DIR}/time64.i)
+set(SWIG_FILES ${CMAKE_CURRENT_SOURCE_DIR}/gnucash_core.i ${CMAKE_CURRENT_SOURCE_DIR}/time64.i )
+set(SWIG_FILES_CC ${CMAKE_CURRENT_SOURCE_DIR}/gnucash_core_cc.i ${CMAKE_CURRENT_SOURCE_DIR}/time64.i )
+
 set(GNUCASH_CORE_C_INCLUDES
     ${CONFIG_H}
     ${CMAKE_SOURCE_DIR}/libgnucash/engine/qofsession.h
@@ -35,6 +37,11 @@ set(GNUCASH_CORE_C_INCLUDES
     ${CMAKE_SOURCE_DIR}/libgnucash/app-utils/gnc-prefs-utils.h
 )
 
+set(GNUCASH_CORE_CC_INCLUDES
+    ${GNUCASH_CORE_C_INCLUDES}
+    ${CMAKE_SOURCE_DIR}/libgnucash/engine/gnc-numeric.h
+)
+
 gnc_add_swig_python_command (swig-gnucash-core
     SWIG_GNUCASH_CORE_C SWIG_GNUCASH_CORE_PY
     gnucash_core.c gnucash_core_c.py
@@ -44,6 +51,15 @@ gnc_add_swig_python_command (swig-gnucash-core
     ${CMAKE_SOURCE_DIR}/common/base-typemaps.i
     ${CMAKE_SOURCE_DIR}/bindings/engine-common.i
     ${GNUCASH_CORE_C_INCLUDES}
+)
+
+gnc_add_swig_python_command (swig-gnucash-core-cc
+    SWIG_GNUCASH_CORE_CC SWIG_GNUCASH_CORE_CC_PY
+    gnucash_core.cc gnucash_core_cc.py
+    ${SWIG_FILES_CC}
+    ${CMAKE_SOURCE_DIR}/common/base-typemaps.i
+    ${CMAKE_SOURCE_DIR}/bindings/engine-common.i
+    ${GNUCASH_CORE_CC_INCLUDES}
 )
 
 # Command to generate the swig-core-utils-python.c wrapper file
@@ -71,13 +87,23 @@ if(WITH_PYTHON)
   )
 
   add_library(gnucash_core_c MODULE ${SWIG_GNUCASH_CORE_C})
+  add_library(gnucash_core_cc MODULE ${SWIG_GNUCASH_CORE_CC})
+
   target_include_directories(gnucash_core_c PRIVATE ${gnucash_core_c_INCLUDE_DIRS})
+  target_include_directories(gnucash_core_cc PRIVATE ${gnucash_core_c_INCLUDE_DIRS})
 
   target_link_libraries(gnucash_core_c gnc-app-utils gnc-engine ${GLIB_LIBS} ${PYTHON_LIBRARIES})
+  target_link_libraries(gnucash_core_cc gnc-app-utils gnc-module ${GLIB_LIBS} ${PYTHON_LIBRARIES})
+  
   set_target_properties(gnucash_core_c PROPERTIES PREFIX "_")
+  set_target_properties(gnucash_core_cc PROPERTIES PREFIX "_")
+
   target_compile_options(gnucash_core_c PRIVATE -Wno-implicit -Wno-missing-prototypes -Wno-declaration-after-statement -Wno-missing-declarations)
+  target_compile_options(gnucash_core_cc PRIVATE -Wno-missing-declarations)
+
   if (HAVE_STRINGOP_TRUNCATION)
     target_compile_options(gnucash_core_c PRIVATE -Wno-error=stringop-truncation)
+    target_compile_options(gnucash_core_cc PRIVATE -Wno-error=stringop-truncation)
   endif()
 
   add_executable(sqlite3test EXCLUDE_FROM_ALL sqlite3test.c ${SWIG_GNUCASH_CORE_C})
@@ -95,7 +121,16 @@ if(WITH_PYTHON)
     LIBRARY DESTINATION ${PYTHON_SYSCONFIG_OUTPUT}/gnucash
     ARCHIVE DESTINATION ${PYTHON_SYSCONFIG_OUTPUT}/gnucash
   )
+  install(TARGETS gnucash_core_cc
+    LIBRARY DESTINATION ${PYTHON_SYSCONFIG_OUTPUT}/gnucash
+    ARCHIVE DESTINATION ${PYTHON_SYSCONFIG_OUTPUT}/gnucash
+  )
+
+
   install(FILES ${PYEXEC_FILES} ${SWIG_GNUCASH_CORE_PY}
+    DESTINATION ${PYTHON_SYSCONFIG_OUTPUT}/gnucash
+  )
+  install(FILES ${PYEXEC_FILES} ${SWIG_GNUCASH_CORE_CC_PY}
     DESTINATION ${PYTHON_SYSCONFIG_OUTPUT}/gnucash
   )
 
@@ -107,10 +142,17 @@ if(WITH_PYTHON)
     COMMAND ${CMAKE_COMMAND} -E copy ${SWIG_GNUCASH_CORE_PY} ${PYTHON_SYSCONFIG_BUILD}/gnucash
     DEPENDS ${SWIG_GNUCASH_CORE_C})
 
+  add_custom_target(gnucash-core-cc-py ALL
+	  COMMAND ${CMAKE_COMMAND} -E copy ${SWIG_GNUCASH_CORE_CC_PY} ${PYTHON_SYSCONFIG_BUILD}/gnucash
+	  DEPENDS ${SWIG_GNUCASH_CORE_CC})
+
   add_custom_target(gnucash-core-c-build ALL
     COMMAND ${CMAKE_COMMAND} -E copy ${LIBDIR_BUILD}/gnucash/_gnucash_core_c${CMAKE_SHARED_MODULE_SUFFIX} ${PYTHON_SYSCONFIG_BUILD}/gnucash
     DEPENDS gnucash_core_c)
 
+  add_custom_target(gnucash-core-cc-build ALL
+    COMMAND ${CMAKE_COMMAND} -E copy ${LIBDIR_BUILD}/gnucash/_gnucash_core_cc${CMAKE_SHARED_MODULE_SUFFIX} ${PYTHON_SYSCONFIG_BUILD}/gnucash
+    DEPENDS gnucash_core_cc)
 
   ### sw_core_utils
 

--- a/bindings/python/example_scripts/simple_book_cc.py
+++ b/bindings/python/example_scripts/simple_book_cc.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+# Test C++
+#
+# use SWIG C++ wrapper
+#
+# modified from simple_book.py
+
+import gnucash
+
+# We need to tell GnuCash the data format to create the new file as (xml://)
+uri = "xml:///tmp/simple_book.gnucash"
+print("uri:", uri)
+
+book = gnucash.Book()
+qofsession = gnucash.gnucash_core_cc.QofSessionImpl(book.instance)
+qofsession.begin(uri, True, True, True)
+
+print(qofsession.get_backend().get_message())
+
+root_account = book.get_root_account()
+
+description = "TEST"
+print("set root account description to", description)
+root_account.SetDescription(description)
+
+print("creating account 'test'")
+account = gnucash.Account(book)
+account.SetName("test")
+
+root_account.append_child(account)
+
+print("saving")
+qofsession.save(None)
+
+print("ending session")
+qofsession.end()
+
+print("reloading")
+
+book = gnucash.Book()
+qofsession = gnucash.gnucash_core_cc.QofSessionImpl(book.instance)
+qofsession.begin(uri, False, False, False)
+qofsession.load(None)
+
+root_account = book.get_root_account()
+description_reloaded = root_account.GetDescription()
+print("root_account description:", description_reloaded)
+
+print("accounts:")
+accounts = root_account.get_children()
+for account in accounts:
+    print(account.GetName())
+
+print("ending session")
+qofsession.end()

--- a/bindings/python/gnucash_core.py
+++ b/bindings/python/gnucash_core.py
@@ -29,6 +29,7 @@
 #  @ingroup python_bindings
 
 from gnucash import gnucash_core_c
+from gnucash import gnucash_core_cc
 from gnucash import _sw_core_utils
 
 from gnucash.function_class import \

--- a/bindings/python/gnucash_core_cc.i
+++ b/bindings/python/gnucash_core_cc.i
@@ -1,0 +1,38 @@
+%module(package="gnucash") gnucash_core_cc
+
+%include <std_string.i>
+
+/* rvalue std::string is not being provided by std_string.i */
+/* QofBackend.get_message() returns std::string&& */
+/* Question regarding this approach:
+   https://stackoverflow.com/questions/62119785/python-swig-wrapper-for-c-rvalue-stdstring*/
+%typemap(out) std::string&& {
+  std::string s = *$1;
+  $result = SWIG_From_std_string(s);
+}
+/* I assume that QofBackend::set_message(std::string &&) will not be used from python */
+%ignore QofBackend::set_message;
+
+/* renames for qofsession.hpp */
+/* prevent Warning 314: 'from' is a python keyword, renaming to '_from' */
+/* TODO: restrict to this class */
+%rename(_from) from; // qofsession.hpp:118 qof_instance_copy_data.from -> qof_instance_copy_data._from as from is reserved keyword in python
+
+%{
+  #include <string>
+  #include "qofsession.h"
+  #include "qofsession.hpp"
+  #include "qof-backend.hpp"
+  #include "qofbackend.h"
+%}
+
+%ignore save_in_progress;
+%ignore qof_session_get_book_id;
+%ignore qof_session_get_uri;
+%include <qofsession.h>
+
+%include <qof-backend.hpp>
+
+%include <qofsession.hpp>
+/* include to get QofBackendError as int */
+%include <qofbackend.h>

--- a/bindings/python/tests/CMakeLists.txt
+++ b/bindings/python/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ set(test_python_bindings_DATA
         test_session.py
         test_split.py
         test_transaction.py
-        test_query.py)
+        test_query.py
+        test_session_cc.py)
 
 set_dist_list(test_python_bindings_DIST CMakeLists.txt ${test_python_bindings_DATA})

--- a/bindings/python/tests/runTests.py.in
+++ b/bindings/python/tests/runTests.py.in
@@ -15,6 +15,7 @@ from test_business import TestBusiness
 from test_commodity import TestCommodity, TestCommodityNamespace
 from test_numeric import TestGncNumeric
 from test_query import TestQuery
+from test_session_cc import TestQofSessionImpl
 
 if __name__ == '__main__':
     unittest.main()

--- a/bindings/python/tests/test_session_cc.py
+++ b/bindings/python/tests/test_session_cc.py
@@ -1,0 +1,19 @@
+# test cases for c++ Session wrapper object
+#
+# @date 2020-06-05
+# @author Christoph Holtermann <mail@c-holtermann.net>
+
+from unittest import TestCase, main
+
+from gnucash import Book
+from gnucash.gnucash_core_cc import QofSessionImpl
+
+class TestQofSessionImpl(TestCase):
+    def test_create_empty_session(self):
+        book = Book()
+        self.ses = QofSessionImpl(book.instance)
+        book_2 = self.ses.get_book()
+        self.assertEqual(book.instance, book_2)
+
+if __name__ == '__main__':
+    main()

--- a/common/cmake_modules/GncAddSwigCommand.cmake
+++ b/common/cmake_modules/GncAddSwigCommand.cmake
@@ -49,6 +49,7 @@ endmacro (gnc_add_swig_guile_command)
 # - _target is the name of a global target that will be set for this wrapper file,
 #    this can be used elsewhere to create a depencency on this wrapper
 # - _out_var will be set to the full path to the generated wrapper file
+#    if name ends with _CC it will be treated as C++ and respective SWIG flags will be set
 # - _py_out_var is the same but for the python module that's generated together with the wrapper
 # - _output is the name of the wrapper file to generate
 # - _py_output is the name of the python module associated with this wrapper
@@ -73,6 +74,10 @@ macro (gnc_add_swig_python_command _target _out_var _py_out_var _output _py_outp
         -Wall -Werror
         ${SWIG_ARGS}
         )
+    set (DEFAULT_SWIG_PYTHON_FLAGS_NO_WERROR
+        -python -py3
+        ${SWIG_ARGS}
+        )
     set (DEFAULT_SWIG_PYTHON_C_INCLUDES
          ${GLIB2_INCLUDE_DIRS}
          ${CMAKE_SOURCE_DIR}/common
@@ -83,6 +88,11 @@ macro (gnc_add_swig_python_command _target _out_var _py_out_var _output _py_outp
 	 )
 
     set (PYTHON_SWIG_FLAGS ${DEFAULT_SWIG_PYTHON_FLAGS})
+    # check if _out_var ends with _CC - in that case set swig flag c++ and disable werror (for now)
+    string(REGEX MATCH "_[^_]+$" _c_or_cc ${_out_var})
+    if (${_c_or_cc} STREQUAL "_CC")
+	set (PYTHON_SWIG_FLAGS -c++ ${DEFAULT_SWIG_PYTHON_FLAGS_NO_WERROR})
+    endif()
     foreach (dir ${DEFAULT_SWIG_PYTHON_C_INCLUDES} ${_include_dirs})
         list (APPEND PYTHON_SWIG_FLAGS "-I${dir}")
     endforeach (dir)


### PR DESCRIPTION
This is an attempt to wrap the c++ parts of gnucash, starting with QofSessionImpl as suggested by @jralls ([back in 2018](https://lists.gnucash.org/pipermail/gnucash-devel/2018-August/042393.html)).
Please have a look at it. It's development in progress. But the example python file and first unit tests work. I'll add some more tests before finishing this PR, clean up the commits and change it according to the discussion which I'm looking forward to.

**Goal**: First steps of making c++ parts of gnucash accessible for python bindings. From my understanding the code base will be moved from c to c++ so the python bindings will need to follow this transition.
**Implementation**: Use QofSessionImpl as a a first c++ structure to wrap. Implement a second python module gnucash_core_cc  to house the c++ methods besides gnucash_core_c which holds the python wrappers of gnucash c files as they are now. Gnucash_core_cc has the results of a swig call with command line argument '-c++'. Cmake files control those two separate swig calls, one for each language that create the respective python modules. They are submodules of the python gnucash module that contains the high level wrappers. High level wrapping for c++ will be a bit easier as the objects don't need to be patched together from the c function calls by the procedures provided by function_class.py but get provided by swig directly.
**History**: I started on this in 2018 but due to involvement in other issues it rested until spring 2020 when I found the time to pick it up again. Due to time passing some misfits might have come up.
**Future**: 
* provide the small amount of high level wrapping to bring the QofSessionImpl object from gnucash_core_cc to gnucash
   * adjust example and unittest to that
* have a look into which other c++ parts make sense to wrap
   *  I did some work on the c++ GncNumeric class
* Gnucash_core_cc may be joined into gnucash_core_c if that is possible and makes more sense.
* Finally move everything from gnucash_core_c to gnucash_core_cc as gnucash will be completely written in c++.
* it might make sense to talk about the content of python modules gnucash, gnucash_core_c and gnucash_core_cc. Methods in gnucash could be called stable, those in gnucash_core_c and gnucash_core_cc private and subject to change for example.