### PR TITLE
Bug 753307 Available invoice reports must be dynamic

### DIFF
--- a/gnucash/gnome/top-level.c
+++ b/gnucash/gnome/top-level.c
@@ -26,6 +26,7 @@
 
 #include <gtk/gtk.h>
 #include <glib/gi18n.h>
+#include <libguile.h>
 #include <stdlib.h>
 
 #include "TransLog.h"
@@ -402,6 +403,23 @@ gnc_save_all_state (gpointer session, gpointer unused)
     LEAVE("");
 }
 
+static void
+add_invoice_reports (void)
+{
+    SCM reports = scm_c_eval_string ("(gnc:available-invoice-reports)");
+
+    for (SCM iter = reports; !scm_is_null (iter); iter = scm_cdr (iter))
+    {
+        int idx = scm_to_int (scm_caar (iter));
+        gchar *guid = scm_to_utf8_string (scm_cadar (iter));
+        gchar *title = scm_to_utf8_string (scm_caddar (iter));
+
+        printf ("at idx %d, report %s, guid %s\n", idx, title, guid);
+        g_free (guid);
+        g_free (title);
+    }
+}
+
 void
 gnc_main_gui_init (void)
 {
@@ -466,6 +484,7 @@ gnc_main_gui_init (void)
     gnc_preferences_add_page("business-prefs.glade", "liststore_printinvoice,days_in_adj,cust_days_in_adj,business_prefs",
                             _("Business"));
 
+    add_invoice_reports ();
     LEAVE(" ");
     return;
 }

--- a/gnucash/report/report.scm
+++ b/gnucash/report/report.scm
@@ -131,3 +131,11 @@
 
 ;; Add hooks when this module is loaded
 (gnc-hook-add-scm-dangler HOOK-SAVE-OPTIONS gnc:save-style-sheet-options)
+
+;; some available invoice reports.
+(define-public (gnc:available-invoice-reports)
+ (list
+  (list 0 "5123a759ceb9483abf2182d01c140e8d" "Printable Invoice")
+  (list 2 "67112f318bef4fc496bdc27d106bbda4" "Easy Invoice")
+  (list 1 "0769e242be474010b4acf264a5512e6e" "Tax Invoice")
+  (list 3 "3ce293441e894423a2425d7a22dd1ac6" "Fancy Invoice")))


### PR DESCRIPTION
The invoice reports and GUIDs must be retrieved dynamically rather than hard coded. Expose list of invoice reports, for use in populating the global preference/book property. WIP. @Bob-IT

The invoice list is exposed out-of-order, to be reordered in C (or guile?)