### PR TITLE
Don't use gnc:last-captured-error

### DIFF
--- a/gnucash/gnome/gnc-plugin-report-system.c
+++ b/gnucash/gnome/gnc-plugin-report-system.c
@@ -137,14 +137,12 @@ static gboolean
 gnc_report_system_report_stream_cb (const char *location, char ** data, int *len)
 {
     gboolean ok;
+    gchar *captured_str;
 
-    ok = gnc_run_report_id_string (location, data);
+    ok = gnc_run_report_id_string_with_error_handling (location, data, &captured_str);
 
     if (!ok)
     {
-        SCM captured = scm_c_eval_string ("gnc:last-captured-error");
-        gchar *captured_str = gnc_scm_to_utf8_string(captured);
-
         *data = g_strdup_printf ("<html><body><h3>%s</h3>"
                                  "<p>%s</p><pre>%s</pre></body></html>",
                                  _("Report error"),

--- a/gnucash/gnucash-commands.cpp
+++ b/gnucash/gnucash-commands.cpp
@@ -260,9 +260,9 @@ return a document object with export-string or export-error.") << std::endl;
 
         if (scm_is_false (id))
             scm_cleanup_and_exit_with_failure (nullptr);
-        char* html;
-        gnc_run_report (scm_to_int(id), &html);
-        if (html && *html)
+        char *html, *errmsg;
+
+        if (gnc_run_report_with_error_handling (scm_to_int(id), &html, &errmsg))
         {
             if (!args->output_file.empty())
             {
@@ -272,6 +272,10 @@ return a document object with export-string or export-error.") << std::endl;
             {
                 std::cout << html << std::endl;
             }
+        }
+        else
+        {
+            std::cerr << errmsg << std::endl;
         }
     }
 

--- a/gnucash/report/gnc-report.h
+++ b/gnucash/report/gnc-report.h
@@ -39,7 +39,13 @@ void gnc_report_init (void);
 
 
 gboolean gnc_run_report (gint report_id, char ** data);
+gboolean gnc_run_report_with_error_handling (gint report_id,
+                                             gchar **data,
+                                             gchar **errmsg);
 gboolean gnc_run_report_id_string (const char * id_string, char **data);
+gboolean gnc_run_report_id_string_with_error_handling (const char * id_string,
+                                                       char **data,
+                                                       gchar **errmsg);
 
 /**
  * @param report The SCM version of the report.

--- a/gnucash/report/report-core.scm
+++ b/gnucash/report/report-core.scm
@@ -76,6 +76,7 @@
 (export gnc:report-needs-save?)
 (export gnc:report-options)
 (export gnc:report-render-html)
+(export gnc:render-report)
 (export gnc:report-run)
 (export gnc:report-serialize)
 (export gnc:report-set-ctext!)
@@ -763,9 +764,17 @@ not found.")))
                (gnc:report-set-dirty?! report #f)  ;; mark it clean
                html)))))
 
+;; render report. will return a 2-element list: either (list html #f)
+;; where html is the report html string, or (list #f captured-error)
+;; where captured-error is the error string.
+(define (gnc:render-report report)
+  (define (get-report) (gnc:report-render-html report #t))
+  (gnc:apply-with-error-handling get-report '()))
+
 ;; looks up the report by id and renders it with gnc:report-render-html
 ;; marks the cursor busy during rendering; returns the html
 (define (gnc:report-run id)
+  (issue-deprecation-warning "gnc:report-run is deprecated. use gnc:render-report instead.")
   (let ((report (gnc-report-find id))
         (html #f))
     (gnc-set-busy-cursor '() #t)

--- a/libgnucash/app-utils/c-interface.scm
+++ b/libgnucash/app-utils/c-interface.scm
@@ -78,11 +78,12 @@
     ((result #f) result)
     ((_ captured-error)
      (display captured-error (current-error-port))
+     ;; the next line will be removed in 5.x - deprecated
      (set! gnc:last-captured-error (gnc:html-string-sanitize captured-error))
      (when (defined? 'gnc:warn) (gnc:warn captured-error))
      #f)))
 
-(define gnc:last-captured-error "")
+(define gnc:last-captured-error "")     ;deprecate - remove in 5.x
 
 ;; This database can be used to store and retrieve translatable
 ;; strings. Strings that are returned by the lookup function are


### PR DESCRIPTION
1. To avoid using the global var `gnc:last-captured-error`, this branch will augment some C functions and handle error by passing a parameter to receive the captured error.
2. ~Also `gnc_set_busy_cursor` is currently disabled -- they seem to belong to `gnc-ui.h` but importing the latter doesn't work.~ (fixed)
