### PR TITLE
Scrubbing and Gtk improvements

### DIFF
--- a/gnucash/gnome-utils/dialog-utils.c
+++ b/gnucash/gnome-utils/dialog-utils.c
@@ -535,6 +535,11 @@ gnc_handle_date_accelerator (GdkEventKey *event,
             g_date_to_struct_tm (&gdate, tm);
         return TRUE;
 
+    case GDK_KEY_question:
+        /* Translators: the []-+MHYRT keyboard shortcuts are hard coded
+           and are not localizable */
+        gnc_info_dialog (NULL, "%s", _("This is a date field. Keyboard shortcuts are available: \n- previous day\n+ next day\nshift- previous week\nshift+ next week\n[,alt- previous month \n],alt+ next month\nctrl- previous year\nctrl+next year\nM beginning of month\nH end of month\nY beginning of year\nR end of year\nT today"));
+        return TRUE;
     default:
         break;
     }

--- a/gnucash/gnome-utils/gnc-date-edit.c
+++ b/gnucash/gnome-utils/gnc-date-edit.c
@@ -884,6 +884,9 @@ create_children (GNCDateEdit *gde)
     gtk_container_add (GTK_CONTAINER (gde->date_button), hbox);
     gtk_widget_show (GTK_WIDGET(hbox));
 
+    gtk_widget_set_tooltip_text (gde->date_entry,
+                                 _("This is a date field. Keyboard shortcuts are available: \n- previous day\n+ next day\nshift- previous week\nshift+ next week\n[,alt- previous month \n],alt+ next month\nctrl- previous year\nctrl+next year\nM beginning of month\nH end of month\nY beginning of year\nR end of year\nT today"));
+
     /* Calendar label, only shown if the date editor has a time field */
     gde->cal_label = gtk_label_new (_("Calendar"));
     gnc_label_set_alignment (gde->cal_label, 0.0, 0.5);

--- a/gnucash/register/register-gnome/datecell-gnome.c
+++ b/gnucash/register/register-gnome/datecell-gnome.c
@@ -623,6 +623,8 @@ gnc_date_cell_realize (BasicCell *bcell, gpointer data)
     box->item_edit = item_edit;
     box->date_picker = GNC_DATE_PICKER (gnc_date_picker_new ());
     gtk_widget_show_all (GTK_WIDGET(box->date_picker));
+    gtk_widget_set_tooltip_text (GTK_WIDGET(item_edit),
+                                 _("This is a date field. Keyboard shortcuts are available: \n- previous day\n+ next day\nshift- previous week\nshift+ next week\n[,alt- previous month \n],alt+ next month\nctrl- previous year\nctrl+next year\nM beginning of month\nH end of month\nY beginning of year\nR end of year\nT today"));
     g_object_ref_sink(box->date_picker);
 
     /* to mark cell as realized, remove the realize method */


### PR DESCRIPTION
Following https://github.com/Gnucash/gnucash/pull/779#issuecomment-688584221

Scrubbing (either from account-tree or register) can be aborted by pressing Escape key. Simpler than an abort button.