### PR TITLE
Bug797678 OFX import should append not replace, existing Notes & Desc

### DIFF
--- a/gnucash/gtkbuilder/dialog-import.glade
+++ b/gnucash/gtkbuilder/dialog-import.glade
@@ -960,7 +960,7 @@
         </child>
         <child>
           <object class="GtkCheckButton" id="show_matched_info_button">
-            <property name="label" translatable="yes">Show _matched information</property>
+            <property name="label" translatable="yes">Show matched _information</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
@@ -974,8 +974,24 @@
           </packing>
         </child>
         <child>
+          <object class="GtkCheckButton" id="append_desc_notes_button">
+            <property name="label" translatable="yes">A_ppend</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="tooltip_text" translatable="yes">When Updating and Clearing a matched transaction, append the imported Description and Notes to the matched Description and Notes instead of replacing them.</property>
+            <property name="use_underline">True</property>
+            <property name="draw_indicator">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>    
+        <child>
           <object class="GtkCheckButton" id="reconcile_after_close_button">
-            <property name="label" translatable="yes">Reconcile after match</property>
+            <property name="label" translatable="yes">_Reconcile after match</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
             <property name="no_show_all">True</property>
@@ -985,7 +1001,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">3</property>
+            <property name="position">4</property>
           </packing>
         </child>
       </object>

--- a/gnucash/import-export/import-backend.h
+++ b/gnucash/import-export/import-backend.h
@@ -238,6 +238,11 @@ void
 gnc_import_TransInfo_set_ref_id (GNCImportTransInfo *info,
                                  guint32 ref_id);
 
+/** Set the append_text for this TransInfo. */
+void
+gnc_import_TransInfo_set_append_text (GNCImportTransInfo *info,
+                                           gboolean append_text);
+
 /**@}*/
 
 /** @name Getters/Setters for GNCImportMatchInfo */

--- a/gnucash/import-export/import-main-matcher.h
+++ b/gnucash/import-export/import-main-matcher.h
@@ -189,6 +189,13 @@ gboolean gnc_gen_trans_list_run (GNCImportMainMatcher *info);
  */
 GtkWidget *gnc_gen_trans_list_widget (GNCImportMainMatcher *info);
 
+/** Returns the append_text widget of this dialog.
+ * @param info A pointer to a the GNCImportMainMatcher structure.
+ * @return A GtkWidget pointer to the append_text widget.
+ */
+GtkWidget *
+gnc_gen_trans_list_append_text_widget (GNCImportMainMatcher *info);
+
 /** Checks whether there are no transactions to match.
  * @param info A pointer to a the GNCImportMainMatcher structure.
  * @return A boolean indicating whether the transaction list is empty.

--- a/libgnucash/engine/Account.cpp
+++ b/libgnucash/engine/Account.cpp
@@ -65,6 +65,7 @@ static const std::string KEY_INCLUDE_CHILDREN("include-children");
 static const std::string KEY_POSTPONE("postpone");
 static const std::string KEY_LOT_MGMT("lot-mgmt");
 static const std::string KEY_ONLINE_ID("online_id");
+static const std::string KEY_IMP_APPEND_TEXT("import-append-text");
 static const std::string AB_KEY("hbci");
 static const std::string AB_ACCOUNT_ID("account-id");
 static const std::string AB_ACCOUNT_UID("account-uid");
@@ -116,6 +117,7 @@ enum
 
     PROP_LOT_NEXT_ID,                   /* KVP */
     PROP_ONLINE_ACCOUNT,                /* KVP */
+    PROP_IMP_APPEND_TEXT,               /* KVP */
     PROP_IS_OPENING_BALANCE,            /* KVP */
     PROP_OFX_INCOME_ACCOUNT,            /* KVP */
     PROP_AB_ACCOUNT_ID,                 /* KVP */
@@ -484,6 +486,9 @@ gnc_account_get_property (GObject         *object,
     case PROP_ONLINE_ACCOUNT:
         qof_instance_get_path_kvp (QOF_INSTANCE (account), value, {KEY_ONLINE_ID});
         break;
+    case PROP_IMP_APPEND_TEXT:
+        g_value_set_boolean(value, xaccAccountGetAppendText(account));
+        break;
     case PROP_OFX_INCOME_ACCOUNT:
         qof_instance_get_path_kvp (QOF_INSTANCE (account), value, {KEY_ASSOC_INCOME_ACCOUNT});
         break;
@@ -612,6 +617,9 @@ gnc_account_set_property (GObject         *object,
         break;
     case PROP_ONLINE_ACCOUNT:
         qof_instance_set_path_kvp (QOF_INSTANCE (account), value, {KEY_ONLINE_ID});
+        break;
+    case PROP_IMP_APPEND_TEXT:
+        xaccAccountSetAppendText(account, g_value_get_boolean(value));
         break;
     case PROP_OFX_INCOME_ACCOUNT:
         qof_instance_set_path_kvp (QOF_INSTANCE (account), value, {KEY_ASSOC_INCOME_ACCOUNT});
@@ -1061,6 +1069,16 @@ gnc_account_class_init (AccountClass *klass)
                           "account for OFX import",
                           NULL,
                           static_cast<GParamFlags>(G_PARAM_READWRITE)));
+
+    g_object_class_install_property
+    (gobject_class,
+     PROP_IMP_APPEND_TEXT,
+     g_param_spec_boolean ("import-append-text",
+                           "Import Append Text",
+                           "Saved state of Append checkbox for setting initial "
+                           "value next time this account is imported.",
+                           FALSE,
+                           static_cast<GParamFlags>(G_PARAM_READWRITE)));
 
      g_object_class_install_property(
        gobject_class,
@@ -4226,6 +4244,18 @@ void
 xaccAccountSetPlaceholder (Account *acc, gboolean val)
 {
     set_boolean_key(acc, {"placeholder"}, val);
+}
+
+gboolean
+xaccAccountGetAppendText (const Account *acc)
+{
+    return boolean_from_key(acc, {"import-append-text"});
+}
+
+void
+xaccAccountSetAppendText (Account *acc, gboolean val)
+{
+    set_boolean_key(acc, {"import-append-text"}, val);
 }
 
 gboolean

--- a/libgnucash/engine/Account.h
+++ b/libgnucash/engine/Account.h
@@ -1217,6 +1217,30 @@ gboolean xaccAccountGetPlaceholder (const Account *account);
  *  @param val The new state for the account's "placeholder" flag. */
 void xaccAccountSetPlaceholder (Account *account, gboolean val);
 
+/** @name Account Append Text flag
+ @{
+*/
+
+/** Get the "import-append-text" flag for an account.  This is the saved
+ *  state of the Append checkbox in the "Generic import transaction matcher"
+ *  used to set the initial state of the Append checkbox next time this
+ *  account is imported.
+ *
+ *  @param account The account whose flag should be retrieved.
+ *
+ *  @return The current state of the account's "import-append-text" flag. */
+gboolean xaccAccountGetAppendText (const Account *account);
+
+/** Set the "import-append-text" flag for an account.  This is the saved
+ *  state of the Append checkbox in the "Generic import transaction matcher"
+ *  used to set the initial state of the Append checkbox next time this
+ *  account is imported.
+ *
+ *  @param account The account whose flag should be retrieved.
+ *
+ *  @param val The new state for the account's "import-append-text" flag. */
+void xaccAccountSetAppendText (Account *account, gboolean val);
+
 /** Get the "opening-balance" flag for an account.  If this flag is set
  *  then the account is used for opening balance transactions.
  *


### PR DESCRIPTION
Add an "Append" checkbox to the bottom of the "Generic import transaction
matcher" window to the left of the "Reconcile after match" checkbox.
When ticked, this causes the imported Description/Notes to be appended
to the matched transaction Description/Notes respectively.
The selected ticked/unticked state of the "Append" checkbox is saved in
a key value pair for the import account, so the next import for that
account will automatically default it to the saved state.
As these mods are limited to the code for the matcher window, this should
work for all the imports that use it - ie ofx & csv file imports (both
tested) & aqbanking (I cannot test).

Can some-one please test aqbanking?

If this gets merged, I'll see if I can also do this for QIF import, and update the documentation.