### PR TITLE
GValue: don't unset until the boxed pointer isn't used anymore

### DIFF
--- a/gnucash/html/gnc-html-webkit2.c
+++ b/gnucash/html/gnc-html-webkit2.c
@@ -142,7 +142,6 @@ gnc_html_webkit_webview_new (void)
       const PangoFontDescription *font =
            (const PangoFontDescription*)g_value_get_boxed (&val);
       default_font_family = pango_font_description_get_family (font);
-      g_value_unset (&val);
      }
 /* Set default webkit settings */
      webkit_settings = webkit_web_view_get_settings (WEBKIT_WEB_VIEW (view));
@@ -162,6 +161,7 @@ gnc_html_webkit_webview_new (void)
           g_object_set (G_OBJECT (webkit_settings),
               "default-font-family", default_font_family, NULL);
      }
+     g_value_unset (&val);
      return view;
 }
 


### PR DESCRIPTION
Because GValue was unset earlier in this function, the `default_font_family` would point to garbage. We need to unset the GValue after the `default_font_family` is used to set the GObject, thereby avoiding a valgrind complaint about accessing unallocated memory.

```
==147251== Invalid read of size 8
==147251==    at 0x4849ECD: memcpy@GLIBC_2.2.5 (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==147251==    by 0x4C60951: g_strdup (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.6800.0)
==147251==    by 0x5A13194: ??? (in /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.6800.0)
==147251==    by 0x5A049EB: g_object_set_valist (in /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.6800.0)
==147251==    by 0x5A04CD3: g_object_set (in /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.6800.0)
==147251==    by 0x6FE3AAC: gnc_html_webkit_webview_new (gnc-html-webkit2.c:162)
==147251==    by 0x6FE3B60: gnc_html_webkit_init (gnc-html-webkit2.c:180)
==147251==    by 0x5A19F29: g_type_create_instance (in /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.6800.0)
==147251==    by 0x5A02ABC: ??? (in /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.6800.0)
==147251==    by 0x5A03A9C: g_object_new_with_properties (in /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.6800.0)
==147251==    by 0x5A045A0: g_object_new (in /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.6800.0)
==147251==    by 0x6FE5E37: gnc_html_webkit_new (gnc-html-webkit2.c:994)
==147251==  Address 0x12db84c0 is 0 bytes inside a block of size 10 free'd
==147251==    at 0x484521F: free (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==147251==    by 0x647641C: pango_font_description_free (in /usr/lib/x86_64-linux-gnu/libpango-1.0.so.0.4800.2)
==147251==    by 0x5A1A217: g_value_unset (in /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.6800.0)
==147251==    by 0x6FE39CD: gnc_html_webkit_webview_new (gnc-html-webkit2.c:145)
==147251==    by 0x6FE3B60: gnc_html_webkit_init (gnc-html-webkit2.c:180)
==147251==    by 0x5A19F29: g_type_create_instance (in /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.6800.0)
==147251==    by 0x5A02ABC: ??? (in /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.6800.0)
==147251==    by 0x5A03A9C: g_object_new_with_properties (in /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.6800.0)
==147251==    by 0x5A045A0: g_object_new (in /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.6800.0)
==147251==    by 0x6FE5E37: gnc_html_webkit_new (gnc-html-webkit2.c:994)
==147251==    by 0x6FE3779: gnc_html_factory_create_html (gnc-html-factory.c:40)
==147251==    by 0x4E33AC0: gnc_plugin_page_report_create_widget (gnc-plugin-page-report.c:463)
==147251==  Block was alloc'd at
==147251==    at 0x4842839: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==147251==    by 0x4C4BD48: g_malloc (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.6800.0)
==147251==    by 0x4C60943: g_strdup (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.6800.0)
==147251==    by 0x6477149: pango_font_description_set_family (in /usr/lib/x86_64-linux-gnu/libpango-1.0.so.0.4800.2)
==147251==    by 0x51FF425: ??? (in /usr/lib/x86_64-linux-gnu/libgtk-3.so.0.2404.21)
==147251==    by 0x535E908: gtk_style_context_get_property (in /usr/lib/x86_64-linux-gnu/libgtk-3.so.0.2404.21)
==147251==    by 0x6FE394E: gnc_html_webkit_webview_new (gnc-html-webkit2.c:137)
==147251==    by 0x6FE3B60: gnc_html_webkit_init (gnc-html-webkit2.c:180)
==147251==    by 0x5A19F29: g_type_create_instance (in /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.6800.0)
==147251==    by 0x5A02ABC: ??? (in /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.6800.0)
==147251==    by 0x5A03A9C: g_object_new_with_properties (in /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.6800.0)
==147251==    by 0x5A045A0: g_object_new (in /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.6800.0)
==147251==
```