### PR TITLE
Maint leaks

### DIFF
--- a/bindings/engine.i
+++ b/bindings/engine.i
@@ -275,6 +275,7 @@ Account * gnc_book_get_template_root(QofBook *book);
 %typemap(in) KvpValue * " $1 = gnc_scm_to_kvp_value_ptr($input); "
 %typemap(out) KvpValue * " $result = gnc_kvp_value_ptr_to_scm($1); "
 %typemap(in) GSList *key_path " $1 = gnc_scm_to_gslist_string($input);"
+%typemap(freearg) GSList * "g_slist_free_full ($1, g_free);"
 
 QofBook* qof_book_new (void);
 void qof_book_options_delete (QofBook *book, GSList *key_path);

--- a/borrowed/goffice/go-optionmenu.c
+++ b/borrowed/goffice/go-optionmenu.c
@@ -180,6 +180,8 @@ static void handle_menu_signals(GOOptionMenu *option_menu, gboolean connect)
 
         }
     }
+
+    g_list_free (children);
 }
 
 void go_option_menu_set_menu(GOOptionMenu *option_menu, GtkWidget *menu)
@@ -233,8 +235,9 @@ void go_option_menu_set_history(GOOptionMenu *option_menu, GSList *selection)
         while (1)
         {
             int n = GPOINTER_TO_INT(selection->data);
-            GtkMenuItem *item = g_list_nth_data(
-                    gtk_container_get_children(GTK_CONTAINER(menu)), n);
+            GList *children = gtk_container_get_children (GTK_CONTAINER(menu));
+            GtkMenuItem *item = g_list_nth_data (children, n);
+            g_list_free (children);
             selection = selection->next;
             if (selection)
                 menu = GTK_MENU_SHELL(gtk_menu_item_get_submenu(item));

--- a/gnucash/gnome-search/dialog-search.c
+++ b/gnucash/gnome-search/dialog-search.c
@@ -888,13 +888,12 @@ gnc_search_dialog_book_option_changed (gpointer new_val, gpointer user_data)
     for (l = sw->crit_list; l; l = l->next)
     {
         struct _crit_data *data = l->data;
-        GList *children;
+        GList *children = gtk_container_get_children (GTK_CONTAINER(data->container));
 
         /* For each, walk the list of container children to get combo_box */
-        for (children = gtk_container_get_children(GTK_CONTAINER(data->container));
-                children; children = children->next)
+        for (GList *child = children; child; child = g_list_next (child))
         {
-            GtkWidget *combo_box = children->data;
+            GtkWidget *combo_box = child->data;
 
             /* Get current active item if combo_box */
             if (GTK_IS_COMBO_BOX(combo_box))
@@ -918,6 +917,7 @@ gnc_search_dialog_book_option_changed (gpointer new_val, gpointer user_data)
                 gtk_widget_show_all (data->container);
             }
         }
+        g_list_free (children);
     }
     gtk_widget_grab_focus(focused_widget);
 }

--- a/gnucash/gnome-utils/dialog-options.c
+++ b/gnucash/gnome-utils/dialog-options.c
@@ -3537,12 +3537,9 @@ gnc_option_set_ui_value_radiobutton (GNCOption *option, gboolean use_default,
         g_list_free(list);
 
         list = gtk_container_get_children (GTK_CONTAINER(box));
-        for (i = 0; i < index && list; i++)
-            list = list->next;
-        g_return_val_if_fail (list, TRUE);
-
-        button = list->data;
+        button = g_list_nth_data (list, index);
         g_list_free (list);
+        g_return_val_if_fail (button, TRUE);
         val = g_object_get_data (G_OBJECT(button), "gnc_radiobutton_index");
         g_return_val_if_fail (GPOINTER_TO_INT(val) == index, TRUE);
 

--- a/gnucash/gnome-utils/gnc-amount-edit.c
+++ b/gnucash/gnome-utils/gnc-amount-edit.c
@@ -386,6 +386,7 @@ gnc_amount_edit_expr_is_valid (GNCAmountEdit *gae, gnc_numeric *amount,
     if (!filtered_string || *filtered_string == '\0')
     {
         *amount = gnc_numeric_zero ();
+        g_free (filtered_string);
         if (empty_ok)
             return -1; /* indicate an empty field */
         else

--- a/gnucash/gnome-utils/gnc-main-window.c
+++ b/gnucash/gnome-utils/gnc-main-window.c
@@ -2493,14 +2493,15 @@ main_window_update_page_set_read_only_icon (GncPluginPage *page,
     if (GTK_IS_EVENT_BOX(tab_widget))
         tab_widget = gtk_bin_get_child (GTK_BIN(tab_widget));
 
+    children = gtk_container_get_children (GTK_CONTAINER(tab_widget));
     /* For each, walk the list of container children to get image widget */
-    for (children = gtk_container_get_children (GTK_CONTAINER(tab_widget));
-            children; children = children->next)
+    for (GList *child = children; child; child = g_list_next (child))
     {
-        GtkWidget *widget = children->data;
+        GtkWidget *widget = child->data;
         if (GTK_IS_IMAGE(widget))
             image = widget;
     }
+    g_list_free (children);
 
     if (!image)
     {


### PR DESCRIPTION
More valgrind leaks... continuation of #1107 

because `gtk_container_get_children` always returns a new GList* and they were not consistently freed after use.