### PR TITLE
Maint stock metadata

### DIFF
--- a/gnucash/gtkbuilder/dialog-account.glade
+++ b/gnucash/gtkbuilder/dialog-account.glade
@@ -1866,6 +1866,139 @@
                 <property name="tab_fill">False</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkBox" id="vbox303">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="border_width">6</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkGrid" id="account_notebook_stock_details_table">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Cash Account</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Dividend Account</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Capital Gains Account</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Fees Account</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="proceeds_account_hbox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <placeholder/>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="dividend_account_hbox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <placeholder/>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="capgains_account_hbox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <placeholder/>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="expenses_acocunt_hbox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <placeholder/>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">3</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <style>
+                  <class name="gnc-class-account"/>
+                </style>
+              </object>
+              <packing>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child type="tab">
+              <object class="GtkLabel" id="account_notebook_details_stock_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Stock Details</property>
+                <property name="justify">center</property>
+              </object>
+              <packing>
+                <property name="position">1</property>
+                <property name="tab_fill">False</property>
+              </packing>
+            </child>
             <style>
               <class name="gnc-class-account"/>
             </style>

--- a/libgnucash/app-utils/gnc-helpers.c
+++ b/libgnucash/app-utils/gnc-helpers.c
@@ -133,3 +133,30 @@ gnc_quoteinfo2scm(gnc_commodity *comm)
     info_scm = scm_cons (name ? scm_from_utf8_string (name) : SCM_BOOL_F, info_scm);
     return info_scm;
 }
+
+void gnc_account_set_linked_account (Account *acc, const gchar *id,
+                                     const Account *target)
+{
+    g_return_if_fail (GNC_IS_ACCOUNT (acc) && id);
+
+    xaccAccountBeginEdit (acc);
+    qof_instance_set (QOF_INSTANCE (acc), id,
+                      target ? qof_instance_get_guid (QOF_INSTANCE (target))
+                      : NULL, NULL);
+    xaccAccountCommitEdit (acc);
+}
+
+Account * gnc_account_get_linked_account (const Account *acc, const gchar *id)
+{
+    GncGUID *guid = NULL;
+    Account *linked_acc;
+    QofBook *book;
+
+    g_return_val_if_fail (GNC_IS_ACCOUNT (acc), NULL);
+
+    book = gnc_account_get_book (acc);
+    qof_instance_get (QOF_INSTANCE(acc), id, &guid, NULL);
+    linked_acc = guid ? xaccAccountLookup (guid, book) : NULL;
+    guid_free (guid);
+    return linked_acc;
+}

--- a/libgnucash/app-utils/gnc-helpers.h
+++ b/libgnucash/app-utils/gnc-helpers.h
@@ -42,5 +42,36 @@ GNCPrintAmountInfo gnc_scm2printinfo(SCM info_scm);
  */
 SCM  gnc_quoteinfo2scm(gnc_commodity *com);
 
+/** Given an account, gets a "linked" account. The linked account is
+ *  identified by an 'id' string. e.g. The source may be a STOCK
+ *  account, and has metadata to identify linked dividends, capital
+ *  gains, broker cash, fees accounts. These accounts are identified
+ *  by the id gchar string. If the guid does not exist the getter will
+ *  return NULL.
+ *
+ * @param acc Source account
+ *
+ * @param id The string identifier
+ *
+ * @return A pointer to the linked account, or NULL
+ *
+ */
+
+Account * gnc_account_get_linked_account (const Account *acc, const gchar *id);
+
+/** Given an account, sets a "linked" account. The linked account is
+ *  identified by an 'id' string. e.g. The source may be a STOCK
+ *  account, and has metadata to identify linked dividends, capital
+ *  gains, broker cash, fees accounts.
+ *
+ * @param acc Source account
+ *
+ * @param id The string identifier
+ *
+ * @param target Target account
+ *
+ */
+void gnc_account_set_linked_account (Account *acc, const gchar *id,
+                                     const Account *target);
 
 #endif

--- a/libgnucash/engine/Account.cpp
+++ b/libgnucash/engine/Account.cpp
@@ -65,6 +65,10 @@ static const std::string KEY_INCLUDE_CHILDREN("include-children");
 static const std::string KEY_POSTPONE("postpone");
 static const std::string KEY_LOT_MGMT("lot-mgmt");
 static const std::string KEY_ONLINE_ID("online_id");
+static const std::string KEY_STOCK_PROCEEDS("stock-proceeds");
+static const std::string KEY_STOCK_EXPENSES("stock-expenses");
+static const std::string KEY_STOCK_DIVIDEND("stock-dividend");
+static const std::string KEY_STOCK_CAPGAINS("stock-capgains");
 static const std::string AB_KEY("hbci");
 static const std::string AB_ACCOUNT_ID("account-id");
 static const std::string AB_ACCOUNT_UID("account-uid");
@@ -122,6 +126,10 @@ enum
     PROP_AB_ACCOUNT_UID,                /* KVP */
     PROP_AB_BANK_CODE,                  /* KVP */
     PROP_AB_TRANS_RETRIEVAL,            /* KVP */
+    PROP_STOCK_PROCEEDS,                /* KVP */
+    PROP_STOCK_DIVIDEND,                /* KVP */
+    PROP_STOCK_CAPGAINS,                /* KVP */
+    PROP_STOCK_EXPENSES,                /* KVP */
 
     PROP_RUNTIME_0,
     PROP_POLICY,                        /* Cached Value */
@@ -506,6 +514,18 @@ gnc_account_get_property (GObject         *object,
     case PROP_AB_TRANS_RETRIEVAL:
         qof_instance_get_path_kvp (QOF_INSTANCE (account), value, {AB_KEY, AB_TRANS_RETRIEVAL});
         break;
+    case PROP_STOCK_PROCEEDS:
+        qof_instance_get_path_kvp (QOF_INSTANCE (account), value, {KEY_STOCK_PROCEEDS});
+        break;
+    case PROP_STOCK_DIVIDEND:
+        qof_instance_get_path_kvp (QOF_INSTANCE (account), value, {KEY_STOCK_DIVIDEND});
+        break;
+    case PROP_STOCK_EXPENSES:
+        qof_instance_get_path_kvp (QOF_INSTANCE (account), value, {KEY_STOCK_EXPENSES});
+        break;
+    case PROP_STOCK_CAPGAINS:
+        qof_instance_get_path_kvp (QOF_INSTANCE (account), value, {KEY_STOCK_CAPGAINS});
+        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
         break;
@@ -634,6 +654,18 @@ gnc_account_set_property (GObject         *object,
         break;
     case PROP_AB_TRANS_RETRIEVAL:
         qof_instance_set_path_kvp (QOF_INSTANCE (account), value, {AB_KEY, AB_TRANS_RETRIEVAL});
+        break;
+    case PROP_STOCK_PROCEEDS:
+        qof_instance_set_path_kvp (QOF_INSTANCE (account), value, {KEY_STOCK_PROCEEDS});
+        break;
+    case PROP_STOCK_DIVIDEND:
+        qof_instance_set_path_kvp (QOF_INSTANCE (account), value, {KEY_STOCK_DIVIDEND});
+        break;
+    case PROP_STOCK_EXPENSES:
+        qof_instance_set_path_kvp (QOF_INSTANCE (account), value, {KEY_STOCK_EXPENSES});
+        break;
+    case PROP_STOCK_CAPGAINS:
+        qof_instance_set_path_kvp (QOF_INSTANCE (account), value, {KEY_STOCK_CAPGAINS});
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
@@ -1116,6 +1148,42 @@ gnc_account_class_init (AccountClass *klass)
                         "The time of the last transaction retrieval for this "
                         "account.",
                         GNC_TYPE_TIME64,
+                        static_cast<GParamFlags>(G_PARAM_READWRITE)));
+
+    g_object_class_install_property
+    (gobject_class,
+     PROP_STOCK_PROCEEDS,
+     g_param_spec_boxed("stock-proceeds",
+                        "Associated stock proceeds account",
+                        "Associated cash account for stock",
+                        GNC_TYPE_GUID,
+                        static_cast<GParamFlags>(G_PARAM_READWRITE)));
+
+    g_object_class_install_property
+    (gobject_class,
+     PROP_STOCK_DIVIDEND,
+     g_param_spec_boxed("stock-dividend",
+                        "Associated stock dividend account",
+                        "Associated dividend income account for stock",
+                        GNC_TYPE_GUID,
+                        static_cast<GParamFlags>(G_PARAM_READWRITE)));
+
+    g_object_class_install_property
+    (gobject_class,
+     PROP_STOCK_EXPENSES,
+     g_param_spec_boxed("stock-expenses",
+                        "Associated stock fees account",
+                        "Associated expenses fees account for stock",
+                        GNC_TYPE_GUID,
+                        static_cast<GParamFlags>(G_PARAM_READWRITE)));
+
+    g_object_class_install_property
+    (gobject_class,
+     PROP_STOCK_CAPGAINS,
+     g_param_spec_boxed("stock-capgains",
+                        "Associated stock capgains account",
+                        "Associated capital gains income account for stock",
+                        GNC_TYPE_GUID,
                         static_cast<GParamFlags>(G_PARAM_READWRITE)));
 
 }


### PR DESCRIPTION
Draft backend and UI for stock-account metadata. This will set up 4 "linked" accounts for a stock-account.

- Dividend & Capgains must be INCOME
- Cash/proceeds must be BANK/ASSET/CASH
- Fees must be EXPENSE

Only 1 account is allowable for each. All of these accounts *must* have the currency `gnc_account_get_currency_or_parent (stock_account)` and cannot be placeholder. Account Properties UI will get/set these accounts, and will be used by both #818 and #978. 