### PR TITLE
Maint disable memory management guile

### DIFF
--- a/bindings/engine.i
+++ b/bindings/engine.i
@@ -67,7 +67,6 @@ GLIST_HELPER_INOUT(TransList, SWIGTYPE_p_Transaction);
 GLIST_HELPER_INOUT(LotList, SWIGTYPE_p_GNCLot);
 GLIST_HELPER_INOUT(AccountList, SWIGTYPE_p_Account);
 GLIST_HELPER_INOUT(PriceList, SWIGTYPE_p_GNCPrice);
-// TODO: free PriceList?
 GLIST_HELPER_INOUT(CommodityList, SWIGTYPE_p_gnc_commodity);
 
 %typemap(newfree) gchar * "g_free($1);"
@@ -102,6 +101,13 @@ static const GncGUID * gncPriceGetGUID(GNCPrice *x)
 static const GncGUID * gncBudgetGetGUID(GncBudget *x)
 { return qof_instance_get_guid(QOF_INSTANCE(x)); }
 %}
+
+%typemap (freearg) AccountList * "g_list_free ($1);"
+%typemap (freearg) PriceList * "g_list_free ($1);"
+%typemap (freearg) SplitList * "g_list_free ($1);"
+%typemap (freearg) TransList * "g_list_free ($1);"
+%typemap (freearg) LotList * "g_list_free ($1);"
+%typemap (freearg) CommodityList * "g_list_free ($1);"
 
 /* NB: The object ownership annotations should already cover all the
 functions currently used in guile, but not all the functions that are

--- a/bindings/guile/engine.scm
+++ b/bindings/guile/engine.scm
@@ -45,6 +45,24 @@
   (issue-deprecation-warning "gnc-pricedb-lookup-latest-before-any-currency-t64 has been renamed to gnc-pricedb-lookup-nearest-before-any-currency-t64")
   (apply gnc-pricedb-lookup-nearest-before-any-currency-t64 args))
 
+;; Reports are not meant to modify pricedb entries, therefore pricedb
+;; memory management is disabled from guile reports.
+(define %PRICE-MEMORY-MANAGEMENT
+  "Calling gnc-price-list-destroy, gnc-price-ref, and gnc-price-unref \
+from guile is disabled.")
+
+(define (make-nop msg)
+  (lambda _ (issue-deprecation-warning msg) #f))
+
+(when (defined? 'gnc-price-list-destroy)
+  (set! gnc-price-list-destroy (make-nop %PRICE-MEMORY-MANAGEMENT)))
+
+(when (defined? 'gnc-price-ref)
+  (set! gnc-price-ref (make-nop %PRICE-MEMORY-MANAGEMENT)))
+
+(when (defined? 'gnc-price-unref)
+  (set! gnc-price-unref (make-nop %PRICE-MEMORY-MANAGEMENT)))
+
 ;; A few account related utility functions which used to be in engine-utilities.scm
 (define (gnc:account-map-descendants thunk account)
   (issue-deprecation-warning "gnc:account-map-descendants is deprecated.")

--- a/gnucash/report/reports/standard/advanced-portfolio.scm
+++ b/gnucash/report/reports/standard/advanced-portfolio.scm
@@ -345,20 +345,19 @@ by preventing negative stock balances.<br/>")
 
   ;; Given a price list and a currency find the price for that currency on the list.
   ;; If there is none for the requested currency, return the first one.
-  ;; The price list is released but the price returned is ref counted.
+  ;; The price returned is ref counted.
   (define (find-price price-list currency)
-    (if (eqv? price-list '()) #f
-      (let ((price (car price-list)))
-        (for-each
-          (lambda (p)
-            (if (gnc-commodity-equiv currency (gnc-price-get-currency p))
+    (and (pair? price-list)
+         (let ((price (car price-list)))
+           (for-each
+            (lambda (p)
+              (cond
+               ((gnc-commodity-equiv currency (gnc-price-get-currency p))
                 (set! price p))
-            (if (gnc-commodity-equiv currency (gnc-price-get-commodity p))
-                (set! price (gnc-price-invert p))))
-          price-list)
-        (gnc-price-ref price)
-        (gnc-price-list-destroy price-list)
-        price)))
+               ((gnc-commodity-equiv currency (gnc-price-get-commodity p))
+                (set! price (gnc-price-invert p)))))
+            price-list)
+           price)))
 
   ;; Return true if either account is the parent of the other or they are siblings
   (define (parent-or-sibling? a1 a2)
@@ -495,7 +494,6 @@ by preventing negative stock balances.<br/>")
                                 (if (not (gnc-numeric-zero-p (gnc:gnc-monetary-amount trans-price)))
                                   ;; We can exchange the price from this transaction into the report currency
                                   (begin
-                                    (if price (gnc-price-unref price))
                                     (set! pricing-txn trans)
                                     (set! price trans-price)
                                     (gnc:debug "Transaction price is " (gnc:monetary->string price))
@@ -954,11 +952,9 @@ by preventing negative stock balances.<br/>")
 	       row-style
 	       activecols)
 
-              (if (and (not use-txn) price) (gnc-price-unref price))
-	      (table-add-stock-rows-internal rest (not odd-row?))
+              (table-add-stock-rows-internal rest (not odd-row?))
 	      )
 	    (begin
-	      (if (and (not use-txn) price) (gnc-price-unref price))
 	      (table-add-stock-rows-internal rest odd-row?)
 	      )
             )

--- a/gnucash/report/reports/standard/portfolio.scm
+++ b/gnucash/report/reports/standard/portfolio.scm
@@ -156,10 +156,8 @@
 			       "number-cell" value)))
 		       ;;(display (format #f "Shares: ~6d  " (gnc-numeric-to-double units)))
 		       ;;(display units) (newline)
-		       (if price (gnc-price-unref price))
 		       (table-add-stock-rows-internal rest (not odd-row?)))
-		(begin (if price (gnc-price-unref price))
-		       (table-add-stock-rows-internal rest odd-row?))))))
+		(begin (table-add-stock-rows-internal rest odd-row?))))))
 
     (set! work-to-do (length accounts))
     (table-add-stock-rows-internal accounts #t)))
@@ -213,40 +211,33 @@
                                (logior (GNC-DENOM-SIGFIGS 5) GNC-RND-ROUND)))))
                   ((pricedb-latest)
                    (lambda (foreign date)
-                     (let* ((price
-                             (gnc-pricedb-lookup-latest-any-currency
-                              pricedb foreign))
-                            (fn (if (and price (> (length price) 0))
-                                    (let* ((the_price
-                                            (if (gnc-commodity-equiv
-                                                 foreign
-                                                 (gnc-price-get-commodity (car price)))
-                                                (car price)
-                                                (gnc-price-invert (car price))))
-                                           (v (gnc-price-get-value the_price)))
-                                          (gnc-price-ref (car price))
-                                          (cons (car price) v))
-                                        (cons #f (gnc-numeric-zero)))))
-                       (if price (gnc-price-list-destroy price))
-                       fn)))
+                     (let* ((price (gnc-pricedb-lookup-latest-any-currency
+                                    pricedb foreign)))
+                       (if (and price (pair? price))
+                           (let* ((the_price
+                                   (if (gnc-commodity-equiv
+                                        foreign
+                                        (gnc-price-get-commodity (car price)))
+                                       (car price)
+                                       (gnc-price-invert (car price))))
+                                  (v (gnc-price-get-value the_price)))
+                             (cons (car price) v))
+                           (cons #f 0)))))
                   ((pricedb-nearest)
                    (lambda (foreign date)
                      (let*  ((price
-                             (gnc-pricedb-lookup-nearest-in-time-any-currency-t64
-                              pricedb foreign (time64CanonicalDayTime date)))
-                            (fn (if (and price (> (length price) 0))
-                                    (let* ((the_price
-                                            (if (gnc-commodity-equiv
-                                                 foreign
-                                                 (gnc-price-get-commodity (car price)))
-                                                (car price)
-                                                (gnc-price-invert (car price))))
-                                           (v (gnc-price-get-value (car price))))
-                                           (gnc-price-ref (car price))
-                                           (cons (car price) v))
-                                         (cons #f (gnc-numeric-zero)))))
-                       (if price (gnc-price-list-destroy price))
-                       fn))))))
+                              (gnc-pricedb-lookup-nearest-in-time-any-currency-t64
+                               pricedb foreign (time64CanonicalDayTime date))))
+                       (if (and price (pair? price))
+                           (let* ((the_price
+                                   (if (gnc-commodity-equiv
+                                        foreign
+                                        (gnc-price-get-commodity (car price)))
+                                       (car price)
+                                       (gnc-price-invert (car price))))
+                                  (v (gnc-price-get-value (car price))))
+                             (cons (car price) v))
+                           (cons #f 0))))))))
 
           (gnc:html-table-set-col-headers!
            table


### PR DESCRIPTION
This one would benefit from a swig expert...

Problem: the 16184daf9573bef0a1892985747711f890a39eed commit to `g_list_free` some `GList*` types was designed to free arguments to `xaccQueryAddAccountMatch` (receives an AccountList*) and `gnc_price_list_equal` (receives two PriceList*). Unfortunately it had unexpectedly caused failures in `test-portfolio`.

Cause: advanced-portfolio and portfolio include code to reference count `GNCPrice` via `gnc-price-ref`, `gnc-price-unref`, and also destroy a `PriceList*` via `gnc-price-list-destroy`. The above commit was causing double free. I think this is unnecessary. Guile reports should have no business ref counting gnc C objects. This PR will perform necessary -- (1) disable `gnc-price-ref`, `gnc-price-unref` and `gnc-price-list-destroy` in guile code, (2) clean up portfolio reports to avoid managing memory and (3) reinstate 16184daf9573bef0a1892985747711f890a39eed to freearg AccountList and PriceList.

However there's a counterpoint: `gncOwner` is a complex object which requires `gncOwnerNew()` and populating it using `gncOwnerInitCustomer` etc, and destroy using `gncOwnerFree`.  Some memory management is currently being done in guile code -- `gncOwnerFree` must be available to guile.

Comments welcome...

See example changes to `gnc_price_list_equal` in swig-engine.c...

```patch

static SCM
_wrap_gnc_price_list_equal (SCM s_0, SCM s_1)
{
#define FUNC_NAME "gnc-price-list-equal"
  PriceList *arg1 = (PriceList *) 0 ;
  PriceList *arg2 = (PriceList *) 0 ;
  SCM gswig_result;
  SWIGUNUSED int gswig_list_p = 0;
  gboolean result;
  
  {
    SCM list = s_0;
    GList *c_list = NULL;
    
    while (!scm_is_null(list)) {
      void *p;
      
      SCM p_scm = SCM_CAR(list);
      if (scm_is_false(p_scm) || scm_is_null(p_scm))
      p = NULL;
      else
      p = SWIG_MustGetPtr(p_scm, SWIGTYPE_p_GNCPrice, 1, 0);
      
      c_list = g_list_prepend(c_list, p);
      list = SCM_CDR(list);
    }
    
    arg1 = g_list_reverse(c_list);
  }
  {
    SCM list = s_1;
    GList *c_list = NULL;
    
    while (!scm_is_null(list)) {
      void *p;
      
      SCM p_scm = SCM_CAR(list);
      if (scm_is_false(p_scm) || scm_is_null(p_scm))
      p = NULL;
      else
      p = SWIG_MustGetPtr(p_scm, SWIGTYPE_p_GNCPrice, 1, 0);
      
      c_list = g_list_prepend(c_list, p);
      list = SCM_CDR(list);
    }
    
    arg2 = g_list_reverse(c_list);
  }
  result = gnc_price_list_equal(arg1,arg2);
  gswig_result = result ? SCM_BOOL_T : SCM_BOOL_F;
+ g_list_free (arg1);
+ g_list_free (arg2);
  
  return gswig_result;
#undef FUNC_NAME
}
```