### PR TITLE
Replace g_memdup by memcpy

### DIFF
--- a/gnucash/register/register-gnome/gnucash-style.c
+++ b/gnucash/register/register-gnome/gnucash-style.c
@@ -57,10 +57,13 @@ static gpointer
 style_create_key (SheetBlockStyle *style)
 {
     static gint key;
+    gpointer new_key;
 
     key = style->cursor->num_rows;
+    new_key = g_malloc(sizeof(key));
+    new_key = memcpy(new_key, &key, sizeof(key));
 
-    return g_memdup(&key, sizeof(key));
+    return new_key;
 }
 
 static void

--- a/libgnucash/app-utils/gnc-ui-balances.c
+++ b/libgnucash/app-utils/gnc-ui-balances.c
@@ -372,9 +372,10 @@ static void sack_foreach_func(gpointer key, gpointer value, gpointer user_data)
     sack_foreach_data_t data = (sack_foreach_data_t) user_data;
     gnc_numeric thisvalue = *(gnc_numeric *) key;
     gnc_numeric reachable_value = gnc_numeric_add_fixed (thisvalue, data->split_value);
+    gpointer new_value = g_malloc(sizeof(gnc_numeric));
 
-    data->reachable_list = g_list_prepend
-        (data->reachable_list, g_memdup (&reachable_value, sizeof (gnc_numeric)));
+    memcpy(new_value, &reachable_value, sizeof(gnc_numeric));
+    data->reachable_list = g_list_prepend(data->reachable_list, new_value);
 }
 
 GList *
@@ -418,6 +419,7 @@ gnc_account_get_autoclear_splits (Account *account, gnc_numeric toclear_value,
     {
         Split *split = (Split *)node->data;
         gnc_numeric split_value = xaccSplitGetAmount (split);
+        gpointer new_value = g_malloc(sizeof(gnc_numeric));
 
         struct _sack_foreach_data_t s_data[1];
         s_data->split_value = split_value;
@@ -427,8 +429,9 @@ gnc_account_get_autoclear_splits (Account *account, gnc_numeric toclear_value,
         g_hash_table_foreach (sack, sack_foreach_func, s_data);
 
         /* Add the value of the split itself to the reachable_list */
+        memcpy(new_value, &split_value, sizeof(gnc_numeric));
         s_data->reachable_list = g_list_prepend
-            (s_data->reachable_list, g_memdup (&split_value, sizeof (gnc_numeric)));
+            (s_data->reachable_list, new_value);
 
         /* Add everything to the sack, looking out for duplicates */
         for (GList *s_node = s_data->reachable_list; s_node; s_node = s_node->next)

--- a/libgnucash/engine/SchedXaction.c
+++ b/libgnucash/engine/SchedXaction.c
@@ -1118,8 +1118,14 @@ gnc_sx_destroy_temporal_state (SXTmpStateData *tsd)
 SXTmpStateData*
 gnc_sx_clone_temporal_state (SXTmpStateData *tsd)
 {
-    SXTmpStateData *toRet;
-    toRet = g_memdup (tsd, sizeof (SXTmpStateData));
+    SXTmpStateData *toRet = NULL;
+
+    if(tsd)
+    {
+        toRet = g_malloc(sizeof(SXTmpStateData));
+        toRet = memcpy (toRet, tsd, sizeof (SXTmpStateData));
+    }
+
     return toRet;
 }
 


### PR DESCRIPTION
GLib is deprecating g_memdup. Since older versions of GLib wouldn't have g_memdup2, this PR replaces occurrences of g_memdup by memcpy.