### PR TITLE
commodity-collector must not round

### DIFF
--- a/gnucash/report/report-utilities.scm
+++ b/gnucash/report/report-utilities.scm
@@ -230,14 +230,11 @@
     ;; helper function to add a (commodity . value) pair to our list.
     ;; If no pair with this commodity exists, we will create one.
     (define (add-commodity-value commodity value)
-      (let ((pair (assoc commodity commoditylist))
-            (rvalue (gnc-numeric-convert
-                     value
-                     (gnc-commodity-get-fraction commodity) GNC-RND-ROUND)))
+      (let ((pair (assoc commodity commoditylist)))
 	(unless pair
 	  (set! pair (list commodity (gnc:make-value-collector)))
 	  (set! commoditylist (cons pair commoditylist)))
-	((cadr pair) 'add rvalue)))
+	((cadr pair) 'add value)))
     
     ;; helper function to walk an association list, adding each
     ;; (commodity . collector) pair to our list at the appropriate

--- a/gnucash/report/test/test-report-utilities.scm
+++ b/gnucash/report/test/test-report-utilities.scm
@@ -249,7 +249,18 @@
       (coll-A 'add USD -25)
       (test-equal "gnc-commodity-collector-allzero? #t"
         #t
-        (gnc-commodity-collector-allzero? coll-A)))
+        (gnc-commodity-collector-allzero? coll-A))
+
+      ;; the following tests whether commodity-collector rounds
+      ;; inappropriately
+      (coll-A 'reset #f #f)
+      (coll-A 'add GBP 1/3)
+      (coll-A 'add GBP 1/3)
+      (coll-A 'add GBP 1/3)
+      (coll-A 'add GBP -1)
+      (test-equal "gnc-commodity-collector does not round inappropriately"
+        '(("GBP" . 0))
+        (collector->list coll-A)))
     (teardown)))
 
 (define (mnemonic->commodity sym)


### PR DESCRIPTION
ensure the commodity-collector adds exact amounts instead of rounding during accumulation.