### PR TITLE
[dialog-invoice] invoice editor reuses invoice report tab

### DIFF
--- a/gnucash/gnome/dialog-invoice.c
+++ b/gnucash/gnome/dialog-invoice.c
@@ -70,6 +70,7 @@
 
 #include "gnc-plugin-business.h"
 #include "gnc-plugin-page-invoice.h"
+#include "gnc-plugin-page-report.h"
 #include "gnc-main-window.h"
 #include "gnc-state.h"
 
@@ -210,6 +211,11 @@ struct _invoice_window
 
     GncOwner     proj_cust;
     GncOwner     proj_job;
+
+    /* the cached reportPage for this invoice. note this is not saved
+       into .gcm file therefore the invoice editor->report link is lost
+       upon restart. */
+    GncPluginPage *reportPage;
 
     /* for Unposting */
     gboolean     reset_tax_tables;
@@ -781,13 +787,14 @@ gnc_invoice_window_blankCB (GtkWidget *widget, gpointer data)
     }
 }
 
-static void
+static GncPluginPage *
 gnc_invoice_window_print_invoice(GtkWindow *parent, GncInvoice *invoice)
 {
     SCM func, arg, arg2;
     SCM args = SCM_EOL;
     int report_id;
     const char *reportname = gnc_plugin_business_get_invoice_printreport();
+    GncPluginPage *reportPage = NULL;
 
     g_return_if_fail (invoice);
     if (!reportname)
@@ -808,13 +815,32 @@ gnc_invoice_window_print_invoice(GtkWindow *parent, GncInvoice *invoice)
 
     /* scm_gc_unprotect_object(func); */
     if (report_id >= 0)
-        reportWindow (report_id, parent);
+    {
+        reportPage = gnc_plugin_page_report_new (report_id);
+        gnc_main_window_open_page (GNC_MAIN_WINDOW (parent), reportPage);
+    }
+
+    return reportPage;
 }
+
+/* From the invoice editor, open the invoice report. This will reuse the
+   invoice report if generated from the current invoice editor. Note the
+   link is lost when GnuCash is restarted. This link may be restored
+   by: scan the current session tabs, identify reports, checking
+   whereby report's report-type matches an invoice report, and the
+   report's invoice option value matches the current invoice. */
 void
 gnc_invoice_window_printCB (GtkWindow* parent, gpointer data)
 {
     InvoiceWindow *iw = data;
-    gnc_invoice_window_print_invoice (parent, iw_get_invoice (iw));
+
+    if (iw->reportPage && GNC_IS_PLUGIN_PAGE (iw->reportPage))
+        gnc_plugin_page_report_reload (GNC_PLUGIN_PAGE_REPORT (iw->reportPage));
+    else
+        iw->reportPage = gnc_invoice_window_print_invoice
+            (parent, iw_get_invoice (iw));
+
+    gnc_main_window_open_page (GNC_MAIN_WINDOW (iw->dialog), iw->reportPage);
 }
 
 static gboolean
@@ -2895,6 +2921,7 @@ gnc_invoice_window_new_invoice (GtkWindow *parent, InvoiceDialogType dialog_type
                                       iw);
 
     /* Setup initial values */
+    iw->reportPage = NULL;
     iw->invoice_guid = *gncInvoiceGetGUID (invoice);
     iw->is_credit_note = gncInvoiceGetIsCreditNote (invoice);
 


### PR DESCRIPTION
Adds linkage from editor to report similar to #930.

Similar to 9f4ba17d8 -- from invoice editor, click Print Invoice to create invoice report. This saves link to invoice, and reuses the report tab if Print Invoice is clicked again.