### PR TITLE
Fix for opening balance account support

### DIFF
--- a/gnucash/gnome-utils/dialog-account.c
+++ b/gnucash/gnome-utils/dialog-account.c
@@ -213,7 +213,7 @@ gnc_account_opening_balance_button_update (AccountWindow *aw, gnc_commodity *com
     Account *ob_account = gnc_account_lookup_by_opening_balance (gnc_book_get_root_account (aw->book), commodity);
     gboolean has_splits = (xaccAccountGetSplitList (account) != NULL);
 
-    if (xaccAccountGetType (account) != ACCT_TYPE_EQUITY)
+    if (aw->type != ACCT_TYPE_EQUITY)
     {
         gtk_widget_set_sensitive (aw->opening_balance_button, FALSE);
         return;


### PR DESCRIPTION
@jralls wrote at #820
>In gnc_account_opening_balance_button_update the account-type test should be on aw->type rather than xaccAccountGetType so that it reflects the state of the dialog rather than the account type before the dialog started.

Fix for #762