### PR TITLE
gnc:format

### DIFF
--- a/bindings/guile/test/CMakeLists.txt
+++ b/bindings/guile/test/CMakeLists.txt
@@ -25,7 +25,6 @@ gnc_add_test_with_guile(test-scm-query test-scm-query.cpp ENGINE_TEST_INCLUDE_DI
 
 
 set(bindings_test_SCHEME
-    test-core-utils.scm
     test-create-account.scm
 )
 
@@ -59,6 +58,7 @@ add_dependencies(check scm-test-engine)
 gnc_add_scheme_tests("${engine_test_SCHEME}")
 
 set (scm_tests_with_srfi64_SOURCES
+  test-core-utils.scm
   test-business-core.scm
   test-scm-engine.scm
   )

--- a/bindings/guile/test/test-core-utils.scm
+++ b/bindings/guile/test/test-core-utils.scm
@@ -13,8 +13,37 @@
     "foobar"
     (N_ "foobar")))
 
+(define (gnc-format-tests)
+  (test-equal "null"
+    ""
+    (gnc:format ""))
+
+  (test-equal "basic"
+    "basic"
+    (gnc:format "basic"))
+
+  (test-equal "basic with unused symbols"
+    "basic"
+    (gnc:format "basic" 'task "testing"))
+
+  (test-equal "one substitution"
+    "basic test"
+    (gnc:format "basic ${job}" 'job "test"))
+
+  (test-equal "two substitutions out of order"
+    "basic test"
+    (gnc:format "${difficulty} ${job}" 'job "test" 'difficulty "basic"))
+
+  (test-equal "trying to reference invalid symbol"
+    "${symbol} does not exist"
+    (gnc:format "${symbol} does not exist" 'existence "none"))
+
+  (test-error "gnc:format syntax error"
+    (gnc:format "${symbol} does not exist" 'existence)))
+
 (define (run-test)
   (test-runner-factory gnc:test-runner)
   (test-begin "test-core-utils")
   (N_-tests)
+  (gnc-format-tests)
   (test-end "test-core-utils"))

--- a/bindings/guile/test/test-core-utils.scm
+++ b/bindings/guile/test/test-core-utils.scm
@@ -1,17 +1,20 @@
-(define exit-code 0)
 (setenv "GNC_UNINSTALLED" "1")
+
+(use-modules (srfi srfi-64))
+(use-modules (tests srfi64-extras))
 (use-modules (gnucash core-utils))
 
-(if (procedure? (module-ref (current-module) 'N_))
-    (display "N_ defined\n")
-    (begin
-      (display "Failed - N_ not defined\n")
-      (set! exit-code -1)))
+(define (N_-tests)
 
-(if (string=? (N_ "foobar") "foobar")
-    (display "N_ works properly\n")
-    (begin
-      (display "Failed - N_ doesn't work\n")
-      (set! exit-code -1)))
+  (test-assert "N_ defined"
+    (module-ref (current-module) 'N_))
 
-(exit exit-code)
+  (test-equal "N_ works properly"
+    "foobar"
+    (N_ "foobar")))
+
+(define (run-test)
+  (test-runner-factory gnc:test-runner)
+  (test-begin "test-core-utils")
+  (N_-tests)
+  (test-end "test-core-utils"))

--- a/gnucash/report/reports/standard/invoice.scm
+++ b/gnucash/report/reports/standard/invoice.scm
@@ -782,9 +782,12 @@ for styling the invoice. Please see the exported report for the CSS class names.
                                 (G_ "Invoice"))))
                (title (if (string-null? custom-title) default-title custom-title))
                ;; Translators: This is the format of the invoice title.
-               ;; The first ~a is "Invoice", "Credit Note"... and the second the number.
+               ;; ${title} is the document type eg "Invoice" "Credit Note"
+               ;; ${ID} is the document ID
                ;; Replace " #" by whatever is common as number abbreviation, i.e. "~a Nr. ~a"
-               (invoice-title (format #f (G_"~a #~a") title (gncInvoiceGetID invoice)))
+               (invoice-title (gnc:format (G_ "${title} #${ID}")
+                                          'title title
+                                          'ID (gncInvoiceGetID invoice)))
                (layout-lookup-table (list (cons 'none #f)
                                           (cons 'picture (gnc:make-html-div/markup
                                                           "picture"


### PR DESCRIPTION
better than `format`

```scheme
(gnc:format "${document} from ${owner}"
 'owner "customer"
 'document "invoice")
```

will return

`"invoice from customer"`