### PR TITLE
Bug 798238 - "New security" dialog doesn't save the "Display symbol"

### DIFF
--- a/gnucash/gnome-utils/dialog-commodity.c
+++ b/gnucash/gnome-utils/dialog-commodity.c
@@ -1301,6 +1301,8 @@ gnc_ui_commodity_dialog_to_object(CommodityWindow * w)
             c = gnc_commodity_new(book, fullname, name_space, mnemonic, code, fraction);
             w->edit_commodity = c;
             gnc_commodity_begin_edit(c);
+
+            gnc_commodity_set_user_symbol(c, user_symbol);
         }
         else
         {


### PR DESCRIPTION
When creating a new commodity the display symbol isn't saved so it defaults to one of the other values as appropriate.

After creating the new commodity (without providing a user symbol), set the user symbol.