### PR TITLE
Auto clear tests

### DIFF
--- a/gnucash/ui/gnc-plugin-page-register-ui.xml
+++ b/gnucash/ui/gnc-plugin-page-register-ui.xml
@@ -44,6 +44,7 @@
         <separator name="ActionsSep1"/>
         <menuitem name="ActionsTransfer" action="ActionsTransferAction"/>
         <menuitem name="ActionsReconcile" action="ActionsReconcileAction"/>
+        <menuitem name="ActionsAutoClear" action="ActionsAutoClearAction"/>
         <menuitem name="ActionsStockSplit" action="ActionsStockSplitAction"/>
         <menuitem name="ActionLots" action="ActionsLotsAction"/>
         <separator name="ActionsSep4"/>

--- a/gnucash/ui/gnc-plugin-page-register2-ui.xml
+++ b/gnucash/ui/gnc-plugin-page-register2-ui.xml
@@ -43,6 +43,7 @@
         <separator name="ActionsSep1"/>
         <menuitem name="ActionsTransfer" action="ActionsTransferAction"/>
         <menuitem name="ActionsReconcile" action="ActionsReconcileAction"/>
+        <menuitem name="ActionsAutoClear" action="ActionsAutoClearAction"/>
         <menuitem name="ActionsStockSplit" action="ActionsStockSplitAction"/>
         <menuitem name="ActionLots" action="ActionsLotsAction"/>
         <separator name="ActionsSep4"/>

--- a/libgnucash/app-utils/test/CMakeLists.txt
+++ b/libgnucash/app-utils/test/CMakeLists.txt
@@ -85,3 +85,21 @@ set_dist_list(test_app_utils_DIST
   ${test_app_utils_scheme_SOURCES}
   ${test_app_utils_SOURCES}
 )
+
+
+set(test_autoclear_SOURCES
+    test-autoclear.cpp
+)
+set(test_autoclear_INCLUDE_DIRS
+    ${APP_UTILS_TEST_INCLUDE_DIRS}
+    ${GTEST_INCLUDE_DIR}
+)
+set(test_autoclear_LIBS
+    ${APP_UTILS_TEST_LIBS}
+    gtest
+)
+
+gnc_add_test(test-autoclear "${test_autoclear_SOURCES}"
+    test_autoclear_INCLUDE_DIRS
+    test_autoclear_LIBS
+)

--- a/libgnucash/app-utils/test/test-autoclear.cpp
+++ b/libgnucash/app-utils/test/test-autoclear.cpp
@@ -31,7 +31,7 @@ extern "C" {
 
 #include "gtest/gtest.h"
 
-const gint64 DENOM = 100; //< Denomerator is always 100 for simplicity.
+static const int64_t DENOM = 100; //< Denomerator is always 100 for simplicity.
 
 struct SplitDatum {
     const char *memo;
@@ -39,100 +39,108 @@ struct SplitDatum {
     bool cleared;
 };
 
-struct TestCase {
+struct Tests {
     gint64 amount;
     const char *expectedErr;
 };
 
-std::vector<SplitDatum> easySplitData = {
-    { "Memo 01", -  8234, true },
-    { "Memo 02", -156326, true },
-    { "Memo 03", -  4500, true },
-    { "Memo 04", -694056, true },
-    { "Memo 05", -  7358, true },
-    { "Memo 06", - 11700, true },
-    { "Memo 07", - 20497, true },
-    { "Memo 08", - 11900, true },
-    { "Memo 09", -  8275, true },
-    { "Memo 10", - 58700, true },
-    { "Memo 11", +100000, true },
-    { "Memo 12", - 13881, true },
-    { "Memo 13", -  5000, true },
-    { "Memo 14", +200000, true },
-    { "Memo 15", - 16800, true },
-    { "Memo 16", -152000, true },
-    { "Memo 17", +160000, false },
-    { "Memo 18", - 63610, false },
-    { "Memo 19", -  2702, false },
-    { "Memo 20", - 15400, false },
-    { "Memo 21", -  3900, false },
-    { "Memo 22", - 22042, false },
-    { "Memo 23", -  2900, false },
-    { "Memo 24", - 10900, false },
-    { "Memo 25", - 44400, false },
-    { "Memo 26", -  9200, false },
-    { "Memo 27", -  7900, false },
-    { "Memo 28", -  1990, false },
-    { "Memo 29", -  7901, false },
-    { "Memo 30", - 61200, false },
+struct TestCase {
+    std::vector<SplitDatum> splits;
+    std::vector<Tests> tests;
 };
 
-std::vector<TestCase> easyTestCases = {
-    { 0, "The selected amount cannot be cleared.", },
-    { -869227, "Account is already at Auto-Clear Balance." }, // No splits need to be cleared.
-    { -869300, "The selected amount cannot be cleared." },
-    { -869230, NULL },
-    { -963272, NULL }, // All splits need to be cleared.
+TestCase easyTestCase = {
+    .splits = {
+        { "Memo 01", -  8234, true },
+        { "Memo 02", -156326, true },
+        { "Memo 03", -  4500, true },
+        { "Memo 04", -694056, true },
+        { "Memo 05", -  7358, true },
+        { "Memo 06", - 11700, true },
+        { "Memo 07", - 20497, true },
+        { "Memo 08", - 11900, true },
+        { "Memo 09", -  8275, true },
+        { "Memo 10", - 58700, true },
+        { "Memo 11", +100000, true },
+        { "Memo 12", - 13881, true },
+        { "Memo 13", -  5000, true },
+        { "Memo 14", +200000, true },
+        { "Memo 15", - 16800, true },
+        { "Memo 16", -152000, true },
+        { "Memo 17", +160000, false },
+        { "Memo 18", - 63610, false },
+        { "Memo 19", -  2702, false },
+        { "Memo 20", - 15400, false },
+        { "Memo 21", -  3900, false },
+        { "Memo 22", - 22042, false },
+        { "Memo 23", -  2900, false },
+        { "Memo 24", - 10900, false },
+        { "Memo 25", - 44400, false },
+        { "Memo 26", -  9200, false },
+        { "Memo 27", -  7900, false },
+        { "Memo 28", -  1990, false },
+        { "Memo 29", -  7901, false },
+        { "Memo 30", - 61200, false },
+    },
+    .tests = {
+        { 0, "The selected amount cannot be cleared.", },
+        { -869227, "Account is already at Auto-Clear Balance." }, // No splits need to be cleared.
+        { -869300, "The selected amount cannot be cleared." },
+        { -869230, NULL },
+        { -963272, NULL }, // All splits need to be cleared.
+    },
 };
 
-std::vector<SplitDatum> ambiguousSplitData = {
-    { "Memo 01", -10, false },
-    { "Memo 02", -10, false },
-    { "Memo 03", -10, false },
+TestCase ambiguousTestCase = {
+    .splits = {
+        { "Memo 01", -10, false },
+        { "Memo 02", -10, false },
+        { "Memo 03", -10, false },
+    },
+    .tests = {
+        { -10, "Cannot uniquely clear splits. Found multiple possibilities." },
+        { -20, "Cannot uniquely clear splits. Found multiple possibilities." },
+
+        // Forbid auto-clear to be too smart. We expect the user to manually deal
+        // with such situations.
+        { -30, "Cannot uniquely clear splits. Found multiple possibilities." },
+    },
 };
 
-std::vector<TestCase> ambiguousTestCases = {
-    { -10, "Cannot uniquely clear splits. Found multiple possibilities." },
-    { -20, "Cannot uniquely clear splits. Found multiple possibilities." },
+class AutoClearTest : public testing::TestWithParam<TestCase> {
+protected:
+    std::shared_ptr<QofBook> book_;
+    Account *account_; // owned by book_
+    TestCase testCase_;
 
-    // Commented out, auto-clear algorithm is not smart enough yet.
-    //{ -30, NULL },
-};
+public:
+    AutoClearTest() :
+        book_(qof_book_new(), qof_book_destroy),
+        account_(xaccMallocAccount(book_.get()))
+    {
+        testCase_ = GetParam();
 
-class AutoClearTest
-    : public testing::TestWithParam<
-        std::pair<
-            std::vector<SplitDatum>,
-            std::vector<TestCase>
-        >
-    > {
+        xaccAccountSetName(account_, "Test Account");
+        xaccAccountBeginEdit(account_);
+        for (auto &d : testCase_.splits) {
+            Split *split = xaccMallocSplit(book_.get());
+            xaccSplitSetMemo(split, d.memo);
+            xaccSplitSetAmount(split, gnc_numeric_create(d.amount, DENOM));
+            xaccSplitSetReconcile(split, d.cleared ? CREC : NREC);
+            xaccSplitSetAccount(split, account_);
+
+            gnc_account_insert_split(account_, split);
+        }
+        xaccAccountCommitEdit(account_);
+    }
 };
 
 TEST_P(AutoClearTest, DoesAutoClear) {
-    auto splitData = GetParam().first;
-    auto testCase = GetParam().second;
-
-    QofBook *book = qof_book_new ();
-    Account *account = xaccMallocAccount(book);
-    xaccAccountSetName(account, "Test Account");
-
-    xaccAccountBeginEdit(account);
-    for (auto &d : splitData) {
-        Split *split = xaccMallocSplit(book);
-        xaccSplitSetMemo(split, d.memo);
-        xaccSplitSetAmount(split, gnc_numeric_create(d.amount, DENOM));
-        xaccSplitSetReconcile(split, d.cleared ? CREC : NREC);
-        xaccSplitSetAccount(split, account);
-
-        gnc_account_insert_split(account, split);
-    }
-    xaccAccountCommitEdit(account);
-
-    for (auto &t : testCase) {
+    for (auto &t : testCase_.tests) {
         gnc_numeric amount_to_clear = gnc_numeric_create(t.amount, DENOM);
         char *err;
 
-        GList *splits_to_clear = gnc_account_get_autoclear_splits(account, amount_to_clear, &err);
+        GList *splits_to_clear = gnc_account_get_autoclear_splits(account_, amount_to_clear, &err);
 
         // Actually clear splits
         for (GList *node = splits_to_clear; node; node = node->next) {
@@ -142,20 +150,18 @@ TEST_P(AutoClearTest, DoesAutoClear) {
 
         ASSERT_STREQ(err, t.expectedErr);
         if (t.expectedErr == NULL) {
-            gnc_numeric c = xaccAccountGetClearedBalance(account);
+            gnc_numeric c = xaccAccountGetClearedBalance(account_);
             ASSERT_EQ(c.num, t.amount);
             ASSERT_EQ(c.denom, DENOM);
         }
     }
-
-    qof_book_destroy(book);
 }
 
 INSTANTIATE_TEST_SUITE_P(
     InstantiationAutoClearTest,
     AutoClearTest,
     testing::Values(
-        std::pair{ easySplitData, easyTestCases },
-        std::pair{ ambiguousSplitData, ambiguousTestCases }
+        easyTestCase,
+        ambiguousTestCase
     )
 );

--- a/libgnucash/app-utils/test/test-autoclear.cpp
+++ b/libgnucash/app-utils/test/test-autoclear.cpp
@@ -27,9 +27,8 @@
 extern "C" {
 #include "../gnc-ui-balances.h"
 }
-#include "Split.h"
-
-#include "gtest/gtest.h"
+#include <Split.h>
+#include <gtest/gtest.h>
 
 static const int64_t DENOM = 100; //< Denomerator is always 100 for simplicity.
 

--- a/libgnucash/app-utils/test/test-autoclear.cpp
+++ b/libgnucash/app-utils/test/test-autoclear.cpp
@@ -31,11 +31,11 @@ extern "C" {
 
 #include "gtest/gtest.h"
 
-const int DENOM = 100; //< Denomerator is always 100 for simplicity.
+const gint64 DENOM = 100; //< Denomerator is always 100 for simplicity.
 
 struct SplitDatum {
     const char *memo;
-    int amount; //< Numerator of amount.
+    gint64 amount; //< Numerator of amount.
     bool cleared;
 };
 
@@ -73,7 +73,7 @@ SplitDatum splitData[] = {
 };
 
 struct TestCase {
-    int amount;
+    gint64 amount;
     const char *expectedErr;
 };
 
@@ -88,14 +88,15 @@ TestCase testCases[] = {
 TEST(AutoClear, AutoClearAll) {
     QofBook *book = qof_book_new ();
     Account *account = xaccMallocAccount(book);
+    xaccAccountSetName(account, "Test Account");
 
     for (auto &d : splitData) {
         Split *split = xaccMallocSplit(book);
         xaccSplitSetMemo(split, d.memo);
         xaccSplitSetAmount(split, gnc_numeric_create(d.amount, DENOM));
         xaccSplitSetReconcile(split, d.cleared ? CREC : NREC);
+        xaccSplitSetAccount(split, account);
 
-        // This way of inserting a split, seems to actualy work best. :D
         gnc_account_insert_split(account, split);
     }
     xaccAccountRecomputeBalance(account);

--- a/libgnucash/app-utils/test/test-autoclear.cpp
+++ b/libgnucash/app-utils/test/test-autoclear.cpp
@@ -58,7 +58,7 @@ SplitDatum splitData[] = {
     { "Memo 16", -152000, true },
     { "Memo 17", +160000, false },
     { "Memo 18", - 63610, false },
-    { "Memo 19", -  2700, false },
+    { "Memo 19", -  2702, false },
     { "Memo 20", - 15400, false },
     { "Memo 21", -  3900, false },
     { "Memo 22", - 22042, false },
@@ -68,7 +68,7 @@ SplitDatum splitData[] = {
     { "Memo 26", -  9200, false },
     { "Memo 27", -  7900, false },
     { "Memo 28", -  1990, false },
-    { "Memo 29", -  7900, false },
+    { "Memo 29", -  7901, false },
     { "Memo 30", - 61200, false },
 };
 
@@ -80,9 +80,9 @@ struct TestCase {
 TestCase testCases[] = {
     { 0, "The selected amount cannot be cleared.", },
     { -869227, "Account is already at Auto-Clear Balance." }, // No splits need to be cleared.
-    { -877127, "Cannot uniquely clear splits. Found multiple possibilities." }, // Two splits need to be cleared.
-    { -891269, NULL }, // One split need to be cleared.
-    { -963269, NULL }, // All splits need to be cleared.
+    { -869300, "The selected amount cannot be cleared." },
+    { -869230, NULL },
+    { -963272, NULL }, // All splits need to be cleared.
 };
 
 TEST(AutoClear, AutoClearAll) {

--- a/libgnucash/app-utils/test/test-autoclear.cpp
+++ b/libgnucash/app-utils/test/test-autoclear.cpp
@@ -1,0 +1,124 @@
+/********************************************************************
+ * test-autoclear.c: test suite for Auto-Clear          	    *
+ * Copyright 2020 Cristian Klein <cristian@kleinlabs.eu>            *
+ *                                                                  *
+ * This program is free software; you can redistribute it and/or    *
+ * modify it under the terms of the GNU General Public License as   *
+ * published by the Free Software Foundation; either version 2 of   *
+ * the License, or (at your option) any later version.              *
+ *                                                                  *
+ * This program is distributed in the hope that it will be useful,  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    *
+ * GNU General Public License for more details.                     *
+ *                                                                  *
+ * You should have received a copy of the GNU General Public License*
+ * along with this program; if not, you can retrieve it from        *
+ * https://www.gnu.org/licenses/old-licenses/gpl-2.0.html            *
+ * or contact:                                                      *
+ *                                                                  *
+ * Free Software Foundation           Voice:  +1-617-542-5942       *
+ * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652       *
+ * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
+ ********************************************************************/
+#include "config.h"
+
+// GoogleTest is written in C++, however, the function we test in C.
+extern "C" {
+#include "../gnc-ui-balances.h"
+}
+#include "Split.h"
+
+#include "gtest/gtest.h"
+
+const int DENOM = 100; //< Denomerator is always 100 for simplicity.
+
+struct SplitDatum {
+    const char *memo;
+    int amount; //< Numerator of amount.
+    bool cleared;
+};
+
+SplitDatum splitData[] = {
+    { "Memo 01", -  8234, true },
+    { "Memo 02", -156326, true },
+    { "Memo 03", -  4500, true },
+    { "Memo 04", -694056, true },
+    { "Memo 05", -  7358, true },
+    { "Memo 06", - 11700, true },
+    { "Memo 07", - 20497, true },
+    { "Memo 08", - 11900, true },
+    { "Memo 09", -  8275, true },
+    { "Memo 10", - 58700, true },
+    { "Memo 11", +100000, true },
+    { "Memo 12", - 13881, true },
+    { "Memo 13", -  5000, true },
+    { "Memo 14", +200000, true },
+    { "Memo 15", - 16800, true },
+    { "Memo 16", -152000, true },
+    { "Memo 17", +160000, false },
+    { "Memo 18", - 63610, false },
+    { "Memo 19", -  2700, false },
+    { "Memo 20", - 15400, false },
+    { "Memo 21", -  3900, false },
+    { "Memo 22", - 22042, false },
+    { "Memo 23", -  2900, false },
+    { "Memo 24", - 10900, false },
+    { "Memo 25", - 44400, false },
+    { "Memo 26", -  9200, false },
+    { "Memo 27", -  7900, false },
+    { "Memo 28", -  1990, false },
+    { "Memo 29", -  7900, false },
+    { "Memo 30", - 61200, false },
+};
+
+struct TestCase {
+    int amount;
+    const char *expectedErr;
+};
+
+TestCase testCases[] = {
+    { 0, "The selected amount cannot be cleared.", },
+    { -869227, "Account is already at Auto-Clear Balance." }, // No splits need to be cleared.
+    { -877127, "Cannot uniquely clear splits. Found multiple possibilities." }, // Two splits need to be cleared.
+    { -891269, NULL }, // One split need to be cleared.
+    { -963269, NULL }, // All splits need to be cleared.
+};
+
+TEST(AutoClear, AutoClearAll) {
+    QofBook *book = qof_book_new ();
+    Account *account = xaccMallocAccount(book);
+
+    for (auto &d : splitData) {
+        Split *split = xaccMallocSplit(book);
+        xaccSplitSetMemo(split, d.memo);
+        xaccSplitSetAmount(split, gnc_numeric_create(d.amount, DENOM));
+        xaccSplitSetReconcile(split, d.cleared ? CREC : NREC);
+
+        // This way of inserting a split, seems to actualy work best. :D
+        gnc_account_insert_split(account, split);
+    }
+    xaccAccountRecomputeBalance(account);
+
+    for (auto &t : testCases) {
+        gnc_numeric amount_to_clear = gnc_numeric_create(t.amount, DENOM);
+        char *err;
+
+        GList *splits_to_clear = gnc_account_get_autoclear_splits(account, amount_to_clear, &err);
+
+        // Actually clear splits
+        for (GList *node = splits_to_clear; node; node = node->next) {
+            Split *split = (Split *)node->data;
+            xaccSplitSetReconcile(split, CREC);
+        }
+
+        ASSERT_STREQ(err, t.expectedErr);
+        if (t.expectedErr == NULL) {
+            gnc_numeric c = xaccAccountGetClearedBalance(account);
+            ASSERT_EQ(c.num, t.amount);
+            ASSERT_EQ(c.denom, DENOM);
+        }
+    }
+
+    qof_book_destroy(book);
+}

--- a/libgnucash/app-utils/test/test-autoclear.cpp
+++ b/libgnucash/app-utils/test/test-autoclear.cpp
@@ -156,11 +156,15 @@ TEST_P(AutoClearTest, DoesAutoClear) {
     }
 }
 
+#ifndef INSTANTIATE_TEST_SUITE_P
 // Silence "no previous declaration for" which is treated as error, due to -Werror
 testing::internal::ParamGenerator<TestCase*> gtest_InstantiationAutoClearTestAutoClearTest_EvalGenerator_();
 std::string gtest_InstantiationAutoClearTestAutoClearTest_EvalGenerateName_(const testing::TestParamInfo<TestCase*>&);
 
 INSTANTIATE_TEST_CASE_P(
+#else // INSTANTIATE_TEST_SUITE_P
+INSTANTIATE_TEST_SUITE_P(
+#endif // INSTANTIATE_TEST_SUITE_P
     InstantiationAutoClearTest,
     AutoClearTest,
     ::testing::Values(

--- a/libgnucash/app-utils/test/test-autoclear.cpp
+++ b/libgnucash/app-utils/test/test-autoclear.cpp
@@ -31,7 +31,7 @@ extern "C" {
 #include <Split.h>
 #include <gtest/gtest.h>
 
-static const int64_t DENOM = 100; //< Denomerator is always 100 for simplicity.
+static const int64_t DENOM = 100; //< Denominator is always 100 for simplicity.
 
 struct SplitDatum {
     const char *memo;

--- a/libgnucash/app-utils/test/test-autoclear.cpp
+++ b/libgnucash/app-utils/test/test-autoclear.cpp
@@ -90,6 +90,7 @@ TEST(AutoClear, AutoClearAll) {
     Account *account = xaccMallocAccount(book);
     xaccAccountSetName(account, "Test Account");
 
+    xaccAccountBeginEdit(account);
     for (auto &d : splitData) {
         Split *split = xaccMallocSplit(book);
         xaccSplitSetMemo(split, d.memo);
@@ -99,7 +100,7 @@ TEST(AutoClear, AutoClearAll) {
 
         gnc_account_insert_split(account, split);
     }
-    xaccAccountRecomputeBalance(account);
+    xaccAccountCommitEdit(account);
 
     for (auto &t : testCases) {
         gnc_numeric amount_to_clear = gnc_numeric_create(t.amount, DENOM);


### PR DESCRIPTION
Hi @christopherlam,

Please find here a first draft of the autoclear tests. Unfortunately, right now the tests fail. The reason is that the test cases include two splits of the same amount. This leads to "Cannot uniquely clear splits. Found multiple possibilities.". This is a limitation of the current algorithm. It could be smarter and suggest a list of splits to clear when none or both of the two splits are included.

How should we proceed?
1. Accept the limitations of the algorithm and simplify the tests accordingly.
2. Improve the algorithm so it can deal with trickier cases.

Let me know what you think.