### PR TITLE
Wording change from "associated document" to "linked document"

### DIFF
--- a/gnucash/gnome/dialog-assoc.c
+++ b/gnucash/gnome/dialog-assoc.c
@@ -1,5 +1,5 @@
 /********************************************************************\
- * dialog-assoc.c -- Associations dialog                            *
+ * dialog-assoc.c -- Links dialog                                   *
  * Copyright (C) 2020 Robert Fewell                                 *
  *                                                                  *
  * This program is free software; you can redistribute it and/or    *
@@ -202,7 +202,7 @@ setup_file_dialog (GtkBuilder *builder, GtkFileChooserButton *fcb,
         GtkWidget *existing_hbox = GTK_WIDGET(gtk_builder_get_object (builder, "existing_hbox"));
         GtkWidget *image = gtk_image_new_from_icon_name ("dialog-warning", GTK_ICON_SIZE_SMALL_TOOLBAR);
         gchar     *use_uri = gnc_assoc_get_use_uri (path_head, uri, scheme);
-        gchar     *uri_label = g_strdup_printf ("%s '%s'", _("Existing Association is"), display_uri);
+        gchar     *uri_label = g_strdup_printf ("%s '%s'", _("Existing Link is"), display_uri);
 
         label = gtk_label_new (uri_label);
 
@@ -539,7 +539,7 @@ row_selected_bus_cb (GtkTreeView *view, GtkTreePath *path,
 
 /* Translators: This is the title of a dialog box for associating an external
    file or URI with the current bill, invoice, transaction, or voucher. */
-        ret_uri = gnc_assoc_get_uri_dialog (GTK_WINDOW(assoc_dialog->window), _("Manage Associated Document"), uri);
+        ret_uri = gnc_assoc_get_uri_dialog (GTK_WINDOW(assoc_dialog->window), _("Manage Document Link"), uri);
 
         if (ret_uri && g_strcmp0 (uri, ret_uri) != 0)
         {
@@ -630,7 +630,7 @@ row_selected_trans_cb (GtkTreeView *view, GtkTreePath *path,
             g_free (uri);
             return;
         }
-        ret_uri = gnc_assoc_get_uri_dialog (GTK_WINDOW(assoc_dialog->window), _("Manage Associated Document"), uri);
+        ret_uri = gnc_assoc_get_uri_dialog (GTK_WINDOW(assoc_dialog->window), _("Manage Document Link"), uri);
 
         if (ret_uri && g_strcmp0 (uri, ret_uri) != 0)
         {
@@ -887,7 +887,7 @@ gnc_assoc_dialog_create (GtkWindow *parent, AssocDialog *assoc_dialog)
     // display path head text and test if present
     gnc_assoc_set_path_head_label (assoc_dialog->path_head_label, NULL, NULL);
 
-    // set the Associate column to be the one that expands
+    // set the Link column to be the one that expands
     tree_column = GTK_TREE_VIEW_COLUMN(gtk_builder_get_object (builder, "assoc"));
     gtk_tree_view_column_set_expand (tree_column, TRUE);
 
@@ -916,7 +916,7 @@ gnc_assoc_dialog_create (GtkWindow *parent, AssocDialog *assoc_dialog)
 
         /* Translators: This is the label of a dialog box that lists all of the
            transaction that have files or URIs associated with them. */
-        gtk_window_set_title (GTK_WINDOW(window), _("Transaction Associations"));
+        gtk_window_set_title (GTK_WINDOW(window), _("Transaction Links"));
 
         gtk_tree_view_column_set_visible (GTK_TREE_VIEW_COLUMN(desc_id_tree_column), FALSE);
         gtk_tree_view_column_set_title (GTK_TREE_VIEW_COLUMN(desc_item_tree_column), _("Description"));
@@ -931,12 +931,12 @@ gnc_assoc_dialog_create (GtkWindow *parent, AssocDialog *assoc_dialog)
         GtkWidget *help_label = GTK_WIDGET(gtk_builder_get_object (builder, "help_label"));
         const gchar *item_string = N_(
             "         To jump to the Business Item, double click on the entry in the id\n"
-            " column, Association column to open the Association or Available to update");
+            " column, Link column to open the Link or Available to update");
 
         /* Translators: This is the label of a dialog box that lists all of the
            invoices, bills, and vouchers that have files or URIs associated with
            them. */
-        gtk_window_set_title (GTK_WINDOW(assoc_dialog->window), _("Business Associations"));
+        gtk_window_set_title (GTK_WINDOW(assoc_dialog->window), _("Business Links"));
         gtk_label_set_text (GTK_LABEL(help_label), gettext (item_string));
 
         g_signal_connect (assoc_dialog->view, "row-activated",

--- a/gnucash/gnome/dialog-assoc.c
+++ b/gnucash/gnome/dialog-assoc.c
@@ -537,7 +537,9 @@ row_selected_bus_cb (GtkTreeView *view, GtkTreePath *path,
             return;
         }
 
-        ret_uri = gnc_assoc_get_uri_dialog (GTK_WINDOW(assoc_dialog->window), _("Change a Business Association"), uri);
+/* Translators: This is the title of a dialog box for associating an external
+   file or URI with the current bill, invoice, transaction, or voucher. */
+        ret_uri = gnc_assoc_get_uri_dialog (GTK_WINDOW(assoc_dialog->window), _("Manage Associated Document"), uri);
 
         if (ret_uri && g_strcmp0 (uri, ret_uri) != 0)
         {
@@ -628,7 +630,7 @@ row_selected_trans_cb (GtkTreeView *view, GtkTreePath *path,
             g_free (uri);
             return;
         }
-        ret_uri = gnc_assoc_get_uri_dialog (GTK_WINDOW(assoc_dialog->window), _("Change a Transaction Association"), uri);
+        ret_uri = gnc_assoc_get_uri_dialog (GTK_WINDOW(assoc_dialog->window), _("Manage Associated Document"), uri);
 
         if (ret_uri && g_strcmp0 (uri, ret_uri) != 0)
         {
@@ -912,6 +914,8 @@ gnc_assoc_dialog_create (GtkWindow *parent, AssocDialog *assoc_dialog)
         GObject *desc_item_tree_column = G_OBJECT(gtk_builder_get_object (builder, "desc_item"));
         GObject *desc_id_tree_column = G_OBJECT(gtk_builder_get_object (builder, "desc_id"));
 
+        /* Translators: This is the label of a dialog box that lists all of the
+           transaction that have files or URIs associated with them. */
         gtk_window_set_title (GTK_WINDOW(window), _("Transaction Associations"));
 
         gtk_tree_view_column_set_visible (GTK_TREE_VIEW_COLUMN(desc_id_tree_column), FALSE);
@@ -929,6 +933,9 @@ gnc_assoc_dialog_create (GtkWindow *parent, AssocDialog *assoc_dialog)
             "         To jump to the Business Item, double click on the entry in the id\n"
             " column, Association column to open the Association or Available to update");
 
+        /* Translators: This is the label of a dialog box that lists all of the
+           invoices, bills, and vouchers that have files or URIs associated with
+           them. */
         gtk_window_set_title (GTK_WINDOW(assoc_dialog->window), _("Business Associations"));
         gtk_label_set_text (GTK_LABEL(help_label), gettext (item_string));
 

--- a/gnucash/gnome/dialog-invoice.c
+++ b/gnucash/gnome/dialog-invoice.c
@@ -2455,7 +2455,7 @@ gnc_invoice_create_page (InvoiceWindow *iw, gpointer page)
     if (assoc_uri)
     {
         gchar *display_uri = gnc_assoc_get_unescaped_just_uri (assoc_uri);
-        gtk_button_set_label (GTK_BUTTON(iw->assoc_link_button), _("Open Association:"));
+        gtk_button_set_label (GTK_BUTTON(iw->assoc_link_button), _("Open Link:"));
         gtk_link_button_set_uri (GTK_LINK_BUTTON(iw->assoc_link_button), display_uri);
         gtk_widget_show (GTK_WIDGET (iw->assoc_link_button));
         g_free (display_uri);

--- a/gnucash/gnome/gnc-plugin-basic-commands.c
+++ b/gnucash/gnome/gnc-plugin-basic-commands.c
@@ -213,8 +213,8 @@ static GtkActionEntry gnc_plugin_actions [] =
         G_CALLBACK (gnc_main_window_cmd_tools_imap_editor)
     },
     {
-        "ToolsTransAssocAction", NULL, N_("_Transaction Associations"), NULL,
-        N_("View all Transaction Associations"),
+        "ToolsTransAssocAction", NULL, N_("_Transaction Links"), NULL,
+        N_("View all Transaction Links"),
         G_CALLBACK (gnc_main_window_cmd_tools_trans_assoc)
     },
 

--- a/gnucash/gnome/gnc-plugin-business.c
+++ b/gnucash/gnome/gnc-plugin-business.c
@@ -275,8 +275,8 @@ static GtkActionEntry gnc_plugin_actions [] =
 
     /* Other menu items */
     {
-        "BusinessAssocOpenAction", NULL, N_("Business _Associations"), NULL,
-        N_("View all Business Associations"),
+        "BusinessAssocOpenAction", NULL, N_("Business _Links"), NULL,
+        N_("View all Business Links"),
         G_CALLBACK (gnc_plugin_business_cmd_assoc)
     },
     {

--- a/gnucash/gnome/gnc-plugin-page-invoice.c
+++ b/gnucash/gnome/gnc-plugin-page-invoice.c
@@ -218,13 +218,13 @@ static GtkActionEntry gnc_plugin_page_invoice_actions [] =
         G_CALLBACK (gnc_plugin_page_invoice_cmd_new_invoice)
     },
     {
-        "BusinessAssociationAction", NULL, "_Manage Associated Document...", NULL,
-        "Manage the associated document",
+        "BusinessAssociationAction", NULL, "_Manage Document Link...", NULL,
+        "Manage document link",
         G_CALLBACK (gnc_plugin_page_invoice_cmd_associate)
     },
     {
-        "BusinessAssociationOpenAction", NULL, "_Open Associated Document", NULL,
-        "Open the associated document",
+        "BusinessAssociationOpenAction", NULL, "_Open Linked Document", NULL,
+        "Open the link document",
         G_CALLBACK (gnc_plugin_page_invoice_cmd_associate_open)
     },
     {
@@ -301,8 +301,8 @@ static action_toolbar_labels invoice_action_labels[] =
     {"EditUnpostInvoiceAction", N_("_Unpost Invoice")},
     {"BusinessNewInvoiceAction", N_("New _Invoice")},
     {"ToolsProcessPaymentAction", N_("_Pay Invoice")},
-    {"BusinessAssociationAction", N_("_Manage Associated Document...")},
-    {"BusinessAssociationOpenAction", N_("_Open Associated Document")},
+    {"BusinessAssociationAction", N_("_Manage Document Link...")},
+    {"BusinessAssociationOpenAction", N_("_Open Linked Document")},
     {NULL, NULL},
 };
 
@@ -322,8 +322,8 @@ static action_toolbar_labels bill_action_labels[] =
     {"EditUnpostInvoiceAction", N_("_Unpost Bill")},
     {"BusinessNewInvoiceAction", N_("New _Bill")},
     {"ToolsProcessPaymentAction", N_("_Pay Bill")},
-    {"BusinessAssociationAction", N_("_Manage Associated Document...")},
-    {"BusinessAssociationOpenAction", N_("_Open Associated Document")},
+    {"BusinessAssociationAction", N_("_Manage Document Link...")},
+    {"BusinessAssociationOpenAction", N_("_Open Linked Document")},
     {NULL, NULL},
 };
 
@@ -343,8 +343,8 @@ static action_toolbar_labels voucher_action_labels[] =
     {"EditUnpostInvoiceAction", N_("_Unpost Voucher")},
     {"BusinessNewInvoiceAction", N_("New _Voucher")},
     {"ToolsProcessPaymentAction", N_("_Pay Voucher")},
-    {"BusinessAssociationAction", N_("_Manage Associated Document...")},
-    {"BusinessAssociationOpenAction", N_("_Open Associated Document")},
+    {"BusinessAssociationAction", N_("_Manage Document Link...")},
+    {"BusinessAssociationOpenAction", N_("_Open Linked Document")},
     {NULL, NULL},
 };
 
@@ -364,8 +364,8 @@ static action_toolbar_labels creditnote_action_labels[] =
     {"EditUnpostInvoiceAction", N_("_Unpost Credit Note")},
     {"BusinessNewInvoiceAction", N_("New _Credit Note")},
     {"ToolsProcessPaymentAction", N_("_Pay Credit Note")},
-    {"BusinessAssociationAction", N_("_Manage Associated Document...")},
-    {"BusinessAssociationOpenAction", N_("_Open Associated Document")},
+    {"BusinessAssociationAction", N_("_Manage Document Link...")},
+    {"BusinessAssociationOpenAction", N_("_Open Linked Document")},
     {NULL, NULL},
 };
 
@@ -380,8 +380,8 @@ static action_toolbar_labels invoice_action_tooltips[] = {
     {"BlankEntryAction", N_("Move to the blank entry at the bottom of the invoice")},
     {"ToolsProcessPaymentAction", N_("Enter a payment for the owner of this invoice") },
     {"ReportsCompanyReportAction", N_("Open a company report window for the owner of this invoice") },
-    {"BusinessAssociationAction", N_("Manage Associated Document")},
-    {"BusinessAssociationOpenAction", N_("Open Associated Document")},
+    {"BusinessAssociationAction", N_("Manage Document Link")},
+    {"BusinessAssociationOpenAction", N_("Open Linked Document")},
     {NULL, NULL},
 };
 
@@ -401,8 +401,8 @@ static action_toolbar_labels bill_action_tooltips[] = {
     {"BlankEntryAction", N_("Move to the blank entry at the bottom of the bill")},
     {"ToolsProcessPaymentAction", N_("Enter a payment for the owner of this bill") },
     {"ReportsCompanyReportAction", N_("Open a company report window for the owner of this bill") },
-    {"BusinessAssociationAction", N_("Manage Associated Document")},
-    {"BusinessAssociationOpenAction", N_("Open Associated Docyment")},
+    {"BusinessAssociationAction", N_("Manage Document Link")},
+    {"BusinessAssociationOpenAction", N_("Open Linked Docyment")},
     {NULL, NULL},
 };
 
@@ -422,8 +422,8 @@ static action_toolbar_labels voucher_action_tooltips[] = {
     {"BlankEntryAction", N_("Move to the blank entry at the bottom of the voucher")},
     {"ToolsProcessPaymentAction", N_("Enter a payment for the owner of this voucher") },
     {"ReportsCompanyReportAction", N_("Open a company report window for the owner of this voucher") },
-    {"BusinessAssociationAction", N_("Manage Associated Document")},
-    {"BusinessAssociationOpenAction", N_("Open Associated Document")},
+    {"BusinessAssociationAction", N_("Manage Document Link")},
+    {"BusinessAssociationOpenAction", N_("Open Linked Document")},
     {NULL, NULL},
 };
 
@@ -443,8 +443,8 @@ static action_toolbar_labels creditnote_action_tooltips[] = {
     {"BlankEntryAction", N_("Move to the blank entry at the bottom of the credit note")},
     {"ToolsProcessPaymentAction", N_("Enter a payment for the owner of this credit note") },
     {"ReportsCompanyReportAction", N_("Open a company report window for the owner of this credit note") },
-    {"BusinessAssociationAction", N_("_Manage Associated Document...")},
-    {"BusinessAssociationOpenAction", N_("Open Associated Document")},
+    {"BusinessAssociationAction", N_("_Manage Document Link...")},
+    {"BusinessAssociationOpenAction", N_("Open Linked Document")},
     {NULL, NULL},
 };
 
@@ -1361,7 +1361,7 @@ gnc_plugin_page_invoice_cmd_associate (GtkAction *action,
     invoice = gnc_invoice_window_get_invoice (priv->iw);
     uri = gncInvoiceGetAssociation (invoice);
 
-    ret_uri = gnc_assoc_get_uri_dialog (parent, _("Manage Associated Document"), uri);
+    ret_uri = gnc_assoc_get_uri_dialog (parent, _("Manage Document Link"), uri);
 
     if (ret_uri && g_strcmp0 (uri, ret_uri) != 0)
     {

--- a/gnucash/gnome/gnc-plugin-page-invoice.c
+++ b/gnucash/gnome/gnc-plugin-page-invoice.c
@@ -218,19 +218,14 @@ static GtkActionEntry gnc_plugin_page_invoice_actions [] =
         G_CALLBACK (gnc_plugin_page_invoice_cmd_new_invoice)
     },
     {
-        "BusinessAssociationAction", NULL, "_Update Association for Invoice", NULL,
-        "Update Association for current Invoice",
+        "BusinessAssociationAction", NULL, "_Manage Associated Document...", NULL,
+        "Manage the associated document",
         G_CALLBACK (gnc_plugin_page_invoice_cmd_associate)
     },
     {
-        "BusinessAssociationOpenAction", NULL, "_Open Association for Invoice", NULL,
-        "Open Association for current Invoice",
+        "BusinessAssociationOpenAction", NULL, "_Open Associated Document", NULL,
+        "Open the associated document",
         G_CALLBACK (gnc_plugin_page_invoice_cmd_associate_open)
-    },
-    {
-        "BusinessAssociationRemoveAction", NULL, "_Remove Association from Invoice", NULL,
-        "Remove Association from Invoice",
-        G_CALLBACK (gnc_plugin_page_invoice_cmd_associate_remove)
     },
     {
         "ToolsProcessPaymentAction", GNC_ICON_INVOICE_PAY, "_Pay Invoice", NULL,
@@ -306,9 +301,8 @@ static action_toolbar_labels invoice_action_labels[] =
     {"EditUnpostInvoiceAction", N_("_Unpost Invoice")},
     {"BusinessNewInvoiceAction", N_("New _Invoice")},
     {"ToolsProcessPaymentAction", N_("_Pay Invoice")},
-    {"BusinessAssociationAction", N_("_Update Association for Invoice")},
-    {"BusinessAssociationOpenAction", N_("_Open Association for Invoice")},
-    {"BusinessAssociationRemoveAction", N_("_Remove Association from Invoice")},
+    {"BusinessAssociationAction", N_("_Manage Associated Document...")},
+    {"BusinessAssociationOpenAction", N_("_Open Associated Document")},
     {NULL, NULL},
 };
 
@@ -328,9 +322,8 @@ static action_toolbar_labels bill_action_labels[] =
     {"EditUnpostInvoiceAction", N_("_Unpost Bill")},
     {"BusinessNewInvoiceAction", N_("New _Bill")},
     {"ToolsProcessPaymentAction", N_("_Pay Bill")},
-    {"BusinessAssociationAction", N_("_Update Association for Bill")},
-    {"BusinessAssociationOpenAction", N_("_Open Association for Bill")},
-    {"BusinessAssociationRemoveAction", N_("_Remove Association from Bill")},
+    {"BusinessAssociationAction", N_("_Manage Associated Document...")},
+    {"BusinessAssociationOpenAction", N_("_Open Associated Document")},
     {NULL, NULL},
 };
 
@@ -350,9 +343,8 @@ static action_toolbar_labels voucher_action_labels[] =
     {"EditUnpostInvoiceAction", N_("_Unpost Voucher")},
     {"BusinessNewInvoiceAction", N_("New _Voucher")},
     {"ToolsProcessPaymentAction", N_("_Pay Voucher")},
-    {"BusinessAssociationAction", N_("_Update Association for Voucher")},
-    {"BusinessAssociationOpenAction", N_("_Open Association for Voucher")},
-    {"BusinessAssociationRemoveAction", N_("_Remove Association from Voucher")},
+    {"BusinessAssociationAction", N_("_Manage Associated Document...")},
+    {"BusinessAssociationOpenAction", N_("_Open Associated Document")},
     {NULL, NULL},
 };
 
@@ -372,9 +364,8 @@ static action_toolbar_labels creditnote_action_labels[] =
     {"EditUnpostInvoiceAction", N_("_Unpost Credit Note")},
     {"BusinessNewInvoiceAction", N_("New _Credit Note")},
     {"ToolsProcessPaymentAction", N_("_Pay Credit Note")},
-    {"BusinessAssociationAction", N_("_Update Association for Credit Note")},
-    {"BusinessAssociationOpenAction", N_("_Open Association for Credit Note")},
-    {"BusinessAssociationRemoveAction", N_("_Remove Association from Credit Note")},
+    {"BusinessAssociationAction", N_("_Manage Associated Document...")},
+    {"BusinessAssociationOpenAction", N_("_Open Associated Document")},
     {NULL, NULL},
 };
 
@@ -389,9 +380,8 @@ static action_toolbar_labels invoice_action_tooltips[] = {
     {"BlankEntryAction", N_("Move to the blank entry at the bottom of the invoice")},
     {"ToolsProcessPaymentAction", N_("Enter a payment for the owner of this invoice") },
     {"ReportsCompanyReportAction", N_("Open a company report window for the owner of this invoice") },
-    {"BusinessAssociationAction", N_("Update Association for current invoice")},
-    {"BusinessAssociationOpenAction", N_("Open Association for current invoice")},
-    {"BusinessAssociationRemoveAction", N_("Remove Association from invoice")},
+    {"BusinessAssociationAction", N_("Manage Associated Document")},
+    {"BusinessAssociationOpenAction", N_("Open Associated Document")},
     {NULL, NULL},
 };
 
@@ -411,9 +401,8 @@ static action_toolbar_labels bill_action_tooltips[] = {
     {"BlankEntryAction", N_("Move to the blank entry at the bottom of the bill")},
     {"ToolsProcessPaymentAction", N_("Enter a payment for the owner of this bill") },
     {"ReportsCompanyReportAction", N_("Open a company report window for the owner of this bill") },
-    {"BusinessAssociationAction", N_("Update Association for current bill")},
-    {"BusinessAssociationOpenAction", N_("Open Association for current bill")},
-    {"BusinessAssociationRemoveAction", N_("Remove Association from bill")},
+    {"BusinessAssociationAction", N_("Manage Associated Document")},
+    {"BusinessAssociationOpenAction", N_("Open Associated Docyment")},
     {NULL, NULL},
 };
 
@@ -433,9 +422,8 @@ static action_toolbar_labels voucher_action_tooltips[] = {
     {"BlankEntryAction", N_("Move to the blank entry at the bottom of the voucher")},
     {"ToolsProcessPaymentAction", N_("Enter a payment for the owner of this voucher") },
     {"ReportsCompanyReportAction", N_("Open a company report window for the owner of this voucher") },
-    {"BusinessAssociationAction", N_("Update Association for current voucher")},
-    {"BusinessAssociationOpenAction", N_("Open Association for current voucher")},
-    {"BusinessAssociationRemoveAction", N_("Remove Association from voucher")},
+    {"BusinessAssociationAction", N_("Manage Associated Document")},
+    {"BusinessAssociationOpenAction", N_("Open Associated Document")},
     {NULL, NULL},
 };
 
@@ -455,9 +443,8 @@ static action_toolbar_labels creditnote_action_tooltips[] = {
     {"BlankEntryAction", N_("Move to the blank entry at the bottom of the credit note")},
     {"ToolsProcessPaymentAction", N_("Enter a payment for the owner of this credit note") },
     {"ReportsCompanyReportAction", N_("Open a company report window for the owner of this credit note") },
-    {"BusinessAssociationAction", N_("Update Association for credit note")},
-    {"BusinessAssociationOpenAction", N_("Open Association for credit note")},
-    {"BusinessAssociationRemoveAction", N_("Remove Association from credit note")},
+    {"BusinessAssociationAction", N_("_Manage Associated Document...")},
+    {"BusinessAssociationOpenAction", N_("Open Associated Document")},
     {NULL, NULL},
 };
 
@@ -1374,7 +1361,7 @@ gnc_plugin_page_invoice_cmd_associate (GtkAction *action,
     invoice = gnc_invoice_window_get_invoice (priv->iw);
     uri = gncInvoiceGetAssociation (invoice);
 
-    ret_uri = gnc_assoc_get_uri_dialog (parent, _("Change a Business Association"), uri);
+    ret_uri = gnc_assoc_get_uri_dialog (parent, _("Manage Associated Document"), uri);
 
     if (ret_uri && g_strcmp0 (uri, ret_uri) != 0)
     {

--- a/gnucash/gnome/gnc-plugin-page-register.c
+++ b/gnucash/gnome/gnc-plugin-page-register.c
@@ -291,11 +291,11 @@ static GncInvoice* invoice_from_split (Split* split);
 /* Translators: This is a menu item that opens a dialog for associating an
    external file or URL with the bill, invoice, transaction, or voucher or
    removing such an association. */
-#define ASSOCIATE_TRANSACTION_LABEL      N_("_Manage Associated Document...")
+#define ASSOCIATE_TRANSACTION_LABEL      N_("_Manage Document Link...")
 /* Translators: This is a menu item that opens an external file or URI that may
    be associated with the current bill, invoice, transaction, or voucher using
    the operating system's default application for the file or URI mime type. */
-#define ASSOCIATE_TRANSACTION_OPEN_LABEL  N_("_Open Associated Document")
+#define ASSOCIATE_TRANSACTION_OPEN_LABEL  N_("_Open Linked Document")
 /* Translators: This is a menu item that will open the bill, invoice, or voucher
    that is posted to the current transaction if there is one. */
 #define JUMP_ASSOCIATED_INVOICE_LABEL     N_("Jump to Invoice")
@@ -309,9 +309,9 @@ static GncInvoice* invoice_from_split (Split* split);
 #define PASTE_TRANSACTION_TIP            N_("Paste the transaction from the clipboard")
 #define DUPLICATE_TRANSACTION_TIP        N_("Make a copy of the current transaction")
 #define DELETE_TRANSACTION_TIP           N_("Delete the current transaction")
-#define ASSOCIATE_TRANSACTION_TIP        N_("Add, change, or unlink the document associated with the current transaction")
-#define ASSOCIATE_TRANSACTION_OPEN_TIP   N_("Open the associated document for the current transaction")
-#define JUMP_ASSOCIATED_INVOICE_TIP      N_("Jump to the associated bill, invoice, or voucher")
+#define ASSOCIATE_TRANSACTION_TIP        N_("Add, change, or unlink the document linked with the current transaction")
+#define ASSOCIATE_TRANSACTION_OPEN_TIP   N_("Open the linked document for the current transaction")
+#define JUMP_ASSOCIATED_INVOICE_TIP      N_("Jump to the linked bill, invoice, or voucher")
 #define CUT_SPLIT_TIP                    N_("Cut the selected split into clipboard")
 #define COPY_SPLIT_TIP                   N_("Copy the selected split into clipboard")
 #define PASTE_SPLIT_TIP                  N_("Paste the split from the clipboard")
@@ -528,7 +528,7 @@ static GtkToggleActionEntry toggle_entries[] =
 {
     {
         "ViewStyleDoubleLineAction", NULL, N_ ("_Double Line"), NULL,
-        N_ ("Show a second line with \"Action\", \"Notes\", and \"File Association\" for each transaction."),
+        N_ ("Show a second line with \"Action\", \"Notes\", and \"File Link\" for each transaction."),
         G_CALLBACK (gnc_plugin_page_register_cmd_style_double_line), FALSE
     },
 
@@ -605,8 +605,8 @@ static action_toolbar_labels toolbar_labels[] =
     { "BlankTransactionAction",             N_ ("Blank") },
     { "ActionsReconcileAction",             N_ ("Reconcile") },
     { "ActionsAutoClearAction",             N_ ("Auto-clear") },
-    { "AssociateTransactionAction",         N_ ("Manage Association") },
-    { "AssociateTransactionOpenAction",     N_ ("Open Association") },
+    { "AssociateTransactionAction",         N_ ("Manage Link") },
+    { "AssociateTransactionOpenAction",     N_ ("Open Link") },
     { "JumpAssociatedInvoiceAction",        N_ ("Invoice") },
     { NULL, NULL },
 };
@@ -1132,7 +1132,7 @@ gnc_plugin_page_register_ui_update (gpointer various,
                                          "UnvoidTransactionAction");
     gtk_action_set_sensitive (GTK_ACTION (action), voided);
 
-    /* Set 'Open and Remove Associated' */
+    /* Set 'Open and Remove Linked' */
     uri = xaccTransGetAssociation (trans);
 
     action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE(page),

--- a/gnucash/gnome/gnc-plugin-page-register.c
+++ b/gnucash/gnome/gnc-plugin-page-register.c
@@ -288,10 +288,17 @@ static GncInvoice* invoice_from_split (Split* split);
 #define PASTE_TRANSACTION_LABEL          N_("_Paste Transaction")
 #define DUPLICATE_TRANSACTION_LABEL      N_("Dup_licate Transaction")
 #define DELETE_TRANSACTION_LABEL         N_("_Delete Transaction")
-#define ASSOCIATE_TRANSACTION_LABEL      N_("Update _Association for Transaction")
-#define ASSOCIATE_TRANSACTION_OPEN_LABEL  N_("_Open Association for Transaction")
-#define ASSOCIATE_TRANSACTION_REMOVE_LABEL N_("Re_move Association from Transaction")
-#define JUMP_ASSOCIATED_INVOICE_LABEL     N_("Open Associated Invoice")
+/* Translators: This is a menu item that opens a dialog for associating an
+   external file or URL with the bill, invoice, transaction, or voucher or
+   removing such an association. */
+#define ASSOCIATE_TRANSACTION_LABEL      N_("_Manage Associated Document...")
+/* Translators: This is a menu item that opens an external file or URI that may
+   be associated with the current bill, invoice, transaction, or voucher using
+   the operating system's default application for the file or URI mime type. */
+#define ASSOCIATE_TRANSACTION_OPEN_LABEL  N_("_Open Associated Document")
+/* Translators: This is a menu item that will open the bill, invoice, or voucher
+   that is posted to the current transaction if there is one. */
+#define JUMP_ASSOCIATED_INVOICE_LABEL     N_("Jump to Invoice")
 #define CUT_SPLIT_LABEL                  N_("Cu_t Split")
 #define COPY_SPLIT_LABEL                 N_("_Copy Split")
 #define PASTE_SPLIT_LABEL                N_("_Paste Split")
@@ -302,10 +309,9 @@ static GncInvoice* invoice_from_split (Split* split);
 #define PASTE_TRANSACTION_TIP            N_("Paste the transaction from the clipboard")
 #define DUPLICATE_TRANSACTION_TIP        N_("Make a copy of the current transaction")
 #define DELETE_TRANSACTION_TIP           N_("Delete the current transaction")
-#define ASSOCIATE_TRANSACTION_TIP        N_("Update Association for the current transaction")
-#define ASSOCIATE_TRANSACTION_OPEN_TIP   N_("Open Association for the current transaction")
-#define ASSOCIATE_TRANSACTION_REMOVE_TIP N_("Remove the association from the current transaction")
-#define JUMP_ASSOCIATED_INVOICE_TIP      N_("Open the associated invoice")
+#define ASSOCIATE_TRANSACTION_TIP        N_("Add, change, or unlink the document associated with the current transaction")
+#define ASSOCIATE_TRANSACTION_OPEN_TIP   N_("Open the associated document for the current transaction")
+#define JUMP_ASSOCIATED_INVOICE_TIP      N_("Jump to the associated bill, invoice, or voucher")
 #define CUT_SPLIT_TIP                    N_("Cut the selected split into clipboard")
 #define COPY_SPLIT_TIP                   N_("Copy the selected split into clipboard")
 #define PASTE_SPLIT_TIP                  N_("Paste the split from the clipboard")
@@ -419,11 +425,6 @@ static GtkActionEntry gnc_plugin_page_register_actions [] =
         G_CALLBACK (gnc_plugin_page_register_cmd_associate_transaction_open)
     },
     {
-        "AssociateTransactionRemoveAction", NULL, ASSOCIATE_TRANSACTION_REMOVE_LABEL, NULL,
-        ASSOCIATE_TRANSACTION_REMOVE_TIP,
-        G_CALLBACK (gnc_plugin_page_register_cmd_associate_transaction_remove)
-    },
-    {
         "JumpAssociatedInvoiceAction", NULL, JUMP_ASSOCIATED_INVOICE_LABEL, NULL,
         JUMP_ASSOCIATED_INVOICE_TIP,
         G_CALLBACK (gnc_plugin_page_register_cmd_jump_associated_invoice)
@@ -483,8 +484,11 @@ static GtkActionEntry gnc_plugin_page_register_actions [] =
         G_CALLBACK (gnc_plugin_page_register_cmd_exchange_rate)
     },
     {
-        "JumpTransactionAction", GNC_ICON_JUMP_TO, N_ ("_Jump"), NULL,
-        N_ ("Jump to the corresponding transaction in the other account"),
+/* Translators: This is a menu item that will open a register tab for the
+   account of the first other account in the current transaction's split list
+   with focus on the current transaction's entry in that register. */
+        "JumpTransactionAction", GNC_ICON_JUMP_TO, N_ ("_Jump to the other account"), NULL,
+        N_ ("Open a new register tab for the other account with focus on this transaction."),
         G_CALLBACK (gnc_plugin_page_register_cmd_jump)
     },
     {
@@ -596,14 +600,14 @@ static action_toolbar_labels toolbar_labels[] =
     { "DeleteTransactionAction",            N_ ("Delete") },
     { "DuplicateTransactionAction",         N_ ("Duplicate") },
     { "SplitTransactionAction",             N_ ("Split") },
+    { "JumpTransactionAction",              N_ ("Jump") },
     { "ScheduleTransactionAction",          N_ ("Schedule") },
     { "BlankTransactionAction",             N_ ("Blank") },
     { "ActionsReconcileAction",             N_ ("Reconcile") },
     { "ActionsAutoClearAction",             N_ ("Auto-clear") },
-    { "AssociateTransactionAction",         N_ ("Update Association") },
+    { "AssociateTransactionAction",         N_ ("Manage Association") },
     { "AssociateTransactionOpenAction",     N_ ("Open Association") },
-    { "AssociateTransactionRemoveAction",   N_ ("Remove Association") },
-    { "JumpAssociatedInvoiceAction",        N_ ("Open Invoice") },
+    { "JumpAssociatedInvoiceAction",        N_ ("Invoice") },
     { NULL, NULL },
 };
 
@@ -987,7 +991,6 @@ static const char* readonly_inactive_actions[] =
     "ScrubAllAction",
     "ScrubCurrentAction",
     "AssociateTransactionAction",
-    "AssociateTransactionRemoveAction",
     NULL
 };
 
@@ -1013,7 +1016,6 @@ static const char* tran_action_labels[] =
     DELETE_TRANSACTION_LABEL,
     ASSOCIATE_TRANSACTION_LABEL,
     ASSOCIATE_TRANSACTION_OPEN_LABEL,
-    ASSOCIATE_TRANSACTION_REMOVE_LABEL,
     JUMP_ASSOCIATED_INVOICE_LABEL,
     NULL
 };
@@ -1028,7 +1030,6 @@ static const char* tran_action_tips[] =
     DELETE_TRANSACTION_TIP,
     ASSOCIATE_TRANSACTION_TIP,
     ASSOCIATE_TRANSACTION_OPEN_TIP,
-    ASSOCIATE_TRANSACTION_REMOVE_TIP,
     JUMP_ASSOCIATED_INVOICE_TIP,
     NULL
 };
@@ -1136,10 +1137,6 @@ gnc_plugin_page_register_ui_update (gpointer various,
 
     action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE(page),
                                          "AssociateTransactionOpenAction");
-    gtk_action_set_sensitive (GTK_ACTION(action), (uri ? TRUE:FALSE));
-
-    action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page),
-                                         "AssociateTransactionRemoveAction");
     gtk_action_set_sensitive (GTK_ACTION(action), (uri ? TRUE:FALSE));
 
     /* Set 'ExecAssociatedInvoice'

--- a/gnucash/gnome/gnc-plugin-page-register2.c
+++ b/gnucash/gnome/gnc-plugin-page-register2.c
@@ -408,7 +408,7 @@ static GtkToggleActionEntry toggle_entries[] =
 {
     {
         "ViewStyleDoubleLineAction", NULL, N_("_Double Line"), NULL,
-        N_("Show a second line with \"Action\", \"Notes\", and \"File Association\" for each transaction."),
+        N_("Show a second line with \"Action\", \"Notes\", and \"File Link\" for each transaction."),
         G_CALLBACK (gnc_plugin_page_register2_cmd_style_double_line), FALSE
     },
 

--- a/gnucash/gnome/gnc-plugin-page-register2.c
+++ b/gnucash/gnome/gnc-plugin-page-register2.c
@@ -370,8 +370,8 @@ static GtkActionEntry gnc_plugin_page_register2_actions [] =
         G_CALLBACK (gnc_plugin_page_register2_cmd_exchange_rate)
     },
     {
-        "JumpTransactionAction", GNC_ICON_JUMP_TO, N_("_Jump"), NULL,
-        N_("Jump to the corresponding transaction in the other account"),
+        "JumpTransactionAction", GNC_ICON_JUMP_TO, N_("_Jump to the other account"), NULL,
+        N_("Open a new register tab for the other account with focus on this transaction."),
         G_CALLBACK (gnc_plugin_page_register2_cmd_jump)
     },
     {
@@ -486,6 +486,7 @@ static action_toolbar_labels toolbar_labels[] =
     { "DeleteTransactionAction", 	  N_("Delete") },
     { "DuplicateTransactionAction", N_("Duplicate") },
     { "SplitTransactionAction",     N_("Split") },
+    { "JumpTransactionAction",      N_("Jump") },
     { "ScheduleTransactionAction",  N_("Schedule") },
     { "BlankTransactionAction",     N_("Blank") },
     { "ActionsReconcileAction",     N_("Reconcile") },

--- a/gnucash/gnome/gnc-split-reg.c
+++ b/gnucash/gnome/gnc-split-reg.c
@@ -1294,7 +1294,7 @@ gsr_default_associate_handler (GNCSplitReg *gsr)
     // fix an earlier error when storing relative paths before version 3.5
     uri = gnc_assoc_convert_trans_associate_uri (trans, gsr->read_only);
 
-    ret_uri = gnc_assoc_get_uri_dialog (GTK_WINDOW(gsr->window), _("Change a Transaction Association"), uri);
+    ret_uri = gnc_assoc_get_uri_dialog (GTK_WINDOW(gsr->window), _("Change a Transaction Link"), uri);
 
     if (ret_uri && g_strcmp0 (uri, ret_uri) != 0)
         xaccTransSetAssociation (trans, ret_uri);

--- a/gnucash/ui/gnc-plugin-page-register-ui.xml
+++ b/gnucash/ui/gnc-plugin-page-register-ui.xml
@@ -24,7 +24,6 @@
       <separator name="TransactionSep3"/>
       <menuitem name="AssociateTransaction" action="AssociateTransactionAction"/>
       <menuitem name="AssociateTransactionOpen" action="AssociateTransactionOpenAction"/>
-      <menuitem name="AssociateTransactionRemove" action="AssociateTransactionRemoveAction"/>
       <separator name="TransactionSep4"/>
       <menuitem name="JumpAssociateInvoice" action="JumpAssociatedInvoiceAction"/>
     </menu>
@@ -101,7 +100,6 @@
       <separator name="PopupSep3"/>
       <menuitem name="AssociateTransaction" action="AssociateTransactionAction"/>
       <menuitem name="AssociateTransactionOpen" action="AssociateTransactionOpenAction"/>
-      <menuitem name="AssociateTransactionRemove" action="AssociateTransactionRemoveAction"/>
       <separator name="PopupSep4"/>
       <menuitem name="JumpAssociateInvoice" action="JumpAssociatedInvoiceAction"/>
       <separator name="PopupSep5"/>


### PR DESCRIPTION
This PR contains jralls' changes in PR#758 for clarifying the menu items of the "associated document", and the subsequent wording change into "linked document.

I'm not sure whether this PR is useful or this should rather be discussed in the other PR#758 but I was interested to see the up-to-date diff in this view. Feel free to reject one of the two PRs so that the subsequent discussion is only in one of them.