### PR TITLE
I18n: Fix grossly wrong wording

### DIFF
--- a/gnucash/gnome/dialog-assoc.c
+++ b/gnucash/gnome/dialog-assoc.c
@@ -537,7 +537,7 @@ row_selected_bus_cb (GtkTreeView *view, GtkTreePath *path,
             return;
         }
 
-        ret_uri = gnc_assoc_get_uri_dialog (GTK_WINDOW(assoc_dialog->window), _("Change a Business Association"), uri);
+        ret_uri = gnc_assoc_get_uri_dialog (GTK_WINDOW(assoc_dialog->window), _("Edit a Business Association"), uri);
 
         if (ret_uri && g_strcmp0 (uri, ret_uri) != 0)
         {
@@ -628,7 +628,7 @@ row_selected_trans_cb (GtkTreeView *view, GtkTreePath *path,
             g_free (uri);
             return;
         }
-        ret_uri = gnc_assoc_get_uri_dialog (GTK_WINDOW(assoc_dialog->window), _("Change a Transaction Association"), uri);
+        ret_uri = gnc_assoc_get_uri_dialog (GTK_WINDOW(assoc_dialog->window), _("Edit a Transaction Association"), uri);
 
         if (ret_uri && g_strcmp0 (uri, ret_uri) != 0)
         {

--- a/gnucash/gnome/gnc-plugin-page-invoice.c
+++ b/gnucash/gnome/gnc-plugin-page-invoice.c
@@ -208,8 +208,8 @@ static GtkActionEntry gnc_plugin_page_invoice_actions [] =
         G_CALLBACK (gnc_plugin_page_invoice_cmd_new_invoice)
     },
     {
-        "BusinessAssociationAction", NULL, "_Update Association for Invoice", NULL,
-        "Update Association for current Invoice",
+        "BusinessAssociationAction", NULL, "Edit _Association for Invoice", NULL,
+        "Edit Association for current Invoice",
         G_CALLBACK (gnc_plugin_page_invoice_cmd_associate)
     },
     {
@@ -308,7 +308,7 @@ static action_toolbar_labels invoice_action_labels[] =
     {"EditUnpostInvoiceAction", N_("_Unpost Invoice")},
     {"BusinessNewInvoiceAction", N_("New _Invoice")},
     {"ToolsProcessPaymentAction", N_("_Pay Invoice")},
-    {"BusinessAssociationAction", N_("_Update Association for Invoice")},
+    {"BusinessAssociationAction", N_("Edit _Association for Invoice")},
     {"BusinessAssociationOpenAction", N_("_Open Association for Invoice")},
     {"BusinessAssociationRemoveAction", N_("_Remove Association from Invoice")},
     {NULL, NULL},
@@ -330,7 +330,7 @@ static action_toolbar_labels bill_action_labels[] =
     {"EditUnpostInvoiceAction", N_("_Unpost Bill")},
     {"BusinessNewInvoiceAction", N_("New _Bill")},
     {"ToolsProcessPaymentAction", N_("_Pay Bill")},
-    {"BusinessAssociationAction", N_("_Update Association for Bill")},
+    {"BusinessAssociationAction", N_("Edit _Association for Bill")},
     {"BusinessAssociationOpenAction", N_("_Open Association for Bill")},
     {"BusinessAssociationRemoveAction", N_("_Remove Association from Bill")},
     {NULL, NULL},
@@ -352,7 +352,7 @@ static action_toolbar_labels voucher_action_labels[] =
     {"EditUnpostInvoiceAction", N_("_Unpost Voucher")},
     {"BusinessNewInvoiceAction", N_("New _Voucher")},
     {"ToolsProcessPaymentAction", N_("_Pay Voucher")},
-    {"BusinessAssociationAction", N_("_Update Association for Voucher")},
+    {"BusinessAssociationAction", N_("Edit _Association for Voucher")},
     {"BusinessAssociationOpenAction", N_("_Open Association for Voucher")},
     {"BusinessAssociationRemoveAction", N_("_Remove Association from Voucher")},
     {NULL, NULL},
@@ -374,7 +374,7 @@ static action_toolbar_labels creditnote_action_labels[] =
     {"EditUnpostInvoiceAction", N_("_Unpost Credit Note")},
     {"BusinessNewInvoiceAction", N_("New _Credit Note")},
     {"ToolsProcessPaymentAction", N_("_Pay Credit Note")},
-    {"BusinessAssociationAction", N_("_Update Association for Credit Note")},
+    {"BusinessAssociationAction", N_("Edit _Association for Credit Note")},
     {"BusinessAssociationOpenAction", N_("_Open Association for Credit Note")},
     {"BusinessAssociationRemoveAction", N_("_Remove Association from Credit Note")},
     {NULL, NULL},
@@ -391,7 +391,7 @@ static action_toolbar_labels invoice_action_tooltips[] = {
     {"BlankEntryAction", N_("Move to the blank entry at the bottom of the invoice")},
     {"ToolsProcessPaymentAction", N_("Enter a payment for the owner of this invoice") },
     {"ReportsCompanyReportAction", N_("Open a company report window for the owner of this invoice") },
-    {"BusinessAssociationAction", N_("Update Association for current invoice")},
+    {"BusinessAssociationAction", N_("Edit Association for current invoice")},
     {"BusinessAssociationOpenAction", N_("Open Association for current invoice")},
     {"BusinessAssociationRemoveAction", N_("Remove Association from invoice")},
     {NULL, NULL},
@@ -413,7 +413,7 @@ static action_toolbar_labels bill_action_tooltips[] = {
     {"BlankEntryAction", N_("Move to the blank entry at the bottom of the bill")},
     {"ToolsProcessPaymentAction", N_("Enter a payment for the owner of this bill") },
     {"ReportsCompanyReportAction", N_("Open a company report window for the owner of this bill") },
-    {"BusinessAssociationAction", N_("Update Association for current bill")},
+    {"BusinessAssociationAction", N_("Edit Association for current bill")},
     {"BusinessAssociationOpenAction", N_("Open Association for current bill")},
     {"BusinessAssociationRemoveAction", N_("Remove Association from bill")},
     {NULL, NULL},
@@ -435,7 +435,7 @@ static action_toolbar_labels voucher_action_tooltips[] = {
     {"BlankEntryAction", N_("Move to the blank entry at the bottom of the voucher")},
     {"ToolsProcessPaymentAction", N_("Enter a payment for the owner of this voucher") },
     {"ReportsCompanyReportAction", N_("Open a company report window for the owner of this voucher") },
-    {"BusinessAssociationAction", N_("Update Association for current voucher")},
+    {"BusinessAssociationAction", N_("Edit Association for current voucher")},
     {"BusinessAssociationOpenAction", N_("Open Association for current voucher")},
     {"BusinessAssociationRemoveAction", N_("Remove Association from voucher")},
     {NULL, NULL},
@@ -457,7 +457,7 @@ static action_toolbar_labels creditnote_action_tooltips[] = {
     {"BlankEntryAction", N_("Move to the blank entry at the bottom of the credit note")},
     {"ToolsProcessPaymentAction", N_("Enter a payment for the owner of this credit note") },
     {"ReportsCompanyReportAction", N_("Open a company report window for the owner of this credit note") },
-    {"BusinessAssociationAction", N_("Update Association for credit note")},
+    {"BusinessAssociationAction", N_("Edit Association for credit note")},
     {"BusinessAssociationOpenAction", N_("Open Association for credit note")},
     {"BusinessAssociationRemoveAction", N_("Remove Association from credit note")},
     {NULL, NULL},
@@ -1376,7 +1376,7 @@ gnc_plugin_page_invoice_cmd_associate (GtkAction *action,
     invoice = gnc_invoice_window_get_invoice (priv->iw);
     uri = gncInvoiceGetAssociation (invoice);
 
-    ret_uri = gnc_assoc_get_uri_dialog (parent, _("Change a Business Association"), uri);
+    ret_uri = gnc_assoc_get_uri_dialog (parent, _("Edit a Business Association"), uri);
 
     if (ret_uri && g_strcmp0 (uri, ret_uri) != 0)
     {

--- a/gnucash/gnome/gnc-plugin-page-register.c
+++ b/gnucash/gnome/gnc-plugin-page-register.c
@@ -292,7 +292,7 @@ static GncInvoice* invoice_from_split (Split* split);
 #define PASTE_TRANSACTION_LABEL          N_("_Paste Transaction")
 #define DUPLICATE_TRANSACTION_LABEL      N_("Dup_licate Transaction")
 #define DELETE_TRANSACTION_LABEL         N_("_Delete Transaction")
-#define ASSOCIATE_TRANSACTION_LABEL      N_("Update _Association for Transaction")
+#define ASSOCIATE_TRANSACTION_LABEL      N_("Edit _Association for Transaction")
 #define ASSOCIATE_TRANSACTION_OPEN_LABEL  N_("_Open Association for Transaction")
 #define ASSOCIATE_TRANSACTION_REMOVE_LABEL N_("Re_move Association from Transaction")
 #define JUMP_ASSOCIATED_INVOICE_LABEL     N_("Open Associated Invoice")
@@ -306,7 +306,7 @@ static GncInvoice* invoice_from_split (Split* split);
 #define PASTE_TRANSACTION_TIP            N_("Paste the transaction from the clipboard")
 #define DUPLICATE_TRANSACTION_TIP        N_("Make a copy of the current transaction")
 #define DELETE_TRANSACTION_TIP           N_("Delete the current transaction")
-#define ASSOCIATE_TRANSACTION_TIP        N_("Update Association for the current transaction")
+#define ASSOCIATE_TRANSACTION_TIP        N_("Edit Association for the current transaction")
 #define ASSOCIATE_TRANSACTION_OPEN_TIP   N_("Open Association for the current transaction")
 #define ASSOCIATE_TRANSACTION_REMOVE_TIP N_("Remove the association from the current transaction")
 #define JUMP_ASSOCIATED_INVOICE_TIP      N_("Open the associated invoice")
@@ -616,7 +616,7 @@ static action_toolbar_labels toolbar_labels[] =
     { "BlankTransactionAction",             N_ ("Blank") },
     { "ActionsReconcileAction",             N_ ("Reconcile") },
     { "ActionsAutoClearAction",             N_ ("Auto-clear") },
-    { "AssociateTransactionAction",         N_ ("Update Association") },
+    { "AssociateTransactionAction",         N_ ("Edit Association") },
     { "AssociateTransactionOpenAction",     N_ ("Open Association") },
     { "AssociateTransactionRemoveAction",   N_ ("Remove Association") },
     { "JumpAssociatedInvoiceAction",        N_ ("Open Invoice") },

--- a/gnucash/gnome/gnc-split-reg.c
+++ b/gnucash/gnome/gnc-split-reg.c
@@ -1374,7 +1374,7 @@ gsr_default_associate_handler (GNCSplitReg *gsr)
     // fix an earlier error when storing relative paths before version 3.5
     uri = gnc_assoc_convert_trans_associate_uri (trans, gsr->read_only);
 
-    ret_uri = gnc_assoc_get_uri_dialog (GTK_WINDOW(gsr->window), _("Change a Transaction Association"), uri);
+    ret_uri = gnc_assoc_get_uri_dialog (GTK_WINDOW(gsr->window), _("Edit a Transaction Association"), uri);
 
     if (ret_uri && g_strcmp0 (uri, ret_uri) != 0)
         xaccTransSetAssociation (trans, ret_uri);

--- a/gnucash/gtkbuilder/dialog-assoc.glade
+++ b/gnucash/gtkbuilder/dialog-assoc.glade
@@ -314,7 +314,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Change Association path head</property>
+                <property name="label" translatable="yes">Edit Association path head</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>
@@ -731,7 +731,7 @@
             <property name="margin_top">3</property>
             <property name="margin_bottom">3</property>
             <property name="label" translatable="yes">   To jump to the Transaction, double click on the entry in the Description
-column, Association column to open the Association or Available to update</property>
+column, Association column to open the Association or Available to edit</property>
           </object>
           <packing>
             <property name="expand">False</property>


### PR DESCRIPTION
Editing the associations must be called editing, not "update" or "change".

The wording in the code is grossly misleading. I understand we are currently in string freeze, but this change needs to go in as soon as string freeze is lifted again. In creating the de.po translation, I had to translate as if the English texts already say "edit", otherwise the texts would be non-comprehensible.