### PR TITLE
Etype might have not been initialized when used

### DIFF
--- a/gnucash/gnome/business-urls.c
+++ b/gnucash/gnome/business-urls.c
@@ -279,6 +279,7 @@ ownerreportCB (const char *location, const char *label,
         break;
     }
     default:
+        etype = "Undefined";
         break;
     }
 


### PR DESCRIPTION
It is used here:

    g_strdup_printf (_("Entity type does not match %s: %s"), etype, location);

But previous it might not have been initialized.