### PR TITLE
Support displaying 9 share digits in the portfolio reports

### DIFF
--- a/gnucash/report/reports/standard/advanced-portfolio.scm
+++ b/gnucash/report/reports/standard/advanced-portfolio.scm
@@ -129,7 +129,7 @@ by preventing negative stock balances.<br/>")
      (gnc:make-number-range-option
       gnc:pagename-display optname-shares-digits
       "d" (N_ "The number of decimal places to use for share numbers.") 2
-      0 6 0 1))
+      0 9 0 1))
 
     (gnc:register-option
       options

--- a/gnucash/report/reports/standard/portfolio.scm
+++ b/gnucash/report/reports/standard/portfolio.scm
@@ -61,7 +61,7 @@
      (gnc:make-number-range-option
       gnc:pagename-general optname-shares-digits
       "e" (N_ "The number of decimal places to use for share numbers.") 2
-      0 6 0 1))
+      0 9 0 1))
 
     ;; Account tab
     (add-option


### PR DESCRIPTION
I've got some fractional shares to 8 decimal places.