### PR TITLE
Fix warnings: missing sentinel in function calls

### DIFF
--- a/gnucash/gnome/assistant-loan.cpp
+++ b/gnucash/gnome/assistant-loan.cpp
@@ -614,7 +614,7 @@ gnc_loan_assistant_create( LoanAssistantData *ldd )
 
             gtk_widget_set_halign (GTK_WIDGET(ldd->prmOrigPrincGAE), GTK_ALIGN_FILL);
             gtk_widget_set_hexpand (GTK_WIDGET(ldd->prmOrigPrincGAE), FALSE);
-            g_object_set (GTK_WIDGET(ldd->prmOrigPrincGAE), "margin", 2, NULL);
+            g_object_set (GTK_WIDGET(ldd->prmOrigPrincGAE), "margin", 2, nullptr);
 
             for ( i = 0; gas_data[i].loc != NULL; i++ )
             {
@@ -637,7 +637,7 @@ gnc_loan_assistant_create( LoanAssistantData *ldd )
 
                 gtk_widget_set_halign (GTK_WIDGET(gas), GTK_ALIGN_FILL);
                 gnc_account_sel_set_hexpand (GNC_ACCOUNT_SEL(gas), true);
-                g_object_set (GTK_WIDGET(gas), "margin", 2, NULL);
+                g_object_set (GTK_WIDGET(gas), "margin", 2, nullptr);
                 *(gas_data[i].loc) = gas;
             }
         }
@@ -679,7 +679,7 @@ gnc_loan_assistant_create( LoanAssistantData *ldd )
 
                 gtk_widget_set_halign (GTK_WIDGET( *gde_data[i].loc ), GTK_ALIGN_START);
                 gtk_widget_set_hexpand (GTK_WIDGET( *gde_data[i].loc ), FALSE);
-                g_object_set (GTK_WIDGET( *gde_data[i].loc ), "margin", 0, NULL);
+                g_object_set (GTK_WIDGET( *gde_data[i].loc ), "margin", 0, nullptr);
             }
 
         }
@@ -1858,25 +1858,25 @@ loan_rev_prep( GtkAssistant *assistant, gpointer user_data )
     renderer = gtk_cell_renderer_text_new();
     column = gtk_tree_view_column_new_with_attributes(_("Date"), renderer,
              "text", LOAN_COL_DATE,
-             NULL);
+             nullptr);
     gtk_tree_view_append_column(ldd->revView, column);
 
     renderer = gtk_cell_renderer_text_new();
     column = gtk_tree_view_column_new_with_attributes(_("Payment"), renderer,
              "text", LOAN_COL_PAYMENT,
-             NULL);
+             nullptr);
     gtk_tree_view_append_column(ldd->revView, column);
 
     renderer = gtk_cell_renderer_text_new();
     column = gtk_tree_view_column_new_with_attributes(_("Principal"), renderer,
              "text", LOAN_COL_PRINCIPAL,
-             NULL);
+             nullptr);
     gtk_tree_view_append_column(ldd->revView, column);
 
     renderer = gtk_cell_renderer_text_new();
     column = gtk_tree_view_column_new_with_attributes(_("Interest"), renderer,
              "text", LOAN_COL_INTEREST,
-             NULL);
+             nullptr);
     gtk_tree_view_append_column(ldd->revView, column);
 
     /* move the appropriate names over into the title array */
@@ -1891,7 +1891,7 @@ loan_rev_prep( GtkAssistant *assistant, gpointer user_data )
             column = gtk_tree_view_column_new_with_attributes
                      (ldd->ld.repayOpts[i]->name, renderer,
                       "text", LOAN_COL_INTEREST + col,
-                      NULL);
+                      nullptr);
             gtk_tree_view_append_column(ldd->revView, column);
             col++;
         }

--- a/gnucash/gnucash-core-app.cpp
+++ b/gnucash/gnucash-core-app.cpp
@@ -307,7 +307,7 @@ load_system_config(void)
 
     update_message("loading system configuration");
     system_config_dir = gnc_path_get_pkgsysconfdir();
-    system_config = g_build_filename(system_config_dir, "config", NULL);
+    system_config = g_build_filename(system_config_dir, "config", nullptr);
     is_system_config_loaded = gfec_try_load(system_config);
     g_free(system_config_dir);
     g_free(system_config);

--- a/gnucash/gnucash.cpp
+++ b/gnucash/gnucash.cpp
@@ -88,7 +88,7 @@ load_system_config(void)
 
     update_message("loading system configuration");
     system_config_dir = gnc_path_get_pkgsysconfdir();
-    system_config = g_build_filename(system_config_dir, "config", NULL);
+    system_config = g_build_filename(system_config_dir, "config", nullptr);
     is_system_config_loaded = gfec_try_load(system_config);
     g_free(system_config_dir);
     g_free(system_config);

--- a/libgnucash/backend/xml/sixtp-utils.cpp
+++ b/libgnucash/backend/xml/sixtp-utils.cpp
@@ -127,7 +127,7 @@ concatenate_child_result_chars (GSList* data_from_children)
         else
         {
             char* temp;
-            temp = g_strconcat (name, (gchar*) cr->data, NULL);
+            temp = g_strconcat (name, (gchar*) cr->data, nullptr);
             g_free (name);
             name = temp;
         }

--- a/libgnucash/core-utils/gnc-filepath-utils.cpp
+++ b/libgnucash/core-utils/gnc-filepath-utils.cpp
@@ -1235,7 +1235,7 @@ gnc_filepath_locate_file (const gchar *default_path, const gchar *name)
     if (g_path_is_absolute (name))
         fullname = g_strdup (name);
     else if (default_path)
-        fullname = g_build_filename (default_path, name, NULL);
+        fullname = g_build_filename (default_path, name, nullptr);
     else
         fullname = gnc_resolve_file_path (name);
 
@@ -1262,7 +1262,7 @@ gnc_filepath_locate_pixmap (const gchar *name)
     gchar *fullname;
     gchar* pkgdatadir = gnc_path_get_pkgdatadir ();
 
-    default_path = g_build_filename (pkgdatadir, "pixmaps", NULL);
+    default_path = g_build_filename (pkgdatadir, "pixmaps", nullptr);
     g_free(pkgdatadir);
     fullname = gnc_filepath_locate_file (default_path, name);
     g_free(default_path);
@@ -1277,7 +1277,7 @@ gnc_filepath_locate_ui_file (const gchar *name)
     gchar *fullname;
     gchar* pkgdatadir = gnc_path_get_pkgdatadir ();
 
-    default_path = g_build_filename (pkgdatadir, "ui", NULL);
+    default_path = g_build_filename (pkgdatadir, "ui", nullptr);
     g_free(pkgdatadir);
     fullname = gnc_filepath_locate_file (default_path, name);
     g_free(default_path);

--- a/libgnucash/engine/Account.cpp
+++ b/libgnucash/engine/Account.cpp
@@ -238,7 +238,7 @@ gchar *gnc_account_name_violations_errmsg (const gchar *separator, GList* invali
         {
             gchar *tmp_list = NULL;
 
-            tmp_list = g_strconcat (account_list, "\n", node->data, NULL );
+            tmp_list = g_strconcat (account_list, "\n", node->data, nullptr);
             g_free ( account_list );
             account_list = tmp_list;
         }
@@ -4750,7 +4750,7 @@ GetOrMakeOrphanAccount (Account *root, gnc_commodity * currency)
     }
 
     accname = g_strconcat (_("Orphaned Gains"), "-",
-                           gnc_commodity_get_mnemonic (currency), NULL);
+                           gnc_commodity_get_mnemonic (currency), nullptr);
 
     /* See if we've got one of these going already ... */
     acc = gnc_account_lookup_by_name(root, accname);

--- a/libgnucash/engine/qof-backend.cpp
+++ b/libgnucash/engine/qof-backend.cpp
@@ -102,7 +102,7 @@ QofBackend::register_backend(const char* directory, const char* module_name)
     {
         auto modname = g_strdup_printf ("lib%s.dylib", module_name);
         g_free (fullpath);
-        fullpath = g_build_filename (absdir, modname, NULL);
+        fullpath = g_build_filename (absdir, modname, nullptr);
         g_free (modname);
     }
     auto backend = g_module_open (fullpath, G_MODULE_BIND_LAZY);

--- a/libgnucash/engine/qofbook.cpp
+++ b/libgnucash/engine/qofbook.cpp
@@ -942,7 +942,7 @@ qof_book_normalize_counter_format_internal(const gchar *p,
 
     /* Copy the string we have so far and add normalized format specifier for long int */
     aux_str = g_strndup (base, p - base);
-    normalized_str = g_strconcat (aux_str, PRIi64, NULL);
+    normalized_str = g_strconcat (aux_str, PRIi64, nullptr);
     g_free (aux_str);
 
     /* Skip length modifier / conversion specifier */
@@ -974,7 +974,7 @@ qof_book_normalize_counter_format_internal(const gchar *p,
 
     /* Add the suffix to our normalized string */
     aux_str = normalized_str;
-    normalized_str = g_strconcat (aux_str, tmp, NULL);
+    normalized_str = g_strconcat (aux_str, tmp, nullptr);
     g_free (aux_str);
 
     /* If we end up here, the string was valid, so return no error

--- a/libgnucash/engine/qoflog.cpp
+++ b/libgnucash/engine/qoflog.cpp
@@ -221,7 +221,7 @@ qof_log_init_filename(const gchar* log_filename)
         if (fout != NULL && fout != stderr && fout != stdout)
             fclose(fout);
 
-        fname = g_strconcat(log_filename, ".XXXXXX.log", NULL);
+        fname = g_strconcat(log_filename, ".XXXXXX.log", nullptr);
 
         if ((fd = g_mkstemp(fname)) != -1)
         {
@@ -450,7 +450,7 @@ qof_log_parse_log_config(const char *filename)
         str = g_strdup_printf ("%d", logger_max_name_length);
         if (qof_logger_format)
             g_free (qof_logger_format);
-        qof_logger_format = g_strconcat ("* %s %*s <%-", str, ".", str, "s> %*s%s%s", NULL);
+        qof_logger_format = g_strconcat ("* %s %*s <%-", str, ".", str, "s> %*s%s%s", nullptr);
 
         g_free (str);
         g_strfreev(levels);


### PR DESCRIPTION
When compiling with `-Werror`,  GNUCash fails to build due to various `error: missing sentinel in function call`.
This patch resolves the issue by passing the appropriate sentinels.