### PR TITLE
while add a new customer/vendor/employee, the address is not necessary.

### DIFF
--- a/gnucash/gnome/dialog-employee.c
+++ b/gnucash/gnome/dialog-employee.c
@@ -205,15 +205,15 @@ gnc_employee_window_ok_cb (GtkWidget *widget, gpointer data)
         return;
 
     /* Make sure we have an address */
-    if (check_entry_nonempty (ew->addr1_entry, NULL) &&
-            check_entry_nonempty (ew->addr2_entry, NULL) &&
-            check_entry_nonempty (ew->addr3_entry, NULL) &&
-            check_entry_nonempty (ew->addr4_entry, NULL))
-    {
-        const char *msg = _("You must enter an address.");
-        gnc_error_dialog (gnc_ui_get_gtk_window (widget), "%s", msg);
-        return;
-    }
+    //if (check_entry_nonempty (ew->addr1_entry, NULL) &&
+    //        check_entry_nonempty (ew->addr2_entry, NULL) &&
+    //        check_entry_nonempty (ew->addr3_entry, NULL) &&
+    //        check_entry_nonempty (ew->addr4_entry, NULL))
+    //{
+    //    const char *msg = _("You must enter an address.");
+    //    gnc_error_dialog (gnc_ui_get_gtk_window (widget), "%s", msg);
+    //    return;
+    //}
 
     /* Set the employee id if one has not been chosen */
     if (g_strcmp0 (gtk_entry_get_text (GTK_ENTRY (ew->id_entry)), "") == 0)

--- a/gnucash/gnome/dialog-vendor.c
+++ b/gnucash/gnome/dialog-vendor.c
@@ -218,15 +218,15 @@ gnc_vendor_window_ok_cb (GtkWidget *widget, gpointer data)
         return;
 
     /* Make sure we have an address */
-    if (check_entry_nonempty (vw->addr1_entry, NULL) &&
-            check_entry_nonempty (vw->addr2_entry, NULL) &&
-            check_entry_nonempty (vw->addr3_entry, NULL) &&
-            check_entry_nonempty (vw->addr4_entry, NULL))
-    {
-        const char *msg = _("You must enter a payment address.");
-        gnc_error_dialog (gnc_ui_get_gtk_window (widget), "%s", msg);
-        return;
-    }
+    //if (check_entry_nonempty (vw->addr1_entry, NULL) &&
+    //        check_entry_nonempty (vw->addr2_entry, NULL) &&
+    //        check_entry_nonempty (vw->addr3_entry, NULL) &&
+    //        check_entry_nonempty (vw->addr4_entry, NULL))
+    //{
+    //    const char *msg = _("You must enter a payment address.");
+    //    gnc_error_dialog (gnc_ui_get_gtk_window (widget), "%s", msg);
+    //    return;
+    //}
 
     /* Check for valid id and set one if necessary */
     if (g_strcmp0 (gtk_entry_get_text (GTK_ENTRY (vw->id_entry)), "") == 0)


### PR DESCRIPTION
sometime I just want to add a customer/vendor/employee as quickly as I can, then complete other information.

but the address is needed, and can’t skip this step.

It will be more efficient if remove the address step.