### PR TITLE
798164 Import transaction window does not allow changing the transaction description 

### DIFF
--- a/gnucash/gnome-utils/gnc-gui-query.c
+++ b/gnucash/gnome-utils/gnc-gui-query.c
@@ -377,3 +377,40 @@ gnc_input_dialog (GtkWidget *parent, const gchar *title, const gchar *msg, const
     
     return user_input;
 }
+
+void
+gnc_info2_dialog (GtkWidget *parent, const gchar *title, const gchar *msg)
+{
+    GtkWidget *dialog, *scrolledwindow, *content_area;
+    GtkWidget *view;
+    GtkTextBuffer *buffer;
+    gint width, height;
+    
+    /* Create the widgets */
+    dialog = gtk_dialog_new_with_buttons (title, GTK_WINDOW (parent),
+                                          GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
+                                          _("_OK"), GTK_RESPONSE_ACCEPT,
+                                          NULL);
+    content_area = gtk_dialog_get_content_area (GTK_DIALOG (dialog));
+    
+    // add a scroll area
+    scrolledwindow = gtk_scrolled_window_new (NULL, NULL);
+    gtk_box_pack_start(GTK_BOX(content_area), scrolledwindow, TRUE, TRUE, 0);
+    
+    // add a textview
+    view = gtk_text_view_new ();
+    gtk_text_view_set_editable (GTK_TEXT_VIEW (view), FALSE);
+    buffer = gtk_text_view_get_buffer (GTK_TEXT_VIEW (view));
+    gtk_text_buffer_set_text (buffer, msg, -1);
+    gtk_container_add (GTK_CONTAINER (scrolledwindow), view);
+    
+    // run the dialog
+    if (parent)
+    {
+        gtk_window_get_size (GTK_WINDOW(parent), &width, &height);
+        gtk_window_set_default_size (GTK_WINDOW(dialog), width, height);
+    }
+    gtk_widget_show_all (dialog);
+    gtk_dialog_run (GTK_DIALOG (dialog));
+    gtk_widget_destroy (dialog);
+}

--- a/gnucash/gnome-utils/gnc-gui-query.c
+++ b/gnucash/gnome-utils/gnc-gui-query.c
@@ -315,3 +315,65 @@ gnc_choose_radio_option_dialog(GtkWidget *parent,
 
     return radio_result;
 }
+
+/********************************************************************\
+ * gnc_input_dialog                                                 *
+ *   simple convenience dialog to get a single value from the user  *
+ *   user may choose between "Ok" and "Cancel"                      *
+ *                                                                  *
+ * NOTE: This function does not return until the dialog is closed   *
+ *                                                                  *
+ * Args:   parent  - the parent window or NULL                      *
+ *         title   - the title of the dialog                        *
+ *         msg     - the message to display                         *
+ *         default_input - will be displayed as default input       *
+ * Return: the input (text) the user entered, if pressed "Ok"       *
+ *         NULL, if pressed "Cancel"                                *
+ \********************************************************************/
+gchar *
+gnc_input_dialog (GtkWidget *parent, const gchar *title, const gchar *msg, const gchar *default_input)
+{
+    GtkWidget *dialog, *label, *content_area;
+    gint result;
+    GtkWidget *view;
+    GtkTextBuffer *buffer;
+    gchar *user_input = NULL;
+    GtkTextIter start, end;
+    
+    /* Create the widgets */
+    dialog = gtk_dialog_new_with_buttons (title, GTK_WINDOW (parent),
+                                          GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
+                                          _("_OK"), GTK_RESPONSE_ACCEPT,
+                                          _("_Cancel"), GTK_RESPONSE_REJECT,
+                                          NULL);
+    content_area = gtk_dialog_get_content_area (GTK_DIALOG (dialog));
+    
+    // add a label
+    label = gtk_label_new (msg);
+    gtk_box_pack_start(GTK_BOX(content_area), label, FALSE, FALSE, 0);
+    
+    // add a textview
+    view = gtk_text_view_new ();
+    gtk_text_view_set_wrap_mode (GTK_TEXT_VIEW (view), GTK_WRAP_WORD_CHAR);
+    buffer = gtk_text_view_get_buffer (GTK_TEXT_VIEW (view));
+    gtk_text_buffer_set_text (buffer, default_input, -1);
+    gtk_box_pack_start(GTK_BOX(content_area), view, TRUE, TRUE, 0);
+    
+    // run the dialog
+    gtk_widget_show_all (dialog);
+    result = gtk_dialog_run (GTK_DIALOG (dialog));
+    
+    if (result == GTK_RESPONSE_REJECT)
+        user_input = 0;
+    else
+    {
+        gtk_text_buffer_get_start_iter (buffer, &start);
+        gtk_text_buffer_get_end_iter (buffer, &end);
+        user_input = gtk_text_buffer_get_text (buffer,
+                                               &start, &end, FALSE);
+    }
+    
+    gtk_widget_destroy (dialog);
+    
+    return user_input;
+}

--- a/gnucash/gnome-utils/gnc-gui-query.c
+++ b/gnucash/gnome-utils/gnc-gui-query.c
@@ -316,6 +316,63 @@ gnc_choose_radio_option_dialog(GtkWidget *parent,
     return radio_result;
 }
 
+static gchar *
+gnc_input_dialog_internal (GtkWidget *parent, const gchar *title, const gchar *msg, const gchar *default_input, gboolean use_entry)
+{
+    gint result;
+    GtkWidget *view;
+    GtkTextBuffer *buffer;
+    gchar *user_input = NULL;
+    GtkTextIter start, end;
+    
+    /* Create the widgets */
+    GtkWidget* dialog = gtk_dialog_new_with_buttons (title, GTK_WINDOW (parent),
+                                          GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
+                                          _("_OK"), GTK_RESPONSE_ACCEPT,
+                                          _("_Cancel"), GTK_RESPONSE_REJECT,
+                                          NULL);
+    GtkWidget* content_area = gtk_dialog_get_content_area (GTK_DIALOG (dialog));
+    
+    // add a label
+    GtkWidget* label = gtk_label_new (msg);
+    gtk_box_pack_start(GTK_BOX(content_area), label, FALSE, FALSE, 0);
+    
+    // add a textview or an entry.
+    if (use_entry)
+    {
+        view = gtk_entry_new ();
+        gtk_entry_set_text (GTK_ENTRY (view), default_input);
+    }
+    else
+    {
+        view = gtk_text_view_new ();
+        gtk_text_view_set_wrap_mode (GTK_TEXT_VIEW (view), GTK_WRAP_WORD_CHAR);
+        buffer = gtk_text_view_get_buffer (GTK_TEXT_VIEW (view));
+        gtk_text_buffer_set_text (buffer, default_input, -1);
+    }
+    gtk_box_pack_start(GTK_BOX(content_area), view, TRUE, TRUE, 0);
+
+    // run the dialog
+    gtk_widget_show_all (dialog);
+    result = gtk_dialog_run (GTK_DIALOG (dialog));
+    
+    if (result != GTK_RESPONSE_REJECT)
+    {
+        if (use_entry)
+            user_input = g_strdup (gtk_entry_get_text ((GTK_ENTRY (view))));
+        else
+        {
+            gtk_text_buffer_get_start_iter (buffer, &start);
+            gtk_text_buffer_get_end_iter (buffer, &end);
+            user_input = gtk_text_buffer_get_text (buffer, &start, &end, FALSE);
+        }
+    }
+    
+    gtk_widget_destroy (dialog);
+    
+    return user_input;
+}
+
 /********************************************************************\
  * gnc_input_dialog                                                 *
  *   simple convenience dialog to get a single value from the user  *
@@ -333,68 +390,36 @@ gnc_choose_radio_option_dialog(GtkWidget *parent,
 gchar *
 gnc_input_dialog (GtkWidget *parent, const gchar *title, const gchar *msg, const gchar *default_input)
 {
-    GtkWidget *dialog, *label, *content_area;
-    gint result;
-    GtkWidget *view;
-    GtkTextBuffer *buffer;
-    gchar *user_input = NULL;
-    GtkTextIter start, end;
-    
-    /* Create the widgets */
-    dialog = gtk_dialog_new_with_buttons (title, GTK_WINDOW (parent),
-                                          GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
-                                          _("_OK"), GTK_RESPONSE_ACCEPT,
-                                          _("_Cancel"), GTK_RESPONSE_REJECT,
-                                          NULL);
-    content_area = gtk_dialog_get_content_area (GTK_DIALOG (dialog));
-    
-    // add a label
-    label = gtk_label_new (msg);
-    gtk_box_pack_start(GTK_BOX(content_area), label, FALSE, FALSE, 0);
-    
-    // add a textview
-    view = gtk_text_view_new ();
-    gtk_text_view_set_wrap_mode (GTK_TEXT_VIEW (view), GTK_WRAP_WORD_CHAR);
-    buffer = gtk_text_view_get_buffer (GTK_TEXT_VIEW (view));
-    gtk_text_buffer_set_text (buffer, default_input, -1);
-    gtk_box_pack_start(GTK_BOX(content_area), view, TRUE, TRUE, 0);
-    
-    // run the dialog
-    gtk_widget_show_all (dialog);
-    result = gtk_dialog_run (GTK_DIALOG (dialog));
-    
-    if (result == GTK_RESPONSE_REJECT)
-        user_input = 0;
-    else
-    {
-        gtk_text_buffer_get_start_iter (buffer, &start);
-        gtk_text_buffer_get_end_iter (buffer, &end);
-        user_input = gtk_text_buffer_get_text (buffer,
-                                               &start, &end, FALSE);
-    }
-    
-    gtk_widget_destroy (dialog);
-    
-    return user_input;
+    return gnc_input_dialog_internal (parent, title, msg, default_input, FALSE);
+}
+
+/********************************************************************\
+ * gnc_input_dialog_with_entry                                      *
+ *   Similar to gnc_input_dialog but use a single line entry widget *
+ *   user may choose between "Ok" and "Cancel"                      *
+ \********************************************************************/
+gchar *
+gnc_input_dialog_with_entry (GtkWidget *parent, const gchar *title, const gchar *msg, const gchar *default_input)
+{
+    return gnc_input_dialog_internal (parent, title, msg, default_input, TRUE);
 }
 
 void
 gnc_info2_dialog (GtkWidget *parent, const gchar *title, const gchar *msg)
 {
-    GtkWidget *dialog, *scrolledwindow, *content_area;
     GtkWidget *view;
     GtkTextBuffer *buffer;
     gint width, height;
     
     /* Create the widgets */
-    dialog = gtk_dialog_new_with_buttons (title, GTK_WINDOW (parent),
+    GtkWidget* dialog = gtk_dialog_new_with_buttons (title, GTK_WINDOW (parent),
                                           GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
                                           _("_OK"), GTK_RESPONSE_ACCEPT,
                                           NULL);
-    content_area = gtk_dialog_get_content_area (GTK_DIALOG (dialog));
+    GtkWidget* content_area = gtk_dialog_get_content_area (GTK_DIALOG (dialog));
     
     // add a scroll area
-    scrolledwindow = gtk_scrolled_window_new (NULL, NULL);
+    GtkWidget* scrolledwindow = gtk_scrolled_window_new (NULL, NULL);
     gtk_box_pack_start(GTK_BOX(content_area), scrolledwindow, TRUE, TRUE, 0);
     
     // add a textview

--- a/gnucash/gnome-utils/gnc-ui.h
+++ b/gnucash/gnome-utils/gnc-ui.h
@@ -104,6 +104,8 @@ extern void
 gnc_error_dialog (GtkWindow *parent,
                   const char *format, ...) G_GNUC_PRINTF (2, 3);
 
+extern gchar *
+gnc_input_dialog (GtkWidget *parent, const gchar *title, const gchar *msg, const gchar *default_input);
 
 extern void
 gnc_gnome_help (GtkWindow *parent, const char *file_name, const char *target_link);

--- a/gnucash/gnome-utils/gnc-ui.h
+++ b/gnucash/gnome-utils/gnc-ui.h
@@ -107,6 +107,9 @@ gnc_error_dialog (GtkWindow *parent,
 extern gchar *
 gnc_input_dialog (GtkWidget *parent, const gchar *title, const gchar *msg, const gchar *default_input);
 
+extern gchar *
+gnc_input_dialog_with_entry (GtkWidget *parent, const gchar *title, const gchar *msg, const gchar *default_input);
+
 extern void
 gnc_info2_dialog (GtkWidget *parent, const gchar *title, const gchar *msg);
 

--- a/gnucash/gnome-utils/gnc-ui.h
+++ b/gnucash/gnome-utils/gnc-ui.h
@@ -108,6 +108,9 @@ extern gchar *
 gnc_input_dialog (GtkWidget *parent, const gchar *title, const gchar *msg, const gchar *default_input);
 
 extern void
+gnc_info2_dialog (GtkWidget *parent, const gchar *title, const gchar *msg);
+
+extern void
 gnc_gnome_help (GtkWindow *parent, const char *file_name, const char *target_link);
 
 int      gnc_choose_radio_option_dialog (GtkWidget *parent,

--- a/gnucash/import-export/bi-import/dialog-bi-import-gui.c
+++ b/gnucash/import-export/bi-import/dialog-bi-import-gui.c
@@ -75,7 +75,6 @@ void gnc_bi_import_gui_open_mode_cb (GtkWidget *widget, gpointer data);
 void gnc_import_gui_type_cb (GtkWidget *widget, gpointer data);
 
 // utils
-static gchar *gnc_input_dialog (GtkWidget *parent, const gchar *title, const gchar *msg, const gchar *default_input);
 static void gnc_info2_dialog (GtkWidget *parent, const gchar *title, const gchar *msg);
 
 #define UNUSED_VAR     __attribute__ ((unused))
@@ -392,70 +391,6 @@ void gnc_import_gui_type_cb (GtkWidget *widget, gpointer data)
 
 }
 
-
-/********************************************************************\
- * gnc_input_dialog                                                 *
- *   simple convenience dialog to get a single value from the user  *
- *   user may choose between "Ok" and "Cancel"                      *
- *                                                                  *
- * NOTE: This function does not return until the dialog is closed   *
- *                                                                  *
- * Args:   parent  - the parent window or NULL                      *
- *         title   - the title of the dialog                        *
- *         msg     - the message to display                         *
- *         default_input - will be displayed as default input       *
- * Return: the input (text) the user entered, if pressed "Ok"       *
- *         NULL, if pressed "Cancel"                                *
-\********************************************************************/
-static gchar *
-gnc_input_dialog (GtkWidget *parent, const gchar *title, const gchar *msg, const gchar *default_input)
-{
-    GtkWidget *dialog, *label, *content_area;
-    gint result;
-    GtkWidget *view;
-    GtkTextBuffer *buffer;
-    gchar *user_input = NULL;
-    GtkTextIter start, end;
-
-    /* Create the widgets */
-    dialog = gtk_dialog_new_with_buttons (title, GTK_WINDOW (parent),
-                                          GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
-                                          _("_OK"), GTK_RESPONSE_ACCEPT,
-                                          _("_Cancel"), GTK_RESPONSE_REJECT,
-                                          NULL);
-    content_area = gtk_dialog_get_content_area (GTK_DIALOG (dialog));
-
-    // add a label
-    label = gtk_label_new (msg);
-    gtk_box_pack_start(GTK_BOX(content_area), label, FALSE, FALSE, 0);
-
-    // add a textview
-    view = gtk_text_view_new ();
-    gtk_text_view_set_wrap_mode (GTK_TEXT_VIEW (view), GTK_WRAP_WORD_CHAR);
-    buffer = gtk_text_view_get_buffer (GTK_TEXT_VIEW (view));
-    gtk_text_buffer_set_text (buffer, default_input, -1);
-    gtk_box_pack_start(GTK_BOX(content_area), view, TRUE, TRUE, 0);
-
-    // run the dialog
-    gtk_widget_show_all (dialog);
-    result = gtk_dialog_run (GTK_DIALOG (dialog));
-
-    if (result == GTK_RESPONSE_REJECT)
-        user_input = 0;
-    else
-    {
-        gtk_text_buffer_get_start_iter (buffer, &start);
-        gtk_text_buffer_get_end_iter (buffer, &end);
-        user_input = gtk_text_buffer_get_text (buffer,
-                                               &start, &end, FALSE);
-    }
-
-    gtk_widget_destroy (dialog);
-
-    return user_input;
-}
-
-
 /********************************************************************\
  * gnc_info2_dialog                                                 *
  *   displays an information dialog box (with scrollable text area) *
@@ -503,3 +438,4 @@ gnc_info2_dialog (GtkWidget *parent, const gchar *title, const gchar *msg)
     gtk_dialog_run (GTK_DIALOG (dialog));
     gtk_widget_destroy (dialog);
 }
+

--- a/gnucash/import-export/bi-import/dialog-bi-import-gui.c
+++ b/gnucash/import-export/bi-import/dialog-bi-import-gui.c
@@ -74,9 +74,6 @@ void gnc_bi_import_gui_option5_cb (GtkWidget *widget, gpointer data);
 void gnc_bi_import_gui_open_mode_cb (GtkWidget *widget, gpointer data);
 void gnc_import_gui_type_cb (GtkWidget *widget, gpointer data);
 
-// utils
-static void gnc_info2_dialog (GtkWidget *parent, const gchar *title, const gchar *msg);
-
 #define UNUSED_VAR     __attribute__ ((unused))
 
 static QofLogModule UNUSED_VAR log_module = G_LOG_DOMAIN; //G_LOG_BUSINESS;
@@ -389,53 +386,5 @@ void gnc_import_gui_type_cb (GtkWidget *widget, gpointer data)
     else if (g_ascii_strcasecmp(name, "radiobuttonBill") == 0)gui->type = "BILL";
     //printf ("TYPE set to, %s\n",gui->type);
 
-}
-
-/********************************************************************\
- * gnc_info2_dialog                                                 *
- *   displays an information dialog box (with scrollable text area) *
- *                                                                  *
- * NOTE: This function does not return until the dialog is closed   *
- *                                                                  *
- * Args:   parent  - the parent window or NULL                      *
- *         title   - the title of the dialog                        *
- *         msg     - the message to display                         *
- * Return: none                                                     *
-\********************************************************************/
-static void
-gnc_info2_dialog (GtkWidget *parent, const gchar *title, const gchar *msg)
-{
-    GtkWidget *dialog, *scrolledwindow, *content_area;
-    GtkWidget *view;
-    GtkTextBuffer *buffer;
-    gint width, height;
-
-    /* Create the widgets */
-    dialog = gtk_dialog_new_with_buttons (title, GTK_WINDOW (parent),
-                                          GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
-                                          _("_OK"), GTK_RESPONSE_ACCEPT,
-                                          NULL);
-    content_area = gtk_dialog_get_content_area (GTK_DIALOG (dialog));
-
-    // add a scroll area
-    scrolledwindow = gtk_scrolled_window_new (NULL, NULL);
-    gtk_box_pack_start(GTK_BOX(content_area), scrolledwindow, TRUE, TRUE, 0);
-
-    // add a textview
-    view = gtk_text_view_new ();
-    gtk_text_view_set_editable (GTK_TEXT_VIEW (view), FALSE);
-    buffer = gtk_text_view_get_buffer (GTK_TEXT_VIEW (view));
-    gtk_text_buffer_set_text (buffer, msg, -1);
-    gtk_container_add (GTK_CONTAINER (scrolledwindow), view);
-
-    // run the dialog
-    if (parent)
-    {
-        gtk_window_get_size (GTK_WINDOW(parent), &width, &height);
-        gtk_window_set_default_size (GTK_WINDOW(dialog), width, height);
-    }
-    gtk_widget_show_all (dialog);
-    gtk_dialog_run (GTK_DIALOG (dialog));
-    gtk_widget_destroy (dialog);
 }
 

--- a/gnucash/import-export/csv-imp/assistant-csv-account-import.c
+++ b/gnucash/import-export/csv-imp/assistant-csv-account-import.c
@@ -65,8 +65,6 @@ void csv_import_hrows_cb (GtkWidget *spin, gpointer user_data );
 void csv_import_file_chooser_file_activated_cb (GtkFileChooser *chooser, CsvImportInfo *info);
 void csv_import_file_chooser_selection_changed_cb (GtkFileChooser *chooser, CsvImportInfo *info);
 
-static gchar *gnc_input_dialog (GtkWidget *parent, const gchar *title, const gchar *msg, const gchar *default_input);
-
 static const gchar *finish_tree_string = N_(
             "The accounts will be imported from the file '%s' when you click 'Apply'.\n\n"
             "You can verify your selections by clicking on 'Back' or 'Cancel' to Abort Import.\n");
@@ -345,74 +343,6 @@ void load_settings (CsvImportInfo *info)
 
 
 /* =============================================================== */
-
-
-/********************************************************************\
- * gnc_input_dialog                                                 *
- *   simple convenience dialog to get a single value from the user  *
- *   user may choose between "Ok" and "Cancel"                      *
- *                                                                  *
- * NOTE: This function does not return until the dialog is closed   *
- *                                                                  *
- * Args:   parent  - the parent window or NULL                      *
- *         title   - the title of the dialog                        *
- *         msg     - the message to display                         *
- *         default_input - will be displayed as default input       *
- * Return: the input (text) the user entered, if pressed "Ok"       *
- *         NULL, if pressed "Cancel"                                *
-\********************************************************************/
-static gchar *
-gnc_input_dialog (GtkWidget *parent, const gchar *title, const gchar *msg, const gchar *default_input)
-{
-    GtkWidget *dialog, *label, *content_area;
-    gint result;
-    GtkWidget *view;
-    GtkTextBuffer *buffer;
-    gchar *user_input;
-    GtkTextIter start, end;
-
-    /* Create the widgets */
-    dialog = gtk_dialog_new_with_buttons (title, GTK_WINDOW(parent),
-                                          GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
-                                          _("_OK"), GTK_RESPONSE_ACCEPT,
-                                          _("_Cancel"), GTK_RESPONSE_REJECT,
-                                          NULL);
-
-    content_area = gtk_dialog_get_content_area (GTK_DIALOG(dialog));
-
-    // add a label
-    label = gtk_label_new (msg);
-    gtk_container_add (GTK_CONTAINER(content_area), label);
-
-    // add a textview
-    view = gtk_text_view_new ();
-    gtk_text_view_set_wrap_mode (GTK_TEXT_VIEW(view), GTK_WRAP_WORD_CHAR);
-    buffer = gtk_text_view_get_buffer (GTK_TEXT_VIEW(view));
-    gtk_text_buffer_set_text (buffer, default_input, -1);
-    gtk_container_add (GTK_CONTAINER(content_area), view);
-
-    // run the dialog
-    gtk_widget_show_all (dialog);
-    result = gtk_dialog_run (GTK_DIALOG(dialog));
-
-    if (result == GTK_RESPONSE_REJECT)
-        user_input = 0;
-    else
-    {
-        gtk_text_buffer_get_start_iter (buffer, &start);
-        gtk_text_buffer_get_end_iter (buffer, &end);
-        user_input = gtk_text_buffer_get_text (buffer,
-                                               &start, &end, FALSE);
-    }
-
-    gtk_widget_destroy (dialog);
-
-    return user_input;
-}
-
-
-/* =============================================================== */
-
 
 /*******************************************************
  * Assistant page prepare functions

--- a/gnucash/import-export/customer-import/dialog-customer-import-gui.c
+++ b/gnucash/import-export/customer-import/dialog-customer-import-gui.c
@@ -69,7 +69,6 @@ void gnc_customer_import_gui_option5_cb (GtkWidget *widget, gpointer data);
 void gnc_customer_import_gui_type_cb (GtkWidget *widget, gpointer data);
 
 // utils
-static gchar *gnc_input_dialog (GtkWidget *parent, const gchar *title, const gchar *msg, const gchar *default_input);
 static void gnc_info2_dialog (GtkWidget *parent, const gchar *title, const gchar *msg);
 
 
@@ -352,70 +351,6 @@ void gnc_customer_import_gui_type_cb (GtkWidget *widget, gpointer data)
     }
     //printf ("TYPE set to, %s\n",gui->type); // DEBUG
 
-}
-
-
-
-/********************************************************************\
- * gnc_input_dialog                                                 *
- *   simple convenience dialog to get a single value from the user  *
- *   user may choose between "Ok" and "Cancel"                      *
- *                                                                  *
- * NOTE: This function does not return until the dialog is closed   *
- *                                                                  *
- * Args:   parent  - the parent window or NULL                      *
- *         title   - the title of the dialog                        *
- *         msg     - the message to display                         *
- *         default_input - will be displayed as default input       *
- * Return: the input (text) the user entered, if pressed "Ok"       *
- *         NULL, if pressed "Cancel"                                *
-\********************************************************************/
-static gchar *
-gnc_input_dialog (GtkWidget *parent, const gchar *title, const gchar *msg, const gchar *default_input)
-{
-    GtkWidget *dialog, *label, *content_area;
-    gint result;
-    GtkWidget *view;
-    GtkTextBuffer *buffer;
-    gchar *user_input;
-    GtkTextIter start, end;
-
-    /* Create the widgets */
-    dialog = gtk_dialog_new_with_buttons (title, GTK_WINDOW (parent),
-                                          GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
-                                          _("_OK"), GTK_RESPONSE_ACCEPT,
-                                          _("_Cancel"), GTK_RESPONSE_REJECT,
-                                          NULL);
-    content_area = gtk_dialog_get_content_area (GTK_DIALOG (dialog));
-
-    // add a label
-    label = gtk_label_new (msg);
-    gtk_box_pack_start(GTK_BOX(content_area), label, FALSE, FALSE, 0);
-
-    // add a textview
-    view = gtk_text_view_new ();
-    gtk_text_view_set_wrap_mode (GTK_TEXT_VIEW (view), GTK_WRAP_WORD_CHAR);
-    buffer = gtk_text_view_get_buffer (GTK_TEXT_VIEW (view));
-    gtk_text_buffer_set_text (buffer, default_input, -1);
-    gtk_box_pack_start(GTK_BOX(content_area), view, TRUE, TRUE, 0);
-    
-    // run the dialog
-    gtk_widget_show_all (dialog);
-    result = gtk_dialog_run (GTK_DIALOG (dialog));
-
-    if (result == GTK_RESPONSE_REJECT)
-        user_input = 0;
-    else
-    {
-        gtk_text_buffer_get_start_iter (buffer, &start);
-        gtk_text_buffer_get_end_iter (buffer, &end);
-        user_input = gtk_text_buffer_get_text (buffer,
-                                               &start, &end, FALSE);
-    }
-
-    gtk_widget_destroy (dialog);
-
-    return user_input;
 }
 
 /********************************************************************\

--- a/gnucash/import-export/customer-import/dialog-customer-import-gui.c
+++ b/gnucash/import-export/customer-import/dialog-customer-import-gui.c
@@ -68,10 +68,6 @@ void gnc_customer_import_gui_option4_cb (GtkWidget *widget, gpointer data);
 void gnc_customer_import_gui_option5_cb (GtkWidget *widget, gpointer data);
 void gnc_customer_import_gui_type_cb (GtkWidget *widget, gpointer data);
 
-// utils
-static void gnc_info2_dialog (GtkWidget *parent, const gchar *title, const gchar *msg);
-
-
 CustomerImportGui *
 gnc_plugin_customer_import_showGUI(GtkWindow *parent)
 {
@@ -351,52 +347,4 @@ void gnc_customer_import_gui_type_cb (GtkWidget *widget, gpointer data)
     }
     //printf ("TYPE set to, %s\n",gui->type); // DEBUG
 
-}
-
-/********************************************************************\
- * gnc_info2_dialog                                                 *
- *   displays an information dialog box (with scrollable text area) *
- *                                                                  *
- * NOTE: This function does not return until the dialog is closed   *
- *                                                                  *
- * Args:   parent  - the parent window or NULL                      *
- *         title   - the title of the dialog                        *
- *         msg     - the message to display                         *
- * Return: none                                                     *
-\********************************************************************/
-static void
-gnc_info2_dialog (GtkWidget *parent, const gchar *title, const gchar *msg)
-{
-    GtkWidget *dialog, *scrolledwindow, *content_area;
-    GtkWidget *view;
-    GtkTextBuffer *buffer;
-    gint width, height;
-
-    /* Create the widgets */
-    dialog = gtk_dialog_new_with_buttons (title, GTK_WINDOW (parent),
-                                          GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
-                                          _("_OK"), GTK_RESPONSE_ACCEPT,
-                                          NULL);
-    content_area = gtk_dialog_get_content_area (GTK_DIALOG (dialog));
-
-    // add a scroll area
-    scrolledwindow = gtk_scrolled_window_new (NULL, NULL);
-    gtk_box_pack_start(GTK_BOX(content_area), scrolledwindow, TRUE, TRUE, 0);
-
-    // add a textview
-    view = gtk_text_view_new ();
-    gtk_text_view_set_editable (GTK_TEXT_VIEW (view), FALSE);
-    buffer = gtk_text_view_get_buffer (GTK_TEXT_VIEW (view));
-    gtk_text_buffer_set_text (buffer, msg, -1);
-    gtk_container_add (GTK_CONTAINER (scrolledwindow), view);
-
-    // run the dialog
-    if (parent)
-    {
-        gtk_window_get_size (GTK_WINDOW(parent), &width, &height);
-        gtk_window_set_default_size (GTK_WINDOW(dialog), width, height);
-    }
-    gtk_widget_show_all (dialog);
-    gtk_dialog_run (GTK_DIALOG (dialog));
-    gtk_widget_destroy (dialog);
 }


### PR DESCRIPTION
I merged the triple definition of the gnc_input_dialog and the double definition of gnc_info2_dialog.
The matching dialog now has 3 additional right-click options to edit description, notes and memo.