### PR TITLE
de.po: fixes for the Account Import Assistant

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -12758,7 +12758,7 @@ msgstr ""
 
 #: gnucash/gtkbuilder/assistant-csv-account-import.glade:54
 msgid "Import Account Assistant"
-msgstr "_Konten importieren"
+msgstr "Konten importieren"
 
 #: gnucash/gtkbuilder/assistant-csv-account-import.glade:69
 msgid ""
@@ -12774,7 +12774,7 @@ msgstr "Wählen Sie die zu importierende Datei"
 
 #: gnucash/gtkbuilder/assistant-csv-account-import.glade:101
 msgid "Number of rows for the Header"
-msgstr "Spaltenanzahl der Kopfzeile"
+msgstr "Anzahl der Kopfzeilen"
 
 #: gnucash/gtkbuilder/assistant-csv-account-import.glade:146
 msgid "Comma Separated"
@@ -12815,13 +12815,13 @@ msgstr ""
 
 #: gnucash/gtkbuilder/assistant-csv-account-import.glade:286
 msgid "Import Accounts Now"
-msgstr "_Konten jetzt importieren"
+msgstr "Konten jetzt importieren"
 
 #: gnucash/gtkbuilder/assistant-csv-account-import.glade:334
 #: gnucash/gtkbuilder/assistant-csv-price-import.glade:1062
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:1151
 msgid "Import Summary"
-msgstr "importiere Kontenübersicht"
+msgstr "Importübersicht"
 
 #: gnucash/gtkbuilder/assistant-csv-export.glade:8
 msgid "CSV Export Assistant"


### PR DESCRIPTION
Here some tiny German translation fixes primarily for the Account Import Assistant, but apply to other relevant dialogues, too (here: `Import Summary`).   