### PR TITLE
Bug 798234 - Use string cache in FloatingTxn and FloatingSplit

### DIFF
--- a/gnucash/register/ledger-core/split-register-copy-ops.h
+++ b/gnucash/register/ledger-core/split-register-copy-ops.h
@@ -84,6 +84,8 @@ void gnc_float_split_set_value (FloatingSplit *fs, gnc_numeric value);
 FloatingSplit *gnc_split_to_float_split (Split *split);
 void gnc_float_split_to_split (const FloatingSplit *fs, Split *split);
 
+void gnc_float_split_free (FloatingSplit *fs);
+
 /* accessors */
 Transaction *gnc_float_txn_get_txn (const FloatingTxn *ft);
 gnc_commodity *gnc_float_txn_get_currency (const FloatingTxn *ft);
@@ -115,5 +117,7 @@ FloatingTxn *gnc_txn_to_float_txn (Transaction *txn, gboolean use_cut_semantics)
 
 void gnc_float_txn_to_txn (const FloatingTxn *ft, Transaction *txn, gboolean do_commit);
 void gnc_float_txn_to_txn_swap_accounts (const FloatingTxn *ft, Transaction *txn, Account *acct1, Account *acct2, gboolean do_commit);
+
+void gnc_float_txn_free (FloatingTxn *ft);
 
 #endif

--- a/gnucash/register/ledger-core/split-register.c
+++ b/gnucash/register/ledger-core/split-register.c
@@ -100,6 +100,7 @@ gnc_copy_split_onto_split (Split* from, Split* to, gboolean use_cut_semantics)
         return;
 
     gnc_float_split_to_split (fs, to);
+    gnc_float_split_free (fs);
 }
 
 void
@@ -117,6 +118,7 @@ gnc_copy_trans_onto_trans (Transaction* from, Transaction* to,
         return;
 
     gnc_float_txn_to_txn (ft, to, do_commit);
+    gnc_float_txn_free (ft);
 }
 
 static int
@@ -819,9 +821,9 @@ gnc_split_register_copy_current_internal (SplitRegister* reg,
 
     /* unprotect the old object, if any */
     if (copied_item.ftype == GNC_TYPE_SPLIT)
-        g_free (copied_item.fs);
+        gnc_float_split_free (copied_item.fs);
     if (copied_item.ftype == GNC_TYPE_TRANSACTION)
-        g_free (copied_item.ft);
+        gnc_float_txn_free (copied_item.ft);
     copied_item.ftype = 0;
 
     if (new_fs)

--- a/gnucash/register/ledger-core/test/utest-split-register-copy-ops.c
+++ b/gnucash/register/ledger-core/test/utest-split-register-copy-ops.c
@@ -276,7 +276,7 @@ test_gnc_split_to_float_split (Fixture *fixture, gconstpointer pData)
     g_assert_true (gnc_numeric_equal(fs->m_value, xaccSplitGetValue (s)));
     g_assert_true (gnc_numeric_equal(fs->m_amount, xaccSplitGetAmount (s)));
 
-    g_free (fs);
+    gnc_float_split_free (fs);
 }
 /* gnc_float_split_to_split
 void gnc_float_split_to_split (const FloatingSplit *fs, Split *split)// C: 2 in 1  Local: 1:0:0
@@ -412,9 +412,7 @@ test_gnc_txn_to_float_txn (Fixture *fixture, gconstpointer pData)
 
     g_assert_null (fsiter->next);
 
-    g_list_free_full(ft->m_splits, g_free);
-    ft->m_splits = NULL;
-    g_free (ft);
+    gnc_float_txn_free (ft);
 }
 static void
 test_gnc_txn_to_float_txn_cut_semantics (Fixture *fixture, gconstpointer pData)
@@ -471,9 +469,7 @@ test_gnc_txn_to_float_txn_cut_semantics (Fixture *fixture, gconstpointer pData)
 
     g_assert_null (fsiter->next);
 
-    g_list_free_full(ft->m_splits, g_free);
-    ft->m_splits = NULL;
-    g_free (ft);
+    gnc_float_txn_free (ft);
 }
 
 


### PR DESCRIPTION
Copied strings may be removed from the string cache while they're in the FloatingTxn/FloatingSplit so take a new reference to them.

Fix memory leaks of FloatingTxn and FloatingSplit when they're used temporarily.

Fix memory leak in FloatingTxn by freeing the m_splits list too.