### PR TITLE
I18N: Add po copyright-holder

### DIFF
--- a/po/gnucash-pot.cmake
+++ b/po/gnucash-pot.cmake
@@ -32,6 +32,7 @@ execute_process(
                         --keyword=translate:1c,2,3,4t
                         --package-name=${PACKAGE_NAME}
                         --package-version=${PROJECT_VERSION}
+                        --copyright-holder=by\ the\ GnuCash\ developers\ and\ the\ translators:
                         --msgid-bugs-address=https://bugs.gnucash.org/enter_bug.cgi?product=GnuCash&component=Translations
   WORKING_DIRECTORY ${PO_BIN_DIR}
   RESULT_VARIABLE GNUCASH_POT_RESULT


### PR DESCRIPTION
I watched, the copyright holder of new po[t] files is currently set to:
`# Copyright (C) 2020 THE GnuCash'S COPYRIGHT HOLDER`

 The commit would set it to "by the translators:"
because the individual (C) comments follow.

Should it stay 

- in this form or 
- be set in a variable,
-  - here or
-  -  more up in the hierarchy?


Older files have:
`Free Software Foundation, Inc.`: old default, OK for files from TP
`THE PACKAGE'S COPYRIGHT HOLDER`: Default, if no package is set
`Gnumatic, Inc.`: dissolved
`gnucash project`
`C-DAC, GIST, Pune, India`.: OK
`by the translators`
`by the respective translator`
Individuals

An interesting aspect from the gettext manual: The msgids were created by the programmers.