### PR TITLE
[gnc-ui-util.c] reduce gnc_numeric val for display

### DIFF
--- a/libgnucash/app-utils/gnc-ui-util.c
+++ b/libgnucash/app-utils/gnc-ui-util.c
@@ -1531,7 +1531,7 @@ PrintAmountInternal(char *buf, gnc_numeric val, const GNCPrintAmountInfo *info)
 
     /* Print the absolute value, but remember sign */
     value_is_negative = gnc_numeric_negative_p (val);
-    val = gnc_numeric_abs (val);
+    val = gnc_numeric_abs (gnc_numeric_reduce (val));
 
     /* Try to print as decimal. */
     value_is_decimal = gnc_numeric_to_decimal(&val, NULL);

--- a/libgnucash/engine/test/gtest-gnc-numeric.cpp
+++ b/libgnucash/engine/test/gtest-gnc-numeric.cpp
@@ -548,4 +548,9 @@ TEST(gnc_numeric_functions, test_conversion_to_decimal)
     EXPECT_NO_THROW(r = c.to_decimal());
     EXPECT_EQ(27434842, r.num());
     EXPECT_EQ(100, r.denom());
+
+    GncNumeric d(5000000000, 50000000);
+    EXPECT_NO_THROW(r = d.to_decimal());
+    EXPECT_EQ(10000, r.num());
+    EXPECT_EQ(100, r.denom());
 }


### PR DESCRIPTION
I'm 100% sure this is safe, but is it the correct fix? Example datafile at https://bugs.gnucash.org/show_bug.cgi?id=797796#c154 will spew a lot of warnings without this fix. These fractions reduce cleanly to 140/1, 170/1, 100/1 etc.

Removes warnings with large numerator & denominator e.g.

```
   GncNumeric 11900000000/85000000 could not be represented as a decimal without rounding.
   GncNumeric 11050000000/65000000 could not be represented as a decimal without rounding.
   GncNumeric 5000000000/50000000 could not be represented as a decimal without rounding.
   GncNumeric 11900000000/85000000 could not be represented as a decimal without rounding.
   GncNumeric 11050000000/65000000 could not be represented as a decimal without rounding.
   GncNumeric 5000000000/50000000 could not be represented as a decimal without rounding.
   GncNumeric 11900000000/85000000 could not be represented as a decimal without rounding.
   GncNumeric 11050000000/65000000 could not be represented as a decimal without rounding.
   GncNumeric 5000000000/50000000 could not be represented as a decimal without rounding.
```