### PR TITLE
Launch external browser to load current report

### DIFF
--- a/gnucash/gnome/gnc-plugin-page-report.c
+++ b/gnucash/gnome/gnc-plugin-page-report.c
@@ -178,6 +178,7 @@ static void gnc_plugin_page_report_stop_cb(GtkAction *action, GncPluginPageRepor
 static void gnc_plugin_page_report_save_cb(GtkAction *action, GncPluginPageReport *rep);
 static void gnc_plugin_page_report_save_as_cb(GtkAction *action, GncPluginPageReport *rep);
 static void gnc_plugin_page_report_export_cb(GtkAction *action, GncPluginPageReport *rep);
+static void gnc_plugin_page_report_open_external_browser_cb (GtkAction *action, GncPluginPageReport *report);
 static void gnc_plugin_page_report_options_cb(GtkAction *action, GncPluginPageReport *rep);
 static void gnc_plugin_page_report_print_cb(GtkAction *action, GncPluginPageReport *rep);
 static void gnc_plugin_page_report_exportpdf_cb(GtkAction *action, GncPluginPageReport *rep);
@@ -1142,6 +1143,7 @@ static action_toolbar_labels toolbar_labels[] =
        to be used as toolbar button label. */
     { "ReportSaveAsAction", N_("Save Config As...") },
     { "FilePrintPDFAction", N_("Make Pdf") },
+    { "OpenExternalBrowserAction", N_("External") },
     { NULL, NULL },
 };
 
@@ -1205,6 +1207,11 @@ gnc_plugin_page_report_constr_init(GncPluginPageReport *plugin_page, gint report
             "FilePrintAction", "document-print", N_("_Print Report..."), "<primary>p",
             N_("Print the current report"),
             G_CALLBACK(gnc_plugin_page_report_print_cb)
+        },
+        {
+            "OpenExternalBrowserAction", "emblem-web",
+            N_("Open in _external browser..."), NULL, N_("Open in external browser"),
+            G_CALLBACK(gnc_plugin_page_report_open_external_browser_cb)
         },
         {
             "FilePrintPDFAction", GNC_ICON_PDF_EXPORT, N_("Export as P_DF..."), NULL,
@@ -1941,6 +1948,19 @@ gnc_plugin_page_report_print_cb( GtkAction *action, GncPluginPageReport *report 
 #endif
 
     g_free (job_name);
+}
+
+static void
+gnc_plugin_page_report_open_external_browser_cb (GtkAction *action,
+                                                 GncPluginPageReport *report)
+{
+    GncPluginPageReportPrivate *priv = GNC_PLUGIN_PAGE_REPORT_GET_PRIVATE(report);
+    GError *error = NULL;
+    if (!gnc_html_open_external_browser (priv->html, &error))
+    {
+        PWARN ("Failed to open uri: %s", error->message);
+        g_error_free (error);
+    }
 }
 
 static void

--- a/gnucash/html/gnc-html.c
+++ b/gnucash/html/gnc-html.c
@@ -509,6 +509,28 @@ gnc_html_copy_to_clipboard( GncHtml* self )
     }
 }
 
+gboolean
+gnc_html_open_external_browser (GncHtml *self, GError **error)
+{
+    static gchar *template = "gnc-report-XXXXXX.html";
+    gchar *filename = g_build_filename (g_get_tmp_dir(), template, NULL);
+
+#ifdef G_OS_WIN32
+    gchar *uri = g_strdup_printf ("file:///%s", filename);
+#else
+    gchar *uri = g_strdup_printf ("file://%s", filename);
+#endif
+
+    gboolean retval = gnc_html_export_to_file (self, filename);
+
+    if (retval)
+        retval = g_app_info_launch_default_for_uri (uri, NULL, error);
+
+    g_free (uri);
+    g_free (filename);
+    return retval;
+}
+
 /**************************************************************
  * gnc_html_export_to_file : wrapper around the builtin function in gtkhtml
  **************************************************************/

--- a/gnucash/html/gnc-html.h
+++ b/gnucash/html/gnc-html.h
@@ -195,6 +195,15 @@ void gnc_html_reload( GncHtml* html, gboolean view );
 void gnc_html_copy_to_clipboard( GncHtml* html );
 
 /**
+ * Launches external browser and load html
+ *
+ * @param html GncHtml object
+ * @param GError object
+ * @return TRUE if successful, FALSE if unsuccessful
+ */
+gboolean gnc_html_open_external_browser (GncHtml *html, GError **error);
+
+/**
  * Exports the html to an external file.
  *
  * @param html GncHtml object

--- a/gnucash/ui/gnc-plugin-page-report-ui.xml
+++ b/gnucash/ui/gnc-plugin-page-report-ui.xml
@@ -45,6 +45,7 @@
       <toolitem name="ReportToolbarExport" action="ReportExportAction"/>
       <toolitem name="ReportToolbarPrint" action="FilePrintAction" />
       <toolitem name="ReportToolbarExportPDF" action="FilePrintPDFAction"/>
+      <toolitem name="ReportToolbarExternal" action="OpenExternalBrowserAction"/>
     </placeholder>
   </toolbar>
 </ui>


### PR DESCRIPTION
Mainly of benefit for Windows builds; will use modern browser instead of libwebkit1. To reuse the previously generated `gnc-report-XXXXXX.html` is unreliable -- it may have been deleted between internal browser rendering and launching external browser.