### PR TITLE
Free template root accounts on book end

### DIFF
--- a/libgnucash/engine/SX-book.c
+++ b/libgnucash/engine/SX-book.c
@@ -127,7 +127,7 @@ sxtg_book_begin (QofBook *book)
 static void
 sxtg_book_end (QofBook *book)
 {
-//    gnc_book_set_template_root (book, NULL);
+    gnc_book_set_template_root (book, NULL);
 }
 
 static gboolean


### PR DESCRIPTION
The template root should be unset so that it's destroyed when the book is ending. This is required to free all the template accounts and referenced strings.