### PR TITLE
Bug 798085 - Incorrect transactions import of deposit with large number amount

### DIFF
--- a/gnucash/import-export/qif-imp/qif-file.scm
+++ b/gnucash/import-export/qif-imp/qif-file.scm
@@ -135,6 +135,12 @@
 	      (unread-char c1)
 	      #f))))
 
+      (define (qif-split-set-amount split value override?)
+        (when (and split
+                   (not-bad-numeric-string? value)
+                   (or override? (not (qif-split:amount split))))
+          (qif-split:set-amount! split value)))
+
       (qif-file:set-path! self path)
       (if (not (access? path R_OK))
           ;; A UTF-8 encoded path won't succeed on some systems, such as
@@ -261,9 +267,13 @@
 
                            ;; T : total amount
                            ((#\T)
-                            (if (and default-split
-                                    (not-bad-numeric-string? value))
-                                (qif-split:set-amount! default-split value)))
+                            (qif-split-set-amount default-split value #f))
+
+                           ;; U : total amount (handle larger amount
+                           ;; than T; present in Quicken 2005
+                           ;; exports). See bug 798085
+                           ((#\U)
+                            (qif-split-set-amount default-split value #t))
 
                            ;; P : payee
                            ((#\P)


### PR DESCRIPTION
Quicken 2005 introduces U amount which sometimes differs from T amount. U amount has larger range, and must override T amount whenever they're not equal.

Example log output:
```
* 21:57:17  WARN <gnc.scm> qif-split has ambiguous amounts. T-21449672.96 U21,500,000.00. using U amount.
* 21:57:17  WARN <gnc.scm> qif-split has ambiguous amounts. T-20949672.96 U22,000,000.00. using U amount.
* 21:57:17  WARN <gnc.scm> qif-split has ambiguous amounts. T-21469672.96 U21,480,000.00. using U amount.
* 21:57:17  WARN <gnc.scm> qif-split has ambiguous amounts. T-21474672.96 U21,475,000.00. using U amount.
* 21:57:17  WARN <gnc.scm> qif-split has ambiguous amounts. T-21474772.96 U21,474,900.00. using U amount.
* 21:57:17  WARN <gnc.scm> qif-split has ambiguous amounts. T-21474822.96 U21,474,850.00. using U amount.
* 21:57:17  WARN <gnc.scm> qif-split has ambiguous amounts. T-21474835.96 U21,474,837.00. using U amount.
* 21:57:17  WARN <gnc.scm> qif-split has ambiguous amounts. T-21474836.48 U21,474,836.48. using U amount.
* 21:57:17  WARN <gnc.scm> qif-split has ambiguous amounts. T-21449672.96 U21,500,000.00. using U amount.
* 21:57:17  WARN <gnc.scm> qif-split has ambiguous amounts. T-20949672.96 U22,000,000.00. using U amount.
* 21:57:17  WARN <gnc.scm> qif-split has ambiguous amounts. T-21469672.96 U21,480,000.00. using U amount.
* 21:57:17  WARN <gnc.scm> qif-split has ambiguous amounts. T-21474672.96 U21,475,000.00. using U amount.
* 21:57:17  WARN <gnc.scm> qif-split has ambiguous amounts. T-21474772.96 U21,474,900.00. using U amount.
* 21:57:17  WARN <gnc.scm> qif-split has ambiguous amounts. T-21474822.96 U21,474,850.00. using U amount.
* 21:57:17  WARN <gnc.scm> qif-split has ambiguous amounts. T-21474835.96 U21,474,837.00. using U amount.
* 21:57:17  WARN <gnc.scm> qif-split has ambiguous amounts. T-21474836.48 U21,474,836.48. using U amount.
```