### PR TITLE
Fix to_string_with_decimal_point_placed

### DIFF
--- a/bindings/python/example_scripts/export_account_totals.py
+++ b/bindings/python/example_scripts/export_account_totals.py
@@ -52,7 +52,7 @@ def to_string_with_decimal_point_placed(number: GncNumeric):
     if len(nominator) <= point_place:  # prepending zeros if the nominator is too short
         nominator = '0' * (point_place - len(nominator)) + nominator
 
-    return '.'.join([nominator[:-point_place - 1], nominator[-point_place:]])
+    return '.'.join([nominator[:-point_place], nominator[-point_place:]])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
>>> nominator='123456'
A digit is missing in the string returned from to_string_with_decimal_point_placed. The -1 error.
>>> point_place=2
>>> nominator[:-point_place - 1], nominator[-point_place:]
('123', '56')