### PR TITLE
Multi account edit

### DIFF
--- a/gnucash/gnome-utils/dialog-account.h
+++ b/gnucash/gnome-utils/dialog-account.h
@@ -69,6 +69,15 @@ account_type_has_auto_interest_payment(type) )
  */
 void gnc_ui_edit_account_window (GtkWindow *parent, Account *account);
 
+/** Display a window for editing the attributes of a list of existing accounts.
+ *
+ *  @param parent The widget on which to parent the dialog.
+ *
+ *  @param acct_list This parameter specifies the list of accounts whose data
+ *  will be edited.
+ */
+void gnc_ui_edit_account_list_window (GtkWindow *parent, GList* acct_list);
+
 
 /** Display a window for creating a new account.  This function will
  *  also initially set the parent account of the new account to what

--- a/gnucash/gnome-utils/gnc-tree-view-account.c
+++ b/gnucash/gnome-utils/gnc-tree-view-account.c
@@ -742,11 +742,15 @@ gnc_tree_view_account_new_with_root (Account *root, gboolean show_root)
     GtkTreeViewColumn *tax_info_column, *acc_color_column;
     GtkCellRenderer *renderer;
     GList *col_list = NULL, *node = NULL;
+    GtkTreeSelection *selection;
 
     ENTER(" ");
     /* Create our view */
     view = g_object_new (GNC_TYPE_TREE_VIEW_ACCOUNT,
                          "name", "gnc-id-account-tree", NULL);
+
+    selection = gtk_tree_view_get_selection (GTK_TREE_VIEW (view));
+    gtk_tree_selection_set_mode (selection, GTK_SELECTION_MULTIPLE);
 
     priv = GNC_TREE_VIEW_ACCOUNT_GET_PRIVATE(GNC_TREE_VIEW_ACCOUNT (view));
 
@@ -1395,7 +1399,12 @@ gnc_tree_view_account_get_selected_account (GncTreeViewAccount *view)
     mode = gtk_tree_selection_get_mode(selection);
     if ((mode != GTK_SELECTION_SINGLE) && (mode != GTK_SELECTION_BROWSE))
     {
-        return NULL;
+        GList* acct_list = gnc_tree_view_account_get_selected_accounts (view);
+        if (acct_list == NULL)
+            return NULL;
+        account = acct_list->data;
+        g_list_free(acct_list);
+        return account;
     }
     if (!gtk_tree_selection_get_selected (selection, &s_model, &s_iter))
     {

--- a/gnucash/gtkbuilder/dialog-account.glade
+++ b/gnucash/gtkbuilder/dialog-account.glade
@@ -431,6 +431,21 @@
               </packing>
             </child>
             <child>
+                <object class="GtkButton" id="cancelallbutton">
+                    <property name="label" translatable="yes">_Cancel All</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="can_default">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="use_underline">True</property>
+                </object>
+                <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">1</property>
+                </packing>
+            </child>
+            <child>
               <object class="GtkButton" id="deletebutton">
                 <property name="label" translatable="yes">_Delete</property>
                 <property name="visible">True</property>
@@ -442,8 +457,23 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
-                <property name="position">1</property>
+                <property name="position">2</property>
               </packing>
+            </child>
+            <child>
+                <object class="GtkButton" id="deleteallbutton">
+                    <property name="label" translatable="yes">_Delete All</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="can_default">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="use_underline">True</property>
+                </object>
+                <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">3</property>
+                </packing>
             </child>
           </object>
           <packing>
@@ -823,7 +853,9 @@
     </child>
     <action-widgets>
       <action-widget response="-6">cancelbutton</action-widget>
+      <action-widget response="-9">cancelallbutton</action-widget>
       <action-widget response="-3">deletebutton</action-widget>
+      <action-widget response="-8">deleteallbutton</action-widget>
     </action-widgets>
     <style>
       <class name="gnc-class-account"/>


### PR DESCRIPTION
The PR is meant as a continuation of multi_account_delete.
To make multi-account simpler I only allow multi-account editing of accounts under the same parent (for now).
The difficulty is to present the data to the user when the accounts have mismatched attributes. Generally, the UI indicates a mismatch (see below) and only when the user makes a selection is the mismatch removed and replaced by the user's selection. If the user does not change the mismatched attributes, they're not modified in the accounts.
Details:

- Mismatched strings are easy: show "mismatched".
- Mismatched flags are easy: the GTK button has a "inconsistent" state.
- Mismatched currency: I add a temporary fake currency "MULTIPLE" which is removed as soon as the user edits the currency.
- Mismatched colors: I don't have a good solution for that: the GTK color button does no offer a way to show "inconsistency". At the moment, I show gray, but that's not very good. Ideas welcome.
- Mismatched parents: Impossible given the current restriction (see above). Changing the parent is supported of course.
- Mismatched Account Types:
   . I switch to a multi-selection type view, and show the different types of the accounts as selected (so you'll see more than 1 type in blue)
   . As soon as the user selects a common type, I switch back to single-selection.

The entire thing is complicated by the fact that GTK does not differentiate (something_changed callbacks triggered when the code changes something internally), and (something_changed callback triggered because the user clicked something). Only when the user makes a selection should the mismatch be collapsed, not when callbacks are triggered internally. In addition, GTK does not have a way to temporary disable callbacks.
An example of this is if the user selects a different parent: this typically changes data in the account type tree/view but we do not want these to understood as if the user had made them.

The solution I'm using is a flag in the aw structure to indicate whether callbacks should be on or not.