### PR TITLE
sort with date then number

### DIFF
--- a/gnucash/gnome/gnc-split-reg.c
+++ b/gnucash/gnome/gnc-split-reg.c
@@ -2006,7 +2006,8 @@ gnc_split_reg_sort_force( GNCSplitReg *gsr, SortType sort_code, gboolean force )
     case BY_DATE:
         p1 = g_slist_prepend (p1, TRANS_DATE_POSTED);
         p1 = g_slist_prepend (p1, SPLIT_TRANS);
-        p2 = standard;
+        p2 = g_slist_prepend (p2, TRANS_NUM);
+        p3 = standard;
         show_present_divider = TRUE;
         break;
     case BY_DATE_ENTERED:

--- a/libgnucash/engine/test-core/test-engine-stuff.cpp
+++ b/libgnucash/engine/test-core/test-engine-stuff.cpp
@@ -1642,7 +1642,8 @@ set_query_sort (QofQuery *q, sort_type_t sort_code)
     case BY_DATE:
         p1 = g_slist_prepend (p1, const_cast<char*>(TRANS_DATE_POSTED));
         p1 = g_slist_prepend (p1, const_cast<char*>(SPLIT_TRANS));
-        p2 = standard;
+        p2 = g_slist_prepend (p2, const_cast<char*>(TRANS_NUM));
+        p3 = standard;
         break;
     case BY_DATE_ENTERED:
         p1 = g_slist_prepend (p1, const_cast<char*>(TRANS_DATE_ENTERED));


### PR DESCRIPTION
When sorting `BY_DATE`, transactions are sorted by `Date` then `Transaction ID`. But `Transaction ID` is merely a random unique byte array, its order is meaningless. On the order hand, `Number` is a user-assigned field, which likely contains sequential info.

Therefore sorting with `Date` then `Number` is more reasonable.