### PR TITLE
Call to flatten bayesian import_map gets percentfunc

### DIFF
--- a/gnucash/gnome/gnc-plugin-page-account-tree.c
+++ b/gnucash/gnome/gnc-plugin-page-account-tree.c
@@ -1939,6 +1939,9 @@ gnc_plugin_page_account_tree_cmd_scrub (GtkAction *action, GncPluginPageAccountT
 
     g_return_if_fail (account != NULL);
 
+    gnc_account_check_import_map_data (gnc_get_current_book (),
+                                       (QofPercentageFunc*)gnc_window_show_progress);
+
     prepare_scrubbing ();
 
     window = GNC_WINDOW(GNC_PLUGIN_PAGE (page)->window);

--- a/libgnucash/engine/Account.h
+++ b/libgnucash/engine/Account.h
@@ -256,6 +256,9 @@ void gnc_book_set_root_account(QofBook *book, Account *root);
 
 /** @} */
 
+/* check import mapping for flattening */
+void gnc_account_check_import_map_data (QofBook *book, QofPercentageFunc *percentage_func);
+
 /** Composes a translatable error message showing which account
  *  names clash with the current account separator. Can be called
  *  after gnc_account_list_name_violations to have a consistent


### PR DESCRIPTION
Attempt to augment account.cpp's `check_import_map_data` to receive a `QofPercentageFunc` argument which is usually `gnc_window_show_progress`.

Ultimately the old code to call `check_import_map_data` will silently upgrade the import map, and new code runnable from UI will upgrade the import map *and* update progressbar. Also not sure which UI call to trigger the conversion -- I've added the trigger into account-tree scrub as a temporary hack.

But I can't figure out how to pass a pointer to callback to `gnc_account_check_import_map_data`, which is skipped if the `QofPercentageFunc` is `nullptr`.
