### PR TITLE
Bug 797847 - Best match probability calculation on import is too pess…

### DIFF
--- a/gnucash/gtkbuilder/dialog-import.glade
+++ b/gnucash/gtkbuilder/dialog-import.glade
@@ -182,7 +182,7 @@
     <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="auto_clear_adj">
-    <property name="lower">6</property>
+    <property name="lower">5</property>
     <property name="upper">12</property>
     <property name="value">6</property>
     <property name="step_increment">1</property>


### PR DESCRIPTION
…imistic

Lowering the minimum value for the auto-clear preference. This is to allow user to still auto
clear even when date don't match quite exactly.