### PR TITLE
Bug644242 - Register Panning

### DIFF
--- a/gnucash/register/register-gnome/gnucash-header.c
+++ b/gnucash/register/register-gnome/gnucash-header.c
@@ -188,6 +188,31 @@ gnc_header_draw_offscreen (GncHeader *header)
 }
 
 
+gint
+gnc_header_get_cell_offset (GncHeader *header, gint col, gint *cell_width)
+{
+    SheetBlockStyle *style = header->style;
+    gint j;
+    gint offset = 0;
+
+    for (j = 0; j < style->ncols; j++)
+    {
+        CellDimensions *cd;
+
+        cd = gnucash_style_get_cell_dimensions (style, 0, j);
+        if (!cd) continue;
+
+        if (j == col)
+        {
+            *cell_width = cd->pixel_width;
+            break;
+        }
+        offset = offset + cd->pixel_width;
+    }
+    return offset;
+}
+
+
 static gboolean
 gnc_header_draw (GtkWidget *header, cairo_t *cr)
 {

--- a/gnucash/register/register-gnome/gnucash-header.c
+++ b/gnucash/register/register-gnome/gnucash-header.c
@@ -79,8 +79,8 @@ gnc_header_draw_offscreen (GncHeader *header)
     if (header->surface)
         cairo_surface_destroy (header->surface);
     header->surface = cairo_image_surface_create (CAIRO_FORMAT_ARGB32,
-                                                header->width,
-                                                header->height);
+                                                  header->width,
+                                                  header->height);
 
     cr = cairo_create (header->surface);
 
@@ -134,7 +134,7 @@ gnc_header_draw_offscreen (GncHeader *header)
 
             cd = gnucash_style_get_cell_dimensions (style, i, j);
             if (!cd) continue;
-            
+
             height = cd->pixel_height;
             if (header->in_resize && (j == header->resize_col))
                 width = header->resize_col_width;
@@ -158,7 +158,7 @@ gnc_header_draw_offscreen (GncHeader *header)
             if (!text)
                 text = "";
 
-            layout = gtk_widget_create_pango_layout (GTK_WIDGET (header->sheet), text);
+            layout = gtk_widget_create_pango_layout (GTK_WIDGET(header->sheet), text);
 
             pango_layout_get_pixel_extents (layout, NULL, &logical_rect);
 
@@ -249,7 +249,7 @@ gnc_header_request_redraw (GncHeader *header)
 static void
 gnc_header_unrealize (GtkWidget *widget)
 {
-    GncHeader *header = GNC_HEADER (widget);
+    GncHeader *header = GNC_HEADER(widget);
     if (header->surface)
         cairo_surface_destroy (header->surface);
     header->surface = NULL;
@@ -262,8 +262,8 @@ gnc_header_unrealize (GtkWidget *widget)
         g_object_unref (header->normal_cursor);
     header->normal_cursor = NULL;
 
-    if (GTK_WIDGET_CLASS (parent_class)->unrealize)
-        GTK_WIDGET_CLASS (parent_class)->unrealize (GTK_WIDGET(header));
+    if (GTK_WIDGET_CLASS(parent_class)->unrealize)
+        GTK_WIDGET_CLASS(parent_class)->unrealize (GTK_WIDGET(header));
 }
 
 
@@ -272,12 +272,12 @@ gnc_header_finalize (GObject *object)
 {
     GncHeader *header;
 
-    header = GNC_HEADER (object);
+    header = GNC_HEADER(object);
 
     g_free (header->cursor_name);
     header->cursor_name = NULL;
 
-    G_OBJECT_CLASS (parent_class)->finalize (object);
+    G_OBJECT_CLASS(parent_class)->finalize (object);
 }
 
 
@@ -289,7 +289,7 @@ gnc_header_reconfigure (GncHeader *header)
     int w, h;
 
     g_return_if_fail (header != NULL);
-    g_return_if_fail (GNC_IS_HEADER (header));
+    g_return_if_fail (GNC_IS_HEADER(header));
 
     sheet = GNUCASH_SHEET(header->sheet);
     old_style = header->style;
@@ -314,8 +314,8 @@ gnc_header_reconfigure (GncHeader *header)
     {
         header->height = h;
         header->width = w;
-        gtk_layout_set_size(GTK_LAYOUT(header), w, h);
-        gtk_widget_set_size_request(GTK_WIDGET(header), -1, h);
+        gtk_layout_set_size (GTK_LAYOUT(header), w, h);
+        gtk_widget_set_size_request (GTK_WIDGET(header), -1, h);
         gnc_header_request_redraw (header);
     }
 }
@@ -325,7 +325,7 @@ gnc_header_set_header_rows (GncHeader *header,
                             int num_phys_rows)
 {
     g_return_if_fail (header != NULL);
-    g_return_if_fail (GNC_IS_HEADER (header));
+    g_return_if_fail (GNC_IS_HEADER(header));
 
     header->num_phys_rows = num_phys_rows;
 }
@@ -348,7 +348,7 @@ pointer_on_resize_line (GncHeader *header, int x, G_GNUC_UNUSED int y, int *col)
     {
         cd = gnucash_style_get_cell_dimensions (style, 0, j);
         if (!cd) continue;
-        
+
         pixels += cd->pixel_width;
         if (x >= pixels - 1 && x <= pixels + 1)
             on_the_line = TRUE;
@@ -453,7 +453,7 @@ gnc_header_event (GtkWidget *widget, GdkEvent *event)
             break;
         }
 
-        if (pointer_on_resize_line(header, x, y, &col) &&
+        if (pointer_on_resize_line (header, x, y, &col) &&
                 gnucash_style_col_is_resizable (header->style, col))
             gdk_window_set_cursor (window, header->resize_cursor);
         else
@@ -560,7 +560,7 @@ gnc_header_get_property (GObject *object,
                          GValue *value,
                          GParamSpec *pspec)
 {
-    GncHeader *header = GNC_HEADER (object);
+    GncHeader *header = GNC_HEADER(object);
 
     switch (param_id)
     {
@@ -571,7 +571,7 @@ gnc_header_get_property (GObject *object,
         g_value_set_string (value, header->cursor_name);
         break;
     default:
-        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, param_id, pspec);
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, param_id, pspec);
         break;
     }
 }
@@ -582,15 +582,15 @@ gnc_header_set_property (GObject *object,
                          const GValue *value,
                          GParamSpec *pspec)
 {
-    GncHeader *header = GNC_HEADER (object);
-    GtkLayout *layout = GTK_LAYOUT (header);
+    GncHeader *header = GNC_HEADER(object);
+    GtkLayout *layout = GTK_LAYOUT(header);
     gboolean needs_update = FALSE;
     gchar *old_name;
 
     switch (param_id)
     {
     case PROP_SHEET:
-        header->sheet = GNUCASH_SHEET (g_value_get_object (value));
+        header->sheet = GNUCASH_SHEET(g_value_get_object (value));
         gtk_scrollable_set_hadjustment (GTK_SCROLLABLE(layout), header->sheet->hadj);
         needs_update = TRUE;
         break;
@@ -603,7 +603,7 @@ gnc_header_set_property (GObject *object,
         g_free (old_name);
         break;
     default:
-        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, param_id, pspec);
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, param_id, pspec);
         break;
     }
 
@@ -625,14 +625,15 @@ gnc_header_init (GncHeader *header)
     header->width = 400;
     header->style = NULL;
 
-    gtk_widget_add_events(GTK_WIDGET(header), (GDK_EXPOSURE_MASK
+    gtk_widget_add_events (GTK_WIDGET(header),
+                          (GDK_EXPOSURE_MASK
                           | GDK_BUTTON_PRESS_MASK
                           | GDK_BUTTON_RELEASE_MASK
                           | GDK_POINTER_MOTION_MASK
                           | GDK_POINTER_MOTION_HINT_MASK));
 
-    g_signal_connect(G_OBJECT(header), "configure_event",
-                     G_CALLBACK(gnc_header_reconfigure), NULL);
+    g_signal_connect (G_OBJECT(header), "configure_event",
+                      G_CALLBACK(gnc_header_reconfigure), NULL);
     gtk_widget_show_all (GTK_WIDGET(header));
 }
 
@@ -640,8 +641,8 @@ gnc_header_init (GncHeader *header)
 static void
 gnc_header_class_init (GncHeaderClass *header_class)
 {
-    GObjectClass  *object_class = G_OBJECT_CLASS (header_class);
-    GtkWidgetClass *item_class = GTK_WIDGET_CLASS (header_class);
+    GObjectClass  *object_class = G_OBJECT_CLASS(header_class);
+    GtkWidgetClass *item_class = GTK_WIDGET_CLASS(header_class);
 
     gtk_widget_class_set_css_name (GTK_WIDGET_CLASS(header_class), "gnc-id-header");
 

--- a/gnucash/register/register-gnome/gnucash-header.h
+++ b/gnucash/register/register-gnome/gnucash-header.h
@@ -74,5 +74,10 @@ void gnc_header_request_redraw (GncHeader *header);
 
 void gnc_header_set_header_rows (GncHeader *header,
                                  int num_phys_rows);
+
+gint gnc_header_get_cell_offset (GncHeader *header,
+                                 gint col,
+                                 gint *cell_width);
+
 /** @} */
 #endif /* GNUCASH_HEADER_H */

--- a/gnucash/register/register-gnome/gnucash-sheet-private.c
+++ b/gnucash/register/register-gnome/gnucash-sheet-private.c
@@ -60,8 +60,8 @@ find_block_by_pixel (GnucashSheet *sheet,
     SheetBlock *block;
     VirtualCellLocation vc_loc = { 1, 0 };
 
-    g_return_val_if_fail(y >= 0, NULL);
-    g_return_val_if_fail(x >= 0, NULL);
+    g_return_val_if_fail (y >= 0, NULL);
+    g_return_val_if_fail (x >= 0, NULL);
 
     do
     {
@@ -199,7 +199,7 @@ get_cell_borders (GnucashSheet *sheet, VirtualLocation virt_loc,
     if (gnc_table_move_vertical_position (sheet->table, &v_loc, -1))
     {
         gnucash_sheet_get_borders (sheet, v_loc, &neighbor);
-        borders->top = MAX (borders->top, neighbor.bottom);
+        borders->top = MAX(borders->top, neighbor.bottom);
     }
 
     /* bottom */
@@ -207,7 +207,7 @@ get_cell_borders (GnucashSheet *sheet, VirtualLocation virt_loc,
     if (gnc_table_move_vertical_position (sheet->table, &v_loc, 1))
     {
         gnucash_sheet_get_borders (sheet, v_loc, &neighbor);
-        borders->bottom = MAX (borders->bottom, neighbor.top);
+        borders->bottom = MAX(borders->bottom, neighbor.top);
     }
 
     /* left */
@@ -216,7 +216,7 @@ get_cell_borders (GnucashSheet *sheet, VirtualLocation virt_loc,
     if (gnc_table_virtual_loc_valid (sheet->table, v_loc, TRUE))
     {
         gnucash_sheet_get_borders (sheet, v_loc, &neighbor);
-        borders->left = MAX (borders->left, neighbor.right);
+        borders->left = MAX(borders->left, neighbor.right);
     }
 
     /* right */
@@ -225,7 +225,7 @@ get_cell_borders (GnucashSheet *sheet, VirtualLocation virt_loc,
     if (gnc_table_virtual_loc_valid (sheet->table, v_loc, TRUE))
     {
         gnucash_sheet_get_borders (sheet, v_loc, &neighbor);
-        borders->right = MAX (borders->right, neighbor.left);
+        borders->right = MAX(borders->right, neighbor.left);
     }
 }
 
@@ -235,7 +235,7 @@ get_cell_borders (GnucashSheet *sheet, VirtualLocation virt_loc,
 specified by numerator and denominator. This is some simple integer arithmetics
 for the case when we don't even need a conversion to floating point and
 backwards. */
-static guint8 inc_intensity_byte(guint8 input, int numerator, int denominator)
+static guint8 inc_intensity_byte (guint8 input, int numerator, int denominator)
 {
     guint8 result_inv, result;
     guint8 input_inv = 0xff - input;
@@ -247,12 +247,12 @@ static guint8 inc_intensity_byte(guint8 input, int numerator, int denominator)
 /** For a given RGB value, increase the color intensity for each of the three
 colors identically by 10 percent (i.e. make them "less black" and "more gray")
 and return this changed RGB value. */
-static guint32 inc_intensity_10percent(guint32 argb)
+static guint32 inc_intensity_10percent (guint32 argb)
 {
     guint32 result =
-            (inc_intensity_byte((argb & 0x00FF0000) >> 16, 8, 10) << 16)
-            + (inc_intensity_byte((argb & 0x0000FF00) >> 8, 8, 10) << 8)
-            + (inc_intensity_byte(argb & 0x000000FF, 8, 10));
+            (inc_intensity_byte ((argb & 0x00FF0000) >> 16, 8, 10) << 16)
+            + (inc_intensity_byte ((argb & 0x0000FF00) >> 8, 8, 10) << 8)
+            + (inc_intensity_byte (argb & 0x000000FF, 8, 10));
     return result;
 }
 #endif
@@ -261,7 +261,7 @@ static guint32 inc_intensity_10percent(guint32 argb)
 specified by numerator and denominator. This is some simple integer arithmetics
 for the case when we don't even need a conversion to floating point and
 backwards. */
-static guint8 dec_intensity_byte(guint8 input, int numerator, int denominator)
+static guint8 dec_intensity_byte (guint8 input, int numerator, int denominator)
 {
     guint8 result;
     result = (input * numerator) / denominator;
@@ -270,14 +270,14 @@ static guint8 dec_intensity_byte(guint8 input, int numerator, int denominator)
 
 /** For a given RGB value, decrease the color intensity for each of the three
 colors identically by 10 percent and return this changed RGB value. */
-static guint32 dec_intensity_10percent(guint32 argb)
+static guint32 dec_intensity_10percent (guint32 argb)
 {
     // Multiply each single byte by 9/10 i.e. by 0.9 which decreases the
     // intensity by 10 percent.
     guint32 result =
-            (dec_intensity_byte((argb & 0x00FF0000) >> 16, 9, 10) << 16)
-            + (dec_intensity_byte((argb & 0x0000FF00) >> 8, 9, 10) << 8)
-            + (dec_intensity_byte(argb & 0x000000FF, 9, 10));
+            (dec_intensity_byte ((argb & 0x00FF0000) >> 16, 9, 10) << 16)
+            + (dec_intensity_byte ((argb & 0x0000FF00) >> 8, 9, 10) << 8)
+            + (dec_intensity_byte (argb & 0x000000FF, 9, 10));
     return result;
 }
 
@@ -326,8 +326,8 @@ draw_cell_line (cairo_t *cr, GdkRGBA *bg_color,
 }
 
 static void
-draw_hatching (cairo_t *cr,
-               double x, double y, G_GNUC_UNUSED double width, double height)
+draw_hatching (cairo_t *cr, double x, double y,
+               G_GNUC_UNUSED double width, double height)
 {
     GdkRGBA *fg_color;
     double h_x = x + 2.5;
@@ -375,10 +375,8 @@ draw_divider_line (cairo_t *cr, VirtualLocation virt_loc,
 }
 
 static void
-draw_cell (GnucashSheet *sheet,
-           SheetBlock *block,
-           VirtualLocation virt_loc,
-           cairo_t *cr,
+draw_cell (GnucashSheet *sheet, SheetBlock *block,
+           VirtualLocation virt_loc, cairo_t *cr,
            int x, int y, int width, int height)
 {
     GncItemEdit *item_edit = GNC_ITEM_EDIT(sheet->item_editor);
@@ -469,20 +467,20 @@ draw_cell (GnucashSheet *sheet,
 
     /* dividing line upper (red) */
     fg_color = &gn_red;
-    draw_divider_line(cr, virt_loc,
-                           table->model->dividing_row_upper, block->style->nrows,
-                           fg_color, x, y, width, height);
+    draw_divider_line (cr, virt_loc,
+                       table->model->dividing_row_upper, block->style->nrows,
+                       fg_color, x, y, width, height);
 
     /* dividing line (blue) */
     fg_color = &gn_blue;
-    draw_divider_line(cr, virt_loc,
-                           table->model->dividing_row, block->style->nrows,
-                           fg_color, x, y, width, height);
+    draw_divider_line (cr, virt_loc,
+                       table->model->dividing_row, block->style->nrows,
+                       fg_color, x, y, width, height);
 
     /* dividing line lower (blue) */
-    draw_divider_line(cr, virt_loc,
-                           table->model->dividing_row_lower, block->style->nrows,
-                           fg_color, x, y, width, height);
+    draw_divider_line (cr, virt_loc,
+                       table->model->dividing_row_lower, block->style->nrows,
+                       fg_color, x, y, width, height);
 
     layout = gtk_widget_create_pango_layout (GTK_WIDGET (sheet), text);
 
@@ -554,10 +552,8 @@ exit:
 }
 
 static void
-draw_block (GnucashSheet *sheet,
-            SheetBlock *block,
-            VirtualLocation virt_loc,
-            cairo_t *cr,
+draw_block (GnucashSheet *sheet, SheetBlock *block,
+            VirtualLocation virt_loc, cairo_t *cr,
             int x, int y, int width, int height)
 {
     CellDimensions *cd;
@@ -565,13 +561,13 @@ draw_block (GnucashSheet *sheet,
     gint y_paint;
     gint w, h;
 
-    for ( virt_loc.phys_row_offset = 0;
+    for (virt_loc.phys_row_offset = 0;
             virt_loc.phys_row_offset < block->style->nrows ;
-            virt_loc.phys_row_offset++ )
+            virt_loc.phys_row_offset++)
     {
-        for ( virt_loc.phys_col_offset = 0;
+        for (virt_loc.phys_col_offset = 0;
                 virt_loc.phys_col_offset < block->style->ncols ;
-                virt_loc.phys_col_offset++ )
+                virt_loc.phys_col_offset++)
         {
             cd = gnucash_style_get_cell_dimensions
                  (block->style,
@@ -618,17 +614,16 @@ gnucash_sheet_draw_internal (GnucashSheet* sheet, cairo_t* cr,
     int height = alloc->height;
     GtkAdjustment * adj;
 
-    adj = gtk_scrollable_get_hadjustment(GTK_SCROLLABLE (sheet));
-    x = (gint) gtk_adjustment_get_value(adj);
-    adj = gtk_scrollable_get_vadjustment(GTK_SCROLLABLE (sheet));
-    y = (gint) gtk_adjustment_get_value(adj);
+    adj = gtk_scrollable_get_hadjustment (GTK_SCROLLABLE(sheet));
+    x = (gint) gtk_adjustment_get_value (adj);
+    adj = gtk_scrollable_get_vadjustment (GTK_SCROLLABLE(sheet));
+    y = (gint) gtk_adjustment_get_value (adj);
 
     if (x < 0 || y < 0)
         return FALSE;
 
     /* compute our initial values where we start drawing */
-    sheet_block = find_block_by_pixel (sheet, x, y,
-                  &virt_loc.vcell_loc);
+    sheet_block = find_block_by_pixel (sheet, x, y, &virt_loc.vcell_loc);
     if (!sheet_block || !sheet_block->style)
         return FALSE;
 
@@ -637,8 +632,7 @@ gnucash_sheet_draw_internal (GnucashSheet* sheet, cairo_t* cr,
     {
         while (TRUE)
         {
-            sheet_block = gnucash_sheet_get_block
-                          (sheet, virt_loc.vcell_loc);
+            sheet_block = gnucash_sheet_get_block (sheet, virt_loc.vcell_loc);
 
             if (!sheet_block || !sheet_block->style)
                 return TRUE;
@@ -655,7 +649,6 @@ gnucash_sheet_draw_internal (GnucashSheet* sheet, cairo_t* cr,
         draw_block (sheet, sheet_block, virt_loc, cr,
                     x, y, width, height);
     }
-
     return TRUE;
 }
 
@@ -669,10 +662,10 @@ gnucash_sheet_draw_cursor (GnucashCursor *cursor, cairo_t *cr)
     int y = 0;
     GtkAdjustment * adj;
 
-    adj = gtk_scrollable_get_hadjustment(GTK_SCROLLABLE (cursor->sheet));
-    x = (gint) gtk_adjustment_get_value(adj);
-    adj = gtk_scrollable_get_vadjustment(GTK_SCROLLABLE (cursor->sheet));
-    y = (gint) gtk_adjustment_get_value(adj);
+    adj = gtk_scrollable_get_hadjustment (GTK_SCROLLABLE(cursor->sheet));
+    x = (gint) gtk_adjustment_get_value (adj);
+    adj = gtk_scrollable_get_vadjustment (GTK_SCROLLABLE(cursor->sheet));
+    y = (gint) gtk_adjustment_get_value (adj);
 
     fg_color = &gn_black;
 

--- a/gnucash/register/register-gnome/gnucash-sheet.c
+++ b/gnucash/register/register-gnome/gnucash-sheet.c
@@ -78,14 +78,14 @@ static GtkLayout *sheet_parent_class;
 static void gnucash_sheet_start_editing_at_cursor (GnucashSheet *sheet);
 
 static gboolean gnucash_sheet_cursor_move (GnucashSheet *sheet,
-        VirtualLocation virt_loc);
+                                           VirtualLocation virt_loc);
 
 static void gnucash_sheet_deactivate_cursor_cell (GnucashSheet *sheet);
 static void gnucash_sheet_activate_cursor_cell (GnucashSheet *sheet,
-        gboolean changed_cells);
+                                                gboolean changed_cells);
 static void gnucash_sheet_stop_editing (GnucashSheet *sheet);
-static gboolean gnucash_sheet_check_direct_update_cell(GnucashSheet *sheet,
-        const VirtualLocation virt_loc);
+static gboolean gnucash_sheet_check_direct_update_cell (GnucashSheet *sheet,
+                                                        const VirtualLocation virt_loc);
 gboolean gnucash_sheet_draw_cb (GtkWidget *widget, cairo_t *cr,
                                 G_GNUC_UNUSED gpointer data);
 
@@ -103,22 +103,22 @@ gboolean gnucash_sheet_draw_cb (GtkWidget *widget, cairo_t *cr,
 static inline void
 gnucash_sheet_set_entry_selection (GnucashSheet *sheet)
 {
-    DEBUG ("Set entry selection to sheet: %d:%d", sheet->bound, sheet->pos);
-    gtk_editable_select_region (GTK_EDITABLE (sheet->entry),
+    DEBUG("Set entry selection to sheet: %d:%d", sheet->bound, sheet->pos);
+    gtk_editable_select_region (GTK_EDITABLE(sheet->entry),
                                 sheet->bound, sheet->pos);
 }
 
 static inline void
 gnucash_sheet_set_selection_from_entry (GnucashSheet *sheet)
 {
-    gtk_editable_get_selection_bounds (GTK_EDITABLE (sheet->entry),
+    gtk_editable_get_selection_bounds (GTK_EDITABLE(sheet->entry),
                                        &sheet->bound, &sheet->pos);
 }
 
 static inline void
 gnucash_sheet_set_selection (GnucashSheet *sheet, int pos, int bound)
 {
-    DEBUG ("Set sheet selection %d:%d", bound, pos);
+    DEBUG("Set sheet selection %d:%d", bound, pos);
     sheet->pos = pos;
     sheet->bound = bound;
     gnucash_sheet_set_entry_selection (sheet);
@@ -161,16 +161,16 @@ gnucash_sheet_clear_selection (GnucashSheet *sheet)
 static inline void
 gnucash_sheet_set_entry_value (GnucashSheet *sheet, const char* value)
 {
-    g_signal_handler_block (G_OBJECT (sheet->entry),
+    g_signal_handler_block (G_OBJECT(sheet->entry),
                             sheet->insert_signal);
-    g_signal_handler_block (G_OBJECT (sheet->entry),
+    g_signal_handler_block (G_OBJECT(sheet->entry),
                             sheet->delete_signal);
 
-    gtk_entry_set_text (GTK_ENTRY (sheet->entry), value);
+    gtk_entry_set_text (GTK_ENTRY(sheet->entry), value);
 
-    g_signal_handler_unblock (G_OBJECT (sheet->entry),
+    g_signal_handler_unblock (G_OBJECT(sheet->entry),
                               sheet->delete_signal);
-    g_signal_handler_unblock (G_OBJECT (sheet->entry),
+    g_signal_handler_unblock (G_OBJECT(sheet->entry),
                               sheet->insert_signal);
 
 }
@@ -192,7 +192,7 @@ gnucash_sheet_cell_valid (GnucashSheet *sheet, VirtualLocation virt_loc)
     SheetBlockStyle *style;
 
     valid = !gnucash_sheet_virt_cell_out_of_bounds (sheet,
-            virt_loc.vcell_loc);
+                                                    virt_loc.vcell_loc);
 
     if (valid)
     {
@@ -212,7 +212,7 @@ static void
 gnucash_sheet_cursor_set (GnucashSheet *sheet, VirtualLocation virt_loc)
 {
     g_return_if_fail (sheet != NULL);
-    g_return_if_fail (GNUCASH_IS_SHEET (sheet));
+    g_return_if_fail (GNUCASH_IS_SHEET(sheet));
 
     g_return_if_fail (virt_loc.vcell_loc.virt_row >= 0 ||
                       virt_loc.vcell_loc.virt_row <= sheet->num_virt_rows);
@@ -327,7 +327,7 @@ gnucash_sheet_set_text_bounds (GnucashSheet *sheet, GdkRectangle *rect,
 
 gint
 gnucash_sheet_get_text_offset (GnucashSheet *sheet, const VirtualLocation virt_loc,
-                                gint rect_width, gint logical_width)
+                               gint rect_width, gint logical_width)
 {
     GncItemEdit *item_edit = GNC_ITEM_EDIT(sheet->item_editor);
     Table *table = sheet->table;
@@ -401,7 +401,7 @@ gnucash_sheet_activate_cursor_cell (GnucashSheet *sheet,
         gnucash_sheet_redraw_block (sheet, virt_loc.vcell_loc);
     else
     {
-        gtk_entry_reset_im_context(GTK_ENTRY (sheet->entry));
+        gtk_entry_reset_im_context (GTK_ENTRY (sheet->entry));
         gnucash_sheet_start_editing_at_cursor (sheet);
 
         // Came here by keyboard, select text, otherwise text cursor to
@@ -446,8 +446,7 @@ gnucash_sheet_activate_cursor_cell (GnucashSheet *sheet,
             }
             gnucash_sheet_set_position (sheet, index + trailing);
         }
-        sheet->direct_update_cell =
-            gnucash_sheet_check_direct_update_cell (sheet, virt_loc);
+        sheet->direct_update_cell = gnucash_sheet_check_direct_update_cell (sheet, virt_loc);
     }
     // when a gui refresh is called, we end up here so only grab the focus
     // if the sheet is showing on the current plugin_page
@@ -526,7 +525,6 @@ gnucash_sheet_y_pixel_to_block (GnucashSheet *sheet, int y)
         if (block->origin_y + block->style->dimensions->height > y)
             break;
     }
-
     return vcell_loc.virt_row;
 }
 
@@ -540,27 +538,24 @@ gnucash_sheet_compute_visible_range (GnucashSheet *sheet)
     gint height;
     gint cy;
     gint top_block;
-//    gint old_visible_blocks, old_visible_rows;
 
     g_return_if_fail (sheet != NULL);
-    g_return_if_fail (GNUCASH_IS_SHEET (sheet));
+    g_return_if_fail (GNUCASH_IS_SHEET(sheet));
 
     gtk_widget_get_allocation (GTK_WIDGET(sheet), &alloc);
     height = alloc.height;
 
     adj = gtk_scrollable_get_vadjustment (GTK_SCROLLABLE(sheet));
-    cy = gtk_adjustment_get_value(adj);
+    cy = gtk_adjustment_get_value (adj);
 
     top_block = gnucash_sheet_y_pixel_to_block (sheet, cy);
 
-//    old_visible_blocks = sheet->num_visible_blocks;
-//    old_visible_rows = sheet->num_visible_phys_rows;
     sheet->num_visible_blocks = 0;
     sheet->num_visible_phys_rows = 0;
 
-    for ( vcell_loc.virt_row = top_block, vcell_loc.virt_col = 0;
-            vcell_loc.virt_row < sheet->num_virt_rows;
-            vcell_loc.virt_row++ )
+    for (vcell_loc.virt_row = top_block, vcell_loc.virt_col = 0;
+         vcell_loc.virt_row < sheet->num_virt_rows;
+         vcell_loc.virt_row++)
     {
         SheetBlock *block;
 
@@ -599,9 +594,9 @@ gnucash_sheet_show_row (GnucashSheet *sheet, gint virt_row)
                               sheet->num_virt_rows - 1);
 
     adj = gtk_scrollable_get_hadjustment (GTK_SCROLLABLE(sheet));
-    cx = gtk_adjustment_get_value(adj);
+    cx = gtk_adjustment_get_value (adj);
     adj = gtk_scrollable_get_vadjustment (GTK_SCROLLABLE(sheet));
-    cy = gtk_adjustment_get_value(adj);
+    cy = gtk_adjustment_get_value (adj);
     x = cx;
 
     gtk_widget_get_allocation (GTK_WIDGET(sheet), &alloc);
@@ -642,7 +637,7 @@ void
 gnucash_sheet_make_cell_visible (GnucashSheet *sheet, VirtualLocation virt_loc)
 {
     g_return_if_fail (sheet != NULL);
-    g_return_if_fail (GNUCASH_IS_SHEET (sheet));
+    g_return_if_fail (GNUCASH_IS_SHEET(sheet));
 
     if (!gnucash_sheet_cell_valid (sheet, virt_loc))
         return;
@@ -670,18 +665,18 @@ gnucash_sheet_show_range (GnucashSheet *sheet,
     g_return_if_fail (sheet != NULL);
     g_return_if_fail (GNUCASH_IS_SHEET(sheet));
 
-    start_loc.virt_row = MAX (start_loc.virt_row, 1);
-    start_loc.virt_row = MIN (start_loc.virt_row,
-                              sheet->num_virt_rows - 1);
+    start_loc.virt_row = MAX(start_loc.virt_row, 1);
+    start_loc.virt_row = MIN(start_loc.virt_row,
+                             sheet->num_virt_rows - 1);
 
-    end_loc.virt_row = MAX (end_loc.virt_row, 1);
-    end_loc.virt_row = MIN (end_loc.virt_row,
-                            sheet->num_virt_rows - 1);
+    end_loc.virt_row = MAX(end_loc.virt_row, 1);
+    end_loc.virt_row = MIN(end_loc.virt_row,
+                           sheet->num_virt_rows - 1);
 
     adj = gtk_scrollable_get_hadjustment (GTK_SCROLLABLE(sheet));
-    cx = gtk_adjustment_get_value(adj);
+    cx = gtk_adjustment_get_value (adj);
     adj = gtk_scrollable_get_vadjustment (GTK_SCROLLABLE(sheet));
-    cy = gtk_adjustment_get_value(adj);
+    cy = gtk_adjustment_get_value (adj);
     x = cx;
 
     gtk_widget_get_allocation (GTK_WIDGET(sheet), &alloc);
@@ -703,7 +698,7 @@ gnucash_sheet_show_range (GnucashSheet *sheet,
     }
 
     if (y > cy)
-        y -= height - MIN (block_height, height);
+        y -= height - MIN(block_height, height);
 
     if ((sheet->height - y) < height)
         y = sheet->height - height;
@@ -727,7 +722,7 @@ gnucash_sheet_update_adjustments (GnucashSheet *sheet)
     GtkAdjustment *vadj;
 
     g_return_if_fail (sheet != NULL);
-    g_return_if_fail (GNUCASH_IS_SHEET (sheet));
+    g_return_if_fail (GNUCASH_IS_SHEET(sheet));
     g_return_if_fail (sheet->vadj != NULL);
 
     vadj = sheet->vadj;
@@ -742,7 +737,7 @@ gnucash_sheet_update_adjustments (GnucashSheet *sheet)
 
 static void
 gnucash_sheet_vadjustment_value_changed (GtkAdjustment *adj,
-        GnucashSheet *sheet)
+                                         GnucashSheet *sheet)
 {
     gnucash_sheet_compute_visible_range (sheet);
 }
@@ -754,7 +749,7 @@ gnucash_sheet_redraw_all (GnucashSheet *sheet)
     g_return_if_fail (sheet != NULL);
     g_return_if_fail (GNUCASH_IS_SHEET(sheet));
 
-    gtk_widget_queue_draw (GTK_WIDGET (sheet));
+    gtk_widget_queue_draw (GTK_WIDGET(sheet));
 
     g_signal_emit_by_name (sheet->reg, "redraw_all");
 }
@@ -787,8 +782,7 @@ gnucash_sheet_redraw_block (GnucashSheet *sheet, VirtualCellLocation vcell_loc)
 
     gtk_widget_get_allocation (GTK_WIDGET(sheet), &alloc);
     h = block->style->dimensions->height;
-    w = MIN(block->style->dimensions->width,
-            alloc.width);
+    w = MIN(block->style->dimensions->width, alloc.width);
 
     gtk_widget_queue_draw_area (GTK_WIDGET(sheet), x, y, w + 1, h + 1);
 }
@@ -812,7 +806,7 @@ gnucash_sheet_finalize (GObject *object)
 {
     GnucashSheet *sheet;
 
-    sheet = GNUCASH_SHEET (object);
+    sheet = GNUCASH_SHEET(object);
 
     g_table_resize (sheet->blocks, 0, 0);
     g_table_destroy (sheet->blocks);
@@ -823,8 +817,8 @@ gnucash_sheet_finalize (GObject *object)
     g_hash_table_destroy (sheet->cursor_styles);
     g_hash_table_destroy (sheet->dimensions_hash_table);
 
-    if (G_OBJECT_CLASS (sheet_parent_class)->finalize)
-        (*G_OBJECT_CLASS (sheet_parent_class)->finalize)(object);
+    if (G_OBJECT_CLASS(sheet_parent_class)->finalize)
+        (*G_OBJECT_CLASS(sheet_parent_class)->finalize)(object);
 }
 
 
@@ -841,10 +835,10 @@ gnucash_sheet_create (Table *table)
     sheet->vadj = gtk_scrollable_get_vadjustment (GTK_SCROLLABLE(sheet));
     sheet->hadj = gtk_scrollable_get_hadjustment (GTK_SCROLLABLE(sheet));
 
-    g_signal_connect (G_OBJECT (sheet->vadj), "value_changed",
-                      G_CALLBACK (gnucash_sheet_vadjustment_value_changed), sheet);
-    g_signal_connect (G_OBJECT (sheet), "draw",
-                      G_CALLBACK (gnucash_sheet_draw_cb), sheet);
+    g_signal_connect (G_OBJECT(sheet->vadj), "value_changed",
+                      G_CALLBACK(gnucash_sheet_vadjustment_value_changed), sheet);
+    g_signal_connect (G_OBJECT(sheet), "draw",
+                      G_CALLBACK(gnucash_sheet_draw_cb), sheet);
 
     LEAVE("%p", sheet);
     return sheet;
@@ -895,12 +889,10 @@ gnucash_sheet_modify_current_cell (GnucashSheet *sheet, const gchar *new_text)
     Table *table = sheet->table;
     VirtualLocation virt_loc;
     int new_text_len;
-
     const char *retval;
-
     int cursor_position, start_sel, end_sel;
 
-    gnucash_cursor_get_virt(GNUCASH_CURSOR(sheet->cursor), &virt_loc);
+    gnucash_cursor_get_virt (GNUCASH_CURSOR(sheet->cursor), &virt_loc);
 
     if (!gnc_table_virtual_loc_valid (table, virt_loc, TRUE))
         return NULL;
@@ -925,7 +917,7 @@ gnucash_sheet_modify_current_cell (GnucashSheet *sheet, const gchar *new_text)
 
     if (retval)
     {
-        DEBUG ("%s", retval ? retval : "nothing");
+        DEBUG("%s", retval ? retval : "nothing");
         gnucash_sheet_set_entry_value (sheet, retval);
         gnucash_sheet_set_position_and_selection (sheet, cursor_position,
                                                   start_sel, end_sel);
@@ -942,19 +934,17 @@ typedef struct
 } select_info;
 
 static gboolean
-gnucash_sheet_direct_event(GnucashSheet *sheet, GdkEvent *event)
+gnucash_sheet_direct_event (GnucashSheet *sheet, GdkEvent *event)
 {
     GtkEditable *editable;
     Table *table = sheet->table;
     VirtualLocation virt_loc;
     gboolean result;
-
     char *new_text = NULL;
-
     int cursor_position, start_sel, end_sel;
     int new_position, new_start, new_end;
 
-    gnucash_cursor_get_virt(GNUCASH_CURSOR(sheet->cursor), &virt_loc);
+    gnucash_cursor_get_virt (GNUCASH_CURSOR(sheet->cursor), &virt_loc);
 
     if (!gnc_table_virtual_loc_valid (table, virt_loc, TRUE))
         return FALSE;
@@ -977,7 +967,7 @@ gnucash_sheet_direct_event(GnucashSheet *sheet, GdkEvent *event)
                                       event);
     if (result)
     {
-        DEBUG ("%s", new_text ? new_text : "nothing");
+        DEBUG("%s", new_text ? new_text : "nothing");
         if (new_text != NULL)
             gnucash_sheet_set_entry_value (sheet, new_text);
         gnucash_sheet_set_position_and_selection (sheet, new_position,
@@ -1015,16 +1005,16 @@ insert_text (const char* old_text, const char* new_text, int pos, int bound)
 static char*
 make_new_text (GnucashSheet *sheet, const char* new_text, int *position)
 {
-    GtkEditable* editable = (GTK_EDITABLE (sheet->entry));
+    GtkEditable* editable = (GTK_EDITABLE(sheet->entry));
     int pos, bound;
-    const char* old_text = gtk_entry_get_text (GTK_ENTRY (sheet->entry));
+    const char* old_text = gtk_entry_get_text (GTK_ENTRY(sheet->entry));
     int old_length = g_utf8_strlen (old_text, -1);
     int insert_length = g_utf8_strlen (new_text, -1);
 
     if (!old_text || old_length == 0)
     {
         *position = insert_length;
-        return g_strdup(new_text);
+        return g_strdup (new_text);
     }
 
     gtk_editable_get_selection_bounds (editable, &bound, &pos);
@@ -1072,12 +1062,12 @@ gnucash_sheet_insert_cb (GtkEditable *editable,
     const char *retval;
     int start_sel = 0, end_sel = 0;
     int old_position = *position;
-    const char* old_text = gtk_entry_get_text (GTK_ENTRY (sheet->entry));
+    const char* old_text = gtk_entry_get_text (GTK_ENTRY(sheet->entry));
 
     g_assert (GTK_WIDGET(editable) == sheet->entry);
     if (sheet->input_cancelled)
     {
-        g_signal_stop_emission_by_name (G_OBJECT (sheet->entry),
+        g_signal_stop_emission_by_name (G_OBJECT(sheet->entry),
                                         "insert_text");
         return;
     }
@@ -1109,7 +1099,7 @@ gnucash_sheet_insert_cb (GtkEditable *editable,
          * IMContext that would reset the selection, and we may need to keep it
          * so save it in the sheet values.
          */
-        DEBUG ("%s, got %s", new_text, retval);
+        DEBUG("%s, got %s", new_text, retval);
         gnucash_sheet_set_position_and_selection (sheet, *position, start_sel,
                                                   end_sel);
 
@@ -1125,9 +1115,9 @@ gnucash_sheet_insert_cb (GtkEditable *editable,
         retval = old_text;
 
         /* reset IMContext if disallowed chars */
-        gtk_entry_reset_im_context (GTK_ENTRY (sheet->entry));
+        gtk_entry_reset_im_context (GTK_ENTRY(sheet->entry));
         /* the entry was disallowed, so we stop the insert signal */
-        g_signal_stop_emission_by_name (G_OBJECT (sheet->entry),
+        g_signal_stop_emission_by_name (G_OBJECT(sheet->entry),
                                         "insert_text");
     }
 }
@@ -1135,7 +1125,7 @@ gnucash_sheet_insert_cb (GtkEditable *editable,
 static char*
 delete_text (GnucashSheet *sheet, int pos, int bound)
 {
-    const char* old_text = gtk_entry_get_text (GTK_ENTRY (sheet->entry));
+    const char* old_text = gtk_entry_get_text (GTK_ENTRY(sheet->entry));
     int old_length = g_utf8_strlen (old_text, -1);
     char* begin, *end;
     char *retval = NULL;
@@ -1176,7 +1166,7 @@ gnucash_sheet_delete_cb (GtkWidget *widget,
     int cursor_position = start_pos;
     int start_sel, end_sel;
 
-    gnucash_cursor_get_virt (GNUCASH_CURSOR (sheet->cursor), &virt_loc);
+    gnucash_cursor_get_virt (GNUCASH_CURSOR(sheet->cursor), &virt_loc);
 
     if (!gnc_table_virtual_loc_valid (table, virt_loc, FALSE))
         return;
@@ -1186,7 +1176,7 @@ gnucash_sheet_delete_cb (GtkWidget *widget,
 
     new_text = delete_text (sheet, start_pos, end_pos);
     new_text_len = strlen (new_text);
-    editable = GTK_EDITABLE (sheet->entry);
+    editable = GTK_EDITABLE(sheet->entry);
     gtk_editable_get_selection_bounds (editable, &start_sel, &end_sel);
     retval = gnc_table_modify_update (table, virt_loc,
                                       NULL, 0,
@@ -1200,7 +1190,7 @@ gnucash_sheet_delete_cb (GtkWidget *widget,
 
     g_signal_stop_emission_by_name (G_OBJECT(sheet->entry), "delete_text");
 
-    DEBUG ("%s", retval ? retval : "nothing");
+    DEBUG("%s", retval ? retval : "nothing");
     gnucash_sheet_set_position_and_selection (sheet, cursor_position,
                                               start_sel, end_sel);
 }
@@ -1208,19 +1198,17 @@ gnucash_sheet_delete_cb (GtkWidget *widget,
 gboolean
 gnucash_sheet_draw_cb (GtkWidget *widget, cairo_t *cr, G_GNUC_UNUSED gpointer data)
 {
-    GnucashSheet *sheet = GNUCASH_SHEET (widget);
+    GnucashSheet *sheet = GNUCASH_SHEET(widget);
     GtkStyleContext *context = gtk_widget_get_style_context (widget);
     GtkAllocation alloc;
-    gboolean result; //FIXME
 
-    gtk_widget_get_allocation(widget, &alloc);
+    gtk_widget_get_allocation (widget, &alloc);
 
     gtk_style_context_save (context);
     gtk_style_context_add_class (context, GTK_STYLE_CLASS_BACKGROUND);
     gtk_render_background (context, cr, 0, 0, alloc.width, alloc.height);
     gtk_style_context_restore (context);
 
-//FIXME what should be done with result being TRUE or FALSE
     gnucash_sheet_draw_internal (sheet, cr, &alloc);
     gnucash_sheet_draw_cursor (sheet->cursor, cr);
 
@@ -1236,7 +1224,7 @@ gnucash_sheet_size_allocate (GtkWidget *widget, GtkAllocation *allocation)
     ENTER("widget=%p, allocation=%p", widget, allocation);
 
     if (GTK_WIDGET_CLASS(sheet_parent_class)->size_allocate)
-        (*GTK_WIDGET_CLASS (sheet_parent_class)->size_allocate)
+        (*GTK_WIDGET_CLASS(sheet_parent_class)->size_allocate)
         (widget, allocation);
 
     if (allocation->height == sheet->window_height &&
@@ -1255,7 +1243,7 @@ gnucash_sheet_size_allocate (GtkWidget *widget, GtkAllocation *allocation)
     sheet->window_height = allocation->height;
     sheet->window_width  = allocation->width;
 
-    gnucash_cursor_configure (GNUCASH_CURSOR (sheet->cursor));
+    gnucash_cursor_configure (GNUCASH_CURSOR(sheet->cursor));
     gnc_header_reconfigure (GNC_HEADER(sheet->header_item));
     gnucash_sheet_set_scroll_region (sheet);
 
@@ -1269,8 +1257,7 @@ gnucash_sheet_size_allocate (GtkWidget *widget, GtkAllocation *allocation)
         virt_loc = sheet->table->current_cursor_loc;
 
         if (gnucash_sheet_cell_valid (sheet, virt_loc))
-            gnucash_sheet_show_row (sheet,
-                                    virt_loc.vcell_loc.virt_row);
+            gnucash_sheet_show_row (sheet, virt_loc.vcell_loc.virt_row);
     }
     gnc_header_request_redraw (GNC_HEADER(sheet->header_item));
     LEAVE(" ");
@@ -1282,7 +1269,7 @@ gnucash_sheet_focus_in_event (GtkWidget *widget, GdkEventFocus *event)
     GnucashSheet *sheet = GNUCASH_SHEET(widget);
 
     if (GTK_WIDGET_CLASS(sheet_parent_class)->focus_in_event)
-        (*GTK_WIDGET_CLASS (sheet_parent_class)->focus_in_event)
+        (*GTK_WIDGET_CLASS(sheet_parent_class)->focus_in_event)
         (widget, event);
 
     gnc_item_edit_focus_in (GNC_ITEM_EDIT(sheet->item_editor));
@@ -1296,7 +1283,7 @@ gnucash_sheet_focus_out_event (GtkWidget *widget, GdkEventFocus *event)
     GnucashSheet *sheet = GNUCASH_SHEET(widget);
 
     if (GTK_WIDGET_CLASS(sheet_parent_class)->focus_out_event)
-        (*GTK_WIDGET_CLASS (sheet_parent_class)->focus_out_event)
+        (*GTK_WIDGET_CLASS(sheet_parent_class)->focus_out_event)
         (widget, event);
 
     gnc_item_edit_focus_out (GNC_ITEM_EDIT(sheet->item_editor));
@@ -1304,8 +1291,8 @@ gnucash_sheet_focus_out_event (GtkWidget *widget, GdkEventFocus *event)
 }
 
 static gboolean
-gnucash_sheet_check_direct_update_cell(GnucashSheet *sheet,
-                                       const VirtualLocation virt_loc)
+gnucash_sheet_check_direct_update_cell (GnucashSheet *sheet,
+                                        const VirtualLocation virt_loc)
 {
     const gchar *type_name;
 
@@ -1327,14 +1314,14 @@ gnucash_sheet_start_editing_at_cursor (GnucashSheet *sheet)
     VirtualLocation virt_loc;
 
     g_return_if_fail (sheet != NULL);
-    g_return_if_fail (GNUCASH_IS_SHEET (sheet));
+    g_return_if_fail (GNUCASH_IS_SHEET(sheet));
 
     gnucash_cursor_get_virt (GNUCASH_CURSOR(sheet->cursor), &virt_loc);
 
     text = gnc_table_get_entry (sheet->table, virt_loc);
 
     gnc_item_edit_configure (GNC_ITEM_EDIT(sheet->item_editor));
-    gtk_widget_show (GTK_WIDGET (sheet->item_editor));
+    gtk_widget_show (GTK_WIDGET(sheet->item_editor));
 
     gtk_entry_set_text (GTK_ENTRY(sheet->entry), text);
 
@@ -1342,11 +1329,11 @@ gnucash_sheet_start_editing_at_cursor (GnucashSheet *sheet)
 
     /* set up the signals */
     sheet->insert_signal =
-        g_signal_connect(G_OBJECT(sheet->entry), "insert_text",
-                         G_CALLBACK(gnucash_sheet_insert_cb), sheet);
+        g_signal_connect (G_OBJECT(sheet->entry), "insert_text",
+                          G_CALLBACK(gnucash_sheet_insert_cb), sheet);
     sheet->delete_signal =
-        g_signal_connect(G_OBJECT(sheet->entry), "delete_text",
-                         G_CALLBACK(gnucash_sheet_delete_cb), sheet);
+        g_signal_connect (G_OBJECT(sheet->entry), "delete_text",
+                          G_CALLBACK(gnucash_sheet_delete_cb), sheet);
 }
 
 static gboolean
@@ -1354,11 +1341,11 @@ gnucash_sheet_button_release_event (GtkWidget *widget, GdkEventButton *event)
 {
     GnucashSheet *sheet;
 
-    g_return_val_if_fail(widget != NULL, TRUE);
-    g_return_val_if_fail(GNUCASH_IS_SHEET(widget), TRUE);
-    g_return_val_if_fail(event != NULL, TRUE);
+    g_return_val_if_fail (widget != NULL, TRUE);
+    g_return_val_if_fail (GNUCASH_IS_SHEET(widget), TRUE);
+    g_return_val_if_fail (event != NULL, TRUE);
 
-    sheet = GNUCASH_SHEET (widget);
+    sheet = GNUCASH_SHEET(widget);
 
     if (sheet->button != event->button)
         return FALSE;
@@ -1381,11 +1368,11 @@ gnucash_scroll_event (GtkWidget *widget, GdkEventScroll *event)
     GtkAdjustment *vadj;
     gfloat v_value;
 
-    g_return_val_if_fail(widget != NULL, TRUE);
-    g_return_val_if_fail(GNUCASH_IS_SHEET(widget), TRUE);
-    g_return_val_if_fail(event != NULL, TRUE);
+    g_return_val_if_fail (widget != NULL, TRUE);
+    g_return_val_if_fail (GNUCASH_IS_SHEET(widget), TRUE);
+    g_return_val_if_fail (event != NULL, TRUE);
 
-    sheet = GNUCASH_SHEET (widget);
+    sheet = GNUCASH_SHEET(widget);
     vadj = sheet->vadj;
     v_value = gtk_adjustment_get_value (vadj);
 
@@ -1409,7 +1396,7 @@ gnucash_scroll_event (GtkWidget *widget, GdkEventScroll *event)
     v_value = CLAMP(v_value, gtk_adjustment_get_lower (vadj),
               gtk_adjustment_get_upper (vadj) - gtk_adjustment_get_page_size (vadj));
 
-    gtk_adjustment_set_value(vadj, v_value);
+    gtk_adjustment_set_value (vadj, v_value);
 
     if (event->delta_y == 0)
     {
@@ -1452,21 +1439,18 @@ gnucash_sheet_button_press_event (GtkWidget *widget, GdkEventButton *event)
 {
     GnucashSheet *sheet;
     VirtualCell *vcell;
-    gboolean changed_cells; //FIXME
-
     VirtualLocation cur_virt_loc;
     VirtualLocation new_virt_loc;
-
     Table *table;
     gboolean abort_move;
     gboolean button_1;
     gboolean do_popup;
 
-    g_return_val_if_fail(widget != NULL, TRUE);
-    g_return_val_if_fail(GNUCASH_IS_SHEET(widget), TRUE);
-    g_return_val_if_fail(event != NULL, TRUE);
+    g_return_val_if_fail (widget != NULL, TRUE);
+    g_return_val_if_fail (GNUCASH_IS_SHEET(widget), TRUE);
+    g_return_val_if_fail (event != NULL, TRUE);
 
-    sheet = GNUCASH_SHEET (widget);
+    sheet = GNUCASH_SHEET(widget);
     table = sheet->table;
 
     if (sheet->button && (sheet->button != event->button))
@@ -1476,8 +1460,8 @@ gnucash_sheet_button_press_event (GtkWidget *widget, GdkEventButton *event)
     if (sheet->button == 3)
         sheet->button = 0;
 
-    if (!gtk_widget_has_focus(widget))
-        gtk_widget_grab_focus(widget);
+    if (!gtk_widget_has_focus (widget))
+        gtk_widget_grab_focus (widget);
 
     button_1 = FALSE;
     do_popup = FALSE;
@@ -1504,8 +1488,8 @@ gnucash_sheet_button_press_event (GtkWidget *widget, GdkEventButton *event)
     sheet->button_x = -1;
     sheet->button_y = -1;
 
-    if (!gnucash_sheet_find_loc_by_pixel(sheet,
-                                        event->x, event->y, &new_virt_loc))
+    if (!gnucash_sheet_find_loc_by_pixel (sheet, event->x, event->y,
+                                          &new_virt_loc))
         return TRUE;
 
     sheet->button_x = event->x;
@@ -1520,7 +1504,7 @@ gnucash_sheet_button_press_event (GtkWidget *widget, GdkEventButton *event)
 
     if (button_1)
     {
-        gtk_grab_add(widget);
+        gtk_grab_add (widget);
         sheet->grabbed = TRUE;
     }
 
@@ -1543,7 +1527,6 @@ gnucash_sheet_button_press_event (GtkWidget *widget, GdkEventButton *event)
     if (abort_move)
         return TRUE;
 
-//FIXME does something need to be done if changed_cells is true or false ?
     gnucash_sheet_cursor_move (sheet, new_virt_loc);
 
     // if clicked in ocument link cell, run call back
@@ -1565,15 +1548,15 @@ gnucash_sheet_button_press_event (GtkWidget *widget, GdkEventButton *event)
 void
 gnucash_sheet_refresh_from_prefs (GnucashSheet *sheet)
 {
-    g_return_if_fail(sheet != NULL);
-    g_return_if_fail(GNUCASH_IS_SHEET(sheet));
+    g_return_if_fail (sheet != NULL);
+    g_return_if_fail (GNUCASH_IS_SHEET(sheet));
 
     sheet->use_gnc_color_theme = gnc_prefs_get_bool (GNC_PREFS_GROUP_GENERAL_REGISTER,
                                                      GNC_PREF_USE_GNUCASH_COLOR_THEME);
-    sheet->use_horizontal_lines = gnc_prefs_get_bool(GNC_PREFS_GROUP_GENERAL_REGISTER,
-                                                     GNC_PREF_DRAW_HOR_LINES);
-    sheet->use_vertical_lines = gnc_prefs_get_bool(GNC_PREFS_GROUP_GENERAL_REGISTER,
-                                                   GNC_PREF_DRAW_VERT_LINES);
+    sheet->use_horizontal_lines = gnc_prefs_get_bool (GNC_PREFS_GROUP_GENERAL_REGISTER,
+                                                      GNC_PREF_DRAW_HOR_LINES);
+    sheet->use_vertical_lines = gnc_prefs_get_bool (GNC_PREFS_GROUP_GENERAL_REGISTER,
+                                                    GNC_PREF_DRAW_VERT_LINES);
 }
 
 static gboolean
@@ -1590,7 +1573,7 @@ gnucash_sheet_clipboard_event (GnucashSheet *sheet, GdkEventKey *event)
     case GDK_KEY_c:
         if (event->state & GDK_MODIFIER_INTENT_PRIMARY_ACCELERATOR)
         {
-            gnc_item_edit_copy_clipboard(item_edit);
+            gnc_item_edit_copy_clipboard (item_edit);
             handled = TRUE;
         }
         break;
@@ -1598,7 +1581,7 @@ gnucash_sheet_clipboard_event (GnucashSheet *sheet, GdkEventKey *event)
     case GDK_KEY_x:
         if (event->state & GDK_MODIFIER_INTENT_PRIMARY_ACCELERATOR)
         {
-            gnc_item_edit_cut_clipboard(item_edit);
+            gnc_item_edit_cut_clipboard (item_edit);
             handled = TRUE;
         }
         break;
@@ -1618,12 +1601,11 @@ gnucash_sheet_clipboard_event (GnucashSheet *sheet, GdkEventKey *event)
         }
         else if (event->state & GDK_MODIFIER_INTENT_PRIMARY_ACCELERATOR)
         {
-            gnc_item_edit_copy_clipboard(item_edit);
+            gnc_item_edit_copy_clipboard (item_edit);
             handled = TRUE;
         }
         break;
     }
-
     return handled;
 }
 
@@ -1642,7 +1624,8 @@ gnucash_sheet_need_horizontal_scroll (GnucashSheet *sheet,
     hscroll_val = (gint) gtk_adjustment_get_value (sheet->hadj);
 
     // offset is the start of the cell for column
-    offset = gnc_header_get_cell_offset (GNC_HEADER(sheet->header_item), new_virt_loc->phys_col_offset, &cell_width);
+    offset = gnc_header_get_cell_offset (GNC_HEADER(sheet->header_item), 
+                                         new_virt_loc->phys_col_offset, &cell_width);
 
     if (((offset + cell_width) > sheet->window_width) || (offset < hscroll_val))
         gtk_adjustment_set_value (sheet->hadj, offset);
@@ -1660,9 +1643,9 @@ process_motion_keys (GnucashSheet *sheet, GdkEventKey *event, gboolean *pass_on,
     {
         case GDK_KEY_Return:
         case GDK_KEY_KP_Enter:
-            g_signal_emit_by_name(sheet->reg, "activate_cursor");
-	    /* Clear the saved selection. */
-	    sheet->pos = sheet->bound;
+            g_signal_emit_by_name (sheet->reg, "activate_cursor");
+            /* Clear the saved selection. */
+            sheet->pos = sheet->bound;
             return TRUE;
             break;
         case GDK_KEY_Tab:
@@ -1670,14 +1653,12 @@ process_motion_keys (GnucashSheet *sheet, GdkEventKey *event, gboolean *pass_on,
             if (event->state & GDK_SHIFT_MASK)
             {
                 *direction = GNC_TABLE_TRAVERSE_LEFT;
-                gnc_table_move_tab (sheet->table, new_virt_loc,
-                                    FALSE);
+                gnc_table_move_tab (sheet->table, new_virt_loc, FALSE);
             }
             else
             {
                 *direction = GNC_TABLE_TRAVERSE_RIGHT;
-                gnc_table_move_tab (sheet->table, new_virt_loc,
-                                    TRUE);
+                gnc_table_move_tab (sheet->table, new_virt_loc, TRUE);
             }
             break;
         case GDK_KEY_KP_Page_Up:
@@ -1719,16 +1700,13 @@ process_motion_keys (GnucashSheet *sheet, GdkEventKey *event, gboolean *pass_on,
             if (event->keyval == GDK_KEY_Menu ||
                 (event->state & GDK_MODIFIER_INTENT_PRIMARY_ACCELERATOR))
             {
-                GncItemEdit *item_edit;
+                GncItemEdit *item_edit = GNC_ITEM_EDIT(sheet->item_editor);
 
-                item_edit = GNC_ITEM_EDIT (sheet->item_editor);
-
-                if (gnc_table_confirm_change (sheet->table,
-                                              cur_virt_loc))
+                if (gnc_table_confirm_change (sheet->table, cur_virt_loc))
                     gnc_item_edit_show_popup (item_edit);
-		/* Clear the saved selection for the new cell. */
-		sheet->pos = sheet->bound;
 
+                /* Clear the saved selection for the new cell. */
+                sheet->pos = sheet->bound;
                 return TRUE;
             }
 
@@ -1742,17 +1720,17 @@ process_motion_keys (GnucashSheet *sheet, GdkEventKey *event, gboolean *pass_on,
         case GDK_KEY_Left:
         case GDK_KEY_Home:
         case GDK_KEY_End:
-	    /* Clear the saved selection, we're not using it. */
-	    sheet->pos = sheet->bound;
-	    *pass_on = TRUE;
-	    break;
+            /* Clear the saved selection, we're not using it. */
+            sheet->pos = sheet->bound;
+            *pass_on = TRUE;
+            break;
         default:
-            if (gnucash_sheet_clipboard_event(sheet, event))
-	    {
-		/* Clear the saved selection. */
-		sheet->pos = sheet->bound;
+            if (gnucash_sheet_clipboard_event (sheet, event))
+            {
+                /* Clear the saved selection. */
+                sheet->pos = sheet->bound;
                 return TRUE;
-	    }
+            }
             *pass_on = TRUE;
             break;
     }
@@ -1790,11 +1768,11 @@ gnucash_sheet_key_press_event_internal (GtkWidget *widget, GdkEventKey *event)
     int distance;
     GdkModifierType modifiers = gtk_accelerator_get_default_mod_mask ();
 
-    g_return_val_if_fail(widget != NULL, TRUE);
-    g_return_val_if_fail(GNUCASH_IS_SHEET(widget), TRUE);
-    g_return_val_if_fail(event != NULL, TRUE);
+    g_return_val_if_fail (widget != NULL, TRUE);
+    g_return_val_if_fail (GNUCASH_IS_SHEET(widget), TRUE);
+    g_return_val_if_fail (event != NULL, TRUE);
 
-    sheet = GNUCASH_SHEET (widget);
+    sheet = GNUCASH_SHEET(widget);
     table = sheet->table;
     /* Don't respond to stand-alone modifier keys. */
     if (event->is_modifier)
@@ -1804,10 +1782,10 @@ gnucash_sheet_key_press_event_internal (GtkWidget *widget, GdkEventKey *event)
      */
     gnucash_sheet_set_selection_from_entry (sheet);
     /* Direct_event gets first whack */
-    if (gnucash_sheet_direct_event(sheet, (GdkEvent *) event))
+    if (gnucash_sheet_direct_event (sheet, (GdkEvent *) event))
         return TRUE;
     /* Followed by the input method */
-    if (gtk_entry_im_context_filter_keypress (GTK_ENTRY (sheet->entry), event))
+    if (gtk_entry_im_context_filter_keypress (GTK_ENTRY(sheet->entry), event))
     {
         /* Restore the saved cursor position in case GtkEntry's IMContext
          * handlers messed with it after we set it in our insert_cb.
@@ -1841,8 +1819,8 @@ gnucash_sheet_key_press_event_internal (GtkWidget *widget, GdkEventKey *event)
     if (abort_move)
     {
         // Make sure the sheet is the focus
-        if (!gtk_widget_has_focus(GTK_WIDGET (sheet)))
-            gtk_widget_grab_focus (GTK_WIDGET (sheet));
+        if (!gtk_widget_has_focus (GTK_WIDGET(sheet)))
+            gtk_widget_grab_focus (GTK_WIDGET(sheet));
         return TRUE;
     }
 
@@ -1860,11 +1838,11 @@ gnucash_sheet_key_press_event (GtkWidget *widget, GdkEventKey *event)
     GnucashSheet *sheet;
     GtkEditable *editable = NULL;
 
-    g_return_val_if_fail(widget != NULL, TRUE);
-    g_return_val_if_fail(GNUCASH_IS_SHEET(widget), TRUE);
-    g_return_val_if_fail(event != NULL, TRUE);
+    g_return_val_if_fail (widget != NULL, TRUE);
+    g_return_val_if_fail (GNUCASH_IS_SHEET(widget), TRUE);
+    g_return_val_if_fail (event != NULL, TRUE);
 
-    sheet = GNUCASH_SHEET (widget);
+    sheet = GNUCASH_SHEET(widget);
     editable = GTK_EDITABLE(sheet->entry);
     /* bug#60582 comment#27 2
            save shift state to enable <shift minus> and <shift equal>
@@ -1884,13 +1862,13 @@ gnucash_sheet_key_press_event (GtkWidget *widget, GdkEventKey *event)
 }
 
 static gint
-gnucash_sheet_key_release_event(GtkWidget *widget, GdkEventKey *event)
+gnucash_sheet_key_release_event (GtkWidget *widget, GdkEventKey *event)
 {
     GnucashSheet *sheet;
 
-    g_return_val_if_fail(widget != NULL, TRUE);
-    g_return_val_if_fail(GNUCASH_IS_SHEET(widget), TRUE);
-    g_return_val_if_fail(event != NULL, TRUE);
+    g_return_val_if_fail (widget != NULL, TRUE);
+    g_return_val_if_fail (GNUCASH_IS_SHEET(widget), TRUE);
+    g_return_val_if_fail (event != NULL, TRUE);
 
     return FALSE;
 }
@@ -1903,7 +1881,7 @@ gnucash_sheet_goto_virt_loc (GnucashSheet *sheet, VirtualLocation virt_loc)
     gboolean abort_move;
     VirtualLocation cur_virt_loc;
 
-    g_return_if_fail(GNUCASH_IS_SHEET(sheet));
+    g_return_if_fail (GNUCASH_IS_SHEET(sheet));
 
     table = sheet->table;
 
@@ -1943,7 +1921,7 @@ GncItemEdit *gnucash_sheet_get_item_edit (GnucashSheet *sheet)
     if (sheet->item_editor == NULL)
         return NULL;
     else
-        return GNC_ITEM_EDIT (sheet->item_editor);
+        return GNC_ITEM_EDIT(sheet->item_editor);
 }
 
 
@@ -1991,10 +1969,9 @@ gnucash_sheet_block_set_from_table (GnucashSheet *sheet,
     if (block->style == NULL)
     {
         block->style = style;
-        gnucash_sheet_style_ref(sheet, block->style);
+        gnucash_sheet_style_ref (sheet, block->style);
         return TRUE;
     }
-
     return FALSE;
 }
 
@@ -2069,7 +2046,7 @@ gnucash_sheet_col_max_width (GnucashSheet *sheet, gint virt_col, gint cell_col)
                 {
                     width += gnc_item_edit_get_button_width (item_edit) + 2; // add 2 for the button margin
                 }
-                max = MAX (max, width);
+                max = MAX(max, width);
             }
         }
     }
@@ -2083,14 +2060,11 @@ void
 gnucash_sheet_set_scroll_region (GnucashSheet *sheet)
 {
     guint new_h, new_w;
-//    GtkWidget *widget;
     GtkAllocation alloc;
     guint old_h, old_w;
 
     if (!sheet)
         return;
-
-//    widget = GTK_WIDGET(sheet);
 
     if (!sheet->header_item || !GNC_HEADER(sheet->header_item)->style)
         return;
@@ -2098,8 +2072,8 @@ gnucash_sheet_set_scroll_region (GnucashSheet *sheet)
     gtk_layout_get_size (GTK_LAYOUT(sheet), &old_w, &old_h);
 
     gtk_widget_get_allocation (GTK_WIDGET(sheet), &alloc);
-    new_h = MAX (sheet->height, alloc.height);
-    new_w  = MAX (sheet->width, alloc.width);
+    new_h = MAX(sheet->height, alloc.height);
+    new_w  = MAX(sheet->width, alloc.width);
 
     if (new_w != old_w || new_h != old_h)
         gtk_layout_set_size (GTK_LAYOUT(sheet), new_w, new_h);
@@ -2186,7 +2160,6 @@ gnucash_sheet_recompute_block_offsets (GnucashSheet *sheet)
         if (i > 0 && block && block->visible)
             height += block->style->dimensions->height;
     }
-
     sheet->height = height;
 }
 
@@ -2225,7 +2198,7 @@ gnucash_sheet_table_load (GnucashSheet *sheet, gboolean do_scroll)
                      vcell->cellblock->num_rows);
         }
 
-    gnc_header_set_header_rows (GNC_HEADER (sheet->header_item),
+    gnc_header_set_header_rows (GNC_HEADER(sheet->header_item),
                                 num_header_phys_rows);
     gnc_header_reconfigure (GNC_HEADER(sheet->header_item));
 
@@ -2321,8 +2294,8 @@ gnucash_sheet_class_init (GnucashSheetClass *klass)
     GObjectClass *gobject_class;
     GtkWidgetClass *widget_class;
 
-    gobject_class = G_OBJECT_CLASS (klass);
-    widget_class = GTK_WIDGET_CLASS (klass);
+    gobject_class = G_OBJECT_CLASS(klass);
+    widget_class = GTK_WIDGET_CLASS(klass);
 
     gtk_widget_class_set_css_name (GTK_WIDGET_CLASS(klass), "gnc-id-sheet");
 
@@ -2376,11 +2349,12 @@ gnucash_sheet_init (GnucashSheet *sheet)
                                  gnucash_sheet_block_construct,
                                  gnucash_sheet_block_destroy, sheet);
 
-    gtk_widget_add_events(GTK_WIDGET(sheet), (GDK_EXPOSURE_MASK
-    | GDK_BUTTON_PRESS_MASK
-    | GDK_BUTTON_RELEASE_MASK
-    | GDK_POINTER_MOTION_MASK
-    | GDK_POINTER_MOTION_HINT_MASK));
+    gtk_widget_add_events (GTK_WIDGET(sheet),
+                          (GDK_EXPOSURE_MASK
+                          | GDK_BUTTON_PRESS_MASK
+                          | GDK_BUTTON_RELEASE_MASK
+                          | GDK_POINTER_MOTION_MASK
+                          | GDK_POINTER_MOTION_HINT_MASK));
 
     /* setup IMContext */
     sheet->direct_update_cell = FALSE;
@@ -2422,10 +2396,11 @@ gnucash_sheet_get_type (void)
 
 static gboolean
 gnucash_sheet_tooltip (GtkWidget  *widget, gint x, gint y,
-               gboolean    keyboard_mode, GtkTooltip *tooltip,
-               gpointer    user_data)
+                       gboolean    keyboard_mode,
+                       GtkTooltip *tooltip,
+                       gpointer    user_data)
 {
-    GnucashSheet *sheet = GNUCASH_SHEET (widget);
+    GnucashSheet *sheet = GNUCASH_SHEET(widget);
     Table *table = sheet->table;
     VirtualLocation virt_loc;
     gchar *tooltip_text;
@@ -2497,7 +2472,7 @@ gnucash_sheet_new (Table *table)
     sheet->cursor = gnucash_cursor_new (sheet);
 
     /* set up the editor */
-    sheet->item_editor = gnc_item_edit_new(sheet);
+    sheet->item_editor = gnc_item_edit_new (sheet);
 
     /* some register data */
     sheet->dimensions_hash_table = g_hash_table_new_full (g_int_hash,
@@ -2506,10 +2481,10 @@ gnucash_sheet_new (Table *table)
 
     /* add tooltips to sheet */
     gtk_widget_set_has_tooltip (GTK_WIDGET(sheet), TRUE);
-    g_signal_connect(G_OBJECT(sheet), "query-tooltip",
-                     G_CALLBACK(gnucash_sheet_tooltip), NULL);
+    g_signal_connect (G_OBJECT(sheet), "query-tooltip",
+                      G_CALLBACK(gnucash_sheet_tooltip), NULL);
 
-    gnucash_sheet_refresh_from_prefs(sheet);
+    gnucash_sheet_refresh_from_prefs (sheet);
 
     return GTK_WIDGET(sheet);
 }

--- a/gnucash/register/register-gnome/gnucash-sheet.h
+++ b/gnucash/register/register-gnome/gnucash-sheet.h
@@ -75,16 +75,16 @@ void gnucash_sheet_redraw_help (GnucashSheet *sheet);
 void gnucash_sheet_redraw_block (GnucashSheet *sheet,
                                  VirtualCellLocation vcell_loc);
 
-const char * gnucash_sheet_modify_current_cell(GnucashSheet *sheet,
-        const gchar *new_text);
+const char * gnucash_sheet_modify_current_cell (GnucashSheet *sheet,
+                                                const gchar *new_text);
 
 gboolean gnucash_sheet_block_set_from_table (GnucashSheet *sheet,
-        VirtualCellLocation vcell_loc);
+                                             VirtualCellLocation vcell_loc);
 
 void gnucash_sheet_set_scroll_region (GnucashSheet *sheet);
 
 void gnucash_sheet_cursor_set_from_table (GnucashSheet *sheet,
-        gboolean do_scroll);
+                                          gboolean do_scroll);
 
 void gnucash_sheet_compute_visible_range (GnucashSheet *sheet);
 

--- a/gnucash/register/register-gnome/gnucash-sheetP.h
+++ b/gnucash/register/register-gnome/gnucash-sheetP.h
@@ -116,9 +116,6 @@ GncItemEdit *gnucash_sheet_get_item_edit (GnucashSheet *sheet);
 void gnucash_sheet_set_popup (GnucashSheet *sheet, GtkWidget *popup, gpointer data);
 void gnucash_sheet_goto_virt_loc (GnucashSheet *sheet, VirtualLocation virt_loc);
 void gnucash_sheet_refresh_from_prefs (GnucashSheet *sheet);
-//Table       *gnucash_sheet_get_table (GnucashSheet *sheet);
-//gint         gnucash_sheet_get_num_virt_rows (GnucashSheet *sheet);
-//gint         gnucash_sheet_get_num_virt_cols (GnucashSheet *sheet);
 
 gboolean   gnucash_sheet_find_loc_by_pixel (GnucashSheet *sheet, gint x, gint y,
                                            VirtualLocation *vcell_loc);


### PR DESCRIPTION
If the horizontal scrollbar is present for a register and you start to tab from one cell to the next one which is not in view the sheet does not scroll to keep the active cell in view.

This commit fixes that by getting the active cell horizontal offset and width and comparing it to the sheet width and window width.
I think it is all OK and does what I think it should with testing on my Linux VM and also Windows 10.
Just thought I would park this here for any comments before pushing at the weekend. 