### PR TITLE
Fix (format) strings, importing ice-9 format where appropriate

### DIFF
--- a/gnucash/report/reports/standard/budget-income-statement.scm
+++ b/gnucash/report/reports/standard/budget-income-statement.scm
@@ -46,6 +46,7 @@
 (use-modules (gnucash core-utils))
 (use-modules (gnucash app-utils))
 (use-modules (gnucash report))
+(use-modules (ice-9 format))
 
 ;; define all option's names and help text so that they are properly
 ;; defined in *one* place.


### PR DESCRIPTION
* because simple-format uses only ~a and ~s
* ice-9's format handles ~f

If we merge this it'll modify strings, unfortunately.