### PR TITLE
Remove "New _Invoice..." from toolbar

### DIFF
--- a/gnucash/gnome/gnc-plugin-business.c
+++ b/gnucash/gnome/gnc-plugin-business.c
@@ -314,13 +314,6 @@ static GtkActionEntry gnc_plugin_actions [] =
         G_CALLBACK (gnc_plugin_business_cmd_test_init_data)
     },
 
-    /* Toolbar */
-    {
-        "ToolbarNewInvoiceAction", GNC_ICON_INVOICE_NEW, N_("New _Invoice..."), NULL,
-        N_("Open the New Invoice dialog"),
-        G_CALLBACK (gnc_plugin_business_cmd_customer_new_invoice)
-    },
-
     /* Register popup menu */
     {
         "RegisterAssignPayment", NULL, N_("Assign as payment..."), NULL,

--- a/gnucash/gtkbuilder/business-prefs.glade
+++ b/gnucash/gtkbuilder/business-prefs.glade
@@ -63,24 +63,6 @@
           </packing>
         </child>
         <child>
-          <object class="GtkCheckButton" id="pref/dialogs.business.invoice/enable-toolbuttons">
-            <property name="label" translatable="yes">Enable extra _buttons</property>
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="has_tooltip">True</property>
-            <property name="tooltip_markup">If active, extra toolbar buttons for common business functions are shown as well. Otherwise they are not shown.</property>
-            <property name="tooltip_text" translatable="yes">If active, extra toolbar buttons for common business functions are shown as well. Otherwise they are not shown.</property>
-            <property name="halign">start</property>
-            <property name="use_underline">True</property>
-            <property name="draw_indicator">True</property>
-          </object>
-          <packing>
-            <property name="left_attach">0</property>
-            <property name="top_attach">1</property>
-          </packing>
-        </child>
-        <child>
           <object class="GtkCheckButton" id="pref/dialogs.business.invoice/use-new-window">
             <property name="label" translatable="yes">_Open in new window</property>
             <property name="visible">True</property>


### PR DESCRIPTION
I do not know why put this button on toolbar. 

It works almost same as "New invoice", very useless.

So I found source code location through weblate, and removed them. 