### PR TITLE
leaks

### DIFF
--- a/gnucash/gnome-search/gnc-general-search.c
+++ b/gnucash/gnome-search/gnc-general-search.c
@@ -405,6 +405,7 @@ create_children (GNCGeneralSearch *gsl,
     g_signal_connect (G_OBJECT (gsl->entry), "focus-out-event",
                       G_CALLBACK (gnc_gsl_focus_out_cb), gsl);
 
+    g_object_unref (list_store);
     g_object_unref(completion);
     gtk_widget_show (gsl->entry);
 

--- a/gnucash/gnome-utils/dialog-object-references.c
+++ b/gnucash/gnome-utils/dialog-object-references.c
@@ -87,6 +87,7 @@ gnc_ui_object_references_show( const gchar* explanation_text, GList* objlist )
     gtk_widget_show_all( dialog );
     gtk_dialog_run( GTK_DIALOG(dialog) );
     g_object_unref(G_OBJECT(builder));
+    g_object_unref (store);
     gtk_widget_destroy( dialog );
 
     LEAVE("");

--- a/gnucash/gnome-utils/gnc-account-sel.c
+++ b/gnucash/gnome-utils/gnc-account-sel.c
@@ -165,7 +165,6 @@ gnc_account_sel_init (GNCAccountSel *gas)
     widget = gtk_combo_box_new_with_model_and_entry (GTK_TREE_MODEL(gas->store));
     gas->combo = GTK_COMBO_BOX(widget);
     gtk_combo_box_set_entry_text_column (GTK_COMBO_BOX(widget), ACCT_COL_NAME);
-    g_object_unref (gas->store);
     g_signal_connect_swapped (gas->combo, "changed",
                               G_CALLBACK(combo_changed_cb), gas);
     gtk_container_add (GTK_CONTAINER(gas), widget);
@@ -416,6 +415,12 @@ gnc_account_sel_dispose (GObject *object)
     g_return_if_fail (GNC_IS_ACCOUNT_SEL(object));
 
     gas = GNC_ACCOUNT_SEL(object);
+
+    if (gas->store)
+    {
+        g_object_unref (gas->store);
+        gas->store = NULL;
+    }
 
     if (gas->eventHandlerId)
     {

--- a/gnucash/gnome-utils/gnc-dense-cal.c
+++ b/gnucash/gnome-utils/gnc-dense-cal.c
@@ -348,6 +348,7 @@ gnc_dense_cal_init(GncDenseCal *dcal)
         gtk_tree_view_insert_column_with_attributes(tree_view, -1, _("Frequency"), gtk_cell_renderer_text_new(), "text", 1, NULL);
         gtk_tree_selection_set_mode (gtk_tree_view_get_selection (GTK_TREE_VIEW(tree_view)), GTK_SELECTION_NONE);
         g_object_set_data(G_OBJECT(dcal->transPopup), "model", tree_data);
+        g_object_unref (tree_data);
         gtk_container_add(GTK_CONTAINER(vbox), GTK_WIDGET(tree_view));
 
         gtk_container_add(GTK_CONTAINER(dcal->transPopup), vbox);

--- a/gnucash/gnome/assistant-hierarchy.c
+++ b/gnucash/gnome/assistant-hierarchy.c
@@ -584,6 +584,8 @@ update_language_region_combos (hierarchy_data *data, const gchar *locale_dir)
     g_signal_connect (data->region_combo, "changed",
                       G_CALLBACK(region_combo_changed_cb), (gpointer)data);
 
+    g_object_unref (language_store);
+    g_object_unref (region_store);
     g_free (start_region);
 }
 

--- a/gnucash/gnome/dialog-print-check.c
+++ b/gnucash/gnome/dialog-print-check.c
@@ -1600,6 +1600,7 @@ initialize_format_combobox (PrintCheckDialog *pcd)
                             GTK_TREE_MODEL(store));
     gtk_combo_box_set_row_separator_func(GTK_COMBO_BOX(pcd->format_combobox),
                                          format_is_a_separator, NULL, NULL);
+    g_object_unref (store);
 }
 
 
@@ -2608,6 +2609,7 @@ gnc_print_check_format_changed (GtkComboBox *widget,
     }
     gtk_list_store_append(GTK_LIST_STORE(p_store), &iter);
     gtk_list_store_set (GTK_LIST_STORE(p_store), &iter, 0, _("Custom"), -1);
+    g_object_unref (p_store);
 
     /* If there's only one thing in the position combobox, make it insensitive */
     sensitive = (pcd->position_max > 0);

--- a/gnucash/gnome/dialog-report-style-sheet.c
+++ b/gnucash/gnome/dialog-report-style-sheet.c
@@ -458,6 +458,7 @@ gnc_style_sheet_select_dialog_destroy_cb (GtkWidget *widget, gpointer user_data)
 
     gnc_unregister_gui_component (ss->component_id);
 
+    g_object_unref (ss->list_store);
     if (ss->toplevel)
     {
         gtk_widget_destroy (ss->toplevel);
@@ -513,7 +514,6 @@ gnc_style_sheet_select_dialog_create (GtkWindow *parent)
     ss->list_view  = GTK_TREE_VIEW(gtk_builder_get_object (builder, "style_sheet_list_view"));
     ss->list_store = gtk_list_store_new (N_COLUMNS, G_TYPE_STRING, G_TYPE_POINTER, G_TYPE_POINTER);
     gtk_tree_view_set_model (ss->list_view, GTK_TREE_MODEL(ss->list_store));
-    g_object_unref (ss->list_store);
 
     renderer = gtk_cell_renderer_text_new ();
     gtk_tree_view_insert_column_with_attributes (ss->list_view, -1,

--- a/gnucash/gnome/gnc-budget-view.c
+++ b/gnucash/gnome/gnc-budget-view.c
@@ -516,6 +516,7 @@ gbv_create_widget (GncBudgetView *budget_view)
     gtk_tree_selection_set_mode (gtk_tree_view_get_selection (totals_tree_view), GTK_SELECTION_NONE);
     gtk_tree_view_set_headers_visible (totals_tree_view, FALSE);
     gtk_tree_view_set_model (totals_tree_view, GTK_TREE_MODEL(totals_tree_model));
+    g_object_unref (totals_tree_model);
 
     // add the totals title column
     totals_title_col = gtk_tree_view_column_new_with_attributes ("", gtk_cell_renderer_text_new (), "text", 0, NULL);

--- a/gnucash/import-export/csv-imp/assistant-csv-account-import.c
+++ b/gnucash/import-export/csv-imp/assistant-csv-account-import.c
@@ -619,6 +619,7 @@ csv_import_close_handler (gpointer user_data)
     g_free (info->starting_dir);
     g_free (info->file_name);
     g_string_free (info->regexp, TRUE);
+    g_object_unref (info->store);
 
     gnc_save_window_size (GNC_PREFS_GROUP, GTK_WINDOW(info->assistant));
     gtk_widget_destroy (info->assistant);

--- a/gnucash/import-export/csv-imp/assistant-csv-price-import.cpp
+++ b/gnucash/import-export/csv-imp/assistant-csv-price-import.cpp
@@ -513,6 +513,7 @@ GtkTreeModel *get_model (bool all_commodity)
     }
     g_list_free (commodity_list);
     g_list_free (namespace_list);
+    g_object_unref (store);
 
     return model;
 }
@@ -572,6 +573,8 @@ CsvImpPriceAssist::CsvImpPriceAssist ()
         // Add Settings combo
         auto settings_store = gtk_list_store_new (2, G_TYPE_POINTER, G_TYPE_STRING);
         settings_combo = GTK_COMBO_BOX(gtk_combo_box_new_with_model_and_entry (GTK_TREE_MODEL(settings_store)));
+        g_object_unref (settings_store);
+
         gtk_combo_box_set_entry_text_column (GTK_COMBO_BOX(settings_combo), SET_NAME);
         gtk_combo_box_set_active (GTK_COMBO_BOX(settings_combo), 0);
 
@@ -1635,6 +1638,7 @@ void CsvImpPriceAssist::preview_refresh_table ()
     }
     gtk_tree_view_set_model (treeview, GTK_TREE_MODEL(store));
     gtk_tree_view_set_tooltip_column (treeview, PREV_COL_ERROR);
+    g_object_unref (store);
 
     /* Adjust treeview to go with the just created model. This consists of adding
      * or removing columns and resetting any parameters related to how

--- a/gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp
+++ b/gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp
@@ -512,6 +512,7 @@ CsvImpTransAssist::CsvImpTransAssist ()
         // Add Settings combo
         auto settings_store = gtk_list_store_new (2, G_TYPE_POINTER, G_TYPE_STRING);
         settings_combo = GTK_COMBO_BOX(gtk_combo_box_new_with_model_and_entry (GTK_TREE_MODEL(settings_store)));
+        g_object_unref (settings_store);
         gtk_combo_box_set_entry_text_column (GTK_COMBO_BOX(settings_combo), SET_NAME);
         gtk_combo_box_set_active (GTK_COMBO_BOX(settings_combo), 0);
 
@@ -1563,6 +1564,7 @@ void CsvImpTransAssist::preview_refresh_table ()
     }
     gtk_tree_view_set_model (treeview, GTK_TREE_MODEL(store));
     gtk_tree_view_set_tooltip_column (treeview, PREV_COL_ERROR);
+    g_object_unref (store);
 
     /* Adjust treeview to go with the just created model. This consists of adding
      * or removing columns and resetting any parameters related to how

--- a/gnucash/register/register-gnome/combocell-gnome.c
+++ b/gnucash/register/register-gnome/combocell-gnome.c
@@ -299,6 +299,12 @@ gnc_combo_cell_gui_destroy (BasicCell* bcell)
             box->item_list = NULL;
         }
 
+        if (box && box->tmp_store)
+        {
+            g_object_unref (box->tmp_store);
+            box->tmp_store = NULL;
+        }
+
         /* allow the widget to be shown again */
         cell->cell.gui_realize = gnc_combo_cell_gui_realize;
         cell->cell.gui_move = NULL;


### PR DESCRIPTION
1. ~Reverts a static string issue.~ ~be mindful commodity nice symbol is a static string and must be reassigned carefully.~ done
2. Also `g_object_unref` a `gtk_list_store_new` GObject to free it properly.