### PR TITLE
798298 reimport ofx

### DIFF
--- a/gnucash/import-export/import-backend.c
+++ b/gnucash/import-export/import-backend.c
@@ -1048,6 +1048,106 @@ gnc_import_process_trans_item (GncImportMatchMap *matchmap,
     return FALSE;
 }
 
+/********************************************************************\
+ * check_trans_online_id() Callback function used by
+ * gnc_import_exists_online_id.  Takes pointers to transaction and split,
+ * returns 0 if their online_ids  do NOT match, or if the split
+ * belongs to the transaction
+\********************************************************************/
+static gint check_trans_online_id(Transaction *trans1, void *user_data)
+{
+    Account *account;
+    Split *split1;
+    Split *split2 = user_data;
+    const gchar *online_id1;
+    const gchar *online_id2;
+
+    account = xaccSplitGetAccount(split2);
+    split1 = xaccTransFindSplitByAccount(trans1, account);
+    if (split1 == split2)
+        return 0;
+
+    /* hack - we really want to iterate over the _splits_ of the account
+       instead of the transactions */
+    g_assert(split1 != NULL);
+
+    if (gnc_import_split_has_online_id(split1))
+        online_id1 = gnc_import_get_split_online_id(split1);
+    else
+        online_id1 = gnc_import_get_trans_online_id(trans1);
+
+    online_id2 = gnc_import_get_split_online_id(split2);
+
+    if ((online_id1 == NULL) ||
+            (online_id2 == NULL) ||
+            (strcmp(online_id1, online_id2) != 0))
+    {
+        return 0;
+    }
+    else
+    {
+        /*printf("test_trans_online_id(): Duplicate found\n");*/
+        return 1;
+    }
+}
+
+static gint collect_trans_online_id(Transaction *trans, void *user_data)
+{
+    Split *split;
+    GHashTable *id_hash = user_data;
+    int i=0;
+    
+    const gchar* online_id = gnc_import_get_trans_online_id (trans);
+    if (online_id)
+        g_hash_table_add (id_hash, (void*) online_id);
+
+    for (GList *splits = xaccTransGetSplitList (trans); splits; splits = splits->next)
+    {
+        if (gnc_import_split_has_online_id (splits->data))
+            g_hash_table_add(id_hash, (void*) gnc_import_get_split_online_id (splits->data));
+    }
+    return 0;
+}
+
+/** Checks whether the given transaction's online_id already exists in
+  its parent account. */
+gboolean gnc_import_exists_online_id (Transaction *trans, GHashTable* acct_id_hash)
+{
+    gboolean online_id_exists = FALSE;
+    Account *dest_acct;
+    Split *source_split;
+
+    /* Look for an online_id in the first split */
+    source_split = xaccTransGetSplit(trans, 0);
+    g_assert(source_split);
+
+    // No online id, no point in continuing. We'd crash if we tried.
+    if (!gnc_import_get_split_online_id (source_split))
+        return FALSE;
+    // Create a hash per account of a hash of all transactions IDs. Then the test below will be fast if
+    // we have many transactions to import.
+    dest_acct = xaccSplitGetAccount (source_split);
+    if (!g_hash_table_contains (acct_id_hash, dest_acct))
+    {
+        GHashTable* new_hash = g_hash_table_new (g_str_hash, g_str_equal);
+        g_hash_table_insert (acct_id_hash, dest_acct, new_hash);
+        xaccAccountForEachTransaction (dest_acct, collect_trans_online_id, new_hash);
+    }
+    online_id_exists = g_hash_table_contains (g_hash_table_lookup (acct_id_hash, dest_acct),
+                                              gnc_import_get_split_online_id (source_split));
+    
+    /* If it does, abort the process for this transaction, since it is
+       already in the system. */
+    if (online_id_exists == TRUE)
+    {
+        DEBUG("%s", "Transaction with same online ID exists, destroying current transaction");
+        xaccTransDestroy(trans);
+        xaccTransCommitEdit(trans);
+    }
+    return online_id_exists;
+}
+
+
 /* ******************************************************************
  */
 

--- a/gnucash/import-export/import-backend.h
+++ b/gnucash/import-export/import-backend.h
@@ -57,6 +57,15 @@ typedef enum _action
 /** @name Non-GUI Functions */
 /*@{*/
 
+/** Checks whether the given transaction's online_id already exists in
+ * its parent account. The given transaction has to be open for
+ * editing. If a matching online_id exists, the transaction is
+ * destroyed (!) and TRUE is returned, otherwise FALSE is returned.
+ *
+ * @param trans The transaction for which to check for an existing
+ * online_id. */
+gboolean gnc_import_exists_online_id (Transaction *trans, GHashTable* acct_id_hash);
+
 /** Evaluates the match between trans_info and split using the provided parameters.
  *
  * @param trans_info The TransInfo for the imported transaction

--- a/gnucash/import-export/import-utilities.c
+++ b/gnucash/import-export/import-utilities.c
@@ -57,6 +57,29 @@ void gnc_import_set_acc_online_id (Account *account, const gchar *id)
     xaccAccountCommitEdit (account);
 }
 
+const gchar * gnc_import_get_trans_online_id (Transaction * transaction)
+{
+    gchar *id = NULL;
+    qof_instance_get (QOF_INSTANCE (transaction), "online-id", &id, NULL);
+    return id;
+}
+/* Not actually used */
+void gnc_import_set_trans_online_id (Transaction *transaction,
+				     const gchar *id)
+{
+    g_return_if_fail (transaction != NULL);
+    xaccTransBeginEdit (transaction);
+    qof_instance_set (QOF_INSTANCE (transaction), "online-id", id, NULL);
+    xaccTransCommitEdit (transaction);
+}
+
+gboolean gnc_import_trans_has_online_id(Transaction * transaction)
+{
+    const gchar * online_id;
+    online_id = gnc_import_get_trans_online_id(transaction);
+    return (online_id != NULL && strlen(online_id) > 0);
+}
+
 const gchar * gnc_import_get_split_online_id (Split * split)
 {
     gchar *id = NULL;

--- a/gnucash/import-export/import-utilities.h
+++ b/gnucash/import-export/import-utilities.h
@@ -49,6 +49,17 @@ const gchar * gnc_import_get_acc_online_id(Account * account);
 void gnc_import_set_acc_online_id(Account * account,
                                   const gchar * string_value);
 /** @} */
+/** @name Setter-getters
+    Setter and getter functions for the online_id field for
+    Transactions.
+	@{
+*/
+const gchar * gnc_import_get_trans_online_id(Transaction * transaction);
+void gnc_import_set_trans_online_id(Transaction * transaction,
+                                    const gchar * string_value);
+/** @} */
+
+gboolean gnc_import_trans_has_online_id(Transaction * transaction);
 
 /** @name Setter-getters
     Setter and getter functions for the online_id field for

--- a/libgnucash/engine/mocks/gmock-Account.cpp
+++ b/libgnucash/engine/mocks/gmock-Account.cpp
@@ -60,6 +60,15 @@ xaccAccountForEachTransaction(const Account *acc, TransactionCallback proc,
     return mockaccount ? mockaccount->for_each_transaction(proc, data) : 0;
 }
 
+SplitList *
+xaccAccountGetSplitList (const Account *account)
+{
+    SCOPED_TRACE("");
+    auto mockaccount = gnc_mockaccount(account);
+    return mockaccount ? mockaccount->xaccAccountGetSplitList() : nullptr;
+}
+
+
 GncImportMatchMap *
 gnc_account_imap_create_imap (Account *acc)
 {

--- a/libgnucash/engine/mocks/gmock-Account.h
+++ b/libgnucash/engine/mocks/gmock-Account.h
@@ -43,6 +43,7 @@ public:
     MOCK_METHOD0(commit_edit, void());
     MOCK_CONST_METHOD0(get_book, QofBook*());
     MOCK_CONST_METHOD2(for_each_transaction, gint(TransactionCallback, void*));
+    MOCK_CONST_METHOD0(xaccAccountGetSplitList, SplitList*());
     MOCK_METHOD0(create_imap, GncImportMatchMap*());
 
 protected:


### PR DESCRIPTION
Reverted the change be6fb1abe that entirely removed the check for online_id in existing registry transactions. Added code to ensure that during the import of a transaction, splits in register transactions that have the same FITID are only ignored if the split in question corresponds to the account into which the transaction is imported.
This re-instate the behavior prior to be6fb1abe which allowed us to re-import the same file twice in a row with the second time showing no transactions to import. It also fixes bug 798298 in cases where the online_id of an imported transaction exists in the split of a register transaction, but corresponds to a different account (there no guarantee that FITID are unique from bank to bank).

What this does not fix is non-compliant OFX files in which FITIDs are reused in the same bank account. 