### PR TITLE
Fix to allow gnucash-cli to run custom reports defined in config-user.scm

### DIFF
--- a/gnucash/report/gnc-report.c
+++ b/gnucash/report/gnc-report.c
@@ -92,6 +92,15 @@ load_custom_reports_stylesheets(void)
         return;
     else is_user_config_loaded = TRUE;
 
+    update_message("loading user configuration");
+    {
+        gchar *config_filename;
+        config_filename = g_build_filename (gnc_userconfig_dir (),
+                                                "config-user.scm", (char *)NULL);
+        gfec_try_load(config_filename);
+        g_free(config_filename);
+    }
+
     update_message("loading saved reports");
     try_load_config_array(saved_report_files);
     update_message("loading stylesheets");


### PR DESCRIPTION
Custom reports normally loaded from the user account for the GUI are not available when running using the command line interface.  Attempting to run a custom report from gnucash-cli results in errors:
WARN <gnc.scm> BUG DETECTED: Scheme exception raised in report options generator procedure named options-gen
OTHER <> bad value

This PR incorporates logic to have gnucash-cli load the user's config-user.scm when running reports.