### PR TITLE
Cleanup and update zh_TW.po to match current codebase.

### DIFF
--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -7,10 +7,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: GnuCash-2.4.3\n"
-"Report-Msgid-Bugs-To: https://bugs.gnucash.org/enter_bug."
-"cgi?product=GnuCash&component=Translations\n"
-"POT-Creation-Date: 2021-04-16 23:36+0200\n"
-"PO-Revision-Date: 2021-06-07 02:34+0000\n"
+"Report-Msgid-Bugs-To: https://bugs.gnucash.org/enter_bug.cgi?"
+"product=GnuCash&component=Translations\n"
+"POT-Creation-Date: 2021-06-07 14:23+0800\n"
+"PO-Revision-Date: 2021-06-07 14:47+0800\n"
 "Last-Translator: Brian Hsu <brianhsu.hsu@gmail.com>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
 "gnucash/gnucash/zh_Hant/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Weblate 4.7-dev\n"
+"X-Generator: Poedit 2.3.1\n"
 
 #: bindings/guile/commodity-table.scm:44
 msgid "ALL NON-CURRENCY"
@@ -86,8 +86,8 @@ msgstr "西歐語系"
 #: borrowed/goffice/go-charmap-sel.c:84
 #: gnucash/gtkbuilder/assistant-loan.glade:969
 #: gnucash/gtkbuilder/dialog-account.glade:1031
-#: gnucash/report/reports/standard/account-piecharts.scm:488
-#: gnucash/report/reports/standard/category-barchart.scm:542
+#: gnucash/report/reports/standard/account-piecharts.scm:477
+#: gnucash/report/reports/standard/category-barchart.scm:530
 msgid "Other"
 msgstr "其他"
 
@@ -452,8 +452,8 @@ msgid ""
 "community. For announcements of new releases, user groups etc. see the table "
 "at https://wiki.gnucash.org/wiki/Mailing_Lists"
 msgstr ""
-"郵件論壇是 GnuCash 社群偏好的溝通方式，包括新版本的公告，使用者群組等等。詳情請見 https://wiki.gnucash.org/wiki/"
-"Mailing_Lists"
+"郵件論壇是 GnuCash 社群偏好的溝通方式，包括新版本的公告，使用者群組等等。詳情"
+"請見 https://wiki.gnucash.org/wiki/Mailing_Lists"
 
 #: doc/tip_of_the_day.list.c:9
 msgid ""
@@ -490,7 +490,9 @@ msgid ""
 "It is possible to change which columns display in the Chart of Accounts. "
 "Just locate the triangle at the far right of the column headings, and click "
 "it to see the different columns available."
-msgstr "您可以更改科目體系裡所顯示的欄位。找到欄位名稱那行最右邊的箭頭，點選後可以看到可以選擇的欄位。"
+msgstr ""
+"您可以更改科目體系裡所顯示的欄位。找到欄位名稱那行最右邊的箭頭，點選後可以看"
+"到可以選擇的欄位。"
 
 #: doc/tip_of_the_day.list.c:27
 msgid ""
@@ -499,8 +501,8 @@ msgid ""
 "register, clicking the right mouse button brings up the transaction menu "
 "options."
 msgstr ""
-"在主視窗中的科目頁籤裡點選滑鼠右鍵 (Mac OS X 中按著 Contrl 並點擊滑鼠) "
-"會出現科目選單選項。在每個登記簿中點選滑鼠右鍵則會出現交易選單選項。"
+"在主視窗中的科目頁籤裡點選滑鼠右鍵 (Mac OS X 中按著 Contrl 並點擊滑鼠) 會出現"
+"科目選單選項。在每個登記簿中點選滑鼠右鍵則會出現交易選單選項。"
 
 #: doc/tip_of_the_day.list.c:32
 msgid ""
@@ -524,7 +526,8 @@ msgid ""
 msgstr ""
 "每筆交易都有一個「筆記」欄位可以讓您記錄有用的資訊。\n"
 "\n"
-"要看見他的話，請點選工具列上的「檢視」選單並點選「雙行」。或者在「偏好設定:登記簿預設值」中，選則雙行模式。"
+"要看見他的話，請點選工具列上的「檢視」選單並點選「雙行」。或者在「偏好設定:登"
+"記簿預設值」中，選則雙行模式。"
 
 #: doc/tip_of_the_day.list.c:44
 msgid ""
@@ -543,8 +546,9 @@ msgid ""
 "'+', '-','*', or '/'. Type the second value and press Enter to record the "
 "calculated amount."
 msgstr ""
-"當您在登記簿中輸入總數時，您可以使用 GnuCash計算機來加、減、乘、除。只要輸入第一個值，然後輸入 '+'、'-'、'*' 或 '/'。"
-"再輸入第二個值並按 Enter 就可以記錄計算後的總數。"
+"當您在登記簿中輸入總數時，您可以使用 GnuCash計算機來加、減、乘、除。只要輸入"
+"第一個值，然後輸入 '+'、'-'、'*' 或 '/'。再輸入第二個值並按 Enter 就可以記錄"
+"計算後的總數。"
 
 #: doc/tip_of_the_day.list.c:54
 msgid ""
@@ -573,7 +577,9 @@ msgid ""
 "Want to see all your subaccount transactions in one register? From the "
 "Accounts tab in the main window, highlight the parent account and select "
 "Edit->Open Subaccounts from the menu."
-msgstr "想在登記簿中看到您子科目的所有交易？在主選單中反白母科目並且從選單中選擇科目->開啟子科目。"
+msgstr ""
+"想在登記簿中看到您子科目的所有交易？在主選單中反白母科目並且從選單中選擇科目-"
+">開啟子科目。"
 
 #: doc/tip_of_the_day.list.c:69
 msgid ""
@@ -595,7 +601,9 @@ msgid ""
 "In the reconcile window, you can press the spacebar to mark transactions as "
 "reconciled. You can also press Tab and Shift-Tab to move between deposits "
 "and withdrawals."
-msgstr "在對帳視窗中，您可以按空白鍵把交易標記為已對帳。您也可以按 Tab 與 Shift-Tab 在存款與提款間移動。"
+msgstr ""
+"在對帳視窗中，您可以按空白鍵把交易標記為已對帳。您也可以按 Tab 與 Shift-Tab "
+"在存款與提款間移動。"
 
 #: doc/tip_of_the_day.list.c:80
 msgid ""
@@ -613,7 +621,9 @@ msgid ""
 "security, which makes it easy to see which online sources your securities "
 "use. Click the triangle at the far right of the column headings to change "
 "the display."
-msgstr "您可以在證券編輯器裡顯示價格來原，讓您更清楚您的證券所使用的價格來源。按下欄位名稱最右邊的三角選，並且選擇您要顯示的欄位。"
+msgstr ""
+"您可以在證券編輯器裡顯示價格來原，讓您更清楚您的證券所使用的價格來源。按下欄"
+"位名稱最右邊的三角選，並且選擇您要顯示的欄位。"
 
 #: doc/tip_of_the_day.list.c:90
 msgid ""
@@ -637,7 +647,9 @@ msgstr ""
 msgid ""
 "To raise the accounts menu in the transfer field of a register page, press "
 "the Menu key or the Ctrl-Down key combination."
-msgstr "您可以按下鍵盤上的 MENU鍵或是使用 Ctrl+下 組合鍵，來打開登記簿裡的轉帳欄位的下拉式選單。"
+msgstr ""
+"您可以按下鍵盤上的 MENU鍵或是使用 Ctrl+下 組合鍵，來打開登記簿裡的轉帳欄位的"
+"下拉式選單。"
 
 #: doc/tip_of_the_day.list.c:102
 msgid ""
@@ -652,18 +664,23 @@ msgid ""
 "To schedule a transaction every year you can choose the monthly basic "
 "frequency and then set 'Every 12 months'."
 msgstr ""
-"排程交易編輯器具有非常靈活的頻率選項。除了基本的每日、每週每月等選項，也可以設定更進階的排程。例如：\n"
+"排程交易編輯器具有非常靈活的頻率選項。除了基本的每日、每週每月等選項，也可以"
+"設定更進階的排程。例如：\n"
 "\n"
-"透過選擇「每週」的選項，並設定「每三週」，您可以排定一個固定每三週執行一次的交易。\n"
+"透過選擇「每週」的選項，並設定「每三週」，您可以排定一個固定每三週執行一次的"
+"交易。\n"
 "\n"
-"透過選擇「每月」排程，並設定「每十二個月一次」，可以排定一個固定每年執行一次的交易。"
+"透過選擇「每月」排程，並設定「每十二個月一次」，可以排定一個固定每年執行一次"
+"的交易。"
 
 #: doc/tip_of_the_day.list.c:111
 msgid ""
 "If you work overnight, you should close and reopen your working registers "
 "after midnight, to get the new date as default for new transactions. It is "
 "not necessary to restart GnuCash."
-msgstr "如果您熬夜工作，您應該關閉再重新打開您的登記簿，以取得用於新交易的新日期。不需要重新啟動 GnuCash。"
+msgstr ""
+"如果您熬夜工作，您應該關閉再重新打開您的登記簿，以取得用於新交易的新日期。不"
+"需要重新啟動 GnuCash。"
 
 #: doc/tip_of_the_day.list.c:115
 msgid ""
@@ -671,15 +688,17 @@ msgid ""
 "the main accounts hierarchy page. To limit your search to a single account, "
 "start the search from that account's register."
 msgstr ""
-"要從您所有交易中尋找特定的交易，可以從科目列表頁籤中，執行搜尋功能(編輯 -> "
-"尋找)。如果只要搜尋某個特定科目中的交易，則從該科目的登記簿中執行搜尋功能。"
+"要從您所有交易中尋找特定的交易，可以從科目列表頁籤中，執行搜尋功能(編輯 -> 尋"
+"找)。如果只要搜尋某個特定科目中的交易，則從該科目的登記簿中執行搜尋功能。"
 
 #: doc/tip_of_the_day.list.c:119
 msgid ""
 "To visually compare on screen the contents of 2 tabs, in one of the tabs, "
 "select Window->New Window with Page from the menu to duplicate that tab in a "
 "new window."
-msgstr "如果要比較兩個頁籤的內容，可以在其中一個頁籤中，選則工具列上的「視窗 -> 將本頁開啟於新視窗中」，來將目前的頁籤顯示在新視窗中。"
+msgstr ""
+"如果要比較兩個頁籤的內容，可以在其中一個頁籤中，選則工具列上的「視窗 -> 將本"
+"頁開啟於新視窗中」，來將目前的頁籤顯示在新視窗中。"
 
 #: doc/tip_of_the_day.list.c:123
 msgid ""
@@ -690,8 +709,10 @@ msgid ""
 "\n"
 "Douglas Adams, \"The Restaurant at the End of the Universe\""
 msgstr ""
-"有個理論指出如果有人發現了宇宙的本質與其存在的理由，宇宙會馬上消失並且以另一個更不尋常且令人難以理解的方式出現。還有另一個理論指出這都已發生 --- "
-"道格拉斯‧亞當斯(Douglas Adams)，《宇宙盡頭的餐廳(The Restaurant at the End of the Universe)》"
+"有個理論指出如果有人發現了宇宙的本質與其存在的理由，宇宙會馬上消失並且以另一"
+"個更不尋常且令人難以理解的方式出現。還有另一個理論指出這都已發生 --- 道格拉"
+"斯‧亞當斯(Douglas Adams)，《宇宙盡頭的餐廳(The Restaurant at the End of the "
+"Universe)》"
 
 #: gnucash/gnome/assistant-acct-period.c:188
 msgid "The book was closed successfully."
@@ -708,8 +729,12 @@ msgid ""
 msgid_plural ""
 "The earliest transaction date found in this book is %s. Based on the "
 "selection made above, this book will be split into %d books."
-msgstr[0] "這本帳簿中最早的交易日期是 %s，根據上面所選的模式，這個帳簿會被分割成 %d 本帳本。"
-msgstr[1] "這本帳簿中最早的交易日期是 %s，根據上面所選的模式，這個帳簿會被分割成 %d 本帳本。"
+msgstr[0] ""
+"這本帳簿中最早的交易日期是 %s，根據上面所選的模式，這個帳簿會被分割成 %d 本帳"
+"本。"
+msgstr[1] ""
+"這本帳簿中最早的交易日期是 %s，根據上面所選的模式，這個帳簿會被分割成 %d 本帳"
+"本。"
 
 #. Translators: Run the assistant in your language to see GTK's translation of the button labels.
 #: gnucash/gnome/assistant-acct-period.c:369
@@ -722,7 +747,8 @@ msgid ""
 "Amend the Title and Notes or Click on \"Next\" to proceed.\n"
 "Click on \"Back\" to adjust the dates or \"Cancel\"."
 msgstr ""
-"您要求建立一本帳簿。這本帳簿會包含至 %s 午夜為止的所有交易，其中包含 %d 筆交易，分佈在 %d 個科目中。\n"
+"您要求建立一本帳簿。這本帳簿會包含至 %s 午夜為止的所有交易，其中包含 %d 筆交"
+"易，分佈在 %d 個科目中。\n"
 "\n"
 "修改標是或筆記，或按下「下一步」繼續。\n"
 "\n"
@@ -738,7 +764,9 @@ msgstr "從 %s 到 %s 期間"
 msgid ""
 "The book will be created with the title %s when you click on \"Apply\". "
 "Click on \"Back\" to adjust, or \"Cancel\" to not create any book."
-msgstr "按下「套用」將會建立這本標題為 %s 的帳簿。按下「返回」進行調整，或按下「取消」來取消建立帳簿。"
+msgstr ""
+"按下「套用」將會建立這本標題為 %s 的帳簿。按下「返回」進行調整，或按下「取"
+"消」來取消建立帳簿。"
 
 #: gnucash/gnome/assistant-acct-period.c:523
 #, c-format
@@ -751,8 +779,8 @@ msgstr ""
 
 #: gnucash/gnome/assistant-acct-period.c:589
 #: gnucash/gtkbuilder/dialog-fincalc.glade:637
-#: gnucash/report/reports/standard/balsheet-pnl.scm:1271
-#: gnucash/report/reports/standard/balsheet-pnl.scm:1276
+#: gnucash/report/reports/standard/balsheet-pnl.scm:1232
+#: gnucash/report/reports/standard/balsheet-pnl.scm:1237
 #: gnucash/report/reports/standard/budget-flow.scm:44
 msgid "Period"
 msgstr "週期"
@@ -804,7 +832,7 @@ msgid "No"
 msgstr "否"
 
 #: gnucash/gnome/assistant-hierarchy.c:1335
-#: gnucash/gnome-utils/dialog-options.c:736
+#: gnucash/gnome-utils/dialog-options.c:733
 #: gnucash/gnome-utils/gnc-tree-view-account.c:988
 #: gnucash/gtkbuilder/dialog-account.glade:272
 #: gnucash/import-export/csv-exp/csv-tree-export.c:158
@@ -842,71 +870,71 @@ msgstr "請選擇用於新科目的貨幣。"
 msgid "New Book Options"
 msgstr "帳簿選項"
 
-#: gnucash/gnome/assistant-loan.cpp:127
+#: gnucash/gnome/assistant-loan.cpp:128
 msgid "Taxes"
 msgstr "稅務"
 
-#: gnucash/gnome/assistant-loan.cpp:127
+#: gnucash/gnome/assistant-loan.cpp:128
 msgid "Tax Payment"
 msgstr "稅務付款"
 
-#: gnucash/gnome/assistant-loan.cpp:128
+#: gnucash/gnome/assistant-loan.cpp:129
 msgid "Insurance"
 msgstr "保險"
 
-#: gnucash/gnome/assistant-loan.cpp:128
+#: gnucash/gnome/assistant-loan.cpp:129
 msgid "Insurance Payment"
 msgstr "保險付款"
 
 #. Translators: PMI stands for Private Mortgage Insurance.
-#: gnucash/gnome/assistant-loan.cpp:130
+#: gnucash/gnome/assistant-loan.cpp:131
 msgid "PMI"
 msgstr "PMI"
 
-#: gnucash/gnome/assistant-loan.cpp:130
+#: gnucash/gnome/assistant-loan.cpp:131
 msgid "PMI Payment"
 msgstr "PMI 付款"
 
-#: gnucash/gnome/assistant-loan.cpp:131
+#: gnucash/gnome/assistant-loan.cpp:132
 msgid "Other Expense"
 msgstr "其他支出"
 
-#: gnucash/gnome/assistant-loan.cpp:131
+#: gnucash/gnome/assistant-loan.cpp:132
 msgid "Miscellaneous Payment"
 msgstr "其他付款"
 
 #. Translators: %s is "Taxes",
 #. "Insurance", or similar.
-#: gnucash/gnome/assistant-loan.cpp:766
+#: gnucash/gnome/assistant-loan.cpp:767
 #, c-format
 msgid "... pay \"%s\"?"
 msgstr "... 付「%s」？"
 
-#: gnucash/gnome/assistant-loan.cpp:778
+#: gnucash/gnome/assistant-loan.cpp:779
 msgid "via Escrow account?"
 msgstr "透過代管科目？"
 
-#: gnucash/gnome/assistant-loan.cpp:925
+#: gnucash/gnome/assistant-loan.cpp:926
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2894
-#: gnucash/register/ledger-core/split-register.c:2587
+#: gnucash/register/ledger-core/split-register.c:2589
 msgid "Loan"
 msgstr "貸款"
 
 #. Translators: %s is "Taxes", or "Insurance", or similar
-#: gnucash/gnome/assistant-loan.cpp:1460
+#: gnucash/gnome/assistant-loan.cpp:1461
 #, c-format
 msgid "Loan Repayment Option: \"%s\""
 msgstr "貸款償還選項：「%s」"
 
 #. Translators: The following symbols will build the *
 #. * header line of exported CSV files:
-#: gnucash/gnome/assistant-loan.cpp:1862 gnucash/gnome/dialog-lot-viewer.c:942
+#: gnucash/gnome/assistant-loan.cpp:1863 gnucash/gnome/dialog-lot-viewer.c:942
 #: gnucash/gnome/gnc-split-reg.c:682 gnucash/gnome/reconcile-view.c:429
 #: gnucash/gnome-utils/gnc-tree-view-price.c:408
 #: gnucash/gtkbuilder/dialog-doclink.glade:644
 #: gnucash/gtkbuilder/dialog-payment.glade:253
 #: gnucash/gtkbuilder/dialog-payment.glade:374
-#: gnucash/gtkbuilder/dialog-transfer.glade:138
+#: gnucash/gtkbuilder/dialog-transfer.glade:126
 #: gnucash/gtkbuilder/gnc-plugin-page-register2.glade:524
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:366
 #: gnucash/import-export/bi-import/dialog-bi-import-gui.c:148
@@ -923,17 +951,17 @@ msgstr "貸款償還選項：「%s」"
 #: gnucash/register/ledger-core/split-register-model.c:232
 #: gnucash/report/reports/standard/account-summary.scm:83
 #: gnucash/report/reports/standard/advanced-portfolio.scm:73
-#: gnucash/report/reports/standard/balsheet-pnl.scm:1104
-#: gnucash/report/reports/standard/balsheet-pnl.scm:1109
+#: gnucash/report/reports/standard/balsheet-pnl.scm:1065
+#: gnucash/report/reports/standard/balsheet-pnl.scm:1070
 #: gnucash/report/reports/standard/cashflow-barchart.scm:336
-#: gnucash/report/reports/standard/category-barchart.scm:632
-#: gnucash/report/reports/standard/category-barchart.scm:653
+#: gnucash/report/reports/standard/category-barchart.scm:620
+#: gnucash/report/reports/standard/category-barchart.scm:641
 #: gnucash/report/reports/standard/general-journal.scm:92
 #: gnucash/report/reports/standard/general-ledger.scm:66
 #: gnucash/report/reports/standard/general-ledger.scm:87
 #: gnucash/report/reports/standard/invoice.scm:88
-#: gnucash/report/reports/standard/invoice.scm:212
-#: gnucash/report/reports/standard/invoice.scm:603
+#: gnucash/report/reports/standard/invoice.scm:199
+#: gnucash/report/reports/standard/invoice.scm:590
 #: gnucash/report/reports/standard/job-report.scm:40
 #: gnucash/report/reports/standard/net-charts.scm:413
 #: gnucash/report/reports/standard/new-owner-report.scm:49
@@ -944,13 +972,13 @@ msgstr "貸款償還選項：「%s」"
 #: gnucash/report/reports/standard/register.scm:353
 #: gnucash/report/reports/support/receipt.eguile.scm:143
 #: gnucash/report/reports/support/taxinvoice.eguile.scm:268
-#: gnucash/report/trep-engine.scm:183 gnucash/report/trep-engine.scm:966
-#: gnucash/report/trep-engine.scm:1094 gnucash/report/trep-engine.scm:1189
+#: gnucash/report/trep-engine.scm:180 gnucash/report/trep-engine.scm:915
+#: gnucash/report/trep-engine.scm:1039 gnucash/report/trep-engine.scm:1134
 msgid "Date"
 msgstr "日期"
 
-#: gnucash/gnome/assistant-loan.cpp:1868 gnucash/gnome/assistant-loan.cpp:2847
-#: gnucash/gnome/assistant-loan.cpp:2909 gnucash/gnome/assistant-loan.cpp:2922
+#: gnucash/gnome/assistant-loan.cpp:1869 gnucash/gnome/assistant-loan.cpp:2848
+#: gnucash/gnome/assistant-loan.cpp:2910 gnucash/gnome/assistant-loan.cpp:2923
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2855
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2896
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2901
@@ -959,10 +987,10 @@ msgstr "日期"
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:3082
 #: gnucash/gtkbuilder/dialog-payment.glade:438
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:132
-#: gnucash/register/ledger-core/split-register.c:2548
-#: gnucash/register/ledger-core/split-register.c:2589
-#: gnucash/register/ledger-core/split-register.c:2594
-#: gnucash/register/ledger-core/split-register.c:2605
+#: gnucash/register/ledger-core/split-register.c:2550
+#: gnucash/register/ledger-core/split-register.c:2591
+#: gnucash/register/ledger-core/split-register.c:2596
+#: gnucash/register/ledger-core/split-register.c:2607
 #: gnucash/report/reports/standard/new-owner-report.scm:298
 #: gnucash/report/reports/standard/owner-report.scm:357
 #: libgnucash/engine/Account.cpp:145 libgnucash/engine/Account.cpp:153
@@ -972,11 +1000,11 @@ msgstr "日期"
 msgid "Payment"
 msgstr "付款"
 
-#: gnucash/gnome/assistant-loan.cpp:1874 gnucash/gnome/assistant-loan.cpp:2942
+#: gnucash/gnome/assistant-loan.cpp:1875 gnucash/gnome/assistant-loan.cpp:2943
 msgid "Principal"
 msgstr "本金"
 
-#: gnucash/gnome/assistant-loan.cpp:1880 gnucash/gnome/assistant-loan.cpp:2962
+#: gnucash/gnome/assistant-loan.cpp:1881 gnucash/gnome/assistant-loan.cpp:2963
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2850
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2887
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2895
@@ -984,22 +1012,22 @@ msgstr "本金"
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2911
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2938
 #: gnucash/import-export/qif-imp/qif-dialog-utils.scm:77
-#: gnucash/register/ledger-core/split-register.c:2543
-#: gnucash/register/ledger-core/split-register.c:2580
-#: gnucash/register/ledger-core/split-register.c:2588
-#: gnucash/register/ledger-core/split-register.c:2595
-#: gnucash/register/ledger-core/split-register.c:2604
-#: gnucash/register/ledger-core/split-register.c:2631
+#: gnucash/register/ledger-core/split-register.c:2545
+#: gnucash/register/ledger-core/split-register.c:2582
+#: gnucash/register/ledger-core/split-register.c:2590
+#: gnucash/register/ledger-core/split-register.c:2597
+#: gnucash/register/ledger-core/split-register.c:2606
+#: gnucash/register/ledger-core/split-register.c:2633
 msgid "Interest"
 msgstr "利息"
 
-#: gnucash/gnome/assistant-loan.cpp:2848
+#: gnucash/gnome/assistant-loan.cpp:2849
 msgid "Escrow Payment"
 msgstr "託管費"
 
 #: gnucash/gnome/assistant-stock-split.c:382
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2946
-#: gnucash/register/ledger-core/split-register.c:2639
+#: gnucash/register/ledger-core/split-register.c:2641
 msgctxt "Action Column"
 msgid "Split"
 msgstr "分割"
@@ -1018,26 +1046,26 @@ msgstr "加入價格時發生錯誤。"
 #: gnucash/import-export/import-match-picker.c:392
 #: gnucash/import-export/qif-imp/dialog-account-picker.c:433
 #: gnucash/register/ledger-core/split-register-model.c:341
-#: gnucash/report/reports/standard/advanced-portfolio.scm:1052
+#: gnucash/report/reports/standard/advanced-portfolio.scm:1033
 #: gnucash/report/reports/standard/budget-flow.scm:41
 #: gnucash/report/reports/standard/budget.scm:47
 #: gnucash/report/reports/standard/cash-flow.scm:47
 #: gnucash/report/reports/standard/general-journal.scm:97
 #: gnucash/report/reports/standard/job-report.scm:36
 #: gnucash/report/reports/standard/lot-viewer.scm:37
-#: gnucash/report/reports/standard/new-owner-report.scm:1139
+#: gnucash/report/reports/standard/new-owner-report.scm:1134
 #: gnucash/report/reports/standard/owner-report.scm:48
 #: gnucash/report/reports/standard/portfolio.scm:253
 #: gnucash/report/reports/standard/register.scm:143
 #: gnucash/report/reports/standard/register.scm:378
-#: gnucash/report/trep-engine.scm:1252
+#: gnucash/report/trep-engine.scm:1197
 msgid "Account"
 msgstr "科目"
 
 #: gnucash/gnome/assistant-stock-split.c:579
 #: gnucash/gnome-utils/gnc-tree-view-commodity.c:362
 #: gnucash/import-export/csv-exp/csv-tree-export.c:157
-#: gnucash/report/reports/standard/advanced-portfolio.scm:1064
+#: gnucash/report/reports/standard/advanced-portfolio.scm:1045
 #: gnucash/report/reports/standard/portfolio.scm:254
 msgid "Symbol"
 msgstr "代號"
@@ -1045,14 +1073,14 @@ msgstr "代號"
 #: gnucash/gnome/assistant-stock-split.c:585
 #: gnucash/gnome/dialog-find-transactions.c:122
 #: gnucash/register/ledger-core/split-register-model.c:419
-#: gnucash/report/reports/standard/advanced-portfolio.scm:1072
+#: gnucash/report/reports/standard/advanced-portfolio.scm:1053
 #: gnucash/report/reports/standard/general-journal.scm:98
 #: gnucash/report/reports/standard/general-ledger.scm:78
 #: gnucash/report/reports/standard/general-ledger.scm:98
 #: gnucash/report/reports/standard/register.scm:146
 #: gnucash/report/reports/standard/register.scm:383
-#: gnucash/report/trep-engine.scm:979 gnucash/report/trep-engine.scm:1104
-#: gnucash/report/trep-engine.scm:1274
+#: gnucash/report/trep-engine.scm:928 gnucash/report/trep-engine.scm:1049
+#: gnucash/report/trep-engine.scm:1219
 msgid "Shares"
 msgstr "股數"
 
@@ -1061,8 +1089,8 @@ msgid "You don't have any stock accounts with balances!"
 msgstr "您沒有任何結算的股票科目！"
 
 #: gnucash/gnome/business-gnome-utils.c:73
-#: gnucash/gnome/business-gnome-utils.c:260 gnucash/gnome/dialog-invoice.c:1502
-#: gnucash/gnome/dialog-invoice.c:1580
+#: gnucash/gnome/business-gnome-utils.c:260 gnucash/gnome/dialog-invoice.c:1510
+#: gnucash/gnome/dialog-invoice.c:1588
 #: gnucash/gnome-utils/gnc-general-select.c:220
 msgid "Select..."
 msgstr "選擇..."
@@ -1073,24 +1101,24 @@ msgid "Edit..."
 msgstr "編輯..."
 
 #: gnucash/gnome/business-gnome-utils.c:219 gnucash/gnome/dialog-doclink.c:804
-#: gnucash/gnome/dialog-invoice.c:2625 gnucash/gnome/dialog-invoice.c:2850
-#: gnucash/gnome/dialog-invoice.c:2851 gnucash/gnome/dialog-invoice.c:3561
+#: gnucash/gnome/dialog-invoice.c:2633 gnucash/gnome/dialog-invoice.c:2858
+#: gnucash/gnome/dialog-invoice.c:2859 gnucash/gnome/dialog-invoice.c:3569
 #: gnucash/gnome-search/dialog-search.c:1073
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:3001
 #: gnucash/gtkbuilder/dialog-bi-import-gui.glade:147
-#: gnucash/report/reports/standard/invoice.scm:787
+#: gnucash/report/reports/standard/invoice.scm:774
 #: libgnucash/engine/Account.cpp:173 libgnucash/engine/gncInvoice.c:1082
 msgid "Bill"
 msgstr "帳單"
 
 #: gnucash/gnome/business-gnome-utils.c:222 gnucash/gnome/dialog-doclink.c:808
-#: gnucash/gnome/dialog-invoice.c:2631 gnucash/gnome/dialog-invoice.c:2857
-#: gnucash/gnome/dialog-invoice.c:2858
+#: gnucash/gnome/dialog-invoice.c:2639 gnucash/gnome/dialog-invoice.c:2865
+#: gnucash/gnome/dialog-invoice.c:2866
 msgid "Voucher"
 msgstr "憑證"
 
 #: gnucash/gnome/business-gnome-utils.c:225 gnucash/gnome/dialog-doclink.c:812
-#: gnucash/gnome/dialog-invoice.c:3575
+#: gnucash/gnome/dialog-invoice.c:3583
 #: gnucash/gnome/gnc-plugin-page-invoice.c:570
 #: gnucash/gnome/gnc-plugin-page-register.c:633
 #: gnucash/gnome/gnc-plugin-page-report.c:1859
@@ -1102,9 +1130,9 @@ msgstr "憑證"
 #: gnucash/gtkbuilder/dialog-invoice.glade:205
 #: gnucash/gtkbuilder/dialog-invoice.glade:816
 #: gnucash/gtkbuilder/dialog-invoice.glade:840
-#: gnucash/register/ledger-core/split-register.c:2593
-#: gnucash/report/reports/standard/invoice.scm:776
-#: gnucash/report/reports/standard/invoice.scm:795
+#: gnucash/register/ledger-core/split-register.c:2595
+#: gnucash/report/reports/standard/invoice.scm:763
+#: gnucash/report/reports/standard/invoice.scm:782
 #: gnucash/report/reports/standard/job-report.scm:403
 #: gnucash/report/reports/standard/receipt.scm:115
 #: gnucash/report/reports/standard/taxinvoice.scm:173
@@ -1121,10 +1149,9 @@ msgstr "發票"
 #: gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp:61
 #: gnucash/import-export/import-pending-matches.c:192
 #: gnucash/report/reports/standard/register.scm:217
-#: gnucash/report/trep-engine.scm:280 gnucash/report/trep-engine.scm:313
-#: gnucash/report/trep-engine.scm:363 gnucash/report/trep-engine.scm:451
-#: gnucash/report/trep-engine.scm:1046 libgnucash/engine/gncOwner.c:213
-#: libgnucash/engine/Recurrence.c:503 libgnucash/engine/Recurrence.c:691
+#: gnucash/report/trep-engine.scm:264 gnucash/report/trep-engine.scm:295
+#: libgnucash/engine/gncOwner.c:213 libgnucash/engine/Recurrence.c:503
+#: libgnucash/engine/Recurrence.c:691
 msgid "None"
 msgstr "無"
 
@@ -1179,7 +1206,7 @@ msgstr ""
 #: gnucash/gtkbuilder/dialog-billterms.glade:182
 #: gnucash/gtkbuilder/dialog-billterms.glade:769
 #: gnucash/gtkbuilder/gnc-frequency.glade:966
-#: gnucash/report/reports/standard/price-scatter.scm:129
+#: gnucash/report/reports/standard/price-scatter.scm:122
 msgid "Days"
 msgstr "日"
 
@@ -1251,19 +1278,19 @@ msgstr "刪除商品？"
 #: gnucash/gnome/gnc-plugin-page-invoice.c:184
 #: gnucash/gnome/gnc-plugin-page-owner-tree.c:1111
 #: gnucash/gnome/gnc-plugin-page-register2.c:1630
-#: gnucash/gnome/gnc-plugin-page-register.c:2011
+#: gnucash/gnome/gnc-plugin-page-register.c:2014
 #: gnucash/gnome/gnc-split-reg.c:975 gnucash/gnome/gnc-split-reg.c:1013
 #: gnucash/gnome/gnc-split-reg.c:1235 gnucash/gnome/gnc-split-reg.c:1503
 #: gnucash/gnome/gnc-split-reg.c:1543 gnucash/gnome/window-reconcile2.c:2125
 #: gnucash/gnome/window-reconcile.c:2346
 #: gnucash/gnome-search/search-account.c:237
 #: gnucash/gnome-utils/dialog-account.c:722
-#: gnucash/gnome-utils/dialog-options.c:224
+#: gnucash/gnome-utils/dialog-options.c:223
 #: gnucash/gnome-utils/dialog-tax-table.c:603
 #: gnucash/gnome-utils/gnc-file.c:118 gnucash/gnome-utils/gnc-file.c:366
 #: gnucash/gnome-utils/gnc-file.c:663 gnucash/gnome-utils/gnc-gui-query.c:300
-#: gnucash/gnome-utils/gnc-main-window.c:1308
-#: gnucash/gnome-utils/gnc-main-window.c:1463
+#: gnucash/gnome-utils/gnc-main-window.c:1309
+#: gnucash/gnome-utils/gnc-main-window.c:1464
 #: gnucash/gnome-utils/gnc-tree-control-split-reg.c:886
 #: gnucash/gnome-utils/gnc-tree-control-split-reg.c:1023
 #: gnucash/gnome-utils/gnc-tree-control-split-reg.c:1063
@@ -1310,8 +1337,8 @@ msgstr "刪除商品？"
 #: gnucash/gtkbuilder/dialog-reset-warnings.glade:25
 #: gnucash/gtkbuilder/dialog-search.glade:67
 #: gnucash/gtkbuilder/dialog-sx.glade:177
-#: gnucash/gtkbuilder/dialog-sx.glade:779
-#: gnucash/gtkbuilder/dialog-sx.glade:1455
+#: gnucash/gtkbuilder/dialog-sx.glade:796
+#: gnucash/gtkbuilder/dialog-sx.glade:1472
 #: gnucash/gtkbuilder/dialog-tax-info.glade:28
 #: gnucash/gtkbuilder/dialog-tax-table.glade:317
 #: gnucash/gtkbuilder/dialog-transfer.glade:24
@@ -1339,8 +1366,8 @@ msgstr "刪除商品？"
 #: gnucash/import-export/bi-import/dialog-bi-import-gui.c:424
 #: gnucash/import-export/csv-imp/assistant-csv-account-import.c:378
 #: gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp:2029
-#: gnucash/import-export/customer-import/dialog-customer-import-gui.c:386
-#: gnucash/register/ledger-core/gncEntryLedger.c:930
+#: gnucash/import-export/customer-import/dialog-customer-import-gui.c:387
+#: gnucash/register/ledger-core/gncEntryLedger.c:931
 #: gnucash/register/ledger-core/gncEntryLedgerControl.c:896
 #: gnucash/register/ledger-core/split-register-control.c:1542
 msgid "_Cancel"
@@ -1351,7 +1378,7 @@ msgstr "取消(_C)"
 #: gnucash/gnome/gnc-plugin-page-account-tree.c:1790
 #: gnucash/gnome/gnc-plugin-page-invoice.c:189
 #: gnucash/gnome/gnc-plugin-page-owner-tree.c:1112
-#: gnucash/gnome/gnc-plugin-page-sx-list.c:162
+#: gnucash/gnome/gnc-plugin-page-sx-list.c:163
 #: gnucash/gnome/window-reconcile2.c:2167 gnucash/gnome/window-reconcile.c:2388
 #: gnucash/gtkbuilder/dialog-account.glade:398
 #: gnucash/gtkbuilder/dialog-billterms.glade:477
@@ -1370,7 +1397,9 @@ msgid ""
 "company) you should enter the same value for:\n"
 "Identification - Company Name, and\n"
 "Payment Address - Name."
-msgstr "您必須輸入公司名稱。若客戶是個人而非公司，請在「識別 - 公司名稱」跟「連絡地址 - 名稱」填相同的名字。"
+msgstr ""
+"您必須輸入公司名稱。若客戶是個人而非公司，請在「識別 - 公司名稱」跟「連絡地"
+"址 - 名稱」填相同的名字。"
 
 #: gnucash/gnome/dialog-customer.c:341
 msgid "You must enter a billing address."
@@ -1413,9 +1442,9 @@ msgid "Customer's Invoices"
 msgstr "客戶的發票"
 
 #: gnucash/gnome/dialog-customer.c:914 gnucash/gnome/dialog-employee.c:695
-#: gnucash/gnome/dialog-invoice.c:3327 gnucash/gnome/dialog-invoice.c:3336
-#: gnucash/gnome/dialog-invoice.c:3347 gnucash/gnome/dialog-invoice.c:3602
-#: gnucash/gnome/dialog-invoice.c:3608 gnucash/gnome/dialog-job.c:562
+#: gnucash/gnome/dialog-invoice.c:3335 gnucash/gnome/dialog-invoice.c:3344
+#: gnucash/gnome/dialog-invoice.c:3355 gnucash/gnome/dialog-invoice.c:3610
+#: gnucash/gnome/dialog-invoice.c:3616 gnucash/gnome/dialog-job.c:562
 #: gnucash/gnome/gnc-plugin-page-owner-tree.c:237
 #: gnucash/gnome/gnc-plugin-page-owner-tree.c:296
 #: gnucash/gtkbuilder/dialog-payment.glade:61
@@ -1434,8 +1463,8 @@ msgstr "帳單連絡人"
 msgid "Customer ID"
 msgstr "客戶 ID"
 
-#: gnucash/gnome/dialog-customer.c:930 gnucash/gnome/dialog-invoice.c:3384
-#: gnucash/gnome/dialog-invoice.c:3418 gnucash/gnome/dialog-vendor.c:733
+#: gnucash/gnome/dialog-customer.c:930 gnucash/gnome/dialog-invoice.c:3392
+#: gnucash/gnome/dialog-invoice.c:3426 gnucash/gnome/dialog-vendor.c:733
 #: gnucash/gnome-utils/gnc-tree-view-owner.c:352
 #: gnucash/gnome-utils/gnc-tree-view-owner.c:360
 #: gnucash/gtkbuilder/dialog-customer.glade:145
@@ -1449,12 +1478,12 @@ msgstr "公司名稱"
 msgid "Contact"
 msgstr "連絡人"
 
-#: gnucash/gnome/dialog-customer.c:939 gnucash/gnome/dialog-invoice.c:3472
-#: gnucash/gnome/dialog-invoice.c:3626 gnucash/gnome/dialog-job.c:592
+#: gnucash/gnome/dialog-customer.c:939 gnucash/gnome/dialog-invoice.c:3480
+#: gnucash/gnome/dialog-invoice.c:3634 gnucash/gnome/dialog-job.c:592
 #: gnucash/gnome/dialog-order.c:889 gnucash/gnome/dialog-vendor.c:742
 #: gnucash/import-export/customer-import/dialog-customer-import-gui.c:129
 #: gnucash/report/reports/aging.scm:538
-#: gnucash/report/reports/standard/new-aging.scm:191
+#: gnucash/report/reports/standard/new-aging.scm:179
 #: gnucash/report/reports/standard/owner-report.scm:76
 msgid "Company"
 msgstr "公司"
@@ -1513,7 +1542,7 @@ msgid "Placeholder account selected. Please try again."
 msgstr "選擇了佔位符號的科目，請重試。"
 
 #: gnucash/gnome/dialog-doclink.c:161
-#: gnucash/gnome/gnc-plugin-page-register.c:4760
+#: gnucash/gnome/gnc-plugin-page-register.c:4771
 msgid "Select document"
 msgstr "選擇文件"
 
@@ -1521,7 +1550,7 @@ msgstr "選擇文件"
 #: gnucash/gnome-search/search-account.c:238
 #: gnucash/gnome-utils/dialog-account.c:723
 #: gnucash/gnome-utils/gnc-gui-query.c:297
-#: gnucash/gnome-utils/gnc-main-window.c:1464
+#: gnucash/gnome-utils/gnc-main-window.c:1465
 #: gnucash/gtkbuilder/assistant-xml-encoding.glade:217
 #: gnucash/gtkbuilder/dialog-account.glade:35
 #: gnucash/gtkbuilder/dialog-account.glade:834
@@ -1561,8 +1590,8 @@ msgstr "選擇文件"
 #: gnucash/gtkbuilder/dialog-report.glade:751
 #: gnucash/gtkbuilder/dialog-reset-warnings.glade:55
 #: gnucash/gtkbuilder/dialog-sx.glade:25 gnucash/gtkbuilder/dialog-sx.glade:192
-#: gnucash/gtkbuilder/dialog-sx.glade:794
-#: gnucash/gtkbuilder/dialog-sx.glade:1471
+#: gnucash/gtkbuilder/dialog-sx.glade:811
+#: gnucash/gtkbuilder/dialog-sx.glade:1488
 #: gnucash/gtkbuilder/dialog-tax-info.glade:58
 #: gnucash/gtkbuilder/dialog-tax-table.glade:332
 #: gnucash/gtkbuilder/dialog-transfer.glade:39
@@ -1588,8 +1617,8 @@ msgstr "選擇文件"
 #: gnucash/import-export/bi-import/dialog-bi-import-gui.c:423
 #: gnucash/import-export/bi-import/dialog-bi-import-gui.c:481
 #: gnucash/import-export/csv-imp/assistant-csv-account-import.c:377
-#: gnucash/import-export/customer-import/dialog-customer-import-gui.c:385
-#: gnucash/import-export/customer-import/dialog-customer-import-gui.c:442
+#: gnucash/import-export/customer-import/dialog-customer-import-gui.c:386
+#: gnucash/import-export/customer-import/dialog-customer-import-gui.c:443
 msgid "_OK"
 msgstr "確定(_O)"
 
@@ -1663,7 +1692,7 @@ msgstr "所有和交易連結的文件"
 #: gnucash/gtkbuilder/dialog-book-close.glade:163
 #: gnucash/gtkbuilder/dialog-choose-owner.glade:97
 #: gnucash/gtkbuilder/dialog-date-close.glade:140
-#: gnucash/gtkbuilder/dialog-transfer.glade:189
+#: gnucash/gtkbuilder/dialog-transfer.glade:177
 #: gnucash/import-export/bi-import/dialog-bi-import-gui.c:149
 #: gnucash/import-export/csv-exp/csv-transactions-export.c:615
 #: gnucash/import-export/csv-exp/csv-transactions-export.c:624
@@ -1676,12 +1705,12 @@ msgstr "所有和交易連結的文件"
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:3761
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:67
 #: gnucash/register/ledger-core/split-register-model.c:295
-#: gnucash/report/reports/standard/account-summary.scm:410
+#: gnucash/report/reports/standard/account-summary.scm:409
 #: gnucash/report/reports/standard/general-journal.scm:96
 #: gnucash/report/reports/standard/general-ledger.scm:70
 #: gnucash/report/reports/standard/general-ledger.scm:90
 #: gnucash/report/reports/standard/invoice.scm:90
-#: gnucash/report/reports/standard/invoice.scm:217
+#: gnucash/report/reports/standard/invoice.scm:204
 #: gnucash/report/reports/standard/job-report.scm:44
 #: gnucash/report/reports/standard/new-owner-report.scm:53
 #: gnucash/report/reports/standard/new-owner-report.scm:244
@@ -1689,8 +1718,8 @@ msgstr "所有和交易連結的文件"
 #: gnucash/report/reports/standard/register.scm:138
 #: gnucash/report/reports/standard/register.scm:368
 #: gnucash/report/reports/support/taxinvoice.eguile.scm:270
-#: gnucash/report/trep-engine.scm:237 gnucash/report/trep-engine.scm:971
-#: gnucash/report/trep-engine.scm:1099 gnucash/report/trep-engine.scm:1232
+#: gnucash/report/trep-engine.scm:227 gnucash/report/trep-engine.scm:920
+#: gnucash/report/trep-engine.scm:1044 gnucash/report/trep-engine.scm:1177
 msgid "Description"
 msgstr "描述"
 
@@ -1747,7 +1776,7 @@ msgstr "員工 ID"
 msgid "Employee Username"
 msgstr "員工使用者名稱"
 
-#: gnucash/gnome/dialog-employee.c:708 gnucash/gnome/dialog-invoice.c:3452
+#: gnucash/gnome/dialog-employee.c:708 gnucash/gnome/dialog-invoice.c:3460
 #: gnucash/gnome-utils/gnc-tree-view-owner.c:364
 msgid "Employee Name"
 msgstr "員工名稱"
@@ -1771,13 +1800,11 @@ msgstr "使用者名稱"
 #: gnucash/gtkbuilder/dialog-customer.glade:773
 #: gnucash/gtkbuilder/dialog-employee.glade:227
 #: gnucash/gtkbuilder/dialog-sx.glade:235
-#: gnucash/gtkbuilder/dialog-sx.glade:830
+#: gnucash/gtkbuilder/dialog-sx.glade:847
 #: gnucash/gtkbuilder/dialog-tax-info.glade:113
 #: gnucash/gtkbuilder/dialog-vendor.glade:245
 #: gnucash/gtkbuilder/gnc-date-format.glade:132
 #: gnucash/import-export/customer-import/dialog-customer-import-gui.c:130
-#: gnucash/report/reports/aging.scm:348
-#: gnucash/report/reports/standard/new-aging.scm:96
 msgid "Name"
 msgstr "名稱"
 
@@ -1859,7 +1886,7 @@ msgstr "結算"
 #: gnucash/report/html-acct-table.scm:567
 #: gnucash/report/reports/standard/equity-statement.scm:169
 #: gnucash/report/reports/standard/income-statement.scm:267
-#: gnucash/report/reports/standard/trial-balance.scm:291
+#: gnucash/report/reports/standard/trial-balance.scm:285
 msgid "Closing Entries"
 msgstr "結帳分錄"
 
@@ -1879,7 +1906,7 @@ msgid "Share Price"
 msgstr "單位股份價格"
 
 #: gnucash/gnome/dialog-find-transactions2.c:124
-#: gnucash/gnome/dialog-invoice.c:3621 gnucash/gnome/dialog-lot-viewer.c:972
+#: gnucash/gnome/dialog-invoice.c:3629 gnucash/gnome/dialog-lot-viewer.c:972
 #: gnucash/gnome/gnc-split-reg.c:694 gnucash/gnome/reconcile-view.c:413
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:2895
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:2907
@@ -1887,14 +1914,13 @@ msgstr "單位股份價格"
 #: gnucash/gtkbuilder/assistant-loan.glade:617
 #: gnucash/gtkbuilder/assistant-loan.glade:764
 #: gnucash/gtkbuilder/dialog-payment.glade:411
-#: gnucash/gtkbuilder/dialog-transfer.glade:112
+#: gnucash/gtkbuilder/dialog-transfer.glade:100
 #: gnucash/import-export/csv-imp/gnc-imp-props-price.cpp:54
 #: gnucash/import-export/import-main-matcher.c:1091
 #: gnucash/import-export/import-match-picker.c:394
 #: gnucash/import-export/import-match-picker.c:434
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:3721
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:3772
-#: gnucash/report/options-utilities.scm:214
 #: gnucash/report/reports/standard/general-journal.scm:101
 #: gnucash/report/reports/standard/general-ledger.scm:81
 #: gnucash/report/reports/standard/general-ledger.scm:101
@@ -1903,20 +1929,20 @@ msgstr "單位股份價格"
 #: gnucash/report/reports/standard/owner-report.scm:59
 #: gnucash/report/reports/standard/register.scm:398
 #: gnucash/report/reports/standard/register.scm:647
-#: gnucash/report/trep-engine.scm:229 gnucash/report/trep-engine.scm:1042
-#: gnucash/report/trep-engine.scm:1093 gnucash/report/trep-engine.scm:1382
-#: gnucash/report/trep-engine.scm:1398 gnucash/report/trep-engine.scm:2092
+#: gnucash/report/trep-engine.scm:220 gnucash/report/trep-engine.scm:987
+#: gnucash/report/trep-engine.scm:1038 gnucash/report/trep-engine.scm:1327
+#: gnucash/report/trep-engine.scm:1343 gnucash/report/trep-engine.scm:2037
 msgid "Amount"
 msgstr "金額"
 
 #: gnucash/gnome/dialog-find-transactions2.c:126
 #: gnucash/gnome/dialog-find-transactions.c:124
 #: gnucash/gnome/dialog-lot-viewer.c:978
-#: gnucash/gnome/dialog-sx-since-last-run.c:1051
+#: gnucash/gnome/dialog-sx-since-last-run.c:1054
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:2885
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:2905
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:78
-#: gnucash/report/reports/standard/advanced-portfolio.scm:1081
+#: gnucash/report/reports/standard/advanced-portfolio.scm:1062
 #: gnucash/report/reports/standard/portfolio.scm:258
 #: gnucash/report/reports/standard/register.scm:158
 #: gnucash/report/reports/standard/register.scm:407
@@ -1925,8 +1951,8 @@ msgstr "價值"
 
 #: gnucash/gnome/dialog-find-transactions2.c:128
 #: gnucash/gnome/dialog-find-transactions.c:126
-#: gnucash/gnome/dialog-invoice.c:3372 gnucash/gnome/dialog-invoice.c:3406
-#: gnucash/gnome/dialog-invoice.c:3440
+#: gnucash/gnome/dialog-invoice.c:3380 gnucash/gnome/dialog-invoice.c:3414
+#: gnucash/gnome/dialog-invoice.c:3448
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:2723
 #: gnucash/gtkbuilder/dialog-invoice.glade:93
 #: gnucash/import-export/bi-import/dialog-bi-import-gui.c:161
@@ -1939,12 +1965,12 @@ msgstr "過帳的日期"
 #: gnucash/gnome/dialog-find-transactions.c:132
 #: gnucash/gnome/dialog-find-transactions.c:171
 #: gnucash/gnome/dialog-find-transactions.c:177
-#: gnucash/gnome/gnc-plugin-page-register.c:2503
-#: gnucash/gnome/gnc-plugin-page-register.c:4209
+#: gnucash/gnome/gnc-plugin-page-register.c:2504
+#: gnucash/gnome/gnc-plugin-page-register.c:4216
 #: gnucash/gnome-search/dialog-search.c:875
 #: gnucash/gnome-search/dialog-search.c:881
 #: gnucash/import-export/csv-exp/csv-transactions-export.c:626
-#: gnucash/report/trep-engine.scm:245
+#: gnucash/report/trep-engine.scm:234
 msgid "Number/Action"
 msgstr "號碼/動作"
 
@@ -1954,7 +1980,7 @@ msgstr "號碼/動作"
 #: gnucash/gnome/dialog-find-transactions.c:133
 #: gnucash/gnome/dialog-find-transactions.c:170
 #: gnucash/gnome/dialog-find-transactions.c:178
-#: gnucash/gnome/gnc-plugin-page-register.c:2508
+#: gnucash/gnome/gnc-plugin-page-register.c:2509
 #: gnucash/gnome/gnc-split-reg.c:703 gnucash/gnome-search/dialog-search.c:874
 #: gnucash/gnome-search/dialog-search.c:882
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:2752
@@ -1968,7 +1994,7 @@ msgstr "號碼/動作"
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:57
 #: gnucash/register/ledger-core/split-register-model.c:327
 #: gnucash/report/reports/standard/invoice.scm:92
-#: gnucash/report/reports/standard/invoice.scm:222
+#: gnucash/report/reports/standard/invoice.scm:209
 msgid "Action"
 msgstr "動作"
 
@@ -1978,13 +2004,13 @@ msgstr "動作"
 #: gnucash/gnome/dialog-find-transactions.c:136
 #: gnucash/gnome/dialog-find-transactions.c:173
 #: gnucash/gnome/dialog-find-transactions.c:179
-#: gnucash/gnome/gnc-plugin-page-register.c:2502
-#: gnucash/gnome/gnc-plugin-page-register.c:4208
+#: gnucash/gnome/gnc-plugin-page-register.c:2503
+#: gnucash/gnome/gnc-plugin-page-register.c:4215
 #: gnucash/gnome-search/dialog-search.c:877
 #: gnucash/gnome-search/dialog-search.c:883
 #: gnucash/import-export/csv-exp/csv-transactions-export.c:614
 #: gnucash/import-export/csv-exp/csv-transactions-export.c:623
-#: gnucash/report/trep-engine.scm:259
+#: gnucash/report/trep-engine.scm:246
 msgid "Transaction Number"
 msgstr "交易編號"
 
@@ -1994,7 +2020,7 @@ msgstr "交易編號"
 #: gnucash/gnome/dialog-find-transactions.c:137
 #: gnucash/gnome/dialog-find-transactions.c:172
 #: gnucash/gnome/dialog-find-transactions.c:180
-#: gnucash/gnome/gnc-plugin-page-register.c:2507
+#: gnucash/gnome/gnc-plugin-page-register.c:2508
 #: gnucash/gnome/gnc-split-reg.c:691 gnucash/gnome-search/dialog-search.c:876
 #: gnucash/gnome-search/dialog-search.c:884
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:2768
@@ -2002,7 +2028,7 @@ msgstr "交易編號"
 #: gnucash/gtkbuilder/gnc-date-format.glade:98
 #: gnucash/import-export/csv-exp/csv-transactions-export.c:614
 #: gnucash/import-export/csv-exp/csv-transactions-export.c:623
-#: gnucash/report/trep-engine.scm:252
+#: gnucash/report/trep-engine.scm:240
 msgid "Number"
 msgstr "號碼"
 
@@ -2020,7 +2046,7 @@ msgstr "描述、筆記、備忘錄"
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:2801
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:2819
 #: gnucash/gtkbuilder/dialog-payment.glade:488
-#: gnucash/gtkbuilder/dialog-transfer.glade:215
+#: gnucash/gtkbuilder/dialog-transfer.glade:203
 #: gnucash/import-export/csv-exp/csv-transactions-export.c:626
 #: gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp:74
 #: gnucash/import-export/import-main-matcher.c:1093
@@ -2031,9 +2057,9 @@ msgstr "描述、筆記、備忘錄"
 #: gnucash/report/reports/standard/general-ledger.scm:91
 #: gnucash/report/reports/standard/register.scm:140
 #: gnucash/report/reports/standard/register.scm:373
-#: gnucash/report/trep-engine.scm:266 gnucash/report/trep-engine.scm:997
-#: gnucash/report/trep-engine.scm:1121 gnucash/report/trep-engine.scm:1242
-#: gnucash/report/trep-engine.scm:1243
+#: gnucash/report/trep-engine.scm:252 gnucash/report/trep-engine.scm:946
+#: gnucash/report/trep-engine.scm:1066 gnucash/report/trep-engine.scm:1187
+#: gnucash/report/trep-engine.scm:1188
 msgid "Memo"
 msgstr "備忘錄"
 
@@ -2050,7 +2076,7 @@ msgstr "備忘錄"
 #: gnucash/gtkbuilder/dialog-invoice.glade:1154
 #: gnucash/gtkbuilder/dialog-order.glade:351
 #: gnucash/gtkbuilder/dialog-order.glade:704
-#: gnucash/gtkbuilder/dialog-transfer.glade:239
+#: gnucash/gtkbuilder/dialog-transfer.glade:227
 #: gnucash/gtkbuilder/dialog-vendor.glade:459
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:514
 #: gnucash/import-export/bi-import/dialog-bi-import-gui.c:146
@@ -2059,13 +2085,13 @@ msgstr "備忘錄"
 #: gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp:66
 #: gnucash/import-export/customer-import/dialog-customer-import-gui.c:138
 #: gnucash/register/ledger-core/split-register-model.c:491
-#: gnucash/report/reports/standard/account-summary.scm:438
+#: gnucash/report/reports/standard/account-summary.scm:437
 #: gnucash/report/reports/standard/balsheet-eg.scm:188
 #: gnucash/report/reports/standard/receipt.scm:38
 #: gnucash/report/reports/standard/taxinvoice.scm:78
-#: gnucash/report/trep-engine.scm:273 gnucash/report/trep-engine.scm:955
-#: gnucash/report/trep-engine.scm:972 gnucash/report/trep-engine.scm:1134
-#: gnucash/report/trep-engine.scm:1242
+#: gnucash/report/trep-engine.scm:258 gnucash/report/trep-engine.scm:904
+#: gnucash/report/trep-engine.scm:921 gnucash/report/trep-engine.scm:1079
+#: gnucash/report/trep-engine.scm:1187
 msgid "Notes"
 msgstr "筆記"
 
@@ -2078,8 +2104,8 @@ msgstr "尋找交易"
 #: gnucash/gnome/dialog-find-transactions.c:129
 #: gnucash/report/reports/standard/general-ledger.scm:67
 #: gnucash/report/reports/standard/general-ledger.scm:88
-#: gnucash/report/trep-engine.scm:190 gnucash/report/trep-engine.scm:967
-#: gnucash/report/trep-engine.scm:1095 gnucash/report/trep-engine.scm:1199
+#: gnucash/report/trep-engine.scm:186 gnucash/report/trep-engine.scm:916
+#: gnucash/report/trep-engine.scm:1040 gnucash/report/trep-engine.scm:1144
 msgid "Reconciled Date"
 msgstr "對帳日期"
 
@@ -2151,186 +2177,187 @@ msgstr "線上 HBCI"
 msgid "You need to supply Billing Information."
 msgstr "您需要提供帳單資訊。"
 
-#: gnucash/gnome/dialog-invoice.c:731
+#: gnucash/gnome/dialog-invoice.c:732
 msgid "Are you sure you want to delete the selected entry?"
 msgstr "您確定要刪除選擇的項目？"
 
-#: gnucash/gnome/dialog-invoice.c:733
+#: gnucash/gnome/dialog-invoice.c:734
 msgid ""
 "This entry is attached to an order and will be deleted from that as well!"
 msgstr "這個項目是附加在訂單上的因此也要刪除其來源！"
 
-#: gnucash/gnome/dialog-invoice.c:862 gnucash/gnome/dialog-invoice.c:3381
-#: gnucash/gnome/dialog-invoice.c:3415 gnucash/gnome/dialog-invoice.c:3449
+#: gnucash/gnome/dialog-invoice.c:870 gnucash/gnome/dialog-invoice.c:3389
+#: gnucash/gnome/dialog-invoice.c:3423 gnucash/gnome/dialog-invoice.c:3457
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:2739
 #: gnucash/import-export/bi-import/dialog-bi-import-gui.c:162
 #: gnucash/register/ledger-core/split-register-model.c:239
 #: gnucash/report/reports/aging.scm:388
-#: gnucash/report/reports/standard/invoice.scm:257
-#: gnucash/report/reports/standard/invoice.scm:608
+#: gnucash/report/reports/standard/invoice.scm:244
+#: gnucash/report/reports/standard/invoice.scm:595
 #: gnucash/report/reports/standard/job-report.scm:41
-#: gnucash/report/reports/standard/new-aging.scm:124
+#: gnucash/report/reports/standard/new-aging.scm:116
 #: gnucash/report/reports/standard/new-owner-report.scm:50
-#: gnucash/report/reports/standard/new-owner-report.scm:971
+#: gnucash/report/reports/standard/new-owner-report.scm:970
 #: gnucash/report/reports/standard/owner-report.scm:51
 #: gnucash/report/reports/standard/owner-report.scm:612
 #: gnucash/report/reports/support/taxinvoice.eguile.scm:233
 msgid "Due Date"
 msgstr "到期日"
 
-#: gnucash/gnome/dialog-invoice.c:863 gnucash/report/reports/aging.scm:389
-#: gnucash/report/reports/standard/new-aging.scm:128
-#: gnucash/report/reports/standard/new-owner-report.scm:975
+#: gnucash/gnome/dialog-invoice.c:871 gnucash/report/reports/aging.scm:389
+#: gnucash/report/reports/standard/new-aging.scm:117
+#: gnucash/report/reports/standard/new-owner-report.scm:971
 #: gnucash/report/reports/standard/owner-report.scm:613
 msgid "Post Date"
 msgstr "過帳日期"
 
-#: gnucash/gnome/dialog-invoice.c:864
+#: gnucash/gnome/dialog-invoice.c:872
 msgid "Post to Account"
 msgstr "過帳到科目"
 
-#: gnucash/gnome/dialog-invoice.c:865
+#: gnucash/gnome/dialog-invoice.c:873
 msgid "Accumulate Splits?"
 msgstr "整合分割？"
 
-#: gnucash/gnome/dialog-invoice.c:957
+#: gnucash/gnome/dialog-invoice.c:965
 msgid "The Invoice must have at least one Entry."
 msgstr "發票必須有一個以上的項目。"
 
-#: gnucash/gnome/dialog-invoice.c:977
+#: gnucash/gnome/dialog-invoice.c:985
 msgid "Do you really want to post the invoice?"
 msgstr "您確定要過帳這張發票？"
 
-#: gnucash/gnome/dialog-invoice.c:995
+#: gnucash/gnome/dialog-invoice.c:1003
 msgid ""
 "One or more of the entries are for accounts different from the invoice/bill "
 "currency. You will be asked a conversion rate for each."
-msgstr "一或多筆資料是使用和發票/帳單不同的幣值的科目，您將會被詢問每筆資料的匯率。"
+msgstr ""
+"一或多筆資料是使用和發票/帳單不同的幣值的科目，您將會被詢問每筆資料的匯率。"
 
-#: gnucash/gnome/dialog-invoice.c:1128
+#: gnucash/gnome/dialog-invoice.c:1136
 msgid "The post action was canceled because not all exchange rates were given."
 msgstr "過帳的動作被取消了，因為不是所有的匯率都有提供。"
 
-#: gnucash/gnome/dialog-invoice.c:1412
+#: gnucash/gnome/dialog-invoice.c:1420
 msgid "Total:"
 msgstr "合計："
 
-#: gnucash/gnome/dialog-invoice.c:1418
+#: gnucash/gnome/dialog-invoice.c:1426
 msgid "Subtotal:"
 msgstr "小計："
 
-#: gnucash/gnome/dialog-invoice.c:1419
+#: gnucash/gnome/dialog-invoice.c:1427
 msgid "Tax:"
 msgstr "稅:"
 
-#: gnucash/gnome/dialog-invoice.c:1423
+#: gnucash/gnome/dialog-invoice.c:1431
 msgid "Total Cash:"
 msgstr "合計現金："
 
-#: gnucash/gnome/dialog-invoice.c:1424
+#: gnucash/gnome/dialog-invoice.c:1432
 msgid "Total Charge:"
 msgstr "合計收費："
 
-#: gnucash/gnome/dialog-invoice.c:1893 gnucash/gnome/dialog-payment.c:1335
+#: gnucash/gnome/dialog-invoice.c:1901 gnucash/gnome/dialog-payment.c:1335
 #: gnucash/gtkbuilder/dialog-invoice.glade:857
-#: gnucash/report/reports/standard/invoice.scm:793
+#: gnucash/report/reports/standard/invoice.scm:780
 #: libgnucash/engine/gncInvoice.c:1088
 msgid "Credit Note"
 msgstr "貸項通知單"
 
-#: gnucash/gnome/dialog-invoice.c:2089
+#: gnucash/gnome/dialog-invoice.c:2097
 msgid "PAID"
 msgstr "已支付"
 
-#: gnucash/gnome/dialog-invoice.c:2091
+#: gnucash/gnome/dialog-invoice.c:2099
 #: gnucash/report/reports/standard/new-owner-report.scm:583
 msgid "UNPAID"
 msgstr "未支付"
 
-#: gnucash/gnome/dialog-invoice.c:2139 gnucash/gnome/dialog-invoice.c:2158
-#: gnucash/gnome/dialog-invoice.c:2177
+#: gnucash/gnome/dialog-invoice.c:2147 gnucash/gnome/dialog-invoice.c:2166
+#: gnucash/gnome/dialog-invoice.c:2185
 msgid "New Credit Note"
 msgstr "新貸項通知單"
 
-#: gnucash/gnome/dialog-invoice.c:2140
+#: gnucash/gnome/dialog-invoice.c:2148
 #: gnucash/gnome/gnc-plugin-page-owner-tree.c:292
 #: gnucash/gnome-search/dialog-search.c:1091
 #: gnucash/gtkbuilder/dialog-invoice.glade:642
 msgid "New Invoice"
 msgstr "新增發票"
 
-#: gnucash/gnome/dialog-invoice.c:2145 gnucash/gnome/dialog-invoice.c:2164
-#: gnucash/gnome/dialog-invoice.c:2183
+#: gnucash/gnome/dialog-invoice.c:2153 gnucash/gnome/dialog-invoice.c:2172
+#: gnucash/gnome/dialog-invoice.c:2191
 msgid "Edit Credit Note"
 msgstr "編輯貸項通知單"
 
-#: gnucash/gnome/dialog-invoice.c:2146
+#: gnucash/gnome/dialog-invoice.c:2154
 msgid "Edit Invoice"
 msgstr "編輯發票"
 
-#: gnucash/gnome/dialog-invoice.c:2149 gnucash/gnome/dialog-invoice.c:2168
-#: gnucash/gnome/dialog-invoice.c:2187
+#: gnucash/gnome/dialog-invoice.c:2157 gnucash/gnome/dialog-invoice.c:2176
+#: gnucash/gnome/dialog-invoice.c:2195
 msgid "View Credit Note"
 msgstr "檢視貸項通知單"
 
-#: gnucash/gnome/dialog-invoice.c:2150
+#: gnucash/gnome/dialog-invoice.c:2158
 msgid "View Invoice"
 msgstr "檢視發票"
 
-#: gnucash/gnome/dialog-invoice.c:2159
+#: gnucash/gnome/dialog-invoice.c:2167
 #: gnucash/gnome/gnc-plugin-page-owner-tree.c:291
 #: gnucash/gnome-search/dialog-search.c:1075
 msgid "New Bill"
 msgstr "新增帳單"
 
-#: gnucash/gnome/dialog-invoice.c:2165
+#: gnucash/gnome/dialog-invoice.c:2173
 msgid "Edit Bill"
 msgstr "編輯帳單"
 
-#: gnucash/gnome/dialog-invoice.c:2169
+#: gnucash/gnome/dialog-invoice.c:2177
 msgid "View Bill"
 msgstr "檢視帳單"
 
-#: gnucash/gnome/dialog-invoice.c:2178
+#: gnucash/gnome/dialog-invoice.c:2186
 #: gnucash/gnome-search/dialog-search.c:1087
 msgid "New Expense Voucher"
 msgstr "新增消費憑證"
 
-#: gnucash/gnome/dialog-invoice.c:2184
+#: gnucash/gnome/dialog-invoice.c:2192
 msgid "Edit Expense Voucher"
 msgstr "編輯消費憑證"
 
-#: gnucash/gnome/dialog-invoice.c:2188
+#: gnucash/gnome/dialog-invoice.c:2196
 msgid "View Expense Voucher"
 msgstr "檢視消費憑證"
 
-#: gnucash/gnome/dialog-invoice.c:2510
+#: gnucash/gnome/dialog-invoice.c:2518
 msgid "Open Linked Document:"
 msgstr "開啟連結文件："
 
-#: gnucash/gnome/dialog-invoice.c:2624 gnucash/gnome/dialog-invoice.c:2849
+#: gnucash/gnome/dialog-invoice.c:2632 gnucash/gnome/dialog-invoice.c:2857
 msgid "Bill Information"
 msgstr "帳單資訊"
 
-#: gnucash/gnome/dialog-invoice.c:2626 gnucash/gnome/dialog-invoice.c:2852
-#: gnucash/gnome/dialog-invoice.c:3422
+#: gnucash/gnome/dialog-invoice.c:2634 gnucash/gnome/dialog-invoice.c:2860
+#: gnucash/gnome/dialog-invoice.c:3430
 msgid "Bill ID"
 msgstr "帳單 ID"
 
-#: gnucash/gnome/dialog-invoice.c:2630 gnucash/gnome/dialog-invoice.c:2856
+#: gnucash/gnome/dialog-invoice.c:2638 gnucash/gnome/dialog-invoice.c:2864
 msgid "Voucher Information"
 msgstr "消費憑證資訊"
 
-#: gnucash/gnome/dialog-invoice.c:2632 gnucash/gnome/dialog-invoice.c:2859
-#: gnucash/gnome/dialog-invoice.c:3456
+#: gnucash/gnome/dialog-invoice.c:2640 gnucash/gnome/dialog-invoice.c:2867
+#: gnucash/gnome/dialog-invoice.c:3464
 msgid "Voucher ID"
 msgstr "憑證 ID"
 
-#: gnucash/gnome/dialog-invoice.c:3189
+#: gnucash/gnome/dialog-invoice.c:3197
 msgid "Date of duplicated entries"
 msgstr "重複相同的項目的日期"
 
-#: gnucash/gnome/dialog-invoice.c:3244
+#: gnucash/gnome/dialog-invoice.c:3252
 msgid ""
 "One or more selected invoices have already been posted.\n"
 "Re-check your selection."
@@ -2338,74 +2365,74 @@ msgstr ""
 "一或多張發票已被過帳過了。\n"
 "請重新檢查您的選擇。"
 
-#: gnucash/gnome/dialog-invoice.c:3248
+#: gnucash/gnome/dialog-invoice.c:3256
 msgid "Do you really want to post these invoices?"
 msgstr "您確定要過帳這些發票？"
 
-#: gnucash/gnome/dialog-invoice.c:3326 gnucash/gnome/dialog-invoice.c:3607
+#: gnucash/gnome/dialog-invoice.c:3334 gnucash/gnome/dialog-invoice.c:3615
 msgid "View/Edit Invoice"
 msgstr "檢視/編輯發票"
 
-#: gnucash/gnome/dialog-invoice.c:3328 gnucash/gnome/dialog-invoice.c:3337
-#: gnucash/gnome/dialog-invoice.c:3348
+#: gnucash/gnome/dialog-invoice.c:3336 gnucash/gnome/dialog-invoice.c:3345
+#: gnucash/gnome/dialog-invoice.c:3356
 #: gnucash/gnome/gnc-plugin-page-invoice.c:455
 #: gnucash/gnome/gnc-plugin-page-register2.c:501
 #: gnucash/gnome/gnc-plugin-page-register.c:624
 msgid "Duplicate"
 msgstr "複製"
 
-#: gnucash/gnome/dialog-invoice.c:3329 gnucash/gnome/dialog-invoice.c:3338
-#: gnucash/gnome/dialog-invoice.c:3349
+#: gnucash/gnome/dialog-invoice.c:3337 gnucash/gnome/dialog-invoice.c:3346
+#: gnucash/gnome/dialog-invoice.c:3357
 #: gnucash/gnome/gnc-plugin-page-invoice.c:459
 msgid "Post"
 msgstr "過帳"
 
-#: gnucash/gnome/dialog-invoice.c:3330 gnucash/gnome/dialog-invoice.c:3339
-#: gnucash/gnome/dialog-invoice.c:3350
+#: gnucash/gnome/dialog-invoice.c:3338 gnucash/gnome/dialog-invoice.c:3347
+#: gnucash/gnome/dialog-invoice.c:3358
 msgid "Printable Report"
 msgstr "可列印的報表"
 
-#: gnucash/gnome/dialog-invoice.c:3335 gnucash/gnome/dialog-invoice.c:3601
+#: gnucash/gnome/dialog-invoice.c:3343 gnucash/gnome/dialog-invoice.c:3609
 msgid "View/Edit Bill"
 msgstr "檢視/編輯帳單"
 
 #. Translators: The terms 'Voucher' and 'Expense Voucher' are used
 #. interchangeably in gnucash and mean the same thing.
-#: gnucash/gnome/dialog-invoice.c:3346
+#: gnucash/gnome/dialog-invoice.c:3354
 msgid "View/Edit Voucher"
 msgstr "檢視/編輯憑證"
 
-#: gnucash/gnome/dialog-invoice.c:3360
+#: gnucash/gnome/dialog-invoice.c:3368
 msgid "Invoice Owner"
 msgstr "發票所有者"
 
-#: gnucash/gnome/dialog-invoice.c:3363
-#: gnucash/report/reports/standard/invoice.scm:327
+#: gnucash/gnome/dialog-invoice.c:3371
+#: gnucash/report/reports/standard/invoice.scm:314
 msgid "Invoice Notes"
 msgstr "發票備註"
 
-#: gnucash/gnome/dialog-invoice.c:3366 gnucash/gnome/dialog-invoice.c:3400
-#: gnucash/gnome/dialog-invoice.c:3434 gnucash/gnome/dialog-invoice.c:3463
+#: gnucash/gnome/dialog-invoice.c:3374 gnucash/gnome/dialog-invoice.c:3408
+#: gnucash/gnome/dialog-invoice.c:3442 gnucash/gnome/dialog-invoice.c:3471
 #: gnucash/gnome/dialog-job.c:575 gnucash/gnome/dialog-job.c:588
 #: gnucash/gnome/dialog-order.c:887 gnucash/gtkbuilder/dialog-invoice.glade:310
 #: gnucash/gtkbuilder/dialog-invoice.glade:944
 #: gnucash/gtkbuilder/dialog-job.glade:217
-#: gnucash/report/reports/standard/invoice.scm:317
+#: gnucash/report/reports/standard/invoice.scm:304
 msgid "Billing ID"
 msgstr "帳單 ID"
 
-#: gnucash/gnome/dialog-invoice.c:3369 gnucash/gnome/dialog-invoice.c:3403
-#: gnucash/gnome/dialog-invoice.c:3437
+#: gnucash/gnome/dialog-invoice.c:3377 gnucash/gnome/dialog-invoice.c:3411
+#: gnucash/gnome/dialog-invoice.c:3445
 msgid "Is Paid?"
 msgstr "已支付？"
 
-#: gnucash/gnome/dialog-invoice.c:3375 gnucash/gnome/dialog-invoice.c:3409
-#: gnucash/gnome/dialog-invoice.c:3443
+#: gnucash/gnome/dialog-invoice.c:3383 gnucash/gnome/dialog-invoice.c:3417
+#: gnucash/gnome/dialog-invoice.c:3451
 msgid "Is Posted?"
 msgstr "是否過帳？"
 
-#: gnucash/gnome/dialog-invoice.c:3378 gnucash/gnome/dialog-invoice.c:3412
-#: gnucash/gnome/dialog-invoice.c:3446 gnucash/gnome/dialog-order.c:876
+#: gnucash/gnome/dialog-invoice.c:3386 gnucash/gnome/dialog-invoice.c:3420
+#: gnucash/gnome/dialog-invoice.c:3454 gnucash/gnome/dialog-order.c:876
 #: gnucash/gtkbuilder/dialog-invoice.glade:67
 #: gnucash/gtkbuilder/dialog-invoice.glade:762
 #: gnucash/gtkbuilder/dialog-order.glade:135
@@ -2414,29 +2441,29 @@ msgstr "是否過帳？"
 msgid "Date Opened"
 msgstr "開發票的日期"
 
-#: gnucash/gnome/dialog-invoice.c:3388
+#: gnucash/gnome/dialog-invoice.c:3396
 #: gnucash/gtkbuilder/dialog-invoice.glade:41
 #: gnucash/gtkbuilder/dialog-invoice.glade:749
 msgid "Invoice ID"
 msgstr "發票 ID"
 
-#: gnucash/gnome/dialog-invoice.c:3394
+#: gnucash/gnome/dialog-invoice.c:3402
 msgid "Bill Owner"
 msgstr "帳單所有者"
 
-#: gnucash/gnome/dialog-invoice.c:3397
+#: gnucash/gnome/dialog-invoice.c:3405
 msgid "Bill Notes"
 msgstr "帳單備註"
 
-#: gnucash/gnome/dialog-invoice.c:3428
+#: gnucash/gnome/dialog-invoice.c:3436
 msgid "Voucher Owner"
 msgstr "憑證所有者"
 
-#: gnucash/gnome/dialog-invoice.c:3431
+#: gnucash/gnome/dialog-invoice.c:3439
 msgid "Voucher Notes"
 msgstr "憑證備註"
 
-#: gnucash/gnome/dialog-invoice.c:3465 gnucash/gnome/dialog-invoice.c:3624
+#: gnucash/gnome/dialog-invoice.c:3473 gnucash/gnome/dialog-invoice.c:3632
 #: gnucash/gnome/dialog-lot-viewer.c:865 gnucash/gnome/dialog-tax-info.c:1236
 #: gnucash/gnome-utils/gnc-tree-view-account.c:811
 #: gnucash/gnome-utils/gnc-tree-view-owner.c:401
@@ -2452,7 +2479,7 @@ msgstr "憑證備註"
 #: gnucash/import-export/csv-exp/csv-tree-export.c:155
 #: gnucash/import-export/csv-imp/csv-account-import.c:154
 #: gnucash/register/ledger-core/split-register-model.c:362
-#: gnucash/report/reports/standard/account-summary.scm:409
+#: gnucash/report/reports/standard/account-summary.scm:408
 #: gnucash/report/reports/standard/job-report.scm:43
 #: gnucash/report/reports/standard/new-owner-report.scm:52
 #: gnucash/report/reports/standard/new-owner-report.scm:243
@@ -2460,30 +2487,30 @@ msgstr "憑證備註"
 msgid "Type"
 msgstr "類型"
 
-#: gnucash/gnome/dialog-invoice.c:3467
+#: gnucash/gnome/dialog-invoice.c:3475
 #: gnucash/register/ledger-core/split-register-model.c:309
 #: gnucash/report/reports/standard/new-owner-report.scm:832
 msgid "Paid"
 msgstr "支付"
 
-#: gnucash/gnome/dialog-invoice.c:3470
+#: gnucash/gnome/dialog-invoice.c:3478
 msgid "Posted"
 msgstr "已過帳"
 
-#: gnucash/gnome/dialog-invoice.c:3475 gnucash/gnome/dialog-invoice.c:3628
+#: gnucash/gnome/dialog-invoice.c:3483 gnucash/gnome/dialog-invoice.c:3636
 msgid "Due"
 msgstr "到期"
 
-#: gnucash/gnome/dialog-invoice.c:3477 gnucash/gnome/dialog-lot-viewer.c:871
+#: gnucash/gnome/dialog-invoice.c:3485 gnucash/gnome/dialog-lot-viewer.c:871
 #: gnucash/gnome/dialog-order.c:894
 msgid "Opened"
 msgstr "已開啟"
 
-#: gnucash/gnome/dialog-invoice.c:3479 gnucash/gnome/dialog-lot-viewer.c:952
+#: gnucash/gnome/dialog-invoice.c:3487 gnucash/gnome/dialog-lot-viewer.c:952
 #: gnucash/gnome/dialog-order.c:896 gnucash/gnome/reconcile-view.c:421
 #: gnucash/gnome/reconcile-view.c:425
 #: gnucash/gtkbuilder/dialog-payment.glade:475
-#: gnucash/gtkbuilder/dialog-transfer.glade:165
+#: gnucash/gtkbuilder/dialog-transfer.glade:153
 #: gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp:64
 #: gnucash/register/ledger-core/split-register-model.c:255
 #: gnucash/register/ledger-core/split-register-model.c:275
@@ -2491,52 +2518,52 @@ msgstr "已開啟"
 #: gnucash/report/reports/standard/general-ledger.scm:89
 #: gnucash/report/reports/standard/register.scm:136
 #: gnucash/report/reports/standard/register.scm:363
-#: gnucash/report/trep-engine.scm:970 gnucash/report/trep-engine.scm:1098
-#: gnucash/report/trep-engine.scm:1214
+#: gnucash/report/trep-engine.scm:919 gnucash/report/trep-engine.scm:1043
+#: gnucash/report/trep-engine.scm:1159
 msgid "Num"
 msgstr "號碼"
 
-#: gnucash/gnome/dialog-invoice.c:3560
+#: gnucash/gnome/dialog-invoice.c:3568
 msgid "Find Bill"
 msgstr "尋找帳單"
 
-#: gnucash/gnome/dialog-invoice.c:3567
+#: gnucash/gnome/dialog-invoice.c:3575
 msgid "Find Expense Voucher"
 msgstr "尋找消費憑證"
 
-#: gnucash/gnome/dialog-invoice.c:3568
+#: gnucash/gnome/dialog-invoice.c:3576
 #: gnucash/gnome-search/dialog-search.c:1085
-#: gnucash/report/reports/standard/invoice.scm:789
+#: gnucash/report/reports/standard/invoice.scm:776
 msgid "Expense Voucher"
 msgstr "消費憑證"
 
-#: gnucash/gnome/dialog-invoice.c:3574
+#: gnucash/gnome/dialog-invoice.c:3582
 msgid "Find Invoice"
 msgstr "尋找發票"
 
 #. Translators: %d is the number of bills/credit notes due. This is a
 #. ngettext(3) message.
-#: gnucash/gnome/dialog-invoice.c:3708
+#: gnucash/gnome/dialog-invoice.c:3716
 #, c-format
 msgid "The following vendor document is due:"
 msgid_plural "The following %d vendor documents are due:"
 msgstr[0] "下列的 %d 份廠商文件已經到期："
 msgstr[1] "下列的 %d 份廠商文件已經到期："
 
-#: gnucash/gnome/dialog-invoice.c:3712
+#: gnucash/gnome/dialog-invoice.c:3720
 msgid "Due Bills Reminder"
 msgstr "帳單到期提醒"
 
 #. Translators: %d is the number of invoices/credit notes due. This is a
 #. ngettext(3) message.
-#: gnucash/gnome/dialog-invoice.c:3719
+#: gnucash/gnome/dialog-invoice.c:3727
 #, c-format
 msgid "The following customer document is due:"
 msgid_plural "The following %d customer documents are due:"
 msgstr[0] "下列的 %d 份客戶文件已到期："
 msgstr[1] "下列的 %d 份客戶文件已到期："
 
-#: gnucash/gnome/dialog-invoice.c:3723
+#: gnucash/gnome/dialog-invoice.c:3731
 msgid "Due Invoices Reminder"
 msgstr "發票到期提醒"
 
@@ -2621,7 +2648,7 @@ msgstr "標題"
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:3115
 #: gnucash/register/ledger-core/split-register-model.c:320
 #: gnucash/register/ledger-core/split-register-model.c:484
-#: gnucash/report/reports/standard/account-summary.scm:423
+#: gnucash/report/reports/standard/account-summary.scm:422
 #: gnucash/report/reports/standard/balance-forecast.scm:248
 #: gnucash/report/reports/standard/job-report.scm:206
 #: gnucash/report/reports/standard/new-owner-report.scm:58
@@ -2716,7 +2743,7 @@ msgid ""
 msgstr "沒有選擇此支付的相關文件，這可能會導至建立沒有建立起關聯的支付。"
 
 #: gnucash/gnome/dialog-payment.c:529 gnucash/gnome/dialog-payment.c:1330
-#: gnucash/report/reports/standard/new-aging.scm:192
+#: gnucash/report/reports/standard/new-aging.scm:180
 #: gnucash/report/reports/standard/new-owner-report.scm:321
 #: gnucash/report/reports/standard/new-owner-report.scm:719
 msgid "Pre-Payment"
@@ -2737,8 +2764,8 @@ msgstr "轉帳跟入帳的科目採用不同的貨幣。請指定轉換匯率。
 #: gnucash/gtkbuilder/dialog-invoice.glade:1058
 #: gnucash/gtkbuilder/dialog-payment.glade:40
 #: gnucash/register/ledger-core/split-register-model.c:291
-#: gnucash/report/reports/standard/customer-summary.scm:280
-#: gnucash/report/reports/standard/customer-summary.scm:313
+#: gnucash/report/reports/standard/customer-summary.scm:264
+#: gnucash/report/reports/standard/customer-summary.scm:297
 #: gnucash/report/reports/standard/job-report.scm:504
 #: gnucash/report/reports/standard/new-owner-report.scm:89
 #: gnucash/report/reports/standard/owner-report.scm:72
@@ -2779,7 +2806,9 @@ msgid ""
 "You have no valid \"Post To\" accounts. Please create an account of type \"%s"
 "\" before you continue to process this payment. Perhaps you want to create "
 "an Invoice or Bill first?"
-msgstr "您沒有有效的「應收付」科目。在繼續處理此支付前，請先建立「%s」類型的科目。也許您想要先建立「發票」或「帳單」？"
+msgstr ""
+"您沒有有效的「應收付」科目。在繼續處理此支付前，請先建立「%s」類型的科目。也"
+"許您想要先建立「發票」或「帳單」？"
 
 #: gnucash/gnome/dialog-payment.c:1579
 msgid ""
@@ -2803,7 +2832,7 @@ msgstr ""
 msgid "Warning"
 msgstr "警告"
 
-#: gnucash/gnome/dialog-payment.c:1599 gnucash/gnome/dialog-payment.c:1717
+#: gnucash/gnome/dialog-payment.c:1599 gnucash/gnome/dialog-payment.c:1719
 msgid "Continue"
 msgstr "繼續"
 
@@ -2815,7 +2844,7 @@ msgstr "繼續"
 msgid "Cancel"
 msgstr "取消"
 
-#: gnucash/gnome/dialog-payment.c:1712
+#: gnucash/gnome/dialog-payment.c:1714
 #, c-format
 msgid ""
 "The transaction has at least one split in a business account that is not "
@@ -2951,8 +2980,8 @@ msgid "Contents"
 msgstr "內容"
 
 #: gnucash/gnome/dialog-report-column-view.c:412
-#: gnucash/report/reports/standard/customer-summary.scm:283
-#: gnucash/report/reports/standard/new-owner-report.scm:1072
+#: gnucash/report/reports/standard/customer-summary.scm:267
+#: gnucash/report/reports/standard/new-owner-report.scm:1067
 #: gnucash/report/reports/standard/owner-report.scm:743
 msgid "Report"
 msgstr "報表"
@@ -2979,9 +3008,9 @@ msgid "Style Sheet Name"
 msgstr "樣式表名稱"
 
 #: gnucash/gnome/dialog-sx-editor2.c:164 gnucash/gnome/dialog-sx-editor.c:166
-#: gnucash/gnome/gnc-plugin-page-sx-list.c:150
+#: gnucash/gnome/gnc-plugin-page-sx-list.c:151
 #: gnucash/gnome/window-reconcile2.c:2162 gnucash/gnome/window-reconcile.c:2383
-#: gnucash/gnome-utils/gnc-main-window.c:273
+#: gnucash/gnome-utils/gnc-main-window.c:274
 #: gnucash/gtkbuilder/dialog-billterms.glade:679
 #: gnucash/gtkbuilder/dialog-commodities.glade:156
 #: gnucash/gtkbuilder/dialog-price.glade:872
@@ -2997,12 +3026,12 @@ msgid "_Transaction"
 msgstr "交易(_T)"
 
 #: gnucash/gnome/dialog-sx-editor2.c:166 gnucash/gnome/dialog-sx-editor.c:168
-#: gnucash/gnome-utils/gnc-main-window.c:274
+#: gnucash/gnome-utils/gnc-main-window.c:275
 msgid "_View"
 msgstr "檢視(_V)"
 
 #: gnucash/gnome/dialog-sx-editor2.c:167 gnucash/gnome/dialog-sx-editor.c:169
-#: gnucash/gnome-utils/gnc-main-window.c:275
+#: gnucash/gnome-utils/gnc-main-window.c:276
 msgid "_Actions"
 msgstr "動作(_A)"
 
@@ -3087,8 +3116,8 @@ msgid ""
 msgstr "目前的範本交易已經變更。您想要記錄它的變更嗎？"
 
 #: gnucash/gnome/dialog-sx-editor2.c:1781 gnucash/gnome/dialog-sx-editor.c:1843
-#: gnucash/gnome/gnc-plugin-page-sx-list.c:245
-#: gnucash/gnome/gnc-plugin-page-sx-list.c:251
+#: gnucash/gnome/gnc-plugin-page-sx-list.c:246
+#: gnucash/gnome/gnc-plugin-page-sx-list.c:252
 msgid "Scheduled Transactions"
 msgstr "已排程的交易"
 
@@ -3161,8 +3190,8 @@ msgstr "已建立"
 
 #: gnucash/gnome/dialog-sx-since-last-run.c:468
 #: gnucash/gtkbuilder/dialog-preferences.glade:1719
-#: gnucash/report/reports/standard/balsheet-pnl.scm:250
-#: gnucash/report/trep-engine.scm:603
+#: gnucash/report/reports/standard/balsheet-pnl.scm:212
+#: gnucash/report/trep-engine.scm:553
 msgid "Never"
 msgstr "永不"
 
@@ -3185,18 +3214,18 @@ msgid_plural ""
 msgstr[0] "現在沒有要輸入的排程交易。(1 個交易被自動建立)"
 msgstr[1] "現在沒有要輸入的排程交易。(%d 個交易被自動建立)"
 
-#: gnucash/gnome/dialog-sx-since-last-run.c:1005
+#: gnucash/gnome/dialog-sx-since-last-run.c:1008
 #: gnucash/gnome-search/dialog-search.c:1101
 msgid "Transaction"
 msgstr "交易"
 
-#: gnucash/gnome/dialog-sx-since-last-run.c:1021
+#: gnucash/gnome/dialog-sx-since-last-run.c:1024
 #: gnucash/gtkbuilder/gnc-plugin-page-register2.glade:666
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:508
 msgid "Status"
 msgstr "狀態"
 
-#: gnucash/gnome/dialog-sx-since-last-run.c:1115
+#: gnucash/gnome/dialog-sx-since-last-run.c:1118
 msgid "Created Transactions"
 msgstr "已建立交易"
 
@@ -3234,7 +3263,8 @@ msgstr "套用(_A)"
 msgid ""
 "CAUTION: If you set TXF categories, and later change 'Type', you will need "
 "to manually reset those categories one at a time"
-msgstr "小心：如果您選擇了 TXF 分類，而後修改了「類型」，那您必須手動一個一個重設分類"
+msgstr ""
+"小心：如果您選擇了 TXF 分類，而後修改了「類型」，那您必須手動一個一個重設分類"
 
 #: gnucash/gnome/dialog-tax-info.c:1394
 msgid "Form"
@@ -3246,7 +3276,9 @@ msgid ""
 "company) you should enter the same value for:\n"
 "Identification - Company Name, and\n"
 "Payment Address - Name."
-msgstr "您必須輸入公司名稱。若廠商是個人而非公司，請在「識別 - 公司名稱」跟「連絡地址 - 名稱」填相同的名字。"
+msgstr ""
+"您必須輸入公司名稱。若廠商是個人而非公司，請在「識別 - 公司名稱」跟「連絡地"
+"址 - 名稱」填相同的名字。"
 
 #: gnucash/gnome/dialog-vendor.c:226
 msgid "You must enter a payment address."
@@ -3285,7 +3317,7 @@ msgstr "廠商 ID"
 msgid "Find Vendor"
 msgstr "尋找廠商"
 
-#: gnucash/gnome/gnc-budget-view.c:499
+#: gnucash/gnome/gnc-budget-view.c:502
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2943
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:2979
 #: gnucash/import-export/qif-imp/qif-dialog-utils.scm:70
@@ -3294,17 +3326,17 @@ msgstr "尋找廠商"
 #: gnucash/import-export/qif-imp/qif-dialog-utils.scm:91
 #: gnucash/import-export/qif-imp/qif-dialog-utils.scm:97
 #: gnucash/import-export/qif-imp/qif-dialog-utils.scm:103
-#: gnucash/register/ledger-core/split-register.c:2636
-#: gnucash/report/reports/standard/advanced-portfolio.scm:1088
-#: gnucash/report/reports/standard/balsheet-pnl.scm:1282
+#: gnucash/register/ledger-core/split-register.c:2638
+#: gnucash/report/reports/standard/advanced-portfolio.scm:1069
+#: gnucash/report/reports/standard/balsheet-pnl.scm:1243
 #: gnucash/report/reports/standard/net-charts.scm:346
 #: gnucash/report/reports/standard/net-charts.scm:416
 #: gnucash/report/report-utilities.scm:204 libgnucash/engine/Account.cpp:171
-#: libgnucash/engine/Account.cpp:4395 libgnucash/engine/Scrub.c:473
+#: libgnucash/engine/Account.cpp:4401
 msgid "Income"
 msgstr "收入"
 
-#: gnucash/gnome/gnc-budget-view.c:502
+#: gnucash/gnome/gnc-budget-view.c:505
 #: gnucash/import-export/qif-imp/qif-dialog-utils.scm:117
 #: gnucash/import-export/qif-imp/qif-dialog-utils.scm:122
 #: gnucash/report/reports/standard/budget-income-statement.scm:516
@@ -3313,42 +3345,42 @@ msgstr "收入"
 msgid "Expenses"
 msgstr "支出"
 
-#: gnucash/gnome/gnc-budget-view.c:505
+#: gnucash/gnome/gnc-budget-view.c:508
 #: gnucash/gnome/gnc-plugin-page-register2.c:497
 #: gnucash/gnome/gnc-plugin-page-register.c:620
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2868
-#: gnucash/register/ledger-core/split-register.c:2561
+#: gnucash/register/ledger-core/split-register.c:2563
 #: gnucash/register/ledger-core/split-register-layout.c:719
 #: gnucash/register/ledger-core/split-register-model.c:348
 #: gnucash/report/reports/standard/register.scm:144
 msgid "Transfer"
 msgstr "轉帳"
 
-#: gnucash/gnome/gnc-budget-view.c:508
+#: gnucash/gnome/gnc-budget-view.c:511
 msgid "Remaining to Budget"
 msgstr "剩餘預算"
 
-#: gnucash/gnome/gnc-budget-view.c:1652 gnucash/gnome/window-reconcile2.c:1069
+#: gnucash/gnome/gnc-budget-view.c:1655 gnucash/gnome/window-reconcile2.c:1069
 #: gnucash/gnome/window-reconcile.c:1122
 #: gnucash/gnome-utils/gnc-tree-view-account.c:923
 #: gnucash/report/html-acct-table.scm:753 gnucash/report/reports/aging.scm:544
 #: gnucash/report/reports/aging.scm:831
-#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:294
-#: gnucash/report/reports/standard/advanced-portfolio.scm:1053
+#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:286
+#: gnucash/report/reports/standard/advanced-portfolio.scm:1034
 #: gnucash/report/reports/standard/budget-flow.scm:168
 #: gnucash/report/reports/standard/budget-flow.scm:247
-#: gnucash/report/reports/standard/budget.scm:510
+#: gnucash/report/reports/standard/budget.scm:498
 #: gnucash/report/reports/standard/cashflow-barchart.scm:345
-#: gnucash/report/reports/standard/customer-summary.scm:470
-#: gnucash/report/reports/standard/customer-summary.scm:472
+#: gnucash/report/reports/standard/customer-summary.scm:454
+#: gnucash/report/reports/standard/customer-summary.scm:456
 #: gnucash/report/reports/standard/invoice.scm:104
-#: gnucash/report/reports/standard/invoice.scm:252
-#: gnucash/report/reports/standard/new-aging.scm:198
-#: gnucash/report/reports/standard/new-aging.scm:323
+#: gnucash/report/reports/standard/invoice.scm:239
+#: gnucash/report/reports/standard/new-aging.scm:186
+#: gnucash/report/reports/standard/new-aging.scm:311
 #: gnucash/report/reports/standard/new-owner-report.scm:327
 #: gnucash/report/reports/standard/portfolio.scm:278
 #: gnucash/report/reports/support/balsheet-eg.eguile.scm:113
-#: gnucash/report/trep-engine.scm:1961
+#: gnucash/report/trep-engine.scm:1906
 msgid "Total"
 msgstr "總計"
 
@@ -3378,7 +3410,7 @@ msgstr "開啟已存在的 GnuCash 檔案"
 
 #: gnucash/gnome/gnc-plugin-basic-commands.c:121
 #: gnucash/gnome-utils/gnc-file.c:100 gnucash/gnome-utils/gnc-file.c:665
-#: gnucash/gnome-utils/gnc-main-window.c:1309
+#: gnucash/gnome-utils/gnc-main-window.c:1310
 #: gnucash/html/gnc-html-webkit1.c:1198
 msgid "_Save"
 msgstr "儲存檔案(_S)"
@@ -3955,7 +3987,7 @@ msgstr "將所選科目的子科目代碼重新編號"
 #: gnucash/gnome/gnc-plugin-page-owner-tree.c:185
 #: gnucash/gnome/gnc-plugin-page-register2.c:340
 #: gnucash/gnome/gnc-plugin-page-register.c:458
-#: gnucash/gnome-utils/gnc-main-window.c:345
+#: gnucash/gnome-utils/gnc-main-window.c:346
 msgid "_Filter By..."
 msgstr "過濾依(_F)..."
 
@@ -3966,8 +3998,8 @@ msgstr "過濾依(_F)..."
 #: gnucash/gnome/gnc-plugin-page-register2.c:344
 #: gnucash/gnome/gnc-plugin-page-register.c:462
 #: gnucash/gnome/gnc-plugin-page-report.c:1231
-#: gnucash/gnome/gnc-plugin-page-sx-list.c:169
-#: gnucash/gnome-utils/gnc-main-window.c:349
+#: gnucash/gnome/gnc-plugin-page-sx-list.c:170
+#: gnucash/gnome-utils/gnc-main-window.c:350
 msgid "_Refresh"
 msgstr "重新整理(_R)"
 
@@ -3977,8 +4009,8 @@ msgstr "重新整理(_R)"
 #: gnucash/gnome/gnc-plugin-page-register2.c:345
 #: gnucash/gnome/gnc-plugin-page-register.c:463
 #: gnucash/gnome/gnc-plugin-page-report.c:1232
-#: gnucash/gnome/gnc-plugin-page-sx-list.c:170
-#: gnucash/gnome-utils/gnc-main-window.c:350
+#: gnucash/gnome/gnc-plugin-page-sx-list.c:171
+#: gnucash/gnome-utils/gnc-main-window.c:351
 msgid "Refresh this window"
 msgstr "重新整理此視窗"
 
@@ -4107,8 +4139,8 @@ msgstr "刪除"
 
 #: gnucash/gnome/gnc-plugin-page-account-tree.c:454
 #: gnucash/gnome/gnc-plugin-page-account-tree.c:1991
-#: gnucash/gnome/gnc-plugin-page-register.c:1960
-#: gnucash/gnome/gnc-plugin-page-register.c:5065
+#: gnucash/gnome/gnc-plugin-page-register.c:1962
+#: gnucash/gnome/gnc-plugin-page-register.c:5076
 msgid "'Check & Repair' is currently running, do you want to abort it?"
 msgstr "「檢查和修復」正在執行中，您確定要中斷嗎？"
 
@@ -4127,9 +4159,9 @@ msgstr "「檢查和修復」正在執行中，您確定要中斷嗎？"
 #: gnucash/report/reports/example/average-balance.scm:296
 #: gnucash/report/reports/example/daily-reports.scm:57
 #: gnucash/report/reports/standard/account-piecharts.scm:70
-#: gnucash/report/reports/standard/account-piecharts.scm:564
+#: gnucash/report/reports/standard/account-piecharts.scm:553
 #: gnucash/report/reports/standard/account-summary.scm:85
-#: gnucash/report/reports/standard/advanced-portfolio.scm:163
+#: gnucash/report/reports/standard/advanced-portfolio.scm:144
 #: gnucash/report/reports/standard/balance-forecast.scm:37
 #: gnucash/report/reports/standard/balance-sheet.scm:86
 #: gnucash/report/reports/standard/balsheet-pnl.scm:81
@@ -4297,7 +4329,7 @@ msgstr "重新整理此視窗。"
 #: gnucash/gnome/gnc-plugin-page-report.c:1137
 #: gnucash/gtkbuilder/assistant-csv-export.glade:107
 #: gnucash/gtkbuilder/dialog-print-check.glade:643
-#: gnucash/gtkbuilder/dialog-sx.glade:892
+#: gnucash/gtkbuilder/dialog-sx.glade:909
 msgid "Options"
 msgstr "選項"
 
@@ -4322,7 +4354,7 @@ msgstr "建立報表"
 #: gnucash/gnome/gnc-plugin-page-budget.c:880
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:110
 #: gnucash/report/reports/standard/budget-barchart.scm:39
-#: gnucash/report/reports/standard/budget-barchart.scm:227
+#: gnucash/report/reports/standard/budget-barchart.scm:211
 #: gnucash/report/reports/standard/budget-flow.scm:43
 #: gnucash/report/reports/standard/budget-income-statement.scm:58
 #: gnucash/report/reports/standard/budget.scm:93
@@ -4370,7 +4402,7 @@ msgstr "複製"
 #: gnucash/gnome/gnc-plugin-page-register2.c:240
 #: gnucash/gnome/gnc-plugin-page-register.c:349
 #: gnucash/gnome/gnc-plugin-page-report.c:1226
-#: gnucash/gnome-utils/gnc-main-window.c:328
+#: gnucash/gnome-utils/gnc-main-window.c:329
 msgid "_Paste"
 msgstr "貼上(_P)"
 
@@ -4466,8 +4498,8 @@ msgstr "以數量排序"
 #: gnucash/gnome-utils/gnc-tree-util-split-reg.c:1137
 #: gnucash/gnome-utils/gnc-tree-util-split-reg.c:1139
 #: gnucash/gtkbuilder/dialog-price.glade:218
-#: gnucash/register/ledger-core/split-register.c:2096
-#: gnucash/register/ledger-core/split-register.c:2099
+#: gnucash/register/ledger-core/split-register.c:2098
+#: gnucash/register/ledger-core/split-register.c:2101
 msgid "_Price"
 msgstr "價格(_P)"
 
@@ -4942,7 +4974,7 @@ msgstr "顯示所有客戶的總覽表"
 
 #: gnucash/gnome/gnc-plugin-page-owner-tree.c:221
 #: gnucash/report/reports/standard/job-report.scm:511
-#: gnucash/report/reports/standard/new-owner-report.scm:1216
+#: gnucash/report/reports/standard/new-owner-report.scm:1211
 msgid "Vendor Report"
 msgstr "廠商報表"
 
@@ -4952,7 +4984,7 @@ msgstr "顯示廠商報表"
 
 #: gnucash/gnome/gnc-plugin-page-owner-tree.c:226
 #: gnucash/report/reports/standard/job-report.scm:505
-#: gnucash/report/reports/standard/new-owner-report.scm:1207
+#: gnucash/report/reports/standard/new-owner-report.scm:1202
 msgid "Customer Report"
 msgstr "客戶報表"
 
@@ -4962,7 +4994,7 @@ msgstr "顯示客戶報表"
 
 #: gnucash/gnome/gnc-plugin-page-owner-tree.c:231
 #: gnucash/report/reports/standard/job-report.scm:514
-#: gnucash/report/reports/standard/new-owner-report.scm:1225
+#: gnucash/report/reports/standard/new-owner-report.scm:1220
 msgid "Employee Report"
 msgstr "員工報表"
 
@@ -5115,35 +5147,35 @@ msgstr "列印支票(_P)..."
 #: gnucash/gnome/gnc-plugin-page-register2.c:230
 #: gnucash/gnome/gnc-plugin-page-register.c:339
 #: gnucash/gnome/gnc-plugin-page-report.c:1216
-#: gnucash/gnome-utils/gnc-main-window.c:318
+#: gnucash/gnome-utils/gnc-main-window.c:319
 msgid "Cu_t"
 msgstr "剪下(_T)"
 
 #: gnucash/gnome/gnc-plugin-page-register2.c:231
 #: gnucash/gnome/gnc-plugin-page-register.c:340
 #: gnucash/gnome/gnc-plugin-page-report.c:1217
-#: gnucash/gnome-utils/gnc-main-window.c:319
+#: gnucash/gnome-utils/gnc-main-window.c:320
 msgid "Cut the current selection and copy it to clipboard"
 msgstr "剪下目前選擇的分割並複製到剪貼簿"
 
 #: gnucash/gnome/gnc-plugin-page-register2.c:235
 #: gnucash/gnome/gnc-plugin-page-register.c:344
 #: gnucash/gnome/gnc-plugin-page-report.c:1221
-#: gnucash/gnome-utils/gnc-main-window.c:323
+#: gnucash/gnome-utils/gnc-main-window.c:324
 msgid "_Copy"
 msgstr "複製(_C)"
 
 #: gnucash/gnome/gnc-plugin-page-register2.c:236
 #: gnucash/gnome/gnc-plugin-page-register.c:345
 #: gnucash/gnome/gnc-plugin-page-report.c:1222
-#: gnucash/gnome-utils/gnc-main-window.c:324
+#: gnucash/gnome-utils/gnc-main-window.c:325
 msgid "Copy the current selection to clipboard"
 msgstr "複製目前選取的部份到剪貼簿"
 
 #: gnucash/gnome/gnc-plugin-page-register2.c:241
 #: gnucash/gnome/gnc-plugin-page-register.c:350
 #: gnucash/gnome/gnc-plugin-page-report.c:1227
-#: gnucash/gnome-utils/gnc-main-window.c:329
+#: gnucash/gnome-utils/gnc-main-window.c:330
 msgid "Paste the clipboard content at the cursor position"
 msgstr "將剪貼簿裡的內容貼上到游標所在的位置"
 
@@ -5199,7 +5231,9 @@ msgstr "上移交易(_U)"
 msgid ""
 "Move the current transaction one row upwards. Only available if the date and "
 "number of both rows are identical and the register window is sorted by date."
-msgstr "將目前交易往上移一行。只有在兩行交易的日期和數字相同，且登記簿是以日期排序時有用。"
+msgstr ""
+"將目前交易往上移一行。只有在兩行交易的日期和數字相同，且登記簿是以日期排序時"
+"有用。"
 
 #: gnucash/gnome/gnc-plugin-page-register2.c:332
 msgid "Move Transaction Do_wn"
@@ -5210,7 +5244,9 @@ msgid ""
 "Move the current transaction one row downwards. Only available if the date "
 "and number of both rows are identical and the register window is sorted by "
 "date."
-msgstr "將目前交易往下移一行。只有在兩行交易的日期和數字相同，且登記簿是以日期排序時有用。"
+msgstr ""
+"將目前交易往下移一行。只有在兩行交易的日期和數字相同，且登記簿是以日期排序時"
+"有用。"
 
 #: gnucash/gnome/gnc-plugin-page-register2.c:363
 #: gnucash/gnome/gnc-plugin-page-register.c:481
@@ -5392,26 +5428,28 @@ msgstr "一般日記帳"
 #. Translators: %s is the name
 #. of the tab page
 #: gnucash/gnome/gnc-plugin-page-register2.c:1620
-#: gnucash/gnome/gnc-plugin-page-register.c:2001
+#: gnucash/gnome/gnc-plugin-page-register.c:2003
 #, c-format
 msgid "Save changes to %s?"
 msgstr "儲存改變到 %s?"
 
 #: gnucash/gnome/gnc-plugin-page-register2.c:1624
-#: gnucash/gnome/gnc-plugin-page-register.c:2005
+#: gnucash/gnome/gnc-plugin-page-register.c:2008
 msgid ""
 "This register has pending changes to a transaction. Would you like to save "
 "the changes to this transaction, discard the transaction, or cancel the "
 "operation?"
-msgstr "此登記簿有等待儲存的交易更動。您想要儲存這個交易的更動，丟棄此筆交易，或是取消這個操作？"
+msgstr ""
+"此登記簿有等待儲存的交易更動。您想要儲存這個交易的更動，丟棄此筆交易，或是取"
+"消這個操作？"
 
 #: gnucash/gnome/gnc-plugin-page-register2.c:1627
-#: gnucash/gnome/gnc-plugin-page-register.c:2008
+#: gnucash/gnome/gnc-plugin-page-register.c:2011
 msgid "_Discard Transaction"
 msgstr "捨棄交易(_D)"
 
 #: gnucash/gnome/gnc-plugin-page-register2.c:1631
-#: gnucash/gnome/gnc-plugin-page-register.c:2012
+#: gnucash/gnome/gnc-plugin-page-register.c:2015
 msgid "_Save Transaction"
 msgstr "儲存交易(_S)"
 
@@ -5420,35 +5458,35 @@ msgstr "儲存交易(_S)"
 #: gnucash/gnome/gnc-plugin-page-register2.c:1707
 #: gnucash/gnome/gnc-plugin-page-register2.c:1730
 #: gnucash/gnome/gnc-plugin-page-register2.c:1778
-#: gnucash/gnome/gnc-plugin-page-register.c:2045
-#: gnucash/gnome/gnc-plugin-page-register.c:2080
-#: gnucash/gnome/gnc-plugin-page-register.c:2093
-#: gnucash/gnome/gnc-plugin-page-register.c:2156
+#: gnucash/gnome/gnc-plugin-page-register.c:2048
+#: gnucash/gnome/gnc-plugin-page-register.c:2083
+#: gnucash/gnome/gnc-plugin-page-register.c:2096
+#: gnucash/gnome/gnc-plugin-page-register.c:2155
 #: gnucash/gnome/gnc-plugin-page-register.c:2261
-#: gnucash/gnome/gnc-plugin-page-register.c:2399
+#: gnucash/gnome/gnc-plugin-page-register.c:2400
 msgid "unknown"
 msgstr "未知"
 
 #: gnucash/gnome/gnc-plugin-page-register2.c:1681
 #: gnucash/gnome/gnc-plugin-page-register2.c:2416
 #: gnucash/gnome/gnc-plugin-page-register.c:906
-#: gnucash/gnome/gnc-plugin-page-register.c:2066
-#: gnucash/gnome/gnc-plugin-page-register.c:3559
+#: gnucash/gnome/gnc-plugin-page-register.c:2069
+#: gnucash/gnome/gnc-plugin-page-register.c:3560
 #: gnucash/report/reports/standard/general-journal.scm:36
 msgid "General Journal"
 msgstr "一般日記帳"
 
 #: gnucash/gnome/gnc-plugin-page-register2.c:1683
 #: gnucash/gnome/gnc-plugin-page-register2.c:2422
-#: gnucash/gnome/gnc-plugin-page-register.c:2068
-#: gnucash/gnome/gnc-plugin-page-register.c:3565
+#: gnucash/gnome/gnc-plugin-page-register.c:2071
+#: gnucash/gnome/gnc-plugin-page-register.c:3566
 msgid "Portfolio"
 msgstr "投資組合"
 
 #: gnucash/gnome/gnc-plugin-page-register2.c:1685
 #: gnucash/gnome/gnc-plugin-page-register2.c:2428
-#: gnucash/gnome/gnc-plugin-page-register.c:2070
-#: gnucash/gnome/gnc-plugin-page-register.c:3571
+#: gnucash/gnome/gnc-plugin-page-register.c:2073
+#: gnucash/gnome/gnc-plugin-page-register.c:3572
 msgid "Search Results"
 msgstr "搜尋結果"
 
@@ -5457,17 +5495,17 @@ msgid "General Journal Report"
 msgstr "一般日記帳報表"
 
 #: gnucash/gnome/gnc-plugin-page-register2.c:2424
-#: gnucash/gnome/gnc-plugin-page-register.c:3567
+#: gnucash/gnome/gnc-plugin-page-register.c:3568
 msgid "Portfolio Report"
 msgstr "投資組合報表"
 
 #: gnucash/gnome/gnc-plugin-page-register2.c:2430
-#: gnucash/gnome/gnc-plugin-page-register.c:3573
+#: gnucash/gnome/gnc-plugin-page-register.c:3574
 msgid "Search Results Report"
 msgstr "搜尋結果報表"
 
 #: gnucash/gnome/gnc-plugin-page-register2.c:2434
-#: gnucash/gnome/gnc-plugin-page-register.c:3577
+#: gnucash/gnome/gnc-plugin-page-register.c:3578
 #: gnucash/gtkbuilder/dialog-preferences.glade:2700
 #: gnucash/report/reports/standard/general-journal.scm:37
 #: gnucash/report/reports/standard/register.scm:64
@@ -5480,75 +5518,77 @@ msgid "Register Report"
 msgstr "登記簿報表"
 
 #: gnucash/gnome/gnc-plugin-page-register2.c:2452
-#: gnucash/gnome/gnc-plugin-page-register.c:3595
+#: gnucash/gnome/gnc-plugin-page-register.c:3596
 msgid "and subaccounts"
 msgstr "及子科目"
 
 #: gnucash/gnome/gnc-plugin-page-register2.c:2484
-#: gnucash/gnome/gnc-plugin-page-register.c:3624
+#: gnucash/gnome/gnc-plugin-page-register.c:3625
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2866
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2885
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2903
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:3021
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:3026
 #: gnucash/gtkbuilder/dialog-payment.glade:312
-#: gnucash/register/ledger-core/split-register.c:2464
-#: gnucash/register/ledger-core/split-register.c:2559
-#: gnucash/register/ledger-core/split-register.c:2578
-#: gnucash/register/ledger-core/split-register.c:2596
+#: gnucash/register/ledger-core/split-register.c:2466
+#: gnucash/register/ledger-core/split-register.c:2561
+#: gnucash/register/ledger-core/split-register.c:2580
+#: gnucash/register/ledger-core/split-register.c:2598
 #: gnucash/report/reports/standard/general-journal.scm:83
 #: gnucash/report/reports/standard/register.scm:343
-#: gnucash/report/reports/standard/trial-balance.scm:596
-#: gnucash/report/trep-engine.scm:1391 gnucash/report/trep-engine.scm:1408
+#: gnucash/report/reports/standard/trial-balance.scm:590
+#: gnucash/report/trep-engine.scm:1336 gnucash/report/trep-engine.scm:1353
 #: libgnucash/engine/Account.cpp:178
 msgid "Credit"
 msgstr "貸方"
 
 #: gnucash/gnome/gnc-plugin-page-register2.c:2487
-#: gnucash/gnome/gnc-plugin-page-register.c:3628
+#: gnucash/gnome/gnc-plugin-page-register.c:3629
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:3102
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:3107
 #: gnucash/gtkbuilder/dialog-payment.glade:296
-#: gnucash/register/ledger-core/split-register.c:2441
+#: gnucash/register/ledger-core/split-register.c:2443
 #: gnucash/report/reports/standard/general-journal.scm:82
 #: gnucash/report/reports/standard/register.scm:341
-#: gnucash/report/reports/standard/trial-balance.scm:593
-#: gnucash/report/trep-engine.scm:1388 gnucash/report/trep-engine.scm:1405
+#: gnucash/report/reports/standard/trial-balance.scm:587
+#: gnucash/report/trep-engine.scm:1333 gnucash/report/trep-engine.scm:1350
 #: libgnucash/engine/Account.cpp:158
 msgid "Debit"
 msgstr "借方"
 
 #: gnucash/gnome/gnc-plugin-page-register2.c:2653
-#: gnucash/gnome/gnc-plugin-page-register.c:3761
+#: gnucash/gnome/gnc-plugin-page-register.c:3762
 msgid "Print checks from multiple accounts?"
 msgstr "列印來自多個科目的支票?"
 
 #: gnucash/gnome/gnc-plugin-page-register2.c:2655
-#: gnucash/gnome/gnc-plugin-page-register.c:3763
+#: gnucash/gnome/gnc-plugin-page-register.c:3764
 msgid ""
 "This search result contains splits from more than one account. Do you want "
 "to print the checks even though they are not all from the same account?"
-msgstr "這個搜尋包含了一個以上的科目裡的分割。您確定要列印支票，即使他們不是全部都在同一個科目中嗎？"
+msgstr ""
+"這個搜尋包含了一個以上的科目裡的分割。您確定要列印支票，即使他們不是全部都在"
+"同一個科目中嗎？"
 
 #: gnucash/gnome/gnc-plugin-page-register2.c:2665
-#: gnucash/gnome/gnc-plugin-page-register.c:3773
+#: gnucash/gnome/gnc-plugin-page-register.c:3774
 msgid "_Print checks"
 msgstr "列印支票(_P)"
 
 #: gnucash/gnome/gnc-plugin-page-register2.c:2685
-#: gnucash/gnome/gnc-plugin-page-register.c:3793
+#: gnucash/gnome/gnc-plugin-page-register.c:3794
 msgid ""
 "You can only print checks from a bank account register or search results."
 msgstr "您只能從銀行科目或搜尋結果中，列印支票。"
 
 #: gnucash/gnome/gnc-plugin-page-register2.c:2897
-#: gnucash/gnome/gnc-plugin-page-register.c:3990
+#: gnucash/gnome/gnc-plugin-page-register.c:3991
 msgid "You cannot void a transaction with reconciled or cleared splits."
 msgstr "不能將已結清或對帳的分割標為無效。"
 
 #. Translators: The %s is the name of the plugin page
 #: gnucash/gnome/gnc-plugin-page-register2.c:3040
-#: gnucash/gnome/gnc-plugin-page-register.c:4261
+#: gnucash/gnome/gnc-plugin-page-register.c:4268
 #: gnucash/gnome-utils/gnc-tree-view-account.c:2328
 #: gnucash/gnome-utils/gnc-tree-view-owner.c:1175
 #, c-format
@@ -5578,7 +5618,7 @@ msgid "Remo_ve Other Splits"
 msgstr "移除交易分割(_V)"
 
 #: gnucash/gnome/gnc-plugin-page-register.c:454
-#: gnucash/gnome-utils/gnc-main-window.c:341
+#: gnucash/gnome-utils/gnc-main-window.c:342
 msgid "_Sort By..."
 msgstr "排序依(_S)..."
 
@@ -5596,95 +5636,95 @@ msgid ""
 "the new register."
 msgstr "您試著在一個科目已經被舊的登記簿打開時，在新的登記簿中打開這個科目。"
 
-#: gnucash/gnome/gnc-plugin-page-register.c:3405
+#: gnucash/gnome/gnc-plugin-page-register.c:3406
 msgid "Filter By:"
 msgstr "過濾依："
 
-#: gnucash/gnome/gnc-plugin-page-register.c:3419
+#: gnucash/gnome/gnc-plugin-page-register.c:3420
 msgid "Start Date:"
 msgstr "開始日期："
 
-#: gnucash/gnome/gnc-plugin-page-register.c:3425
+#: gnucash/gnome/gnc-plugin-page-register.c:3426
 msgid "Show previous number of days:"
 msgstr "顯示之前幾天："
 
-#: gnucash/gnome/gnc-plugin-page-register.c:3432
+#: gnucash/gnome/gnc-plugin-page-register.c:3433
 msgid "End Date:"
 msgstr "結束日期:"
 
-#: gnucash/gnome/gnc-plugin-page-register.c:3442
-#: gnucash/report/trep-engine.scm:146 gnucash/report/trep-engine.scm:420
+#: gnucash/gnome/gnc-plugin-page-register.c:3443
+#: gnucash/report/trep-engine.scm:146
 msgid "Unreconciled"
 msgstr "未對帳"
 
-#: gnucash/gnome/gnc-plugin-page-register.c:3444
+#: gnucash/gnome/gnc-plugin-page-register.c:3445
 #: gnucash/gnome-search/search-reconciled.c:224
 #: gnucash/gnome-utils/gnc-tree-view-account.c:875
-#: gnucash/report/trep-engine.scm:147 gnucash/report/trep-engine.scm:425
+#: gnucash/report/trep-engine.scm:147
 msgid "Cleared"
 msgstr "已結清"
 
-#: gnucash/gnome/gnc-plugin-page-register.c:3446
+#: gnucash/gnome/gnc-plugin-page-register.c:3447
 #: gnucash/gnome-search/search-reconciled.c:227
 #: gnucash/gnome-utils/gnc-tree-view-account.c:889
 #: gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp:75
 #: gnucash/import-export/import-match-picker.c:437
-#: gnucash/report/trep-engine.scm:148 gnucash/report/trep-engine.scm:430
+#: gnucash/report/trep-engine.scm:148
 msgid "Reconciled"
 msgstr "已對帳"
 
-#: gnucash/gnome/gnc-plugin-page-register.c:3448
+#: gnucash/gnome/gnc-plugin-page-register.c:3449
 #: gnucash/gnome-search/search-reconciled.c:230
 #: gnucash/report/trep-engine.scm:149
 msgid "Frozen"
 msgstr "凍結"
 
-#: gnucash/gnome/gnc-plugin-page-register.c:3450
+#: gnucash/gnome/gnc-plugin-page-register.c:3451
 #: gnucash/gnome-search/search-reconciled.c:233
 #: gnucash/report/trep-engine.scm:150
 msgid "Voided"
 msgstr "無效"
 
-#: gnucash/gnome/gnc-plugin-page-register.c:3454
-#: gnucash/gnome/gnc-plugin-page-register.c:3456
+#: gnucash/gnome/gnc-plugin-page-register.c:3455
+#: gnucash/gnome/gnc-plugin-page-register.c:3457
 msgid "Hide:"
 msgstr "隱藏:"
 
-#: gnucash/gnome/gnc-plugin-page-register.c:3456
+#: gnucash/gnome/gnc-plugin-page-register.c:3457
 msgid "Show:"
 msgstr "顯示:"
 
-#: gnucash/gnome/gnc-plugin-page-register.c:3561
-#: gnucash/gnome/gnc-plugin-page-register.c:3579
+#: gnucash/gnome/gnc-plugin-page-register.c:3562
+#: gnucash/gnome/gnc-plugin-page-register.c:3580
 #: gnucash/report/reports/standard/transaction.scm:33
 msgid "Transaction Report"
 msgstr "交易報表"
 
-#: gnucash/gnome/gnc-plugin-page-register.c:3997
+#: gnucash/gnome/gnc-plugin-page-register.c:3998
 #: gnucash/gnome/gnc-split-reg.c:1160
 #: gnucash/gnome-utils/gnc-tree-control-split-reg.c:68
 #, c-format
 msgid "This transaction is marked read-only with the comment: '%s'"
 msgstr "這個交易被標記為唯讀，其註解: '%s'"
 
-#: gnucash/gnome/gnc-plugin-page-register.c:4077
+#: gnucash/gnome/gnc-plugin-page-register.c:4078
 #: gnucash/gnome/gnc-split-reg.c:1131
 #: gnucash/gnome-utils/gnc-tree-control-split-reg.c:1121
 msgid "A reversing entry has already been created for this transaction."
 msgstr "此交易已經建立過反向交易。"
 
-#: gnucash/gnome/gnc-plugin-page-register.c:4084
+#: gnucash/gnome/gnc-plugin-page-register.c:4091
 msgid "Reverse Transaction"
 msgstr "反向交易"
 
-#: gnucash/gnome/gnc-plugin-page-register.c:4085
+#: gnucash/gnome/gnc-plugin-page-register.c:4092
 #: gnucash/gtkbuilder/gnc-plugin-page-register2.glade:73
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:624
 msgid "New Transaction Information"
 msgstr "新的交易資訊"
 
 #. Translators: The %s is the name of the plugin page
-#: gnucash/gnome/gnc-plugin-page-register.c:4173
+#: gnucash/gnome/gnc-plugin-page-register.c:4180
 #, c-format
 msgid "Sort %s by..."
 msgstr "排序 %s 依..."
@@ -5692,32 +5732,32 @@ msgstr "排序 %s 依..."
 #. Translators: %s refer to the following in
 #. order: invoice type, invoice ID, owner name,
 #. posted date, amount
-#: gnucash/gnome/gnc-plugin-page-register.c:4751
+#: gnucash/gnome/gnc-plugin-page-register.c:4762
 #, c-format
 msgid "%s %s from %s, posted %s, amount %s"
 msgstr "%s %s 從 %s，過帳於 %s，金額 %s"
 
-#: gnucash/gnome/gnc-plugin-page-register.c:4761
+#: gnucash/gnome/gnc-plugin-page-register.c:4772
 msgid "Several documents are linked with this transaction. Please choose one:"
 msgstr "有數份文件和這個交易有連結。請選擇其中一個："
 
-#: gnucash/gnome/gnc-plugin-page-register.c:4762
+#: gnucash/gnome/gnc-plugin-page-register.c:4773
 #: gnucash/gnome-search/dialog-search.c:323
 #: gnucash/gnome-utils/gnc-cell-renderer-date.c:172
 msgid "Select"
 msgstr "選擇"
 
-#: gnucash/gnome/gnc-plugin-page-register.c:4810
+#: gnucash/gnome/gnc-plugin-page-register.c:4821
 msgid "Go to Date"
 msgstr "跳到指定日期"
 
-#: gnucash/gnome/gnc-plugin-page-register.c:5088
+#: gnucash/gnome/gnc-plugin-page-register.c:5099
 #, c-format
 msgid "Checking splits in current register: %u of %u"
 msgstr "檢查此登記簿中的分割中：%u / %u"
 
-#: gnucash/gnome/gnc-plugin-page-report.c:302
-#: gnucash/gnome/gnc-plugin-page-report.c:303
+#: gnucash/gnome/gnc-plugin-page-report.c:300
+#: gnucash/gnome/gnc-plugin-page-report.c:301
 msgid "The numeric ID of the report."
 msgstr "報表的數字編號。"
 
@@ -5759,7 +5799,9 @@ msgstr "更新目前報表所儲存的組態。報表組態將被存檔在 %s �
 msgid ""
 "Add the current report's configuration to the 'Reports->Saved Report "
 "Configurations' menu. The report configuration will be saved in the file %s."
-msgstr "新增目前的報表組態到「報表->已儲存的報表組態」選單。報表組態會被存檔在 %s 中。"
+msgstr ""
+"新增目前的報表組態到「報表->已儲存的報表組態」選單。報表組態會被存檔在 %s "
+"中。"
 
 #: gnucash/gnome/gnc-plugin-page-report.c:1205
 msgid "_Print Report..."
@@ -5880,7 +5922,8 @@ msgstr "檔案 %s 已存在。您確定要覆蓋它？"
 msgid ""
 "This report must be upgraded to return a document object with export-string "
 "or export-error."
-msgstr "這份報表需要升級，以回傳一個具有 export-string 或 export-error 的文件物件。"
+msgstr ""
+"這份報表需要升級，以回傳一個具有 export-string 或 export-error 的文件物件。"
 
 #: gnucash/gnome/gnc-plugin-page-report.c:1765
 #, c-format
@@ -5893,7 +5936,7 @@ msgstr "GnuCash-報表"
 
 #: gnucash/gnome/gnc-plugin-page-report.c:1851
 #: gnucash/gtkbuilder/business-prefs.glade:26
-#: gnucash/report/reports/standard/invoice.scm:903
+#: gnucash/report/reports/standard/invoice.scm:890
 msgid "Printable Invoice"
 msgstr "可列印的發票"
 
@@ -5908,21 +5951,21 @@ msgstr "稅務發票"
 
 #: gnucash/gnome/gnc-plugin-page-report.c:1853
 #: gnucash/gtkbuilder/business-prefs.glade:32
-#: gnucash/report/reports/standard/invoice.scm:912
+#: gnucash/report/reports/standard/invoice.scm:899
 msgid "Easy Invoice"
 msgstr "簡單發票"
 
 #: gnucash/gnome/gnc-plugin-page-report.c:1854
 #: gnucash/gtkbuilder/business-prefs.glade:35
-#: gnucash/report/reports/standard/invoice.scm:921
+#: gnucash/report/reports/standard/invoice.scm:908
 msgid "Fancy Invoice"
 msgstr "精美的發票"
 
-#: gnucash/gnome/gnc-plugin-page-sx-list.c:136
+#: gnucash/gnome/gnc-plugin-page-sx-list.c:137
 msgid "_Scheduled"
 msgstr "已排程(_S)"
 
-#: gnucash/gnome/gnc-plugin-page-sx-list.c:138
+#: gnucash/gnome/gnc-plugin-page-sx-list.c:139
 #: gnucash/gtkbuilder/dialog-billterms.glade:495
 #: gnucash/gtkbuilder/dialog-commodity.glade:656
 #: gnucash/gtkbuilder/dialog-report.glade:338
@@ -5932,46 +5975,50 @@ msgstr "已排程(_S)"
 msgid "_New"
 msgstr "新增(_N)"
 
-#: gnucash/gnome/gnc-plugin-page-sx-list.c:139
+#: gnucash/gnome/gnc-plugin-page-sx-list.c:140
 msgid "Create a new scheduled transaction"
 msgstr "建立新的排程交易"
 
-#: gnucash/gnome/gnc-plugin-page-sx-list.c:144
+#: gnucash/gnome/gnc-plugin-page-sx-list.c:145
 msgid "_New 2"
 msgstr "新增 2(_N)"
 
-#: gnucash/gnome/gnc-plugin-page-sx-list.c:145
+#: gnucash/gnome/gnc-plugin-page-sx-list.c:146
 msgid "Create a new scheduled transaction 2"
 msgstr "建立新的排程交易 2"
 
-#: gnucash/gnome/gnc-plugin-page-sx-list.c:151
+#: gnucash/gnome/gnc-plugin-page-sx-list.c:152
 msgid "Edit the selected scheduled transaction"
 msgstr "編輯選擇的排程交易"
 
-#: gnucash/gnome/gnc-plugin-page-sx-list.c:156
+#: gnucash/gnome/gnc-plugin-page-sx-list.c:157
 msgid "_Edit 2"
 msgstr "編輯 2(_E)"
 
-#: gnucash/gnome/gnc-plugin-page-sx-list.c:157
+#: gnucash/gnome/gnc-plugin-page-sx-list.c:158
 msgid "Edit the selected scheduled transaction 2"
 msgstr "編輯選擇的排程交易 2"
 
-#: gnucash/gnome/gnc-plugin-page-sx-list.c:163
+#: gnucash/gnome/gnc-plugin-page-sx-list.c:164
 msgid "Delete the selected scheduled transaction"
 msgstr "刪除選擇的排程交易"
 
-#: gnucash/gnome/gnc-plugin-page-sx-list.c:382
+#: gnucash/gnome/gnc-plugin-page-sx-list.c:441
 #: gnucash/gtkbuilder/dialog-account.glade:554
 msgid "Transactions"
 msgstr "交易"
 
-#: gnucash/gnome/gnc-plugin-page-sx-list.c:442
+#: gnucash/gnome/gnc-plugin-page-sx-list.c:507
 msgid "Upcoming Transactions"
 msgstr "接下來的交易"
 
-#: gnucash/gnome/gnc-plugin-page-sx-list.c:797
+#. Translators: This is a ngettext(3) message, %d is the number of scheduled transactions deleted
+#: gnucash/gnome/gnc-plugin-page-sx-list.c:871
+#, c-format
 msgid "Do you really want to delete this scheduled transaction?"
-msgstr "您確定要刪除這個排程交易？"
+msgid_plural "Do you really want to delete %d scheduled transactions?"
+msgstr[0] "您確定要刪除這個排程交易？"
+msgstr[1] "您確定要刪除 %d 個排程交易？"
 
 #: gnucash/gnome/gnc-plugin-register2.c:57
 #: gnucash/gnome/gnc-plugin-register.c:58
@@ -6069,7 +6116,9 @@ msgid ""
 "The register displayed is for Account Payable or Account Receivable. "
 "Changing the entries may cause harm, please use the business options to "
 "change the entries."
-msgstr "此登錄簿中顯示的是應收帳款或應付帳款。更改這些分錄可能會造成問題，請使用商務功能來更改這些分錄。"
+msgstr ""
+"此登錄簿中顯示的是應收帳款或應付帳款。更改這些分錄可能會造成問題，請使用商務"
+"功能來更改這些分錄。"
 
 #: gnucash/gnome/gnc-split-reg2.c:937 gnucash/gnome/gnc-split-reg.c:2447
 msgid "This account register is read-only."
@@ -6113,16 +6162,16 @@ msgid "Statement Date"
 msgstr "結帳日期"
 
 #: gnucash/gnome/gnc-split-reg.c:711 gnucash/report/reports/aging.scm:361
-#: gnucash/report/reports/standard/customer-summary.scm:144
-#: gnucash/report/reports/standard/new-aging.scm:110
-#: gnucash/report/trep-engine.scm:441
+#: gnucash/report/reports/standard/customer-summary.scm:129
+#: gnucash/report/reports/standard/new-aging.scm:104
+#: gnucash/report/trep-engine.scm:403
 msgid "Descending"
 msgstr "遞減"
 
 #: gnucash/gnome/gnc-split-reg.c:713 gnucash/report/reports/aging.scm:360
-#: gnucash/report/reports/standard/customer-summary.scm:141
-#: gnucash/report/reports/standard/new-aging.scm:109
-#: gnucash/report/trep-engine.scm:438
+#: gnucash/report/reports/standard/customer-summary.scm:128
+#: gnucash/report/reports/standard/new-aging.scm:103
+#: gnucash/report/trep-engine.scm:401
 msgid "Ascending"
 msgstr "遞增"
 
@@ -6139,7 +6188,8 @@ msgstr "將分割 '%s' 從交易 '%s' 中剪下？"
 msgid ""
 "You would be removing a reconciled split! This is not a good idea as it will "
 "cause your reconciled balance to be off."
-msgstr "您將會移除已對帳的分割！這並不是一個好主意，因為那會使您已對帳的結餘不平衡。"
+msgstr ""
+"您將會移除已對帳的分割！這並不是一個好主意，因為那會使您已對帳的結餘不平衡。"
 
 #: gnucash/gnome/gnc-split-reg.c:917
 msgid "You cannot cut this split."
@@ -6152,8 +6202,9 @@ msgid ""
 "from this window, or you may navigate to a register that shows another side "
 "of this same transaction and remove the split from that register."
 msgstr ""
-"這是將此交易錨定到這個登記簿的分割，您不可以在這個登記簿視窗中移除它。但您可以在這個視窗中移除整筆交易，或移動到顯示此交易另一側的登記簿，並從那個登記簿裡"
-"移除這個分割。"
+"這是將此交易錨定到這個登記簿的分割，您不可以在這個登記簿視窗中移除它。但您可"
+"以在這個視窗中移除整筆交易，或移動到顯示此交易另一側的登記簿，並從那個登記簿"
+"裡移除這個分割。"
 
 #: gnucash/gnome/gnc-split-reg.c:948 gnucash/gnome/gnc-split-reg.c:1476
 #: gnucash/gnome-utils/gnc-tree-control-split-reg.c:996
@@ -6177,7 +6228,9 @@ msgstr "剪下目前的交易？"
 msgid ""
 "You would be removing a transaction with reconciled splits! This is not a "
 "good idea as it will cause your reconciled balance to be off."
-msgstr "您將會移除包含已對帳的分割的交易！這並不是一個好主意，因為那會使您已對帳的結餘不平衡。"
+msgstr ""
+"您將會移除包含已對帳的分割的交易！這並不是一個好主意，因為那會使您已對帳的結"
+"餘不平衡。"
 
 #: gnucash/gnome/gnc-split-reg.c:1014
 msgid "_Cut Transaction"
@@ -6193,7 +6246,9 @@ msgstr "無法修改或刪除這個交易。"
 msgid ""
 "The date of this transaction is older than the \"Read-Only Threshold\" set "
 "for this book. This setting can be changed in File->Properties->Accounts."
-msgstr "此筆交易的日期，超過了帳簿設定的「交易唯讀日期門檻」。這個設定可以從「檔案->內容->科目」中變更。"
+msgstr ""
+"此筆交易的日期，超過了帳簿設定的「交易唯讀日期門檻」。這個設定可以從「檔案->"
+"內容->科目」中變更。"
 
 #: gnucash/gnome/gnc-split-reg.c:1208
 #: gnucash/gnome-utils/gnc-tree-control-split-reg.c:840
@@ -6246,8 +6301,9 @@ msgid ""
 "from this window, or you may navigate to a register that shows another side "
 "of this same transaction and delete the split from that register."
 msgstr ""
-"這是將此交易錨定到這個登記簿的分割，您不可以在這個登記簿視窗中刪除它。但您可以在這個視窗中刪除整筆交易，或移動到顯示此交易另一側的登記簿，並從那個登記簿裡"
-"刪除這個分割。"
+"這是將此交易錨定到這個登記簿的分割，您不可以在這個登記簿視窗中刪除它。但您可"
+"以在這個視窗中刪除整筆交易，或移動到顯示此交易另一側的登記簿，並從那個登記簿"
+"裡刪除這個分割。"
 
 #: gnucash/gnome/gnc-split-reg.c:1520
 #: gnucash/gnome-utils/gnc-tree-control-split-reg.c:1040
@@ -6309,7 +6365,8 @@ msgid ""
 "You may also open an individual account instead of a set of accounts."
 msgstr ""
 "選擇的子科目中有不能編輯交易的子科目。\n"
-"如果您要編輯這個登記簿的交易，請開啟子科目選項並且關閉佔位符號核取方塊。您也可以開啟個別的科目而不是一次開啟一組科目。"
+"如果您要編輯這個登記簿的交易，請開啟子科目選項並且關閉佔位符號核取方塊。您也"
+"可以開啟個別的科目而不是一次開啟一組科目。"
 
 #: gnucash/gnome/gnucash.appdata.xml.in.in:5
 #: gnucash/gnome/gnucash.desktop.in.in:6
@@ -6334,8 +6391,9 @@ msgid ""
 "principles like double-entry accounting to ensure balanced books and "
 "accurate reports."
 msgstr ""
-"設計成簡單易用，但又強大並具有彈性。GnuCash "
-"可以讓您追蹤銀行帳戶、股票、收入和開支。雖然和記帳簿一樣直覺和快速，但它使用了專業的會計原則，像是複式計帳，以確保帳簿平衡，以及精確的報表。"
+"設計成簡單易用，但又強大並具有彈性。GnuCash 可以讓您追蹤銀行帳戶、股票、收入"
+"和開支。雖然和記帳簿一樣直覺和快速，但它使用了專業的會計原則，像是複式計帳，"
+"以確保帳簿平衡，以及精確的報表。"
 
 #: gnucash/gnome/gnucash.appdata.xml.in.in:15
 msgid "With GnuCash you can (but are not limited to):"
@@ -6365,7 +6423,9 @@ msgstr "設定排程交易來避免重覆輸入資料"
 msgid ""
 "Exchange by CSV/FinTS(former HBCI) or import SWIFT-MT9xx/QIF/OFX data "
 "including Transaction Matching"
-msgstr "以 CSV/TinTS (前 HBCI) 交換資料，或從 SWIFT-MT9xx/QIF/OFX 匯入資料，並包括交易配對"
+msgstr ""
+"以 CSV/TinTS (前 HBCI) 交換資料，或從 SWIFT-MT9xx/QIF/OFX 匯入資料，並包括交"
+"易配對"
 
 #: gnucash/gnome/gnucash.appdata.xml.in.in:23
 msgid "Perform financial calculations, such as a loan repayment"
@@ -6558,7 +6618,7 @@ msgstr "科目(_A)"
 #: gnucash/gnome/window-reconcile2.c:2104
 #: gnucash/gnome/window-reconcile2.c:2185 gnucash/gnome/window-reconcile.c:2325
 #: gnucash/gnome/window-reconcile.c:2406
-#: gnucash/gnome-utils/gnc-main-window.c:281
+#: gnucash/gnome-utils/gnc-main-window.c:282
 #: gnucash/gtkbuilder/dialog-account.glade:1119
 #: gnucash/gtkbuilder/dialog-bi-import-gui.glade:23
 #: gnucash/gtkbuilder/dialog-book-close.glade:22
@@ -6576,7 +6636,7 @@ msgstr "科目(_A)"
 #: gnucash/gtkbuilder/dialog-preferences.glade:258
 #: gnucash/gtkbuilder/dialog-print-check.glade:316
 #: gnucash/gtkbuilder/dialog-search.glade:21
-#: gnucash/gtkbuilder/dialog-sx.glade:763
+#: gnucash/gtkbuilder/dialog-sx.glade:780
 #: gnucash/gtkbuilder/dialog-vendor.glade:47
 #: gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp:2073
 msgid "_Help"
@@ -6628,7 +6688,7 @@ msgid "Edit the main account for this register"
 msgstr "編輯此登記簿的主科目"
 
 #: gnucash/gnome/window-reconcile2.c:2148 gnucash/gnome/window-reconcile.c:2369
-#: gnucash/gnome-utils/gnc-main-window.c:356
+#: gnucash/gnome-utils/gnc-main-window.c:357
 msgid "_Check & Repair"
 msgstr "檢查&修復(_C)"
 
@@ -6689,7 +6749,8 @@ msgstr[1] "您選則的結帳日期，比今天的日期晚 %d 天。"
 msgid ""
 "This may cause issues for future reconciliation actions on this account. "
 "Please double-check this is the date you intended."
-msgstr "這可能會造成未來對帳此科目時有問題，請再次確認這個日期是您想選擇的日期。"
+msgstr ""
+"這可能會造成未來對帳此科目時有問題，請再次確認這個日期是您想選擇的日期。"
 
 #: gnucash/gnome/window-reconcile.c:1852
 msgid ""
@@ -6703,13 +6764,15 @@ msgid ""
 "statement date. These splits may make reconciliation difficult. If this is "
 "the case, you may use Find Transactions to find them, unreconcile, and re-"
 "reconcile."
-msgstr "此科目含有對帳日期比結帳日期晚的分割，這些分割可能會造成對帳的困難。如果是這樣，您可以使用「尋找交易」來找到他們，取消對帳並重新對帳。"
+msgstr ""
+"此科目含有對帳日期比結帳日期晚的分割，這些分割可能會造成對帳的困難。如果是這"
+"樣，您可以使用「尋找交易」來找到他們，取消對帳並重新對帳。"
 
-#: gnucash/gnome/window-report.c:115
+#: gnucash/gnome/window-report.c:112
 msgid "Set the report options you want using this dialog."
 msgstr "使用這個對話盒設定您想要的報表選項。"
 
-#: gnucash/gnome/window-report.c:232
+#: gnucash/gnome/window-report.c:229
 msgid "There are no options for this report."
 msgstr "這個報表沒有可用的選項。"
 
@@ -6953,12 +7016,15 @@ msgid ""
 "file.\n"
 msgstr ""
 "\n"
-"您嘗試讀取的檔案是來自較舊版本的 "
-"GnuCash。較舊版本的檔案格式沒有關於所使用的字元編碼的詳細資訊，這代表了檔案裡的文字可能會有多種不同的解讀方式。這種不確定性沒有辦法自動解決，但 "
-"GnuCash 2.0 的檔案格式，包含了所有需要的字元編碼的資訊，所以您不用再重新經歷這個步驟。\n"
+"您嘗試讀取的檔案是來自較舊版本的 GnuCash。較舊版本的檔案格式沒有關於所使用的"
+"字元編碼的詳細資訊，這代表了檔案裡的文字可能會有多種不同的解讀方式。這種不確"
+"定性沒有辦法自動解決，但 GnuCash 2.0 的檔案格式，包含了所有需要的字元編碼的資"
+"訊，所以您不用再重新經歷這個步驟。\n"
 "\n"
-"GnuCash 會試著去猜測您的檔案裡的字元編碼。在下一頁裡，GnuCash 會顯示出我們猜測出的文字，您必須檢查這些文字看起來對不對。如果一切看起來正常"
-"，您可以直接按下「下一步」。如果他包含了亂碼，那您應該選擇不同的字元編碼，並看看結果如何。您可以透過點選相對應的按鈕，來編輯字元編輯列表。\n"
+"GnuCash 會試著去猜測您的檔案裡的字元編碼。在下一頁裡，GnuCash 會顯示出我們猜"
+"測出的文字，您必須檢查這些文字看起來對不對。如果一切看起來正常，您可以直接按"
+"下「下一步」。如果他包含了亂碼，那您應該選擇不同的字元編碼，並看看結果如何。"
+"您可以透過點選相對應的按鈕，來編輯字元編輯列表。\n"
 "\n"
 "現在請按下「下一步」，並為您的檔案選擇正確的字元編碼。\n"
 
@@ -6974,7 +7040,8 @@ msgid ""
 "\n"
 "You can also go back and verify your selections by clicking on \"Back\"."
 msgstr ""
-"此檔案已被成功讀取。如果您按下「套用」，他將會被儲存並且重新讀取到主程式中。透過這個方式，您也會在同個資料夾中有可以正常使用的備份檔案。\n"
+"此檔案已被成功讀取。如果您按下「套用」，他將會被儲存並且重新讀取到主程式中。"
+"透過這個方式，您也會在同個資料夾中有可以正常使用的備份檔案。\n"
 "\n"
 "\n"
 "您也可以按下「返回」回到上一個步驟，再次確認您的選擇。"
@@ -7192,27 +7259,29 @@ msgstr "(%d) 新科目"
 msgid "New Account"
 msgstr "新增科目"
 
-#: gnucash/gnome-utils/dialog-account.c:2180
+#: gnucash/gnome-utils/dialog-account.c:2181
 #, c-format
 msgid ""
 "Renumber the immediate sub-accounts of %s? This will replace the account "
 "code field of each child account with a newly generated code."
-msgstr "重新編碼 %s 科目的下一層子科目？這會將子科目的科目代碼，一個一個改成新生成的代碼。"
+msgstr ""
+"重新編碼 %s 科目的下一層子科目？這會將子科目的科目代碼，一個一個改成新生成的"
+"代碼。"
 
-#: gnucash/gnome-utils/dialog-account.c:2285
+#: gnucash/gnome-utils/dialog-account.c:2286
 #, c-format
 msgid ""
 "Set the account color for account '%s' including all sub-accounts to the "
 "selected color"
 msgstr "設定包含「%s」此科目以及其下所有子科目的顏色，到所選擇的顏色"
 
-#: gnucash/gnome-utils/dialog-account.c:2312
+#: gnucash/gnome-utils/dialog-account.c:2313
 #, c-format
 msgid ""
 "Set the account placeholder value for account '%s' including all sub-accounts"
 msgstr "設定包含「%s」及其所有子科目是否為佔位符號的設定"
 
-#: gnucash/gnome-utils/dialog-account.c:2326
+#: gnucash/gnome-utils/dialog-account.c:2327
 #, c-format
 msgid ""
 "Set the account hidden value for account '%s' including all sub-accounts"
@@ -7291,15 +7360,15 @@ msgid "Cu_rrency"
 msgstr "貨幣(_R)"
 
 #: gnucash/gnome-utils/dialog-commodity.c:760
-#: gnucash/gnome-utils/dialog-options.c:720
+#: gnucash/gnome-utils/dialog-options.c:717
 #: gnucash/gnome-utils/gnc-tree-view-owner.c:412
 #: gnucash/gnome-utils/gnc-tree-view-price.c:402
 #: gnucash/gtkbuilder/dialog-customer.glade:511
 #: gnucash/gtkbuilder/dialog-employee.glade:610
+#: gnucash/gtkbuilder/dialog-transfer.glade:415
 #: gnucash/gtkbuilder/dialog-transfer.glade:428
-#: gnucash/gtkbuilder/dialog-transfer.glade:441
 #: gnucash/gtkbuilder/dialog-vendor.glade:507
-#: gnucash/report/trep-engine.scm:101 libgnucash/engine/Account.cpp:4394
+#: gnucash/report/trep-engine.scm:101 libgnucash/engine/Account.cpp:4400
 msgid "Currency"
 msgstr "貨幣"
 
@@ -7394,8 +7463,8 @@ msgstr "另存新檔..."
 msgid "_Save As"
 msgstr "另存新檔(_S)"
 
-#: gnucash/gnome-utils/dialog-options.c:226
-#: gnucash/gnome-utils/gnc-main-window.c:305
+#: gnucash/gnome-utils/dialog-options.c:225
+#: gnucash/gnome-utils/gnc-main-window.c:306
 #: gnucash/gtkbuilder/dialog-billterms.glade:731
 #: gnucash/gtkbuilder/dialog-commodities.glade:174
 #: gnucash/gtkbuilder/dialog-custom-report.glade:45
@@ -7420,24 +7489,26 @@ msgstr "另存新檔(_S)"
 msgid "_Close"
 msgstr "關閉(_C)"
 
-#: gnucash/gnome-utils/dialog-options.c:660
+#: gnucash/gnome-utils/dialog-options.c:657
 msgid ""
 "Because no accounts have been set up yet, you will need to return to this "
 "dialog (via File->Properties), after account setup, if you want to set a "
 "default gain/loss account."
-msgstr "由於目前您並未設定任何科目，如果您想要設定預設的獲利/虧損科目，需要在設定好科目後，重新回到這個對話盒。(透過檔案->內容選單)"
+msgstr ""
+"由於目前您並未設定任何科目，如果您想要設定預設的獲利/虧損科目，需要在設定好科"
+"目後，重新回到這個對話盒。(透過檔案->內容選單)"
 
-#: gnucash/gnome-utils/dialog-options.c:704
+#: gnucash/gnome-utils/dialog-options.c:701
 msgid "Select no account"
 msgstr "未選擇科目"
 
-#: gnucash/gnome-utils/dialog-options.c:737
+#: gnucash/gnome-utils/dialog-options.c:734
 #: gnucash/gnome-utils/gnc-tree-view-account.c:989
 msgctxt "Column header for 'Placeholder'"
 msgid "P"
 msgstr "佔位"
 
-#: gnucash/gnome-utils/dialog-options.c:804
+#: gnucash/gnome-utils/dialog-options.c:801
 msgid ""
 "There are no income or expense accounts of the specified\n"
 "book currency; you will have to return to this dialog\n"
@@ -7448,7 +7519,7 @@ msgstr ""
 "您需要在設定好科目後，重新回到這個對話盒(透過檔案->內容)，\n"
 "來選擇預設的獲利/虧損科目。"
 
-#: gnucash/gnome-utils/dialog-options.c:872
+#: gnucash/gnome-utils/dialog-options.c:869
 #: gnucash/import-export/qif-imp/dialog-account-picker.c:299
 #, c-format
 msgid ""
@@ -7456,86 +7527,86 @@ msgid ""
 "Please choose a different account."
 msgstr "科目 %s 是佔位符號並且不允許交易。請選擇另一個科目。"
 
-#: gnucash/gnome-utils/dialog-options.c:1299
+#: gnucash/gnome-utils/dialog-options.c:1278
 msgid "Book currency"
 msgstr "帳簿貨幣"
 
-#: gnucash/gnome-utils/dialog-options.c:1324
+#: gnucash/gnome-utils/dialog-options.c:1303
 msgid "Default lot tracking policy"
 msgstr "預設的分堆追踨策略"
 
-#: gnucash/gnome-utils/dialog-options.c:1347
+#: gnucash/gnome-utils/dialog-options.c:1326
 msgid "Default gain/loss account"
 msgstr "預設獲利 / 虧損科目"
 
-#: gnucash/gnome-utils/dialog-options.c:1513
-#: gnucash/gnome-utils/dialog-options.c:1657
+#: gnucash/gnome-utils/dialog-options.c:1492
+#: gnucash/gnome-utils/dialog-options.c:1636
 msgid "Select All"
 msgstr "選擇全部"
 
-#: gnucash/gnome-utils/dialog-options.c:1515
+#: gnucash/gnome-utils/dialog-options.c:1494
 msgid "Select all accounts."
 msgstr "選擇所有科目。"
 
-#: gnucash/gnome-utils/dialog-options.c:1520
-#: gnucash/gnome-utils/dialog-options.c:1664
+#: gnucash/gnome-utils/dialog-options.c:1499
+#: gnucash/gnome-utils/dialog-options.c:1643
 msgid "Clear All"
 msgstr "清除全部"
 
-#: gnucash/gnome-utils/dialog-options.c:1522
+#: gnucash/gnome-utils/dialog-options.c:1501
 msgid "Clear the selection and unselect all accounts."
 msgstr "清除選擇並取消選擇所有的科目。"
 
-#: gnucash/gnome-utils/dialog-options.c:1527
+#: gnucash/gnome-utils/dialog-options.c:1506
 msgid "Select Children"
 msgstr "選擇子科目"
 
-#: gnucash/gnome-utils/dialog-options.c:1529
+#: gnucash/gnome-utils/dialog-options.c:1508
 msgid "Select all descendents of selected account."
 msgstr "選擇選定科目的所有子科目。"
 
-#: gnucash/gnome-utils/dialog-options.c:1535
-#: gnucash/gnome-utils/dialog-options.c:1671
+#: gnucash/gnome-utils/dialog-options.c:1514
+#: gnucash/gnome-utils/dialog-options.c:1650
 msgid "Select Default"
 msgstr "選擇預設值"
 
-#: gnucash/gnome-utils/dialog-options.c:1537
+#: gnucash/gnome-utils/dialog-options.c:1516
 msgid "Select the default account selection."
 msgstr "選擇預設的科目選擇。"
 
-#: gnucash/gnome-utils/dialog-options.c:1554
+#: gnucash/gnome-utils/dialog-options.c:1533
 msgid "Show Hidden Accounts"
 msgstr "顯示隱藏的科目"
 
-#: gnucash/gnome-utils/dialog-options.c:1556
+#: gnucash/gnome-utils/dialog-options.c:1535
 msgid "Show accounts that have been marked hidden."
 msgstr "顯示被標記為隱藏的科目。"
 
-#: gnucash/gnome-utils/dialog-options.c:1659
+#: gnucash/gnome-utils/dialog-options.c:1638
 msgid "Select all entries."
 msgstr "選擇所有的項目。"
 
-#: gnucash/gnome-utils/dialog-options.c:1666
+#: gnucash/gnome-utils/dialog-options.c:1645
 msgid "Clear the selection and unselect all entries."
 msgstr "清除現在的選擇，並且取消選取所有的相目。"
 
-#: gnucash/gnome-utils/dialog-options.c:1673
+#: gnucash/gnome-utils/dialog-options.c:1652
 msgid "Select the default selection."
 msgstr "採用預設的選擇。"
 
-#: gnucash/gnome-utils/dialog-options.c:1867
+#: gnucash/gnome-utils/dialog-options.c:1846
 msgid "Reset defaults"
 msgstr "全設回預設值"
 
-#: gnucash/gnome-utils/dialog-options.c:1869
+#: gnucash/gnome-utils/dialog-options.c:1848
 msgid "Reset all values to their defaults."
 msgstr "所有值重設回預設狀態。"
 
-#: gnucash/gnome-utils/dialog-options.c:2270
+#: gnucash/gnome-utils/dialog-options.c:2249
 msgid "Page"
 msgstr "頁"
 
-#: gnucash/gnome-utils/dialog-options.c:2897
+#: gnucash/gnome-utils/dialog-options.c:2876
 #: gnucash/gnome-utils/dialog-preferences.c:1465
 #: gnucash/gtkbuilder/dialog-fincalc.glade:254
 #: gnucash/gtkbuilder/dialog-fincalc.glade:269
@@ -7545,23 +7616,23 @@ msgstr "頁"
 msgid "Clear"
 msgstr "清除"
 
-#: gnucash/gnome-utils/dialog-options.c:2898
+#: gnucash/gnome-utils/dialog-options.c:2877
 msgid "Clear any selected image file."
 msgstr "清除已選的圖片檔。"
 
-#: gnucash/gnome-utils/dialog-options.c:2900
+#: gnucash/gnome-utils/dialog-options.c:2879
 msgid "Select image"
 msgstr "選擇圖片"
 
-#: gnucash/gnome-utils/dialog-options.c:2902
+#: gnucash/gnome-utils/dialog-options.c:2881
 msgid "Select an image file."
 msgstr "選擇圖片檔案。"
 
-#: gnucash/gnome-utils/dialog-options.c:3082
+#: gnucash/gnome-utils/dialog-options.c:3061
 msgid "Pixels"
 msgstr "像素"
 
-#: gnucash/gnome-utils/dialog-options.c:3088
+#: gnucash/gnome-utils/dialog-options.c:3067
 msgid "Percent"
 msgstr "百分比"
 
@@ -7643,7 +7714,7 @@ msgid "Show the income and expense accounts"
 msgstr "顯示收入與支出科目"
 
 #: gnucash/gnome-utils/dialog-transfer.c:703
-#: gnucash/report/trep-engine.scm:2163 gnucash/report/trep-engine.scm:2169
+#: gnucash/report/trep-engine.scm:2108 gnucash/report/trep-engine.scm:2114
 msgid "Error"
 msgstr "錯誤"
 
@@ -7670,7 +7741,7 @@ msgstr "轉帳的來源與目的不能為同一個科目！"
 #: gnucash/gnome-utils/dialog-transfer.c:1448
 #: gnucash/gnome-utils/gnc-tree-control-split-reg.c:1958
 #: gnucash/register/ledger-core/gncEntryLedger.c:85
-#: gnucash/register/ledger-core/split-register.c:1977
+#: gnucash/register/ledger-core/split-register.c:1979
 #, c-format
 msgid "The account %s does not allow transactions."
 msgstr "此科目 %s 不接受交易。"
@@ -7705,12 +7776,12 @@ msgid "Debit Account"
 msgstr "借方科目"
 
 #: gnucash/gnome-utils/dialog-transfer.c:1990
-#: gnucash/gtkbuilder/dialog-transfer.glade:283
+#: gnucash/gtkbuilder/dialog-transfer.glade:270
 msgid "Transfer From"
 msgstr "轉帳自"
 
 #: gnucash/gnome-utils/dialog-transfer.c:1994
-#: gnucash/gtkbuilder/dialog-transfer.glade:344
+#: gnucash/gtkbuilder/dialog-transfer.glade:331
 msgid "Transfer To"
 msgstr "轉帳到"
 
@@ -7719,7 +7790,7 @@ msgid "Debit Amount"
 msgstr "借方金額"
 
 #: gnucash/gnome-utils/dialog-transfer.c:2056
-#: gnucash/gtkbuilder/dialog-transfer.glade:568
+#: gnucash/gtkbuilder/dialog-transfer.glade:555
 msgid "To Amount"
 msgstr "金額"
 
@@ -7778,15 +7849,19 @@ msgid_plural ""
 "\n"
 "Should your file be saved automatically?"
 msgstr[0] ""
-"您的資料檔案必須存檔到硬碟上以儲存您的變更。GnuCash 有每 %d 分鐘自動存檔的功能，就如同您每次按下「儲存檔案」按鈕一樣。\n"
+"您的資料檔案必須存檔到硬碟上以儲存您的變更。GnuCash 有每 %d 分鐘自動存檔的功"
+"能，就如同您每次按下「儲存檔案」按鈕一樣。\n"
 "\n"
-"您可以透過「編輯->偏好設定->一般->自動存檔時間間隔」，來更改自動存檔的間隔或關閉這個功能。\n"
+"您可以透過「編輯->偏好設定->一般->自動存檔時間間隔」，來更改自動存檔的間隔或"
+"關閉這個功能。\n"
 "\n"
 "要幫您的自動儲存您的檔案嗎？"
 msgstr[1] ""
-"您的資料檔案必須存檔到硬碟上以儲存您的變更。GnuCash 有每 %d 分鐘自動存檔的功能，就如同您每次按下「儲存檔案」按鈕一樣。\n"
+"您的資料檔案必須存檔到硬碟上以儲存您的變更。GnuCash 有每 %d 分鐘自動存檔的功"
+"能，就如同您每次按下「儲存檔案」按鈕一樣。\n"
 "\n"
-"您可以透過「編輯->偏好設定->一般->自動存檔時間間隔」，來更改自動存檔的間隔或關閉這個功能。\n"
+"您可以透過「編輯->偏好設定->一般->自動存檔時間間隔」，來更改自動存檔的間隔或"
+"關閉這個功能。\n"
 "\n"
 "要幫您的自動儲存您的檔案嗎？"
 
@@ -7818,21 +7893,21 @@ msgid "Use Shift combined with Return or Keypad Enter to finish editing"
 msgstr "使用 Shift 加 Return 鍵，或數字鍵盤上的 Enter 鍵來結束編輯"
 
 #: gnucash/gnome-utils/gnc-date-delta.c:224
-#: gnucash/report/reports/standard/price-scatter.scm:130
+#: gnucash/report/reports/standard/price-scatter.scm:123
 msgid "Weeks"
 msgstr "週"
 
 #: gnucash/gnome-utils/gnc-date-delta.c:226
 #: gnucash/gtkbuilder/assistant-loan.glade:12
 #: gnucash/gtkbuilder/gnc-date-format.glade:169
-#: gnucash/report/reports/standard/price-scatter.scm:132
+#: gnucash/report/reports/standard/price-scatter.scm:125
 msgid "Months"
 msgstr "月"
 
 #: gnucash/gnome-utils/gnc-date-delta.c:228
 #: gnucash/gtkbuilder/assistant-loan.glade:15
 #: gnucash/gtkbuilder/gnc-date-format.glade:181
-#: gnucash/report/reports/standard/price-scatter.scm:135
+#: gnucash/report/reports/standard/price-scatter.scm:128
 msgid "Years"
 msgstr "年"
 
@@ -7877,7 +7952,7 @@ msgid "View"
 msgstr "檢視"
 
 #: gnucash/gnome-utils/gnc-dense-cal.c:335
-#: gnucash/report/stylesheets/footer.scm:383
+#: gnucash/report/stylesheets/footer.scm:377
 msgid "Date: "
 msgstr "日期： "
 
@@ -7886,7 +7961,7 @@ msgstr "日期： "
 #: gnucash/gtkbuilder/dialog-fincalc.glade:741
 #: gnucash/gtkbuilder/dialog-fincalc.glade:754
 #: gnucash/gtkbuilder/dialog-sx.glade:248
-#: gnucash/gtkbuilder/dialog-sx.glade:1378
+#: gnucash/gtkbuilder/dialog-sx.glade:1395
 #: gnucash/gtkbuilder/gnc-frequency.glade:592
 msgid "Frequency"
 msgstr "頻率"
@@ -7895,7 +7970,7 @@ msgstr "頻率"
 msgid "(unnamed)"
 msgstr "(未命名)"
 
-#: gnucash/gnome-utils/gnc-file.c:94 gnucash/gnome-utils/gnc-main-window.c:285
+#: gnucash/gnome-utils/gnc-file.c:94 gnucash/gnome-utils/gnc-main-window.c:286
 #: gnucash/import-export/bi-import/gnc-plugin-bi-import.c:57
 #: gnucash/import-export/customer-import/gnc-plugin-customer-import.c:57
 msgid "_Import"
@@ -7912,7 +7987,7 @@ msgstr "匯入"
 msgid "Save"
 msgstr "儲存檔案"
 
-#: gnucash/gnome-utils/gnc-file.c:106 gnucash/gnome-utils/gnc-main-window.c:286
+#: gnucash/gnome-utils/gnc-file.c:106 gnucash/gnome-utils/gnc-main-window.c:287
 msgid "_Export"
 msgstr "匯出(_E)"
 
@@ -8008,7 +8083,9 @@ msgid ""
 "GnuCash could not write to %s. That database may be on a read-only file "
 "system, you may not have write permission for the directory or your anti-"
 "virus software is preventing this action."
-msgstr "GnuCash 無法寫入 %s。可能是資料庫放在唯讀的檔案系統，或是您沒有該目錄的寫入權限，又或者防毒軟體不允許這個操作。"
+msgstr ""
+"GnuCash 無法寫入 %s。可能是資料庫放在唯讀的檔案系統，或是您沒有該目錄的寫入權"
+"限，又或者防毒軟體不允許這個操作。"
 
 #: gnucash/gnome-utils/gnc-file.c:385
 #, c-format
@@ -8082,7 +8159,8 @@ msgstr "無法產生 %s 的備分檔案"
 msgid ""
 "Could not write to file %s. Check that you have permission to write to this "
 "file and that there is sufficient space to create it."
-msgstr "無法寫入檔案到 %s。請檢查您具有寫入檔案的權限，以及仍有足夠的空間建立檔案。"
+msgstr ""
+"無法寫入檔案到 %s。請檢查您具有寫入檔案的權限，以及仍有足夠的空間建立檔案。"
 
 #: gnucash/gnome-utils/gnc-file.c:473
 #, c-format
@@ -8121,8 +8199,9 @@ msgid ""
 "but cannot safely save to it. It will be marked read-only until you do File-"
 ">Save As, but data may be lost in writing to the old version."
 msgstr ""
-"這個資料庫來自較新版本的 "
-"GnuCash。現在這個版本能夠讀取，但無法安全的寫入。資料庫將被標記為唯讀，直到您執行「檔案->另存新檔」，但資料可能會在寫入成舊的版本時移失。"
+"這個資料庫來自較新版本的 GnuCash。現在這個版本能夠讀取，但無法安全的寫入。資"
+"料庫將被標記為唯讀，直到您執行「檔案->另存新檔」，但資料可能會在寫入成舊的版"
+"本時移失。"
 
 #: gnucash/gnome-utils/gnc-file.c:505
 msgid ""
@@ -8141,9 +8220,10 @@ msgid ""
 "installing a different version of \"libdbi\". Please see https://bugs."
 "gnucash.org/show_bug.cgi?id=611936 for more information."
 msgstr ""
-"在您系統上安裝的 libdbi 函式庫，無法正確儲存天文數字。這表式 GnuCash 無法正確使用 SQL 資料庫。GnuCash "
-"將不會開啟或儲存您的資料庫，直到您透過安裝不同版本的 libdbi 來解決這個問題。請參閱 https://bugs.gnucash.org/"
-"show_bug.cgi?id=611936 以獲得詳情。"
+"在您系統上安裝的 libdbi 函式庫，無法正確儲存天文數字。這表式 GnuCash 無法正確"
+"使用 SQL 資料庫。GnuCash 將不會開啟或儲存您的資料庫，直到您透過安裝不同版本"
+"的 libdbi 來解決這個問題。請參閱 https://bugs.gnucash.org/show_bug.cgi?"
+"id=611936 以獲得詳情。"
 
 #: gnucash/gnome-utils/gnc-file.c:527
 msgid ""
@@ -8152,8 +8232,9 @@ msgid ""
 "your SQL database. Please see https://bugs.gnucash.org/show_bug.cgi?"
 "id=645216 for more information."
 msgstr ""
-"GnuCash 無法完成針對 libdbi 函式庫的 bug 相關的一個關鍵性測試。這有可能是因為您的 SQL 資料庫未設定正確的權限。請參閱 "
-"https://bugs.gnucash.org/show_bug.cgi?id=645216 以獲得詳情。"
+"GnuCash 無法完成針對 libdbi 函式庫的 bug 相關的一個關鍵性測試。這有可能是因為"
+"您的 SQL 資料庫未設定正確的權限。請參閱 https://bugs.gnucash.org/show_bug."
+"cgi?id=645216 以獲得詳情。"
 
 #: gnucash/gnome-utils/gnc-file.c:537
 msgid ""
@@ -8162,8 +8243,9 @@ msgid ""
 "older version of Gnucash (it will report an \"error parsing the file\"). If "
 "you wish to preserve the old version, exit without saving."
 msgstr ""
-"這個檔案是來自較舊版本的 GnuCash，並且會在此版本的 GnuCash 儲存時升級檔案格式。您將無法在舊版的 GnuCash "
-"中載入這個檔案(它會顯示「無法解析檔案」的錯誤訊息)。如果您希望保留舊版的檔案，離開並且不要存檔。"
+"這個檔案是來自較舊版本的 GnuCash，並且會在此版本的 GnuCash 儲存時升級檔案格"
+"式。您將無法在舊版的 GnuCash 中載入這個檔案(它會顯示「無法解析檔案」的錯誤訊"
+"息)。如果您希望保留舊版的檔案，離開並且不要存檔。"
 
 #: gnucash/gnome-utils/gnc-file.c:548
 #, c-format
@@ -8175,7 +8257,7 @@ msgid "Save changes to the file?"
 msgstr "將變更存到檔案中？"
 
 #: gnucash/gnome-utils/gnc-file.c:655
-#: gnucash/gnome-utils/gnc-main-window.c:1302
+#: gnucash/gnome-utils/gnc-main-window.c:1303
 #, c-format
 msgid "If you don't save, changes from the past %d minute will be discarded."
 msgid_plural ""
@@ -8206,7 +8288,8 @@ msgid ""
 "action. If you proceed you may not be able to save any changes. What would "
 "you like to do?"
 msgstr ""
-"這個資料庫可能放在唯讀的檔案系統，或是您沒有該目錄的寫入權限，或是您的防毒軟體阻檔了這個動作。您若繼續操作，可能會無法存下任何資料修改。您想要怎麼做？"
+"這個資料庫可能放在唯讀的檔案系統，或是您沒有該目錄的寫入權限，或是您的防毒軟"
+"體阻檔了這個動作。您若繼續操作，可能會無法存下任何資料修改。您想要怎麼做？"
 
 #: gnucash/gnome-utils/gnc-file.c:849
 #: gnucash/gtkbuilder/dialog-file-access.glade:98
@@ -8225,7 +8308,7 @@ msgstr "無論如何都開啟(_A)"
 msgid "Open _Folder"
 msgstr "打開資料夾(_F)"
 
-#: gnucash/gnome-utils/gnc-file.c:864 gnucash/gnome-utils/gnc-main-window.c:310
+#: gnucash/gnome-utils/gnc-file.c:864 gnucash/gnome-utils/gnc-main-window.c:311
 msgid "_Quit"
 msgstr "離開(_Q)"
 
@@ -8266,7 +8349,7 @@ msgid ""
 msgstr "還原會讓所有 %s 未儲存的變更遺失。您確定要繼續嗎？"
 
 #: gnucash/gnome-utils/gnc-file.c:1699
-#: gnucash/gnome-utils/gnc-main-window.c:1270
+#: gnucash/gnome-utils/gnc-main-window.c:1271
 msgid "<unknown>"
 msgstr "<未知>"
 
@@ -8305,289 +8388,289 @@ msgstr "GnuCash 無法打開連結的文件："
 msgid "Enter a user name and password to connect to: %s"
 msgstr "輸入使用者名稱與密碼以連接：%s"
 
-#: gnucash/gnome-utils/gnc-main-window.c:131
+#: gnucash/gnome-utils/gnc-main-window.c:132
 #, c-format
 msgid "Changes will be saved automatically in %u seconds"
 msgstr "變更將會在 %u 秒內自動儲存"
 
-#: gnucash/gnome-utils/gnc-main-window.c:272
+#: gnucash/gnome-utils/gnc-main-window.c:273
 msgid "_File"
 msgstr "檔案(_F)"
 
-#: gnucash/gnome-utils/gnc-main-window.c:276
+#: gnucash/gnome-utils/gnc-main-window.c:277
 msgid "Tra_nsaction"
 msgstr "交易(_N)"
 
-#: gnucash/gnome-utils/gnc-main-window.c:277
+#: gnucash/gnome-utils/gnc-main-window.c:278
 msgid "_Reports"
 msgstr "報表(_R)"
 
-#: gnucash/gnome-utils/gnc-main-window.c:278
+#: gnucash/gnome-utils/gnc-main-window.c:279
 msgid "_Tools"
 msgstr "工具(_T)"
 
-#: gnucash/gnome-utils/gnc-main-window.c:279
+#: gnucash/gnome-utils/gnc-main-window.c:280
 msgid "E_xtensions"
 msgstr "延伸(_X)"
 
-#: gnucash/gnome-utils/gnc-main-window.c:280
+#: gnucash/gnome-utils/gnc-main-window.c:281
 msgid "_Windows"
 msgstr "視窗(_W)"
 
-#: gnucash/gnome-utils/gnc-main-window.c:288
+#: gnucash/gnome-utils/gnc-main-window.c:289
 msgid "_Print..."
 msgstr "列印(_P)..."
 
-#: gnucash/gnome-utils/gnc-main-window.c:289
+#: gnucash/gnome-utils/gnc-main-window.c:290
 msgid "Print the currently active page"
 msgstr "列印目前的頁面"
 
-#: gnucash/gnome-utils/gnc-main-window.c:295
+#: gnucash/gnome-utils/gnc-main-window.c:296
 msgid "Pa_ge Setup..."
 msgstr "設定列印格式(_G)..."
 
-#: gnucash/gnome-utils/gnc-main-window.c:296
+#: gnucash/gnome-utils/gnc-main-window.c:297
 msgid "Specify the page size and orientation for printing"
 msgstr "指定列印的紙張大小及方向"
 
-#: gnucash/gnome-utils/gnc-main-window.c:300
+#: gnucash/gnome-utils/gnc-main-window.c:301
 msgid "Proper_ties"
 msgstr "內容(_T)"
 
-#: gnucash/gnome-utils/gnc-main-window.c:301
+#: gnucash/gnome-utils/gnc-main-window.c:302
 msgid "Edit the properties of the current file"
 msgstr "檢視並編輯這個檔案的內容"
 
-#: gnucash/gnome-utils/gnc-main-window.c:306
+#: gnucash/gnome-utils/gnc-main-window.c:307
 msgid "Close the currently active page"
 msgstr "關閉本分頁"
 
-#: gnucash/gnome-utils/gnc-main-window.c:311
+#: gnucash/gnome-utils/gnc-main-window.c:312
 msgid "Quit this application"
 msgstr "離開本程式"
 
-#: gnucash/gnome-utils/gnc-main-window.c:333
+#: gnucash/gnome-utils/gnc-main-window.c:334
 msgid "Pr_eferences"
 msgstr "偏好設定(_E)"
 
-#: gnucash/gnome-utils/gnc-main-window.c:334
+#: gnucash/gnome-utils/gnc-main-window.c:335
 msgid "Edit the global preferences of GnuCash"
 msgstr "編輯 GnuCash 的全域偏好設定"
 
-#: gnucash/gnome-utils/gnc-main-window.c:342
+#: gnucash/gnome-utils/gnc-main-window.c:343
 msgid "Select sorting criteria for this page view"
 msgstr "設定此頁面的排序依據"
 
-#: gnucash/gnome-utils/gnc-main-window.c:346
+#: gnucash/gnome-utils/gnc-main-window.c:347
 msgid "Select the account types that should be displayed."
 msgstr "選擇要顯示的科目類型。"
 
-#: gnucash/gnome-utils/gnc-main-window.c:358
+#: gnucash/gnome-utils/gnc-main-window.c:359
 msgid "Reset _Warnings..."
 msgstr "重設警告訊息(_W)..."
 
-#: gnucash/gnome-utils/gnc-main-window.c:359
+#: gnucash/gnome-utils/gnc-main-window.c:360
 msgid "Reset the state of all warning messages so they will be shown again."
 msgstr "重設所有警告訊息的狀態，使訊息能再次出現。"
 
-#: gnucash/gnome-utils/gnc-main-window.c:363
+#: gnucash/gnome-utils/gnc-main-window.c:364
 msgid "Re_name Page"
 msgstr "重新命名本頁 (_N)"
 
-#: gnucash/gnome-utils/gnc-main-window.c:364
+#: gnucash/gnome-utils/gnc-main-window.c:365
 msgid "Rename this page."
 msgstr "重新命名本頁。"
 
-#: gnucash/gnome-utils/gnc-main-window.c:371
+#: gnucash/gnome-utils/gnc-main-window.c:372
 msgid "_New Window"
 msgstr "開新視窗(_N)"
 
-#: gnucash/gnome-utils/gnc-main-window.c:372
+#: gnucash/gnome-utils/gnc-main-window.c:373
 msgid "Open a new top-level GnuCash window."
 msgstr "開啟新的 GnuCash 視窗。"
 
-#: gnucash/gnome-utils/gnc-main-window.c:376
+#: gnucash/gnome-utils/gnc-main-window.c:377
 msgid "New Window with _Page"
 msgstr "將本頁開啟於新視窗中(_P)"
 
-#: gnucash/gnome-utils/gnc-main-window.c:377
+#: gnucash/gnome-utils/gnc-main-window.c:378
 msgid "Move the current page to a new top-level GnuCash window."
 msgstr "將本頁移到新開的 GnuCash 視窗。"
 
-#: gnucash/gnome-utils/gnc-main-window.c:384
+#: gnucash/gnome-utils/gnc-main-window.c:385
 msgid "Tutorial and Concepts _Guide"
 msgstr "教學與觀念指南(_G)"
 
-#: gnucash/gnome-utils/gnc-main-window.c:385
+#: gnucash/gnome-utils/gnc-main-window.c:386
 msgid "Open the GnuCash Tutorial"
 msgstr "開啟 GnuCash 教學手冊"
 
-#: gnucash/gnome-utils/gnc-main-window.c:389
+#: gnucash/gnome-utils/gnc-main-window.c:390
 msgid "_Contents"
 msgstr "內容(_C)"
 
-#: gnucash/gnome-utils/gnc-main-window.c:390
+#: gnucash/gnome-utils/gnc-main-window.c:391
 msgid "Open the GnuCash Help"
 msgstr "開啟 GnuCash 說明"
 
-#: gnucash/gnome-utils/gnc-main-window.c:394
+#: gnucash/gnome-utils/gnc-main-window.c:395
 msgid "_About"
 msgstr "關於(_A)"
 
-#: gnucash/gnome-utils/gnc-main-window.c:395
+#: gnucash/gnome-utils/gnc-main-window.c:396
 msgid "About GnuCash"
 msgstr "關於 GnuCash"
 
-#: gnucash/gnome-utils/gnc-main-window.c:407
+#: gnucash/gnome-utils/gnc-main-window.c:408
 msgid "_Toolbar"
 msgstr "工具列(_T)"
 
-#: gnucash/gnome-utils/gnc-main-window.c:408
+#: gnucash/gnome-utils/gnc-main-window.c:409
 msgid "Show/hide the toolbar on this window"
 msgstr "顯示/隱藏此視窗的工具列"
 
-#: gnucash/gnome-utils/gnc-main-window.c:412
+#: gnucash/gnome-utils/gnc-main-window.c:413
 msgid "Su_mmary Bar"
 msgstr "摘要列(_M)"
 
-#: gnucash/gnome-utils/gnc-main-window.c:413
+#: gnucash/gnome-utils/gnc-main-window.c:414
 msgid "Show/hide the summary bar on this window"
 msgstr "顯示/隱藏此視窗的摘要列"
 
-#: gnucash/gnome-utils/gnc-main-window.c:417
+#: gnucash/gnome-utils/gnc-main-window.c:418
 msgid "Stat_us Bar"
 msgstr "狀態列(_U)"
 
-#: gnucash/gnome-utils/gnc-main-window.c:418
+#: gnucash/gnome-utils/gnc-main-window.c:419
 msgid "Show/hide the status bar on this window"
 msgstr "顯示/隱藏此視窗的狀態列"
 
-#: gnucash/gnome-utils/gnc-main-window.c:430
+#: gnucash/gnome-utils/gnc-main-window.c:431
 msgid "Window _1"
 msgstr "視窗 _1"
 
-#: gnucash/gnome-utils/gnc-main-window.c:431
+#: gnucash/gnome-utils/gnc-main-window.c:432
 msgid "Window _2"
 msgstr "視窗 _2"
 
-#: gnucash/gnome-utils/gnc-main-window.c:432
+#: gnucash/gnome-utils/gnc-main-window.c:433
 msgid "Window _3"
 msgstr "視窗 _3"
 
-#: gnucash/gnome-utils/gnc-main-window.c:433
+#: gnucash/gnome-utils/gnc-main-window.c:434
 msgid "Window _4"
 msgstr "視窗 _4"
 
-#: gnucash/gnome-utils/gnc-main-window.c:434
+#: gnucash/gnome-utils/gnc-main-window.c:435
 msgid "Window _5"
 msgstr "視窗 _5"
 
-#: gnucash/gnome-utils/gnc-main-window.c:435
+#: gnucash/gnome-utils/gnc-main-window.c:436
 msgid "Window _6"
 msgstr "視窗 _6"
 
-#: gnucash/gnome-utils/gnc-main-window.c:436
+#: gnucash/gnome-utils/gnc-main-window.c:437
 msgid "Window _7"
 msgstr "視窗 _7"
 
-#: gnucash/gnome-utils/gnc-main-window.c:437
+#: gnucash/gnome-utils/gnc-main-window.c:438
 msgid "Window _8"
 msgstr "視窗 _8"
 
-#: gnucash/gnome-utils/gnc-main-window.c:438
+#: gnucash/gnome-utils/gnc-main-window.c:439
 msgid "Window _9"
 msgstr "視窗 _9"
 
-#: gnucash/gnome-utils/gnc-main-window.c:439
+#: gnucash/gnome-utils/gnc-main-window.c:440
 msgid "Window _0"
 msgstr "視窗 _0"
 
-#: gnucash/gnome-utils/gnc-main-window.c:1254
+#: gnucash/gnome-utils/gnc-main-window.c:1255
 #, c-format
 msgid "Save changes to file %s before closing?"
 msgstr "在關閉之前存檔到 %s？"
 
-#: gnucash/gnome-utils/gnc-main-window.c:1257
+#: gnucash/gnome-utils/gnc-main-window.c:1258
 #, c-format
 msgid ""
 "If you don't save, changes from the past %d hours and %d minutes will be "
 "discarded."
 msgstr "如果您不存檔，過去 %d 小時 %d 分鐘的變更將會被丟棄。"
 
-#: gnucash/gnome-utils/gnc-main-window.c:1259
+#: gnucash/gnome-utils/gnc-main-window.c:1260
 #, c-format
 msgid ""
 "If you don't save, changes from the past %d days and %d hours will be "
 "discarded."
 msgstr "如果您不存檔，過去 %d 天 %d 小時的變更將會被丟棄。"
 
-#: gnucash/gnome-utils/gnc-main-window.c:1307
+#: gnucash/gnome-utils/gnc-main-window.c:1308
 msgid "Close _Without Saving"
 msgstr "直接關閉不儲存(_W)"
 
-#: gnucash/gnome-utils/gnc-main-window.c:1452
+#: gnucash/gnome-utils/gnc-main-window.c:1453
 msgid "This window is closing and will not be restored."
 msgstr "此視窗將會被關閉且不會被回復。"
 
-#: gnucash/gnome-utils/gnc-main-window.c:1458
+#: gnucash/gnome-utils/gnc-main-window.c:1459
 msgid "Close Window?"
 msgstr "關閉此視窗？"
 
 #. Translators: This string is shown in the window title if this
 #. document is, well, read-only.
-#: gnucash/gnome-utils/gnc-main-window.c:1588
+#: gnucash/gnome-utils/gnc-main-window.c:1589
 msgid "(read-only)"
 msgstr "(唯讀)"
 
-#: gnucash/gnome-utils/gnc-main-window.c:1596
+#: gnucash/gnome-utils/gnc-main-window.c:1597
 msgid "Unsaved Book"
 msgstr "未儲存的帳簿"
 
-#: gnucash/gnome-utils/gnc-main-window.c:1759
+#: gnucash/gnome-utils/gnc-main-window.c:1760
 msgid "Last modified on %a, %b %d, %Y at %I:%M %p"
 msgstr "最後修改於 %Y 年 %b %d 日 (%a) %p %I:%M"
 
 #. Translators: This message appears in the status bar after opening the file.
-#: gnucash/gnome-utils/gnc-main-window.c:1762
+#: gnucash/gnome-utils/gnc-main-window.c:1763
 #, c-format
 msgid "File %s opened. %s"
 msgstr "已開啟檔案 %s。%s"
 
-#: gnucash/gnome-utils/gnc-main-window.c:2884
+#: gnucash/gnome-utils/gnc-main-window.c:2885
 msgctxt "lower case key for short cut to 'Accounts'"
 msgid "a"
 msgstr "a"
 
-#: gnucash/gnome-utils/gnc-main-window.c:2974
+#: gnucash/gnome-utils/gnc-main-window.c:2975
 msgid "Unable to save to database."
 msgstr "無法存到資料庫。"
 
-#: gnucash/gnome-utils/gnc-main-window.c:2976
+#: gnucash/gnome-utils/gnc-main-window.c:2977
 msgid "Unable to save to database: Book is marked read-only."
 msgstr "無法存到資料庫：帳簿已標為唯讀。"
 
-#: gnucash/gnome-utils/gnc-main-window.c:4318
+#: gnucash/gnome-utils/gnc-main-window.c:4322
 #: gnucash/gtkbuilder/assistant-qif-import.glade:975
 msgid "Book Options"
 msgstr "帳簿選項"
 
 #. Translators: %s will be replaced with the current year
-#: gnucash/gnome-utils/gnc-main-window.c:4702
+#: gnucash/gnome-utils/gnc-main-window.c:4706
 #, c-format
 msgid "Copyright © 1997-%s The GnuCash contributors."
 msgstr "版權所有 © 1997-%s GnuCash 的貢獻者們。"
 
-#: gnucash/gnome-utils/gnc-main-window.c:4714
-#: gnucash/gnome-utils/gnc-splash.c:97
+#: gnucash/gnome-utils/gnc-main-window.c:4718
+#: gnucash/gnome-utils/gnc-splash.c:98
 msgid "Version"
 msgstr "版本"
 
-#: gnucash/gnome-utils/gnc-main-window.c:4715
-#: gnucash/gnome-utils/gnc-splash.c:98 gnucash/gnucash-core-app.cpp:306
+#: gnucash/gnome-utils/gnc-main-window.c:4719
+#: gnucash/gnome-utils/gnc-splash.c:99 gnucash/gnucash-core-app.cpp:306
 msgid "Build ID"
 msgstr "建置號"
 
-#: gnucash/gnome-utils/gnc-main-window.c:4723
+#: gnucash/gnome-utils/gnc-main-window.c:4727
 msgid "Accounting for personal and small business finance."
 msgstr "個人及小企業的會計軟體。"
 
@@ -8595,7 +8678,7 @@ msgstr "個人及小企業的會計軟體。"
 #. Enter your name or that of your team and an email contact for feedback.
 #. The string can have multiple rows, so you can also add a list of
 #. contributors.
-#: gnucash/gnome-utils/gnc-main-window.c:4732
+#: gnucash/gnome-utils/gnc-main-window.c:4736
 msgid "translator-credits"
 msgstr ""
 "Chao-Hsiung Liao <pesder.liao@msa.hinet.net>, 2003.\n"
@@ -8604,7 +8687,7 @@ msgstr ""
 "Tryneeds (http://tryneeds.westart.tw/tryneeds/) team, 2011-2012.\n"
 "Brian Hsu <brianhsu.hsu@gmail.com>, 2021."
 
-#: gnucash/gnome-utils/gnc-main-window.c:4735
+#: gnucash/gnome-utils/gnc-main-window.c:4739
 msgid "Visit the GnuCash website."
 msgstr "造訪 GnuCash 網站。"
 
@@ -8682,11 +8765,11 @@ msgstr "本會計週期結束時間"
 msgid "End of previous accounting period"
 msgstr "前一會計週期結束時間"
 
-#: gnucash/gnome-utils/gnc-splash.c:112
+#: gnucash/gnome-utils/gnc-splash.c:113
 msgid "Loading..."
 msgstr "載入中..."
 
-#: gnucash/gnome-utils/gnc-sx-list-tree-model-adapter.c:490
+#: gnucash/gnome-utils/gnc-sx-list-tree-model-adapter.c:515
 msgid "never"
 msgstr "永不"
 
@@ -8707,7 +8790,7 @@ msgid ""
 msgstr "目前的交易已經變更。繼續前您想要記錄變更，或是取消？"
 
 #: gnucash/gnome-utils/gnc-tree-control-split-reg.c:149
-#: gnucash/register/ledger-core/gncEntryLedger.c:931
+#: gnucash/register/ledger-core/gncEntryLedger.c:932
 #: gnucash/register/ledger-core/gncEntryLedgerControl.c:897
 #: gnucash/register/ledger-core/split-register.c:474
 msgid "_Record"
@@ -8796,7 +8879,9 @@ msgid ""
 "The entered date of the duplicated transaction is older than the \"Read-Only "
 "Threshold\" set for this book. This setting can be changed in File-"
 ">Properties->Accounts."
-msgstr "輸入的重覆的交易日期，超過了帳簿中設定的「交易唯讀日期門檻」。這個設定可以從「檔案->內容->科目」中變更。"
+msgstr ""
+"輸入的重覆的交易日期，超過了帳簿中設定的「交易唯讀日期門檻」。這個設定可以從"
+"「檔案->內容->科目」中變更。"
 
 #. Translators: This message will be presented when a user
 #. attempts to record a transaction without splits
@@ -8808,7 +8893,8 @@ msgstr "空白交的易資訊不足？"
 msgid ""
 "The blank transaction does not have enough information to save it. Would you "
 "like to return to the transaction to update, or cancel the save?"
-msgstr "此空白的交易沒有足夠的資訊可以儲存。您想要反回交易以進行更新，或是取消儲存？"
+msgstr ""
+"此空白的交易沒有足夠的資訊可以儲存。您想要反回交易以進行更新，或是取消儲存？"
 
 #. Translators: Return to the transaction to update
 #: gnucash/gnome-utils/gnc-tree-control-split-reg.c:1737
@@ -8825,7 +8911,9 @@ msgstr "將分割標記為未對帳？"
 msgid ""
 "You are about to mark a reconciled split as unreconciled. Doing so might "
 "make future reconciliation difficult! Continue with this change?"
-msgstr "您即將把已對帳交易改標記成未對帳。這麼做可能使未來的對帳很困難！繼續這個修改？"
+msgstr ""
+"您即將把已對帳交易改標記成未對帳。這麼做可能使未來的對帳很困難！繼續這個修"
+"改？"
 
 #: gnucash/gnome-utils/gnc-tree-control-split-reg.c:1826
 #: gnucash/register/ledger-core/split-register-control.c:1849
@@ -8833,7 +8921,7 @@ msgid "_Unreconcile"
 msgstr "未對帳(_U)"
 
 #: gnucash/gnome-utils/gnc-tree-control-split-reg.c:1911
-#: gnucash/register/ledger-core/split-register-model.c:2226
+#: gnucash/register/ledger-core/split-register-model.c:2233
 msgid "Change reconciled split?"
 msgstr "變更已對帳的分割？"
 
@@ -8851,16 +8939,18 @@ msgstr "變更連結到已對帳分割的分割？"
 msgid ""
 "You are about to change a split that is linked to a reconciled split. Doing "
 "so might make future reconciliation difficult! Continue with this change?"
-msgstr "您即將要修改連連到已對帳分割的分割。這麼做可能使未來的對帳很困難！繼續這個修改？"
+msgstr ""
+"您即將要修改連連到已對帳分割的分割。這麼做可能使未來的對帳很困難！繼續這個修"
+"改？"
 
 #: gnucash/gnome-utils/gnc-tree-control-split-reg.c:1934
-#: gnucash/register/ledger-core/split-register-model.c:2250
+#: gnucash/register/ledger-core/split-register-model.c:2257
 msgid "Chan_ge Split"
 msgstr "變更分割(_G)"
 
 #: gnucash/gnome-utils/gnc-tree-control-split-reg.c:1959
 #: gnucash/register/ledger-core/gncEntryLedger.c:86
-#: gnucash/register/ledger-core/split-register.c:1978
+#: gnucash/register/ledger-core/split-register.c:1980
 #, c-format
 msgid "The account %s does not exist. Would you like to create it?"
 msgstr "科目 %s 不存在。您想要建立它嗎？"
@@ -8874,36 +8964,36 @@ msgid "New top level account"
 msgstr "新增頂端層級科目"
 
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2847
-#: gnucash/register/ledger-core/split-register.c:2540
+#: gnucash/register/ledger-core/split-register.c:2542
 msgctxt "Action Column"
 msgid "Deposit"
 msgstr "存款"
 
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2848
-#: gnucash/register/ledger-core/split-register.c:2541
+#: gnucash/register/ledger-core/split-register.c:2543
 msgid "Withdraw"
 msgstr "提款"
 
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2849
-#: gnucash/register/ledger-core/split-register.c:2542
+#: gnucash/register/ledger-core/split-register.c:2544
 msgid "Check"
 msgstr "支票"
 
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2851
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2882
-#: gnucash/register/ledger-core/split-register.c:2544
-#: gnucash/register/ledger-core/split-register.c:2575
+#: gnucash/register/ledger-core/split-register.c:2546
+#: gnucash/register/ledger-core/split-register.c:2577
 msgid "ATM Deposit"
 msgstr "ATM 存款"
 
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2852
-#: gnucash/register/ledger-core/split-register.c:2545
-#: gnucash/register/ledger-core/split-register.c:2576
+#: gnucash/register/ledger-core/split-register.c:2547
+#: gnucash/register/ledger-core/split-register.c:2578
 msgid "ATM Draw"
 msgstr "ATM 提款"
 
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2853
-#: gnucash/register/ledger-core/split-register.c:2546
+#: gnucash/register/ledger-core/split-register.c:2548
 msgid "Teller"
 msgstr "出納員"
 
@@ -8911,15 +9001,15 @@ msgstr "出納員"
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:2973
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:3059
 #: gnucash/register/ledger-core/gncEntryLedgerLoad.c:133
-#: gnucash/register/ledger-core/gncEntryLedgerModel.c:529
-#: gnucash/register/ledger-core/gncEntryLedgerModel.c:1093
-#: gnucash/register/ledger-core/split-register.c:2547
+#: gnucash/register/ledger-core/gncEntryLedgerModel.c:532
+#: gnucash/register/ledger-core/gncEntryLedgerModel.c:1096
+#: gnucash/register/ledger-core/split-register.c:2549
 #: libgnucash/engine/Account.cpp:151 libgnucash/engine/Account.cpp:165
 msgid "Charge"
 msgstr "索價"
 
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2856
-#: gnucash/register/ledger-core/split-register.c:2549
+#: gnucash/register/ledger-core/split-register.c:2551
 #: gnucash/report/reports/standard/receipt.scm:208
 #: gnucash/report/reports/standard/receipt.scm:210
 #: gnucash/report/reports/support/receipt.eguile.scm:278
@@ -8934,11 +9024,11 @@ msgstr "收據"
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2950
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:2968
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:3046
-#: gnucash/register/ledger-core/split-register.c:2550
-#: gnucash/register/ledger-core/split-register.c:2564
-#: gnucash/register/ledger-core/split-register.c:2600
-#: gnucash/register/ledger-core/split-register.c:2611
-#: gnucash/register/ledger-core/split-register.c:2643
+#: gnucash/register/ledger-core/split-register.c:2552
+#: gnucash/register/ledger-core/split-register.c:2566
+#: gnucash/register/ledger-core/split-register.c:2602
+#: gnucash/register/ledger-core/split-register.c:2613
+#: gnucash/register/ledger-core/split-register.c:2645
 #: libgnucash/engine/Account.cpp:146 libgnucash/engine/Account.cpp:167
 #: libgnucash/engine/Account.cpp:175 libgnucash/engine/Account.cpp:176
 msgid "Increase"
@@ -8951,18 +9041,18 @@ msgstr "增加"
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2951
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:2961
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:3053
-#: gnucash/register/ledger-core/split-register.c:2551
-#: gnucash/register/ledger-core/split-register.c:2565
-#: gnucash/register/ledger-core/split-register.c:2601
-#: gnucash/register/ledger-core/split-register.c:2612
-#: gnucash/register/ledger-core/split-register.c:2644
+#: gnucash/register/ledger-core/split-register.c:2553
+#: gnucash/register/ledger-core/split-register.c:2567
+#: gnucash/register/ledger-core/split-register.c:2603
+#: gnucash/register/ledger-core/split-register.c:2614
+#: gnucash/register/ledger-core/split-register.c:2646
 #: libgnucash/engine/Account.cpp:147 libgnucash/engine/Account.cpp:155
 #: libgnucash/engine/Account.cpp:156 libgnucash/engine/Account.cpp:166
 msgid "Decrease"
 msgstr "減少"
 
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2860
-#: gnucash/register/ledger-core/split-register.c:2553
+#: gnucash/register/ledger-core/split-register.c:2555
 msgid "POS"
 msgstr "收銀機"
 
@@ -8973,7 +9063,7 @@ msgstr "收銀機"
 #: gnucash/gtkbuilder/dialog-employee.glade:253
 #: gnucash/gtkbuilder/dialog-vendor.glade:271
 #: gnucash/import-export/customer-import/dialog-customer-import-gui.c:135
-#: gnucash/register/ledger-core/split-register.c:2554
+#: gnucash/register/ledger-core/split-register.c:2556
 #: gnucash/report/reports/aging.scm:692
 #: gnucash/report/reports/support/taxinvoice.eguile.scm:175
 msgid "Phone"
@@ -8982,23 +9072,23 @@ msgstr "電話"
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2862
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2888
 #: gnucash/gtkbuilder/dialog-imap-editor.glade:156
-#: gnucash/register/ledger-core/split-register.c:2555
-#: gnucash/register/ledger-core/split-register.c:2581
+#: gnucash/register/ledger-core/split-register.c:2557
+#: gnucash/register/ledger-core/split-register.c:2583
 msgid "Online"
 msgstr "線上交易"
 
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2864
-#: gnucash/register/ledger-core/split-register.c:2557
+#: gnucash/register/ledger-core/split-register.c:2559
 msgid "AutoDep"
 msgstr "自動存款"
 
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2865
-#: gnucash/register/ledger-core/split-register.c:2558
+#: gnucash/register/ledger-core/split-register.c:2560
 msgid "Wire"
 msgstr "電報"
 
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2867
-#: gnucash/register/ledger-core/split-register.c:2560
+#: gnucash/register/ledger-core/split-register.c:2562
 msgid "Direct Debit"
 msgstr "直接債務備註"
 
@@ -9012,14 +9102,14 @@ msgstr "直接債務備註"
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2932
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2952
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:3071
-#: gnucash/register/ledger-core/split-register.c:2566
-#: gnucash/register/ledger-core/split-register.c:2570
-#: gnucash/register/ledger-core/split-register.c:2577
-#: gnucash/register/ledger-core/split-register.c:2585
-#: gnucash/register/ledger-core/split-register.c:2602
-#: gnucash/register/ledger-core/split-register.c:2613
-#: gnucash/register/ledger-core/split-register.c:2618
-#: gnucash/register/ledger-core/split-register.c:2645
+#: gnucash/register/ledger-core/split-register.c:2568
+#: gnucash/register/ledger-core/split-register.c:2572
+#: gnucash/register/ledger-core/split-register.c:2579
+#: gnucash/register/ledger-core/split-register.c:2587
+#: gnucash/register/ledger-core/split-register.c:2604
+#: gnucash/register/ledger-core/split-register.c:2615
+#: gnucash/register/ledger-core/split-register.c:2620
+#: gnucash/register/ledger-core/split-register.c:2647
 #: libgnucash/engine/Account.cpp:148 libgnucash/engine/Account.cpp:149
 #: libgnucash/engine/Account.cpp:150
 msgid "Buy"
@@ -9035,14 +9125,14 @@ msgstr "買"
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2933
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2953
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:2991
-#: gnucash/register/ledger-core/split-register.c:2567
-#: gnucash/register/ledger-core/split-register.c:2571
-#: gnucash/register/ledger-core/split-register.c:2582
-#: gnucash/register/ledger-core/split-register.c:2586
-#: gnucash/register/ledger-core/split-register.c:2603
-#: gnucash/register/ledger-core/split-register.c:2614
-#: gnucash/register/ledger-core/split-register.c:2619
-#: gnucash/register/ledger-core/split-register.c:2646
+#: gnucash/register/ledger-core/split-register.c:2569
+#: gnucash/register/ledger-core/split-register.c:2573
+#: gnucash/register/ledger-core/split-register.c:2584
+#: gnucash/register/ledger-core/split-register.c:2588
+#: gnucash/register/ledger-core/split-register.c:2605
+#: gnucash/register/ledger-core/split-register.c:2616
+#: gnucash/register/ledger-core/split-register.c:2621
+#: gnucash/register/ledger-core/split-register.c:2648
 #: libgnucash/engine/Account.cpp:168 libgnucash/engine/Account.cpp:169
 #: libgnucash/engine/Account.cpp:170
 msgid "Sell"
@@ -9051,9 +9141,9 @@ msgstr "賣"
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2879
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2886
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2935
-#: gnucash/register/ledger-core/split-register.c:2572
-#: gnucash/register/ledger-core/split-register.c:2579
-#: gnucash/register/ledger-core/split-register.c:2628
+#: gnucash/register/ledger-core/split-register.c:2574
+#: gnucash/register/ledger-core/split-register.c:2581
+#: gnucash/register/ledger-core/split-register.c:2630
 msgid "Fee"
 msgstr "費用"
 
@@ -9063,24 +9153,24 @@ msgstr "ATM 提款"
 
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2913
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:2984
-#: gnucash/register/ledger-core/split-register.c:2606
+#: gnucash/register/ledger-core/split-register.c:2608
 #: libgnucash/engine/Account.cpp:172
 msgid "Rebate"
 msgstr "折扣"
 
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2914
-#: gnucash/register/ledger-core/split-register.c:2607
+#: gnucash/register/ledger-core/split-register.c:2609
 msgid "Paycheck"
 msgstr "薪水"
 
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2927
 #: gnucash/import-export/qif-imp/qif-dialog-utils.scm:109
 #: gnucash/import-export/qif-imp/qif-dialog-utils.scm:113
-#: gnucash/register/ledger-core/split-register.c:2620
+#: gnucash/register/ledger-core/split-register.c:2622
 #: gnucash/report/reports/standard/balance-sheet.scm:502
-#: gnucash/report/reports/standard/balsheet-pnl.scm:1122
+#: gnucash/report/reports/standard/balsheet-pnl.scm:1083
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:724
-#: libgnucash/app-utils/gnc-ui-util.c:1044 libgnucash/engine/Account.cpp:4397
+#: libgnucash/app-utils/gnc-ui-util.c:1044 libgnucash/engine/Account.cpp:4403
 msgid "Equity"
 msgstr "財產淨值"
 
@@ -9089,41 +9179,41 @@ msgstr "財產淨值"
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:2939
 #: gnucash/import-export/bi-import/dialog-bi-import-gui.c:153
 #: gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp:73
-#: gnucash/register/ledger-core/split-register.c:2627
+#: gnucash/register/ledger-core/split-register.c:2629
 #: gnucash/register/ledger-core/split-register-model.c:402
-#: gnucash/report/reports/standard/advanced-portfolio.scm:1076
+#: gnucash/report/reports/standard/advanced-portfolio.scm:1057
 #: gnucash/report/reports/standard/general-journal.scm:99
 #: gnucash/report/reports/standard/general-ledger.scm:79
 #: gnucash/report/reports/standard/general-ledger.scm:99
-#: gnucash/report/reports/standard/invoice.scm:232
+#: gnucash/report/reports/standard/invoice.scm:219
 #: gnucash/report/reports/standard/portfolio.scm:257
 #: gnucash/report/reports/standard/price-scatter.scm:40
-#: gnucash/report/reports/standard/price-scatter.scm:303
-#: gnucash/report/reports/standard/price-scatter.scm:317
+#: gnucash/report/reports/standard/price-scatter.scm:296
+#: gnucash/report/reports/standard/price-scatter.scm:310
 #: gnucash/report/reports/standard/register.scm:150
 #: gnucash/report/reports/standard/register.scm:393
-#: gnucash/report/trep-engine.scm:981 gnucash/report/trep-engine.scm:1105
-#: gnucash/report/trep-engine.scm:1296
+#: gnucash/report/trep-engine.scm:930 gnucash/report/trep-engine.scm:1050
+#: gnucash/report/trep-engine.scm:1241
 msgid "Price"
 msgstr "價格"
 
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2937
-#: gnucash/register/ledger-core/split-register.c:2630
+#: gnucash/register/ledger-core/split-register.c:2632
 msgid "Dividend"
 msgstr "股利"
 
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2940
-#: gnucash/register/ledger-core/split-register.c:2633
+#: gnucash/register/ledger-core/split-register.c:2635
 msgid "LTCG"
 msgstr "長期資本利得"
 
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2942
-#: gnucash/register/ledger-core/split-register.c:2635
+#: gnucash/register/ledger-core/split-register.c:2637
 msgid "STCG"
 msgstr "短期資本利得"
 
 #: gnucash/gnome-utils/gnc-tree-model-split-reg.c:2945
-#: gnucash/register/ledger-core/split-register.c:2638
+#: gnucash/register/ledger-core/split-register.c:2640
 msgid "Dist"
 msgstr "分配"
 
@@ -9141,8 +9231,8 @@ msgstr "-- 股票分割 --"
 #. Translators: This is a date format, see i.e.
 #. https://www.gnu.org/software/libc/manual/html_node/Formatting-Calendar-Time.html
 #: gnucash/gnome-utils/gnc-tree-util-split-reg.c:436
-#: gnucash/register/ledger-core/gncEntryLedgerModel.c:576
-#: gnucash/register/ledger-core/split-register-model.c:1000
+#: gnucash/register/ledger-core/gncEntryLedgerModel.c:579
+#: gnucash/register/ledger-core/split-register-model.c:1007
 msgid "%A %d %B %Y"
 msgstr "%Y %B %d (%A)"
 
@@ -9151,21 +9241,24 @@ msgid ""
 "The entered date of the new transaction is older than the \"Read-Only "
 "Threshold\" set for this book. This setting can be changed in File-"
 ">Properties->Accounts."
-msgstr "輸入的新交易的日期，超過了帳簿設定的「交易唯讀日期門檻」。這個設定可以從「檔案->內容->科目」中變更。"
+msgstr ""
+"輸入的新交易的日期，超過了帳簿設定的「交易唯讀日期門檻」。這個設定可以從「檔"
+"案->內容->科目」中變更。"
 
 #: gnucash/gnome-utils/gnc-tree-util-split-reg.c:861
 msgid ""
 "Exchange Rate Canceled, using existing rate or default 1 to 1 rate if this "
 "is a new transaction."
-msgstr "取消匯率變更，使用原有匯率。或如果這是一筆新交易，將會使用 1 做為預設匯率。"
+msgstr ""
+"取消匯率變更，使用原有匯率。或如果這是一筆新交易，將會使用 1 做為預設匯率。"
 
 #: gnucash/gnome-utils/gnc-tree-util-split-reg.c:1122
-#: gnucash/register/ledger-core/split-register.c:2082
+#: gnucash/register/ledger-core/split-register.c:2084
 msgid "Recalculate Transaction"
 msgstr "重新計算交易"
 
 #: gnucash/gnome-utils/gnc-tree-util-split-reg.c:1123
-#: gnucash/register/ledger-core/split-register.c:2083
+#: gnucash/register/ledger-core/split-register.c:2085
 msgid ""
 "The values entered for this transaction are inconsistent. Which value would "
 "you like to have recalculated?"
@@ -9174,30 +9267,30 @@ msgstr "在此交易中輸入的數值不一致。您希望重新計算那一個
 #: gnucash/gnome-utils/gnc-tree-util-split-reg.c:1130
 #: gnucash/gnome-utils/gnc-tree-util-split-reg.c:1132
 #: gnucash/gtkbuilder/assistant-stock-split.glade:137
-#: gnucash/register/ledger-core/split-register.c:2089
-#: gnucash/register/ledger-core/split-register.c:2092
+#: gnucash/register/ledger-core/split-register.c:2091
+#: gnucash/register/ledger-core/split-register.c:2094
 msgid "_Shares"
 msgstr "股份(_S)"
 
 #: gnucash/gnome-utils/gnc-tree-util-split-reg.c:1130
 #: gnucash/gnome-utils/gnc-tree-util-split-reg.c:1137
 #: gnucash/gnome-utils/gnc-tree-util-split-reg.c:1144
-#: gnucash/register/ledger-core/split-register.c:2090
-#: gnucash/register/ledger-core/split-register.c:2097
-#: gnucash/register/ledger-core/split-register.c:2104
+#: gnucash/register/ledger-core/split-register.c:2092
+#: gnucash/register/ledger-core/split-register.c:2099
+#: gnucash/register/ledger-core/split-register.c:2106
 msgid "Changed"
 msgstr "已變更"
 
 #: gnucash/gnome-utils/gnc-tree-util-split-reg.c:1144
 #: gnucash/gnome-utils/gnc-tree-util-split-reg.c:1146
 #: gnucash/gtkbuilder/dialog-tax-table.glade:495
-#: gnucash/register/ledger-core/split-register.c:2103
-#: gnucash/register/ledger-core/split-register.c:2106
+#: gnucash/register/ledger-core/split-register.c:2105
+#: gnucash/register/ledger-core/split-register.c:2108
 msgid "_Value"
 msgstr "數值(_V)"
 
 #: gnucash/gnome-utils/gnc-tree-util-split-reg.c:1166
-#: gnucash/register/ledger-core/split-register.c:2115
+#: gnucash/register/ledger-core/split-register.c:2117
 msgid "_Recalculate"
 msgstr "重新計算(_R)"
 
@@ -9206,12 +9299,12 @@ msgstr "重新計算(_R)"
 #: gnucash/import-export/csv-exp/csv-transactions-export.c:613
 #: gnucash/import-export/csv-exp/csv-transactions-export.c:627
 #: gnucash/import-export/csv-exp/csv-tree-export.c:155
-#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:291
+#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:283
 #: gnucash/report/reports/standard/general-ledger.scm:72
 #: gnucash/report/reports/standard/general-ledger.scm:92
-#: gnucash/report/reports/standard/trial-balance.scm:599
-#: gnucash/report/trep-engine.scm:169 gnucash/report/trep-engine.scm:1007
-#: gnucash/report/trep-engine.scm:1100
+#: gnucash/report/reports/standard/trial-balance.scm:593
+#: gnucash/report/trep-engine.scm:168 gnucash/report/trep-engine.scm:956
+#: gnucash/report/trep-engine.scm:1045
 msgid "Account Name"
 msgstr "科目名稱"
 
@@ -9223,13 +9316,12 @@ msgstr "商品"
 
 #: gnucash/gnome-utils/gnc-tree-view-account.c:822
 #: gnucash/import-export/csv-exp/csv-tree-export.c:156
-#: gnucash/report/options-utilities.scm:212
-#: gnucash/report/reports/standard/account-summary.scm:115
-#: gnucash/report/reports/standard/account-summary.scm:408
+#: gnucash/report/reports/standard/account-summary.scm:120
+#: gnucash/report/reports/standard/account-summary.scm:407
 #: gnucash/report/reports/standard/general-ledger.scm:74
 #: gnucash/report/reports/standard/general-ledger.scm:94
-#: gnucash/report/trep-engine.scm:176 gnucash/report/trep-engine.scm:975
-#: gnucash/report/trep-engine.scm:1122
+#: gnucash/report/trep-engine.scm:174 gnucash/report/trep-engine.scm:924
+#: gnucash/report/trep-engine.scm:1067
 msgid "Account Code"
 msgstr "科目代碼"
 
@@ -9481,8 +9573,8 @@ msgid "Status Bar"
 msgstr "狀態列"
 
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:1247
-#: gnucash/report/reports/standard/balsheet-eg.scm:379
-#: libgnucash/engine/Scrub.c:415
+#: gnucash/report/reports/standard/balsheet-eg.scm:370
+#: libgnucash/engine/Scrub.c:417
 msgid "Imbalance"
 msgstr "失調"
 
@@ -9612,12 +9704,12 @@ msgid "Receive"
 msgstr "收到"
 
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:3064
-#: gnucash/report/reports/standard/balsheet-pnl.scm:1286
-#: gnucash/report/reports/standard/customer-summary.scm:131
-#: gnucash/report/reports/standard/customer-summary.scm:318
+#: gnucash/report/reports/standard/balsheet-pnl.scm:1247
+#: gnucash/report/reports/standard/customer-summary.scm:120
+#: gnucash/report/reports/standard/customer-summary.scm:302
 #: gnucash/report/reports/standard/net-charts.scm:367
 #: gnucash/report/reports/standard/net-charts.scm:416
-#: libgnucash/engine/Account.cpp:152 libgnucash/engine/Account.cpp:4396
+#: libgnucash/engine/Account.cpp:152 libgnucash/engine/Account.cpp:4402
 #: libgnucash/engine/gncInvoice.c:1084
 msgid "Expense"
 msgstr "支出"
@@ -9652,43 +9744,43 @@ msgid "Enter the transaction number, such as the check number"
 msgstr "輸入交易號碼，像是支票號碼"
 
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:3196
-#: gnucash/register/ledger-core/split-register-model.c:1132
+#: gnucash/register/ledger-core/split-register-model.c:1139
 msgid "Enter the name of the Customer"
 msgstr "輸入此客戶的名稱"
 
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:3198
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:3207
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:3216
-#: gnucash/register/ledger-core/split-register-model.c:1169
+#: gnucash/register/ledger-core/split-register-model.c:1176
 msgid "Enter notes for the transaction"
 msgstr "輸入此交易的筆記"
 
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:3200
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:3209
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:3218
-#: gnucash/register/ledger-core/split-register-model.c:1330
+#: gnucash/register/ledger-core/split-register-model.c:1337
 msgid "Enter a description of the split"
 msgstr "輸入此分割的敘述"
 
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:3205
-#: gnucash/register/ledger-core/split-register-model.c:1135
+#: gnucash/register/ledger-core/split-register-model.c:1142
 msgid "Enter the name of the Vendor"
 msgstr "輸入此廠商的名稱"
 
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:3214
-#: gnucash/register/ledger-core/split-register-model.c:1138
+#: gnucash/register/ledger-core/split-register-model.c:1145
 msgid "Enter a description of the transaction"
 msgstr "輸入此交易的敘述"
 
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:3228
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:3232
-#: gnucash/register/ledger-core/split-register-model.c:1492
-#: gnucash/register/ledger-core/split-register-model.c:1559
+#: gnucash/register/ledger-core/split-register-model.c:1499
+#: gnucash/register/ledger-core/split-register-model.c:1566
 msgid "Enter the account to transfer from, or choose one from the list"
 msgstr "輸入轉帳來源科目，或從列表中選擇一個"
 
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:3230
-#: gnucash/register/ledger-core/split-register-model.c:1202
+#: gnucash/register/ledger-core/split-register-model.c:1209
 msgid "Reason the transaction was voided"
 msgstr "此交易被標為無效的原因"
 
@@ -9707,7 +9799,7 @@ msgstr "輸入買或賣的股份數量"
 
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:3272
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:3284
-#: gnucash/register/ledger-core/split-register-model.c:1440
+#: gnucash/register/ledger-core/split-register-model.c:1447
 msgid "Enter the number of shares bought or sold"
 msgstr "輸入買或賣的股份數量"
 
@@ -9720,22 +9812,22 @@ msgid "Enter the rate"
 msgstr "輸入匯率"
 
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:3314
-#: gnucash/register/ledger-core/split-register-model.c:1404
+#: gnucash/register/ledger-core/split-register-model.c:1411
 msgid "Enter the effective share price"
 msgstr "輸入有效股份價格"
 
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:3324
-#: gnucash/register/ledger-core/split-register-model.c:2385
+#: gnucash/register/ledger-core/split-register-model.c:2392
 msgid "Enter credit formula for real transaction"
 msgstr "輸入實際交易的貸方公式"
 
 #: gnucash/gnome-utils/gnc-tree-view-split-reg.c:3334
-#: gnucash/register/ledger-core/split-register-model.c:2351
+#: gnucash/register/ledger-core/split-register-model.c:2358
 msgid "Enter debit formula for real transaction"
 msgstr "輸入實際交易的借方公式"
 
 #: gnucash/gnome-utils/gnc-tree-view-sx-list.c:140
-#: gnucash/gtkbuilder/dialog-sx.glade:1047
+#: gnucash/gtkbuilder/dialog-sx.glade:1064
 #: gnucash/report/html-utilities.scm:337
 msgid "Enabled"
 msgstr "啟用"
@@ -9868,12 +9960,12 @@ msgstr "這是開發中版本。它可能會運作不正常。"
 msgid "Report bugs and other problems to gnucash-devel@gnucash.org"
 msgstr "請將程式錯誤或其他的問題回報到 gnucash-devel@gnucash.org"
 
-#. Translators: {1} will be replaced with a URL
+#. Translators: {1} will be replaced with an URL
 #: gnucash/gnucash-core-app.cpp:84
 msgid "You can also lookup and file bug reports at {1}"
 msgstr "您也可以在 {1} 查詢和回報錯誤"
 
-#. Translators: {1} will be replaced with a URL
+#. Translators: {1} will be replaced with an URL
 #: gnucash/gnucash-core-app.cpp:86
 msgid "To find the last stable version, please refer to {1}"
 msgstr "要找到最新的穩定版本，請參考 {1}"
@@ -9934,13 +10026,17 @@ msgstr ""
 msgid ""
 "File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
-msgstr "日誌寫入的檔案；預為為 \"/tmp/gnucash.trace\"；可以是 \"stderr\" 或\"stdout\"。"
+msgstr ""
+"日誌寫入的檔案；預為為 \"/tmp/gnucash.trace\"；可以是 \"stderr\" 或\"stdout"
+"\"。"
 
 #: gnucash/gnucash-core-app.cpp:342
 msgid ""
 "Set the prefix for gsettings schemas for gsettings queries. This can be "
 "useful to have a different settings tree while debugging."
-msgstr "設定 gsettings 查詢時所使用的 schemas 前綴。可以在除錯時，需使用不同的設 定樹的時候使用這個選項。"
+msgstr ""
+"設定 gsettings 查詢時所使用的 schemas 前綴。可以在除錯時，需使用不同的設 定樹"
+"的時候使用這個選項。"
 
 #: gnucash/gnucash-core-app.cpp:344
 msgid "Hidden Options"
@@ -10055,7 +10151,7 @@ msgstr ""
 #: gnucash/gschemas/org.gnucash.dialogs.import.qif.gschema.xml.in:41
 #: gnucash/gschemas/org.gnucash.dialogs.reconcile.gschema.xml.in:25
 #: gnucash/gschemas/org.gnucash.dialogs.sxs.gschema.xml.in:10
-#: gnucash/gschemas/org.gnucash.dialogs.sxs.gschema.xml.in:40
+#: gnucash/gschemas/org.gnucash.dialogs.sxs.gschema.xml.in:45
 #: gnucash/gschemas/org.gnucash.dialogs.totd.gschema.xml.in:10
 #: gnucash/import-export/aqb/gschemas/org.gnucash.dialogs.flicker.gschema.xml.in:6
 #: gnucash/import-export/aqb/gschemas/org.gnucash.dialogs.import.hbci.gschema.xml.in:5
@@ -10099,7 +10195,7 @@ msgstr "視窗最後所在的位置及大小"
 #: gnucash/gschemas/org.gnucash.dialogs.import.qif.gschema.xml.in:42
 #: gnucash/gschemas/org.gnucash.dialogs.reconcile.gschema.xml.in:26
 #: gnucash/gschemas/org.gnucash.dialogs.sxs.gschema.xml.in:11
-#: gnucash/gschemas/org.gnucash.dialogs.sxs.gschema.xml.in:41
+#: gnucash/gschemas/org.gnucash.dialogs.sxs.gschema.xml.in:46
 #: gnucash/gschemas/org.gnucash.dialogs.totd.gschema.xml.in:11
 #: gnucash/import-export/aqb/gschemas/org.gnucash.dialogs.flicker.gschema.xml.in:7
 #: gnucash/import-export/aqb/gschemas/org.gnucash.dialogs.import.hbci.gschema.xml.in:6
@@ -10108,7 +10204,9 @@ msgid ""
 "This setting describes the size and position of the window when it was last "
 "closed. The numbers are the X and Y coordinates of the top left corner of "
 "the window followed by the width and height of the window."
-msgstr "此設定描述了上次視窗關閉時的大小與所在位置。這些數字是由螢幕左上角開始計算的 X Y 座標，緊接著是視窗的寬和高。"
+msgstr ""
+"此設定描述了上次視窗關閉時的大小與所在位置。這些數字是由螢幕左上角開始計算的 "
+"X Y 座標，緊接著是視窗的寬和高。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.business.gschema.xml.in:24
 #: gnucash/gschemas/org.gnucash.dialogs.business.gschema.xml.in:39
@@ -10129,7 +10227,9 @@ msgstr "只搜尋作用中的資料"
 msgid ""
 "If active, only the 'active' items in the current class will be searched. "
 "Otherwise all items in the current class will be searched."
-msgstr "如果啟用，則只會搜尋目前項目類型裡「作用中」的項目。否則的話，會搜尋目前項目類型裡的所有項目。"
+msgstr ""
+"如果啟用，則只會搜尋目前項目類型裡「作用中」的項目。否則的話，會搜尋目前項目"
+"類型裡的所有項目。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.business.gschema.xml.in:107
 #: gnucash/gschemas/org.gnucash.dialogs.business.gschema.xml.in:149
@@ -10157,8 +10257,9 @@ msgid ""
 "are documents with opposite sign. For example for an invoice, customer "
 "credit notes and negative invoices are considered counter documents."
 msgstr ""
-"在過帳時，自動嘗試在未清預付款和沖銷單據中支付客戶單據。當然，預付款和文件必須是同一個客戶。沖銷單據是具有相反符號的文件。例如，對於客戶發票而言，客戶信用"
-"單或負金額的客戶發票是沖銷單據。"
+"在過帳時，自動嘗試在未清預付款和沖銷單據中支付客戶單據。當然，預付款和文件必"
+"須是同一個客戶。沖銷單據是具有相反符號的文件。例如，對於客戶發票而言，客戶信"
+"用單或負金額的客戶發票是沖銷單據。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.business.gschema.xml.in:117
 msgid "Show invoices due reminder at startup"
@@ -10171,8 +10272,9 @@ msgid ""
 "definition of \"soon\" is controlled by the \"Days in Advance\" setting. "
 "Otherwise GnuCash does not check for due invoices."
 msgstr ""
-"如果啟用，則 GnuCash 在啟動時會檢查是否有快到期的發票。如果有，會顯示提醒對話盒給使用者。「快到期」的定義是由「Days in "
-"Advance」控制。否則的話，GnuCah 不會檢查發票到期日。"
+"如果啟用，則 GnuCash 在啟動時會檢查是否有快到期的發票。如果有，會顯示提醒對話"
+"盒給使用者。「快到期」的定義是由「Days in Advance」控制。否則的話，GnuCah 不"
+"會檢查發票到期日。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.business.gschema.xml.in:122
 msgid "Show invoices due within this many days"
@@ -10183,7 +10285,9 @@ msgid ""
 "This field defines the number of days in advance that GnuCash will check for "
 "due invoices. Its value is only used if the \"Notify when due\" setting is "
 "active."
-msgstr "此欄位定義了 GnuCash 會提前多少天檢查到期發票。此值只有在「到期時通知」選項啟用時才會被使用。"
+msgstr ""
+"此欄位定義了 GnuCash 會提前多少天檢查到期發票。此值只有在「到期時通知」選項啟"
+"用時才會被使用。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.business.gschema.xml.in:127
 msgid "Enable extra toolbar buttons for business"
@@ -10194,7 +10298,9 @@ msgstr "針對商務功能啟用額外的工具列按鈕"
 msgid ""
 "If active, extra toolbar buttons for common business functions are shown as "
 "well. Otherwise they are not shown."
-msgstr "如果啟用，則會在工具列上顯示常用的商務功能的按鈕。不然的話，他們不會顯示在工具列上。"
+msgstr ""
+"如果啟用，則會在工具列上顯示常用的商務功能的按鈕。不然的話，他們不會顯示在工"
+"具列上。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.business.gschema.xml.in:132
 #: gnucash/gtkbuilder/business-prefs.glade:320
@@ -10213,7 +10319,9 @@ msgstr "在新視窗中開啟發票"
 msgid ""
 "If active, each new invoice will be opened in a new window. Otherwise a new "
 "invoice will be opened as a tab in the main window."
-msgstr "如果啟用，則發票會在新視窗中開啟。否則的話，發票會在主視窗中以頁籤的方式開始。"
+msgstr ""
+"如果啟用，則發票會在新視窗中開啟。否則的話，發票會在主視窗中以頁籤的方式開"
+"始。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.business.gschema.xml.in:142
 msgid "Accumulate multiple splits into one"
@@ -10224,7 +10332,9 @@ msgid ""
 "If this field is active then multiple entries in an invoice that transfer to "
 "the same account will be accumulated into a single split. This field can be "
 "overridden per invoice in the Posting dialog."
-msgstr "如果啟用此欄位，則發票中轉帳至同一科目的項目將會被整合至單一的分割中。此欄位可以每張發票的被過帳對話盒中的設定覆蓋。"
+msgstr ""
+"如果啟用此欄位，則發票中轉帳至同一科目的項目將會被整合至單一的分割中。此欄位"
+"可以每張發票的被過帳對話盒中的設定覆蓋。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.business.gschema.xml.in:155
 #: gnucash/gtkbuilder/business-prefs.glade:275
@@ -10235,8 +10345,9 @@ msgid ""
 "opposite sign. For example for a bill, vendor credit notes and negative "
 "bills are considered counter documents."
 msgstr ""
-"在過帳時，自動嘗試在未清預付款和沖銷單據中支付供應商單據。當然，預付款和文件必須來自同一供應商。沖銷單據是具有相反符號的文件。例如，對於供應商帳單而言，供"
-"應商貸項通知單或負金額的供應商帳單是沖銷單據。"
+"在過帳時，自動嘗試在未清預付款和沖銷單據中支付供應商單據。當然，預付款和文件"
+"必須來自同一供應商。沖銷單據是具有相反符號的文件。例如，對於供應商帳單而言，"
+"供應商貸項通知單或負金額的供應商帳單是沖銷單據。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.business.gschema.xml.in:159
 msgid "Show bills due reminder at startup"
@@ -10249,8 +10360,9 @@ msgid ""
 "definition of \"soon\" is controlled by the \"Days in Advance\" setting. "
 "Otherwise GnuCash does not check for due bills."
 msgstr ""
-"如果啟用，則 GnuCash 在啟動時會檢查是否有快到期的帳單。如果有，會顯示提醒對話盒給使用者。「快到期」的定義是由「Days in "
-"Advance」控制。否則的話，GnuCah 不會檢查帳單到期日。"
+"如果啟用，則 GnuCash 在啟動時會檢查是否有快到期的帳單。如果有，會顯示提醒對話"
+"盒給使用者。「快到期」的定義是由「Days in Advance」控制。否則的話，GnuCah 不"
+"會檢查帳單到期日。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.business.gschema.xml.in:164
 msgid "Show bills due within this many days"
@@ -10261,7 +10373,9 @@ msgid ""
 "This field defines the number of days in advance that GnuCash will check for "
 "due bills. Its value is only used if the \"Notify when due\" setting is "
 "active."
-msgstr "此欄位定義了 GnuCash 會提前多少天檢查到期帳單。此值只有在「到期時通知」選項啟用時才會被使用。"
+msgstr ""
+"此欄位定義了 GnuCash 會提前多少天檢查到期帳單。此值只有在「到期時通知」選項啟"
+"用時才會被使用。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.checkprinting.gschema.xml.in:5
 msgid "GUID of predefined check format to use"
@@ -10271,7 +10385,8 @@ msgstr "要使用的預定義的支票格式 GUID"
 msgid ""
 "This value specifies the predefined check format to use. The number is the "
 "guid of a known check format."
-msgstr "此數值指定了要使用的預先定義好的支票格式。該數字是已知的支票格式的 GUID。"
+msgstr ""
+"此數值指定了要使用的預先定義好的支票格式。該數字是已知的支票格式的 GUID。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.checkprinting.gschema.xml.in:10
 msgid "Which check position to print"
@@ -10282,7 +10397,9 @@ msgid ""
 "On preprinted checks containing multiple checks per page, this setting "
 "specifies which check position to print. The possible values are 0, 1 and 2, "
 "corresponding to the top, middle and bottom checks on the page."
-msgstr "預先印製的支票會在一頁上含有多張支標，此設定將會指定支票印製的位置。可能的值為 0, 1, 2，分別對應到頁面上方、中間與底部。"
+msgstr ""
+"預先印製的支票會在一頁上含有多張支標，此設定將會指定支票印製的位置。可能的值"
+"為 0, 1, 2，分別對應到頁面上方、中間與底部。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.checkprinting.gschema.xml.in:15
 #: gnucash/gschemas/org.gnucash.dialogs.checkprinting.gschema.xml.in:16
@@ -10308,8 +10425,9 @@ msgid ""
 "any valid strftime string; for more information about this format, read the "
 "manual page of strftime by \"man 3 strftime\"."
 msgstr ""
-"如果日期格式被設定為使用自定，則此數值用來做為給 strftime 函式產生日期字串的參數使用。它可以是任何有效的strftime "
-"字串；關於此格式的更多資訊，可以透過「man 3 strfitme」指令閱讀 strftime 的說明文件。"
+"如果日期格式被設定為使用自定，則此數值用來做為給 strftime 函式產生日期字串的"
+"參數使用。它可以是任何有效的strftime 字串；關於此格式的更多資訊，可以透過"
+"「man 3 strfitme」指令閱讀 strftime 的說明文件。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.checkprinting.gschema.xml.in:30
 msgid "Units in which the custom coordinates are expressed"
@@ -10338,7 +10456,9 @@ msgid ""
 "This value contains the X,Y coordinates for the start of the date line on "
 "the check. Coordinates are from the lower left corner of the specified check "
 "position."
-msgstr "此數直指定了支標上日期行起點所在的 X, Y 座標。座標由該支票所在位置的左下角開始計算。"
+msgstr ""
+"此數直指定了支標上日期行起點所在的 X, Y 座標。座標由該支票所在位置的左下角開"
+"始計算。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.checkprinting.gschema.xml.in:45
 msgid "Position of check amount in words"
@@ -10349,7 +10469,9 @@ msgid ""
 "This value contains the X,Y coordinates for the start of the written amount "
 "line on the check. Coordinates are from the lower left corner of the "
 "specified check position."
-msgstr "此數直指定了支標上以文字表示的金額行起點所在的 X, Y 座標。座標由該支票所在位址的左下角開始計算。"
+msgstr ""
+"此數直指定了支標上以文字表示的金額行起點所在的 X, Y 座標。座標由該支票所在位"
+"址的左下角開始計算。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.checkprinting.gschema.xml.in:50
 msgid "Position of check amount in numbers"
@@ -10360,7 +10482,9 @@ msgid ""
 "This value contains the X,Y coordinates for the start of the numerical "
 "amount line on the check. Coordinates are from the lower left corner of the "
 "specified check position."
-msgstr "此數直指定了支標上以數字表示的金額行起點所在的 X, Y 座標。座標由該支票所在位址的左下角開始計算。"
+msgstr ""
+"此數直指定了支標上以數字表示的金額行起點所在的 X, Y 座標。座標由該支票所在位"
+"址的左下角開始計算。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.checkprinting.gschema.xml.in:55
 msgid "Position of payee address"
@@ -10371,7 +10495,9 @@ msgid ""
 "This value contains the X,Y coordinates for the start of the payee address "
 "line on the check. Coordinates are from the lower left corner of the "
 "specified check position."
-msgstr "此數直指定了支標上收款人地址行起點所在的 X, Y 座標。座標由該支票所在位置的左下角開始計算。"
+msgstr ""
+"此數直指定了支標上收款人地址行起點所在的 X, Y 座標。座標由該支票所在位置的左"
+"下角開始計算。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.checkprinting.gschema.xml.in:60
 msgid "Position of notes line"
@@ -10382,7 +10508,9 @@ msgid ""
 "This value contains the X,Y coordinates for the start of the notes line on "
 "the check. Coordinates are from the lower left corner of the specified check "
 "position."
-msgstr "此數直指定了支標上筆記行起點所在的 X, Y 座標。座標由該支票所在位置的左下角開始計算。"
+msgstr ""
+"此數直指定了支標上筆記行起點所在的 X, Y 座標。座標由該支票所在位置的左下角開"
+"始計算。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.checkprinting.gschema.xml.in:65
 msgid "Position of memo line"
@@ -10393,7 +10521,9 @@ msgid ""
 "This value contains the X,Y coordinates for the start of the memo line on "
 "the check. Coordinates are from the lower left corner of the specified check "
 "position."
-msgstr "此數直指定了支標上備忘錄行起點所在的 X, Y 座標。座標由該支票所在位置的左下角開始計算。"
+msgstr ""
+"此數直指定了支標上備忘錄行起點所在的 X, Y 座標。座標由該支票所在位置的左下角"
+"開始計算。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.checkprinting.gschema.xml.in:70
 msgid "Offset for complete check"
@@ -10403,7 +10533,9 @@ msgstr "整張支票的位移"
 msgid ""
 "This value contains the X,Y offset for the complete check. Coordinates are "
 "from the lower left corner of the specified check position."
-msgstr "此數直指定了整張支票起點所在的 X, Y 座標。座標由該支票所在位置的左下角開始計算。"
+msgstr ""
+"此數直指定了整張支票起點所在的 X, Y 座標。座標由該支票所在位置的左下角開始計"
+"算。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.checkprinting.gschema.xml.in:75
 msgid "Rotation angle"
@@ -10422,7 +10554,9 @@ msgid ""
 "This value contains the X,Y coordinates for the start of the split's amount "
 "line on the check. Coordinates are from the lower left corner of the "
 "specified check position."
-msgstr "此數直指定了支標上分割金額行起點所在的 X, Y 座標。座標由該支票所在位置的左下角開始計算。"
+msgstr ""
+"此數直指定了支標上分割金額行起點所在的 X, Y 座標。座標由該支票所在位置的左下"
+"角開始計算。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.checkprinting.gschema.xml.in:85
 msgid "Position of split's memo line"
@@ -10433,7 +10567,9 @@ msgid ""
 "This value contains the X,Y coordinates for the start of the split's memo "
 "line on the check. Coordinates are from the lower left corner of the "
 "specified check position."
-msgstr "此數直指定了支標上分割備忘錄起點所在的 X, Y 座標。座標由該支票所在位置的左下角開始計算。"
+msgstr ""
+"此數直指定了支標上分割備忘錄起點所在的 X, Y 座標。座標由該支票所在位置的左下"
+"角開始計算。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.checkprinting.gschema.xml.in:90
 msgid "Position of split's account line"
@@ -10444,7 +10580,9 @@ msgid ""
 "This value contains the X,Y coordinates for the start of the split's account "
 "line on the check. Coordinates are from the lower left corner of the "
 "specified check position."
-msgstr "此數直指定了支標上分割科目行起點所在的 X, Y 座標。座標由該支票所在位置的左下角開始計算。"
+msgstr ""
+"此數直指定了支標上分割科目行起點所在的 X, Y 座標。座標由該支票所在位置的左下"
+"角開始計算。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.checkprinting.gschema.xml.in:95
 msgid "Print the date format below the date."
@@ -10454,7 +10592,8 @@ msgstr "在日期下方列印日期格式。"
 msgid ""
 "Each time the date is printed, print the date format immediately below in 8 "
 "point type using the characters Y, M, and D."
-msgstr "列印日期時，在其下方以 8 點大小的字體印上其所使用的日期格式字元 Y, M 與 D。"
+msgstr ""
+"列印日期時，在其下方以 8 點大小的字體印上其所使用的日期格式字元 Y, M 與 D。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.checkprinting.gschema.xml.in:100
 msgid "The default check printing font"
@@ -10464,7 +10603,8 @@ msgstr "預設用來列印支票的字型"
 msgid ""
 "The default font to use when printing checks. This value will be overridden "
 "by any font specified in a check description file."
-msgstr "列印支標時預設使用的字體。此數值可以被在任何指定了字型的支票描述檔覆寫。"
+msgstr ""
+"列印支標時預設使用的字體。此數值可以被在任何指定了字型的支票描述檔覆寫。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.checkprinting.gschema.xml.in:105
 #: gnucash/gschemas/org.gnucash.dialogs.checkprinting.gschema.xml.in:106
@@ -10500,7 +10640,9 @@ msgstr "最後一次使用的路徑名稱"
 msgid ""
 "This field contains the last pathname used by this window. It will be used "
 "as the initial filename/pathname the next time this window is opened."
-msgstr "此欄位含有這個視最新的路徑名稱。將會用做下一次此視窗被開啟時預設的檔案/路徑名稱。"
+msgstr ""
+"此欄位含有這個視最新的路徑名稱。將會用做下一次此視窗被開啟時預設的檔案/路徑名"
+"稱。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.export.csv.gschema.xml.in:17
 msgid "Window geometry"
@@ -10521,7 +10663,8 @@ msgstr "水平分隔線的位置。"
 msgid ""
 "This setting indicates whether to search in all items in the current class, "
 "or only in 'active' items in the current class."
-msgstr "此設定指定了是否要在現在的類型中搜尋所有的項目，或是只搜尋「作用中」的項目。"
+msgstr ""
+"此設定指定了是否要在現在的類型中搜尋所有的項目，或是只搜尋「作用中」的項目。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.gschema.xml.in:189
 #: gnucash/gschemas/org.gnucash.dialogs.gschema.xml.in:190
@@ -10545,7 +10688,9 @@ msgstr "「新增檔案」時顯示新科目體系設定"
 msgid ""
 "If active, the \"New Hierarchy\" window will be shown whenever the \"New File"
 "\" menu item is chosen. Otherwise it will not be shown."
-msgstr "如果啟用，則每當使用「新增檔案」的選單選項時，都會顯示「新科目體系」視窗。否則的話不會被顯示。"
+msgstr ""
+"如果啟用，則每當使用「新增檔案」的選單選項時，都會顯示「新科目體系」視窗。否"
+"則的話不會被顯示。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.gschema.xml.in:227
 #: gnucash/gschemas/org.gnucash.dialogs.gschema.xml.in:228
@@ -10562,7 +10707,9 @@ msgid ""
 "Enable the SKIP action in the transaction matcher. If enabled, a transaction "
 "whose best match's score is in the yellow zone (above the Auto-ADD threshold "
 "but below the Auto-CLEAR threshold) will be skipped by default."
-msgstr "在交易配對中啟用略過的動作。如果啟用，則一筆交易的最高配對分數如果在黃色區(比自動新增門檻高低比自動結清門檻低)，則此筆交易則會被略過。"
+msgstr ""
+"在交易配對中啟用略過的動作。如果啟用，則一筆交易的最高配對分數如果在黃色區(比"
+"自動新增門檻高低比自動結清門檻低)，則此筆交易則會被略過。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.import.generic.gschema.xml.in:10
 msgid "Enable UPDATE match action"
@@ -10577,8 +10724,9 @@ msgid ""
 "transaction will cause the existing transaction to be updated and cleared by "
 "default."
 msgstr ""
-"在交易配對中啟用更新與對帳動作。如果啟用，若一筆交易的最佳配對分數比自動結清門檻高，並且和配對出的已存在交易中的日期或金額不符，則該筆已存在的交易會被更新"
-"並且預設為已結清。"
+"在交易配對中啟用更新與對帳動作。如果啟用，若一筆交易的最佳配對分數比自動結清"
+"門檻高，並且和配對出的已存在交易中的日期或金額不符，則該筆已存在的交易會被更"
+"新並且預設為已結清。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.import.generic.gschema.xml.in:15
 msgid "Use bayesian matching"
@@ -10589,7 +10737,9 @@ msgid ""
 "Enables bayesian matching when matching imported transaction against "
 "existing transactions. Otherwise a less sophisticated rule-based matching "
 "mechanism will be used."
-msgstr "使用貝氏比對法將匯入的交易與已存在的交易進行配對。否則的話會使用另一個較簡單的，基於規則 (rule-based) 的配對機制。"
+msgstr ""
+"使用貝氏比對法將匯入的交易與已存在的交易進行配對。否則的話會使用另一個較簡單"
+"的，基於規則 (rule-based) 的配對機制。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.import.generic.gschema.xml.in:20
 msgid "Minimum score to be displayed"
@@ -10611,7 +10761,9 @@ msgid ""
 "be added automatically. A transaction whose best match's score is in the red "
 "zone (above the display minimum score but below or equal to the Add match "
 "score) will be added to the GnuCash file by default."
-msgstr "此欄位指定了交易配對會被自動加入的門檻值。任何在紅色區域(高於最低顯示分數但低於或等於新增分數)的交易，會預設新增至 GnuCash 檔案。"
+msgstr ""
+"此欄位指定了交易配對會被自動加入的門檻值。任何在紅色區域(高於最低顯示分數但低"
+"於或等於新增分數)的交易，會預設新增至 GnuCash 檔案。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.import.generic.gschema.xml.in:30
 msgid "Clear matching transactions above this score"
@@ -10623,7 +10775,9 @@ msgid ""
 "be cleared by default. A transaction whose best match's score is in the "
 "green zone (above or equal to this Clear threshold) will be cleared by "
 "default."
-msgstr "此欄位指定了交易配對會被自動結清的門檻值。任何在綠色區域(等於或高於自動結清門檻)的交易，會預設為已結清。"
+msgstr ""
+"此欄位指定了交易配對會被自動結清的門檻值。任何在綠色區域(等於或高於自動結清門"
+"檻)的交易，會預設為已結清。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.import.generic.gschema.xml.in:35
 msgid "Maximum ATM fee amount in your area"
@@ -10641,9 +10795,12 @@ msgid ""
 "whatever is the maximum such fee in your area (in units of your local "
 "currency), so the transaction will be recognised as a match."
 msgstr ""
-"這個欄位指定了當配對交易時，要考慮進去的手續費。在某些地方商用的 ATM（不屬於公家金融機構）是設置在便利商店裡的。這些 ATM "
-"會將它的費用直接加到總額裡，而不會在您每月的銀行費用中顯示為分開的個別交易。舉例來說，您提款 $100 ，但是加上手續費總共要收費 $115 。"
-"如果您自己輸入 $100，總額將會不符。您應該要把這個數值設為您所處地區對這種收費的最大值（以您當地貨幣的單位計算），這樣一來交易便會識別為相符。"
+"這個欄位指定了當配對交易時，要考慮進去的手續費。在某些地方商用的 ATM（不屬於"
+"公家金融機構）是設置在便利商店裡的。這些 ATM 會將它的費用直接加到總額裡，而不"
+"會在您每月的銀行費用中顯示為分開的個別交易。舉例來說，您提款 $100 ，但是加上"
+"手續費總共要收費 $115 。如果您自己輸入 $100，總額將會不符。您應該要把這個數值"
+"設為您所處地區對這種收費的最大值（以您當地貨幣的單位計算），這樣一來交易便會"
+"識別為相符。"
 
 #. Preferences->Online Banking:Generic
 #: gnucash/gschemas/org.gnucash.dialogs.import.generic.gschema.xml.in:40
@@ -10657,7 +10814,9 @@ msgid ""
 "Enables the automatic creation of new commodities if any unknown commodity "
 "is encountered during import. Otherwise the user will be asked what to do "
 "with each unknown commodity."
-msgstr "啟用後如果在匯入的過程中有未知的商品，會自動建立商品。不然的話使用者會被針對未知的商品，一個一個詢問要如何處理。"
+msgstr ""
+"啟用後如果在匯入的過程中有未知的商品，會自動建立商品。不然的話使用者會被針對"
+"未知的商品，一個一個詢問要如何處理。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.import.generic.gschema.xml.in:58
 msgid "Display or hide reconciled matches"
@@ -10705,7 +10864,9 @@ msgid ""
 "If active, all transactions marked as cleared in the register will appear "
 "already selected in the reconcile dialog. Otherwise no transactions will be "
 "initially selected."
-msgstr "如果啟用，則被標記為已結清的交易在過帳對話盒中將會被自動勾選。否則的話一開始不會勾選任何交易。"
+msgstr ""
+"如果啟用，則被標記為已結清的交易在過帳對話盒中將會被自動勾選。否則的話一開始"
+"不會勾選任何交易。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.reconcile.gschema.xml.in:10
 msgid "Prompt for interest charges"
@@ -10718,7 +10879,9 @@ msgid ""
 "user to enter a transaction for the interest charge or payment. Currently "
 "only enabled for Bank, Credit, Mutual, Asset, Receivable, Payable, and "
 "Liability accounts."
-msgstr "在對帳會有利息支出或收入的科目之前，提示使用者輸入利息支出或收入的交易。目前只能用在銀行、信用卡、共同基金、資產、應收、應付與負債科目。"
+msgstr ""
+"在對帳會有利息支出或收入的科目之前，提示使用者輸入利息支出或收入的交易。目前"
+"只能用在銀行、信用卡、共同基金、資產、應收、應付與負債科目。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.reconcile.gschema.xml.in:15
 msgid "Prompt for credit card payment"
@@ -10739,7 +10902,9 @@ msgstr "總是對帳到今天"
 msgid ""
 "If active, always open the reconcile dialog using today's date for the "
 "statement date, regardless of previous reconciliations."
-msgstr "如果啟用，在開啟對帳視窗時，總是使用今天的日期做為結帳日期，而不管上一次的對帳。"
+msgstr ""
+"如果啟用，在開啟對帳視窗時，總是使用今天的日期做為結帳日期，而不管上一次的對"
+"帳。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.sxs.gschema.xml.in:17
 msgid "Run \"since last run\" dialog when a file is opened."
@@ -10752,8 +10917,9 @@ msgid ""
 "the initial opening of the data file when GnuCash starts. If this setting is "
 "active, run the \"since last run\" process, otherwise it is not run."
 msgstr ""
-"此選項控制是否在資料檔被打開時，自動執行排程交易的「自上次運行」裡的動作。這包括 GnuCash "
-"啟動時自動開啟的資料檔。如果此選項被勾選則會執行「自上次運行」的動作，否則不會執行。"
+"此選項控制是否在資料檔被打開時，自動執行排程交易的「自上次運行」裡的動作。這"
+"包括 GnuCash 啟動時自動開啟的資料檔。如果此選項被勾選則會執行「自上次運行」的"
+"動作，否則不會執行。"
 
 #: gnucash/gschemas/org.gnucash.dialogs.sxs.gschema.xml.in:22
 msgid "Show \"since last run\" notification dialog when a file is opened."
@@ -10767,43 +10933,59 @@ msgid ""
 "opening of the data file when GnuCash starts. If this setting is active, "
 "show the dialog, otherwise it is not shown."
 msgstr ""
-"此選項控制是否在資料檔被打開時，自動顯示排程交易的「自上次運行」通知對話盒（如果有設定打開檔案時執行「自上次執行後」的動作）。這包括 GnuCash "
-"啟動時自動開啟的資料檔。如果此選項被勾選則會顯示對話盒，否則不會顯示。"
+"此選項控制是否在資料檔被打開時，自動顯示排程交易的「自上次運行」通知對話盒"
+"（如果有設定打開檔案時執行「自上次執行後」的動作）。這包括 GnuCash 啟動時自動"
+"開啟的資料檔。如果此選項被勾選則會顯示對話盒，否則不會顯示。"
 
-#: gnucash/gschemas/org.gnucash.dialogs.sxs.gschema.xml.in:30
+#: gnucash/gschemas/org.gnucash.dialogs.sxs.gschema.xml.in:27
+msgid ""
+"Set \"Review Created Transactions\" as the default for the \"since last run"
+"\" dialog."
+msgstr "在「自上次執行後」對話盒中，預設勾選「核對已建立的交易」。"
+
+#: gnucash/gschemas/org.gnucash.dialogs.sxs.gschema.xml.in:28
+msgid ""
+"This setting controls whether as default the \"review created transactions\" "
+"is set for the \"since last run\" dialog."
+msgstr ""
+"此設定控制了「自從上次執行」對話盒中，是否預設勾選「檢查已建立的交易」。"
+
+#: gnucash/gschemas/org.gnucash.dialogs.sxs.gschema.xml.in:35
 msgid "Set the \"auto create\" flag by default"
 msgstr "預設勾選「自動建立交易」選項"
 
-#: gnucash/gschemas/org.gnucash.dialogs.sxs.gschema.xml.in:31
+#: gnucash/gschemas/org.gnucash.dialogs.sxs.gschema.xml.in:36
 msgid ""
 "If active, any newly created scheduled transaction will have its 'auto "
 "create' flag set active by default. The user can change this flag during "
 "transaction creation, or at any later time by editing the scheduled "
 "transaction."
 msgstr ""
-"如果啟用，任何新建立的排程交易都會預設勾選「自動建立」的選項。使用者可以在交易建立時更改這個設定，或在之後任何時間，透過編輯已排程的交易來修改此選項。"
+"如果啟用，任何新建立的排程交易都會預設勾選「自動建立」的選項。使用者可以在交"
+"易建立時更改這個設定，或在之後任何時間，透過編輯已排程的交易來修改此選項。"
 
-#: gnucash/gschemas/org.gnucash.dialogs.sxs.gschema.xml.in:35
-#: gnucash/gschemas/org.gnucash.dialogs.sxs.gschema.xml.in:36
+#: gnucash/gschemas/org.gnucash.dialogs.sxs.gschema.xml.in:40
+#: gnucash/gschemas/org.gnucash.dialogs.sxs.gschema.xml.in:41
 msgid "How many days in advance to notify the user."
 msgstr "在多少天前通知使用者。"
 
-#: gnucash/gschemas/org.gnucash.dialogs.sxs.gschema.xml.in:47
+#: gnucash/gschemas/org.gnucash.dialogs.sxs.gschema.xml.in:52
 msgid "Set the \"notify\" flag by default"
 msgstr "預設勾選「當建立時通知我」的選項"
 
-#: gnucash/gschemas/org.gnucash.dialogs.sxs.gschema.xml.in:48
+#: gnucash/gschemas/org.gnucash.dialogs.sxs.gschema.xml.in:53
 msgid ""
 "If active, any newly created scheduled transaction will have its 'notify' "
 "flag set by default. The user can change this flag during transaction "
 "creation, or at any later time by editing the scheduled transaction. This "
 "setting only has meaning if the create-auto setting is active."
 msgstr ""
-"如果啟用，任何新建立的排程交易都會預設勾選「當建立時通知我」的選項。使用者可以在交易建立時更改這個設定，或在之後任何時間，透過編輯已排程的交易來修改此選項"
-"。"
+"如果啟用，任何新建立的排程交易都會預設勾選「當建立時通知我」的選項。使用者可"
+"以在交易建立時更改這個設定，或在之後任何時間，透過編輯已排程的交易來修改此選"
+"項。"
 
-#: gnucash/gschemas/org.gnucash.dialogs.sxs.gschema.xml.in:52
-#: gnucash/gschemas/org.gnucash.dialogs.sxs.gschema.xml.in:53
+#: gnucash/gschemas/org.gnucash.dialogs.sxs.gschema.xml.in:57
+#: gnucash/gschemas/org.gnucash.dialogs.sxs.gschema.xml.in:58
 msgid "How many days in advance to remind the user."
 msgstr "提前多少天提醒使用者。"
 
@@ -10820,20 +11002,24 @@ msgstr "在 GnuCash 開始時顯示「每日一訣」"
 msgid ""
 "Enables the \"Tip Of The Day\" when GnuCash starts up. If active, the dialog "
 "will be shown. Otherwise it will not be shown."
-msgstr "開啟 GnuCash 啟動時的「每日一訣」功能。如果勾選，將顯示對話盒。否則將不會顯示對話盒。"
+msgstr ""
+"開啟 GnuCash 啟動時的「每日一訣」功能。如果勾選，將顯示對話盒。否則將不會顯示"
+"對話盒。"
 
 #: gnucash/gschemas/org.gnucash.general.finance-quote.gschema.xml.in:5
-#: gnucash/gtkbuilder/dialog-preferences.glade:3632
+#: gnucash/gtkbuilder/dialog-preferences.glade:3651
 msgid "Alpha Vantage API key"
 msgstr "Alpha Vantage API 金鑰"
 
 #: gnucash/gschemas/org.gnucash.general.finance-quote.gschema.xml.in:6
-#: gnucash/gtkbuilder/dialog-preferences.glade:3631
-#: gnucash/gtkbuilder/dialog-preferences.glade:3643
+#: gnucash/gtkbuilder/dialog-preferences.glade:3650
+#: gnucash/gtkbuilder/dialog-preferences.glade:3662
 msgid ""
 "To retrieve online quotes from Alphavantage, this key needs to be set. A key "
 "can be retrieved from the Alpha Vantage website."
-msgstr "為了能夠從 Alphavantage 取得報價，需要設定此金鑰。您可以從 Alphavantage的網站上取得一把金鑰。"
+msgstr ""
+"為了能夠從 Alphavantage 取得報價，需要設定此金鑰。您可以從 Alphavantage的網站"
+"上取得一把金鑰。"
 
 #: gnucash/gschemas/org.gnucash.gschema.xml.in:10
 msgid "The version of these settings"
@@ -10843,7 +11029,9 @@ msgstr "這些設定的版本"
 msgid ""
 "This is used internally to determine whether some preferences may need "
 "conversion when switching to a newer version of GnuCash."
-msgstr "此設定為內部用來決定某些偏好設定在切換到新版本的 GnuCash 時是否要進行轉換之用。"
+msgstr ""
+"此設定為內部用來決定某些偏好設定在切換到新版本的 GnuCash 時是否要進行轉換之"
+"用。"
 
 #: gnucash/gschemas/org.gnucash.gschema.xml.in:15
 msgid "Save window sizes and locations"
@@ -10855,8 +11043,8 @@ msgid ""
 "is closed. The sizes and locations of content windows will be remembered "
 "when you quit GnuCash. Otherwise the sizes will not be saved."
 msgstr ""
-"如果啟用，則各對話盒視窗的大小與位置會在關閉時儲存。GnuCash 的主視窗大小與位置則會在您離開 Gnucash "
-"時儲存。否則的話，視窗大小將不會被儲存。"
+"如果啟用，則各對話盒視窗的大小與位置會在關閉時儲存。GnuCash 的主視窗大小與位"
+"置則會在您離開 Gnucash 時儲存。否則的話，視窗大小將不會被儲存。"
 
 #: gnucash/gschemas/org.gnucash.gschema.xml.in:20
 msgid "Character to use as separator between account names"
@@ -10869,8 +11057,9 @@ msgid ""
 "character, or any of the following strings: \"colon\", \"slash\", \"backslash"
 "\", \"dash\" and \"period\"."
 msgstr ""
-"此設定決定了要用來分隔科目名稱各個部份的字元。可以使用的值為任何一個非數字或字母的 Unicode 字元，或以下任何字串：\"colon\"、"
-"\"slash\"、\"backslash\"、\"dash\" 和 \"period\"。"
+"此設定決定了要用來分隔科目名稱各個部份的字元。可以使用的值為任何一個非數字或"
+"字母的 Unicode 字元，或以下任何字串：\"colon\"、\"slash\"、\"backslash"
+"\"、\"dash\" 和 \"period\"。"
 
 #: gnucash/gschemas/org.gnucash.gschema.xml.in:25
 msgid "Transaction Linked Files head path"
@@ -10897,7 +11086,9 @@ msgstr "顯示自動存檔的說明"
 msgid ""
 "If active, GnuCash shows an explanation of the auto-save feature the first "
 "time that feature is started. Otherwise no extra explanation is shown."
-msgstr "如果啟用，GnuCash 會在自動儲存功能第一次執行時顯示說明。否則的話，不會有額外的說明。"
+msgstr ""
+"如果啟用，GnuCash 會在自動儲存功能第一次執行時顯示說明。否則的話，不會有額外"
+"的說明。"
 
 #: gnucash/gschemas/org.gnucash.gschema.xml.in:40
 msgid "Auto-save time interval"
@@ -10908,7 +11099,8 @@ msgstr "自動存檔的時間間隔"
 msgid ""
 "The number of minutes until saving of the data file to harddisk will be "
 "started automatically. If zero, no saving will be started automatically."
-msgstr "在自動存檔功能開始儲存檔案到硬碟前等待幾分鐘。如果設定成零，則不會自動存檔。"
+msgstr ""
+"在自動存檔功能開始儲存檔案到硬碟前等待幾分鐘。如果設定成零，則不會自動存檔。"
 
 #: gnucash/gschemas/org.gnucash.gschema.xml.in:45
 #: gnucash/gtkbuilder/dialog-preferences.glade:1773
@@ -10922,7 +11114,9 @@ msgid ""
 "limited number of seconds for an answer. If the user didn't answer within "
 "that time, the changes will be saved automatically and the question window "
 "closed."
-msgstr "如果啟用，則「關閉檔案時儲存」的詢問視窗只會維持指定的時間等待回答。如果使用者沒有在指定的時間內選擇回答，則會自動儲存檔案並關閉視窗。"
+msgstr ""
+"如果啟用，則「關閉檔案時儲存」的詢問視窗只會維持指定的時間等待回答。如果使用"
+"者沒有在指定的時間內選擇回答，則會自動儲存檔案並關閉視窗。"
 
 #: gnucash/gschemas/org.gnucash.gschema.xml.in:50
 msgid "Time to wait for answer"
@@ -10949,7 +11143,9 @@ msgid ""
 "If active, GnuCash will automatically insert a decimal point into values "
 "that are entered without one. Otherwise GnuCash will not modify entered "
 "numbers."
-msgstr "如果啟用，GnuCash 會自動插入小數點到未輸入小數位數的數值中。否則的話，GnuCash 不會更動輸入的數字。"
+msgstr ""
+"如果啟用，GnuCash 會自動插入小數點到未輸入小數位數的數值中。否則的話，"
+"GnuCash 不會更動輸入的數字。"
 
 #: gnucash/gschemas/org.gnucash.gschema.xml.in:65
 msgid "Number of automatic decimal places"
@@ -10971,7 +11167,9 @@ msgid ""
 "If active, GnuCash will round prices as necessary to display them as "
 "decimals instead of displaying the exact fraction if the fractional part "
 "cannot be exactly represented as a decimal."
-msgstr "如果啟用，GnuCash 將會針對分數部份無法以精確的小數點表示的價格，進行必要的四捨五入，而非以分數的方式顯示。"
+msgstr ""
+"如果啟用，GnuCash 將會針對分數部份無法以精確的小數點表示的價格，進行必要的四"
+"捨五入，而非以分數的方式顯示。"
 
 #: gnucash/gschemas/org.gnucash.gschema.xml.in:75
 #: gnucash/gtkbuilder/dialog-preferences.glade:1725
@@ -10988,8 +11186,9 @@ msgid ""
 "keep old files for a number of days. How many days is defined in key 'retain-"
 "days'"
 msgstr ""
-"此設定指定了要如何處理舊的日誌 / 備份檔案。「forever」代表保留所有舊檔案。「never」代表不保留舊的日誌 / "
-"備份檔，每次存檔時舊版的檔案都會被刪除。「days」代表將舊檔保留幾天，保留的天數由「retain-days」此鍵定義。"
+"此設定指定了要如何處理舊的日誌 / 備份檔案。「forever」代表保留所有舊檔案。"
+"「never」代表不保留舊的日誌 / 備份檔，每次存檔時舊版的檔案都會被刪除。"
+"「days」代表將舊檔保留幾天，保留的天數由「retain-days」此鍵定義。"
 
 #: gnucash/gschemas/org.gnucash.gschema.xml.in:80
 #: gnucash/gtkbuilder/dialog-preferences.glade:1743
@@ -11027,8 +11226,9 @@ msgid ""
 "status of the account. The setting \"none\" doesn't reverse the sign on any "
 "balances."
 msgstr ""
-"這個設定允許某些科目的餘額使用相反的正負號。想要看到帶負號的開支與帶正號的收入的使用者，可以使用「income-"
-"expense」選項。想要看到科目餘額反應出「借 / 貸」狀態的使用者，可以使用「credit」選項。「none」選項則不更動任何正負號。"
+"這個設定允許某些科目的餘額使用相反的正負號。想要看到帶負號的開支與帶正號的收"
+"入的使用者，可以使用「income-expense」選項。想要看到科目餘額反應出「借 / 貸」"
+"狀態的使用者，可以使用「credit」選項。「none」選項則不更動任何正負號。"
 
 #: gnucash/gschemas/org.gnucash.gschema.xml.in:100
 #: gnucash/gtkbuilder/dialog-preferences.glade:659
@@ -11051,7 +11251,9 @@ msgid ""
 "If active the account hierarchy will colorize the account using the "
 "account's custom color if set. This can serve as a visual aid to quickly "
 "identify accounts."
-msgstr "如果啟用，則科目體系中會使用科目的自訂顏色顯示科目（如果有設定）。這可以做為視覺輔助以快速辨識科目。"
+msgstr ""
+"如果啟用，則科目體系中會使用科目的自訂顏色顯示科目（如果有設定）。這可以做為"
+"視覺輔助以快速辨識科目。"
 
 #: gnucash/gschemas/org.gnucash.gschema.xml.in:115
 msgid "Use account colors in the tabs of open account registers"
@@ -11062,7 +11264,9 @@ msgid ""
 "If active the account register tabs will be colored using the account's "
 "custom color if set. This can serve as a visual aid to quickly identify "
 "accounts."
-msgstr "如果啟用，則會在登記簿頁籤上顯示科目的訂定顏色。這可以做為視覺輔助以快速辨識科目。"
+msgstr ""
+"如果啟用，則會在登記簿頁籤上顯示科目的訂定顏色。這可以做為視覺輔助以快速辨識"
+"科目。"
 
 #: gnucash/gschemas/org.gnucash.gschema.xml.in:120
 msgid "Use formal account labels"
@@ -11088,7 +11292,8 @@ msgid ""
 "this setting, pages can always be closed via the \"close\" menu item or the "
 "\"close\" button on toolbar."
 msgstr ""
-"如果啟用，則可關閉的頁籤會顯示「關閉」按鈕。否則的話，該按鈕不會顯示在頁籤上。不管此設定為何，都可以使用選單或是工具列上的「關閉」選項將頁面關閉。"
+"如果啟用，則可關閉的頁籤會顯示「關閉」按鈕。否則的話，該按鈕不會顯示在頁籤"
+"上。不管此設定為何，都可以使用選單或是工具列上的「關閉」選項將頁面關閉。"
 
 #: gnucash/gschemas/org.gnucash.gschema.xml.in:130
 msgid "Width of notebook tabs"
@@ -11099,195 +11304,217 @@ msgid ""
 "This key specifies the maximum width of notebook tabs. If the text in the "
 "tab is longer than this value (the test is approximate) then the tab label "
 "will have the middle cut and replaced with an ellipsis."
-msgstr "此設定指定了頁籤的最大寬度。如果頁籤裡的文字超過這個長度（以近似值測試），則此頁籤的標籤會被中途截斷並以省略號代替。"
+msgstr ""
+"此設定指定了頁籤的最大寬度。如果頁籤裡的文字超過這個長度（以近似值測試），則"
+"此頁籤的標籤會被中途截斷並以省略號代替。"
 
 #: gnucash/gschemas/org.gnucash.gschema.xml.in:135
+msgid "Opens new tab adjacent to current tab instead of at the end"
+msgstr "在目前的頁籤旁開啟新頁籤，而非在最後端開啟"
+
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:136
+msgid ""
+"If active, new tabs are opened adjacent to current tab. If inactive, the new "
+"tabs are opened instead at the end."
+msgstr "如果啟用，頁籤會緊接在目前頁籤旁開啟。否則的話，會在最後側開啟。"
+
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:140
 #: gnucash/gtkbuilder/dialog-preferences.glade:926
 msgid "Use the system locale currency for all newly created accounts."
 msgstr "針對所有新建立的科目，使用系統的地區設定裡的貨幣。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:136
 #: gnucash/gschemas/org.gnucash.gschema.xml.in:141
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:354
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:146
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:359
 msgid ""
 "This setting controls the source of the default currency for new accounts. "
 "If set to \"locale\" then GnuCash will retrieve the default currency from "
 "the user's locale setting. If set to \"other\", GnuCash will use the setting "
 "specified by the currency-other key."
 msgstr ""
-"此設定控制了新建科目時預設使用的貨幣來源。若設定成「locale」，則 GnuCash 會從使用者的地區設定取得預設的貨幣類型。若設定為「other」，"
-"則 GnuCash 會使用在「currency-other」此鍵中所指定的貨幣。"
+"此設定控制了新建科目時預設使用的貨幣來源。若設定成「locale」，則 GnuCash 會從"
+"使用者的地區設定取得預設的貨幣類型。若設定為「other」，則 GnuCash 會使用在"
+"「currency-other」此鍵中所指定的貨幣。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:140
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:145
 #: gnucash/gtkbuilder/dialog-preferences.glade:906
 msgid "Use the specified currency for all newly created accounts."
 msgstr "新開的科目使用此貨幣。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:145
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:150
 msgid "Default currency for new accounts"
 msgstr "用於新科目的預設貨幣"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:146
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:151
 msgid ""
 "This setting specifies the default currency used for new accounts if the "
 "currency-choice setting is set to \"other\". This field must contain the "
 "three letter ISO 4217 code for a currency (e.g. USD, GBP, RUB)."
 msgstr ""
-"此設定指定了若貨幣選項被設成「other」時，建立新科目時的預設貨幣。此欄位必須使用 ISO 4217 所定義的以三個字母所組成的代碼（例如 "
-"USD、GBP、RUB）。"
+"此設定指定了若貨幣選項被設成「other」時，建立新科目時的預設貨幣。此欄位必須使"
+"用 ISO 4217 所定義的以三個字母所組成的代碼（例如 USD、GBP、RUB）。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:150
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:155
 msgid "Use 24 hour time format"
 msgstr "使用 24 小時制時間格式"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:151
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:156
 msgid ""
 "If active, use a 24 hour time format. Otherwise use a 12 hour time format."
 msgstr "使用 24 小時制(代替 12 小時制)時間。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:155
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:160
 msgid "Date format choice"
 msgstr "選擇日期格式"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:156
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:161
 msgid ""
 "This setting chooses the way dates are displayed in GnuCash. Possible values "
 "for this setting are \"locale\" to use the system locale setting, \"ce\" for "
 "Continental Europe style dates, \"iso\" for ISO 8601 standard dates , \"uk\" "
 "for United Kingdom style dates, and \"us\" for United States style dates."
 msgstr ""
-"此設定定義了在 GnuCash 中日期的顯示方式。可使用的值為：「locale」代表使用系統地區設定，「ce」為歐洲大陸風格的日期，「iso」為 ISO "
-"8061 的標準日期，「uk」為英式風格的日期，而「us」則是美式風格的日期。"
+"此設定定義了在 GnuCash 中日期的顯示方式。可使用的值為：「locale」代表使用系統"
+"地區設定，「ce」為歐洲大陸風格的日期，「iso」為 ISO 8061 的標準日期，「uk」為"
+"英式風格的日期，而「us」則是美式風格的日期。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:160
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:165
 #: gnucash/gtkbuilder/dialog-preferences.glade:1108
 msgid "In the current calendar year"
 msgstr "用今年"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:161
 #: gnucash/gschemas/org.gnucash.gschema.xml.in:166
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:171
 msgid ""
 "When a date is entered without year it can be completed so that it will be "
 "within the current calendar year or close to the current date based on a "
 "sliding window starting a set number of months backwards in time."
-msgstr "當輸入未含有年份的日月期，它可以被自動補齊至當前的日曆年或往前推算幾個月的範圍內的年份。"
+msgstr ""
+"當輸入未含有年份的日月期，它可以被自動補齊至當前的日曆年或往前推算幾個月的範"
+"圍內的年份。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:165
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:170
 msgid ""
 "In a sliding 12-month window starting a configurable number of months before "
 "the current month"
 msgstr "用 12 個月的區間，自本月往前多久開始計算的一個可調整的數字"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:170
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:175
 msgid "Maximum number of months to go back."
 msgstr "最多可往回推算幾個月。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:171
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:176
 #: gnucash/gtkbuilder/dialog-preferences.glade:1134
 msgid ""
 "Dates will be completed so that they are close to the current date. Enter "
 "the maximum number of months to go backwards in time when completing dates."
-msgstr "日期會使用離目前日期最近的日期補完。請輸入自動補完時，最久往回推幾個月。"
+msgstr ""
+"日期會使用離目前日期最近的日期補完。請輸入自動補完時，最久往回推幾個月。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:175
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:180
 msgid "Show Horizontal Grid Lines"
 msgstr "顯示水平格線"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:176
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:181
 msgid ""
 "If active, horizontal grid lines will be shown on table displays. Otherwise "
 "no horizontal grid lines will be shown."
 msgstr "如果啟用，則會在表格中顯示水平格線。否則的話不會顯示水平格線。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:180
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:185
 msgid "Show Vertical Grid Lines"
 msgstr "顯示垂直格線"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:181
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:186
 msgid ""
 "If active, vertical grid lines will be shown on table displays. Otherwise no "
 "vertical grid lines will be shown."
 msgstr "如果啟用，則會在表格中顯示垂直格線。否則的話不會顯示垂直格線。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:185
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:190
 msgid "Show splash screen"
 msgstr "顯示軟體啟動資訊畫面"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:186
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:191
 msgid ""
 "If active, a splash screen will be shown at startup. Otherwise no splash "
 "screen will be shown."
 msgstr "如果啟用，則啟動時會顯示啟動畫面。否則的話不會顯示啟動畫面。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:190
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:195
 #: gnucash/gtkbuilder/dialog-preferences.glade:3366
 msgid "Display the notebook tabs at the top of the window."
 msgstr "在視窗上方顯示頁籤。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:191
 #: gnucash/gschemas/org.gnucash.gschema.xml.in:196
 #: gnucash/gschemas/org.gnucash.gschema.xml.in:201
 #: gnucash/gschemas/org.gnucash.gschema.xml.in:206
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:211
 msgid ""
 "This setting determines the edge at which the tabs for switching pages in "
 "notebooks are drawn. Possible values are \"top\", \"left\", \"bottom\" and "
 "\"right\". It defaults to \"top\"."
 msgstr ""
-"這個設定用來決定頁籤要顯示在哪裡。可能的值為 \"top\", \"left\", \"bottom\" 以及\"right\"。預設的值為 \"top"
-"\"。"
+"這個設定用來決定頁籤要顯示在哪裡。可能的值為 \"top\", \"left\", \"bottom\" 以"
+"及\"right\"。預設的值為 \"top\"。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:195
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:200
 #: gnucash/gtkbuilder/dialog-preferences.glade:3385
 msgid "Display the notebook tabs at the bottom of the window."
 msgstr "在視窗下方顯示頁籤。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:200
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:205
 #: gnucash/gtkbuilder/dialog-preferences.glade:3404
 msgid "Display the notebook tabs at the left of the window."
 msgstr "在視窗左方顯示頁籤。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:205
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:210
 #: gnucash/gtkbuilder/dialog-preferences.glade:3423
 msgid "Display the notebook tabs at the right of the window."
 msgstr "在視窗右方顯示頁籤。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:210
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:215
 #: gnucash/gtkbuilder/dialog-preferences.glade:3455
 msgid "Display the summary bar at the top of the page."
 msgstr "於頁籤最上方顯示摘要列。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:211
 #: gnucash/gschemas/org.gnucash.gschema.xml.in:216
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:221
 msgid ""
 "This setting determines the edge at which the summary bar for various pages "
 "is drawn. Possible values are \"top\" and \"bottom\". It defaults to \"bottom"
 "\"."
-msgstr "這個選項決定了要在哪一側來顯示各頁的摘要列。可能的值為 \"top\" 和 \"bottom\"。預設值是 \"bottom\"。"
+msgstr ""
+"這個選項決定了要在哪一側來顯示各頁的摘要列。可能的值為 \"top\" 和 \"bottom"
+"\"。預設值是 \"bottom\"。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:215
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:220
 #: gnucash/gtkbuilder/dialog-preferences.glade:3474
 msgid "Display the summary bar at the bottom of the page."
 msgstr "於頁籤最下方顯示摘要列。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:220
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:225
 #: gnucash/gtkbuilder/dialog-preferences.glade:3324
 msgid "Closing a tab moves to the most recently visited tab."
 msgstr "關閉頁籤時移動到最近使用的頁籤。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:221
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:226
 msgid ""
 "If active, closing a tab moves to the most recently visited tab. Otherwise "
 "closing a tab moves one tab to the left."
-msgstr "如果啟用，則關閉目前頁籤後會跳到最近檢視的過的頁籤。否則的話會移至左邊的頁籤。"
+msgstr ""
+"如果啟用，則關閉目前頁籤後會跳到最近檢視的過的頁籤。否則的話會移至左邊的頁"
+"籤。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:225
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:230
 #: gnucash/gtkbuilder/dialog-preferences.glade:1421
 msgid ""
 "Set book option on new files to use split \"action\" field for \"Num\" field "
 "on registers/reports"
-msgstr "設定開檔檔案時，將帳簿設定為在登記簿/報表中，「號碼」欄位顯示分割中的「動作」"
+msgstr ""
+"設定開檔檔案時，將帳簿設定為在登記簿/報表中，「號碼」欄位顯示分割中的「動作」"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:226
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:231
 #: gnucash/gtkbuilder/dialog-preferences.glade:1427
 msgid ""
 "If selected, the default book option for new files is set so that the 'Num' "
@@ -11297,14 +11524,16 @@ msgid ""
 "files is set so that the 'Num' cell on registers shows/updates the "
 "transaction 'num' field."
 msgstr ""
-"如果選則此選項，則當建立新的檔案時，登記簿中的「號碼」欄位，會用來顯示和更新分割中的「動作」欄位，交易的「號碼」欄位則會在雙行模式下的第二行顯示(單行)模"
-"式則不會顯示。否則預設的登記簿中的選項，將會是登記簿裡的「號碼」欄位，用來顯示和更新交易中的「號碼」欄位。"
+"如果選則此選項，則當建立新的檔案時，登記簿中的「號碼」欄位，會用來顯示和更新"
+"分割中的「動作」欄位，交易的「號碼」欄位則會在雙行模式下的第二行顯示(單行)模"
+"式則不會顯示。否則預設的登記簿中的選項，將會是登記簿裡的「號碼」欄位，用來顯"
+"示和更新交易中的「號碼」欄位。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:235
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:240
 msgid "Color the register using a gnucash specific color theme"
 msgstr "登記簿使用 GnuCash 的顏色主題"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:236
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:241
 msgid ""
 "When enabled the register will use a GnuCash specific color theme (green/"
 "yellow). Otherwise it will use the system color theme. Regardless of this "
@@ -11312,24 +11541,25 @@ msgid ""
 "css file to be stored in the gnucash used config directory. More information "
 "can be found in the gnucash FAQ."
 msgstr ""
-"當啟用時登記簿會使用 GnuCash 特定的顏色主題（綠色 / 黃色）。曾則的話會使用系統的預設顏色主題。不論此設定為何，使用者可以隨時使用 "
-"GnuCash 所使用的設定資料夾裡的特定 CSS 檔覆蓋這個設定。您可以在 GnuCash 的 FAQ 找到更多的資訊。"
+"當啟用時登記簿會使用 GnuCash 特定的顏色主題（綠色 / 黃色）。曾則的話會使用系"
+"統的預設顏色主題。不論此設定為何，使用者可以隨時使用 GnuCash 所使用的設定資料"
+"夾裡的特定 CSS 檔覆蓋這個設定。您可以在 GnuCash 的 FAQ 找到更多的資訊。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:240
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:245
 msgid "Superseded by \"use-gnucash-color-theme\""
 msgstr "被 use-gnucash-color-theme 抑制"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:241
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:246
 msgid ""
 "This option is temporarily kept around for backwards compatibility. It will "
 "be removed in a future version."
 msgstr "此選項暫時為了向後相容而保留。在未來的版本中會移除此設定。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:245
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:250
 msgid "\"Enter\" key moves to bottom of register"
 msgstr "按「Enter」鍵移至登記簿底端的空白交易處"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:246
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:251
 msgid ""
 "If active, pressing the enter key will move to the bottom of the register. "
 "Otherwise pressing the enter key will move to the next transaction line."
@@ -11337,87 +11567,97 @@ msgstr ""
 "選擇此項時，在使用者按下「Enter」後會移至底部的空白交易。否則，則會往下移一"
 "列。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:250
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:251
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:255
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:256
 msgid "Automatically raise the list of accounts or actions during input"
 msgstr "在輸入時自動跳出科目列表或動作列表"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:255
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:260
 msgid "Move to Transfer field when memorised transaction auto filled"
 msgstr "當自動填入記憶的交易後移到轉帳欄位"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:256
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:261
 msgid ""
 "If active then after a memorised transaction is automatically filled in the "
 "cursor will move to the Transfer field. If not active then it skips to the "
 "value field."
-msgstr "如果啟用，在依過往記憶自補齊轉帳欄位後，游標會移到轉帳欄位。否則的話，游標會跳過這個欄位。"
+msgstr ""
+"如果啟用，在依過往記憶自補齊轉帳欄位後，游標會移到轉帳欄位。否則的話，游標會"
+"跳過這個欄位。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:260
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:265
 msgid "Create a new window for each new register"
 msgstr "為每個登記簿開啟新的視窗"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:261
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:266
 msgid ""
 "If active, each new register will be opened in a new window. Otherwise each "
 "new register will be opened as a tab in the main window."
-msgstr "如果啟用，則登記簿會在新視窗中開啟。否則的話，登記簿會在主視窗中以頁籤的方式開始。"
+msgstr ""
+"如果啟用，則登記簿會在新視窗中開啟。否則的話，登記簿會在主視窗中以頁籤的方式"
+"開始。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:265
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:270
 msgid "Color all lines of a transaction the same"
 msgstr "同一筆交易使用相同的顏色"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:266
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:271
 msgid ""
 "If active all lines that make up a single transaction will use the same "
 "color for their background. Otherwise the background colors are alternated "
 "on each line."
-msgstr "如果啟用，則交易中的每一行都會使用相同的背景色。否則的話背景色會交替更換。"
+msgstr ""
+"如果啟用，則交易中的每一行都會使用相同的背景色。否則的話背景色會交替更換。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:270
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:275
 msgid "Show horizontal borders in a register"
 msgstr "在登記簿中顯示細格的水平邊線"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:271
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:276
 msgid ""
 "Show horizontal borders between rows in a register. If active the border "
 "between cells will be indicated with a heavy line. Otherwise the border "
 "between cells will not be marked."
-msgstr "於登記簿中顯示細格的水平邊線。如果啟用，則細格的邊緣會有粗線，不然的話細格的邊界將不會被標式出來。"
+msgstr ""
+"於登記簿中顯示細格的水平邊線。如果啟用，則細格的邊緣會有粗線，不然的話細格的"
+"邊界將不會被標式出來。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:275
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:280
 msgid "Show vertical borders in a register"
 msgstr "在登記簿中顯示細格的垂直邊線"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:276
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:281
 msgid ""
 "Show vertical borders between columns in a register. If active the border "
 "between cells will be indicated with a heavy line. Otherwise the border "
 "between cells will not be marked."
-msgstr "於登記簿中顯示細格的垂直邊線。如果啟用，則細格的邊緣會有粗線，不然的話細格的邊界將不會被標式出來。"
+msgstr ""
+"於登記簿中顯示細格的垂直邊線。如果啟用，則細格的邊緣會有粗線，不然的話細格的"
+"邊界將不會被標式出來。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:280
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:285
 msgid "Show future transactions after the blank transaction in a register"
 msgstr "在登記簿中將未來交易顯示在空白交易之後"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:281
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:286
 msgid ""
 "Show future transactions after the blank transaction in a register. If "
 "active then transactions with a date in the future will be displayed at the "
 "bottom of the register after the blank transaction. Otherwise the blank "
 "transaction will be at the bottom of the register after all transactions."
 msgstr ""
-"登記簿中未來的交易排在空白交易之後。如果啟用，則日期為未來的交易，將會顯示在登記簿的最下方，空白交易之後。否則的話，則空白交易會在登記簿的最下方，所有交易"
-"之後。"
+"登記簿中未來的交易排在空白交易之後。如果啟用，則日期為未來的交易，將會顯示在"
+"登記簿的最下方，空白交易之後。否則的話，則空白交易會在登記簿的最下方，所有交"
+"易之後。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:285
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:290
 #: gnucash/gtkbuilder/dialog-preferences.glade:2758
 msgid "Show all transactions on one line or in double line mode on two."
 msgstr "以一行顯示全部交易，或在雙行模式中以兩行顯示。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:286
 #: gnucash/gschemas/org.gnucash.gschema.xml.in:291
 #: gnucash/gschemas/org.gnucash.gschema.xml.in:296
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:301
 msgid ""
 "This field specifies the default view style when opening a new register "
 "window. Possible values are \"ledger\", \"auto-ledger\" and \"journal\". The "
@@ -11426,166 +11666,177 @@ msgid ""
 "transaction to show all splits. The \"journal\" setting shows all "
 "transactions in expanded form."
 msgstr ""
-"此欄位指定了當開啟新的登計簿時，要使用哪種檢視風格。可用的值為「ledger」、「auto-"
-"ledger」與「journal」。「ledger」代表針對一筆交易，使用一或兩行兩顯示。「auto-"
-"ledger」也相同，但同時會將目前所在的交易展開，顯示的所有分割。「journal」會將所有交易以全部展開的方式顯示。"
+"此欄位指定了當開啟新的登計簿時，要使用哪種檢視風格。可用的值為「ledger」、"
+"「auto-ledger」與「journal」。「ledger」代表針對一筆交易，使用一或兩行兩顯"
+"示。「auto-ledger」也相同，但同時會將目前所在的交易展開，顯示的所有分割。"
+"「journal」會將所有交易以全部展開的方式顯示。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:290
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:295
 #: gnucash/gtkbuilder/dialog-preferences.glade:2777
 msgid ""
 "Automatically expand the current transaction to show all splits. All other "
 "transactions are shown on one line or in double line mode on two."
-msgstr "自動將目前的交易展並顯示所有的分割。所有其他的交易則使用一行來顯示，或是在雙行模式下以兩行來顯示。"
+msgstr ""
+"自動將目前的交易展並顯示所有的分割。所有其他的交易則使用一行來顯示，或是在雙"
+"行模式下以兩行來顯示。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:295
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:300
 #: gnucash/gtkbuilder/dialog-preferences.glade:2796
 msgid "All transactions are expanded to show all splits."
 msgstr "展開顯示全部分割交易。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:300
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:305
 msgid ""
 "Show a second line with \"Action\", \"Notes\", and \"Linked Documents\" for "
 "each transaction."
 msgstr "針對每行交易，以第二行顯示「對作」、「筆記」和「連結的文件」。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:301
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:306
 msgid ""
 "Show a second line with \"Action\", \"Notes\", and \"Linked Documents\" for "
 "each transaction in a register. This is the default setting for when a "
 "register is first opened. The setting can be changed at any time via the "
 "\"View->Double Line\" menu item."
 msgstr ""
-"在登記簿中的每筆交易裡，增加第二行以顯示「動作」、「筆記」以及「連結的文件」。這是任何登記簿第一次被打開時的預設值。此設定可以在任意時間點透過選單列上的「"
-"檢視->雙行」選項進行變更。"
+"在登記簿中的每筆交易裡，增加第二行以顯示「動作」、「筆記」以及「連結的文"
+"件」。這是任何登記簿第一次被打開時的預設值。此設定可以在任意時間點透過選單列"
+"上的「檢視->雙行」選項進行變更。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:305
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:310
 msgid "Only display leaf account names."
 msgstr "只顯示最底層科目的名稱。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:306
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:311
 msgid ""
 "Show only the names of the leaf accounts in the register and in the account "
 "selection popup. The default behaviour is to display the full name, "
 "including the path in the account tree. Activating this option implies that "
 "you use unique leaf names."
 msgstr ""
-"在登記簿和科目選擇彈出視窗中，只顯示底層科目名稱。預設的行為是顯示完整的名稱，包含科目體系裡完整的路徑。啟用這個選項代表了您在底層科目裡都使用不同的名稱。"
+"在登記簿和科目選擇彈出視窗中，只顯示底層科目名稱。預設的行為是顯示完整的名"
+"稱，包含科目體系裡完整的路徑。啟用這個選項代表了您在底層科目裡都使用不同的名"
+"稱。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:310
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:315
 msgid "Show the entered and reconcile dates"
 msgstr "顯示輸入與對帳日期"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:311
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:316
 #: gnucash/gtkbuilder/dialog-preferences.glade:2940
 msgid ""
 "Show the date when the transaction was entered below the posted date and "
 "reconciled date on split row."
 msgstr "在交易過帳日期下方顯示輸入日期，並在分割列顯示對帳日期。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:315
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:320
 msgid "Show entered and reconciled dates on selection"
 msgstr "於所選擇的項目上顯示輸入與對帳日期"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:316
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:321
 #: gnucash/gtkbuilder/dialog-preferences.glade:2988
 msgid "Show the entered date and reconciled date on transaction selection."
 msgstr "在選定的交易上顯示輸入日期與對帳日期。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:320
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:325
 msgid "Show the calendar buttons"
 msgstr "顯示日曆按鈕"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:321
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:326
 #: gnucash/gtkbuilder/dialog-preferences.glade:2956
 msgid "Show the calendar buttons Cancel, Today and Select."
 msgstr "在日曆中顯示「取消」、「今天」、「選擇」按鈕。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:325
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:330
 msgid "Move the selection to the blank split on expand"
 msgstr "展開交易時移至空白分割"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:326
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:331
 #: gnucash/gtkbuilder/dialog-preferences.glade:2972
 msgid ""
 "This will move the selection to the blank split when the transaction is "
 "expanded."
 msgstr "當交易展開時移動至空白的分割上。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:330
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:335
 msgid "Number of transactions to show in a register."
 msgstr "登記簿中所顯示的交易數量。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:331
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:336
 #: gnucash/gtkbuilder/dialog-preferences.glade:2827
 msgid ""
 "Show this many transactions in a register. A value of zero means show all "
 "transactions."
 msgstr "在登記簿中顯示多少交易，0 表示顯示所有交易。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:335
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:340
 msgid "Number of characters for auto complete."
 msgstr "自動補齊前所需的字元數。"
 
 #. Register2 feature
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:336
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:341
 #: gnucash/gtkbuilder/dialog-preferences.glade:2917
 msgid ""
 "This sets the number of characters before auto complete starts for "
 "description, notes and memo fields."
 msgstr "設定在描述、筆記和備忘錄欄位開始自動補齊前，要先輸入幾個字元。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:343
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:348
 msgid "Create a new window for each new report"
 msgstr "開啟報表時顯示在新視窗中"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:344
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:349
 msgid ""
 "If active, each new report will be opened in its own window. Otherwise new "
 "reports will be opened as tabs in the main window."
-msgstr "如果啟用，則報表會在新視窗中開啟。否則的話，報表會在主視窗中以頁籤的方式開始。"
+msgstr ""
+"如果啟用，則報表會在新視窗中開啟。否則的話，報表會在主視窗中以頁籤的方式開"
+"始。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:348
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:353
 #: gnucash/gtkbuilder/dialog-preferences.glade:3193
 msgid "Use the system locale currency for all newly created reports."
 msgstr "針對新建立的報表，使用系統的地區設定裡的貨幣。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:349
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:359
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:354
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:364
 msgid ""
 "This setting controls the default currency used for reports. If set to "
 "\"locale\" then GnuCash will retrieve the default currency from the user's "
 "locale setting. If set to \"other\", GnuCash will use the setting specified "
 "by the currency-other key."
 msgstr ""
-"此設定控制了報表預設使用的貨幣來源。若設定成「locale」，則 GnuCash 會從使用者的地區設定取得預設的貨幣類型。若設定為「other」，則 "
-"GnuCash 會使用在「currency-other」此鍵中所指定的貨幣。"
+"此設定控制了報表預設使用的貨幣來源。若設定成「locale」，則 GnuCash 會從使用者"
+"的地區設定取得預設的貨幣類型。若設定為「other」，則 GnuCash 會使用在"
+"「currency-other」此鍵中所指定的貨幣。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:353
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:358
 #: gnucash/gtkbuilder/dialog-preferences.glade:3173
 msgid "Use the specified currency for all newly created reports."
 msgstr "新產生的報表使用此貨幣。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:358
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:363
 msgid "Default currency for new reports"
 msgstr "用於新報表的預設貨幣"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:363
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:368
 msgid "Zoom factor to use by default for reports."
 msgstr "報表預設的縮放比例。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:364
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:369
 #: gnucash/gtkbuilder/dialog-preferences.glade:3208
 msgid ""
 "On high resolution screens reports tend to be hard to read. This option "
 "allows you to scale reports up by the set factor. For example setting this "
 "to 2.0 will display reports at twice their typical size."
-msgstr "在高解析度的螢幕上，報表可能會較難閱讀。這個選項允許您依比例放大報表。例如當設定成 2.0 時，報表會比他們一般的大小大兩倍。"
+msgstr ""
+"在高解析度的螢幕上，報表可能會較難閱讀。這個選項允許您依比例放大報表。例如當"
+"設定成 2.0 時，報表會比他們一般的大小大兩倍。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:373
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:378
 msgid "PDF export file name format"
 msgstr "匯出的 PDF 檔案名稱格式"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:374
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:379
 #, c-format
 msgid ""
 "This setting chooses the file name for PDF export. This is a sprintf(3) "
@@ -11596,15 +11847,16 @@ msgid ""
 "in filenames, such as '/', will be replaced with underscores '_' in the "
 "resulting file name."
 msgstr ""
-"此設定定義了匯出 PDF 時的檔案名稱。這是一個含有三個參數的 sprintf(3) "
-"字串：「%1$s」是像「發票」之類的報表名稱、「%2$s」則是報表號碼，以發票報表而言就是發票號碼。「%3$s」是依照「filename-date-"
-"format」所定義的格式表達的報表日期。註：任何在檔名中不允許出現的字元，像是「/」，會在輸出的檔名中被替換為「_」。"
+"此設定定義了匯出 PDF 時的檔案名稱。這是一個含有三個參數的 sprintf(3) 字串："
+"「%1$s」是像「發票」之類的報表名稱、「%2$s」則是報表號碼，以發票報表而言就是"
+"發票號碼。「%3$s」是依照「filename-date-format」所定義的格式表達的報表日期。"
+"註：任何在檔名中不允許出現的字元，像是「/」，會在輸出的檔名中被替換為「_」。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:378
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:383
 msgid "PDF export file name date format choice"
 msgstr "匯出的 PDF 檔案名稱的日期格式"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:379
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:384
 msgid ""
 "This setting chooses the way dates are used in the filename of PDF export. "
 "Possible values for this setting are \"locale\" to use the system locale "
@@ -11612,23 +11864,24 @@ msgid ""
 "standard dates , \"uk\" for United Kingdom style dates, and \"us\" for "
 "United States style dates."
 msgstr ""
-"此設定定義了在 GnuCash 匯出 PDF "
-"的檔案名稱中的日期格式。可使用的值為：「locale」代表使用系統地區設定，「ce」為歐洲大陸風格的日期，「iso」為 ISO 8061 "
-"的標準日期，「uk」為英式風格的日期，而「us」則是美式風格的日期。"
+"此設定定義了在 GnuCash 匯出 PDF 的檔案名稱中的日期格式。可使用的值為："
+"「locale」代表使用系統地區設定，「ce」為歐洲大陸風格的日期，「iso」為 ISO "
+"8061 的標準日期，「uk」為英式風格的日期，而「us」則是美式風格的日期。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:385
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:390
 msgid "Allow file incompatibility with older versions."
 msgstr "允許與舊版本文件不相容。"
 
-#: gnucash/gschemas/org.gnucash.gschema.xml.in:386
+#: gnucash/gschemas/org.gnucash.gschema.xml.in:391
 msgid ""
 "If active, gnucash will be allowed to intentionally break file compatibility "
 "with older versions, so that a data file saved in this version cannot be "
 "read by an older version again. Otherwise gnucash will write data files only "
 "in formats that can be read by older versions as well."
 msgstr ""
-"如果啟用，則允許 GnuCash 刻意破壞存檔與舊版本的相容性，讓此版本的存檔資料無法再次被舊版的 GnuCash 讀取。否則的話，GnuCash "
-"會以可以讓舊版本讀取的檔案格式進行存檔。"
+"如果啟用，則允許 GnuCash 刻意破壞存檔與舊版本的相容性，讓此版本的存檔資料無法"
+"再次被舊版的 GnuCash 讀取。否則的話，GnuCash 會以可以讓舊版本讀取的檔案格式進"
+"行存檔。"
 
 #: gnucash/gschemas/org.gnucash.history.gschema.xml.in:5
 msgid "Number of files in history"
@@ -11639,7 +11892,9 @@ msgid ""
 "This setting contains the number of files to keep in the Recently Opened "
 "Files menu. This value may be set to zero to disable the file history. This "
 "number has a maximum value of 10."
-msgstr "此設定指定了「最近開啟的檔案」選單中所保留的檔案數量。可將此值設為零以禁用檔案歷史。此數值的最大值為 10。"
+msgstr ""
+"此設定指定了「最近開啟的檔案」選單中所保留的檔案數量。可將此值設為零以禁用檔"
+"案歷史。此數值的最大值為 10。"
 
 #: gnucash/gschemas/org.gnucash.history.gschema.xml.in:10
 msgid "Most recently opened file"
@@ -11706,7 +11961,9 @@ msgstr "儲存發票項目的更動"
 msgid ""
 "This dialog is presented when you attempt to move out of a modified invoice "
 "entry. The changed data must be either saved or discarded."
-msgstr "這個對話盒會在您嚐試移除發票中修改過的項目時顯示。必須儲存變更的資料，或此移除會被取消。"
+msgstr ""
+"這個對話盒會在您嚐試移除發票中修改過的項目時顯示。必須儲存變更的資料，或此移"
+"除會被取消。"
 
 #: gnucash/gschemas/org.gnucash.warnings.gschema.xml.in:24
 #: gnucash/gschemas/org.gnucash.warnings.gschema.xml.in:127
@@ -11718,7 +11975,9 @@ msgstr "重複已更動的發票欄位"
 msgid ""
 "This dialog is presented when you attempt to duplicate a modified invoice "
 "entry. The changed data must be saved or the duplication canceled."
-msgstr "這個對話盒會在您嚐試複製一份修改過的發票時顯示。必須儲存變更的資料，或此複製會被取消。"
+msgstr ""
+"這個對話盒會在您嚐試複製一份修改過的發票時顯示。必須儲存變更的資料，或此複製"
+"會被取消。"
 
 #: gnucash/gschemas/org.gnucash.warnings.gschema.xml.in:29
 #: gnucash/gschemas/org.gnucash.warnings.gschema.xml.in:132
@@ -11740,7 +11999,8 @@ msgstr "刪除商品與其價格"
 msgid ""
 "This dialog is presented before allowing you to delete a commodity that has "
 "price quotes attached. Deleting the commodity will delete the quotes as well."
-msgstr "這個對話盒會在允許您刪除含有報價的商品前顯示。刪除商品也會一併刪除報價。"
+msgstr ""
+"這個對話盒會在允許您刪除含有報價的商品前顯示。刪除商品也會一併刪除報價。"
 
 #: gnucash/gschemas/org.gnucash.warnings.gschema.xml.in:39
 #: gnucash/gschemas/org.gnucash.warnings.gschema.xml.in:142
@@ -11776,7 +12036,9 @@ msgid ""
 "This dialog is presented before allowing you to edit an accounts payable/"
 "accounts receivable account. These account types are reserved for the "
 "business features and should rarely be manipulated manually."
-msgstr "這個對話盒會在允許您編輯應付 / 應收帳款科目前顯示。這類型的科目是給商務功能使用的，一般而言不應該手動操作。"
+msgstr ""
+"這個對話盒會在允許您編輯應付 / 應收帳款科目前顯示。這類型的科目是給商務功能使"
+"用的，一般而言不應該手動操作。"
 
 #: gnucash/gschemas/org.gnucash.warnings.gschema.xml.in:54
 #: gnucash/gschemas/org.gnucash.warnings.gschema.xml.in:157
@@ -11799,7 +12061,9 @@ msgid ""
 "This dialog is presented before allowing you to change the contents of a "
 "reconciled split. Allowing these changes can make it hard to perform future "
 "reconciliations."
-msgstr "這個對話盒會在您嚐試修改已對帳的交易時顯示。允許這些變更可能會讓未來的對帳變困難。"
+msgstr ""
+"這個對話盒會在您嚐試修改已對帳的交易時顯示。允許這些變更可能會讓未來的對帳變"
+"困難。"
 
 #: gnucash/gschemas/org.gnucash.warnings.gschema.xml.in:64
 #: gnucash/gschemas/org.gnucash.warnings.gschema.xml.in:167
@@ -11812,7 +12076,9 @@ msgid ""
 "This dialog is presented before allowing you to mark a transaction split as "
 "unreconciled. Doing so will throw off the reconciled value of the register "
 "and can make it hard to perform future reconciliations."
-msgstr "這個對話盒會在允許您將交易分割標記為未對帳前顯示。這麼做會丟棄登記簿中已對帳的金額，並且使得未來對帳時有困難。"
+msgstr ""
+"這個對話盒會在允許您將交易分割標記為未對帳前顯示。這麼做會丟棄登記簿中已對帳"
+"的金額，並且使得未來對帳時有困難。"
 
 #: gnucash/gschemas/org.gnucash.warnings.gschema.xml.in:69
 #: gnucash/gschemas/org.gnucash.warnings.gschema.xml.in:172
@@ -11837,7 +12103,9 @@ msgid ""
 "This dialog is presented before allowing you to remove a reconciled split "
 "from a transaction. Doing so will throw off the reconciled value of the "
 "register and can make it hard to perform future reconciliations."
-msgstr "這個對話盒會在允許您將已對帳的分割從交易中移除前顯示。這麼做會丟棄登記簿中已對帳的金額，並且使得未來對帳時有困難。"
+msgstr ""
+"這個對話盒會在允許您將已對帳的分割從交易中移除前顯示。這麼做會丟棄登記簿中已"
+"對帳的金額，並且使得未來對帳時有困難。"
 
 #: gnucash/gschemas/org.gnucash.warnings.gschema.xml.in:79
 #: gnucash/gschemas/org.gnucash.warnings.gschema.xml.in:84
@@ -11851,7 +12119,9 @@ msgstr "刪除交易中的全部分割"
 msgid ""
 "This dialog is presented before allowing you to remove all splits from a "
 "transaction."
-msgstr "這個對話盒會在允許您將所有分割從交易中移除前顯示。這麼做會丟棄登記簿中已對帳的金額，並且使得未來對帳時有困難。"
+msgstr ""
+"這個對話盒會在允許您將所有分割從交易中移除前顯示。這麼做會丟棄登記簿中已對帳"
+"的金額，並且使得未來對帳時有困難。"
 
 #: gnucash/gschemas/org.gnucash.warnings.gschema.xml.in:85
 #: gnucash/gschemas/org.gnucash.warnings.gschema.xml.in:188
@@ -11860,7 +12130,8 @@ msgid ""
 "some reconciled splits) from a transaction. Doing so will throw off the "
 "reconciled value of the register and can make it hard to perform future "
 "reconciliations."
-msgstr "這個對話盒會在允許您將所有分割（且含有某些已對帳的分割）從交易中移除前顯示。"
+msgstr ""
+"這個對話盒會在允許您將所有分割（且含有某些已對帳的分割）從交易中移除前顯示。"
 
 #: gnucash/gschemas/org.gnucash.warnings.gschema.xml.in:89
 #: gnucash/gschemas/org.gnucash.warnings.gschema.xml.in:192
@@ -11883,7 +12154,9 @@ msgid ""
 "This dialog is presented before allowing you to delete a transaction that "
 "contains reconciled splits. Doing so will throw off the reconciled value of "
 "the register and can make it hard to perform future reconciliations."
-msgstr "這個對話盒會在允許您刪除含有已對帳分割的交易前顯示。這麼做會丟棄登記簿中的已對帳金額並且使得未來執行對帳時變得困難。"
+msgstr ""
+"這個對話盒會在允許您刪除含有已對帳分割的交易前顯示。這麼做會丟棄登記簿中的已"
+"對帳金額並且使得未來執行對帳時變得困難。"
 
 #: gnucash/gschemas/org.gnucash.warnings.gschema.xml.in:99
 #: gnucash/gschemas/org.gnucash.warnings.gschema.xml.in:202
@@ -11895,7 +12168,9 @@ msgstr "重複已變更的交易"
 msgid ""
 "This dialog is presented when you attempt to duplicate a modified "
 "transaction. The changed data must be saved or the duplication canceled."
-msgstr "這個對話盒會在您嚐試複製一份修改過的交易時顯示。必須儲存變更的資料，或此複製會被取消。"
+msgstr ""
+"這個對話盒會在您嚐試複製一份修改過的交易時顯示。必須儲存變更的資料，或此複製"
+"會被取消。"
 
 #: gnucash/gschemas/org.gnucash.warnings.gschema.xml.in:104
 #: gnucash/gschemas/org.gnucash.warnings.gschema.xml.in:207
@@ -11907,7 +12182,9 @@ msgstr "儲存交易的更動"
 msgid ""
 "This dialog is presented when you attempt to move out of a modified "
 "transaction. The changed data must be either saved or discarded."
-msgstr "這個對話盒會在您嚐試移除修改過的交易時顯示。必須儲存變更的資料，或此移除會被取消。"
+msgstr ""
+"這個對話盒會在您嚐試移除修改過的交易時顯示。必須儲存變更的資料，或此移除會被"
+"取消。"
 
 #: gnucash/gschemas/org.gnucash.window.pages.account.tree.gschema.xml.in:5
 #: gnucash/gschemas/org.gnucash.window.pages.account.tree.gschema.xml.in:6
@@ -11937,8 +12214,9 @@ msgid ""
 "date specified by the start-date key. If set to anything else, GnuCash will "
 "retrieve the starting date specified by the start-period key."
 msgstr ""
-"此設定控制了獲利 / 虧損計算方式所使用的開始日期的種類。如果設定成「absolute」，GnuCash 會從「start-"
-"date」此鍵中取得開始日期。如果是其他值，則 GnuCash 會從「start-period」此鍵中取得開始日期。"
+"此設定控制了獲利 / 虧損計算方式所使用的開始日期的種類。如果設定成"
+"「absolute」，GnuCash 會從「start-date」此鍵中取得開始日期。如果是其他值，則 "
+"GnuCash 會從「start-period」此鍵中取得開始日期。"
 
 #: gnucash/gschemas/org.gnucash.window.pages.account.tree.gschema.xml.in:20
 msgid "Use absolute profit/loss starting date"
@@ -11954,8 +12232,8 @@ msgid ""
 "the start-choice setting is set to \"absolute\". This field should contain a "
 "date as represented in seconds from January 1st, 1970."
 msgstr ""
-"若「start-choice」設定成「absolute」，則此設定定義了計算獲利 / 虧損時所使用的開始日期。這個欄位應該用從 1970 年 1 月 1 "
-"號所經過的秒數來表達開始日期。"
+"若「start-choice」設定成「absolute」，則此設定定義了計算獲利 / 虧損時所使用的"
+"開始日期。這個欄位應該用從 1970 年 1 月 1 號所經過的秒數來表達開始日期。"
 
 #: gnucash/gschemas/org.gnucash.window.pages.account.tree.gschema.xml.in:30
 msgid "Starting time period identifier"
@@ -11967,8 +12245,8 @@ msgid ""
 "the start-choice setting is set to anything other than \"absolute\". This "
 "field should contain a value between 0 and 8."
 msgstr ""
-"若「start-choice」設定成「absolute」之外的值，則此設定定義了計算獲利 / 虧損時所使用的開始日期。此欄位應該使用 0 到 8 "
-"之間的數值表示。"
+"若「start-choice」設定成「absolute」之外的值，則此設定定義了計算獲利 / 虧損時"
+"所使用的開始日期。此欄位應該使用 0 到 8 之間的數值表示。"
 
 #: gnucash/gschemas/org.gnucash.window.pages.account.tree.gschema.xml.in:35
 msgid "Use relative profit/loss ending date"
@@ -11982,8 +12260,9 @@ msgid ""
 "date specified by the end-date key. If set to anything else, GnuCash will "
 "retrieve the ending date specified by the end-period key."
 msgstr ""
-"此設定控制了獲利 / 虧損計算方式所使用的結束日期的種類。如果設定成「absolute」，GnuCash 會從「start-"
-"date」此鍵中取得結束日期。如果是其他值，則 GnuCash 會從「start-period」此鍵中取得結束日期。"
+"此設定控制了獲利 / 虧損計算方式所使用的結束日期的種類。如果設定成"
+"「absolute」，GnuCash 會從「start-date」此鍵中取得結束日期。如果是其他值，則 "
+"GnuCash 會從「start-period」此鍵中取得結束日期。"
 
 #: gnucash/gschemas/org.gnucash.window.pages.account.tree.gschema.xml.in:40
 msgid "Use absolute profit/loss ending date"
@@ -11999,8 +12278,8 @@ msgid ""
 "end-choice setting is set to \"absolute\". This field should contain a date "
 "as represented in seconds from January 1st, 1970."
 msgstr ""
-"若「start-choice」設定成「absolute」，則此設定定義了計算獲利 / 虧損時所使用的結束日期。這個欄位應該用從 1970 年 1 月 1 "
-"號所經過的秒數來表達結束日期。"
+"若「start-choice」設定成「absolute」，則此設定定義了計算獲利 / 虧損時所使用的"
+"結束日期。這個欄位應該用從 1970 年 1 月 1 號所經過的秒數來表達結束日期。"
 
 #: gnucash/gschemas/org.gnucash.window.pages.account.tree.gschema.xml.in:50
 msgid "Ending time period identifier"
@@ -12012,8 +12291,8 @@ msgid ""
 "end-choice setting is set to anything other than \"absolute\". This field "
 "should contain a value between 0 and 8."
 msgstr ""
-"若「start-choice」設定成「absolute」之外的值，則此設定定義了計算獲利 / 虧損時所使用的結束日期。此欄位應該使用 0 到 8 "
-"之間的數值表示。"
+"若「start-choice」設定成「absolute」之外的值，則此設定定義了計算獲利 / 虧損時"
+"所使用的結束日期。此欄位應該使用 0 到 8 之間的數值表示。"
 
 #: gnucash/gschemas/org.gnucash.window.pages.gschema.xml.in:5
 msgid "Display this column"
@@ -12043,7 +12322,8 @@ msgid ""
 msgstr ""
 "這個精靈將會協助您設定會計週期。\n"
 "\n"
-"危險：這個功能目前無法正常運作，仍在開發當中。它很有可能對您的資料造成無法修復的損壞！"
+"危險：這個功能目前無法正常運作，仍在開發當中。它很有可能對您的資料造成無法修"
+"復的損壞！"
 
 #: gnucash/gtkbuilder/assistant-acct-period.glade:27
 msgid "Setup Account Period"
@@ -12058,7 +12338,8 @@ msgid ""
 "Books will be closed at midnight on the selected date."
 msgstr ""
 "\n"
-"選擇會計週期以及關帳日期，關帳日期不能是未來時間，且必須大於上一次的關帳日期。\n"
+"選擇會計週期以及關帳日期，關帳日期不能是未來時間，且必須大於上一次的關帳日"
+"期。\n"
 "\n"
 "帳簿將會在選擇的日期關帳。"
 
@@ -12107,9 +12388,11 @@ msgstr ""
 "\n"
 "這個精靈將會協助您從檔案中會入科目。\n"
 "\n"
-"匯入的檔案的格式，必須和從檔案選單中「匯出科目體系到 CSV」所匯出的檔案格式相同，因為其格式是固定的。\n"
+"匯入的檔案的格式，必須和從檔案選單中「匯出科目體系到 CSV」所匯出的檔案格式相"
+"同，因為其格式是固定的。\n"
 "\n"
-"如果該科目原本不存在，則只要所指定的證券或貨幣存在，就會依據科目全名建立該科目。若該科目已存在，則下列四個欄位會被更新：科目代碼、描述、筆記和顏色。\n"
+"如果該科目原本不存在，則只要所指定的證券或貨幣存在，就會依據科目全名建立該科"
+"目。若該科目已存在，則下列四個欄位會被更新：科目代碼、描述、筆記和顏色。\n"
 "\n"
 "按下「下一步」繼續，或按下「取消」中止匯入。\n"
 
@@ -12251,7 +12534,7 @@ msgstr "選擇全部(_A)"
 #: gnucash/gtkbuilder/assistant-csv-export.glade:433
 #: gnucash/gtkbuilder/assistant-loan.glade:1201
 #: gnucash/report/reports/standard/job-report.scm:563
-#: gnucash/report/reports/standard/new-owner-report.scm:1172
+#: gnucash/report/reports/standard/new-owner-report.scm:1167
 #: gnucash/report/reports/standard/owner-report.scm:795
 msgid "Date Range"
 msgstr "日期範圍"
@@ -12384,18 +12667,22 @@ msgid ""
 msgstr ""
 "這個精靈將會協助您從 CSV 檔中匯入價格。\n"
 "\n"
-"若要成功匯入，須要以下這些必填的欄位：日期、金額、商品命名空間、商品代號與報價貨幣別。如果所有項目都是針對同一個商品 / "
-"報價貨幣別，則您可以從下拉選單中選取它們，且必填欄位會是日期與金額。\n"
-"可以選擇使用不同的選擇來指定分隔符號，也可以選擇使用固定寬度的欄位。當選擇使用固定寬度欄位的選擇時，在表格上的資料列點兩下將可以設定欄位寬度，並且點選滑鼠"
-"右鍵可以在需要時修改他們。\n"
-"範例：\"FTSE\",\"RR.L\",\"21/11/2016\",5.345,\"GBP\" 或 CURRENCY;USD;2016-11-21;1"
-".56;GBP\n"
+"若要成功匯入，須要以下這些必填的欄位：日期、金額、商品命名空間、商品代號與報"
+"價貨幣別。如果所有項目都是針對同一個商品 / 報價貨幣別，則您可以從下拉選單中選"
+"取它們，且必填欄位會是日期與金額。\n"
+"可以選擇使用不同的選擇來指定分隔符號，也可以選擇使用固定寬度的欄位。當選擇使"
+"用固定寬度欄位的選擇時，在表格上的資料列點兩下將可以設定欄位寬度，並且點選滑"
+"鼠右鍵可以在需要時修改他們。\n"
+"範例：\"FTSE\",\"RR.L\",\"21/11/2016\",5.345,\"GBP\" 或 CURRENCY;"
+"USD;2016-11-21;1.56;GBP\n"
 "\n"
-"有選項可以指定要跳過檔案開頭和結尾多少列，或是略過檔案中的交替行數，這可以在您的檔案有標頭時使用。此外若有需要，也有選項可以讓您選擇覆蓋掉某日已存在的價格"
-"。\n"
+"有選項可以指定要跳過檔案開頭和結尾多少列，或是略過檔案中的交替行數，這可以在"
+"您的檔案有標頭時使用。此外若有需要，也有選項可以讓您選擇覆蓋掉某日已存在的價"
+"格。\n"
 "\n"
-"最後，對於重複的匯入，在預覽頁中有載入和儲存設定按鈕。您可以儲存調整過後的設定並且在之後的匯入中使用。另外在載入您的設定之後，您也可以針對相似的匯入進行微"
-"調並以其他名稱儲存。注意您無法儲存至預設的設定。\n"
+"最後，對於重複的匯入，在預覽頁中有載入和儲存設定按鈕。您可以儲存調整過後的設"
+"定並且在之後的匯入中使用。另外在載入您的設定之後，您也可以針對相似的匯入進行"
+"微調並以其他名稱儲存。注意您無法儲存至預設的設定。\n"
 "\n"
 "這個操作無法還原，請確認您有可用的備份。\n"
 "\n"
@@ -12494,7 +12781,8 @@ msgstr "允許舊有的價格被覆蓋。"
 msgid ""
 "Normally prices are not over written, select this to change that. This "
 "setting is not saved."
-msgstr "一般而言，價格不會被覆蓋，除非勾選此選項來改變這個行為。這個設定不會被儲存。"
+msgstr ""
+"一般而言，價格不會被覆蓋，除非勾選此選項來改變這個行為。這個設定不會被儲存。"
 
 #: gnucash/gtkbuilder/assistant-csv-price-import.glade:563
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:564
@@ -12544,10 +12832,13 @@ msgid ""
 "* if \"Leading Lines to Skip\" is set to 4, the first line to import will be "
 "line 5. Lines 6, 8, 10,... will be skipped."
 msgstr ""
-"從真正匯入的第一行算起，會每兩行才進行匯入。此選項也會將「略過開頭多少行」也考慮進去。\n"
+"從真正匯入的第一行算起，會每兩行才進行匯入。此選項也會將「略過開頭多少行」也"
+"考慮進去。\n"
 "例如\n"
-"* 若「略過開頭多少行」設定為 3，則第一筆被匯入的資料會在檔案第 4 行。第 5, 7, 9,... 行會被忽略。\n"
-"* 若「略過開頭多少行」設定為 4，則第一筆被匯入的資料會在檔案第 5 行。第 6, 8, 10,... 行會被忽略。"
+"* 若「略過開頭多少行」設定為 3，則第一筆被匯入的資料會在檔案第 4 行。第 5, "
+"7, 9,... 行會被忽略。\n"
+"* 若「略過開頭多少行」設定為 4，則第一筆被匯入的資料會在檔案第 5 行。第 6, "
+"8, 10,... 行會被忽略。"
 
 #: gnucash/gtkbuilder/assistant-csv-price-import.glade:793
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:805
@@ -12622,7 +12913,8 @@ msgid ""
 "imports. After loading your settings you can also tweak them again for "
 "similar imports and save them under another name."
 msgstr ""
-"這個精靈將會協助您匯入含有欄位分隔的交易列表檔案。它同時支援以分隔符號（例如以逗號區隔或以分號區隔）或以固定寬度分隔欄位的檔案。\n"
+"這個精靈將會協助您匯入含有欄位分隔的交易列表檔案。它同時支援以分隔符號（例如"
+"以逗號區隔或以分號區隔）或以固定寬度分隔欄位的檔案。\n"
 "\n"
 "若要成功匯入，匯入的檔案必須具有以下三個欄位：\n"
 "• 日期欄\n"
@@ -12631,12 +12923,14 @@ msgstr ""
 "\n"
 "如果檔案內沒有科目相關的資訊，可以選擇所有匯入的資料預設使用的科目。\n"
 "\n"
-"除了可選擇分隔符號之外，匯入精靈也有一些其他的選項。例如檔案開頭或結尾要跳過的行數，或跳過奇數行。支援數種日期和數字格式，亦可指定檔案編碼。\n"
+"除了可選擇分隔符號之外，匯入精靈也有一些其他的選項。例如檔案開頭或結尾要跳過"
+"的行數，或跳過奇數行。支援數種日期和數字格式，亦可指定檔案編碼。\n"
 "\n"
 "此匯入精靈可以處理將單筆交以單行表示，每行代表一個交易分割的檔案。\n"
 "\n"
-"最後，對於重覆匯入，在預覽頁有載入和儲存設定的按鈕。您可以將您修改的設定儲存，並在之後的匯入中重復使用他們。在載入設定後，您也可以針對相似的匯入微調設定，"
-"並以不同的名稱儲存這些設定。"
+"最後，對於重覆匯入，在預覽頁有載入和儲存設定的按鈕。您可以將您修改的設定儲"
+"存，並在之後的匯入中重復使用他們。在載入設定後，您也可以針對相似的匯入微調設"
+"定，並以不同的名稱儲存這些設定。"
 
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:74
 msgid "Transaction Import Assistant"
@@ -12661,10 +12955,14 @@ msgid ""
 "information is empty or the same as the first transaction line the importer "
 "will consider this line part of the same transaction."
 msgstr ""
-"一般而言匯入精靈會假設匯入的檔案裡每一行對應到一個交易。每一行都含有一筆交易的一或兩個分割。\n"
+"一般而言匯入精靈會假設匯入的檔案裡每一行對應到一個交易。每一行都含有一筆交易"
+"的一或兩個分割。\n"
 "\n"
-"當勾選「多個分割」時，匯入精靈會假設一筆交易會連續以多行來表示，每行提供了該交易中的其中一個分割的資訊，第一行則提供了該交易的整體資訊。\n"
-"要知道哪些行屬於同一筆交易，匯入精靈會比對每一行中提供的交易資訊。如果該資訊是空值，或是和第一個交易行相同，則匯入精靈會認為該行是屬於同一個交易的一部份。"
+"當勾選「多個分割」時，匯入精靈會假設一筆交易會連續以多行來表示，每行提供了該"
+"交易中的其中一個分割的資訊，第一行則提供了該交易的整體資訊。\n"
+"要知道哪些行屬於同一筆交易，匯入精靈會比對每一行中提供的交易資訊。如果該資訊"
+"是空值，或是和第一個交易行相同，則匯入精靈會認為該行是屬於同一個交易的一部"
+"份。"
 
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:767
 msgid ""
@@ -12677,10 +12975,13 @@ msgid ""
 "* if 'Leading Lines to Skip' is set to 4, the first line to import will be "
 "line 5. Lines 6, 8, 10,... will be skipped."
 msgstr ""
-"從真正匯入的第一行算起，會每兩行才進行匯入。此選項也會將「略過開頭多少行」也考慮進去。\n"
+"從真正匯入的第一行算起，會每兩行才進行匯入。此選項也會將「略過開頭多少行」也"
+"考慮進去。\n"
 "例如\n"
-"* 若「略過開頭多少行」設定為 3，則第一筆被匯入的資料會在檔案第 4 行。第 5, 7, 9,... 行會被忽略。\n"
-"* 若「略過開頭多少行」設定為 4，則第一筆被匯入的資料會在檔案第 5 行。第 6, 8, 10,... 行會被忽略。"
+"* 若「略過開頭多少行」設定為 3，則第一筆被匯入的資料會在檔案第 4 行。第 5, "
+"7, 9,... 行會被忽略。\n"
+"* 若「略過開頭多少行」設定為 4，則第一筆被匯入的資料會在檔案第 5 行。第 6, "
+"8, 10,... 行會被忽略。"
 
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:833
 msgid "<b>Account</b>"
@@ -12739,10 +13040,12 @@ msgstr ""
 "\n"
 "在下一頁中，您可以將各筆交易關連到類別中。\n"
 "\n"
-"如果這是您<i>首次匯入到新建立的檔案</i>，您將會看到設定帳簿選項的對話盒，因為這些選項會影響到您匯入的資料要如何轉換成 GnuCash "
-"的交易。如果這是一個既有的檔案，則不會顯示該對話盒。\n"
+"如果這是您<i>首次匯入到新建立的檔案</i>，您將會看到設定帳簿選項的對話盒，因為"
+"這些選項會影響到您匯入的資料要如何轉換成 GnuCash 的交易。如果這是一個既有的檔"
+"案，則不會顯示該對話盒。\n"
 "\n"
-"如果這是您<i>首次匯入</i>，則您會發現所有資料都要進行關聯。在之後的匯入中，匯入精靈會試著依照上一次的匯入來自動關連交易。\n"
+"如果這是您<i>首次匯入</i>，則您會發現所有資料都要進行關聯。在之後的匯入中，匯"
+"入精靈會試著依照上一次的匯入來自動關連交易。\n"
 "\n"
 "關連正確性的信心程度，則會以色條顯示。\n"
 "\n"
@@ -12770,9 +13073,11 @@ msgid ""
 "\n"
 "Click 'Cancel' if you do not wish to create any new accounts now."
 msgstr ""
-"這個精靈會協助您建立一組 GnuCash 科目，包括您的資產(像是投資、支票或儲蓄帳號)、負債(像是貸款)與您可能會有的各種不同的收入和支出。\n"
+"這個精靈會協助您建立一組 GnuCash 科目，包括您的資產(像是投資、支票或儲蓄帳"
+"號)、負債(像是貸款)與您可能會有的各種不同的收入和支出。\n"
 "\n"
-"您可以在這邊選擇看起來和您需要相近的科目。當此精靈完成時，您可以在之後任何的時間新增、重新命名、修改或刪除科目。您也可以建立子科目，或者移動目科(包含其子"
+"您可以在這邊選擇看起來和您需要相近的科目。當此精靈完成時，您可以在之後任何的"
+"時間新增、重新命名、修改或刪除科目。您也可以建立子科目，或者移動目科(包含其子"
 "科目)到其他母科目中。\n"
 "如果您現在不希望建立任何新科目，點選「取消」。"
 
@@ -12797,7 +13102,9 @@ msgid ""
 "Select language and region specific categories that correspond to the ways "
 "that you foresee you will use GnuCash. Each category you select will cause "
 "several accounts to be created."
-msgstr "選擇和您預計的 GnuCash 用途相對應的語言和地區中的科目類型。每一個您選定的科目類型，都會產生其所指定的會計科目。"
+msgstr ""
+"選擇和您預計的 GnuCash 用途相對應的語言和地區中的科目類型。每一個您選定的科目"
+"類型，都會產生其所指定的會計科目。"
 
 #: gnucash/gtkbuilder/assistant-hierarchy.glade:169
 msgid "<b>Categories</b>"
@@ -12822,14 +13129,18 @@ msgstr "%s 中的科目"
 msgid ""
 "If not satisfied with the available templates, please read the wiki page "
 "linked below and share your new or improved template."
-msgstr "如果您不滿意上面提供的範本，請閱讀下方的 Wiki 頁面連結，並且分享您新的，或經過改進的範本。"
+msgstr ""
+"如果您不滿意上面提供的範本，請閱讀下方的 Wiki 頁面連結，並且分享您新的，或經"
+"過改進的範本。"
 
 #: gnucash/gtkbuilder/assistant-hierarchy.glade:490
 msgid ""
 "The selection you make here is only the starting point for your personalized "
 "account hierarchy. Accounts can be added, renamed, moved, or deleted by hand "
 "later at any time."
-msgstr "您在此處所選擇的，只是您個人的科目體系的起跑點。您隨時可以在稍後手動新增、重新命名、移動、刪除科目。"
+msgstr ""
+"您在此處所選擇的，只是您個人的科目體系的起跑點。您隨時可以在稍後手動新增、重"
+"新命名、移動、刪除科目。"
 
 #: gnucash/gtkbuilder/assistant-hierarchy.glade:507
 msgid "GnuCash Account Template Wiki"
@@ -12860,11 +13171,14 @@ msgstr ""
 "\n"
 "如果您想修改科目名稱，點選該科目再點科目名就能修改。\n"
 "\n"
-"有些科目被標記為「佔位符號」，這種科目只是為了建立科目體系用的，通常不會有交易或起始餘額。如果您想讓一個科目如此，點選該科目的核取方塊。\n"
+"有些科目被標記為「佔位符號」，這種科目只是為了建立科目體系用的，通常不會有交"
+"易或起始餘額。如果您想讓一個科目如此，點選該科目的核取方塊。\n"
 "\n"
-"如果您希望一個科目有起始餘額，點選該科目再點起始餘額那欄就能輸入一開始的餘額。\n"
+"如果您希望一個科目有起始餘額，點選該科目再點起始餘額那欄就能輸入一開始的餘"
+"額。\n"
 "\n"
-"<b>注意</b>: 除了財產淨值（股東權益）跟佔位符號之外，所有科目都可以有起始餘額。\n"
+"<b>注意</b>: 除了財產淨值（股東權益）跟佔位符號之外，所有科目都可以有起始餘"
+"額。\n"
 
 #: gnucash/gtkbuilder/assistant-hierarchy.glade:575
 msgid "Setup selected accounts"
@@ -12956,8 +13270,9 @@ msgid ""
 "If you make a mistake or want to make changes later, you can edit the "
 "created Scheduled Transactions directly."
 msgstr ""
-"這是 GnuCash 中逐步建立貸款償還設定的方法。在這個精靈中，您可以輸入您的貸款與其償還的參數，以及投資回收率的詳細情形。使用這些資訊， "
-"GnuCash 會建立適當的排程交易。\n"
+"這是 GnuCash 中逐步建立貸款償還設定的方法。在這個精靈中，您可以輸入您的貸款與"
+"其償還的參數，以及投資回收率的詳細情形。使用這些資訊， GnuCash 會建立適當的排"
+"程交易。\n"
 "\n"
 "如果您輸入錯誤或稍後想做修改，您可以直接編輯建立好的排程交易。"
 
@@ -12986,6 +13301,7 @@ msgstr "輸入貸款詳情，最少需要選擇一個有效的貸款科目以及
 #: gnucash/report/reports/standard/cash-flow.scm:42
 #: gnucash/report/reports/standard/category-barchart.scm:69
 #: gnucash/report/reports/standard/equity-statement.scm:65
+#: gnucash/report/reports/standard/ifrs-cost-basis.scm:53
 #: gnucash/report/reports/standard/income-statement.scm:58
 #: gnucash/report/reports/standard/lot-viewer.scm:35
 #: gnucash/report/reports/standard/net-charts.scm:39
@@ -13006,7 +13322,8 @@ msgstr "貸款科目"
 msgid ""
 "Enter the number of months still to be paid off. This determines both the "
 "remaining principle and the duration of the scheduled transaction."
-msgstr "請輸入剩餘待支付的期（月）數。這會用來計算剩餘的本金和排程交易的持續時間。"
+msgstr ""
+"請輸入剩餘待支付的期（月）數。這會用來計算剩餘的本金和排程交易的持續時間。"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:296
 msgid "Months Remaining"
@@ -13016,7 +13333,9 @@ msgstr "剩餘月數"
 msgid ""
 "Enter the annual interest rate in percent. Accepts values from 0.001 - 100. "
 "The Mortgage Assistant does not support zero-interest loans."
-msgstr "以百分比的型式輸入年利率。可接受的範圍為 0.001 - 100。貸款精靈不支援零利率貸款。"
+msgstr ""
+"以百分比的型式輸入年利率。可接受的範圍為 0.001 - 100。貸款精靈不支援零利率貸"
+"款。"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:367
 #: gnucash/register/ledger-core/gncEntryLedgerLoad.c:55
@@ -13145,6 +13464,7 @@ msgstr "範圍"
 #: gnucash/report/reports/standard/cash-flow.scm:43
 #: gnucash/report/reports/standard/category-barchart.scm:70
 #: gnucash/report/reports/standard/equity-statement.scm:66
+#: gnucash/report/reports/standard/ifrs-cost-basis.scm:54
 #: gnucash/report/reports/standard/income-statement.scm:59
 #: gnucash/report/reports/standard/lot-viewer.scm:36
 #: gnucash/report/reports/standard/net-charts.scm:40
@@ -13188,10 +13508,11 @@ msgid ""
 "Click \"Next\" to start loading your QIF data, or \"Cancel\" to abort the "
 "process."
 msgstr ""
-"GnuCash 可以從 Quiken/QuickBooks、MS Money、Moneydance 與許多其他程式所產生的 QIF (Quicken "
-"交換格式) 檔案匯入金融資料。\n"
+"GnuCash 可以從 Quiken/QuickBooks、MS Money、Moneydance 與許多其他程式所產生"
+"的 QIF (Quicken 交換格式) 檔案匯入金融資料。\n"
 "\n"
-"匯入的程序有許多步驟。直到您在程序的最後點選「套用」之前，您的 GnuCash 科目將不會被變更。\n"
+"匯入的程序有許多步驟。直到您在程序的最後點選「套用」之前，您的 GnuCash 科目將"
+"不會被變更。\n"
 "\n"
 "點選「下一步」以開始載入您的 QIF 資料，或「取消」以放棄程序。"
 
@@ -13209,7 +13530,8 @@ msgid ""
 "You will have the opportunity to load as many files as you wish, so don't "
 "worry if your data is in multiple files.\n"
 msgstr ""
-"請選擇要載入的檔案。當您點選「下一步」時，檔案將會被載入並分析。您可能需要回答一些關於此檔案中的科目的問題。\n"
+"請選擇要載入的檔案。當您點選「下一步」時，檔案將會被載入並分析。您可能需要回"
+"答一些關於此檔案中的科目的問題。\n"
 "\n"
 "您將有機會載入任何數量的檔案，因此即使您的資料位於不同的檔案中也不用擔心。\n"
 
@@ -13241,10 +13563,12 @@ msgid ""
 "software are likely to be in \"d-m-y\" or day-month-year format, where US "
 "QIF files are likely to be \"m-d-y\" or month-day-year.\n"
 msgstr ""
-"此 QIF 檔案格式沒有指定日期中的年、月、日等要素以何種順序列印。程式在大多數情形下能夠自動判定在特別的檔案中所使用的格式。然而，您正匯入的檔案存在一種"
-"以上適用於此資料的可能的格式。\n"
+"此 QIF 檔案格式沒有指定日期中的年、月、日等要素以何種順序列印。程式在大多數情"
+"形下能夠自動判定在特別的檔案中所使用的格式。然而，您正匯入的檔案存在一種以上"
+"適用於此資料的可能的格式。\n"
 "\n"
-"請選擇此檔案的日期格式。歐洲軟體建立的 QIF 檔案可能用「日-月-年」格式，而美國的 QIF 檔案可能用「月-日-年」。\n"
+"請選擇此檔案的日期格式。歐洲軟體建立的 QIF 檔案可能用「日-月-年」格式，而美國"
+"的 QIF 檔案可能用「月-日-年」。\n"
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:332
 #: gnucash/gtkbuilder/assistant-qif-import.glade:417
@@ -13264,9 +13588,11 @@ msgid ""
 "accounting program, you should use the same account name that was used in "
 "that program.\n"
 msgstr ""
-"您正在載入的 QIF 檔案所包含的交易似乎僅用於一個科目，但是檔案沒有指定這個科目的名稱。\n"
+"您正在載入的 QIF 檔案所包含的交易似乎僅用於一個科目，但是檔案沒有指定這個科目"
+"的名稱。\n"
 "\n"
-"請輸入這個科目的名稱。如果此檔案是從其他會計程式匯出的，您應該使用在原程式中所使用的同樣的科目名稱。\n"
+"請輸入這個科目的名稱。如果此檔案是從其他會計程式匯出的，您應該使用在原程式中"
+"所使用的同樣的科目名稱。\n"
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:380
 msgid "Account name"
@@ -13285,7 +13611,8 @@ msgid ""
 "Click \"Next\" to finish loading files and move to the next step of the QIF "
 "import process."
 msgstr ""
-"如果您此時還有更多資料要匯入，點選「載入其他檔案」。您可以在您的科目儲存於不同 QIF 檔案時這麼做。\n"
+"如果您此時還有更多資料要匯入，點選「載入其他檔案」。您可以在您的科目儲存於不"
+"同 QIF 檔案時這麼做。\n"
 "\n"
 "點選「下一步」以結束載入檔案並且移至 QIF 匯入程序的下一個步驟。"
 
@@ -13318,12 +13645,15 @@ msgid ""
 "page so you can change them if you want to, but it is safe to leave them "
 "alone.\n"
 msgstr ""
-"下一頁中，在您的 QIF 檔案中的科目與任何您持有的股票或共同基金將會與 GnuCash 科目配對。如果 GnuCash "
-"科目已經存有相同或近似名稱與適合的類型，那個科目將會被視為相符；否則 GnuCash 會用在 QIF 科目中相同的名稱與類型來建立新的科目。"
-"如果您不喜歡建議的 GnuCash科目，點選以改變它。\n"
+"下一頁中，在您的 QIF 檔案中的科目與任何您持有的股票或共同基金將會與 GnuCash "
+"科目配對。如果 GnuCash 科目已經存有相同或近似名稱與適合的類型，那個科目將會被"
+"視為相符；否則 GnuCash 會用在 QIF 科目中相同的名稱與類型來建立新的科目。如果"
+"您不喜歡建議的 GnuCash科目，點選以改變它。\n"
 "\n"
-"注意 GnuCash 將會建立許多不存在於您其他個人財務程式的科目，包括您的每一個持股都有個別的科目、佣金的個別科目、做為您的期初餘額來源的「資產淨值」科"
-"目(預設上是保留收入的子科目)、其他。這些科目全部會出現在下一頁，因此如果有需要您可以改變他們，但是不管他們也是安全的。\n"
+"注意 GnuCash 將會建立許多不存在於您其他個人財務程式的科目，包括您的每一個持股"
+"都有個別的科目、佣金的個別科目、做為您的期初餘額來源的「資產淨值」科目(預設上"
+"是保留收入的子科目)、其他。這些科目全部會出現在下一頁，因此如果有需要您可以改"
+"變他們，但是不管他們也是安全的。\n"
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:553
 msgid "Accounts and stock holdings"
@@ -13359,9 +13689,11 @@ msgid ""
 "If you change your mind later, you can reorganize the account structure "
 "safely within GnuCash."
 msgstr ""
-"GnuCash 使用個別的收入與支出科目而不是分類來歸類您的交易。您的 QIF 檔案中的每個分類將被轉換成 GnuCash 科目。\n"
+"GnuCash 使用個別的收入與支出科目而不是分類來歸類您的交易。您的 QIF 檔案中的每"
+"個分類將被轉換成 GnuCash 科目。\n"
 "\n"
-"下一頁中，您將有機會查看 QIF 分類與 GnuCash 科目之間的配對。您可以雙擊含有您不喜歡的分類名稱那一行來改變配對結果。\n"
+"下一頁中，您將有機會查看 QIF 分類與 GnuCash 科目之間的配對。您可以雙擊含有您"
+"不喜歡的分類名稱那一行來改變配對結果。\n"
 "\n"
 "假如您稍後改變心意，您也可以在 GnuCash 中安全地重新組織科目結構。"
 
@@ -13384,10 +13716,12 @@ msgid ""
 "these transactions are assigned to the 'Unspecified' account in GnuCash. If "
 "you select a different account, it will be remembered for future QIF files."
 msgstr ""
-"自銀行或其他金融機構下載的 QIF 檔案可能沒有包含讓科目與分類正確地分配到 GnuCash 科目的有關資訊。\n"
+"自銀行或其他金融機構下載的 QIF 檔案可能沒有包含讓科目與分類正確地分配到 "
+"GnuCash 科目的有關資訊。\n"
 "\n"
-"在下一頁裡，您將會看到以非 QIF 科目或分類的型態出現在交易的收款人與備忘錄欄位的文字。預設上這些交易會被分派到 GnuCash "
-"的「未指定」科目。如果您選擇不同的科目，它也會被記下並應用在未來的 QIF 檔案。"
+"在下一頁裡，您將會看到以非 QIF 科目或分類的型態出現在交易的收款人與備忘錄欄位"
+"的文字。預設上這些交易會被分派到 GnuCash 的「未指定」科目。如果您選擇不同的科"
+"目，它也會被記下並應用在未來的 QIF 檔案。"
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:815
 msgid "Payees and memos"
@@ -13417,8 +13751,9 @@ msgid ""
 "setting book options will not be shown a second time when you go forward. "
 "You can access it directly from the menu via File->Properties."
 msgstr ""
-"由於您正在建立新的檔案，接下來您將會看到帳簿設定對話盒。這會影響到 GnuCash "
-"如何匯入交易。若您在並非取消且重頭開始的情況下，則從第二次開始，您回到這一頁之後帳簿選項將不會在下一步出現。您可以直接從「檔案->內容」選單開啟它。"
+"由於您正在建立新的檔案，接下來您將會看到帳簿設定對話盒。這會影響到 GnuCash 如"
+"何匯入交易。若您在並非取消且重頭開始的情況下，則從第二次開始，您回到這一頁之"
+"後帳簿選項將不會在下一步出現。您可以直接從「檔案->內容」選單開啟它。"
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:1001
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:2642
@@ -13442,11 +13777,13 @@ msgid ""
 "If you don't see your exchange listed, or none of the available choices are "
 "appropriate, you can enter a new one."
 msgstr ""
-"下面將要求您提供您匯入的 QIF 檔案中，與股票、共同基金或其他投資相關的資訊。GnuCash 需要其他 QIF 檔案格式中並未提供的關於這些投資的細節。"
+"下面將要求您提供您匯入的 QIF 檔案中，與股票、共同基金或其他投資相關的資訊。"
+"GnuCash 需要其他 QIF 檔案格式中並未提供的關於這些投資的細節。\n"
 "\n"
-"\n"
-"每個股票、共同基金或其他投資都必須有一個命稱和縮寫，例如股票代碼。由於一些彼此無關的投資商品可能會有相同的縮寫，您也需要指定您需入的縮寫是哪一種類型。例如"
-"，您可以選擇定義了該代號的券交所 (NASDAQ, NYSE 等)，或選擇投資類型。（譯註：台灣證券交易所請選擇 TSEC）\n"
+"每個股票、共同基金或其他投資都必須有一個命稱和縮寫，例如股票代碼。由於一些彼"
+"此無關的投資商品可能會有相同的縮寫，您也需要指定您需入的縮寫是哪一種類型。例"
+"如，您可以選擇定義了該代號的券交所 (NASDAQ, NYSE 等)，或選擇投資類型。（譯"
+"註：台灣證券交易所請選擇 TSEC）\n"
 "\n"
 "如果在列表中沒有找到您的證券交易所，或沒有合適的選項，您可以自行建立。"
 
@@ -13494,11 +13831,13 @@ msgid ""
 "Click \"Next\" to review the possible matches."
 msgstr ""
 "\n"
-"如果您正匯入從銀行或其他金融機構下載的 QIF 檔案，QIF 檔案中的一些資訊可能與已經在您的 GnuCash 科目中的資訊相同。為了避免重複，"
-"GnuCash 會嘗試配對既存的相同交易並需要您來幫忙確認。\n"
+"如果您正匯入從銀行或其他金融機構下載的 QIF 檔案，QIF 檔案中的一些資訊可能與已"
+"經在您的 GnuCash 科目中的資訊相同。為了避免重複，GnuCash 會嘗試配對既存的相同"
+"交易並需要您來幫忙確認。\n"
 "\n"
-"下一頁中，您將會看到一個匯入交易的列表。當您每選一筆交易，可能相符的交易會列在下方。若您在其中發現有相符的交易，請點選它。您可以透過 \"相符?\" "
-"這個欄位來確認所選的交易。\n"
+"下一頁中，您將會看到一個匯入交易的列表。當您每選一筆交易，可能相符的交易會列"
+"在下方。若您在其中發現有相符的交易，請點選它。您可以透過 \"相符?\" 這個欄位來"
+"確認所選的交易。\n"
 "\n"
 "點選「下一步」以檢視相同的交易。"
 
@@ -13531,9 +13870,11 @@ msgid ""
 "\n"
 "Click \"Cancel\" to abort the QIF import process."
 msgstr ""
-"點選「套用」以自籌畫區匯入資料並更新您的 GnuCash 科目。您已經輸入的科目與分類配對資訊會被儲存並做為您下次使用QIF 匯入功能的預設值。\n"
+"點選「套用」以自籌畫區匯入資料並更新您的 GnuCash 科目。您已經輸入的科目與分類"
+"配對資訊會被儲存並做為您下次使用QIF 匯入功能的預設值。\n"
 "\n"
-"點選「返回」以檢查您的科目與分類配對，您可以改變用於新科目的貨幣與證券設定，或新增更多檔案至籌畫區。\n"
+"點選「返回」以檢查您的科目與分類配對，您可以改變用於新科目的貨幣與證券設定，"
+"或新增更多檔案至籌畫區。\n"
 "\n"
 "點選「取消」以放棄 QIF 匯入程序。"
 
@@ -13643,7 +13984,9 @@ msgid ""
 "If you are finished creating the stock split or merger, press \"Apply\". You "
 "may also press \"Back\" to review your choices, or \"Cancel\" to quit "
 "without making any changes."
-msgstr "如果您已完成建立股票分割或合併，按下「套用」。您也可以按「反迴」來檢查您的選擇，或「取消」不做任何變更而離開。"
+msgstr ""
+"如果您已完成建立股票分割或合併，按下「套用」。您也可以按「反迴」來檢查您的選"
+"擇，或「取消」不做任何變更而離開。"
 
 #: gnucash/gtkbuilder/assistant-stock-split.glade:424
 msgid "Stock Split Finish"
@@ -13751,7 +14094,9 @@ msgstr "在新視窗中開啟(_O)"
 msgid ""
 "If checked, each invoice will be opened in its own top level window. If "
 "clear, the invoice will be opened in the current window."
-msgstr "如果勾選，則開啟每張發票時，會在獨立的視窗中顯示。如果沒有勾選，則會在目前的視窗中開啟發票。"
+msgstr ""
+"如果勾選，則開啟每張發票時，會在獨立的視窗中顯示。如果沒有勾選，則會在目前的"
+"視窗中開啟發票。"
 
 #: gnucash/gtkbuilder/business-prefs.glade:103
 msgid "_Accumulate splits on post"
@@ -13762,7 +14107,9 @@ msgid ""
 "Whether multiple entries in an invoice which transfer to the same account "
 "should be accumulated into a single split by default. This setting can be "
 "changed in the Post dialog."
-msgstr "如果發票中有多筆分錄都是轉帳到同一個科目，則預設在過帳時，將其整合至同一個分割中。這個設定可以在「過帳」的對話盒中更動。"
+msgstr ""
+"如果發票中有多筆分錄都是轉帳到同一個科目，則預設在過帳時，將其整合至同一個分"
+"割中。這個設定可以在「過帳」的對話盒中更動。"
 
 #: gnucash/gtkbuilder/business-prefs.glade:134
 msgid "<b>Invoices</b>"
@@ -13857,7 +14204,7 @@ msgstr "勾選要一併更動所選科目和子科目的設定相目"
 
 #: gnucash/gtkbuilder/dialog-account.glade:199
 #: gnucash/gtkbuilder/dialog-account.glade:1330
-#: gnucash/report/html-style-sheet.scm:259 gnucash/report/report-core.scm:293
+#: gnucash/report/html-style-sheet.scm:259 gnucash/report/report-core.scm:299
 #: gnucash/report/stylesheets/plain.scm:232
 msgid "Default"
 msgstr "預設值"
@@ -13866,7 +14213,9 @@ msgstr "預設值"
 msgid ""
 "If any account has an existing color it will not be replaced unless the "
 "following is ticked."
-msgstr "如果任何科目已經有設定的顏色，那只有在下面的核取方塊被勾選時，他的顏色才會被改變。"
+msgstr ""
+"如果任何科目已經有設定的顏色，那只有在下面的核取方塊被勾選時，他的顏色才會被"
+"改變。"
 
 #: gnucash/gtkbuilder/dialog-account.glade:232
 msgid "Replace any existing account colors"
@@ -13939,7 +14288,7 @@ msgid "_Default"
 msgstr "預設值(_D)"
 
 #: gnucash/gtkbuilder/dialog-account.glade:956
-#: gnucash/report/reports/standard/account-summary.scm:117
+#: gnucash/report/reports/standard/account-summary.scm:122
 msgid "Account Type"
 msgstr "科目類型"
 
@@ -14015,7 +14364,9 @@ msgid ""
 "This account is present solely as a placeholder in the hierarchy. "
 "Transactions may not be posted to this account, only to sub-accounts of this "
 "account."
-msgstr "這個科目是用來在科目體系中做為佔位符(placeholder)的。您不能將交易過帳到這個科目，只能過帳到它的子科目。"
+msgstr ""
+"這個科目是用來在科目體系中做為佔位符(placeholder)的。您不能將交易過帳到這個科"
+"目，只能過帳到它的子科目。"
 
 #: gnucash/gtkbuilder/dialog-account.glade:1464
 msgid "H_idden"
@@ -14029,8 +14380,9 @@ msgid ""
 "account tree and check the \"show hidden accounts\" option. Doing so will "
 "allow you to select the account and reopen this dialog."
 msgstr ""
-"這個科目(以及其所有的子科目)，將會在科目體系中隱藏，也不會在登錄簿中的科目選單中出現。要重設這個選項，您必須先打開「過濾依...」對話盒，並且在勾選「顯"
-"示被隱藏的科目」的選項。透過這個方式，您可以選擇這個科目並且重新打開這個對話盒。"
+"這個科目(以及其所有的子科目)，將會在科目體系中隱藏，也不會在登錄簿中的科目選"
+"單中出現。要重設這個選項，您必須先打開「過濾依...」對話盒，並且在勾選「顯示被"
+"隱藏的科目」的選項。透過這個方式，您可以選擇這個科目並且重新打開這個對話盒。"
 
 #: gnucash/gtkbuilder/dialog-account.glade:1480
 msgid "Auto _interest transfer"
@@ -14045,7 +14397,8 @@ msgstr "與稅相關(_X)"
 msgid ""
 "Use Edit->Tax Report Options to set the tax-related flag and assign a tax "
 "code to this account."
-msgstr "使用「編輯->稅務報表選項」設定稅務相關的選項，並且指定這個科目的稅務編號。"
+msgstr ""
+"使用「編輯->稅務報表選項」設定稅務相關的選項，並且指定這個科目的稅務編號。"
 
 #: gnucash/gtkbuilder/dialog-account.glade:1513
 msgid "Opening balance"
@@ -14421,8 +14774,9 @@ msgid ""
 "retrieving quotes online, this field must exactly match the ticker symbol "
 "used by the quote source (including case). "
 msgstr ""
-"輸入此商品/股票的代碼 (例如台積電可輸入 2330.TW 或元大台灣 50 可輸入 0050.TW)。如果您使用線上取價功能（譯註：台灣股市可使用 "
-"Yahoo as JSON 做為報價來源），則此欄位必須與使用的來源所用的代碼完全一致(包括大小寫)。 "
+"輸入此商品/股票的代碼 (例如台積電可輸入 2330.TW 或元大台灣 50 可輸入 0050."
+"TW)。如果您使用線上取價功能（譯註：台灣股市可使用 Yahoo as JSON 做為報價來"
+"源），則此欄位必須與使用的來源所用的代碼完全一致(包括大小寫)。 "
 
 #: gnucash/gtkbuilder/dialog-commodity.glade:165
 msgid ""
@@ -14445,7 +14799,9 @@ msgstr "<b>報價來源資訊</b>"
 msgid ""
 "Enter a display symbol. This can safely be left blank, in which case the "
 "ticker symbol or the currency ISO code will be used."
-msgstr "輸入顯示符號。這個欄位可以留白，若留白的話，會使用商品代碼或是 ISO裡指定的該貨幣的符號。"
+msgstr ""
+"輸入顯示符號。這個欄位可以留白，若留白的話，會使用商品代碼或是 ISO裡指定的該"
+"貨幣的符號。"
 
 #: gnucash/gtkbuilder/dialog-commodity.glade:342
 msgid "Type of quote source"
@@ -14560,7 +14916,7 @@ msgstr "帳單地址"
 #: gnucash/import-export/bi-import/dialog-bi-import-gui.c:156
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:72
 #: gnucash/report/reports/standard/invoice.scm:98
-#: gnucash/report/reports/standard/invoice.scm:237
+#: gnucash/report/reports/standard/invoice.scm:224
 msgid "Discount"
 msgstr "折扣"
 
@@ -14641,7 +14997,8 @@ msgid ""
 "Configuration\" from\n"
 "the Reports menu or tool bar."
 msgstr ""
-"要建立並儲存的報表組態，請先從報表選單中打開報表，依照您的喜好更改報表選項，\n"
+"要建立並儲存的報表組態，請先從報表選單中打開報表，依照您的喜好更改報表選"
+"項，\n"
 "再從報表選單或是工具列上點選「儲存報表組態」。"
 
 #: gnucash/gtkbuilder/dialog-date-close.glade:7
@@ -14657,13 +15014,17 @@ msgstr "更改連結文件的預設開頭路徑"
 msgid ""
 "Existing relative file path links will be converted to absolute ones by "
 "combining them with the existing path head unless box unticked."
-msgstr "除非這個核取方塊被打勾，否則已經存在的相對路徑檔案連結，將會變成與原本的開頭路徑和併的絕對路徑。"
+msgstr ""
+"除非這個核取方塊被打勾，否則已經存在的相對路徑檔案連結，將會變成與原本的開頭"
+"路徑和併的絕對路徑。"
 
 #: gnucash/gtkbuilder/dialog-doclink.glade:140
 msgid ""
 "Existing absolute file path links will be converted to relative ones by "
 "comparing them to the new path head unless box unticked."
-msgstr "除非這個核取方塊被打勾，否則已經存在的絕對路徑檔案連結，將會轉換成與新指定的路徑比對後的相對路徑。"
+msgstr ""
+"除非這個核取方塊被打勾，否則已經存在的絕對路徑檔案連結，將會轉換成與新指定的"
+"路徑比對後的相對路徑。"
 
 #: gnucash/gtkbuilder/dialog-doclink.glade:178
 msgid "Note: Only Document Links that are not read-only will be changed."
@@ -14809,7 +15170,7 @@ msgstr "每年三次"
 
 #: gnucash/gtkbuilder/dialog-fincalc.glade:21
 #: gnucash/gtkbuilder/dialog-fincalc.glade:62
-#: gnucash/gtkbuilder/dialog-sx.glade:138 gnucash/report/trep-engine.scm:345
+#: gnucash/gtkbuilder/dialog-sx.glade:138 gnucash/report/trep-engine.scm:323
 msgid "Quarterly"
 msgstr "一季"
 
@@ -14823,9 +15184,9 @@ msgstr "每兩個月"
 #: gnucash/gtkbuilder/dialog-sx.glade:135
 #: gnucash/gtkbuilder/gnc-frequency.glade:180
 #: gnucash/gtkbuilder/gnc-frequency.glade:1408
-#: gnucash/report/reports/standard/account-piecharts.scm:124
-#: gnucash/report/reports/standard/category-barchart.scm:123
-#: gnucash/report/trep-engine.scm:336 libgnucash/engine/Recurrence.c:761
+#: gnucash/report/reports/standard/account-piecharts.scm:119
+#: gnucash/report/reports/standard/category-barchart.scm:120
+#: gnucash/report/trep-engine.scm:315 libgnucash/engine/Recurrence.c:761
 #: libgnucash/engine/Recurrence.c:775
 msgid "Monthly"
 msgstr "每月"
@@ -14846,9 +15207,9 @@ msgstr "每兩週"
 #: gnucash/gtkbuilder/dialog-sx.glade:129
 #: gnucash/gtkbuilder/gnc-frequency.glade:174
 #: gnucash/gtkbuilder/gnc-frequency.glade:993
-#: gnucash/report/reports/standard/account-piecharts.scm:127
-#: gnucash/report/reports/standard/category-barchart.scm:126
-#: gnucash/report/trep-engine.scm:327 libgnucash/engine/Recurrence.c:623
+#: gnucash/report/reports/standard/account-piecharts.scm:120
+#: gnucash/report/reports/standard/category-barchart.scm:121
+#: gnucash/report/trep-engine.scm:307 libgnucash/engine/Recurrence.c:623
 msgid "Weekly"
 msgstr "每週"
 
@@ -15088,8 +15449,9 @@ msgid ""
 "rows and then Right Click to select a transfer account. Only rows with \"A\" "
 "checked can be added to a selection."
 msgstr ""
-"您可以選擇多筆交易並且統一指定所有選擇的交易要指定的科目。使用「Ctrl+滑鼠左鍵」或「Shift+滑鼠左鍵」以選取多行，並且點選滑鼠右鍵選擇轉帳科目。只"
-"有被標記為「新增」的交易可以加入到選擇中。"
+"您可以選擇多筆交易並且統一指定所有選擇的交易要指定的科目。使用「Ctrl+滑鼠左"
+"鍵」或「Shift+滑鼠左鍵」以選取多行，並且點選滑鼠右鍵選擇轉帳科目。只有被標記"
+"為「新增」的交易可以加入到選擇中。"
 
 #: gnucash/gtkbuilder/dialog-import.glade:466
 msgid ""
@@ -15101,7 +15463,9 @@ msgstr "此交易需要您的介入，否則很有可能匯入後借貸不平衡
 msgid ""
 "This transaction will be imported balanced (you may still want to double "
 "check the match or destination account)."
-msgstr "此筆交易將會以借貸平衡的狀態匯入（但您可能仍然想要再次檢查其配對或目的科目）。"
+msgstr ""
+"此筆交易將會以借貸平衡的狀態匯入（但您可能仍然想要再次檢查其配對或目的科"
+"目）。"
 
 #: gnucash/gtkbuilder/dialog-import.glade:472
 msgid "This transaction requires your intervention or it will NOT be imported."
@@ -15111,29 +15475,31 @@ msgstr "此交易需要您的介入，否則將不會被匯入。"
 msgid ""
 "Double click on the transaction to either change the matching transaction in "
 "GnuCash or the destination account of the auto-balance split (if required)."
-msgstr "在交易上點兩小以變更其與 GnuCash 交易的配對，或（需要的話）變更自動結算分割中的目的科目。"
+msgstr ""
+"在交易上點兩小以變更其與 GnuCash 交易的配對，或（需要的話）變更自動結算分割中"
+"的目的科目。"
 
 #: gnucash/gtkbuilder/dialog-import.glade:480
 msgid "Transaction List Help"
 msgstr "交易列表說明"
 
 #: gnucash/gtkbuilder/dialog-import.glade:529
-#: gnucash/report/stylesheets/footer.scm:123
-#: gnucash/report/stylesheets/footer.scm:130
-#: gnucash/report/stylesheets/footer.scm:137
-#: gnucash/report/stylesheets/footer.scm:144
-#: gnucash/report/stylesheets/footer.scm:151
-#: gnucash/report/stylesheets/footer.scm:159
-#: gnucash/report/stylesheets/footer.scm:167
-#: gnucash/report/stylesheets/footer.scm:175
+#: gnucash/report/stylesheets/footer.scm:117
+#: gnucash/report/stylesheets/footer.scm:124
+#: gnucash/report/stylesheets/footer.scm:131
+#: gnucash/report/stylesheets/footer.scm:138
+#: gnucash/report/stylesheets/footer.scm:145
+#: gnucash/report/stylesheets/footer.scm:153
+#: gnucash/report/stylesheets/footer.scm:161
+#: gnucash/report/stylesheets/footer.scm:169
+#: gnucash/report/stylesheets/head-or-tail.scm:163
 #: gnucash/report/stylesheets/head-or-tail.scm:170
 #: gnucash/report/stylesheets/head-or-tail.scm:177
 #: gnucash/report/stylesheets/head-or-tail.scm:184
 #: gnucash/report/stylesheets/head-or-tail.scm:191
-#: gnucash/report/stylesheets/head-or-tail.scm:198
-#: gnucash/report/stylesheets/head-or-tail.scm:206
-#: gnucash/report/stylesheets/head-or-tail.scm:214
-#: gnucash/report/stylesheets/head-or-tail.scm:222
+#: gnucash/report/stylesheets/head-or-tail.scm:199
+#: gnucash/report/stylesheets/head-or-tail.scm:207
+#: gnucash/report/stylesheets/head-or-tail.scm:215
 #: gnucash/report/stylesheets/plain.scm:62
 msgid "Colors"
 msgstr "顏色"
@@ -15369,8 +15735,8 @@ msgid ""
 "will be displayed again next time you start GnuCash. If you press the <i>No</"
 "i> button, it will not be displayed again."
 msgstr ""
-"如果按「<i>是</i>」按鈕，下次啟動 GnuCash 時，「<i>歡迎使用 "
-"GnuCash!</i>」對話盒將再次顯示。如按「<i>否</i>」按鈕，該對話盒將不會再次顯示。"
+"如果按「<i>是</i>」按鈕，下次啟動 GnuCash 時，「<i>歡迎使用 GnuCash!</i>」對"
+"話盒將再次顯示。如按「<i>否</i>」按鈕，該對話盒將不會再次顯示。"
 
 #: gnucash/gtkbuilder/dialog-new-user.glade:211
 msgid "<span size=\"larger\" weight=\"bold\">Welcome to GnuCash!</span>"
@@ -15383,8 +15749,9 @@ msgid ""
 "the <i>OK</i> button or press the <i>Cancel</i> button if you don't want to "
 "perform any of them."
 msgstr ""
-"大多數的使用者，喜歡在開始使用 GnuCash "
-"時執行一些事先定義好的動作。請從下方選擇這些動作，並且按下「<i>確定</i>」按鈕，或您不想執行任何動作的話，請按下「<i>取消</i>」。"
+"大多數的使用者，喜歡在開始使用 GnuCash 時執行一些事先定義好的動作。請從下方選"
+"擇這些動作，並且按下「<i>確定</i>」按鈕，或您不想執行任何動作的話，請按下"
+"「<i>取消</i>」。"
 
 #: gnucash/gtkbuilder/dialog-new-user.glade:245
 msgid "C_reate a new set of accounts"
@@ -15481,9 +15848,11 @@ msgid ""
 msgstr ""
 "此發票的應付金額。\n"
 "\n"
-"如果您選擇了一張發票，GnuCash 會提示您尚需支付的金額。您可以更改金額來進行部份支付或超額支付。\n"
+"如果您選擇了一張發票，GnuCash 會提示您尚需支付的金額。您可以更改金額來進行部"
+"份支付或超額支付。\n"
 "\n"
-"在超額支付的情況下，如果沒有選擇發票，GnuCash 會自動將剩餘金額指派給此公司第一張尚未付款的發票。"
+"在超額支付的情況下，如果沒有選擇發票，GnuCash 會自動將剩餘金額指派給此公司第"
+"一張尚未付款的發票。"
 
 #: gnucash/gtkbuilder/dialog-payment.glade:462
 #: gnucash/report/reports/standard/new-owner-report.scm:298
@@ -15579,7 +15948,9 @@ msgstr "包含非貨幣的總合(_N)"
 msgid ""
 "If checked, non-currency commodities will be shown in the summary bar. If "
 "clear, only currencies will be shown."
-msgstr "如果勾選，則非貨幣類型的商品會顯示在摘要列中。如果沒有勾選，則只有貨幣會被顯示在摘要列中。"
+msgstr ""
+"如果勾選，則非貨幣類型的商品會顯示在摘要列中。如果沒有勾選，則只有貨幣會被顯"
+"示在摘要列中。"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:390
 msgid "_Relative"
@@ -15691,8 +16062,9 @@ msgid ""
 "the following strings: \"colon\" \"slash\", \"backslash\", \"dash\" and "
 "\"period\"."
 msgstr ""
-"這個字元會用來區分科目中的每個部份。合法的值是任何一個非字母與數字的字元，或是下列任何一個字串：\"colon\", \"slash\", "
-"\"backslash\", \"dash\" 以及 \"period\"。"
+"這個字元會用來區分科目中的每個部份。合法的值是任何一個非字母與數字的字元，或"
+"是下列任何一個字串：\"colon\", \"slash\", \"backslash\", \"dash\" 以及 "
+"\"period\"。"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:900
 #: gnucash/gtkbuilder/dialog-preferences.glade:3167
@@ -15809,8 +16181,8 @@ msgstr "記錄檔/備份檔保留幾天。"
 #: gnucash/gtkbuilder/dialog-preferences.glade:1486
 #: gnucash/gtkbuilder/dialog-sx.glade:619
 #: gnucash/gtkbuilder/dialog-sx.glade:658
-#: gnucash/gtkbuilder/dialog-sx.glade:970
-#: gnucash/gtkbuilder/dialog-sx.glade:1030
+#: gnucash/gtkbuilder/dialog-sx.glade:987
+#: gnucash/gtkbuilder/dialog-sx.glade:1047
 msgid "days"
 msgstr "天"
 
@@ -15866,15 +16238,16 @@ msgstr "顯示確認自動存檔的詢問(_Q)"
 msgid ""
 "If active, GnuCash shows a confirmation question each time the auto-save "
 "feature is started. Otherwise no extra explanation is shown."
-msgstr "如果勾選，GnuCash 會在每一次進行自動存檔時進行詢問。否則不會有另外的訊息。"
+msgstr ""
+"如果勾選，GnuCash 會在每一次進行自動存檔時進行詢問。否則不會有另外的訊息。"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1737
-#: gnucash/gtkbuilder/dialog-sx.glade:1217
+#: gnucash/gtkbuilder/dialog-sx.glade:1234
 msgid "For"
 msgstr "指定"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1755
-#: gnucash/gtkbuilder/dialog-sx.glade:1185
+#: gnucash/gtkbuilder/dialog-sx.glade:1202
 msgid "Forever"
 msgstr "永遠"
 
@@ -15899,7 +16272,8 @@ msgstr "在表格上顯示水平線"
 msgid ""
 "Enable horizontal grid lines on table displays. These will mainly be tree "
 "views like the Accounts page."
-msgstr "在表格上顯示水平線。這主要會影響像是「科目」頁籤這類中的樹狀顯示的畫面。"
+msgstr ""
+"在表格上顯示水平線。這主要會影響像是「科目」頁籤這類中的樹狀顯示的畫面。"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1923
 msgid "Enable vertical grid lines on table displays"
@@ -15909,7 +16283,8 @@ msgstr "在表格上顯示垂直線"
 msgid ""
 "Enable vertical grid lines on table displays. These will mainly be tree "
 "views like the Accounts page."
-msgstr "在表格上顯示垂直線。這主要會影響像是「科目」頁籤這類中的樹狀顯示的畫面。"
+msgstr ""
+"在表格上顯示垂直線。這主要會影響像是「科目」頁籤這類中的樹狀顯示的畫面。"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1943
 msgid "<b>Linked Files</b>"
@@ -15953,7 +16328,9 @@ msgid ""
 "A transaction whose best match's score is in the red zone (above the display "
 "threshold but below or equal to the Auto-ADD threshold) will be ADDed by "
 "default."
-msgstr "其最高配對分數在紅色區（高於顯示門檻但低於或等於自動新增門檻）的交易會預設為已加入。"
+msgstr ""
+"其最高配對分數在紅色區（高於顯示門檻但低於或等於自動新增門檻）的交易會預設為"
+"已加入。"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2163
 msgid ""
@@ -16032,7 +16409,8 @@ msgid ""
 "If checked, pressing the 'Enter' key will move to the location of the blank "
 "transaction in the register. If clear, pressing the 'Enter' key will move "
 "down one row."
-msgstr "選擇此項時，在使用者按下「Enter」後會移至空白交易。否則，則會往下移一列。"
+msgstr ""
+"選擇此項時，在使用者按下「Enter」後會移至空白交易。否則，則會往下移一列。"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2441
 msgid "_Auto-raise lists"
@@ -16094,7 +16472,9 @@ msgstr "使用 GnuCash 內建的顏色主題(_U)"
 msgid ""
 "GnuCash uses a yellow/green theme by default for register windows. Uncheck "
 "this if you want to use the system color theme instead."
-msgstr "GnuCash 預設使用黃色/綠色做為登記簿的顏色主題。如果您想使用系統預設的顏色主題，取消勾選此選項。"
+msgstr ""
+"GnuCash 預設使用黃色/綠色做為登記簿的顏色主題。如果您想使用系統預設的顏色主"
+"題，取消勾選此選項。"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2595
 msgid "Double _mode colors alternate with transactions"
@@ -16123,14 +16503,14 @@ msgid "Show vertical borders on the cells."
 msgstr "顯示細格的垂直邊線。"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2662
-#: gnucash/report/reports/standard/invoice.scm:201
-#: gnucash/report/reports/standard/invoice.scm:207
-#: gnucash/report/reports/standard/invoice.scm:348
-#: gnucash/report/reports/standard/invoice.scm:355
-#: gnucash/report/reports/standard/invoice.scm:362
-#: gnucash/report/reports/standard/invoice.scm:369
-#: gnucash/report/reports/standard/invoice.scm:376
-#: gnucash/report/reports/standard/invoice.scm:383
+#: gnucash/report/reports/standard/invoice.scm:188
+#: gnucash/report/reports/standard/invoice.scm:194
+#: gnucash/report/reports/standard/invoice.scm:335
+#: gnucash/report/reports/standard/invoice.scm:342
+#: gnucash/report/reports/standard/invoice.scm:349
+#: gnucash/report/reports/standard/invoice.scm:356
+#: gnucash/report/reports/standard/invoice.scm:363
+#: gnucash/report/reports/standard/invoice.scm:370
 msgid "Layout"
 msgstr "排版"
 
@@ -16143,7 +16523,9 @@ msgid ""
 "If checked, transactions with a date in the future will be displayed at the "
 "bottom of the register after the blank transaction. If clear, the blank "
 "transaction will be at the bottom of the register after all transactions."
-msgstr "如果勾選，則日期為未來的交易，將會顯示在登記簿的最下方，空白交易之後。如果沒有勾選，則空白交易會在登記簿的最下方，所有交易之後。"
+msgstr ""
+"如果勾選，則日期為未來的交易，將會顯示在登記簿的最下方，空白交易之後。如果沒"
+"有勾選，則空白交易會在登記簿的最下方，所有交易之後。"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2719
 msgid "<b>Default Style</b>"
@@ -16183,7 +16565,9 @@ msgstr "在新視窗中開啟登記簿(_W)"
 msgid ""
 "If checked, each register will be opened in its own top level window. If "
 "clear, the register will be opened in the current window."
-msgstr "如果勾選，則每個登錄簿會在新視窗中開啟。如果沒有勾選，則登錄簿會在目前的視窗中開啟。"
+msgstr ""
+"如果勾選，則每個登錄簿會在新視窗中開啟。如果沒有勾選，則登錄簿會在目前的視窗"
+"中開啟。"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2881
 msgid "_Only display leaf account names"
@@ -16196,8 +16580,9 @@ msgid ""
 "display the full name, including the path in the account tree. Checking this "
 "option implies that you use unique leaf names."
 msgstr ""
-"如果勾選，則登錄簿中的科目選擇選單中，只會顯示最底層的科目名稱。預設的行為是顯示完整的科目名稱，包括科目體系中所有的路徑。勾選此選項，隱含著您最底層的所有"
-"科目名稱，都必須是不同的。"
+"如果勾選，則登錄簿中的科目選擇選單中，只會顯示最底層的科目名稱。預設的行為是"
+"顯示完整的科目名稱，包括科目體系中所有的路徑。勾選此選項，隱含著您最底層的所"
+"有科目名稱，都必須是不同的。"
 
 #. Register2 feature
 #: gnucash/gtkbuilder/dialog-preferences.glade:2902
@@ -16244,7 +16629,9 @@ msgstr "在新視窗中開啟報表(_W)"
 msgid ""
 "If checked, each report will be opened in its own top level window. If "
 "clear, the report will be opened in the current window."
-msgstr "如果勾選，則報表會在新的視窗中被開啟。如果沒有勾選，則報表會在使用中的視窗裡開啟。"
+msgstr ""
+"如果勾選，則報表會在新的視窗中被開啟。如果沒有勾選，則報表會在使用中的視窗裡"
+"開啟。"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3145
 #: gnucash/gtkbuilder/dialog-preferences.glade:3225
@@ -16318,7 +16705,9 @@ msgstr "在每個頁籤上顯示關閉按鈕，這個按鈕的功能和選單上
 msgid ""
 "If the text in the tab is longer than this value (the test is approximate) "
 "then the tab label will have the middle cut and replaced with an ellipsis."
-msgstr "如果頁籤中的文字長度超過這個數值(使用近似值)，則該頁籤的標籤將會被截斷並且以省略符號代替。"
+msgstr ""
+"如果頁籤中的文字長度超過這個數值(使用近似值)，則該頁籤的標籤將會被截斷並且以"
+"省略符號代替。"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3557
 msgid "characters"
@@ -16328,12 +16717,20 @@ msgstr "字元"
 msgid "_Width"
 msgstr "寬度(_W)"
 
-#: gnucash/gtkbuilder/dialog-preferences.glade:3613
+#: gnucash/gtkbuilder/dialog-preferences.glade:3587
+msgid "Open new tabs _adjacent to current tab"
+msgstr "將新頁籤開啟在目前的頁籤旁邊(_A)"
+
+#: gnucash/gtkbuilder/dialog-preferences.glade:3593
+msgid "Opens new tab adjacent to current tab instead of at the end."
+msgstr "在目前的頁籤旁開啟新頁籤，而非在最後端開啟。"
+
+#: gnucash/gtkbuilder/dialog-preferences.glade:3632
 msgid "Windows"
 msgstr "視窗"
 
-#: gnucash/gtkbuilder/dialog-preferences.glade:3656
-#: gnucash/gtkbuilder/dialog-preferences.glade:3679
+#: gnucash/gtkbuilder/dialog-preferences.glade:3675
+#: gnucash/gtkbuilder/dialog-preferences.glade:3698
 msgid "Online Quotes"
 msgstr "線上報價"
 
@@ -16346,8 +16743,6 @@ msgid "Ask"
 msgstr "委賣價"
 
 #: gnucash/gtkbuilder/dialog-price.glade:18
-#: gnucash/report/reports/standard/budget-barchart.scm:78
-#: gnucash/report/reports/standard/budget.scm:124
 msgid "Last"
 msgstr "成交價"
 
@@ -16403,7 +16798,9 @@ msgstr "每季最後(_Q)"
 msgid ""
 "Keep the last price of each fiscal quarter if present before date. The "
 "fiscal quarter is derived from the accounting period end date."
-msgstr "保留所選擇的日期前，每個財務季度最後一次的價格。財務季度會由會計週期的結束時間推算出來。"
+msgstr ""
+"保留所選擇的日期前，每個財務季度最後一次的價格。財務季度會由會計週期的結束時"
+"間推算出來。"
 
 #: gnucash/gtkbuilder/dialog-price.glade:516
 msgid "Last of _Period"
@@ -16413,7 +16810,9 @@ msgstr "會計期間的最後一個(_P)"
 msgid ""
 "Keep the last price of each fiscal period if present before date. The fiscal "
 "period is derived from the accounting period end date."
-msgstr "保留所選擇的日期前，每個會計期間最後一次的價格。會計時間會由會計週期的結束時間推算出來。"
+msgstr ""
+"保留所選擇的日期前，每個會計期間最後一次的價格。會計時間會由會計週期的結束時"
+"間推算出來。"
 
 #: gnucash/gtkbuilder/dialog-price.glade:533
 msgid "_Scaled"
@@ -16425,8 +16824,9 @@ msgid ""
 "'One a month' is used for dates older than a year and 'One a week' is used "
 "for dates older than six months to a year."
 msgstr ""
-"透過依比例的選項，價格將會相對於所選的日期的距離移除。超過一年以上的日期，會使用「每月保留一個」的方式，而超過六個月到一年間的日期，會使用「每週保留一個」"
-"的方式進行移除。"
+"透過依比例的選項，價格將會相對於所選的日期的距離移除。超過一年以上的日期，會"
+"使用「每月保留一個」的方式，而超過六個月到一年間的日期，會使用「每週保留一"
+"個」的方式進行移除。"
 
 #: gnucash/gtkbuilder/dialog-price.glade:585
 msgid "First Date"
@@ -16471,14 +16871,15 @@ msgid ""
 msgstr ""
 "如果啟用，則由程式加入的價格會被刪除。\n"
 "\n"
-"為了讓包含了多種貨幣的交易，在科目頁和報表中都有正確的「最接近時間」的價格，這個價格會由程式新增。移除此價格的話，可能會造成這些資料較不準確。"
+"為了讓包含了多種貨幣的交易，在科目頁和報表中都有正確的「最接近時間」的價格，"
+"這個價格會由程式新增。移除此價格的話，可能會造成這些資料較不準確。"
 
 #: gnucash/gtkbuilder/dialog-price.glade:752
 msgid "Before _Date"
 msgstr "刪除此日期之前的價格(_D)"
 
 #: gnucash/gtkbuilder/dialog-price.glade:795
-#: gnucash/report/reports/standard/price-scatter.scm:87
+#: gnucash/report/reports/standard/price-scatter.scm:82
 msgid "Price Database"
 msgstr "價格資料庫"
 
@@ -16519,7 +16920,9 @@ msgid ""
 "Enter a title for this custom format. This title will appear in the \"Check "
 "format\" selector of the Print Check dialog. Using the title of an existing "
 "custom format will cause that format to be overwritten."
-msgstr "輸入此自訂格式的標題。此標題會顯示在列印支票對話盒中的「支票格式」下拉選單中。若輸入已經存在的自訂格式標題，則會覆蓋掉原有的格式。"
+msgstr ""
+"輸入此自訂格式的標題。此標題會顯示在列印支票對話盒中的「支票格式」下拉選單"
+"中。若輸入已經存在的自訂格式標題，則會覆蓋掉原有的格式。"
 
 #: gnucash/gtkbuilder/dialog-print-check.glade:244
 msgid "Inches"
@@ -16734,7 +17137,9 @@ msgid ""
 "You have requested that the following warning dialogs not be presented. To "
 "re-enable any of these dialogs, select the check box next to the dialog, "
 "then click OK."
-msgstr "您要求不要顯示以下的警告對話盒。若要重新啟用以下任何對話盒，勾選這些對話盒旁的核取方塊並按下「確定」。"
+msgstr ""
+"您要求不要顯示以下的警告對話盒。若要重新啟用以下任何對話盒，勾選這些對話盒旁"
+"的核取方塊並按下「確定」。"
 
 #: gnucash/gtkbuilder/dialog-reset-warnings.glade:120
 msgid "_Unselect All"
@@ -16819,8 +17224,8 @@ msgstr "下列的排程交易用到了被刪除的科目，必須修正。按確
 #: gnucash/gtkbuilder/dialog-sx.glade:126
 #: gnucash/gtkbuilder/gnc-frequency.glade:171
 #: gnucash/gtkbuilder/gnc-frequency.glade:759
-#: gnucash/report/reports/standard/category-barchart.scm:129
-#: gnucash/report/trep-engine.scm:320 libgnucash/engine/Recurrence.c:744
+#: gnucash/report/reports/standard/category-barchart.scm:122
+#: gnucash/report/trep-engine.scm:301 libgnucash/engine/Recurrence.c:744
 msgid "Daily"
 msgstr "每日"
 
@@ -16829,8 +17234,8 @@ msgid "Bi-Weekly"
 msgstr "每兩週"
 
 #: gnucash/gtkbuilder/dialog-sx.glade:141
-#: gnucash/report/reports/standard/account-piecharts.scm:121
-#: gnucash/report/trep-engine.scm:354 libgnucash/engine/Recurrence.c:787
+#: gnucash/report/reports/standard/account-piecharts.scm:118
+#: gnucash/report/trep-engine.scm:331 libgnucash/engine/Recurrence.c:787
 msgid "Yearly"
 msgstr "年度"
 
@@ -16908,67 +17313,77 @@ msgstr "多久前建立(_T)"
 msgid "R_emind in advance"
 msgstr "幾天前提醒(_E)"
 
-#: gnucash/gtkbuilder/dialog-sx.glade:748
+#: gnucash/gtkbuilder/dialog-sx.glade:724
+msgid "Set 'Re_view Created Transactions' as default"
+msgstr "預設勾選「核對已建立的交易」(_V)"
+
+#: gnucash/gtkbuilder/dialog-sx.glade:728
+msgid ""
+"Set 'Review Created Transactions' as the default in the 'Since Last Run' "
+"dialog."
+msgstr "在「自上次執行後」對話盒中，預設勾選「核對已建立的交易」。"
+
+#: gnucash/gtkbuilder/dialog-sx.glade:765
 msgid "Edit Scheduled Transaction"
 msgstr "編輯排程的交易"
 
-#: gnucash/gtkbuilder/dialog-sx.glade:913
+#: gnucash/gtkbuilder/dialog-sx.glade:930
 msgid "Create in advance"
 msgstr "多久前建立"
 
-#: gnucash/gtkbuilder/dialog-sx.glade:928
+#: gnucash/gtkbuilder/dialog-sx.glade:945
 msgid "Remind in advance"
 msgstr "幾天前提醒"
 
-#: gnucash/gtkbuilder/dialog-sx.glade:987
+#: gnucash/gtkbuilder/dialog-sx.glade:1004
 msgid "Create automatically"
 msgstr "自動建立"
 
-#: gnucash/gtkbuilder/dialog-sx.glade:991
+#: gnucash/gtkbuilder/dialog-sx.glade:1008
 msgid "Conditional on splits not having variables"
 msgstr "只適用於沒有變數的分割"
 
-#: gnucash/gtkbuilder/dialog-sx.glade:1062
+#: gnucash/gtkbuilder/dialog-sx.glade:1079
 msgid "Notify me when created"
 msgstr "當建立時通知我"
 
-#: gnucash/gtkbuilder/dialog-sx.glade:1110
+#: gnucash/gtkbuilder/dialog-sx.glade:1127
 msgid "<b>Occurrences</b>"
 msgstr "<b>重複發生</b>"
 
-#: gnucash/gtkbuilder/dialog-sx.glade:1133
+#: gnucash/gtkbuilder/dialog-sx.glade:1150
 msgid "Last Occurred: "
 msgstr "上次發生: "
 
-#: gnucash/gtkbuilder/dialog-sx.glade:1167
+#: gnucash/gtkbuilder/dialog-sx.glade:1184
 msgid "Repeats:"
 msgstr "重複:"
 
-#: gnucash/gtkbuilder/dialog-sx.glade:1201
+#: gnucash/gtkbuilder/dialog-sx.glade:1218
 msgid "Until"
 msgstr "直到"
 
-#: gnucash/gtkbuilder/dialog-sx.glade:1236
+#: gnucash/gtkbuilder/dialog-sx.glade:1253
 msgid "occurrences"
 msgstr "發生次數"
 
-#: gnucash/gtkbuilder/dialog-sx.glade:1248
+#: gnucash/gtkbuilder/dialog-sx.glade:1265
 msgid "remaining"
 msgstr "剩幾次"
 
-#: gnucash/gtkbuilder/dialog-sx.glade:1330
+#: gnucash/gtkbuilder/dialog-sx.glade:1347
 msgid "Overview"
 msgstr "概觀"
 
-#: gnucash/gtkbuilder/dialog-sx.glade:1403
+#: gnucash/gtkbuilder/dialog-sx.glade:1420
 msgid "Template Transaction"
 msgstr "交易範本"
 
-#: gnucash/gtkbuilder/dialog-sx.glade:1437
+#: gnucash/gtkbuilder/dialog-sx.glade:1454
 msgid "Since Last Run..."
 msgstr "自上次執行後..."
 
-#: gnucash/gtkbuilder/dialog-sx.glade:1537
+#: gnucash/gtkbuilder/dialog-sx.glade:1554
 msgid "_Review created transactions"
 msgstr "核對已建立的交易(_R)"
 
@@ -17081,21 +17496,21 @@ msgstr "匯兌資金"
 msgid "<b>Basic Information</b>"
 msgstr "<b>基本資訊</b>"
 
-#: gnucash/gtkbuilder/dialog-transfer.glade:451
-#: gnucash/gtkbuilder/dialog-transfer.glade:467
+#: gnucash/gtkbuilder/dialog-transfer.glade:438
+#: gnucash/gtkbuilder/dialog-transfer.glade:454
 #: gnucash/report/reports/standard/net-charts.scm:47
 msgid "Show Income/Expense"
 msgstr "顯示收入/支出"
 
-#: gnucash/gtkbuilder/dialog-transfer.glade:500
+#: gnucash/gtkbuilder/dialog-transfer.glade:487
 msgid "<b>Currency Transfer</b>"
 msgstr "<b>貨幣兌換</b>"
 
-#: gnucash/gtkbuilder/dialog-transfer.glade:528
+#: gnucash/gtkbuilder/dialog-transfer.glade:515
 msgid "Exchange Rate"
 msgstr "匯率"
 
-#: gnucash/gtkbuilder/dialog-transfer.glade:609
+#: gnucash/gtkbuilder/dialog-transfer.glade:596
 msgid "_Fetch Rate"
 msgstr "取得匯率(_F)"
 
@@ -17723,7 +18138,7 @@ msgstr "預算週期"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:634
 #: gnucash/report/reports/standard/general-ledger.scm:126
-#: gnucash/report/trep-engine.scm:83 gnucash/report/trep-engine.scm:1129
+#: gnucash/report/trep-engine.scm:83 gnucash/report/trep-engine.scm:1074
 msgid "Show Account Code"
 msgstr "顯示科目代碼"
 
@@ -17868,7 +18283,6 @@ msgid "Keep normal account order."
 msgstr "保持正常科目順序。"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:867
-#: gnucash/report/trep-engine.scm:184
 msgid "Sort by date."
 msgstr "以日期排序。"
 
@@ -17898,17 +18312,14 @@ msgid "Amo_unt"
 msgstr "總額(_U)"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:943
-#: gnucash/report/trep-engine.scm:230
 msgid "Sort by amount."
 msgstr "以總額排序。"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:962
-#: gnucash/report/trep-engine.scm:267
 msgid "Sort by memo."
 msgstr "以備忘錄排序。"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:981
-#: gnucash/report/trep-engine.scm:238
 msgid "Sort by description."
 msgstr "以描述排序。"
 
@@ -18005,7 +18416,9 @@ msgid ""
 "Use this dialog if you want GnuCash to automatically find which transactions "
 "are cleared, given an ending balance. For example, said ending balance can "
 "be the current balance given by your bank online."
-msgstr "如果您希望透過指定結束餘額來讓 GnuCash 自動找出哪些交易已被結清，可以使用此對話視窗。例如，結束餘額可以是您網路銀行目前的餘額。"
+msgstr ""
+"如果您希望透過指定結束餘額來讓 GnuCash 自動找出哪些交易已被結清，可以使用此對"
+"話視窗。例如，結束餘額可以是您網路銀行目前的餘額。"
 
 #: gnucash/gtkbuilder/window-autoclear.glade:101
 msgid "Caution!"
@@ -18016,7 +18429,9 @@ msgid ""
 "This tool might be slow or abort if the number of uncleared splits is more "
 "than approximately 20. In that case please clear at least some of them "
 "manually."
-msgstr "如果未結清的分割大約超過 20 個的時候，此工具將會變慢會中止。這種狀況下，您應該至少手動結清其中一些分割。"
+msgstr ""
+"如果未結清的分割大約超過 20 個的時候，此工具將會變慢會中止。這種狀況下，您應"
+"該至少手動結清其中一些分割。"
 
 #: gnucash/gtkbuilder/window-autoclear.glade:138
 #: gnucash/gtkbuilder/window-reconcile.glade:117
@@ -18047,7 +18462,8 @@ msgstr "包含子科目(_S)"
 msgid ""
 "Include all descendant accounts in the reconcile. All of them must use the "
 "same commodity as this one."
-msgstr "在對帳視窗中包含所有的子科目。有所子科目必須使用和此科目相同的商品或貨幣。"
+msgstr ""
+"在對帳視窗中包含所有的子科目。有所子科目必須使用和此科目相同的商品或貨幣。"
 
 #: gnucash/gtkbuilder/window-reconcile.glade:257
 msgid "Statement Date is after today"
@@ -18155,7 +18571,8 @@ msgstr ""
 "\n"
 "詳細資訊請見 https://wiki.gnucash.org/wiki/AqBanking。\n"
 "\n"
-"註：不保證任何事情。有些銀行的線上銀行伺服器實作得很爛。您不應該依賴網路銀行進行時間緊迫的轉帳，因為有時這些銀行在轉帳被拒絕時不會給您正確的回應。"
+"註：不保證任何事情。有些銀行的線上銀行伺服器實作得很爛。您不應該依賴網路銀行"
+"進行時間緊迫的轉帳，因為有時這些銀行在轉帳被拒絕時不會給您正確的回應。"
 
 #: gnucash/import-export/aqb/assistant-ab-initial.glade:71
 msgid "Initial Online Banking Setup"
@@ -18188,8 +18605,9 @@ msgid ""
 "match it to a GnuCash account or select incorrect matches and click \"Delete "
 "selected matches\". Click \"Next\" when all desired accounts are matching."
 msgstr ""
-"若您要將網路銀行帳戶與 GnuCash "
-"科目配對，請於網路銀行帳戶名稱上點兩上，或選擇錯誤的配對並點選「刪除選定的配對」。當所有想要的科目都配對完成後，請點選「下一步」。"
+"若您要將網路銀行帳戶與 GnuCash 科目配對，請於網路銀行帳戶名稱上點兩上，或選擇"
+"錯誤的配對並點選「刪除選定的配對」。當所有想要的科目都配對完成後，請點選「下"
+"一步」。"
 
 #: gnucash/import-export/aqb/assistant-ab-initial.glade:177
 msgid "_Delete selected matches"
@@ -18209,7 +18627,8 @@ msgid ""
 "\n"
 "Press \"Apply\" now."
 msgstr ""
-"現在所有用來配對 GnuCash 科目的網路銀行帳號的設定已經完成。您現在可以在那些科目上使用網路銀行的功能。\n"
+"現在所有用來配對 GnuCash 科目的網路銀行帳號的設定已經完成。您現在可以在那些科"
+"目上使用網路銀行的功能。\n"
 "\n"
 "如果您想要增加別的銀行、使用者或帳號，您隨時可以再次啟動這個精靈。\n"
 "\n"
@@ -18333,7 +18752,9 @@ msgstr "設定延遲時間，數值愈小則閃爍圖型的重複速度越快。
 msgid ""
 "Hold the TAN generator in front of the animated graphic. The markings "
 "(triangles) on the graphic must match those on the TAN generator."
-msgstr "將交易認證編碼 (TAN) 產生器拿到動畫圖型前方。圖型上的標記 (三角型) 必須對準 TAN 產生器上的標記。"
+msgstr ""
+"將交易認證編碼 (TAN) 產生器拿到動畫圖型前方。圖型上的標記 (三角型) 必須對準 "
+"TAN 產生器上的標記。"
 
 #: gnucash/import-export/aqb/dialog-ab.glade:802
 msgid "Con_firm Password"
@@ -18348,7 +18769,9 @@ msgid ""
 "If active, the PIN for FinTS/AqBanking actions will be remembered in memory "
 "during a session. Otherwise it will have to be entered again each time "
 "during a session when it is needed."
-msgstr "如果啟用，則會在工作階段中記憶 FinTS/AqBanking 動作的 PIN 碼。否則的話，在工作階段中每次需要 PIN 碼時都要重新輸入。"
+msgstr ""
+"如果啟用，則會在工作階段中記憶 FinTS/AqBanking 動作的 PIN 碼。否則的話，在工"
+"作階段中每次需要 PIN 碼時都要重新輸入。"
 
 #: gnucash/import-export/aqb/dialog-ab.glade:886
 msgid "Name for new template"
@@ -18481,7 +18904,9 @@ msgstr "完成後日誌視窗(_C)"
 msgid ""
 "If active, the window will be closed automatically when you finish the HBCI/"
 "AqBanking import process. Otherwise it will stay open."
-msgstr "如果勾選，則視窗會在您完成 HBCI/AqBanking 匯入流程後自動關閉。不然的話，它會維持開啟的狀態。"
+msgstr ""
+"如果勾選，則視窗會在您完成 HBCI/AqBanking 匯入流程後自動關閉。不然的話，它會"
+"維持開啟的狀態。"
 
 #: gnucash/import-export/aqb/dialog-ab-pref.glade:51
 msgid "Remember the _PIN in memory"
@@ -18494,8 +18919,8 @@ msgid ""
 "during a session. Otherwise it will have to be entered again each time "
 "during a session when it is needed."
 msgstr ""
-"如果勾選，則 HBCI/AqBanking 所使用的 PIN 碼會在工作階段中被儲存在記憶體中。不然的話，您必須在工作階段期中，每次需要的時候都輸入 "
-"PIN 碼。"
+"如果勾選，則 HBCI/AqBanking 所使用的 PIN 碼會在工作階段中被儲存在記憶體中。不"
+"然的話，您必須在工作階段期中，每次需要的時候都輸入 PIN 碼。"
 
 #: gnucash/import-export/aqb/dialog-ab-pref.glade:69
 msgid "_Verbose debug messages"
@@ -18517,7 +18942,9 @@ msgid ""
 "the MT940 file. Normally GNUcash ignores this text. However by activating "
 "this option, the transaction text is used for the transaction description "
 "too."
-msgstr "有些銀行將交易描述放在 MT940 檔案中的「交易文本」欄位。但透過啟用這個選項，交易文本欄位也會做為交易描述來使用。"
+msgstr ""
+"有些銀行將交易描述放在 MT940 檔案中的「交易文本」欄位。但透過啟用這個選項，交"
+"易文本欄位也會做為交易描述來使用。"
 
 #: gnucash/import-export/aqb/dialog-ab-trans.c:294
 #: gnucash/import-export/aqb/dialog-ab-trans.c:303
@@ -18598,8 +19025,9 @@ msgid ""
 "execute the command line program \"aqhbci-tool\" for your account, as "
 "follows: aqhbci-tool4 getaccsepa -b %s -a %s"
 msgstr ""
-"您的本地端銀行帳戶尚未存有 SEPA 帳戶資訊。非常抱歉，但在此開發中版本，有一個需要執行的步驟還未在 GnuCash 裡直接實作。請為您的帳戶執行 "
-"\"aqhbci-tool\" 此命令列程式，指令為：aqhbci-tool4 getaccsepa -b %s -a %s"
+"您的本地端銀行帳戶尚未存有 SEPA 帳戶資訊。非常抱歉，但在此開發中版本，有一個"
+"需要執行的步驟還未在 GnuCash 裡直接實作。請為您的帳戶執行 \"aqhbci-tool\" 此"
+"命令列程式，指令為：aqhbci-tool4 getaccsepa -b %s -a %s"
 
 #: gnucash/import-export/aqb/dialog-ab-trans.c:564
 msgid ""
@@ -18624,7 +19052,9 @@ msgid ""
 "The amount is zero or the amount field could not be interpreted correctly. "
 "You might have mixed up decimal point and comma, compared to your locale "
 "settings. This does not result in a valid online transfer job."
-msgstr "金額為零或是金額欄位無法被正確解析。您可能將小數點和逗號搞混了，請與您的區域設定比較以確定是否相同。無法產生有效的線上轉帳作業。"
+msgstr ""
+"金額為零或是金額欄位無法被正確解析。您可能將小數點和逗號搞混了，請與您的區域"
+"設定比較以確定是否相同。無法產生有效的線上轉帳作業。"
 
 #: gnucash/import-export/aqb/dialog-ab-trans.c:635
 msgid ""
@@ -18700,7 +19130,8 @@ msgstr "網路銀行匯入回傳在此特定時間週期中沒有包含交易。
 msgid ""
 "You have changed the list of online transfer templates, but you cancelled "
 "the transfer dialog. Do you nevertheless want to store the changes?"
-msgstr "您變更了線上轉帳的範本列表，但您取消了轉帳對話盒。您仍然要儲存這些變更嗎？"
+msgstr ""
+"您變更了線上轉帳的範本列表，但您取消了轉帳對話盒。您仍然要儲存這些變更嗎？"
 
 #: gnucash/import-export/aqb/gnc-ab-transfer.c:184
 msgid ""
@@ -18715,7 +19146,8 @@ msgid ""
 msgstr ""
 "後端程式在準備這個工作時發生錯誤。無法執行此項工作。\n"
 "\n"
-"這很有可能是您的銀行不支援您選擇的工作，或您的網路銀行沒有足夠的權限執行此工作。詳細的錯誤訊息，可能會顯示在您的主控台日誌中。\n"
+"這很有可能是您的銀行不支援您選擇的工作，或您的網路銀行沒有足夠的權限執行此工"
+"作。詳細的錯誤訊息，可能會顯示在您的主控台日誌中。\n"
 "\n"
 "您要重新輸入此項工作嗎？"
 
@@ -18756,7 +19188,7 @@ msgid "Unspecified"
 msgstr "未指定的"
 
 #: gnucash/import-export/aqb/gnc-ab-utils.c:543
-#: gnucash/report/report-utilities.scm:196 libgnucash/engine/Account.cpp:4387
+#: gnucash/report/report-utilities.scm:196 libgnucash/engine/Account.cpp:4393
 msgid "Bank"
 msgstr "銀行"
 
@@ -18773,7 +19205,8 @@ msgid ""
 msgstr ""
 "後端程式在準備這個工作時發生錯誤。無法執行此項工作。\n"
 "\n"
-"這很有可能是您的銀行不支援您選擇的工作，或您的網路銀行沒有足夠的權限執行此工作。詳細的錯誤訊息，可能會顯示在您的主控台日誌中。\n"
+"這很有可能是您的銀行不支援您選擇的工作，或您的網路銀行沒有足夠的權限執行此工"
+"作。詳細的錯誤訊息，可能會顯示在您的主控台日誌中。\n"
 "\n"
 "您要重新輸入此項工作嗎？"
 
@@ -18818,8 +19251,9 @@ msgid ""
 msgstr ""
 "下載的網路銀行結餘為零。\n"
 "\n"
-"這有可能是這是正確的結餘，或您的銀行不支援這個網路銀行版本的結餘下載。如果是後者，您應該在網路銀行 (AqBanking 或 HBCI) "
-"設定中選擇不同的網路銀行版本。設定完成後，再重新下載網路銀行結餘。"
+"這有可能是這是正確的結餘，或您的銀行不支援這個網路銀行版本的結餘下載。如果是"
+"後者，您應該在網路銀行 (AqBanking 或 HBCI) 設定中選擇不同的網路銀行版本。設定"
+"完成後，再重新下載網路銀行結餘。"
 
 #: gnucash/import-export/aqb/gnc-ab-utils.c:1156
 #, c-format
@@ -18883,7 +19317,8 @@ msgid ""
 "\n"
 "%s"
 msgstr ""
-"執行工作時發生錯誤：%2$d 中的 %1$d 個工作失敗。請檢查日誌視窗或 gnucash.trace 以取得切確的錯誤訊息，\n"
+"執行工作時發生錯誤：%2$d 中的 %1$d 個工作失敗。請檢查日誌視窗或 gnucash."
+"trace 以取得切確的錯誤訊息，\n"
 "\n"
 "%3$s"
 
@@ -18899,8 +19334,11 @@ msgid ""
 msgid_plural ""
 "All %d jobs were executed successfully, but as a precaution please check the "
 "log window for potential errors."
-msgstr[0] "成功執行此工作，但為了小心起見，請檢查日誌視窗是否有任何可能的錯誤。"
-msgstr[1] "成功執行所有的 %d 件工作，但為了小心起見，請檢查日誌視窗是否有任何可能的錯誤。"
+msgstr[0] ""
+"成功執行此工作，但為了小心起見，請檢查日誌視窗是否有任何可能的錯誤。"
+msgstr[1] ""
+"成功執行所有的 %d 件工作，但為了小心起見，請檢查日誌視窗是否有任何可能的錯"
+"誤。"
 
 #: gnucash/import-export/aqb/gnc-gwen-gui.c:1113
 #, c-format
@@ -18928,7 +19366,9 @@ msgstr "網路銀行設定(_O)..."
 msgid ""
 "Initial setup of Online Banking access (HBCI, or OFX DirectConnect, using "
 "AqBanking)"
-msgstr "網路銀行存取的初始設定(使用 AqBanking 進行 HBCI 或 OFX DirectConnect 通信協定)"
+msgstr ""
+"網路銀行存取的初始設定(使用 AqBanking 進行 HBCI 或 OFX DirectConnect 通信協"
+"定)"
 
 #: gnucash/import-export/aqb/gnc-plugin-aqbanking.c:101
 msgid "Get _Balance"
@@ -19047,7 +19487,8 @@ msgid ""
 "AqBanking library offers various import formats (called \"profiles\") of "
 "which you can choose one here."
 msgstr ""
-"此設定指定了當匯入 DTAUS 檔案時所使用的資料格式。AqBanking 函式庫提供了您可以在此選擇的各式匯入格式（被稱為「profile」）。"
+"此設定指定了當匯入 DTAUS 檔案時所使用的資料格式。AqBanking 函式庫提供了您可以"
+"在此選擇的各式匯入格式（被稱為「profile」）。"
 
 #: gnucash/import-export/aqb/gschemas/org.gnucash.dialogs.import.hbci.gschema.xml.in:40
 msgid "CSV import data format"
@@ -19058,7 +19499,9 @@ msgid ""
 "This setting specifies the data format when importing CSV files. The "
 "AqBanking library offers various import formats (called \"profiles\") of "
 "which you can choose one here."
-msgstr "此設定指定了當匯入 CSV 檔案時所使用的資料格式。AqBanking 函式庫提供了您可以在此選擇的各式匯入格式（被稱為「profile」）。"
+msgstr ""
+"此設定指定了當匯入 CSV 檔案時所使用的資料格式。AqBanking 函式庫提供了您可以在"
+"此選擇的各式匯入格式（被稱為「profile」）。"
 
 #: gnucash/import-export/aqb/gschemas/org.gnucash.dialogs.import.hbci.gschema.xml.in:45
 msgid "SWIFT MT940 import data format"
@@ -19070,8 +19513,8 @@ msgid ""
 "AqBanking library offers various import formats (called \"profiles\") of "
 "which you can choose one here."
 msgstr ""
-"此設定指定了當匯入 SWIFT MT940 檔案時所使用的資料格式。AqBanking "
-"函式庫提供了您可以在此選擇的各式匯入格式（被稱為「profile」）。"
+"此設定指定了當匯入 SWIFT MT940 檔案時所使用的資料格式。AqBanking 函式庫提供了"
+"您可以在此選擇的各式匯入格式（被稱為「profile」）。"
 
 #: gnucash/import-export/aqb/gschemas/org.gnucash.dialogs.import.hbci.gschema.xml.in:50
 msgid "SWIFT MT942 import data format"
@@ -19083,8 +19526,8 @@ msgid ""
 "AqBanking library offers various import formats (called \"profiles\") of "
 "which you can choose one here."
 msgstr ""
-"此設定指定了當匯入 SWIFT MT942 檔案時所使用的資料格式。AqBanking "
-"函式庫提供了您可以在此選擇的各式匯入格式（被稱為「profile」）。"
+"此設定指定了當匯入 SWIFT MT942 檔案時所使用的資料格式。AqBanking 函式庫提供了"
+"您可以在此選擇的各式匯入格式（被稱為「profile」）。"
 
 #: gnucash/import-export/bi-import/dialog-bi-import.c:297
 #, c-format
@@ -19221,7 +19664,7 @@ msgstr "帳單 ID"
 #: gnucash/import-export/bi-import/dialog-bi-import-gui.c:152
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:92
 #: gnucash/report/reports/standard/invoice.scm:94
-#: gnucash/report/reports/standard/invoice.scm:227
+#: gnucash/report/reports/standard/invoice.scm:214
 msgid "Quantity"
 msgstr "數量"
 
@@ -19235,7 +19678,7 @@ msgstr "折扣方式"
 
 #: gnucash/import-export/bi-import/dialog-bi-import-gui.c:157
 #: gnucash/report/reports/standard/invoice.scm:100
-#: gnucash/report/reports/standard/invoice.scm:242
+#: gnucash/report/reports/standard/invoice.scm:229
 msgid "Taxable"
 msgstr "應納稅的"
 
@@ -19287,25 +19730,25 @@ msgstr ""
 "- 更新發票數量：%u"
 
 #: gnucash/import-export/bi-import/dialog-bi-import-gui.c:229
-#: gnucash/import-export/customer-import/dialog-customer-import-gui.c:205
+#: gnucash/import-export/customer-import/dialog-customer-import-gui.c:206
 msgid "These lines were ignored during import"
 msgstr "以下這幾行在匯入時被忽略"
 
 #: gnucash/import-export/bi-import/dialog-bi-import-gui.c:236
 #: gnucash/import-export/csv-imp/assistant-csv-account-import.c:462
-#: gnucash/import-export/customer-import/dialog-customer-import-gui.c:212
+#: gnucash/import-export/customer-import/dialog-customer-import-gui.c:213
 msgid "The input file can not be opened."
 msgstr "輸入檔無法開啟。"
 
 #: gnucash/import-export/bi-import/dialog-bi-import-gui.c:357
 #: gnucash/import-export/csv-imp/assistant-csv-account-import.c:304
-#: gnucash/import-export/customer-import/dialog-customer-import-gui.c:325
+#: gnucash/import-export/customer-import/dialog-customer-import-gui.c:326
 msgid "Adjust regular expression used for import"
 msgstr "調整匯入時使用的正規表示式"
 
 #: gnucash/import-export/bi-import/dialog-bi-import-gui.c:357
 #: gnucash/import-export/csv-imp/assistant-csv-account-import.c:305
-#: gnucash/import-export/customer-import/dialog-customer-import-gui.c:325
+#: gnucash/import-export/customer-import/dialog-customer-import-gui.c:326
 msgid ""
 "This regular expression is used to parse the import file. Modify according "
 "to your needs.\n"
@@ -19354,7 +19797,8 @@ msgstr ""
 "\n"
 "%s\n"
 "\n"
-"雖然有些交易可能會有多個分割散落在所選擇的科目中，但他們只會被匯出一次。他們會出現在第一個被處理，且具有該交易的分割的科目下。\n"
+"雖然有些交易可能會有多個分割散落在所選擇的科目中，但他們只會被匯出一次。他們"
+"會出現在第一個被處理，且具有該交易的分割的科目下。\n"
 "\n"
 "價格 / 費率欄位的格式由偏好設定內的\n"
 "「數字、日期、時間」->「強制使用小數點顯示價格」控制。\n"
@@ -19371,7 +19815,9 @@ msgstr "每筆交易會有多行，每行代表了一個分割。"
 msgid ""
 "There will be one row for each transaction, equivalent to a single row in a "
 "register in 'Basic Ledger' mode. As such some transfer detail could be lost."
-msgstr "每筆交易僅會有一行，和登記簿中的「基本分類帳」模式相同。因此，有些交易細節可能會遺失。"
+msgstr ""
+"每筆交易僅會有一行，和登記簿中的「基本分類帳」模式相同。因此，有些交易細節可"
+"能會遺失。"
 
 #. Translators: %s is the file name.
 #: gnucash/import-export/csv-exp/assistant-csv-export.c:109
@@ -19421,7 +19867,8 @@ msgid ""
 "logging!\n"
 "You may need to enable debugging.\n"
 msgstr ""
-"匯出檔案遇到問題，這可能是因為磁碟空間不夠，權限問題或是無法存取資料夾。請檢查日誌檔以取得詳細的記錄！。\n"
+"匯出檔案遇到問題，這可能是因為磁碟空間不夠，權限問題或是無法存取資料夾。請檢"
+"查日誌檔以取得詳細的記錄！。\n"
 "您可以需要啟用除錯模式。\n"
 
 #: gnucash/import-export/csv-exp/assistant-csv-export.c:767
@@ -19520,8 +19967,10 @@ msgstr ""
 "\n"
 "您可以按下「返回」確認您的選擇，或按下「取消」中止匯入。\n"
 "\n"
-"如果您是直接匯入至新建立的檔案，則一開始您會見到設定帳簿選項的對話盒，因為這些選項可能會影響到匯入的資料要如何轉換成 GnuCash 的交易。\n"
-"註：在匯入後，您可能需要使用「檢視 / 過濾依 / 其他」的選單選項，選擇您要如何顯示未被使用的科目。\n"
+"如果您是直接匯入至新建立的檔案，則一開始您會見到設定帳簿選項的對話盒，因為這"
+"些選項可能會影響到匯入的資料要如何轉換成 GnuCash 的交易。\n"
+"註：在匯入後，您可能需要使用「檢視 / 過濾依 / 其他」的選單選項，選擇您要如何"
+"顯示未被使用的科目。\n"
 
 #: gnucash/import-export/csv-imp/assistant-csv-account-import.c:528
 #, c-format
@@ -20046,19 +20495,19 @@ msgstr "出貨連絡人傳真"
 msgid "Shipping Email"
 msgstr "出貨連絡人 Email"
 
-#: gnucash/import-export/customer-import/dialog-customer-import-gui.c:176
+#: gnucash/import-export/customer-import/dialog-customer-import-gui.c:177
 msgid "Import Customers from csv"
 msgstr "從 CSV 檔案中匯入客戶"
 
-#: gnucash/import-export/customer-import/dialog-customer-import-gui.c:192
+#: gnucash/import-export/customer-import/dialog-customer-import-gui.c:193
 msgid "customers"
 msgstr "客戶"
 
-#: gnucash/import-export/customer-import/dialog-customer-import-gui.c:193
+#: gnucash/import-export/customer-import/dialog-customer-import-gui.c:194
 msgid "vendors"
 msgstr "廠商"
 
-#: gnucash/import-export/customer-import/dialog-customer-import-gui.c:201
+#: gnucash/import-export/customer-import/dialog-customer-import-gui.c:202
 #, c-format
 msgid ""
 "Import results:\n"
@@ -20226,7 +20675,6 @@ msgid "Manual"
 msgstr "手動"
 
 #: gnucash/import-export/import-pending-matches.c:196
-#: gnucash/report/reports/standard/balsheet-eg.scm:219
 msgid "Auto"
 msgstr "自動"
 
@@ -20338,14 +20786,18 @@ msgstr "輸入此商品的名稱或簡述，例如「Red Hat 股票」。"
 msgid ""
 "Enter the ticker symbol or other well known abbreviation, such as \"RHT\". "
 "If there isn't one, or you don't know it, create your own."
-msgstr "輸入股票代碼或其他眾所周知的縮寫，例如「2330.TW」(台積電)。如果該股票沒有代碼或你不知道其代碼，請自行創立一個。"
+msgstr ""
+"輸入股票代碼或其他眾所周知的縮寫，例如「2330.TW」(台積電)。如果該股票沒有代碼"
+"或你不知道其代碼，請自行創立一個。"
 
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:866
 msgid ""
 "Select the exchange on which the symbol is traded, or select the type of "
 "investment (such as FUND for mutual funds.) If you don't see your exchange "
 "or an appropriate investment type, you can enter a new one."
-msgstr "選擇您的商品代碼所在的交易所，或是選擇該投資的類型（例如共同基金可選擇 FUND）。如果您沒有找到您的交易所或合適的投資類型，您可以自行建立。"
+msgstr ""
+"選擇您的商品代碼所在的交易所，或是選擇該投資的類型（例如共同基金可選擇 "
+"FUND）。如果您沒有找到您的交易所或合適的投資類型，您可以自行建立。"
 
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:906
 msgid "_Name or description"
@@ -20435,7 +20887,9 @@ msgid ""
 "When you press the Start Button, GnuCash will load your QIF file. If there "
 "are no errors or warnings, you will automatically proceed to the next step. "
 "Otherwise, the details will be shown below for your review."
-msgstr "當您按下開始按鈕，GnuCash 會載入您的 QIF 檔案。如果沒有任何錯誤或警告，會自動進入下一個步驟。否則的話，會顯示詳情供您檢查。"
+msgstr ""
+"當您按下開始按鈕，GnuCash 會載入您的 QIF 檔案。如果沒有任何錯誤或警告，會自動"
+"進入下一個步驟。否則的話，會顯示詳情供您檢查。"
 
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:2649
 msgid "Choose the QIF file currency"
@@ -20468,7 +20922,9 @@ msgid ""
 "When you press the Start Button, GnuCash will import your QIF data. If there "
 "are no errors or warnings, you will automatically proceed to the next step. "
 "Otherwise, the details will be shown below for your review."
-msgstr "當您按下開始按鈕，GnuCash 會匯入您的 QIF 資料。如果沒有任何錯誤或警告，會進動進入下一個步驟。否則的話，會顯示詳情供您檢查。"
+msgstr ""
+"當您按下開始按鈕，GnuCash 會匯入您的 QIF 資料。如果沒有任何錯誤或警告，會進動"
+"進入下一個步驟。否則的話，會顯示詳情供您檢查。"
 
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:3414
 msgid "GnuCash was unable to save your mapping preferences."
@@ -20543,8 +20999,8 @@ msgstr "資本利得 (短期)"
 #: gnucash/import-export/qif-imp/qif-dialog-utils.scm:110
 #: gnucash/import-export/qif-imp/qif-dialog-utils.scm:114
 #: gnucash/report/reports/standard/balance-sheet.scm:509
-#: gnucash/report/reports/standard/balsheet-pnl.scm:1131
-#: gnucash/report/reports/standard/balsheet-pnl.scm:1146
+#: gnucash/report/reports/standard/balsheet-pnl.scm:1092
+#: gnucash/report/reports/standard/balsheet-pnl.scm:1107
 #: gnucash/report/reports/support/balsheet-eg.eguile.scm:189
 #: libgnucash/app-utils/gnc-ui-util.c:953
 msgid "Retained Earnings"
@@ -20790,7 +21246,7 @@ msgid "Welcome to GnuCash"
 msgstr "歡迎使用 GnuCash"
 
 #: gnucash/python/init.py:103
-#: gnucash/report/reports/example/hello-world.scm:488
+#: gnucash/report/reports/example/hello-world.scm:474
 msgid "Have a nice day!"
 msgstr "祝您有美好的一天！"
 
@@ -20811,12 +21267,12 @@ msgstr "專案"
 msgid "Material"
 msgstr "材料"
 
-#: gnucash/register/ledger-core/gncEntryLedger.c:914
+#: gnucash/register/ledger-core/gncEntryLedger.c:915
 #: gnucash/register/ledger-core/gncEntryLedgerControl.c:875
 msgid "Save the current entry?"
 msgstr "儲存目前的項目？"
 
-#: gnucash/register/ledger-core/gncEntryLedger.c:916
+#: gnucash/register/ledger-core/gncEntryLedger.c:917
 msgid ""
 "The current transaction has been changed. Would you like to record the "
 "changes before duplicating this entry, or cancel the duplication?"
@@ -20963,9 +21419,9 @@ msgid ">"
 msgstr ">"
 
 #: gnucash/register/ledger-core/gncEntryLedgerLoad.c:130
-#: gnucash/register/ledger-core/gncEntryLedgerModel.c:527
-#: gnucash/register/ledger-core/gncEntryLedgerModel.c:1091
-#: gnucash/report/report-utilities.scm:197 libgnucash/engine/Account.cpp:4388
+#: gnucash/register/ledger-core/gncEntryLedgerModel.c:530
+#: gnucash/register/ledger-core/gncEntryLedgerModel.c:1094
+#: gnucash/report/report-utilities.scm:197 libgnucash/engine/Account.cpp:4394
 msgid "Cash"
 msgstr "現金"
 
@@ -21007,13 +21463,12 @@ msgid "Invoiced?"
 msgstr "已開發票？"
 
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:117
-#: gnucash/report/options-utilities.scm:236
-#: gnucash/report/reports/standard/invoice.scm:262
+#: gnucash/report/reports/standard/invoice.scm:249
 msgid "Subtotal"
 msgstr "小計"
 
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:122
-#: gnucash/report/reports/standard/invoice.scm:551
+#: gnucash/report/reports/standard/invoice.scm:538
 #: gnucash/report/reports/standard/new-owner-report.scm:55
 #: gnucash/report/reports/standard/owner-report.scm:56
 #: libgnucash/app-utils/business-options.scm:78
@@ -21024,112 +21479,112 @@ msgstr "稅"
 msgid "Billable?"
 msgstr "可計費？"
 
-#: gnucash/register/ledger-core/gncEntryLedgerModel.c:545
+#: gnucash/register/ledger-core/gncEntryLedgerModel.c:548
 msgid ""
 "Enter the income/expense account for the Entry, or choose one from the list"
 msgstr "輸入此項目的收入/支出科目，或從清單中選擇一個"
 
-#: gnucash/register/ledger-core/gncEntryLedgerModel.c:558
+#: gnucash/register/ledger-core/gncEntryLedgerModel.c:561
 msgid "Enter the type of Entry"
 msgstr "輸入項目的類別"
 
-#: gnucash/register/ledger-core/gncEntryLedgerModel.c:588
+#: gnucash/register/ledger-core/gncEntryLedgerModel.c:591
 msgid "Enter the Entry Description"
 msgstr "輸入項目描述"
 
-#: gnucash/register/ledger-core/gncEntryLedgerModel.c:604
+#: gnucash/register/ledger-core/gncEntryLedgerModel.c:607
 msgid "Enter the Discount Amount"
 msgstr "輸入折扣總額"
 
-#: gnucash/register/ledger-core/gncEntryLedgerModel.c:607
+#: gnucash/register/ledger-core/gncEntryLedgerModel.c:610
 msgid "Enter the Discount Percent"
 msgstr "輸入折扣百分比"
 
-#: gnucash/register/ledger-core/gncEntryLedgerModel.c:610
+#: gnucash/register/ledger-core/gncEntryLedgerModel.c:613
 msgid "Enter the Discount ... unknown type"
 msgstr "輸入折扣 ... 未知的類型"
 
-#: gnucash/register/ledger-core/gncEntryLedgerModel.c:628
+#: gnucash/register/ledger-core/gncEntryLedgerModel.c:631
 msgid "Discount Type: Monetary Value"
 msgstr "折扣類型：貨幣數值"
 
-#: gnucash/register/ledger-core/gncEntryLedgerModel.c:631
+#: gnucash/register/ledger-core/gncEntryLedgerModel.c:634
 msgid "Discount Type: Percent"
 msgstr "折扣類型：百分比"
 
-#: gnucash/register/ledger-core/gncEntryLedgerModel.c:634
+#: gnucash/register/ledger-core/gncEntryLedgerModel.c:637
 msgid "Select the Discount Type"
 msgstr "選擇折扣類型"
 
-#: gnucash/register/ledger-core/gncEntryLedgerModel.c:651
+#: gnucash/register/ledger-core/gncEntryLedgerModel.c:654
 msgid "Tax computed after discount is applied"
 msgstr "在套用折扣後計算稅金"
 
-#: gnucash/register/ledger-core/gncEntryLedgerModel.c:654
+#: gnucash/register/ledger-core/gncEntryLedgerModel.c:657
 msgid "Discount and tax both applied on pretax value"
 msgstr "折扣和稅金都以未稅價格計算"
 
-#: gnucash/register/ledger-core/gncEntryLedgerModel.c:657
+#: gnucash/register/ledger-core/gncEntryLedgerModel.c:660
 msgid "Discount computed after tax is applied"
 msgstr "以稅後價格計算折扣"
 
-#: gnucash/register/ledger-core/gncEntryLedgerModel.c:660
+#: gnucash/register/ledger-core/gncEntryLedgerModel.c:663
 msgid "Select how to compute the Discount and Taxes"
 msgstr "選擇要如何計算折扣與稅金"
 
-#: gnucash/register/ledger-core/gncEntryLedgerModel.c:673
+#: gnucash/register/ledger-core/gncEntryLedgerModel.c:676
 msgid "Enter the unit-Price for this Entry"
 msgstr "輸入此項目的單位價格"
 
-#: gnucash/register/ledger-core/gncEntryLedgerModel.c:685
+#: gnucash/register/ledger-core/gncEntryLedgerModel.c:688
 msgid "Enter the Quantity of units for this Entry"
 msgstr "編輯此項目的單位數量"
 
-#: gnucash/register/ledger-core/gncEntryLedgerModel.c:697
+#: gnucash/register/ledger-core/gncEntryLedgerModel.c:700
 msgid "Enter the Tax Table to apply to this entry"
 msgstr "輸入要套用到這個項目的稅金表格"
 
-#: gnucash/register/ledger-core/gncEntryLedgerModel.c:706
+#: gnucash/register/ledger-core/gncEntryLedgerModel.c:709
 msgid "Is this entry taxable?"
 msgstr "此項目已含稅？"
 
-#: gnucash/register/ledger-core/gncEntryLedgerModel.c:715
+#: gnucash/register/ledger-core/gncEntryLedgerModel.c:718
 msgid "Is the tax already included in the price of this entry?"
 msgstr "稅金是否已經包含在這個項目的價格中？"
 
-#: gnucash/register/ledger-core/gncEntryLedgerModel.c:733
+#: gnucash/register/ledger-core/gncEntryLedgerModel.c:736
 msgid "Is this entry invoiced?"
 msgstr "此項目是否已開發票？"
 
-#: gnucash/register/ledger-core/gncEntryLedgerModel.c:739
+#: gnucash/register/ledger-core/gncEntryLedgerModel.c:742
 msgid "Is this entry credited?"
 msgstr "此項目是否已開貸項通知單？"
 
-#: gnucash/register/ledger-core/gncEntryLedgerModel.c:743
+#: gnucash/register/ledger-core/gncEntryLedgerModel.c:746
 msgid "Include this entry on this invoice?"
 msgstr "是否在此發票中包含此項目？"
 
-#: gnucash/register/ledger-core/gncEntryLedgerModel.c:747
+#: gnucash/register/ledger-core/gncEntryLedgerModel.c:750
 msgid "Include this entry on this credit note?"
 msgstr "是否在此貸項通知單中包含此項目？"
 
-#: gnucash/register/ledger-core/gncEntryLedgerModel.c:750
+#: gnucash/register/ledger-core/gncEntryLedgerModel.c:753
 msgid "Unknown EntryLedger Type"
 msgstr "未知的項目分類帳類型"
 
-#: gnucash/register/ledger-core/gncEntryLedgerModel.c:763
+#: gnucash/register/ledger-core/gncEntryLedgerModel.c:766
 msgid "The subtotal value of this entry "
 msgstr "這個項目的小計值 "
 
-#: gnucash/register/ledger-core/gncEntryLedgerModel.c:775
+#: gnucash/register/ledger-core/gncEntryLedgerModel.c:778
 msgid "The total tax of this entry "
 msgstr "這個項目的總稅金 "
 
-#: gnucash/register/ledger-core/gncEntryLedgerModel.c:784
+#: gnucash/register/ledger-core/gncEntryLedgerModel.c:787
 msgid "Is this entry billable to a customer or job?"
 msgstr "這個項目對客戶或工作是否可開帳單？"
 
-#: gnucash/register/ledger-core/gncEntryLedgerModel.c:793
+#: gnucash/register/ledger-core/gncEntryLedgerModel.c:796
 msgid "How did you pay for this item?"
 msgstr "您要如何支付此項目的款項？"
 
@@ -21160,7 +21615,9 @@ msgid ""
 "This is the split anchoring this transaction to the register. You may not "
 "overwrite it from this register window. You may overwrite it if you navigate "
 "to a register that shows another side of this same transaction."
-msgstr "這是將此交易定錨到登記簿的分割，您無法從這個登記簿視窗中覆寫他。您可以切換到相同交易的另一側科目的登記簿視窗，來覆寫這個分割。"
+msgstr ""
+"這是將此交易定錨到登記簿的分割，您無法從這個登記簿視窗中覆寫他。您可以切換到"
+"相同交易的另一側科目的登記簿視窗，來覆寫這個分割。"
 
 #: gnucash/register/ledger-core/split-register.c:1005
 msgid ""
@@ -21185,7 +21642,9 @@ msgid ""
 "The current transaction has been changed. Would you like to record the "
 "changes before moving to a new transaction, discard the changes, or return "
 "to the changed transaction?"
-msgstr "目前的交易已經變更。在移動到新的交易前，您想要記錄他的變更，捨棄變更或是回到已變更的交易？"
+msgstr ""
+"目前的交易已經變更。在移動到新的交易前，您想要記錄他的變更，捨棄變更或是回到"
+"已變更的交易？"
 
 #. Translators: The 'sample:' items are
 #. strings which are not displayed, but only
@@ -21215,7 +21674,7 @@ msgstr "交易的描述"
 #: gnucash/register/ledger-core/split-register-model.c:334
 #: gnucash/report/reports/standard/new-owner-report.scm:219
 #: gnucash/report/reports/standard/new-owner-report.scm:452
-#: gnucash/report/trep-engine.scm:1292 gnucash/report/trep-engine.scm:1293
+#: gnucash/report/trep-engine.scm:1237 gnucash/report/trep-engine.scm:1238
 msgctxt "Column header for 'Document Link'"
 msgid "L"
 msgstr "L"
@@ -21310,64 +21769,64 @@ msgstr "合計股份"
 msgid "Reconciled on %s"
 msgstr "已於 %s 對帳"
 
-#: gnucash/register/ledger-core/split-register-model.c:1013
+#: gnucash/register/ledger-core/split-register-model.c:1020
 msgid "Scheduled"
 msgstr "已排程"
 
-#: gnucash/register/ledger-core/split-register-model.c:1062
+#: gnucash/register/ledger-core/split-register-model.c:1069
 msgid ""
 "Enter a reference, such as an invoice or check number, common to all entry "
 "lines (splits)"
 msgstr "輸入屬於交易的參照，像是發票或支票號碼，所有分割共用(各行共用)。"
 
-#: gnucash/register/ledger-core/split-register-model.c:1064
+#: gnucash/register/ledger-core/split-register-model.c:1071
 msgid ""
 "Enter a reference, such as an invoice or check number, unique to each entry "
 "line (split)"
 msgstr "輸入屬於分割的參照，像是發票或支票號碼，只屬於特定分割(各行獨立)。"
 
-#: gnucash/register/ledger-core/split-register-model.c:1069
+#: gnucash/register/ledger-core/split-register-model.c:1076
 msgid ""
 "Enter a reference, such as a check number, common to all entry lines (splits)"
 msgstr "輸入屬於交易的參照，像是支票號碼，所有分割共用(各行共用)。"
 
-#: gnucash/register/ledger-core/split-register-model.c:1071
+#: gnucash/register/ledger-core/split-register-model.c:1078
 msgid ""
 "Enter a reference, such as a check number, unique to each entry line (split)"
 msgstr "輸入屬於分割的參照，像是支票號碼，只屬於特定分割(各行獨立)。"
 
-#: gnucash/register/ledger-core/split-register-model.c:1092
+#: gnucash/register/ledger-core/split-register-model.c:1099
 msgid ""
 "Enter a transaction reference, such as an invoice or check number, common to "
 "all entry lines (splits)"
 msgstr "輸入屬於交易的參照，像是發票或支票號碼，所有分割共用(各行共用)。"
 
-#: gnucash/register/ledger-core/split-register-model.c:1096
+#: gnucash/register/ledger-core/split-register-model.c:1103
 msgid ""
 "Enter a transaction reference that will be common to all entry lines (splits)"
 msgstr "輸入將會成為該筆交易所有分割共用的參照"
 
-#: gnucash/register/ledger-core/split-register-model.c:1301
+#: gnucash/register/ledger-core/split-register-model.c:1308
 msgid "Enter an action type, or choose one from the list"
 msgstr "輸入交易的類型，或從列表中選擇一個"
 
-#: gnucash/register/ledger-core/split-register-model.c:1302
+#: gnucash/register/ledger-core/split-register-model.c:1309
 msgid ""
 "Enter a reference number, such as the next check number, or choose an action "
 "type from the list"
 msgstr "輸入參照號碼，例如下一張支票編號。或是從動作列表中選擇"
 
-#: gnucash/register/ledger-core/split-register-model.c:1569
+#: gnucash/register/ledger-core/split-register-model.c:1576
 msgid ""
 "This transaction has multiple splits; press the Split button to see them all"
 msgstr "這個交易有複數的分割；按下分割按鈕以查看全部的分割"
 
-#: gnucash/register/ledger-core/split-register-model.c:1572
+#: gnucash/register/ledger-core/split-register-model.c:1579
 msgid ""
 "This transaction is a stock split; press the Split button to see details"
 msgstr "這個交易是一個股票分割；按下分割按鈕以查看詳情"
 
-#: gnucash/register/ledger-core/split-register-model.c:2091
+#: gnucash/register/ledger-core/split-register-model.c:2098
 #, c-format
 msgid ""
 "Cannot modify or delete this transaction. This transaction is marked read-"
@@ -21379,11 +21838,11 @@ msgstr ""
 "\n"
 "「%s」"
 
-#: gnucash/register/ledger-core/split-register-model.c:2215
+#: gnucash/register/ledger-core/split-register-model.c:2222
 msgid "Change transaction containing a reconciled split?"
 msgstr "變更含有已對帳分割的交易？"
 
-#: gnucash/register/ledger-core/split-register-model.c:2217
+#: gnucash/register/ledger-core/split-register-model.c:2224
 #, c-format
 msgid ""
 "The transaction you are about to change contains reconciled splits in the "
@@ -21397,14 +21856,16 @@ msgstr ""
 "\n"
 "您確定要繼續嗎？"
 
-#: gnucash/register/ledger-core/split-register-model.c:2228
+#: gnucash/register/ledger-core/split-register-model.c:2235
 msgid ""
 "You are about to change a protected field of a reconciled split. If you "
 "continue editing this split it will be unreconciled. This might make future "
 "reconciliation difficult! Continue with this change?"
-msgstr "您即將要修改已對帳分割的保護欄位。如果您繼續編輯，則此分割會取消對帳，這麼做可能使未來的對帳很困難！繼續這個修改？"
+msgstr ""
+"您即將要修改已對帳分割的保護欄位。如果您繼續編輯，則此分割會取消對帳，這麼做"
+"可能使未來的對帳很困難！繼續這個修改？"
 
-#: gnucash/register/ledger-core/split-register-model.c:2253
+#: gnucash/register/ledger-core/split-register-model.c:2260
 msgid "Chan_ge Transaction"
 msgstr "變更交易(_G)"
 
@@ -21413,9 +21874,11 @@ msgid ""
 "The entered date of the transaction is older than the \"Read-Only Threshold"
 "\" set for this book. This setting can be changed in File->Properties-"
 ">Accounts, resetting to the threshold."
-msgstr "輸入的此筆交易的日期，超過了帳簿設定的「交易唯讀日期門檻」。這個設定可以從「檔案->內容->科目」中變更。"
+msgstr ""
+"輸入的此筆交易的日期，超過了帳簿設定的「交易唯讀日期門檻」。這個設定可以從"
+"「檔案->內容->科目」中變更。"
 
-#: gnucash/register/register-gnome/gnucash-item-list.c:528
+#: gnucash/register/register-gnome/gnucash-item-list.c:530
 msgid "List"
 msgstr "列表"
 
@@ -21424,7 +21887,7 @@ msgstr "列表"
 msgid "Template file \"~a\" can not be read"
 msgstr "範本檔「~a」無法讀取"
 
-#: gnucash/report/html-chart.scm:455
+#: gnucash/report/html-chart.scm:463
 msgid "Load"
 msgstr "載入"
 
@@ -21519,9 +21982,8 @@ msgid "No budgets exist. You must create at least one budget."
 msgstr "沒有已存在的預算。您必須至少建立一個預算。"
 
 #: gnucash/report/html-utilities.scm:337
-#: gnucash/report/reports/standard/balsheet-pnl.scm:140
-#: gnucash/report/reports/standard/balsheet-pnl.scm:141
-#: gnucash/report/reports/standard/new-owner-report.scm:949
+#: gnucash/report/reports/standard/balsheet-pnl.scm:154
+#: gnucash/report/reports/standard/new-owner-report.scm:956
 msgid "Disabled"
 msgstr "禁用"
 
@@ -21538,7 +22000,7 @@ msgid "This report requires accounts to be selected in the report options."
 msgstr "這個報表需要在選項中有選定的科目。"
 
 #: gnucash/report/html-utilities.scm:405
-#: gnucash/report/reports/standard/price-scatter.scm:267
+#: gnucash/report/reports/standard/price-scatter.scm:260
 msgid "No data"
 msgstr "無資料"
 
@@ -21565,121 +22027,53 @@ msgid "The amount of time between data points."
 msgstr "資料點之間的時間長度。"
 
 #: gnucash/report/options-utilities.scm:66
-msgid "Day"
-msgstr "日"
-
-#: gnucash/report/options-utilities.scm:66
-msgid "One Day."
-msgstr ""
+msgid "One Day"
+msgstr "一天"
 
 #: gnucash/report/options-utilities.scm:67
-#: gnucash/report/reports/standard/balsheet-pnl.scm:164
-msgid "Week"
-msgstr "週"
-
-#: gnucash/report/options-utilities.scm:67
-#: gnucash/report/reports/standard/balsheet-pnl.scm:165
-#, fuzzy
-msgid "One Week."
-msgstr "一星期以前"
-
-#: gnucash/report/options-utilities.scm:68
 #: gnucash/report/reports/standard/balsheet-pnl.scm:160
-msgid "2Week"
-msgstr "2 週"
+msgid "One Week"
+msgstr "一星期"
 
 #: gnucash/report/options-utilities.scm:68
-#: gnucash/report/reports/standard/balsheet-pnl.scm:161
-#, fuzzy
-msgid "Two Weeks."
+#: gnucash/report/reports/standard/balsheet-pnl.scm:159
+msgid "Two Weeks"
 msgstr "兩週"
 
 #: gnucash/report/options-utilities.scm:69
-#: gnucash/report/reports/standard/balsheet-pnl.scm:156
-msgid "Month"
-msgstr "月"
+#: gnucash/report/reports/standard/balsheet-pnl.scm:158
+msgid "One Month"
+msgstr "一個月"
 
-#: gnucash/report/options-utilities.scm:69
+#: gnucash/report/options-utilities.scm:70
 #: gnucash/report/reports/standard/balsheet-pnl.scm:157
-#, fuzzy
-msgid "One Month."
-msgstr "一個月以前"
-
-#: gnucash/report/options-utilities.scm:70
-#: gnucash/report/reports/standard/balsheet-pnl.scm:152
-msgid "Quarter"
-msgstr "季"
-
-#: gnucash/report/options-utilities.scm:70
-#: gnucash/report/reports/standard/balsheet-pnl.scm:153
-#, fuzzy
-msgid "One Quarter."
-msgstr "季"
+msgid "Quarter Year"
+msgstr "一季"
 
 #: gnucash/report/options-utilities.scm:71
-#: gnucash/report/reports/standard/balsheet-pnl.scm:148
+#: gnucash/report/reports/standard/balsheet-pnl.scm:156
 msgid "Half Year"
 msgstr "半年"
 
-#: gnucash/report/options-utilities.scm:71
-#: gnucash/report/reports/standard/balsheet-pnl.scm:149
-#, fuzzy
-msgid "Half Year."
-msgstr "半年"
-
 #: gnucash/report/options-utilities.scm:72
-#: gnucash/report/reports/standard/balsheet-pnl.scm:144
-msgid "Year"
-msgstr "年"
+#: gnucash/report/reports/standard/balsheet-pnl.scm:155
+msgid "One Year"
+msgstr "一年"
 
-#: gnucash/report/options-utilities.scm:72
-#: gnucash/report/reports/standard/balsheet-pnl.scm:145
-#, fuzzy
-msgid "One Year."
-msgstr "一年以前"
-
-#: gnucash/report/options-utilities.scm:85 gnucash/report/trep-engine.scm:415
+#: gnucash/report/options-utilities.scm:84
 msgid "All"
 msgstr "全部"
 
-#: gnucash/report/options-utilities.scm:85
-msgid "All accounts"
-msgstr "所有科目"
-
-#: gnucash/report/options-utilities.scm:86
-msgid "Top-level."
-msgstr "頂端層級。"
-
-#: gnucash/report/options-utilities.scm:87
-msgid "Second-level."
-msgstr "第二層級。"
-
-#: gnucash/report/options-utilities.scm:88
-msgid "Third-level."
-msgstr "第三層級。"
-
-#: gnucash/report/options-utilities.scm:89
-msgid "Fourth-level."
-msgstr "第四層級。"
-
-#: gnucash/report/options-utilities.scm:90
-msgid "Fifth-level."
-msgstr "第五層級。"
-
-#: gnucash/report/options-utilities.scm:91
-msgid "Sixth-level."
-msgstr "第六層級。"
-
-#: gnucash/report/options-utilities.scm:101
+#: gnucash/report/options-utilities.scm:100
 msgid "Show accounts to this depth, overriding any other option."
 msgstr "顯示科目至此深度，無視其他任何選項。"
 
-#: gnucash/report/options-utilities.scm:109
+#: gnucash/report/options-utilities.scm:108
 msgid ""
 "Override account-selection and show sub-accounts of all selected accounts?"
 msgstr "無視科目的選擇並顯示所有已選科目的子科目？"
 
-#: gnucash/report/options-utilities.scm:122
+#: gnucash/report/options-utilities.scm:121
 #: gnucash/report/reports/standard/account-summary.scm:87
 #: gnucash/report/reports/standard/balance-sheet.scm:88
 #: gnucash/report/reports/standard/balsheet-pnl.scm:82
@@ -21689,190 +22083,142 @@ msgstr "無視科目的選擇並顯示所有已選科目的子科目？"
 msgid "Report on these accounts, if display depth allows."
 msgstr "如果顯示深度允許，提出這些科目的報表。"
 
-#: gnucash/report/options-utilities.scm:134
+#: gnucash/report/options-utilities.scm:133
 msgid "Select the currency to display the values of this report in."
 msgstr "選擇用來顯示這份報表的數值的貨幣。"
 
-#: gnucash/report/options-utilities.scm:144
+#: gnucash/report/options-utilities.scm:143
 #: gnucash/report/reports/standard/advanced-portfolio.scm:81
 #: gnucash/report/reports/standard/price-scatter.scm:78
 msgid "The source of price information."
 msgstr "價格資訊來源。"
 
-#: gnucash/report/options-utilities.scm:146
-msgid "Average Cost"
-msgstr "平均費用"
+#: gnucash/report/options-utilities.scm:144
+msgid "Average cost of purchases weighted by volume"
+msgstr "依照過去採購的數量的加權平均"
 
-#: gnucash/report/options-utilities.scm:147
-msgid "The volume-weighted average cost of purchases."
-msgstr ""
-
-#: gnucash/report/options-utilities.scm:149
-#: gnucash/report/reports/standard/price-scatter.scm:81
-msgid "Weighted Average"
-msgstr "加權平均數"
-
-#: gnucash/report/options-utilities.scm:150
-#: gnucash/report/reports/standard/price-scatter.scm:82
-#, fuzzy
-msgid "The weighted average of all currency transactions of the past."
+#: gnucash/report/options-utilities.scm:145
+msgid "Weighted average of all transactions in the past"
 msgstr "過去所有貨幣交易的加權平均數"
 
-#: gnucash/report/options-utilities.scm:152
-#: gnucash/report/reports/standard/advanced-portfolio.scm:83
+#: gnucash/report/options-utilities.scm:146
+msgid "Last up through report date"
+msgstr "截至報告日"
+
+#: gnucash/report/options-utilities.scm:147
+msgid "Closest to report date"
+msgstr "與報表時間最接近的"
+
+#: gnucash/report/options-utilities.scm:148
+#: gnucash/report/reports/standard/advanced-portfolio.scm:82
 msgid "Most recent"
 msgstr "最新的"
 
-#: gnucash/report/options-utilities.scm:153
-#: gnucash/report/reports/standard/advanced-portfolio.scm:84
-msgid "The most recent recorded price."
-msgstr "最新的記錄價格。"
-
-#: gnucash/report/options-utilities.scm:155
-#: gnucash/report/reports/standard/advanced-portfolio.scm:86
-msgid "Nearest in time"
-msgstr "時間上最接近"
-
-#: gnucash/report/options-utilities.scm:156
-#: gnucash/report/reports/standard/advanced-portfolio.scm:87
-msgid "The price recorded nearest in time to the report date."
-msgstr "時間上最接近報表日期的記錄價格。"
-
-#: gnucash/report/options-utilities.scm:169
+#: gnucash/report/options-utilities.scm:160
 msgid "Width of plot in pixels."
 msgstr "製圖寬度(像素)。"
 
-#: gnucash/report/options-utilities.scm:177
+#: gnucash/report/options-utilities.scm:168
 msgid "Height of plot in pixels."
 msgstr "製圖高度(像素)。"
 
-#: gnucash/report/options-utilities.scm:188
+#: gnucash/report/options-utilities.scm:179
 msgid "Choose the marker for each data point."
 msgstr "選擇每一個資料點的標誌。"
 
-#: gnucash/report/options-utilities.scm:191
+#: gnucash/report/options-utilities.scm:182
 msgid "Diamond"
 msgstr "菱形"
 
-#: gnucash/report/options-utilities.scm:191
-msgid "Hollow diamond"
-msgstr "空心的菱形"
-
-#: gnucash/report/options-utilities.scm:192
+#: gnucash/report/options-utilities.scm:183
 msgid "Circle"
 msgstr "圓形"
 
-#: gnucash/report/options-utilities.scm:192
-msgid "Hollow circle"
-msgstr "空心的圓形"
-
-#: gnucash/report/options-utilities.scm:193
+#: gnucash/report/options-utilities.scm:184
 msgid "Square"
 msgstr "方形"
 
-#: gnucash/report/options-utilities.scm:193
-msgid "Hollow square"
-msgstr "空心的方形"
-
-#: gnucash/report/options-utilities.scm:194
+#: gnucash/report/options-utilities.scm:185
 msgid "Cross"
 msgstr "交叉"
 
-#: gnucash/report/options-utilities.scm:195
+#: gnucash/report/options-utilities.scm:186
 msgid "Plus"
 msgstr "加號"
 
-#: gnucash/report/options-utilities.scm:196
+#: gnucash/report/options-utilities.scm:187
 msgid "Dash"
 msgstr "橫線"
 
-#: gnucash/report/options-utilities.scm:197
+#: gnucash/report/options-utilities.scm:188
 msgid "Filled diamond"
 msgstr "實心菱形"
 
-#: gnucash/report/options-utilities.scm:197
-msgid "Diamond filled with color"
-msgstr "以顏色填滿的菱形"
-
-#: gnucash/report/options-utilities.scm:198
+#: gnucash/report/options-utilities.scm:189
 msgid "Filled circle"
 msgstr "填滿的圓形"
 
-#: gnucash/report/options-utilities.scm:198
-msgid "Circle filled with color"
-msgstr "以顏色填滿的圓形"
-
-#: gnucash/report/options-utilities.scm:199
+#: gnucash/report/options-utilities.scm:190
 msgid "Filled square"
 msgstr "填滿的方形"
 
-#: gnucash/report/options-utilities.scm:199
-msgid "Square filled with color"
-msgstr "以顏色填滿的方形"
-
-#: gnucash/report/options-utilities.scm:209
+#: gnucash/report/options-utilities.scm:200
 msgid "Choose the method for sorting accounts."
 msgstr "請選擇排序科目的方法。"
 
-#: gnucash/report/options-utilities.scm:212
-msgid "Alphabetical by account code."
-msgstr "以科目代碼做字母排序。"
+#: gnucash/report/options-utilities.scm:203
+msgid "Alphabetical by account code"
+msgstr "以科目代碼做字母排序"
 
-#: gnucash/report/options-utilities.scm:213
-msgid "Alphabetical"
-msgstr "字母順序"
+#: gnucash/report/options-utilities.scm:204
+msgid "Alphabetical by account name"
+msgstr "以科目名稱做字母排序"
 
-#: gnucash/report/options-utilities.scm:213
-msgid "Alphabetical by account name."
-msgstr "以科目名稱做字母排序。"
+#: gnucash/report/options-utilities.scm:205
+msgid "Numerical by descending amount"
+msgstr "根據金額進行遞減排序"
 
-#: gnucash/report/options-utilities.scm:214
-msgid "By amount, largest to smallest."
-msgstr "依金額，從最大到最小"
-
-#: gnucash/report/options-utilities.scm:230
+#: gnucash/report/options-utilities.scm:223
 msgid "How to show the balances of parent accounts."
 msgstr "如何顯示母科目的結餘。"
 
-#: gnucash/report/options-utilities.scm:233
-#: gnucash/report/reports/standard/account-summary.scm:113
+#: gnucash/report/options-utilities.scm:224
+msgid "Account Balance in the parent account, excluding any subaccounts."
+msgstr "只顯示母科目中的結餘，排除任何的子科目。"
+
+#: gnucash/report/options-utilities.scm:225
+msgid "Do not show any balances of parent accounts."
+msgstr "不顯示母科目的結餘。"
+
+#: gnucash/report/options-utilities.scm:228
+#: gnucash/report/reports/standard/account-summary.scm:118
 msgid "Account Balance"
 msgstr "科目結餘"
 
-#: gnucash/report/options-utilities.scm:234
-msgid "Show only the balance in the parent account, excluding any subaccounts."
-msgstr "只顯示母科目中的結餘，排除任何的子科目。"
+#: gnucash/report/options-utilities.scm:229
+msgid "Calculate Subtotal"
+msgstr "計算小計"
 
-#: gnucash/report/options-utilities.scm:237
-msgid ""
-"Calculate the subtotal for this parent account and all of its subaccounts, "
-"and show this as the parent account balance."
-msgstr "計算此科目中的小計與低下所有的子科目的小計總額，並以此做為母科目的結餘顯示。"
-
-#: gnucash/report/options-utilities.scm:239
-#: gnucash/report/options-utilities.scm:254
+#: gnucash/report/options-utilities.scm:230
+#: gnucash/report/options-utilities.scm:246
 msgid "Do not show"
 msgstr "不要顯示"
 
 #: gnucash/report/options-utilities.scm:240
-msgid "Do not show any balances of parent accounts."
-msgstr "不顯示母科目的結餘。"
-
-#: gnucash/report/options-utilities.scm:248
 msgid "How to show account subtotals for parent accounts."
 msgstr "如何顯示母科目的小計。"
 
-#: gnucash/report/options-utilities.scm:251
-msgid "Show subtotals"
-msgstr "顯示小計"
-
-#: gnucash/report/options-utilities.scm:252
+#: gnucash/report/options-utilities.scm:241
 msgid "Show subtotals for selected parent accounts which have subaccounts."
 msgstr "顯示所選定的具有子科目的母科目小計。"
 
-#: gnucash/report/options-utilities.scm:255
+#: gnucash/report/options-utilities.scm:242
 msgid "Do not show any subtotals for parent accounts."
 msgstr "不顯示母科目的小計。"
+
+#: gnucash/report/options-utilities.scm:245
+msgid "Show subtotals"
+msgstr "顯示小計"
 
 #: gnucash/report/report-core.scm:150
 msgid "_Assets & Liabilities"
@@ -21903,22 +22249,22 @@ msgid "_Custom"
 msgstr "自訂(_C)"
 
 #: gnucash/report/report-core.scm:160
-#: gnucash/report/reports/standard/invoice.scm:257
+#: gnucash/report/reports/standard/invoice.scm:244
+#: gnucash/report/reports/standard/invoice.scm:249
+#: gnucash/report/reports/standard/invoice.scm:254
 #: gnucash/report/reports/standard/invoice.scm:262
-#: gnucash/report/reports/standard/invoice.scm:267
+#: gnucash/report/reports/standard/invoice.scm:268
 #: gnucash/report/reports/standard/invoice.scm:275
 #: gnucash/report/reports/standard/invoice.scm:281
-#: gnucash/report/reports/standard/invoice.scm:288
+#: gnucash/report/reports/standard/invoice.scm:287
 #: gnucash/report/reports/standard/invoice.scm:294
-#: gnucash/report/reports/standard/invoice.scm:300
-#: gnucash/report/reports/standard/invoice.scm:307
-#: gnucash/report/reports/standard/invoice.scm:312
-#: gnucash/report/reports/standard/invoice.scm:317
-#: gnucash/report/reports/standard/invoice.scm:322
-#: gnucash/report/reports/standard/invoice.scm:327
-#: gnucash/report/reports/standard/invoice.scm:332
-#: gnucash/report/reports/standard/invoice.scm:337
-#: gnucash/report/reports/standard/invoice.scm:342
+#: gnucash/report/reports/standard/invoice.scm:299
+#: gnucash/report/reports/standard/invoice.scm:304
+#: gnucash/report/reports/standard/invoice.scm:309
+#: gnucash/report/reports/standard/invoice.scm:314
+#: gnucash/report/reports/standard/invoice.scm:319
+#: gnucash/report/reports/standard/invoice.scm:324
+#: gnucash/report/reports/standard/invoice.scm:329
 #: gnucash/report/reports/standard/receipt.scm:40
 #: gnucash/report/reports/standard/register.scm:353
 #: gnucash/report/reports/standard/register.scm:359
@@ -21954,7 +22300,9 @@ msgid ""
 "One of your reports has a report-guid that is a duplicate. Please check the "
 "report system, especially your saved reports, for a report with this report-"
 "guid: "
-msgstr "您的其中一份報表具有重覆的 report-guid。請檢查您的報表系統（特別是您儲中的報表中）有以下 report-guid 的報表： "
+msgstr ""
+"您的其中一份報表具有重覆的 report-guid。請檢查您的報表系統（特別是您儲中的報"
+"表中）有以下 report-guid 的報表： "
 
 #: gnucash/report/report-core.scm:211
 msgid "Wrong report definition: "
@@ -21964,18 +22312,13 @@ msgstr "錯誤的報表定義： "
 msgid " Report is missing a GUID."
 msgstr " 報表中沒有 GUID。"
 
-#: gnucash/report/report-core.scm:287
+#: gnucash/report/report-core.scm:293
 msgid "Enter a descriptive name for this report."
 msgstr "為此報表輸入敘述名稱。"
 
-#: gnucash/report/report-core.scm:292
+#: gnucash/report/report-core.scm:298
 msgid "Select a stylesheet for the report."
 msgstr "選擇用於此報表的樣式表。"
-
-#: gnucash/report/report-core.scm:300
-#, fuzzy
-msgid "stylesheet."
-msgstr "樣式表"
 
 #: gnucash/report/reports/aging.scm:38
 #: gnucash/report/reports/standard/new-aging.scm:40
@@ -21983,7 +22326,7 @@ msgid "Sort By"
 msgstr "排序依"
 
 #: gnucash/report/reports/aging.scm:39
-#: gnucash/report/reports/standard/customer-summary.scm:78
+#: gnucash/report/reports/standard/customer-summary.scm:77
 #: gnucash/report/reports/standard/new-aging.scm:41
 msgid "Sort Order"
 msgstr "排列順序"
@@ -21992,7 +22335,7 @@ msgstr "排列順序"
 #: gnucash/report/reports/example/average-balance.scm:43
 #: gnucash/report/reports/example/daily-reports.scm:54
 #: gnucash/report/reports/standard/account-piecharts.scm:67
-#: gnucash/report/reports/standard/account-summary.scm:125
+#: gnucash/report/reports/standard/account-summary.scm:130
 #: gnucash/report/reports/standard/advanced-portfolio.scm:76
 #: gnucash/report/reports/standard/balance-forecast.scm:44
 #: gnucash/report/reports/standard/balance-sheet.scm:136
@@ -22018,7 +22361,7 @@ msgstr "報表的貨幣"
 #: gnucash/report/reports/example/average-balance.scm:44
 #: gnucash/report/reports/example/daily-reports.scm:55
 #: gnucash/report/reports/standard/account-piecharts.scm:68
-#: gnucash/report/reports/standard/account-summary.scm:126
+#: gnucash/report/reports/standard/account-summary.scm:131
 #: gnucash/report/reports/standard/advanced-portfolio.scm:40
 #: gnucash/report/reports/standard/balance-forecast.scm:45
 #: gnucash/report/reports/standard/balance-sheet.scm:137
@@ -22082,7 +22425,8 @@ msgstr "地址電子郵件"
 msgid ""
 "Transactions relating to '~a' contain more than one currency. This report is "
 "not designed to cope with this possibility."
-msgstr "與「~a」的相關交易包含一種以上的貨幣。這個報表並不是被設計來處理這種情形的。"
+msgstr ""
+"與「~a」的相關交易包含一種以上的貨幣。這個報表並不是被設計來處理這種情形的。"
 
 #: gnucash/report/reports/aging.scm:345
 #: gnucash/report/reports/standard/new-aging.scm:93
@@ -22090,85 +22434,52 @@ msgid "Sort companies by."
 msgstr "依此排序公司。"
 
 #: gnucash/report/reports/aging.scm:348
-#: gnucash/report/reports/standard/new-aging.scm:97
-#, fuzzy
-msgid "Name of the company."
+#: gnucash/report/reports/standard/new-aging.scm:95
+msgid "Name of the company"
 msgstr "公司的名稱"
 
 #: gnucash/report/reports/aging.scm:349
-#: gnucash/report/reports/standard/new-aging.scm:99
-msgid "Total Owed"
-msgstr "負債總計"
-
-#: gnucash/report/reports/aging.scm:349
-#: gnucash/report/reports/standard/new-aging.scm:100
-#, fuzzy
-msgid "Total amount owed to/from Company."
-msgstr "與公司間的負債總額"
+#: gnucash/report/reports/standard/new-aging.scm:96
+msgid "Total amount owed to/from Company"
+msgstr "該公司的未付 / 未收總額"
 
 #: gnucash/report/reports/aging.scm:350
-#: gnucash/report/reports/standard/new-aging.scm:102
+#: gnucash/report/reports/standard/new-aging.scm:97
 msgid "Bracket Total Owed"
 msgstr "階層負債總計"
 
-#: gnucash/report/reports/aging.scm:350
-#: gnucash/report/reports/standard/new-aging.scm:103
-#, fuzzy
-msgid "Amount owed in oldest bracket - if same go to next oldest."
-msgstr "最老階層的負債總額 - 如果相同則移至次老的"
-
 #: gnucash/report/reports/aging.scm:357
-#: gnucash/report/reports/standard/new-aging.scm:107
+#: gnucash/report/reports/standard/new-aging.scm:101
 msgid "Sort order."
 msgstr "排列順序。"
-
-#: gnucash/report/reports/aging.scm:360
-msgid "0 .. 999,999.99, A .. Z."
-msgstr "0 .. 999,999.99, A .. Z."
-
-#: gnucash/report/reports/aging.scm:361
-msgid "999,999.99 .. 0, Z .. A."
-msgstr "999,999.99 .. 0, Z .. A."
 
 #: gnucash/report/reports/aging.scm:368
 msgid ""
 "Show multi-currency totals. If not selected, convert all totals to report "
 "currency."
-msgstr "顯示多重貨幣的總和。如果沒有選擇此項，所有的總和都會轉換成報表使用的貨幣。"
+msgstr ""
+"顯示多重貨幣的總和。如果沒有選擇此項，所有的總和都會轉換成報表使用的貨幣。"
 
 #: gnucash/report/reports/aging.scm:377
-#: gnucash/report/reports/standard/new-aging.scm:115
+#: gnucash/report/reports/standard/new-aging.scm:109
 msgid "Show all vendors/customers even if they have a zero balance."
 msgstr "顯示所有廠商 / 客戶，即便他們的結餘為零。"
 
 #: gnucash/report/reports/aging.scm:385
-#: gnucash/report/reports/standard/new-aging.scm:120
-#: gnucash/report/reports/standard/new-owner-report.scm:967
+#: gnucash/report/reports/standard/new-aging.scm:114
+#: gnucash/report/reports/standard/new-owner-report.scm:968
 #: gnucash/report/reports/standard/owner-report.scm:609
 msgid "Leading date."
 msgstr "交付週期。"
-
-#: gnucash/report/reports/aging.scm:388
-#: gnucash/report/reports/standard/new-aging.scm:125
-#: gnucash/report/reports/standard/new-owner-report.scm:972
-#: gnucash/report/reports/standard/owner-report.scm:612
-msgid "Due date is leading."
-msgstr ""
-
-#: gnucash/report/reports/aging.scm:389
-#: gnucash/report/reports/standard/new-aging.scm:129
-#: gnucash/report/reports/standard/new-owner-report.scm:976
-#: gnucash/report/reports/standard/owner-report.scm:613
-#, fuzzy
-msgid "Post date is leading."
-msgstr "日期的位置"
 
 #: gnucash/report/reports/aging.scm:401
 #: gnucash/report/reports/standard/new-aging.scm:50
 msgid ""
 "Display Address Name. This, and other fields, may be useful if copying this "
 "report to a spreadsheet for use in a mail merge."
-msgstr "顯示地址名稱。這個選項以及其他選項，可能會對於將此報表貼到試算表中有不同程度的幫助。"
+msgstr ""
+"顯示地址名稱。這個選項以及其他選項，可能會對於將此報表貼到試算表中有不同程度"
+"的幫助。"
 
 #: gnucash/report/reports/aging.scm:410
 #: gnucash/report/reports/standard/new-aging.scm:52
@@ -22211,9 +22522,7 @@ msgid "Display Active status."
 msgstr "是否顯示作用中狀態。"
 
 #: gnucash/report/reports/aging.scm:539
-#: gnucash/report/reports/standard/budget-barchart.scm:72
-#: gnucash/report/reports/standard/budget.scm:118
-#: gnucash/report/reports/standard/new-aging.scm:193
+#: gnucash/report/reports/standard/new-aging.scm:181
 #: gnucash/report/reports/standard/new-owner-report.scm:322
 #: gnucash/report/reports/standard/owner-report.scm:259
 msgid "Current"
@@ -22221,7 +22530,7 @@ msgstr "現在"
 
 #: gnucash/report/reports/aging.scm:540
 #: gnucash/report/reports/standard/job-report.scm:159
-#: gnucash/report/reports/standard/new-aging.scm:194
+#: gnucash/report/reports/standard/new-aging.scm:182
 #: gnucash/report/reports/standard/new-owner-report.scm:323
 #: gnucash/report/reports/standard/owner-report.scm:260
 msgid "0-30 days"
@@ -22229,7 +22538,7 @@ msgstr "0-30 天"
 
 #: gnucash/report/reports/aging.scm:541
 #: gnucash/report/reports/standard/job-report.scm:160
-#: gnucash/report/reports/standard/new-aging.scm:195
+#: gnucash/report/reports/standard/new-aging.scm:183
 #: gnucash/report/reports/standard/new-owner-report.scm:324
 #: gnucash/report/reports/standard/owner-report.scm:261
 msgid "31-60 days"
@@ -22237,7 +22546,7 @@ msgstr "31-60 天"
 
 #: gnucash/report/reports/aging.scm:542
 #: gnucash/report/reports/standard/job-report.scm:161
-#: gnucash/report/reports/standard/new-aging.scm:196
+#: gnucash/report/reports/standard/new-aging.scm:184
 #: gnucash/report/reports/standard/new-owner-report.scm:325
 #: gnucash/report/reports/standard/owner-report.scm:262
 msgid "61-90 days"
@@ -22245,20 +22554,20 @@ msgstr "61-90 天"
 
 #: gnucash/report/reports/aging.scm:543
 #: gnucash/report/reports/standard/job-report.scm:162
-#: gnucash/report/reports/standard/new-aging.scm:197
+#: gnucash/report/reports/standard/new-aging.scm:185
 #: gnucash/report/reports/standard/new-owner-report.scm:326
 #: gnucash/report/reports/standard/owner-report.scm:263
 msgid "91+ days"
 msgstr "91+ 天"
 
 #: gnucash/report/reports/aging.scm:774
-#: gnucash/report/reports/standard/new-aging.scm:162
+#: gnucash/report/reports/standard/new-aging.scm:150
 msgctxt "One-letter indication for 'yes'"
 msgid "Y"
 msgstr "是"
 
 #: gnucash/report/reports/aging.scm:774
-#: gnucash/report/reports/standard/new-aging.scm:162
+#: gnucash/report/reports/standard/new-aging.scm:150
 msgctxt "One-letter indication for 'no'"
 msgid "N"
 msgstr "否"
@@ -22332,8 +22641,8 @@ msgstr "進行此科目的交易報表。"
 
 #: gnucash/report/reports/example/average-balance.scm:116
 #: gnucash/report/reports/example/average-balance.scm:303
-#: gnucash/report/reports/standard/category-barchart.scm:187
-#: gnucash/report/reports/standard/category-barchart.scm:260
+#: gnucash/report/reports/standard/category-barchart.scm:175
+#: gnucash/report/reports/standard/category-barchart.scm:248
 #: gnucash/report/reports/standard/net-charts.scm:133
 #: gnucash/report/reports/standard/net-charts.scm:225
 msgid "Show table"
@@ -22341,7 +22650,7 @@ msgstr "顯示表格"
 
 #: gnucash/report/reports/example/average-balance.scm:117
 #: gnucash/report/reports/standard/cashflow-barchart.scm:125
-#: gnucash/report/reports/standard/category-barchart.scm:188
+#: gnucash/report/reports/standard/category-barchart.scm:176
 #: gnucash/report/reports/standard/net-charts.scm:134
 msgid "Display a table of the selected data."
 msgstr "顯示已選資料的表格。"
@@ -22366,32 +22675,16 @@ msgstr "要產生的圖形種類。"
 
 #: gnucash/report/reports/example/average-balance.scm:129
 #: gnucash/report/reports/example/average-balance.scm:149
-#: gnucash/report/reports/standard/advanced-portfolio.scm:95
-#: gnucash/report/trep-engine.scm:1962 libgnucash/engine/policy.c:58
+#: gnucash/report/trep-engine.scm:1907 libgnucash/engine/policy.c:58
 msgid "Average"
 msgstr "平均"
 
-#: gnucash/report/reports/example/average-balance.scm:129
-#, fuzzy
-msgid "Average Balance."
-msgstr "平均餘額"
-
 #: gnucash/report/reports/example/average-balance.scm:130
 #: gnucash/report/reports/example/average-balance.scm:151
-#: gnucash/report/reports/standard/customer-summary.scm:121
-#: gnucash/report/reports/standard/customer-summary.scm:314
+#: gnucash/report/reports/standard/customer-summary.scm:117
+#: gnucash/report/reports/standard/customer-summary.scm:298
 msgid "Profit"
 msgstr "利潤"
-
-#: gnucash/report/reports/example/average-balance.scm:130
-#, fuzzy
-msgid "Profit (Gain minus Loss)."
-msgstr "利潤 (獲利減去虧損)"
-
-#: gnucash/report/reports/example/average-balance.scm:131
-#, fuzzy
-msgid "Gain And Loss."
-msgstr "獲利與虧損"
 
 #: gnucash/report/reports/example/average-balance.scm:149
 msgid "Period start"
@@ -22438,9 +22731,18 @@ msgstr "顯示以星期幾區分的支出圓餅圖"
 
 #: gnucash/report/reports/example/daily-reports.scm:58
 #: gnucash/report/reports/standard/account-piecharts.scm:71
+#: gnucash/report/reports/standard/account-summary.scm:88
+#: gnucash/report/reports/standard/balance-sheet.scm:89
+#: gnucash/report/reports/standard/balsheet-eg.scm:148
+#: gnucash/report/reports/standard/balsheet-pnl.scm:84
+#: gnucash/report/reports/standard/budget-balance-sheet.scm:55
+#: gnucash/report/reports/standard/budget-barchart.scm:46
+#: gnucash/report/reports/standard/budget-income-statement.scm:77
 #: gnucash/report/reports/standard/category-barchart.scm:76
-msgid "Show Accounts until level"
-msgstr "顯示此層級之前的科目"
+#: gnucash/report/reports/standard/income-statement.scm:64
+#: gnucash/report/reports/standard/trial-balance.scm:79
+msgid "Levels of Subaccounts"
+msgstr "子科目層數"
 
 #: gnucash/report/reports/example/daily-reports.scm:61
 #: gnucash/report/reports/standard/account-piecharts.scm:74
@@ -22448,27 +22750,27 @@ msgid "Show Totals"
 msgstr "顯示總數"
 
 #: gnucash/report/reports/example/daily-reports.scm:94
-#: gnucash/report/reports/standard/account-piecharts.scm:137
-#: gnucash/report/reports/standard/category-barchart.scm:138
+#: gnucash/report/reports/standard/account-piecharts.scm:126
+#: gnucash/report/reports/standard/category-barchart.scm:130
 #: gnucash/report/reports/standard/net-charts.scm:92
 msgid "Report on these accounts, if chosen account level allows."
 msgstr "如果選擇的科目層級允許，提出這些科目的報表。"
 
 #: gnucash/report/reports/example/daily-reports.scm:109
-#: gnucash/report/reports/standard/account-piecharts.scm:167
+#: gnucash/report/reports/standard/account-piecharts.scm:156
 msgid "Show the total balance in legend?"
 msgstr "在圖例中顯示全部結餘？"
 
 #: gnucash/report/reports/example/daily-reports.scm:273
-#: gnucash/report/reports/standard/account-piecharts.scm:546
+#: gnucash/report/reports/standard/account-piecharts.scm:535
 #: gnucash/report/reports/standard/balance-forecast.scm:276
-#: gnucash/report/reports/standard/balsheet-pnl.scm:932
-#: gnucash/report/reports/standard/budget.scm:512
+#: gnucash/report/reports/standard/balsheet-pnl.scm:893
+#: gnucash/report/reports/standard/budget.scm:500
 #: gnucash/report/reports/standard/cashflow-barchart.scm:276
 #: gnucash/report/reports/standard/cash-flow.scm:190
-#: gnucash/report/reports/standard/category-barchart.scm:519
+#: gnucash/report/reports/standard/category-barchart.scm:507
 #: gnucash/report/reports/standard/net-charts.scm:330
-#: gnucash/report/reports/standard/price-scatter.scm:203
+#: gnucash/report/reports/standard/price-scatter.scm:196
 #: libgnucash/app-utils/date-utilities.scm:187
 #, scheme-format
 msgid "~a to ~a"
@@ -22476,13 +22778,13 @@ msgstr "~a 到 ~a"
 
 #: gnucash/report/reports/example/hello-world.scm:57
 #: gnucash/report/reports/example/hello-world.scm:67
-#: gnucash/report/reports/example/hello-world.scm:89
-#: gnucash/report/reports/example/hello-world.scm:100
-#: gnucash/report/reports/example/hello-world.scm:109
-#: gnucash/report/reports/example/hello-world.scm:116
-#: gnucash/report/reports/example/hello-world.scm:123
-#: gnucash/report/reports/example/hello-world.scm:134
-#: gnucash/report/reports/example/hello-world.scm:152
+#: gnucash/report/reports/example/hello-world.scm:81
+#: gnucash/report/reports/example/hello-world.scm:92
+#: gnucash/report/reports/example/hello-world.scm:101
+#: gnucash/report/reports/example/hello-world.scm:108
+#: gnucash/report/reports/example/hello-world.scm:115
+#: gnucash/report/reports/example/hello-world.scm:126
+#: gnucash/report/reports/example/hello-world.scm:144
 msgid "Hello, World!"
 msgstr "哈囉，世界！"
 
@@ -22499,181 +22801,158 @@ msgid "Multi Choice Option"
 msgstr "複選選項"
 
 #: gnucash/report/reports/example/hello-world.scm:68
-#: gnucash/report/reports/standard/budget-barchart.scm:154
 msgid "This is a multi choice option."
 msgstr "這是一個複選選項。"
 
-#: gnucash/report/reports/example/hello-world.scm:70
+#: gnucash/report/reports/example/hello-world.scm:69
 msgid "First Option"
 msgstr "第一選項"
 
-#: gnucash/report/reports/example/hello-world.scm:71
-#, fuzzy
-msgid "Help for first option."
-msgstr "第一選項說明"
-
-#: gnucash/report/reports/example/hello-world.scm:73
+#: gnucash/report/reports/example/hello-world.scm:70
 msgid "Second Option"
 msgstr "第二選項"
 
-#: gnucash/report/reports/example/hello-world.scm:74
-#, fuzzy
-msgid "Help for second option."
-msgstr "第二選項說明"
-
-#: gnucash/report/reports/example/hello-world.scm:76
+#: gnucash/report/reports/example/hello-world.scm:71
 msgid "Third Option"
 msgstr "第三選項"
 
-#: gnucash/report/reports/example/hello-world.scm:77
-#, fuzzy
-msgid "Help for third option."
-msgstr "第三選項說明"
-
-#: gnucash/report/reports/example/hello-world.scm:79
+#: gnucash/report/reports/example/hello-world.scm:72
 msgid "Fourth Options"
 msgstr "第四選項"
 
-#: gnucash/report/reports/example/hello-world.scm:80
-msgid "The fourth option rules!"
-msgstr "第四選項才是王道！"
-
-#: gnucash/report/reports/example/hello-world.scm:89
+#: gnucash/report/reports/example/hello-world.scm:81
 msgid "String Option"
 msgstr "字串選項"
 
-#: gnucash/report/reports/example/hello-world.scm:90
+#: gnucash/report/reports/example/hello-world.scm:82
 msgid "This is a string option."
 msgstr "這是一個字串選項。"
 
-#: gnucash/report/reports/example/hello-world.scm:90
-#: gnucash/report/reports/example/hello-world.scm:327
-#: gnucash/report/reports/example/hello-world.scm:501
+#: gnucash/report/reports/example/hello-world.scm:82
+#: gnucash/report/reports/example/hello-world.scm:313
+#: gnucash/report/reports/example/hello-world.scm:487
 msgid "Hello, World"
 msgstr "哈囉，世界"
 
-#: gnucash/report/reports/example/hello-world.scm:100
+#: gnucash/report/reports/example/hello-world.scm:92
 msgid "Just a Date Option"
 msgstr "只是日期選項"
 
-#: gnucash/report/reports/example/hello-world.scm:101
+#: gnucash/report/reports/example/hello-world.scm:93
 msgid "This is a date option."
 msgstr "這是一個日期選項。"
 
-#: gnucash/report/reports/example/hello-world.scm:109
+#: gnucash/report/reports/example/hello-world.scm:101
 msgid "Time and Date Option"
 msgstr "時間與日期選項"
 
-#: gnucash/report/reports/example/hello-world.scm:110
+#: gnucash/report/reports/example/hello-world.scm:102
 msgid "This is a date option with time."
 msgstr "這是有時間的日期選項。"
 
-#: gnucash/report/reports/example/hello-world.scm:116
+#: gnucash/report/reports/example/hello-world.scm:108
 msgid "Combo Date Option"
 msgstr "結合日期選項"
 
-#: gnucash/report/reports/example/hello-world.scm:117
+#: gnucash/report/reports/example/hello-world.scm:109
 msgid "This is a combination date option."
 msgstr "這是一個組合日期選項。"
 
-#: gnucash/report/reports/example/hello-world.scm:123
+#: gnucash/report/reports/example/hello-world.scm:115
 msgid "Relative Date Option"
 msgstr "相關日期選項"
 
-#: gnucash/report/reports/example/hello-world.scm:124
+#: gnucash/report/reports/example/hello-world.scm:116
 msgid "This is a relative date option."
 msgstr "這是一個相對日期選項。"
 
-#: gnucash/report/reports/example/hello-world.scm:134
+#: gnucash/report/reports/example/hello-world.scm:126
 msgid "Number Option"
 msgstr "數字選項"
 
-#: gnucash/report/reports/example/hello-world.scm:135
+#: gnucash/report/reports/example/hello-world.scm:127
 msgid "This is a number option."
 msgstr "這是一個數字選項。"
 
-#: gnucash/report/reports/example/hello-world.scm:152
-#: gnucash/report/stylesheets/footer.scm:124
-#: gnucash/report/stylesheets/head-or-tail.scm:171
+#: gnucash/report/reports/example/hello-world.scm:144
+#: gnucash/report/stylesheets/footer.scm:118
+#: gnucash/report/stylesheets/head-or-tail.scm:164
 #: gnucash/report/stylesheets/plain.scm:47
 msgid "Background Color"
 msgstr "背景顏色"
 
-#: gnucash/report/reports/example/hello-world.scm:153
+#: gnucash/report/reports/example/hello-world.scm:145
 msgid "This is a color option."
 msgstr "這是一個顏色選項。"
 
-#: gnucash/report/reports/example/hello-world.scm:174
-#: gnucash/report/reports/example/hello-world.scm:187
-#: gnucash/report/reports/example/hello-world.scm:215
+#: gnucash/report/reports/example/hello-world.scm:166
+#: gnucash/report/reports/example/hello-world.scm:179
+#: gnucash/report/reports/example/hello-world.scm:201
 msgid "Hello Again"
 msgstr "再次哈囉"
 
-#: gnucash/report/reports/example/hello-world.scm:174
+#: gnucash/report/reports/example/hello-world.scm:166
 msgid "An account list option"
 msgstr "科目列表選項"
 
-#: gnucash/report/reports/example/hello-world.scm:175
+#: gnucash/report/reports/example/hello-world.scm:167
 msgid "This is an account list option."
 msgstr "這是一個科目列表選項。"
 
-#: gnucash/report/reports/example/hello-world.scm:187
+#: gnucash/report/reports/example/hello-world.scm:179
 msgid "A list option"
 msgstr "列表選項"
 
-#: gnucash/report/reports/example/hello-world.scm:188
+#: gnucash/report/reports/example/hello-world.scm:180
 msgid "This is a list option."
 msgstr "這是一個列表選項。"
 
-#: gnucash/report/reports/example/hello-world.scm:191
-#: gnucash/report/reports/example/hello-world.scm:217
+#: gnucash/report/reports/example/hello-world.scm:182
+#: gnucash/report/reports/example/hello-world.scm:203
 msgid "The Good"
 msgstr "好的"
 
-#: gnucash/report/reports/example/hello-world.scm:192
-#: gnucash/report/reports/example/hello-world.scm:218
-msgid "Good option."
-msgstr "好的選擇。"
-
-#: gnucash/report/reports/example/hello-world.scm:194
-#: gnucash/report/reports/example/hello-world.scm:220
+#: gnucash/report/reports/example/hello-world.scm:183
+#: gnucash/report/reports/example/hello-world.scm:206
 msgid "The Bad"
 msgstr "壞的"
 
-#: gnucash/report/reports/example/hello-world.scm:195
-#: gnucash/report/reports/example/hello-world.scm:221
-msgid "Bad option."
-msgstr "壞的選擇。"
-
-#: gnucash/report/reports/example/hello-world.scm:197
-#: gnucash/report/reports/example/hello-world.scm:223
+#: gnucash/report/reports/example/hello-world.scm:184
+#: gnucash/report/reports/example/hello-world.scm:209
 msgid "The Ugly"
 msgstr "醜的"
 
-#: gnucash/report/reports/example/hello-world.scm:198
-#: gnucash/report/reports/example/hello-world.scm:224
-msgid "Ugly option."
-msgstr "醜的選擇。"
-
-#: gnucash/report/reports/example/hello-world.scm:204
+#: gnucash/report/reports/example/hello-world.scm:190
 msgid "Testing"
 msgstr "測試中"
 
-#: gnucash/report/reports/example/hello-world.scm:204
+#: gnucash/report/reports/example/hello-world.scm:190
 msgid "Crash the report"
 msgstr "報表當掉"
 
-#: gnucash/report/reports/example/hello-world.scm:206
+#: gnucash/report/reports/example/hello-world.scm:192
 msgid ""
 "This is for testing. Your reports probably shouldn't have an option like "
 "this."
 msgstr "這是測試用的。您的報表應該不會有像這個的選項。"
 
-#: gnucash/report/reports/example/hello-world.scm:215
+#: gnucash/report/reports/example/hello-world.scm:201
 msgid "This is a Radio Button option."
 msgstr "這是一個收音機按鈕選項。"
 
-#: gnucash/report/reports/example/hello-world.scm:342
+#: gnucash/report/reports/example/hello-world.scm:204
+msgid "Good option."
+msgstr "好的選擇。"
+
+#: gnucash/report/reports/example/hello-world.scm:207
+msgid "Bad option."
+msgstr "壞的選擇。"
+
+#: gnucash/report/reports/example/hello-world.scm:210
+msgid "Ugly option."
+msgstr "醜的選擇。"
+
+#: gnucash/report/reports/example/hello-world.scm:328
 msgid ""
 "This is a sample GnuCash report. See the guile (scheme) source code in the "
 "scm/report directory for details on writing your own reports, or extending "
@@ -22682,113 +22961,115 @@ msgstr ""
 "這是 GnuCash 的範例報表。想知道關於寫出自己的報表或擴充現有報表的詳細資料，請"
 "查閱在 scm/report 目錄的 guile (scheme) 原始碼。"
 
-#: gnucash/report/reports/example/hello-world.scm:348
+#: gnucash/report/reports/example/hello-world.scm:334
 #, scheme-format
 msgid ""
 "For help on writing reports, or to contribute your brand new, totally cool "
 "report, consult the mailing list ~a."
 msgstr "要幫忙撰寫報表，或貢獻您獨特、新奇又酷的報表，請參考通信論壇 ~a。"
 
-#: gnucash/report/reports/example/hello-world.scm:353
+#: gnucash/report/reports/example/hello-world.scm:339
 msgid ""
 "For details on subscribing to that list, see &lt;https://www.gnucash.org/"
 "&gt;."
 msgstr "需要訂閱通信論壇的詳情，請看 &lt;http://www.gnucash.org/&gt;。"
 
-#: gnucash/report/reports/example/hello-world.scm:354
+#: gnucash/report/reports/example/hello-world.scm:340
 msgid ""
 "You can learn more about writing scheme at &lt;https://www.scheme.com/tspl2d/"
 "&gt;."
-msgstr "您可以從 &lt;http://www.scheme.com/tspl2d/&gt; 學習到更多關於如何寫 scheme 程式。"
+msgstr ""
+"您可以從 &lt;http://www.scheme.com/tspl2d/&gt; 學習到更多關於如何寫 scheme 程"
+"式。"
 
-#: gnucash/report/reports/example/hello-world.scm:358
+#: gnucash/report/reports/example/hello-world.scm:344
 #, scheme-format
 msgid "The current time is ~a."
 msgstr "現在時刻是 ~a。"
 
-#: gnucash/report/reports/example/hello-world.scm:363
+#: gnucash/report/reports/example/hello-world.scm:349
 #, scheme-format
 msgid "The boolean option is ~a."
 msgstr "布林選項是 ~a。"
 
-#: gnucash/report/reports/example/hello-world.scm:364
+#: gnucash/report/reports/example/hello-world.scm:350
 msgid "true"
 msgstr "真值(true)"
 
-#: gnucash/report/reports/example/hello-world.scm:364
+#: gnucash/report/reports/example/hello-world.scm:350
 msgid "false"
 msgstr "假值(false)"
 
-#: gnucash/report/reports/example/hello-world.scm:368
+#: gnucash/report/reports/example/hello-world.scm:354
 #, scheme-format
 msgid "The radio button option is ~a."
 msgstr "收音機選項是 ~a。"
 
-#: gnucash/report/reports/example/hello-world.scm:373
+#: gnucash/report/reports/example/hello-world.scm:359
 #, scheme-format
 msgid "The multi-choice option is ~a."
 msgstr "複選選項是 ~a。"
 
-#: gnucash/report/reports/example/hello-world.scm:378
+#: gnucash/report/reports/example/hello-world.scm:364
 #, scheme-format
 msgid "The string option is ~a."
 msgstr "字串選項是 ~a。"
 
-#: gnucash/report/reports/example/hello-world.scm:383
+#: gnucash/report/reports/example/hello-world.scm:369
 #, scheme-format
 msgid "The date option is ~a."
 msgstr "日期選項是 ~a。"
 
-#: gnucash/report/reports/example/hello-world.scm:388
+#: gnucash/report/reports/example/hello-world.scm:374
 #, scheme-format
 msgid "The date and time option is ~a."
 msgstr "日期與時間選項是 ~a。"
 
-#: gnucash/report/reports/example/hello-world.scm:393
+#: gnucash/report/reports/example/hello-world.scm:379
 #, scheme-format
 msgid "The relative date option is ~a."
 msgstr "相對日期選項是 ~a。"
 
-#: gnucash/report/reports/example/hello-world.scm:398
+#: gnucash/report/reports/example/hello-world.scm:384
 #, scheme-format
 msgid "The combination date option is ~a."
 msgstr "結合日期選項是 ~a。"
 
-#: gnucash/report/reports/example/hello-world.scm:403
+#: gnucash/report/reports/example/hello-world.scm:389
 #, scheme-format
 msgid "The number option is ~a."
 msgstr "數字選項是 ~a。"
 
-#: gnucash/report/reports/example/hello-world.scm:414
+#: gnucash/report/reports/example/hello-world.scm:400
 #, scheme-format
 msgid "The number option formatted as currency is ~a."
 msgstr "貨幣形式的數字選項為 ~a。"
 
-#: gnucash/report/reports/example/hello-world.scm:426
+#: gnucash/report/reports/example/hello-world.scm:412
 msgid "Items you selected:"
 msgstr "您選擇的項目："
 
-#: gnucash/report/reports/example/hello-world.scm:437
+#: gnucash/report/reports/example/hello-world.scm:423
 msgid "List items selected"
 msgstr "列表中被選擇的項目"
 
-#: gnucash/report/reports/example/hello-world.scm:442
+#: gnucash/report/reports/example/hello-world.scm:428
 msgid "(You selected no list items.)"
 msgstr "(您沒有選擇列表中的項目。)"
 
-#: gnucash/report/reports/example/hello-world.scm:478
+#: gnucash/report/reports/example/hello-world.scm:464
 msgid "You have selected no accounts."
 msgstr "您沒有選擇科目。"
 
-#: gnucash/report/reports/example/hello-world.scm:483
+#: gnucash/report/reports/example/hello-world.scm:469
 msgid "Display help"
 msgstr "顯示說明"
 
-#: gnucash/report/reports/example/hello-world.scm:512
+#: gnucash/report/reports/example/hello-world.scm:498
 msgid "Sample Report with Examples"
 msgstr "具有範例的樣本報表"
 
-#: gnucash/report/reports/example/hello-world.scm:516
+#: gnucash/report/reports/example/hello-world.scm:502
 msgid "A sample report with examples."
 msgstr "具有範例的樣本報表。"
 
@@ -22841,177 +23122,117 @@ msgstr "覆蓋或修改「從：」與「到：」。"
 msgid "Use From - To"
 msgstr "使用 從 - 到"
 
-#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:154
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:184
-#, fuzzy
-msgid "Use From - To period."
-msgstr "使用 從 - 到期間"
-
 #: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:155
 #: gnucash/report/reports/locale-specific/us/taxtxf.scm:185
-msgid "1st Est Tax Quarter"
-msgstr "第一稅季"
-
-#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:155
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:185
-#, fuzzy
-msgid "Jan 1 - Mar 31."
-msgstr "一月 1 - 三月 31"
+msgid "1st Est Tax Quarter (Jan 1 - Mar 31)"
+msgstr "第一預估稅季 (1 月 1 號 - 3 月 31 號)"
 
 #: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:156
 #: gnucash/report/reports/locale-specific/us/taxtxf.scm:186
-msgid "2nd Est Tax Quarter"
-msgstr "第二稅季"
-
-#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:156
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:186
-#, fuzzy
-msgid "Apr 1 - May 31."
-msgstr "四月 1 - 五月 31"
+msgid "2nd Est Tax Quarter (Apr 1 - May 31)"
+msgstr "第二預估稅季 (4 月 1 號 - 5 月 31 號)"
 
 #. Translators: The US tax quarters are different from
 #. actual year's quarters! See the definition of
 #. tax-qtr-real-qtr-year variable above.
 #: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:157
 #: gnucash/report/reports/locale-specific/us/taxtxf.scm:190
-msgid "3rd Est Tax Quarter"
-msgstr "第三稅季"
-
-#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:157
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:190
-#, fuzzy
-msgid "Jun 1 - Aug 31."
-msgstr "六月 1 - 八月 31"
+msgid "3rd Est Tax Quarter (Jun 1 - Aug 31)"
+msgstr "第三預估稅季 (6 月 1 號 - 8 月 31 號)"
 
 #: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:158
 #: gnucash/report/reports/locale-specific/us/taxtxf.scm:191
-msgid "4th Est Tax Quarter"
-msgstr "第四稅季"
-
-#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:158
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:191
-#, fuzzy
-msgid "Sep 1 - Dec 31."
-msgstr "九月 1 - 十二月 31"
+msgid "4th Est Tax Quarter (Sep 1 - Dec 31)"
+msgstr "第四預估稅季 (9 月 1 號 - 12 月 31 號)"
 
 #: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:159
 #: gnucash/report/reports/locale-specific/us/taxtxf.scm:192
 msgid "Last Year"
 msgstr "去年"
 
-#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:159
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:192
-#, fuzzy
-msgid "Last Year."
-msgstr "去年"
+#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:160
+#: gnucash/report/reports/locale-specific/us/taxtxf.scm:193
+msgid "Last Yr 1st Est Tax Qtr (Jan 1 - Mar 31)"
+msgstr "去年第一預估稅季 (1 月 1 號 - 3 月 31 號)"
 
 #: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:161
 #: gnucash/report/reports/locale-specific/us/taxtxf.scm:194
-msgid "Last Yr 1st Est Tax Qtr"
-msgstr "去年第一稅季"
-
-#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:162
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:195
-#, fuzzy
-msgid "Jan 1 - Mar 31, Last year."
-msgstr "去年一月 1 - 三月 31"
-
-#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:164
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:197
-msgid "Last Yr 2nd Est Tax Qtr"
-msgstr "去年第二稅季"
-
-#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:165
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:198
-#, fuzzy
-msgid "Apr 1 - May 31, Last year."
-msgstr "去年四月 1 - 五月 31"
-
-#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:167
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:200
-msgid "Last Yr 3rd Est Tax Qtr"
-msgstr "去年第三稅季"
+msgid "Last Yr 2nd Est Tax Qtr (Apr 1 - May 31)"
+msgstr "去年第二預估稅季 (4 月 1 號 - 5 月 31 號)"
 
 #. Translators: The US tax quarters are different from
 #. actual year's quarters! See the definition of
 #. tax-qtr-real-qtr-year variable above.
-#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:168
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:204
-#, fuzzy
-msgid "Jun 1 - Aug 31, Last year."
-msgstr "去年六月 1 - 八月 31"
+#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:162
+#: gnucash/report/reports/locale-specific/us/taxtxf.scm:198
+msgid "Last Yr 3rd Est Tax Qtr (Jun 1 - Aug 31)"
+msgstr "去年第三預估稅季 (6 月 1 號 - 8 月 31 號)"
 
-#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:170
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:206
-msgid "Last Yr 4th Est Tax Qtr"
-msgstr "去年第四稅季"
+#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:163
+#: gnucash/report/reports/locale-specific/us/taxtxf.scm:199
+msgid "Last Yr 4th Est Tax Qtr (Sep 1 - Dec 31)"
+msgstr "去年第四預估稅季 (9 月 1 號 - 12 月 31 號)"
 
-#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:171
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:207
-#, fuzzy
-msgid "Sep 1 - Dec 31, Last year."
-msgstr "去年九月 1 - 十二月 31"
-
-#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:175
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:211
+#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:167
+#: gnucash/report/reports/locale-specific/us/taxtxf.scm:203
 msgid "Select Accounts (none = all)"
 msgstr "選擇科目 (無=全選)"
 
-#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:176
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:212
+#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:168
+#: gnucash/report/reports/locale-specific/us/taxtxf.scm:204
 msgid "Select accounts."
 msgstr "選擇科目。"
 
-#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:182
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:218
+#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:174
+#: gnucash/report/reports/locale-specific/us/taxtxf.scm:210
 msgid "Suppress $0.00 values"
 msgstr "抑制 $0.00 值"
 
-#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:183
+#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:175
 msgid "$0.00 valued Accounts won't be printed."
 msgstr "其值為 $0.00 的科目不會列印出來。"
 
-#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:187
+#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:179
 msgid "Print Full account names"
 msgstr "列印科目全名"
 
-#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:188
+#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:180
 msgid "Print all Parent account names."
 msgstr "列印所有母科目的名稱。"
 
-#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:266
+#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:258
 msgid ""
 "WARNING: There are duplicate TXF codes assigned to some accounts. Only TXF "
 "codes with payer sources may be repeated."
 msgstr "警告：某些科目分配到相同的 TXF 碼。只有具付款人來源的 TXF 碼會被重複。"
 
-#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:816
+#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:808
 #, scheme-format
 msgid "Period from ~a to ~a"
 msgstr "從 ~a 到 ~a 期間"
 
-#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:853
+#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:845
 msgid "Tax Report & XML Export"
 msgstr "稅務報表 & XML 匯出"
 
-#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:855
+#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:847
 msgid "Taxable Income / Deductible Expenses / Export to .XML file"
 msgstr "應納稅的收入 / 可減免的支出 / 匯出至 .XML 檔案"
 
+#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:851
 #: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:859
-#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:867
 msgid "Taxable Income / Deductible Expenses"
 msgstr "應納稅的收入 / 可減免的支出"
 
-#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:860
+#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:852
 msgid "This report shows your Taxable Income and Deductible Expenses."
 msgstr "這個報表顯示您應納稅的收入與可減免的支出。"
 
-#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:864
+#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:856
 msgid "XML"
 msgstr "XML"
 
-#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:868
+#: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:860
 msgid "This page shows your Taxable Income and Deductible Expenses."
 msgstr "這一頁顯示您應納稅的收入與可減免的支出。"
 
@@ -23019,114 +23240,105 @@ msgstr "這一頁顯示您應納稅的收入與可減免的支出。"
 msgid "Tax Schedule Report/TXF Export"
 msgstr "稅務計畫報表/ TXF 匯出"
 
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:219
+#: gnucash/report/reports/locale-specific/us/taxtxf.scm:211
 msgid "$0.00 valued Tax codes won't be printed."
 msgstr "其值為 $0.00 的稅不會列印出來。"
 
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:223
+#: gnucash/report/reports/locale-specific/us/taxtxf.scm:215
 msgid "Do not print full account names"
 msgstr "不列印科目全名"
 
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:224
+#: gnucash/report/reports/locale-specific/us/taxtxf.scm:216
 msgid "Do not print all Parent account names."
 msgstr "不列印所有母科目的名稱。"
 
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:228
+#: gnucash/report/reports/locale-specific/us/taxtxf.scm:220
 msgid "Print all Transfer To/From Accounts"
 msgstr "顯示所有來源/目的科目"
 
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:229
+#: gnucash/report/reports/locale-specific/us/taxtxf.scm:221
 msgid "Print all split details for multi-split transactions."
 msgstr "印出含有多分割交易的明細。"
 
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:233
+#: gnucash/report/reports/locale-specific/us/taxtxf.scm:225
 msgid "Print TXF export parameters"
 msgstr "列印 TXF 匯出參數"
 
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:234
+#: gnucash/report/reports/locale-specific/us/taxtxf.scm:226
 msgid "Show TXF export parameters for each TXF code/account on report."
 msgstr "針對報表中的每個 TXF 代碼 / 科目顯示匯出參數。"
 
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:239
+#: gnucash/report/reports/locale-specific/us/taxtxf.scm:231
 msgid "Do not print T-Num:Memo data"
 msgstr "不列印交易-編號:備忘錄的內容"
 
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:240
+#: gnucash/report/reports/locale-specific/us/taxtxf.scm:232
 msgid "Do not print T-Num:Memo data for transactions."
 msgstr "不列印交易的編號:備忘錄的內容。"
 
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:243
+#: gnucash/report/reports/locale-specific/us/taxtxf.scm:235
 msgid "Do not print Action:Memo data"
 msgstr "不列印動作:備忘錄內容"
 
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:244
+#: gnucash/report/reports/locale-specific/us/taxtxf.scm:236
 msgid "Do not print Action:Memo data for transactions."
 msgstr "不列印示交易的動作:備忘錄內容。"
 
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:248
+#: gnucash/report/reports/locale-specific/us/taxtxf.scm:240
 msgid "Do not print transaction detail"
 msgstr "不要列印交易明細"
 
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:249
+#: gnucash/report/reports/locale-specific/us/taxtxf.scm:241
 msgid "Do not print transaction detail for accounts."
 msgstr "不要列印科目交易明細。"
 
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:253
+#: gnucash/report/reports/locale-specific/us/taxtxf.scm:245
 msgid "Do not use special date processing"
 msgstr "不要針對日期進行特殊處理"
 
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:254
+#: gnucash/report/reports/locale-specific/us/taxtxf.scm:246
 msgid "Do not print transactions out of specified dates."
 msgstr "不要列印超過指定日期的交易。"
 
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:258
+#: gnucash/report/reports/locale-specific/us/taxtxf.scm:250
 msgid "Currency conversion date"
 msgstr "貨幣轉換日期"
 
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:259
+#: gnucash/report/reports/locale-specific/us/taxtxf.scm:251
 msgid "Select date to use for PriceDB lookups."
 msgstr "請選擇要用來查詢價格資料庫的日期。"
 
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:262
-msgid "Nearest transaction date"
+#: gnucash/report/reports/locale-specific/us/taxtxf.scm:254
+msgid "Nearest to transaction date"
 msgstr "最接近交易的日期"
 
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:262
-#, fuzzy
-msgid "Use nearest to transaction date."
-msgstr "使用是最接近交易的日期"
+#: gnucash/report/reports/locale-specific/us/taxtxf.scm:256
+#: gnucash/report/reports/standard/advanced-portfolio.scm:83
+msgid "Nearest to report date"
+msgstr "最接近報表產生時間的日期"
 
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:264
-msgid "Nearest report date"
-msgstr "時間上最接近"
-
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:264
-#, fuzzy
-msgid "Use nearest to report date."
-msgstr "很接近"
-
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:3334
+#: gnucash/report/reports/locale-specific/us/taxtxf.scm:3326
 msgid "Tax Schedule Report & TXF Export"
 msgstr "稅務計畫報表 & TXF 匯出"
 
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:3336
+#: gnucash/report/reports/locale-specific/us/taxtxf.scm:3328
 msgid ""
 "Taxable Income/Deductible Expenses with Transaction Detail/Export to .TXF "
 "file"
 msgstr "應納稅的收入 / 含交易詳情的可減免支出 / 匯出至 .TXF 檔案"
 
+#: gnucash/report/reports/locale-specific/us/taxtxf.scm:3332
 #: gnucash/report/reports/locale-specific/us/taxtxf.scm:3340
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:3348
 msgid "Taxable Income/Deductible Expenses"
 msgstr "應納稅的收入 / 可減免的支出"
 
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:3341
+#: gnucash/report/reports/locale-specific/us/taxtxf.scm:3333
 msgid ""
 "This report shows transaction detail for your accounts related to Income "
 "Taxes."
 msgstr "這個報表顯示您和所得稅相關科目的交易詳情。"
 
-#: gnucash/report/reports/locale-specific/us/taxtxf.scm:3349
+#: gnucash/report/reports/locale-specific/us/taxtxf.scm:3341
 msgid "This page shows transaction detail for relevant Income Tax accounts."
 msgstr "此頁顯示您與所得稅相關的科目的交易詳情。"
 
@@ -23229,69 +23441,57 @@ msgid ""
 "rather as the average e.g. per month."
 msgstr "選擇是否該顯示全部時間週期的總金額，而不是平均值（例如每月平均）。"
 
-#: gnucash/report/reports/standard/account-piecharts.scm:118
-#: gnucash/report/reports/standard/category-barchart.scm:120
+#: gnucash/report/reports/standard/account-piecharts.scm:117
+#: gnucash/report/reports/standard/category-barchart.scm:119
 msgid "No Averaging"
 msgstr "不平均"
 
-#: gnucash/report/reports/standard/account-piecharts.scm:119
-#: gnucash/report/reports/standard/category-barchart.scm:121
-#, fuzzy
-msgid "Just show the amounts, without any averaging."
-msgstr "只顯示數量，不顯示平均"
+#: gnucash/report/reports/standard/account-piecharts.scm:141
+#: gnucash/report/reports/standard/account-summary.scm:90
+#: gnucash/report/reports/standard/balance-sheet.scm:91
+#: gnucash/report/reports/standard/balsheet-eg.scm:149
+#: gnucash/report/reports/standard/balsheet-pnl.scm:85
+#: gnucash/report/reports/standard/budget-balance-sheet.scm:57
+#: gnucash/report/reports/standard/budget-barchart.scm:48
+#: gnucash/report/reports/standard/budget-income-statement.scm:79
+#: gnucash/report/reports/standard/category-barchart.scm:142
+#: gnucash/report/reports/standard/income-statement.scm:66
+#: gnucash/report/reports/standard/trial-balance.scm:81
+msgid "Maximum number of levels in the account tree displayed."
+msgstr "最多顯示到科目數中的第幾層。"
 
-#: gnucash/report/reports/standard/account-piecharts.scm:122
-msgid "Show the average yearly amount during the reporting period."
-msgstr ""
-
-#: gnucash/report/reports/standard/account-piecharts.scm:125
-#: gnucash/report/reports/standard/category-barchart.scm:124
-msgid "Show the average monthly amount during the reporting period."
-msgstr ""
-
-#: gnucash/report/reports/standard/account-piecharts.scm:128
-#: gnucash/report/reports/standard/category-barchart.scm:127
-msgid "Show the average weekly amount during the reporting period."
-msgstr ""
-
-#: gnucash/report/reports/standard/account-piecharts.scm:152
-#: gnucash/report/reports/standard/category-barchart.scm:150
-#, fuzzy
-msgid "Show accounts to this depth and not further."
-msgstr "顯示科目到此深度，不再往下"
-
-#: gnucash/report/reports/standard/account-piecharts.scm:160
-#: gnucash/report/reports/standard/category-barchart.scm:157
+#: gnucash/report/reports/standard/account-piecharts.scm:149
+#: gnucash/report/reports/standard/category-barchart.scm:149
 msgid "Show the full account name in legend?"
 msgstr "在圖例中顯示科目全名？"
 
-#: gnucash/report/reports/standard/account-piecharts.scm:161
+#: gnucash/report/reports/standard/account-piecharts.scm:150
 msgid "Show the full security name in the legend?"
 msgstr "在圖例中顯示證券全名？"
 
-#: gnucash/report/reports/standard/account-piecharts.scm:173
+#: gnucash/report/reports/standard/account-piecharts.scm:162
 msgid "Show the percentage in legend?"
 msgstr "在圖例中顯示比例？"
 
-#: gnucash/report/reports/standard/account-piecharts.scm:179
+#: gnucash/report/reports/standard/account-piecharts.scm:168
 msgid "Maximum number of slices in pie."
 msgstr "圓餅中最多畫出數量最大的前幾片。"
 
-#: gnucash/report/reports/standard/account-piecharts.scm:414
+#: gnucash/report/reports/standard/account-piecharts.scm:403
 msgid "Yearly Average"
 msgstr "年平均"
 
-#: gnucash/report/reports/standard/account-piecharts.scm:415
-#: gnucash/report/reports/standard/category-barchart.scm:327
+#: gnucash/report/reports/standard/account-piecharts.scm:404
+#: gnucash/report/reports/standard/category-barchart.scm:315
 msgid "Monthly Average"
 msgstr "月平均"
 
-#: gnucash/report/reports/standard/account-piecharts.scm:416
-#: gnucash/report/reports/standard/category-barchart.scm:328
+#: gnucash/report/reports/standard/account-piecharts.scm:405
+#: gnucash/report/reports/standard/category-barchart.scm:316
 msgid "Weekly Average"
 msgstr "週平均"
 
-#: gnucash/report/reports/standard/account-piecharts.scm:550
+#: gnucash/report/reports/standard/account-piecharts.scm:539
 #, scheme-format
 msgid "Balance at ~a"
 msgstr "~a 的結算"
@@ -23346,39 +23546,29 @@ msgstr "公司名稱"
 msgid "Name of company/individual."
 msgstr "公司 / 個人的名字。"
 
-#: gnucash/report/reports/standard/account-summary.scm:88
-#: gnucash/report/reports/standard/balance-sheet.scm:89
-#: gnucash/report/reports/standard/balsheet-eg.scm:148
-#: gnucash/report/reports/standard/balsheet-pnl.scm:84
-#: gnucash/report/reports/standard/budget-balance-sheet.scm:55
-#: gnucash/report/reports/standard/budget-barchart.scm:46
-#: gnucash/report/reports/standard/budget-income-statement.scm:77
-#: gnucash/report/reports/standard/income-statement.scm:64
-#: gnucash/report/reports/standard/trial-balance.scm:79
-msgid "Levels of Subaccounts"
-msgstr "子科目層數"
-
-#: gnucash/report/reports/standard/account-summary.scm:90
-#: gnucash/report/reports/standard/balance-sheet.scm:91
-#: gnucash/report/reports/standard/balsheet-eg.scm:149
-#: gnucash/report/reports/standard/balsheet-pnl.scm:85
-#: gnucash/report/reports/standard/budget-balance-sheet.scm:57
-#: gnucash/report/reports/standard/budget-barchart.scm:48
-#: gnucash/report/reports/standard/budget-income-statement.scm:79
-#: gnucash/report/reports/standard/income-statement.scm:66
-#: gnucash/report/reports/standard/trial-balance.scm:81
-msgid "Maximum number of levels in the account tree displayed."
-msgstr "最多顯示到科目數中的第幾層。"
-
 #: gnucash/report/reports/standard/account-summary.scm:91
 msgid "Depth limit behavior"
 msgstr "深度限制的行為"
 
-#: gnucash/report/reports/standard/account-summary.scm:93
+#: gnucash/report/reports/standard/account-summary.scm:95
 msgid "How to treat accounts which exceed the specified depth limit (if any)."
 msgstr "如果有超過深度的科目，針對這些科目要如何處理。"
 
-#: gnucash/report/reports/standard/account-summary.scm:95
+#: gnucash/report/reports/standard/account-summary.scm:96
+msgid ""
+"Show the total balance, including balances in subaccounts, of any account at "
+"the depth limit."
+msgstr "顯示餘額，包括任何到達深度限制的科目及其子科目的餘額。"
+
+#: gnucash/report/reports/standard/account-summary.scm:97
+msgid "Raise accounts deeper than the depth limit to the depth limit."
+msgstr "將超過深度限制的科目提升至指定的限制深度。"
+
+#: gnucash/report/reports/standard/account-summary.scm:98
+msgid "Omit any accounts deeper than the depth limit."
+msgstr "略過所有超過此深度的科目。"
+
+#: gnucash/report/reports/standard/account-summary.scm:100
 #: gnucash/report/reports/standard/balance-sheet.scm:96
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:62
 #: gnucash/report/reports/standard/budget-income-statement.scm:84
@@ -23386,7 +23576,7 @@ msgstr "如果有超過深度的科目，針對這些科目要如何處理。"
 msgid "Parent account balances"
 msgstr "母科目結餘"
 
-#: gnucash/report/reports/standard/account-summary.scm:96
+#: gnucash/report/reports/standard/account-summary.scm:101
 #: gnucash/report/reports/standard/balance-sheet.scm:97
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:63
 #: gnucash/report/reports/standard/budget-income-statement.scm:85
@@ -23394,7 +23584,7 @@ msgstr "母科目結餘"
 msgid "Parent account subtotals"
 msgstr "母科目小計"
 
-#: gnucash/report/reports/standard/account-summary.scm:98
+#: gnucash/report/reports/standard/account-summary.scm:103
 #: gnucash/report/reports/standard/balance-sheet.scm:99
 #: gnucash/report/reports/standard/balsheet-pnl.scm:93
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:65
@@ -23404,7 +23594,7 @@ msgstr "母科目小計"
 msgid "Include accounts with zero total balances"
 msgstr "包含結餘為零的科目"
 
-#: gnucash/report/reports/standard/account-summary.scm:100
+#: gnucash/report/reports/standard/account-summary.scm:105
 #: gnucash/report/reports/standard/balance-sheet.scm:101
 #: gnucash/report/reports/standard/balsheet-pnl.scm:94
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:67
@@ -23414,7 +23604,7 @@ msgstr "包含結餘為零的科目"
 msgid "Include accounts with zero total (recursive) balances in this report."
 msgstr "在此報表中包含零結餘（遞回計算）的科目。"
 
-#: gnucash/report/reports/standard/account-summary.scm:101
+#: gnucash/report/reports/standard/account-summary.scm:106
 #: gnucash/report/reports/standard/balance-sheet.scm:102
 #: gnucash/report/reports/standard/balsheet-pnl.scm:96
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:68
@@ -23423,7 +23613,7 @@ msgstr "在此報表中包含零結餘（遞回計算）的科目。"
 msgid "Omit zero balance figures"
 msgstr "略過零結餘的數值"
 
-#: gnucash/report/reports/standard/account-summary.scm:103
+#: gnucash/report/reports/standard/account-summary.scm:108
 #: gnucash/report/reports/standard/balance-sheet.scm:104
 #: gnucash/report/reports/standard/balsheet-pnl.scm:97
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:70
@@ -23432,7 +23622,7 @@ msgstr "略過零結餘的數值"
 msgid "Show blank space in place of any zero balances which would be shown."
 msgstr "若結餘為零則顯示空白。"
 
-#: gnucash/report/reports/standard/account-summary.scm:105
+#: gnucash/report/reports/standard/account-summary.scm:110
 #: gnucash/report/reports/standard/balance-sheet.scm:106
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:72
 #: gnucash/report/reports/standard/budget-income-statement.scm:94
@@ -23441,7 +23631,7 @@ msgstr "若結餘為零則顯示空白。"
 msgid "Show accounting-style rules"
 msgstr "顯示會計格式的格線"
 
-#: gnucash/report/reports/standard/account-summary.scm:107
+#: gnucash/report/reports/standard/account-summary.scm:112
 #: gnucash/report/reports/standard/balance-sheet.scm:108
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:74
 #: gnucash/report/reports/standard/budget-income-statement.scm:96
@@ -23450,7 +23640,7 @@ msgstr "顯示會計格式的格線"
 msgid "Use rules beneath columns of added numbers like accountants do."
 msgstr "和會計師一樣在相同的數字下方畫上格線。"
 
-#: gnucash/report/reports/standard/account-summary.scm:109
+#: gnucash/report/reports/standard/account-summary.scm:114
 #: gnucash/report/reports/standard/balance-sheet.scm:110
 #: gnucash/report/reports/standard/balsheet-eg.scm:158
 #: gnucash/report/reports/standard/balsheet-pnl.scm:99
@@ -23461,7 +23651,7 @@ msgstr "和會計師一樣在相同的數字下方畫上格線。"
 msgid "Display accounts as hyperlinks"
 msgstr "以超連結顯示科目"
 
-#: gnucash/report/reports/standard/account-summary.scm:111
+#: gnucash/report/reports/standard/account-summary.scm:116
 #: gnucash/report/reports/standard/balance-sheet.scm:111
 #: gnucash/report/reports/standard/balsheet-eg.scm:159
 #: gnucash/report/reports/standard/balsheet-pnl.scm:100
@@ -23472,35 +23662,35 @@ msgstr "以超連結顯示科目"
 msgid "Shows each account in the table as a hyperlink to its register window."
 msgstr "在表格中以連結到登記簿的超連結的型式顯示科目。"
 
-#: gnucash/report/reports/standard/account-summary.scm:114
+#: gnucash/report/reports/standard/account-summary.scm:119
 msgid "Show an account's balance."
 msgstr "顯示科目結餘。"
 
-#: gnucash/report/reports/standard/account-summary.scm:116
+#: gnucash/report/reports/standard/account-summary.scm:121
 msgid "Show an account's account code."
 msgstr "顯示科目代碼。"
 
-#: gnucash/report/reports/standard/account-summary.scm:118
+#: gnucash/report/reports/standard/account-summary.scm:123
 msgid "Show an account's account type."
 msgstr "顯示科目類別。"
 
-#: gnucash/report/reports/standard/account-summary.scm:119
+#: gnucash/report/reports/standard/account-summary.scm:124
 msgid "Account Description"
 msgstr "科目描述"
 
-#: gnucash/report/reports/standard/account-summary.scm:120
+#: gnucash/report/reports/standard/account-summary.scm:125
 msgid "Show an account's description."
 msgstr "顯示科目描述。"
 
-#: gnucash/report/reports/standard/account-summary.scm:121
+#: gnucash/report/reports/standard/account-summary.scm:126
 msgid "Account Notes"
 msgstr "科目備註"
 
-#: gnucash/report/reports/standard/account-summary.scm:122
+#: gnucash/report/reports/standard/account-summary.scm:127
 msgid "Show an account's notes."
 msgstr "顯示科目備註。"
 
-#: gnucash/report/reports/standard/account-summary.scm:124
+#: gnucash/report/reports/standard/account-summary.scm:129
 #: gnucash/report/reports/standard/balance-sheet.scm:135
 #: gnucash/report/reports/standard/balsheet-eg.scm:185
 #: gnucash/report/reports/standard/balsheet-pnl.scm:112
@@ -23512,7 +23702,7 @@ msgstr "顯示科目備註。"
 msgid "Commodities"
 msgstr "商品"
 
-#: gnucash/report/reports/standard/account-summary.scm:127
+#: gnucash/report/reports/standard/account-summary.scm:132
 #: gnucash/report/reports/standard/balance-sheet.scm:138
 #: gnucash/report/reports/standard/balsheet-eg.scm:180
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:104
@@ -23523,7 +23713,7 @@ msgstr "商品"
 msgid "Show Foreign Currencies"
 msgstr "顯示外國貨幣"
 
-#: gnucash/report/reports/standard/account-summary.scm:129
+#: gnucash/report/reports/standard/account-summary.scm:134
 #: gnucash/report/reports/standard/balance-sheet.scm:140
 #: gnucash/report/reports/standard/balsheet-eg.scm:182
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:106
@@ -23534,7 +23724,7 @@ msgstr "顯示外國貨幣"
 msgid "Display any foreign currency amount in an account."
 msgstr "顯示科目中外國貨幣的金額。"
 
-#: gnucash/report/reports/standard/account-summary.scm:130
+#: gnucash/report/reports/standard/account-summary.scm:135
 #: gnucash/report/reports/standard/balance-sheet.scm:141
 #: gnucash/report/reports/standard/balsheet-pnl.scm:130
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:107
@@ -23546,7 +23736,7 @@ msgstr "顯示科目中外國貨幣的金額。"
 msgid "Show Exchange Rates"
 msgstr "顯示匯率"
 
-#: gnucash/report/reports/standard/account-summary.scm:131
+#: gnucash/report/reports/standard/account-summary.scm:136
 #: gnucash/report/reports/standard/balance-sheet.scm:142
 #: gnucash/report/reports/standard/balsheet-pnl.scm:131
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:108
@@ -23558,44 +23748,28 @@ msgstr "顯示匯率"
 msgid "Show the exchange rates used."
 msgstr "顯示使用的匯率。"
 
-#: gnucash/report/reports/standard/account-summary.scm:190
+#: gnucash/report/reports/standard/account-summary.scm:194
 msgid "Recursive Balance"
 msgstr "遞迴計算結餘"
 
-#: gnucash/report/reports/standard/account-summary.scm:191
-msgid ""
-"Show the total balance, including balances in subaccounts, of any account at "
-"the depth limit."
-msgstr "顯示餘額，包括任何到達深度限制的科目及其子科目的餘額。"
-
-#: gnucash/report/reports/standard/account-summary.scm:193
+#: gnucash/report/reports/standard/account-summary.scm:195
 msgid "Raise Accounts"
 msgstr "提升科目"
-
-#: gnucash/report/reports/standard/account-summary.scm:194
-#, fuzzy
-msgid "Shows accounts deeper than the depth limit at the depth limit."
-msgstr "顯示科目至此深度，無視其他任何選項。"
 
 #: gnucash/report/reports/standard/account-summary.scm:196
 msgid "Omit Accounts"
 msgstr "省略科目"
 
-#: gnucash/report/reports/standard/account-summary.scm:197
-#, fuzzy
-msgid "Disregard completely any accounts deeper than the depth limit."
-msgstr "顯示科目至此深度，無視其他任何選項。"
-
 #. Translators: This is part of the report title, which is capitalzed in English, but not all other languages
-#: gnucash/report/reports/standard/account-summary.scm:326
+#: gnucash/report/reports/standard/account-summary.scm:325
 #: gnucash/report/reports/standard/equity-statement.scm:302
 #: gnucash/report/reports/standard/income-statement.scm:406
-#: gnucash/report/reports/standard/trial-balance.scm:413
+#: gnucash/report/reports/standard/trial-balance.scm:407
 #, scheme-format
 msgid "For Period Covering ~a to ~a"
 msgstr "包含 ~a 至 ~a 的會計期間"
 
-#: gnucash/report/reports/standard/account-summary.scm:411
+#: gnucash/report/reports/standard/account-summary.scm:410
 msgid "Account title"
 msgstr "科目名稱"
 
@@ -23641,156 +23815,136 @@ msgstr "偏好使用價格資料庫中的資料"
 msgid "How to report brokerage fees"
 msgstr "如何處理手續費"
 
-#: gnucash/report/reports/standard/advanced-portfolio.scm:93
+#: gnucash/report/reports/standard/advanced-portfolio.scm:88
 msgid "Basis calculation method."
 msgstr "成本計算方式。"
 
-#: gnucash/report/reports/standard/advanced-portfolio.scm:96
-msgid "Use average cost of all shares for basis."
-msgstr "用平均股價當成本。"
+#: gnucash/report/reports/standard/advanced-portfolio.scm:89
+msgid "Average cost of all shares"
+msgstr "平均價格"
 
-#: gnucash/report/reports/standard/advanced-portfolio.scm:98
-msgid "FIFO"
+#: gnucash/report/reports/standard/advanced-portfolio.scm:90
+msgid "First-in first-out"
 msgstr "先進先出"
 
-#: gnucash/report/reports/standard/advanced-portfolio.scm:99
-msgid "Use first-in first-out method for basis."
-msgstr "以先進先出方式計算成本。"
-
-#: gnucash/report/reports/standard/advanced-portfolio.scm:101
-msgid "LIFO"
+#: gnucash/report/reports/standard/advanced-portfolio.scm:91
+msgid "Last-in first-out"
 msgstr "後進先出"
 
-#: gnucash/report/reports/standard/advanced-portfolio.scm:102
-msgid "Use last-in first-out method for basis."
-msgstr "以後進先出方式計算成本"
-
-#: gnucash/report/reports/standard/advanced-portfolio.scm:108
+#: gnucash/report/reports/standard/advanced-portfolio.scm:96
 msgid "Prefer use of price editor pricing over transactions, where applicable."
 msgstr "當可行的時候，偏好用價格資料庫裡的價格而非交易價格。"
 
-#: gnucash/report/reports/standard/advanced-portfolio.scm:114
+#: gnucash/report/reports/standard/advanced-portfolio.scm:102
 msgid "How to report commissions and other brokerage fees."
 msgstr "如何顯示手續費。"
 
-#: gnucash/report/reports/standard/advanced-portfolio.scm:116
+#: gnucash/report/reports/standard/advanced-portfolio.scm:103
 msgid "Include in basis"
 msgstr "包含在成本中"
 
-#: gnucash/report/reports/standard/advanced-portfolio.scm:117
-msgid "Include brokerage fees in the basis for the asset."
-msgstr "將手續費計算在成本中"
+#: gnucash/report/reports/standard/advanced-portfolio.scm:104
+msgid "Include in gain/loss"
+msgstr "包含在獲利 / 虧損中"
 
-#: gnucash/report/reports/standard/advanced-portfolio.scm:119
-msgid "Include in gain"
-msgstr "包含在獲利中"
+#: gnucash/report/reports/standard/advanced-portfolio.scm:105
+msgid "Omit from report"
+msgstr "不顯示在報表中"
 
-#: gnucash/report/reports/standard/advanced-portfolio.scm:120
-msgid "Include brokerage fees in the gain and loss but not in the basis."
-msgstr "將手續費計算在獲利 / 虧損欄位，而不計算在成本中。"
-
-#: gnucash/report/reports/standard/advanced-portfolio.scm:122
-msgid "Ignore"
-msgstr "忽略"
-
-#: gnucash/report/reports/standard/advanced-portfolio.scm:123
-msgid "Ignore brokerage fees entirely."
-msgstr "完全忽略手續費。"
-
-#: gnucash/report/reports/standard/advanced-portfolio.scm:130
+#: gnucash/report/reports/standard/advanced-portfolio.scm:111
 msgid "Display the ticker symbols."
 msgstr "顯示股票代碼。"
 
-#: gnucash/report/reports/standard/advanced-portfolio.scm:137
+#: gnucash/report/reports/standard/advanced-portfolio.scm:118
 msgid "Display exchange listings."
 msgstr "顯示交易所。"
 
-#: gnucash/report/reports/standard/advanced-portfolio.scm:144
+#: gnucash/report/reports/standard/advanced-portfolio.scm:125
 msgid "Display numbers of shares in accounts."
 msgstr "顯示股份數量。"
 
-#: gnucash/report/reports/standard/advanced-portfolio.scm:150
+#: gnucash/report/reports/standard/advanced-portfolio.scm:131
 #: gnucash/report/reports/standard/portfolio.scm:63
 msgid "The number of decimal places to use for share numbers."
 msgstr "用在股份數字的小數位數。"
 
-#: gnucash/report/reports/standard/advanced-portfolio.scm:157
+#: gnucash/report/reports/standard/advanced-portfolio.scm:138
 msgid "Display share prices."
 msgstr "顯示股價。"
 
-#: gnucash/report/reports/standard/advanced-portfolio.scm:165
+#: gnucash/report/reports/standard/advanced-portfolio.scm:146
 #: gnucash/report/reports/standard/portfolio.scm:71
 msgid "Stock Accounts to report on."
 msgstr "要提出報表的股票科目。"
 
-#: gnucash/report/reports/standard/advanced-portfolio.scm:177
+#: gnucash/report/reports/standard/advanced-portfolio.scm:158
 #: gnucash/report/reports/standard/portfolio.scm:83
 msgid "Include accounts that have a zero share balances."
 msgstr "包含有零股份結算的科目。"
 
-#: gnucash/report/reports/standard/advanced-portfolio.scm:1068
+#: gnucash/report/reports/standard/advanced-portfolio.scm:1049
 #: gnucash/report/reports/standard/portfolio.scm:255
 msgid "Listing"
 msgstr "上市櫃交易所"
 
-#: gnucash/report/reports/standard/advanced-portfolio.scm:1080
+#: gnucash/report/reports/standard/advanced-portfolio.scm:1061
 msgid "Basis"
 msgstr "成本"
 
-#: gnucash/report/reports/standard/advanced-portfolio.scm:1082
+#: gnucash/report/reports/standard/advanced-portfolio.scm:1063
 #: gnucash/report/reports/standard/cashflow-barchart.scm:291
 #: gnucash/report/reports/standard/cashflow-barchart.scm:337
 #: gnucash/report/reports/standard/cash-flow.scm:279
 msgid "Money In"
 msgstr "金錢流入"
 
-#: gnucash/report/reports/standard/advanced-portfolio.scm:1083
+#: gnucash/report/reports/standard/advanced-portfolio.scm:1064
 #: gnucash/report/reports/standard/cashflow-barchart.scm:297
 #: gnucash/report/reports/standard/cashflow-barchart.scm:338
 #: gnucash/report/reports/standard/cash-flow.scm:300
 msgid "Money Out"
 msgstr "金錢流出"
 
-#: gnucash/report/reports/standard/advanced-portfolio.scm:1084
+#: gnucash/report/reports/standard/advanced-portfolio.scm:1065
 msgid "Realized Gain"
 msgstr "已實現獲利(虧損)"
 
-#: gnucash/report/reports/standard/advanced-portfolio.scm:1085
+#: gnucash/report/reports/standard/advanced-portfolio.scm:1066
 msgid "Unrealized Gain"
 msgstr "未實現獲利(虧損)"
 
-#: gnucash/report/reports/standard/advanced-portfolio.scm:1086
+#: gnucash/report/reports/standard/advanced-portfolio.scm:1067
 msgid "Total Gain"
 msgstr "總獲利"
 
-#: gnucash/report/reports/standard/advanced-portfolio.scm:1087
+#: gnucash/report/reports/standard/advanced-portfolio.scm:1068
 msgid "Rate of Gain"
 msgstr "獲利率"
 
-#: gnucash/report/reports/standard/advanced-portfolio.scm:1091
+#: gnucash/report/reports/standard/advanced-portfolio.scm:1072
 msgid "Brokerage Fees"
 msgstr "手續費"
 
-#: gnucash/report/reports/standard/advanced-portfolio.scm:1093
+#: gnucash/report/reports/standard/advanced-portfolio.scm:1074
 msgid "Total Return"
 msgstr "總報酬"
 
-#: gnucash/report/reports/standard/advanced-portfolio.scm:1094
+#: gnucash/report/reports/standard/advanced-portfolio.scm:1075
 msgid "Rate of Return"
 msgstr "報酬率"
 
-#: gnucash/report/reports/standard/advanced-portfolio.scm:1191
+#: gnucash/report/reports/standard/advanced-portfolio.scm:1172
 msgid ""
 "* this commodity data was built using transaction pricing instead of the "
 "price list."
 msgstr "* 此商品的資料使用的價格為交易時的價格，而價格列表裡的價格。"
 
-#: gnucash/report/reports/standard/advanced-portfolio.scm:1193
+#: gnucash/report/reports/standard/advanced-portfolio.scm:1174
 msgid ""
 "If you are in a multi-currency situation, the exchanges may not be correct."
 msgstr "如果您使用多種貨幣，則匯率有可能不正確。"
 
-#: gnucash/report/reports/standard/advanced-portfolio.scm:1198
+#: gnucash/report/reports/standard/advanced-portfolio.scm:1179
 msgid "** this commodity has no price and a price of 1 has been used."
 msgstr "** 此商品沒有價格資料，將會使用 1 做為價格。"
 
@@ -23799,13 +23953,13 @@ msgid "Balance Forecast"
 msgstr "結餘預測"
 
 #: gnucash/report/reports/standard/balance-forecast.scm:38
-#: gnucash/report/reports/standard/budget-barchart.scm:134
+#: gnucash/report/reports/standard/budget-barchart.scm:122
 #: gnucash/report/reports/standard/budget-flow.scm:87
 #: gnucash/report/reports/standard/cashflow-barchart.scm:88
 #: gnucash/report/reports/standard/income-gst-statement.scm:127
 #: gnucash/report/reports/standard/income-gst-statement.scm:137
 #: gnucash/report/reports/standard/trial-balance.scm:78
-#: gnucash/report/trep-engine.scm:687
+#: gnucash/report/trep-engine.scm:636
 msgid "Report on these accounts."
 msgstr "針這這些科目製作報表。"
 
@@ -23845,7 +23999,9 @@ msgstr "保留金額之上的增加的目標金額"
 msgid ""
 "The target is used to plan for a future large purchase, which will be added "
 "as a line above the reserve amount."
-msgstr "目標金額線可用來替未來的大型採購做計劃。此金額會與保留金額相加，並在圖表上顯示一條在保留金額之上的線。"
+msgstr ""
+"目標金額線可用來替未來的大型採購做計劃。此金額會與保留金額相加，並在圖表上顯"
+"示一條在保留金額之上的線。"
 
 #: gnucash/report/reports/standard/balance-forecast.scm:67
 msgid "Show future minimum"
@@ -23866,7 +24022,7 @@ msgid "Reserve"
 msgstr "保留"
 
 #: gnucash/report/reports/standard/balance-sheet.scm:71
-#: gnucash/report/reports/standard/trial-balance.scm:574
+#: gnucash/report/reports/standard/trial-balance.scm:568
 msgid "Balance Sheet"
 msgstr "資產負債表"
 
@@ -23999,18 +24155,18 @@ msgid "Trading Losses"
 msgstr "交易虧損"
 
 #: gnucash/report/reports/standard/balance-sheet.scm:519
-#: gnucash/report/reports/standard/balsheet-pnl.scm:1126
-#: gnucash/report/reports/standard/balsheet-pnl.scm:1141
+#: gnucash/report/reports/standard/balsheet-pnl.scm:1087
+#: gnucash/report/reports/standard/balsheet-pnl.scm:1102
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:759
 #: gnucash/report/reports/standard/equity-statement.scm:472
-#: gnucash/report/reports/standard/trial-balance.scm:735
+#: gnucash/report/reports/standard/trial-balance.scm:729
 msgid "Unrealized Gains"
 msgstr "未實現獲利(虧損)"
 
 #: gnucash/report/reports/standard/balance-sheet.scm:520
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:760
 #: gnucash/report/reports/standard/equity-statement.scm:473
-#: gnucash/report/reports/standard/trial-balance.scm:736
+#: gnucash/report/reports/standard/trial-balance.scm:730
 msgid "Unrealized Losses"
 msgstr "未實現虧損"
 
@@ -24029,14 +24185,12 @@ msgid "Balance Sheet (eguile)"
 msgstr "資產負債表 (eguile)"
 
 #: gnucash/report/reports/standard/balsheet-eg.scm:144
-msgid "1- or 2-column report"
-msgstr "一或二欄報表"
+msgid "Report format"
+msgstr "報表格式"
 
 #: gnucash/report/reports/standard/balsheet-eg.scm:146
-msgid ""
-"The balance sheet can be displayed with either 1 or 2 columns. 'auto' means "
-"that the layout will be adjusted to fit the width of the page."
-msgstr "資產負債表可以用一欄或兩欄顯示。「自動」表示將會自動依照頁面寬度進行調整。"
+msgid "The balance sheet can be displayed with either 1 or 2 columns."
+msgstr "資產負債表可以用一欄或兩欄顯示。"
 
 #: gnucash/report/reports/standard/balsheet-eg.scm:154
 msgid "Exclude accounts with zero total balances"
@@ -24085,7 +24239,9 @@ msgid ""
 "The file name of the eguile template part of this report. This file must be "
 "in your .gnucash directory, or else in its proper place within the GnuCash "
 "installation directories."
-msgstr "此報表中 eguile 模板的檔案名稱。此檔案必須在您的 .gnucash 資料夾中，或是 GnuCash 程式所有的資料夾中適當的地方。"
+msgstr ""
+"此報表中 eguile 模板的檔案名稱。此檔案必須在您的 .gnucash 資料夾中，或是 "
+"GnuCash 程式所有的資料夾中適當的地方。"
 
 #: gnucash/report/reports/standard/balsheet-eg.scm:172
 #: gnucash/report/reports/standard/receipt.scm:46
@@ -24099,10 +24255,11 @@ msgid ""
 "this file should be in your .gnucash directory, or else in its proper place "
 "within the GnuCash installation directories."
 msgstr ""
-"此份報表所要使用的 CSS 樣式表檔案名稱。如果有指定，則此檔案應位於您的 .gnucash 資料夾，或是 GnuCash 所安裝的資料夾裡適當的位置。"
+"此份報表所要使用的 CSS 樣式表檔案名稱。如果有指定，則此檔案應位於您的 ."
+"gnucash 資料夾，或是 GnuCash 所安裝的資料夾裡適當的位置。"
 
 #: gnucash/report/reports/standard/balsheet-eg.scm:175
-#: gnucash/report/reports/standard/invoice.scm:342
+#: gnucash/report/reports/standard/invoice.scm:329
 msgid "Extra Notes"
 msgstr "額外備註"
 
@@ -24111,63 +24268,45 @@ msgstr "額外備註"
 msgid "Notes added at end of invoice -- may contain HTML markup."
 msgstr "在發票底部添加的備讓 -- 可以包含 HTML 標籤。"
 
-#: gnucash/report/reports/standard/balsheet-eg.scm:220
-msgid "Adjust the layout to fit the width of the screen or page."
-msgstr ""
+#: gnucash/report/reports/standard/balsheet-eg.scm:218
+msgid "Adjust the layout to fit the width of the screen or page"
+msgstr "根據螢幕或頁面大小調整選擇合適的方式"
 
-#: gnucash/report/reports/standard/balsheet-eg.scm:222
-msgid "One"
-msgstr "一"
-
-#: gnucash/report/reports/standard/balsheet-eg.scm:223
-#, fuzzy
-msgid "Display liabilities and equity below assets."
+#: gnucash/report/reports/standard/balsheet-eg.scm:219
+msgid "Display liabilities and equity below assets"
 msgstr "在資產下方顯示負債與淨值"
 
+#: gnucash/report/reports/standard/balsheet-eg.scm:220
+msgid "Display assets on the left, liabilities and equity on the right"
+msgstr "將資產顯示在左方；負債、股東權益顯示在右方"
+
+#: gnucash/report/reports/standard/balsheet-eg.scm:224
+msgid "Sign: -$10.00"
+msgstr "負號： -$10.00"
+
 #: gnucash/report/reports/standard/balsheet-eg.scm:225
-msgid "Two"
-msgstr "二"
+msgid "Brackets: ($10.00)"
+msgstr "括號：($10.00)"
 
-#: gnucash/report/reports/standard/balsheet-eg.scm:226
-#, fuzzy
-msgid "Display assets on the left, liabilities and equity on the right."
-msgstr "將資產顯示在左方；將負債、股東權益顯示在右方"
-
-#: gnucash/report/reports/standard/balsheet-eg.scm:231
-#, fuzzy
-msgid "Sign"
-msgstr "單行"
-
-#: gnucash/report/reports/standard/balsheet-eg.scm:232
-msgid "Prefix negative amounts with a minus sign, e.g. -$10.00."
-msgstr ""
-
-#: gnucash/report/reports/standard/balsheet-eg.scm:234
-#, fuzzy
-msgid "Brackets"
-msgstr "往後"
-
-#: gnucash/report/reports/standard/balsheet-eg.scm:235
-msgid "Surround negative amounts with brackets, e.g. ($100.00)."
-msgstr ""
-
-#: gnucash/report/reports/standard/balsheet-eg.scm:253
+#: gnucash/report/reports/standard/balsheet-eg.scm:244
 msgid ""
 "(Development version -- don't rely on the numbers on this report without "
 "double-checking them.<br>Change the 'Extra Notes' option to get rid of this "
 "message)"
-msgstr "(開發版本 -- 請不要再沒有經過仔細確認的情況下就使用這個報表上的數字。<br>要刪除這個訊息，請修改選項中的「額外備註」。)"
+msgstr ""
+"(開發版本 -- 請不要再沒有經過仔細確認的情況下就使用這個報表上的數字。<br>要刪"
+"除這個訊息，請修改選項中的「額外備註」。)"
 
-#: gnucash/report/reports/standard/balsheet-eg.scm:382
-#: libgnucash/engine/Scrub.c:124
+#: gnucash/report/reports/standard/balsheet-eg.scm:373
+#: libgnucash/engine/Scrub.c:126
 msgid "Orphan"
 msgstr "無主的"
 
-#: gnucash/report/reports/standard/balsheet-eg.scm:557
+#: gnucash/report/reports/standard/balsheet-eg.scm:548
 msgid "Balance Sheet using eguile-gnc"
 msgstr "資產負債表 (使用 eguile-gnc)"
 
-#: gnucash/report/reports/standard/balsheet-eg.scm:558
+#: gnucash/report/reports/standard/balsheet-eg.scm:549
 msgid "Display a balance sheet (using eguile template)"
 msgstr "顯示使用 eguile 範本的資產負債表"
 
@@ -24219,7 +24358,7 @@ msgid "Add options summary"
 msgstr "加入可選的摘要"
 
 #: gnucash/report/reports/standard/balsheet-pnl.scm:76
-#: gnucash/report/trep-engine.scm:591
+#: gnucash/report/trep-engine.scm:546
 msgid "Add summary of options."
 msgstr "加入可選的摘要。"
 
@@ -24244,8 +24383,9 @@ msgid ""
 "account. If this option is disabled, subtotals are displayed below parent "
 "and children groups."
 msgstr ""
-"如果勾選此選項，則子科目小計的金額會包含在母科目金額中，且母科目若本身有其金額，會以子科目的型式顯示在下一行。若未勾選此選項，則小計會顯示在母科目與子科目"
-"群組下方。"
+"如果勾選此選項，則子科目小計的金額會包含在母科目金額中，且母科目若本身有其金"
+"額，會以子科目的型式顯示在下一行。若未勾選此選項，則小計會顯示在母科目與子科"
+"目群組下方。"
 
 #: gnucash/report/reports/standard/balsheet-pnl.scm:102
 msgid "Display amounts as hyperlinks"
@@ -24294,7 +24434,7 @@ msgid "Show original currency amount"
 msgstr "顯示原本的貨幣金額"
 
 #: gnucash/report/reports/standard/balsheet-pnl.scm:124
-#: gnucash/report/trep-engine.scm:574
+#: gnucash/report/trep-engine.scm:529
 msgid "Also show original currency amounts"
 msgstr "也顯示原本的貨幣金額"
 
@@ -24308,70 +24448,58 @@ msgid ""
 "profit & loss."
 msgstr "如果以多欄顯示各期間的獲利 / 虧損，則同時顯示整體的獲利 / 虧損。"
 
-#: gnucash/report/reports/standard/balsheet-pnl.scm:247
-#: gnucash/report/trep-engine.scm:600
+#: gnucash/report/reports/standard/balsheet-pnl.scm:211
+#: gnucash/report/trep-engine.scm:552
 msgid "Always"
 msgstr "總是"
 
-#: gnucash/report/reports/standard/balsheet-pnl.scm:248
-#: gnucash/report/trep-engine.scm:601
-msgid "Always display summary."
-msgstr "總是顯示摘要。"
-
-#: gnucash/report/reports/standard/balsheet-pnl.scm:251
-#: gnucash/report/trep-engine.scm:604
-#, fuzzy
-msgid "Disable report summary."
-msgstr "科目摘要"
-
-#: gnucash/report/reports/standard/balsheet-pnl.scm:506
-#: gnucash/report/reports/standard/balsheet-pnl.scm:662
-#: gnucash/report/trep-engine.scm:1619
+#: gnucash/report/reports/standard/balsheet-pnl.scm:467
+#: gnucash/report/reports/standard/balsheet-pnl.scm:623
+#: gnucash/report/trep-engine.scm:1564
 msgid "Total For "
 msgstr "小計 "
 
-#: gnucash/report/reports/standard/balsheet-pnl.scm:869
+#: gnucash/report/reports/standard/balsheet-pnl.scm:830
 msgid "missing"
 msgstr "不明"
 
-#: gnucash/report/reports/standard/balsheet-pnl.scm:1115
-#: libgnucash/engine/Account.cpp:4389
+#: gnucash/report/reports/standard/balsheet-pnl.scm:1076
+#: libgnucash/engine/Account.cpp:4395
 msgid "Asset"
 msgstr "資產"
 
-#: gnucash/report/reports/standard/balsheet-pnl.scm:1118
-#: libgnucash/engine/Account.cpp:4391
+#: gnucash/report/reports/standard/balsheet-pnl.scm:1079
+#: libgnucash/engine/Account.cpp:4397
 msgid "Liability"
 msgstr "負債"
 
-#: gnucash/report/reports/standard/balsheet-pnl.scm:1136
+#: gnucash/report/reports/standard/balsheet-pnl.scm:1097
 msgid "Liability and Equity"
 msgstr "負債 / 淨值"
 
-#: gnucash/report/reports/standard/balsheet-pnl.scm:1154
-#: gnucash/report/reports/standard/balsheet-pnl.scm:1297
+#: gnucash/report/reports/standard/balsheet-pnl.scm:1115
+#: gnucash/report/reports/standard/balsheet-pnl.scm:1258
 msgid "Exchange Rates"
 msgstr "匯率"
 
-#: gnucash/report/reports/standard/balsheet-pnl.scm:1164
-#: gnucash/report/reports/standard/budget-barchart.scm:157
+#: gnucash/report/reports/standard/balsheet-pnl.scm:1125
 msgid "Barchart"
 msgstr "長條圖"
 
-#: gnucash/report/reports/standard/balsheet-pnl.scm:1227
+#: gnucash/report/reports/standard/balsheet-pnl.scm:1188
 msgid " to "
 msgstr " 到 "
 
-#: gnucash/report/reports/standard/balsheet-pnl.scm:1290
-#: gnucash/report/reports/standard/trial-balance.scm:861
+#: gnucash/report/reports/standard/balsheet-pnl.scm:1251
+#: gnucash/report/reports/standard/trial-balance.scm:855
 msgid "Net Income"
 msgstr "淨收入"
 
-#: gnucash/report/reports/standard/balsheet-pnl.scm:1326
+#: gnucash/report/reports/standard/balsheet-pnl.scm:1287
 msgid "Balance Sheet (Multicolumn)"
 msgstr "資產負債表 (多欄)"
 
-#: gnucash/report/reports/standard/balsheet-pnl.scm:1327
+#: gnucash/report/reports/standard/balsheet-pnl.scm:1288
 msgid "Income Statement (Multicolumn)"
 msgstr "損益表 (多欄)"
 
@@ -24390,10 +24518,10 @@ msgid ""
 msgstr "是否在報表中新增幾行，用來顯示執行預算後重新計算的總數。"
 
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:111
-#: gnucash/report/reports/standard/budget-barchart.scm:98
+#: gnucash/report/reports/standard/budget-barchart.scm:86
 #: gnucash/report/reports/standard/budget-flow.scm:56
 #: gnucash/report/reports/standard/budget-income-statement.scm:59
-#: gnucash/report/reports/standard/budget.scm:137
+#: gnucash/report/reports/standard/budget.scm:125
 msgid "Budget to use."
 msgstr "使用的預算。"
 
@@ -24504,83 +24632,62 @@ msgstr "結束週期"
 msgid "Select exact period that ends the reporting range."
 msgstr "選擇報表結束的預算週期。"
 
+#: gnucash/report/reports/standard/budget-barchart.scm:65
+#: gnucash/report/reports/standard/budget.scm:111
+msgid "First budget period"
+msgstr "第一個預算週期"
+
 #: gnucash/report/reports/standard/budget-barchart.scm:66
 #: gnucash/report/reports/standard/budget.scm:112
-msgid "First"
-msgstr ""
+msgid "Previous budget period"
+msgstr "前一個預算週期"
 
 #: gnucash/report/reports/standard/budget-barchart.scm:67
 #: gnucash/report/reports/standard/budget.scm:113
-#, fuzzy
-msgid "The first period of the budget"
-msgstr "報表的標題"
+msgid "Current budget period"
+msgstr "目前的預算週期"
+
+#: gnucash/report/reports/standard/budget-barchart.scm:68
+#: gnucash/report/reports/standard/budget.scm:114
+msgid "Next budget period"
+msgstr "下一個預算週期"
 
 #: gnucash/report/reports/standard/budget-barchart.scm:69
 #: gnucash/report/reports/standard/budget.scm:115
-#, fuzzy
-msgid "Previous"
-msgstr "第一選項"
-
-#: gnucash/report/reports/standard/budget-barchart.scm:70
-#: gnucash/report/reports/standard/budget.scm:116
-msgid ""
-"Budget period was before current period, according to report evaluation date"
-msgstr ""
-
-#: gnucash/report/reports/standard/budget-barchart.scm:73
-#: gnucash/report/reports/standard/budget.scm:119
-msgid "Current period, according to report evaluation date"
-msgstr ""
-
-#: gnucash/report/reports/standard/budget-barchart.scm:75
-#: gnucash/report/reports/standard/budget.scm:121
-msgid "Next"
-msgstr ""
-
-#: gnucash/report/reports/standard/budget-barchart.scm:76
-#: gnucash/report/reports/standard/budget.scm:122
-msgid "Next period, according to report evaluation date"
-msgstr ""
-
-#: gnucash/report/reports/standard/budget-barchart.scm:79
-#: gnucash/report/reports/standard/budget.scm:125
 msgid "Last budget period"
 msgstr "最後的預算週期"
 
-#: gnucash/report/reports/standard/budget-barchart.scm:81
-#: gnucash/report/reports/standard/budget.scm:127
+#: gnucash/report/reports/standard/budget-barchart.scm:70
+#: gnucash/report/reports/standard/budget.scm:116
 msgid "Manual period selection"
 msgstr "手動選取預算週期"
 
-#: gnucash/report/reports/standard/budget-barchart.scm:82
-#: gnucash/report/reports/standard/budget.scm:128
-msgid "Explicitly select period value with spinner below"
-msgstr ""
-
-#: gnucash/report/reports/standard/budget-barchart.scm:148
+#: gnucash/report/reports/standard/budget-barchart.scm:136
 msgid "Calculate as running sum?"
 msgstr "是否要計算當前總數？"
 
-#: gnucash/report/reports/standard/budget-barchart.scm:158
-msgid "Show the report as a bar chart."
-msgstr "以長條圖的型式顯示報表。"
+#: gnucash/report/reports/standard/budget-barchart.scm:142
+msgid "Select which chart type to use."
+msgstr "選擇要使用哪種圖表。"
 
-#: gnucash/report/reports/standard/budget-barchart.scm:160
-msgid "Linechart"
+#: gnucash/report/reports/standard/budget-barchart.scm:144
+#: gnucash/report/reports/standard/category-barchart.scm:156
+msgid "Bar Chart"
+msgstr "長條圖"
+
+#: gnucash/report/reports/standard/budget-barchart.scm:145
+#: gnucash/report/reports/standard/category-barchart.scm:157
+msgid "Line Chart"
 msgstr "折線圖"
-
-#: gnucash/report/reports/standard/budget-barchart.scm:161
-msgid "Show the report as a line chart."
-msgstr "以折線圖的型式顯示圖表。"
 
 #. Translators: Bgt and Act refer to budgeted and
 #. actual total amounts.
-#: gnucash/report/reports/standard/budget-barchart.scm:216
+#: gnucash/report/reports/standard/budget-barchart.scm:200
 #, scheme-format
 msgid "Bgt: ~a Act: ~a"
 msgstr "預算: ~a 實際: ~a"
 
-#: gnucash/report/reports/standard/budget-barchart.scm:222
+#: gnucash/report/reports/standard/budget-barchart.scm:206
 msgid "Actual"
 msgstr "實際"
 
@@ -24807,7 +24914,9 @@ msgstr "包含所選定的週期範圍之前的匯總資料。"
 msgid ""
 "Include in report previous periods as single collapsed column (one for all "
 "periods before starting)"
-msgstr "在報表中包括將之前的週期（後預算開始後直到所選的開始週期的第一個週期）收合成一欄的欄位。"
+msgstr ""
+"在報表中包括將之前的週期（後預算開始後直到所選的開始週期的第一個週期）收合成"
+"一欄的欄位。"
 
 #: gnucash/report/reports/standard/budget.scm:86
 msgid "Include collapsed periods after selected."
@@ -24817,20 +24926,22 @@ msgstr "包含所選定的週期範圍之後的匯總資料。"
 msgid ""
 "Include in report further periods as single collapsed column (one for all "
 "periods after ending and to the end of budget range)"
-msgstr "在報表中包括將未來的週期（結束週期後，直到預算結束的範圍內的所有預算週期）收合成一欄的欄位。"
+msgstr ""
+"在報表中包括將未來的週期（結束週期後，直到預算結束的範圍內的所有預算週期）收"
+"合成一欄的欄位。"
 
 #. Translators: Abbreviation for "Budget" amount
-#: gnucash/report/reports/standard/budget.scm:536
+#: gnucash/report/reports/standard/budget.scm:524
 msgid "Bgt"
 msgstr "預算"
 
 #. Translators: Abbreviation for "Actual" amount
-#: gnucash/report/reports/standard/budget.scm:541
+#: gnucash/report/reports/standard/budget.scm:529
 msgid "Act"
 msgstr "實際"
 
 #. Translators: Abbreviation for "Difference" amount
-#: gnucash/report/reports/standard/budget.scm:546
+#: gnucash/report/reports/standard/budget.scm:534
 msgid "Diff"
 msgstr "差額"
 
@@ -24838,7 +24949,7 @@ msgstr "差額"
 #. budget will report on budgeted and actual
 #. amounts from the beginning of budget, instead
 #. of only using the budget-period amounts.
-#: gnucash/report/reports/standard/budget.scm:776
+#: gnucash/report/reports/standard/budget.scm:764
 msgid "using accumulated amounts"
 msgstr "使用從所有預算週期累計的金額"
 
@@ -24991,58 +25102,38 @@ msgstr "使用堆疊長圖型"
 msgid "Maximum Bars"
 msgstr "最大條數"
 
-#: gnucash/report/reports/standard/category-barchart.scm:130
-msgid "Show the average daily amount during the reporting period."
-msgstr ""
-
-#: gnucash/report/reports/standard/category-barchart.scm:165
-msgid "Bar Chart"
-msgstr "長條圖"
-
-#: gnucash/report/reports/standard/category-barchart.scm:166
-msgid "Use bar charts."
-msgstr "使用長條圖"
-
-#: gnucash/report/reports/standard/category-barchart.scm:168
-msgid "Line Chart"
-msgstr "折線圖"
-
-#: gnucash/report/reports/standard/category-barchart.scm:169
-msgid "Use line charts."
-msgstr "使用折線圖"
-
-#: gnucash/report/reports/standard/category-barchart.scm:175
+#: gnucash/report/reports/standard/category-barchart.scm:163
 msgid "Show charts as stacked charts?"
 msgstr "要用堆疊形式顯示圖表？"
 
-#: gnucash/report/reports/standard/category-barchart.scm:181
+#: gnucash/report/reports/standard/category-barchart.scm:169
 msgid "Maximum number of stacks in the chart."
 msgstr "圖表中條的最大堆疊數量。"
 
-#: gnucash/report/reports/standard/category-barchart.scm:290
+#: gnucash/report/reports/standard/category-barchart.scm:278
 msgid "Invalid dates"
 msgstr "無效的日期"
 
-#: gnucash/report/reports/standard/category-barchart.scm:291
+#: gnucash/report/reports/standard/category-barchart.scm:279
 msgid "Start date must be earlier than End date"
 msgstr "開始日期必須早於結束日期"
 
-#: gnucash/report/reports/standard/category-barchart.scm:329
+#: gnucash/report/reports/standard/category-barchart.scm:317
 msgid "Daily Average"
 msgstr "日平均"
 
-#: gnucash/report/reports/standard/category-barchart.scm:520
+#: gnucash/report/reports/standard/category-barchart.scm:508
 #, scheme-format
 msgid "Balances ~a to ~a"
 msgstr "~a 到 ~a 的結餘"
 
-#: gnucash/report/reports/standard/category-barchart.scm:641
-#: gnucash/report/reports/standard/category-barchart.scm:662
-#: gnucash/report/trep-engine.scm:1688 gnucash/report/trep-engine.scm:1947
+#: gnucash/report/reports/standard/category-barchart.scm:629
+#: gnucash/report/reports/standard/category-barchart.scm:650
+#: gnucash/report/trep-engine.scm:1633 gnucash/report/trep-engine.scm:1892
 msgid "Grand Total"
 msgstr "總和"
 
-#: gnucash/report/reports/standard/category-barchart.scm:676
+#: gnucash/report/reports/standard/category-barchart.scm:664
 #: gnucash/report/reports/standard/net-charts.scm:466
 msgid "No exportable data"
 msgstr "沒有可匯出的資料"
@@ -25073,101 +25164,68 @@ msgstr "顯示公司地址"
 msgid "Show your own company's address and the date of printing."
 msgstr "顯示您的公司地址與列印日期。"
 
-#: gnucash/report/reports/standard/customer-summary.scm:71
+#: gnucash/report/reports/standard/customer-summary.scm:70
 msgid "Show Lines with All Zeros"
 msgstr "顯示全部為零的資料列"
 
-#: gnucash/report/reports/standard/customer-summary.scm:72
+#: gnucash/report/reports/standard/customer-summary.scm:71
 msgid ""
 "Show the table lines with customers which did not have any transactions in "
 "the reporting period, hence would show all zeros in the columns."
 msgstr "在表格中顯示報表週期中沒有任何交易的客戶，由此所有的欄位都會顯示零。"
 
-#: gnucash/report/reports/standard/customer-summary.scm:73
+#: gnucash/report/reports/standard/customer-summary.scm:72
 msgid "Show Inactive Customers"
 msgstr "顯示非作用中的客戶"
 
-#: gnucash/report/reports/standard/customer-summary.scm:74
+#: gnucash/report/reports/standard/customer-summary.scm:73
 msgid "Include customers that have been marked inactive."
 msgstr "顯示被標記為非作用中的客戶。"
 
-#: gnucash/report/reports/standard/customer-summary.scm:76
+#: gnucash/report/reports/standard/customer-summary.scm:75
 msgid "Sort Column"
 msgstr "排序欄位"
 
-#: gnucash/report/reports/standard/customer-summary.scm:77
+#: gnucash/report/reports/standard/customer-summary.scm:76
 msgid "Choose the column by which the result table is sorted."
 msgstr "選擇用來排序表格的欄位。"
 
-#: gnucash/report/reports/standard/customer-summary.scm:79
-#, fuzzy
-msgid "Choose the ordering of the column sort: Either ascending or descending."
-msgstr "欄位遞增或遞減排序"
+#: gnucash/report/reports/standard/customer-summary.scm:78
+msgid "Choose the ordering of the column sort."
+msgstr "選擇欄位使用遞增或遞減排序。"
 
-#: gnucash/report/reports/standard/customer-summary.scm:118
+#: gnucash/report/reports/standard/customer-summary.scm:116
 msgid "Customer Name"
 msgstr "客戶編號"
 
+#: gnucash/report/reports/standard/customer-summary.scm:118
+msgid "Markup (which is profit amount divided by sales)"
+msgstr "利潤率 (獲利除以銷售額)"
+
 #: gnucash/report/reports/standard/customer-summary.scm:119
-#, fuzzy
-msgid "Sort alphabetically by customer name."
-msgstr "以科目名稱做字母排序"
-
-#: gnucash/report/reports/standard/customer-summary.scm:122
-#, fuzzy
-msgid "Sort by profit amount."
-msgstr "以總額排序"
-
-#. Translators: "Markup" is profit amount divided by sales amount
-#: gnucash/report/reports/standard/customer-summary.scm:125
-#: gnucash/report/reports/standard/customer-summary.scm:315
-msgid "Markup"
-msgstr "純益率"
-
-#: gnucash/report/reports/standard/customer-summary.scm:126
-msgid "Sort by markup (which is profit amount divided by sales)."
-msgstr ""
-
-#: gnucash/report/reports/standard/customer-summary.scm:128
-#: gnucash/report/reports/standard/customer-summary.scm:316
+#: gnucash/report/reports/standard/customer-summary.scm:300
 #: gnucash/report/reports/standard/income-gst-statement.scm:127
 msgid "Sales"
 msgstr "銷售"
 
-#: gnucash/report/reports/standard/customer-summary.scm:129
-#, fuzzy
-msgid "Sort by sales amount."
-msgstr "以銷售總額排序"
-
-#: gnucash/report/reports/standard/customer-summary.scm:132
-#, fuzzy
-msgid "Sort by expense amount."
-msgstr "以支出總額排序"
-
-#: gnucash/report/reports/standard/customer-summary.scm:142
-#, fuzzy
-msgid "A to Z, smallest to largest."
-msgstr "A 到 Z，最小到最大"
-
-#: gnucash/report/reports/standard/customer-summary.scm:145
-#, fuzzy
-msgid "Z to A, largest to smallest."
-msgstr "Z 到 A，最大到最小"
-
-#: gnucash/report/reports/standard/customer-summary.scm:286
+#: gnucash/report/reports/standard/customer-summary.scm:270
 #, scheme-format
 msgid "~a ~a - ~a"
 msgstr "~a ~a - ~a"
 
-#: gnucash/report/reports/standard/customer-summary.scm:306
+#: gnucash/report/reports/standard/customer-summary.scm:290
 msgid "No valid customer found."
 msgstr "查無有效客戶。"
 
-#: gnucash/report/reports/standard/customer-summary.scm:394
+#: gnucash/report/reports/standard/customer-summary.scm:299
+msgid "Markup"
+msgstr "純益率"
+
+#: gnucash/report/reports/standard/customer-summary.scm:378
 msgid "No Customer"
 msgstr "沒有客戶"
 
-#: gnucash/report/reports/standard/customer-summary.scm:508
+#: gnucash/report/reports/standard/customer-summary.scm:492
 msgid "Customer Summary"
 msgstr "客戶摘要"
 
@@ -25218,7 +25276,7 @@ msgstr "將「結帳分錄模式」視為式規表示式。"
 
 #: gnucash/report/reports/standard/equity-statement.scm:423
 #: gnucash/report/reports/standard/income-statement.scm:480
-#: gnucash/report/reports/standard/trial-balance.scm:405
+#: gnucash/report/reports/standard/trial-balance.scm:399
 msgid "for Period"
 msgstr "於期間"
 
@@ -25247,7 +25305,7 @@ msgstr "資本減少"
 #: gnucash/report/reports/standard/general-ledger.scm:68
 #: gnucash/report/reports/standard/register.scm:135
 #: gnucash/report/reports/standard/register.scm:359
-#: gnucash/report/trep-engine.scm:969 gnucash/report/trep-engine.scm:1097
+#: gnucash/report/trep-engine.scm:918 gnucash/report/trep-engine.scm:1042
 msgid "Num/Action"
 msgstr "號碼/動作"
 
@@ -25255,8 +25313,8 @@ msgstr "號碼/動作"
 #: gnucash/report/reports/standard/general-ledger.scm:82
 #: gnucash/report/reports/standard/general-ledger.scm:102
 #: gnucash/report/reports/standard/register.scm:412
-#: gnucash/report/trep-engine.scm:984 gnucash/report/trep-engine.scm:1118
-#: gnucash/report/trep-engine.scm:1414
+#: gnucash/report/trep-engine.scm:933 gnucash/report/trep-engine.scm:1063
+#: gnucash/report/trep-engine.scm:1359
 msgid "Running Balance"
 msgstr "逐筆結計餘額"
 
@@ -25264,7 +25322,7 @@ msgstr "逐筆結計餘額"
 #: gnucash/report/reports/standard/general-ledger.scm:83
 #: gnucash/report/reports/standard/general-ledger.scm:103
 #: gnucash/report/reports/standard/register.scm:417
-#: gnucash/report/trep-engine.scm:985
+#: gnucash/report/trep-engine.scm:934
 msgid "Totals"
 msgstr "合計"
 
@@ -25279,43 +25337,43 @@ msgid "Sorting"
 msgstr "排序"
 
 #: gnucash/report/reports/standard/general-ledger.scm:69
-#: gnucash/report/trep-engine.scm:990 gnucash/report/trep-engine.scm:1212
-#: gnucash/report/trep-engine.scm:1221
+#: gnucash/report/trep-engine.scm:939 gnucash/report/trep-engine.scm:1157
+#: gnucash/report/trep-engine.scm:1166
 msgid "Trans Number"
 msgstr "交易號碼"
 
 #: gnucash/report/reports/standard/general-ledger.scm:73
 #: gnucash/report/reports/standard/general-ledger.scm:93
-#: gnucash/report/trep-engine.scm:927 gnucash/report/trep-engine.scm:974
-#: gnucash/report/trep-engine.scm:1120
+#: gnucash/report/trep-engine.scm:876 gnucash/report/trep-engine.scm:923
+#: gnucash/report/trep-engine.scm:1065
 msgid "Use Full Account Name"
 msgstr "使用科目全名"
 
 #: gnucash/report/reports/standard/general-ledger.scm:75
 #: gnucash/report/reports/standard/general-ledger.scm:95
-#: gnucash/report/trep-engine.scm:215 gnucash/report/trep-engine.scm:931
-#: gnucash/report/trep-engine.scm:1017 gnucash/report/trep-engine.scm:1103
+#: gnucash/report/trep-engine.scm:208 gnucash/report/trep-engine.scm:880
+#: gnucash/report/trep-engine.scm:966 gnucash/report/trep-engine.scm:1048
 msgid "Other Account Name"
 msgstr "其他科目名稱"
 
 #: gnucash/report/reports/standard/general-ledger.scm:76
 #: gnucash/report/reports/standard/general-ledger.scm:96
-#: gnucash/report/trep-engine.scm:947 gnucash/report/trep-engine.scm:977
-#: gnucash/report/trep-engine.scm:1128
+#: gnucash/report/trep-engine.scm:896 gnucash/report/trep-engine.scm:926
+#: gnucash/report/trep-engine.scm:1073
 msgid "Use Full Other Account Name"
 msgstr "使用完整的其他科目名稱"
 
 #: gnucash/report/reports/standard/general-ledger.scm:77
 #: gnucash/report/reports/standard/general-ledger.scm:97
-#: gnucash/report/trep-engine.scm:222 gnucash/report/trep-engine.scm:951
-#: gnucash/report/trep-engine.scm:978 gnucash/report/trep-engine.scm:1125
+#: gnucash/report/trep-engine.scm:214 gnucash/report/trep-engine.scm:900
+#: gnucash/report/trep-engine.scm:927 gnucash/report/trep-engine.scm:1070
 msgid "Other Account Code"
 msgstr "其他科目代碼"
 
 #: gnucash/report/reports/standard/general-ledger.scm:84
 #: gnucash/report/reports/standard/general-ledger.scm:104
-#: gnucash/report/trep-engine.scm:935 gnucash/report/trep-engine.scm:1061
-#: gnucash/report/trep-engine.scm:1162
+#: gnucash/report/trep-engine.scm:884 gnucash/report/trep-engine.scm:1006
+#: gnucash/report/trep-engine.scm:1107
 msgid "Sign Reverses"
 msgstr "改變正負號"
 
@@ -25330,7 +25388,7 @@ msgid "Primary Key"
 msgstr "排序主鍵"
 
 #: gnucash/report/reports/standard/general-ledger.scm:125
-#: gnucash/report/trep-engine.scm:82 gnucash/report/trep-engine.scm:1131
+#: gnucash/report/trep-engine.scm:82 gnucash/report/trep-engine.scm:1076
 msgid "Show Full Account Name"
 msgstr "顯示完整的科目名稱"
 
@@ -25386,15 +25444,19 @@ msgid ""
 "liability, A/Payable or A/Receivable accounts, a split to a tax account, e."
 "g. Income:Sales -$1000, A/Receivable $1100, Liability:GST on Sales -$100."
 msgstr ""
-"此報報可用於計算當局應繳/應收的定期營業稅。請從「編輯報表選項」中選取您的業業銷售與採購科目。每筆交易除了在資產、負債、應付帳款與應收帳款之外，也可以含有"
-"與稅務相關的科目的分割。例如收入:銷售 -$1000, 應收帳款 $1000，負債:銷售商品和服務稅 -$100。"
+"此報報可用於計算當局應繳/應收的定期營業稅。請從「編輯報表選項」中選取您的業業"
+"銷售與採購科目。每筆交易除了在資產、負債、應付帳款與應收帳款之外，也可以含有"
+"與稅務相關的科目的分割。例如收入:銷售 -$1000, 應收帳款 $1000，負債:銷售商品和"
+"服務稅 -$100。"
 
 #: gnucash/report/reports/standard/income-gst-statement.scm:56
 msgid ""
 "These tax accounts can either be populated using the standard register, or "
 "from Business Invoices and Bills which will require Tax Tables to be set up "
 "correctly. Please see the documentation."
-msgstr "這些稅務科目可以從一般的登記簿中填寫，但在稅務表格有正確設定的情況下，也可以從商務發票或帳單中擷取。請見文件說明。"
+msgstr ""
+"這些稅務科目可以從一般的登記簿中填寫，但在稅務表格有正確設定的情況下，也可以"
+"從商務發票或帳單中擷取。請見文件說明。"
 
 #: gnucash/report/reports/standard/income-gst-statement.scm:60
 msgid ""
@@ -25405,8 +25467,10 @@ msgid ""
 "ASSET for taxes paid on expenses, and type LIABILITY for taxes collected on "
 "sales."
 msgstr ""
-"您必須在報表選項中選取記錄了已收和已付的商品與服務稅 / 加值稅的科目。這些科目必須含有在商品與服務稅 / "
-"加值稅申報期間中，已繳納或應扣除的稅金金額。對於支出時所付的稅金，必須是「資產」科目，對於銷售時收取的稅金，則必須是「負債」科目。"
+"您必須在報表選項中選取記錄了已收和已付的商品與服務稅 / 加值稅的科目。這些科目"
+"必須含有在商品與服務稅 / 加值稅申報期間中，已繳納或應扣除的稅金金額。對於支出"
+"時所付的稅金，必須是「資產」科目，對於銷售時收取的稅金，則必須是「負債」科"
+"目。"
 
 #: gnucash/report/reports/standard/income-gst-statement.scm:66
 msgid ""
@@ -25414,8 +25478,8 @@ msgid ""
 "in the VAT account description. EU Goods sales and purchase accounts may be "
 "tagged with *EUGOODS* in the account description."
 msgstr ""
-"注意英國的格式中，可能指定了歐盟加值稅科目的描述中必須標上 *EUVAT* 的標籤。歐盟貨物銷售或採購科目可以在科目的描述中標上 *EUGOODS* "
-"標籤。"
+"注意英國的格式中，可能指定了歐盟加值稅科目的描述中必須標上 *EUVAT* 的標籤。歐"
+"盟貨物銷售或採購科目可以在科目的描述中標上 *EUGOODS* 標籤。"
 
 #: gnucash/report/reports/standard/income-gst-statement.scm:71
 msgid "This message will be removed when tax accounts are specified."
@@ -25446,7 +25510,7 @@ msgid "Display individual tax columns rather than their sum"
 msgstr "於獨立的欄位顯示稅金，而非顯示總計"
 
 #: gnucash/report/reports/standard/income-gst-statement.scm:112
-#: gnucash/report/reports/standard/income-gst-statement.scm:349
+#: gnucash/report/reports/standard/income-gst-statement.scm:352
 msgid "Gross Balance"
 msgstr "總餘額"
 
@@ -25455,7 +25519,7 @@ msgid "Display the gross balance (gross sales - gross purchases)"
 msgstr "顯示總餘額(總銷售 - 總採購)"
 
 #: gnucash/report/reports/standard/income-gst-statement.scm:114
-#: gnucash/report/reports/standard/income-gst-statement.scm:357
+#: gnucash/report/reports/standard/income-gst-statement.scm:360
 msgid "Net Balance"
 msgstr "淨餘額"
 
@@ -25464,7 +25528,7 @@ msgid "Display the net balance (sales without tax - purchases without tax)"
 msgstr "顯示淨餘額(未稅銷售額 - 未稅採購額)"
 
 #: gnucash/report/reports/standard/income-gst-statement.scm:117
-#: gnucash/report/reports/standard/income-gst-statement.scm:364
+#: gnucash/report/reports/standard/income-gst-statement.scm:367
 msgid "Tax payable"
 msgstr "顯示應付稅額"
 
@@ -25488,66 +25552,67 @@ msgid ""
 "These accounts must be of type ASSET for taxes paid on expenses, and type "
 "LIABILITY for taxes collected on sales."
 msgstr ""
-"請選取記錄了已收和已付的商品與服務稅 / 加值稅的科目。這些科目必須含有在商品與服務稅 / "
-"加值稅申報期間中，已繳納或應扣除的稅金金額。對於支出時所付的稅金，必須是「資產」科目，對於銷售時收取的稅金，則必須是「負債」科目。"
+"請選取記錄了已收和已付的商品與服務稅 / 加值稅的科目。這些科目必須含有在商品與"
+"服務稅 / 加值稅申報期間中，已繳納或應扣除的稅金金額。對於支出時所付的稅金，必"
+"須是「資產」科目，對於銷售時收取的稅金，則必須是「負債」科目。"
 
 #: gnucash/report/reports/standard/income-gst-statement.scm:157
-#: gnucash/report/reports/standard/income-gst-statement.scm:158
+#: gnucash/report/reports/standard/income-gst-statement.scm:161
 msgid "Report Format"
 msgstr "報表格式"
 
-#: gnucash/report/reports/standard/income-gst-statement.scm:160
-#: gnucash/report/reports/standard/income-gst-statement.scm:161
+#: gnucash/report/reports/standard/income-gst-statement.scm:162
+#: gnucash/report/reports/standard/income-gst-statement.scm:171
 msgid "Default Format"
 msgstr "預設格式"
 
 #: gnucash/report/reports/standard/income-gst-statement.scm:163
-msgid "Australia BAS"
-msgstr "澳洲商務報表"
-
-#: gnucash/report/reports/standard/income-gst-statement.scm:164
 msgid ""
 "Australia Business Activity Statement. Specify sales, purchase and tax "
 "accounts."
 msgstr "澳洲商業活動報表。指定銷售、採購和稅務科目。"
 
-#: gnucash/report/reports/standard/income-gst-statement.scm:167
-msgid "UK VAT Return"
-msgstr "英國增值稅申報"
-
-#: gnucash/report/reports/standard/income-gst-statement.scm:168
+#: gnucash/report/reports/standard/income-gst-statement.scm:165
 msgid ""
 "UK VAT Return. Specify sales, purchase and tax accounts. EU rules may be "
 "used. Denote EU VAT accounts *EUVAT* in account description, and denote EU "
 "goods sales and purchases accounts with *EUGOODS* in the account description."
 msgstr ""
-"英國加值稅申報。指定銷售、採購和稅務科目。可使用歐盟規則。在科目描述中標記 *EUVAT* 代表歐盟加值稅科目，標記 *EUGOODS* "
-"代表貨物銷售或採購科目。"
+"英國加值稅申報。指定銷售、採購和稅務科目。可使用歐盟規則。在科目描述中標記 "
+"*EUVAT* 代表歐盟加值稅科目，標記 *EUGOODS* 代表貨物銷售或採購科目。"
+
+#: gnucash/report/reports/standard/income-gst-statement.scm:172
+msgid "Australia BAS"
+msgstr "澳洲商務報表"
+
+#: gnucash/report/reports/standard/income-gst-statement.scm:173
+msgid "UK VAT Return"
+msgstr "英國增值稅申報"
 
 #. Translators: "Gross Sales" refer to Net Sales + GST/VAT on Sales
-#: gnucash/report/reports/standard/income-gst-statement.scm:309
+#: gnucash/report/reports/standard/income-gst-statement.scm:312
 msgid "Gross Sales"
 msgstr "銷總額售"
 
-#: gnucash/report/reports/standard/income-gst-statement.scm:316
+#: gnucash/report/reports/standard/income-gst-statement.scm:319
 msgid "Net Sales"
 msgstr "淨銷售"
 
-#: gnucash/report/reports/standard/income-gst-statement.scm:323
+#: gnucash/report/reports/standard/income-gst-statement.scm:326
 msgid "Tax on Sales"
 msgstr "銷售稅額"
 
 #. Translators: "Gross Purchases" refer to Net Purchase +
 #. GST/VAT on Purchase
-#: gnucash/report/reports/standard/income-gst-statement.scm:327
+#: gnucash/report/reports/standard/income-gst-statement.scm:330
 msgid "Gross Purchases"
 msgstr "總採購額"
 
-#: gnucash/report/reports/standard/income-gst-statement.scm:335
+#: gnucash/report/reports/standard/income-gst-statement.scm:338
 msgid "Net Purchases"
 msgstr "淨採購額"
 
-#: gnucash/report/reports/standard/income-gst-statement.scm:343
+#: gnucash/report/reports/standard/income-gst-statement.scm:346
 msgid "Tax on Purchases"
 msgstr "採購稅額"
 
@@ -25569,8 +25634,7 @@ msgid ""
 msgstr "是否在報表中包括交易科目結餘。"
 
 #: gnucash/report/reports/standard/income-statement.scm:517
-#: libgnucash/engine/Account.cpp:4401 libgnucash/engine/Scrub.c:481
-#: libgnucash/engine/Scrub.c:549
+#: libgnucash/engine/Account.cpp:4407 libgnucash/engine/Scrub.c:486
 msgid "Trading"
 msgstr "交易"
 
@@ -25579,7 +25643,7 @@ msgid "Total Trading"
 msgstr "交易總額"
 
 #: gnucash/report/reports/standard/income-statement.scm:571
-#: gnucash/report/reports/standard/trial-balance.scm:573
+#: gnucash/report/reports/standard/trial-balance.scm:567
 msgid "Income Statement"
 msgstr "損益表"
 
@@ -25588,7 +25652,7 @@ msgid "Profit & Loss"
 msgstr "損益"
 
 #: gnucash/report/reports/standard/invoice.scm:102
-#: gnucash/report/reports/standard/invoice.scm:247
+#: gnucash/report/reports/standard/invoice.scm:234
 #: gnucash/report/reports/standard/receipt.scm:60
 #: gnucash/report/reports/standard/receipt.scm:131
 #: gnucash/report/reports/standard/taxinvoice.scm:116
@@ -25596,90 +25660,70 @@ msgstr "損益"
 msgid "Tax Amount"
 msgstr "稅金總額"
 
-#. Translators: "Their details" refer to the invoice 'other party' details i.e. client/vendor name/address/ID
-#: gnucash/report/reports/standard/invoice.scm:113
-msgid "Their details"
-msgstr ""
-
-#: gnucash/report/reports/standard/invoice.scm:114
+#: gnucash/report/reports/standard/invoice.scm:112
 msgid "Client or vendor name, address and ID"
 msgstr "客戶或廠商名稱、地址與 ID"
 
-#. Translators: "Our details" refer to the book owner's details i.e. name/address/tax-ID
-#: gnucash/report/reports/standard/invoice.scm:117
-#, fuzzy
-msgid "Our details"
-msgstr "工作對話盒"
-
-#: gnucash/report/reports/standard/invoice.scm:118
+#: gnucash/report/reports/standard/invoice.scm:113
 msgid "Company name, address and tax-ID"
 msgstr "公司的名稱、地址與稅號"
 
-#: gnucash/report/reports/standard/invoice.scm:120
-#, fuzzy
-msgid "Invoice details"
-msgstr "發票項目"
-
-#: gnucash/report/reports/standard/invoice.scm:121
+#: gnucash/report/reports/standard/invoice.scm:114
 msgid "Invoice date, due date, billing ID, terms, job details"
 msgstr "發票日期、到期日、帳單 ID、條款、工作詳情"
 
-#: gnucash/report/reports/standard/invoice.scm:123
-#: gnucash/report/reports/standard/invoice.scm:124
+#: gnucash/report/reports/standard/invoice.scm:115
 msgid "Today's date"
 msgstr "今日日期"
 
-#: gnucash/report/reports/standard/invoice.scm:126
-#: gnucash/report/reports/standard/invoice.scm:127
+#: gnucash/report/reports/standard/invoice.scm:116
 msgid "Picture"
 msgstr "圖片"
 
-#. Translators: "(empty)" refers to invoice header section being left blank
-#: gnucash/report/reports/standard/invoice.scm:130
-msgid "(empty)"
-msgstr "(空白)"
-
-#: gnucash/report/reports/standard/invoice.scm:131
+#. Translators: "Empty space" refers to invoice header section being left blank
+#: gnucash/report/reports/standard/invoice.scm:119
 msgid "Empty space"
 msgstr "空白空間"
 
-#: gnucash/report/reports/standard/invoice.scm:195
+#: gnucash/report/reports/standard/invoice.scm:182
 msgid "Custom Title"
 msgstr "自訂標題"
 
-#: gnucash/report/reports/standard/invoice.scm:196
+#: gnucash/report/reports/standard/invoice.scm:183
 msgid "A custom string to replace Invoice, Bill or Expense Voucher."
 msgstr "用以取代發票 / 帳單 / 消費憑證的客製化字串。"
 
-#: gnucash/report/reports/standard/invoice.scm:201
+#: gnucash/report/reports/standard/invoice.scm:188
 #: gnucash/report/stylesheets/css.scm:118
 #: gnucash/report/stylesheets/css.scm:224
 msgid "CSS"
 msgstr "CSS"
 
-#: gnucash/report/reports/standard/invoice.scm:201
+#: gnucash/report/reports/standard/invoice.scm:188
 msgid ""
 "CSS code. This field specifies the CSS code for styling the invoice. Please "
 "see the exported report for the CSS class names."
-msgstr "CSS 程式碼。這個欄位用來指定發票風格的 CSS 程式碼。請檢視匯出的報表，以取得 CSS 的類別名稱。"
+msgstr ""
+"CSS 程式碼。這個欄位用來指定發票風格的 CSS 程式碼。請檢視匯出的報表，以取得 "
+"CSS 的類別名稱。"
 
-#: gnucash/report/reports/standard/invoice.scm:207
+#: gnucash/report/reports/standard/invoice.scm:194
 msgid "Picture Location"
 msgstr "圖片位置"
 
-#: gnucash/report/reports/standard/invoice.scm:207
+#: gnucash/report/reports/standard/invoice.scm:194
 msgid "Location for Picture"
 msgstr "圖片的位置"
 
-#: gnucash/report/reports/standard/invoice.scm:212
-#: gnucash/report/reports/standard/invoice.scm:217
-#: gnucash/report/reports/standard/invoice.scm:222
-#: gnucash/report/reports/standard/invoice.scm:227
-#: gnucash/report/reports/standard/invoice.scm:232
-#: gnucash/report/reports/standard/invoice.scm:237
-#: gnucash/report/reports/standard/invoice.scm:242
-#: gnucash/report/reports/standard/invoice.scm:247
-#: gnucash/report/reports/standard/invoice.scm:252
+#: gnucash/report/reports/standard/invoice.scm:199
+#: gnucash/report/reports/standard/invoice.scm:204
+#: gnucash/report/reports/standard/invoice.scm:209
+#: gnucash/report/reports/standard/invoice.scm:214
+#: gnucash/report/reports/standard/invoice.scm:219
+#: gnucash/report/reports/standard/invoice.scm:224
+#: gnucash/report/reports/standard/invoice.scm:229
+#: gnucash/report/reports/standard/invoice.scm:234
+#: gnucash/report/reports/standard/invoice.scm:239
 #: gnucash/report/reports/standard/job-report.scm:369
 #: gnucash/report/reports/standard/job-report.scm:374
 #: gnucash/report/reports/standard/job-report.scm:379
@@ -25697,7 +25741,7 @@ msgstr "圖片的位置"
 #: gnucash/report/reports/standard/new-owner-report.scm:936
 #: gnucash/report/reports/standard/new-owner-report.scm:941
 #: gnucash/report/reports/standard/new-owner-report.scm:946
-#: gnucash/report/reports/standard/new-owner-report.scm:961
+#: gnucash/report/reports/standard/new-owner-report.scm:962
 #: gnucash/report/reports/standard/owner-report.scm:556
 #: gnucash/report/reports/standard/owner-report.scm:561
 #: gnucash/report/reports/standard/owner-report.scm:566
@@ -25711,205 +25755,205 @@ msgstr "圖片的位置"
 msgid "Display Columns"
 msgstr "顯示欄"
 
-#: gnucash/report/reports/standard/invoice.scm:213
+#: gnucash/report/reports/standard/invoice.scm:200
 #: gnucash/report/reports/standard/register.scm:354
 #: gnucash/report/reports/standard/taxinvoice.scm:135
-#: gnucash/report/trep-engine.scm:966
+#: gnucash/report/trep-engine.scm:915
 msgid "Display the date?"
 msgstr "是否顯示日期？"
 
-#: gnucash/report/reports/standard/invoice.scm:218
+#: gnucash/report/reports/standard/invoice.scm:205
 #: gnucash/report/reports/standard/register.scm:369
-#: gnucash/report/trep-engine.scm:971
+#: gnucash/report/trep-engine.scm:920
 msgid "Display the description?"
 msgstr "是否顯示敘述？"
 
-#: gnucash/report/reports/standard/invoice.scm:223
+#: gnucash/report/reports/standard/invoice.scm:210
 msgid "Display the action?"
 msgstr "是否顯示動作？"
 
-#: gnucash/report/reports/standard/invoice.scm:228
+#: gnucash/report/reports/standard/invoice.scm:215
 msgid "Display the quantity of items?"
 msgstr "是否顯示項目的數量？"
 
-#: gnucash/report/reports/standard/invoice.scm:233
+#: gnucash/report/reports/standard/invoice.scm:220
 msgid "Display the price per item?"
 msgstr "顯示每個項目的價格？"
 
-#: gnucash/report/reports/standard/invoice.scm:238
+#: gnucash/report/reports/standard/invoice.scm:225
 msgid "Display the entry's discount?"
 msgstr "顯示項目的折扣？"
 
-#: gnucash/report/reports/standard/invoice.scm:243
+#: gnucash/report/reports/standard/invoice.scm:230
 msgid "Display the entry's taxable status?"
 msgstr "顯示項目的含稅狀態？"
 
-#: gnucash/report/reports/standard/invoice.scm:248
+#: gnucash/report/reports/standard/invoice.scm:235
 msgid "Display each entry's total total tax?"
 msgstr "顯示每個項目總計稅金總額？"
 
-#: gnucash/report/reports/standard/invoice.scm:253
+#: gnucash/report/reports/standard/invoice.scm:240
 msgid "Display the entry's value?"
 msgstr "顯示項目的價值？"
 
-#: gnucash/report/reports/standard/invoice.scm:258
+#: gnucash/report/reports/standard/invoice.scm:245
 msgid "Display due date?"
 msgstr "是否顯示到期日？"
 
-#: gnucash/report/reports/standard/invoice.scm:263
+#: gnucash/report/reports/standard/invoice.scm:250
 msgid "Display the subtotals?"
 msgstr "是否顯示小計？"
 
-#: gnucash/report/reports/standard/invoice.scm:267
+#: gnucash/report/reports/standard/invoice.scm:254
 msgid "Payable to"
 msgstr "應付給"
 
-#: gnucash/report/reports/standard/invoice.scm:268
+#: gnucash/report/reports/standard/invoice.scm:255
 msgid "Display the Payable to: information."
 msgstr "顯示應付：資訊。"
 
-#: gnucash/report/reports/standard/invoice.scm:275
+#: gnucash/report/reports/standard/invoice.scm:262
 msgid "Payable to string"
 msgstr "應付給字串"
 
-#: gnucash/report/reports/standard/invoice.scm:276
+#: gnucash/report/reports/standard/invoice.scm:263
 msgid "The phrase for specifying to whom payments should be made."
 msgstr "用來顯示應該付款給誰的語句。"
 
-#: gnucash/report/reports/standard/invoice.scm:277
+#: gnucash/report/reports/standard/invoice.scm:264
 msgid "Please make all checks payable to"
 msgstr "請將所有支票支付給"
 
-#: gnucash/report/reports/standard/invoice.scm:281
+#: gnucash/report/reports/standard/invoice.scm:268
 msgid "Company contact"
 msgstr "公司連絡方式"
 
-#: gnucash/report/reports/standard/invoice.scm:282
+#: gnucash/report/reports/standard/invoice.scm:269
 msgid "Display the Company contact information."
 msgstr "顯示公司聯絡資訊。"
 
-#: gnucash/report/reports/standard/invoice.scm:288
+#: gnucash/report/reports/standard/invoice.scm:275
 msgid "Company contact string"
 msgstr "公司聯絡字串"
 
-#: gnucash/report/reports/standard/invoice.scm:289
+#: gnucash/report/reports/standard/invoice.scm:276
 msgid "The phrase used to introduce the company contact."
 msgstr "用來介紹公司連絡人的文字。"
 
-#: gnucash/report/reports/standard/invoice.scm:290
+#: gnucash/report/reports/standard/invoice.scm:277
 msgid "Please direct all enquiries to"
 msgstr "請將所有詢問導向"
 
-#: gnucash/report/reports/standard/invoice.scm:294
+#: gnucash/report/reports/standard/invoice.scm:281
 msgid "Minimum # of entries"
 msgstr "最低項目數量"
 
-#: gnucash/report/reports/standard/invoice.scm:295
+#: gnucash/report/reports/standard/invoice.scm:282
 msgid "The minimum number of invoice entries to display."
 msgstr "最少顯示多少發票項目。"
 
-#: gnucash/report/reports/standard/invoice.scm:300
+#: gnucash/report/reports/standard/invoice.scm:287
 msgid "Use Detailed Tax Summary"
 msgstr "使用詳細的稅額摘要"
 
-#: gnucash/report/reports/standard/invoice.scm:301
+#: gnucash/report/reports/standard/invoice.scm:288
 msgid ""
 "Display all tax categories separately (one per line) instead of one single "
 "tax line.?"
 msgstr "針對所有的稅別單獨列出(一行一個)，而不僅用使用單一行顯示稅務資訊？"
 
-#: gnucash/report/reports/standard/invoice.scm:307
+#: gnucash/report/reports/standard/invoice.scm:294
 msgid "References"
 msgstr "參照"
 
-#: gnucash/report/reports/standard/invoice.scm:308
+#: gnucash/report/reports/standard/invoice.scm:295
 msgid "Display the invoice references?"
 msgstr "是否顯示發票參照？"
 
-#: gnucash/report/reports/standard/invoice.scm:312
+#: gnucash/report/reports/standard/invoice.scm:299
 msgid "Billing Terms"
 msgstr "支付條款"
 
-#: gnucash/report/reports/standard/invoice.scm:313
+#: gnucash/report/reports/standard/invoice.scm:300
 msgid "Display the invoice billing terms?"
 msgstr "是否顯示發票支付條款？"
 
-#: gnucash/report/reports/standard/invoice.scm:318
+#: gnucash/report/reports/standard/invoice.scm:305
 msgid "Display the billing id?"
 msgstr "是否顯示記帳 id？"
 
-#: gnucash/report/reports/standard/invoice.scm:322
+#: gnucash/report/reports/standard/invoice.scm:309
 msgid "Invoice owner ID"
 msgstr "發票所有者 ID"
 
-#: gnucash/report/reports/standard/invoice.scm:323
+#: gnucash/report/reports/standard/invoice.scm:310
 msgid "Display the customer/vendor id?"
 msgstr "是否顯示客戶 / 廠商 ID ？"
 
-#: gnucash/report/reports/standard/invoice.scm:328
+#: gnucash/report/reports/standard/invoice.scm:315
 msgid "Display the invoice notes?"
 msgstr "是否顯示發票備註？"
 
-#: gnucash/report/reports/standard/invoice.scm:332
+#: gnucash/report/reports/standard/invoice.scm:319
 msgid "Payments"
 msgstr "付款"
 
-#: gnucash/report/reports/standard/invoice.scm:333
+#: gnucash/report/reports/standard/invoice.scm:320
 msgid "Display the payments applied to this invoice?"
 msgstr "是否顯示此發票的付款？"
 
-#: gnucash/report/reports/standard/invoice.scm:337
+#: gnucash/report/reports/standard/invoice.scm:324
 msgid "Job Details"
 msgstr "工作詳情"
 
-#: gnucash/report/reports/standard/invoice.scm:338
+#: gnucash/report/reports/standard/invoice.scm:325
 msgid "Display the job name for this invoice?"
 msgstr "是否顯示此發票的工作名稱？"
 
-#: gnucash/report/reports/standard/invoice.scm:343
+#: gnucash/report/reports/standard/invoice.scm:330
 msgid "Extra notes to put on the invoice."
 msgstr "發票上的額外備註。"
 
-#: gnucash/report/reports/standard/invoice.scm:344
+#: gnucash/report/reports/standard/invoice.scm:331
 #: gnucash/report/reports/standard/taxinvoice.scm:213
 msgid "Thank you for your patronage!"
 msgstr "謝謝惠顧！"
 
-#: gnucash/report/reports/standard/invoice.scm:348
+#: gnucash/report/reports/standard/invoice.scm:335
 msgid "Row 1 Left"
 msgstr "第一列左側"
 
-#: gnucash/report/reports/standard/invoice.scm:355
+#: gnucash/report/reports/standard/invoice.scm:342
 msgid "Row 1 Right"
 msgstr "第一列右側"
 
-#: gnucash/report/reports/standard/invoice.scm:362
+#: gnucash/report/reports/standard/invoice.scm:349
 msgid "Row 2 Left"
 msgstr "第二列左側"
 
-#: gnucash/report/reports/standard/invoice.scm:369
+#: gnucash/report/reports/standard/invoice.scm:356
 msgid "Row 2 Right"
 msgstr "第二列右側"
 
-#: gnucash/report/reports/standard/invoice.scm:376
+#: gnucash/report/reports/standard/invoice.scm:363
 msgid "Row 3 Left"
 msgstr "第三列左側"
 
-#: gnucash/report/reports/standard/invoice.scm:383
+#: gnucash/report/reports/standard/invoice.scm:370
 msgid "Row 3 Right"
 msgstr "第三列右側"
 
-#: gnucash/report/reports/standard/invoice.scm:436
+#: gnucash/report/reports/standard/invoice.scm:423
 #: gnucash/report/reports/standard/job-report.scm:239
 msgid "Payment, thank you!"
 msgstr "已付款，謝謝您！"
 
 #. Translators: This "T" is displayed in the taxable column, if this entry contains tax
-#: gnucash/report/reports/standard/invoice.scm:491
+#: gnucash/report/reports/standard/invoice.scm:478
 msgid "T"
 msgstr "稅率"
 
-#: gnucash/report/reports/standard/invoice.scm:538
+#: gnucash/report/reports/standard/invoice.scm:525
 #: gnucash/report/reports/standard/receipt.scm:58
 #: gnucash/report/reports/standard/receipt.scm:127
 #: gnucash/report/reports/standard/taxinvoice.scm:114
@@ -25917,7 +25961,7 @@ msgstr "稅率"
 msgid "Net Price"
 msgstr "淨額"
 
-#: gnucash/report/reports/standard/invoice.scm:554
+#: gnucash/report/reports/standard/invoice.scm:541
 #: gnucash/report/reports/standard/receipt.scm:61
 #: gnucash/report/reports/standard/receipt.scm:133
 #: gnucash/report/reports/standard/taxinvoice.scm:117
@@ -25925,7 +25969,7 @@ msgstr "淨額"
 msgid "Total Price"
 msgstr "總額"
 
-#: gnucash/report/reports/standard/invoice.scm:574
+#: gnucash/report/reports/standard/invoice.scm:561
 #: gnucash/report/reports/standard/receipt.scm:63
 #: gnucash/report/reports/standard/receipt.scm:137
 #: gnucash/report/reports/standard/taxinvoice.scm:119
@@ -25933,32 +25977,32 @@ msgstr "總額"
 msgid "Amount Due"
 msgstr "到期總數"
 
-#: gnucash/report/reports/standard/invoice.scm:615
+#: gnucash/report/reports/standard/invoice.scm:602
 #: gnucash/report/reports/support/taxinvoice.eguile.scm:225
 msgid "Invoice in progress..."
 msgstr "發票處理中..."
 
-#: gnucash/report/reports/standard/invoice.scm:623
+#: gnucash/report/reports/standard/invoice.scm:610
 msgid "Reference:"
 msgstr "參照："
 
-#: gnucash/report/reports/standard/invoice.scm:635
+#: gnucash/report/reports/standard/invoice.scm:622
 msgid "Terms:"
 msgstr "條款:"
 
-#: gnucash/report/reports/standard/invoice.scm:645
+#: gnucash/report/reports/standard/invoice.scm:632
 msgid "Job number:"
 msgstr "工作編號："
 
-#: gnucash/report/reports/standard/invoice.scm:650
+#: gnucash/report/reports/standard/invoice.scm:637
 msgid "Job name:"
 msgstr "工作名稱："
 
-#: gnucash/report/reports/standard/invoice.scm:696
+#: gnucash/report/reports/standard/invoice.scm:683
 msgid "REF"
 msgstr "參照"
 
-#: gnucash/report/reports/standard/invoice.scm:777
+#: gnucash/report/reports/standard/invoice.scm:764
 msgid ""
 "No valid invoice selected. Click on the Options button and select the "
 "invoice to use."
@@ -25967,7 +26011,7 @@ msgstr "未選擇有效的發票。點選「選項」按鈕並選取發票。"
 #. Translators: This is the format of the invoice title.
 #. The first ~a is "Invoice", "Credit Note"... and the second the number.
 #. Replace " #" by whatever is common as number abbreviation, i.e. "~a Nr. ~a"
-#: gnucash/report/reports/standard/invoice.scm:800
+#: gnucash/report/reports/standard/invoice.scm:787
 #, scheme-format
 msgid "~a #~a"
 msgstr "~a #~a"
@@ -26026,7 +26070,7 @@ msgid "Display the transaction amount?"
 msgstr "是否顯示交易金額？"
 
 #: gnucash/report/reports/standard/job-report.scm:508
-#: gnucash/report/reports/standard/new-owner-report.scm:1234
+#: gnucash/report/reports/standard/new-owner-report.scm:1229
 msgid "Job Report"
 msgstr "工作報表"
 
@@ -26139,69 +26183,48 @@ msgstr "收入 & 支出折線圖"
 msgid ""
 "No valid A/Payable or A/Receivable account found. Please ensure valid AP/AR "
 "account exists."
-msgstr "沒有有效的應付帳款或應收帳款科目。請確認科目體系裡有應收或應付帳款科目。"
+msgstr ""
+"沒有有效的應付帳款或應收帳款科目。請確認科目體系裡有應收或應付帳款科目。"
 
 #: gnucash/report/reports/standard/new-aging.scm:64
 msgid ""
 "A/Payable or A/Receivable accounts exist but have no suitable transactions."
 msgstr "有應收或應付帳款科目，但沒有適合的交易。"
 
-#: gnucash/report/reports/standard/new-aging.scm:109
-#, fuzzy
-msgid "Alphabetical order"
-msgstr "字母順序"
-
-#: gnucash/report/reports/standard/new-aging.scm:110
-#, fuzzy
-msgid "Reverse alphabetical order"
-msgstr "登記簿順序"
-
-#: gnucash/report/reports/standard/new-aging.scm:341
+#: gnucash/report/reports/standard/new-aging.scm:329
 #: gnucash/report/reports/standard/new-owner-report.scm:546
 msgid "Please note some transactions were not processed"
 msgstr "請注意有些交易沒有被處理"
 
-#: gnucash/report/reports/standard/new-aging.scm:374
+#: gnucash/report/reports/standard/new-aging.scm:362
 #, scheme-format
 msgid "Invalid Txn Type ~a"
 msgstr "無效的交易類型 ~a"
 
-#: gnucash/report/reports/standard/new-aging.scm:384
+#: gnucash/report/reports/standard/new-aging.scm:372
 msgid "Payment has no owner"
 msgstr "付款沒有所有者"
 
-#: gnucash/report/reports/standard/new-aging.scm:414
+#: gnucash/report/reports/standard/new-aging.scm:402
 #: gnucash/report/reports/standard/receivables.scm:65
 msgid "Address source."
 msgstr "地址來源。"
 
-#: gnucash/report/reports/standard/new-aging.scm:417
+#: gnucash/report/reports/standard/new-aging.scm:404
 #: gnucash/report/reports/standard/receivables.scm:68
-msgid "Billing"
-msgstr "帳單"
+msgid "Billing address"
+msgstr "帳單地址"
 
-#: gnucash/report/reports/standard/new-aging.scm:418
-#: gnucash/report/reports/standard/receivables.scm:68
-#, fuzzy
-msgid "Address fields from billing address."
-msgstr "您必須輸入帳單地址。"
-
-#: gnucash/report/reports/standard/new-aging.scm:420
+#: gnucash/report/reports/standard/new-aging.scm:405
 #: gnucash/report/reports/standard/receivables.scm:69
-#, fuzzy
-msgid "Shipping"
-msgstr "出貨連絡人"
+msgid "Shipping address"
+msgstr "出貨地址"
 
-#: gnucash/report/reports/standard/new-aging.scm:421
-#: gnucash/report/reports/standard/receivables.scm:69
-msgid "Address fields from shipping address."
-msgstr ""
-
-#: gnucash/report/reports/standard/new-aging.scm:435
+#: gnucash/report/reports/standard/new-aging.scm:419
 msgid "Payable Aging"
 msgstr "應付帳款帳齡"
 
-#: gnucash/report/reports/standard/new-aging.scm:444
+#: gnucash/report/reports/standard/new-aging.scm:428
 msgid "Receivable Aging"
 msgstr "應收帳款帳齡"
 
@@ -26252,7 +26275,7 @@ msgid "Partial Amount"
 msgstr "剩餘金額"
 
 #: gnucash/report/reports/standard/new-owner-report.scm:299
-#: gnucash/report/trep-engine.scm:980 gnucash/report/trep-engine.scm:1106
+#: gnucash/report/trep-engine.scm:929 gnucash/report/trep-engine.scm:1051
 msgid "Link"
 msgstr "連結"
 
@@ -26299,52 +26322,52 @@ msgstr "顯示期間的貸方欄？"
 
 #: gnucash/report/reports/standard/new-owner-report.scm:942
 #: gnucash/report/reports/standard/register.scm:413
-#: gnucash/report/trep-engine.scm:984
+#: gnucash/report/trep-engine.scm:933
 msgid "Display a running balance?"
 msgstr "顯示逐筆結計的餘額？"
 
-#: gnucash/report/reports/standard/new-owner-report.scm:947
+#: gnucash/report/reports/standard/new-owner-report.scm:950
 msgid "Show linked transactions"
 msgstr "顯示連結的交易"
 
-#: gnucash/report/reports/standard/new-owner-report.scm:950
+#: gnucash/report/reports/standard/new-owner-report.scm:951
 msgid "Linked transactions are hidden."
 msgstr "連結的交易已被隱藏。"
 
 #: gnucash/report/reports/standard/new-owner-report.scm:952
-msgid "Simple"
-msgstr "簡單"
-
-#: gnucash/report/reports/standard/new-owner-report.scm:953
 msgid "Invoices show if paid, payments show invoice numbers."
 msgstr "發票顯示是否已支付，付款顯示發票號碼。"
 
-#: gnucash/report/reports/standard/new-owner-report.scm:955
-msgid "Detailed"
-msgstr "詳細"
-
-#: gnucash/report/reports/standard/new-owner-report.scm:956
+#: gnucash/report/reports/standard/new-owner-report.scm:953
 msgid ""
 "Invoices show list of payments, payments show list of invoices and amounts."
 msgstr "發票顯示付款列表，付款顯示發票列表及金額。"
 
-#: gnucash/report/reports/standard/new-owner-report.scm:962
+#: gnucash/report/reports/standard/new-owner-report.scm:957
+msgid "Simple"
+msgstr "簡單"
+
+#: gnucash/report/reports/standard/new-owner-report.scm:958
+msgid "Detailed"
+msgstr "詳細"
+
+#: gnucash/report/reports/standard/new-owner-report.scm:963
 msgid "Display document link?"
 msgstr "顯示文件連結？"
 
-#: gnucash/report/reports/standard/new-owner-report.scm:1087
+#: gnucash/report/reports/standard/new-owner-report.scm:1082
 msgid "No valid account found"
 msgstr "找不到有效的科目"
 
-#: gnucash/report/reports/standard/new-owner-report.scm:1088
+#: gnucash/report/reports/standard/new-owner-report.scm:1083
 msgid "This report requires a valid AP/AR account to be available."
 msgstr "這個報表需要有有效的應收 / 應付科目才能使用。"
 
-#: gnucash/report/reports/standard/new-owner-report.scm:1111
+#: gnucash/report/reports/standard/new-owner-report.scm:1106
 msgid "No transactions found."
 msgstr "找不到交易。"
 
-#: gnucash/report/reports/standard/new-owner-report.scm:1112
+#: gnucash/report/reports/standard/new-owner-report.scm:1107
 #: gnucash/report/trep-engine.scm:130
 msgid "No matching transactions found"
 msgstr "找不到相符的交易"
@@ -26409,72 +26432,66 @@ msgstr "標記顏色"
 msgid "Calculate the price of this commodity."
 msgstr "計算此商品的價格。"
 
-#: gnucash/report/reports/standard/price-scatter.scm:84
+#: gnucash/report/reports/standard/price-scatter.scm:80
+msgid "Weighted Average"
+msgstr "加權平均數"
+
+#: gnucash/report/reports/standard/price-scatter.scm:81
 msgid "Actual Transactions"
 msgstr "實際交易"
 
-#: gnucash/report/reports/standard/price-scatter.scm:85
-#, fuzzy
-msgid "The instantaneous price of actual currency transactions in the past."
-msgstr "過去實際貨幣交易的即時價格"
-
 #: gnucash/report/reports/standard/price-scatter.scm:88
-#, fuzzy
-msgid "The recorded prices."
-msgstr "記錄的價格"
-
-#: gnucash/report/reports/standard/price-scatter.scm:95
 msgid "Plot commodity per currency rather than currency per commodity."
 msgstr "畫出每一單位貨幣所能兌換的商品數量，而非每單位商品數量所需的貨幣。"
 
-#: gnucash/report/reports/standard/price-scatter.scm:111
+#: gnucash/report/reports/standard/price-scatter.scm:104
 msgid "Color of the marker."
 msgstr "標記的顏色。"
 
-#: gnucash/report/reports/standard/price-scatter.scm:131
+#: gnucash/report/reports/standard/price-scatter.scm:124
 msgid "Double-Weeks"
 msgstr "雙週"
 
-#: gnucash/report/reports/standard/price-scatter.scm:133
+#: gnucash/report/reports/standard/price-scatter.scm:126
 msgid "Quarters"
 msgstr "季"
 
-#: gnucash/report/reports/standard/price-scatter.scm:134
+#: gnucash/report/reports/standard/price-scatter.scm:127
 msgid "Half Years"
 msgstr "半年"
 
-#: gnucash/report/reports/standard/price-scatter.scm:229
+#: gnucash/report/reports/standard/price-scatter.scm:222
 msgid "Identical commodities"
 msgstr "完全相同的商品"
 
-#: gnucash/report/reports/standard/price-scatter.scm:230
+#: gnucash/report/reports/standard/price-scatter.scm:223
 msgid ""
 "Your selected commodity and the currency of the report are identical. It "
 "doesn't make sense to show prices for identical commodities."
 msgstr "您選擇的商品與報表的貨幣是完全相同的。顯示同樣商品的價格是沒意義的。"
 
-#: gnucash/report/reports/standard/price-scatter.scm:268
+#: gnucash/report/reports/standard/price-scatter.scm:261
 msgid ""
 "There is no price information available for the selected commodities in the "
 "selected time period."
 msgstr "所選定的商品在指定的時間週期中並沒有可用的價格資訊。"
 
-#: gnucash/report/reports/standard/price-scatter.scm:273
+#: gnucash/report/reports/standard/price-scatter.scm:266
 msgid "Only one price"
 msgstr "只有一個價格"
 
-#: gnucash/report/reports/standard/price-scatter.scm:274
+#: gnucash/report/reports/standard/price-scatter.scm:267
 msgid ""
 "There was only one single price found for the selected commodities in the "
 "selected time period. This doesn't give a useful plot."
 msgstr ""
 "所選定的商品在指定的時間週期中僅能找到一個價格。這並不能成為一張有用的圖。"
 
-#: gnucash/report/reports/standard/price-scatter.scm:280
+#: gnucash/report/reports/standard/price-scatter.scm:273
 msgid "All Prices equal"
 msgstr "所有價格均等"
 
-#: gnucash/report/reports/standard/price-scatter.scm:281
+#: gnucash/report/reports/standard/price-scatter.scm:274
 msgid ""
 "All the prices found are equal. This would result in a plot with one "
 "straight line. Unfortunately, the plotting tool can't handle that."
@@ -26482,11 +26499,11 @@ msgstr ""
 "所有找到的價格都相等。這會產生一個只有一條直線的圖。很不幸地，繪圖工具不能處"
 "理這種情況。"
 
-#: gnucash/report/reports/standard/price-scatter.scm:287
+#: gnucash/report/reports/standard/price-scatter.scm:280
 msgid "All Prices at the same date"
 msgstr "所有價格的日期相同"
 
-#: gnucash/report/reports/standard/price-scatter.scm:288
+#: gnucash/report/reports/standard/price-scatter.scm:281
 msgid ""
 "All the prices found are from the same date. This would result in a plot "
 "with one straight line. Unfortunately, the plotting tool can't handle that."
@@ -26494,7 +26511,7 @@ msgstr ""
 "所有找到的價格日期都相同。這會產生只有一條直線的圖。很不幸地，繪圖工具不能處"
 "理這種情況。"
 
-#: gnucash/report/reports/standard/price-scatter.scm:320
+#: gnucash/report/reports/standard/price-scatter.scm:313
 msgid "Price Scatterplot"
 msgstr "價格散佈圖"
 
@@ -26599,7 +26616,9 @@ msgid ""
 "The file name of the eguile template part of this report. This file should "
 "either be in your .gnucash directory, or else in its proper place within the "
 "GnuCash installation directories."
-msgstr "此份報表所要使用的 eguile 模板檔案名稱。此檔案應位於您的 .gnucash 資料夾，或是 GnuCash 所安裝的資料夾裡適當的位置。"
+msgstr ""
+"此份報表所要使用的 eguile 模板檔案名稱。此檔案應位於您的 .gnucash 資料夾，或"
+"是 GnuCash 所安裝的資料夾裡適當的位置。"
 
 #: gnucash/report/reports/standard/receipt.scm:84
 #: gnucash/report/reports/standard/taxinvoice.scm:152
@@ -26607,7 +26626,9 @@ msgid ""
 "The file name of the CSS stylesheet to use with this report. This file "
 "should either be in your .gnucash directory, or else in its proper place "
 "within the GnuCash installation directories."
-msgstr "此份報表所要使用的 CSS 樣式表檔案名稱。此檔案應位於您的 .gnucash 資料夾，或是 GnuCash 所安裝的資料夾裡適當的位置。"
+msgstr ""
+"此份報表所要使用的 CSS 樣式表檔案名稱。此檔案應位於您的 .gnucash 資料夾，或"
+"是 GnuCash 所安裝的資料夾裡適當的位置。"
 
 #: gnucash/report/reports/standard/receipt.scm:88
 #: gnucash/report/reports/standard/taxinvoice.scm:156
@@ -26628,7 +26649,9 @@ msgid ""
 "Width of the header logo in CSS format, e.g. 10% or 32px. Leave blank to "
 "display the logo at its natural width. The height of the logo will be scaled "
 "accordingly."
-msgstr "標頭的商標的寬度，以 CSS 的型式來表示，例如 10% 或 32px。若留白則會使用預設的寬度，高度將會自動依照寬度進行調整。"
+msgstr ""
+"標頭的商標的寬度，以 CSS 的型式來表示，例如 10% 或 32px。若留白則會使用預設的"
+"寬度，高度將會自動依照寬度進行調整。"
 
 #: gnucash/report/reports/standard/receipt.scm:100
 msgid "Name of a file containing a logo to be used on the footer of the report"
@@ -26639,7 +26662,9 @@ msgid ""
 "Width of the footer logo in CSS format, e.g. 10% or 32px. Leave blank to "
 "display the logo at its natural width. The height of the logo will be scaled "
 "accordingly."
-msgstr "註腳的商標的寬度，以 CSS 的型式來表示，例如 10% 或 32px。若留白則會使用預設的寬度，高度將會自動依照寬度進行調整。"
+msgstr ""
+"註腳的商標的寬度，以 CSS 的型式來表示，例如 10% 或 32px。若留白則會使用預設的"
+"寬度，高度將會自動依照寬度進行調整。"
 
 #: gnucash/report/reports/standard/receipt.scm:107
 msgid "The format for the date->string conversion for today's date."
@@ -26677,7 +26702,9 @@ msgid ""
 "The reconcile report is designed to be similar to the formal reconciliation "
 "tool. Please select the account from Report Options. Please note the dates "
 "specified in the options will apply to the Reconciliation Date."
-msgstr "對帳報表設計成和正式的對帳功能類似。請從報表選項中選取科目。請注意在選項中選取的日期，也會被套用到對帳日期上。"
+msgstr ""
+"對帳報表設計成和正式的對帳功能類似。請從報表選項中選取科目。請注意在選項中選"
+"取的日期，也會被套用到對帳日期上。"
 
 # src/gnome/glade-gnc-dialogs.c:1476
 #: gnucash/report/reports/standard/reconcile-report.scm:103
@@ -26707,12 +26734,12 @@ msgid "Display the check number/action?"
 msgstr "是否顯示支票的號碼 / 動作？"
 
 #: gnucash/report/reports/standard/register.scm:364
-#: gnucash/report/trep-engine.scm:969 gnucash/report/trep-engine.scm:970
+#: gnucash/report/trep-engine.scm:918 gnucash/report/trep-engine.scm:919
 msgid "Display the check number?"
 msgstr "是否顯示支票號碼？"
 
 #: gnucash/report/reports/standard/register.scm:374
-#: gnucash/report/trep-engine.scm:998
+#: gnucash/report/trep-engine.scm:947
 msgid "Display the memo?"
 msgstr "顯示備忘錄？"
 
@@ -26721,7 +26748,7 @@ msgid "Display the account?"
 msgstr "是否顯示科目？"
 
 #: gnucash/report/reports/standard/register.scm:384
-#: gnucash/report/trep-engine.scm:979
+#: gnucash/report/trep-engine.scm:928
 msgid "Display the number of shares?"
 msgstr "是否顯示股份數量？"
 
@@ -26730,35 +26757,23 @@ msgid "Display the name of lot the shares are in?"
 msgstr "是否顯示股份所在的分堆？"
 
 #: gnucash/report/reports/standard/register.scm:394
-#: gnucash/report/trep-engine.scm:981
+#: gnucash/report/trep-engine.scm:930
 msgid "Display the shares price?"
 msgstr "顯示股份價格？"
 
 #: gnucash/report/reports/standard/register.scm:399
-#: gnucash/report/trep-engine.scm:1043
+#: gnucash/report/trep-engine.scm:988
 msgid "Display the amount?"
 msgstr "是否顯示總額？"
 
 #: gnucash/report/reports/standard/register.scm:402
-#: gnucash/report/trep-engine.scm:1033 gnucash/report/trep-engine.scm:1047
-msgid "Single"
-msgstr "單行"
-
-#: gnucash/report/reports/standard/register.scm:402
-#: gnucash/report/trep-engine.scm:1047
-#, fuzzy
-msgid "Single Column Display."
+#: gnucash/report/trep-engine.scm:992
+msgid "Single Column"
 msgstr "單欄顯示"
 
 #: gnucash/report/reports/standard/register.scm:403
-#: gnucash/report/trep-engine.scm:1048
-msgid "Double"
-msgstr "雙欄"
-
-#: gnucash/report/reports/standard/register.scm:403
-#: gnucash/report/trep-engine.scm:1048
-#, fuzzy
-msgid "Two Column Display."
+#: gnucash/report/trep-engine.scm:993
+msgid "Two Columns"
 msgstr "雙欄顯示"
 
 #: gnucash/report/reports/standard/register.scm:408
@@ -26766,7 +26781,7 @@ msgid "Display the value in transaction currency?"
 msgstr "是否以交易貨幣顯示價值？"
 
 #: gnucash/report/reports/standard/register.scm:418
-#: gnucash/report/trep-engine.scm:985
+#: gnucash/report/trep-engine.scm:934
 msgid "Display the totals?"
 msgstr "是否顯示合計？"
 
@@ -26939,7 +26954,9 @@ msgid ""
 "Width of the logo in CSS format, e.g. 10% or 32px. Leave blank to display "
 "the logo at its natural width. The height of the logo will be scaled "
 "accordingly."
-msgstr "以 CSS 型式表示的商標寬度，例如 10% 或 32px，若留白則會使用預設寬度。高度會依照寬度自動調整。"
+msgstr ""
+"以 CSS 型式表示的商標寬度，例如 10% 或 32px，若留白則會使用預設寬度。高度會依"
+"照寬度自動調整。"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:166
 msgid "Border-collapse?"
@@ -27018,7 +27035,7 @@ msgid ""
 msgstr "顯示含有稅務資訊欄的澳洲顧客戶發票(使用 eguile 模板)"
 
 #: gnucash/report/reports/standard/trial-balance.scm:61
-#: gnucash/report/reports/standard/trial-balance.scm:570
+#: gnucash/report/reports/standard/trial-balance.scm:564
 msgid "Trial Balance"
 msgstr "試算表"
 
@@ -27050,7 +27067,9 @@ msgstr "總額調整科目。"
 msgid ""
 "Do not net, but show gross debit/credit adjustments to these accounts. "
 "Merchandising businesses will normally select their inventory accounts here."
-msgstr "不進行淨額計算，但顯示針對這些科目的借方、貸方調整總額。銷售業通常會在此選擇他們的庫存科目。"
+msgstr ""
+"不進行淨額計算，但顯示針對這些科目的借方、貸方調整總額。銷售業通常會在此選擇"
+"他們的庫存科目。"
 
 #: gnucash/report/reports/standard/trial-balance.scm:87
 msgid "Income summary accounts"
@@ -27061,7 +27080,9 @@ msgid ""
 "Adjustments made to these accounts are gross adjusted (see above) in the "
 "Adjustments, Adjusted Trial Balance, and Income Statement columns. Mostly "
 "useful for merchandising businesses."
-msgstr "在調整表、經調整試算表與損益表的欄位中，這些科目的調整，是經過總額調整的（見上方）。主要用於銷售業。"
+msgstr ""
+"在調整表、經調整試算表與損益表的欄位中，這些科目的調整，是經過總額調整的（見"
+"上方）。主要用於銷售業。"
 
 #: gnucash/report/reports/standard/trial-balance.scm:92
 msgid "Adjusting Entries pattern"
@@ -27088,43 +27109,31 @@ msgid ""
 "Causes the Adjusting Entries Pattern to be treated as a regular expression."
 msgstr "將「調整分錄模式」視為正規表示式。"
 
+#: gnucash/report/reports/standard/trial-balance.scm:203
+msgid "General journal exact balances"
+msgstr "一般日記帳報表"
+
 #: gnucash/report/reports/standard/trial-balance.scm:204
-msgid "Current Trial Balance"
-msgstr "目前試算表"
+msgid "No adjusting/closing entries"
+msgstr "忽略調整 / 關帳分錄"
 
 #: gnucash/report/reports/standard/trial-balance.scm:205
-msgid "Uses the exact balances in the general journal"
-msgstr ""
+msgid "Full end-of-period work sheet"
+msgstr "完整的期末工作表"
 
-#: gnucash/report/reports/standard/trial-balance.scm:207
-msgid "Pre-adjustment Trial Balance"
-msgstr "預調整試算表"
-
-#: gnucash/report/reports/standard/trial-balance.scm:208
-msgid "Ignores Adjusting/Closing entries"
-msgstr "忽略調整分錄/結帳分錄"
-
-#: gnucash/report/reports/standard/trial-balance.scm:210
-msgid "Work Sheet"
-msgstr "工作表"
-
-#: gnucash/report/reports/standard/trial-balance.scm:211
-msgid "Creates a complete end-of-period work sheet"
-msgstr ""
-
-#: gnucash/report/reports/standard/trial-balance.scm:279
+#: gnucash/report/reports/standard/trial-balance.scm:273
 msgid "Adjusting Entries"
 msgstr "調整分錄"
 
-#: gnucash/report/reports/standard/trial-balance.scm:571
+#: gnucash/report/reports/standard/trial-balance.scm:565
 msgid "Adjustments"
 msgstr "調整"
 
-#: gnucash/report/reports/standard/trial-balance.scm:572
+#: gnucash/report/reports/standard/trial-balance.scm:566
 msgid "Adjusted Trial Balance"
 msgstr "調整後試算表"
 
-#: gnucash/report/reports/standard/trial-balance.scm:861
+#: gnucash/report/reports/standard/trial-balance.scm:855
 msgid "Net Loss"
 msgstr "淨虧損"
 
@@ -27200,7 +27209,9 @@ msgstr "沒有選擇發票 -- 請使用選項選單選擇一張發票。"
 msgid ""
 "This report is designed for customer (sales) invoices only. Please use the "
 "Options menu to select an <em>Invoice</em>, not a Bill or Expense Voucher."
-msgstr "此報表僅為客戶（發票）設計。請使用「選項」選單按鈕選擇一張「<em>發票</em>」，而不是帳單或消費憑證。"
+msgstr ""
+"此報表僅為客戶（發票）設計。請使用「選項」選單按鈕選擇一張「<em>發票</em>」，"
+"而不是帳單或消費憑證。"
 
 #: gnucash/report/reports/support/taxinvoice.eguile.scm:193
 msgid "Website"
@@ -27309,7 +27320,7 @@ msgstr "公司或團體名稱。"
 
 #: gnucash/report/stylesheets/footer.scm:76
 #: gnucash/report/stylesheets/head-or-tail.scm:95
-#: gnucash/report/stylesheets/plain.scm:58 gnucash/report/trep-engine.scm:1056
+#: gnucash/report/stylesheets/plain.scm:58 gnucash/report/trep-engine.scm:1001
 msgid "Enable Links"
 msgstr "啟動鏈結"
 
@@ -27320,8 +27331,8 @@ msgid "Enable hyperlinks in reports."
 msgstr "啟動報表中的超連結。"
 
 #: gnucash/report/stylesheets/footer.scm:83
+#: gnucash/report/stylesheets/footer.scm:425
 #: gnucash/report/stylesheets/footer.scm:431
-#: gnucash/report/stylesheets/footer.scm:437
 msgid "Footer"
 msgstr "頁面註腳"
 
@@ -27332,11 +27343,11 @@ msgstr "要用來做為頁面註腳的文件。"
 #: gnucash/report/stylesheets/footer.scm:89
 #: gnucash/report/stylesheets/footer.scm:95
 #: gnucash/report/stylesheets/footer.scm:102
-#: gnucash/report/stylesheets/footer.scm:117
+#: gnucash/report/stylesheets/footer.scm:111
 #: gnucash/report/stylesheets/head-or-tail.scm:138
 #: gnucash/report/stylesheets/head-or-tail.scm:143
 #: gnucash/report/stylesheets/head-or-tail.scm:149
-#: gnucash/report/stylesheets/head-or-tail.scm:164
+#: gnucash/report/stylesheets/head-or-tail.scm:157
 msgid "Images"
 msgstr "圖片"
 
@@ -27369,195 +27380,177 @@ msgstr "報表頂端的橫幅。"
 msgid "Heading Alignment"
 msgstr "標題對齊"
 
-#: gnucash/report/stylesheets/footer.scm:106
-#: gnucash/report/stylesheets/head-or-tail.scm:153
+#: gnucash/report/stylesheets/footer.scm:105
+#: gnucash/report/stylesheets/head-or-tail.scm:152
 msgid "Left"
 msgstr "左"
 
-#: gnucash/report/stylesheets/footer.scm:107
-#: gnucash/report/stylesheets/head-or-tail.scm:154
-#, fuzzy
-msgid "Align the banner to the left."
-msgstr "標題對齊左邊"
-
-#: gnucash/report/stylesheets/footer.scm:109
-#: gnucash/report/stylesheets/head-or-tail.scm:156
+#: gnucash/report/stylesheets/footer.scm:106
+#: gnucash/report/stylesheets/head-or-tail.scm:153
 msgid "Center"
 msgstr "中"
 
-#: gnucash/report/stylesheets/footer.scm:110
-#: gnucash/report/stylesheets/head-or-tail.scm:157
-#, fuzzy
-msgid "Align the banner in the center."
-msgstr "標題對齊中間"
-
-#: gnucash/report/stylesheets/footer.scm:112
-#: gnucash/report/stylesheets/head-or-tail.scm:159
+#: gnucash/report/stylesheets/footer.scm:107
+#: gnucash/report/stylesheets/head-or-tail.scm:154
 msgid "Right"
 msgstr "右"
 
-#: gnucash/report/stylesheets/footer.scm:113
-#: gnucash/report/stylesheets/head-or-tail.scm:160
-#, fuzzy
-msgid "Align the banner to the right."
-msgstr "標題對齊右邊"
-
-#: gnucash/report/stylesheets/footer.scm:118
-#: gnucash/report/stylesheets/head-or-tail.scm:165
+#: gnucash/report/stylesheets/footer.scm:112
+#: gnucash/report/stylesheets/head-or-tail.scm:158
 msgid "Logo"
 msgstr "商標"
 
-#: gnucash/report/stylesheets/footer.scm:118
-#: gnucash/report/stylesheets/head-or-tail.scm:165
+#: gnucash/report/stylesheets/footer.scm:112
+#: gnucash/report/stylesheets/head-or-tail.scm:158
 msgid "Company logo image."
 msgstr "公司商標圖案。"
 
-#: gnucash/report/stylesheets/footer.scm:124
-#: gnucash/report/stylesheets/head-or-tail.scm:171
+#: gnucash/report/stylesheets/footer.scm:118
+#: gnucash/report/stylesheets/head-or-tail.scm:164
 msgid "General background color for report."
 msgstr "報表的通用背景顏色。"
 
-#: gnucash/report/stylesheets/footer.scm:131
-#: gnucash/report/stylesheets/head-or-tail.scm:178
+#: gnucash/report/stylesheets/footer.scm:125
+#: gnucash/report/stylesheets/head-or-tail.scm:171
 msgid "Text Color"
 msgstr "文字顏色"
 
-#: gnucash/report/stylesheets/footer.scm:131
-#: gnucash/report/stylesheets/head-or-tail.scm:178
+#: gnucash/report/stylesheets/footer.scm:125
+#: gnucash/report/stylesheets/head-or-tail.scm:171
 msgid "Normal body text color."
 msgstr "一般內文的顏色。"
 
-#: gnucash/report/stylesheets/footer.scm:138
-#: gnucash/report/stylesheets/head-or-tail.scm:185
+#: gnucash/report/stylesheets/footer.scm:132
+#: gnucash/report/stylesheets/head-or-tail.scm:178
 msgid "Link Color"
 msgstr "鏈結顏色"
 
-#: gnucash/report/stylesheets/footer.scm:138
-#: gnucash/report/stylesheets/head-or-tail.scm:185
+#: gnucash/report/stylesheets/footer.scm:132
+#: gnucash/report/stylesheets/head-or-tail.scm:178
 msgid "Link text color."
 msgstr "鏈結文字的顏色。"
 
-#: gnucash/report/stylesheets/footer.scm:145
-#: gnucash/report/stylesheets/head-or-tail.scm:192
+#: gnucash/report/stylesheets/footer.scm:139
+#: gnucash/report/stylesheets/head-or-tail.scm:185
 msgid "Table Cell Color"
 msgstr "表格細格顏色"
 
-#: gnucash/report/stylesheets/footer.scm:145
-#: gnucash/report/stylesheets/head-or-tail.scm:192
+#: gnucash/report/stylesheets/footer.scm:139
+#: gnucash/report/stylesheets/head-or-tail.scm:185
 msgid "Default background for table cells."
 msgstr "表格中細格的預設背景。"
 
-#: gnucash/report/stylesheets/footer.scm:152
-#: gnucash/report/stylesheets/head-or-tail.scm:199
+#: gnucash/report/stylesheets/footer.scm:146
+#: gnucash/report/stylesheets/head-or-tail.scm:192
 #: gnucash/report/stylesheets/plain.scm:63
 msgid "Alternate Table Cell Color"
 msgstr "代用表格細格顏色"
 
-#: gnucash/report/stylesheets/footer.scm:153
-#: gnucash/report/stylesheets/head-or-tail.scm:200
+#: gnucash/report/stylesheets/footer.scm:147
+#: gnucash/report/stylesheets/head-or-tail.scm:193
 msgid "Default alternate background for table cells."
 msgstr "表格申細格的預設代用背景。"
 
-#: gnucash/report/stylesheets/footer.scm:160
-#: gnucash/report/stylesheets/head-or-tail.scm:207
+#: gnucash/report/stylesheets/footer.scm:154
+#: gnucash/report/stylesheets/head-or-tail.scm:200
 msgid "Subheading/Subtotal Cell Color"
 msgstr "副標題/小計細格顏色"
 
-#: gnucash/report/stylesheets/footer.scm:161
-#: gnucash/report/stylesheets/head-or-tail.scm:208
+#: gnucash/report/stylesheets/footer.scm:155
+#: gnucash/report/stylesheets/head-or-tail.scm:201
 msgid "Default color for subtotal rows."
 msgstr "小計列的預設顏色。"
 
-#: gnucash/report/stylesheets/footer.scm:168
-#: gnucash/report/stylesheets/head-or-tail.scm:215
+#: gnucash/report/stylesheets/footer.scm:162
+#: gnucash/report/stylesheets/head-or-tail.scm:208
 msgid "Sub-subheading/total Cell Color"
 msgstr "次-副標題/合計細格顏色"
 
-#: gnucash/report/stylesheets/footer.scm:169
-#: gnucash/report/stylesheets/head-or-tail.scm:216
+#: gnucash/report/stylesheets/footer.scm:163
+#: gnucash/report/stylesheets/head-or-tail.scm:209
 msgid "Color for subsubtotals."
 msgstr "小小計顏色。"
 
-#: gnucash/report/stylesheets/footer.scm:176
-#: gnucash/report/stylesheets/head-or-tail.scm:223
+#: gnucash/report/stylesheets/footer.scm:170
+#: gnucash/report/stylesheets/head-or-tail.scm:216
 msgid "Grand Total Cell Color"
 msgstr "「總和」細格顏色"
 
-#: gnucash/report/stylesheets/footer.scm:177
-#: gnucash/report/stylesheets/head-or-tail.scm:224
+#: gnucash/report/stylesheets/footer.scm:171
+#: gnucash/report/stylesheets/head-or-tail.scm:217
 msgid "Color for grand totals."
 msgstr "「總和」的顏色。"
 
+#: gnucash/report/stylesheets/footer.scm:177
 #: gnucash/report/stylesheets/footer.scm:183
 #: gnucash/report/stylesheets/footer.scm:189
-#: gnucash/report/stylesheets/footer.scm:195
-#: gnucash/report/stylesheets/head-or-tail.scm:230
-#: gnucash/report/stylesheets/head-or-tail.scm:236
-#: gnucash/report/stylesheets/head-or-tail.scm:242
+#: gnucash/report/stylesheets/head-or-tail.scm:223
+#: gnucash/report/stylesheets/head-or-tail.scm:229
+#: gnucash/report/stylesheets/head-or-tail.scm:235
 #: gnucash/report/stylesheets/plain.scm:68
 #: gnucash/report/stylesheets/plain.scm:73
 #: gnucash/report/stylesheets/plain.scm:78
 msgid "Tables"
 msgstr "表格"
 
-#: gnucash/report/stylesheets/footer.scm:184
-#: gnucash/report/stylesheets/head-or-tail.scm:231
+#: gnucash/report/stylesheets/footer.scm:178
+#: gnucash/report/stylesheets/head-or-tail.scm:224
 #: gnucash/report/stylesheets/plain.scm:69
 msgid "Table cell spacing"
 msgstr "細格空間"
 
-#: gnucash/report/stylesheets/footer.scm:184
-#: gnucash/report/stylesheets/head-or-tail.scm:231
+#: gnucash/report/stylesheets/footer.scm:178
+#: gnucash/report/stylesheets/head-or-tail.scm:224
 #: gnucash/report/stylesheets/plain.scm:69
 msgid "Space between table cells."
 msgstr "細格間距。"
 
-#: gnucash/report/stylesheets/footer.scm:190
-#: gnucash/report/stylesheets/head-or-tail.scm:237
+#: gnucash/report/stylesheets/footer.scm:184
+#: gnucash/report/stylesheets/head-or-tail.scm:230
 #: gnucash/report/stylesheets/plain.scm:74
 msgid "Table cell padding"
 msgstr "表格框內距"
 
-#: gnucash/report/stylesheets/footer.scm:190
-#: gnucash/report/stylesheets/head-or-tail.scm:237
+#: gnucash/report/stylesheets/footer.scm:184
+#: gnucash/report/stylesheets/head-or-tail.scm:230
 #: gnucash/report/stylesheets/plain.scm:74
 msgid "Space between table cell edge and content."
 msgstr "表格格線與內容之間的距離。"
 
-#: gnucash/report/stylesheets/footer.scm:196
-#: gnucash/report/stylesheets/head-or-tail.scm:243
+#: gnucash/report/stylesheets/footer.scm:190
+#: gnucash/report/stylesheets/head-or-tail.scm:236
 #: gnucash/report/stylesheets/plain.scm:79
 msgid "Table border width"
 msgstr "框線寬度"
 
-#: gnucash/report/stylesheets/footer.scm:196
-#: gnucash/report/stylesheets/head-or-tail.scm:243
+#: gnucash/report/stylesheets/footer.scm:190
+#: gnucash/report/stylesheets/head-or-tail.scm:236
 #: gnucash/report/stylesheets/plain.scm:79
 msgid "Bevel depth on tables."
 msgstr "表格斜角深度。"
 
-#: gnucash/report/stylesheets/footer.scm:377
-#: gnucash/report/stylesheets/head-or-tail.scm:432
-#: gnucash/report/stylesheets/head-or-tail.scm:526
+#: gnucash/report/stylesheets/footer.scm:371
+#: gnucash/report/stylesheets/head-or-tail.scm:425
+#: gnucash/report/stylesheets/head-or-tail.scm:519
 msgid "Prepared by: "
 msgstr "製作： "
 
-#: gnucash/report/stylesheets/footer.scm:380
-#: gnucash/report/stylesheets/head-or-tail.scm:440
-#: gnucash/report/stylesheets/head-or-tail.scm:534
+#: gnucash/report/stylesheets/footer.scm:374
+#: gnucash/report/stylesheets/head-or-tail.scm:433
+#: gnucash/report/stylesheets/head-or-tail.scm:527
 msgid "Prepared for: "
 msgstr "製作對象： "
 
-#: gnucash/report/stylesheets/footer.scm:419
-#: gnucash/report/stylesheets/footer.scm:435
+#: gnucash/report/stylesheets/footer.scm:413
+#: gnucash/report/stylesheets/footer.scm:429
 msgid "Easy"
 msgstr "簡單"
 
-#: gnucash/report/stylesheets/footer.scm:425
+#: gnucash/report/stylesheets/footer.scm:419
 msgid "Fancy"
 msgstr "精美"
 
-#: gnucash/report/stylesheets/footer.scm:436
+#: gnucash/report/stylesheets/footer.scm:430
 msgid "Technicolor"
 msgstr "鮮明色彩"
 
@@ -27640,19 +27633,19 @@ msgstr "在底部顯示 GnuCash 版本"
 msgid "Per default the GnuCash version will be shown before the report data."
 msgstr "預設會在報表上方顯示 GnuCash 版本。"
 
+#: gnucash/report/stylesheets/head-or-tail.scm:442
 #: gnucash/report/stylesheets/head-or-tail.scm:449
-#: gnucash/report/stylesheets/head-or-tail.scm:456
+#: gnucash/report/stylesheets/head-or-tail.scm:536
 #: gnucash/report/stylesheets/head-or-tail.scm:543
-#: gnucash/report/stylesheets/head-or-tail.scm:550
 msgid "Report Creation Date: "
 msgstr "報表建立日期： "
 
-#: gnucash/report/stylesheets/head-or-tail.scm:558
+#: gnucash/report/stylesheets/head-or-tail.scm:551
 msgid "GnuCash "
 msgstr "GnuCash "
 
-#: gnucash/report/stylesheets/head-or-tail.scm:573
-#: gnucash/report/stylesheets/head-or-tail.scm:577
+#: gnucash/report/stylesheets/head-or-tail.scm:566
+#: gnucash/report/stylesheets/head-or-tail.scm:570
 msgid "Head or Tail"
 msgstr "標頭或註腳"
 
@@ -27680,7 +27673,7 @@ msgstr "過濾器類型"
 msgid "Subtotal Table"
 msgstr "小計表格"
 
-#: gnucash/report/trep-engine.scm:84 gnucash/report/trep-engine.scm:1133
+#: gnucash/report/trep-engine.scm:84 gnucash/report/trep-engine.scm:1078
 msgid "Show Account Description"
 msgstr "顯示科目描述"
 
@@ -27724,7 +27717,7 @@ msgstr "反向過濾"
 msgid "Transaction Filter is case insensitive"
 msgstr "過濾交易時不區分大小寫"
 
-#: gnucash/report/trep-engine.scm:119 gnucash/report/trep-engine.scm:199
+#: gnucash/report/trep-engine.scm:119 gnucash/report/trep-engine.scm:194
 msgid "Reconciled Status"
 msgstr "對帳狀態"
 
@@ -27742,271 +27735,111 @@ msgid ""
 "selection specified in the Options panel."
 msgstr "找不到跟所給的時間間隔與所選科目相符的交易。"
 
-#: gnucash/report/trep-engine.scm:170
-#, fuzzy
-msgid "Sort & subtotal by account name."
-msgstr "以科目名稱排序與小計"
-
-#: gnucash/report/trep-engine.scm:177
-#, fuzzy
-msgid "Sort & subtotal by account code."
-msgstr "以科目代碼排序與小計"
-
-#: gnucash/report/trep-engine.scm:191
-#, fuzzy
-msgid "Sort by the Reconciled Date."
-msgstr "以對帳日期排序"
-
-#: gnucash/report/trep-engine.scm:200
-#, fuzzy
-msgid "Sort by the Reconciled Status"
-msgstr "以對帳日期排序"
-
-#: gnucash/report/trep-engine.scm:208
+#: gnucash/report/trep-engine.scm:202
 msgid "Register Order"
 msgstr "登記簿順序"
 
-#: gnucash/report/trep-engine.scm:209
-#, fuzzy
-msgid "Sort as in the register."
-msgstr "以登記簿排序"
-
-#: gnucash/report/trep-engine.scm:216
-#, fuzzy
-msgid "Sort by account transferred from/to's name."
-msgstr "以轉帳目標/來源科目名稱排序"
-
-#: gnucash/report/trep-engine.scm:223
-#, fuzzy
-msgid "Sort by account transferred from/to's code."
-msgstr "以轉帳目標/來源科目代碼排序"
-
-#: gnucash/report/trep-engine.scm:246
-#, fuzzy
-msgid "Sort by check number/action."
-msgstr "以號碼排序"
-
-#: gnucash/report/trep-engine.scm:253
-#, fuzzy
-msgid "Sort by check/transaction number."
-msgstr "以支票/交易號碼排序"
-
-#: gnucash/report/trep-engine.scm:260
-#, fuzzy
-msgid "Sort by transaction number."
-msgstr "以支票/交易號碼排序"
-
-#: gnucash/report/trep-engine.scm:274
-#, fuzzy
-msgid "Sort by transaction notes."
-msgstr "以支票/交易號碼排序"
-
-#: gnucash/report/trep-engine.scm:281
-#, fuzzy
-msgid "Do not sort."
-msgstr "不要排序"
-
-#: gnucash/report/trep-engine.scm:314
-#, fuzzy
-msgid "None."
-msgstr "無"
-
-#: gnucash/report/trep-engine.scm:321
-#, fuzzy
-msgid "Daily."
-msgstr "每日"
-
-#: gnucash/report/trep-engine.scm:328
-#, fuzzy
-msgid "Weekly."
-msgstr "每週"
-
-#: gnucash/report/trep-engine.scm:337
-#, fuzzy
-msgid "Monthly."
-msgstr "每月"
-
-#: gnucash/report/trep-engine.scm:346
-#, fuzzy
-msgid "Quarterly."
-msgstr "一季"
-
-#: gnucash/report/trep-engine.scm:355
-#, fuzzy
-msgid "Yearly."
-msgstr "年度"
-
-#: gnucash/report/trep-engine.scm:364
-#, fuzzy
-msgid "Do not do any filtering."
+#: gnucash/report/trep-engine.scm:339
+msgid "Do not do any filtering"
 msgstr "不使用任何過濾器"
 
-#: gnucash/report/trep-engine.scm:367
+#: gnucash/report/trep-engine.scm:342
 msgid "Include Transactions to/from Filter Accounts"
 msgstr "包含過濾器所指定科目的交易"
 
-#: gnucash/report/trep-engine.scm:368
-#, fuzzy
-msgid "Include transactions to/from filter accounts only."
-msgstr "只包含 流進/流出 過濾器所指定科目的交易"
-
-#: gnucash/report/trep-engine.scm:371
+#: gnucash/report/trep-engine.scm:345
 msgid "Exclude Transactions to/from Filter Accounts"
 msgstr "不包含過濾器所指定科目的交易"
 
-#: gnucash/report/trep-engine.scm:372
-#, fuzzy
-msgid "Exclude transactions to/from all filter accounts."
-msgstr "不包含所有 流進/流出 過濾器所指定科目的交易"
-
-#: gnucash/report/trep-engine.scm:378
+#: gnucash/report/trep-engine.scm:351
 msgid "Non-void only"
 msgstr "不包含無效的"
 
-#: gnucash/report/trep-engine.scm:379
-#, fuzzy
-msgid "Show only non-voided transactions."
-msgstr "只顯示不是無效的交易"
-
-#: gnucash/report/trep-engine.scm:383
+#: gnucash/report/trep-engine.scm:355
 msgid "Void only"
 msgstr "只有無效的"
 
-#: gnucash/report/trep-engine.scm:384
-#, fuzzy
-msgid "Show only voided transactions."
-msgstr "只顯示無效的交易"
-
-#: gnucash/report/trep-engine.scm:388
-msgid "Both"
-msgstr "都"
-
-#: gnucash/report/trep-engine.scm:389
-#, fuzzy
-msgid "Show both (and include void transactions in totals)."
+#: gnucash/report/trep-engine.scm:359
+msgid "Both (and include void transactions in totals)"
 msgstr "兩者都顯示（並且在總計中包含無效的交易）"
 
-#: gnucash/report/trep-engine.scm:394
+#: gnucash/report/trep-engine.scm:364
 msgid "Exclude closing transactions"
 msgstr "排除關帳交易"
 
-#: gnucash/report/trep-engine.scm:395
-#, fuzzy
-msgid "Exclude closing transactions from report."
-msgstr "不包含所有 流進/流出 過濾器所指定科目的交易"
-
-#: gnucash/report/trep-engine.scm:399
+#: gnucash/report/trep-engine.scm:368
 msgid "Show both closing and regular transactions"
 msgstr "只顯示普通和關帳交易"
 
-#: gnucash/report/trep-engine.scm:400
-#, fuzzy
-msgid "Show both (and include closing transactions in totals)."
-msgstr "兩者都顯示（並且在總計中包含無效的交易）"
-
-#: gnucash/report/trep-engine.scm:404
+#: gnucash/report/trep-engine.scm:372
 msgid "Show closing transactions only"
 msgstr "只顯示關帳交易"
 
-#: gnucash/report/trep-engine.scm:405
-#, fuzzy
-msgid "Show only closing transactions."
-msgstr "只顯示無效的交易"
-
-#: gnucash/report/trep-engine.scm:416
+#: gnucash/report/trep-engine.scm:382
 msgid "Show All Transactions"
 msgstr "顯示所有交易"
 
-#: gnucash/report/trep-engine.scm:421
+#: gnucash/report/trep-engine.scm:386
 msgid "Unreconciled only"
 msgstr "只顯示未對帳的交易"
 
-#: gnucash/report/trep-engine.scm:426
+#: gnucash/report/trep-engine.scm:390
 msgid "Cleared only"
 msgstr "只顯示已結清的交易"
 
-#: gnucash/report/trep-engine.scm:431
+#: gnucash/report/trep-engine.scm:394
 msgid "Reconciled only"
 msgstr "只顯示已對帳的交易"
 
-#: gnucash/report/trep-engine.scm:439
-#, fuzzy
-msgid "Smallest to largest, earliest to latest."
-msgstr "最小到最大，最早到最晚"
-
-#: gnucash/report/trep-engine.scm:442
-#, fuzzy
-msgid "Largest to smallest, latest to earliest."
-msgstr "最大到最小，最晚到最早"
-
-#: gnucash/report/trep-engine.scm:447
+#: gnucash/report/trep-engine.scm:408
 msgid "Use Global Preference"
 msgstr "使用全域偏好設定"
 
-#: gnucash/report/trep-engine.scm:448
-msgid "Use reversing option specified in global preference."
-msgstr ""
-
-#: gnucash/report/trep-engine.scm:452
-#, fuzzy
-msgid "Don't change any displayed amounts."
+#: gnucash/report/trep-engine.scm:411
+msgid "Don't change any displayed amounts"
 msgstr "不要變更任何已顯示的總額"
 
-#: gnucash/report/trep-engine.scm:455
+#: gnucash/report/trep-engine.scm:414
 msgid "Income and Expense"
 msgstr "收入與支出"
 
-#: gnucash/report/trep-engine.scm:456
-#, fuzzy
-msgid "Reverse amount display for Income and Expense Accounts."
-msgstr "反轉收入與支出的總額顯示"
-
-#: gnucash/report/trep-engine.scm:459
+#: gnucash/report/trep-engine.scm:417
 msgid "Credit Accounts"
 msgstr "貸方科目"
 
-#: gnucash/report/trep-engine.scm:460
-#, fuzzy
-msgid ""
-"Reverse amount display for Liability, Payable, Equity, Credit Card, and "
-"Income accounts."
-msgstr "反轉債務、應付、資產淨值、信用卡與收入科目的總額顯示"
-
-#: gnucash/report/trep-engine.scm:562
+#: gnucash/report/trep-engine.scm:517
 msgid "Convert all transactions into a common currency."
 msgstr "轉換全部的交易到統一的貨幣單位。"
 
-#: gnucash/report/trep-engine.scm:585
+#: gnucash/report/trep-engine.scm:540
 msgid "Formats the table suitable for cut & paste exporting with extra cells."
 msgstr "使用額外的欄位排版，以使表格適合使用複製與貼上的方式匯出。"
 
-#: gnucash/report/trep-engine.scm:597
+#: gnucash/report/trep-engine.scm:551
 msgid "If no transactions matched"
 msgstr "如果沒有符合的交易"
 
-#: gnucash/report/trep-engine.scm:598
-#, fuzzy
-msgid "Display summary if no transactions were matched."
-msgstr "是否顯示交易參照？"
-
-#: gnucash/report/trep-engine.scm:611
+#: gnucash/report/trep-engine.scm:560
 msgid ""
 "Show only accounts whose full name matches this filter e.g. ':Travel' will "
 "match Expenses:Travel:Holiday and Expenses:Business:Travel. It can be left "
 "blank, which will disable the filter."
-msgstr "只顯示科目全名符合這個過濾器的科目。例如「旅行」會找「支出:旅行:渡假」或「支出:商務:旅行」。可以留白，如此一來將不會使用過濾器。"
+msgstr ""
+"只顯示科目全名符合這個過濾器的科目。例如「旅行」會找「支出:旅行:渡假」或「支"
+"出:商務:旅行」。可以留白，如此一來將不會使用過濾器。"
 
-#: gnucash/report/trep-engine.scm:620
+#: gnucash/report/trep-engine.scm:569
 msgid ""
 "By default the account filter will search substring only. Set this to true "
 "to enable full POSIX regular expressions capabilities. 'Car|Flights' will "
 "match both Expenses:Car and Expenses:Flights. Use a period (.) to match a "
 "single character e.g. '20../.' will match 'Travel 2017/1 London'. "
 msgstr ""
-"科目過濾預設只會搜尋符合的子字串，勾選這個選項將會啟用完整的 POSIX 正規表示式功能。 「汔車|班機」將會搜尋出「支出:汔車」和「支出:班機」。"
-"使用句號 (.) 來比對單一字元。例如「20../.」將會搜尋出「2017/1 倫敦旅遊」。 "
+"科目過濾預設只會搜尋符合的子字串，勾選這個選項將會啟用完整的 POSIX 正規表示式"
+"功能。 「汔車|班機」將會搜尋出「支出:汔車」和「支出:班機」。使用句號 (.) 來比"
+"對單一字元。例如「20../.」將會搜尋出「2017/1 倫敦旅遊」。 "
 
-#: gnucash/report/trep-engine.scm:629
+#: gnucash/report/trep-engine.scm:578
 msgid ""
 "Show only transactions where description, notes, or memo matches this "
 "filter.\n"
@@ -28014,198 +27847,196 @@ msgid ""
 "memo. It can be left blank, which will disable the filter."
 msgstr ""
 "只顯示描述、筆記或備註符合這個過濾器的交易。\n"
-"例如「#gift」會找到所有在描述、筆記或備註有 #gift 字樣的交易。可以留白，如此一來將不會使用此過濾器。"
+"例如「#gift」會找到所有在描述、筆記或備註有 #gift 字樣的交易。可以留白，如此"
+"一來將不會使用此過濾器。"
 
-#: gnucash/report/trep-engine.scm:638
+#: gnucash/report/trep-engine.scm:587
 msgid ""
 "By default the transaction filter will search substring only. Set this to "
 "true to enable full POSIX regular expressions capabilities. '#work|#family' "
 "will match both tags within description, notes or memo. "
-msgstr "交易過濾預設只會搜尋符合的子字串，勾選這個選項將會啟用完整的 POSIX 正規表示式功能。 "
+msgstr ""
+"交易過濾預設只會搜尋符合的子字串，勾選這個選項將會啟用完整的 POSIX 正規表示式"
+"功能。 "
 
-#: gnucash/report/trep-engine.scm:647
+#: gnucash/report/trep-engine.scm:596
 msgid "If this option is selected, transactions matching filter are excluded."
 msgstr "如果勾選此選項，則符合過濾規則的交易將被排除。"
 
-#: gnucash/report/trep-engine.scm:654
+#: gnucash/report/trep-engine.scm:603
 msgid ""
 "If this option is selected, transactions matching filter is not case "
 "sensitive."
 msgstr "如果勾選此選項，則過濾交易時不區分大小寫。"
 
-#: gnucash/report/trep-engine.scm:660
+#: gnucash/report/trep-engine.scm:609
 msgid "Filter by reconcile status."
 msgstr "使用對帳狀態過濾。"
 
-#: gnucash/report/trep-engine.scm:667
+#: gnucash/report/trep-engine.scm:616
 msgid "How to handle void transactions."
 msgstr "如何處理無效的交易。"
 
-#: gnucash/report/trep-engine.scm:674
+#: gnucash/report/trep-engine.scm:623
 msgid ""
 "By default most users should not include closing transactions in a "
 "transaction report. Closing transactions are transfers from income and "
 "expense accounts to equity, and must usually be excluded from periodic "
 "reporting."
-msgstr "預設的情況下，多數使用者不應該將結帳分錄包括在報表中。結帳分錄是將收入與支出科目轉帳至淨值科目的交易，他們通常必須從週期性的表報中排除。"
+msgstr ""
+"預設的情況下，多數使用者不應該將結帳分錄包括在報表中。結帳分錄是將收入與支出"
+"科目轉帳至淨值科目的交易，他們通常必須從週期性的表報中排除。"
 
-#: gnucash/report/trep-engine.scm:700
+#: gnucash/report/trep-engine.scm:649
 msgid "Filter on these accounts."
 msgstr "過濾這些科目。"
 
-#: gnucash/report/trep-engine.scm:708
+#: gnucash/report/trep-engine.scm:657
 msgid "Filter account."
 msgstr "過濾科目。"
 
-#: gnucash/report/trep-engine.scm:801
+#: gnucash/report/trep-engine.scm:750
 msgid "Sort by this criterion first."
 msgstr "優先以此準則排序。"
 
-#: gnucash/report/trep-engine.scm:812
+#: gnucash/report/trep-engine.scm:761
 msgid "Show the full account name for subtotals and subheadings?"
 msgstr "顯示小計與小標題的科目全名？"
 
-#: gnucash/report/trep-engine.scm:819
+#: gnucash/report/trep-engine.scm:768
 msgid "Show the account code for subtotals and subheadings?"
 msgstr "顯示小計與小標題的科目代碼？"
 
-#: gnucash/report/trep-engine.scm:826
+#: gnucash/report/trep-engine.scm:775
 msgid "Show the account description for subheadings?"
 msgstr "顯示小計與小標題的科目描述？"
 
-#: gnucash/report/trep-engine.scm:833
+#: gnucash/report/trep-engine.scm:782
 msgid "Show the informal headers for debit/credit accounts?"
 msgstr "顯示借貸科目的口語標頭？"
 
-#: gnucash/report/trep-engine.scm:840
+#: gnucash/report/trep-engine.scm:789
 msgid "Add indenting columns with grouping and subtotals?"
 msgstr "針對各群組和小計縮排？"
 
-#: gnucash/report/trep-engine.scm:847
+#: gnucash/report/trep-engine.scm:796
 msgid "Show subtotals only, hiding transactional detail?"
 msgstr "只顯示小計，不顯示交易細節？"
 
-#: gnucash/report/trep-engine.scm:854
+#: gnucash/report/trep-engine.scm:803
 msgid "Subtotal according to the primary key?"
 msgstr "根據主鍵小計？"
 
-#: gnucash/report/trep-engine.scm:863 gnucash/report/trep-engine.scm:902
+#: gnucash/report/trep-engine.scm:812 gnucash/report/trep-engine.scm:851
 msgid "Do a date subtotal."
 msgstr "進行日期小計。"
 
-#: gnucash/report/trep-engine.scm:873
+#: gnucash/report/trep-engine.scm:822
 msgid "Order of primary sorting."
 msgstr "主要排序的順序。"
 
-#: gnucash/report/trep-engine.scm:882
+#: gnucash/report/trep-engine.scm:831
 msgid "Sort by this criterion second."
 msgstr "以此準則排序次之。"
 
-#: gnucash/report/trep-engine.scm:893
+#: gnucash/report/trep-engine.scm:842
 msgid "Subtotal according to the secondary key?"
 msgstr "根據次關鍵小計？"
 
-#: gnucash/report/trep-engine.scm:912
+#: gnucash/report/trep-engine.scm:861
 msgid "Order of Secondary sorting."
 msgstr "次要排序的順序。"
 
-#: gnucash/report/trep-engine.scm:967
+#: gnucash/report/trep-engine.scm:916
 msgid "Display the reconciled date?"
 msgstr "是否顯示對帳日期？"
 
-#: gnucash/report/trep-engine.scm:972
+#: gnucash/report/trep-engine.scm:921
 msgid "Display the notes if the memo is unavailable?"
 msgstr "如果沒有備忘錄，是否要顯示筆記？"
 
-#: gnucash/report/trep-engine.scm:974 gnucash/report/trep-engine.scm:977
+#: gnucash/report/trep-engine.scm:923 gnucash/report/trep-engine.scm:926
 msgid "Display the full account name?"
 msgstr "顯示科目全名？"
 
-#: gnucash/report/trep-engine.scm:975
+#: gnucash/report/trep-engine.scm:924
 msgid "Display the account code?"
 msgstr "顯示科目代碼？"
 
-#: gnucash/report/trep-engine.scm:978
+#: gnucash/report/trep-engine.scm:927
 msgid "Display the other account code?"
 msgstr "顯示其他科目代碼？"
 
-#: gnucash/report/trep-engine.scm:980
+#: gnucash/report/trep-engine.scm:929
 msgid "Display the transaction linked document"
 msgstr "顯示交易連結文件"
 
-#: gnucash/report/trep-engine.scm:983
+#: gnucash/report/trep-engine.scm:932
 msgid "Display a subtotal summary table."
 msgstr "顯示小計摘要表格。"
 
-#: gnucash/report/trep-engine.scm:991
+#: gnucash/report/trep-engine.scm:940
 msgid "Display the trans number?"
 msgstr "顯示交易號碼？"
 
-#: gnucash/report/trep-engine.scm:1008
+#: gnucash/report/trep-engine.scm:957
 msgid "Display the account name?"
 msgstr "顯示科目名稱？"
 
-#: gnucash/report/trep-engine.scm:1018
+#: gnucash/report/trep-engine.scm:967
 msgid ""
 "Display the other account name? (if this is a split transaction, this "
 "parameter is guessed)."
 msgstr "顯示其他科目名稱？(如果這是分割交易，此參數會被預測)。"
 
-#: gnucash/report/trep-engine.scm:1027
+#: gnucash/report/trep-engine.scm:976
 msgid "Amount of detail to display per transaction."
 msgstr "每筆交易要顯示的細節數量。"
 
-#: gnucash/report/trep-engine.scm:1030
-msgid "Multi-Line"
-msgstr "多行"
+#: gnucash/report/trep-engine.scm:978
+msgid "One split per line"
+msgstr "一行一個分割"
 
-#: gnucash/report/trep-engine.scm:1031
-#, fuzzy
-msgid "Display all splits in a transaction on a separate line."
-msgstr "是否顯示交易參照？"
+#: gnucash/report/trep-engine.scm:979
+msgid "One transaction per line"
+msgstr "一行一筆交易"
 
-#: gnucash/report/trep-engine.scm:1034
-msgid ""
-"Display one line per transaction, merging multiple splits where required."
-msgstr ""
+#: gnucash/report/trep-engine.scm:991
+msgid "Hide"
+msgstr "隱藏"
 
-#: gnucash/report/trep-engine.scm:1046
-#, fuzzy
-msgid "No amount display."
-msgstr "沒有總額顯示"
-
-#: gnucash/report/trep-engine.scm:1057
+#: gnucash/report/trep-engine.scm:1002
 msgid "Enable hyperlinks in amounts."
 msgstr "在金額上使用超連結。"
 
-#: gnucash/report/trep-engine.scm:1062
+#: gnucash/report/trep-engine.scm:1007
 msgid "Reverse amount display for certain account types."
 msgstr "反轉某些科目類型的金額顯示。"
 
-#: gnucash/report/trep-engine.scm:1213
+#: gnucash/report/trep-engine.scm:1158
 msgid "Num/T-Num"
 msgstr "號碼/交易號碼"
 
-#: gnucash/report/trep-engine.scm:1262
+#: gnucash/report/trep-engine.scm:1207
 msgid "Transfer from/to"
 msgstr "轉帳 從/到"
 
 #. Translators: Balance b/f stands for "Balance
 #. brought forward".
-#: gnucash/report/trep-engine.scm:1463
+#: gnucash/report/trep-engine.scm:1408
 msgid "Balance b/f"
 msgstr "餘額承前"
 
-#: gnucash/report/trep-engine.scm:1630
+#: gnucash/report/trep-engine.scm:1575
 msgid "Split Transaction"
 msgstr "分割交易"
 
-#: gnucash/report/trep-engine.scm:1878
+#: gnucash/report/trep-engine.scm:1823
 msgid "CSV disabled for double column amounts"
 msgstr "CSV 不支援雙欄金額"
 
 #. Translators: Both ~a's are dates
-#: gnucash/report/trep-engine.scm:2270
+#: gnucash/report/trep-engine.scm:2215
 #, scheme-format
 msgid "From ~a to ~a"
 msgstr "從 ~a 到 ~a"
@@ -28344,7 +28175,8 @@ msgstr "用來產生消費憑證編號的格式化字串。這是一個 printf �
 msgid ""
 "The previous expense voucher number generated. This number will be "
 "incremented to generate the next voucher number."
-msgstr "上一個產生的消費憑證編號。會用這個編號加一，來做為下一個產生的消費憑證編號。"
+msgstr ""
+"上一個產生的消費憑證編號。會用這個編號加一，來做為下一個產生的消費憑證編號。"
 
 #: libgnucash/app-utils/business-prefs.scm:60
 msgid "Job number format"
@@ -28465,7 +28297,8 @@ msgid ""
 "account register windows. If zero, all transactions can be edited and none "
 "are read-only."
 msgstr ""
-"請選擇經過幾天後，交易將會變成唯讀且不能更改。唯讀的日期的門檻會在登記簿中以紅線顯示。如果設定成 0，代表所有交易都是可以更改的，而沒有唯讀的交易。"
+"請選擇經過幾天後，交易將會變成唯讀且不能更改。唯讀的日期的門檻會在登記簿中以"
+"紅線顯示。如果設定成 0，代表所有交易都是可以更改的，而沒有唯讀的交易。"
 
 #: libgnucash/app-utils/business-prefs.scm:153
 msgid ""
@@ -28474,8 +28307,9 @@ msgid ""
 "register. Has corresponding effect on business features, reporting and "
 "imports/exports."
 msgstr ""
-"勾選的話，登記簿中的「號碼」欄位，會用來操作分割中的「動作」欄位。交易的「號碼」欄位則會在登記簿中的第二行上以「T-Num」欄位顯示。此設定也會在商務、報"
-"表、匯入匯出功能中生效。"
+"勾選的話，登記簿中的「號碼」欄位，會用來操作分割中的「動作」欄位。交易的「號"
+"碼」欄位則會在登記簿中的第二行上以「T-Num」欄位顯示。此設定也會在商務、報表、"
+"匯入匯出功能中生效。"
 
 #: libgnucash/app-utils/business-prefs.scm:159
 msgid ""
@@ -28496,7 +28330,9 @@ msgstr "您的商務的電子稅號"
 msgid ""
 "Tried to look up an undefined date symbol '~a'. This report was probably "
 "saved by a later version of GnuCash. Defaulting to today."
-msgstr "試著找尋未定義的日期符號「~a」，這份報表可能是由較新版本的 GnuCash 所儲存。預設成今天。"
+msgstr ""
+"試著找尋未定義的日期符號「~a」，這份報表可能是由較新版本的 GnuCash 所儲存。預"
+"設成今天。"
 
 #: libgnucash/app-utils/date-utilities.scm:923
 msgid "First day of the current calendar year."
@@ -28740,23 +28576,23 @@ msgstr "數值的錯誤"
 
 #. Translators: A list of error messages from the Scheduled Transactions (SX).
 #. They might appear in their editor or in "Since last run".
-#: libgnucash/app-utils/gnc-sx-instance-model.c:992
+#: libgnucash/app-utils/gnc-sx-instance-model.c:1018
 #, c-format
 msgid "Unknown account for guid [%s], cancelling SX [%s] creation."
 msgstr "未知的科目 GUID [%s]，取消排程交易 [%s] 的建立。"
 
-#: libgnucash/app-utils/gnc-sx-instance-model.c:1045
+#: libgnucash/app-utils/gnc-sx-instance-model.c:1071
 #, c-format
 msgid "Error parsing SX [%s] key [%s]=formula [%s] at [%s]: %s."
 msgstr "排程交易 [%s] 解析錯誤。鍵值 [%s]=公式 [%s] 於 [%s]: %s。"
 
-#: libgnucash/app-utils/gnc-sx-instance-model.c:1099
-#: libgnucash/app-utils/gnc-sx-instance-model.c:1760
+#: libgnucash/app-utils/gnc-sx-instance-model.c:1125
+#: libgnucash/app-utils/gnc-sx-instance-model.c:1789
 #, c-format
 msgid "Error %d in SX [%s] final gnc_numeric value, using 0 instead."
 msgstr "錯誤 %d。排程交易 [%s] 的 gnc_numeric 計算值有誤，改用 0。"
 
-#: libgnucash/app-utils/gnc-sx-instance-model.c:1769
+#: libgnucash/app-utils/gnc-sx-instance-model.c:1798
 #, c-format
 msgid "No exchange rate available in SX [%s] for %s -> %s, value is zero."
 msgstr "排程交易 [%s] 中沒有從 %s 到 %s 的可用匯率，該值將為零。"
@@ -28888,14 +28724,16 @@ msgstr "期初餘額"
 #. Translators: the 3 ~a below refer to (1) option type (2) unknown
 #. new option name, (3) fallback option name. The order is
 #. important, and must not be changed.
-#: libgnucash/app-utils/options.scm:159
+#: libgnucash/app-utils/options.scm:158
 #, scheme-format
 msgid ""
 "This report was saved using a later version of GnuCash. One of the newer ~a "
 "options '~a' is not available, fallback to the option '~a'."
-msgstr "此報表是使用較新的 GnuCash 版本建立的。其中較新的 ~a 選項「~a」此版本無法使用，改回使用「~a」。"
+msgstr ""
+"此報表是使用較新的 GnuCash 版本建立的。其中較新的 ~a 選項「~a」此版本無法使"
+"用，改回使用「~a」。"
 
-#: libgnucash/app-utils/option-util.c:1663
+#: libgnucash/app-utils/option-util.c:1630
 #, c-format
 msgid ""
 "There is a problem with option %s:%s.\n"
@@ -28904,7 +28742,7 @@ msgstr ""
 "選項 %s:%s 有誤。\n"
 "%s"
 
-#: libgnucash/app-utils/option-util.c:1664
+#: libgnucash/app-utils/option-util.c:1631
 msgid "Invalid option value"
 msgstr "無效的選項值"
 
@@ -28936,7 +28774,9 @@ msgstr "新的位址："
 msgid ""
 "If you no longer intend to run {1} 2.6.x or older on this system you can "
 "safely remove the old directory."
-msgstr "如果您不打算在此系統上使用 {1} 2.6.x 或更舊的版本，您可以放心的刪除舊的資料夾。"
+msgstr ""
+"如果您不打算在此系統上使用 {1} 2.6.x 或更舊的版本，您可以放心的刪除舊的資料"
+"夾。"
 
 #: libgnucash/core-utils/gnc-filepath-utils.cpp:691
 msgid "In addition:"
@@ -28981,40 +28821,40 @@ msgstr ""
 "下方為這些科目的列表：\n"
 "%s"
 
-#: libgnucash/engine/Account.cpp:4390
+#: libgnucash/engine/Account.cpp:4396
 msgid "Credit Card"
 msgstr "信用卡"
 
-#: libgnucash/engine/Account.cpp:4392
+#: libgnucash/engine/Account.cpp:4398
 msgid "Stock"
 msgstr "股票"
 
-#: libgnucash/engine/Account.cpp:4393
+#: libgnucash/engine/Account.cpp:4399
 msgid "Mutual Fund"
 msgstr "共同基金"
 
-#: libgnucash/engine/Account.cpp:4398
+#: libgnucash/engine/Account.cpp:4404
 msgid "A/Receivable"
 msgstr "A/應收"
 
-#: libgnucash/engine/Account.cpp:4399
+#: libgnucash/engine/Account.cpp:4405
 msgid "A/Payable"
 msgstr "A/應付"
 
-#: libgnucash/engine/Account.cpp:4400
+#: libgnucash/engine/Account.cpp:4406
 msgid "Root"
 msgstr "根"
 
-#: libgnucash/engine/Account.cpp:4842
+#: libgnucash/engine/Account.cpp:4857
 msgid "Orphaned Gains"
 msgstr "無主的獲利"
 
-#: libgnucash/engine/Account.cpp:4856 libgnucash/engine/cap-gains.c:806
+#: libgnucash/engine/Account.cpp:4871 libgnucash/engine/cap-gains.c:806
 #: libgnucash/engine/cap-gains.c:811 libgnucash/engine/cap-gains.c:812
 msgid "Realized Gain/Loss"
 msgstr "已實現獲利 / 虧損"
 
-#: libgnucash/engine/Account.cpp:4858
+#: libgnucash/engine/Account.cpp:4873
 msgid ""
 "Realized Gains or Losses from Commodity or Trading Accounts that haven't "
 "been recorded elsewhere."
@@ -29070,7 +28910,9 @@ msgid ""
 "This Dataset contains features not supported by this version of GnuCash. You "
 "must use a newer version of GnuCash in order to support the following "
 "features:"
-msgstr "此資料檔包含了這個版本的 GnuCash 所不支援的功能。您需要使用舊新版的 GnuCash 來支援以下的功能："
+msgstr ""
+"此資料檔包含了這個版本的 GnuCash 所不支援的功能。您需要使用舊新版的 GnuCash "
+"來支援以下的功能："
 
 #: libgnucash/engine/gncInvoice.c:1696
 msgid "Extra to Charge Card"
@@ -29080,7 +28922,7 @@ msgstr "額外的簽帳卡"
 msgid "Generated from an invoice. Try unposting the invoice."
 msgstr "從發票產生。試著取消過帳此發票。"
 
-#: libgnucash/engine/gncInvoice.c:2158
+#: libgnucash/engine/gncInvoice.c:2159
 msgid " (posted)"
 msgstr " (已過帳)"
 
@@ -29204,8 +29046,8 @@ msgid ""
 "Please delete this transaction. Explanation at https://wiki.gnucash.org/wiki/"
 "Business_Features_Issues#I_can.27t_delete_a_transaction_of_type_.22I.22_from_the_AR.2FAP_account"
 msgstr ""
-"請刪除此交易。詳細的說明請見：https://wiki.gnucash.org/wiki/Business_Features_Issues#I_can."
-"27t_delete_a_transaction_of_type_.22I.22_from_the_AR.2FAP_account"
+"請刪除此交易。詳細的說明請見：https://wiki.gnucash.org/wiki/"
+"Business_Features_Issues#I_can.27t_delete_a_transaction_of_type_.22I.22_from_the_AR.2FAP_account"
 
 #: libgnucash/engine/ScrubBusiness.c:616
 #, c-format
@@ -29217,12 +29059,12 @@ msgstr "檢查科目 %s 中的商務分堆：%u / %u"
 msgid "Checking business splits in account %s: %u of %u"
 msgstr "檢查科目 %s 中的商務分割：%u / %u"
 
-#: libgnucash/engine/Scrub.c:142
+#: libgnucash/engine/Scrub.c:144
 #, c-format
 msgid "Looking for orphans in account %s: %u of %u"
 msgstr "檢查科目 %s 中的無主交易：%u / %u"
 
-#: libgnucash/engine/Scrub.c:352
+#: libgnucash/engine/Scrub.c:354
 #, c-format
 msgid "Looking for imbalances in account %s: %u of %u"
 msgstr "檢查科目 %s 的失衡：%u / %u"
@@ -29244,1225 +29086,3 @@ msgstr "交易已無效"
 #: libgnucash/tax/us/txf.scm:122
 msgid "No help available."
 msgstr "沒有說明。"
-
-#, fuzzy
-#~ msgid "Path head for Linked File Relative Paths"
-#~ msgstr "匯入交易的第一個分割:"
-
-#, fuzzy
-#~ msgid ""
-#~ "\n"
-#~ "You first need to apply for Online Banking access at your bank. If your "
-#~ "bank decides to grant you electronic access, they will send you a letter "
-#~ "containing:\n"
-#~ "* The bank code of your bank\n"
-#~ "* The user ID that identifies you to your bank\n"
-#~ "* The Internet address of your bank's Online Banking server\n"
-#~ "* For HBCI Online Banking, information about the cryptographic public key "
-#~ "of your bank (\"Ini-Letter\").\n"
-#~ "\n"
-#~ "This information will be needed in the following. Press \"Next\" now.\n"
-#~ "\n"
-#~ "NOTE: NO WARRANTIES FOR ANYTHING. Some banks run a poorly implemented "
-#~ "Online Banking server. You should not rely on time-critical transfers "
-#~ "through Online Banking, because sometimes the bank does not give you "
-#~ "correct feedback when a transfer is rejected.\n"
-#~ "\n"
-#~ "Press \"Cancel\" if you do not wish to setup any Online Banking "
-#~ "connection now.\n"
-#~ "\n"
-#~ "Lastly, for repeated imports the preview page has buttons to Load and "
-#~ "Save the settings. To save the settings, tweak the settings to your "
-#~ "preferences (optionally starting from an existing preset), then "
-#~ "(optionally change the settings name and press the Save Settings button. "
-#~ "Note you can't save to built-in presets.\n"
-#~ "\n"
-#~ "This operation is not reversible, so make sure you have a working "
-#~ "backup.\n"
-#~ "\n"
-#~ "Click on \"Next\" to proceed or \"Cancel\" to Abort Import."
-#~ msgstr ""
-#~ "(使用 HBCI 或 OFX 連線方式，台灣的銀行尚未提供。)\n"
-#~ "這個精靈會幫助您設定與您的網路銀行的連線。\n"
-#~ "\n"
-#~ "您首先要向您的銀行申請網路銀行存取權。如果您的銀行決定授予您電子化存取權，"
-#~ "銀行會寄給您一封信，裡面包含:\n"
-#~ "* 您的銀行的銀行代碼\n"
-#~ "* 使用者 ID ，讓您的銀行能辨認您\n"
-#~ "* 您銀行伺服器的網路位址\n"
-#~ "* 對於 HBCI 網路銀行, 您銀行的加密公開金鑰的相關資訊(\"Ini-Letter\")。\n"
-#~ "\n"
-#~ "這些資訊會在稍後用到。現在請按「向前」。\n"
-#~ "\n"
-#~ "注意：不 擔 保 任 何 事。部份銀行的網路銀行功能實作不完全。對於時間緊迫的"
-#~ "轉帳您不應該依賴網路銀行存取的方式，因為有時候轉帳被拒絕時銀行不一定能給您"
-#~ "正確的回饋。\n"
-#~ "\n"
-#~ "如果您現在不希望設定任何網路銀行連線，請按「取消」。"
-
-#, fuzzy
-#~ msgid "Select Columns"
-#~ msgstr "選擇科目"
-
-#, fuzzy
-#~ msgid "Report format"
-#~ msgstr "選擇匯出格式"
-
-#~ msgid "Show Asset & Liability bars"
-#~ msgstr "顯示資產&債務長條"
-
-#~ msgid "Show Net Worth bars"
-#~ msgstr "顯示價值淨額長條"
-
-#, fuzzy
-#~ msgid "Reconcile Status"
-#~ msgstr "對帳日期"
-
-#, fuzzy
-#~ msgid ">>"
-#~ msgstr ">"
-
-#, fuzzy
-#~ msgid "<<"
-#~ msgstr "<"
-
-#, fuzzy
-#~ msgid "<b>Accounts</b>"
-#~ msgstr "<b>科目(_A)</b>"
-
-#, fuzzy
-#~ msgid "<b>Dates</b>"
-#~ msgstr "<b>說明(_N)</b>"
-
-#, fuzzy
-#~ msgid "<b>Currency To</b>"
-#~ msgstr "<b>貨幣兌換</b>"
-
-#, fuzzy
-#~ msgid "<b>Notes</b>"
-#~ msgstr "<b>說明(_N)</b>"
-
-#, fuzzy
-#~ msgid "<b>Book Options</b>"
-#~ msgstr "<b>選項</b>"
-
-#~ msgid "<b>General</b>"
-#~ msgstr "<b>一般</b>"
-
-#~ msgid "<b>Transactions</b>"
-#~ msgstr "<b>交易</b>"
-
-#~ msgid "<b>Identification</b>"
-#~ msgstr "<b>識別</b>"
-
-#~ msgid "<b>_Parent Account</b>"
-#~ msgstr "<b>母科目(_P)</b>"
-
-#~ msgid "<b>QIF Import</b>"
-#~ msgstr "<b>QIF 匯入</b>"
-
-#~ msgid "<b>Terms</b>"
-#~ msgstr "<b>條款</b>"
-
-#~ msgid "<b>Securities</b>"
-#~ msgstr "<b>證券</b>"
-
-#, fuzzy
-#~ msgid "<b>Security Information</b>"
-#~ msgstr "證券資訊"
-
-#~ msgid "<b>1. Choose the file to import</b>"
-#~ msgstr "<b>1. 選擇匯入檔</b>"
-
-#~ msgid "<b>3. Select import options</b>"
-#~ msgstr "<b>3. 選擇匯入選項</b>"
-
-#, fuzzy
-#~ msgid "<b>4. Preview</b>"
-#~ msgstr "<b>3. 預覽</b>"
-
-#, fuzzy
-#~ msgid "<b>Period</b>"
-#~ msgstr "<b>週期：</b>"
-
-#~ msgid "<b>Colors</b>"
-#~ msgstr "<b>顏色</b>"
-
-#~ msgid "<b>_Notes</b>"
-#~ msgstr "<b>說明(_N)</b>"
-
-#, fuzzy
-#~ msgid "<b>Amount</b>"
-#~ msgstr "<b>科目(_A)</b>"
-
-#~ msgid "<b>Start Date</b>"
-#~ msgstr "<b>開始日期</b>"
-
-#~ msgid "<b>End Date</b>"
-#~ msgstr "<b>結束日期</b>"
-
-#, fuzzy
-#~ msgid "<b>Account Color</b>"
-#~ msgstr "<b>科目(_A)</b>"
-
-#~ msgid "<b>Fancy Date Format</b>"
-#~ msgstr "<b>精美的日期格式</b>"
-
-#~ msgid "<b>Date Format</b>"
-#~ msgstr "<b>日期格式</b>"
-
-#, fuzzy
-#~ msgid "<b>Layout</b>"
-#~ msgstr "<b>科目(_A)</b>"
-
-#, fuzzy
-#~ msgid "<b>Default zoom level</b>"
-#~ msgstr "<b>預設樣式</b>"
-
-#, fuzzy
-#~ msgid "<b>Online Quotes</b>"
-#~ msgstr "取得線上報價(_G)"
-
-#~ msgid "<b>Name</b>"
-#~ msgstr "<b>名稱</b>"
-
-#~ msgid "<b>Options</b>"
-#~ msgstr "<b>選項</b>"
-
-#~ msgid "<b>Income Tax Identity</b>"
-#~ msgstr "<b>所得稅籍</b>"
-
-#~ msgid "<b>Tax Tables</b>"
-#~ msgstr "<b>稅金表格</b>"
-
-#~ msgid "<b>Tax Table</b>"
-#~ msgstr "<b>稅金表格</b>"
-
-#~ msgid "<b>Transfer From</b>"
-#~ msgstr "<b>轉帳自</b>"
-
-#~ msgid "<b>Transfer To</b>"
-#~ msgstr "<b>轉帳到</b>"
-
-#~ msgid "<b>New Transaction Information</b>"
-#~ msgstr "<b>新增交易資訊</b>"
-
-#~ msgid "<b>Progress</b>"
-#~ msgstr "<b>進度</b>"
-
-#~ msgid "<b>From</b>"
-#~ msgstr "<b>轉帳自</b>"
-
-#~ msgid "<b>To</b>"
-#~ msgstr "<b>到</b>"
-
-#~ msgid "<b>Online Banking</b>"
-#~ msgstr "<b>網路銀行</b>"
-
-#, fuzzy
-#~ msgid "Search from "
-#~ msgstr "搜尋 "
-
-#, fuzzy
-#~ msgid "Search from Root"
-#~ msgstr "搜尋結果"
-
-#, fuzzy
-#~ msgid "Search from Sub Account"
-#~ msgstr "檢查和修復科目(_A)"
-
-#, fuzzy
-#~ msgid "_Search"
-#~ msgstr "搜尋 "
-
-#~ msgid "Company Name "
-#~ msgstr "公司名稱 "
-
-#~ msgid "Increasing"
-#~ msgstr "遞增"
-
-#~ msgid "Decreasing"
-#~ msgstr "遞減"
-
-#, fuzzy
-#~ msgid "full_name"
-#~ msgstr "全名(_F)："
-
-#, fuzzy
-#~ msgid "name"
-#~ msgstr "使用者名稱"
-
-#, fuzzy
-#~ msgid "code"
-#~ msgstr "Unicode"
-
-#, fuzzy
-#~ msgid "description"
-#~ msgstr "描述"
-
-#, fuzzy
-#~ msgid "color"
-#~ msgstr "顏色"
-
-#, fuzzy
-#~ msgid "notes"
-#~ msgstr "筆記"
-
-#, fuzzy
-#~ msgid "commoditym"
-#~ msgstr "商品"
-
-#, fuzzy
-#~ msgid "commodityn"
-#~ msgstr "商品"
-
-#, fuzzy
-#~ msgid "hidden"
-#~ msgstr "隱藏(_I)"
-
-#, fuzzy
-#~ msgid "tax"
-#~ msgstr "稅"
-
-#, fuzzy
-#~ msgid "placeholder"
-#~ msgstr "Placeholder"
-
-#, fuzzy
-#~ msgid "Searching for splits to clear ..."
-#~ msgstr "搜尋項目位於"
-
-#~ msgid "0"
-#~ msgstr "0"
-
-#~ msgid "1 /"
-#~ msgstr "1 /"
-
-#, fuzzy
-#~ msgid "07/31/2013"
-#~ msgstr "07/31/2005"
-
-#, fuzzy
-#~ msgid "31/07/2013"
-#~ msgstr "31/07/2005"
-
-#, fuzzy
-#~ msgid "31.07.2013"
-#~ msgstr "31.07.2005"
-
-#, fuzzy
-#~ msgid "2013-07-31"
-#~ msgstr "2005-07-31"
-
-#, fuzzy
-#~ msgid "30"
-#~ msgstr "0"
-
-#~ msgid "<b>Auto-Clear Information</b>"
-#~ msgstr "<b>自動結清資訊</b>"
-
-#~ msgid "Exchange rates"
-#~ msgstr "匯率"
-
-#, c-format
-#~ msgid "Bad URL %s"
-#~ msgstr "不正確的 URL %s"
-
-#, c-format
-#~ msgid "No such Account entity: %s"
-#~ msgstr "沒有這個科目實體： %s"
-
-#, fuzzy
-#~ msgid "Change a Business Association"
-#~ msgstr "交易資訊"
-
-#, fuzzy
-#~ msgid "Transaction Associations"
-#~ msgstr "交易資訊"
-
-#, fuzzy
-#~ msgid "Open Association:"
-#~ msgstr "動作"
-
-#, fuzzy
-#~ msgid "_Transaction Associations"
-#~ msgstr "交易資訊"
-
-#, fuzzy
-#~ msgid "Business _Associations"
-#~ msgstr "交易資訊"
-
-#, fuzzy
-#~ msgid "_Update Association for Invoice"
-#~ msgstr "重複相同的發票(_D)"
-
-#, fuzzy
-#~ msgid "_Open Association for Invoice"
-#~ msgstr "重複相同的發票(_D)"
-
-#, fuzzy
-#~ msgid "_Remove Association from Invoice"
-#~ msgstr "重複相同的發票(_D)"
-
-#, fuzzy
-#~ msgid "_Update Association for Bill"
-#~ msgstr "以描述排序"
-
-#, fuzzy
-#~ msgid "_Open Association for Bill"
-#~ msgstr "重複相同的發票(_D)"
-
-#, fuzzy
-#~ msgid "_Remove Association from Bill"
-#~ msgstr "以描述排序"
-
-#, fuzzy
-#~ msgid "_Open Association for Voucher"
-#~ msgstr "重複相同的發票(_D)"
-
-#, fuzzy
-#~ msgid "_Update Association for Credit Note"
-#~ msgstr "編輯報表選項"
-
-#, fuzzy
-#~ msgid "_Open Association for Credit Note"
-#~ msgstr "重複相同的發票(_D)"
-
-#, fuzzy
-#~ msgid "_Remove Association from Credit Note"
-#~ msgstr "編輯報表選項"
-
-#, fuzzy
-#~ msgid "Update Association for current invoice"
-#~ msgstr "重複相同的發票(_D)"
-
-#, fuzzy
-#~ msgid "Open Association for current invoice"
-#~ msgstr "重複相同的發票(_D)"
-
-#, fuzzy
-#~ msgid "Remove Association from invoice"
-#~ msgstr "重複相同的發票(_D)"
-
-#, fuzzy
-#~ msgid "Open Association for current bill"
-#~ msgstr "重複相同的發票(_D)"
-
-#, fuzzy
-#~ msgid "Open Association for current voucher"
-#~ msgstr "重複相同的發票(_D)"
-
-#, fuzzy
-#~ msgid "Update Association for credit note"
-#~ msgstr "編輯報表選項"
-
-#, fuzzy
-#~ msgid "Open Association for credit note"
-#~ msgstr "重複相同的發票(_D)"
-
-#~ msgid "Jump to the corresponding transaction in the other account"
-#~ msgstr "跳至其他科目中對應的交易"
-
-#, fuzzy
-#~ msgid "Update _Association for Transaction"
-#~ msgstr "自動建立新交易(_A)"
-
-#, fuzzy
-#~ msgid "_Open Association for Transaction"
-#~ msgstr "自動建立新交易(_A)"
-
-#, fuzzy
-#~ msgid "Re_move Association from Transaction"
-#~ msgstr "刪除交易中的一個分割"
-
-#, fuzzy
-#~ msgid "Open Associated Invoice"
-#~ msgstr "重複相同的發票(_D)"
-
-#, fuzzy
-#~ msgid "Update Association for the current transaction"
-#~ msgstr "製作目前交易的拷貝"
-
-#, fuzzy
-#~ msgid "Remove the association from the current transaction"
-#~ msgstr "移除目前交易中的所有分割"
-
-#, fuzzy
-#~ msgid "Open the associated invoice"
-#~ msgstr "開啟尋找發票對話盒"
-
-#, fuzzy
-#~ msgid "Update Association"
-#~ msgstr "動作"
-
-#, fuzzy
-#~ msgid "Open Association"
-#~ msgstr "動作"
-
-#, fuzzy
-#~ msgid "Remove Association"
-#~ msgstr "動作"
-
-#, fuzzy
-#~ msgid "Open Invoice"
-#~ msgstr "新增發票"
-
-#, fuzzy
-#~ msgid "Currency account registers"
-#~ msgstr "目前科目(_U)"
-
-#, fuzzy
-#~ msgid "Business account registers"
-#~ msgstr "這個科目登記簿唯讀。"
-
-#, fuzzy
-#~ msgid "Journal registers"
-#~ msgstr "準備好建立"
-
-#, fuzzy
-#~ msgid "Stock account registers"
-#~ msgstr "用於證券「%s」的股票科目"
-
-#, fuzzy
-#~ msgid "Portfolio registers"
-#~ msgstr "投資組合報表"
-
-#, fuzzy
-#~ msgid "Register group Unknown"
-#~ msgstr "在新視窗中開啟登記簿(_W)"
-
-#, fuzzy
-#~ msgid "_File Association"
-#~ msgstr "動作"
-
-#, fuzzy
-#~ msgid "_Location Association"
-#~ msgstr "以描述排序"
-
-#, fuzzy
-#~ msgid "All Associations"
-#~ msgstr "動作"
-
-#, fuzzy
-#~ msgid "_Locate Associations"
-#~ msgstr "以描述排序"
-
-#, fuzzy
-#~ msgid "Association"
-#~ msgstr "動作"
-
-#~ msgid "Date/Time"
-#~ msgstr "日期/時間"
-
-#, fuzzy
-#~ msgid "20"
-#~ msgstr "0"
-
-#, fuzzy
-#~ msgid "Path head for Associated files"
-#~ msgstr "匯入交易的第一個分割:"
-
-#, fuzzy
-#~ msgid "<b>Associated Files</b>"
-#~ msgstr "<b>檔案</b>"
-
-#, fuzzy
-#~ msgid "Date-opened"
-#~ msgstr "開發票的日期"
-
-#, fuzzy
-#~ msgid "Date-posted"
-#~ msgstr "張貼的日期"
-
-#, fuzzy
-#~ msgctxt "Column header for 'Associate'"
-#~ msgid "A"
-#~ msgstr "A"
-
-#, fuzzy
-#~ msgid "One year."
-#~ msgstr "一年以前"
-
-#, fuzzy, scheme-format
-#~ msgid "No transactions were found associated with the ~a."
-#~ msgstr "目前的交易尚未結算。"
-
-#, fuzzy
-#~ msgid "Font to use for the main heading"
-#~ msgstr "主要標題所用的字型"
-
-#, fuzzy
-#~ msgid "Font to use for everything else"
-#~ msgstr "其他所有地方用到的字型"
-
-#, fuzzy
-#~ msgid "Display the transaction association"
-#~ msgstr "是否顯示交易描述？"
-
-#, fuzzy
-#~ msgid "Enable links"
-#~ msgstr "啟動鏈結"
-
-#, fuzzy
-#~ msgid "Outflow to Expenses"
-#~ msgstr "總支出"
-
-#, fuzzy
-#~ msgid "Outflow to Asset/Equity/Liability"
-#~ msgstr "顯示資產&債務長條"
-
-#~ msgid "Open an existing Budget"
-#~ msgstr "開啟已存在的預算"
-
-#, fuzzy
-#~ msgid "Delete Budget"
-#~ msgstr "刪除預算(_D)"
-
-#~ msgid "Delete this budget"
-#~ msgstr "刪除目前的預算"
-
-#, fuzzy
-#~ msgid "_Associate File with Transaction"
-#~ msgstr "自動建立新交易(_A)"
-
-#, fuzzy
-#~ msgid "Open the associated file or location with the current transaction"
-#~ msgstr "以目前交易做為範本建立排程的交易"
-
-#, fuzzy
-#~ msgid "Associate File with Transaction"
-#~ msgstr "自動建立新交易(_A)"
-
-#, fuzzy
-#~ msgid "Associate Location with Transaction"
-#~ msgstr "自動建立新交易(_A)"
-
-#, fuzzy
-#~ msgid "This transaction is not associated with a URI."
-#~ msgstr "目前的交易尚未結算。"
-
-#~ msgid "Add price quotes to given GnuCash datafile"
-#~ msgstr "增加報價至指定的 GnuCash 檔案"
-
-#~ msgid "FILE"
-#~ msgstr "FILE"
-
-#~ msgid "REGEXP"
-#~ msgstr "REGEXP"
-
-#, c-format
-#~ msgid "GnuCash %s"
-#~ msgstr "GnuCash %s"
-
-#~ msgid "Due Day: "
-#~ msgstr "到期日: "
-
-#~ msgid "Discount Day: "
-#~ msgstr "折扣日: "
-
-#~ msgid "Discount %: "
-#~ msgstr "折扣 %: "
-
-#, fuzzy
-#~ msgid "Online ID"
-#~ msgstr "線上交易"
-
-#~ msgid "<b>Generic Importer</b>"
-#~ msgstr "<b>通用匯入器</b>"
-
-#~ msgid "\"U+R\""
-#~ msgstr "\"U+R\""
-
-#~ msgid "\"R\""
-#~ msgstr "\"R\""
-
-#, fuzzy
-#~ msgid "<b>Path head for Transaction Association Files</b>"
-#~ msgstr "<b>新增交易資訊</b>"
-
-#~ msgid "_Password:"
-#~ msgstr "密碼(_P)："
-
-#, fuzzy
-#~ msgid "Payable Aging (beta)"
-#~ msgstr "應付帳款帳齡"
-
-#, fuzzy
-#~ msgid "Receivable Aging (beta)"
-#~ msgstr "應收帳款帳齡"
-
-#, fuzzy
-#~ msgid "Customer Report (beta)"
-#~ msgstr "客戶報表"
-
-#, fuzzy
-#~ msgid "Vendor Report (beta)"
-#~ msgstr "廠商報表"
-
-#, fuzzy
-#~ msgid "Employee Report (beta)"
-#~ msgstr "員工報表"
-
-#~ msgid "Welcome Sample Report"
-#~ msgstr "歡迎來到樣本報表"
-
-#~ msgid "Welcome-to-GnuCash report screen"
-#~ msgstr "歡迎來到 GnuCash 報表畫面"
-
-#~ msgid "An error occurred when processing the template:"
-#~ msgstr "在處理範本時發生錯誤:"
-
-#~ msgid "Include sub-account balances in printed balance?"
-#~ msgstr "在列印的結餘中包含子科目結算？"
-
-#~ msgid "Group the accounts in main categories?"
-#~ msgstr "把科目歸類到主分類？"
-
-#~ msgid "Display the account's foreign currency amount?"
-#~ msgstr "顯示科目中外來貨幣的總額？"
-
-#~ msgid "_Sample & Custom"
-#~ msgstr "樣本 & 自訂(_S)"
-
-#, fuzzy
-#~ msgid "Display a period credits column?"
-#~ msgstr "顯示項目的折扣"
-
-#, fuzzy
-#~ msgid "Display a period debits column?"
-#~ msgstr "顯示項目的折扣"
-
-#, fuzzy
-#~ msgid "Delete Settings"
-#~ msgstr "刪除分割(_D)"
-
-#~ msgid "These rows were deleted:"
-#~ msgstr "這些列已被刪除:"
-
-#, fuzzy
-#~ msgid "Are you sure you have bills/invoices to update?"
-#~ msgstr "您確定要這麼作嗎？"
-
-#, fuzzy
-#~ msgid "id"
-#~ msgstr "支付"
-
-#, fuzzy
-#~ msgid "company"
-#~ msgstr "公司"
-
-#, fuzzy
-#~ msgid "phone"
-#~ msgstr "電話"
-
-#, fuzzy
-#~ msgid "fax"
-#~ msgstr "傳真"
-
-#, fuzzy
-#~ msgid "email"
-#~ msgstr "電子郵件"
-
-#, fuzzy
-#~ msgid "shipname"
-#~ msgstr "使用者名稱"
-
-#~ msgid "Expense Report"
-#~ msgstr "支出報表"
-
-#, fuzzy
-#~ msgid "Prepayments"
-#~ msgstr "付款"
-
-#, fuzzy
-#~ msgid "Pre-payment"
-#~ msgstr "預付款"
-
-#~ msgid "Period:"
-#~ msgstr "期間:"
-
-#~ msgid "Action Column|Split"
-#~ msgstr "股票分割"
-
-#, fuzzy
-#~ msgid "Are you sure you want to delete the entries?"
-#~ msgstr "您確定要刪除這個項目？"
-
-#, fuzzy
-#~ msgid "Transfers"
-#~ msgstr "轉帳"
-
-#~ msgid "Title:"
-#~ msgstr "標題:"
-
-#~ msgid "Notes:"
-#~ msgstr "筆記:"
-
-#~ msgid "Interest Rate:"
-#~ msgstr "利率:"
-
-#~ msgid "Amount:"
-#~ msgstr "總額:"
-
-#~ msgid "Type:"
-#~ msgstr "類型："
-
-#~ msgid "Payment From:"
-#~ msgstr "付款來自:"
-
-#~ msgid "Name:"
-#~ msgstr "名稱："
-
-#~ msgid "Payment To:"
-#~ msgstr "付款到:"
-
-#~ msgid "_Date:"
-#~ msgstr "日期(_D)："
-
-#~ msgid "_Shares:"
-#~ msgstr "股數(_S):"
-
-#~ msgid "_Memo:"
-#~ msgstr "備忘錄(_M):"
-
-#, fuzzy
-#~ msgid "Whether to display the list of Invoices Due at startup."
-#~ msgstr "是否於啟動時顯示帳單到期清單。"
-
-#~ msgid "Customer Number: "
-#~ msgstr "客戶編號: "
-
-#~ msgid "Company Name: "
-#~ msgstr "公司名稱: "
-
-#~ msgid "Name: "
-#~ msgstr "名稱: "
-
-#~ msgid "Address: "
-#~ msgstr "地址: "
-
-#~ msgid "Phone: "
-#~ msgstr "電話: "
-
-#~ msgid "Fax: "
-#~ msgstr "傳真: "
-
-#~ msgid "Email: "
-#~ msgstr "電子郵件: "
-
-#~ msgid "Currency: "
-#~ msgstr "貨幣: "
-
-#~ msgid "Discount: "
-#~ msgstr "折扣: "
-
-#~ msgid "Tax Included: "
-#~ msgstr "含稅: "
-
-#~ msgid "Employee Number: "
-#~ msgstr "員工編號: "
-
-#~ msgid "Username: "
-#~ msgstr "使用者名稱: "
-
-#, fuzzy
-#~ msgid "_Clear"
-#~ msgstr "清除"
-
-#~ msgid "total"
-#~ msgstr "總額"
-
-#~ msgid "Frequency:"
-#~ msgstr "頻率:"
-
-#, fuzzy
-#~ msgid "Find Account Dialog"
-#~ msgstr "科目刪除"
-
-#~ msgid "Customer: "
-#~ msgstr "客戶: "
-
-#~ msgid "Job: "
-#~ msgstr "工作: "
-
-#~ msgid "_Price:"
-#~ msgstr "價格(_P):"
-
-#, fuzzy
-#~ msgid "Source:"
-#~ msgstr "來源(_O)："
-
-#~ msgid "_Notes:"
-#~ msgstr "筆記(_N):"
-
-#~ msgid "_Address:"
-#~ msgstr "地址(_A):"
-
-#, fuzzy
-#~ msgid "End: "
-#~ msgstr "結束:"
-
-#~ msgid "For:"
-#~ msgstr "多久:"
-
-#, fuzzy
-#~ msgid "Transaction Association Dialog"
-#~ msgstr "交易資訊"
-
-#~ msgid "Vendor Number: "
-#~ msgstr "廠商編號: "
-
-#~ msgid "Tax Table:"
-#~ msgstr "稅金表格:"
-
-#~ msgid "End:"
-#~ msgstr "結束:"
-
-#~ msgid "Reconciled:R"
-#~ msgstr "已對帳:R"
-
-#~ msgid "Difference:"
-#~ msgstr "差額："
-
-#~ msgid "()"
-#~ msgstr "()"
-
-#~ msgid "Column letter for 'Placeholder'|P"
-#~ msgstr "P"
-
-#~ msgid "View:"
-#~ msgstr "檢視:"
-
-#~ msgid "Action Column|Deposit"
-#~ msgstr "存款"
-
-#~ msgid "Column letter for 'Get Quotes'|Q"
-#~ msgstr "Q"
-
-#, fuzzy
-#~ msgid "Column letter for 'Active'|A"
-#~ msgstr "Q"
-
-#~ msgid "Single-character short column-title form of 'Enabled'|E"
-#~ msgstr "啟用"
-
-#~ msgid "_Balance:"
-#~ msgstr "結餘(_B)："
-
-#~ msgid "Description:"
-#~ msgstr "敘述："
-
-#~ msgid "GnuCash Options"
-#~ msgstr "GnuCash 選項"
-
-#~ msgid "_Account:"
-#~ msgstr "科目(_A):"
-
-#~ msgid "_Value: "
-#~ msgstr "價值(_V): "
-
-#~ msgid "_Type: "
-#~ msgstr "類型(_T): "
-
-#~ msgid "_Name: "
-#~ msgstr "名稱(_N): "
-
-#, fuzzy
-#~ msgid "_Back"
-#~ msgstr "往後"
-
-#, fuzzy
-#~ msgid "_Forward"
-#~ msgstr "往前"
-
-#~ msgid "Date:"
-#~ msgstr "日期："
-
-#~ msgid "Num:"
-#~ msgstr "號碼："
-
-#~ msgid "Memo:"
-#~ msgstr "備忘錄："
-
-#~ msgid "Currency:"
-#~ msgstr "貨幣："
-
-#~ msgid "December 31, 2000"
-#~ msgstr "十二月 31, 2000"
-
-#~ msgid "Months:"
-#~ msgstr "月："
-
-#~ msgid "Years:"
-#~ msgstr "年："
-
-#~ msgid "_Now"
-#~ msgstr "現在(_N)"
-
-#~ msgid "Password:"
-#~ msgstr "密碼："
-
-#~ msgid "something"
-#~ msgstr "某事"
-
-#~ msgid "Enter an Online Direct Debit Note"
-#~ msgstr "輸入線上直接債務備註"
-
-#~ msgid "Debited Account Number"
-#~ msgstr "借方帳號號碼"
-
-#~ msgid "Debited Account Bank Code"
-#~ msgstr "借方帳號銀行代碼"
-
-#~ msgid "Credited Account Number"
-#~ msgstr "貸方帳號號碼"
-
-#~ msgid "Credited Account Bank Code"
-#~ msgstr "貸方帳號銀行代碼"
-
-#~ msgid "_Issue Transaction..."
-#~ msgstr "發布交易(_I)..."
-
-#, fuzzy
-#~ msgid "Issue a new transaction online through Online Banking"
-#~ msgstr "透過 HBCI 在線上發布新的交易"
-
-#~ msgid "_Direct Debit..."
-#~ msgstr "自動扣款(_D)..."
-
-#, fuzzy
-#~ msgid "Issue a new direct debit note online through Online Banking"
-#~ msgstr "透過 HBCI 在線上發布新的直接債務"
-
-#~ msgid "Import a MT940 file into GnuCash"
-#~ msgstr "匯入 MT940 檔案到 GnuCash"
-
-#~ msgid "Import a MT942 file into GnuCash"
-#~ msgstr "匯入 MT942 檔案到 GnuCash"
-
-#, fuzzy
-#~ msgid "Save the Import Settings."
-#~ msgstr "選擇匯出格式"
-
-#, fuzzy
-#~ msgid " duplicated and "
-#~ msgstr "複製"
-
-#, fuzzy
-#~ msgid "Commodity From"
-#~ msgstr "商品"
-
-#~ msgid "I_mport"
-#~ msgstr "匯入(_M)"
-
-#~ msgid "Account name:"
-#~ msgstr "科目名稱："
-
-#~ msgid "sample:X"
-#~ msgstr "sample:X"
-
-#~ msgid "sample:Action"
-#~ msgstr "sample:動作"
-
-#~ msgid "sample(DT):+%"
-#~ msgstr "sample(DT):+%"
-
-#~ msgid "sample(DH):+%"
-#~ msgstr "sample(DH):+%"
-
-#~ msgid "sample:T?"
-#~ msgstr "sample:T?"
-
-#~ msgid "sample:TI"
-#~ msgstr "sample:TI"
-
-#~ msgid "sample:Tax Table 1"
-#~ msgstr "sample:稅金表格 1"
-
-#~ msgid "sample:BI"
-#~ msgstr "sample:BI"
-
-#~ msgid "sample:Payment"
-#~ msgstr "sample:付款"
-
-#~ msgid "sample:99999"
-#~ msgstr "sample:99999"
-
-#~ msgid "Type:T"
-#~ msgstr "sample:T"
-
-#~ msgid "%s %s - %s"
-#~ msgstr "%s %s - %s"
-
-#~ msgid "Charge Type"
-#~ msgstr "費用類型"
-
-#, fuzzy
-#~ msgid "Display the charge type?"
-#~ msgstr "顯示股份價格？"
-
-#~ msgid "My Company"
-#~ msgstr "我的公司"
-
-#~ msgid "Display my company name and address?"
-#~ msgstr "顯示我公司的名稱及地址？"
-
-#~ msgid "My Company ID"
-#~ msgstr "我公司的 ID"
-
-#~ msgid "Display my company ID?"
-#~ msgstr "是否顯示我公司的 ID？"
-
-#~ msgid "Individual Taxes"
-#~ msgstr "個別稅金"
-
-#~ msgid "Display all the individual taxes?"
-#~ msgstr "是否顯示所有的個別稅金？"
-
-#~ msgid "Invoice Width"
-#~ msgstr "發票寬度"
-
-#~ msgid "The minimum width of the invoice."
-#~ msgstr "發票最小的寬度。"
-
-#~ msgid "Text"
-#~ msgstr "文字"
-
-#, fuzzy
-#~ msgid "Extra notes to put on the invoice (simple HTML is accepted)."
-#~ msgstr "發票上的額外備註。(允許簡單的 HTML)"
-
-#~ msgid "%s #%d"
-#~ msgstr "%s #%d"
-
-#~ msgid "Phone:"
-#~ msgstr "電話:"
-
-#~ msgid "Fax:"
-#~ msgstr "傳真:"
-
-#~ msgid "Web:"
-#~ msgstr "網頁:"
-
-#~ msgid "%s&nbsp;#"
-#~ msgstr "%s&nbsp;#"
-
-#~ msgid "%s&nbsp;Date"
-#~ msgstr "%s&nbsp;日期"
-
-#, fuzzy
-#~ msgid "Due&nbsp;Date"
-#~ msgstr "%s&nbsp;日期"
-
-#, fuzzy
-#~ msgid "Job name"
-#~ msgstr "工作名稱"
-
-#, fuzzy
-#~ msgid "Report Currency"
-#~ msgstr "報表的貨幣"
-
-#, fuzzy
-#~ msgid "Payment received, thank you."
-#~ msgstr "付款已收到，謝謝您"
-
-#, fuzzy
-#~ msgid "Shade alternate transactions"
-#~ msgstr "淡化其它交易"
-
-#~ msgid "%s: %s - %s"
-#~ msgstr "%s: %s - %s"
-
-#, fuzzy
-#~ msgid "Roll up budget amounts to parent"
-#~ msgstr "科目刪除"
-
-#~ msgid "%s: %s"
-#~ msgstr "%s: %s"
-
-#~ msgid "%s and subaccounts"
-#~ msgstr "%s 和子科目"
-
-#, fuzzy
-#~ msgid "Account Matcher"
-#~ msgstr "科目名稱"
-
-#, fuzzy
-#~ msgid "Transaction Matcher"
-#~ msgstr "交易日期"
-
-#~ msgid "Show the full account name for subtotals and subtitles?"
-#~ msgstr "顯示小計與小標題的科目全名？"
-
-#~ msgid "Show the account code for subtotals and subtitles?"
-#~ msgstr "顯示小計與小標題的科目代碼？"
-
-#, fuzzy
-#~ msgid "Individual income columns"
-#~ msgstr "個別稅金"
-
-#, fuzzy
-#~ msgid "Reverse amount display for income-related columns."
-#~ msgstr "反轉收入與支出的總額顯示"
-
-#~ msgid "From %s To %s"
-#~ msgstr "從 %s 到 %s"
-
-#~ msgid "Primary Subtotals/headings"
-#~ msgstr "主要小計/標題"
-
-#~ msgid "Secondary Subtotals/headings"
-#~ msgstr "次要小計/標題"
-
-#~ msgid "Split Odd"
-#~ msgstr "奇數分割"
-
-#~ msgid "Split Even"
-#~ msgstr "偶數分割"
-
-#, fuzzy
-#~ msgid "No accounts were matched"
-#~ msgstr "沒有選定科目"
-
-#~ msgid "Client"
-#~ msgstr "客戶"
-
-#, fuzzy
-#~ msgid ""
-#~ "No account were found that match the options specified in the Options "
-#~ "panels."
-#~ msgstr "找不到跟所給的時間間隔與所選科目相符的交易。"
-
-#, fuzzy
-#~ msgid " regex"
-#~ msgstr "符合正規表示式"
-
-#, fuzzy
-#~ msgid "Accounts produced"
-#~ msgstr "科目代碼"
-
-#~ msgid "not cleared:n"
-#~ msgstr "not cleared:n"
-
-#~ msgid "cleared:c"
-#~ msgstr "cleared:c"
-
-#~ msgid "reconciled:y"
-#~ msgstr "reconciled:y"
-
-#~ msgid "frozen:f"
-#~ msgstr "frozen:f"
-
-#~ msgid "void:v"
-#~ msgstr "void:v"
-
-#, fuzzy
-#~ msgid "example description..."
-#~ msgstr "名稱或描述(_N):"
-
-#~ msgid "Continuing with good quotes."
-#~ msgstr "以已取回的報價繼續。"
-
-#, fuzzy
-#~ msgid "Adding remaining good quotes."
-#~ msgstr "加入剩餘的可靠報價。"


### PR DESCRIPTION
This translation file hasn't been maintained for years. It contains lots of useless / misleading comments or fuzzy entry left by msgmerge, and lots of file reference does not match the latest code base.

This makes it hard to translate both on Weblate, or use desktop program like PoEdit after download the po file from Weblate. 

I've updated and merge it with latest .pot template generated from latest source code in `maint` branch.

I've also tried upload it to Weblate directly, but apparently it won't delete those garbage comment and won't add msgid that didn't exist in the current po file. 