### PR TITLE
Object that are not freed / destroyed

### DIFF
--- a/libgnucash/engine/SX-book.c
+++ b/libgnucash/engine/SX-book.c
@@ -127,7 +127,8 @@ sxtg_book_begin (QofBook *book)
 static void
 sxtg_book_end (QofBook *book)
 {
-//    gnc_book_set_template_root (book, NULL);
+    // Leave destroying template root account till after the scheduled
+    // transactions have been destroyed in gnc_sx_book_end.
 }
 
 static gboolean
@@ -180,7 +181,7 @@ static QofObject sxtg_object_def =
 {
     DI(.interface_version = ) QOF_OBJECT_VERSION,
     DI(.e_type            = ) GNC_ID_SXTG,
-    DI(.type_label        = ) "Scheduled Transaction Templates",
+    DI(.type_label        = ) "Scheduled Transaction Group",
     DI(.create            = ) NULL,
     DI(.book_begin        = ) sxtg_book_begin,
     DI(.book_end          = ) sxtg_book_end,
@@ -281,6 +282,7 @@ book_sxes_end(QofBook* book)
     sxes = qof_collection_get_data(col);
     if (sxes != NULL)
     {
+        g_list_free(sxes->sx_list);
         g_object_unref(sxes);
         qof_collection_set_data(col, NULL);
     }

--- a/libgnucash/engine/SchedXaction.c
+++ b/libgnucash/engine/SchedXaction.c
@@ -497,17 +497,8 @@ xaccSchedXactionFree( SchedXaction *sx )
 
     delete_template_trans( sx );
 
-    /*
-     * xaccAccountDestroy removes the account from
-     * its group for us AFAICT.  If shutting down,
-     * the account is being deleted separately.
-     */
-
-    if (!qof_book_shutting_down(qof_instance_get_book(sx)))
-    {
-        xaccAccountBeginEdit(sx->template_acct);
-        xaccAccountDestroy(sx->template_acct);
-    }
+    xaccAccountBeginEdit( sx->template_acct );
+    xaccAccountDestroy( sx->template_acct );
 
     for ( l = sx->deferredList; l; l = l->next )
     {

--- a/libgnucash/engine/SchedXaction.c
+++ b/libgnucash/engine/SchedXaction.c
@@ -32,6 +32,7 @@
 
 #include "Account.h"
 #include "SX-book.h"
+#include "SX-book-p.h"
 #include "SX-ttinfo.h"
 #include "SchedXaction.h"
 #include "Transaction.h"
@@ -510,7 +511,11 @@ xaccSchedXactionFree( SchedXaction *sx )
         g_list_free( sx->deferredList );
         sx->deferredList = NULL;
     }
-
+    if ( sx->schedule )
+    {
+        g_list_free( sx->schedule );
+        sx->schedule = NULL;
+    }
     /* qof_instance_release (&sx->inst); */
     g_object_unref( sx );
 }
@@ -1208,6 +1213,9 @@ gnc_sx_book_end(QofBook* book)
 
     col = qof_book_get_collection(book, GNC_ID_SCHEDXACTION);
     qof_collection_foreach(col, destroy_sx_on_book_close, NULL);
+
+    // Now destroy the template root account
+    gnc_book_set_template_root (book, NULL);
 }
 
 #ifdef _MSC_VER

--- a/libgnucash/engine/Transaction.c
+++ b/libgnucash/engine/Transaction.c
@@ -1769,7 +1769,7 @@ xaccTransRollbackEdit (Transaction *trans)
             xaccSplitRollbackEdit(s);
             SWAP_STR(s->action, so->action);
             SWAP_STR(s->memo, so->memo);
-	    qof_instance_copy_kvp (QOF_INSTANCE (s), QOF_INSTANCE (so));
+            qof_instance_copy_kvp (QOF_INSTANCE (s), QOF_INSTANCE (so));
             s->reconciled = so->reconciled;
             s->amount = so->amount;
             s->value = so->value;
@@ -1778,7 +1778,6 @@ xaccTransRollbackEdit (Transaction *trans)
             //SET_GAINS_A_VDIRTY(s);
             s->date_reconciled = so->date_reconciled;
             qof_instance_mark_clean(QOF_INSTANCE(s));
-            xaccFreeSplit(so);
         }
         else
         {
@@ -1805,6 +1804,10 @@ xaccTransRollbackEdit (Transaction *trans)
         }
     }
     g_list_free(slist);
+
+    // orig->splits may still have duped splits so free them
+    for (node = orig->splits; node; node = node->next)
+        xaccFreeSplit(node->data);
     g_list_free(orig->splits);
     orig->splits = NULL;
 

--- a/libgnucash/engine/gnc-pricedb.c
+++ b/libgnucash/engine/gnc-pricedb.c
@@ -2488,6 +2488,9 @@ convert_price (const gnc_commodity *from, const gnc_commodity *to, PriceTuple tu
 
     price = gnc_numeric_div (to_val, from_val, GNC_DENOM_AUTO, no_round);
 
+    gnc_price_unref (tuple.from);
+    gnc_price_unref (tuple.to);
+
     if (from_cur == from && to_cur == to)
         return price;
 

--- a/libgnucash/engine/gncBillTerm.c
+++ b/libgnucash/engine/gncBillTerm.c
@@ -838,13 +838,27 @@ static void _gncBillTermCreate (QofBook *book)
     qof_book_set_data (book, _GNC_MOD_NAME, bi);
 }
 
+
+static void
+destroy_billterm_on_book_close (QofInstance *ent, gpointer data)
+{
+    GncBillTerm *term = GNC_BILLTERM(ent);
+
+    gncBillTermBeginEdit (term);
+    gncBillTermDestroy (term);
+}
+
 static void _gncBillTermDestroy (QofBook *book)
 {
     struct _book_info *bi;
+    QofCollection *col;
 
     if (!book) return;
 
     bi = qof_book_get_data (book, _GNC_MOD_NAME);
+
+    col = qof_book_get_collection (book, GNC_ID_BILLTERM);
+    qof_collection_foreach (col, destroy_billterm_on_book_close, NULL);
 
     g_list_free (bi->terms);
     g_free (bi);

--- a/libgnucash/engine/gncCustomer.c
+++ b/libgnucash/engine/gncCustomer.c
@@ -353,6 +353,8 @@ static void gncCustomerFree (GncCustomer *cust)
     gncAddressDestroy (cust->addr);
     gncAddressBeginEdit (cust->shipaddr);
     gncAddressDestroy (cust->shipaddr);
+
+    gncJobFreeList (cust->jobs);
     g_list_free (cust->jobs);
     g_free (cust->balance);
 

--- a/libgnucash/engine/gncCustomer.c
+++ b/libgnucash/engine/gncCustomer.c
@@ -358,11 +358,12 @@ static void gncCustomerFree (GncCustomer *cust)
     g_list_free (cust->jobs);
     g_free (cust->balance);
 
-    if (cust->terms)
-        gncBillTermDecRef (cust->terms);
-    if (cust->taxtable)
+    if (!qof_book_shutting_down (qof_instance_get_book (QOF_INSTANCE(cust))))
     {
-        gncTaxTableDecRef (cust->taxtable);
+        if (cust->terms)
+            gncBillTermDecRef (cust->terms);
+        if (cust->taxtable)
+            gncTaxTableDecRef (cust->taxtable);
     }
 
     /* qof_instance_release (&cust->inst); */

--- a/libgnucash/engine/gncEntry.c
+++ b/libgnucash/engine/gncEntry.c
@@ -462,10 +462,14 @@ static void gncEntryFree (GncEntry *entry)
         gncAccountValueDestroy (entry->i_tax_values);
     if (entry->b_tax_values)
         gncAccountValueDestroy (entry->b_tax_values);
-    if (entry->i_tax_table)
-        gncTaxTableDecRef (entry->i_tax_table);
-    if (entry->b_tax_table)
-        gncTaxTableDecRef (entry->b_tax_table);
+
+    if (!qof_book_shutting_down (qof_instance_get_book (QOF_INSTANCE(entry))))
+    {
+        if (entry->i_tax_table)
+            gncTaxTableDecRef (entry->i_tax_table);
+        if (entry->b_tax_table)
+            gncTaxTableDecRef (entry->b_tax_table);
+    }
 
     /* qof_instance_release (&entry->inst); */
     g_object_unref (entry);

--- a/libgnucash/engine/gncInvoice.c
+++ b/libgnucash/engine/gncInvoice.c
@@ -423,10 +423,14 @@ static void gncInvoiceFree (GncInvoice *invoice)
     g_list_free (invoice->entries);
     g_list_free (invoice->prices);
 
-    if (invoice->printname) g_free (invoice->printname);
+    if (invoice->printname)
+        g_free (invoice->printname);
 
-    if (invoice->terms)
-        gncBillTermDecRef (invoice->terms);
+    if (!qof_book_shutting_down (qof_instance_get_book (QOF_INSTANCE(invoice))))
+    {
+        if (invoice->terms)
+            gncBillTermDecRef (invoice->terms);
+    }
 
     /* qof_instance_release (&invoice->inst); */
     g_object_unref (invoice);

--- a/libgnucash/engine/gncJob.c
+++ b/libgnucash/engine/gncJob.c
@@ -231,6 +231,18 @@ GncJob *gncJobCreate (QofBook *book)
     return job;
 }
 
+static void free_job_list (GncJob *job)
+{
+    gncJobBeginEdit (job);
+    gncJobDestroy (job);
+}
+
+void gncJobFreeList (GList *jobs)
+{
+    GList *job_list = g_list_copy (jobs);
+    g_list_free_full (job_list, (GDestroyNotify)free_job_list);
+}
+
 void gncJobDestroy (GncJob *job)
 {
     if (!job) return;

--- a/libgnucash/engine/gncJob.h
+++ b/libgnucash/engine/gncJob.h
@@ -57,6 +57,7 @@ GType gnc_job_get_type(void);
 
 GncJob *gncJobCreate (QofBook *book);
 void gncJobDestroy (GncJob *job);
+void gncJobFreeList (GList *jobs);
 
 /** \name Set Functions
 @{

--- a/libgnucash/engine/gncTaxTable.c
+++ b/libgnucash/engine/gncTaxTable.c
@@ -1015,13 +1015,26 @@ static void _gncTaxTableCreate (QofBook *book)
     qof_book_set_data (book, _GNC_MOD_NAME, bi);
 }
 
+static void
+destroy_taxtable_on_book_close (QofInstance *ent, gpointer data)
+{
+    GncTaxTable *table = GNC_TAXTABLE(ent);
+
+    gncTaxTableBeginEdit (table);
+    gncTaxTableDestroy (table);
+}
+
 static void _gncTaxTableDestroy (QofBook *book)
 {
     struct _book_info *bi;
+    QofCollection *col;
 
     if (!book) return;
 
     bi = qof_book_get_data (book, _GNC_MOD_NAME);
+
+    col = qof_book_get_collection (book, GNC_ID_TAXTABLE);
+    qof_collection_foreach (col, destroy_taxtable_on_book_close, NULL);
 
     g_list_free (bi->tables);
     g_free (bi);

--- a/libgnucash/engine/gncVendor.c
+++ b/libgnucash/engine/gncVendor.c
@@ -496,6 +496,8 @@ static void gncVendorFree (GncVendor *vendor)
     CACHE_REMOVE (vendor->notes);
     gncAddressBeginEdit (vendor->addr);
     gncAddressDestroy (vendor->addr);
+
+    gncJobFreeList (vendor->jobs);
     g_list_free (vendor->jobs);
     g_free (vendor->balance);
 

--- a/libgnucash/engine/gncVendor.c
+++ b/libgnucash/engine/gncVendor.c
@@ -501,10 +501,13 @@ static void gncVendorFree (GncVendor *vendor)
     g_list_free (vendor->jobs);
     g_free (vendor->balance);
 
-    if (vendor->terms)
-        gncBillTermDecRef (vendor->terms);
-    if (vendor->taxtable)
-        gncTaxTableDecRef (vendor->taxtable);
+    if (!qof_book_shutting_down (qof_instance_get_book (QOF_INSTANCE(vendor))))
+    {
+        if (vendor->terms)
+            gncBillTermDecRef (vendor->terms);
+        if (vendor->taxtable)
+            gncTaxTableDecRef (vendor->taxtable);
+    }
 
     /* qof_instance_release (&vendor->inst); */
     g_object_unref (vendor);


### PR DESCRIPTION
Chris mentioned a problem with Tax Tables not being freed on closure so had a look and I think the first commit fixes that. In the same commit there is a fix for Bill Terms as they are very similar.

I thought I would have a look at the other objects and found Jobs were not being destroyed when Customer and Vendors are so that's the second commit followed by Accounts and Scheduled Transactions Accounts.
The last commit, which I have commented out, would delete Scheduled transaction accounts that have no splits when the root template account is destroyed, This is an extension of #1082, I had 30 which does work but it fails test 22, so not sure if I need to change the test or maybe the commit is wrong.

There are two other objects that I have not yet got to the bottom of...
I have 52 g_object_new prices but only 48 destroyed and Splits, g_object_new is used in three functions, xaccMallocSplit, xaccDupeSplit and xaccSplitCloneNoKvp which does not show up in my tests.
12034 malloced splits
12083 duped splits
24068 freed splits
12034 destroyed splits.
@christopherlam see if this helps with your memory leaks.
