### PR TITLE
fix spurious error about uninitialized have_end

### DIFF
--- a/gnucash/gnome-utils/gnc-tree-view-account.c
+++ b/gnucash/gnome-utils/gnc-tree-view-account.c
@@ -1676,7 +1676,7 @@ gnc_tree_view_account_select_subaccounts (GncTreeViewAccount *view,
     GtkTreeSelection *selection;
     GtkTreePath *sp_account, *sp_start, *sp_end;
     GtkTreeIter si_account, si_start, si_end;
-    gboolean have_start, have_end;
+    gboolean have_start, have_end = FALSE;
     gint num_children;
 
     ENTER("view %p, account %p (%s)", view, account, xaccAccountGetName(account));


### PR DESCRIPTION
in gnc_tree_view_account_select_subaccounts, gcc thinks have_end might
not be initialized, but since the function exits if num_children == 0,
the while (num_children) loop will always be entered. Silence the
warning.