### PR TITLE
Fix CZK currency partname to nominative singular

### DIFF
--- a/libgnucash/engine/iso-4217-currencies.xml
+++ b/libgnucash/engine/iso-4217-currencies.xml
@@ -799,7 +799,7 @@
   isocode="CZK"
   fullname="Czech Koruna"
   unitname="koruna"
-  partname="haleru"
+  partname="haler"
   namespace="ISO4217"
   exchange-code="203"
   parts-per-unit="100"


### PR DESCRIPTION
"Haléřů" is plural genetive, "Haléř" is singular nominative. 
https://cs.wikipedia.org/wiki/Hal%C3%A9%C5%99