### PR TITLE
Bug 797819 - When upgrading open register widths lost

### DIFF
--- a/gnucash/gnome/gnc-split-reg.c
+++ b/gnucash/gnome/gnc-split-reg.c
@@ -555,10 +555,15 @@ gsr_create_table( GNCSplitReg *gsr )
     // see if register group has the date_width key, old format pre 4.0
     has_date_width = g_key_file_has_key (state_file, register_state_section, "date_width", NULL);
 
-    // if this is from a page recreate and no register state use those settings,
+    // if this is from a page recreate and no date_width use register state for settings,
     // register state width information is dropped at the end of function.
-    if (gsr->page_state_name && !has_date_width)
-        group = gsr->page_state_name;
+    if (gsr->page_state_name)
+    {
+        if (g_key_file_has_key (state_file, gsr->page_state_name, "date_width", NULL))
+            group = gsr->page_state_name;  // new format with widths
+        else
+            group = register_state_section;
+    }
     else
     {
         // if no default state, use register state if available


### PR DESCRIPTION
I was going to push the fix but then decided to created this PR so it can be decided if you want me to revert this change for account registers and keep for Business or something else.

What would happen with this change, on first load of open registers, the page state section will not have width information so the register state section will be used. In the new format the width information is also stored with the page state information but that may be reverted depending on what is required to do.

On first load of a closed register,  a check is made to see if there is user default state for that register group type, if so that will be used for widths. If there is no default state, then the old register state information is used.

Once the register is loaded, if there was no user default state for that register group type, the current register state is saved to the register group state and hence used for any other register of that group type. Once this is done the old register state is removed as there is no longer a need to save it all the time.

As I see it, if you want to keep individual register state also so...
For already open tabs, use the page state as that also has the width information but as stated above that may be reverted.
For opening register pages, use register state if present, then register group state if present and then finally calculated widths, the last two would only seed the register state widths.

This could probably be achieved with a slight change of code and not deleting the register state, so setting the register group state widths would only be used for new registers layouts to seed there own register state information.

Part of this was an ability to reset the register width state, this could be added at a later date with another menu option that reset the widths to what ever the register group widths are.

@jralls 
@gjanssens 
I hope this makes sense, I probably have enough time to make the changes so please advise.


 