### PR TITLE
qof_instance_dispose should remove its type string from the string cache

### DIFF
--- a/libgnucash/engine/qofinstance.cpp
+++ b/libgnucash/engine/qofinstance.cpp
@@ -319,9 +319,8 @@ qof_instance_dispose (GObject *instp)
     QofInstance* inst = QOF_INSTANCE(instp);
 
     priv = GET_PRIVATE(instp);
-    if (!priv->collection)
-        return;
-    qof_collection_remove_entity(inst);
+    if (priv->collection)
+        qof_collection_remove_entity(inst);
 
     CACHE_REMOVE(inst->e_type);
     inst->e_type = NULL;


### PR DESCRIPTION
If QofInstancePrivate has no collection then qof_instance_dispose() returns without completing the rest of its dispose processes.

Change the check for a collection so that it only affects the call to qof_collection_remove_entity().