### PR TITLE
Bug 128772 - Account Help Button does not work

### DIFF
--- a/gnucash/gnome-search/dialog-search.c
+++ b/gnucash/gnome-search/dialog-search.c
@@ -653,7 +653,7 @@ search_cancel_cb (GtkButton *button, GNCSearchWindow *sw)
 static void
 search_help_cb (GtkButton *button, GNCSearchWindow *sw)
 {
-    gnc_gnome_help (HF_HELP, HL_FIND_TRANSACTIONS);
+    gnc_gnome_help (GTK_WINDOW(sw->dialog), HF_HELP, HL_FIND_TRANSACTIONS);
 }
 
 static void

--- a/gnucash/gnome-utils/dialog-account.c
+++ b/gnucash/gnome-utils/dialog-account.c
@@ -1020,11 +1020,11 @@ gnc_account_window_response_cb (GtkDialog *dialog,
         {
         case NEW_ACCOUNT:
             DEBUG("new acct dialog, HELP");
-            gnc_gnome_help(HF_HELP, HL_ACC);
+            gnc_gnome_help (GTK_WINDOW(dialog), HF_HELP, HL_ACC);
             break;
         case EDIT_ACCOUNT:
             DEBUG("edit acct dialog, HELP");
-            gnc_gnome_help(HF_HELP, HL_ACCEDIT);
+            gnc_gnome_help (GTK_WINDOW(dialog), HF_HELP, HL_ACCEDIT);
             break;
         default:
             g_assert_not_reached ();

--- a/gnucash/gnome-utils/dialog-book-close.c
+++ b/gnucash/gnome-utils/dialog-book-close.c
@@ -279,7 +279,7 @@ gnc_book_close_response_cb(GtkDialog *dialog, gint response, GtkDialog *unused)
     switch (response)
     {
     case GTK_RESPONSE_HELP:
-        gnc_gnome_help(HF_HELP, HL_CLOSE_BOOK);
+        gnc_gnome_help (GTK_WINDOW(dialog), HF_HELP, HL_CLOSE_BOOK);
         break;
     case GTK_RESPONSE_OK:
         cbw->close_date = gnc_date_edit_get_date(GNC_DATE_EDIT(cbw->close_date_widget));

--- a/gnucash/gnome-utils/dialog-commodity.c
+++ b/gnucash/gnome-utils/dialog-commodity.c
@@ -106,9 +106,6 @@ struct commodity_window
 typedef struct select_commodity_window SelectCommodityWindow;
 typedef struct commodity_window CommodityWindow;
 
-static gnc_commodity_help_callback help_callback = NULL;
-
-
 /* The commodity selection window */
 static SelectCommodityWindow *
 gnc_ui_select_commodity_create(const gnc_commodity * orig_sel,
@@ -128,17 +125,6 @@ gboolean gnc_ui_commodity_dialog_to_object(CommodityWindow * w);
 #if 0
 static void gnc_ui_select_commodity_response_cb (GtkDialog * dialog, gint response, gpointer data);
 #endif
-
-
-/********************************************************************
- * gnc_ui_commodity_set_help_callback
- ********************************************************************/
-void
-gnc_ui_commodity_set_help_callback (gnc_commodity_help_callback cb)
-{
-    help_callback = cb;
-}
-
 
 /********************************************************************
  * gnc_ui_select_commodity_modal_full()
@@ -890,7 +876,6 @@ gnc_ui_build_commodity_dialog(const char * selected_namespace,
                               gboolean     edit)
 {
     CommodityWindow * retval = g_new0(CommodityWindow, 1);
-    GtkWidget *help_button;
     GtkWidget *box;
     GtkWidget *menu;
     GtkWidget *widget, *sec_label;
@@ -919,10 +904,6 @@ gnc_ui_build_commodity_dialog(const char * selected_namespace,
         gtk_window_set_transient_for (GTK_WINDOW (retval->dialog), GTK_WINDOW (parent));
 
     retval->edit_commodity = NULL;
-
-    help_button = GTK_WIDGET(gtk_builder_get_object (builder, "help_button"));
-    if (!help_callback)
-        gtk_widget_hide (help_button);
 
     /* Get widget pointers */
     retval->fullname_entry = GTK_WIDGET(gtk_builder_get_object (builder, "fullname_entry"));
@@ -1158,8 +1139,7 @@ gnc_ui_common_commodity_modal(gnc_commodity *commodity,
             break;
         case GTK_RESPONSE_HELP:
             DEBUG("case HELP");
-            if (help_callback)
-                help_callback ();
+            gnc_gnome_help (GTK_WINDOW(win->dialog), HF_HELP, HL_COMMODITY);
             break;
         default:	/* Cancel, Escape, Close, etc. */
             DEBUG("default: %d", value);

--- a/gnucash/gnome-utils/dialog-commodity.h
+++ b/gnucash/gnome-utils/dialog-commodity.h
@@ -57,16 +57,6 @@ typedef enum
 			       anything. */
 } dialog_commodity_mode;
 
-typedef void (* gnc_commodity_help_callback)(void);
-
-/** This function is used to set the action routine for the help
- *  button in the commodity dialog windows.  If the action routine is
- *  unset, the help button will not be visible to the user.
- *
- *  @param cb The function to be called when the user clicks the help
- *  button. */
-void gnc_ui_commodity_set_help_callback (gnc_commodity_help_callback cb);
-
 
 /** @name Commodity Selection */
 /** @{ */

--- a/gnucash/gnome-utils/dialog-file-access.c
+++ b/gnucash/gnome-utils/dialog-file-access.c
@@ -125,7 +125,7 @@ gnc_ui_file_access_response_cb(GtkDialog *dialog, gint response, GtkDialog *unus
     switch ( response )
     {
     case GTK_RESPONSE_HELP:
-        gnc_gnome_help( HF_HELP, HL_GLOBPREFS );
+        gnc_gnome_help (GTK_WINDOW(dialog), HF_HELP, HL_GLOBPREFS );
         break;
 
     case GTK_RESPONSE_OK:

--- a/gnucash/gnome-utils/dialog-preferences.c
+++ b/gnucash/gnome-utils/dialog-preferences.c
@@ -1197,7 +1197,7 @@ gnc_preferences_response_cb (GtkDialog *dialog, gint response, GtkDialog *unused
     switch (response)
     {
     case GTK_RESPONSE_HELP:
-        gnc_gnome_help (HF_HELP, HL_GLOBPREFS);
+        gnc_gnome_help (GTK_WINDOW(dialog), HF_HELP, HL_GLOBPREFS);
         break;
 
     case GTK_RESPONSE_DELETE_EVENT:

--- a/gnucash/gnome-utils/gnc-gnome-utils.c
+++ b/gnucash/gnome-utils/gnc-gnome-utils.c
@@ -144,12 +144,6 @@ gnc_options_dialog_set_style_sheet_options_help_cb (GNCOptionWin *win)
                                     NULL);
 }
 
-static void
-gnc_commodity_help_cb (void)
-{
-    gnc_gnome_help (NULL, HF_HELP, HL_COMMODITY);
-}
-
 /* gnc_configure_date_format
  *    sets dateFormat to the current value on the scheme side
  *
@@ -773,7 +767,6 @@ gnc_gui_init(void)
                                 gnc_gui_refresh_all,
                                 NULL);
 
-    gnc_ui_commodity_set_help_callback (gnc_commodity_help_cb);
     gnc_file_set_shutdown_callback (gnc_shutdown);
 
     gnc_options_dialog_set_global_help_cb (gnc_global_options_help_cb, NULL);

--- a/gnucash/gnome-utils/gnc-gnome-utils.c
+++ b/gnucash/gnome-utils/gnc-gnome-utils.c
@@ -90,13 +90,13 @@ gnc_gnome_utils_init (void)
 static void
 gnc_global_options_help_cb (GNCOptionWin *win, gpointer dat)
 {
-    gnc_gnome_help (HF_HELP, HL_GLOBPREFS);
+    gnc_gnome_help (GTK_WINDOW(gnc_options_dialog_widget (win)), HF_HELP, HL_GLOBPREFS);
 }
 
 static void
 gnc_book_options_help_cb (GNCOptionWin *win, gpointer dat)
 {
-    gnc_gnome_help (HF_HELP, HL_BOOK_OPTIONS);
+    gnc_gnome_help (GTK_WINDOW(gnc_options_dialog_widget (win)), HF_HELP, HL_BOOK_OPTIONS);
 }
 
 void
@@ -133,7 +133,7 @@ gnc_options_dialog_set_new_book_option_values (GNCOptionDB *odb)
 static void
 gnc_style_sheet_options_help_cb (GNCOptionWin *win, gpointer dat)
 {
-    gnc_gnome_help (HF_HELP, HL_STYLE_SHEET);
+    gnc_gnome_help (GTK_WINDOW(gnc_options_dialog_widget (win)), HF_HELP, HL_STYLE_SHEET);
 }
 
 void
@@ -147,7 +147,7 @@ gnc_options_dialog_set_style_sheet_options_help_cb (GNCOptionWin *win)
 static void
 gnc_commodity_help_cb (void)
 {
-    gnc_gnome_help (HF_HELP, HL_COMMODITY);
+    gnc_gnome_help (NULL, HF_HELP, HL_COMMODITY);
 }
 
 /* gnc_configure_date_format
@@ -240,7 +240,7 @@ gnc_add_css_file (void)
  * ?anchor varient, see https://gitlab.gnome.org/GNOME/yelp/issues/116
  */
 static gchar *
-gnc_gnome_help_yelp_anchor_fix (const char *file_name, const char *anchor)
+gnc_gnome_help_yelp_anchor_fix (GtkWindow *parent, const char *file_name, const char *anchor)
 {
     const gchar * const *sdatadirs = g_get_system_data_dirs ();
     const gchar * const *langs = g_get_language_names ();
@@ -261,7 +261,7 @@ gnc_gnome_help_yelp_anchor_fix (const char *file_name, const char *anchor)
 
     if (!help_path)
     {
-        gnc_error_dialog (NULL, "%s\n%s", _(msg_no_help_found), _(msg_no_help_reason));
+        gnc_error_dialog (parent, "%s\n%s", _(msg_no_help_found), _(msg_no_help_reason));
         PERR("Unable to find 'gnome/help' directory");
         return NULL;
     }
@@ -283,7 +283,7 @@ gnc_gnome_help_yelp_anchor_fix (const char *file_name, const char *anchor)
         uri = g_strconcat ("ghelp:", full_path, "?", anchor, NULL);
     else
     {
-        gnc_error_dialog (NULL, "%s\n%s", _(msg_no_help_found), _(msg_no_help_reason));
+        gnc_error_dialog (parent, "%s\n%s", _(msg_no_help_found), _(msg_no_help_reason));
         PERR("Unable to find valid help language directory");
         return NULL;
     }
@@ -298,7 +298,7 @@ gnc_gnome_help_yelp_anchor_fix (const char *file_name, const char *anchor)
  * toolkit.
  */
 void
-gnc_gnome_help (const char *dir, const char *detail)
+gnc_gnome_help (GtkWindow *parent, const char *dir, const char *detail)
 {
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
     NSString *subdir = [NSString stringWithUTF8String: dir];
@@ -339,9 +339,9 @@ gnc_gnome_help (const char *dir, const char *detail)
                   componentsJoinedByString: @"-"];
         if (![[NSFileManager defaultManager] fileExistsAtPath: docs_dir])
         {
-            gnc_error_dialog(NULL, "%s\n%s\n%s: %s", _(msg_no_help_found),
-                             _(msg_no_help_reason),
-                             _(msg_no_help_location), [docs_dir UTF8String]);
+            gnc_error_dialog (parent, "%s\n%s\n%s: %s", _(msg_no_help_found),
+                              _(msg_no_help_reason),
+                              _(msg_no_help_location), [docs_dir UTF8String]);
             [pool release];
             return;
         }
@@ -431,13 +431,13 @@ gnc_gnome_help (const char *dir, const char *detail)
         [[NSWorkspace sharedWorkspace] openURL: url];
     else
     {
-       gnc_error_dialog(NULL, "%s\n%s", _(msg_no_help_found), _(msg_no_help_reason));
+       gnc_error_dialog (parent, "%s\n%s", _(msg_no_help_found), _(msg_no_help_reason));
     }
     [pool release];
 }
 #elif defined G_OS_WIN32 /* G_OS_WIN32 */
 void
-gnc_gnome_help (const char *file_name, const char *anchor)
+gnc_gnome_help (GtkWindow *parent, const char *file_name, const char *anchor)
 {
     const gchar * const *lang;
     gchar *pkgdatadir, *fullpath, *found = NULL;
@@ -459,7 +459,7 @@ gnc_gnome_help (const char *file_name, const char *anchor)
 
     if (!found)
     {
-        gnc_error_dialog (NULL, "%s\n%s", _(msg_no_help_found), _(msg_no_help_reason));
+        gnc_error_dialog (parent, "%s\n%s", _(msg_no_help_found), _(msg_no_help_reason));
     }
     else
     {
@@ -469,14 +469,14 @@ gnc_gnome_help (const char *file_name, const char *anchor)
 }
 #else
 void
-gnc_gnome_help (const char *file_name, const char *anchor)
+gnc_gnome_help (GtkWindow *parent, const char *file_name, const char *anchor)
 {
     GError *error = NULL;
     gchar *uri = NULL;
     gboolean success = TRUE;
 
     if (anchor)
-        uri = gnc_gnome_help_yelp_anchor_fix (file_name, anchor);
+        uri = gnc_gnome_help_yelp_anchor_fix (parent, file_name, anchor);
     else
         uri = g_strconcat ("ghelp:", file_name, NULL);
 
@@ -491,7 +491,7 @@ gnc_gnome_help (const char *file_name, const char *anchor)
 
     g_assert(error != NULL);
     {
-        gnc_error_dialog(NULL, "%s\n%s", _(msg_no_help_found), _(msg_no_help_reason));
+        gnc_error_dialog (parent, "%s\n%s", _(msg_no_help_found), _(msg_no_help_reason));
     }
     PERR ("%s", error->message);
     g_error_free(error);

--- a/gnucash/gnome-utils/gnc-gnome-utils.h
+++ b/gnucash/gnome-utils/gnc-gnome-utils.h
@@ -53,11 +53,13 @@ void gnc_add_css_file (void);
  *  This routine will display an error message
  *  if it can't find the help file or can't open the help browser.
  *
+ *  @param parent The parent window for any dialogs.
+ *
  *  @param file_name The name of the help file.
  *
  *  @param anchor The anchor the help browser should scroll to.
  */
-void gnc_gnome_help (const char *file_name,
+void gnc_gnome_help (GtkWindow *parent, const char *file_name,
                      const char *anchor);
 /** Launch the default browser and open the provided URI.
  */

--- a/gnucash/gnome-utils/gnc-main-window.c
+++ b/gnucash/gnome-utils/gnc-main-window.c
@@ -4529,13 +4529,13 @@ gnc_main_window_cmd_window_raise (GtkAction *action,
 static void
 gnc_main_window_cmd_help_tutorial (GtkAction *action, GncMainWindow *window)
 {
-    gnc_gnome_help (HF_GUIDE, NULL);
+    gnc_gnome_help (GTK_WINDOW(window), HF_GUIDE, NULL);
 }
 
 static void
 gnc_main_window_cmd_help_contents (GtkAction *action, GncMainWindow *window)
 {
-    gnc_gnome_help (HF_HELP, NULL);
+    gnc_gnome_help (GTK_WINDOW(window), HF_HELP, NULL);
 }
 
 /** This is a helper function to find a data file and suck it into

--- a/gnucash/gnome-utils/gnc-ui.h
+++ b/gnucash/gnome-utils/gnc-ui.h
@@ -106,7 +106,7 @@ gnc_error_dialog (GtkWindow *parent,
 
 
 extern void
-gnc_gnome_help (const char *file_name, const char *target_link);
+gnc_gnome_help (GtkWindow *parent, const char *file_name, const char *target_link);
 
 int      gnc_choose_radio_option_dialog (GtkWidget *parent,
         const char *title,

--- a/gnucash/gnome/dialog-custom-report.c
+++ b/gnucash/gnome/dialog-custom-report.c
@@ -107,7 +107,8 @@ custom_report_dialog_close_cb(GtkWidget* widget, gpointer data)
 void
 custom_report_help_cb (GtkWidget *widget, gpointer data)
 {
-    gnc_gnome_help(HF_HELP, HL_USAGE_CUSTOMREP);
+    CustomReportDialog *crd = data;
+    gnc_gnome_help (GTK_WINDOW(crd->dialog), HF_HELP, HL_USAGE_CUSTOMREP);
 }
 
 void

--- a/gnucash/gnome/dialog-customer.c
+++ b/gnucash/gnome/dialog-customer.c
@@ -390,7 +390,8 @@ gnc_customer_window_cancel_cb (GtkWidget *widget, gpointer data)
 void
 gnc_customer_window_help_cb (GtkWidget *widget, gpointer data)
 {
-    gnc_gnome_help(HF_HELP, HL_USAGE_CUSTOMER);
+    CustomerWindow *cw = data;
+    gnc_gnome_help (GTK_WINDOW(cw->dialog), HF_HELP, HL_USAGE_CUSTOMER);
 }
 
 void

--- a/gnucash/gnome/dialog-employee.c
+++ b/gnucash/gnome/dialog-employee.c
@@ -248,7 +248,8 @@ gnc_employee_window_cancel_cb (GtkWidget *widget, gpointer data)
 void
 gnc_employee_window_help_cb (GtkWidget *widget, gpointer data)
 {
-    gnc_gnome_help(HF_HELP, HL_USAGE_EMPLOYEE);
+    EmployeeWindow *ew = data;
+    gnc_gnome_help (GTK_WINDOW(ew->dialog), HF_HELP, HL_USAGE_EMPLOYEE);
 }
 
 void

--- a/gnucash/gnome/dialog-invoice.c
+++ b/gnucash/gnome/dialog-invoice.c
@@ -544,13 +544,13 @@ gnc_invoice_window_help_cb (GtkWidget *widget, gpointer data)
     switch(owner_type)
     {
         case GNC_OWNER_CUSTOMER:
-           gnc_gnome_help (HF_HELP, HL_USAGE_INVOICE);
+           gnc_gnome_help (GTK_WINDOW(iw->dialog), HF_HELP, HL_USAGE_INVOICE);
            break;
         case GNC_OWNER_VENDOR:
-           gnc_gnome_help (HF_HELP, HL_USAGE_BILL);
+           gnc_gnome_help (GTK_WINDOW(iw->dialog), HF_HELP, HL_USAGE_BILL);
            break;
         default:
-           gnc_gnome_help (HF_HELP, HL_USAGE_VOUCHER);
+           gnc_gnome_help (GTK_WINDOW(iw->dialog), HF_HELP, HL_USAGE_VOUCHER);
            break;
     }
 }

--- a/gnucash/gnome/dialog-job.c
+++ b/gnucash/gnome/dialog-job.c
@@ -202,7 +202,8 @@ gnc_job_window_cancel_cb (GtkWidget *widget, gpointer data)
 void
 gnc_job_window_help_cb (GtkWidget *widget, gpointer data)
 {
-    gnc_gnome_help (HF_HELP, HL_USAGE_JOB);
+    JobWindow *jw = data;
+    gnc_gnome_help (GTK_WINDOW(jw->dialog), HF_HELP, HL_USAGE_JOB);
 }
 
 

--- a/gnucash/gnome/dialog-new-user.c
+++ b/gnucash/gnome/dialog-new-user.c
@@ -122,7 +122,7 @@ gnc_ui_new_user_ok_cb (GtkWidget * widget, gpointer data)
     }
     else if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (new_user->tutorial_button)))
     {
-        gnc_gnome_help (HF_GUIDE, NULL);
+        gnc_gnome_help (GTK_WINDOW(new_user->window), HF_GUIDE, NULL);
         gncp_new_user_finish ();
     }
     gtk_widget_destroy (new_user->window);

--- a/gnucash/gnome/dialog-order.c
+++ b/gnucash/gnome/dialog-order.c
@@ -232,7 +232,8 @@ gnc_order_window_cancel_cb (GtkWidget *widget, gpointer data)
 void
 gnc_order_window_help_cb (GtkWidget *widget, gpointer data)
 {
-    gnc_gnome_help(HF_HELP, HL_USAGE_BILL);
+    OrderWindow *ow = data;
+    gnc_gnome_help (GTK_WINDOW(ow->dialog), HF_HELP, HL_USAGE_BILL);
 }
 
 void

--- a/gnucash/gnome/dialog-print-check.c
+++ b/gnucash/gnome/dialog-print-check.c
@@ -2675,7 +2675,7 @@ gnc_ui_print_check_response_cb(GtkDialog *dialog,
     switch (response)
     {
     case GTK_RESPONSE_HELP:
-        gnc_gnome_help(HF_HELP, HL_PRINTCHECK);
+        gnc_gnome_help (GTK_WINDOW(dialog), HF_HELP, HL_PRINTCHECK);
         return;
 
     case GTK_RESPONSE_OK:

--- a/gnucash/gnome/dialog-sx-editor.c
+++ b/gnucash/gnome/dialog-sx-editor.c
@@ -230,7 +230,7 @@ editor_cancel_button_clicked_cb( GtkButton *b, GncSxEditorDialog *sxed )
 static void
 editor_help_button_clicked_cb(GtkButton *b, GncSxEditorDialog *sxed)
 {
-    gnc_gnome_help(HF_HELP, HL_SXEDITOR);
+    gnc_gnome_help (GTK_WINDOW(sxed->dialog), HF_HELP, HL_SXEDITOR);
 }
 
 

--- a/gnucash/gnome/dialog-sx-editor2.c
+++ b/gnucash/gnome/dialog-sx-editor2.c
@@ -227,7 +227,7 @@ editor_cancel_button_clicked_cb (GtkButton *b, GncSxEditorDialog2 *sxed)
 static void
 editor_help_button_clicked_cb (GtkButton *b, GncSxEditorDialog2 *sxed)
 {
-    gnc_gnome_help (HF_HELP, HL_SXEDITOR);
+    gnc_gnome_help (GTK_WINDOW(sxed->dialog), HF_HELP, HL_SXEDITOR);
 }
 
 

--- a/gnucash/gnome/dialog-vendor.c
+++ b/gnucash/gnome/dialog-vendor.c
@@ -261,7 +261,8 @@ gnc_vendor_window_cancel_cb (GtkWidget *widget, gpointer data)
 void
 gnc_vendor_window_help_cb (GtkWidget *widget, gpointer data)
 {
-    gnc_gnome_help(HF_HELP, HL_USAGE_VENDOR);
+    VendorWindow *vw = data;
+    gnc_gnome_help (GTK_WINDOW(vw->dialog), HF_HELP, HL_USAGE_VENDOR);
 }
 
 void

--- a/gnucash/gnome/gnc-plugin-report-system.c
+++ b/gnucash/gnome/gnc-plugin-report-system.c
@@ -244,9 +244,9 @@ gnc_report_system_help_url_cb (const char *location, const char *label,
     g_return_val_if_fail (location != NULL, FALSE);
 
     if (label && (*label != '\0'))
-        gnc_gnome_help (location, label);
+        gnc_gnome_help (GTK_WINDOW(result->parent), location, label);
     else
-        gnc_gnome_help (location, NULL);
+        gnc_gnome_help (GTK_WINDOW(result->parent), location, NULL);
     return TRUE;
 }
 

--- a/gnucash/gnome/window-reconcile.c
+++ b/gnucash/gnome/window-reconcile.c
@@ -1153,7 +1153,8 @@ gnc_reconcile_window_get_current_split(RecnWindow *recnData)
 static void
 gnc_ui_reconcile_window_help_cb(GtkWidget *widget, gpointer data)
 {
-    gnc_gnome_help(HF_HELP, HL_RECNWIN);
+    RecnWindow *recnData = data;
+    gnc_gnome_help (GTK_WINDOW(recnData->window), HF_HELP, HL_RECNWIN);
 }
 
 

--- a/gnucash/gnome/window-reconcile2.c
+++ b/gnucash/gnome/window-reconcile2.c
@@ -1101,7 +1101,8 @@ gnc_reconcile_window_get_current_split (RecnWindow2 *recnData)
 static void
 gnc_ui_reconcile_window_help_cb (GtkWidget *widget, gpointer data)
 {
-    gnc_gnome_help (HF_HELP, HL_RECNWIN);
+    RecnWindow2 *recnData = data;
+    gnc_gnome_help (GTK_WINDOW(recnData->window), HF_HELP, HL_RECNWIN);
 }
 
 

--- a/gnucash/import-export/bi-import/dialog-bi-import-gui.c
+++ b/gnucash/import-export/bi-import/dialog-bi-import-gui.c
@@ -252,7 +252,8 @@ gnc_bi_import_gui_cancel_cb (GtkWidget *widget, gpointer data)
 void
 gnc_bi_import_gui_help_cb (GtkWidget *widget, gpointer data)
 {
-    gnc_gnome_help (HF_GUIDE, HL_IMPORT_BC);
+    BillImportGui *gui = data;
+    gnc_gnome_help (GTK_WINDOW(gui->dialog), HF_GUIDE, HL_IMPORT_BC);
 }
 
 static void

--- a/gnucash/import-export/customer-import/dialog-customer-import-gui.c
+++ b/gnucash/import-export/customer-import/dialog-customer-import-gui.c
@@ -228,7 +228,8 @@ gnc_customer_import_gui_cancel_cb (GtkWidget *widget, gpointer data)
 void
 gnc_customer_import_gui_help_cb (GtkWidget *widget, gpointer data)
 {
-    gnc_gnome_help (HF_GUIDE, HL_IMPORT_CUST);
+    CustomerImportGui *gui = data;
+    gnc_gnome_help (GTK_WINDOW(gui->dialog), HF_GUIDE, HL_IMPORT_CUST);
 }
 
 static void


### PR DESCRIPTION
I am unsure about this one, I was looking at the bug and the context help was not working. I do not know how long it has not been working but hopefully not from the report date.

From testing, when pressing the help button, the following uri is created for the new account help button...
'ghelp:gnucash-help?acct-create' and used to open the gnome help app.

This segfaults in yelp at the '?' as 'ghelp:gnucash-help' does work.
To prove try at a command prompt...
gnome-help ghelp:gnucash-help?acct-create which segfaults but this...
gnome-help ghelp:/usr/share/gnome/help/gnucash-help/C/gnucash-help.xml?acct-create works.

To fix this, I have changed the context help to use the full path to the help files.
Looking at this I think I should add a test for getting a valid path and maybe an error dialog but will wait for any feedback first.