### PR TITLE
Maint Generic Import Transaction Matcher - fix crashes

### DIFF
--- a/gnucash/import-export/import-main-matcher.c
+++ b/gnucash/import-export/import-main-matcher.c
@@ -870,6 +870,10 @@ get_action_for_path (GtkTreePath* path, GtkTreeModel *model)
     GtkTreeIter iter;
     gtk_tree_model_get_iter (model, &iter, path);
     gtk_tree_model_get (model, &iter, DOWNLOADED_COL_DATA, &trans_info, -1);
+    if (!trans_info)
+        // selected row is a potential match  (depth 2)
+        // instead of an imported transaction (depth 1)
+        return GNCImport_INVALID_ACTION;
     return gnc_import_TransInfo_get_action (trans_info);
 }
 

--- a/gnucash/import-export/import-main-matcher.c
+++ b/gnucash/import-export/import-main-matcher.c
@@ -976,8 +976,8 @@ gnc_gen_trans_onButtonPressed_cb (GtkTreeView *treeview,
                 GList* selected;
                 GtkTreeModel *model;
                 selected = gtk_tree_selection_get_selected_rows (selection, &model);
-                get_action_for_path (selected->data, model);
-                if (get_action_for_path (selected->data, model) == GNCImport_ADD)
+                if (gtk_tree_path_get_depth ((GtkTreePath *)selected->data) == 1 &&
+                    get_action_for_path (selected->data, model) == GNCImport_ADD)
                     gnc_gen_trans_view_popup_menu (treeview, event, info);
                 g_list_free_full (selected, (GDestroyNotify)gtk_tree_path_free);
             }


### PR DESCRIPTION
Fix 2 core dumps. Both dumped core in gnc_import_TransInfo_get_action() because info
is null
1. After double clicking on a potential match line, then right clicking
on the the parent transaction of the potential match
2. After rubber banding a group of transactions which also includes an
expanded potential match. Sometimes also need to right click the
selection to trigger the core dump.

Also remove an unneeded duplicate call to get_action_for_path().