### PR TITLE
srfi-64 in guile was fixed causing failing tests to not report failure properly

### DIFF
--- a/bindings/guile/test/srfi64-extras.scm
+++ b/bindings/guile/test/srfi64-extras.scm
@@ -45,5 +45,5 @@
       (lambda (runner)
         (format #t "Source:~a\npass = ~a, fail = ~a\n"
                 (test-result-ref runner 'source-file) num-passed num-failed)
-        (zero? num-failed)))
+        (exit (zero? num-failed))))
     runner))


### PR DESCRIPTION
From my understanding:
1. a change [1] in guile 3.0.7 includes an upstream srfi-64 bugfix[2] regarding test-end
2. this means in guile-3.0.7 onwards test-end does not return whether the num-failures is zero as written [3] see test-balsheet-pnl.scm currently
3. this means the test-runner in srfi64-extras.scm and tests need to be modified similarly to https://github.com/aconchillo/guile-json/pull/73 to allow failures to be detected by `ninja check` when guile is 3.0.7 or later.
4. edit -- may need to copy https://github.com/aconchillo/guile-json/pull/74/ too

[1] https://git.savannah.gnu.org/cgit/guile.git/commit/?id=de5d1a7f99b8e952b115237ebc29633062f99bb9
[2] https://github.com/scheme-requests-for-implementation/srfi-64/commit/7cf4c010398850b45f5a6939bb73f747605a0513
[3] current code https://github.com/Gnucash/gnucash/blob/6bf5a618debee47d90317ff287767ba6d1fd32fa/bindings/guile/test/srfi64-extras.scm#L48
[4] test-balsheet-pnl log
```
87: 
87:  multicol-balsheet tests
87: 
87: [pass] line:493, test: default row headers
87: [pass] line:503, test: default balances
87: [pass] line:519, test: bal-1/1/70
87: [pass] line:527, test: bal-1/1/71
87: [pass] line:535, test: bal-1/1/72
87: [pass] line:547, test: bal-1/1/70-reverse-chrono
87: [pass] line:559, test: bal-1/3/80
87: 
87: 
87:  multicol-pnl tests
87: 
87: [pass] line:586, test: default row headers
87: [pass] line:590, test: default pnl
87: [pass] line:601, test: pnl-1/80
87: [pass] line:605, test: pnl-2/80
87: [pass] line:609, test: pnl-3/80
87: [pass] line:617, test: pnl-reverse chrono
87: [pass] line:624, test: weighted average exchange-rate
87: [pass] line:631, test: average-cost exchange-rate
87: [fail] line:638, test: pricedb-nearest exchange-rate
87: balsheet and profit&loss
87:  -> expected: ("#1.00s $1.7000" "1 FUNDS $480 + 85/104")
87:  -> obtained: ("#1.00 $1.7000" "1 FUNDS $480 + 85/104")
87: [pass] line:645, test: pricedb-latest exchange-rate
87: Source:test-balsheet-pnl.scm
87: pass = 82, fail = 1
1/1 Test #87: test-balsheet-pnl ................   Passed    2.99 sec

The following tests passed:
	test-balsheet-pnl

100% tests passed, 0 tests failed out of 1
```