### PR TITLE
More memory leaks

### DIFF
--- a/bindings/engine.i
+++ b/bindings/engine.i
@@ -77,6 +77,8 @@ declarations in the header files, some of which are included by
 engine-common.i */
 
 %newobject gnc_account_get_full_name;
+%newobject xaccTransGetAPARAcctSplitList;
+%newobject xaccTransGetPaymentAcctSplitList;
 
 %include "engine-common.i"
 

--- a/gnucash/gnome-utils/gnc-tree-model-owner.c
+++ b/gnucash/gnome-utils/gnc-tree-model-owner.c
@@ -192,6 +192,9 @@ gnc_tree_model_owner_finalize (GObject *object)
     model = GNC_TREE_MODEL_OWNER (object);
     priv = GNC_TREE_MODEL_OWNER_GET_PRIVATE(model);
 
+    if (priv->owner_list)
+        g_list_free_full (priv->owner_list, (GDestroyNotify) gncOwnerFree);
+
     priv->book       = NULL;
     priv->owner_list = NULL;
 
@@ -976,6 +979,9 @@ gnc_tree_model_owner_event_handler (QofInstance *entity,
         /* Tell the filters/views where the new owner was added. */
         DEBUG("add owner %p (%s)", &owner, gncOwnerGetName(&owner));
         /* First update our copy of the owner list. This isn't done automatically */
+        if (priv->owner_list)
+            g_list_free_full (priv->owner_list, (GDestroyNotify) gncOwnerFree);
+
         priv->owner_list = gncBusinessGetOwnerList (priv->book,
                            gncOwnerTypeToQofIdType(priv->owner_type), TRUE);
         increment_stamp(model);

--- a/gnucash/report/gnc-report.c
+++ b/gnucash/report/gnc-report.c
@@ -336,9 +336,11 @@ gnc_get_default_report_font_family(void)
 
     pango_font_description_free (font_desc);
 
-    if (default_font_family == NULL ||
-        g_str_has_prefix (default_font_family, ".AppleSystemUIFont"))
-        return g_strdup("Arial");
+    if (g_str_has_prefix (default_font_family, ".AppleSystemUIFont"))
+    {
+        g_free (default_font_family);
+        return g_strdup ("Arial");
+    }
     else
         return default_font_family;
 }


### PR DESCRIPTION
Continuation of #1029 from valgrind.

`owner_list` is populated with `gncBusinessGetOwnerList` which calls `get_ownerlist_cb` which calls `gncOwnerNew`, and must be freed with `gncOwnerFree`.