### PR TITLE
Aging-report must not consider splits outside report period

### DIFF
--- a/gnucash/gnome/business-urls.c
+++ b/gnucash/gnome/business-urls.c
@@ -213,7 +213,7 @@ ownerreportCB (const char *location, const char *label,
     GncOwner owner;
     Account *acc;
     GHashTable *query_ht;
-    time64 enddate;
+    time64 enddate = INT64_MAX;
     gboolean show_report = TRUE;
 
     g_return_val_if_fail (location != NULL, FALSE);
@@ -293,7 +293,13 @@ ownerreportCB (const char *location, const char *label,
 
     /* Ok, let's run this report */
     if (show_report)
-        gnc_business_call_owner_report (result->parent, &owner, acc);
+    {
+        if (enddate != INT64_MAX)
+            gnc_business_call_owner_report_with_enddate (result->parent, &owner,
+                                                         acc, enddate);
+        else
+            gnc_business_call_owner_report (result->parent, &owner, acc);
+    }
 
     g_hash_table_destroy (query_ht);
     return show_report;

--- a/gnucash/gnome/dialog-invoice.c
+++ b/gnucash/gnome/dialog-invoice.c
@@ -1162,6 +1162,14 @@ void gnc_invoice_window_new_invoice_cb (GtkWindow *parent, gpointer data)
 
 void gnc_business_call_owner_report (GtkWindow *parent, GncOwner *owner, Account *acc)
 {
+    gnc_business_call_owner_report_with_enddate (parent, owner, acc, INT64_MAX);
+}
+
+void gnc_business_call_owner_report_with_enddate (GtkWindow *parent,
+                                                  GncOwner *owner,
+                                                  Account *acc,
+                                                  time64 enddate)
+{
     int id;
     SCM args;
     SCM func;
@@ -1171,8 +1179,12 @@ void gnc_business_call_owner_report (GtkWindow *parent, GncOwner *owner, Account
 
     args = SCM_EOL;
 
-    func = scm_c_eval_string ("gnc:owner-report-create");
+    func = scm_c_eval_string ("gnc:owner-report-create-with-enddate");
     g_return_if_fail (scm_is_procedure (func));
+
+    /* set the enddate */
+    arg = (enddate != INT64_MAX) ? scm_from_int64 (enddate) : SCM_BOOL_F;
+    args = scm_cons (arg, args);
 
     if (acc)
     {

--- a/gnucash/gnome/dialog-invoice.h
+++ b/gnucash/gnome/dialog-invoice.h
@@ -67,6 +67,11 @@ GNCSearchWindow * gnc_invoice_search (GtkWindow *parent, GncInvoice *start, GncO
 
 void gnc_business_call_owner_report (GtkWindow* parent, GncOwner *owner, Account *acc);
 
+void gnc_business_call_owner_report_with_enddate (GtkWindow* parent,
+                                                  GncOwner *owner,
+                                                  Account *acc,
+                                                  time64 enddate);
+
 void gnc_invoice_window_sort (InvoiceWindow *iw, invoice_sort_type_t sort_code);
 
 GtkWidget * gnc_invoice_window_create_summary_bar (InvoiceWindow *iw);

--- a/gnucash/report/html-utilities.scm
+++ b/gnucash/report/html-utilities.scm
@@ -94,7 +94,7 @@
       (else
        ""))))
 
-(define (gnc:owner-report-text owner acc)
+(define* (gnc:owner-report-text owner acc #:optional date)
   (let* ((end-owner (gncOwnerGetEndOwner owner))
          (type (gncOwnerGetType end-owner)))
     (gnc-build-url
@@ -105,6 +105,7 @@
             ((eqv? type GNC-OWNER-EMPLOYEE) "owner=e:")
             (else "unknown-type="))
       (gncOwnerReturnGUID end-owner)
+      (if date (format #f "&enddate=~a" date) "")
       (if (null? acc) "" (string-append "&acct=" (gncAccountGetGUID acc))))
      "")))
 

--- a/gnucash/report/report-utilities.scm
+++ b/gnucash/report/report-utilities.scm
@@ -908,7 +908,13 @@
         (let* ((invoice (gncInvoiceGetInvoiceFromTxn
                          (xaccSplitGetParent (car splits))))
                (lot (gncInvoiceGetPostedLot invoice))
-               (bal (gnc-lot-get-balance lot))
+               (lot-splits (gnc-lot-get-split-list lot))
+               (bal (fold
+                     (lambda (a b)
+                       (if (<= (xaccTransGetDate (xaccSplitGetParent a)) to-date)
+                           (+ (xaccSplitGetAmount a) b)
+                           b))
+                     0 lot-splits))
                (bal (if receivable? bal (- bal)))
                (date (if (eq? date-type 'postdate)
                          (gncInvoiceGetDatePosted invoice)

--- a/gnucash/report/reports/aging.scm
+++ b/gnucash/report/reports/aging.scm
@@ -807,7 +807,7 @@ copying this report to a spreadsheet for use in a mail merge.")
 				   (cons
 				    (gnc:make-html-text
 				     (gnc:html-markup-anchor
-				      (gnc:owner-report-text owner account)
+				      (gnc:owner-report-text owner account report-date)
 				      total))
 				    rest))))
 

--- a/gnucash/report/reports/reports.scm
+++ b/gnucash/report/reports/reports.scm
@@ -38,6 +38,7 @@
 (export gnc:payables-report-create)
 (export gnc:receivables-report-create)
 (export gnc:owner-report-create)
+(export gnc:owner-report-create-with-enddate)
 
 (define report-dirs (list
     '(gnucash reports standard) ; prefix for standard reports included in gnucash
@@ -48,7 +49,8 @@
 ; and then load all reports found in the given prefixes
 (let* ((loc (gnc-locale-name))
        (loc-spec (if (string-prefix? "de_DE" loc) 'de_DE 'us))
-       (all-dirs (append report-dirs (list (list 'gnucash 'reports 'locale-specific loc-spec)))))
+       (all-dirs (append report-dirs
+                         `((gnucash reports locale-specific ,loc-spec)))))
       (report-module-loader all-dirs))
 
 (use-modules (gnucash engine))
@@ -86,3 +88,4 @@
 
 (use-modules (gnucash reports standard new-owner-report))
 (define gnc:owner-report-create owner-report-create)
+(define gnc:owner-report-create-with-enddate owner-report-create-with-enddate)

--- a/gnucash/report/reports/standard/new-aging.scm
+++ b/gnucash/report/reports/standard/new-aging.scm
@@ -230,7 +230,9 @@ exist but have no suitable transactions."))
               (else (op-num (car aging1) (car aging2)))))))))
 
     ;; set default title
-    (gnc:html-document-set-title! document report-title)
+    (gnc:html-document-set-title!
+     document
+     (format #f "~a - ~a" report-title (qof-print-date report-date)))
 
     (cond
      ((null? accounts)
@@ -309,7 +311,7 @@ exist but have no suitable transactions."))
                               "number-cell"
                               (gnc:make-html-text
                                (gnc:html-markup-anchor
-                                (gnc:owner-report-text owner account)
+                                (gnc:owner-report-text owner account report-date)
                                 (gnc:make-gnc-monetary comm aging-total)))))
                             (options->address options receivable owner)))))
                       (sort owners-and-aging sort-aging<?))


### PR DESCRIPTION
A few preliminary changes to enable `&enddate=NNN` in aging -> owner-report urls.

Then the final (contentious) change: aging-report was querying invoice's lot's balance to determine whether it is paid. It will now consider only invoice activity within the aging-report period specified.

I think the C code is clean, and the scm change is reasonable.
