### PR TITLE
Several optimisations

### DIFF
--- a/gnucash/gnome-utils/gnc-recurrence.c
+++ b/gnucash/gnome-utils/gnc-recurrence.c
@@ -517,20 +517,15 @@ GList *
 gnc_recurrence_comp_get_list(GncRecurrenceComp *grc)
 {
     GList *rlist = NULL, *children;
-    gint i;
-
 
     children = gtk_container_get_children(GTK_CONTAINER(grc->vbox));
-    for (i = 0; i < g_list_length(children); i++)
+    for (GList *n = children; n; n = n->next)
     {
-        GncRecurrence *gr;
-        const Recurrence *r;
-        gr = GNC_RECURRENCE(g_list_nth_data(children, i));
-        r = gnc_recurrence_get(gr);
-        rlist = g_list_append(rlist, (gpointer)r);
+        const Recurrence *r = gnc_recurrence_get (GNC_RECURRENCE (n->data));
+        rlist = g_list_prepend (rlist, (gpointer)r);
     }
     g_list_free(children);
-    return rlist;
+    return g_list_reverse (rlist);
 }
 
 

--- a/gnucash/gnome-utils/gnc-sx-instance-dense-cal-adapter.c
+++ b/gnucash/gnome-utils/gnc-sx-instance-dense-cal-adapter.c
@@ -192,11 +192,10 @@ gsidca_get_contained(GncDenseCalModel *model)
     {
         GncSxInstances *sx_instances = (GncSxInstances*)sxes->data;
         if (xaccSchedXactionGetEnabled(sx_instances->sx))
-        {
-            list = g_list_append(list, GUINT_TO_POINTER(GPOINTER_TO_UINT(sx_instances->sx)));
-        }
+            list = g_list_prepend (list, GUINT_TO_POINTER
+                                   (GPOINTER_TO_UINT (sx_instances->sx)));
     }
-    return list;
+    return g_list_reverse (list);
 }
 
 static gchar*

--- a/gnucash/gnome-utils/gnc-tree-model-split-reg.c
+++ b/gnucash/gnome-utils/gnc-tree-model-split-reg.c
@@ -638,7 +638,7 @@ gnc_tree_model_split_reg_load (GncTreeModelSplitReg *model, GList *slist, Accoun
 
     model->number_of_trans_in_full_tlist = g_list_length (priv->full_tlist);
 
-    if (g_list_length (priv->full_tlist) < NUM_OF_TRANS*3)
+    if (model->number_of_trans_in_full_tlist < NUM_OF_TRANS*3)
     {
         // Copy the full_tlist to tlist
         priv->tlist = g_list_copy (priv->full_tlist);
@@ -647,8 +647,11 @@ gnc_tree_model_split_reg_load (GncTreeModelSplitReg *model, GList *slist, Accoun
     {
         if (model->position_of_trans_in_full_tlist < (NUM_OF_TRANS*3))
             gtm_sr_reg_load (model, VIEW_HOME, NUM_OF_TRANS*3);
-        else if (model->position_of_trans_in_full_tlist > g_list_length (priv->full_tlist) - (NUM_OF_TRANS*3))
+
+        else if (model->position_of_trans_in_full_tlist >
+                 model->number_of_trans_in_full_tlist - (NUM_OF_TRANS*3))
             gtm_sr_reg_load (model, VIEW_END, NUM_OF_TRANS*3);
+
         else
             gtm_sr_reg_load (model, VIEW_GOTO, model->position_of_trans_in_full_tlist);
     }

--- a/gnucash/gnome-utils/gnc-tree-model-split-reg.c
+++ b/gnucash/gnome-utils/gnc-tree-model-split-reg.c
@@ -624,25 +624,14 @@ gnc_tree_model_split_reg_load (GncTreeModelSplitReg *model, GList *slist, Accoun
     if (model->current_trans == NULL)
         model->current_trans = priv->btrans;
 
+    /* Get a list of Unique Transactions from an slist */
+    priv->full_tlist = xaccSplitListGetUniqueTransactionsReversed (slist);
+
+    /* Add the blank transaction to the full_tlist */
+    priv->full_tlist = g_list_prepend (priv->full_tlist, priv->btrans);
+
     if (model->sort_direction == GTK_SORT_ASCENDING)
-    {
-        /* Get a list of Unique Transactions from an slist */
-        priv->full_tlist = xaccSplitListGetUniqueTransactions (slist);
-
-        /* Add the blank transaction to the full_tlist */
-        priv->full_tlist = g_list_append (priv->full_tlist, priv->btrans);
-    }
-    else
-    {
-        /* Get a list of Unique Transactions from an slist */
-        priv->full_tlist = xaccSplitListGetUniqueTransactions (slist);
-
-        /* Add the blank transaction to the full_tlist */
-        priv->full_tlist = g_list_append (priv->full_tlist, priv->btrans);
-
-        /* Reverse the full_tlist */
         priv->full_tlist = g_list_reverse (priv->full_tlist);
-    }
 
     // Update the scrollbar
     gnc_tree_model_split_reg_sync_scrollbar (model);

--- a/gnucash/gnome-utils/gnc-tree-view-account.c
+++ b/gnucash/gnome-utils/gnc-tree-view-account.c
@@ -1557,7 +1557,7 @@ get_selected_accounts_helper (GtkTreeModel *s_model,
     /* Only selected if it passes the filter */
     if (gtvsi->priv->filter_fn == NULL || gtvsi->priv->filter_fn(account, gtvsi->priv->filter_data))
     {
-        gtvsi->return_list = g_list_append(gtvsi->return_list, account);
+        gtvsi->return_list = g_list_prepend (gtvsi->return_list, account);
     }
 }
 
@@ -1580,6 +1580,7 @@ gnc_tree_view_account_get_selected_accounts (GncTreeViewAccount *view)
     info.priv = GNC_TREE_VIEW_ACCOUNT_GET_PRIVATE(view);
     selection = gtk_tree_view_get_selection (GTK_TREE_VIEW(view));
     gtk_tree_selection_selected_foreach(selection, get_selected_accounts_helper, &info);
+    info.return_list = g_list_reverse (info.return_list);
     return info.return_list;
 }
 

--- a/gnucash/gnome-utils/window-main-summarybar.c
+++ b/gnucash/gnome-utils/window-main-summarybar.c
@@ -432,14 +432,7 @@ gnc_main_window_summary_refresh (GNCMainSummary * summary)
         gtk_combo_box_set_active(GTK_COMBO_BOX(summary->totals_combo), 0);
     }
 
-    /* Free the list we created for this */
-    for (current = g_list_first(currency_list);
-            current;
-            current = g_list_next(current))
-    {
-        g_free(current->data);
-    }
-    g_list_free(currency_list);
+    g_list_free_full (currency_list, g_free);
 }
 
 static gchar*

--- a/gnucash/gnome/assistant-loan.cpp
+++ b/gnucash/gnome/assistant-loan.cpp
@@ -3014,13 +3014,15 @@ loan_create_sxes( LoanAssistantData *ldd )
             g_string_free( gstr, TRUE );
             gstr = NULL;
 
-            repaySXes = g_list_append( repaySXes, tcSX );
+            repaySXes = g_list_prepend (repaySXes, tcSX);
 
         }
 
         /* repayment */
         ld_setup_repayment_sx( ldd, rod, paymentSX, tcSX );
     }
+
+    repaySXes = g_list_reverse (repaySXes);
     /* Create the SXes */
     {
         GList *l;

--- a/gnucash/gnome/dialog-imap-editor.c
+++ b/gnucash/gnome/dialog-imap-editor.c
@@ -308,7 +308,7 @@ find_invalid_mappings (GtkTreeModel *model, GtkTreePath *path,
         if (((g_strcmp0 (head, "online_id") == 0) && (depth == 1)) || (depth == 2))
         {
              GtkTreeRowReference *rowref = gtk_tree_row_reference_new (model, path);
-             *rowref_list = g_list_append (*rowref_list, rowref);
+             *rowref_list = g_list_prepend (*rowref_list, rowref);
         }
     }
     g_free (head);
@@ -324,9 +324,6 @@ gnc_imap_remove_invalid_maps (ImapDialog *imap_dialog)
     gtk_tree_model_foreach (imap_dialog->model,
                             (GtkTreeModelForeachFunc)find_invalid_mappings,
                             &rr_list);
-
-    // reverse the reference list
-    rr_list = g_list_reverse (rr_list);
 
     // Suspend GUI refreshing
     gnc_suspend_gui_refresh();

--- a/gnucash/gnome/dialog-lot-viewer.c
+++ b/gnucash/gnome/dialog-lot-viewer.c
@@ -228,12 +228,12 @@ lv_show_splits_free (GNCLotViewer *lv)
         Split *split = node->data;
         if (NULL == xaccSplitGetLot(split))
         {
-            filtered_list = g_list_append(filtered_list, split);
+            filtered_list = g_list_prepend (filtered_list, split);
         }
     }
 
     /* display list */
-    gnc_split_viewer_fill(lv, lv->split_free_store, filtered_list);
+    gnc_split_viewer_fill(lv, lv->split_free_store, g_list_reverse (filtered_list));
 }
 
 /* ======================================================================== */

--- a/gnucash/gnome/dialog-lot-viewer.c
+++ b/gnucash/gnome/dialog-lot-viewer.c
@@ -234,6 +234,7 @@ lv_show_splits_free (GNCLotViewer *lv)
 
     /* display list */
     gnc_split_viewer_fill(lv, lv->split_free_store, g_list_reverse (filtered_list));
+    g_list_free (filtered_list);
 }
 
 /* ======================================================================== */

--- a/gnucash/gnome/gnc-budget-view.c
+++ b/gnucash/gnome/gnc-budget-view.c
@@ -1629,7 +1629,7 @@ gnc_budget_view_refresh (GncBudgetView *budget_view)
         if (col != NULL)
         {
             gtk_tree_view_append_column (priv->totals_tree_view, col);
-            totals_col_list = g_list_append (totals_col_list, col);
+            totals_col_list = g_list_prepend (totals_col_list, col);
         }
 
         num_periods_visible = g_list_length (col_list);
@@ -1639,7 +1639,7 @@ gnc_budget_view_refresh (GncBudgetView *budget_view)
     gdk_rgba_free (note_color_selected);
 
     priv->period_col_list = col_list;
-    priv->totals_col_list = totals_col_list;
+    priv->totals_col_list = g_list_reverse (totals_col_list);
 
     if (priv->total_col == NULL)
     {

--- a/gnucash/gnome/gnc-plugin-page-register.c
+++ b/gnucash/gnome/gnc-plugin-page-register.c
@@ -3722,7 +3722,7 @@ gnc_plugin_page_register_cmd_print_check (GtkAction* action,
         {
             if (xaccSplitGetAccount (split) == account)
             {
-                splits = g_list_append (splits, split);
+                splits = g_list_prepend (splits, split);
                 gnc_ui_print_check_dialog_create (window, splits);
                 g_list_free (splits);
             }
@@ -3733,7 +3733,7 @@ gnc_plugin_page_register_cmd_print_check (GtkAction* action,
                 split = gnc_split_register_get_current_trans_split (reg, NULL);
                 if (split)
                 {
-                    splits = g_list_append (splits, split);
+                    splits = g_list_prepend (splits, split);
                     gnc_ui_print_check_dialog_create (window, splits);
                     g_list_free (splits);
                 }
@@ -5349,18 +5349,19 @@ gppr_account_destroy_cb (Account* account)
         ledger_type = gnc_ledger_display_type (priv->ledger);
         if (ledger_type == LD_GL)
         {
-            kill = g_list_append (kill, page);
+            kill = g_list_prepend (kill, page);
             /* kill it */
         }
         else if ((ledger_type == LD_SINGLE) || (ledger_type == LD_SUBACCOUNT))
         {
             if (guid_compare (acct_guid, &priv->key) == 0)
             {
-                kill = g_list_append (kill, page);
+                kill = g_list_prepend (kill, page);
             }
         }
     }
 
+    kill = g_list_reverse (kill);
     /* Now kill them. */
     for (item = kill; item; item = g_list_next (item))
     {

--- a/gnucash/gnome/gnc-plugin-page-register.c
+++ b/gnucash/gnome/gnc-plugin-page-register.c
@@ -3785,6 +3785,7 @@ gnc_plugin_page_register_cmd_print_check (GtkAction* action,
             }
         }
         gnc_ui_print_check_dialog_create (window, splits);
+        g_list_free (splits);
     }
     else
     {
@@ -5368,6 +5369,7 @@ gppr_account_destroy_cb (Account* account)
         page = (GncPluginPageRegister*)item->data;
         gnc_main_window_close_page (GNC_PLUGIN_PAGE (page));
     }
+    g_list_free (kill);
 }
 
 /** This function is the handler for all event messages from the

--- a/gnucash/gnome/gnc-plugin-page-register2.c
+++ b/gnucash/gnome/gnc-plugin-page-register2.c
@@ -2614,7 +2614,7 @@ gnc_plugin_page_register2_cmd_print_check (GtkAction *action,
         {
             if (xaccSplitGetAccount(split) == account)
             {
-                splits = g_list_append(splits, split);
+                splits = g_list_prepend (splits, split);
                 gnc_ui_print_check_dialog_create (window, splits);
                 g_list_free(splits);
             }
@@ -2625,7 +2625,7 @@ gnc_plugin_page_register2_cmd_print_check (GtkAction *action,
                 split = gnc_tree_model_split_reg_trans_get_split_equal_to_ancestor(trans, account);
                 if (split)
                 {
-                    splits = g_list_append(splits, split);
+                    splits = g_list_prepend (splits, split);
                     gnc_ui_print_check_dialog_create (window, splits);
                     g_list_free(splits);
                 }
@@ -4008,18 +4008,19 @@ gppr_account_destroy_cb (Account *account)
         ledger_type = gnc_ledger_display2_type (priv->ledger);
         if (ledger_type == LD2_GL)
         {
-            kill = g_list_append(kill, page);
+            kill = g_list_prepend (kill, page);
             /* kill it */
         }
         else if ((ledger_type == LD2_SINGLE) || (ledger_type == LD2_SUBACCOUNT))
         {
             if (guid_compare(acct_guid, &priv->key) == 0)
             {
-                kill = g_list_append(kill, page);
+                kill = g_list_prepend (kill, page);
             }
         }
     }
 
+    kill = g_list_reverse (kill);
     /* Now kill them. */
     for (item = kill; item; item = g_list_next(item))
     {

--- a/gnucash/gnome/gnc-plugin-page-register2.c
+++ b/gnucash/gnome/gnc-plugin-page-register2.c
@@ -2677,6 +2677,7 @@ gnc_plugin_page_register2_cmd_print_check (GtkAction *action,
             }
         }
         gnc_ui_print_check_dialog_create (window, splits);
+        g_list_free (splits);
     }
     else
     {
@@ -4027,6 +4028,7 @@ gppr_account_destroy_cb (Account *account)
         page = (GncPluginPageRegister2 *)item->data;
         gnc_main_window_close_page(GNC_PLUGIN_PAGE(page));
     }
+    g_list_free (kill);
 }
 
 /** This function is the handler for all event messages from the

--- a/libgnucash/app-utils/gnc-sx-instance-model.c
+++ b/libgnucash/app-utils/gnc-sx-instance-model.c
@@ -522,9 +522,10 @@ gnc_sx_get_instances(const GDate *range_end, gboolean include_disabled)
             SchedXaction *sx = (SchedXaction*)sx_iter->data;
             if (xaccSchedXactionGetEnabled(sx))
             {
-                enabled_sxes = g_list_append(enabled_sxes, sx);
+                enabled_sxes = g_list_prepend (enabled_sxes, sx);
             }
         }
+        enabled_sxes = g_list_reverse (enabled_sxes);
         instances->sx_instance_list = gnc_g_list_map(enabled_sxes, (GncGMapFunc)_gnc_sx_gen_instances, (gpointer)range_end);
         g_list_free(enabled_sxes);
     }

--- a/libgnucash/core-utils/gnc-glib-utils.c
+++ b/libgnucash/core-utils/gnc-glib-utils.c
@@ -265,9 +265,9 @@ gnc_g_list_map(GList* list, GncGMapFunc fn, gpointer user_data)
     GList *rtn = NULL;
     for (; list != NULL; list = list->next)
     {
-        rtn = g_list_append(rtn, (*fn)(list->data, user_data));
+        rtn = g_list_prepend (rtn, (*fn)(list->data, user_data));
     }
-    return rtn;
+    return g_list_reverse (rtn);
 }
 
 void

--- a/libgnucash/engine/SX-book.c
+++ b/libgnucash/engine/SX-book.c
@@ -380,12 +380,12 @@ gnc_sx_get_sxes_referencing_account(QofBook *book, Account *acct)
             GncGUID *guid = NULL;
             qof_instance_get (QOF_INSTANCE (s), "sx-account", &guid, NULL);
             if (guid_equal(acct_guid, guid))
-                rtn = g_list_append(rtn, sx);
+                rtn = g_list_prepend (rtn, sx);
 
             guid_free (guid);
         }
     }
-    return rtn;
+    return g_list_reverse (rtn);
 }
 
 /* ========================== END OF FILE =============================== */

--- a/libgnucash/engine/ScrubBusiness.c
+++ b/libgnucash/engine/ScrubBusiness.c
@@ -400,9 +400,10 @@ gncScrubLotDanglingPayments (GNCLot *lot)
         if (gnc_numeric_compare (gnc_numeric_abs (free_val), gnc_numeric_abs (ll_val)) > 0)
             continue;
 
-        filtered_list = g_list_append(filtered_list, free_split);
+        filtered_list = g_list_prepend (filtered_list, free_split);
     }
 
+    filtered_list = g_list_reverse (filtered_list);
     match_list = gncSLFindOffsSplits (filtered_list, ll_val);
     g_list_free (filtered_list);
 

--- a/libgnucash/engine/Split.c
+++ b/libgnucash/engine/Split.c
@@ -893,21 +893,32 @@ xaccSplitEqual(const Split *sa, const Split *sb,
  * xaccSplitListGetUniqueTransactions
  ********************************************************************/
 GList *
-xaccSplitListGetUniqueTransactions(const GList *splits)
+xaccSplitListGetUniqueTransactionsReversed (const GList *splits)
 {
-    const GList *snode;
+    GHashTable *txn_hash = g_hash_table_new (NULL, NULL);
     GList *transList = NULL;
+    const GList *snode;
 
-    for(snode = splits; snode; snode = snode->next)
+    for (snode = splits; snode; snode = snode->next)
     {
         Transaction *trans = xaccSplitGetParent((Split *)(snode->data));
 
-        GList *item = g_list_find (transList, trans);
-        if (item == NULL)
-            transList = g_list_append (transList, trans);
+        if (g_hash_table_contains (txn_hash, trans))
+            continue;
+
+        g_hash_table_insert (txn_hash, trans, NULL);
+        transList = g_list_prepend (transList, trans);
     }
+    g_hash_table_destroy (txn_hash);
     return transList;
 }
+
+GList *
+xaccSplitListGetUniqueTransactions(const GList *splits)
+{
+    return g_list_reverse (xaccSplitListGetUniqueTransactionsReversed (splits));
+}
+
 /*################## Added for Reg2 #################*/
 
 

--- a/libgnucash/engine/Split.h
+++ b/libgnucash/engine/Split.h
@@ -359,6 +359,7 @@ Split      * xaccSplitLookup (const GncGUID *guid, QofBook *book);
 
 /*################## Added for Reg2 #################*/
 /* Get a GList of unique transactions containing the given list of Splits. */
+GList *xaccSplitListGetUniqueTransactionsReversed (const GList *splits);
 GList *xaccSplitListGetUniqueTransactions(const GList *splits);
 /*################## Added for Reg2 #################*/
 /** Add a peer split to this split's lot-split list.

--- a/libgnucash/engine/Transaction.c
+++ b/libgnucash/engine/Transaction.c
@@ -569,7 +569,7 @@ xaccTransSortSplits (Transaction *trans)
         split = node->data;
         if (gnc_numeric_negative_p (xaccSplitGetValue(split)))
             continue;
-        new_list = g_list_append(new_list, split);
+        new_list = g_list_prepend (new_list, split);
     }
 
     /* then credits */
@@ -578,12 +578,12 @@ xaccTransSortSplits (Transaction *trans)
         split = node->data;
         if (!gnc_numeric_negative_p (xaccSplitGetValue(split)))
             continue;
-        new_list = g_list_append(new_list, split);
+        new_list = g_list_prepend (new_list, split);
     }
 
     /* install newly sorted list */
     g_list_free(trans->splits);
-    trans->splits = new_list;
+    trans->splits = g_list_reverse (new_list);
 }
 
 

--- a/libgnucash/engine/gncCustomer.c
+++ b/libgnucash/engine/gncCustomer.c
@@ -705,9 +705,9 @@ GList * gncCustomerGetJoblist (const GncCustomer *cust, gboolean show_all)
         {
             GncJob *j = iterator->data;
             if (gncJobGetActive (j))
-                list = g_list_append (list, j);
+                list = g_list_prepend (list, j);
         }
-        return list;
+        return g_list_reverse (list);
     }
 }
 


### PR DESCRIPTION
* mainly prepend&reverse instead of appending lists.
* introduces `xaccSplitListGetUniqueTransactionsReversed` -- assists in buildling splitlist, seems only used for Register2. This commit removes O(N^2) which should speed it up.