### PR TITLE
Make prototypes static for autoclear unit test

### DIFF
--- a/libgnucash/app-utils/test/test-autoclear.cpp
+++ b/libgnucash/app-utils/test/test-autoclear.cpp
@@ -157,9 +157,9 @@ TEST_P(AutoClearTest, DoesAutoClear) {
 }
 
 #ifndef INSTANTIATE_TEST_SUITE_P
-// Silence "no previous declaration for" which is treated as error, due to -Werror
-testing::internal::ParamGenerator<TestCase*> gtest_InstantiationAutoClearTestAutoClearTest_EvalGenerator_();
-std::string gtest_InstantiationAutoClearTestAutoClearTest_EvalGenerateName_(const testing::TestParamInfo<TestCase*>&);
+// Silence "no previous declaration for" (treated as error due to -Werror) when building with GoogleTest < 1.8.1
+static testing::internal::ParamGenerator<TestCase*> gtest_InstantiationAutoClearTestAutoClearTest_EvalGenerator_();
+static std::string gtest_InstantiationAutoClearTestAutoClearTest_EvalGenerateName_(const testing::TestParamInfo<TestCase*>&);
 
 INSTANTIATE_TEST_CASE_P(
 #else // INSTANTIATE_TEST_SUITE_P


### PR DESCRIPTION
With the explicit prototype in place unit test builds on Debian Buster (using
buster-backports) fail with "error: testing::internal::ParamGenerator<TestCase*>
gtest_InstantiationAutoClearTestAutoClearTest_EvalGenerator_() was declared
extern and later static [-fpermissive]".

According to the comment preceding the declaration the only intent for the
explicit prototype seems to be to silence a warning which would cause a build
failure when using -Werror. As builds on Debian unstable seem to build just
fine without this explicit declaration I consider it safe to just drop it.

This is the full build log showing the build failure on Debian Buster without this change.
https://buildd.debian.org/status/fetch.php?pkg=gnucash&arch=amd64&ver=1%3A4.4-1%7Ebpo10%2B1&stamp=1610592036