### PR TITLE
Multi-account selection and Delete

### DIFF
--- a/gnucash/gnome-utils/gnc-tree-view-account.c
+++ b/gnucash/gnome-utils/gnc-tree-view-account.c
@@ -742,11 +742,15 @@ gnc_tree_view_account_new_with_root (Account *root, gboolean show_root)
     GtkTreeViewColumn *tax_info_column, *acc_color_column;
     GtkCellRenderer *renderer;
     GList *col_list = NULL, *node = NULL;
+    GtkTreeSelection *selection;
 
     ENTER(" ");
     /* Create our view */
     view = g_object_new (GNC_TYPE_TREE_VIEW_ACCOUNT,
                          "name", "gnc-id-account-tree", NULL);
+
+    selection = gtk_tree_view_get_selection (GTK_TREE_VIEW (view));
+    gtk_tree_selection_set_mode (selection, GTK_SELECTION_MULTIPLE);
 
     priv = GNC_TREE_VIEW_ACCOUNT_GET_PRIVATE(GNC_TREE_VIEW_ACCOUNT (view));
 
@@ -1395,7 +1399,12 @@ gnc_tree_view_account_get_selected_account (GncTreeViewAccount *view)
     mode = gtk_tree_selection_get_mode(selection);
     if ((mode != GTK_SELECTION_SINGLE) && (mode != GTK_SELECTION_BROWSE))
     {
-        return NULL;
+        GList* acct_list = gnc_tree_view_account_get_selected_accounts (view);
+        if (acct_list == NULL)
+            return NULL;
+        account = acct_list->data;
+        g_list_free(acct_list);
+        return account;
     }
     if (!gtk_tree_selection_get_selected (selection, &s_model, &s_iter))
     {

--- a/gnucash/gtkbuilder/dialog-account.glade
+++ b/gnucash/gtkbuilder/dialog-account.glade
@@ -431,6 +431,21 @@
               </packing>
             </child>
             <child>
+                <object class="GtkButton" id="cancelallbutton">
+                    <property name="label" translatable="yes">_Cancel All</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="can_default">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="use_underline">True</property>
+                </object>
+                <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">1</property>
+                </packing>
+            </child>
+            <child>
               <object class="GtkButton" id="deletebutton">
                 <property name="label" translatable="yes">_Delete</property>
                 <property name="visible">True</property>
@@ -442,8 +457,23 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
-                <property name="position">1</property>
+                <property name="position">2</property>
               </packing>
+            </child>
+            <child>
+                <object class="GtkButton" id="deleteallbutton">
+                    <property name="label" translatable="yes">_Delete All</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="can_default">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="use_underline">True</property>
+                </object>
+                <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">3</property>
+                </packing>
             </child>
           </object>
           <packing>
@@ -823,7 +853,9 @@
     </child>
     <action-widgets>
       <action-widget response="-6">cancelbutton</action-widget>
+      <action-widget response="-9">cancelallbutton</action-widget>
       <action-widget response="-3">deletebutton</action-widget>
+      <action-widget response="-8">deleteallbutton</action-widget>
     </action-widgets>
     <style>
       <class name="gnc-class-account"/>


### PR DESCRIPTION
This is an ease-of-use improvement, especially for new users. Most of us don't typically change our accounts once our books are setup I imagine, but new users do.

Trying to keep this message brief.

Somebody in the past must have looked at multi-account actions because there already was functioning (but never called) code to get the list of selected accounts.

Only the Delete action is currently available when multiple accounts are selected in the account page. But I will follow up with another PR that implements the multi-account edit action.

- GC used to delete accounts on the spot if there was no transactions or subaccounts in them. I removed that: you always have to confirm.
- Once you've chosen what to do with the transactions and subbacounts, I check that the selected actions are compatible with all accounts selected for delete. I ask for confirmation, then I delete all accounts.
- Moving transactions used to be allowed only to an account of the same type as the deleted account. I'm not sure why this is strictly enforced, but I removed it as it does not seem warranted. I could add a warning to tell the user.