### PR TITLE
Disable initial report animation

### DIFF
--- a/gnucash/report/html-chart.scm
+++ b/gnucash/report/html-chart.scm
@@ -155,6 +155,8 @@
                  (cons 'datasets #())))
     (cons 'options (list
                     (cons 'maintainAspectRatio #f)
+                    (cons 'animation (list
+                                      (cons 'duration 0)))
                     (cons 'chartArea (list
                                       (cons 'backgroundColor "#fffdf6")))
                     (cons 'legend (list

--- a/gnucash/report/reports/standard/budget-barchart.scm
+++ b/gnucash/report/reports/standard/budget-barchart.scm
@@ -204,8 +204,8 @@
       (gnc:html-chart-set-y-axis-label! chart (gnc-commodity-get-mnemonic curr))
 
       ;; disable animation; with multiple accounts selected this report
-      ;; will create several charts, all will want to animate
-      (gnc:html-chart-set! chart '(options animation duration) 0)
+      ;; will create several charts, all will want to animate. Initial
+      ;; animation is already disabled globally.
       (gnc:html-chart-set! chart '(options hover animationDuration) 0)
       (gnc:html-chart-set! chart '(options responsiveAnimationDuration) 0)
       (gnc:html-chart-set-title!


### PR DESCRIPTION
Previously, every reload caused the chart to move through an animation, which
prevented visual comparison of state before and after reload.