### PR TITLE
WIP autoclear upgrade

### DIFF
--- a/gnucash/gnome-utils/CMakeLists.txt
+++ b/gnucash/gnome-utils/CMakeLists.txt
@@ -48,7 +48,7 @@ set (gnome_utils_SOURCES
   dialog-utils.c
   gnc-account-sel.c
   gnc-amount-edit.c
-  gnc-autoclear.c
+  gnc-autoclear.cpp
   gnc-autosave.c
   gnc-cell-renderer-text-flag.c
   gnc-cell-renderer-text-view.c

--- a/gnucash/gnome-utils/gnc-autoclear.c
+++ b/gnucash/gnome-utils/gnc-autoclear.c
@@ -103,19 +103,19 @@ sack_foreach_func (gnc_numeric *thisvalue, GList *splits, sack_data *data)
 
 static void dump_sack (gnc_numeric *thisvalue, GList *splits, sack_data *data)
 {
-    DEBUG ("%6.2f:", gnc_numeric_to_double (*thisvalue));
+    printf ("%6.2f:", gnc_numeric_to_double (*thisvalue));
     if (splits == DUP_LIST)
-        DEBUG (" DUPE");
+        printf (" DUPE");
     else
         for (GList *n = splits; n; n = n->next)
-            DEBUG (" [%5.2f]", gnc_numeric_to_double (xaccSplitGetAmount (n->data)));
-    DEBUG ("\n");
+            printf (" [%5.2f]", gnc_numeric_to_double (xaccSplitGetAmount (n->data)));
+    printf ("\n");
 }
 
 static void
 sack_free (gnc_numeric *thisvalue, GList *splits, sack_data *data)
 {
-    dump_sack (thisvalue, splits, data);
+    /* dump_sack (thisvalue, splits, data); */
     g_free (thisvalue);
     if (splits != DUP_LIST)
         g_list_free (splits);

--- a/gnucash/gnome-utils/gnc-autoclear.cpp
+++ b/gnucash/gnome-utils/gnc-autoclear.cpp
@@ -139,13 +139,13 @@ gnc_autoclear_get_splits (Account *account, gnc_numeric toclear_value,
 
     if (gnc_numeric_zero_p (toclear_value))
     {
-        g_set_error (error, autoclear_quark, AUTOCLEAR_NOP,
+        g_set_error (error, autoclear_quark, AUTOCLEAR_NOP, "%s",
                      _("Account is already at Auto-Clear Balance."));
         goto skip_knapsack;
     }
     else if (nc_vector.empty ())
     {
-        g_set_error (error, autoclear_quark, AUTOCLEAR_NOP,
+        g_set_error (error, autoclear_quark, AUTOCLEAR_NOP, "%s",
                      _("No uncleared splits found."));
         goto skip_knapsack;
     }
@@ -174,7 +174,7 @@ gnc_autoclear_get_splits (Account *account, gnc_numeric toclear_value,
             gint64 new_value;
             if (__builtin_add_overflow (map_value, amount.num, &new_value))
             {
-                g_set_error (error, autoclear_quark, AUTOCLEAR_OVERLOAD,
+                g_set_error (error, autoclear_quark, AUTOCLEAR_OVERLOAD, "%s",
                              "Overflow error: Amount numbers are too large!");
                 goto skip_knapsack;
             }
@@ -196,7 +196,7 @@ gnc_autoclear_get_splits (Account *account, gnc_numeric toclear_value,
 
         if (G_UNLIKELY ((clock () - start_ticks) > MAX_AUTOCLEAR_TICKS))
         {
-            g_set_error (error, autoclear_quark, AUTOCLEAR_OVERLOAD,
+            g_set_error (error, autoclear_quark, AUTOCLEAR_OVERLOAD, "%s",
                          _("Too many uncleared splits"));
             goto skip_knapsack;
         }
@@ -205,7 +205,7 @@ gnc_autoclear_get_splits (Account *account, gnc_numeric toclear_value,
         if (G_UNLIKELY (try_toclear != sack.end() &&
                         try_toclear->second.empty()))
         {
-            g_set_error (error, autoclear_quark, AUTOCLEAR_MULTIPLE,
+            g_set_error (error, autoclear_quark, AUTOCLEAR_MULTIPLE, "%s",
                          _("Cannot uniquely clear splits. Found multiple possibilities."));
             goto skip_knapsack;
         }
@@ -227,7 +227,7 @@ gnc_autoclear_get_splits (Account *account, gnc_numeric toclear_value,
     /* Check solution */
     if (sack.find (toclear_value.num) == sack.end())
     {
-        g_set_error (error, autoclear_quark, AUTOCLEAR_UNABLE,
+        g_set_error (error, autoclear_quark, AUTOCLEAR_UNABLE, "%s",
                      _("The selected amount cannot be cleared."));
         goto skip_knapsack;
     }

--- a/gnucash/gnome-utils/gnc-autoclear.cpp
+++ b/gnucash/gnome-utils/gnc-autoclear.cpp
@@ -32,7 +32,6 @@
 #include "inttypes.h"
 #include "Account.h"
 #include "Split.h"
-#include "SplitP.h"
 #include "Transaction.h"
 #include "gncOwner.h"
 #include "qof.h"
@@ -142,12 +141,7 @@ gnc_autoclear_get_splits (Account *account, gnc_numeric toclear_value,
                  xaccTransGetDate (xaccSplitGetParent (split)) > end_date)
             DEBUG ("skipping split after statement_date %p", split);
         else
-        {
-            auto s = static_cast<std::shared_ptr<Split>>(split);
-            auto new_s = new Split;
-            memcpy (new_s, &s, sizeof(Split));
-            nc_vector.emplace_back (s);
-        }
+            nc_vector.emplace_back (std::make_shared<Split>(split));
     }
 
     if (gnc_numeric_zero_p (toclear_value))

--- a/gnucash/gnome-utils/gnc-autoclear.cpp
+++ b/gnucash/gnome-utils/gnc-autoclear.cpp
@@ -73,8 +73,8 @@ static void looping_update_status (GtkLabel *label, guint nc_progress,
     if (!label)
         return;
 
-    auto text = g_strdup_printf ("%u/%u splits processed, %u combos",
-                                       nc_progress, nc_size, size);
+    auto text = g_strdup_printf (_("%u/%u splits, %u combinations produced"),
+                                 nc_progress, nc_size, size);
     status_update (label, text);
     g_free (text);
 }

--- a/gnucash/gnome-utils/gnc-autoclear.cpp
+++ b/gnucash/gnome-utils/gnc-autoclear.cpp
@@ -190,7 +190,7 @@ gnc_autoclear_get_splits (Account *account, gnc_numeric toclear_value,
         }
 
         for (auto& item : workvector)
-            sack[item.reachable_amount] = item.splits_vector;
+            sack.insert_or_assign(item.reachable_amount, std::move(item.splits_vector));
 
         looping_update_status (label, ++nc_progress, nc_vector.size (), sack.size ());
 

--- a/gnucash/gnome-utils/gnc-autoclear.cpp
+++ b/gnucash/gnome-utils/gnc-autoclear.cpp
@@ -143,6 +143,8 @@ gnc_autoclear_get_splits (Account *account, gnc_numeric toclear_value,
             nc_vector.push_back (split);
     }
 
+    nc_vector.shrink_to_fit ();
+
     if (gnc_numeric_zero_p (toclear_value))
     {
         g_set_error (error, autoclear_quark, AUTOCLEAR_NOP, "%s",

--- a/gnucash/gnome-utils/gnc-autoclear.cpp
+++ b/gnucash/gnome-utils/gnc-autoclear.cpp
@@ -78,7 +78,7 @@ static void looping_update_status (GtkLabel *label, guint nc_progress,
     if (!label)
         return;
     now = clock ();
-    if (now > *next_update_tick) [[unlikely]]
+    if (G_UNLIKELY (now > *next_update_tick))
     {
         gchar *text = g_strdup_printf ("%u/%u splits processed, %u combos",
                                        nc_progress, nc_size, size);
@@ -193,7 +193,7 @@ gnc_autoclear_get_splits (Account *account, gnc_numeric toclear_value,
 
         nc_progress++;
 
-        if ((clock () - start_ticks) > MAX_AUTOCLEAR_TICKS) [[unlikely]]
+        if (G_UNLIKELY ((clock () - start_ticks) > MAX_AUTOCLEAR_TICKS))
         {
             g_set_error (error, autoclear_quark, AUTOCLEAR_OVERLOAD,
                          _("Too many uncleared splits"));
@@ -201,7 +201,7 @@ gnc_autoclear_get_splits (Account *account, gnc_numeric toclear_value,
         }
 
         auto try_toclear = sack.find (toclear_value.num);
-        if (try_toclear != sack.end() && try_toclear->second == DUP_VEC) [[unlikely]]
+        if (G_UNLIKELY (try_toclear != sack.end() && try_toclear->second == DUP_VEC))
         {
             g_set_error (error, autoclear_quark, AUTOCLEAR_MULTIPLE,
                          _("Cannot uniquely clear splits. Found multiple possibilities."));

--- a/gnucash/gnome-utils/gnc-autoclear.cpp
+++ b/gnucash/gnome-utils/gnc-autoclear.cpp
@@ -183,7 +183,9 @@ gnc_autoclear_get_splits (Account *account, gnc_numeric toclear_value,
                 workvector.emplace_back (new_value, SplitVec{});
             else
             {
-                auto new_splits = map_splits;
+                SplitVec new_splits{};
+                new_splits.reserve(map_splits.size() + 1);
+                new_splits = map_splits;
                 new_splits.push_back (split);
                 workvector.emplace_back (new_value, std::move(new_splits));
             }

--- a/gnucash/gnome-utils/gnc-autoclear.cpp
+++ b/gnucash/gnome-utils/gnc-autoclear.cpp
@@ -151,6 +151,7 @@ gnc_autoclear_get_splits (Account *account, gnc_numeric toclear_value,
     }
 
     start_ticks = clock ();
+    sack.reserve(nc_vector.size() * 4);
 
     for (auto& split : nc_vector)
     {

--- a/gnucash/gnome-utils/gnc-autoclear.cpp
+++ b/gnucash/gnome-utils/gnc-autoclear.cpp
@@ -32,6 +32,7 @@
 #include "inttypes.h"
 #include "Account.h"
 #include "Split.h"
+#include "SplitP.h"
 #include "Transaction.h"
 #include "gncOwner.h"
 #include "qof.h"
@@ -141,7 +142,12 @@ gnc_autoclear_get_splits (Account *account, gnc_numeric toclear_value,
                  xaccTransGetDate (xaccSplitGetParent (split)) > end_date)
             DEBUG ("skipping split after statement_date %p", split);
         else
-            nc_vector.emplace_back (std::make_shared<Split>(split));
+        {
+            auto s = static_cast<std::shared_ptr<Split>>(split);
+            auto new_s = new Split;
+            memcpy (new_s, &s, sizeof(Split));
+            nc_vector.emplace_back (s);
+        }
     }
 
     if (gnc_numeric_zero_p (toclear_value))

--- a/gnucash/gnome-utils/gnc-autoclear.cpp
+++ b/gnucash/gnome-utils/gnc-autoclear.cpp
@@ -116,6 +116,8 @@ gnc_autoclear_get_splits (Account *account, gnc_numeric toclear_value,
 
     *splits = nullptr;
 
+    nc_vector.reserve(g_list_length(xaccAccountGetSplitList(account)));
+
     /* Extract which splits are not cleared and compute the amount we have to clear */
     for (GList *node = xaccAccountGetSplitList (account); node; node = node->next)
     {

--- a/gnucash/gnome-utils/gnc-autoclear.cpp
+++ b/gnucash/gnome-utils/gnc-autoclear.cpp
@@ -58,8 +58,8 @@ struct WorkItem
 {
     gint64 reachable_amount;
     SplitVec splits_vector;
-    WorkItem (const gint64 amount, SplitVec splits)
-        : reachable_amount (amount), splits_vector(splits){}
+    WorkItem (const gint64 amount, SplitVec&& splits)
+        : reachable_amount (amount), splits_vector(std::move(splits)){}
 };
 
 static void status_update (GtkLabel *label, gchar *status)
@@ -164,7 +164,7 @@ gnc_autoclear_get_splits (Account *account, gnc_numeric toclear_value,
         else
         {
             SplitVec new_splits = { split };
-            workvector.emplace_back (amount.num, new_splits);
+            workvector.emplace_back (amount.num, std::move(new_splits));
         }
 
         // printf ("new split. sack size = %ld\n", sack.size());
@@ -185,7 +185,7 @@ gnc_autoclear_get_splits (Account *account, gnc_numeric toclear_value,
             {
                 auto new_splits = map_splits;
                 new_splits.push_back (split);
-                workvector.emplace_back (new_value, new_splits);
+                workvector.emplace_back (new_value, std::move(new_splits));
             }
         }
 

--- a/gnucash/gnome-utils/gnc-autoclear.cpp
+++ b/gnucash/gnome-utils/gnc-autoclear.cpp
@@ -50,6 +50,7 @@ typedef enum
 #define MAX_AUTOCLEAR_SECONDS 10
 
 #define MAX_AUTOCLEAR_TICKS CLOCKS_PER_SEC * MAX_AUTOCLEAR_SECONDS
+#define MAX_SACK_SIZE 4000000
 
 using SplitVec = std::vector<Split*>;
 
@@ -219,7 +220,8 @@ gnc_autoclear_get_splits (Account *account, gnc_numeric toclear_value,
 
         looping_update_status (label, ++nc_progress, nc_vector.size (), sack.size ());
 
-        if (G_UNLIKELY ((clock () - start_ticks) > MAX_AUTOCLEAR_TICKS))
+        if (G_UNLIKELY (((clock () - start_ticks) > MAX_AUTOCLEAR_TICKS) ||
+                        (sack.size () > MAX_SACK_SIZE)))
         {
             g_set_error (error, autoclear_quark, AUTOCLEAR_OVERLOAD, "%s",
                          _("Too many uncleared splits"));

--- a/gnucash/gnome-utils/gnc-autoclear.cpp
+++ b/gnucash/gnome-utils/gnc-autoclear.cpp
@@ -183,7 +183,13 @@ gnc_autoclear_get_splits (Account *account, gnc_numeric toclear_value,
 
         for (auto& [map_value, map_splits] : sack)
         {
-            auto new_value = map_value + amount.num;
+            gint64 new_value;
+            if (__builtin_add_overflow (map_value, amount.num, &new_value))
+            {
+                g_set_error (error, autoclear_quark, AUTOCLEAR_OVERLOAD,
+                             "Overflow error: Amount numbers are too large!");
+                goto skip_knapsack;
+            }
             if (map_splits == DUP_VEC || sack.find (new_value) != sack.end ())
                 workvector.emplace_back (new_value, DUP_VEC);
             else

--- a/gnucash/gnome-utils/gnc-autoclear.cpp
+++ b/gnucash/gnome-utils/gnc-autoclear.cpp
@@ -97,13 +97,30 @@ static void looping_update_status (GtkLabel *label, guint nc_progress,
     }
 }
 
+class Hasher
+{
+public:
+    size_t operator() (gint64 const& key) const
+    {
+        return key;
+    }
+};
+class EqualFn
+{
+public:
+    bool operator() (gint64 const& t1, gint64 const& t2) const
+    {
+        return (t1 == t2);
+    }
+};
+
 gboolean
 gnc_autoclear_get_splits (Account *account, gnc_numeric toclear_value,
                           time64 end_date,
                           GList **splits, GError **error, GtkLabel *label)
 {
     std::vector<Split*> nc_vector;
-    std::unordered_map<gint64, std::vector<Split*>> sack;
+    std::unordered_map<gint64, std::vector<Split*>, Hasher, EqualFn> sack;
     guint nc_progress = 0;
     clock_t start_ticks;
     gboolean debugging_enabled = qof_log_check (G_LOG_DOMAIN, QOF_LOG_DEBUG);

--- a/gnucash/gnome-utils/gnc-autoclear.h
+++ b/gnucash/gnome-utils/gnc-autoclear.h
@@ -24,14 +24,15 @@
 #ifndef GNC_AUTOCLEAR_H
 #define GNC_AUTOCLEAR_H
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #include <glib.h>
 #include <stdint.h>
 #include <gtk/gtk.h>
 #include <Account.h>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 /** Account splits are analysed; attempts to find a unique combination
  *  of uncleared splits which would set cleared balance to
@@ -47,5 +48,9 @@ GList * gnc_account_get_autoclear_splits (Account *account, gnc_numeric toclear_
 gboolean gnc_autoclear_get_splits (Account *account, gnc_numeric toclear_value,
                                    time64 end_date,
                                    GList **splits, GError **error, GtkLabel *label);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/gnucash/gnome-utils/gnc-autoclear.h
+++ b/gnucash/gnome-utils/gnc-autoclear.h
@@ -25,6 +25,8 @@
 #define GNC_AUTOCLEAR_H
 
 #include <glib.h>
+#include <stdint.h>
+#include <gtk/gtk.h>
 #include <Account.h>
 
 #ifdef __cplusplus
@@ -40,8 +42,10 @@ extern "C" {
 GList * gnc_account_get_autoclear_splits (Account *account, gnc_numeric toclear_value,
                                           gchar **errmsg);
 
-#ifdef __cplusplus
-}
-#endif
+/* same as above, but returns TRUE if successful, and FALSE if
+   unsuccessful and sets GError appropriately */
+gboolean gnc_autoclear_get_splits (Account *account, gnc_numeric toclear_value,
+                                   time64 end_date,
+                                   GList **splits, GError **error, GtkLabel *label);
 
 #endif

--- a/gnucash/gnome-utils/test/test-autoclear.cpp
+++ b/gnucash/gnome-utils/test/test-autoclear.cpp
@@ -100,9 +100,8 @@ TestCase ambiguousTestCase = {
         { -10, "Cannot uniquely clear splits. Found multiple possibilities." },
         { -20, "Cannot uniquely clear splits. Found multiple possibilities." },
 
-        // Forbid auto-clear to be too smart. We expect the user to manually deal
-        // with such situations.
-        { -30, "Cannot uniquely clear splits. Found multiple possibilities." },
+        // -30 can be cleared by returning all three -10 splits
+        { -30, nullptr },
     },
 };
 

--- a/gnucash/gnome/window-autoclear.c
+++ b/gnucash/gnome/window-autoclear.c
@@ -124,18 +124,12 @@ gnc_autoclear_window_ok_cb (GtkWidget *widget,
 {
     GList *toclear_list = NULL;
     gnc_numeric toclear_value;
-    gchar *errmsg = NULL;
     GError* error = NULL;
 
     g_return_if_fail (widget && data);
 
     /* test for valid value */
-    if (!gnc_amount_edit_evaluate (GNC_AMOUNT_EDIT(data->end_value), &error))
-    {
-        errmsg = g_strdup (error->message);
-        g_error_free (error);
-    }
-    else
+    if (gnc_amount_edit_evaluate (GNC_AMOUNT_EDIT(data->end_value), &error))
     {
         toclear_value = gnc_amount_edit_get_amount(data->end_value);
 
@@ -145,19 +139,19 @@ gnc_autoclear_window_ok_cb (GtkWidget *widget,
         toclear_value = gnc_numeric_convert
             (toclear_value, xaccAccountGetCommoditySCU(data->account), GNC_HOW_RND_ROUND);
 
-        toclear_list = gnc_account_get_autoclear_splits
-            (data->account, toclear_value, &errmsg);
+        gnc_autoclear_get_splits (data->account, toclear_value, INT64_MAX,
+                                  &toclear_list, &error, data->status_label);
     }
 
-    if (errmsg)
+    if (error && error->message)
     {
         GtkWidget *entry = gnc_amount_edit_gtk_entry (GNC_AMOUNT_EDIT(data->end_value));
-        gtk_label_set_text (data->status_label, errmsg);
+        gtk_label_set_text (data->status_label, error->message);
         if (gnc_numeric_check (toclear_value) == 0)
             gnc_amount_edit_set_amount (data->end_value, toclear_value);
         gtk_widget_grab_focus (GTK_WIDGET(entry));
         gnc_amount_edit_select_region (GNC_AMOUNT_EDIT(data->end_value), 0, -1);
-        g_free (errmsg);
+        g_error_free (error);
     }
     else
     {

--- a/gnucash/gnome/window-reconcile.c
+++ b/gnucash/gnome/window-reconcile.c
@@ -358,11 +358,10 @@ update_autoclear_status (startRecnWindowData *data)
             if (xaccTransGetDate (xaccSplitGetParent (n->data)) <= new_date)
                 nc_length++;
         }
-        len_str = g_strdup_printf ("%d splits will be analysed.", nc_length);
-        if (nc_length > 15)
+        len_str = g_strdup_printf (_("%d splits will be analysed."), nc_length);
+        if (nc_length > 18)
             status = g_strconcat
-                (len_str, "\n",
-                 "This is likely to overload the autoclear algorithm.",
+                (len_str, "\n", _("This may overload the autoclear algorithm."),
                  NULL);
         else
             status = g_strdup (len_str);
@@ -681,7 +680,7 @@ gnc_save_reconcile_interval(Account *account, time64 statement_date)
         xaccAccountSetReconcileLastInterval(account, months, days);
 }
 
-static gboolean
+static void
 launch_autoclear (GtkWidget *parent, Account *account, gnc_numeric balance,
                   startRecnWindowData data)
 {
@@ -694,7 +693,7 @@ launch_autoclear (GtkWidget *parent, Account *account, gnc_numeric balance,
     {
         gnc_info_dialog (GTK_WINDOW (parent), "%s", error->message);
         g_error_free (error);
-        return FALSE;
+        return;
     }
 
     /* now set autocleared splits */
@@ -702,7 +701,7 @@ launch_autoclear (GtkWidget *parent, Account *account, gnc_numeric balance,
         xaccSplitSetReconcile (node->data, CREC);
 
     g_list_free (autoclear_splits);
-    return TRUE;
+    return;
 }
 
 static void
@@ -947,14 +946,7 @@ startRecnWindow(GtkWidget *parent, Account *account,
 
         if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (data.autoclear_toggle)))
         {
-            if (launch_autoclear (parent, account, *new_ending, data))
-            {
-                /* success. splits are cleared. show reconcile window. */
-            }
-            else
-            {
-                /* autoclear failed. user must manually reconcile. */
-            }
+            launch_autoclear (parent, account, *new_ending, data);
         }
     }
     // must remove the focus-out handler

--- a/gnucash/gtkbuilder/window-reconcile.glade
+++ b/gnucash/gtkbuilder/window-reconcile.glade
@@ -78,7 +78,7 @@
               </packing>
             </child>
             <child>
-              <!-- n-columns=2 n-rows=4 -->
+              <!-- n-columns=2 n-rows=5 -->
               <object class="GtkGrid" id="table1">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
@@ -197,6 +197,27 @@
                   </packing>
                 </child>
                 <child>
+                  <object class="GtkCheckButton" id="autoclear_check">
+                    <property name="label" translatable="yes">Auto-clear</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="tooltip-text" translatable="yes">Use this option if you want GnuCash to automatically find which transactions are cleared, given an ending balance. For example, said ending balance can be the current balance given by your bank online.</property>
+                    <property name="use-underline">True</property>
+                    <property name="draw-indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">4</property>
+                  </packing>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
                   <placeholder/>
                 </child>
               </object>
@@ -269,6 +290,18 @@
                 <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="position">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="autoclear_status">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="justify">center</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">4</property>
               </packing>
             </child>
           </object>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -147,7 +147,7 @@ gnucash/gnome-utils/dialog-userpass.c
 gnucash/gnome-utils/dialog-utils.c
 gnucash/gnome-utils/gnc-account-sel.c
 gnucash/gnome-utils/gnc-amount-edit.c
-gnucash/gnome-utils/gnc-autoclear.c
+gnucash/gnome-utils/gnc-autoclear.cpp
 gnucash/gnome-utils/gnc-autosave.c
 gnucash/gnome-utils/gnc-cell-renderer-text-flag.c
 gnucash/gnome-utils/gnc-cell-renderer-text-view.c


### PR DESCRIPTION
upgrade autoclear.... can handle autoclear amounts eg splits $10 $10 $10 can clear $30 easily.

~@cristiklein would need amending test-autoclear.~ Offshoot from #811.

todo:
- [x] very leaky
- [x] reinstate limits on knapsack hash size
- [x] ~can separate knapsack generation and query and reinstate live feedback~
- [x] cache `nc_list` the account-specific list of uncleared splits. Will be reused when modifying date & autoclear toggle. If account has 1000s of cleared, and <100 uncleared splits, should speed up startRecnWindow as the user changes/tweaks the statement date.