### PR TITLE
Bug355496 - Read Only Registers

### DIFF
--- a/gnucash/gnome-utils/gnc-main-window.c
+++ b/gnucash/gnome-utils/gnc-main-window.c
@@ -2442,6 +2442,76 @@ main_window_update_page_color (GncPluginPage *page,
 }
 
 
+void
+main_window_update_page_set_read_only_icon (GncPluginPage *page,
+                                            gboolean read_only)
+{
+    GncMainWindow *window;
+    GncMainWindowPrivate *priv;
+    GtkWidget *tab_widget;
+    GtkWidget *image = NULL;
+    GList *children;
+    gchar *image_name = NULL;
+    const gchar *icon_name;
+
+    ENTER(" ");
+
+    window = GNC_MAIN_WINDOW(page->window);
+
+    /* Get the notebook tab widget */
+    main_window_find_tab_widget (window, page, &tab_widget);
+    priv = GNC_MAIN_WINDOW_GET_PRIVATE(window);
+
+    if (!tab_widget)
+    {
+        LEAVE("no tab widget");
+        return;
+    }
+
+    if (GTK_IS_EVENT_BOX(tab_widget))
+        tab_widget = gtk_bin_get_child (GTK_BIN(tab_widget));
+
+    /* For each, walk the list of container children to get image widget */
+    for (children = gtk_container_get_children (GTK_CONTAINER(tab_widget));
+            children; children = children->next)
+    {
+        GtkWidget *widget = children->data;
+        if (GTK_IS_IMAGE(widget))
+            image = widget;
+    }
+
+    if (!image)
+    {
+        LEAVE("no image to replace");
+        return;
+    }
+
+    g_object_get (image, "icon-name", &image_name, NULL);
+
+    if (read_only)
+        icon_name = "changes-prevent-symbolic";
+    else
+        icon_name = GNC_PLUGIN_PAGE_GET_CLASS(page)->tab_icon;
+
+    if (g_strcmp0 (icon_name, image_name) == 0)
+    {
+        LEAVE("page icon the same, no need to replace");
+        g_free (image_name);
+        return;
+    }
+    gtk_container_remove (GTK_CONTAINER(tab_widget), image);
+    image = gtk_image_new_from_icon_name (icon_name, GTK_ICON_SIZE_MENU);
+    gtk_widget_show (image);
+
+    gtk_container_add (GTK_CONTAINER(tab_widget), image);
+    gtk_widget_set_margin_start (GTK_WIDGET(image), 5);
+    gtk_box_reorder_child (GTK_BOX(tab_widget), image, 0);
+
+    g_free (image_name);
+    LEAVE("done");
+}
+
+
 static void
 gnc_main_window_tab_entry_activate (GtkWidget *entry,
                                     GncPluginPage *page)

--- a/gnucash/gnome-utils/gnc-main-window.h
+++ b/gnucash/gnome-utils/gnc-main-window.h
@@ -185,6 +185,15 @@ void
 main_window_update_page_color (GncPluginPage *page,
                                const gchar *color_in);
 
+/** Update the icon on the page tabs in the main window.
+ *
+ *  @param page The page to be updated.
+ *  @param read_only If set a padlock icon will be displayed
+ *  for the page tab icon if it had one.
+*/
+void
+main_window_update_page_set_read_only_icon (GncPluginPage *page,
+                                            gboolean read_only);
 
 /** Manually add a set of actions to the specified window.  Plugins
  *  whose user interface is not hard coded (e.g. the menu-additions *

--- a/gnucash/gnome/gnc-plugin-page-register.c
+++ b/gnucash/gnome/gnc-plugin-page-register.c
@@ -1086,7 +1086,7 @@ gnc_plugin_page_register_ui_update (gpointer various,
     GncPluginPageRegisterPrivate* priv;
     SplitRegister* reg;
     GtkAction* action;
-    gboolean expanded, voided, read_only = FALSE;
+    gboolean expanded, voided, read_only = FALSE, read_only_reg = FALSE;
     Transaction* trans;
     GList* invoices;
     CursorClass cursor_class;
@@ -1106,62 +1106,83 @@ gnc_plugin_page_register_ui_update (gpointer various,
     g_signal_handlers_unblock_by_func
     (action, gnc_plugin_page_register_cmd_expand_transaction, page);
 
+    /* If we are in a readonly book, or possibly a place holder
+     * account register make any modifying action inactive */
+    if (qof_book_is_readonly (gnc_get_current_book()) ||
+        gnc_split_reg_get_read_only (priv->gsr))
+        read_only_reg = TRUE;
+
     /* Set available actions based on read only */
     trans = gnc_split_register_get_current_trans (reg);
 
-    if (trans)
-        read_only = xaccTransIsReadonlyByPostedDate (trans);
-    voided = xaccTransHasSplitsInState (trans, VREC);
-
-    action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page),
-                                         "CutTransactionAction");
-    gtk_action_set_sensitive (GTK_ACTION (action), !read_only & !voided);
-
-    action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page),
-                                         "PasteTransactionAction");
-    gtk_action_set_sensitive (GTK_ACTION (action), !read_only & !voided);
-
-    action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page),
-                                         "DeleteTransactionAction");
-    gtk_action_set_sensitive (GTK_ACTION (action), !read_only & !voided);
-
-    action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page),
-                                         "DuplicateTransactionAction");
-    gtk_action_set_sensitive (GTK_ACTION (action), TRUE);
-
-    if (cursor_class == CURSOR_CLASS_SPLIT)
+    /* If the register is not read only, make any modifying action active
+     * to start with */
+    if (!read_only_reg)
     {
+        const char** iter;
+        for (iter = readonly_inactive_actions; *iter; ++iter)
+        {
+            /* Set the action's sensitivity */
+            GtkAction* action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page), *iter);
+            gtk_action_set_sensitive (action, TRUE);
+        }
+
+        if (trans)
+            read_only = xaccTransIsReadonlyByPostedDate (trans);
+
+        voided = xaccTransHasSplitsInState (trans, VREC);
+
+        action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page),
+                                             "CutTransactionAction");
+        gtk_action_set_sensitive (GTK_ACTION (action), !read_only & !voided);
+
+        action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page),
+                                             "PasteTransactionAction");
+        gtk_action_set_sensitive (GTK_ACTION (action), !read_only & !voided);
+
+        action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page),
+                                             "DeleteTransactionAction");
+        gtk_action_set_sensitive (GTK_ACTION (action), !read_only & !voided);
+
         action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page),
                                              "DuplicateTransactionAction");
+        gtk_action_set_sensitive (GTK_ACTION (action), !read_only & TRUE);
+
+        if (cursor_class == CURSOR_CLASS_SPLIT)
+        {
+            action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page),
+                                                 "DuplicateTransactionAction");
+            gtk_action_set_sensitive (GTK_ACTION (action), !read_only & !voided);
+        }
+
+        action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page),
+                                             "RemoveTransactionSplitsAction");
         gtk_action_set_sensitive (GTK_ACTION (action), !read_only & !voided);
+
+        /* Set 'Void' and 'Unvoid' */
+        if (read_only)
+            voided = TRUE;
+
+        action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page),
+                                             "VoidTransactionAction");
+        gtk_action_set_sensitive (GTK_ACTION (action), !voided);
+
+        if (read_only)
+            voided = FALSE;
+
+        action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page),
+                                             "UnvoidTransactionAction");
+        gtk_action_set_sensitive (GTK_ACTION (action), voided);
     }
 
-    action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page),
-                                         "RemoveTransactionSplitsAction");
-    gtk_action_set_sensitive (GTK_ACTION (action), !read_only & !voided);
-
-    /* Set 'Void' and 'Unvoid' */
-    if (read_only)
-        voided = TRUE;
-
-    action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page),
-                                         "VoidTransactionAction");
-    gtk_action_set_sensitive (GTK_ACTION (action), !voided);
-
-    if (read_only)
-        voided = FALSE;
-
-    action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page),
-                                         "UnvoidTransactionAction");
-    gtk_action_set_sensitive (GTK_ACTION (action), voided);
-
     /* Set 'Open and Remove Linked Documents' */
-    uri = xaccTransGetDocLink (trans);
-
     action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE(page),
                                          "LinkedTransactionOpenAction");
-    gtk_action_set_sensitive (GTK_ACTION(action), (uri ? TRUE:FALSE));
-
+    if (trans)
+    {
+        uri = xaccTransGetDocLink (trans);
+        gtk_action_set_sensitive (GTK_ACTION(action), (uri ? TRUE:FALSE));
+    }
     /* Set 'ExecAssociatedInvoice'
        We can determine an invoice from a txn if either
        - it is an invoice transaction
@@ -1169,15 +1190,17 @@ gnc_plugin_page_register_ui_update (gpointer various,
     */
     action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page),
                                          "JumpLinkedInvoiceAction");
-
-    invoices = invoices_from_transaction (trans);
-    gtk_action_set_sensitive (GTK_ACTION (action), (invoices != NULL));
-    g_list_free (invoices);
+    if (trans)
+    {
+        invoices = invoices_from_transaction (trans);
+        gtk_action_set_sensitive (GTK_ACTION (action), (invoices != NULL));
+        g_list_free (invoices);
+    }
 
     gnc_plugin_business_split_reg_ui_update (GNC_PLUGIN_PAGE (page));
 
-    /* If we are in a readonly book, make any modifying action inactive */
-    if (qof_book_is_readonly (gnc_get_current_book()))
+    /* If we are read only, make any modifying action inactive */
+    if (read_only_reg)
     {
         const char** iter;
         for (iter = readonly_inactive_actions; *iter; ++iter)
@@ -1937,7 +1960,7 @@ finish_scrub (GncPluginPage* page)
                                 (GNC_PLUGIN_PAGE(page))),
                                 FALSE,
                                 _("'Check & Repair' is currently running, do you want to abort it?"));
-        
+
         show_abort_verify = FALSE;
 
         if (ret)
@@ -5020,10 +5043,10 @@ scrub_kp_handler (GtkWidget *widget, GdkEventKey *event, gpointer data)
         {
             gboolean abort_scrub = gnc_verify_dialog (GTK_WINDOW(widget), FALSE,
                  _("'Check & Repair' is currently running, do you want to abort it?"));
-        
+
             if (abort_scrub)
                 gnc_set_abort_scrub (TRUE);
-        
+
             return TRUE;
         }
     default:

--- a/gnucash/gnome/gnc-plugin-page-register.c
+++ b/gnucash/gnome/gnc-plugin-page-register.c
@@ -1126,6 +1126,7 @@ gnc_plugin_page_register_ui_update (gpointer various,
             GtkAction* action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page), *iter);
             gtk_action_set_sensitive (action, TRUE);
         }
+        main_window_update_page_set_read_only_icon (GNC_PLUGIN_PAGE(page), FALSE);
 
         if (trans)
             read_only = xaccTransIsReadonlyByPostedDate (trans);
@@ -1209,6 +1210,7 @@ gnc_plugin_page_register_ui_update (gpointer various,
             GtkAction* action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE (page), *iter);
             gtk_action_set_sensitive (action, FALSE);
         }
+        main_window_update_page_set_read_only_icon (GNC_PLUGIN_PAGE(page), TRUE);
     }
 
     /* Modifying action descriptions based on cursor class */
@@ -3512,6 +3514,27 @@ gnc_plugin_page_register_set_filter_tooltip (GncPluginPageRegister* page)
     LEAVE (" ");
 }
 
+
+static void
+gnc_plugin_page_register_update_page_icon (GncPluginPage* plugin_page)
+{
+    GncPluginPageRegisterPrivate* priv;
+    gboolean read_only;
+
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page));
+
+    priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
+
+    if (qof_book_is_readonly (gnc_get_current_book()) ||
+        gnc_split_reg_get_read_only (priv->gsr))
+        read_only = TRUE;
+    else
+        read_only = FALSE;
+
+    main_window_update_page_set_read_only_icon (GNC_PLUGIN_PAGE(plugin_page),
+                                                read_only);
+}
+
 /************************************************************/
 /*                  Report Helper Functions                 */
 /************************************************************/
@@ -5393,6 +5416,9 @@ gnc_plugin_page_register_event_handler (QofInstance* entity,
             main_window_update_page_name (GNC_PLUGIN_PAGE (page), label);
             color = gnc_plugin_page_register_get_tab_color (GNC_PLUGIN_PAGE (page));
             main_window_update_page_color (GNC_PLUGIN_PAGE (page), color);
+            // update page icon if read only registers
+            gnc_plugin_page_register_update_page_icon (GNC_PLUGIN_PAGE (page));
+
             g_free (color);
             g_free (label);
         }

--- a/gnucash/gnome/gnc-split-reg.c
+++ b/gnucash/gnome/gnc-split-reg.c
@@ -2444,8 +2444,30 @@ gboolean
 gtk_callback_bug_workaround (gpointer argp)
 {
     dialog_args *args = argp;
-    const gchar *read_only = _("This account register is read-only.");
+    const gchar *read_only_this = _("This account register is read-only.");
+    const gchar *read_only_acc = _("The '%s' account register is read-only.");
+    gchar *read_only = NULL;
     GtkWidget *dialog;
+    GNCLedgerDisplayType ledger_type = gnc_ledger_display_type (args->gsr->ledger);
+    Account *acc = gnc_ledger_display_leader (args->gsr->ledger);
+    const gchar *acc_name = NULL;
+    gchar *tmp = NULL;
+
+    if (acc)
+    {
+        acc_name = xaccAccountGetName (acc);
+
+        if (ledger_type == LD_SINGLE)
+            read_only = g_strdup_printf (read_only_acc, acc_name);
+        else
+        {
+            gchar *tmp = g_strconcat (acc_name, "+", NULL);
+            read_only = g_strdup_printf (read_only_acc, tmp);
+            g_free (tmp);
+        }
+    }
+    else
+        read_only = g_strdup (read_only_this);
 
     dialog = gtk_message_dialog_new(GTK_WINDOW(args->gsr->window),
                                     GTK_DIALOG_DESTROY_WITH_PARENT,
@@ -2456,6 +2478,7 @@ gtk_callback_bug_workaround (gpointer argp)
             "%s", args->string);
     gnc_dialog_run(GTK_DIALOG(dialog), GNC_PREF_WARN_REG_IS_READ_ONLY);
     gtk_widget_destroy(dialog);
+    g_free(read_only);
     g_free(args);
     return FALSE;
 }

--- a/gnucash/gnome/gnc-split-reg.c
+++ b/gnucash/gnome/gnc-split-reg.c
@@ -73,7 +73,7 @@ static GtkWidget* add_summary_label( GtkWidget *summarybar, gboolean pack_start,
 
 static void gsr_summarybar_set_arrow_draw (GNCSplitReg *gsr);
 
-static void gnc_split_reg_determine_read_only( GNCSplitReg *gsr );
+static void gnc_split_reg_determine_read_only( GNCSplitReg *gsr, gboolean show_dialog );
 static gboolean is_trans_readonly_and_warn (GtkWindow *parent, Transaction *trans);
 
 static GNCPlaceholderType gnc_split_reg_get_placeholder( GNCSplitReg *gsr );
@@ -378,7 +378,7 @@ gnc_split_reg_init2( GNCSplitReg *gsr )
 {
     if ( !gsr ) return;
 
-    gnc_split_reg_determine_read_only( gsr );
+    gnc_split_reg_determine_read_only( gsr, TRUE );
 
     gsr_setup_status_widgets( gsr );
     /* ordering is important here... setup_status before create_table */
@@ -2488,7 +2488,7 @@ gtk_callback_bug_workaround (gpointer argp)
  **/
 static
 void
-gnc_split_reg_determine_read_only( GNCSplitReg *gsr )
+gnc_split_reg_determine_read_only( GNCSplitReg *gsr, gboolean show_dialog )
 {
     SplitRegister *reg;
 
@@ -2542,7 +2542,8 @@ gnc_split_reg_determine_read_only( GNCSplitReg *gsr )
         args = g_malloc(sizeof(dialog_args));
         args->string = string;
         args->gsr = gsr;
-        g_timeout_add (250, gtk_callback_bug_workaround, args); /* 0.25 seconds */
+        if (show_dialog)
+            g_timeout_add (250, gtk_callback_bug_workaround, args); /* 0.25 seconds */
     }
 
     /* Make the contents immutable */
@@ -2631,7 +2632,16 @@ gnc_split_reg_get_summarybar( GNCSplitReg *gsr )
 gboolean
 gnc_split_reg_get_read_only( GNCSplitReg *gsr )
 {
+    SplitRegister *reg;
+
     g_assert( gsr );
+
+    // reset read_only flag
+    gsr->read_only = FALSE;
+    gnc_split_reg_determine_read_only (gsr, FALSE);
+
+    reg = gnc_ledger_display_get_split_register( gsr->ledger );
+    gnc_split_register_set_read_only( reg, gsr->read_only );
     return gsr->read_only;
 }
 

--- a/gnucash/gnome/gnc-split-reg2.c
+++ b/gnucash/gnome/gnc-split-reg2.c
@@ -934,8 +934,30 @@ gboolean
 gtk_callback_bug_workaround (gpointer argp)
 {
     dialog_args *args = argp;
-    const gchar *read_only = _("This account register is read-only.");
+    const gchar *read_only_this = _("This account register is read-only.");
+    const gchar *read_only_acc = _("The '%s' account register is read-only.");
+    gchar *read_only = NULL;
     GtkWidget *dialog;
+    GNCLedgerDisplay2Type ledger_type = gnc_ledger_display2_type (args->gsr->ledger);
+    Account *acc = gnc_ledger_display2_leader (args->gsr->ledger);
+    const gchar *acc_name = NULL;
+    gchar *tmp = NULL;
+
+    if (acc)
+    {
+        acc_name = xaccAccountGetName (acc);
+
+        if (ledger_type == LD2_SINGLE)
+            read_only = g_strdup_printf (read_only_acc, acc_name);
+        else
+        {
+            gchar *tmp = g_strconcat (acc_name, "+", NULL);
+            read_only = g_strdup_printf (read_only_acc, tmp);
+            g_free (tmp);
+        }
+    }
+    else
+        read_only = g_strdup (read_only_this);
 
     dialog = gtk_message_dialog_new (GTK_WINDOW(args->gsr->window),
                                     GTK_DIALOG_DESTROY_WITH_PARENT,
@@ -946,6 +968,7 @@ gtk_callback_bug_workaround (gpointer argp)
             "%s", args->string);
     gnc_dialog_run (GTK_DIALOG (dialog), GNC_PREF_WARN_REG_IS_READ_ONLY);
     gtk_widget_destroy (dialog);
+    g_free(read_only);
     g_free (args);
     return FALSE;
 }

--- a/gnucash/gnome/gnc-split-reg2.c
+++ b/gnucash/gnome/gnc-split-reg2.c
@@ -53,7 +53,7 @@ void gnc_split_reg2_raise (GNCSplitReg2 *gsr);
 static GtkWidget* add_summary_label (GtkWidget *summarybar,
                                      const char *label_str);
 
-static void gnc_split_reg2_determine_read_only (GNCSplitReg2 *gsr);
+static void gnc_split_reg2_determine_read_only (GNCSplitReg2 *gsr, gboolean show_dialog);
 
 static void gnc_split_reg2_determine_account_pr (GNCSplitReg2 *gsr);
 
@@ -200,7 +200,7 @@ gnc_split_reg2_init2 (GNCSplitReg2 *gsr)
 {
     if (!gsr) return;
 
-    gnc_split_reg2_determine_read_only (gsr);
+    gnc_split_reg2_determine_read_only (gsr, TRUE);
 
     gnc_split_reg2_determine_account_pr (gsr);
 
@@ -978,7 +978,7 @@ gtk_callback_bug_workaround (gpointer argp)
  **/
 static
 void
-gnc_split_reg2_determine_read_only (GNCSplitReg2 *gsr) //this works
+gnc_split_reg2_determine_read_only (GNCSplitReg2 *gsr, gboolean show_dialog)
 {
 
     if (qof_book_is_readonly (gnc_get_current_book()))
@@ -1018,7 +1018,8 @@ gnc_split_reg2_determine_read_only (GNCSplitReg2 *gsr) //this works
         gsr->read_only = TRUE;
         /* Put up a warning dialog */
         args->gsr = gsr;
-        g_timeout_add (250, gtk_callback_bug_workaround, args); /* 0.25 seconds */
+        if (show_dialog)
+            g_timeout_add (250, gtk_callback_bug_workaround, args); /* 0.25 seconds */
     }
 }
 
@@ -1125,6 +1126,10 @@ gboolean
 gnc_split_reg2_get_read_only (GNCSplitReg2 *gsr)
 {
     g_assert (gsr);
+
+    // reset read_only flag
+    gsr->read_only = FALSE;
+    gnc_split_reg2_determine_read_only (gsr, FALSE);
     return gsr->read_only;
 }
 

--- a/gnucash/register/register-gnome/gnucash-sheet-private.c
+++ b/gnucash/register/register-gnome/gnucash-sheet-private.c
@@ -408,6 +408,17 @@ draw_cell (GnucashSheet *sheet, SheetBlock *block,
     color_type = gnc_table_get_color (table, virt_loc, &hatching);
     gnucash_get_style_classes (sheet, stylectxt, color_type, use_neg_class);
 
+    if (sheet->read_only)
+    {
+        if (!gtk_style_context_has_class (stylectxt, GTK_STYLE_CLASS_BACKGROUND))
+            gtk_style_context_set_state (stylectxt, GTK_STATE_FLAG_INSENSITIVE);
+    }
+    else
+    {
+        if (gtk_style_context_has_class (stylectxt, GTK_STYLE_CLASS_BACKGROUND))
+            gtk_style_context_set_state (stylectxt, GTK_STATE_FLAG_NORMAL);
+    }
+
     // Are we in a read-only row? Then make the background color somewhat more grey.
     if ((virt_loc.phys_row_offset < block->style->nrows)
                 && (table->model->dividing_row_upper >= 0)
@@ -626,6 +637,8 @@ gnucash_sheet_draw_internal (GnucashSheet* sheet, cairo_t* cr,
     sheet_block = find_block_by_pixel (sheet, x, y, &virt_loc.vcell_loc);
     if (!sheet_block || !sheet_block->style)
         return FALSE;
+
+    sheet->read_only = gnc_table_model_read_only (sheet->table->model);
 
     for ( ; virt_loc.vcell_loc.virt_row < sheet->num_virt_rows;
             virt_loc.vcell_loc.virt_row++ )

--- a/gnucash/register/register-gnome/gnucash-sheetP.h
+++ b/gnucash/register/register-gnome/gnucash-sheetP.h
@@ -44,6 +44,7 @@ struct _GnucashSheet
     gpointer popup_data;
 
     Table *table;
+    gboolean read_only;
 
     GtkWidget *reg;
 


### PR DESCRIPTION
Hopefully straight forward bug.
The first commit adds the account name to the read only warning dialog so when you start Gnucash with a read only register open you can tell which register the dialog refers to.
The second commit adds a test for the register being read only so that the same actions disabled for a read only book can be applied.

As part of the bug report, there was a request for some indication that a register is read only. The second commit my well of fulfilled that by disabling the menu actions but was wondering if more is required. One simple idea would be to augment the title with some text as this changes for each register tab, another idea was maybe to change the account icon to a padlock, slightly more involved but doable.

I will push this next weekend if no further indication required.