### PR TITLE
sorting sources

### DIFF
--- a/libgnucash/quotes/gnc-fq-dump.in
+++ b/libgnucash/quotes/gnc-fq-dump.in
@@ -167,7 +167,7 @@ my $q = Finance::Quote->new;
 $q->timeout(60);
 
 if ($#ARGV < 1) {
-  my @sources = $q->sources();
+  my @sources = sort $q->sources();
   printf "\nUsage: $0 [-v] <quote-source> <stock> [<stock> ...]\n\n";
   printf "-v: verbose\n";
   printf "Available sources are: \n     %s\n\n", join(' ', @sources);


### PR DESCRIPTION
I've did a small bash script that retrieve the sources from gnc-fq-dump and try to find one source that has the specific stock. At that point I've noticed that the sources returned by Finance::Quote have always a different order. Just wondering if it is done in that way intentionally (?)