### PR TITLE
remove debug information for time conversion

### DIFF
--- a/bindings/python/time64.i
+++ b/bindings/python/time64.i
@@ -109,8 +109,6 @@
         PyDateTime_IMPORT;
         struct tm t;
         gnc_localtime_r(&$1, &t);
-        printf("\nConverting %d hours and %d minutes in zone %ld %s to python local time\n",
-               t.tm_hour, t.tm_min, t.tm_gmtoff/3600, t.tm_isdst ? "DST" : "STD");
         $result = PyDateTime_FromDateAndTime(t.tm_year + 1900, t.tm_mon + 1,
                                              t.tm_mday, t.tm_hour, t.tm_min,
                                              t.tm_sec, 0);


### PR DESCRIPTION
After a recent commit (a11065b823f14fbc32bb1fc132304e36f486c8b0) the python bindings have become exceedingly chatty. I rather remove this debug info than trying to make it optional as it seems a bit too complicated to me to achieve this. I suppose this has been used only for the work on @jralls commit and removing it is ok, John?