### PR TITLE
Mark most parent accounts as placeholders in Danish templates

### DIFF
--- a/data/accounts/da/acctchrt_car.gnucash-xea
+++ b/data/accounts/da/acctchrt_car.gnucash-xea
@@ -56,6 +56,12 @@
   </act:commodity>
   <act:description>Udgifter</act:description>
   <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Bil</act:name>
@@ -67,6 +73,12 @@
   </act:commodity>
   <act:description>Bil</act:description>
   <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Vægtafgift</act:name>
@@ -122,6 +134,12 @@
   </act:commodity>
   <act:description>Forsikring</act:description>
   <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Bilforsikring</act:name>

--- a/data/accounts/da/acctchrt_common.gnucash-xea
+++ b/data/accounts/da/acctchrt_common.gnucash-xea
@@ -57,6 +57,12 @@
   </act:commodity>
   <act:description>Aktiver</act:description>
   <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Aktuelle aktiver</act:name>
@@ -68,6 +74,12 @@
   </act:commodity>
   <act:description>Aktuelle aktiver</act:description>
   <act:parent type="new">98f262dfab9a2b99ac42919dcf58d304</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Checkkonto</act:name>
@@ -112,6 +124,12 @@
   </act:commodity>
   <act:description>Passiver</act:description>
   <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Forventede udgifter</act:name>
@@ -123,6 +141,12 @@
   </act:commodity>
   <act:description>Forventede udgifter</act:description>
   <act:parent type="new">19a911feed9b41b8b01be036a2aed9fe</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Kreditkort</act:name>
@@ -145,6 +169,12 @@
   </act:commodity>
   <act:description>Indtægter</act:description>
   <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Bonus</act:name>
@@ -178,6 +208,12 @@
   </act:commodity>
   <act:description>Renteindtægter</act:description>
   <act:parent type="new">a7ab23dd2d41616042034d5a012a0850</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Checkrenter</act:name>
@@ -244,6 +280,12 @@
   </act:commodity>
   <act:description>Udgifter</act:description>
   <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Justering</act:name>
@@ -563,6 +605,12 @@
   </act:commodity>
   <act:description>Skatter og afgifter</act:description>
   <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Stat</act:name>
@@ -618,6 +666,12 @@
   </act:commodity>
   <act:description>Forsyning</act:description>
   <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>El</act:name>

--- a/data/accounts/da/acctchrt_homeloan.gnucash-xea
+++ b/data/accounts/da/acctchrt_homeloan.gnucash-xea
@@ -56,6 +56,12 @@
   </act:commodity>
   <act:description>Passiver</act:description>
   <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Lån</act:name>
@@ -67,6 +73,12 @@
   </act:commodity>
   <act:description>Lån</act:description>
   <act:parent type="new">6664763bd1ea41462cba5ef856d9c00c</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Realkreditlån</act:name>
@@ -89,6 +101,12 @@
   </act:commodity>
   <act:description>Udgifter</act:description>
   <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Renter</act:name>
@@ -100,6 +118,12 @@
   </act:commodity>
   <act:description>Renter</act:description>
   <act:parent type="new">2f076f5ae073173a11d33420cd39fa4d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Realkreditrenter</act:name>

--- a/data/accounts/da/acctchrt_homeown.gnucash-xea
+++ b/data/accounts/da/acctchrt_homeown.gnucash-xea
@@ -56,6 +56,12 @@
   </act:commodity>
   <act:description>Udgifter</act:description>
   <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Vedligehold af bolig</act:name>
@@ -89,6 +95,12 @@
   </act:commodity>
   <act:description>Forsikring</act:description>
   <act:parent type="new">84732f5fdd27b6463d75bf958e3a4b06</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Husforsikring</act:name>
@@ -111,6 +123,12 @@
   </act:commodity>
   <act:description>Skatter/afgifter</act:description>
   <act:parent type="new">84732f5fdd27b6463d75bf958e3a4b06</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Ejendomsskat</act:name>


### PR DESCRIPTION
Most of these, like "Udgifter", correspond directly to directly to en_GB
equivalents, like "Expenses". However, unlike in the en_GB version, the parent
accounts in the Danish templates are not marked as placeholders.

I have used my own judgement in a few cases where there was no direct equivalent
in the en_GB templates.

This was also discussed on the gnucash mailing list: https://lists.gnucash.org/pipermail/gnucash-user/2021-January/094762.html (and replies).