### PR TITLE
More leaks

### DIFF
--- a/gnucash/register/register-core/cellblock.c
+++ b/gnucash/register/register-core/cellblock.c
@@ -79,7 +79,7 @@ gnc_cellblock_destroy (CellBlock *cellblock)
 {
     if (!cellblock) return;
 
-    g_ptr_array_free (cellblock->cells, FALSE);
+    g_ptr_array_free (cellblock->cells, TRUE);
     cellblock->cells = NULL;
 
     g_free (cellblock->cursor_name);

--- a/libgnucash/engine/gnc-commodity.c
+++ b/libgnucash/engine/gnc-commodity.c
@@ -1183,11 +1183,13 @@ const char*
 gnc_commodity_get_user_symbol(const gnc_commodity *cm)
 {
     GValue v = G_VALUE_INIT;
+    static char* retval = NULL;
     if (!cm) return NULL;
     qof_instance_get_kvp (QOF_INSTANCE(cm), &v, 1, "user_symbol");
-    if (G_VALUE_HOLDS_STRING (&v))
-        return g_value_get_string (&v);
-    return NULL;
+    g_free (retval);
+    retval = G_VALUE_HOLDS_STRING (&v) ? g_value_dup_string (&v): NULL;
+    g_value_unset (&v);
+    return retval;
 }
 
 /********************************************************************


### PR DESCRIPTION
More valgrind. Continuation #1113 

1. `GPtrArray` was freed but not its contents. Was causing numerous leaks. This change seems safe but cannot confirm.
2. Returning static string for `gnc_commodity_get_user_symbol` in a thread-unsafe strategy. Is the `const` in the function signature reliable in signalling the function callers that the returned pointer must not be freed?