### PR TITLE
Fix build with glib2 2.67.3+

### DIFF
--- a/gnucash/gnome-utils/gnc-amount-edit.h
+++ b/gnucash/gnome-utils/gnc-amount-edit.h
@@ -32,6 +32,8 @@
 #include "qof.h"
 #include "gnc-ui-util.h"
 
+#include <gtk/gtk.h>
+
 #define GNC_TYPE_AMOUNT_EDIT          (gnc_amount_edit_get_type())
 #define GNC_AMOUNT_EDIT(obj)          G_TYPE_CHECK_INSTANCE_CAST (obj, GNC_TYPE_AMOUNT_EDIT, GNCAmountEdit)
 #define GNC_AMOUNT_EDIT_CLASS(klass)  G_TYPE_CHECK_CLASS_CAST (klass, GNC_TYPE_AMOUNT_EDIT, GNCAmountEditClass)

--- a/gnucash/gnome-utils/gnc-tree-model-commodity.c
+++ b/gnucash/gnome-utils/gnc-tree-model-commodity.c
@@ -36,6 +36,7 @@
 
 #include <config.h>
 
+#include <glib/gi18n.h>
 #include <gtk/gtk.h>
 #include <string.h>
 

--- a/gnucash/gnome/assistant-loan.cpp
+++ b/gnucash/gnome/assistant-loan.cpp
@@ -26,8 +26,6 @@
 extern "C"
 {
 #include <config.h>
-#include <gtk/gtk.h>
-#include <glib/gi18n.h>
 #include <string.h>
 #include <stdlib.h>
 #include <math.h>
@@ -52,6 +50,9 @@ extern "C"
 #endif
 }
 
+#include <glib.h>
+#include <glib/gi18n.h>
+#include <gtk/gtk.h>
 #include <gnc-locale-utils.hpp>
 #include <boost/locale.hpp>
 #include <string>

--- a/gnucash/import-export/csv-imp/gnc-imp-props-price.cpp
+++ b/gnucash/import-export/csv-imp/gnc-imp-props-price.cpp
@@ -27,12 +27,12 @@ extern "C" {
 #include <windows.h>
 #endif
 
-#include <glib.h>
-#include <glib/gi18n.h>
-
 #include "engine-helpers.h"
 #include "gnc-ui-util.h"
 }
+
+#include <glib.h>
+#include <glib/gi18n.h>
 
 #include <exception>
 #include <map>

--- a/gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp
+++ b/gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp
@@ -26,8 +26,6 @@ extern "C" {
 #include <windows.h>
 #endif
 
-#include <glib.h>
-#include <glib/gi18n.h>
 
 #include "engine-helpers.h"
 #include "gnc-csv-account-map.h"
@@ -38,6 +36,9 @@ extern "C" {
 #include <gnc-exp-parser.h>
 
 }
+
+#include <glib.h>
+#include <glib/gi18n.h>
 
 #include <algorithm>
 #include <exception>

--- a/gnucash/register/register-gnome/datecell-gnome.c
+++ b/gnucash/register/register-gnome/datecell-gnome.c
@@ -37,6 +37,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <glib/gi18n.h>
 #include <gdk/gdkkeysyms.h>
 
 #include "datecell.h"

--- a/libgnucash/app-utils/gnc-sx-instance-model.c
+++ b/libgnucash/app-utils/gnc-sx-instance-model.c
@@ -32,6 +32,7 @@
 
 #include <config.h>
 #include <glib.h>
+#include <glib/gi18n.h>
 #include <glib-object.h>
 #include <stdlib.h>
 

--- a/libgnucash/app-utils/gnc-ui-balances.c
+++ b/libgnucash/app-utils/gnc-ui-balances.c
@@ -29,6 +29,7 @@
 #include "gnc-ui-util.h"
 
 #include <glib.h>
+#include <glib/gi18n.h>
 
 #include "Account.h"
 #include "Split.h"

--- a/libgnucash/backend/dbi/gnc-backend-dbi.cpp
+++ b/libgnucash/backend/dbi/gnc-backend-dbi.cpp
@@ -37,9 +37,6 @@ extern "C"
 
 #include <inttypes.h>
 #include <errno.h>
-#include <glib.h>
-#include <glib/gstdio.h>
-
 #include "qof.h"
 #include "qofquery-p.h"
 #include "qofquerycore-p.h"
@@ -61,6 +58,10 @@ extern "C"
 #endif
 
 }
+
+#include <glib.h>
+#include <glib/gstdio.h>
+
 #include <boost/regex.hpp>
 #include <string>
 #include <iomanip>

--- a/libgnucash/backend/sql/gnc-address-sql.cpp
+++ b/libgnucash/backend/sql/gnc-address-sql.cpp
@@ -31,12 +31,12 @@ extern "C"
 {
 #include <config.h>
 
-#include <glib.h>
-
 #include "gnc-engine.h"
 
 #include "gncAddress.h"
 }
+#include <glib.h>
+
 #include <cstdlib>
 #include <cstring>
 #include <sstream>

--- a/libgnucash/backend/sql/gnc-book-sql.cpp
+++ b/libgnucash/backend/sql/gnc-book-sql.cpp
@@ -29,8 +29,6 @@ extern "C"
 {
 #include <config.h>
 
-#include <glib.h>
-
 #include "qof.h"
 
 #include "gnc-engine.h"
@@ -41,6 +39,8 @@ extern "C"
 #include "splint-defs.h"
 #endif
 }
+
+#include <glib.h>
 
 #include "gnc-sql-connection.hpp"
 #include "gnc-sql-backend.hpp"

--- a/libgnucash/backend/sql/gnc-customer-sql.cpp
+++ b/libgnucash/backend/sql/gnc-customer-sql.cpp
@@ -31,7 +31,6 @@ extern "C"
 {
 #include <config.h>
 
-#include <glib.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -39,6 +38,8 @@ extern "C"
 #include "gncCustomerP.h"
 #include "gncTaxTableP.h"
 }
+
+#include <glib.h>
 
 #include "gnc-sql-connection.hpp"
 #include "gnc-sql-backend.hpp"

--- a/libgnucash/backend/sql/gnc-employee-sql.cpp
+++ b/libgnucash/backend/sql/gnc-employee-sql.cpp
@@ -31,13 +31,13 @@ extern "C"
 {
 #include <config.h>
 
-#include <glib.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "gnc-commodity.h"
 #include "gncEmployeeP.h"
 }
+#include <glib.h>
 
 #include "gnc-sql-connection.hpp"
 #include "gnc-sql-backend.hpp"

--- a/libgnucash/backend/sql/gnc-entry-sql.cpp
+++ b/libgnucash/backend/sql/gnc-entry-sql.cpp
@@ -31,7 +31,6 @@ extern "C"
 {
 #include <config.h>
 
-#include <glib.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -40,6 +39,7 @@ extern "C"
 #include "gncInvoiceP.h"
 #include "gncTaxTableP.h"
 }
+#include <glib.h>
 
 #include "gnc-sql-connection.hpp"
 #include "gnc-sql-backend.hpp"

--- a/libgnucash/backend/sql/gnc-job-sql.cpp
+++ b/libgnucash/backend/sql/gnc-job-sql.cpp
@@ -31,12 +31,12 @@ extern "C"
 {
 #include <config.h>
 
-#include <glib.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "gncJobP.h"
 }
+#include <glib.h>
 
 #include "gnc-sql-connection.hpp"
 #include "gnc-sql-backend.hpp"

--- a/libgnucash/backend/sql/gnc-price-sql.cpp
+++ b/libgnucash/backend/sql/gnc-price-sql.cpp
@@ -29,8 +29,6 @@ extern "C"
 {
 #include <config.h>
 
-#include <glib.h>
-
 #include "qof.h"
 #include "gnc-pricedb.h"
 
@@ -38,6 +36,7 @@ extern "C"
 #include "splint-defs.h"
 #endif
 }
+#include <glib.h>
 
 #include "gnc-sql-connection.hpp"
 #include "gnc-sql-backend.hpp"

--- a/libgnucash/backend/sql/gnc-recurrence-sql.cpp
+++ b/libgnucash/backend/sql/gnc-recurrence-sql.cpp
@@ -29,8 +29,6 @@ extern "C"
 {
 #include <config.h>
 
-#include <glib.h>
-
 #include "qof.h"
 #include "gnc-engine.h"
 #include "Recurrence.h"
@@ -39,6 +37,7 @@ extern "C"
 #include "splint-defs.h"
 #endif
 }
+#include <glib.h>
 
 #include "gnc-sql-connection.hpp"
 #include "gnc-sql-backend.hpp"

--- a/libgnucash/backend/sql/gnc-schedxaction-sql.cpp
+++ b/libgnucash/backend/sql/gnc-schedxaction-sql.cpp
@@ -29,8 +29,6 @@ extern "C"
 {
 #include <config.h>
 
-#include <glib.h>
-
 #include "qof.h"
 #include "SchedXaction.h"
 #include "SX-book.h"
@@ -40,6 +38,8 @@ extern "C"
 #include "splint-defs.h"
 #endif
 }
+
+#include <glib.h>
 
 #include "gnc-sql-connection.hpp"
 #include "gnc-sql-backend.hpp"

--- a/libgnucash/backend/sql/gnc-vendor-sql.cpp
+++ b/libgnucash/backend/sql/gnc-vendor-sql.cpp
@@ -30,8 +30,6 @@
 extern "C"
 {
 #include <config.h>
-
-#include <glib.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -40,6 +38,8 @@ extern "C"
 #include "gncVendorP.h"
 #include "gncTaxTableP.h"
 }
+
+#include <glib.h>
 
 #include "gnc-sql-connection.hpp"
 #include "gnc-sql-backend.hpp"

--- a/libgnucash/backend/xml/gnc-account-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-account-xml-v2.cpp
@@ -25,13 +25,13 @@
 extern "C"
 {
 #include <config.h>
-
-#include <glib.h>
 #include <stdlib.h>
 #include <string.h>
 #include <AccountP.h>
 #include <Account.h>
 }
+
+#include <glib.h>
 
 #include "gnc-xml-helper.h"
 #include "sixtp.h"

--- a/libgnucash/backend/xml/gnc-address-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-address-xml-v2.cpp
@@ -24,11 +24,11 @@
 extern "C"
 {
 #include <config.h>
-
-#include <glib.h>
 #include <stdlib.h>
 #include <string.h>
 }
+#include <glib.h>
+
 #include "gnc-xml-helper.h"
 
 #include "sixtp.h"

--- a/libgnucash/backend/xml/gnc-backend-xml.cpp
+++ b/libgnucash/backend/xml/gnc-backend-xml.cpp
@@ -32,9 +32,6 @@ extern "C"
 #include <config.h>
 
 
-#include <glib.h>
-#include <glib/gi18n.h>
-#include <glib/gstdio.h>
 #include <libintl.h>
 #include <locale.h>
 #include <fcntl.h>
@@ -75,6 +72,10 @@ extern "C"
 # include "strptime.h"
 #endif
 }
+
+#include <glib.h>
+#include <glib/gi18n.h>
+#include <glib/gstdio.h>
 
 #include <gnc-backend-prov.hpp>
 #include "gnc-backend-xml.h"

--- a/libgnucash/backend/xml/gnc-bill-term-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-bill-term-xml-v2.cpp
@@ -24,8 +24,6 @@
 extern "C"
 {
 #include <config.h>
-
-#include <glib.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/libgnucash/backend/xml/gnc-book-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-book-xml-v2.cpp
@@ -25,12 +25,12 @@
 extern "C"
 {
 #include <config.h>
-
-#include <glib.h>
 #include <stdlib.h>
 #include <string.h>
 #include "qof.h"
 }
+
+#include <glib.h>
 
 #include "gnc-xml-helper.h"
 

--- a/libgnucash/backend/xml/gnc-budget-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-budget-xml-v2.cpp
@@ -24,11 +24,11 @@
 extern "C"
 {
 #include <config.h>
-
-#include <glib.h>
 #include <stdlib.h>
 #include <string.h>
 }
+
+#include <glib.h>
 
 #include "gnc-xml-helper.h"
 #include "sixtp.h"

--- a/libgnucash/backend/xml/gnc-commodity-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-commodity-xml-v2.cpp
@@ -24,12 +24,12 @@
 extern "C"
 {
 #include <config.h>
-
-#include <glib.h>
 #include <string.h>
 #include "AccountP.h"
 #include "Account.h"
 }
+
+#include <glib.h>
 
 #include "gnc-xml-helper.h"
 #include "sixtp.h"

--- a/libgnucash/backend/xml/gnc-customer-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-customer-xml-v2.cpp
@@ -24,8 +24,6 @@
 extern "C"
 {
 #include <config.h>
-
-#include <glib.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -33,6 +31,8 @@ extern "C"
 #include "gncCustomerP.h"
 #include "gncTaxTableP.h"
 }
+
+#include <glib.h>
 
 #include "gnc-xml-helper.h"
 #include "gnc-customer-xml-v2.h"

--- a/libgnucash/backend/xml/gnc-employee-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-employee-xml-v2.cpp
@@ -24,12 +24,11 @@
 extern "C"
 {
 #include <config.h>
-
-#include <glib.h>
 #include <stdlib.h>
 #include <string.h>
 #include "gncEmployeeP.h"
 }
+#include <glib.h>
 
 #include "gnc-xml-helper.h"
 #include "sixtp.h"

--- a/libgnucash/backend/xml/gnc-entry-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-entry-xml-v2.cpp
@@ -24,8 +24,6 @@
 extern "C"
 {
 #include <config.h>
-
-#include <glib.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -34,6 +32,8 @@ extern "C"
 #include "gncInvoiceP.h"
 #include "gncTaxTableP.h"
 }
+
+#include <glib.h>
 
 #include "gnc-xml-helper.h"
 #include "sixtp.h"

--- a/libgnucash/backend/xml/gnc-freqspec-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-freqspec-xml-v2.cpp
@@ -25,13 +25,12 @@
 extern "C"
 {
 #include <config.h>
-
-#include <glib.h>
 #include <string.h>
 #include "qof.h"
 #include "SchedXaction.h"
 #include "FreqSpec.h"
 }
+#include <glib.h>
 
 #include "gnc-xml-helper.h"
 #include "sixtp.h"

--- a/libgnucash/backend/xml/gnc-invoice-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-invoice-xml-v2.cpp
@@ -24,14 +24,13 @@
 extern "C"
 {
 #include <config.h>
-
-#include <glib.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "gncBillTermP.h"
 #include "gncInvoiceP.h"
 }
+#include <glib.h>
 
 #include "gnc-xml-helper.h"
 #include "sixtp.h"

--- a/libgnucash/backend/xml/gnc-job-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-job-xml-v2.cpp
@@ -24,12 +24,11 @@
 extern "C"
 {
 #include <config.h>
-
-#include <glib.h>
 #include <stdlib.h>
 #include <string.h>
 #include "gncJobP.h"
 }
+#include <glib.h>
 
 #include "gnc-xml-helper.h"
 #include "sixtp.h"

--- a/libgnucash/backend/xml/gnc-lot-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-lot-xml-v2.cpp
@@ -25,13 +25,12 @@
 extern "C"
 {
 #include <config.h>
-
-#include <glib.h>
 #include <stdlib.h>
 #include <string.h>
 #include "gnc-lot.h"
 #include "gnc-lot-p.h"
 }
+#include <glib.h>
 
 #include "gnc-xml-helper.h"
 #include "sixtp.h"

--- a/libgnucash/backend/xml/gnc-order-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-order-xml-v2.cpp
@@ -24,12 +24,11 @@
 extern "C"
 {
 #include <config.h>
-
-#include <glib.h>
 #include <stdlib.h>
 #include <string.h>
 #include "gncOrderP.h"
 }
+#include <glib.h>
 
 #include "gnc-xml-helper.h"
 #include "sixtp.h"

--- a/libgnucash/backend/xml/gnc-owner-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-owner-xml-v2.cpp
@@ -24,8 +24,6 @@
 extern "C"
 {
 #include <config.h>
-
-#include <glib.h>
 #include <stdlib.h>
 #include <string.h>
 #include "gncCustomerP.h"
@@ -33,6 +31,7 @@ extern "C"
 #include "gncVendorP.h"
 #include "gncEmployeeP.h"
 }
+#include <glib.h>
 
 #include "gnc-xml-helper.h"
 #include "sixtp.h"

--- a/libgnucash/backend/xml/gnc-recurrence-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-recurrence-xml-v2.cpp
@@ -24,12 +24,11 @@
 extern "C"
 {
 #include <config.h>
-
-#include <glib.h>
 #include <string.h>
 #include "qof.h"
 #include "Recurrence.h"
 }
+#include <glib.h>
 
 #include "gnc-xml.h"
 #include "gnc-xml-helper.h"

--- a/libgnucash/backend/xml/gnc-schedxaction-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-schedxaction-xml-v2.cpp
@@ -23,12 +23,11 @@
 extern "C"
 {
 #include <config.h>
-
-#include <glib.h>
 #include <string.h>
 
 #include "SX-book.h"
 }
+#include <glib.h>
 
 #include "gnc-xml-helper.h"
 #include "sixtp.h"

--- a/libgnucash/backend/xml/gnc-tax-table-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-tax-table-xml-v2.cpp
@@ -24,13 +24,12 @@
 extern "C"
 {
 #include <config.h>
-
-#include <glib.h>
 #include <stdlib.h>
 #include <string.h>
 #include "gncEntry.h"
 #include "gncTaxTableP.h"
 }
+#include <glib.h>
 
 #include "gnc-xml-helper.h"
 #include "sixtp.h"

--- a/libgnucash/backend/xml/gnc-transaction-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-transaction-xml-v2.cpp
@@ -24,8 +24,6 @@
 extern "C"
 {
 #include <config.h>
-
-#include <glib.h>
 #include <string.h>
 #include "AccountP.h"
 #include "Transaction.h"
@@ -33,6 +31,7 @@ extern "C"
 #include "gnc-lot.h"
 #include "gnc-lot-p.h"
 }
+#include <glib.h>
 #include "gnc-xml-helper.h"
 
 #include "sixtp.h"

--- a/libgnucash/backend/xml/gnc-vendor-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-vendor-xml-v2.cpp
@@ -24,8 +24,6 @@
 extern "C"
 {
 #include <config.h>
-
-#include <glib.h>
 #include <stdlib.h>
 #include <string.h>
 #include "gncBillTermP.h"
@@ -33,6 +31,7 @@ extern "C"
 #include "gncTaxTableP.h"
 }
 
+#include <glib.h>
 #include "gnc-xml-helper.h"
 #include "sixtp.h"
 #include "sixtp-utils.h"

--- a/libgnucash/backend/xml/gnc-xml-backend.cpp
+++ b/libgnucash/backend/xml/gnc-xml-backend.cpp
@@ -27,8 +27,6 @@ extern "C"
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/stat.h>
-#include <glib.h>
-#include <glib/gstdio.h>
 #include <regex.h>
 
 #include <gnc-engine.h> //for GNC_MOD_BACKEND
@@ -38,6 +36,8 @@ extern "C"
 
 }
 
+#include <glib.h>
+#include <glib/gstdio.h>
 #include <sstream>
 
 #include "gnc-xml-backend.hpp"

--- a/libgnucash/backend/xml/gnc-xml-helper.cpp
+++ b/libgnucash/backend/xml/gnc-xml-helper.cpp
@@ -21,10 +21,7 @@
  * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
  *                                                                  *
 \********************************************************************/
-extern "C"
-{
 #include <glib.h>
-}
 
 #include "gnc-xml-helper.h"
 

--- a/libgnucash/backend/xml/gnc-xml-helper.h
+++ b/libgnucash/backend/xml/gnc-xml-helper.h
@@ -24,6 +24,9 @@
 
 #ifndef GNC_XML_HELPER_H
 #define GNC_XML_HELPER_H
+
+#include <glib.h>
+
 extern "C"
 {
 #include <libxml/xmlversion.h>

--- a/libgnucash/backend/xml/io-example-account.cpp
+++ b/libgnucash/backend/xml/io-example-account.cpp
@@ -41,9 +41,6 @@ extern "C"
 # include <unistd.h>
 #endif
 
-#include <glib.h>
-#include <glib/gi18n.h>
-#include <glib/gstdio.h>
 #include "gnc-engine.h"
 #include "Scrub.h"
 #include "TransLog.h"
@@ -53,6 +50,9 @@ extern "C"
 #endif
 }
 
+#include <glib.h>
+#include <glib/gi18n.h>
+#include <glib/gstdio.h>
 #include "sixtp.h"
 
 #include "gnc-xml.h"

--- a/libgnucash/backend/xml/io-gncxml-gen.h
+++ b/libgnucash/backend/xml/io-gncxml-gen.h
@@ -24,10 +24,8 @@
 
 #ifndef IO_GNCXML_GEN_H
 #define IO_GNCXML_GEN_H
-extern "C"
-{
+
 #include <glib.h>
-}
 
 #include "sixtp.h"
 

--- a/libgnucash/backend/xml/io-gncxml-v2.cpp
+++ b/libgnucash/backend/xml/io-gncxml-v2.cpp
@@ -36,8 +36,6 @@ extern "C"
 #endif
 #include <windows.h>
 #endif
-#include <glib.h>
-#include <glib/gstdio.h>
 #include <fcntl.h>
 #include <string.h>
 #ifdef HAVE_UNISTD_H
@@ -65,6 +63,9 @@ extern "C"
 # define g_open _open
 #endif
 }
+
+#include <glib.h>
+#include <glib/gstdio.h>
 
 #include "gnc-xml-backend.hpp"
 #include "sixtp-parsers.h"

--- a/libgnucash/backend/xml/io-utils.cpp
+++ b/libgnucash/backend/xml/io-utils.cpp
@@ -26,9 +26,9 @@ extern "C"
 #include <config.h>
 
 #include <stdio.h>
+}
 
 #include <glib.h>
-}
 
 #include "gnc-xml.h"
 #include "io-utils.h"

--- a/libgnucash/backend/xml/sixtp-dom-generators.cpp
+++ b/libgnucash/backend/xml/sixtp-dom-generators.cpp
@@ -25,10 +25,10 @@ extern "C"
 #define __EXTENSIONS__
 
 #include <config.h>
-#include <glib.h>
 
 #include <gnc-date.h>
 }
+#include <glib.h>
 
 #include "gnc-xml-helper.h"
 #include "sixtp-dom-generators.h"

--- a/libgnucash/backend/xml/sixtp-dom-parsers.cpp
+++ b/libgnucash/backend/xml/sixtp-dom-parsers.cpp
@@ -24,13 +24,13 @@ extern "C"
 {
 #include <config.h>
 
-#include <glib.h>
 #include <string.h>
 
-#include "gnc-xml-helper.h"
 #include <gnc-engine.h>
 }
 
+#include <glib.h>
+#include "gnc-xml-helper.h"
 #include "sixtp-utils.h"
 #include "sixtp-dom-parsers.h"
 #include <kvp-frame.hpp>

--- a/libgnucash/backend/xml/sixtp-to-dom-parser.cpp
+++ b/libgnucash/backend/xml/sixtp-to-dom-parser.cpp
@@ -23,11 +23,10 @@
 extern "C"
 {
 #include <config.h>
-
-#include <glib.h>
-
 #include <ctype.h>
 }
+
+#include <glib.h>
 
 #include "sixtp-parsers.h"
 #include "sixtp-utils.h"

--- a/libgnucash/backend/xml/sixtp.cpp
+++ b/libgnucash/backend/xml/sixtp.cpp
@@ -23,9 +23,6 @@
 extern "C"
 {
 #include <config.h>
-
-#include <glib.h>
-#include <glib/gstdio.h>
 #include <string.h>
 #include <ctype.h>
 #include <stdarg.h>
@@ -36,6 +33,9 @@ extern "C"
 # define g_fopen fopen
 #endif
 }
+
+#include <glib.h>
+#include <glib/gstdio.h>
 
 #include "sixtp.h"
 #include "sixtp-parsers.h"

--- a/libgnucash/backend/xml/sixtp.h
+++ b/libgnucash/backend/xml/sixtp.h
@@ -25,12 +25,12 @@
 #define SIXTP_H
 extern "C"
 {
-#include <glib.h>
 #include <stdio.h>
 
 #include <stdarg.h>
 #include "gnc-engine.h"
 }
+#include <glib.h>
 #include "gnc-xml-helper.h"
 #include "gnc-backend-xml.h"
 

--- a/libgnucash/core-utils/gnc-filepath-utils.cpp
+++ b/libgnucash/core-utils/gnc-filepath-utils.cpp
@@ -26,6 +26,11 @@
  * @author Copyright (c) 2000 Dave Peticolas
  */
 
+#include <glib.h>
+#include <glib/gi18n.h>
+#include <glib/gprintf.h>
+#include <glib/gstdio.h>
+
 extern "C" {
 #include <config.h>
 
@@ -35,10 +40,6 @@ extern "C" {
 #include <Shlobj.h>
 #endif
 
-#include <glib.h>
-#include <glib/gi18n.h>
-#include <glib/gprintf.h>
-#include <glib/gstdio.h>
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/libgnucash/core-utils/gnc-locale-utils.cpp
+++ b/libgnucash/core-utils/gnc-locale-utils.cpp
@@ -19,10 +19,7 @@
  * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652       *
  * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
 \********************************************************************/
-extern "C"
-{
 #include <glib.h>
-}
 #include <clocale>
 #include <boost/locale.hpp>
 #include "gnc-locale-utils.hpp"

--- a/libgnucash/core-utils/gnc-prefs.h
+++ b/libgnucash/core-utils/gnc-prefs.h
@@ -45,7 +45,11 @@
 #ifndef GNC_PREFS_H
 #define GNC_PREFS_H
 
+#ifdef __cplusplus
+extern "C++" {
 #include <glib.h>
+}
+#endif
 
 /* Preference groups used across multiple modules */
 #define GNC_PREFS_GROUP_GENERAL           "general"

--- a/libgnucash/engine/SX-book.h
+++ b/libgnucash/engine/SX-book.h
@@ -42,7 +42,11 @@
 typedef struct xaccSchedXactionsDef SchedXactions;
 typedef struct _SchedXactionsClass SchedXactionsClass;
 
+#ifdef __cplusplus
+extern "C++" {
 #include <glib.h>
+}
+#endif
 #include "SchedXaction.h"
 #include "qof.h"
 

--- a/libgnucash/engine/engine-helpers.h
+++ b/libgnucash/engine/engine-helpers.h
@@ -25,7 +25,11 @@
 #ifndef ENGINE_HELPERS_H
 #define ENGINE_HELPERS_H
 
+#ifdef __cplusplus
+extern "C++" {
 #include <glib.h>
+}
+#endif
 
 #include "gnc-engine.h"
 #include "Account.h"

--- a/libgnucash/engine/gnc-commodity.h
+++ b/libgnucash/engine/gnc-commodity.h
@@ -49,8 +49,13 @@
 typedef struct _GncCommodityClass gnc_commodityClass;
 typedef struct _GncCommodityNamespaceClass gnc_commodity_namespaceClass;
 
+#ifdef __cplusplus
+extern "C++" {
 #include <glib.h>
 #include <glib/gi18n.h>
+}
+#endif
+
 #include "gnc-engine.h"
 
 #ifdef __cplusplus

--- a/libgnucash/engine/gnc-date.cpp
+++ b/libgnucash/engine/gnc-date.cpp
@@ -26,11 +26,11 @@
 \********************************************************************/
 
 #define __EXTENSIONS__
+#include <glib.h>
 extern "C"
 {
 
 #include <config.h>
-#include <glib.h>
 #include <libintl.h>
 #include <stdlib.h>
 #include "platform.h"

--- a/libgnucash/engine/gnc-date.h
+++ b/libgnucash/engine/gnc-date.h
@@ -68,12 +68,21 @@
 
 #ifndef GNC_DATE_H
 #define GNC_DATE_H
+
+
 #ifdef __cplusplus
 extern "C"
 {
 #endif
- 
+
+#ifdef __cplusplus
+extern "C++" {
+#endif
 #include <glib-object.h>
+#ifdef __cplusplus
+}
+#endif
+ 
 #include <time.h>
 
 /**

--- a/libgnucash/engine/gnc-engine.h
+++ b/libgnucash/engine/gnc-engine.h
@@ -36,7 +36,12 @@
 #ifndef GNC_ENGINE_H
 #define GNC_ENGINE_H
 
+#ifdef __cplusplus
+extern "C++" {
 #include <glib.h>
+}
+#endif
+
 #include "qof.h"
 
 #ifdef __cplusplus

--- a/libgnucash/engine/gnc-numeric.cpp
+++ b/libgnucash/engine/gnc-numeric.cpp
@@ -26,7 +26,6 @@ extern "C"
 {
 #include <config.h>
 
-#include <glib.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -35,6 +34,7 @@ extern "C"
 #include "qof.h"
 }
 
+#include <glib.h>
 #include <stdint.h>
 #include <boost/regex.hpp>
 #include <boost/locale/encoding_utf.hpp>

--- a/libgnucash/engine/gncBusiness.h
+++ b/libgnucash/engine/gncBusiness.h
@@ -34,7 +34,11 @@
 #ifndef GNC_BUSINESS_H_
 #define GNC_BUSINESS_H_
 
+#ifdef __cplusplus
+extern "C++" {
 #include <glib.h>
+}
+#endif
 #include "qof.h"
 #include "Account.h"
 

--- a/libgnucash/engine/gncEntry.h
+++ b/libgnucash/engine/gncEntry.h
@@ -31,6 +31,12 @@
 #ifndef GNC_ENTRY_H_
 #define GNC_ENTRY_H_
 
+#ifdef __cplusplus
+extern "C++" {
+#include <glib.h>
+}
+#endif
+
 typedef struct _gncEntry GncEntry;
 typedef struct _gncEntryClass GncEntryClass;
 

--- a/libgnucash/engine/qof-string-cache.cpp
+++ b/libgnucash/engine/qof-string-cache.cpp
@@ -31,11 +31,12 @@ extern "C"
 #include <config.h>
 
 #include <ctype.h>
-#include <glib.h>
 #include <stdlib.h>
 #include <string.h>
 #include "qof.h"
 }
+
+#include <glib.h>
 
 /* Uncomment if you need to log anything.
 static QofLogModule log_module = QOF_MOD_UTIL;

--- a/libgnucash/engine/qof.h
+++ b/libgnucash/engine/qof.h
@@ -68,7 +68,11 @@
 */
 /** @} */
 
+#ifdef __cplusplus
+extern "C++" {
 #include <glib.h>
+}
+#endif
 #include "qofid.h"
 #include "qoflog.h"
 #include "gnc-date.h"

--- a/libgnucash/engine/qofbook.cpp
+++ b/libgnucash/engine/qofbook.cpp
@@ -41,7 +41,6 @@ extern "C"
 #include <stdlib.h>
 #include <string.h>
 
-#include <glib.h>
 #ifdef GNC_PLATFORM_WINDOWS
   /* Mingw disables the standard type macros for C++ without this override. */
 #define __STDC_FORMAT_MACROS = 1
@@ -50,6 +49,7 @@ extern "C"
 
 }
 
+#include <glib.h>
 #include "qof.h"
 #include "qofevent-p.h"
 #include "qofbackend.h"

--- a/libgnucash/engine/qofchoice.cpp
+++ b/libgnucash/engine/qofchoice.cpp
@@ -21,13 +21,8 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-extern "C"
-{
-
 #include <config.h>
 #include <glib.h>
-
-}
 
 #include "qof.h"
 #include "qofchoice.h"

--- a/libgnucash/engine/qofclass.cpp
+++ b/libgnucash/engine/qofclass.cpp
@@ -21,11 +21,8 @@
  *                                                                  *
 \********************************************************************/
 
-extern "C"
-{
 #include <config.h>
 #include <glib.h>
-}
 
 #include "qof.h"
 #include "qofclass-p.h"

--- a/libgnucash/engine/qofevent.cpp
+++ b/libgnucash/engine/qofevent.cpp
@@ -22,11 +22,8 @@
  *                                                                  *
  ********************************************************************/
 
-extern "C"
-{
 #include <config.h>
 #include <glib.h>
-}
 
 #include "qof.h"
 #include "qofevent-p.h"

--- a/libgnucash/engine/qofid.cpp
+++ b/libgnucash/engine/qofid.cpp
@@ -26,9 +26,9 @@ extern "C"
 {
 #include <config.h>
 #include <string.h>
-#include <glib.h>
 }
 
+#include <glib.h>
 #include "qof.h"
 #include "qofid-p.h"
 #include "qofinstance-p.h"

--- a/libgnucash/engine/qoflog.cpp
+++ b/libgnucash/engine/qoflog.cpp
@@ -34,8 +34,6 @@ extern "C"
 #include <windows.h>
 #endif
 
-#include <glib.h>
-#include <glib/gstdio.h>
 #ifdef HAVE_UNISTD_H
 # include <unistd.h>
 #else
@@ -48,10 +46,12 @@ extern "C"
 #include <string.h>
 #include <stdio.h>
 
-#undef G_LOG_DOMAIN
-#define G_LOG_DOMAIN "qof.log"
 }
 
+#include <glib.h>
+#include <glib/gstdio.h>
+#undef G_LOG_DOMAIN
+#define G_LOG_DOMAIN "qof.log"
 #include "qof.h"
 #include "qoflog.h"
 #include <string>

--- a/libgnucash/engine/qofobject.cpp
+++ b/libgnucash/engine/qofobject.cpp
@@ -23,11 +23,8 @@
  * Copyright (C) 2001 Derek Atkins
  * Author: Derek Atkins <warlord@MIT.EDU>
  */
-extern "C"
-{
 #include <config.h>
 #include <glib.h>
-}
 
 #include "qof.h"
 #include "qofobject-p.h"

--- a/libgnucash/engine/qofquery.cpp
+++ b/libgnucash/engine/qofquery.cpp
@@ -27,11 +27,11 @@ extern "C"
 
 #include <sys/types.h>
 #include <time.h>
-#include <glib.h>
 #include <regex.h>
 #include <string.h>
 }
 
+#include <glib.h>
 #include "qof.h"
 #include "qof-backend.hpp"
 #include "qofbook-p.h"

--- a/libgnucash/engine/qofsession.cpp
+++ b/libgnucash/engine/qofsession.cpp
@@ -48,13 +48,13 @@ extern "C"
 # endif
 #endif
 
-#include <glib.h>
 #include "qof.h"
 #include "qofobject-p.h"
 
 static QofLogModule log_module = QOF_MOD_SESSION;
 } //extern 'C'
 
+#include <glib.h>
 #include "qofbook-p.h"
 #include "qof-backend.hpp"
 #include "qofsession.hpp"


### PR DESCRIPTION
glib headers should not be included with 'extern "C"'.

Change in glib that caused this: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/1715

Discussion of whether to work around it in glib: https://gitlab.gnome.org/GNOME/glib/-/merge_requests/1935. This was rejected, the suggestion there was to fix it in the including programs.

It may be possible for an expert in the header inclusion hierarchy to make a more targeted fix - I just kept editing files until it built.

Build tested on Fedora rawhide, smoke tested by starting the program with a new account from scratch.
