### PR TITLE
i18n: Fix missing context in single-character translated strings

### DIFF
--- a/gnucash/gnome-utils/gnc-tree-view-account.c
+++ b/gnucash/gnome-utils/gnc-tree-view-account.c
@@ -920,7 +920,7 @@ gnc_tree_view_account_new_with_root (Account *root, gboolean show_root)
 
     /* Translators: The C is the column title and stands for Color, this should be one character */
     acc_color_column
-        = gnc_tree_view_add_text_column(view, _("C"), "account-color", NULL,
+        = gnc_tree_view_add_text_column(view, C_("Shorthand column title for: Color", "C"), "account-color", NULL,
                                         "xx",
                                         GNC_TREE_VIEW_COLUMN_DATA_NONE,
                                         GNC_TREE_VIEW_COLUMN_VISIBLE_ALWAYS,

--- a/gnucash/import-export/import-main-matcher.c
+++ b/gnucash/import-export/import-main-matcher.c
@@ -803,16 +803,16 @@ gnc_gen_trans_init_view (GNCImportMainMatcher *info,
     add_text_column (view, _("Memo"), DOWNLOADED_COL_MEMO, TRUE);
     add_toggle_column (view,
                        /* toggle column: add new transaction */
-                       _("A"), DOWNLOADED_COL_ACTION_ADD,
+                       C_("Shorthand column heading for: Adding txn", "A"), DOWNLOADED_COL_ACTION_ADD,
                        G_CALLBACK(gnc_gen_trans_add_toggled_cb), info);
     column = add_toggle_column (view,
-            /* toggle column: update existing transaction & mark it reconciled */
-            _("U+C"), DOWNLOADED_COL_ACTION_UPDATE,
+                                /* toggle column: update existing transaction & mark it cleared */
+                                C_("Shorthand column heading for: Updating plus Clearing txn", "U+C"), DOWNLOADED_COL_ACTION_UPDATE,
                                G_CALLBACK(gnc_gen_trans_update_toggled_cb), info);
     gtk_tree_view_column_set_visible (column, show_update);
     add_toggle_column (view,
-            /* toggle column: mark existing transaction reconciled */
-            _("C"), DOWNLOADED_COL_ACTION_CLEAR,
+                       /* toggle column: mark existing transaction cleared */
+                       C_("Shorthand column heading for: Clearing txn", "C"), DOWNLOADED_COL_ACTION_CLEAR,
                       G_CALLBACK(gnc_gen_trans_clear_toggled_cb), info);
 
     /* The last column has multiple renderers */


### PR DESCRIPTION
The single-character column heading "C" is used for "Color" in one place, and for "Cleared" in another place. Obviously this must be fixed by adding context, otherwise grossly wrong translations will show up (as is currently the case for German and the "Cleared" column in the import matcher, see screenshot)
