### PR TITLE
From Budget editor, add toolbar and Edit menu to run budget report

### DIFF
--- a/gnucash/gnome/gnc-plugin-page-budget.c
+++ b/gnucash/gnome/gnc-plugin-page-budget.c
@@ -263,7 +263,9 @@ typedef struct GncPluginPageBudgetPrivate
     gnc_numeric allValue;
     allperiods_action action;
 
-    /* the cached reportPage for this budget */
+    /* the cached reportPage for this budget. note this is not saved
+       into .gcm file therefore the budget editor->report link is lost
+       upon restart. */
     GncPluginPage *reportPage;
 } GncPluginPageBudgetPrivate;
 
@@ -1284,6 +1286,12 @@ gnc_plugin_page_budget_cmd_budget_note(GtkAction *action,
     g_object_unref(G_OBJECT(builder));
 }
 
+/* From the budget editor, open the budget report. This will reuse the
+   budget report if generated from the current budget editor. Note the
+   reuse is lost when GnuCash is restarted. This link may be restored
+   by: scan the current session tabs, identify reports, checking
+   whereby report's report-type matches a budget report, and the
+   report's budget option value matches the current budget. */
 static void
 gnc_plugin_page_budget_cmd_budget_report (GtkAction *action,
                                           GncPluginPageBudget *page)

--- a/gnucash/gnome/gnc-plugin-page-budget.c
+++ b/gnucash/gnome/gnc-plugin-page-budget.c
@@ -42,7 +42,11 @@
 #include <glib/gi18n.h>
 #include "gnc-date-edit.h"
 
+#include "swig-runtime.h"
+#include "libguile.h"
+
 #include "gnc-plugin-page-register.h"
+#include "gnc-plugin-page-report.h"
 #include "gnc-budget.h"
 #include "gnc-features.h"
 
@@ -127,6 +131,8 @@ static void gnc_plugin_page_budget_cmd_refresh (GtkAction *action,
                                                 GncPluginPageBudget *page);
 static void gnc_plugin_page_budget_cmd_budget_note (GtkAction *action,
                                                     GncPluginPageBudget *page);
+static void gnc_plugin_page_budget_cmd_budget_report (GtkAction *action,
+                                                      GncPluginPageBudget *page);
 static void allperiods_budget_helper (GtkTreeModel *model, GtkTreePath *path,
                                       GtkTreeIter *iter, gpointer data);
 
@@ -177,6 +183,12 @@ static GtkActionEntry gnc_plugin_page_budget_actions [] =
         N_("Edit note for the selected account and period"),
         G_CALLBACK (gnc_plugin_page_budget_cmd_budget_note)
     },
+    {
+        "BudgetReportAction", "system-run", N_("Budget Report"),
+        NULL,
+        N_("Run budget report"),
+        G_CALLBACK (gnc_plugin_page_budget_cmd_budget_report)
+    },
     /* View menu */
     {
         "ViewFilterByAction", NULL, N_("_Filter By..."), NULL, NULL,
@@ -211,6 +223,7 @@ static action_toolbar_labels toolbar_labels[] =
     { "EstimateBudgetAction",       N_("Estimate") },
     { "AllPeriodsBudgetAction",     N_("All Periods") },
     { "BudgetNoteAction",           N_("Note") },
+    { "BudgetReportAction",         N_("Run Report") },
     { NULL, NULL },
 };
 
@@ -250,6 +263,8 @@ typedef struct GncPluginPageBudgetPrivate
     gnc_numeric allValue;
     allperiods_action action;
 
+    /* the cached reportPage for this budget */
+    GncPluginPage *reportPage;
 } GncPluginPageBudgetPrivate;
 
 G_DEFINE_TYPE_WITH_PRIVATE(GncPluginPageBudget, gnc_plugin_page_budget, GNC_TYPE_PLUGIN_PAGE)
@@ -289,6 +304,7 @@ gnc_plugin_page_budget_new (GncBudget *budget)
     priv->budget = budget;
     priv->delete_budget = FALSE;
     priv->key = *gnc_budget_get_guid (budget);
+    priv->reportPage = NULL;
     label = g_strdup_printf ("%s: %s", _("Budget"), gnc_budget_get_name (budget));
     g_object_set (G_OBJECT(plugin_page), "page-name", label, NULL);
     g_free (label);
@@ -1266,6 +1282,38 @@ gnc_plugin_page_budget_cmd_budget_note(GtkAction *action,
     }
     gtk_widget_destroy(dialog);
     g_object_unref(G_OBJECT(builder));
+}
+
+static void
+gnc_plugin_page_budget_cmd_budget_report (GtkAction *action,
+                                          GncPluginPageBudget *page)
+{
+    GncPluginPageBudgetPrivate *priv;
+
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_BUDGET (page));
+
+    priv = GNC_PLUGIN_PAGE_BUDGET_GET_PRIVATE (page);
+
+    if (priv->reportPage && GNC_IS_PLUGIN_PAGE (priv->reportPage))
+        gnc_plugin_page_report_reload (GNC_PLUGIN_PAGE_REPORT (priv->reportPage));
+    else
+    {
+        SCM func = scm_c_eval_string ("gnc:budget-report-create");
+        SCM arg = SWIG_NewPointerObj (priv->budget, SWIG_TypeQuery ("_p_budget_s"), 0);
+        int report_id;
+
+        g_return_if_fail (scm_is_procedure (func));
+
+        arg = scm_apply_0 (func, scm_list_1 (arg));
+        g_return_if_fail (scm_is_exact (arg));
+
+        report_id = scm_to_int (arg);
+        g_return_if_fail (report_id >= 0);
+
+        priv->reportPage = gnc_plugin_page_report_new (report_id);
+    }
+
+    gnc_main_window_open_page (GNC_MAIN_WINDOW (priv->dialog), priv->reportPage);
 }
 
 static void

--- a/gnucash/gnome/gnc-plugin-page-budget.c
+++ b/gnucash/gnome/gnc-plugin-page-budget.c
@@ -172,7 +172,7 @@ static GtkActionEntry gnc_plugin_page_budget_actions [] =
         G_CALLBACK(gnc_plugin_page_budget_cmd_allperiods_budget)
     },
     {
-        "BudgetNoteAction", "system-run", N_("Edit Note"),
+        "BudgetNoteAction", "text-x-generic", N_("Edit Note"),
         NULL,
         N_("Edit note for the selected account and period"),
         G_CALLBACK (gnc_plugin_page_budget_cmd_budget_note)

--- a/gnucash/gnome/gnc-plugin-page-report.c
+++ b/gnucash/gnome/gnc-plugin-page-report.c
@@ -1427,6 +1427,12 @@ gnc_plugin_page_report_back_cb( GtkAction *action, GncPluginPageReport *report )
     }
 }
 
+void
+gnc_plugin_page_report_reload (GncPluginPageReport *report)
+{
+    gnc_plugin_page_report_reload_cb (NULL, report);
+}
+
 static void
 gnc_plugin_page_report_reload_cb( GtkAction *action, GncPluginPageReport *report )
 {

--- a/gnucash/gnome/gnc-plugin-page-report.h
+++ b/gnucash/gnome/gnc-plugin-page-report.h
@@ -75,6 +75,8 @@ GType gnc_plugin_page_report_get_type( void );
  */
 GncPluginPage *gnc_plugin_page_report_new( int reportId );
 
+void gnc_plugin_page_report_reload (GncPluginPageReport *report);
+
 // entry-point from scm menu-extension callback [gnc:menu-extension].
 void       gnc_main_window_open_report (int report_id, GncMainWindow *window);
 // directly called through from above

--- a/gnucash/report/reports/reports.scm
+++ b/gnucash/report/reports/reports.scm
@@ -37,6 +37,7 @@
 (use-modules (gnucash reports standard new-aging))
 (use-modules (gnucash reports standard new-owner-report))
 
+(export gnc:budget-report-create)
 (export gnc:register-report-create)
 (export gnc:invoice-report-create)
 (export gnc:payables-report-create)
@@ -77,6 +78,15 @@
         ;; Invalid report-template-id, so let's return zero as an invalid report id.
         0
         ))
+
+(define budget-ID "810ed4b25ef0486ea43bbd3dddb32b11")
+(define (gnc:budget-report-create budget)
+  (if (gnc:find-report-template budget-ID)
+      (let* ((options (gnc:make-report-options budget-ID))
+             (bgt-op (gnc:lookup-option options gnc:pagename-general "Budget")))
+        (gnc:option-set-value bgt-op budget)
+        (gnc:make-report budget-ID options))
+      -1))
 
 (define gnc:payables-report-create payables-report-create-internal)
 (define gnc:receivables-report-create receivables-report-create-internal)

--- a/gnucash/ui/gnc-plugin-page-budget-ui.xml
+++ b/gnucash/ui/gnc-plugin-page-budget-ui.xml
@@ -6,6 +6,7 @@
         <menuitem name="AllPeriods" action="AllPeriodsBudgetAction"/>
         <menuitem name="Delete" action="DeleteBudgetAction"/>
         <menuitem name="Note" action="BudgetNoteAction"/>
+        <menuitem name="Report" action="BudgetReportAction"/>
       </placeholder>
       <menuitem name="Options" action="OptionsBudgetAction"/>
     </menu>
@@ -30,6 +31,7 @@
       <toolitem name="AllPeriods" action="AllPeriodsBudgetAction"/>
       <toolitem name="Delete" action="DeleteBudgetAction"/>
       <toolitem name="Note" action="BudgetNoteAction"/>
+      <toolitem name="Report" action="BudgetReportAction"/>
     </placeholder>
   </toolbar>
 </ui>


### PR DESCRIPTION
This parallels the invoice editor "Print Invoice" functionality. Runs the budget report using current budget.

![image](https://user-images.githubusercontent.com/1975870/110209317-b6f11300-7e83-11eb-93a2-dbb26e27d9bf.png)
