### PR TITLE
Add missing #include <algorithm> into gnc-imp-settings-csv-price.cpp

### DIFF
--- a/gnucash/import-export/csv-imp/gnc-imp-settings-csv-price.cpp
+++ b/gnucash/import-export/csv-imp/gnc-imp-settings-csv-price.cpp
@@ -28,7 +28,11 @@
 
 #include "gnc-imp-settings-csv.hpp"
 #include "gnc-imp-settings-csv-price.hpp"
+#include <algorithm>
+#include <memory>
 #include <sstream>
+#include <string>
+#include <vector>
 
 extern "C"
 {


### PR DESCRIPTION
Found in failed win maint nightlies.

Suggesstion by shaggy.

I am not sure about [un]conditional include.

[Edit] [IRC log](https://lists.gnucash.org/logs/2020/06/16.html#T20:52:51)