### PR TITLE
more GValue string leaks plugged

### DIFF
--- a/libgnucash/engine/Account.cpp
+++ b/libgnucash/engine/Account.cpp
@@ -6021,23 +6021,10 @@ gnc_account_imap_get_info (Account *acc, const char *category)
 gchar *
 gnc_account_get_map_entry (Account *acc, const char *head, const char *category)
 {
-    GValue v = G_VALUE_INIT;
-    gchar *text = NULL;
-    std::vector<std::string> path {head};
     if (category)
-        path.emplace_back (category);
-    if (qof_instance_has_path_slot (QOF_INSTANCE (acc), path))
-    {
-        qof_instance_get_path_kvp (QOF_INSTANCE (acc), &v, path);
-        if (G_VALUE_HOLDS_STRING (&v))
-        {
-            gchar const *string;
-            string = g_value_get_string (&v);
-            text = g_strdup (string);
-        }
-    }
-    g_value_unset (&v);
-    return text;
+        return get_kvp_string_path (acc, {head, category});
+    else
+        return get_kvp_string_path (acc, {head});
 }
 
 

--- a/libgnucash/engine/Account.h
+++ b/libgnucash/engine/Account.h
@@ -469,7 +469,7 @@ Account * xaccAccountGainsAccount (Account *acc, gnc_commodity *curr);
 void dxaccAccountSetPriceSrc (Account *account, const char *src);
 /** Get a string that identifies the Finance::Quote backend that
  *  should be used to retrieve online prices.  See price-quotes.scm
- *  for more information.
+ *  for more information. This function uses a static char*.
  *
  *  @deprecated Price quote information is now stored on the
  *  commodity, not the account. */
@@ -1588,7 +1588,8 @@ gnc_commodity * DxaccAccountGetCurrency (const Account *account);
 void dxaccAccountSetQuoteTZ (Account *account, const char *tz);
 /** Get the timezone to be used when interpreting the results from a
  *  given Finance::Quote backend.  Unfortunately, the upstream sources
- *  don't label their output, so the user has to specify this bit.
+ *  don't label their output, so the user has to specify this
+ *  bit. This function uses a static char*.
  *
  *  @deprecated Price quote information is now stored on the
  *  commodity, not the account. */

--- a/libgnucash/engine/AccountP.h
+++ b/libgnucash/engine/AccountP.h
@@ -133,6 +133,9 @@ typedef struct AccountPrivate
     TriState equity_type;
     char *notes;
     char *color;
+    char *tax_us_code;
+    char *tax_us_pns;
+    char *last_num;
     char *sort_order;
     char *filter;
 

--- a/libgnucash/engine/test/utest-Account.cpp
+++ b/libgnucash/engine/test/utest-Account.cpp
@@ -1216,6 +1216,33 @@ test_gnc_account_kvp_setters_getters (Fixture *fixture, gconstpointer pData)
     xaccAccountSetNotes (account, nullptr);
     g_assert_cmpstr (xaccAccountGetNotes (account), ==, nullptr);
 
+    // STOCK_ACCOUNT tests from now on
+    xaccAccountSetType (account, ACCT_TYPE_STOCK);
+
+    // dxaccAccountGetPriceSrc getter/setter
+    g_assert_cmpstr (dxaccAccountGetPriceSrc (account), ==, nullptr);
+
+    dxaccAccountSetPriceSrc (account, "boo");
+    g_assert_cmpstr (dxaccAccountGetPriceSrc (account), ==, "boo");
+
+    dxaccAccountSetPriceSrc (account, "");
+    g_assert_cmpstr (dxaccAccountGetPriceSrc (account), ==, "");
+
+    dxaccAccountSetPriceSrc (account, nullptr);
+    g_assert_cmpstr (dxaccAccountGetPriceSrc (account), ==, nullptr);
+
+    // dxaccAccountGetQuoteTZ getter/setter
+    g_assert_cmpstr (dxaccAccountGetQuoteTZ (account), ==, nullptr);
+
+    dxaccAccountSetQuoteTZ (account, "boo");
+    g_assert_cmpstr (dxaccAccountGetQuoteTZ (account), ==, "boo");
+
+    dxaccAccountSetQuoteTZ (account, "");
+    g_assert_cmpstr (dxaccAccountGetQuoteTZ (account), ==, "");
+
+    dxaccAccountSetQuoteTZ (account, nullptr);
+    g_assert_cmpstr (dxaccAccountGetQuoteTZ (account), ==, nullptr);
+
     xaccAccountBeginEdit (account);
     xaccAccountDestroy (account);
 }


### PR DESCRIPTION
After this, the only remaining GValue string leaks in account.cpp are `dxaccAccountGetQuoteTZ` and `dxaccAccountGetPriceSrc`.  To plug them would require adding more member in the `AccountPrivate` struct, which does not seem worthwhile.

tests done in 15852031d and a5d101d and 7a878e88cef08857450da2842dbe37e6d1d2d242