### PR TITLE
Avoid leaking string cache entries for "" in Transaction and Split

### DIFF
--- a/libgnucash/engine/Split.c
+++ b/libgnucash/engine/Split.c
@@ -564,8 +564,8 @@ xaccDupeSplit (const Split *s)
     split->orig_acc = s->orig_acc;
     split->lot = s->lot;
 
-    split->memo = CACHE_INSERT(s->memo);
-    split->action = CACHE_INSERT(s->action);
+    CACHE_REPLACE(split->memo, s->memo);
+    CACHE_REPLACE(split->action, s->action);
 
     qof_instance_copy_kvp (QOF_INSTANCE (split), QOF_INSTANCE (s));
 

--- a/libgnucash/engine/Transaction.c
+++ b/libgnucash/engine/Transaction.c
@@ -602,8 +602,8 @@ dupe_trans (const Transaction *from)
 
     to = g_object_new (GNC_TYPE_TRANSACTION, NULL);
 
-    to->num         = CACHE_INSERT (from->num);
-    to->description = CACHE_INSERT (from->description);
+    CACHE_REPLACE (to->num, from->num);
+    CACHE_REPLACE (to->description, from->description);
 
     to->splits = g_list_copy (from->splits);
     for (node = to->splits; node; node = node->next)
@@ -647,8 +647,8 @@ xaccTransCloneNoKvp (const Transaction *from)
 
     to->date_entered    = from->date_entered;
     to->date_posted     = from->date_posted;
-    to->num             = CACHE_INSERT (from->num);
-    to->description     = CACHE_INSERT (from->description);
+    CACHE_REPLACE (to->num, from->num);
+    CACHE_REPLACE (to->description, from->description);
     to->common_currency = from->common_currency;
     qof_instance_copy_version(to, from);
     qof_instance_copy_version_check(to, from);


### PR DESCRIPTION
When g_object_new() is used, the strings that default to "" are added to the string cache. These are then not correctly removed when updating them with new values when cloning a Transaction/Split.

Use CACHE_REPLACE instead of CACHE_INSERT.