### PR TITLE
[gnc-plugin-page-register] Goto Date

### DIFF
--- a/gnucash/ui/gnc-plugin-page-register-ui.xml
+++ b/gnucash/ui/gnc-plugin-page-register-ui.xml
@@ -48,6 +48,7 @@
         <menuitem name="ActionLots" action="ActionsLotsAction"/>
         <separator name="ActionsSep4"/>
         <menuitem name="BlankTransaction" action="BlankTransactionAction"/>
+        <menuitem name="GotoDate" action="GotoDateAction"/>
         <menuitem name="SplitTransaction" action="SplitTransactionAction"/>
         <menuitem name="EditExchangeRate" action="EditExchangeRateAction"/>
         <menuitem name="ScheduleTransaction" action="ScheduleTransactionAction"/>
@@ -106,6 +107,7 @@
       <menuitem name="JumpAssociateInvoice" action="JumpAssociatedInvoiceAction"/>
       <separator name="PopupSep5"/>
       <menuitem name="BlankTransaction" action="BlankTransactionAction"/>
+      <menuitem name="GotoDate" action="GotoDateAction"/>
       <menuitem name="SplitTransaction" action="SplitTransactionAction"/>
       <menuitem name="EditExchangeRate" action="EditExchangeRateAction"/>
       <menuitem name="ScheduleTransaction" action="ScheduleTransactionAction"/>


### PR DESCRIPTION
Adds ability to jump to arbitrary date.

Finds first split whose posted date >= specified date, and jump to it.

Works best when the register is sorted by posted-date. Also works with other sorting, although it'll jump to the first split found whose posted_date >= specified_date. Not sure if we need to offer clear filter prompt.

@gjanssens 

![image](https://user-images.githubusercontent.com/1975870/91975521-0a38ac00-ed0f-11ea-98ba-1e96453a90d7.png)
