### PR TITLE
Reports page changes

### DIFF
--- a/gnucash/gnome-utils/gnc-main-window.c
+++ b/gnucash/gnome-utils/gnc-main-window.c
@@ -67,6 +67,7 @@
 #include "gnc-ui-util.h"
 #include "gnc-uri-utils.h"
 #include "gnc-version.h"
+#include "gnc-warnings.h"
 #include "gnc-window.h"
 #include "gnc-prefs.h"
 #include "option-util.h"
@@ -1422,6 +1423,32 @@ gnc_main_window_delete_event (GtkWidget *window,
 
     if (already_dead)
         return TRUE;
+
+    if (g_list_length (active_windows) > 1)
+    {
+        gint response;
+        GtkWidget *dialog;
+        gchar *message = _("This window is closing and will not be restored.");
+
+        dialog = gtk_message_dialog_new (GTK_WINDOW (window),
+                                         GTK_DIALOG_DESTROY_WITH_PARENT,
+                                         GTK_MESSAGE_QUESTION,
+                                         GTK_BUTTONS_NONE,
+                                         "%s", _("Close Window?"));
+        gtk_message_dialog_format_secondary_text (GTK_MESSAGE_DIALOG(dialog),
+                                                  "%s", message);
+
+        gtk_dialog_add_buttons (GTK_DIALOG(dialog),
+                              _("_Cancel"), GTK_RESPONSE_CANCEL,
+                              _("_OK"), GTK_RESPONSE_YES,
+                               (gchar *)NULL);
+        gtk_dialog_set_default_response (GTK_DIALOG(dialog), GTK_RESPONSE_YES);
+        response = gnc_dialog_run (GTK_DIALOG(dialog), GNC_PREF_WARN_CLOSING_WINDOW_QUESTION);
+        gtk_widget_destroy (dialog);
+
+        if (response == GTK_RESPONSE_CANCEL)
+            return TRUE;
+    }
 
     if (!gnc_main_window_finish_pending(GNC_MAIN_WINDOW(window)))
     {

--- a/gnucash/gnome-utils/gnc-main-window.h
+++ b/gnucash/gnome-utils/gnc-main-window.h
@@ -348,6 +348,16 @@ gboolean gnc_main_window_popup_menu_cb (GtkWidget *widget,
  */
 void gnc_main_window_restore_all_windows(const GKeyFile *keyfile);
 
+/** Check if the main window is restoring the plugin pages. This is
+ *  used on report pages to delay the creation of the report till the
+ *  page is focused.
+ *
+ *  @param window When window whose pages should be checked.
+ *
+ *  @return TRUE if pages are being restored
+ */
+gboolean gnc_main_window_is_restoring_pages (GncMainWindow *window);
+
 /** Save the persistent state of all windows.
  *
  *  @param keyfile The GKeyFile to contain persistent window state.

--- a/gnucash/gnome/gnc-plugin-page-report.c
+++ b/gnucash/gnome/gnc-plugin-page-report.c
@@ -253,7 +253,7 @@ gnc_plugin_page_report_focus_widget (GncPluginPage *report_plugin_page)
 
         if (window && !gnc_main_window_is_restoring_pages (GNC_MAIN_WINDOW(window)))
         {
-            GtkWidget * widget = gnc_html_get_widget (priv->html);
+            GtkWidget *widget = gnc_html_get_webview (priv->html);
 
             gnc_plugin_page_report_load_uri (report_plugin_page);
 
@@ -752,14 +752,11 @@ static void
 gnc_plugin_page_report_destroy_widget(GncPluginPage *plugin_page)
 {
     GncPluginPageReportPrivate *priv;
-    GtkWidget *widget;
 
     // FIXME: cleanup other resources.
 
     PINFO("destroy widget");
     priv = GNC_PLUGIN_PAGE_REPORT_GET_PRIVATE(plugin_page);
-
-    widget = gnc_html_get_widget(priv->html);
 
     // Remove the page_changed signal callback
     gnc_plugin_page_disconnect_page_changed (GNC_PLUGIN_PAGE(plugin_page));

--- a/gnucash/gschemas/org.gnucash.warnings.gschema.xml.in
+++ b/gnucash/gschemas/org.gnucash.warnings.gschema.xml.in
@@ -9,6 +9,11 @@
       <summary>Print checks from multiple accounts</summary>
       <description>This dialog is presented if you try to print checks from multiple accounts at the same time.</description>
     </key>
+    <key name="closing-window-question" type="i">
+      <default>0</default>
+      <summary>Confirm Window Close</summary>
+      <description>This dialog is presented when there is more than one window.</description>
+    </key>
     <key name="inv-entry-mod" type="i">
       <default>0</default>
       <summary>Commit changes to a invoice entry</summary>
@@ -106,6 +111,11 @@
       <default>0</default>
       <summary>Print checks from multiple accounts</summary>
       <description>This dialog is presented if you try to print checks from multiple accounts at the same time.</description>
+    </key>
+    <key name="closing-window-question" type="i">
+      <default>0</default>
+      <summary>Confirm Window Close</summary>
+      <description>This dialog is presented when there is more than one window.</description>
     </key>
     <key name="inv-entry-mod" type="i">
       <default>0</default>

--- a/gnucash/html/gnc-html.c
+++ b/gnucash/html/gnc-html.c
@@ -574,6 +574,39 @@ gnc_html_get_widget( GncHtml* self )
     return GNC_HTML_GET_PRIVATE(self)->container;
 }
 
+
+GtkWidget *
+gnc_html_get_webview( GncHtml* self )
+{
+    GncHtmlPrivate* priv;
+    GList *sw_list = NULL;
+    GtkWidget *webview = NULL;
+
+    g_return_val_if_fail (self != NULL, NULL);
+    g_return_val_if_fail (GNC_IS_HTML(self), NULL);
+
+    priv = GNC_HTML_GET_PRIVATE(self);
+    sw_list = gtk_container_get_children (GTK_CONTAINER(priv->container));
+
+    if (sw_list) // the scroll window has only one child
+    {
+#ifdef WEBKIT1
+        webview = sw_list->data;
+#else
+        GList *vp_list = gtk_container_get_children (GTK_CONTAINER(sw_list->data));
+ 
+        if (vp_list) // the viewport has only one child
+        {
+            webview = vp_list->data;
+            g_list_free (vp_list);
+        }
+#endif
+    }
+    g_list_free (sw_list);
+    return webview;
+}
+
+
 void
 gnc_html_set_parent( GncHtml* self, GtkWindow* parent )
 {

--- a/gnucash/html/gnc-html.h
+++ b/gnucash/html/gnc-html.h
@@ -257,6 +257,15 @@ gnc_html_history* gnc_html_get_history( GncHtml* html );
 GtkWidget* gnc_html_get_widget( GncHtml* html );
 
 /**
+ * Returns the webview widget for this html engine
+ *
+ * @param html GncHtml object
+ * @return webview widget
+ */
+GtkWidget* gnc_html_get_webview( GncHtml* html );
+
+
+/**
  * Sets the parent window for this html engine.  The engine will be embedded in this parent.
  *
  * @param html GncHtml object


### PR DESCRIPTION
This has stemmed from Bug 797982 which causes Gnucash to sometimes crash when changing books when using 'File->Open' from the first book and there are open report pages. @jralls traced this down to the use of the g_idle_add to load the reports.

To fix this I have done away with the g_idle_add and the reports now load when the page has focus. To achieve this a flag is set at the start of the restoring window pages and reset at the end which is tested on report page focus. This has the benefit of reducing the load time if the last open page is not a report page BUT when you switch to a report page you will need to wait for the report to be rendered.

While looking at this I noticed that the page focus was focusing on the scroll window and not the Webkit webview so changed that which led to the commit for intercepting the Ctrl+Alt+Page_Up/Down on the report pages which is used for notebook navigation.

The last commit adds two key combinations Ctrl+Alt+Menu to raise the notebook page select menu and I think a translatable key combo of Ctrl+Alt+a to jump to the Accounts page for those heavy keyboard users. @christopherlam 

I have tested this on my Linux VM and Windows 10 and seems to be OK but please give it a try. 