### PR TITLE
Bug 379126 - Combine multiple splits for the same transaction

### DIFF
--- a/gnucash/register/ledger-core/split-register-load.c
+++ b/gnucash/register/ledger-core/split-register-load.c
@@ -556,8 +556,8 @@ gnc_split_register_load (SplitRegister* reg, GList* slist,
         }
     }
 
-    if (multi_line)
-        trans_table = g_hash_table_new (g_direct_hash, g_direct_equal);
+    /* create the has table for duplicat transactions */
+    trans_table = g_hash_table_new (g_direct_hash, g_direct_equal);
 
     /* populate the table */
     for (node = slist; node; node = node->next)
@@ -583,14 +583,11 @@ gnc_split_register_load (SplitRegister* reg, GList* slist,
         if (trans == blank_trans)
             continue;
 
-        if (multi_line)
-        {
-            /* Skip this split if its transaction has already been loaded. */
-            if (g_hash_table_lookup (trans_table, trans))
-                continue;
+        /* Skip this split if its transaction has already been loaded. */
+        if (g_hash_table_lookup (trans_table, trans))
+            continue;
 
-            g_hash_table_insert (trans_table, trans, trans);
-        }
+        g_hash_table_insert (trans_table, trans, trans);
 
         if (info->show_present_divider &&
             use_autoreadonly &&
@@ -670,8 +667,7 @@ gnc_split_register_load (SplitRegister* reg, GList* slist,
             start_primary_color = !start_primary_color;
     }
 
-    if (multi_line)
-        g_hash_table_destroy (trans_table);
+    g_hash_table_destroy (trans_table);
 
     /* add the blank split at the end. */
     if (pending_trans == blank_trans)

--- a/libgnucash/engine/engine-helpers.h
+++ b/libgnucash/engine/engine-helpers.h
@@ -34,6 +34,12 @@
 
 typedef void (*GncBOCb)    (gpointer new_val, gpointer user_data);
 
+/** Gets the action field for when multiple splits for the same account
+ *  are in the same transaction. If all splits have no action text or
+ *  they all have different text then '-- Multi Line --' is returned. If
+ *  all action texts are the same then that text is returned.*/
+const char * gnc_get_action_multi (const Transaction *trans, const Split *split);
+
 /** Gets the transaction Number or split Action based on book option:
   * if the book option is TRUE (split action is used for NUM) and a
   * split is provided, split-action is returned; if book option is FALSE


### PR DESCRIPTION
This started from @christopherlam  bug 797998 which linked to bug 379126 by @gjanssens 

Currently when you have multiple splits for the same account in the same transaction they will appear in the register multiple times, one for each split when viewed in basic view. This has been confusing for users so this commit changes that so with the basic view, the splits values for the account are added together.

The action field is replaced with '-- Multi Line --' as suggested in the bug when the split actions are all blank or different as seen in the images.

I was surprised that you could change the debit/credit value in basic view when '-- Split Transaction --' is shown, you do get the little squares but for this change I think it would be safer to disallow changes to debit/credit and action fields when it is a multi line transaction and may be the '-- Split Transaction --' should be changed to some thing else, maybe '-- Multi Home Split Transaction --', not really sure what .

You will see for prices I have used the average value, not sure if that makes sense so maybe it should be blank.

Have enabled trading and the use transaction num/action swap and that looks OK. 
On the registers I have tested, the sums seem to be correct but further testing will be required.
Thoughts.

Some Screen shots...
Before
![checking-before](https://user-images.githubusercontent.com/15702727/98830124-efcb2f00-2431-11eb-9ec5-4de909721c42.png)
![stock-before](https://user-images.githubusercontent.com/15702727/98827227-87c71980-242e-11eb-885c-325da9f574d1.png)
After
![checking-after](https://user-images.githubusercontent.com/15702727/98827096-5d755c00-242e-11eb-8472-ec2e3fb6cfe6.png)
![stock-after](https://user-images.githubusercontent.com/15702727/98827240-8bf33700-242e-11eb-9f01-998816e906a9.png)
