### PR TITLE
Fix Typo: rename some labels

### DIFF
--- a/gnucash/gtkbuilder/dialog-preferences.glade
+++ b/gnucash/gtkbuilder/dialog-preferences.glade
@@ -1748,7 +1748,7 @@ many months before the current month</property>
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="pref/general/retain-type-days">
-                    <property name="label" translatable="yes">For</property>
+                    <property name="label" translatable="yes">For Day(s)</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>


### PR DESCRIPTION
Just making it more clear while using "new customer dialog" and "find customer dialog"