### PR TITLE
Improve auto-clear

### DIFF
--- a/gnucash/gnome/window-autoclear.c
+++ b/gnucash/gnome/window-autoclear.c
@@ -139,6 +139,8 @@ gnc_autoclear_window_ok_cb (GtkWidget *widget,
 
     /* Value we have to reach */
     toclear_value = gnc_amount_edit_get_amount(data->end_value);
+    if (gnc_reverse_balance(data->account))
+        toclear_value = gnc_numeric_neg(toclear_value);
     toclear_value = gnc_numeric_convert(toclear_value, xaccAccountGetCommoditySCU(data->account), GNC_HOW_RND_NEVER);
 
     /* Extract which splits are not cleared and compute the amount we have to clear */
@@ -332,6 +334,8 @@ autoClearWindow (GtkWidget *parent, Account *account)
 
     /* pre-fill with current balance */
     after = xaccAccountGetBalance(data->account);
+    if (gnc_reverse_balance(data->account))
+        after = gnc_numeric_neg(after);
     gnc_amount_edit_set_amount (GNC_AMOUNT_EDIT (data->end_value), after);
     gtk_widget_grab_focus(GTK_WIDGET(data->end_value));
 

--- a/gnucash/gnome/window-autoclear.c
+++ b/gnucash/gnome/window-autoclear.c
@@ -303,6 +303,7 @@ autoClearWindow (GtkWidget *parent, Account *account)
     GtkBuilder *builder;
     AutoClearWindow *data;
     char *title;
+    gnc_numeric after;
 
     data = g_new0 (AutoClearWindow, 1);
     data->account = account;
@@ -328,6 +329,10 @@ autoClearWindow (GtkWidget *parent, Account *account)
 
     label = GTK_LABEL(gtk_builder_get_object (builder, "end_label"));
     gtk_label_set_mnemonic_widget(label, GTK_WIDGET(data->end_value));
+
+    /* pre-fill with current balance */
+    after = xaccAccountGetBalance(data->account);
+    gnc_amount_edit_set_amount (GNC_AMOUNT_EDIT (data->end_value), after);
     gtk_widget_grab_focus(GTK_WIDGET(data->end_value));
 
     data->status_label = GTK_LABEL(gtk_builder_get_object (builder, "status_label"));

--- a/gnucash/gtkbuilder/window-autoclear.glade
+++ b/gnucash/gtkbuilder/window-autoclear.glade
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.36.0 -->
+<!-- Generated with glade 3.22.2 -->
 <interface>
   <requires lib="gtk+" version="3.22"/>
   <object class="GtkDialog" id="auto_clear_start_dialog">
     <property name="can_focus">False</property>
     <property name="resizable">False</property>
     <property name="type_hint">dialog</property>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox6">
         <property name="visible">True</property>
@@ -68,8 +71,11 @@
               <object class="GtkLabel" id="label1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">&lt;b&gt;Auto-Clear Information&lt;/b&gt;</property>
+                <property name="label" translatable="yes">&lt;b&gt;Auto-Clear Information&lt;/b&gt;
+Use this dialog if you want GnuCash to automatically find which transactions are cleared, given an ending balance. For example, said ending balance can be the current balance given by your online bank.</property>
                 <property name="use_markup">True</property>
+                <property name="wrap">True</property>
+                <property name="max_width_chars">80</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -143,8 +149,5 @@
       <action-widget response="-6">cancel_button</action-widget>
       <action-widget response="-5">ok_button</action-widget>
     </action-widgets>
-    <child type="titlebar">
-      <placeholder/>
-    </child>
   </object>
 </interface>

--- a/gnucash/gtkbuilder/window-autoclear.glade
+++ b/gnucash/gtkbuilder/window-autoclear.glade
@@ -72,7 +72,9 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes">&lt;b&gt;Auto-Clear Information&lt;/b&gt;
-Use this dialog if you want GnuCash to automatically find which transactions are cleared, given an ending balance. For example, said ending balance can be the current balance given by your online bank.</property>
+Use this dialog if you want GnuCash to automatically find which transactions are cleared, given an ending balance. For example, said ending balance can be the current balance given by your online bank.
+
+&lt;b&gt;Note&lt;/b&gt;: The complexity of this algorithm is quite high (&lt;a href="https://en.wikipedia.org/wiki/Knapsack_problem#Computational_complexity"&gt;O(nW)&lt;/a&gt;). Use this only on a dozen of uncleared splits.</property>
                 <property name="use_markup">True</property>
                 <property name="wrap">True</property>
                 <property name="max_width_chars">80</property>


### PR DESCRIPTION
This PR extends GnuCash's auto-clear feature as [requested](https://bugs.gnucash.org/show_bug.cgi?id=608436#c13). Specifically:

1. The auto-clear window includes more documentation in the UI, to clarify its intended usage and algorithmic complexity.

2. The auto-clear window value is pre-populated with the current balance value, to make it more obvious how the feature is meant to be used.

3. The auto-clear window value respects account balance reversal.