### PR TITLE
Fix Typo: between "new customer/vendor/employee" and "find customer/vendor/employee"

### DIFF
--- a/gnucash/gnome/dialog-customer.c
+++ b/gnucash/gnome/dialog-customer.c
@@ -921,7 +921,7 @@ gnc_customer_search (GtkWindow *parent, GncCustomer *start, QofBook *book)
                                            CUSTOMER_SHIPADDR, ADDRESS_NAME, NULL);
         params = gnc_search_param_prepend (params, _("Billing Contact"), NULL, type,
                                            CUSTOMER_ADDR, ADDRESS_NAME, NULL);
-        params = gnc_search_param_prepend (params, _("Customer ID"), NULL, type,
+        params = gnc_search_param_prepend (params, _("Customer Number"), NULL, type,
                                            CUSTOMER_ID, NULL);
         params = gnc_search_param_prepend (params, _("Company Name"), NULL, type,
                                            CUSTOMER_NAME, NULL);
@@ -930,11 +930,11 @@ gnc_customer_search (GtkWindow *parent, GncCustomer *start, QofBook *book)
     /* Build the column list in reverse order */
     if (columns == NULL)
     {
-        columns = gnc_search_param_prepend (columns, _("Contact"), NULL, type,
+        columns = gnc_search_param_prepend (columns, _("Billing Contact"), NULL, type,
                                             CUSTOMER_ADDR, ADDRESS_NAME, NULL);
-        columns = gnc_search_param_prepend (columns, _("Company"), NULL, type,
+        columns = gnc_search_param_prepend (columns, _("Company Name"), NULL, type,
                                             CUSTOMER_NAME, NULL);
-        columns = gnc_search_param_prepend (columns, _("ID #"), NULL, type,
+        columns = gnc_search_param_prepend (columns, _("Customer Number"), NULL, type,
                                             CUSTOMER_ID, NULL);
     }
 

--- a/gnucash/gnome/dialog-employee.c
+++ b/gnucash/gnome/dialog-employee.c
@@ -714,11 +714,11 @@ gnc_employee_search (GtkWindow *parent, GncEmployee *start, QofBook *book)
     /* Build parameter list in reverse order */
     if (params == NULL)
     {
-        params = gnc_search_param_prepend (params, _("Employee ID"), NULL, type,
-                                           EMPLOYEE_ID, NULL);
-        params = gnc_search_param_prepend (params, _("Employee Username"), NULL,
+        params = gnc_search_param_prepend (params, _("Username"), NULL,
                                            type, EMPLOYEE_USERNAME, NULL);
-        params = gnc_search_param_prepend (params, _("Employee Name"), NULL,
+        params = gnc_search_param_prepend (params, _("Employee Number"), NULL, type,
+                                           EMPLOYEE_ID, NULL);
+        params = gnc_search_param_prepend (params, _("Payment Name"), NULL,
                                            type, EMPLOYEE_ADDR, ADDRESS_NAME, NULL);
     }
 
@@ -727,9 +727,9 @@ gnc_employee_search (GtkWindow *parent, GncEmployee *start, QofBook *book)
     {
         columns = gnc_search_param_prepend (columns, _("Username"), NULL, type,
                                             EMPLOYEE_USERNAME, NULL);
-        columns = gnc_search_param_prepend (columns, _("ID #"), NULL, type,
+        columns = gnc_search_param_prepend (columns, _("Employee Number"), NULL, type,
                                             EMPLOYEE_ID, NULL);
-        columns = gnc_search_param_prepend (columns, _("Name"), NULL, type,
+        columns = gnc_search_param_prepend (columns, _("Payment Name"), NULL, type,
                                             EMPLOYEE_ADDR, ADDRESS_NAME, NULL);
     }
 

--- a/gnucash/gnome/dialog-vendor.c
+++ b/gnucash/gnome/dialog-vendor.c
@@ -713,9 +713,9 @@ gnc_vendor_search (GtkWindow *parent, GncVendor *start, QofBook *book)
     /* Build parameter list in reverse order */
     if (params == NULL)
     {
-        params = gnc_search_param_prepend (params, _("Billing Contact"), NULL, type,
+        params = gnc_search_param_prepend (params, _("Payment Contact"), NULL, type,
                                            VENDOR_ADDR, ADDRESS_NAME, NULL);
-        params = gnc_search_param_prepend (params, _("Vendor ID"), NULL, type,
+        params = gnc_search_param_prepend (params, _("Vendor Number"), NULL, type,
                                            VENDOR_ID, NULL);
         params = gnc_search_param_prepend (params, _("Company Name"), NULL, type,
                                            VENDOR_NAME, NULL);
@@ -724,11 +724,11 @@ gnc_vendor_search (GtkWindow *parent, GncVendor *start, QofBook *book)
     /* Build the column list in reverse order */
     if (columns == NULL)
     {
-        columns = gnc_search_param_prepend (columns, _("Contact"), NULL, type,
+        columns = gnc_search_param_prepend (columns, _("Payment Contact"), NULL, type,
                                             VENDOR_ADDR, ADDRESS_NAME, NULL);
-        columns = gnc_search_param_prepend (columns, _("Company"), NULL, type,
+        columns = gnc_search_param_prepend (columns, _("Company Name"), NULL, type,
                                             VENDOR_NAME, NULL);
-        columns = gnc_search_param_prepend (columns, _("ID #"), NULL, type,
+        columns = gnc_search_param_prepend (columns, _("Vendor Number"), NULL, type,
                                             VENDOR_ID, NULL);
     }
 

--- a/gnucash/gtkbuilder/dialog-customer.glade
+++ b/gnucash/gtkbuilder/dialog-customer.glade
@@ -240,7 +240,7 @@
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="halign">end</property>
-                            <property name="label" translatable="yes">Name</property>
+                            <property name="label" translatable="yes">Contact</property>
                             <property name="justify">right</property>
                           </object>
                           <packing>
@@ -770,7 +770,7 @@
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="halign">end</property>
-                            <property name="label" translatable="yes">Name</property>
+                            <property name="label" translatable="yes">Contact</property>
                             <property name="justify">right</property>
                           </object>
                           <packing>
@@ -966,7 +966,7 @@
               <object class="GtkLabel" id="label12">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Shipping Address</property>
+                <property name="label" translatable="yes">Shipping Information</property>
                 <property name="justify">center</property>
               </object>
               <packing>

--- a/gnucash/gtkbuilder/dialog-vendor.glade
+++ b/gnucash/gtkbuilder/dialog-vendor.glade
@@ -242,7 +242,7 @@
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="halign">end</property>
-                            <property name="label" translatable="yes">Name</property>
+                            <property name="label" translatable="yes">Contact</property>
                             <property name="justify">right</property>
                           </object>
                           <packing>


### PR DESCRIPTION
The strings doesn't match, so I do this, making it more clear while using these functions.