### PR TITLE
Bug 797997 - Gnucash File can not be found on Windows from command line.

### DIFF
--- a/gnucash/gnucash-cli.cpp
+++ b/gnucash/gnucash-cli.cpp
@@ -38,6 +38,9 @@ extern "C" {
 
 #include <boost/locale.hpp>
 #include <boost/optional.hpp>
+#ifdef __MINGW32__
+#include <boost/nowide/args.hpp>
+#endif
 #include <iostream>
 
 namespace bl = boost::locale;
@@ -195,7 +198,9 @@ int
 main(int argc, char **argv)
 {
     Gnucash::GnucashCli application (argv[0]);
-
+#ifdef __MINGW32__
+    boost::nowide::args a(argc, argv); // Fix arguments - make them UTF-8
+#endif
     application.parse_command_line (argc, argv);
     application.start (argc, argv);
 

--- a/gnucash/gnucash-core-app.cpp
+++ b/gnucash/gnucash-core-app.cpp
@@ -345,24 +345,14 @@ load_user_config(void)
     try_load_config_array(stylesheet_files);
 }
 
-
 static void
 gnc_log_init (const std::vector <std::string> log_flags,
               const boost::optional <std::string> &log_to_filename)
 {
     if (log_to_filename && !log_to_filename->empty())
     {
-#ifdef __MINGW64__
-        auto *utf8_filename = g_utf16_to_utf8 (log_to_filename->c_str(), -1, NULL, NULL, NULL);
-#else
         auto utf8_filename = log_to_filename->c_str();
-#endif
-
         qof_log_init_filename_special (utf8_filename);
-
-#ifdef __MINGW64__
-        g_free (utf8_filename);
-#endif
     }
     else
     {

--- a/gnucash/gnucash.cpp
+++ b/gnucash/gnucash.cpp
@@ -61,6 +61,9 @@ extern "C" {
 
 #include <boost/locale.hpp>
 #include <boost/optional.hpp>
+#ifdef __MINGW32__
+#include <boost/nowide/args.hpp>
+#endif
 #include <iostream>
 #include <gnc-locale-utils.hpp>
 
@@ -387,7 +390,9 @@ int
 main(int argc, char ** argv)
 {
     Gnucash::Gnucash application (argv[0]);
-
+#ifdef __MINGW32__
+    boost::nowide::args a(argc, argv); // Fix arguments - make them UTF-8
+#endif
     /* We need to initialize gtk before looking up all modules */
     if(!gtk_init_check (&argc, &argv))
     {


### PR DESCRIPTION
This is NOT complete, more of am I doing the right thing, probably not...

If the path to the Gnucash file is like C:\Temp\Comité\myfile.gnucash on a Windows PC, the file will not be found. This also applies to the log file when --logto C:\Temp\Comité\mylog.txt

I started looking at the m_file_to_load and I noticed that the m_log_to_filename was used differently, it used a conversion function g_utf16_to_utf8 so started to and try and get the --logto to work.

First off, the windows macros "\_\_MINGW64__" was used but I think this is wrong as we still build 32bit Windows, changed them "\_\_MINGW32__" which then highlighted a problem with it using guichar2. So after some thought I came up with this which does work for the --logto but not sure if it is any good and whether it can be applied to m_file_to_load which is used in many more places. The other thought was whether these member variables should be wstring's.
