### PR TITLE
797854 global interest pay bug1

### DIFF
--- a/gnucash/gnome-utils/dialog-account.c
+++ b/gnucash/gnome-utils/dialog-account.c
@@ -157,6 +157,7 @@ void gnc_account_name_insert_text_cb (GtkWidget   *entry,
                                       gint         length,
                                       gint        *position,
                                       gpointer     data);
+static void set_auto_interest_box (AccountWindow *aw);
 
 /** Implementation *******************************************************/
 
@@ -278,9 +279,7 @@ gnc_account_to_ui(AccountWindow *aw)
     gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (aw->hidden_button),
                                   flag);
 
-    flag = xaccAccountGetAutoInterest (account);
-    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (aw->auto_interest_button),
-                                  flag);
+    set_auto_interest_box (aw);
     LEAVE(" ");
 }
 
@@ -1098,12 +1097,13 @@ static void
 set_auto_interest_box(AccountWindow *aw)
 {
     Account* account = aw_get_account (aw);
-    gboolean flag = account_type_has_auto_interest_xfer (aw->type);
-    gtk_widget_set_sensitive (GTK_WIDGET (aw->auto_interest_button), flag);
-    if (!flag)
-        gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (aw->auto_interest_button), FALSE);
-    gtk_widget_set_sensitive (GTK_WIDGET (aw->auto_interest_button_label), flag);
-   
+    gboolean type_ok = account_type_has_auto_interest_xfer (aw->type);
+    gboolean pref_set = xaccAccountGetAutoInterest (account);
+    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (aw->auto_interest_button),
+                                  type_ok && pref_set);
+    gtk_widget_set_sensitive (GTK_WIDGET (aw->auto_interest_button), type_ok);
+    gtk_widget_set_sensitive (GTK_WIDGET (aw->auto_interest_button_label),
+                                          type_ok);
 }
 
 static void

--- a/gnucash/gnome-utils/dialog-account.c
+++ b/gnucash/gnome-utils/dialog-account.c
@@ -116,6 +116,8 @@ typedef struct _AccountWindow
     GtkWidget * tax_related_button;
     GtkWidget * placeholder_button;
     GtkWidget * hidden_button;
+    GtkWidget * auto_interest_button;
+    GtkWidget * auto_interest_button_label;
 
     gint component_id;
 } AccountWindow;
@@ -274,6 +276,10 @@ gnc_account_to_ui(AccountWindow *aw)
 
     flag = xaccAccountGetHidden (account);
     gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (aw->hidden_button),
+                                  flag);
+
+    flag = xaccAccountGetAutoInterest (account);
+    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (aw->auto_interest_button),
                                   flag);
     LEAVE(" ");
 }
@@ -442,6 +448,11 @@ gnc_ui_to_account(AccountWindow *aw)
         gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (aw->hidden_button));
     if (xaccAccountGetHidden (account) != flag)
         xaccAccountSetHidden (account, flag);
+
+    flag =
+    gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (aw->auto_interest_button));
+    if (xaccAccountGetAutoInterest (account) != flag)
+        xaccAccountSetAutoInterest (account, flag);
 
     parent_account = gnc_tree_view_account_get_selected_account (GNC_TREE_VIEW_ACCOUNT (aw->parent_tree));
 
@@ -1084,6 +1095,18 @@ gnc_account_parent_changed_cb (GtkTreeSelection *selection, gpointer data)
 }
 
 static void
+set_auto_interest_box(AccountWindow *aw)
+{
+    Account* account = aw_get_account (aw);
+    gboolean flag = account_type_has_auto_interest_xfer (aw->type);
+    gtk_widget_set_sensitive (GTK_WIDGET (aw->auto_interest_button), flag);
+    if (!flag)
+        gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (aw->auto_interest_button), FALSE);
+    gtk_widget_set_sensitive (GTK_WIDGET (aw->auto_interest_button_label), flag);
+   
+}
+
+static void
 gnc_account_type_changed_cb (GtkTreeSelection *selection, gpointer data)
 {
     AccountWindow *aw = data;
@@ -1120,6 +1143,7 @@ gnc_account_type_changed_cb (GtkTreeSelection *selection, gpointer data)
         gnc_amount_edit_set_amount (GNC_AMOUNT_EDIT (aw->opening_balance_edit),
                                     gnc_numeric_zero ());
     }
+    set_auto_interest_box(aw);
 }
 
 static void
@@ -1389,6 +1413,10 @@ gnc_account_window_create(GtkWindow *parent, AccountWindow *aw)
     aw->tax_related_button = GTK_WIDGET(gtk_builder_get_object (builder, "tax_related_button"));
     aw->placeholder_button = GTK_WIDGET(gtk_builder_get_object (builder, "placeholder_button"));
     aw->hidden_button = GTK_WIDGET(gtk_builder_get_object (builder, "hidden_button"));
+    aw->auto_interest_button = GTK_WIDGET(gtk_builder_get_object (builder, "auto_interest_button"));
+    aw->auto_interest_button_label = GTK_WIDGET(gtk_builder_get_object (builder, "label405"));
+    set_auto_interest_box(aw);
+
 
     box = GTK_WIDGET(gtk_builder_get_object (builder, "opening_balance_box"));
     amount = gnc_amount_edit_new ();

--- a/gnucash/gnome-utils/dialog-account.h
+++ b/gnucash/gnome-utils/dialog-account.h
@@ -26,6 +26,23 @@
 
 #include "Account.h"
 
+/* Note: make sure to update the help text for this in prefs.scm if these
+ * change!  These macros define the account types for which an auto interest
+ * xfer dialog could pop up, if the user's preferences allow it.
+ */
+#define account_type_has_auto_interest_charge(type)  (((type) == ACCT_TYPE_CREDIT) || \
+((type) == ACCT_TYPE_LIABILITY) ||\
+((type) == ACCT_TYPE_PAYABLE))
+
+#define account_type_has_auto_interest_payment(type) (((type) == ACCT_TYPE_BANK)  || \
+((type) == ACCT_TYPE_ASSET) || \
+((type) == ACCT_TYPE_MUTUAL) || \
+((type) == ACCT_TYPE_RECEIVABLE))
+
+#define account_type_has_auto_interest_xfer(type) \
+(  account_type_has_auto_interest_charge(type) || \
+account_type_has_auto_interest_payment(type) )
+
 /** @addtogroup GUI
     @{ */
 /** @addtogroup GuiAccount Creating and editing accounts in the GUI

--- a/gnucash/gnome/window-reconcile2.c
+++ b/gnucash/gnome/window-reconcile2.c
@@ -56,9 +56,9 @@
 #include "gnc-window.h"
 #include "reconcile-view.h"
 #include "window-reconcile2.h"
+#include "Account.h"
 
 #define WINDOW_RECONCILE_CM_CLASS "window-reconcile"
-#define GNC_PREF_AUTO_INTEREST_TRANSFER "auto-interest-transfer"
 #define GNC_PREF_AUTO_CC_PAYMENT        "auto-cc-payment"
 #define GNC_PREF_ALWAYS_REC_TO_TODAY    "always-reconcile-to-today"
 
@@ -119,23 +119,6 @@ typedef struct _startRecnWindowData
     time64         date;            /* the interest xfer reconcile date        */
 } startRecnWindowData;
 
-
-/* Note: make sure to update the help text for this in prefs.scm if these
- * change!  These macros define the account types for which an auto interest
- * xfer dialog could pop up, if the user's preferences allow it.
- */
-#define account_type_has_auto_interest_charge(type)  (((type) == ACCT_TYPE_CREDIT) || \
-                                                      ((type) == ACCT_TYPE_LIABILITY) ||\
-						      ((type) == ACCT_TYPE_PAYABLE))
-
-#define account_type_has_auto_interest_payment(type) (((type) == ACCT_TYPE_BANK)  || \
-                                                      ((type) == ACCT_TYPE_ASSET) || \
-                                                      ((type) == ACCT_TYPE_MUTUAL) || \
-						      ((type) == ACCT_TYPE_RECEIVABLE))
-
-#define account_type_has_auto_interest_xfer(type) \
-  (  account_type_has_auto_interest_charge(type) || \
-    account_type_has_auto_interest_payment(type) )
 
 /** PROTOTYPES ******************************************************/
 static gnc_numeric recnRecalculateBalance (RecnWindow2 *recnData);
@@ -366,21 +349,6 @@ gnc_start_recn2_children_changed (GtkWidget *widget, startRecnWindowData *data)
 }
 
 
-/* For a given account, determine if an auto interest xfer dialog should be
- * shown, based on both the per-account flag as well as the global reconcile
- * option.  The global option is the default that is used if there is no
- * per-account option.
- */
-static gboolean
-gnc_recn_interest_xfer_get_auto_interest_xfer_allowed (Account *account)
-{
-    gboolean auto_xfer;
-
-    auto_xfer = gnc_prefs_get_bool (GNC_PREFS_GROUP_RECONCILE, GNC_PREF_AUTO_INTEREST_TRANSFER);
-    return xaccAccountGetAutoInterestXfer (account, auto_xfer);
-}
-
-
 /********************************************************************\
  * recnInterestXferWindow                                           *
  *   opens up a window to prompt the user to enter an interest      *
@@ -421,11 +389,6 @@ static void
 gnc_recn_interest_xfer_no_auto_clicked_cb (GtkButton *button,
         startRecnWindowData *data)
 {
-    /* Indicate that the user doesn't want
-     * an auto interest xfer for this account.
-     */
-    xaccAccountSetAutoInterestXfer (data->account, FALSE);
-
     /* shut down the interest xfer dialog */
     gnc_xfer_dialog_close (data->xferData);
 
@@ -568,10 +531,6 @@ gnc_reconcile_interest_xfer_run (startRecnWindowData *data)
 void
 gnc_start_recn2_interest_clicked_cb (GtkButton *button, startRecnWindowData *data)
 {
-    /* indicate in account that user wants
-     * an auto interest xfer for this account */
-    xaccAccountSetAutoInterestXfer (data->account, TRUE);
-
     /* make the button unclickable since we're popping up the window */
     if (data->xfer_button)
         gtk_widget_set_sensitive (GTK_WIDGET (data->xfer_button), FALSE);
@@ -671,8 +630,7 @@ startRecnWindow (GtkWidget *parent, Account *account,
     data.date = *statement_date;
 
     /* whether to have an automatic interest xfer dialog or not */
-    auto_interest_xfer_option =
-        gnc_recn_interest_xfer_get_auto_interest_xfer_allowed (account);
+    auto_interest_xfer_option = xaccAccountGetAutoInterest (account);
 
     data.include_children = xaccAccountGetReconcileChildrenStatus (account);
 

--- a/gnucash/gtkbuilder/dialog-account.glade
+++ b/gnucash/gtkbuilder/dialog-account.glade
@@ -1503,6 +1503,20 @@
                           </packing>
                         </child>
                         <child>
+                            <object class="GtkCheckButton" id="auto_interest_button">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="tooltip_text" translatable="yes">Prior to reconciling an account which charges or pays interest, prompt the user to enter a transaction for the interest charge or payment. Currently only enabled for Bank, Credit, Mutual, Asset, Receivable, Payable, and Liability accounts.</property>
+                                <property name="halign">start</property>
+                                <property name="draw_indicator">True</property>
+                            </object>
+                            <packing>
+                                <property name="left_attach">1</property>
+                                <property name="top_attach">10</property>
+                            </packing>
+                        </child>
+                        <child>
                           <object class="GtkCheckButton" id="tax_related_button">
                             <property name="visible">True</property>
                             <property name="sensitive">False</property>
@@ -1559,6 +1573,20 @@
                             <property name="left_attach">0</property>
                             <property name="top_attach">7</property>
                           </packing>
+                        </child>
+                        <child>
+                            <object class="GtkLabel" id="label405">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="halign">end</property>
+                                <property name="label" translatable="yes">Auto _interest transfer</property>
+                                <property name="use_underline">True</property>
+                                <property name="mnemonic_widget">auto_interest_button</property>
+                            </object>
+                            <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">10</property>
+                            </packing>
                         </child>
                       </object>
                       <packing>

--- a/gnucash/gtkbuilder/dialog-preferences.glade
+++ b/gnucash/gtkbuilder/dialog-preferences.glade
@@ -2378,24 +2378,6 @@ many months before the current month</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkCheckButton" id="pref/dialogs.reconcile/auto-interest-transfer">
-                    <property name="label" translatable="yes">Automatic _interest transfer</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="has_tooltip">True</property>
-                    <property name="tooltip_markup">Prior to reconciling an account which charges or pays interest, prompt the user to enter a transaction for the interest charge or payment. Currently only enabled for Bank, Credit, Mutual, Asset, Receivable, Payable, and Liability accounts.</property>
-                    <property name="tooltip_text" translatable="yes">Prior to reconciling an account which charges or pays interest, prompt the user to enter a transaction for the interest charge or payment. Currently only enabled for Bank, Credit, Mutual, Asset, Receivable, Payable, and Liability accounts.</property>
-                    <property name="halign">start</property>
-                    <property name="use_underline">True</property>
-                    <property name="draw_indicator">True</property>
-                  </object>
-                  <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">7</property>
-                  </packing>
-                </child>
-                <child>
                   <object class="GtkCheckButton" id="pref/dialogs.reconcile/auto-cc-payment">
                     <property name="label" translatable="yes">Automatic credit card _payment</property>
                     <property name="visible">True</property>
@@ -2410,7 +2392,7 @@ many months before the current month</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">8</property>
+                    <property name="top_attach">7</property>
                   </packing>
                 </child>
                 <child>
@@ -2428,7 +2410,7 @@ many months before the current month</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">9</property>
+                    <property name="top_attach">8</property>
                   </packing>
                 </child>
                 <child>
@@ -2438,7 +2420,7 @@ many months before the current month</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">10</property>
+                    <property name="top_attach">9</property>
                   </packing>
                 </child>
                 <child>
@@ -2451,7 +2433,7 @@ many months before the current month</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">11</property>
+                    <property name="top_attach">10</property>
                   </packing>
                 </child>
                 <child>
@@ -2469,7 +2451,7 @@ many months before the current month</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">12</property>
+                    <property name="top_attach">11</property>
                   </packing>
                 </child>
                 <child>
@@ -2487,7 +2469,7 @@ many months before the current month</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">13</property>
+                    <property name="top_attach">12</property>
                   </packing>
                 </child>
                 <child>
@@ -2505,7 +2487,7 @@ many months before the current month</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">14</property>
+                    <property name="top_attach">13</property>
                   </packing>
                 </child>
                 <child>
@@ -2523,7 +2505,7 @@ many months before the current month</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">15</property>
+                    <property name="top_attach">14</property>
                   </packing>
                 </child>
                 <child>
@@ -2533,7 +2515,7 @@ many months before the current month</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">16</property>
+                    <property name="top_attach">15</property>
                   </packing>
                 </child>
                 <child>
@@ -2546,7 +2528,7 @@ many months before the current month</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">17</property>
+                    <property name="top_attach">16</property>
                   </packing>
                 </child>
                 <child>
@@ -2564,7 +2546,7 @@ many months before the current month</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">18</property>
+                    <property name="top_attach">17</property>
                   </packing>
                 </child>
               </object>

--- a/libgnucash/engine/Account.cpp
+++ b/libgnucash/engine/Account.cpp
@@ -106,6 +106,7 @@ enum
 
     PROP_HIDDEN,                        /* Table slot exists, but in KVP in memory & xml */
     PROP_PLACEHOLDER,                   /* Table slot exists, but in KVP in memory & xml */
+    PROP_AUTO_INTEREST,
     PROP_FILTER,                        /* KVP */
     PROP_SORT_ORDER,                    /* KVP */
     PROP_SORT_REVERSED,
@@ -460,6 +461,9 @@ gnc_account_get_property (GObject         *object,
     case PROP_HIDDEN:
         g_value_set_boolean(value, xaccAccountGetHidden(account));
         break;
+    case PROP_AUTO_INTEREST:
+        g_value_set_boolean (value, xaccAccountGetAutoInterest (account));
+        break;
     case PROP_PLACEHOLDER:
         g_value_set_boolean(value, xaccAccountGetPlaceholder(account));
         break;
@@ -584,6 +588,9 @@ gnc_account_set_property (GObject         *object,
         break;
     case PROP_HIDDEN:
         xaccAccountSetHidden(account, g_value_get_boolean(value));
+        break;
+    case PROP_AUTO_INTEREST:
+        xaccAccountSetAutoInterest (account, g_value_get_boolean (value));
         break;
     case PROP_PLACEHOLDER:
         xaccAccountSetPlaceholder(account, g_value_get_boolean(value));
@@ -973,6 +980,16 @@ gnc_account_class_init (AccountClass *klass)
                            FALSE,
                            static_cast<GParamFlags>(G_PARAM_READWRITE)));
 
+    g_object_class_install_property
+    (gobject_class,
+     PROP_AUTO_INTEREST,
+     g_param_spec_boolean ("auto-interest-transfer",
+                           "Auto Interest",
+                           "Whether an interest transfer should be automatically  "
+                           "added before reconcile.",
+                           FALSE,
+                           static_cast<GParamFlags>(G_PARAM_READWRITE)));
+    
     g_object_class_install_property
     (gobject_class,
      PROP_PLACEHOLDER,
@@ -4093,6 +4110,21 @@ xaccAccountGetDescendantPlaceholder (const Account *acc)
 }
 
 /********************************************************************\
+ \********************************************************************/
+
+gboolean
+xaccAccountGetAutoInterest (const Account *acc)
+{
+    return boolean_from_key (acc, {KEY_RECONCILE_INFO, "auto-interest-transfer"});
+}
+
+void
+xaccAccountSetAutoInterest (Account *acc, gboolean val)
+{
+    set_boolean_key (acc, {KEY_RECONCILE_INFO, "auto-interest-transfer"}, val);
+}
+
+/********************************************************************\
 \********************************************************************/
 
 gboolean
@@ -4648,28 +4680,6 @@ xaccAccountClearReconcilePostpone (Account *acc)
     qof_instance_set_path_kvp (QOF_INSTANCE(acc), nullptr, {KEY_RECONCILE_INFO, KEY_POSTPONE});
     mark_account (acc);
     xaccAccountCommitEdit (acc);
-}
-
-/********************************************************************\
-\********************************************************************/
-
-/* xaccAccountGetAutoInterestXfer: determine whether the auto interest
- * xfer option is enabled for this account, and return that value.
- * If it is not defined for the account, return the default value.
- */
-gboolean
-xaccAccountGetAutoInterestXfer (const Account *acc, gboolean default_value)
-{
-    return boolean_from_key (acc, {KEY_RECONCILE_INFO, "auto-interest-transfer"});
-}
-
-/********************************************************************\
-\********************************************************************/
-
-void
-xaccAccountSetAutoInterestXfer (Account *acc, gboolean option)
-{
-    set_boolean_key (acc, {KEY_RECONCILE_INFO, "auto-interest-transfer"}, option);
 }
 
 /********************************************************************\

--- a/libgnucash/engine/Account.h
+++ b/libgnucash/engine/Account.h
@@ -455,18 +455,6 @@ void dxaccAccountSetPriceSrc (Account *account, const char *src);
  *  @deprecated Price quote information is now stored on the
  *  commodity, not the account. */
 const char * dxaccAccountGetPriceSrc (const Account *account);
-
-/** Returns a per-account flag: Prior to reconciling an account which
-    charges or pays interest, this flag tells whether to prompt the
-    user to enter a transaction for the interest charge or
-    payment. This per-account flag overrides the global preference. */
-gboolean xaccAccountGetAutoInterestXfer (const Account *account,
-        gboolean default_value);
-/** Sets a per-account flag: Prior to reconciling an account which
-    charges or pays interest, this flag tells whether to prompt the
-    user to enter a transaction for the interest charge or
-    payment. This per-account flag overrides the global preference. */
-void xaccAccountSetAutoInterestXfer (Account *account, gboolean value);
 /** @} */
 
 /** @name Account Commodity setters/getters
@@ -1223,6 +1211,29 @@ void xaccAccountSetHidden (Account *acc, gboolean val);
  *  @return Whether or not this account should be "hidden". */
 gboolean xaccAccountIsHidden (const Account *acc);
 /** @} */
+    
+/** @name Account Auto Interest flag
+ @{
+ */
+
+/** Get the "auto interest" flag for an account.  If this flag is set then
+ *  the account (and any children) will trigger an interest transfer after reconciling.
+ *
+ *  @param acc The account whose flag should be retrieved.
+ *
+ *  @return The current state of the account's "auto interest" flag. */
+gboolean xaccAccountGetAutoInterest (const Account *acc);
+
+/** Set the "auto interest" flag for an account.  If this flag is set then
+ *  the account (and any children) will trigger an interest transfer after reconciling.
+ *
+ *  @param acc The account whose flag should be retrieved.
+ *
+ *  @param val The new state for the account's "auto interest" flag. */
+void xaccAccountSetAutoInterest (Account *acc, gboolean val);
+
+/** @} */
+
 
 /** @name Account Tax related getters/setters
  @{


### PR DESCRIPTION
Bug 797854 - Global Register Preference to prompt for interest payment is not being honored.

A new per-account preference is added to let the user decide whether the interest transaction dialog should be
opened automatically before the reconcile. This preference is only enabled for certain types of accounts and
the code that decides that was moved to Account.h as is it now used in two separate place.