### PR TITLE
Html Help dialog - Experiment

### DIFF
--- a/gnucash/gnome-utils/gnc-gnome-utils.h
+++ b/gnucash/gnome-utils/gnc-gnome-utils.h
@@ -48,19 +48,32 @@ void gnc_gnome_utils_init (void);
  */
 void gnc_add_css_file (void);
 
-/** Launch the systems default help browser, gnome's yelp for linux,
- *  and open to a given link within a given file.
+typedef struct help_dialog_args
+{
+    GtkWindow   *parent;
+    const gchar *dir_name;
+    const gchar *anchor;
+} help_dialog_args;
+
+/** This sets the help dialog function to be called for the
+ *  gnome help.
+ */
+void gnc_gnome_help_set_help_dialog_func (GFunc cb, gpointer user_data);
+
+/** Launch a dialog with a gnc_html widget contained
+ *  and open to a given link within a given a directory.
  *  This routine will display an error message
  *  if it can't find the help file or can't open the help browser.
  *
  *  @param parent The parent window for any dialogs.
  *
- *  @param file_name The name of the help file.
+ *  @param dir_name The name of the help directory.
  *
  *  @param anchor The anchor the help browser should scroll to.
  */
-void gnc_gnome_help (GtkWindow *parent, const char *file_name,
+void gnc_gnome_help (GtkWindow *parent, const char *dir_name,
                      const char *anchor);
+
 /** Launch the default browser and open the provided URI.
  */
 void gnc_launch_doclink (GtkWindow *parent, const char *uri);

--- a/gnucash/gnome-utils/gnc-ui.h
+++ b/gnucash/gnome-utils/gnc-ui.h
@@ -39,40 +39,36 @@
 
 
 /** Help Files ******************************************************/
-#ifdef G_OS_WIN32
-#    define HF_GUIDE         "gnucash-guide.chm"
-#    define HF_HELP          "gnucash-help.chm"
-#elif defined MAC_INTEGRATION
-#    define HF_GUIDE         "GnuCash Guide"
-#    define HF_HELP          "GnuCash Help"
-#else
-#    define HF_GUIDE         "gnucash-guide"
-#    define HF_HELP          "gnucash-help"
-#endif
+#define HF_HELP       "gnucash-help"
+#define HF_HELP_HOME  "index.html"
+#define HF_GUIDE      "gnucash-guide"
+#define HF_GUIDE_HOME "index.html"
 
 /** Links in the Help Files *****************************************/
-#define HL_USAGE_BSNSS       "busnss-ar-setup1"
-#define HL_USAGE_INVOICE     "busnss-ar-invoices1"
-#define HL_USAGE_VOUCHER     "busnss-emply-newvchr"
-#define HL_USAGE_BILL        "busnss-ap-bills1"
-#define HL_USAGE_CUSTOMER    "busnss-ar-customers1"
-#define HL_USAGE_VENDOR      "busnss-ap-vendors1"
-#define HL_USAGE_EMPLOYEE    "busnss-emply"
-#define HL_USAGE_JOB         "busnss-ar-jobs1"
-#define HL_ACC               "acct-create"
-#define HL_ACCEDIT           "acct-edit"
-#define HL_COMMODITY         "tool-commodity"
-#define HL_FIND_TRANSACTIONS "tool-find"
-#define HL_GLOBPREFS         "set-prefs"
-#define HL_PRINTCHECK        "print-check"
-#define HL_RECNWIN           "acct-reconcile"
-#define HL_SXEDITOR          "trans-sched"
-#define HL_BOOK_OPTIONS      "book-options"
-#define HL_STYLE_SHEET       "change-style"
-#define HL_CLOSE_BOOK        "tool-close-book"
-#define HL_USAGE_CUSTOMREP   "report-saving"
-#define HL_IMPORT_BC         "busnss-imp-bills-invoices"
-#define HL_IMPORT_CUST       "busnss-imp-customer-vendor"
+#define HL_USAGE_BSNSS       "ch07.html#busnss-ar-setup1"
+#define HL_USAGE_INVOICE     "ch07s04.html#busnss-ar-invoices1"
+#define HL_USAGE_VOUCHER     "ch07s13.html#busnss-emply-newvchr"
+#define HL_USAGE_BILL        "ch07s10.html#busnss-ap-bills1"
+#define HL_USAGE_CUSTOMER    "ch07s03.html#busnss-ar-customers1"
+#define HL_USAGE_VENDOR      "ch07s09.html#busnss-ap-vendors1"
+#define HL_USAGE_EMPLOYEE    "ch07s13.html#busnss-emply"
+#define HL_USAGE_JOB         "ch07s05.html#busnss-ar-jobs1"
+#define HL_ACC               "ch05s04.html#acct-create"
+#define HL_ACCEDIT           "ch05s05.html#acct-edit"
+#define HL_COMMODITY         "ch08s07.html#tool-commodity"
+#define HL_FIND_TRANSACTIONS "ch08.html#tool-find"
+#define HL_GLOBPREFS         "ch10s02.html#set-prefs"
+#define HL_PRINTCHECK        "ch06s15.html#print-check"
+#define HL_RECNWIN           "ch05s08.html#acct-reconcile"
+#define HL_SXEDITOR          "ch06s13.html#trans-sched"
+#define HL_BOOK_OPTIONS      "ch10s03.html#book-options"
+#define HL_STYLE_SHEET       "ch10s04.html#change-style"
+#define HL_CLOSE_BOOK        "ch08s09.html#tool-close-book"
+#define HL_USAGE_CUSTOMREP   "ch09.html#report-saving"
+#define HL_IMPORT_BC         "ch18.html#busnss-imp-bills-invoices"
+#define HL_IMPORT_CUST       "ch18s02.html"
+/*********************************************************************/
+
 
 /* GTK Windows - Common Response Codes */
 
@@ -106,7 +102,7 @@ gnc_error_dialog (GtkWindow *parent,
 
 
 extern void
-gnc_gnome_help (GtkWindow *parent, const char *file_name, const char *target_link);
+gnc_gnome_help (GtkWindow *parent, const char *dir_name, const char *anchor);
 
 int      gnc_choose_radio_option_dialog (GtkWidget *parent,
         const char *title,

--- a/gnucash/gnome/CMakeLists.txt
+++ b/gnucash/gnome/CMakeLists.txt
@@ -18,6 +18,7 @@ set (gnc_gnome_noinst_HEADERS
   dialog-find-account.h
   dialog-find-transactions.h
   dialog-find-transactions2.h
+  dialog-help.h
   dialog-imap-editor.h
   dialog-invoice.h
   dialog-job.h
@@ -87,6 +88,7 @@ set (gnc_gnome_SOURCES
   dialog-find-account.c
   dialog-find-transactions.c
   dialog-find-transactions2.c
+  dialog-help.c
   dialog-imap-editor.c
   dialog-invoice.c
   dialog-job.c

--- a/gnucash/gnome/dialog-help.c
+++ b/gnucash/gnome/dialog-help.c
@@ -662,6 +662,9 @@ gnc_help_dialog_create (HelpDialog *help_dialog, GtkWindow *parent)
     // handle any external secure links so they open in default browser
     gnc_html_register_url_handler (URL_TYPE_SECURE, gnc_dialog_help_file_url_cb);
 
+    // disable the webkit inspector applet
+    gnc_html_inspector_enable (help_dialog->html, FALSE);
+
     help_dialog->entry = GTK_WIDGET(gtk_builder_get_object (builder, "entry_search"));
 
     completion = gtk_entry_completion_new ();

--- a/gnucash/gnome/dialog-help.c
+++ b/gnucash/gnome/dialog-help.c
@@ -1,0 +1,617 @@
+/********************************************************************\
+ * dialog-help.c -- Gnucash Help Window                             *
+ * Copyright (C) 2021 Robert Fewell                                 *
+ *                                                                  *
+ * This program is free software; you can redistribute it and/or    *
+ * modify it under the terms of the GNU General Public License as   *
+ * published by the Free Software Foundation; either version 2 of   *
+ * the License, or (at your option) any later version.              *
+ *                                                                  *
+ * This program is distributed in the hope that it will be useful,  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    *
+ * GNU General Public License for more details.                     *
+ *                                                                  *
+ * You should have received a copy of the GNU General Public License*
+ * along with this program; if not, contact:                        *
+ *                                                                  *
+ * Free Software Foundation           Voice:  +1-617-542-5942       *
+ * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652       *
+ * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
+\********************************************************************/
+
+#include <config.h>
+
+#include <gtk/gtk.h>
+#include <glib/gi18n.h>
+
+#include "dialog-help.h"
+#include "dialog-utils.h"
+#include "gnc-gnome-utils.h"
+
+#include "gnc-html-history.h"
+#include "gnc-html.h"
+#include "gnc-html-factory.h"
+#include "gnc-ui.h"
+
+#include "file-utils.h"
+
+#include "gnc-component-manager.h"
+#include "gnc-session.h"
+
+#include "gnc-ui.h"
+#include "gnc-ui-util.h"
+
+#define DIALOG_HELP_CM_CLASS  "dialog-help"
+#define GNC_PREFS_GROUP       "dialogs.help"
+
+#define WEB_URL  "https://www.gnucash.org"
+#define WIKI_URL "https://wiki.gnucash.org/wiki/GnuCash"
+#define BUG_URL  "https://bugs.gnucash.org"
+
+const gchar *msg_no_help_found = N_("GnuCash could not find the files for the help documentation.");
+const gchar *msg_no_help_reason = N_("This is likely because the \"gnucash-docs\" package is not properly installed.");
+
+const gchar *msg_no_help_file = N_("Unable to find html file in a valid language directory");
+
+typedef struct
+{
+    GtkWidget    *window;
+    GtkWidget    *main_container;
+
+    GncHtml      *html;
+
+    gboolean      is_help;
+    GtkWidget    *button;
+    const char   *dir_name;
+    const char   *anchor;
+    gchar        *help_path;
+    gchar        *url;
+
+    gint          component_id;
+    QofSession   *session;
+
+}HelpDialog;
+
+/* This static indicates the debugging module that this .o belongs to.  */
+static QofLogModule log_module = GNC_MOD_GUI;
+
+void gnc_help_dialog_back_button_cb (GtkWidget *widget, gpointer user_data);
+void gnc_help_dialog_forward_button_cb (GtkWidget *widget, gpointer user_data);
+void gnc_help_dialog_home_button_cb (GtkWidget *widget, gpointer user_data);
+
+void gnc_help_dialog_web_button_cb (GtkWidget *widget, gpointer user_data);
+void gnc_help_dialog_wiki_button_cb (GtkWidget *widget, gpointer user_data);
+void gnc_help_dialog_bug_button_cb (GtkWidget *widget, gpointer user_data);
+
+void gnc_help_dialog_help_guide_button_cb (GtkWidget *widget, gpointer user_data);
+void gnc_help_dialog_close_button_cb (GtkWidget *widget, gpointer user_data);
+
+static void
+close_handler (gpointer user_data)
+{
+    HelpDialog *help_dialog = user_data;
+
+    ENTER(" ");
+    gnc_save_window_size (GNC_PREFS_GROUP, GTK_WINDOW(help_dialog->window));
+    gtk_widget_destroy (GTK_WIDGET(help_dialog->window));
+    LEAVE(" ");
+}
+
+static gboolean
+gnc_help_dialog_window_delete_event_cb (GtkWidget *widget,
+                                        GdkEvent  *event,
+                                        gpointer   user_data)
+{
+    HelpDialog *help_dialog = user_data;
+    // this cb allows the window size to be saved on closing with the X
+    gnc_save_window_size (GNC_PREFS_GROUP, GTK_WINDOW(help_dialog->window));
+    return FALSE;
+}
+
+static void
+gnc_help_dialog_window_destroy_cb (GtkWidget *object, gpointer user_data)
+{
+    HelpDialog *help_dialog = user_data;
+
+    ENTER(" ");
+    gnc_unregister_gui_component_by_data (DIALOG_HELP_CM_CLASS, help_dialog);
+
+    gnc_html_destroy (help_dialog->html);
+
+    help_dialog->main_container = NULL;
+    help_dialog->html           = NULL;
+
+    g_free (help_dialog->url);
+    g_free (help_dialog->help_path);
+
+    if (help_dialog->window)
+    {
+        gtk_widget_destroy (help_dialog->window);
+        help_dialog->window = NULL;
+    }
+    g_free (help_dialog);
+    LEAVE(" ");
+}
+
+static gboolean
+gnc_help_dialog_window_key_press_cb (GtkWidget *widget, GdkEventKey *event,
+                                     gpointer user_data)
+{
+    HelpDialog *help_dialog = user_data;
+
+    if (event->keyval == GDK_KEY_Escape)
+    {
+        close_handler (help_dialog);
+        return TRUE;
+    }
+    else
+        return FALSE;
+}
+
+static void
+open_url (GtkWidget *parent, const gchar *url)
+{
+    GError *error = NULL;
+    gboolean success = gtk_show_uri_on_window (NULL, url, gtk_get_current_event_time (), &error);
+
+    if (success)
+        return;
+
+    gnc_error_dialog (GTK_WINDOW(parent), _("There was a problem opening the external link...\n '%s'"), url);
+
+    PERR("%s", error->message);
+    g_error_free (error);
+}
+
+void
+gnc_help_dialog_web_button_cb (GtkWidget *widget, gpointer user_data)
+{
+    HelpDialog *help_dialog = user_data;
+    open_url (help_dialog->window, WEB_URL);
+}
+
+void
+gnc_help_dialog_wiki_button_cb (GtkWidget *widget, gpointer user_data)
+{
+    HelpDialog *help_dialog = user_data;
+    open_url (help_dialog->window, WIKI_URL);
+}
+
+void
+gnc_help_dialog_bug_button_cb (GtkWidget *widget, gpointer user_data)
+{
+    HelpDialog *help_dialog = user_data;
+    open_url (help_dialog->window, BUG_URL);
+}
+
+static void
+gnc_help_dialog_set_title (HelpDialog *help_dialog)
+{
+    if (help_dialog->is_help)
+    {
+        gtk_window_set_title (GTK_WINDOW(help_dialog->window), _("GnuCash Help Manual"));
+        gtk_button_set_label (GTK_BUTTON(help_dialog->button), _("_Guide"));
+    }
+    else
+    {
+        gtk_window_set_title (GTK_WINDOW(help_dialog->window), _("GnuCash Tutorial and Concepts Guide"));
+        gtk_button_set_label (GTK_BUTTON(help_dialog->button), _("_Help"));
+    }
+}
+
+static gchar *
+gnc_help_dialog_get_help_path (GtkWindow *parent, const char *dir_name)
+{
+    const gchar * const *sdatadirs = g_get_system_data_dirs ();
+    const gchar * const *langs = g_get_language_names ();
+    const gchar *lookfor = "gnucash/help/";
+    gchar *help_path = NULL;
+    gchar *help_file = NULL;
+    gchar *full_path = NULL;
+    gchar *url_path  = NULL;
+
+    ENTER("dir_name is '%s'", dir_name);
+    for (; *sdatadirs; sdatadirs++)
+    {
+        gchar *filepath = g_build_filename (*sdatadirs, lookfor, NULL);
+        if (g_file_test (filepath, G_FILE_TEST_EXISTS))
+            help_path = g_strdup (filepath);
+        g_free (filepath);
+    }
+
+    if (!help_path)
+    {
+        gnc_error_dialog (GTK_WINDOW(parent), "%s\n%s", _(msg_no_help_found), _(msg_no_help_reason));
+        PERR("Unable to find 'gnucash/help' directory");
+        LEAVE(" ");
+        return NULL;
+    }
+
+    if (g_strcmp0 (dir_name, HF_HELP) == 0)
+        help_file = g_strconcat (dir_name, "/", HF_HELP_HOME, NULL);
+    else
+        help_file = g_strconcat (dir_name, "/", HF_GUIDE_HOME, NULL);
+
+    for (; *langs; langs++)
+    {
+        gchar *filename = g_build_filename (help_path, *langs, help_file, NULL);
+        if (g_file_test (filename, G_FILE_TEST_EXISTS))
+            full_path = g_strdup (filename);
+        g_free (filename);
+    }
+    g_free (help_path);
+
+    if (full_path)
+    {
+        gchar *ptr = g_strrstr (full_path, help_file);
+        url_path = g_strndup (full_path, (ptr - full_path));
+    }
+    else
+    {
+        gnc_error_dialog (GTK_WINDOW(parent), "%s\n%s", _(msg_no_help_found), _(msg_no_help_file));
+        PERR("Unable to find valid html file in a language directory");
+        g_free (help_file);
+        LEAVE(" ");
+        return NULL;
+    }
+    g_free (help_file);
+    g_free (full_path);
+    LEAVE("Returned help path is '%s'", url_path);
+    return url_path;
+}
+
+static gchar *
+gnc_help_dialog_build_url (GtkWindow *parent, const char *help_path,
+                           const char *dir_name, const char *anchor)
+{
+    const gchar *url_start = NULL;
+    gchar *help_file = NULL;
+    gchar *url = NULL;
+    gchar *anch = NULL;
+
+    ENTER("help_path is '%s', dir_name is '%s', anchor is '%s'", help_path, dir_name, anchor);
+
+    if (anchor)
+    {
+        gchar **split = g_strsplit (anchor, "#", 2);
+        help_file = g_strconcat (help_path, dir_name, "/", split[0], NULL);
+        anch = g_strdup (split[1]);
+        g_strfreev (split);
+    }
+    else
+    {
+        if (g_strcmp0 (dir_name, HF_HELP) == 0)
+            help_file = g_strconcat (help_path, dir_name, "/", HF_HELP_HOME, NULL);
+        else
+            help_file = g_strconcat (help_path, dir_name, "/", HF_GUIDE_HOME, NULL);
+    }
+
+#ifdef G_OS_WIN32
+    url_start = "file:///";
+#else
+    url_start = "file://";
+#endif
+
+    if (g_file_test (help_file, G_FILE_TEST_EXISTS))
+    {
+        if (anchor)
+            url = g_strconcat (url_start, help_file, "#", anch, NULL);
+        else
+            url = g_strconcat (url_start, help_file, NULL);
+    }
+    else
+    {
+        gnc_error_dialog (GTK_WINDOW(parent), "%s\n%s", _(msg_no_help_found), _(msg_no_help_file));
+        PERR("Unable to find valid html file in a language directory");
+        g_free (help_file);
+        g_free (anch);
+        LEAVE(" ");
+        return NULL;
+    }
+    g_free (help_file);
+    g_free (anch);
+
+    LEAVE("Returned url is '%s'", url);
+    return url;
+}
+
+static void
+update_titles (HelpDialog *help_dialog, const gchar *url)
+{
+    gboolean changed = FALSE;
+
+    if (g_strrstr (url, HF_HELP))
+    {
+        if (!help_dialog->is_help)
+            changed = TRUE;
+        help_dialog->is_help = TRUE;
+        help_dialog->dir_name = HF_HELP;
+    }
+    else
+    {
+        if (help_dialog->is_help)
+            changed = TRUE;
+        help_dialog->is_help = FALSE;
+        help_dialog->dir_name = HF_GUIDE;
+    }
+    if (changed)
+        gnc_help_dialog_set_title (help_dialog);
+}
+
+void
+gnc_help_dialog_home_button_cb (GtkWidget *widget, gpointer user_data)
+{
+    HelpDialog *help_dialog = user_data;
+    gchar *url = NULL;
+
+    if (help_dialog->is_help)
+        url = gnc_help_dialog_build_url (GTK_WINDOW(help_dialog->window),
+                                         help_dialog->help_path, HF_HELP, HF_HELP_HOME);
+    else
+        url = gnc_help_dialog_build_url (GTK_WINDOW(help_dialog->window),
+                                         help_dialog->help_path, HF_GUIDE, HF_GUIDE_HOME);
+
+    PINFO("Home url is: %s", url);
+
+    if (!url)
+        return;
+
+    gnc_html_show_docs (help_dialog->html, URL_TYPE_FILE, url, "Help", FALSE);
+    update_titles (help_dialog, url);
+    g_free (url);
+}
+
+void
+gnc_help_dialog_back_button_cb (GtkWidget *widget, gpointer user_data)
+{
+    HelpDialog *help_dialog = user_data;
+    const gchar *url = gnc_html_go_back (GNC_HTML(help_dialog->html));
+
+    PINFO("Back url is: %s", url);
+
+    if (!url)
+        return;
+
+    update_titles (help_dialog, url);
+}
+
+void
+gnc_help_dialog_forward_button_cb (GtkWidget *widget, gpointer user_data)
+{
+    HelpDialog *help_dialog = user_data;
+    const gchar *url = gnc_html_go_forward (GNC_HTML(help_dialog->html));
+
+    PINFO("Forward url is: %s", url);
+
+    if (!url)
+        return;
+
+    update_titles (help_dialog, url);
+}
+
+void
+gnc_help_dialog_close_button_cb (GtkWidget *widget, gpointer user_data)
+{
+    HelpDialog *help_dialog = user_data;
+    gnc_close_gui_component (help_dialog->component_id);
+}
+
+static gboolean
+gnc_dialog_help_file_url_cb (const char *location, const char *label,
+                             gboolean new_window, GNCURLResult *result)
+{
+    g_return_val_if_fail (location != NULL, FALSE);
+    g_return_val_if_fail (result != NULL, FALSE);
+
+    ENTER("type '%s', location '%s', label '%s'", result->url_type, location, label);
+
+    if (g_strcmp0 (result->url_type, URL_TYPE_SECURE) == 0)
+    {
+        gchar *url = g_strconcat ("https:", location, NULL);
+        open_url (GTK_WIDGET(result->parent), url);
+        g_free (url);
+    }
+    LEAVE(" ");
+    return TRUE;
+}
+
+void
+gnc_help_dialog_help_guide_button_cb (GtkWidget *widget, gpointer user_data)
+{
+    HelpDialog *help_dialog = user_data;
+    gchar *url = NULL;
+    const gchar *dir_name;
+
+    if (help_dialog->is_help)
+        dir_name = HF_GUIDE;
+    else
+        dir_name = HF_HELP;
+
+    url = gnc_help_dialog_build_url (GTK_WINDOW(help_dialog->window),
+                                     help_dialog->help_path, dir_name, NULL);
+
+    if (url)
+    {
+        help_dialog->anchor = NULL;
+
+        g_free (help_dialog->url);
+        help_dialog->url = url;
+        help_dialog->dir_name = dir_name;
+
+        gnc_html_show_docs (help_dialog->html, URL_TYPE_FILE, help_dialog->url, "Help", FALSE);
+        update_titles (help_dialog, help_dialog->url);
+    }
+}
+
+static void
+gnc_help_dialog_create (HelpDialog *help_dialog, GtkWindow *parent)
+{
+    GtkWidget      *window;
+    GtkBuilder     *builder;
+    GtkWidget      *button;
+    GtkWindow      *topLvl;
+    GtkWindowGroup *group;
+
+    ENTER(" ");
+    builder = gtk_builder_new ();
+    gnc_builder_add_from_file (builder, "dialog-help.glade", "image1");
+    gnc_builder_add_from_file (builder, "dialog-help.glade", "image2");
+    gnc_builder_add_from_file (builder, "dialog-help.glade", "image3");
+    gnc_builder_add_from_file (builder, "dialog-help.glade", "help_window");
+
+    window = GTK_WIDGET(gtk_builder_get_object (builder, "help_window"));
+    help_dialog->window = window;
+
+    // add this dialog to a new window group so it is not effected by modal setting
+    group = gtk_window_group_new ();
+    gtk_window_group_add_window (group, GTK_WINDOW(window));
+    g_object_unref (group);
+
+    // Set the name for this dialog so it can be easily manipulated with css
+    gtk_widget_set_name (GTK_WIDGET(window), "gnc-id-help-window");
+
+    help_dialog->session = gnc_get_current_session ();
+
+    help_dialog->main_container = GTK_WIDGET(gtk_builder_get_object (builder, "main-container"));
+
+    topLvl = gnc_ui_get_main_window (NULL);
+    help_dialog->html = gnc_html_factory_create_html ();
+    gnc_html_set_parent (help_dialog->html, topLvl);
+
+    gtk_container_add (GTK_CONTAINER(help_dialog->main_container),
+                       gnc_html_get_widget (help_dialog->html));
+
+    gtk_widget_set_hexpand (GTK_WIDGET(gnc_html_get_widget (help_dialog->html)), TRUE);
+    gtk_widget_set_vexpand (GTK_WIDGET(gnc_html_get_widget (help_dialog->html)), TRUE);
+
+    // handle any external secure links so they open in default browser
+    gnc_html_register_url_handler (URL_TYPE_SECURE, gnc_dialog_help_file_url_cb);
+
+    help_dialog->is_help = TRUE;
+
+    help_dialog->button = GTK_WIDGET(gtk_builder_get_object (builder, "help_guide_button"));
+
+    update_titles (help_dialog, help_dialog->url);
+
+    //  typical file paths used
+    // 'file:///usr/share/gnucash/help/C/gnucash-help/index.html'
+    // 'file:///usr/share/gnucash/help/C/gnucash-help/ch06s15.html#print-check'
+    // 'file:///c:/Program%20Files%20(x86)/gnucash/share/gnucash/help/C/gnucash-help/ch06s15.html#print-check'
+
+    gnc_html_show_docs (help_dialog->html, URL_TYPE_FILE, help_dialog->url, "Help", FALSE);
+
+    g_signal_connect (help_dialog->window, "destroy",
+                      G_CALLBACK (gnc_help_dialog_window_destroy_cb), help_dialog);
+
+    g_signal_connect (help_dialog->window, "delete-event",
+                      G_CALLBACK(gnc_help_dialog_window_delete_event_cb), help_dialog);
+
+    g_signal_connect (help_dialog->window, "key_press_event",
+                      G_CALLBACK (gnc_help_dialog_window_key_press_cb), help_dialog);
+
+    gtk_builder_connect_signals_full (builder, gnc_builder_connect_full_func, help_dialog);
+
+    g_object_unref (G_OBJECT(builder));
+
+    gnc_restore_window_size (GNC_PREFS_GROUP, GTK_WINDOW(help_dialog->window),
+                             GTK_WINDOW(parent));
+    LEAVE(" ");
+}
+
+static void
+refresh_handler (GHashTable *changes, gpointer user_data)
+{
+    ENTER(" ");
+    LEAVE(" ");
+}
+
+/********************************************************************\
+ * gnc_help_dialog                                                  *
+ * opens a window showing Gnucash Help information                  *
+ *                                                                  *
+ * Args:   parent  - the parent of the window to be created         *
+ * Return: nothing                                                  *
+\********************************************************************/
+void
+gnc_help_dialog_with_args (GtkWindow *parent, const char *dir_name, const char *anchor)
+{
+    HelpDialog *help_dialog;
+    gchar *url = NULL;
+    gchar *help_path = NULL;
+    GList *dlgExists = NULL;
+
+    ENTER(" ");
+
+    help_path = gnc_help_dialog_get_help_path (parent, dir_name);
+    if (!help_path)
+    {
+        LEAVE("no help path");
+        return;
+    }
+
+    url = gnc_help_dialog_build_url (parent, help_path, dir_name, anchor);
+    if (!url)
+    {
+        g_free (help_path);
+        LEAVE("no url");
+        return;
+    }
+
+    dlgExists = gnc_find_gui_components (DIALOG_HELP_CM_CLASS, NULL, NULL);
+
+    if (dlgExists != NULL)
+        help_dialog = (HelpDialog*)dlgExists->data;
+    else
+        help_dialog = g_new0 (HelpDialog, 1);
+
+    if (help_dialog->help_path)
+        g_free (help_dialog->help_path);
+    if (help_dialog->url)
+        g_free (help_dialog->url);
+    help_dialog->url = url;
+    help_dialog->dir_name = dir_name;
+    help_dialog->anchor = anchor;
+    help_dialog->help_path = help_path;
+
+    if (dlgExists != NULL)
+    {
+        gnc_html_show_docs (help_dialog->html, URL_TYPE_FILE, url, "Help", FALSE);
+
+        update_titles (help_dialog, url);
+        gtk_window_present (GTK_WINDOW(help_dialog->window));
+        g_list_free (dlgExists);
+        LEAVE("existing help dialog raised");
+        return;
+    }
+    gnc_help_dialog_create (help_dialog, parent);
+
+    help_dialog->component_id = gnc_register_gui_component (DIALOG_HELP_CM_CLASS,
+                                                            refresh_handler,
+                                                            close_handler,
+                                                            help_dialog);
+
+    gnc_gui_component_set_session (help_dialog->component_id,
+                                   help_dialog->session);
+
+    gtk_widget_show_all (help_dialog->window);
+    LEAVE("new help dialog created");
+}
+
+void
+gnc_help_dialog_with_struct (gpointer user_data)
+{
+    help_dialog_args *args = user_data;
+
+    if (args)
+    {
+        gnc_help_dialog_with_args (GTK_WINDOW(args->parent), args->dir_name, args->anchor);
+        g_free (args);
+    }
+}
+
+void
+gnc_help_dialog_set_help_func (GFunc cb, gpointer user_data)
+{
+    gnc_gnome_help_set_help_dialog_func ((GFunc)cb, user_data);
+}

--- a/gnucash/gnome/dialog-help.h
+++ b/gnucash/gnome/dialog-help.h
@@ -1,0 +1,52 @@
+/********************************************************************\
+ * dialog-help.h -- GnuCash help window                             *
+ * Copyright (C) 2021 Robert Fewell                                 *
+ *                                                                  *
+ * This program is free software; you can redistribute it and/or    *
+ * modify it under the terms of the GNU General Public License as   *
+ * published by the Free Software Foundation; either version 2 of   *
+ * the License, or (at your option) any later version.              *
+ *                                                                  *
+ * This program is distributed in the hope that it will be useful,  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    *
+ * GNU General Public License for more details.                     *
+ *                                                                  *
+ * You should have received a copy of the GNU General Public License*
+ * along with this program; if not, contact:                        *
+ *                                                                  *
+ * Free Software Foundation           Voice:  +1-617-542-5942       *
+ * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652       *
+ * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
+\********************************************************************/
+
+#ifndef DIALOG_HELP_H
+#define DIALOG_HELP_H
+
+/**
+ * Create a Help Dialog based on a pointer to a help_dialog_args
+ *  structure.
+ *
+ * @param user_data A help_dialog_args structure
+ */
+void gnc_help_dialog_with_struct (gpointer user_data);
+
+/**
+ * Create a Help Dialog based arguments
+ *
+ * @param parent The parent widget window
+ * @param dir_name The directory to load the html pages from
+ * @param anchor The page to load, maybe of the form print-check.html#print-check
+ */
+void gnc_help_dialog_with_args (GtkWindow *parent, const char *dir_name,
+                                const char *anchor);
+
+/**
+ * Set the function to call when a help link is used
+ *
+ * @param cd The help dialog function
+ * @param user_data A help_dialog_args structure
+ */
+void gnc_help_dialog_set_help_func (GFunc cb, gpointer user_data);
+
+#endif

--- a/gnucash/gnome/top-level.c
+++ b/gnucash/gnome/top-level.c
@@ -36,6 +36,7 @@
 #include "dialog-doclink.h"
 #include "dialog-commodity.h"
 #include "dialog-invoice.h"
+#include "dialog-help.h"
 #include "dialog-preferences.h"
 #include "dialog-options.h"
 #include "dialog-sx-editor.h"
@@ -465,6 +466,9 @@ gnc_main_gui_init (void)
     /* The parameters are; glade file, items to add from glade file - last being the dialog, preference tab name */
     gnc_preferences_add_page("business-prefs.glade", "liststore_printinvoice,days_in_adj,cust_days_in_adj,business_prefs",
                             _("Business"));
+
+    // set up the function to be used for help/guide
+    gnc_help_dialog_set_help_func ((GFunc)gnc_help_dialog_with_struct, NULL);
 
     LEAVE(" ");
     return;

--- a/gnucash/gschemas/org.gnucash.dialogs.gschema.xml.in
+++ b/gnucash/gschemas/org.gnucash.dialogs.gschema.xml.in
@@ -1,6 +1,7 @@
 <schemalist gettext-domain="@PROJECT_NAME@">
   <schema id="org.gnucash.dialogs" path="/org/gnucash/dialogs/">
     <child name="account" schema="org.gnucash.dialogs.account"/>
+    <child name="help" schema="org.gnucash.dialogs.help"/>
     <child name="imap-editor" schema="org.gnucash.dialogs.imap-editor"/>
     <child name="preferences" schema="org.gnucash.dialogs.preferences"/>
     <child name="price-editor" schema="org.gnucash.dialogs.price-editor"/>
@@ -28,6 +29,16 @@
 
   <schema id="org.gnucash.dialogs.account" path="/org/gnucash/dialogs/account/">
     <key name="last-geometry" type="(iiii)">
+      <default>(-1,-1,-1,-1)</default>
+      <summary>Last window position and size</summary>
+      <description>This setting describes the size and position of the window when it was last closed.
+        The numbers are the X and Y coordinates of the top left corner of the window
+        followed by the width and height of the window.</description>
+    </key>
+  </schema>
+
+  <schema id="org.gnucash.dialogs.help" path="/org/gnucash/dialogs/help/">
+    <key type="(iiii)" name="last-geometry">
       <default>(-1,-1,-1,-1)</default>
       <summary>Last window position and size</summary>
       <description>This setting describes the size and position of the window when it was last closed.

--- a/gnucash/gtkbuilder/CMakeLists.txt
+++ b/gnucash/gtkbuilder/CMakeLists.txt
@@ -28,6 +28,7 @@ set (gtkbuilder_SOURCES
         dialog-file-access.glade
         dialog-fincalc.glade
         dialog-find-account.glade
+        dialog-help.glade
         dialog-imap-editor.glade
         dialog-import.glade
         dialog-invoice.glade

--- a/gnucash/gtkbuilder/dialog-help.glade
+++ b/gnucash/gtkbuilder/dialog-help.glade
@@ -79,6 +79,22 @@
                 <property name="position">2</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkSearchEntry" id="entry_search">
+                <property name="can_focus">True</property>
+                <property name="no_show_all">True</property>
+                <property name="max_width_chars">60</property>
+                <property name="primary_icon_name">edit-find-symbolic</property>
+                <property name="primary_icon_activatable">False</property>
+                <property name="primary_icon_sensitive">False</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="pack_type">end</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/gnucash/gtkbuilder/dialog-help.glade
+++ b/gnucash/gtkbuilder/dialog-help.glade
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.36.0 -->
+<interface>
+  <requires lib="gtk+" version="3.22"/>
+  <object class="GtkImage" id="image1">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">go-previous-symbolic</property>
+  </object>
+  <object class="GtkImage" id="image2">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">go-next-symbolic</property>
+  </object>
+  <object class="GtkImage" id="image3">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">go-home-symbolic</property>
+  </object>
+  <object class="GtkWindow" id="help_window">
+    <property name="can_focus">False</property>
+    <property name="title" translatable="yes">GnuCash Help Manual</property>
+    <property name="default_width">600</property>
+    <property name="default_height">400</property>
+    <child>
+      <object class="GtkBox" id="dialog-vbox">
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <child>
+              <object class="GtkButton" id="back_button">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="tooltip_text" translatable="yes">Go Backwards one page.</property>
+                <property name="image">image1</property>
+                <property name="always_show_image">True</property>
+                <signal name="clicked" handler="gnc_help_dialog_back_button_cb" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="home_button">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="tooltip_text" translatable="yes">Go to Home Page.</property>
+                <property name="image">image3</property>
+                <property name="always_show_image">True</property>
+                <signal name="clicked" handler="gnc_help_dialog_home_button_cb" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="forward_button">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="tooltip_text" translatable="yes">Go Forwards one page.</property>
+                <property name="image">image2</property>
+                <property name="image_position">right</property>
+                <property name="always_show_image">True</property>
+                <signal name="clicked" handler="gnc_help_dialog_forward_button_cb" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="main-container">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="margin_bottom">6</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButtonBox" id="buttonbox">
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="web_button">
+                <property name="label" translatable="yes">Gnu_Cash</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="tooltip_text" translatable="yes">Opens in default Browser</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="gnc_help_dialog_web_button_cb" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+                <property name="secondary">True</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="wiki_button">
+                <property name="label" translatable="yes">_Wiki</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="tooltip_text" translatable="yes">Opens in default Browser</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="gnc_help_dialog_wiki_button_cb" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+                <property name="secondary">True</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="bug_button">
+                <property name="label" translatable="yes">Bug _Tracker</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="tooltip_text" translatable="yes">Opens in default Browser</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="gnc_help_dialog_bug_button_cb" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">2</property>
+                <property name="secondary">True</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="help_guide_button">
+                <property name="label" translatable="yes">_Guide</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="gnc_help_dialog_help_guide_button_cb" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="pack_type">end</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="close_button">
+                <property name="label" translatable="yes">_Close</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="can_default">True</property>
+                <property name="has_default">True</property>
+                <property name="receives_default">False</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="gnc_help_dialog_close_button_cb" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="pack_type">end</property>
+                <property name="position">4</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="pack_type">end</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
+  </object>
+</interface>

--- a/gnucash/html/gnc-html-webkit1.c
+++ b/gnucash/html/gnc-html-webkit1.c
@@ -120,6 +120,7 @@ static const gchar* impl_webkit_go_forward( GncHtml* self );
 
 static void impl_webkit_show_data( GncHtml* self, const gchar* data, int datalen );
 static void impl_webkit_reload( GncHtml* self, gboolean force_rebuild );
+static void impl_webkit_inspector_enable( GncHtml* self, gboolean enable );
 static void impl_webkit_copy_to_clipboard( GncHtml* self );
 static gboolean impl_webkit_export_to_file( GncHtml* self, const gchar* filepath );
 static void impl_webkit_print( GncHtml* self, const gchar* jobname, gboolean export_pdf );
@@ -239,6 +240,7 @@ gnc_html_webkit_class_init( GncHtmlWebkitClass* klass )
     html_class->go_back = impl_webkit_go_back;
     html_class->go_forward = impl_webkit_go_forward;
     html_class->reload = impl_webkit_reload;
+    html_class->inspector_enable = impl_webkit_inspector_enable;
     html_class->copy_to_clipboard = impl_webkit_copy_to_clipboard;
     html_class->export_to_file = impl_webkit_export_to_file;
     html_class->print = impl_webkit_print;
@@ -1057,6 +1059,27 @@ impl_webkit_reload( GncHtml* self, gboolean force_rebuild )
         webkit_web_view_reload( priv->web_view );
 }
 
+
+/********************************************************************
+ * impl_webkit_inspector_enable
+ * sets the visibility of the wekit inspector
+ * default is enabled, set visible to FALSE to disable
+ ********************************************************************/
+
+static void
+impl_webkit_inspector_enable( GncHtml* self, gboolean enable )
+{
+     GncHtmlWebkitPrivate* priv;
+     WebKitWebSettings *settings = NULL;
+
+     g_return_if_fail( self != NULL );
+     g_return_if_fail( GNC_IS_HTML_WEBKIT(self) );
+
+     priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
+
+     settings = webkit_web_view_get_settings (priv->web_view);
+     g_object_set (G_OBJECT(settings), "enable-developer-extras", enable, NULL);
+}
 
 /********************************************************************
  * gnc_html_new

--- a/gnucash/html/gnc-html-webkit2.c
+++ b/gnucash/html/gnc-html-webkit2.c
@@ -125,6 +125,7 @@ static const gchar* impl_webkit_go_forward( GncHtml* self );
 
 static void impl_webkit_show_data( GncHtml* self, const gchar* data, int datalen );
 static void impl_webkit_reload( GncHtml* self, gboolean force_rebuild );
+static void impl_webkit_inspector_enable( GncHtml* self, gboolean enable );
 static void impl_webkit_copy_to_clipboard( GncHtml* self );
 static gboolean impl_webkit_export_to_file( GncHtml* self, const gchar* filepath );
 static void impl_webkit_print (GncHtml* self,const gchar* jobname);
@@ -240,6 +241,7 @@ gnc_html_webkit_class_init( GncHtmlWebkitClass* klass )
      html_class->go_back = impl_webkit_go_back;
      html_class->go_forward = impl_webkit_go_forward;
      html_class->reload = impl_webkit_reload;
+     html_class->inspector_enable = impl_webkit_inspector_enable;
      html_class->copy_to_clipboard = impl_webkit_copy_to_clipboard;
      html_class->export_to_file = impl_webkit_export_to_file;
      html_class->print = impl_webkit_print;
@@ -1007,6 +1009,26 @@ impl_webkit_reload( GncHtml* self, gboolean force_rebuild )
           webkit_web_view_reload( priv->web_view );
 }
 
+/********************************************************************
+ * impl_webkit_inspector_enable
+ * sets the visibility of the wekit inspector
+ * default is enabled, set visible to FALSE to disable
+ ********************************************************************/
+
+static void
+impl_webkit_inspector_enable( GncHtml* self, gboolean enable )
+{
+     GncHtmlWebkitPrivate* priv;
+     WebKitSettings *settings = NULL;
+
+     g_return_if_fail( self != NULL );
+     g_return_if_fail( GNC_IS_HTML_WEBKIT(self) );
+
+     priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
+
+     settings = webkit_web_view_get_settings (priv->web_view);
+     webkit_settings_set_enable_developer_extras (settings, enable);
+}
 
 /********************************************************************
  * gnc_html_new

--- a/gnucash/html/gnc-html.c
+++ b/gnucash/html/gnc-html.c
@@ -90,6 +90,7 @@ gnc_html_class_init( GncHtmlClass* klass )
     klass->show_url = NULL;
     klass->show_data = NULL;
     klass->reload = NULL;
+    klass->inspector_enable = NULL;
     klass->copy_to_clipboard = NULL;
     klass->export_to_file = NULL;
     klass->go_back = NULL;
@@ -427,6 +428,28 @@ gnc_html_reload( GncHtml* self, gboolean force_rebuild )
     else
     {
         DEBUG( "'reload' not implemented" );
+    }
+}
+
+/********************************************************************
+ * gnc_html_inspector_enable
+ * sets the visibility of the wekit inspector
+ * default is enabled, set visible to FALSE to disable
+ ********************************************************************/
+
+void
+gnc_html_inspector_enable( GncHtml* self, gboolean enable )
+{
+    g_return_if_fail( self != NULL );
+    g_return_if_fail( GNC_IS_HTML(self) );
+
+    if ( GNC_HTML_GET_CLASS(self)->inspector_enable != NULL )
+    {
+        GNC_HTML_GET_CLASS(self)->inspector_enable( self, enable );
+    }
+    else
+    {
+        DEBUG( "'webkit inspector visibility' not implemented" );
     }
 }
 

--- a/gnucash/html/gnc-html.h
+++ b/gnucash/html/gnc-html.h
@@ -143,6 +143,7 @@ struct _GncHtmlClass
     const gchar* (*go_forward)( GncHtml* html );
     void (*show_data)( GncHtml* html, const gchar* data, int datalen );
     void (*reload)( GncHtml* html, gboolean force_rebuild );
+    void (*inspector_enable)( GncHtml* html, gboolean enable );
     void (*copy_to_clipboard)( GncHtml* html );
     gboolean (*export_to_file)( GncHtml* html, const gchar* file );
 #ifdef WEBKIT1
@@ -201,6 +202,14 @@ void gnc_html_show_data( GncHtml* html, const gchar* data, int datalen );
  * @param view if TRUE, view is reloaded, if FALSE, report is recreated
  */
 void gnc_html_reload( GncHtml* html, gboolean view );
+
+/**
+ * Set the visibility of the Webkit inspector for GncHtml object.
+ *
+ * @param html GncHtml object
+ * @param view if FALSE, webkit inspector disabled
+ */
+void gnc_html_inspector_enable( GncHtml* html, gboolean enable );
 
 /**
  * Copies the html to the clipboard

--- a/gnucash/html/gnc-html.h
+++ b/gnucash/html/gnc-html.h
@@ -134,6 +134,13 @@ struct _GncHtmlClass
                       const gchar* location,
                       const gchar* label,
                       gboolean new_window_hint );
+    void (*show_docs)( GncHtml* html,
+                      URLType type,
+                      const gchar* location,
+                      const gchar* label,
+                      gboolean new_window_hint );
+    const gchar* (*go_back)( GncHtml* html );
+    const gchar* (*go_forward)( GncHtml* html );
     void (*show_data)( GncHtml* html, const gchar* data, int datalen );
     void (*reload)( GncHtml* html, gboolean force_rebuild );
     void (*copy_to_clipboard)( GncHtml* html );
@@ -163,6 +170,14 @@ struct _GncHtml
  * @param html GncHtml object to destroy
  */
 void gnc_html_destroy( GncHtml* html );
+
+/**
+ * Displays a URL directly in a GncHtml object.
+ *
+ * @param html GncHtml object
+ */
+void gnc_html_show_docs( GncHtml* html, URLType type, const gchar* location,
+                         const gchar* label, gboolean new_window_hint );
 
 /**
  * Displays a URL in a GncHtml object.
@@ -202,6 +217,22 @@ void gnc_html_copy_to_clipboard( GncHtml* html );
  * @param TRUE if successful, FALSE if unsuccessful
  */
 gboolean gnc_html_export_to_file( GncHtml* html, const gchar* filename );
+
+/**
+ * Go Back a page.
+ *
+ * @param html GncHtml object
+ * @return the url if available or NULL
+ */
+const gchar* gnc_html_go_back ( GncHtml* html );
+
+/**
+ * Go Forward.
+ *
+ * @param html GncHtml object
+ * @return the url if available or NULL
+ */
+const gchar* gnc_html_go_forward ( GncHtml* html );
 
 #ifdef WEBKIT1
 /**
@@ -263,7 +294,6 @@ GtkWidget* gnc_html_get_widget( GncHtml* html );
  * @return webview widget
  */
 GtkWidget* gnc_html_get_webview( GncHtml* html );
-
 
 /**
  * Sets the parent window for this html engine.  The engine will be embedded in this parent.

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -67,6 +67,7 @@ gnucash/gnome/dialog-fincalc.c
 gnucash/gnome/dialog-find-account.c
 gnucash/gnome/dialog-find-transactions2.c
 gnucash/gnome/dialog-find-transactions.c
+gnucash/gnome/dialog-help.c
 gnucash/gnome/dialog-imap-editor.c
 gnucash/gnome/dialog-invoice.c
 gnucash/gnome/dialog-job.c
@@ -263,6 +264,7 @@ gnucash/gtkbuilder/dialog-employee.glade
 gnucash/gtkbuilder/dialog-file-access.glade
 gnucash/gtkbuilder/dialog-fincalc.glade
 gnucash/gtkbuilder/dialog-find-account.glade
+gnucash/gtkbuilder/dialog-help.glade
 gnucash/gtkbuilder/dialog-imap-editor.glade
 gnucash/gtkbuilder/dialog-import.glade
 gnucash/gtkbuilder/dialog-invoice.glade


### PR DESCRIPTION
Before Christmas it was suggested that maybe the help should be based on html pages and thus use the existing webkit.
So to see what it could look like I cobbled together this. I started of with extracting the html help files from the Mac dmg file to use as a basis and can be seen below.

There is only one dialog so successive use of any help button will use existing window.
The Guide button toggles between Help and Guide so pages open in dialog.
The three buttons bottom left open in default external browser.
The only links supported in the dialog are secure ones which again open in the default external browser.
The location of the help files are 'share\gnucash\help\x\gnucash-help' but that could be changed
The Windows help files are named based on chapters, e.g. ch08s09.html as opposed to full section names.
HTML page appearance looks set at build time and not easily changed unless maybe there is reference to an external CSS file in appropriate directory that the user could change, thinking of those users with dark themes might not like a white page background.

Not sure if this is going to progress but thought it worthwhile as an experiment.
Bob

.
![mac-version](https://user-images.githubusercontent.com/15702727/107215393-28fc4680-6a03-11eb-8c6e-e2cbc3bbe6a6.jpg)

I then decided to use the Windows built html files, see below...
![win-version](https://user-images.githubusercontent.com/15702727/107216053-18000500-6a04-11eb-8f4c-96d4bdc4e21c.jpg)
 Which also included a toc.hhc file and I parsed this to add a search entry...
![win-version-ac](https://user-images.githubusercontent.com/15702727/107216290-77f6ab80-6a04-11eb-9cb3-db81b3a7c9ac.jpg)

Below are the 'C' language files I used zipped up separately to get below the 10MB limit...
[help-guide.zip](https://github.com/Gnucash/gnucash/files/5943537/help-guide.zip)
[help-help.zip](https://github.com/Gnucash/gnucash/files/5943554/help-help.zip)


