### PR TITLE
[report-core] sandbox running report to prevent freeze

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,12 +275,11 @@ include (${SWIG_USE_FILE})
 string(REGEX MATCH "^[0-9]+[.]" SWIG_MAJOR ${SWIG_VERSION})
 
 # Find Guile and determine which version we are using.
-# Look for guile versions in this order: 3.0 > 2.2 > 2.0
+# Look for guile versions in this order: 3.0 > 2.2.1
 
 # guile library and include dir
 pkg_check_modules (GUILE3 guile-3.0 QUIET)
-pkg_check_modules (GUILE22 guile-2.2 QUIET)
-pkg_check_modules (GUILE2 guile-2.0>=2.0.9 QUIET)
+pkg_check_modules (GUILE22 guile-2.2>=2.2.1 QUIET)
 
 if (GUILE3_FOUND) # found guile-3.0
   add_definitions (-DHAVE_GUILE30)
@@ -295,7 +294,7 @@ if (GUILE3_FOUND) # found guile-3.0
   message(STATUS "Using guile-3.0.x")
   find_program (GUILE_EXECUTABLE NAMES guile3.0 guile)
 
-elseif (GUILE22_FOUND) # found guile-2.2
+elseif (GUILE22_FOUND) # found guile-2.2.1
   add_definitions (-DHAVE_GUILE22)
   set(HAVE_GUILE2 TRUE)
   set(GUILE_EFFECTIVE_VERSION 2.2)
@@ -308,21 +307,8 @@ elseif (GUILE22_FOUND) # found guile-2.2
   message(STATUS "Using guile-2.2.x")
   find_program (GUILE_EXECUTABLE NAMES guile2.2 guile)
 
-elseif (GUILE2_FOUND) # found guile-2.0
-  add_definitions (-DHAVE_GUILE20)
-  set(HAVE_GUILE2 TRUE)
-  set(GUILE_EFFECTIVE_VERSION 2.0)
-  set(GUILE_INCLUDE_DIRS ${GUILE2_INCLUDE_DIRS})
-  set(GUILE_LDFLAGS ${GUILE2_LDFLAGS})
-  find_program (GUILD_EXECUTABLE NAMES guild2.0 guild)
-  if (NOT GUILD_EXECUTABLE)
-    message (SEND_ERROR "The guild executable was not found, but is required. Please set GUILD_EXECUTABLE.")
-  endif()
-  message(STATUS "Using guile-2.0.x")
-  find_program (GUILE_EXECUTABLE NAMES guile2.0 guile)
-
 else()
-  message (FATAL_ERROR "Neither guile 3.0, guile 2.2, nor guile 2.0 were found GnuCash can't run without one of them. Ensure that one is installed and can be found with pkg-config.")
+  message (FATAL_ERROR "Neither guile 3.0, nor guile 2.2.1 were found GnuCash can't run without one of them. Ensure that one is installed and can be found with pkg-config.")
 endif()
 
 if (NOT GUILE_EXECUTABLE)

--- a/README.dependencies
+++ b/README.dependencies
@@ -57,7 +57,7 @@ Libraries/Deps
   cmake                 3.10                    Build system manager
   glib2                 2.56.1
   gtk+3                 3.22.30
-  guile                 3.0, 2.2 or 2.0.9       Must be built with regex
+  guile                 3.0, 2.2.1              Must be built with regex
                                                 support enabled
   libxml2               2.9.4
   gettext               0.20                    Required to build gnucash.pot,

--- a/gnucash/report/report-core.scm
+++ b/gnucash/report/report-core.scm
@@ -30,6 +30,7 @@
 (use-modules (gnucash core-utils))
 (use-modules (gnucash gnome-utils))
 (use-modules (ice-9 match))
+(use-modules (ice-9 sandbox))
 (use-modules (srfi srfi-1))
 (use-modules (srfi srfi-9))
 (use-modules (srfi srfi-26))
@@ -748,7 +749,10 @@ not found.")))
 ;; where captured-error is the error string.
 (define (gnc:render-report report)
   (define (get-report) (gnc:report-render-html report #t))
-  (gnc:apply-with-error-handling get-report '()))
+  (call-with-time-limit
+   10
+   (lambda () (gnc:apply-with-error-handling get-report '()))
+   (lambda () (list #f "Report exceeds time limit. Aborted."))))
 
 ;; "thunk" should take the report-type and the report template record
 (define (gnc:report-templates-for-each thunk)


### PR DESCRIPTION
Guile has mechanism to run some code with strict _time_ and/or _memory_ limits. See https://www.gnu.org/software/guile/manual/html_node/Sandboxed-Evaluation.html

This change will ensure any report (built-in or custom) will be aborted if it exceeds 10 seconds. eg. adding `(sleep 10)` to a report renderer will display error message instead of an indeterminate freeze. This change could also be applied to `gnc:apply-with-error-handling` which will also trap qif-importer. `call-with-time-and-allocation-limits` may also be used to limit memory used too.

Thoughts?

![image](https://user-images.githubusercontent.com/1975870/126992814-78e6be3c-dad4-4896-af21-b90bcc1925e6.png)
