### PR TITLE
from_price and to_price may be uninitialized in extract_comon_prices

### DIFF
--- a/libgnucash/engine/gnc-pricedb.c
+++ b/libgnucash/engine/gnc-pricedb.c
@@ -2439,7 +2439,7 @@ extract_common_prices (PriceList *from_prices, PriceList *to_prices,
 {
     PriceTuple retval = {NULL, NULL};
     GList *from_node = NULL, *to_node = NULL;
-    GNCPrice *from_price, *to_price;
+    GNCPrice *from_price = NULL, *to_price = NULL;
 
     for (from_node = from_prices; from_node != NULL;
          from_node = g_list_next(from_node))


### PR DESCRIPTION
Fix the compilation error on gcc 10:

    gnucash/libgnucash/engine/gnc-pricedb.c: In function âextract_common_pricesâ:
    gnucash/libgnucash/engine/gnc-pricedb.c:2469:40: error:
    to_price may be used uninitialized in this function [-Werror=maybe-uninitialized]
     2469 |     if (from_price == NULL || to_price == NULL)
           |                                        ^
           gnucash/libgnucash/engine/gnc-pricedb.c:2469:20:
           error: âfrom_priceâ may be used uninitialized in this
           function [-Werror=maybe-uninitialized]
            2469 |     if (from_price == NULL || to_price == NULL)
                  |                    ^