### PR TITLE
Import matcher: add extra checkbox to make memo column invisible

### DIFF
--- a/gnucash/gtkbuilder/dialog-import.glade
+++ b/gnucash/gtkbuilder/dialog-import.glade
@@ -926,7 +926,7 @@
         <property name="halign">center</property>
         <child>
           <object class="GtkCheckButton" id="show_source_account_button">
-            <property name="label" translatable="yes">Show the _Account column</property>
+            <property name="label" translatable="yes">Show _Account column</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
@@ -941,6 +941,22 @@
           </packing>
         </child>
         <child>
+          <object class="GtkCheckButton" id="show_memo_column_button">
+            <property name="label" translatable="yes">Show _Memo column</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="halign">center</property>
+            <property name="use_underline">True</property>
+            <property name="draw_indicator">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkCheckButton" id="show_matched_info_button">
             <property name="label" translatable="yes">Show _matched information</property>
             <property name="visible">True</property>
@@ -952,7 +968,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">2</property>
           </packing>
         </child>
         <child>


### PR DESCRIPTION
Does what the title says: In addition to the "account column" checkbox, another one for the memo column is added.

During implementation I was puzzled because of the super-obvious code duplication in the two functions `gnc_gen_trans_assist_new` and `gnc_gen_trans_list_new` - but I didn't feel called to clean up all of this duplication, only in the parts that I added. Anyone else may feel free to step up here.