### PR TITLE
General progress

### DIFF
--- a/gnucash/gnome-utils/dialog-file-access.c
+++ b/gnucash/gnome-utils/dialog-file-access.c
@@ -161,6 +161,7 @@ gnc_ui_file_access_response_cb(GtkDialog *dialog, gint response, GtkDialog *unus
         break;
 
     case GTK_RESPONSE_CANCEL:
+    case GTK_RESPONSE_DELETE_EVENT:
         break;
 
     default:

--- a/gnucash/gnome-utils/dialog-file-access.c
+++ b/gnucash/gnome-utils/dialog-file-access.c
@@ -343,6 +343,7 @@ gnc_ui_file_access (GtkWindow *parent, int type)
             faw->starting_dir = g_path_get_dirname( filepath );
             g_free ( filepath );
         }
+        g_free (last);
     }
     if (!faw->starting_dir)
         faw->starting_dir = gnc_get_default_directory(settings_section);

--- a/gnucash/gnome-utils/gnc-plugin-file-history.c
+++ b/gnucash/gnome-utils/gnc-plugin-file-history.c
@@ -256,6 +256,7 @@ gnc_history_remove_file (const char *oldfile)
                 }
                 j++;
             }
+            g_free (filename);
         }
         g_free(from);
     }
@@ -283,12 +284,18 @@ gboolean gnc_history_test_for_file (const char *oldfile)
         filename = gnc_prefs_get_string(GNC_PREFS_GROUP_HISTORY, from);
         g_free(from);
 
-        if (filename && (g_utf8_collate(oldfile, filename) == 0))
+        if (!filename)
+            continue;
+
+        if (g_utf8_collate(oldfile, filename) == 0)
         {
             found = TRUE;
+            g_free (filename);
             break;
         }
+        g_free (filename);
     }
+
     return found;
 }
 
@@ -488,7 +495,7 @@ gnc_plugin_history_list_changed (gpointer prefs,
                                  gpointer user_data)
 {
     GncMainWindow *window;
-    const gchar *filename;
+    gchar *filename;
     gint index;
 
     ENTER("");
@@ -509,6 +516,7 @@ gnc_plugin_history_list_changed (gpointer prefs,
 
     filename = gnc_prefs_get_string (GNC_PREFS_GROUP_HISTORY, pref);
     gnc_history_update_action (window, index, filename);
+    g_free (filename);
 
     gnc_main_window_actions_updated (window);
     LEAVE("");

--- a/gnucash/gnome/dialog-print-check.c
+++ b/gnucash/gnome/dialog-print-check.c
@@ -609,8 +609,11 @@ gnc_ui_print_restore_dialog(PrintCheckDialog *pcd)
     if (guid == NULL)
         gtk_combo_box_set_active(GTK_COMBO_BOX(pcd->format_combobox), 0);
     else if (strcmp(guid, "custom") == 0)
+    {
         gtk_combo_box_set_active(GTK_COMBO_BOX(pcd->format_combobox),
                                  pcd->format_max - 1);
+        g_free (guid);
+    }
     else
     {
         model = gtk_combo_box_get_model(GTK_COMBO_BOX(pcd->format_combobox));
@@ -622,7 +625,9 @@ gnc_ui_print_restore_dialog(PrintCheckDialog *pcd)
         {
             gtk_combo_box_set_active(GTK_COMBO_BOX(pcd->format_combobox), 0);
         }
+        g_free (guid);
     }
+
     active = gnc_prefs_get_int(GNC_PREFS_GROUP, GNC_PREF_CHECK_POSITION);
 
     /* If the check format used last time no longer exists, then the saved check

--- a/gnucash/gnome/gnc-plugin-page-report.c
+++ b/gnucash/gnome/gnc-plugin-page-report.c
@@ -1753,34 +1753,23 @@ static gchar *report_create_jobname(GncPluginPageReportPrivate *priv)
 
     {
         // Look up the date format that was chosen in the preferences database
-        QofDateFormat date_format_here;
-        QofDateFormat date_format_old = qof_date_format_get();
-        char *format_code = gnc_prefs_get_string(GNC_PREFS_GROUP_REPORT_PDFEXPORT,
-                            GNC_PREF_FILENAME_DATE_FMT);
+        QofDateFormat date_format_here = QOF_DATE_FORMAT_ISO;
+        char *format_code = gnc_prefs_get_string (GNC_PREFS_GROUP_REPORT_PDFEXPORT,
+                                                  GNC_PREF_FILENAME_DATE_FMT);
+        const gchar *date_format_string;
         if (*format_code == '\0')
         {
             g_free(format_code);
             format_code = g_strdup("locale");
         }
 
-        if (gnc_date_string_to_dateformat(format_code, &date_format_here))
-        {
-            PERR("Incorrect date format code");
-            if (format_code != NULL)
-                free(format_code);
-        }
+        if (gnc_date_string_to_dateformat (format_code, &date_format_here))
+            PERR("Incorrect date format code, using ISO-8601.");
 
-        // To apply this chosen date format, temporarily switch the
-        // process-wide default to our chosen date format. Note: It is a
-        // totally brain-dead implementation of qof_print_date() to not offer a
-        // variation where the QofDateFormat can be passed as an argument.
-        // Hrmpf.
-        qof_date_format_set(date_format_here);
+        date_format_string = qof_date_format_get_string (date_format_here);
 
-        job_date = qof_print_date( time( NULL ) );
-
-        // Restore to the original general  date format
-        qof_date_format_set(date_format_old);
+        job_date = gnc_print_time64 (gnc_time (NULL), date_format_string);
+        g_free (format_code);
     }
 
 

--- a/gnucash/report/reports/standard/balance-forecast.scm
+++ b/gnucash/report/reports/standard/balance-forecast.scm
@@ -169,6 +169,7 @@ date point, a projected minimum balance including scheduled transactions."))
                         price currency
                         (gnc:accounts-get-commodities accounts #f)
                         to-date #f #f))
+          (iso-date (qof-date-format-get-string QOF-DATE-FORMAT-ISO))
           (accounts-balancelist
            (map
             (lambda (acc)
@@ -281,11 +282,10 @@ date point, a projected minimum balance including scheduled transactions."))
         (gnc:html-chart-set-y-axis-label!
          chart (gnc-commodity-get-mnemonic currency))
         ;; Set series labels
-        (let ((old-fmt (qof-date-format-get)))
-          (qof-date-format-set QOF-DATE-FORMAT-ISO)
-          (gnc:html-chart-set-data-labels!
-           chart (map qof-print-date (map cadr intervals)))
-          (qof-date-format-set old-fmt))
+        (gnc:html-chart-set-data-labels!
+         chart (map (lambda (data)
+                      (gnc-print-time64 (cadr data) iso-date))
+                    intervals))
 
         ;; Set currency symbol
         (gnc:html-chart-set-currency-iso!

--- a/gnucash/report/reports/standard/category-barchart.scm
+++ b/gnucash/report/reports/standard/category-barchart.scm
@@ -26,6 +26,7 @@
 (define-module (gnucash reports standard category-barchart))
 (use-modules (srfi srfi-1))
 (use-modules (srfi srfi-9))
+(use-modules (srfi srfi-26))
 (use-modules (ice-9 match))
 (use-modules (gnucash engine))
 (use-modules (gnucash utilities))
@@ -640,8 +641,7 @@ developing over time"))
 
              (cond
               ((eq? export-type 'csv)
-               (let ((old-fmt (qof-date-format-get)))
-                 (qof-date-format-set QOF-DATE-FORMAT-ISO)
+               (let ((iso-date (qof-date-format-get-string QOF-DATE-FORMAT-ISO)))
                  (gnc:html-document-set-export-string
                   document
                   (gnc:lists->csv
@@ -665,9 +665,8 @@ developing over time"))
                              (if (pair? (cdr all-data))
                                  (list (apply gnc:monetary+ row))
                                  '())))
-                          (map qof-print-date dates-list)
-                          (apply zip (map cadr all-data))))))
-                 (qof-date-format-set old-fmt)))))
+                          (map (cut gnc-print-time64 <> iso-date) dates-list)
+                          (apply zip (map cadr all-data))))))))))
 
            ;; else if empty data
            (gnc:html-document-add-object!

--- a/gnucash/report/reports/standard/net-charts.scm
+++ b/gnucash/report/reports/standard/net-charts.scm
@@ -444,8 +444,7 @@
 
              (cond
               ((eq? export-type 'csv)
-               (let ((old-fmt (qof-date-format-get)))
-                 (qof-date-format-set QOF-DATE-FORMAT-ISO)
+               (let ((iso-date (qof-date-format-get-string QOF-DATE-FORMAT-ISO)))
                  (gnc:html-document-set-export-string
                   document
                   (gnc:lists->csv
@@ -453,10 +452,9 @@
                              (map G_ '("Date" "Income" "Expense" "Net Profit"))
                              (map G_ '("Date" "Assets" "Liabilities" "Net Worth")))
                          (map list
-                              (map qof-print-date dates-list)
+                              (map (cut gnc-print-time64 <> iso-date) dates-list)
                               minuend-balances
-                              subtrahend-balances difference-balances))))
-                 (qof-date-format-set old-fmt)))))
+                              subtrahend-balances difference-balances))))))))
            (gnc:html-document-add-object!
             document
             (gnc:html-make-empty-data-warning

--- a/gnucash/report/trep-engine.scm
+++ b/gnucash/report/trep-engine.scm
@@ -2266,20 +2266,19 @@ warning will be removed in GnuCash 5.0"))
 
           (cond
            ((eq? export-type 'csv)
-            (let ((old-date-fmt (qof-date-format-get))
-                  (dummy (qof-date-format-set QOF-DATE-FORMAT-ISO))
-                  (infolist
-                   (list
-                    (list "from" (qof-print-date begindate))
-                    (list "to" (qof-print-date enddate)))))
-              (qof-date-format-set old-date-fmt)
-              (cond
-               ((list? csvlist)
+            (cond
+             ((pair? csvlist)
+              (let ((iso-date (qof-date-format-get-string QOF-DATE-FORMAT-ISO)))
                 (gnc:html-document-set-export-string
-                 document (lists->csv (append infolist csvlist))))
+                 document
+                 (lists->csv
+                  (cons*
+                   `("from" ,(gnc-print-time64 begindate iso-date))
+                   `("to" ,(gnc-print-time64 enddate iso-date))
+                   csvlist)))))
 
-               (else
-                (gnc:html-document-set-export-error document csvlist)))))))))))
+             (else
+              (gnc:html-document-set-export-error document csvlist))))))))))
 
     (gnc:report-finished)
 


### PR DESCRIPTION
Main improvement is use  api `gnc_print_time64` which accepts time64 and date format string. Allows reports and other code to format time64 to string without saving/setting/restoring current QofDateFormat.

Also a few other C cleanups - gnc_prefs_get_string always returns a newly-allocated string which must be g_freed.