### PR TITLE
Replace g_memdup with g_memdup2

### DIFF
--- a/gnucash/register/register-gnome/gnucash-style.c
+++ b/gnucash/register/register-gnome/gnucash-style.c
@@ -60,7 +60,7 @@ style_create_key (SheetBlockStyle *style)
 
     key = style->cursor->num_rows;
 
-    return g_memdup(&key, sizeof(key));
+    return g_memdup2(&key, sizeof(key));
 }
 
 static void

--- a/libgnucash/app-utils/gnc-ui-balances.c
+++ b/libgnucash/app-utils/gnc-ui-balances.c
@@ -374,7 +374,7 @@ static void sack_foreach_func(gpointer key, gpointer value, gpointer user_data)
     gnc_numeric reachable_value = gnc_numeric_add_fixed (thisvalue, data->split_value);
 
     data->reachable_list = g_list_prepend
-        (data->reachable_list, g_memdup (&reachable_value, sizeof (gnc_numeric)));
+        (data->reachable_list, g_memdup2 (&reachable_value, sizeof (gnc_numeric)));
 }
 
 GList *
@@ -428,7 +428,7 @@ gnc_account_get_autoclear_splits (Account *account, gnc_numeric toclear_value,
 
         /* Add the value of the split itself to the reachable_list */
         s_data->reachable_list = g_list_prepend
-            (s_data->reachable_list, g_memdup (&split_value, sizeof (gnc_numeric)));
+            (s_data->reachable_list, g_memdup2 (&split_value, sizeof (gnc_numeric)));
 
         /* Add everything to the sack, looking out for duplicates */
         for (GList *s_node = s_data->reachable_list; s_node; s_node = s_node->next)

--- a/libgnucash/engine/SchedXaction.c
+++ b/libgnucash/engine/SchedXaction.c
@@ -1119,7 +1119,7 @@ SXTmpStateData*
 gnc_sx_clone_temporal_state (SXTmpStateData *tsd)
 {
     SXTmpStateData *toRet;
-    toRet = g_memdup (tsd, sizeof (SXTmpStateData));
+    toRet = g_memdup2 (tsd, sizeof (SXTmpStateData));
     return toRet;
 }
 


### PR DESCRIPTION
`g_memdup` has been deprecated and the recommendation from Gnome team is to port to `g_memdup2`. This PR does that.

I am merging to master as `g_memdup2` is in GLlib >= 2.67.3.
https://discourse.gnome.org/t/port-your-module-from-g-memdup-to-g-memdup2-now/5538