### PR TITLE
Developer log

### DIFF
--- a/bindings/guile/core-utils.scm
+++ b/bindings/guile/core-utils.scm
@@ -41,6 +41,7 @@
 (export gnc:string-locale<?)
 (export gnc:string-locale>?)
 (export gnc:version)
+(export gnc:issue-deprecation-warning)
 
 ;; loads modules and re-exports all its public interface into the
 ;; current module
@@ -75,6 +76,10 @@
 
 (define gnc:string-locale<? string-locale<?)
 (define gnc:string-locale>? string-locale>?)
+
+(define (gnc:issue-deprecation-warning str)
+  (issue-deprecation-warning str)
+  (gnc-add-developer-log-entry str))
 
 ;; Custom unbound-variable exception printer: instead of generic "In
 ;; procedure module-lookup: Unbound variable: varname", it will first

--- a/gnucash/gnome-utils/gnc-main-window.c
+++ b/gnucash/gnome-utils/gnc-main-window.c
@@ -157,6 +157,7 @@ static void gnc_main_window_cmd_page_setup (GtkAction *action, GncMainWindow *wi
 static void gnc_main_window_cmd_file_properties (GtkAction *action, GncMainWindow *window);
 static void gnc_main_window_cmd_file_close (GtkAction *action, GncMainWindow *window);
 static void gnc_main_window_cmd_file_quit (GtkAction *action, GncMainWindow *window);
+static void gnc_main_window_cmd_dev_log (GtkAction *action, GncMainWindow *window);
 static void gnc_main_window_cmd_edit_cut (GtkAction *action, GncMainWindow *window);
 static void gnc_main_window_cmd_edit_copy (GtkAction *action, GncMainWindow *window);
 static void gnc_main_window_cmd_edit_paste (GtkAction *action, GncMainWindow *window);
@@ -311,6 +312,11 @@ static GtkActionEntry gnc_menu_actions [] =
         "FileQuitAction", "application-exit", N_("_Quit"), "<primary>Q",
         N_("Quit this application"),
         G_CALLBACK (gnc_main_window_cmd_file_quit)
+    },
+    {
+        "DevLogAction", NULL, N_("_Developer Log"), NULL,
+        N_("Show developer log"),
+        G_CALLBACK (gnc_main_window_cmd_dev_log)
     },
 
     /* Edit menu */
@@ -4354,6 +4360,23 @@ gnc_main_window_cmd_file_close (GtkAction *action, GncMainWindow *window)
     page = priv->current_page;
     gnc_main_window_close_page(page);
 }
+
+static void
+gnc_main_window_cmd_dev_log (GtkAction *action, GncMainWindow *window)
+{
+    gchar *logstr;
+    if (gnc_developer_log_empty ())
+    {
+        PWARN ("devlog empty. this button should be disabled.");
+        return;
+    }
+
+    logstr = gnc_get_developer_log ();
+    if (gnc_verify_dialog (NULL, TRUE, "Dev Log\n\n%s\n\nYes to clear", logstr))
+        gnc_clear_developer_log ();
+    g_free (logstr);
+}
+
 
 static void
 gnc_main_window_cmd_file_quit (GtkAction *action, GncMainWindow *window)

--- a/gnucash/report/reports/example/hello-world.scm
+++ b/gnucash/report/reports/example/hello-world.scm
@@ -194,6 +194,11 @@ Your reports probably shouldn't have an \
 option like this.") 
       #f))
 
+    (add-option
+     (gnc:make-simple-boolean-option
+      (N_ "Testing") (N_ "Add deprecation warning")
+      "b" "Logs a deprecation warning" #f))
+
     ;; This is a Radio Button option. The user can only select one 
     ;; value from the list of buttons.
     (add-option
@@ -246,9 +251,13 @@ option like this.")
         (list-val     (op-value "Hello Again"   "A list option"))
         (radio-val    (op-value "Hello Again"   "A Radio Button option"))
         (crash-val    (op-value "Testing"       "Crash the report"))
+        (deprecation  (op-value "Testing"       "Add deprecation warning"))
         
         ;; document will be the HTML document that we return.
         (document (gnc:make-html-document)))
+
+    (when deprecation
+      (gnc:issue-deprecation-warning "This is a deprecation warning"))
 
     ;; Crash if asked to.
     (if crash-val (string-length #f)) ;; string-length needs a string

--- a/gnucash/ui/gnc-main-window-ui.xml
+++ b/gnucash/ui/gnc-main-window-ui.xml
@@ -133,6 +133,7 @@
   <toolbar name="DefaultToolbar">
     <placeholder name="ToolbarSavePlaceholder"/>
     <toolitem name="ToolbarClose" action="FileCloseAction"/>
+    <toolitem name="ToolbarDevLog" action="DevLogAction"/>
     <separator name="ToolbarSep1"/>
     <placeholder name="DefaultToolbarPlaceholder"/>
   </toolbar>

--- a/libgnucash/core-utils/gnc-version.c
+++ b/libgnucash/core-utils/gnc-version.c
@@ -66,3 +66,57 @@ const int gnc_gnucash_major_version(void)
 {
     return PROJECT_VERSION_MAJOR;
 }
+
+static GList * developer_log = NULL;
+
+gboolean gnc_developer_log_empty (void)
+{
+    return (!developer_log);
+}
+
+void gnc_add_developer_log_entry (gchar *str)
+{
+    developer_log = g_list_prepend (developer_log, g_strdup (str));
+}
+
+void gnc_clear_developer_log (void)
+{
+    g_list_free_full (developer_log, g_free);
+    developer_log = NULL;
+}
+
+static char * mystrcat (char* dest, const char* src)
+{
+     while (*dest) dest++;
+     while ((*dest++ = *src++));
+     return --dest;
+}
+
+static gchar * string_join (GList *strings, const gchar *sep)
+{
+    gchar *outstr, *p;
+    gint len = 1, seplen = strlen (sep);
+
+    for (GList *n = strings; n; n = n->next)
+        len += strlen (n->data) + seplen;
+
+    if (len > 4000)
+        return g_strdup ("Devlog exceeds 4Kb.");
+
+    outstr = g_new0 (gchar, len);
+    p = outstr;
+
+    for (GList *n = strings; n; n = n->next)
+    {
+        p = mystrcat (p, n->data);
+        if (n->next)
+            p = mystrcat (p, sep);
+    }
+
+    return outstr;
+}
+
+gchar * gnc_get_developer_log (void)
+{
+    return string_join (g_list_reverse (developer_log), "\n");
+}

--- a/libgnucash/core-utils/gnc-version.c
+++ b/libgnucash/core-utils/gnc-version.c
@@ -67,56 +67,37 @@ const int gnc_gnucash_major_version(void)
     return PROJECT_VERSION_MAJOR;
 }
 
-static GList * developer_log = NULL;
+static gchar developer_log[1010];
+static gboolean overflow = FALSE;
 
 gboolean gnc_developer_log_empty (void)
 {
-    return (!developer_log);
+    return (developer_log[0] == '\0');
 }
 
 void gnc_add_developer_log_entry (gchar *str)
 {
-    developer_log = g_list_prepend (developer_log, g_strdup (str));
+    if (overflow)
+        return;
+    else if ((strlen (developer_log) + strlen (str)) < 1000)
+    {
+        gchar *p = developer_log;
+        strcat (p, "\n");
+        strcat (p, str);
+    }
+    else
+        overflow = TRUE;
 }
 
 void gnc_clear_developer_log (void)
 {
-    g_list_free_full (developer_log, g_free);
-    developer_log = NULL;
-}
-
-static char * mystrcat (char* dest, const char* src)
-{
-     while (*dest) dest++;
-     while ((*dest++ = *src++));
-     return --dest;
-}
-
-static gchar * string_join (GList *strings, const gchar *sep)
-{
-    gchar *outstr, *p;
-    gint len = 1, seplen = strlen (sep);
-
-    for (GList *n = strings; n; n = n->next)
-        len += strlen (n->data) + seplen;
-
-    if (len > 4000)
-        return g_strdup ("Devlog exceeds 4Kb.");
-
-    outstr = g_new0 (gchar, len);
-    p = outstr;
-
-    for (GList *n = strings; n; n = n->next)
-    {
-        p = mystrcat (p, n->data);
-        if (n->next)
-            p = mystrcat (p, sep);
-    }
-
-    return outstr;
+    overflow = FALSE;
+    developer_log[0] = '\0';
 }
 
 gchar * gnc_get_developer_log (void)
 {
-    return string_join (g_list_reverse (developer_log), "\n");
+    return overflow ?
+        g_strconcat (developer_log, "\n", "Further entries truncated", NULL) :
+        g_strdup (developer_log);
 }

--- a/libgnucash/core-utils/gnc-version.h
+++ b/libgnucash/core-utils/gnc-version.h
@@ -38,6 +38,7 @@
 #ifndef GNC_VERSION_H
 #define GNC_VERSION_H
 #include "gnc-vcs-info.h"
+#include <glib.h>
 
 /** Parse <prefix>/etc/gnucash/environment and set environment variables
  *  based on the contents of that file. Read the comments in
@@ -49,6 +50,11 @@ const char *gnc_build_id(void);
 const char *gnc_vcs_rev(void);
 const char *gnc_vcs_rev_date(void);
 const int gnc_gnucash_major_version(void);
+
+gboolean gnc_developer_log_empty (void);
+void gnc_add_developer_log_entry (gchar *str);
+void gnc_clear_developer_log (void);
+gchar * gnc_get_developer_log (void);
 
 #endif /* GNC_VERSION_H */
 


### PR DESCRIPTION
Developer Log -- see `hello-world.scm` to add an entry into deprecation log.
As discussed in 4e38b685e27589d0d4346cd2d5caf5a762f97877

Pending:
1. nice icon - warning, or info 'i' icon
2. ideally this toolbar item should be hidden if the devlog is empty
3. textarea instead of `gnc_info_dialog`?

![image](https://user-images.githubusercontent.com/1975870/121898553-06609e00-cd13-11eb-81ae-99f8a64e2053.png)
