### PR TITLE
Add two new preferences for import for PR #935

### DIFF
--- a/gnucash/gnome-utils/dialog-preferences.c
+++ b/gnucash/gnome-utils/dialog-preferences.c
@@ -1360,6 +1360,8 @@ gnc_preferences_dialog_create (GtkWindow *parent)
     gnc_builder_add_from_file (builder, "dialog-preferences.glade", "auto_add_adj");
     gnc_builder_add_from_file (builder, "dialog-preferences.glade", "auto_clear_adj");
     gnc_builder_add_from_file (builder, "dialog-preferences.glade", "match_adj");
+    gnc_builder_add_from_file (builder, "dialog-preferences.glade", "likely_day_threshold");
+    gnc_builder_add_from_file (builder, "dialog-preferences.glade", "unlikely_day_threshold");
     gnc_builder_add_from_file (builder, "dialog-preferences.glade", "gnucash_preferences_dialog");
 
     dialog = GTK_WIDGET(gtk_builder_get_object (builder, "gnucash_preferences_dialog"));

--- a/gnucash/gschemas/org.gnucash.dialogs.import.generic.gschema.xml.in
+++ b/gnucash/gschemas/org.gnucash.dialogs.import.generic.gschema.xml.in
@@ -20,6 +20,16 @@
       <summary>Minimum score to be displayed</summary>
       <description>This field specifies the minimum matching score a potential matching transaction must have to be displayed in the match list.</description>
     </key>
+    <key name="match-date-threshold" type="d">
+      <default>4.0</default>
+      <summary>Likely matching transaction within these days</summary>
+      <description>This field specifies the maximum number of days a transaction is likely to be a match in the list.</description>
+    </key>
+    <key name="match-date-not-threshold" type="d">
+      <default>14.0</default>
+      <summary>UnLikely matching a transaction outside of these days</summary>
+      <description>This field specifies the minimum number of days a transaction is unlikely to be a match in the list.</description>
+    </key>
     <key name="auto-add-threshold" type="d">
       <default>3.0</default>
       <summary>Add matching transactions below this score</summary>

--- a/gnucash/gtkbuilder/dialog-preferences.glade
+++ b/gnucash/gtkbuilder/dialog-preferences.glade
@@ -82,6 +82,13 @@
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>
+  <object class="GtkAdjustment" id="likely_day_threshold">
+    <property name="lower">1</property>
+    <property name="upper">30</property>
+    <property name="value">4</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
   <object class="GtkAdjustment" id="match_adj">
     <property name="upper">6</property>
     <property name="step_increment">1</property>
@@ -232,6 +239,13 @@ Press 'Close' to return to the preference window
     <property name="lower">1</property>
     <property name="upper">100</property>
     <property name="value">30</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="unlikely_day_threshold">
+    <property name="lower">1</property>
+    <property name="upper">50</property>
+    <property name="value">14</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>
@@ -2107,7 +2121,7 @@ many months before the current month</property>
                   </object>
                   <packing>
                     <property name="left_attach">1</property>
-                    <property name="top_attach">7</property>
+                    <property name="top_attach">9</property>
                   </packing>
                 </child>
                 <child>
@@ -2187,7 +2201,7 @@ many months before the current month</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">7</property>
+                    <property name="top_attach">9</property>
                   </packing>
                 </child>
                 <child>
@@ -2265,8 +2279,78 @@ many months before the current month</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">8</property>
+                    <property name="top_attach">10</property>
                     <property name="width">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label26">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes" comments="Preferences-&gt;Online Banking:Generic">Likely match _day threshold</property>
+                    <property name="use_underline">True</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">7</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label27">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes" comments="Preferences-&gt;Online Banking:Generic">_Unlikely match day threshold</property>
+                    <property name="use_underline">True</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">8</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="pref/dialogs.import.generic/match-date-threshold">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="has_tooltip">True</property>
+                    <property name="tooltip_markup">A transaction whose date is within the threshold is likely to be a match. Default is 4 days.</property>
+                    <property name="tooltip_text" translatable="yes">A transaction whose date is within the threshold is likely to be a match. Default is 4 days.</property>
+                    <property name="invisible_char">●</property>
+                    <property name="text">6</property>
+                    <property name="primary_icon_activatable">False</property>
+                    <property name="secondary_icon_activatable">False</property>
+                    <property name="adjustment">likely_day_threshold</property>
+                    <property name="climb_rate">1</property>
+                    <property name="snap_to_ticks">True</property>
+                    <property name="numeric">True</property>
+                    <property name="value">4</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">7</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="pref/dialogs.import.generic/match-date-not-threshold">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="has_tooltip">True</property>
+                    <property name="tooltip_markup">A transaction whose date is outside the threshold is unlikely to be a match. Default is 14 days.</property>
+                    <property name="tooltip_text" translatable="yes">A transaction whose date is outside the threshold is unlikely to be a match. Default is 14 days.</property>
+                    <property name="invisible_char">●</property>
+                    <property name="text">6</property>
+                    <property name="primary_icon_activatable">False</property>
+                    <property name="secondary_icon_activatable">False</property>
+                    <property name="adjustment">unlikely_day_threshold</property>
+                    <property name="climb_rate">1</property>
+                    <property name="snap_to_ticks">True</property>
+                    <property name="numeric">True</property>
+                    <property name="value">14</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">8</property>
                   </packing>
                 </child>
               </object>

--- a/gnucash/import-export/import-backend.c
+++ b/gnucash/import-export/import-backend.c
@@ -46,20 +46,13 @@
 
 #define GNCIMPORT_DESC    "desc"
 #define GNCIMPORT_MEMO    "memo"
-#define GNCIMPORT_PAYEE    "payee"
+#define GNCIMPORT_PAYEE   "payee"
 
 /********************************************************************\
  *   Constants                                                      *
 \********************************************************************/
 
 static QofLogModule log_module = GNC_MOD_IMPORT;
-
-/********************************************************************\
- *   Constants, should ideally be defined a user preference dialog  *
-\********************************************************************/
-
-static const int MATCH_DATE_THRESHOLD = 4; /*within 4 days*/
-static const int MATCH_DATE_NOT_THRESHOLD = 14;
 
 /********************************************************************\
  *   Forward declared prototypes                                    *
@@ -622,6 +615,8 @@ matchmap_store_destination (GncImportMatchMap *matchmap,
 void split_find_match (GNCImportTransInfo * trans_info,
                               Split * split,
                               gint display_threshold,
+                              gint date_threshold,
+                              gint date_not_threshold,
                               double fuzzy_amount_difference)
 {
     /* DEBUG("Begin"); */
@@ -691,12 +686,12 @@ void split_find_match (GNCImportTransInfo * trans_info,
             prob = prob + 3;
             /*DEBUG("heuristics:  probability + 3 (date)");*/
         }
-        else if (datediff_day <= MATCH_DATE_THRESHOLD)
+        else if (datediff_day <= date_threshold)
         {
             prob = prob + 2;
             /*DEBUG("heuristics:  probability + 2 (date)");*/
         }
-        else if (datediff_day > MATCH_DATE_NOT_THRESHOLD)
+        else if (datediff_day > date_not_threshold)
         {
             /* Extra penalty if that split lies awfully far away from
                the given one. */

--- a/gnucash/import-export/import-backend.h
+++ b/gnucash/import-export/import-backend.h
@@ -74,11 +74,17 @@ gboolean gnc_import_exists_online_id (Transaction *trans, GHashTable* acct_id_ha
  *
  * @param display_threshold Minimum match score to include split in the list of matches.
  *
+ * @param date_threshold Maximum number of days a match considered likely.
+ *
+ * @param date_not_threshold Minimum number of days a match is considered unlikely.
+ *
  * @param fuzzy_amount_difference Maximum amount difference to consider the match good.
  */
 void split_find_match (GNCImportTransInfo * trans_info,
                        Split * split,
                        gint display_threshold,
+                       gint date_threshold,
+                       gint date_not_threshold,
                        double fuzzy_amount_difference);
 
 /** Iterates through all splits of the originating account of

--- a/gnucash/import-export/import-main-matcher.c
+++ b/gnucash/import-export/import-main-matcher.c
@@ -1802,6 +1802,8 @@ typedef struct _match_struct
 {
     GNCImportTransInfo* transaction_info;
     gint display_threshold;
+    gint date_threshold;
+    gint date_not_threshold;
     double fuzzy_amount;
 } match_struct;
 
@@ -1809,7 +1811,10 @@ static void
 match_helper (Split* data, match_struct* s)
 {
     split_find_match (s->transaction_info, data,
-                      s->display_threshold, s->fuzzy_amount);
+                      s->display_threshold, 
+                      s->date_threshold,
+                      s->date_not_threshold,
+                      s->fuzzy_amount);
 }
 
 /* Iterate through the imported transactions selecting matches from the
@@ -1823,6 +1828,10 @@ perform_matching (GNCImportMainMatcher *gui, GHashTable *account_hash)
     GtkTreeModel* model = gtk_tree_view_get_model (gui->view);
     gint display_threshold =
         gnc_import_Settings_get_display_threshold (gui->user_settings);
+    gint date_threshold =
+        gnc_import_Settings_get_date_threshold (gui->user_settings);
+    gint date_not_threshold =
+        gnc_import_Settings_get_date_not_threshold (gui->user_settings);
     double fuzzy_amount =
         gnc_import_Settings_get_fuzzy_amount (gui->user_settings);
 
@@ -1834,7 +1843,7 @@ perform_matching (GNCImportMainMatcher *gui, GHashTable *account_hash)
         gboolean match_selected_manually;
         GNCImportTransInfo* txn_info = imported_txn->data;
         Account *importaccount = xaccSplitGetAccount (gnc_import_TransInfo_get_fsplit (txn_info));
-        match_struct s = {txn_info, display_threshold, fuzzy_amount};
+        match_struct s = {txn_info, display_threshold, date_threshold, date_not_threshold, fuzzy_amount};
 
         g_slist_foreach (g_hash_table_lookup (account_hash, importaccount),
                          (GFunc) match_helper, &s);

--- a/gnucash/import-export/import-settings.c
+++ b/gnucash/import-export/import-settings.c
@@ -52,6 +52,10 @@ struct _genimportsettings
     gboolean action_add_enabled;
     gboolean action_clear_enabled;
 
+    /**Transaction who's date is within threshold is likely match */
+    int date_threshold;
+    /**Transaction who's date is outside threshold is an unlikely match */
+    int date_not_threshold;
     /**Transaction who's best match probability is equal or higher than
        this will reconcile their best match by default */
     int clear_threshold;
@@ -94,7 +98,10 @@ gnc_import_Settings_new (void)
         (int)gnc_prefs_get_float (GNC_PREFS_GROUP_IMPORT, GNC_PREF_AUTO_ADD_THRESHOLD);
     settings->display_threshold =
         (int)gnc_prefs_get_float (GNC_PREFS_GROUP_IMPORT, GNC_PREF_MATCH_THRESHOLD);
-
+    settings->date_threshold =
+        (int)gnc_prefs_get_float (GNC_PREFS_GROUP_IMPORT, GNC_PREF_MATCH_DATE_THRESHOLD);
+    settings->date_not_threshold =
+        (int)gnc_prefs_get_float (GNC_PREFS_GROUP_IMPORT, GNC_PREF_MATCH_DATE_NOT_THRESHOLD);
     settings->fuzzy_amount =
         gnc_prefs_get_float (GNC_PREFS_GROUP_IMPORT, GNC_PREF_ATM_FEE_THRESHOLD);
 
@@ -160,11 +167,24 @@ gint gnc_import_Settings_get_display_threshold (GNCImportSettings *settings)
     return settings->display_threshold;
 };
 
+gint gnc_import_Settings_get_date_threshold (GNCImportSettings *settings)
+{
+    g_assert (settings);
+    return settings->date_threshold;
+}
+
+gint gnc_import_Settings_get_date_not_threshold (GNCImportSettings *settings)
+{
+    g_assert (settings);
+    return settings->date_not_threshold;
+}
+
 void gnc_import_Settings_set_match_date_hardlimit (GNCImportSettings *s, gint m)
 {
     g_assert(s);
     s->match_date_hardlimit = m;
 }
+
 gint gnc_import_Settings_get_match_date_hardlimit (const GNCImportSettings *s)
 {
     g_assert(s);

--- a/gnucash/import-export/import-settings.h
+++ b/gnucash/import-export/import-settings.h
@@ -85,6 +85,10 @@ gint gnc_import_Settings_get_add_threshold (GNCImportSettings *settings);
 */
 gint gnc_import_Settings_get_display_threshold (GNCImportSettings *settings);
 
+gint gnc_import_Settings_get_date_threshold (GNCImportSettings *settings);
+
+gint gnc_import_Settings_get_date_not_threshold (GNCImportSettings *settings);
+
 /** @param match_date_hardlimit The number of days that a matching
  * split may differ from the given transaction before it is discarded
  * immediately. In other words, any split that is more distant from

--- a/gnucash/import-export/import-utilities.h
+++ b/gnucash/import-export/import-utilities.h
@@ -27,15 +27,16 @@
 
 
 /** The preferences used by the importer */
-#define GNC_PREFS_GROUP_IMPORT        "dialogs.import.generic"
-#define GNC_PREF_ENABLE_SKIP          "enable-skip"
-#define GNC_PREF_ENABLE_UPDATE        "enable-update"
-#define GNC_PREF_USE_BAYES            "use-bayes"
-#define GNC_PREF_ATM_FEE_THRESHOLD    "atm-fee-threshold"
-#define GNC_PREF_AUTO_CLEAR_THRESHOLD "auto-clear-threshold"
-#define GNC_PREF_AUTO_ADD_THRESHOLD   "auto-add-threshold"
-#define GNC_PREF_MATCH_THRESHOLD      "match-threshold"
-
+#define GNC_PREFS_GROUP_IMPORT            "dialogs.import.generic"
+#define GNC_PREF_ENABLE_SKIP              "enable-skip"
+#define GNC_PREF_ENABLE_UPDATE            "enable-update"
+#define GNC_PREF_USE_BAYES                "use-bayes"
+#define GNC_PREF_ATM_FEE_THRESHOLD        "atm-fee-threshold"
+#define GNC_PREF_AUTO_CLEAR_THRESHOLD     "auto-clear-threshold"
+#define GNC_PREF_AUTO_ADD_THRESHOLD       "auto-add-threshold"
+#define GNC_PREF_MATCH_THRESHOLD          "match-threshold"
+#define GNC_PREF_MATCH_DATE_THRESHOLD     "match-date-threshold"
+#define GNC_PREF_MATCH_DATE_NOT_THRESHOLD "match-date-not-threshold"
 
 #include "Account.h"
 


### PR DESCRIPTION
In the import-backend.c source file two constants were defined with a
comment about they should ideally be added to the user preference
dialog. This commit does that, the two preferences are
match-date-threshold which is the number of days a transaction match is
likely and match-date-not-threshold which is the number of days a
transaction match is considered not likely.