### PR TITLE
Owner-Report can display business document links

### DIFF
--- a/gnucash/gnome/top-level.c
+++ b/gnucash/gnome/top-level.c
@@ -47,6 +47,7 @@
 #include "gnc-engine.h"
 #include "gnc-file.h"
 #include "gnc-hooks.h"
+#include "gncInvoice.h"
 #include "gfec.h"
 #include "gnc-main-window.h"
 #include "gnc-menu-extensions.h"
@@ -120,6 +121,7 @@ gnc_html_register_url_cb (const char *location, const char *label,
     Split       * split = NULL;
     Account     * account = NULL;
     Transaction * trans;
+    GncInvoice  * invoice;
     GList       * node;
     GncGUID       guid;
     QofInstance * entity = NULL;
@@ -177,6 +179,19 @@ gnc_html_register_url_cb (const char *location, const char *label,
         trans = (Transaction *) entity;
         gnc_doclink_open_uri (gnc_ui_get_gtk_window (GTK_WIDGET (result->parent)),
                               xaccTransGetDocLink (trans));
+        return TRUE;
+    }
+
+    else if (strncmp ("invoice-doclink-guid=", location,
+                      strlen ("invoice-doclink-guid=")) == 0)
+    {
+        if (!validate_type("invoice-doclink-guid=", location, GNC_ID_INVOICE,
+                           result, &guid, &entity))
+            return FALSE;
+
+        invoice = (GncInvoice *) entity;
+        gnc_doclink_open_uri (gnc_ui_get_gtk_window (GTK_WIDGET (result->parent)),
+                              gncInvoiceGetDocLink (invoice));
         return TRUE;
     }
 

--- a/gnucash/report/html-utilities.scm
+++ b/gnucash/report/html-utilities.scm
@@ -48,6 +48,9 @@
 (define (gnc:transaction-doclink-anchor-text trans)
   (gnc:register-guid "trans-doclink-guid=" (gncTransGetGUID trans)))
 
+(define (gnc:invoice-doclink-anchor-text invoice)
+  (gnc:register-guid "invoice-doclink-guid=" (gncInvoiceReturnGUID invoice)))
+
 (define (gnc:report-anchor-text report-id)
   (gnc-build-url URL-TYPE-REPORT
 		      (string-append "id=" (number->string report-id))
@@ -157,6 +160,11 @@
 (define (gnc:html-transaction-doclink-anchor trans text)
   (gnc:make-html-text (gnc:html-markup-anchor
                        (gnc:transaction-doclink-anchor-text trans)
+                       text)))
+
+(define (gnc:html-invoice-doclink-anchor invoice text)
+  (gnc:make-html-text (gnc:html-markup-anchor
+                       (gnc:invoice-doclink-anchor-text invoice)
                        text)))
 
 (define (gnc:html-price-anchor price value)

--- a/gnucash/report/report.scm
+++ b/gnucash/report/report.scm
@@ -93,6 +93,7 @@
 (export gnc:html-split-anchor)
 (export gnc:html-transaction-anchor)
 (export gnc:html-transaction-doclink-anchor)
+(export gnc:html-invoice-doclink-anchor)
 (export gnc:html-price-anchor)
 (export gnc:customer-anchor-text)
 (export gnc:job-anchor-text)

--- a/gnucash/report/reports/standard/new-owner-report.scm
+++ b/gnucash/report/reports/standard/new-owner-report.scm
@@ -57,7 +57,7 @@
 (define debit-header (N_ "Debits"))
 (define balance-header (N_ "Balance"))
 (define doclink-header (N_ "Document Links"))
-(define linked-txns-header (N_ "Links"))
+(define linked-txns-header (N_ "Transaction Links"))
 
 (define javascript "
 <script>

--- a/libgnucash/app-utils/options.scm
+++ b/libgnucash/app-utils/options.scm
@@ -1681,6 +1681,9 @@ the option '~a'."))
       ("Void Transactions" "Filter" "Void Transactions")
       ("Account Substring" "Filter" "Account Name Filter")
       ("Enable links" #f "Enable Links")
+      ;; new-owner-report.scm, renamed Oct 2020 to differentiate with
+      ;; Document Links:
+      ("Links" #f "Transaction Links")
       ;; invoice.scm, renamed November 2018
       ("Individual Taxes" #f "Use Detailed Tax Summary")
       ;; income-gst-statement.scm


### PR DESCRIPTION
Partial PR. Handle `invoice-doclink-guid=` links. This PR currently sends doclink URI in URL; it should send invoice GUID, and `top-level.c` would retrieve gncInvoice from GUID. Not sure how to do this. @Bob-IT ?

Not sure whether to add doclink as a separate column, or linkify the "Invoice" in the Type column.

Also "Display/Document Links" will now clash with "Display/Links" option.

Progress so far:
![image](https://user-images.githubusercontent.com/1975870/95017212-a8d66680-0647-11eb-9ce1-32bbf0abd39f.png)
