### PR TITLE
Commit root accounts after loading from XML

### DIFF
--- a/libgnucash/backend/xml/io-gncxml-v2.cpp
+++ b/libgnucash/backend/xml/io-gncxml-v2.cpp
@@ -699,6 +699,7 @@ qof_session_load_from_xml_file_v2_full (
     QofBookFileType type)
 {
     Account* root;
+    Account* template_root;
     sixtp_gdv2* gd;
     sixtp* top_parser;
     sixtp* main_parser;
@@ -851,12 +852,18 @@ qof_session_load_from_xml_file_v2_full (
     /* commit all groups, this completes the BeginEdit started when the
      * account_end_handler finished reading the account.
      */
+    template_root = gnc_book_get_template_root (book);
     gnc_account_foreach_descendant (root,
                                     (AccountCb) xaccAccountCommitEdit,
                                     NULL);
-    gnc_account_foreach_descendant (gnc_book_get_template_root (book),
+    gnc_account_foreach_descendant (template_root,
                                     (AccountCb) xaccAccountCommitEdit,
                                     NULL);
+    /* if these exist in the XML file then they will be uncommitted */
+    if (qof_instance_get_editlevel(root) != 0)
+        xaccAccountCommitEdit(root);
+    if (qof_instance_get_editlevel(template_root) != 0)
+        xaccAccountCommitEdit(template_root);
 
     /* start logging again */
     xaccLogEnable ();

--- a/libgnucash/backend/xml/test/test-load-xml2.cpp
+++ b/libgnucash/backend/xml/test/test-load-xml2.cpp
@@ -108,6 +108,9 @@ test_load_file (const char* filename)
     do_test (gnc_account_get_book (root) == book,
              "book and root account don't match");
 
+    do_test (qof_instance_get_editlevel(root) == 0,
+             "root account editlevel is not 0");
+
     do_test_args (qof_session_get_error (session) == ERR_BACKEND_NO_ERR,
                   "session load xml2", __FILE__, __LINE__,
                   "qof error=%d for file [%s]",


### PR DESCRIPTION
The root accounts start with a non-zero editlevel because BeginEdit is called for them during loading but not committed after loading.

If the book is then closed without performing any further edits that would require a commit, the Account book_end process does nothing because the root account is still being edited and so none of the accounts are freed.
