### PR TITLE
Revist Bug798093

### DIFF
--- a/libgnucash/engine/Account.cpp
+++ b/libgnucash/engine/Account.cpp
@@ -3120,26 +3120,31 @@ gnc_account_lookup_by_full_name (const Account *any_acc,
     return found;
 }
 
-Account*
+GList*
 gnc_account_lookup_by_type_and_commodity (Account* root,
                                           const char* name,
                                           GNCAccountType acctype,
                                           gnc_commodity* commodity)
 {
+    GList *retval{};
     auto rpriv{GET_PRIVATE(root)};
     for (auto node = rpriv->children; node; node = node->next)
     {
         auto account{static_cast<Account*>(node->data)};
-        if (xaccAccountGetType (account) == acctype &&
-            gnc_commodity_equiv(xaccAccountGetCommodity (account), commodity))
+        if (xaccAccountGetType (account) == acctype)
         {
-            if (name && strcmp(name, xaccAccountGetName(account)))
-                continue; //name doesn't match so skip this one
+            if (commodity &&
+                !gnc_commodity_equiv(xaccAccountGetCommodity (account),
+                                     commodity))
+                continue;
 
-            return account;
+            if (name && strcmp(name, xaccAccountGetName(account)))
+                continue;
+
+            retval = g_list_prepend(retval, account);
         }
     }
-    return nullptr;
+    return retval;
 }
 
 void

--- a/libgnucash/engine/Account.cpp
+++ b/libgnucash/engine/Account.cpp
@@ -3127,34 +3127,16 @@ gnc_account_lookup_by_type_and_commodity (Account* root,
                                           gnc_commodity* commodity)
 {
     auto rpriv{GET_PRIVATE(root)};
-    if (rpriv->type == acctype &&
-        gnc_commodity_equiv(rpriv->commodity, commodity))
-    {
-        if (name)
-        {
-            if (strcmp(name, rpriv->accountName) == 0)
-                return root;
-        }
-        else
-        {
-            return root;
-        }
-    }
-
-    /* Nope. Make sure the types are compatible */
-    if (!xaccAccountTypesCompatible(rpriv->type, acctype))
-        return nullptr;
-
-    /* Recurse */
     for (auto node = rpriv->children; node; node = node->next)
     {
         auto account{static_cast<Account*>(node->data)};
+        if (xaccAccountGetType (account) == acctype &&
+            gnc_commodity_equiv(xaccAccountGetCommodity (account), commodity))
         {
-            auto child{gnc_account_lookup_by_type_and_commodity(account, name,
-                                                                acctype,
-                                                                commodity)};
-            if (child)
-                return child;
+            if (name && strcmp(name, xaccAccountGetName(account)))
+                continue; //name doesn't match so skip this one
+
+            return account;
         }
     }
     return nullptr;

--- a/libgnucash/engine/Account.h
+++ b/libgnucash/engine/Account.h
@@ -938,24 +938,24 @@ Account *gnc_account_lookup_by_code (const Account *parent,
  */
 Account *gnc_account_lookup_by_opening_balance (Account *account, gnc_commodity *commodity);
 
-/** Find a direct child account matching name, GNCAccountType, and commodity.
+/** Find a direct child account matching name, GNCAccountType, and/or commodity.
  *
- * Note that commodity matching is by equivalence: If the
- * mnemonic/symbol and namespace are the same, it matches.
+ * Name and commodity may be nullptr in which case the accounts in the
+ * list may have any value for those properties.  Note that commodity
+ * matching is by equivalence: If the mnemonic/symbol and namespace
+ * are the same, it matches.
  *
  *  @param root The account among whose children one expects to find
  *  the account.
- *  @param name The name of the account to look for. If nullptr the
- *  returned account will match only on acctype and commodity.
+ *  @param name The name of the account to look for or nullptr.
  *  @param acctype The GNCAccountType to match.
- *  @param commodity The commodity in which the account should be denominated.
- *  @return The book's trading account for the given commodity if
- *  trading accounts are enabled and one exists; NULL otherwise.
+ *  @param commodity The commodity in which the account should be denominated or nullptr.
+ *  @return A GList of children matching the supplied parameters.
  */
-Account *gnc_account_lookup_by_type_and_commodity (Account* root,
-                                                   const char* name,
-                                                   GNCAccountType acctype,
-                                                   gnc_commodity* commodity);
+GList *gnc_account_lookup_by_type_and_commodity (Account* root,
+                                                 const char* name,
+                                                 GNCAccountType acctype,
+                                                 gnc_commodity* commodity);
 /** @} */
 
 /* ------------------ */

--- a/libgnucash/engine/Scrub.c
+++ b/libgnucash/engine/Scrub.c
@@ -110,6 +110,7 @@ TransScrubOrphansFast (Transaction *trans, Account *root)
 
     if (!trans) return;
     g_return_if_fail (root);
+    g_return_if_fail (trans->common_currency);
 
     for (node = trans->splits; node; node = node->next)
     {


### PR DESCRIPTION
Reverts ed486a5 as that was based on seriously misunderstanding what was going on.

0f8d9f6 changes the way trading accounts are found from looking at their names and ignoring account types to looking for account-types and commodities and ignoring names in order to fix [Bug 798093](https://bugs.gnucash.org/show_bug.cgi?id=798093) with the added (supposed) advantage of allowing the top level trading account to have any name.

Sadly I overlooked a key issue in that commit: The top-level trading account and any placeholders were created with the transaction currency of the transaction that caused them to be created. The new logic wouldn't find the existing ones if the current transaction has a different currency, so it would make a new hierarchy.

This PR changes in two ways: When looking for the top-level trading account and namespace placeholder account it will accept any account currency, and if it needs to create one or both it will get the book's root account currency (if the book is old and doesn't have one it will use the currency of the first top-level income account). If, thanks to 0f8d96 there's more than one top-level trading account or namespace placeholder it will prefer one in the root account-currency but if that doesn't exist it will use the first one found.

