### PR TITLE
Increase the maximum threshold for date mismatch

### DIFF
--- a/gnucash/import-export/import-backend.c
+++ b/gnucash/import-export/import-backend.c
@@ -58,8 +58,14 @@ static QofLogModule log_module = GNC_MOD_IMPORT;
  *   Constants, should ideally be defined a user preference dialog  *
 \********************************************************************/
 
-static const int MATCH_DATE_THRESHOLD = 4; /*within 4 days*/
-static const int MATCH_DATE_NOT_THRESHOLD = 14;
+/* If the date matches within 4 days, it's probably the same transaction */
+static const int MATCH_DATE_THRESHOLD = 4;
+
+/* If the date is apart of more than a month, it's very likely not the same
+ * transaction. Some credit card companies delay things by a month, so having
+ * less than a month here would cause issues with matching transactions for
+ * these users */
+static const int MATCH_DATE_NOT_THRESHOLD = 40;
 
 /********************************************************************\
  *   Forward declared prototypes                                    *


### PR DESCRIPTION
Some french banks (that issue credit cards) have OFX files that count
the transaction as dated of the 5 of the month that follows the actual
expense. This means that the date offset between the invoice (that is at
the date of the expense) and the OFX file can be up to around 30-35
days.

So without this change, “usual” scores for such transactions are:
  +3 for cent-accurate amount
  -5 for date that mismatches by more than the max threshold
  +1 when lucky for matching the description or memo
thus leading to a score of -1, which can literally never match, as the
setting for reducing the minimal score for matches can only go down to
zero. And thus OFX matching would be impossible with the window, without
duplicating the transactions and then manually doing the matching
manually.

The only alternative to making this change that I could see would be to
parse the actual date, which the bank OFX includes in the description
field, and to compare with this date. It would probably be a more
precise solution, but would I think be pretty awfully bank-specific,
which in turn makes it a probably bad idea.

-----

Note: I'm not sure whether to do this PR against maint or master… I'll probably be applying the patch to my local gnucash instance anyway, so I'm PRing against maint, but I'd be happy to retarget to master if you think that's the place such a change should happen!

Anyway, thank you for this awesome program, I started using it only recently but it's already being great :)