### PR TITLE
GNCAmountEdit changes, followup to PR964

### DIFF
--- a/gnucash/gnome-search/search-double.c
+++ b/gnucash/gnome-search/search-double.c
@@ -30,6 +30,7 @@
 
 #include "gnc-amount-edit.h"
 #include "qof.h"
+#include "gnc-gui-query.h"
 
 #include "search-double.h"
 #include "search-core-utils.h"
@@ -148,12 +149,21 @@ static gboolean
 gncs_validate (GNCSearchCoreType *fe)
 {
     GNCSearchDouble *fi = (GNCSearchDouble *)fe;
+    GNCSearchDoublePrivate *priv;
     gboolean valid = TRUE;
 
     g_return_val_if_fail (fi, FALSE);
     g_return_val_if_fail (IS_GNCSEARCH_DOUBLE (fi), FALSE);
 
-    /* XXX */
+    priv = _PRIVATE(fi);
+
+    if (!gnc_amount_edit_evaluate (GNC_AMOUNT_EDIT(priv->gae)))
+    {
+        gchar *err_msg = gnc_amount_edit_get_error_message (GNC_AMOUNT_EDIT(priv->gae));
+        gnc_error_dialog (GTK_WINDOW(priv->parent), "%s", err_msg);
+        valid = FALSE;
+        g_free (err_msg);
+    }
 
     return valid;
 }

--- a/gnucash/gnome-search/search-int64.c
+++ b/gnucash/gnome-search/search-int64.c
@@ -30,6 +30,7 @@
 
 #include "gnc-amount-edit.h"
 #include "qof.h"
+#include "gnc-gui-query.h"
 
 #include "search-int64.h"
 #include "search-core-utils.h"
@@ -149,12 +150,21 @@ static gboolean
 gncs_validate (GNCSearchCoreType *fe)
 {
     GNCSearchInt64 *fi = (GNCSearchInt64 *)fe;
+    GNCSearchInt64Private *priv;
     gboolean valid = TRUE;
 
     g_return_val_if_fail (fi, FALSE);
     g_return_val_if_fail (IS_GNCSEARCH_INT64 (fi), FALSE);
 
-    /* XXX */
+    priv = _PRIVATE(fi);
+
+    if (!gnc_amount_edit_evaluate (GNC_AMOUNT_EDIT(priv->gae)))
+    {
+        gchar *err_msg = gnc_amount_edit_get_error_message (GNC_AMOUNT_EDIT(priv->gae));
+        gnc_error_dialog (GTK_WINDOW(priv->parent), "%s", err_msg);
+        valid = FALSE;
+        g_free (err_msg);
+    }
 
     return valid;
 }

--- a/gnucash/gnome-search/search-numeric.c
+++ b/gnucash/gnome-search/search-numeric.c
@@ -30,6 +30,7 @@
 
 #include "gnc-amount-edit.h"
 #include "qof.h"
+#include "gnc-gui-query.h"
 
 #include "search-numeric.h"
 #include "search-core-utils.h"
@@ -178,13 +179,21 @@ static gboolean
 gncs_validate (GNCSearchCoreType *fe)
 {
     GNCSearchNumeric *fi = (GNCSearchNumeric *)fe;
+    GNCSearchNumericPrivate *priv;
     gboolean valid = TRUE;
 
     g_return_val_if_fail (fi, FALSE);
     g_return_val_if_fail (IS_GNCSEARCH_NUMERIC (fi), FALSE);
 
-    /* XXX */
+    priv = _PRIVATE(fi);
 
+    if (!gnc_amount_edit_evaluate (GNC_AMOUNT_EDIT(priv->gae)))
+    {
+        gchar *err_msg = gnc_amount_edit_get_error_message (GNC_AMOUNT_EDIT(priv->gae));
+        gnc_error_dialog (GTK_WINDOW(priv->parent), "%s", err_msg);
+        valid = FALSE;
+        g_free (err_msg);
+    }
     return valid;
 }
 

--- a/gnucash/gnome-utils/dialog-transfer.c
+++ b/gnucash/gnome-utils/dialog-transfer.c
@@ -529,6 +529,8 @@ gnc_xfer_dialog_from_tree_selection_changed_cb (GtkTreeSelection *selection,
     gnc_amount_edit_set_fraction (GNC_AMOUNT_EDIT (xferData->amount_edit),
                                   xaccAccountGetCommoditySCU (account));
 
+    gnc_amount_edit_evaluate (GNC_AMOUNT_EDIT (xferData->amount_edit));
+
     gnc_xfer_dialog_curr_acct_activate(xferData);
 
     /* Reload the xferDialog quickfill if it is based on the from account */
@@ -560,6 +562,8 @@ gnc_xfer_dialog_to_tree_selection_changed_cb (GtkTreeSelection *selection, gpoin
                                     print_info);
     gnc_amount_edit_set_fraction (GNC_AMOUNT_EDIT (xferData->to_amount_edit),
                                   xaccAccountGetCommoditySCU (account));
+
+    gnc_amount_edit_evaluate (GNC_AMOUNT_EDIT (xferData->to_amount_edit));
 
     gnc_xfer_dialog_curr_acct_activate(xferData);
 

--- a/gnucash/gnome-utils/gnc-amount-edit.c
+++ b/gnucash/gnome-utils/gnc-amount-edit.c
@@ -35,6 +35,7 @@
 #include "gnc-ui-util.h"
 #include "qof.h"
 #include "dialog-utils.h"
+#include "gnc-ui.h"
 
 #ifdef G_OS_WIN32
 # include <gdk/gdkwin32.h>
@@ -53,6 +54,8 @@ static void gnc_amount_edit_init (GNCAmountEdit *gae);
 static void gnc_amount_edit_class_init (GNCAmountEditClass *klass);
 static void gnc_amount_edit_changed (GtkEditable *gae,
                                      gpointer user_data);
+static void gnc_amount_edit_paste_clipboard (GNCAmountEdit *gae,
+                                             gpointer user_data);
 static gint gnc_amount_edit_key_press (GtkWidget   *widget,
                                        GdkEventKey *event);
 
@@ -120,20 +123,85 @@ gnc_amount_edit_init (GNCAmountEdit *gae)
     gae->print_info = gnc_default_print_info (FALSE);
     gae->fraction = 0;
     gae->evaluate_on_enter = FALSE;
+    gae->block_changed = FALSE;
 
     // Set the name for this widget so it can be easily manipulated with css
     gtk_widget_set_name (GTK_WIDGET(gae), "gnc-id-amount-edit");
 
     g_signal_connect (G_OBJECT(gae), "changed",
-                      G_CALLBACK(gnc_amount_edit_changed), NULL);
+                      G_CALLBACK(gnc_amount_edit_changed), gae);
+
+    g_signal_connect (G_OBJECT(gae), "paste-clipboard",
+                      G_CALLBACK(gnc_amount_edit_paste_clipboard), NULL);
 }
 
 static void
 gnc_amount_edit_changed (GtkEditable *editable, gpointer user_data)
 {
-    /*GTK_EDITABLE_CLASS(parent_class)->changed(editable);*/
+    GNCAmountEdit *gae = GNC_AMOUNT_EDIT(user_data);
+     /*GTK_EDITABLE_CLASS(parent_class)->changed(editable);*/
+    if (gae->block_changed)
+        g_signal_stop_emission_by_name (G_OBJECT(gae), "changed");
 
     GNC_AMOUNT_EDIT(editable)->need_to_parse = TRUE;
+}
+
+static void
+gnc_amount_edit_paste_clipboard (GNCAmountEdit *gae, gpointer user_data)
+{
+    GtkClipboard *clipboard = gtk_widget_get_clipboard (GTK_WIDGET(gae),
+                                                        GDK_SELECTION_CLIPBOARD);
+    gchar *text = gtk_clipboard_wait_for_text (clipboard);
+
+    if (text)
+    {
+        gchar *filtered_text = gnc_filter_text_for_control_chars (text);
+        gchar *existing = gtk_editable_get_chars (GTK_EDITABLE(gae), 0, -1);
+        gint start_pos, end_pos;
+        gint position;
+
+        if (!filtered_text)
+        {
+            g_free (text);
+            g_free (existing);
+            return;
+        }
+
+        position = gtk_editable_get_position (GTK_EDITABLE(gae));
+
+        if (gtk_editable_get_selection_bounds (GTK_EDITABLE(gae),
+                                               &start_pos, &end_pos))
+        {
+            gint old_len = g_utf8_strlen (existing, -1);
+            gchar *begin = g_utf8_substring (existing, 0, start_pos);
+            gchar *end = g_utf8_substring (existing, end_pos, old_len);
+            gchar *changed_text = g_strdup_printf ("%s%s%s", begin, filtered_text, end);
+
+            gae->block_changed = TRUE;
+            gtk_editable_delete_text (GTK_EDITABLE(gae), 0, -1);
+            gae->block_changed = FALSE;
+
+            gtk_editable_insert_text (GTK_EDITABLE(gae),
+                                      changed_text, -1, &position);
+
+            position = start_pos + g_utf8_strlen (filtered_text, -1);
+
+            g_free (begin);
+            g_free (end);
+            g_free (changed_text);
+        }
+        else
+            gtk_editable_insert_text (GTK_EDITABLE(gae),
+                                      filtered_text, -1, &position);
+
+        gtk_editable_set_position (GTK_EDITABLE(gae), position);
+
+        g_signal_stop_emission_by_name (G_OBJECT(gae), "paste-clipboard");
+
+        g_free (text);
+        g_free (existing);
+        g_free (filtered_text);
+    }
 }
 
 static gint

--- a/gnucash/gnome-utils/gnc-amount-edit.c
+++ b/gnucash/gnome-utils/gnc-amount-edit.c
@@ -27,6 +27,7 @@
 #include <config.h>
 
 #include <gtk/gtk.h>
+#include <glib/gi18n.h>
 #include <gdk/gdkkeysyms.h>
 
 #include "gnc-amount-edit.h"
@@ -44,6 +45,8 @@
 /* Signal codes */
 enum
 {
+    ACTIVATE,
+    CHANGED,
     AMOUNT_CHANGED,
     LAST_SIGNAL
 };
@@ -54,39 +57,47 @@ static void gnc_amount_edit_init (GNCAmountEdit *gae);
 static void gnc_amount_edit_class_init (GNCAmountEditClass *klass);
 static void gnc_amount_edit_changed (GtkEditable *gae,
                                      gpointer user_data);
-static void gnc_amount_edit_paste_clipboard (GNCAmountEdit *gae,
+static void gnc_amount_edit_paste_clipboard (GtkEntry *entry,
                                              gpointer user_data);
 static gint gnc_amount_edit_key_press (GtkWidget   *widget,
-                                       GdkEventKey *event);
+                                       GdkEventKey *event,
+                                       gpointer user_data);
 
-static GtkEntryClass *parent_class;
+#define GNC_AMOUNT_EDIT_PATH "gnc-amount-edit-path"
 
-GType
-gnc_amount_edit_get_type (void)
+G_DEFINE_TYPE (GNCAmountEdit, gnc_amount_edit, GTK_TYPE_BOX)
+
+static void
+gnc_amount_edit_finalize (GObject *object)
 {
-    static GType amount_edit_type = 0;
+    g_return_if_fail (object != NULL);
+    g_return_if_fail (GNC_IS_AMOUNT_EDIT(object));
 
-    if (amount_edit_type == 0)
-    {
-        GTypeInfo amount_edit_info =
-        {
-            sizeof (GNCAmountEditClass),
-            NULL,
-            NULL,
-            (GClassInitFunc) gnc_amount_edit_class_init,
-            NULL,
-            NULL,
-            sizeof (GNCAmountEdit),
-            0,
-            (GInstanceInitFunc) gnc_amount_edit_init
-        };
+    G_OBJECT_CLASS (gnc_amount_edit_parent_class)->finalize (object);
+}
 
-        amount_edit_type = g_type_register_static (GTK_TYPE_ENTRY,
-                                                   "GNCAmountEdit",
-                                                    &amount_edit_info,
-                                                    0);
-    }
-    return amount_edit_type;
+static void
+gnc_amount_edit_dispose (GObject *object)
+{
+    GNCAmountEdit *gae;
+
+    g_return_if_fail (object != NULL);
+    g_return_if_fail (GNC_IS_AMOUNT_EDIT(object));
+
+    gae = GNC_AMOUNT_EDIT(object);
+
+    if (gae->disposed)
+        return;
+
+    gae->disposed = TRUE;
+
+    gtk_widget_destroy (GTK_WIDGET(gae->entry));
+    gae->entry = NULL;
+
+    gtk_widget_destroy (GTK_WIDGET(gae->image));
+    gae->image = NULL;
+
+    G_OBJECT_CLASS (gnc_amount_edit_parent_class)->dispose (object);
 }
 
 static void
@@ -94,10 +105,31 @@ gnc_amount_edit_class_init (GNCAmountEditClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
     GtkWidgetClass *widget_class = GTK_WIDGET_CLASS(klass);
- /* GtkEditableClass *editable_class = GTK_EDITABLE_CLASS(g_type_interface_peek
-                                                         (klass, GTK_TYPE_EDITABLE)); */
 
-    parent_class = g_type_class_peek_parent (klass);
+    object_class->dispose = gnc_amount_edit_dispose;
+    object_class->finalize = gnc_amount_edit_finalize;
+
+    amount_edit_signals [ACTIVATE] =
+        g_signal_new ("activate",
+                      G_OBJECT_CLASS_TYPE(object_class),
+                      G_SIGNAL_RUN_FIRST,
+                      G_STRUCT_OFFSET(GNCAmountEditClass, activate),
+                      NULL,
+                      NULL,
+                      g_cclosure_marshal_VOID__VOID,
+                      G_TYPE_NONE,
+                      0);
+
+    amount_edit_signals [CHANGED] =
+        g_signal_new ("changed",
+                      G_OBJECT_CLASS_TYPE(object_class),
+                      G_SIGNAL_RUN_FIRST,
+                      G_STRUCT_OFFSET(GNCAmountEditClass, changed),
+                      NULL,
+                      NULL,
+                      g_cclosure_marshal_VOID__VOID,
+                      G_TYPE_NONE,
+                      0);
 
     amount_edit_signals [AMOUNT_CHANGED] =
         g_signal_new ("amount_changed",
@@ -109,54 +141,69 @@ gnc_amount_edit_class_init (GNCAmountEditClass *klass)
                       g_cclosure_marshal_VOID__VOID,
                       G_TYPE_NONE,
                       0);
-
-    widget_class->key_press_event = gnc_amount_edit_key_press;
-
- /* editable_class->changed = gnc_amount_edit_changed; */
 }
 
 static void
 gnc_amount_edit_init (GNCAmountEdit *gae)
 {
+    gtk_orientable_set_orientation (GTK_ORIENTABLE(gae),
+                                    GTK_ORIENTATION_HORIZONTAL);
+
+    gae->entry = GTK_ENTRY(gtk_entry_new());
     gae->need_to_parse = FALSE;
     gae->amount = gnc_numeric_zero ();
     gae->print_info = gnc_default_print_info (FALSE);
     gae->fraction = 0;
     gae->evaluate_on_enter = FALSE;
+    gae->validate_on_change = FALSE;
     gae->block_changed = FALSE;
+    gae->error_position = -1;
+    gae->show_warning_symbol = TRUE;
 
     // Set the name for this widget so it can be easily manipulated with css
     gtk_widget_set_name (GTK_WIDGET(gae), "gnc-id-amount-edit");
 
-    g_signal_connect (G_OBJECT(gae), "changed",
+    g_signal_connect (G_OBJECT(gae->entry), "key-press-event",
+                      G_CALLBACK(gnc_amount_edit_key_press), gae);
+
+    g_signal_connect (G_OBJECT(gae->entry), "changed",
                       G_CALLBACK(gnc_amount_edit_changed), gae);
 
-    g_signal_connect (G_OBJECT(gae), "paste-clipboard",
-                      G_CALLBACK(gnc_amount_edit_paste_clipboard), NULL);
+    g_signal_connect (G_OBJECT(gae->entry), "paste-clipboard",
+                      G_CALLBACK(gnc_amount_edit_paste_clipboard), gae);
 }
 
 static void
 gnc_amount_edit_changed (GtkEditable *editable, gpointer user_data)
 {
     GNCAmountEdit *gae = GNC_AMOUNT_EDIT(user_data);
-     /*GTK_EDITABLE_CLASS(parent_class)->changed(editable);*/
-    if (gae->block_changed)
-        g_signal_stop_emission_by_name (G_OBJECT(gae), "changed");
 
-    GNC_AMOUNT_EDIT(editable)->need_to_parse = TRUE;
+    gae->need_to_parse = TRUE;
+
+    if (gae->block_changed)
+        return;
+
+    if (gae->validate_on_change)
+    {
+        gnc_numeric amount;
+        gnc_amount_edit_expr_is_valid (gae, &amount, TRUE);
+    }
+
+    g_signal_emit (gae, amount_edit_signals [CHANGED], 0);
 }
 
 static void
-gnc_amount_edit_paste_clipboard (GNCAmountEdit *gae, gpointer user_data)
+gnc_amount_edit_paste_clipboard (GtkEntry *entry, gpointer user_data)
 {
-    GtkClipboard *clipboard = gtk_widget_get_clipboard (GTK_WIDGET(gae),
+    GNCAmountEdit *gae = GNC_AMOUNT_EDIT(user_data);
+    GtkClipboard *clipboard = gtk_widget_get_clipboard (GTK_WIDGET(entry),
                                                         GDK_SELECTION_CLIPBOARD);
     gchar *text = gtk_clipboard_wait_for_text (clipboard);
 
     if (text)
     {
         gchar *filtered_text = gnc_filter_text_for_control_chars (text);
-        gchar *existing = gtk_editable_get_chars (GTK_EDITABLE(gae), 0, -1);
+        gchar *existing = gtk_editable_get_chars (GTK_EDITABLE(entry), 0, -1);
         gint start_pos, end_pos;
         gint position;
 
@@ -167,9 +214,15 @@ gnc_amount_edit_paste_clipboard (GNCAmountEdit *gae, gpointer user_data)
             return;
         }
 
-        position = gtk_editable_get_position (GTK_EDITABLE(gae));
+        if (gtk_widget_get_visible (GTK_WIDGET(gae->image)))
+        {
+            gtk_widget_hide (GTK_WIDGET(gae->image));
+            gtk_widget_set_tooltip_text (GTK_WIDGET(gae->image), NULL);
+        }
 
-        if (gtk_editable_get_selection_bounds (GTK_EDITABLE(gae),
+        position = gtk_editable_get_position (GTK_EDITABLE(entry));
+
+        if (gtk_editable_get_selection_bounds (GTK_EDITABLE(entry),
                                                &start_pos, &end_pos))
         {
             gint old_len = g_utf8_strlen (existing, -1);
@@ -178,10 +231,10 @@ gnc_amount_edit_paste_clipboard (GNCAmountEdit *gae, gpointer user_data)
             gchar *changed_text = g_strdup_printf ("%s%s%s", begin, filtered_text, end);
 
             gae->block_changed = TRUE;
-            gtk_editable_delete_text (GTK_EDITABLE(gae), 0, -1);
+            gtk_editable_delete_text (GTK_EDITABLE(entry), 0, -1);
             gae->block_changed = FALSE;
 
-            gtk_editable_insert_text (GTK_EDITABLE(gae),
+            gtk_editable_insert_text (GTK_EDITABLE(entry),
                                       changed_text, -1, &position);
 
             position = start_pos + g_utf8_strlen (filtered_text, -1);
@@ -191,12 +244,12 @@ gnc_amount_edit_paste_clipboard (GNCAmountEdit *gae, gpointer user_data)
             g_free (changed_text);
         }
         else
-            gtk_editable_insert_text (GTK_EDITABLE(gae),
+            gtk_editable_insert_text (GTK_EDITABLE(entry),
                                       filtered_text, -1, &position);
 
-        gtk_editable_set_position (GTK_EDITABLE(gae), position);
+        gtk_editable_set_position (GTK_EDITABLE(entry), position);
 
-        g_signal_stop_emission_by_name (G_OBJECT(gae), "paste-clipboard");
+        g_signal_stop_emission_by_name (G_OBJECT(entry), "paste-clipboard");
 
         g_free (text);
         g_free (existing);
@@ -205,10 +258,16 @@ gnc_amount_edit_paste_clipboard (GNCAmountEdit *gae, gpointer user_data)
 }
 
 static gint
-gnc_amount_edit_key_press (GtkWidget *widget, GdkEventKey *event)
+gnc_amount_edit_key_press (GtkWidget *widget, GdkEventKey *event, gpointer user_data)
 {
-    GNCAmountEdit *gae = GNC_AMOUNT_EDIT(widget);
+    GNCAmountEdit *gae = GNC_AMOUNT_EDIT(user_data);
     gint result;
+
+    if (gtk_widget_get_visible (GTK_WIDGET(gae->image)))
+    {
+        gtk_widget_hide (GTK_WIDGET(gae->image));
+        gtk_widget_set_tooltip_text (GTK_WIDGET(gae->image), NULL);
+    }
 
 #ifdef G_OS_WIN32
     /* gdk never sends GDK_KEY_KP_Decimal on win32. See #486658 */
@@ -225,17 +284,21 @@ gnc_amount_edit_key_press (GtkWidget *widget, GdkEventKey *event)
         }
     }
 
-    result = (* GTK_WIDGET_CLASS(parent_class)->key_press_event)(widget, event);
+    result = (* GTK_WIDGET_GET_CLASS(widget)->key_press_event)(widget, event);
 
     switch (event->keyval)
     {
     case GDK_KEY_Return:
         if (gae->evaluate_on_enter)
             break;
+        else
+            g_signal_emit (gae, amount_edit_signals [ACTIVATE], 0);
         if (event->state & (GDK_MODIFIER_INTENT_DEFAULT_MOD_MASK))
             break;
         return result;
     case GDK_KEY_KP_Enter:
+        if (!gae->evaluate_on_enter)
+            g_signal_emit (gae, amount_edit_signals [ACTIVATE], 0);
         break;
     default:
         return result;
@@ -243,16 +306,23 @@ gnc_amount_edit_key_press (GtkWidget *widget, GdkEventKey *event)
 
     gnc_amount_edit_evaluate (gae);
 
+    g_signal_emit (gae, amount_edit_signals [ACTIVATE], 0);
+
     return TRUE;
 }
 
 GtkWidget *
 gnc_amount_edit_new (void)
 {
-    GNCAmountEdit *gae;
+    GNCAmountEdit *gae = g_object_new (GNC_TYPE_AMOUNT_EDIT, NULL);
 
-    gae = g_object_new (GNC_TYPE_AMOUNT_EDIT, NULL);
-    gtk_widget_show (GTK_WIDGET(gae));
+    gtk_box_pack_start (GTK_BOX(gae), GTK_WIDGET(gae->entry), TRUE, TRUE, 0);
+    gtk_entry_set_width_chars (GTK_ENTRY(gae->entry), 12);
+    gae->image = gtk_image_new_from_icon_name ("dialog-warning", GTK_ICON_SIZE_SMALL_TOOLBAR);
+    gtk_box_pack_start (GTK_BOX(gae), GTK_WIDGET(gae->image), FALSE, FALSE, 6);
+    gtk_widget_set_no_show_all (GTK_WIDGET(gae->image), TRUE);
+    gtk_widget_hide (GTK_WIDGET(gae->image));
+    gtk_widget_show_all (GTK_WIDGET(gae));
 
     return GTK_WIDGET(gae);
 }
@@ -270,6 +340,12 @@ get_original_error_position (const gchar *string, const gchar *symbol,
 
     if (error_pos == 0)
         return ret;
+
+    if (!symbol)
+        return error_pos;
+
+    if (g_strrstr (string, symbol) == NULL)
+        return error_pos;
 
     split_text = g_strsplit (string, symbol, -1);
     split_text_len = g_strv_length (split_text);
@@ -306,14 +382,22 @@ gnc_amount_edit_expr_is_valid (GNCAmountEdit *gae, gnc_numeric *amount,
     const gnc_commodity *comm;
     char *filtered_string;
     gint error_position;
-    const gchar *symbol;
+    const gchar *symbol = NULL;
 
     g_return_val_if_fail (gae != NULL, -1);
     g_return_val_if_fail (GNC_IS_AMOUNT_EDIT(gae), -1);
 
-    string = gtk_entry_get_text (GTK_ENTRY(gae));
+    string = gtk_entry_get_text (GTK_ENTRY(gae->entry));
+
+    if (gtk_widget_get_visible (GTK_WIDGET(gae->image)))
+    {
+        gtk_widget_hide (GTK_WIDGET(gae->image));
+        gtk_widget_set_tooltip_text (GTK_WIDGET(gae->image), NULL);
+    }
 
     comm = gae->print_info.commodity;
+
+    gae->error_position = -1;
 
     filtered_string = gnc_filter_text_for_currency_commodity (comm, string, &symbol);
 
@@ -340,13 +424,22 @@ gnc_amount_edit_expr_is_valid (GNCAmountEdit *gae, gnc_numeric *amount,
     {
         gint filtered_error = get_original_error_position (string, symbol,
                                                           (error_loc - filtered_string));
-        error_position = filtered_error + ERROR_POSITION_BASE;
+        gae->error_position = filtered_error + ERROR_POSITION_BASE;
     }
     else
-        error_position = 1;
+        gae->error_position = 1;
+
+    if (gae->show_warning_symbol)
+    {
+        gchar *err_msg = gnc_amount_edit_get_error_message (gae);
+        gtk_widget_set_tooltip_text (GTK_WIDGET(gae->image), err_msg);
+        gtk_widget_show (GTK_WIDGET(gae->image));
+        gtk_widget_queue_resize (GTK_WIDGET(gae->entry));
+        g_free (err_msg);
+    }
 
     g_free (filtered_string);
-    return error_position;
+    return gae->error_position;
 }
 
 gboolean
@@ -379,13 +472,13 @@ gnc_amount_edit_evaluate (GNCAmountEdit *gae)
         if (!gnc_numeric_equal (amount, old_amount))
             g_signal_emit (gae, amount_edit_signals [AMOUNT_CHANGED], 0);
 
-        gtk_editable_set_position (GTK_EDITABLE(gae), -1);
+        gtk_editable_set_position (GTK_EDITABLE(gae->entry), -1);
 
         return TRUE;
     }
 
     /* Parse error */
-    gtk_editable_set_position (GTK_EDITABLE(gae), result - ERROR_POSITION_BASE);
+    gtk_editable_set_position (GTK_EDITABLE(gae->entry), result - ERROR_POSITION_BASE);
     return FALSE;
 }
 
@@ -420,9 +513,15 @@ gnc_amount_edit_set_amount (GNCAmountEdit *gae, gnc_numeric amount)
     g_return_if_fail (GNC_IS_AMOUNT_EDIT(gae));
     g_return_if_fail (!gnc_numeric_check (amount));
 
+    if (gtk_widget_get_visible (GTK_WIDGET(gae->image)))
+    {
+        gtk_widget_hide (GTK_WIDGET(gae->image));
+        gtk_widget_set_tooltip_text (GTK_WIDGET(gae->image), NULL);
+    }
+
     /* Update the display. */
     amount_string = xaccPrintAmount (amount, gae->print_info);
-    gtk_entry_set_text (GTK_ENTRY(gae), amount_string);
+    gtk_entry_set_text (GTK_ENTRY(gae->entry), amount_string);
 
     gae->amount = amount;
     gae->need_to_parse = FALSE;
@@ -475,7 +574,7 @@ gnc_amount_edit_gtk_entry (GNCAmountEdit *gae)
     g_return_val_if_fail (gae != NULL, NULL);
     g_return_val_if_fail (GNC_IS_AMOUNT_EDIT(gae), NULL);
 
-    return GTK_WIDGET(gae);
+    return GTK_WIDGET(gae->entry);
 }
 
 void
@@ -486,4 +585,52 @@ gnc_amount_edit_set_evaluate_on_enter (GNCAmountEdit *gae,
     g_return_if_fail (GNC_IS_AMOUNT_EDIT(gae));
 
     gae->evaluate_on_enter = evaluate_on_enter;
+}
+
+void
+gnc_amount_edit_set_validate_on_change (GNCAmountEdit *gae,
+                                        gboolean validate_on_change)
+{
+    g_return_if_fail (gae != NULL);
+    g_return_if_fail (GNC_IS_AMOUNT_EDIT(gae));
+
+    gae->validate_on_change = validate_on_change;
+}
+
+void
+gnc_amount_edit_select_region (GNCAmountEdit *gae,
+                               gint start_pos,
+                               gint end_pos)
+{
+    g_return_if_fail (gae != NULL);
+    g_return_if_fail (GNC_IS_AMOUNT_EDIT(gae));
+
+    gtk_editable_select_region (GTK_EDITABLE(gae->entry),
+                                start_pos,
+                                end_pos);
+}
+
+gchar *
+gnc_amount_edit_get_error_message (GNCAmountEdit *gae)
+{
+    g_return_val_if_fail (gae != NULL, NULL);
+
+    if (gae->error_position <= 0) // no error
+        return NULL;
+    else if (gae->error_position == 1) // error but no error position
+        return g_strdup_printf (_("An error occurred while processing '%s'"),
+                                gtk_entry_get_text (GTK_ENTRY(gae->entry)));
+    else // error and position of error
+        return g_strdup_printf (_("An error occurred while processing '%s' at position %d"),
+                                gtk_entry_get_text (GTK_ENTRY(gae->entry)),
+                                gae->error_position - ERROR_POSITION_BASE);
+}
+
+void
+gnc_amount_edit_show_warning_symbol (GNCAmountEdit *gae, gboolean show)
+{
+    g_return_if_fail (gae != NULL);
+    g_return_if_fail (GNC_IS_AMOUNT_EDIT(gae));
+
+    gae->show_warning_symbol = show;
 }

--- a/gnucash/gnome-utils/gnc-amount-edit.c
+++ b/gnucash/gnome-utils/gnc-amount-edit.c
@@ -286,7 +286,7 @@ gnc_amount_edit_expr_is_valid (GNCAmountEdit *gae, gnc_numeric *amount,
 
     /* Not ok */
     if (error_loc != NULL)
-        return  error_loc - string;
+        return (error_loc - string) + ERROR_POSITION_BASE;
     else
         return 1;
 }
@@ -325,7 +325,7 @@ gnc_amount_edit_evaluate (GNCAmountEdit *gae)
     }
 
     /* Parse error */
-    gtk_editable_set_position (GTK_EDITABLE(gae), result);
+    gtk_editable_set_position (GTK_EDITABLE(gae), result - ERROR_POSITION_BASE);
     return FALSE;
 }
 

--- a/gnucash/gnome-utils/gnc-amount-edit.c
+++ b/gnucash/gnome-utils/gnc-amount-edit.c
@@ -1,35 +1,27 @@
-/*
- * gnc-amount-edit.c -- Amount editor widget
- *
- * Copyright (C) 2000 Dave Peticolas <dave@krondo.com>
- * All rights reserved.
- *
- * Gnucash is free software; you can redistribute it and/or modify it
- * under the terms of the GNU Library General Public License as
- * published by the Free Software Foundation; either version 2 of the
- * License, or (at your option) any later version.
- *
- * Gnucash is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Library General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, contact:
- *
- * Free Software Foundation           Voice:  +1-617-542-5942
- * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652
- * Boston, MA  02110-1301,  USA       gnu@gnu.org
- *
- */
+/********************************************************************\
+ * gnc-amount-edit.h -- amount editor widget                        *
+ *                                                                  *
+ * Copyright (C) 2000 Dave Peticolas <dave@krondo.com>              *
+ *                                                                  *
+ * This program is free software; you can redistribute it and/or    *
+ * modify it under the terms of the GNU General Public License as   *
+ * published by the Free Software Foundation; either version 2 of   *
+ * the License, or (at your option) any later version.              *
+ *                                                                  *
+ * This program is distributed in the hope that it will be useful,  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    *
+ * GNU General Public License for more details.                     *
+ *                                                                  *
+ * You should have received a copy of the GNU General Public License*
+ * along with this program; if not, contact:                        *
+ *                                                                  *
+ * Free Software Foundation           Voice:  +1-617-542-5942       *
+ * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652       *
+ * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
+\********************************************************************/
 /*
   @NOTATION@
- */
-
-/*
- * Amount editor widget
- *
- * Authors: Dave Peticolas <dave@krondo.com>
  */
 
 #include <config.h>
@@ -55,24 +47,17 @@ enum
     LAST_SIGNAL
 };
 
-
 static guint amount_edit_signals [LAST_SIGNAL] = { 0 };
 
-
-static void gnc_amount_edit_init         (GNCAmountEdit      *gae);
-static void gnc_amount_edit_class_init   (GNCAmountEditClass *klass);
-static void gnc_amount_edit_changed      (GtkEditable        *gae, gpointer data);
-static gint gnc_amount_edit_key_press    (GtkWidget          *widget,
-        GdkEventKey        *event);
-
+static void gnc_amount_edit_init (GNCAmountEdit *gae);
+static void gnc_amount_edit_class_init (GNCAmountEditClass *klass);
+static void gnc_amount_edit_changed (GtkEditable *gae,
+                                     gpointer user_data);
+static gint gnc_amount_edit_key_press (GtkWidget   *widget,
+                                       GdkEventKey *event);
 
 static GtkEntryClass *parent_class;
 
-/**
- * gnc_amount_edit_get_type:
- *
- * Returns the GType for the GNCAmountEdit widget
- */
 GType
 gnc_amount_edit_get_type (void)
 {
@@ -94,32 +79,28 @@ gnc_amount_edit_get_type (void)
         };
 
         amount_edit_type = g_type_register_static (GTK_TYPE_ENTRY,
-                           "GNCAmountEdit",
-                           &amount_edit_info,
-                           0);
+                                                   "GNCAmountEdit",
+                                                    &amount_edit_info,
+                                                    0);
     }
-
     return amount_edit_type;
 }
 
 static void
 gnc_amount_edit_class_init (GNCAmountEditClass *klass)
 {
-    GObjectClass *object_class;
-    GtkWidgetClass *widget_class;
-    /* GtkEditableClass *editable_class; */
-
-    object_class = G_OBJECT_CLASS (klass);
-    widget_class = GTK_WIDGET_CLASS (klass);
-    /* editable_class = GTK_EDITABLE_CLASS (g_type_interface_peek (klass, GTK_TYPE_EDITABLE)); */
+    GObjectClass *object_class = G_OBJECT_CLASS(klass);
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS(klass);
+ /* GtkEditableClass *editable_class = GTK_EDITABLE_CLASS(g_type_interface_peek
+                                                         (klass, GTK_TYPE_EDITABLE)); */
 
     parent_class = g_type_class_peek_parent (klass);
 
     amount_edit_signals [AMOUNT_CHANGED] =
         g_signal_new ("amount_changed",
-                      G_OBJECT_CLASS_TYPE (object_class),
+                      G_OBJECT_CLASS_TYPE(object_class),
                       G_SIGNAL_RUN_FIRST,
-                      G_STRUCT_OFFSET (GNCAmountEditClass, amount_changed),
+                      G_STRUCT_OFFSET(GNCAmountEditClass, amount_changed),
                       NULL,
                       NULL,
                       g_cclosure_marshal_VOID__VOID,
@@ -128,7 +109,7 @@ gnc_amount_edit_class_init (GNCAmountEditClass *klass)
 
     widget_class->key_press_event = gnc_amount_edit_key_press;
 
-    /* editable_class->changed = gnc_amount_edit_changed; */
+ /* editable_class->changed = gnc_amount_edit_changed; */
 }
 
 static void
@@ -143,20 +124,20 @@ gnc_amount_edit_init (GNCAmountEdit *gae)
     // Set the name for this widget so it can be easily manipulated with css
     gtk_widget_set_name (GTK_WIDGET(gae), "gnc-id-amount-edit");
 
-    g_signal_connect (G_OBJECT (gae), "changed",
-                      G_CALLBACK (gnc_amount_edit_changed), NULL);
+    g_signal_connect (G_OBJECT(gae), "changed",
+                      G_CALLBACK(gnc_amount_edit_changed), NULL);
 }
 
 static void
-gnc_amount_edit_changed (GtkEditable *editable, gpointer data)
+gnc_amount_edit_changed (GtkEditable *editable, gpointer user_data)
 {
-    /*GTK_EDITABLE_CLASS (parent_class)->changed(editable);*/
+    /*GTK_EDITABLE_CLASS(parent_class)->changed(editable);*/
 
     GNC_AMOUNT_EDIT(editable)->need_to_parse = TRUE;
 }
 
 static gint
-gnc_amount_edit_key_press(GtkWidget *widget, GdkEventKey *event)
+gnc_amount_edit_key_press (GtkWidget *widget, GdkEventKey *event)
 {
     GNCAmountEdit *gae = GNC_AMOUNT_EDIT(widget);
     gint result;
@@ -176,7 +157,7 @@ gnc_amount_edit_key_press(GtkWidget *widget, GdkEventKey *event)
         }
     }
 
-    result = (* GTK_WIDGET_CLASS (parent_class)->key_press_event)(widget, event);
+    result = (* GTK_WIDGET_CLASS(parent_class)->key_press_event)(widget, event);
 
     switch (event->keyval)
     {
@@ -197,15 +178,6 @@ gnc_amount_edit_key_press(GtkWidget *widget, GdkEventKey *event)
     return TRUE;
 }
 
-/**
- * gnc_amount_edit_new:
- *
- * Creates a new GNCAmountEdit widget which can be used to provide
- * an easy to use way for entering amounts, allowing the user to
- * enter and evaluate expressions.
- *
- * Returns a GNCAmountEdit widget.
- */
 GtkWidget *
 gnc_amount_edit_new (void)
 {
@@ -214,25 +186,9 @@ gnc_amount_edit_new (void)
     gae = g_object_new (GNC_TYPE_AMOUNT_EDIT, NULL);
     gtk_widget_show (GTK_WIDGET(gae));
 
-    return GTK_WIDGET (gae);
+    return GTK_WIDGET(gae);
 }
 
-/**
- * gnc_amount_edit_expr_is_valid
- * @gae: The GNCAmountEdit widget
- * @amount: parameter to hold the value of the parsed expression
- * @empty_ok: if true, an empty field is skipped, otherwise an empty field
- *            parses as 0
- *
- * If needed, parse the expression in the amount entry. If there's no
- * parsing error, it returns the amount, otherwise it returns the
- * position in the expression where the error occurred.
- *
- * Return *  0 if the parsing was successful (note that if !empty_ok,
- *             an empty field will parse to 0)
- *        * -1 if the field is empty and that's ok (empty_ok)
- *        * error position if there was a parsing error
- */
 gint
 gnc_amount_edit_expr_is_valid (GNCAmountEdit *gae, gnc_numeric *amount,
                                gboolean empty_ok)
@@ -241,13 +197,13 @@ gnc_amount_edit_expr_is_valid (GNCAmountEdit *gae, gnc_numeric *amount,
     char *error_loc;
     gboolean ok;
 
-    g_return_val_if_fail(gae != NULL, -1);
-    g_return_val_if_fail(GNC_IS_AMOUNT_EDIT(gae), -1);
+    g_return_val_if_fail (gae != NULL, -1);
+    g_return_val_if_fail (GNC_IS_AMOUNT_EDIT(gae), -1);
 
-    string = gtk_entry_get_text(GTK_ENTRY(gae));
+    string = gtk_entry_get_text (GTK_ENTRY(gae));
     if (!string || *string == '\0')
     {
-        *amount = gnc_numeric_zero();
+        *amount = gnc_numeric_zero ();
         if (empty_ok)
             return -1; /* indicate an empty field */
         else
@@ -267,26 +223,14 @@ gnc_amount_edit_expr_is_valid (GNCAmountEdit *gae, gnc_numeric *amount,
         return 1;
 }
 
-
-/**
- * gnc_amount_edit_evaluate
- * @gae: The GNCAmountEdit widget
- *
- * If needed, parse the expression in the amount entry
- * and replace the expression with the result of evaluation.
- * If there is a parsing error, don't change the expression entry,
- * but do put the cursor at the point of the error.
- *
- * Return TRUE if parsing was successful or there was no need to parse.
- */
 gboolean
 gnc_amount_edit_evaluate (GNCAmountEdit *gae)
 {
     gint result;
     gnc_numeric amount;
 
-    g_return_val_if_fail(gae != NULL, FALSE);
-    g_return_val_if_fail(GNC_IS_AMOUNT_EDIT(gae), FALSE);
+    g_return_val_if_fail (gae != NULL, FALSE);
+    g_return_val_if_fail (GNC_IS_AMOUNT_EDIT(gae), FALSE);
 
 
     if (!gae->need_to_parse)
@@ -317,62 +261,36 @@ gnc_amount_edit_evaluate (GNCAmountEdit *gae)
     return FALSE;
 }
 
-
-/**
- * gnc_amount_edit_get_amount:
- * @gae: The GNCAmountEdit widget
- *
- * Returns the amount entered in the GNCAmountEdit widget,
- * parsing the expression if necessary. The result of parsing
- * replaces the expression.
- */
 gnc_numeric
 gnc_amount_edit_get_amount (GNCAmountEdit *gae)
 {
-    g_return_val_if_fail(gae != NULL, gnc_numeric_zero ());
-    g_return_val_if_fail(GNC_IS_AMOUNT_EDIT(gae), gnc_numeric_zero ());
+    g_return_val_if_fail (gae != NULL, gnc_numeric_zero ());
+    g_return_val_if_fail (GNC_IS_AMOUNT_EDIT(gae), gnc_numeric_zero ());
 
     gnc_amount_edit_evaluate (gae);
 
     return gae->amount;
 }
 
-
-/**
- * gnc_amount_edit_get_amount:
- * @gae: The GNCAmountEdit widget
- *
- * Returns the amount entered in the GNCAmountEdit widget,
- * parsing the expression if necessary. The result of parsing
- * replaces the expression.
- */
 double
 gnc_amount_edit_get_damount (GNCAmountEdit *gae)
 {
-    g_return_val_if_fail(gae != NULL, 0.0);
-    g_return_val_if_fail(GNC_IS_AMOUNT_EDIT(gae), 0.0);
+    g_return_val_if_fail (gae != NULL, 0.0);
+    g_return_val_if_fail (GNC_IS_AMOUNT_EDIT(gae), 0.0);
 
     gnc_amount_edit_evaluate (gae);
 
     return gnc_numeric_to_double (gae->amount);
 }
 
-
-/**
- * gnc_amount_edit_set_amount:
- * @gae: The GNCAmountEdit widget
- * @amount: The amount to set
- *
- * Returns nothing.
- */
 void
 gnc_amount_edit_set_amount (GNCAmountEdit *gae, gnc_numeric amount)
 {
     const char * amount_string;
 
-    g_return_if_fail(gae != NULL);
-    g_return_if_fail(GNC_IS_AMOUNT_EDIT(gae));
-    g_return_if_fail(!gnc_numeric_check (amount));
+    g_return_if_fail (gae != NULL);
+    g_return_if_fail (GNC_IS_AMOUNT_EDIT(gae));
+    g_return_if_fail (!gnc_numeric_check (amount));
 
     /* Update the display. */
     amount_string = xaccPrintAmount (amount, gae->print_info);
@@ -382,21 +300,14 @@ gnc_amount_edit_set_amount (GNCAmountEdit *gae, gnc_numeric amount)
     gae->need_to_parse = FALSE;
 }
 
-/**
- * gnc_amount_edit_set_amount:
- * @gae: The GNCAmountEdit widget
- * @amount: The amount to set
- *
- * Returns nothing.
- */
 void
 gnc_amount_edit_set_damount (GNCAmountEdit *gae, double damount)
 {
     gnc_numeric amount;
     int fraction;
 
-    g_return_if_fail(gae != NULL);
-    g_return_if_fail(GNC_IS_AMOUNT_EDIT(gae));
+    g_return_if_fail (gae != NULL);
+    g_return_if_fail (GNC_IS_AMOUNT_EDIT(gae));
 
     if (gae->fraction > 0)
         fraction = gae->fraction;
@@ -408,73 +319,43 @@ gnc_amount_edit_set_damount (GNCAmountEdit *gae, double damount)
     gnc_amount_edit_set_amount (gae, amount);
 }
 
-/**
- * gnc_amount_edit_set_print_flags:
- * @gae: The GNCAmountEdit widget
- * @print_flags: The print flags to set
- *
- * Returns nothing.
- */
 void
 gnc_amount_edit_set_print_info (GNCAmountEdit *gae,
                                 GNCPrintAmountInfo print_info)
 {
-    g_return_if_fail(gae != NULL);
-    g_return_if_fail(GNC_IS_AMOUNT_EDIT(gae));
+    g_return_if_fail (gae != NULL);
+    g_return_if_fail (GNC_IS_AMOUNT_EDIT(gae));
 
     gae->print_info = print_info;
     gae->print_info.use_symbol = 0;
 }
 
-
-/**
- * gnc_amount_edit_set_fraction:
- * @gae: The GNCAmountEdit widget
- * @fraction: The fraction to set
- *
- * Returns nothing.
- */
 void
 gnc_amount_edit_set_fraction (GNCAmountEdit *gae, int fraction)
 {
-    g_return_if_fail(gae != NULL);
-    g_return_if_fail(GNC_IS_AMOUNT_EDIT(gae));
+    g_return_if_fail (gae != NULL);
+    g_return_if_fail (GNC_IS_AMOUNT_EDIT(gae));
 
     fraction = MAX (0, fraction);
 
     gae->fraction = fraction;
 }
 
-
-/**
- * gnc_amount_edit_gtk_entry:
- * @gae: The GNCAmountEdit widget
- *
- * Returns the gtk entry of the widget..
- */
 GtkWidget *
 gnc_amount_edit_gtk_entry (GNCAmountEdit *gae)
 {
-    g_return_val_if_fail(gae != NULL, NULL);
-    g_return_val_if_fail(GNC_IS_AMOUNT_EDIT(gae), NULL);
+    g_return_val_if_fail (gae != NULL, NULL);
+    g_return_val_if_fail (GNC_IS_AMOUNT_EDIT(gae), NULL);
 
-    return (GtkWidget *)gae;
+    return GTK_WIDGET(gae);
 }
 
-
-/**
- * gnc_amount_edit_set_evaluate_on_enter:
- * @gae: The GNCAmountEdit widget
- * @evaluate_on_enter: The flag value to set
- *
- * Returns nothing.
- */
 void
 gnc_amount_edit_set_evaluate_on_enter (GNCAmountEdit *gae,
                                        gboolean evaluate_on_enter)
 {
-    g_return_if_fail(gae != NULL);
-    g_return_if_fail(GNC_IS_AMOUNT_EDIT(gae));
+    g_return_if_fail (gae != NULL);
+    g_return_if_fail (GNC_IS_AMOUNT_EDIT(gae));
 
     gae->evaluate_on_enter = evaluate_on_enter;
 }

--- a/gnucash/gnome-utils/gnc-amount-edit.h
+++ b/gnucash/gnome-utils/gnc-amount-edit.h
@@ -1,27 +1,25 @@
-/*
- * gnc-amount-edit.h -- amount editor widget
- *
- * Copyright (C) 2000 Dave Peticolas <dave@krondo.com>
- * All rights reserved.
- *
- * GnuCash is free software; you can redistribute it and/or modify it
- * under the terms of the GNU Library General Public License as
- * published by the Free Software Foundation; either version 2 of the
- * License, or (at your option) any later version.
- *
- * Gnucash is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Library General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, contact:
- *
- * Free Software Foundation           Voice:  +1-617-542-5942
- * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652
- * Boston, MA  02110-1301,  USA       gnu@gnu.org
- *
- */
+/********************************************************************\
+ * gnc-amount-edit.h -- amount editor widget                        *
+ *                                                                  *
+ * Copyright (C) 2000 Dave Peticolas <dave@krondo.com>              *
+ *                                                                  *
+ * This program is free software; you can redistribute it and/or    *
+ * modify it under the terms of the GNU General Public License as   *
+ * published by the Free Software Foundation; either version 2 of   *
+ * the License, or (at your option) any later version.              *
+ *                                                                  *
+ * This program is distributed in the hope that it will be useful,  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    *
+ * GNU General Public License for more details.                     *
+ *                                                                  *
+ * You should have received a copy of the GNU General Public License*
+ * along with this program; if not, contact:                        *
+ *                                                                  *
+ * Free Software Foundation           Voice:  +1-617-542-5942       *
+ * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652       *
+ * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
+\********************************************************************/
 /*
   @NOTATION@
  */
@@ -34,10 +32,10 @@
 
 #include <gtk/gtk.h>
 
-#define GNC_TYPE_AMOUNT_EDIT          (gnc_amount_edit_get_type())
-#define GNC_AMOUNT_EDIT(obj)          G_TYPE_CHECK_INSTANCE_CAST (obj, GNC_TYPE_AMOUNT_EDIT, GNCAmountEdit)
-#define GNC_AMOUNT_EDIT_CLASS(klass)  G_TYPE_CHECK_CLASS_CAST (klass, GNC_TYPE_AMOUNT_EDIT, GNCAmountEditClass)
-#define GNC_IS_AMOUNT_EDIT(obj)       G_TYPE_CHECK_INSTANCE_TYPE (obj, GNC_TYPE_AMOUNT_EDIT)
+#define GNC_TYPE_AMOUNT_EDIT          (gnc_amount_edit_get_type ())
+#define GNC_AMOUNT_EDIT(obj)          G_TYPE_CHECK_INSTANCE_CAST(obj, GNC_TYPE_AMOUNT_EDIT, GNCAmountEdit)
+#define GNC_AMOUNT_EDIT_CLASS(klass)  G_TYPE_CHECK_CLASS_CAST(klass, GNC_TYPE_AMOUNT_EDIT, GNCAmountEditClass)
+#define GNC_IS_AMOUNT_EDIT(obj)       G_TYPE_CHECK_INSTANCE_TYPE(obj, GNC_TYPE_AMOUNT_EDIT)
 
 typedef struct
 {
@@ -63,29 +61,131 @@ typedef struct
     void (*amount_changed) (GNCAmountEdit *gae);
 } GNCAmountEditClass;
 
-GType     gnc_amount_edit_get_type        (void);
+/**
+ * gnc_amount_edit_get_type:
+ *
+ * Returns the GType for the GNCAmountEdit widget
+ */
+GType gnc_amount_edit_get_type (void);
 
-GtkWidget *gnc_amount_edit_new            (void);
+/**
+ * gnc_amount_edit_new:
+ *
+ * Creates a new GNCAmountEdit widget which can be used to provide
+ * an easy to use way for entering amounts, allowing the user to
+ * enter and evaluate expressions.
+ *
+ * Returns a GNCAmountEdit widget.
+ */
+GtkWidget *gnc_amount_edit_new (void);
 
-GtkWidget *gnc_amount_edit_gtk_entry      (GNCAmountEdit *gae);
+/**
+ * gnc_amount_edit_gtk_entry:
+ * @gae: The GNCAmountEdit widget
+ *
+ * Returns the gtk entry of the widget..
+ */
+GtkWidget *gnc_amount_edit_gtk_entry (GNCAmountEdit *gae);
 
-void      gnc_amount_edit_set_amount      (GNCAmountEdit *gae,
-        gnc_numeric amount);
-void      gnc_amount_edit_set_damount     (GNCAmountEdit *gae,
-        double amount);
+/**
+ * gnc_amount_edit_set_amount:
+ * @gae: The GNCAmountEdit widget
+ * @amount: The amount to set as gnc_numeric
+ *
+ * Returns nothing.
+ */
+void gnc_amount_edit_set_amount (GNCAmountEdit *gae,
+                                 gnc_numeric amount);
 
-gnc_numeric gnc_amount_edit_get_amount    (GNCAmountEdit *gae);
-double      gnc_amount_edit_get_damount   (GNCAmountEdit *gae);
+/**
+ * gnc_amount_edit_set_damount:
+ * @gae: The GNCAmountEdit widget
+ * @amount: The amount to set as a double
+ *
+ * Returns nothing.
+ */
+void gnc_amount_edit_set_damount (GNCAmountEdit *gae,
+                                  double amount);
 
-gint      gnc_amount_edit_expr_is_valid (GNCAmountEdit *gae, gnc_numeric *amount,
-        gboolean empty_ok);
-gboolean  gnc_amount_edit_evaluate        (GNCAmountEdit *gae);
+/**
+ * gnc_amount_edit_get_amount:
+ * @gae: The GNCAmountEdit widget
+ *
+ * Returns the amount entered in the GNCAmountEdit widget as
+ * a gnc_numeric, parsing the expression if necessary.
+ * The result of parsing replaces the expression.
+ */
+gnc_numeric gnc_amount_edit_get_amount (GNCAmountEdit *gae);
 
-void      gnc_amount_edit_set_print_info  (GNCAmountEdit *gae,
-        GNCPrintAmountInfo print_info);
+/**
+ * gnc_amount_edit_get_damount:
+ * @gae: The GNCAmountEdit widget
+ *
+ * Returns the amount entered in the GNCAmountEdit widget as
+ * a double, parsing the expression if necessary.
+ * The result of parsing replaces the expression.
+ */
+double gnc_amount_edit_get_damount (GNCAmountEdit *gae);
 
-void      gnc_amount_edit_set_fraction    (GNCAmountEdit *gae, int fraction);
+/**
+ * gnc_amount_edit_expr_is_valid
+ * @gae: The GNCAmountEdit widget
+ * @amount: parameter to hold the value of the parsed expression
+ * @empty_ok: if true, an empty field is skipped, otherwise an empty field
+ *            parses as 0
+ *
+ * If needed, parse the expression in the amount entry. If there's no
+ * parsing error, it returns the amount, otherwise it returns the
+ * position in the expression where the error occurred.
+ *
+ * Return *  0 if the parsing was successful (note that if !empty_ok,
+ *             an empty field will parse to 0)
+ *        * -1 if the field is empty and that's ok (empty_ok)
+ *        * error position if there was a parsing error
+ */
+gint gnc_amount_edit_expr_is_valid (GNCAmountEdit *gae,
+                                    gnc_numeric *amount,
+                                    gboolean empty_ok);
 
-void      gnc_amount_edit_set_evaluate_on_enter (GNCAmountEdit *gae,
-        gboolean evaluate_on_enter);
+/**
+ * gnc_amount_edit_evaluate
+ * @gae: The GNCAmountEdit widget
+ *
+ * If needed, parse the expression in the amount entry
+ * and replace the expression with the result of evaluation.
+ * If there is a parsing error, don't change the expression entry,
+ * but do put the cursor at the point of the error.
+ *
+ * Return TRUE if parsing was successful or there was no need to parse.
+ */
+gboolean gnc_amount_edit_evaluate (GNCAmountEdit *gae);
+
+/**
+ * gnc_amount_edit_set_print_flags:
+ * @gae: The GNCAmountEdit widget
+ * @print_flags: The print flags to set
+ *
+ * Returns nothing.
+ */
+void gnc_amount_edit_set_print_info (GNCAmountEdit *gae,
+                                     GNCPrintAmountInfo print_info);
+
+/**
+ * gnc_amount_edit_set_fraction:
+ * @gae: The GNCAmountEdit widget
+ * @fraction: The fraction to set
+ *
+ * Returns nothing.
+ */
+void gnc_amount_edit_set_fraction (GNCAmountEdit *gae, int fraction);
+
+/**
+ * gnc_amount_edit_set_evaluate_on_enter:
+ * @gae: The GNCAmountEdit widget
+ * @evaluate_on_enter: The flag value to set
+ *
+ * Returns nothing.
+ */
+void gnc_amount_edit_set_evaluate_on_enter (GNCAmountEdit *gae,
+                                            gboolean evaluate_on_enter);
 #endif

--- a/gnucash/gnome-utils/gnc-amount-edit.h
+++ b/gnucash/gnome-utils/gnc-amount-edit.h
@@ -41,8 +41,11 @@
 
 typedef struct
 {
-    GtkEntry entry;
+    GtkBox    box;
+    GtkEntry *entry;
+    GtkWidget *image;
 
+    gboolean disposed;
     gboolean need_to_parse;
 
     GNCPrintAmountInfo print_info;
@@ -54,14 +57,21 @@ typedef struct
     int fraction;
 
     gboolean evaluate_on_enter;
+    gboolean validate_on_change;
+
+    gboolean show_warning_symbol;
+
+    gint error_position;
 
 } GNCAmountEdit;
 
 typedef struct
 {
-    GtkEntryClass parent_class;
+    GtkBoxClass parent_class;
 
     /* Signals for notification/filtering of changes */
+    void (*activate) (GNCAmountEdit *gae);
+    void (*changed) (GNCAmountEdit *gae);
     void (*amount_changed) (GNCAmountEdit *gae);
 } GNCAmountEditClass;
 
@@ -70,7 +80,7 @@ typedef struct
  *
  * Returns the GType for the GNCAmountEdit widget
  */
-GType gnc_amount_edit_get_type (void);
+GType gnc_amount_edit_get_type (void) G_GNUC_CONST;
 
 /**
  * gnc_amount_edit_new:
@@ -193,4 +203,44 @@ void gnc_amount_edit_set_fraction (GNCAmountEdit *gae, int fraction);
  */
 void gnc_amount_edit_set_evaluate_on_enter (GNCAmountEdit *gae,
                                             gboolean evaluate_on_enter);
+
+/**
+ * gnc_amount_edit_set_validate_on_change:
+ * @gae: The GNCAmountEdit widget
+ * @validate_on_change: The flag value to set
+ *
+ * Returns nothing.
+ */
+void gnc_amount_edit_set_validate_on_change (GNCAmountEdit *gae,
+                                             gboolean validate_on_change);
+
+/**
+ * gnc_amount_edit_select_region:
+ * @gae: The GNCAmountEdit widget
+ * @start_pos: start of region
+ * @end_pos: end of region
+ *
+ * Returns nothing.
+ */
+void gnc_amount_edit_select_region (GNCAmountEdit *gae,
+                                    gint start_pos,
+                                    gint end_pos);
+
+/**
+ * gnc_amount_edit_get_error_message:
+ * @gae: The GNCAmountEdit widget
+ *
+ * Returns the error message, should be freed by caller.
+ */
+gchar *gnc_amount_edit_get_error_message (GNCAmountEdit *gae);
+
+/**
+ * gnc_amount_edit_show_warning_symbol:
+ * @gae: The GNCAmountEdit widget
+ * @show: default is TRUE to show warning symbol, FALSE to not.
+ *
+ * Returns nothing.
+ */
+void gnc_amount_edit_show_warning_symbol (GNCAmountEdit *gae, gboolean show);
+
 #endif

--- a/gnucash/gnome-utils/gnc-amount-edit.h
+++ b/gnucash/gnome-utils/gnc-amount-edit.h
@@ -45,6 +45,8 @@ typedef struct
 
     GNCPrintAmountInfo print_info;
 
+    gboolean block_changed;
+
     gnc_numeric amount;
 
     int fraction;

--- a/gnucash/gnome-utils/gnc-amount-edit.h
+++ b/gnucash/gnome-utils/gnc-amount-edit.h
@@ -37,6 +37,8 @@
 #define GNC_AMOUNT_EDIT_CLASS(klass)  G_TYPE_CHECK_CLASS_CAST(klass, GNC_TYPE_AMOUNT_EDIT, GNCAmountEditClass)
 #define GNC_IS_AMOUNT_EDIT(obj)       G_TYPE_CHECK_INSTANCE_TYPE(obj, GNC_TYPE_AMOUNT_EDIT)
 
+#define ERROR_POSITION_BASE 1000
+
 typedef struct
 {
     GtkEntry entry;
@@ -143,7 +145,8 @@ double gnc_amount_edit_get_damount (GNCAmountEdit *gae);
  * Return *  0 if the parsing was successful (note that if !empty_ok,
  *             an empty field will parse to 0)
  *        * -1 if the field is empty and that's ok (empty_ok)
- *        * error position if there was a parsing error
+ *        * error position if there was a parsing error which is offset
+ *          by ERROR_POSITION_BASE
  */
 gint gnc_amount_edit_expr_is_valid (GNCAmountEdit *gae,
                                     gnc_numeric *amount,

--- a/gnucash/gnome/assistant-loan.cpp
+++ b/gnucash/gnome/assistant-loan.cpp
@@ -618,6 +618,9 @@ gnc_loan_assistant_create( LoanAssistantData *ldd )
             gtk_widget_set_hexpand (GTK_WIDGET(ldd->prmOrigPrincGAE), FALSE);
             g_object_set (GTK_WIDGET(ldd->prmOrigPrincGAE), "margin", 2, nullptr);
 
+            g_signal_connect (G_OBJECT(ldd->prmOrigPrincGAE), "changed",
+                              G_CALLBACK(loan_info_page_valid_cb), ldd);
+
             for ( i = 0; gas_data[i].loc != NULL; i++ )
             {
                 GNCAccountSel *gas = GNC_ACCOUNT_SEL(gnc_account_sel_new());
@@ -1061,10 +1064,26 @@ gboolean
 loan_info_page_complete( GtkAssistant *assistant, gpointer user_data )
 {
     LoanAssistantData *ldd = static_cast<LoanAssistantData*> (user_data);
+    GNCPrintAmountInfo print_info;
+    gnc_commodity *currency;
+    gint result;
+    gnc_numeric value;
 
     ldd->ld.primaryAcct = gnc_account_sel_get_account( ldd->prmAccountGAS );
     /* Test for valid Account */
     if ( ldd->ld.primaryAcct == NULL )
+        return FALSE;
+
+    /* Test for loan amount */
+    currency = xaccAccountGetCommodity (ldd->ld.primaryAcct);
+    print_info = gnc_commodity_print_info (currency, FALSE);
+    gnc_amount_edit_set_print_info (GNC_AMOUNT_EDIT(ldd->prmOrigPrincGAE), print_info);
+    gnc_amount_edit_set_fraction (GNC_AMOUNT_EDIT(ldd->prmOrigPrincGAE),
+                                  gnc_commodity_get_fraction (currency));
+
+    result = gnc_amount_edit_expr_is_valid (GNC_AMOUNT_EDIT(ldd->prmOrigPrincGAE),
+                                            &value, FALSE);
+    if (result >= 1)
         return FALSE;
 
     return TRUE;

--- a/gnucash/gnome/assistant-stock-split.c
+++ b/gnucash/gnome/assistant-stock-split.c
@@ -274,6 +274,8 @@ gnc_stock_split_assistant_details_complete (GtkAssistant *assistant,
         gpointer user_data)
 {
     StockSplitInfo *info = user_data;
+    GNCPrintAmountInfo print_info;
+    gnc_commodity *currency;
     gnc_numeric amount;
     gint result;
 
@@ -283,6 +285,12 @@ gnc_stock_split_assistant_details_complete (GtkAssistant *assistant,
 
     if (gnc_numeric_zero_p (amount))
         return FALSE; /* field value is 0 */
+
+    currency = gnc_currency_edit_get_currency (GNC_CURRENCY_EDIT(info->price_currency_edit));
+    print_info = gnc_commodity_print_info (currency, FALSE);
+    gnc_amount_edit_set_print_info (GNC_AMOUNT_EDIT (info->price_edit), print_info);
+    gnc_amount_edit_set_fraction (GNC_AMOUNT_EDIT (info->price_edit),
+                                  gnc_commodity_get_fraction (currency));
 
     result = gnc_amount_edit_expr_is_valid (GNC_AMOUNT_EDIT (info->price_edit), &amount, TRUE);
     if (result == -1)
@@ -640,6 +648,8 @@ gnc_stock_split_assistant_create (StockSplitInfo *info)
         gnc_currency_edit_set_currency (GNC_CURRENCY_EDIT(info->price_currency_edit), gnc_default_currency());
         gtk_widget_show (info->price_currency_edit);
         gtk_grid_attach (GTK_GRID(table), info->price_currency_edit, 1, 6, 1, 1);
+        g_signal_connect (info->price_currency_edit, "changed",
+                          G_CALLBACK (gnc_stock_split_details_valid_cb), info);
     }
 
     /* Cash page Widgets */

--- a/gnucash/gnome/dialog-customer.c
+++ b/gnucash/gnome/dialog-customer.c
@@ -323,6 +323,8 @@ gnc_customer_window_ok_cb (GtkWidget *widget, gpointer data)
     CustomerWindow *cw = data;
     gnc_numeric min, max;
     gchar *string;
+    gnc_commodity *currency;
+    GNCPrintAmountInfo print_info;
 
     /* Check for valid company name */
     if (check_entry_nonempty (cw->company_entry,
@@ -351,6 +353,12 @@ gnc_customer_window_ok_cb (GtkWidget *widget, gpointer data)
                            _("Discount percentage must be between 0-100 "
                              "or you must leave it blank.")))
         return;
+
+    currency = gnc_currency_edit_get_currency (GNC_CURRENCY_EDIT(cw->currency_edit));
+    print_info = gnc_commodity_print_info (currency, FALSE);
+    gnc_amount_edit_set_print_info (GNC_AMOUNT_EDIT (cw->credit_amount), print_info);
+    gnc_amount_edit_set_fraction (GNC_AMOUNT_EDIT (cw->credit_amount),
+                                  gnc_commodity_get_fraction (currency));
 
     if (check_edit_amount (cw->credit_amount, &min, NULL,
                            _("Credit must be a positive amount or "

--- a/gnucash/gnome/dialog-employee.c
+++ b/gnucash/gnome/dialog-employee.c
@@ -193,6 +193,8 @@ gnc_employee_window_ok_cb (GtkWidget *widget, gpointer data)
 {
     EmployeeWindow *ew = data;
     gchar *string;
+    GNCPrintAmountInfo print_info;
+    gnc_commodity *currency;
 
     /* Check for valid username */
     if (check_entry_nonempty (ew->username_entry,
@@ -222,6 +224,20 @@ gnc_employee_window_ok_cb (GtkWidget *widget, gpointer data)
         gtk_entry_set_text (GTK_ENTRY (ew->id_entry), string);
         g_free(string);
     }
+
+    /* Check for valid workday amount */
+    if (!gnc_amount_edit_evaluate (GNC_AMOUNT_EDIT(ew->workday_amount)))
+        return;
+
+    currency = gnc_currency_edit_get_currency (GNC_CURRENCY_EDIT(ew->currency_edit));
+    print_info = gnc_commodity_print_info (currency, FALSE);
+    gnc_amount_edit_set_print_info (GNC_AMOUNT_EDIT (ew->rate_amount), print_info);
+    gnc_amount_edit_set_fraction (GNC_AMOUNT_EDIT (ew->rate_amount),
+                                  gnc_commodity_get_fraction (currency));
+
+    /* Check for valid rate amount */
+    if (!gnc_amount_edit_evaluate (GNC_AMOUNT_EDIT(ew->rate_amount)))
+        return;
 
     /* Now save it off */
     {

--- a/gnucash/gnome/dialog-fincalc.c
+++ b/gnucash/gnome/dialog-fincalc.c
@@ -181,6 +181,7 @@ static void
 gui_to_fi(FinCalcDialog *fcd)
 {
     GtkToggleButton *toggle;
+    GtkWidget *entry;
     gnc_numeric npp;
     int i;
     const gchar *text;
@@ -189,7 +190,8 @@ gui_to_fi(FinCalcDialog *fcd)
         return;
 
     /* treat PAYMENT_PERIODS as a plain GtkEntry */
-    text = gtk_entry_get_text (GTK_ENTRY(GNC_AMOUNT_EDIT(fcd->amounts[PAYMENT_PERIODS])));
+    entry = gnc_amount_edit_gtk_entry (GNC_AMOUNT_EDIT(fcd->amounts[PAYMENT_PERIODS]));
+    text = gtk_entry_get_text (GTK_ENTRY(entry));
     if (text && *text)
     {
         gnc_numeric out;
@@ -240,7 +242,8 @@ fincalc_update_calc_button_cb(GtkWidget *unused, FinCalcDialog *fcd)
 
     for (i = 0; i < NUM_FIN_CALC_VALUES; i++)
     {
-        text = gtk_entry_get_text(GTK_ENTRY(fcd->amounts[i]));
+        GtkWidget *entry = gnc_amount_edit_gtk_entry (GNC_AMOUNT_EDIT(fcd->amounts[i]));
+        text = gtk_entry_get_text(GTK_ENTRY(entry));
         if ((text == NULL) || (*text == '\0'))
         {
             gtk_widget_set_sensitive(GTK_WIDGET(fcd->calc_button), TRUE);
@@ -284,10 +287,14 @@ fincalc_compounding_radio_toggled(GtkToggleButton *togglebutton, gpointer data)
 void
 fincalc_amount_clear_clicked_cb(GtkButton *button, FinCalcDialog *fcd)
 {
-    GtkEntry * edit = GTK_ENTRY(g_object_get_data(G_OBJECT(button), "edit"));
+    GNCAmountEdit * edit = GNC_AMOUNT_EDIT(g_object_get_data(G_OBJECT(button), "edit"));
+    GtkWidget * entry = gnc_amount_edit_gtk_entry (edit);
+    gnc_numeric value;
 
-    if (edit && GTK_IS_ENTRY(edit))
-        gtk_entry_set_text(edit, "");
+    if (entry && GTK_IS_ENTRY(entry))
+        gtk_entry_set_text(GTK_ENTRY(entry), "");
+
+    gnc_amount_edit_expr_is_valid (edit, &value, TRUE);
 }
 
 void
@@ -340,7 +347,8 @@ can_calc_value(FinCalcDialog *fcd, FinCalcValue value, int *error_item)
     for (i = 0; i < NUM_FIN_CALC_VALUES; i++)
         if (i != value)
         {
-            string = gtk_entry_get_text(GTK_ENTRY(fcd->amounts[i]));
+            GtkWidget *entry = gnc_amount_edit_gtk_entry (GNC_AMOUNT_EDIT (fcd->amounts[i]));
+            string = gtk_entry_get_text(GTK_ENTRY(entry));
             if ((string == NULL) || (*string == '\0'))
             {
                 *error_item = i;
@@ -387,10 +395,9 @@ can_calc_value(FinCalcDialog *fcd, FinCalcValue value, int *error_item)
         {
             /* treat PAYMENT_PERIODS as a plain GtkEntry */
             GNCAmountEdit *edit = GNC_AMOUNT_EDIT(fcd->amounts[PAYMENT_PERIODS]);
-            const gchar *text = gtk_entry_get_text (GTK_ENTRY(edit));
-            gboolean result = string_to_gnc_numeric (text, &nvalue);
+            gint result = gnc_amount_edit_expr_is_valid (edit, &nvalue, TRUE);
 
-            if (!result)
+            if (result >= 1)
             {
                 *error_item = PAYMENT_PERIODS;
                 return bad_exp;
@@ -430,9 +437,9 @@ calc_value(FinCalcDialog *fcd, FinCalcValue value)
 
         gnc_error_dialog (GTK_WINDOW (fcd->dialog), "%s", string);
         if (error_item == 0)
-            entry = fcd->amounts[0];
+            entry = gnc_amount_edit_gtk_entry (GNC_AMOUNT_EDIT(fcd->amounts[0]));
         else
-            entry = fcd->amounts[error_item];
+            entry = gnc_amount_edit_gtk_entry (GNC_AMOUNT_EDIT(fcd->amounts[error_item]));
         gtk_widget_grab_focus (entry);
         return;
     }
@@ -473,7 +480,8 @@ fincalc_calc_clicked_cb(GtkButton *button, FinCalcDialog *fcd)
 
     for (i = 0; i < NUM_FIN_CALC_VALUES; i++)
     {
-        text = gtk_entry_get_text(GTK_ENTRY(fcd->amounts[i]));
+        GtkWidget *entry = gnc_amount_edit_gtk_entry (GNC_AMOUNT_EDIT(fcd->amounts[i]));
+        text = gtk_entry_get_text(GTK_ENTRY(entry));
         if ((text != NULL) && (*text != '\0'))
             continue;
         calc_value(fcd, i);
@@ -545,6 +553,7 @@ fincalc_init_gae (GNCAmountEdit *edit,
                   gint fraction)
 {
     GNCPrintAmountInfo print_info;
+    GtkWidget *entry;
 
     print_info = gnc_integral_print_info ();
     print_info.min_decimal_places = min_places;
@@ -553,7 +562,8 @@ fincalc_init_gae (GNCAmountEdit *edit,
     gnc_amount_edit_set_print_info (edit, print_info);
     gnc_amount_edit_set_fraction (edit, fraction);
     gnc_amount_edit_set_evaluate_on_enter (edit, TRUE);
-    gtk_entry_set_alignment (GTK_ENTRY(edit), 1.0);
+    entry = gnc_amount_edit_gtk_entry (edit);
+    gtk_entry_set_alignment (GTK_ENTRY(entry), 1.0);
 }
 
 /** Initialize an edit field that will display a number in the users
@@ -567,6 +577,7 @@ fincalc_init_commodity_gae (GNCAmountEdit *edit)
     GNCPrintAmountInfo print_info;
     gnc_commodity *commodity;
     gint fraction;
+    GtkWidget *entry;
 
     commodity = gnc_default_currency();
     fraction = gnc_commodity_get_fraction(commodity);
@@ -575,7 +586,8 @@ fincalc_init_commodity_gae (GNCAmountEdit *edit)
     gnc_amount_edit_set_print_info (edit, print_info);
     gnc_amount_edit_set_fraction (edit, fraction);
     gnc_amount_edit_set_evaluate_on_enter (edit, TRUE);
-    gtk_entry_set_alignment (GTK_ENTRY(edit), 1.0);
+    entry = gnc_amount_edit_gtk_entry (edit);
+    gtk_entry_set_alignment (GTK_ENTRY(entry), 1.0);
 }
 
 void
@@ -622,7 +634,7 @@ gnc_ui_fincalc_dialog_create(GtkWindow *parent)
     edit = gnc_amount_edit_new();
     fincalc_init_gae (GNC_AMOUNT_EDIT (edit), 0, 0, 1);
     fcd->amounts[PAYMENT_PERIODS] = edit;
-    gtk_box_pack_end(GTK_BOX(hbox), edit, FALSE, FALSE, 0);
+    gtk_box_pack_end(GTK_BOX(hbox), edit, TRUE, TRUE, 0);
     g_signal_connect (G_OBJECT(edit), "changed",
                       G_CALLBACK (fincalc_update_calc_button_cb), fcd);
 
@@ -633,7 +645,7 @@ gnc_ui_fincalc_dialog_create(GtkWindow *parent)
     edit = gnc_amount_edit_new();
     fincalc_init_gae (GNC_AMOUNT_EDIT (edit), 2, 5, 100000);
     fcd->amounts[INTEREST_RATE] = edit;
-    gtk_box_pack_end(GTK_BOX(hbox), edit, FALSE, FALSE, 0);
+    gtk_box_pack_end(GTK_BOX(hbox), edit, TRUE, TRUE, 0);
     g_signal_connect (G_OBJECT(edit), "changed",
                       G_CALLBACK (fincalc_update_calc_button_cb), fcd);
 
@@ -644,7 +656,7 @@ gnc_ui_fincalc_dialog_create(GtkWindow *parent)
     edit = gnc_amount_edit_new();
     fincalc_init_commodity_gae (GNC_AMOUNT_EDIT (edit));
     fcd->amounts[PRESENT_VALUE] = edit;
-    gtk_box_pack_end(GTK_BOX(hbox), edit, FALSE, FALSE, 0);
+    gtk_box_pack_end(GTK_BOX(hbox), edit, TRUE, TRUE, 0);
     g_signal_connect (G_OBJECT(edit), "changed",
                       G_CALLBACK (fincalc_update_calc_button_cb), fcd);
 
@@ -655,7 +667,7 @@ gnc_ui_fincalc_dialog_create(GtkWindow *parent)
     edit = gnc_amount_edit_new();
     fincalc_init_commodity_gae (GNC_AMOUNT_EDIT (edit));
     fcd->amounts[PERIODIC_PAYMENT] = edit;
-    gtk_box_pack_end(GTK_BOX(hbox), edit, FALSE, FALSE, 0);
+    gtk_box_pack_end(GTK_BOX(hbox), edit, TRUE, TRUE, 0);
     g_signal_connect (G_OBJECT(edit), "changed",
                       G_CALLBACK (fincalc_update_calc_button_cb), fcd);
 
@@ -666,7 +678,7 @@ gnc_ui_fincalc_dialog_create(GtkWindow *parent)
     edit = gnc_amount_edit_new();
     fincalc_init_commodity_gae (GNC_AMOUNT_EDIT (edit));
     fcd->amounts[FUTURE_VALUE] = edit;
-    gtk_box_pack_end(GTK_BOX(hbox), edit, FALSE, FALSE, 0);
+    gtk_box_pack_end(GTK_BOX(hbox), edit, TRUE, TRUE, 0);
     g_signal_connect (G_OBJECT(edit), "changed",
                       G_CALLBACK (fincalc_update_calc_button_cb), fcd);
 

--- a/gnucash/gnome/dialog-invoice.c
+++ b/gnucash/gnome/dialog-invoice.c
@@ -1364,7 +1364,7 @@ static gboolean
 gnc_invoice_window_leave_to_charge_cb (GtkWidget *widget, GdkEventFocus *event,
                                        gpointer data)
 {
-    gnc_amount_edit_evaluate (GNC_AMOUNT_EDIT (widget));
+    gnc_amount_edit_evaluate (GNC_AMOUNT_EDIT (data));
     return FALSE;
 }
 
@@ -2552,7 +2552,7 @@ gnc_invoice_create_page (InvoiceWindow *iw, gpointer page)
 
         g_signal_connect(G_OBJECT(gnc_amount_edit_gtk_entry(GNC_AMOUNT_EDIT(edit))),
                          "focus-out-event",
-                         G_CALLBACK(gnc_invoice_window_leave_to_charge_cb), iw);
+                         G_CALLBACK(gnc_invoice_window_leave_to_charge_cb), edit);
         g_signal_connect(G_OBJECT(edit), "amount_changed",
                          G_CALLBACK(gnc_invoice_window_changed_to_charge_cb), iw);
     }

--- a/gnucash/gnome/dialog-job.c
+++ b/gnucash/gnome/dialog-job.c
@@ -151,6 +151,14 @@ gnc_job_verify_ok (JobWindow *jw)
         return FALSE;
     }
 
+    /* Check for valid rate */
+    if (!gnc_amount_edit_evaluate (GNC_AMOUNT_EDIT(jw->rate_entry)))
+    {
+        const char *message = _("The rate amount must be valid or you must leave it blank.");
+        gnc_error_dialog (GTK_WINDOW (jw->dialog), "%s", message);
+        return FALSE;
+    }
+
     /* Set a valid id if one was not created */
     res = gtk_entry_get_text (GTK_ENTRY (jw->id_entry));
     if (g_strcmp0 (res, "") == 0)

--- a/gnucash/gnome/dialog-payment.c
+++ b/gnucash/gnome/dialog-payment.c
@@ -201,6 +201,7 @@ void gnc_payment_acct_tree_row_activated_cb (GtkWidget *widget, GtkTreePath *pat
         GtkTreeViewColumn *column, PaymentWindow *pw);
 void gnc_payment_leave_amount_cb (GtkWidget *widget, GdkEventFocus *event,
                                   PaymentWindow *pw);
+void gnc_payment_activate_amount_cb (GtkWidget *widget, PaymentWindow *pw);
 void gnc_payment_window_fill_docs_list (PaymentWindow *pw);
 
 
@@ -221,6 +222,7 @@ gnc_payment_window_check_payment (PaymentWindow *pw)
     gboolean enable_xfer_acct = TRUE;
     gboolean allow_payment = TRUE;
     GtkTreeSelection *selection;
+    gint c_result, d_result;
 
     if (!pw)
         return FALSE;
@@ -242,11 +244,24 @@ gnc_payment_window_check_payment (PaymentWindow *pw)
         goto update_cleanup;
     }
 
+    /* Verify the credit / debit amounts are valid */
+    d_result = gnc_amount_edit_expr_is_valid (GNC_AMOUNT_EDIT(pw->amount_debit_edit),
+                                              &amount_deb, FALSE);
+
+    c_result = gnc_amount_edit_expr_is_valid (GNC_AMOUNT_EDIT(pw->amount_credit_edit),
+                                              &amount_cred, FALSE);
+
+    if ((d_result >= 1) || (c_result >= 1))
+    {
+        conflict_msg = _("There is a problem with the Payment or Refund amount.");
+        allow_payment = FALSE;
+        goto update_cleanup;
+    }
+
     /* Test the total amount */
-    amount_deb  = gnc_amount_edit_get_amount (GNC_AMOUNT_EDIT (pw->amount_debit_edit));
-    amount_cred = gnc_amount_edit_get_amount (GNC_AMOUNT_EDIT (pw->amount_credit_edit));
     pw->amount_tot = gnc_numeric_sub (amount_cred, amount_deb,
-                                      gnc_commodity_get_fraction (xaccAccountGetCommodity (pw->post_acct)),
+                                      gnc_commodity_get_fraction (
+                                      xaccAccountGetCommodity (pw->post_acct)),
                                       GNC_HOW_RND_ROUND_HALF_UP);
 
     if (gnc_numeric_check (pw->amount_tot) || gnc_numeric_zero_p (pw->amount_tot))
@@ -1104,22 +1119,38 @@ gnc_payment_leave_amount_cb (G_GNUC_UNUSED GtkWidget *widget,
                              G_GNUC_UNUSED GdkEventFocus *event,
                              PaymentWindow *pw)
 {
-    gnc_numeric amount_deb, amount_cred, amount_tot;
+    gboolean d_payment_ok = FALSE;
+    gboolean c_payment_ok = FALSE;
 
     if (! pw->amount_credit_edit || ! pw->amount_debit_edit)
         return;
 
-    /* If both credit and debit amount are entered, simplify it to either one */
-    amount_deb  = gnc_amount_edit_get_amount (GNC_AMOUNT_EDIT (pw->amount_debit_edit));
-    amount_cred = gnc_amount_edit_get_amount (GNC_AMOUNT_EDIT (pw->amount_credit_edit));
-    amount_tot = gnc_numeric_sub (amount_cred, amount_deb,
-                                  gnc_commodity_get_fraction (xaccAccountGetCommodity (pw->post_acct)),
-                                  GNC_HOW_RND_ROUND_HALF_UP);
+    c_payment_ok = gnc_amount_edit_evaluate (GNC_AMOUNT_EDIT(pw->amount_credit_edit));
+    d_payment_ok = gnc_amount_edit_evaluate (GNC_AMOUNT_EDIT(pw->amount_debit_edit));
 
-    gnc_ui_payment_window_set_amount (pw, amount_tot);
+    if (c_payment_ok && d_payment_ok)
+    {
+        gnc_numeric amount_deb, amount_cred, amount_tot;
 
+        /* If both credit and debit amount are entered, simplify it to either one */
+        amount_deb  = gnc_amount_edit_get_amount (GNC_AMOUNT_EDIT (pw->amount_debit_edit));
+        amount_cred = gnc_amount_edit_get_amount (GNC_AMOUNT_EDIT (pw->amount_credit_edit));
+        amount_tot = gnc_numeric_sub (amount_cred, amount_deb,
+                                      gnc_commodity_get_fraction (
+                                      xaccAccountGetCommodity (pw->post_acct)),
+                                      GNC_HOW_RND_ROUND_HALF_UP);
+
+        gnc_ui_payment_window_set_amount (pw, amount_tot);
+    }
     /* Reflect if the payment could complete now */
     gnc_payment_window_check_payment (pw);
+}
+
+void
+gnc_payment_activate_amount_cb (G_GNUC_UNUSED GtkWidget *widget,
+                                PaymentWindow *pw)
+{
+      gnc_payment_leave_amount_cb (NULL, NULL, pw);
 }
 
 /* Select the list of accounts to show in the tree */
@@ -1294,6 +1325,10 @@ new_payment_window (GtkWindow *parent, QofBook *book, InitialPaymentInfo *tx_inf
                      "focus-out-event",
                      G_CALLBACK(gnc_payment_leave_amount_cb), pw);
 
+    g_signal_connect(G_OBJECT(pw->amount_debit_edit),
+                     "activate",
+                     G_CALLBACK(gnc_payment_activate_amount_cb), pw);
+
     pw->amount_credit_edit = gnc_amount_edit_new ();
     gnc_amount_edit_set_evaluate_on_enter (GNC_AMOUNT_EDIT (pw->amount_credit_edit),
                                            TRUE);
@@ -1301,6 +1336,10 @@ new_payment_window (GtkWindow *parent, QofBook *book, InitialPaymentInfo *tx_inf
     g_signal_connect(G_OBJECT(gnc_amount_edit_gtk_entry(GNC_AMOUNT_EDIT(pw->amount_credit_edit))),
                      "focus-out-event",
                      G_CALLBACK(gnc_payment_leave_amount_cb), pw);
+
+    g_signal_connect(G_OBJECT(pw->amount_credit_edit),
+                     "activate",
+                     G_CALLBACK(gnc_payment_activate_amount_cb), pw);
 
     box = GTK_WIDGET (gtk_builder_get_object (builder, "date_box"));
     pw->date_edit = gnc_date_edit_new (time(NULL), FALSE, FALSE);

--- a/gnucash/gnome/dialog-price-editor.c
+++ b/gnucash/gnome/dialog-price-editor.c
@@ -246,6 +246,7 @@ pedit_dialog_replace_found_price (PriceEditDialog *pedit_dialog,
 static const char *
 gui_to_price (PriceEditDialog *pedit_dialog)
 {
+    GNCPrintAmountInfo print_info;
     gnc_commodity *commodity;
     gnc_commodity *currency;
     gchar         *name_space;
@@ -273,6 +274,11 @@ gui_to_price (PriceEditDialog *pedit_dialog)
 
     type = type_index_to_string
            (gtk_combo_box_get_active (GTK_COMBO_BOX (pedit_dialog->type_combobox)));
+
+    print_info = gnc_commodity_print_info (currency, FALSE);
+    gnc_amount_edit_set_print_info (GNC_AMOUNT_EDIT (pedit_dialog->price_edit), print_info);
+    gnc_amount_edit_set_fraction (GNC_AMOUNT_EDIT (pedit_dialog->price_edit),
+                                  gnc_commodity_get_fraction (currency));
 
     if (!gnc_amount_edit_evaluate (GNC_AMOUNT_EDIT (pedit_dialog->price_edit)))
         return _("You must enter a valid amount.");
@@ -521,16 +527,16 @@ gnc_price_pedit_dialog_create (GtkWidget *parent,
     w = gnc_amount_edit_new ();
     pedit_dialog->price_edit = w;
     gtk_box_pack_start (GTK_BOX (box), w, TRUE, TRUE, 0);
+    entry = gnc_amount_edit_gtk_entry (GNC_AMOUNT_EDIT (w));
     gnc_amount_edit_set_evaluate_on_enter (GNC_AMOUNT_EDIT (w), TRUE);
     print_info = gnc_default_price_print_info (gnc_currency_edit_get_currency (GNC_CURRENCY_EDIT (pedit_dialog->currency_edit)));
     gnc_amount_edit_set_print_info (GNC_AMOUNT_EDIT (w), print_info);
-    gtk_entry_set_activates_default(GTK_ENTRY(w), TRUE);
+    gtk_entry_set_activates_default(GTK_ENTRY(entry), TRUE);
     gtk_widget_show (w);
     label = GTK_WIDGET(gtk_builder_get_object (builder, "price_label"));
     gtk_label_set_mnemonic_widget (GTK_LABEL(label), w);
 
-    entry = gnc_amount_edit_gtk_entry (GNC_AMOUNT_EDIT (w));
-    g_signal_connect (G_OBJECT (entry), "changed",
+    g_signal_connect (G_OBJECT (w), "changed",
                       G_CALLBACK (pedit_data_changed_cb), pedit_dialog);
 
     w = GTK_WIDGET(gtk_builder_get_object (builder, "pd_cancel_button"));

--- a/gnucash/gnome/window-autoclear.c
+++ b/gnucash/gnome/window-autoclear.c
@@ -122,28 +122,37 @@ void
 gnc_autoclear_window_ok_cb (GtkWidget *widget,
                             AutoClearWindow *data)
 {
-    GList *toclear_list;
+    GList *toclear_list = NULL;
     gnc_numeric toclear_value;
     gchar *errmsg = NULL;
 
     g_return_if_fail (widget && data);
 
-    toclear_value = gnc_amount_edit_get_amount(data->end_value);
+    /* test for valid value */
+    if (!gnc_amount_edit_evaluate (GNC_AMOUNT_EDIT(data->end_value)))
+        errmsg = gnc_amount_edit_get_error_message (GNC_AMOUNT_EDIT(data->end_value));
+    else
+    {
+        toclear_value = gnc_amount_edit_get_amount(data->end_value);
 
-    if (gnc_reverse_balance(data->account))
-        toclear_value = gnc_numeric_neg (toclear_value);
+        if (gnc_reverse_balance(data->account))
+            toclear_value = gnc_numeric_neg (toclear_value);
 
-    toclear_value = gnc_numeric_convert
-        (toclear_value, xaccAccountGetCommoditySCU(data->account), GNC_HOW_RND_ROUND);
+        toclear_value = gnc_numeric_convert
+            (toclear_value, xaccAccountGetCommoditySCU(data->account), GNC_HOW_RND_ROUND);
 
-    toclear_list = gnc_account_get_autoclear_splits
-        (data->account, toclear_value, &errmsg);
+        toclear_list = gnc_account_get_autoclear_splits
+            (data->account, toclear_value, &errmsg);
+    }
 
     if (errmsg)
     {
+        GtkWidget *entry = gnc_amount_edit_gtk_entry (GNC_AMOUNT_EDIT(data->end_value));
         gtk_label_set_text (data->status_label, errmsg);
-        gnc_amount_edit_set_amount (data->end_value, toclear_value);
-        gtk_editable_select_region (GTK_EDITABLE (data->end_value), 0, -1);
+        if (gnc_numeric_check (toclear_value) == 0)
+            gnc_amount_edit_set_amount (data->end_value, toclear_value);
+        gtk_widget_grab_focus (GTK_WIDGET(entry));
+        gnc_amount_edit_select_region (GNC_AMOUNT_EDIT(data->end_value), 0, -1);
         g_free (errmsg);
     }
     else
@@ -197,6 +206,8 @@ autoClearWindow (GtkWidget *parent, Account *account)
     AutoClearWindow *data;
     char *title;
     gnc_numeric after;
+    GNCPrintAmountInfo print_info;
+    gnc_commodity *currency;
 
     data = g_new0 (AutoClearWindow, 1);
     data->account = account;
@@ -217,6 +228,13 @@ autoClearWindow (GtkWidget *parent, Account *account)
 
     /* Add amount edit box */
     data->end_value = GNC_AMOUNT_EDIT(gnc_amount_edit_new());
+
+    currency = xaccAccountGetCommodity (account);
+    print_info = gnc_commodity_print_info (currency, FALSE);
+    gnc_amount_edit_set_print_info (GNC_AMOUNT_EDIT(data->end_value), print_info);
+    gnc_amount_edit_set_fraction (GNC_AMOUNT_EDIT(data->end_value),
+                                  gnc_commodity_get_fraction (currency));
+
     g_signal_connect(GTK_WIDGET(data->end_value), "activate",
                      G_CALLBACK(gnc_autoclear_window_ok_cb), data);
 
@@ -232,7 +250,7 @@ autoClearWindow (GtkWidget *parent, Account *account)
         after = gnc_numeric_neg(after);
     gnc_amount_edit_set_amount (GNC_AMOUNT_EDIT (data->end_value), after);
     gtk_widget_grab_focus(GTK_WIDGET(data->end_value));
-    gtk_editable_select_region (GTK_EDITABLE (data->end_value), 0, -1);
+    gnc_amount_edit_select_region (GNC_AMOUNT_EDIT (data->end_value), 0, -1);
 
     data->status_label = GTK_LABEL(gtk_builder_get_object (builder, "status_label"));
 

--- a/gnucash/gnome/window-reconcile.c
+++ b/gnucash/gnome/window-reconcile.c
@@ -316,11 +316,20 @@ gnc_start_recn_update_cb(GtkWidget *widget, GdkEventFocus *event,
                          startRecnWindowData *data)
 {
     gnc_numeric value;
+    gint result = gnc_amount_edit_expr_is_valid (GNC_AMOUNT_EDIT(data->end_value),
+                                                 &value, TRUE);
 
-    gnc_amount_edit_evaluate (GNC_AMOUNT_EDIT(data->end_value));
+    data->user_set_value = FALSE;
 
-    value = gnc_amount_edit_get_amount (GNC_AMOUNT_EDIT(data->end_value));
-    data->user_set_value = !gnc_numeric_equal(value, data->original_value);
+    if (result < 1) // OK
+    {
+        if (result == -1) // blank entry is valid
+        {
+            gnc_amount_edit_set_amount (GNC_AMOUNT_EDIT(data->end_value), value);
+            gnc_amount_edit_select_region (GNC_AMOUNT_EDIT(data->end_value), 0, -1);
+        }
+        data->user_set_value = !gnc_numeric_equal (value, data->original_value);
+    }
     return FALSE;
 }
 
@@ -391,6 +400,9 @@ actions on this account. Please double-check this is the date you intended."));
     /* update the amount edit with the amount */
     gnc_amount_edit_set_amount (GNC_AMOUNT_EDIT (data->end_value),
                                 new_balance);
+
+    gnc_start_recn_update_cb (GTK_WIDGET(data->end_value), NULL, data);
+
 }
 
 
@@ -648,8 +660,10 @@ startRecnWindow(GtkWidget *parent, Account *account,
     gboolean auto_interest_xfer_option;
     GNCPrintAmountInfo print_info;
     gnc_numeric ending;
+    GtkWidget *entry;
     char *title;
-    int result;
+    int result = -6;
+    gulong fo_handler_id;
 
     /* Initialize the data structure that will be used for several callbacks
      * throughout this file with the relevant info.  Some initialization is
@@ -698,7 +712,7 @@ startRecnWindow(GtkWidget *parent, Account *account,
 
     {
         GtkWidget *start_value, *box;
-        GtkWidget *entry, *label;
+        GtkWidget *label;
         GtkWidget *interest = NULL;
 
         start_value = GTK_WIDGET(gtk_builder_get_object (builder, "start_value"));
@@ -746,8 +760,9 @@ startRecnWindow(GtkWidget *parent, Account *account,
 
         entry = gnc_amount_edit_gtk_entry (GNC_AMOUNT_EDIT (end_value));
         gtk_editable_select_region (GTK_EDITABLE(entry), 0, -1);
-        g_signal_connect(G_OBJECT(entry), "focus-out-event",
-                         G_CALLBACK(gnc_start_recn_update_cb), (gpointer) &data);
+        fo_handler_id = g_signal_connect (G_OBJECT(entry), "focus-out-event",
+                                          G_CALLBACK(gnc_start_recn_update_cb),
+                                          (gpointer) &data);
         gtk_entry_set_activates_default(GTK_ENTRY(entry), TRUE);
 
         /* if it's possible to enter an interest payment or charge for this
@@ -789,7 +804,16 @@ startRecnWindow(GtkWidget *parent, Account *account,
         gnc_reconcile_interest_xfer_run( &data );
     }
 
-    result = gtk_dialog_run(GTK_DIALOG(dialog));
+    while (gtk_dialog_run (GTK_DIALOG(dialog)) == GTK_RESPONSE_OK)
+    {
+        /* If response is OK but end_value not valid, try again */
+        if (gnc_amount_edit_evaluate (GNC_AMOUNT_EDIT(end_value)))
+        {
+            result = GTK_RESPONSE_OK;
+            break;
+        }
+    }
+
     if (result == GTK_RESPONSE_OK)
     {
         *new_ending = gnc_amount_edit_get_amount (GNC_AMOUNT_EDIT (end_value));
@@ -802,6 +826,8 @@ startRecnWindow(GtkWidget *parent, Account *account,
 
         gnc_save_reconcile_interval(account, *statement_date);
     }
+    // must remove the focus-out handler
+    g_signal_handler_disconnect (G_OBJECT(entry), fo_handler_id);
     gtk_widget_destroy (dialog);
     g_object_unref(G_OBJECT(builder));
 

--- a/gnucash/gnome/window-reconcile2.c
+++ b/gnucash/gnome/window-reconcile2.c
@@ -306,11 +306,20 @@ gnc_start_recn2_update_cb (GtkWidget *widget, GdkEventFocus *event,
                          startRecnWindowData *data)
 {
     gnc_numeric value;
+    gint result = gnc_amount_edit_expr_is_valid (GNC_AMOUNT_EDIT(data->end_value),
+                                                 &value, TRUE);
 
-    gnc_amount_edit_evaluate (GNC_AMOUNT_EDIT (data->end_value));
+    data->user_set_value = FALSE;
 
-    value = gnc_amount_edit_get_amount (GNC_AMOUNT_EDIT (data->end_value));
-    data->user_set_value = !gnc_numeric_equal (value, data->original_value);
+    if (result < 1) // OK
+    {
+        if (result == -1) // blank entry is valid
+        {
+            gnc_amount_edit_set_amount (GNC_AMOUNT_EDIT(data->end_value), value);
+            gnc_amount_edit_select_region (GNC_AMOUNT_EDIT(data->end_value), 0, -1);
+        }
+        data->user_set_value = !gnc_numeric_equal (value, data->original_value);
+    }
     return FALSE;
 }
 
@@ -335,6 +344,9 @@ gnc_start_recn2_date_changed (GtkWidget *widget, startRecnWindowData *data)
     /* update the amount edit with the amount */
     gnc_amount_edit_set_amount (GNC_AMOUNT_EDIT (data->end_value),
                                 new_balance);
+
+    gnc_start_recn2_update_cb (GTK_WIDGET(data->end_value), NULL, data);
+
 }
 
 
@@ -616,8 +628,10 @@ startRecnWindow (GtkWidget *parent, Account *account,
     gboolean auto_interest_xfer_option;
     GNCPrintAmountInfo print_info;
     gnc_numeric ending;
+    GtkWidget *entry;
     char *title;
-    int result;
+    int result = -6;
+    gulong fo_handler_id;
 
     /* Initialize the data structure that will be used for several callbacks
      * throughout this file with the relevant info.  Some initialization is
@@ -665,7 +679,7 @@ startRecnWindow (GtkWidget *parent, Account *account,
 
     {
         GtkWidget *start_value, *box;
-        GtkWidget *entry, *label;
+        GtkWidget *label;
         GtkWidget *interest = NULL;
 
         start_value = GTK_WIDGET (gtk_builder_get_object (builder, "start_value"));
@@ -709,8 +723,9 @@ startRecnWindow (GtkWidget *parent, Account *account,
 
         entry = gnc_amount_edit_gtk_entry (GNC_AMOUNT_EDIT (end_value));
         gtk_editable_select_region (GTK_EDITABLE (entry), 0, -1);
-        g_signal_connect (G_OBJECT (entry), "focus-out-event",
-                         G_CALLBACK (gnc_start_recn2_update_cb), (gpointer) &data);
+        fo_handler_id = g_signal_connect (G_OBJECT(entry), "focus-out-event",
+                                          G_CALLBACK(gnc_start_recn2_update_cb),
+                                          (gpointer) &data);
         gtk_entry_set_activates_default (GTK_ENTRY (entry), TRUE);
 
         /* if it's possible to enter an interest payment or charge for this
@@ -749,7 +764,16 @@ startRecnWindow (GtkWidget *parent, Account *account,
         gnc_reconcile_interest_xfer_run (&data);
     }
 
-    result = gtk_dialog_run (GTK_DIALOG (dialog));
+    while (gtk_dialog_run (GTK_DIALOG(dialog)) == GTK_RESPONSE_OK)
+    {
+        /* If response is OK but end_value not valid, try again */
+        if (gnc_amount_edit_evaluate (GNC_AMOUNT_EDIT(end_value)))
+        {
+            result = GTK_RESPONSE_OK;
+            break;
+        }
+    }
+
     if (result == GTK_RESPONSE_OK)
     {
         *new_ending = gnc_amount_edit_get_amount (GNC_AMOUNT_EDIT (end_value));
@@ -762,6 +786,8 @@ startRecnWindow (GtkWidget *parent, Account *account,
 
         gnc_save_reconcile_interval (account, *statement_date);
     }
+    // must remove the focus-out handler
+    g_signal_handler_disconnect (G_OBJECT(entry), fo_handler_id);
     gtk_widget_destroy (dialog);
     g_object_unref (G_OBJECT (builder));
 

--- a/gnucash/gtkbuilder/dialog-fincalc.glade
+++ b/gnucash/gtkbuilder/dialog-fincalc.glade
@@ -382,6 +382,7 @@
                     </child>
                     <child>
                       <object class="GtkBox" id="payment_periods_hbox">
+                        <property name="width_request">150</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="spacing">6</property>
@@ -396,6 +397,7 @@
                     </child>
                     <child>
                       <object class="GtkBox" id="interest_rate_hbox">
+                        <property name="width_request">150</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="spacing">6</property>
@@ -410,6 +412,7 @@
                     </child>
                     <child>
                       <object class="GtkBox" id="present_value_hbox">
+                        <property name="width_request">150</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="spacing">6</property>
@@ -424,6 +427,7 @@
                     </child>
                     <child>
                       <object class="GtkBox" id="periodic_payment_hbox">
+                        <property name="width_request">150</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="spacing">6</property>
@@ -438,6 +442,7 @@
                     </child>
                     <child>
                       <object class="GtkBox" id="future_value_hbox">
+                        <property name="width_request">150</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="spacing">6</property>

--- a/gnucash/gtkbuilder/dialog-transfer.glade
+++ b/gnucash/gtkbuilder/dialog-transfer.glade
@@ -82,18 +82,6 @@
                   <packing>
                     <property name="left_attach">0</property>
                     <property name="top_attach">0</property>
-                    <property name="width">2</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="label">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label">    </property>
-                  </object>
-                  <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">1</property>
                   </packing>
                 </child>
                 <child>
@@ -259,7 +247,6 @@
                   <packing>
                     <property name="left_attach">0</property>
                     <property name="top_attach">1</property>
-                    <property name="width">2</property>
                   </packing>
                 </child>
               </object>

--- a/gnucash/register/ledger-core/split-register-load.c
+++ b/gnucash/register/ledger-core/split-register-load.c
@@ -368,6 +368,7 @@ gnc_split_register_load (SplitRegister* reg, GList* slist,
     Split* split;
     Table* table;
     GList* node;
+    gnc_commodity *account_comm = NULL;
 
     gboolean start_primary_color = TRUE;
     gboolean found_pending = FALSE;
@@ -407,14 +408,24 @@ gnc_split_register_load (SplitRegister* reg, GList* slist,
     pending_trans = xaccTransLookup (&info->pending_trans_guid,
                                      gnc_get_current_book());
 
+    if (default_account)
+        account_comm = gnc_account_get_currency_or_parent (default_account);
+
+    if (!account_comm)
+        account_comm = gnc_default_currency ();
+
     /* Bug 742089: Set the debit and credit cells' print_info to the account */
     gnc_price_cell_set_print_info
     ((PriceCell*) gnc_table_layout_get_cell (table->layout, DEBT_CELL),
-     gnc_account_print_info (default_account, FALSE));
+     gnc_commodity_print_info (account_comm, FALSE));
 
     gnc_price_cell_set_print_info
     ((PriceCell*) gnc_table_layout_get_cell (table->layout, CRED_CELL),
-     gnc_account_print_info (default_account, FALSE));
+     gnc_commodity_print_info (account_comm, FALSE));
+
+    gnc_price_cell_set_print_info
+    ((PriceCell*) gnc_table_layout_get_cell (reg->table->layout, PRIC_CELL),
+     gnc_commodity_print_info (account_comm, FALSE));
 
     gnc_doclink_cell_set_use_glyphs
     ((Doclinkcell *) gnc_table_layout_get_cell (table->layout, DOCLINK_CELL));

--- a/gnucash/register/register-gnome/gnucash-item-edit.c
+++ b/gnucash/register/register-gnome/gnucash-item-edit.c
@@ -77,7 +77,7 @@ gnc_item_edit_tb_get_property (GObject *object,
                                GValue *value,
                                GParamSpec *pspec)
 {
-    GncItemEditTb *item_edit_tb = GNC_ITEM_EDIT_TB (object);
+    GncItemEditTb *item_edit_tb = GNC_ITEM_EDIT_TB(object);
 
     switch (param_id)
     {
@@ -85,7 +85,7 @@ gnc_item_edit_tb_get_property (GObject *object,
         g_value_take_object (value, item_edit_tb->sheet);
         break;
     default:
-        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, param_id, pspec);
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, param_id, pspec);
         break;
     }
 }
@@ -96,30 +96,30 @@ gnc_item_edit_tb_set_property (GObject *object,
                                const GValue *value,
                                GParamSpec *pspec)
 {
-    GncItemEditTb *item_edit_tb = GNC_ITEM_EDIT_TB (object);
+    GncItemEditTb *item_edit_tb = GNC_ITEM_EDIT_TB(object);
 
     switch (param_id)
     {
     case PROP_SHEET:
-        item_edit_tb->sheet = GNUCASH_SHEET (g_value_get_object (value));
+        item_edit_tb->sheet = GNUCASH_SHEET(g_value_get_object (value));
         break;
     default:
-        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, param_id, pspec);
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, param_id, pspec);
         break;
     }
 }
 
 static void
 gnc_item_edit_tb_get_preferred_width (GtkWidget *widget,
-                                   gint *minimal_width,
-                                   gint *natural_width)
+                                      gint *minimal_width,
+                                      gint *natural_width)
 {
-    GncItemEditTb *tb = GNC_ITEM_EDIT_TB (widget);
+    GncItemEditTb *tb = GNC_ITEM_EDIT_TB(widget);
     GncItemEdit *item_edit = GNC_ITEM_EDIT(tb->sheet->item_editor);
     GtkStyleContext *context = gtk_widget_get_style_context (GTK_WIDGET(tb));
     GtkBorder border;
     gint x, y, w, h = 2, width = 0;
-    gnc_item_edit_get_pixel_coords (GNC_ITEM_EDIT (item_edit), &x, &y, &w, &h);
+    gnc_item_edit_get_pixel_coords (GNC_ITEM_EDIT(item_edit), &x, &y, &w, &h);
     width = ((h - 2)*2)/3;
 
     gtk_style_context_get_border (context, GTK_STATE_FLAG_NORMAL, &border);
@@ -133,13 +133,13 @@ gnc_item_edit_tb_get_preferred_width (GtkWidget *widget,
 
 static void
 gnc_item_edit_tb_get_preferred_height (GtkWidget *widget,
-                                    gint *minimal_width,
-                                    gint *natural_width)
+                                       gint *minimal_width,
+                                       gint *natural_width)
 {
-    GncItemEditTb *tb = GNC_ITEM_EDIT_TB (widget);
+    GncItemEditTb *tb = GNC_ITEM_EDIT_TB(widget);
     GncItemEdit *item_edit = GNC_ITEM_EDIT(tb->sheet->item_editor);
     gint x, y, w, h = 2;
-    gnc_item_edit_get_pixel_coords (GNC_ITEM_EDIT (item_edit), &x, &y, &w, &h);
+    gnc_item_edit_get_pixel_coords (GNC_ITEM_EDIT(item_edit), &x, &y, &w, &h);
     *minimal_width = *natural_width = (h - 2);
 }
 
@@ -153,8 +153,8 @@ gnc_item_edit_tb_class_init (GncItemEditTbClass *gnc_item_edit_tb_class)
 
     gnc_item_edit_tb_parent_class = g_type_class_peek_parent (gnc_item_edit_tb_class);
 
-    object_class = G_OBJECT_CLASS (gnc_item_edit_tb_class);
-    widget_class = GTK_WIDGET_CLASS (gnc_item_edit_tb_class);
+    object_class = G_OBJECT_CLASS(gnc_item_edit_tb_class);
+    widget_class = GTK_WIDGET_CLASS(gnc_item_edit_tb_class);
 
     object_class->get_property = gnc_item_edit_tb_get_property;
     object_class->set_property = gnc_item_edit_tb_set_property;
@@ -184,18 +184,18 @@ gnc_item_edit_tb_get_type (void)
             sizeof (GncItemEditTbClass),
             NULL,
             NULL,
-            (GClassInitFunc) gnc_item_edit_tb_class_init,
+            (GClassInitFunc)gnc_item_edit_tb_class_init,
             NULL,
             NULL,
             sizeof (GncItemEditTb),
             0, /* n_preallocs */
-            (GInstanceInitFunc) gnc_item_edit_tb_init,
+            (GInstanceInitFunc)gnc_item_edit_tb_init,
             NULL,
         };
         gnc_item_edit_tb_type =
-            g_type_register_static(GTK_TYPE_TOGGLE_BUTTON,
-                                   "GncItemEditTb",
-                                   &gnc_item_edit_tb_info, 0);
+            g_type_register_static (GTK_TYPE_TOGGLE_BUTTON,
+                                    "GncItemEditTb",
+                                    &gnc_item_edit_tb_info, 0);
     }
     return gnc_item_edit_tb_type;
 }
@@ -204,10 +204,9 @@ GtkWidget *
 gnc_item_edit_tb_new (GnucashSheet *sheet)
 {
     GtkStyleContext *context;
-    GncItemEditTb *item_edit_tb =
-            g_object_new (GNC_TYPE_ITEM_EDIT_TB,
-                          "sheet", sheet,
-                           NULL);
+    GncItemEditTb *item_edit_tb = g_object_new (GNC_TYPE_ITEM_EDIT_TB,
+                                                "sheet", sheet,
+                                                NULL);
 
     context = gtk_widget_get_style_context (GTK_WIDGET(item_edit_tb));
     gtk_style_context_add_class (context, GTK_STYLE_CLASS_BUTTON);
@@ -237,11 +236,10 @@ gnc_item_edit_get_pixel_coords (GncItemEdit *item_edit,
     xd = block->origin_x;
     yd = block->origin_y;
 
-    gnucash_sheet_style_get_cell_pixel_rel_coords
-    (item_edit->style,
-     item_edit->virt_loc.phys_row_offset,
-     item_edit->virt_loc.phys_col_offset,
-     x, y, w, h);
+    gnucash_sheet_style_get_cell_pixel_rel_coords (item_edit->style,
+                                                   item_edit->virt_loc.phys_row_offset,
+                                                   item_edit->virt_loc.phys_col_offset,
+                                                   x, y, w, h);
 
     // alter cell size of first column
     if (item_edit->virt_loc.phys_col_offset == 0)
@@ -282,7 +280,7 @@ gnc_item_edit_focus_in (GncItemEdit *item_edit)
     g_return_if_fail (GNC_IS_ITEM_EDIT(item_edit));
 
     ev.type = GDK_FOCUS_CHANGE;
-    ev.window = gtk_widget_get_window (GTK_WIDGET (item_edit->sheet));
+    ev.window = gtk_widget_get_window (GTK_WIDGET(item_edit->sheet));
     ev.in = TRUE;
     gtk_widget_event (item_edit->editor, (GdkEvent*) &ev);
 }
@@ -296,7 +294,7 @@ gnc_item_edit_focus_out (GncItemEdit *item_edit)
     g_return_if_fail (GNC_IS_ITEM_EDIT(item_edit));
 
     ev.type = GDK_FOCUS_CHANGE;
-    ev.window = gtk_widget_get_window (GTK_WIDGET (item_edit->sheet));
+    ev.window = gtk_widget_get_window (GTK_WIDGET(item_edit->sheet));
     ev.in = FALSE;
     gtk_widget_event (item_edit->editor, (GdkEvent*) &ev);
 }
@@ -336,7 +334,7 @@ gnc_item_edit_init (GncItemEdit *item_edit)
     item_edit->style = NULL;
     item_edit->button_width = MIN_BUTT_WIDTH;
 
-    gnc_virtual_location_init(&item_edit->virt_loc);
+    gnc_virtual_location_init (&item_edit->virt_loc);
 }
 
 void
@@ -351,9 +349,8 @@ gnc_item_edit_configure (GncItemEdit *item_edit)
     item_edit->virt_loc.vcell_loc.virt_row = cursor->row;
     item_edit->virt_loc.vcell_loc.virt_col = cursor->col;
 
-    item_edit->style =
-        gnucash_sheet_get_style (sheet,
-                                 item_edit->virt_loc.vcell_loc);
+    item_edit->style = gnucash_sheet_get_style (sheet,
+                           item_edit->virt_loc.vcell_loc);
 
     item_edit->virt_loc.phys_row_offset = cursor->cell.row;
     item_edit->virt_loc.phys_col_offset = cursor->cell.col;
@@ -373,27 +370,27 @@ gnc_item_edit_configure (GncItemEdit *item_edit)
             xalign = 0.5;
             break;
     }
-    gtk_entry_set_alignment(GTK_ENTRY(item_edit->editor), xalign);
+    gtk_entry_set_alignment (GTK_ENTRY(item_edit->editor), xalign);
 
     if (!gnc_table_is_popup (sheet->table, item_edit->virt_loc))
         gnc_item_edit_set_popup (item_edit, NULL, NULL, NULL,
                                  NULL, NULL, NULL, NULL);
 
     g_idle_add_full (G_PRIORITY_HIGH_IDLE,
-                    (GSourceFunc) gnc_item_edit_update, item_edit, NULL);
+                    (GSourceFunc)gnc_item_edit_update, item_edit, NULL);
 }
 
 
 void
 gnc_item_edit_cut_clipboard (GncItemEdit *item_edit)
 {
-    gtk_editable_cut_clipboard(GTK_EDITABLE(item_edit->editor));
+    gtk_editable_cut_clipboard (GTK_EDITABLE(item_edit->editor));
 }
 
 void
 gnc_item_edit_copy_clipboard (GncItemEdit *item_edit)
 {
-    gtk_editable_copy_clipboard(GTK_EDITABLE(item_edit->editor));
+    gtk_editable_copy_clipboard (GTK_EDITABLE(item_edit->editor));
 }
 
 void
@@ -454,7 +451,7 @@ gnc_item_edit_paste_clipboard (GncItemEdit *item_edit)
 static gboolean
 key_press_popup_cb (GtkWidget *widget, GdkEventKey *event, gpointer data)
 {
-    GncItemEdit *item_edit = GNC_ITEM_EDIT (data);
+    GncItemEdit *item_edit = GNC_ITEM_EDIT(data);
 
     g_signal_stop_emission_by_name (widget, "key_press_event");
 
@@ -467,7 +464,7 @@ key_press_popup_cb (GtkWidget *widget, GdkEventKey *event, gpointer data)
 static void
 gnc_item_edit_popup_toggled (GtkToggleButton *button, gpointer data)
 {
-    GncItemEdit *item_edit = GNC_ITEM_EDIT (data);
+    GncItemEdit *item_edit = GNC_ITEM_EDIT(data);
     gboolean show_popup;
 
     show_popup = gtk_toggle_button_get_active (button);
@@ -482,14 +479,14 @@ gnc_item_edit_popup_toggled (GtkToggleButton *button, gpointer data)
         if (!gnc_table_confirm_change (table, virt_loc))
         {
             g_signal_handlers_block_matched
-            (button, G_SIGNAL_MATCH_DATA,
-             0, 0, NULL, NULL, data);
+                 (button, G_SIGNAL_MATCH_DATA,
+                 0, 0, NULL, NULL, data);
 
             gtk_toggle_button_set_active (button, FALSE);
 
             g_signal_handlers_unblock_matched
-            (button, G_SIGNAL_MATCH_DATA,
-             0, 0, NULL, NULL, data);
+                (button, G_SIGNAL_MATCH_DATA,
+                 0, 0, NULL, NULL, data);
 
             return;
         }
@@ -505,14 +502,14 @@ gnc_item_edit_popup_toggled (GtkToggleButton *button, gpointer data)
 
 
 static void
-block_toggle_signals(GncItemEdit *item_edit)
+block_toggle_signals (GncItemEdit *item_edit)
 {
     GObject *obj;
 
     if (!item_edit->popup_toggle.signals_connected)
         return;
 
-    obj = G_OBJECT (item_edit->popup_toggle.tbutton);
+    obj = G_OBJECT(item_edit->popup_toggle.tbutton);
 
     g_signal_handlers_block_matched (obj, G_SIGNAL_MATCH_DATA,
                                      0, 0, NULL, NULL, item_edit);
@@ -520,14 +517,14 @@ block_toggle_signals(GncItemEdit *item_edit)
 
 
 static void
-unblock_toggle_signals(GncItemEdit *item_edit)
+unblock_toggle_signals (GncItemEdit *item_edit)
 {
     GObject *obj;
 
     if (!item_edit->popup_toggle.signals_connected)
         return;
 
-    obj = G_OBJECT (item_edit->popup_toggle.tbutton);
+    obj = G_OBJECT(item_edit->popup_toggle.tbutton);
 
     g_signal_handlers_unblock_matched (obj, G_SIGNAL_MATCH_DATA,
                                        0, 0, NULL, NULL, item_edit);
@@ -538,7 +535,7 @@ static gboolean
 draw_background_cb (GtkWidget *widget, cairo_t *cr, gpointer user_data)
 {
     GtkStyleContext *stylectxt = gtk_widget_get_style_context (widget);
-    GncItemEdit *item_edit = GNC_ITEM_EDIT (user_data);
+    GncItemEdit *item_edit = GNC_ITEM_EDIT(user_data);
     gint width = gtk_widget_get_allocated_width (widget);
     gint height = gtk_widget_get_allocated_height (widget);
     guint32 color_type;
@@ -565,7 +562,7 @@ preedit_changed_cb (GtkEntry* entry, gchar *preedit, GncItemEdit* item_edit)
 {
     int pos, bound;
     item_edit->preedit_length = g_utf8_strlen (preedit, -1); // Note codepoints not bytes
-    DEBUG ("%s %lu", preedit, item_edit->preedit_length);
+    DEBUG("%s %lu", preedit, item_edit->preedit_length);
 }
 
 
@@ -578,7 +575,7 @@ draw_text_cursor_cb (GtkWidget *widget, cairo_t *cr, gpointer user_data)
     GtkStateFlags flags = gtk_widget_get_state_flags (GTK_WIDGET(widget));
     gint height = gtk_widget_get_allocated_height (widget);
     PangoLayout *layout = gtk_entry_get_layout (GTK_ENTRY(widget));
-    const char *pango_text = pango_layout_get_text(layout);
+    const char *pango_text = pango_layout_get_text (layout);
     GdkRGBA *fg_color;
     GdkRGBA color;
     gint x_offset;
@@ -602,7 +599,7 @@ draw_text_cursor_cb (GtkWidget *widget, cairo_t *cr, gpointer user_data)
         gint cursor_byte_pos = cursor_pos < text_len ?
             g_utf8_offset_to_pointer (pango_text, cursor_pos) - pango_text :
             strlen (pango_text);
-        DEBUG ("Cursor: %d, byte offset %d, text byte len %zu", cursor_pos,
+        DEBUG("Cursor: %d, byte offset %d, text byte len %zu", cursor_pos,
                cursor_byte_pos, strlen (pango_text));
         pango_layout_get_cursor_pos (layout, cursor_byte_pos,
                                      &strong_pos, NULL);
@@ -610,7 +607,7 @@ draw_text_cursor_cb (GtkWidget *widget, cairo_t *cr, gpointer user_data)
     }
     else
     {
-        DEBUG ("No text, cursor at %d.", x_offset);
+        DEBUG("No text, cursor at %d.", x_offset);
         cursor_x = x_offset;
     }
     // Now draw a vertical line
@@ -634,7 +631,7 @@ draw_text_cursor_cb (GtkWidget *widget, cairo_t *cr, gpointer user_data)
 static gboolean
 draw_arrow_cb (GtkWidget *widget, cairo_t *cr, gpointer data)
 {
-    GncItemEdit *item_edit = GNC_ITEM_EDIT (data);
+    GncItemEdit *item_edit = GNC_ITEM_EDIT(data);
     GtkStyleContext *context = gtk_widget_get_style_context (widget);
     gint width = gtk_widget_get_allocated_width (widget);
     gint height = gtk_widget_get_allocated_height (widget);
@@ -663,7 +660,7 @@ connect_popup_toggle_signals (GncItemEdit *item_edit)
 {
     GObject *object;
 
-    g_return_if_fail(GNC_IS_ITEM_EDIT(item_edit));
+    g_return_if_fail (GNC_IS_ITEM_EDIT(item_edit));
 
     if (item_edit->popup_toggle.signals_connected)
         return;
@@ -679,7 +676,7 @@ connect_popup_toggle_signals (GncItemEdit *item_edit)
                       item_edit);
 
     g_signal_connect_after (object, "draw",
-                            G_CALLBACK (draw_arrow_cb),
+                            G_CALLBACK(draw_arrow_cb),
                             item_edit);
 
     item_edit->popup_toggle.signals_connected = TRUE;
@@ -689,14 +686,13 @@ connect_popup_toggle_signals (GncItemEdit *item_edit)
 static void
 disconnect_popup_toggle_signals (GncItemEdit *item_edit)
 {
-    g_return_if_fail(GNC_IS_ITEM_EDIT(item_edit));
+    g_return_if_fail (GNC_IS_ITEM_EDIT(item_edit));
 
     if (!item_edit->popup_toggle.signals_connected)
         return;
 
-    g_signal_handlers_disconnect_matched
-    (item_edit->popup_toggle.tbutton, G_SIGNAL_MATCH_DATA,
-     0, 0, NULL, NULL, item_edit);
+    g_signal_handlers_disconnect_matched (item_edit->popup_toggle.tbutton,
+        G_SIGNAL_MATCH_DATA, 0, 0, NULL, NULL, item_edit);
 
     item_edit->popup_toggle.signals_connected = FALSE;
 }
@@ -713,7 +709,7 @@ gnc_item_edit_get_property (GObject *object,
                             GValue *value,
                             GParamSpec *pspec)
 {
-    GncItemEdit *item_edit = GNC_ITEM_EDIT (object);
+    GncItemEdit *item_edit = GNC_ITEM_EDIT(object);
 
     switch (param_id)
     {
@@ -721,7 +717,7 @@ gnc_item_edit_get_property (GObject *object,
         g_value_take_object (value, item_edit->sheet);
         break;
     default:
-        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, param_id, pspec);
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, param_id, pspec);
         break;
     }
 }
@@ -732,14 +728,14 @@ gnc_item_edit_set_property (GObject *object,
                             const GValue *value,
                             GParamSpec *pspec)
 {
-    GncItemEdit *item_edit = GNC_ITEM_EDIT (object);
+    GncItemEdit *item_edit = GNC_ITEM_EDIT(object);
     switch (param_id)
     {
     case PROP_SHEET:
-        item_edit->sheet = GNUCASH_SHEET (g_value_get_object (value));
+        item_edit->sheet = GNUCASH_SHEET(g_value_get_object (value));
         break;
     default:
-        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, param_id, pspec);
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, param_id, pspec);
         break;
     }
 }
@@ -750,7 +746,7 @@ gnc_item_edit_get_preferred_width (GtkWidget *widget,
                                    gint *natural_width)
 {
     gint x, y, w = 1, h;
-    gnc_item_edit_get_pixel_coords (GNC_ITEM_EDIT (widget), &x, &y, &w, &h);
+    gnc_item_edit_get_pixel_coords (GNC_ITEM_EDIT(widget), &x, &y, &w, &h);
     *minimal_width = *natural_width = w - 1;
 }
 
@@ -761,7 +757,7 @@ gnc_item_edit_get_preferred_height (GtkWidget *widget,
                                     gint *natural_width)
 {
     gint x, y, w, h = 1;
-    gnc_item_edit_get_pixel_coords (GNC_ITEM_EDIT (widget), &x, &y, &w, &h);
+    gnc_item_edit_get_pixel_coords (GNC_ITEM_EDIT(widget), &x, &y, &w, &h);
     *minimal_width = *natural_width = h - 1;
 }
 
@@ -778,8 +774,8 @@ gnc_item_edit_class_init (GncItemEditClass *gnc_item_edit_class)
 
     gnc_item_edit_parent_class = g_type_class_peek_parent (gnc_item_edit_class);
 
-    object_class = G_OBJECT_CLASS (gnc_item_edit_class);
-    widget_class = GTK_WIDGET_CLASS (gnc_item_edit_class);
+    object_class = G_OBJECT_CLASS(gnc_item_edit_class);
+    widget_class = GTK_WIDGET_CLASS(gnc_item_edit_class);
 
     object_class->get_property = gnc_item_edit_get_property;
     object_class->set_property = gnc_item_edit_set_property;
@@ -822,9 +818,9 @@ gnc_item_edit_get_type (void)
         };
 
         gnc_item_edit_type =
-            g_type_register_static(GTK_TYPE_BOX,
-                                   "GncItemEdit",
-                                   &gnc_item_edit_info, 0);
+            g_type_register_static (GTK_TYPE_BOX,
+                                    "GncItemEdit",
+                                    &gnc_item_edit_info, 0);
     }
 
     return gnc_item_edit_type;
@@ -885,7 +881,8 @@ gnc_item_edit_get_button_width (GncItemEdit *item_edit)
             return item_edit->button_width;
         else
         {
-            GtkStyleContext *context = gtk_widget_get_style_context (GTK_WIDGET(item_edit->popup_toggle.tbutton));
+            GtkStyleContext *context = gtk_widget_get_style_context (
+                                           GTK_WIDGET(item_edit->popup_toggle.tbutton));
             GtkBorder border;
 
             gtk_style_context_get_border (context, GTK_STATE_FLAG_NORMAL, &border);
@@ -918,16 +915,15 @@ gnc_item_edit_new (GnucashSheet *sheet)
     GtkBorder padding;
     GtkBorder margin;
     GtkBorder border;
-    GncItemEdit *item_edit =
-            g_object_new (GNC_TYPE_ITEM_EDIT,
-                          "sheet", sheet,
-                          "spacing",     0,
-                          "homogeneous", FALSE,
-                           NULL);
+    GncItemEdit *item_edit = g_object_new (GNC_TYPE_ITEM_EDIT,
+                                           "sheet", sheet,
+                                           "spacing",     0,
+                                           "homogeneous", FALSE,
+                                            NULL);
     gtk_layout_put (GTK_LAYOUT(sheet), GTK_WIDGET(item_edit), 0, 0);
 
     /* Create the text entry */
-    item_edit->editor = gtk_entry_new();
+    item_edit->editor = gtk_entry_new ();
     sheet->entry = item_edit->editor;
     gtk_entry_set_width_chars (GTK_ENTRY(item_edit->editor), 1);
     gtk_box_pack_start (GTK_BOX(item_edit), item_edit->editor, TRUE, TRUE, 0);
@@ -949,48 +945,48 @@ gnc_item_edit_new (GnucashSheet *sheet)
 
     // Connect to the draw signal so we can draw a cursor
     g_signal_connect_after (item_edit->editor, "draw",
-                            G_CALLBACK (draw_text_cursor_cb), item_edit);
+                            G_CALLBACK(draw_text_cursor_cb), item_edit);
 
     g_signal_connect (item_edit->editor, "preedit-changed",
-                      G_CALLBACK (preedit_changed_cb), item_edit);
+                      G_CALLBACK(preedit_changed_cb), item_edit);
 
     // Fill in the background so the underlying sheet cell can not be seen
     g_signal_connect (item_edit, "draw",
-                            G_CALLBACK (draw_background_cb), item_edit);
+                      G_CALLBACK(draw_background_cb), item_edit);
 
     // This call back intercepts the mouse button event so the main
     // register popup menu can be displayed instead of the entry one.
     g_signal_connect (item_edit->editor, "button-press-event",
-                            G_CALLBACK (button_press_cb), sheet);
+                      G_CALLBACK(button_press_cb), sheet);
 
     /* Create the popup button
        It will only be displayed when the cell being edited provides
        a popup item (like a calendar or account list) */
     item_edit->popup_toggle.tbutton = gnc_item_edit_tb_new (sheet);
-    gtk_toggle_button_set_mode (GTK_TOGGLE_BUTTON (item_edit->popup_toggle.tbutton), FALSE);
+    gtk_toggle_button_set_mode (GTK_TOGGLE_BUTTON(item_edit->popup_toggle.tbutton), FALSE);
 
     /* Wrap the popup button in an event box to give it its own gdkwindow.
      * Without one the button would disappear behind the grid object. */
-    item_edit->popup_toggle.ebox = gtk_event_box_new();
-    g_object_ref(item_edit->popup_toggle.ebox);
-    gtk_container_add(GTK_CONTAINER(item_edit->popup_toggle.ebox),
-                      item_edit->popup_toggle.tbutton);
+    item_edit->popup_toggle.ebox = gtk_event_box_new ();
+    g_object_ref (item_edit->popup_toggle.ebox);
+    gtk_container_add (GTK_CONTAINER(item_edit->popup_toggle.ebox),
+                       item_edit->popup_toggle.tbutton);
 
     gtk_box_pack_start (GTK_BOX(item_edit), item_edit->popup_toggle.ebox, FALSE, FALSE, 0);
-    gtk_widget_show_all(GTK_WIDGET(item_edit));
-    g_signal_connect(G_OBJECT(item_edit), "destroy",
-                     G_CALLBACK(gnc_item_edit_destroying), NULL);
+    gtk_widget_show_all (GTK_WIDGET(item_edit));
+    g_signal_connect (G_OBJECT(item_edit), "destroy",
+                      G_CALLBACK(gnc_item_edit_destroying), NULL);
     return GTK_WIDGET(item_edit);
 }
 
 static void
 gnc_item_edit_destroying (GtkWidget *item_edit, gpointer data)
 {
-    if (GNC_ITEM_EDIT (item_edit)->popup_height_signal_id > 0)
-        g_signal_handler_disconnect (GNC_ITEM_EDIT (item_edit)->popup_item,
-                                     GNC_ITEM_EDIT (item_edit)->popup_height_signal_id);
+    if (GNC_ITEM_EDIT(item_edit)->popup_height_signal_id > 0)
+        g_signal_handler_disconnect (GNC_ITEM_EDIT(item_edit)->popup_item,
+                                     GNC_ITEM_EDIT(item_edit)->popup_height_signal_id);
 
-    while (g_idle_remove_by_data((gpointer)item_edit))
+    while (g_idle_remove_by_data ((gpointer)item_edit))
         continue;
 }
 
@@ -1009,7 +1005,7 @@ check_popup_height_is_true (GtkWidget    *widget,
         gtk_container_remove (GTK_CONTAINER(item_edit->sheet), item_edit->popup_item);
 
         g_idle_add_full (G_PRIORITY_HIGH_IDLE,
-                        (GSourceFunc) gnc_item_edit_update, item_edit, NULL);
+                        (GSourceFunc)gnc_item_edit_update, item_edit, NULL);
     }
 }
 
@@ -1039,14 +1035,14 @@ gnc_item_edit_show_popup (GncItemEdit *item_edit)
 
     sheet_width = sheet->width;
 
-    gtk_widget_get_allocation (GTK_WIDGET (sheet), &alloc);
+    gtk_widget_get_allocation (GTK_WIDGET(sheet), &alloc);
     view_height = alloc.height;
 
-    vadj = gtk_scrollable_get_vadjustment(GTK_SCROLLABLE(sheet));
-    hadj = gtk_scrollable_get_hadjustment(GTK_SCROLLABLE(sheet));
+    vadj = gtk_scrollable_get_vadjustment (GTK_SCROLLABLE(sheet));
+    hadj = gtk_scrollable_get_hadjustment (GTK_SCROLLABLE(sheet));
 
-    y_offset = gtk_adjustment_get_value(vadj);
-    x_offset = gtk_adjustment_get_value(hadj);
+    y_offset = gtk_adjustment_get_value (vadj);
+    x_offset = gtk_adjustment_get_value (hadj);
     gnc_item_edit_get_pixel_coords (item_edit, &x, &y, &w, &h);
 
     popup_x = x;
@@ -1054,7 +1050,7 @@ gnc_item_edit_show_popup (GncItemEdit *item_edit)
     up_height = y - y_offset;
     down_height = view_height - (up_height + h);
 
-    popup_max_height = MAX (up_height, down_height);
+    popup_max_height = MAX(up_height, down_height);
     popup_max_width = sheet_width - popup_x + x_offset; // always pops to the right
 
     if (item_edit->popup_get_height)
@@ -1121,7 +1117,7 @@ gnc_item_edit_show_popup (GncItemEdit *item_edit)
         if (popup_width > popup_max_width)
         {
             popup_x -= popup_width - popup_max_width;
-            popup_x = MAX (0, popup_x);
+            popup_x = MAX(0, popup_x);
         }
         else
             popup_x = x;
@@ -1134,13 +1130,13 @@ gnc_item_edit_show_popup (GncItemEdit *item_edit)
 void
 gnc_item_edit_hide_popup (GncItemEdit *item_edit)
 {
-    g_return_if_fail(item_edit != NULL);
-    g_return_if_fail(GNC_IS_ITEM_EDIT(item_edit));
+    g_return_if_fail (item_edit != NULL);
+    g_return_if_fail (GNC_IS_ITEM_EDIT(item_edit));
 
     if (!item_edit->is_popup)
         return;
 
-    if (gtk_widget_get_parent (GTK_WIDGET(item_edit->popup_item)) != GTK_WIDGET (item_edit->sheet))
+    if (gtk_widget_get_parent (GTK_WIDGET(item_edit->popup_item)) != GTK_WIDGET(item_edit->sheet))
         return;
 
     gtk_container_remove (GTK_CONTAINER(item_edit->sheet), item_edit->popup_item);
@@ -1149,9 +1145,9 @@ gnc_item_edit_hide_popup (GncItemEdit *item_edit)
     item_edit->popup_toggle.arrow_down = TRUE;
 
     gtk_toggle_button_set_active
-    (GTK_TOGGLE_BUTTON(item_edit->popup_toggle.tbutton), FALSE);
+        (GTK_TOGGLE_BUTTON(item_edit->popup_toggle.tbutton), FALSE);
 
-    gtk_widget_grab_focus (GTK_WIDGET (item_edit->sheet));
+    gtk_widget_grab_focus (GTK_WIDGET(item_edit->sheet));
 }
 
 
@@ -1181,7 +1177,7 @@ gnc_item_edit_set_popup (GncItemEdit    *item_edit,
     }
     else
     {
-        if (GNC_ITEM_EDIT (item_edit)->popup_height_signal_id > 0)
+        if (GNC_ITEM_EDIT(item_edit)->popup_height_signal_id > 0)
         {
             g_signal_handler_disconnect (item_edit->popup_item, item_edit->popup_height_signal_id);
             item_edit->popup_height_signal_id = 0;
@@ -1215,9 +1211,9 @@ gnc_item_edit_get_has_selection (GncItemEdit *item_edit)
     GtkEditable *editable;
 
     g_return_val_if_fail ((item_edit != NULL), FALSE);
-    g_return_val_if_fail (GNC_IS_ITEM_EDIT (item_edit), FALSE);
+    g_return_val_if_fail (GNC_IS_ITEM_EDIT(item_edit), FALSE);
 
-    editable = GTK_EDITABLE (item_edit->editor);
-    return gtk_editable_get_selection_bounds(editable, NULL, NULL);
+    editable = GTK_EDITABLE(item_edit->editor);
+    return gtk_editable_get_selection_bounds (editable, NULL, NULL);
 }
 

--- a/libgnucash/app-utils/gnc-ui-util.c
+++ b/libgnucash/app-utils/gnc-ui-util.c
@@ -2737,3 +2737,31 @@ gnc_filter_text_for_currency_symbol (const gchar *symbol,
     g_strfreev (split);
     return ret_text;
 }
+
+gchar *
+gnc_filter_text_for_currency_commodity (const gnc_commodity *comm,
+                                        const gchar *incoming_text,
+                                        const gchar **symbol)
+{
+    if (!incoming_text)
+    {
+        *symbol = NULL;
+        return NULL;
+    }
+
+    if (!gnc_commodity_is_currency (comm))
+    {
+        *symbol = NULL;
+        return g_strdup (incoming_text);
+    }
+
+    if (comm)
+        *symbol = gnc_commodity_get_nice_symbol (comm);
+    else
+        *symbol = gnc_commodity_get_nice_symbol (gnc_default_currency ());
+
+    if (g_strrstr (incoming_text, *symbol) == NULL)
+        return g_strdup (incoming_text);
+
+    return gnc_filter_text_for_currency_symbol (*symbol, incoming_text);
+}

--- a/libgnucash/app-utils/gnc-ui-util.c
+++ b/libgnucash/app-utils/gnc-ui-util.c
@@ -2712,3 +2712,27 @@ gnc_filter_text_for_control_chars (const gchar *text)
     }
     return g_string_free (filtered, FALSE);
 }
+
+gchar *
+gnc_filter_text_for_currency_symbol (const gchar *symbol,
+                                     const gchar *incoming_text)
+{
+    gchar *ret_text = NULL;
+    gchar **split;
+
+    if (!incoming_text)
+        return NULL;
+
+    if (!symbol)
+       return g_strdup (incoming_text);
+
+    if (g_strrstr (incoming_text, symbol) == NULL)
+        return g_strdup (incoming_text);
+
+    split = g_strsplit (incoming_text, symbol, -1);
+
+    ret_text = g_strjoinv (NULL, split);
+
+    g_strfreev (split);
+    return ret_text;
+}

--- a/libgnucash/app-utils/gnc-ui-util.c
+++ b/libgnucash/app-utils/gnc-ui-util.c
@@ -1414,6 +1414,7 @@ gnc_default_share_print_info (void)
     if (!got_it)
     {
         info = gnc_default_print_info_helper (5);
+        info.monetary = 0;
         got_it = TRUE;
     }
 

--- a/libgnucash/app-utils/gnc-ui-util.h
+++ b/libgnucash/app-utils/gnc-ui-util.h
@@ -397,6 +397,15 @@ void gnc_ui_util_init (void);
 
 void gnc_ui_util_remove_registered_prefs (void);
 
+/** Returns the incoming text removed of control characters
+ *
+ * @param incoming_text The text to filter
+ *
+ * @return The incoming text filtered of control characters to be
+ *         freed by the caller.
+*/
+gchar * gnc_filter_text_for_control_chars (const gchar *incoming_text);
+
 #endif
 /** @} */
 /** @} */

--- a/libgnucash/app-utils/gnc-ui-util.h
+++ b/libgnucash/app-utils/gnc-ui-util.h
@@ -406,6 +406,17 @@ void gnc_ui_util_remove_registered_prefs (void);
 */
 gchar * gnc_filter_text_for_control_chars (const gchar *incoming_text);
 
+/** Returns the incoming text removed of a currency symbol
+ *
+ * @param symbol to remove
+ *
+ * @param incoming_text The text to filter
+ *
+ * @return The incoming text with symbol removed to be freed by the caller
+*/
+gchar * gnc_filter_text_for_currency_symbol (const gchar *symbol,
+                                             const gchar *incoming_text);
+
 #endif
 /** @} */
 /** @} */

--- a/libgnucash/app-utils/gnc-ui-util.h
+++ b/libgnucash/app-utils/gnc-ui-util.h
@@ -417,6 +417,20 @@ gchar * gnc_filter_text_for_control_chars (const gchar *incoming_text);
 gchar * gnc_filter_text_for_currency_symbol (const gchar *symbol,
                                              const gchar *incoming_text);
 
+/** Returns the incoming text removed of currency symbol
+ * 
+ * @param comm commodity of entry if known
+ * 
+ * @param incoming_text The text to filter
+ *
+ * @param symbol return the symbol used
+ *
+ * @return The incoming text with symbol removed to be freed by the caller
+*/
+gchar * gnc_filter_text_for_currency_commodity (const gnc_commodity *comm,
+                                                const gchar *incoming_text,
+                                                const gchar **symbol);
+
 #endif
 /** @} */
 /** @} */


### PR DESCRIPTION
These commits allow filtering of control characters and currency symbols when pasting in to a GNCAmountEdit widget and also the display of a warning triangle when the verification of the entry fails along with tool tip for the error.

To display the warning triangle, the GNCAmountEdit parent class is changed from GtkEntry to a GtkBox so that I can pack that with an entry and image widget.

Following that, the commits are mainly to do with accommodating the change of widget and use in various source files but also added some verification of the entries used as some dialogs were not testing for a valid entry before proceeding.