### PR TITLE
Maint deprecate xacc account count splits

### DIFF
--- a/gnucash/gnome-utils/dialog-account.c
+++ b/gnucash/gnome-utils/dialog-account.c
@@ -1389,7 +1389,7 @@ gnc_account_window_create(GtkWindow *parent, AccountWindow *aw)
                          &aw->commodity_mode);
 
     // If the account has transactions, prevent changes by displaying a label and tooltip
-    if (xaccAccountCountSplits (aw_get_account (aw), FALSE) > 0)
+    if (xaccAccountGetSplitList (aw_get_account (aw)) != NULL)
     {
         const gchar *sec_name = gnc_commodity_get_printname (xaccAccountGetCommodity(aw_get_account (aw)));
         GtkWidget *label = gtk_label_new (sec_name);
@@ -1473,7 +1473,7 @@ gnc_account_window_create(GtkWindow *parent, AccountWindow *aw)
     //   immutable if gnucash depends on details that would be lost/missing
     //   if changing from/to such a type. At the time of this writing the
     //   immutable types are AR, AP and trading types.
-    if (xaccAccountCountSplits (aw_get_account (aw), FALSE) > 0)
+    if (xaccAccountGetSplitList (aw_get_account (aw)) != NULL)
     {
         GNCAccountType atype = xaccAccountGetType (aw_get_account (aw));
         compat_types = xaccAccountTypesCompatibleWith (atype);

--- a/gnucash/gnome-utils/gnc-tree-view-account.c
+++ b/gnucash/gnome-utils/gnc-tree-view-account.c
@@ -2046,7 +2046,7 @@ gnc_plugin_page_account_tree_filter_accounts (Account *account,
 
     if (!fd->show_unused)
     {
-        if (xaccAccountCountSplits(account, TRUE) == 0)
+        if (gnc_account_and_descendants_empty(account))
         {
             LEAVE(" hide: unused");
             return FALSE;

--- a/gnucash/gnome/dialog-find-account.c
+++ b/gnucash/gnome/dialog-find-account.c
@@ -189,7 +189,7 @@ fill_model (GtkTreeModel *model, Account *account)
 {
     GtkTreeIter   iter;
     gchar        *fullname = gnc_account_get_full_name (account);
-    gint          splits = xaccAccountCountSplits (account, TRUE);
+    gboolean      acc_empty = gnc_account_and_descendants_empty (account);
     gnc_numeric   total = xaccAccountGetBalanceInCurrency (account, NULL, TRUE);
 
     PINFO("Add to Store: Account '%s'", fullname);
@@ -200,7 +200,7 @@ fill_model (GtkTreeModel *model, Account *account)
                         ACC_FULL_NAME, fullname, ACCOUNT, account,
                         PLACE_HOLDER, (xaccAccountGetPlaceholder (account) == TRUE ? "emblem-default" : NULL),
                         HIDDEN, (xaccAccountGetHidden (account) == TRUE ? "emblem-default" : NULL),
-                        NOT_USED, (splits == 0 ? "emblem-default" : NULL),
+                        NOT_USED, (acc_empty ? "emblem-default" : NULL),
                         BAL_ZERO, (gnc_numeric_zero_p (total) == TRUE ? "emblem-default" : NULL),
                         TAX, (xaccAccountGetTaxRelated (account) == TRUE ? "emblem-default" : NULL), -1);
     g_free (fullname);

--- a/gnucash/gnome/gnc-plugin-page-account-tree.c
+++ b/gnucash/gnome/gnc-plugin-page-account-tree.c
@@ -1643,7 +1643,7 @@ gnc_plugin_page_account_tree_cmd_delete_account (GtkAction *action, GncPluginPag
     }
 
     // If no transaction or children just delete it.
-    if (!(xaccAccountCountSplits (account, FALSE) ||
+    if (!(xaccAccountGetSplitList (account) != NULL ||
           gnc_account_n_children (account)))
     {
         do_delete_account (account, NULL, NULL, NULL);

--- a/libgnucash/engine/Account.cpp
+++ b/libgnucash/engine/Account.cpp
@@ -3933,11 +3933,11 @@ xaccAccountFindOpenLots (const Account *acc,
             continue;
 
         /* Ok, this is a valid lot.  Add it to our list of lots */
-        if (sort_func)
-            retval = g_list_insert_sorted (retval, lot, sort_func);
-        else
-            retval = g_list_prepend (retval, lot);
+        retval = g_list_prepend (retval, lot);
     }
+
+    if (sort_func)
+        retval = g_list_sort (retval, sort_func);
 
     return retval;
 }

--- a/libgnucash/engine/Account.cpp
+++ b/libgnucash/engine/Account.cpp
@@ -3887,6 +3887,20 @@ xaccAccountCountSplits (const Account *acc, gboolean include_children)
     return nr;
 }
 
+gboolean gnc_account_and_descendants_empty (Account *acc)
+{
+    g_return_val_if_fail (GNC_IS_ACCOUNT (acc), FALSE);
+    if (xaccAccountGetSplitList (acc)) return FALSE;
+    auto empty = TRUE;
+    auto *children = gnc_account_get_children (acc);
+    for (auto *n = children; n && empty; n = n->next)
+    {
+        empty = gnc_account_and_descendants_empty ((Account*)n->data);
+    }
+    g_list_free (children);
+    return empty;
+}
+
 LotList *
 xaccAccountGetLotList (const Account *acc)
 {

--- a/libgnucash/engine/Account.h
+++ b/libgnucash/engine/Account.h
@@ -256,6 +256,12 @@ void gnc_book_set_root_account(QofBook *book, Account *root);
 
 /** @} */
 
+/*  Tests account and descendants -- if all have no splits then return TRUE.
+ *  Otherwise if any account or its descendants have split return FALSE.
+ */
+
+gboolean gnc_account_and_descendants_empty (Account *acc);
+
 /** Composes a translatable error message showing which account
  *  names clash with the current account separator. Can be called
  *  after gnc_account_list_name_violations to have a consistent
@@ -1020,7 +1026,9 @@ SplitList* xaccAccountGetSplitList (const Account *account);
 
 
 /** The xaccAccountCountSplits() routine returns the number of all
- *    the splits in the account.
+ *    the splits in the account. xaccAccountCountSplits is O(N). if
+ *    testing for emptiness, use xaccAccountGetSplitList != NULL.
+
  * @param acc the account for which to count the splits
  *
  * @param include_children also count splits in descendants (TRUE) or

--- a/libgnucash/engine/gncOwner.c
+++ b/libgnucash/engine/gncOwner.c
@@ -1045,12 +1045,14 @@ gncOwnerSetLotLinkMemo (Transaction *ll_txn)
 
         title = g_strdup_printf ("%s %s", gncInvoiceGetTypeString (invoice), gncInvoiceGetID (invoice));
 
-        titles = g_list_insert_sorted (titles, title, (GCompareFunc)g_strcmp0);
+        titles = g_list_prepend (titles, title);
         splits = g_list_prepend (splits, split); // splits don't need to be sorted
     }
 
     if (!titles)
         return; // We didn't find document lots
+
+    titles = g_list_sort (titles, (GCompareFunc)g_strcmp0);
 
     // Create the memo as we'd want it to be
     new_memo = g_strconcat (memo_prefix, titles->data, NULL);

--- a/libgnucash/engine/test/utest-Invoice.c
+++ b/libgnucash/engine/test/utest-Invoice.c
@@ -175,6 +175,12 @@ test_invoice_post ( Fixture *fixture, gconstpointer pData )
     g_assert(!gncInvoiceIsPosted(fixture->invoice));
 }
 
+static gboolean account_has_one_split (const Account *acc)
+{
+    GList *splits = xaccAccountGetSplitList (acc);
+    return (splits && !(splits->next));
+}
+
 static void
 test_invoice_posted_trans ( Fixture *fixture, gconstpointer pData )
 {
@@ -183,8 +189,8 @@ test_invoice_posted_trans ( Fixture *fixture, gconstpointer pData )
     gnc_numeric total = gncInvoiceGetTotal(fixture->invoice);
     gnc_numeric acct_balance, acct2_balance;
 
-    g_assert (1 == xaccAccountCountSplits (fixture->account, FALSE));
-    g_assert (1 == xaccAccountCountSplits (fixture->account2, FALSE));
+    g_assert (account_has_one_split (fixture->account));
+    g_assert (account_has_one_split (fixture->account2));
 
     acct_balance = xaccAccountGetBalance(fixture->account);
     acct2_balance = xaccAccountGetBalance(fixture->account2);


### PR DESCRIPTION
I'll put forward the claim that xaccAccountCountSplits is poorly used; the exact number of splits is hardly useful and the information desired can be gleaned much more effectively using `xaccAccountGetSplitList` or `gnc_account_and_descendants_empty`, a new method. I'd hope these commits are self explanatory and will be welcome.