### PR TITLE
Fix unhandled exception in gnc_numeric_ functions

### DIFF
--- a/libgnucash/engine/gnc-numeric.cpp
+++ b/libgnucash/engine/gnc-numeric.cpp
@@ -756,9 +756,9 @@ gnc_numeric_add(gnc_numeric a, gnc_numeric b,
     {
         return gnc_numeric_error(GNC_ERROR_ARG);
     }
-    denom = denom_lcd(a, b, denom, how);
     try
     {
+        denom = denom_lcd(a, b, denom, how);
         if ((how & GNC_NUMERIC_DENOM_MASK) != GNC_HOW_DENOM_EXACT)
         {
             GncNumeric an (a), bn (b);
@@ -810,9 +810,9 @@ gnc_numeric_sub(gnc_numeric a, gnc_numeric b,
     {
         return gnc_numeric_error(GNC_ERROR_ARG);
     }
-    denom = denom_lcd(a, b, denom, how);
     try
     {
+        denom = denom_lcd(a, b, denom, how);
         if ((how & GNC_NUMERIC_DENOM_MASK) != GNC_HOW_DENOM_EXACT)
         {
             GncNumeric an (a), bn (b);
@@ -863,9 +863,10 @@ gnc_numeric_mul(gnc_numeric a, gnc_numeric b,
     {
         return gnc_numeric_error(GNC_ERROR_ARG);
     }
-    denom = denom_lcd(a, b, denom, how);
+
     try
     {
+        denom = denom_lcd(a, b, denom, how);
         if ((how & GNC_NUMERIC_DENOM_MASK) != GNC_HOW_DENOM_EXACT)
         {
             GncNumeric an (a), bn (b);
@@ -917,9 +918,9 @@ gnc_numeric_div(gnc_numeric a, gnc_numeric b,
     {
         return gnc_numeric_error(GNC_ERROR_ARG);
     }
-    denom = denom_lcd(a, b, denom, how);
     try
     {
+        denom = denom_lcd(a, b, denom, how);
         if ((how & GNC_NUMERIC_DENOM_MASK) != GNC_HOW_DENOM_EXACT)
         {
             GncNumeric an (a), bn (b);


### PR DESCRIPTION
Those four functions:

- `gnc_numeric_add`
- `gnc_numeric_sub`
- `gnc_numeric_mul`
- `gnc_numeric_div`

have a lengthy try/catch block that catches overflow exceptions. Outside of each of these blocks there is an invocation to `denom_lcd`:

```C
// gnucash/libgnucash/engine/gnc-numeric.cpp:761
denom = denom_lcd(a, b, denom, how);
```

The problem with that is `denom_lcd` has a cast to `std::int64_t` which may cause an exception.

```C
// gnucash/libgnucash/engine/gnc-numeric.cpp:736
static int64_t
denom_lcd(gnc_numeric a, gnc_numeric b, int64_t denom, int how)
{
    ...
    denom = static_cast<int64_t>(ad.lcm(bd));
    ....
}
```

```C++
// gnucash/libgnucash/engine/gnc-int128.cpp:131
GncInt128::operator int64_t() const
{
    ...
    if ((flags & (overflow | NaN)) || isBig())
        throw std::overflow_error ("Value too large to represent as int64_t");
    ...
}
```

This PR moves all of the `denom_lcd` calls inside respective try/catch blocks, which then properly reports an error instead of crashing GnuCash.