### PR TITLE
Update price database for imported transactions

### DIFF
--- a/bindings/engine.i
+++ b/bindings/engine.i
@@ -421,6 +421,7 @@ void qof_book_set_string_option(QofBook* book, const char* opt_name, const char*
     SET_ENUM("PRICE-SOURCE-USER-PRICE");
     SET_ENUM("PRICE-SOURCE-XFER-DLG-VAL");
     SET_ENUM("PRICE-SOURCE-SPLIT-REG");
+    SET_ENUM("PRICE-SOURCE-SPLIT-IMPORT");
     SET_ENUM("PRICE-SOURCE-STOCK-SPLIT");
     SET_ENUM("PRICE-SOURCE-TEMP");
     SET_ENUM("PRICE-SOURCE-INVALID");

--- a/gnucash/import-export/import-backend.c
+++ b/gnucash/import-export/import-backend.c
@@ -840,6 +840,7 @@ gnc_import_process_trans_item (GncImportMatchMap *matchmap,
 {
     Split * other_split;
     gnc_numeric imbalance_value;
+    Transaction *trans;
 
     /* DEBUG("Begin"); */
 
@@ -894,7 +895,9 @@ gnc_import_process_trans_item (GncImportMatchMap *matchmap,
         xaccSplitSetDateReconciledSecs(gnc_import_TransInfo_get_fsplit (trans_info),
                                        gnc_time (NULL));
         /* Done editing. */
-        xaccTransCommitEdit(gnc_import_TransInfo_get_trans (trans_info));
+        trans = gnc_import_TransInfo_get_trans (trans_info);
+        xaccTransCommitEdit(trans);
+        xaccTransRecordPrice(trans);
         return TRUE;
     case GNCImport_UPDATE:
     {

--- a/gnucash/import-export/import-backend.c
+++ b/gnucash/import-export/import-backend.c
@@ -897,7 +897,7 @@ gnc_import_process_trans_item (GncImportMatchMap *matchmap,
         /* Done editing. */
         trans = gnc_import_TransInfo_get_trans (trans_info);
         xaccTransCommitEdit(trans);
-        xaccTransRecordPrice(trans);
+        xaccTransRecordPrice(trans, PRICE_SOURCE_SPLIT_IMPORT);
         return TRUE;
     case GNCImport_UPDATE:
     {

--- a/gnucash/import-export/qif-imp/qif-to-gnc.scm
+++ b/gnucash/import-export/qif-imp/qif-to-gnc.scm
@@ -445,7 +445,7 @@
 
                   ;; rebalance and commit everything
                   (xaccTransCommitEdit gnc-xtn)
-		  (xaccTransRecordPrice gnc-xtn))))
+                  (xaccTransRecordPrice gnc-xtn))))
           (qif-file:xtns qif-file)))
        sorted-qif-files-list)
 

--- a/gnucash/import-export/qif-imp/qif-to-gnc.scm
+++ b/gnucash/import-export/qif-imp/qif-to-gnc.scm
@@ -445,7 +445,7 @@
 
                   ;; rebalance and commit everything
                   (xaccTransCommitEdit gnc-xtn)
-                  (xaccTransRecordPrice gnc-xtn))))
+                  (xaccTransRecordPrice gnc-xtn PRICE-SOURCE-SPLIT-IMPORT))))
           (qif-file:xtns qif-file)))
        sorted-qif-files-list)
 

--- a/gnucash/import-export/qif-imp/qif-to-gnc.scm
+++ b/gnucash/import-export/qif-imp/qif-to-gnc.scm
@@ -444,7 +444,8 @@
                                                  progress-dialog)
 
                   ;; rebalance and commit everything
-                  (xaccTransCommitEdit gnc-xtn))))
+                  (xaccTransCommitEdit gnc-xtn)
+		  (xaccTransRecordPrice gnc-xtn))))
           (qif-file:xtns qif-file)))
        sorted-qif-files-list)
 

--- a/libgnucash/engine/Transaction.c
+++ b/libgnucash/engine/Transaction.c
@@ -3116,25 +3116,27 @@ record_price(Split *split,
     time64 time;
     gboolean swap;
 
-    account = xaccSplitGetAccount(split);
-    if (!xaccAccountIsPriced(account)) {
+    account = xaccSplitGetAccount (split);
+    if (!xaccAccountIsPriced (account))
+    {
        return;
     }
-    amount = xaccSplitGetAmount(split);
-    if (gnc_numeric_zero_p(amount)) {
+    amount = xaccSplitGetAmount (split);
+    if (gnc_numeric_zero_p (amount))
+    {
        return;
     }
-    trans = xaccSplitGetParent(split);
-    value = gnc_numeric_div(xaccSplitGetValue(split), amount,
-                            GNC_DENOM_AUTO,
-                            GNC_HOW_DENOM_EXACT);
+    trans = xaccSplitGetParent (split);
+    value = gnc_numeric_div (xaccSplitGetValue (split), amount,
+                             GNC_DENOM_AUTO,
+                             GNC_HOW_DENOM_EXACT);
     book = qof_instance_get_book (QOF_INSTANCE (account));
     pricedb = gnc_pricedb_get_db (book);
     comm = xaccAccountGetCommodity (account);
     curr = xaccTransGetCurrency (trans);
     scu = gnc_commodity_get_fraction (curr);
     swap = FALSE;
-    time = xaccTransGetDate(trans);
+    time = xaccTransGetDate (trans);
     price = gnc_pricedb_lookup_day_t64 (pricedb, comm, curr, time);
     if (gnc_commodity_equiv (comm, gnc_price_get_currency (price)))
         swap = TRUE;
@@ -3148,7 +3150,7 @@ record_price(Split *split,
             gnc_price_unref (price);
             return;
         }
-        if (gnc_price_get_source (price) < PRICE_SOURCE_XFER_DLG_VAL)
+        if (gnc_price_get_source (price) < PRICE_SOURCE_SPLIT_IMPORT)
         {
             /* Existing price is preferred over this one. */
             gnc_price_unref (price);
@@ -3188,17 +3190,12 @@ record_price(Split *split,
 void
 xaccTransRecordPrice(Transaction *trans)
 {
-   Split *s;
-   int i = 0;
-
     /* XXX: move this into xaccSplitCommitEdit and other callers of
     * gnc_pricedb_add_price from split-register.c, gnc-imp-props-price.cpp
     * etc.
     */
-   while ((s = xaccTransGetSplit(trans, i)) != NULL) {
-      record_price(s, PRICE_SOURCE_SPLIT_IMPORT);
-      i++;
-   }
+   for (GList *n = xaccTransGetSplitList (trans); n; n = n->next)
+      record_price (n->data, PRICE_SOURCE_SPLIT_IMPORT);
 }
 
 /************************ END OF ************************************\

--- a/libgnucash/engine/Transaction.c
+++ b/libgnucash/engine/Transaction.c
@@ -3101,8 +3101,8 @@ _utest_trans_fill_functions (void)
 }
 
 static void
-record_price(Split *split,
-             PriceSource source)
+record_price (Split *split,
+              PriceSource source)
 {
     Transaction *trans;
     Account *account;
@@ -3150,7 +3150,7 @@ record_price(Split *split,
             gnc_price_unref (price);
             return;
         }
-        if (gnc_price_get_source (price) < PRICE_SOURCE_SPLIT_IMPORT)
+        if (gnc_price_get_source (price) < source)
         {
             /* Existing price is preferred over this one. */
             gnc_price_unref (price);
@@ -3188,14 +3188,14 @@ record_price(Split *split,
 }
 
 void
-xaccTransRecordPrice(Transaction *trans)
+xaccTransRecordPrice (Transaction *trans, PriceSource source)
 {
     /* XXX: move this into xaccSplitCommitEdit and other callers of
     * gnc_pricedb_add_price from split-register.c, gnc-imp-props-price.cpp
     * etc.
     */
    for (GList *n = xaccTransGetSplitList (trans); n; n = n->next)
-      record_price (n->data, PRICE_SOURCE_SPLIT_IMPORT);
+      record_price (n->data, source);
 }
 
 /************************ END OF ************************************\

--- a/libgnucash/engine/Transaction.c
+++ b/libgnucash/engine/Transaction.c
@@ -3100,5 +3100,106 @@ _utest_trans_fill_functions (void)
     return func;
 }
 
+static void
+record_price(Split *split,
+             PriceSource source)
+{
+    Transaction *trans;
+    Account *account;
+    QofBook* book;
+    GNCPriceDB* pricedb;
+    gnc_commodity* comm;
+    gnc_commodity* curr;
+    GNCPrice* price;
+    gnc_numeric price_value, value, amount;
+    int scu;
+    time64 time;
+    gboolean swap;
+
+    account = xaccSplitGetAccount(split);
+    if (!xaccAccountIsPriced(account)) {
+       return;
+    }
+    amount = xaccSplitGetAmount(split);
+    if (gnc_numeric_zero_p(amount)) {
+       return;
+    }
+    trans = xaccSplitGetParent(split);
+    value = gnc_numeric_div(xaccSplitGetValue(split), amount,
+                            GNC_DENOM_AUTO,
+                            GNC_HOW_DENOM_EXACT);
+    book = qof_instance_get_book (QOF_INSTANCE (account));
+    pricedb = gnc_pricedb_get_db (book);
+    comm = xaccAccountGetCommodity (account);
+    curr = xaccTransGetCurrency (trans);
+    scu = gnc_commodity_get_fraction (curr);
+    swap = FALSE;
+    time = xaccTransGetDate(trans);
+    price = gnc_pricedb_lookup_day_t64 (pricedb, comm, curr, time);
+    if (gnc_commodity_equiv (comm, gnc_price_get_currency (price)))
+        swap = TRUE;
+
+    if (price)
+    {
+        price_value = gnc_price_get_value (price);
+        if (gnc_numeric_equal (swap ? gnc_numeric_invert (value) : value,
+                               price_value))
+        {
+            gnc_price_unref (price);
+            return;
+        }
+        if (gnc_price_get_source (price) < PRICE_SOURCE_XFER_DLG_VAL)
+        {
+            /* Existing price is preferred over this one. */
+            gnc_price_unref (price);
+            return;
+        }
+        if (swap)
+        {
+            value = gnc_numeric_invert (value);
+            scu = gnc_commodity_get_fraction (comm);
+        }
+        value = gnc_numeric_convert (value, scu * COMMODITY_DENOM_MULT,
+                                     GNC_HOW_RND_ROUND_HALF_UP);
+        gnc_price_begin_edit (price);
+        gnc_price_set_time64 (price, time);
+        gnc_price_set_source (price, source);
+        gnc_price_set_typestr (price, PRICE_TYPE_TRN);
+        gnc_price_set_value (price, value);
+        gnc_price_commit_edit (price);
+        gnc_price_unref (price);
+        return;
+    }
+
+    value = gnc_numeric_convert (value, scu * COMMODITY_DENOM_MULT,
+                                 GNC_HOW_RND_ROUND_HALF_UP);
+    price = gnc_price_create (book);
+    gnc_price_begin_edit (price);
+    gnc_price_set_commodity (price, comm);
+    gnc_price_set_currency (price, curr);
+    gnc_price_set_time64 (price, time);
+    gnc_price_set_source (price, source);
+    gnc_price_set_typestr (price, PRICE_TYPE_TRN);
+    gnc_price_set_value (price, value);
+    gnc_pricedb_add_price (pricedb, price);
+    gnc_price_commit_edit (price);
+}
+
+void
+xaccTransRecordPrice(Transaction *trans)
+{
+   Split *s;
+   int i = 0;
+
+    /* XXX: move this into xaccSplitCommitEdit and other callers of
+    * gnc_pricedb_add_price from split-register.c, gnc-imp-props-price.cpp
+    * etc.
+    */
+   while ((s = xaccTransGetSplit(trans, i)) != NULL) {
+      record_price(s, PRICE_SOURCE_SPLIT_IMPORT);
+      i++;
+   }
+}
+
 /************************ END OF ************************************\
 \************************* FILE *************************************/

--- a/libgnucash/engine/Transaction.h
+++ b/libgnucash/engine/Transaction.h
@@ -92,6 +92,7 @@ typedef struct _TransactionClass TransactionClass;
 
 #include "gnc-commodity.h"
 #include "gnc-engine.h"
+#include "gnc-pricedb.h"
 #include "Split.h"
 
 #ifdef __cplusplus
@@ -767,10 +768,10 @@ time64 xaccTransGetVoidTime(const Transaction *tr);
 void xaccTransDump (const Transaction *trans, const char *tag);
 #endif
 
-/** The xaccTransRecord() method iterates through the splits and
+/** The xaccTransRecordPrice() method iterates through the splits and
  *  and record the non-currency equivalent prices in the price database.
  */
-void xaccTransRecordPrice (Transaction *trans);
+void xaccTransRecordPrice (Transaction *trans, PriceSource source);
 
 
 #define RECONCILED_MATCH_TYPE	"reconciled-match"

--- a/libgnucash/engine/Transaction.h
+++ b/libgnucash/engine/Transaction.h
@@ -767,6 +767,12 @@ time64 xaccTransGetVoidTime(const Transaction *tr);
 void xaccTransDump (const Transaction *trans, const char *tag);
 #endif
 
+/** The xaccTransRecord() method iterates through the splits and
+ *  and record the non-currency equivalent prices in the price database.
+ */
+void xaccTransRecordPrice (Transaction *trans);
+
+
 #define RECONCILED_MATCH_TYPE	"reconciled-match"
 
 /** \deprecated */

--- a/libgnucash/engine/Transaction.h
+++ b/libgnucash/engine/Transaction.h
@@ -770,6 +770,9 @@ void xaccTransDump (const Transaction *trans, const char *tag);
 
 /** The xaccTransRecordPrice() method iterates through the splits and
  *  and record the non-currency equivalent prices in the price database.
+ *
+ *  @param trans The transaction whose price is recorded
+ *  @param source The price priority level
  */
 void xaccTransRecordPrice (Transaction *trans, PriceSource source);
 

--- a/libgnucash/engine/gnc-pricedb.c
+++ b/libgnucash/engine/gnc-pricedb.c
@@ -124,6 +124,7 @@ static const char* source_names[(size_t)PRICE_SOURCE_INVALID + 1] =
     /* String retained for backwards compatibility. */
     "user:xfer-dialog",
     "user:split-register",
+    "user:split-import",
     "user:stock-split",
     "user:invoice-post", /* Retained for backwards compatibility */
     "temporary",

--- a/libgnucash/engine/gnc-pricedb.h
+++ b/libgnucash/engine/gnc-pricedb.h
@@ -173,6 +173,7 @@ typedef enum
     PRICE_SOURCE_USER_PRICE,       // "user:price"
     PRICE_SOURCE_XFER_DLG_VAL,     // "user:xfer-dialog"
     PRICE_SOURCE_SPLIT_REG,        // "user:split-register"
+    PRICE_SOURCE_SPLIT_IMPORT,     // "user:split-import"
     PRICE_SOURCE_STOCK_SPLIT,      // "user:stock-split"
     PRICE_SOURCE_INVOICE,          // "user:invoice-post"
     PRICE_SOURCE_TEMP,             // "temporary"

--- a/libgnucash/engine/mocks/gmock-Transaction.cpp
+++ b/libgnucash/engine/mocks/gmock-Transaction.cpp
@@ -144,3 +144,10 @@ xaccTransDestroy (Transaction *trans)
     ASSERT_TRUE(GNC_IS_MOCKTRANSACTION(trans));
     gnc_mocktransaction(trans)->destroy();
 }
+
+void
+xaccTransRecordPrice (Transaction *trans)
+{
+    g_return_if_fail(GNC_IS_MOCKTRANSACTION(trans));
+    ((MockTransaction*)trans)->recordPrice();
+}

--- a/libgnucash/engine/mocks/gmock-Transaction.cpp
+++ b/libgnucash/engine/mocks/gmock-Transaction.cpp
@@ -146,7 +146,7 @@ xaccTransDestroy (Transaction *trans)
 }
 
 void
-xaccTransRecordPrice (Transaction *trans)
+xaccTransRecordPrice (Transaction *trans, PriceSource source)
 {
     g_return_if_fail(GNC_IS_MOCKTRANSACTION(trans));
     ((MockTransaction*)trans)->recordPrice();

--- a/libgnucash/engine/mocks/gmock-Transaction.h
+++ b/libgnucash/engine/mocks/gmock-Transaction.h
@@ -66,6 +66,7 @@ public:
     MOCK_CONST_METHOD0(get_num, const char *());
     MOCK_CONST_METHOD0(is_open, gboolean());
     MOCK_METHOD0(destroy, void());
+    MOCK_METHOD0(recordPrice, void());
 
 protected:
     // Protect destructor to avoid MockTransaction objects to be created on stack. MockTransaction


### PR DESCRIPTION
When a transaction is added from the ledger, price database is updated properly.
But if the transaction is imported, there is no price db update.

This change adds the proper pricedb update in the import path (qfx/ofx/qif).
Tested with make check