### PR TITLE
Bug 798195 - No option in the user interface to set the opening balancece of an existing account

### DIFF
--- a/gnucash/gnome-utils/dialog-account.c
+++ b/gnucash/gnome-utils/dialog-account.c
@@ -1977,7 +1977,8 @@ gnc_ui_edit_account_window(GtkWindow *parent, Account *account)
     gnc_resume_gui_refresh ();
 
     gtk_widget_show_all (aw->dialog);
-    gtk_widget_hide (aw->opening_balance_page);
+    if (xaccAccountGetSplitList (account) != NULL)
+        gtk_widget_hide (aw->opening_balance_page);
 
     parent_acct = gnc_account_get_parent (account);
     if (parent_acct == NULL)


### PR DESCRIPTION
Previously, opening balances could only be entered through the hierarchy
assistant or when creating a new account. This excludes the entry of opening
balances for accounts that were already included in the chart of accounts
when the file was created, but were not used. In these cases, it was
necessary to manually create an entry in the corresponding account.

By enabling the opening balance page when editing accounts when there are
no transactions, the same procedure as for new creation is enabled.