### PR TITLE
Bug797945 - Imap Changes

### DIFF
--- a/gnucash/gnome-utils/gnc-file.c
+++ b/gnucash/gnome-utils/gnc-file.c
@@ -119,7 +119,7 @@ gnc_file_dialog_int (GtkWindow *parent,
                    NULL);
     if (multi)
         gtk_file_chooser_set_select_multiple (GTK_FILE_CHOOSER (file_box), TRUE);
-    
+
     if (ok_icon)
         gnc_gtk_dialog_add_button(file_box, okbutton, ok_icon, GTK_RESPONSE_ACCEPT);
     else

--- a/gnucash/gnome-utils/gnc-file.c
+++ b/gnucash/gnome-utils/gnc-file.c
@@ -1140,6 +1140,10 @@ gnc_file_open_file (GtkWindow *parent, const char * newfile, gboolean open_reado
     if (!gnc_file_query_save (parent, TRUE))
         return FALSE;
 
+    /* Reset the flag that indicates the conversion of the bayes KVP
+     * entries has been run */
+    gnc_account_reset_convert_bayes_to_flat ();
+
     return gnc_post_file_open (parent, newfile, open_readonly);
 }
 

--- a/gnucash/gnome/gnc-plugin-basic-commands.c
+++ b/gnucash/gnome/gnc-plugin-basic-commands.c
@@ -449,6 +449,10 @@ gnc_main_window_cmd_file_open (GtkAction *action, GncMainWindowActionData *data)
     if (!gnc_main_window_all_finish_pending())
         return;
 
+    /* Reset the flag that indicates the conversion of the bayes KVP
+     * entries has been run */
+    gnc_account_reset_convert_bayes_to_flat ();
+
     gnc_window_set_progressbar_window (GNC_WINDOW(data->window));
 #ifdef HAVE_DBI_DBI_H
     gnc_ui_file_access_for_open (GTK_WINDOW (data->window));

--- a/libgnucash/engine/Account.cpp
+++ b/libgnucash/engine/Account.cpp
@@ -55,6 +55,9 @@ static QofLogModule log_module = GNC_MOD_ACCOUNT;
 /* The Canonical Account Separator.  Pre-Initialized. */
 static gchar account_separator[8] = ".";
 static gunichar account_uc_separator = ':';
+
+static bool imap_convert_bayes_to_flat_run = false;
+
 /* Predefined KVP paths */
 static const std::string KEY_ASSOC_INCOME_ACCOUNT("ofx/associated-income-account");
 static const std::string KEY_RECONCILE_INFO("reconcile-info");
@@ -5602,6 +5605,12 @@ imap_convert_bayes_to_flat (QofBook * book)
     return ret;
 }
 
+void
+gnc_account_reset_convert_bayes_to_flat (void)
+{
+    imap_convert_bayes_to_flat_run = false;
+}
+
 /*
  * Here we check to see the state of import map data.
  *
@@ -5616,10 +5625,13 @@ imap_convert_bayes_to_flat (QofBook * book)
 static void
 check_import_map_data (QofBook *book)
 {
-    if (gnc_features_check_used (book, GNC_FEATURE_GUID_FLAT_BAYESIAN))
+    if (gnc_features_check_used (book, GNC_FEATURE_GUID_FLAT_BAYESIAN) ||
+        imap_convert_bayes_to_flat_run)
         return;
+
     /* This function will set GNC_FEATURE_GUID_FLAT_BAYESIAN if necessary.*/
     imap_convert_bayes_to_flat (book);
+    imap_convert_bayes_to_flat_run = true;
 }
 
 static constexpr double threshold = .90 * probability_factor; /* 90% */

--- a/libgnucash/engine/Account.cpp
+++ b/libgnucash/engine/Account.cpp
@@ -992,7 +992,7 @@ gnc_account_class_init (AccountClass *klass)
                            "added before reconcile.",
                            FALSE,
                            static_cast<GParamFlags>(G_PARAM_READWRITE)));
-    
+
     g_object_class_install_property
     (gobject_class,
      PROP_PLACEHOLDER,
@@ -1865,12 +1865,12 @@ gnc_account_set_balance_dirty (Account *acc)
 void gnc_account_set_defer_bal_computation (Account *acc, gboolean defer)
 {
     AccountPrivate *priv;
-    
+
     g_return_if_fail (GNC_IS_ACCOUNT (acc));
-    
+
     if (qof_instance_get_destroying (acc))
         return;
-    
+
     priv = GET_PRIVATE (acc);
     priv->defer_bal_computation = defer;
 }

--- a/libgnucash/engine/Account.h
+++ b/libgnucash/engine/Account.h
@@ -360,7 +360,7 @@ void gnc_account_set_balance_dirty (Account *acc);
  *
  *  @param acc Set the flag on this account. */
 void gnc_account_set_sort_dirty (Account *acc);
-    
+
 /** Set the defer balance flag. If defer is true, the account balance
  * is not automatically computed, which can save a lot of time if
  * multiple operations have to be done on the same account. If
@@ -371,7 +371,7 @@ void gnc_account_set_sort_dirty (Account *acc);
  *
  *  @param defer New value for the flag. */
 void gnc_account_set_defer_bal_computation (Account *acc, gboolean defer);
-    
+
 /** Insert the given split from an account.
  *
  *  @param acc The account to which the split should be added.
@@ -976,7 +976,7 @@ guint32 xaccAccountTypesValid(void);
  *  Asset or Liability type, but not a business account type
  *  (meaning not an Accounts Payable/Accounts Receivable). */
 gboolean xaccAccountIsAssetLiabType(GNCAccountType t);
-    
+
 /** Convenience function to return the fundamental type
  * asset/liability/income/expense/equity given an account type. */
 GNCAccountType xaccAccountTypeGetFundamental (GNCAccountType t);
@@ -1224,7 +1224,7 @@ void xaccAccountSetHidden (Account *acc, gboolean val);
  *  @return Whether or not this account should be "hidden". */
 gboolean xaccAccountIsHidden (const Account *acc);
 /** @} */
-    
+
 /** @name Account Auto Interest flag
  @{
  */

--- a/libgnucash/engine/Account.h
+++ b/libgnucash/engine/Account.h
@@ -1504,6 +1504,11 @@ void gnc_account_delete_map_entry (Account *acc, char *head, char *category,
  */
 void gnc_account_delete_all_bayes_maps (Account *acc);
 
+/** Reset the flag that indicates the function imap_convert_bayes_to_flat
+ *  has been run
+ */
+void gnc_account_reset_convert_bayes_to_flat (void);
+
 /** @} */
 
 

--- a/libgnucash/engine/test/gtest-import-map.cpp
+++ b/libgnucash/engine/test/gtest-import-map.cpp
@@ -345,6 +345,8 @@ TEST_F(ImapBayesTest, ConvertBayesData)
     root->set_path({IMAP_FRAME_BAYES, sausage, "Expense#Drink"}, val3);
     root->set_path({IMAP_FRAME_BAYES, foo, "Expense#Food"}, new KvpValue{*val2});
     root->set_path({IMAP_FRAME_BAYES, salt, acct1_guid}, new KvpValue{*val1});
+    /* make sure to reset the conversion has been run flag */
+    gnc_account_reset_convert_bayes_to_flat ();
     /*Calling into the imap functions should trigger a conversion.*/
     gnc_account_imap_add_account_bayes(t_imap, t_list5, t_expense_account2); //pork and sausage; account Food
     // convert from 'Asset-Bank' to 'Asset-Bank' guid


### PR DESCRIPTION
I was going to push this but decided to create a PR instead for comment.

This is a follow up to John's recent push which stops the imap convert to flat from running the same number of times equal to the number accounts in the list when there are no bayes KVP. With no bayes KVP entries the feature GNC_FEATURE_GUID_FLAT_BAYESIAN will never be set.

I think it is OK.