### PR TITLE
Add mailing lists as footer of translator credits

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -9121,7 +9121,9 @@ msgstr "Contabilidad financiara personal y pequeños negocios."
 msgid "translator-credits"
 msgstr ""
 "Francisco Javier Serrador <serrador@tecknolabs.com>  7-ene-2019\n"
-"Eneko Lacunza <enlar@enlar.net>"
+"Eneko Lacunza <enlar@enlar.net>\n"
+"\n"
+"Comunidad GnuCash de habla hispana <gnucash-es@gnucash.org>"
 
 #: gnucash/gnome-utils/gnc-main-window.c:4540
 msgid "Visit the GnuCash website."

--- a/po/nl.po
+++ b/po/nl.po
@@ -8951,7 +8951,9 @@ msgstr ""
 "• Benno Schulenberg <benno@vertaalt.nl>, 2007\n"
 "• Jeroen ten Berge <twinbit@home.nl>, 2004\n"
 "• Hendrik-Jan Heins <hjh@passys.nl>, 2003\n"
-"• Jan Willem Harmanny <jwharmanny@zeelandnet.nl>, 2002"
+"• Jan Willem Harmanny <jwharmanny@zeelandnet.nl>, 2002\n"
+"\n"
+"Nederlandstalige GnuCash-gemeenschap <gnucash-nl@gnucash.org>"
 
 #: gnucash/gnome-utils/gnc-main-window.c:4540
 msgid "Visit the GnuCash website."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1,17 +1,19 @@
-# Brazilian Portuguese translation of GnuCash
+# Brazilian Portuguese translations for GnuCash package.
 # Copyright (C) 2001, 2003, 2007 Free Software Foundation, Inc.
+# Copyright (C) 2011-15 by the GnuCash developers and the translators listed below.
+# This file is distributed under the same license as the GnuCash package.
+# Miguel Rozsas <miguel@rozsas.eng.br>, 2014.
+# Dorneles Treméa <dorneles@tremea.com>, 2011.
+# Leslie H. Watter <watter@gmail.com>, 2007.
+# Carlos Cleber Pereira Cassol <ccassol@gmail.com>, 2007.
+# Leonardo Ferreira Fontenelle <leo.fontenelle@gmail.com>, 2007.
+# Goedson Teixeira Paixão <goedson@debian.org>, 2007.
 # Jon Lapham <lapham@jandr.org>, 2003,2004
 # Jose Carlos Nascimento <joseca@psabs.com>, 2001.
-# Goedson Teixeira Paixão <goedson@debian.org>, 2007.
-# Leonardo Ferreira Fontenelle <leo.fontenelle@gmail.com>, 2007.
-# Carlos Cleber Pereira Cassol <ccassol@gmail.com>, 2007.
-# Leslie H. Watter <watter@gmail.com>, 2007.
-# Dorneles Treméa <dorneles@tremea.com>, 2011.
-# Miguel Rozsas <miguel@rozsas.eng.br>, 2014.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: GnuCash 2.2\n"
+"Project-Id-Version: GnuCash 2.6.3\n"
 "Report-Msgid-Bugs-To: https://bugs.gnucash.org/enter_bug.cgi?"
 "product=GnuCash&component=Translations\n"
 "POT-Creation-Date: 2020-10-14 01:49+0200\n"
@@ -9010,10 +9012,17 @@ msgstr "- GnuCash: Gerenciador financeiro pessoal e para pequenos negócios"
 #: gnucash/gnome-utils/gnc-main-window.c:4537
 msgid "translator-credits"
 msgstr ""
-"Jose Carlos Nascimento <joseca@psabs.com>\n"
-"Goedson Teixeira Paixão <goedson@debian.org>\n"
-"Leonardo Ferreira Fontenelle <leo.fontenelle@gmail.com>\n"
-"Cleber Cassol <ccassol@gmail.com>"
+"Miguel Rozsas, 2014\n"
+"Dorneles Treméa, 2011\n"
+"Leslie H. Watter, 2007\n"
+"Cleber Cassol, 2007\n"
+"Leonardo Ferreira Fontenelle, 2007\n"
+"Goedson Teixeira Paixão, 2007\n"
+"Jon Lapham, 2003-2004\n"
+"Jose Carlos Nascimento, 2001\n"
+"\n"
+"Sugestões e críticas à comunidade GnuCash de língua portuguesa do Brasil "
+"<gnucash-br@gnucash.org>"
 
 #: gnucash/gnome-utils/gnc-main-window.c:4540
 msgid "Visit the GnuCash website."


### PR DESCRIPTION
In several languages, the language team is already set to the corresponding gnucash mailing list, but the "Language Team:" entry in the po headers is intended for bots. This PR appends it to the msgstr of msgid "translator-credits" to get it user visible in the translator section of Help->About->Credits.

Language, state, optional review:
de: set since years,
es: this commit, <yoann@laboussole.coop>
it:  set since years, <foti.giuseppe@gmail.com>
nl: this commit, @gjanssens 

Still not applied: [pt_] BR, which has 2 possible lists:
pt [_pt], Pedro is in https://translationproject.org/team/pt.html, "Language Team:" contains the TP address, but gnucash is there marked as external. We should perhaps talk with Pedro.
pt_BR has no conflicts. I will apply it later
