### PR TITLE
Locking fixes for the XML backend

### DIFF
--- a/libgnucash/backend/xml/gnc-xml-backend.cpp
+++ b/libgnucash/backend/xml/gnc-xml-backend.cpp
@@ -723,7 +723,7 @@ GncXmlBackend::get_file_lock (bool break_lock)
         {
             close (m_lockfd);
             m_lockfd = -1;
-            g_unlink (m_lockfile.c_str());
+            /* Don't unlink m_lockfile, it does not belong to us. */
             m_lockfile.clear();
         }
         return false;
@@ -745,7 +745,7 @@ GncXmlBackend::get_file_lock (bool break_lock)
             g_unlink (linkfile.str().c_str());
             close (m_lockfd);
             m_lockfd = -1;
-            g_unlink (m_lockfile.c_str());
+            /* Don't unlink m_lockfile, it does not belong to us. */
             m_lockfile.clear();
         }
         return false;
@@ -763,7 +763,7 @@ GncXmlBackend::get_file_lock (bool break_lock)
             g_unlink (linkfile.str().c_str());
             close (m_lockfd);
             m_lockfd = -1;
-            g_unlink (m_lockfile.c_str());
+            /* Don't unlink m_lockfile, it does not belong to us. */
             m_lockfile.clear();
         }
         return false;

--- a/libgnucash/backend/xml/gnc-xml-backend.cpp
+++ b/libgnucash/backend/xml/gnc-xml-backend.cpp
@@ -171,8 +171,11 @@ GncXmlBackend::session_end()
     if (!m_linkfile.empty())
         g_unlink (m_linkfile.c_str());
 
-    if (m_lockfd > 0)
+    if (m_lockfd != -1)
+    {
         close (m_lockfd);
+        m_lockfd = -1;
+    }
 
     if (!m_lockfile.empty())
     {
@@ -643,7 +646,7 @@ GncXmlBackend::get_file_lock ()
 
     m_lockfd = g_open (m_lockfile.c_str(), O_RDWR | O_CREAT | O_EXCL ,
                          S_IRUSR | S_IWUSR);
-    if (m_lockfd < 0)
+    if (m_lockfd == -1)
     {
         /* oops .. we can't create the lockfile .. */
         switch (errno)
@@ -708,6 +711,7 @@ GncXmlBackend::get_file_lock ()
         set_error(ERR_BACKEND_LOCKED);
         g_unlink (linkfile.str().c_str());
         close (m_lockfd);
+        m_lockfd = -1;
         g_unlink (m_lockfile.c_str());
         return false;
     }
@@ -721,6 +725,7 @@ GncXmlBackend::get_file_lock ()
         set_message(msg + m_lockfile);
         g_unlink (linkfile.str().c_str());
         close (m_lockfd);
+        m_lockfd = -1;
         g_unlink (m_lockfile.c_str());
         return false;
     }
@@ -730,6 +735,7 @@ GncXmlBackend::get_file_lock ()
         set_error(ERR_BACKEND_LOCKED);
         g_unlink (linkfile.str().c_str());
         close (m_lockfd);
+        m_lockfd = -1;
         g_unlink (m_lockfile.c_str());
         return false;
     }

--- a/libgnucash/backend/xml/gnc-xml-backend.cpp
+++ b/libgnucash/backend/xml/gnc-xml-backend.cpp
@@ -641,6 +641,7 @@ GncXmlBackend::get_file_lock ()
     {
         /* oops .. file is locked by another user  .. */
         set_error(ERR_BACKEND_LOCKED);
+        m_lockfile.clear();
         return false;
     }
 
@@ -664,6 +665,7 @@ GncXmlBackend::get_file_lock ()
             PWARN ("Unable to create the lockfile %s: %s",
                    m_lockfile.c_str(), strerror(errno));
         set_error(be_err);
+        m_lockfile.clear();
         return false;
     }
 
@@ -713,6 +715,7 @@ GncXmlBackend::get_file_lock ()
         close (m_lockfd);
         m_lockfd = -1;
         g_unlink (m_lockfile.c_str());
+        m_lockfile.clear();
         return false;
     }
 
@@ -727,6 +730,7 @@ GncXmlBackend::get_file_lock ()
         close (m_lockfd);
         m_lockfd = -1;
         g_unlink (m_lockfile.c_str());
+        m_lockfile.clear();
         return false;
     }
 
@@ -737,6 +741,7 @@ GncXmlBackend::get_file_lock ()
         close (m_lockfd);
         m_lockfd = -1;
         g_unlink (m_lockfile.c_str());
+        m_lockfile.clear();
         return false;
     }
 

--- a/libgnucash/backend/xml/gnc-xml-backend.hpp
+++ b/libgnucash/backend/xml/gnc-xml-backend.hpp
@@ -49,7 +49,7 @@ public:
 
 private:
     bool save_may_clobber_data();
-    bool get_file_lock();
+    bool get_file_lock(bool break_lock);
     bool link_or_make_backup(const std::string& orig, const std::string& bkup);
     bool backup_file();
     bool write_to_file(bool make_backup);

--- a/libgnucash/backend/xml/gnc-xml-backend.hpp
+++ b/libgnucash/backend/xml/gnc-xml-backend.hpp
@@ -60,7 +60,7 @@ private:
     std::string m_dirname;
     std::string m_lockfile;
     std::string m_linkfile;
-    int m_lockfd;
+    int m_lockfd = -1;
 
     QofBook* m_book = nullptr;  /* The primary, main open book */
 };


### PR DESCRIPTION
The lock file is closed even if it's not open, because m_lockfd is not initialised. Initialise it and be consistent in how it is checked for validity. (Tested)

**The lock file is deleted on session_end even if it's not acquired.** Fix this so that we don't unlock without holding the lock. (Tested)

The "break lock" process ignores the lock but does not try to acquire it. Unlink and try to acquire it. (Untested)

The NFS link checking process unlinks the lock file even if the check failed. We may not hold the lock at this point so don't do this. (Untested)