### PR TITLE
Transaction Report and Reconciled Report, and filtering by Posted/Reconciled/Entered/other dates.

### DIFF
--- a/gnucash/report/reports/standard/reconcile-report.scm
+++ b/gnucash/report/reports/standard/reconcile-report.scm
@@ -46,6 +46,9 @@
      (gnc:lookup-option options gnc:pagename-general "End Date")
      (cons 'relative 'today))
     (gnc:option-set-value
+     (gnc:lookup-option options gnc:pagename-general "Date Filter")
+     'reconciled)
+    (gnc:option-set-value
      (gnc:lookup-option options gnc:pagename-display "Reconciled Date") #t)
     (gnc:option-set-value
      (gnc:lookup-option options gnc:pagename-display "Running Balance") #f)
@@ -62,10 +65,6 @@ Options. Please note the dates specified in the options will apply \
 to the Reconciliation Date.")
    (gnc:html-markup-br)
    (gnc:html-markup-br)))
-
-(define (split->reconcile-date split)
-  (and (char=? (xaccSplitGetReconcile split) #\y)
-       (xaccSplitGetDateReconciled split)))
 
 (define (reconcile-report-calculated-cells options)
   (letrec
@@ -94,8 +93,6 @@ to the Reconciliation Date.")
   (gnc:trep-renderer
    rpt
    #:custom-calculated-cells reconcile-report-calculated-cells
-   #:split->date split->reconcile-date
-   #:split->date-include-false? #t
    #:empty-report-message reconcile-report-instructions))
 
 (gnc:define-report

--- a/gnucash/report/trep-engine.scm
+++ b/gnucash/report/trep-engine.scm
@@ -94,6 +94,7 @@
 ;;General
 (define optname-startdate (N_ "Start Date"))
 (define optname-enddate (N_ "End Date"))
+(define optname-date-source (N_ "Date Filter"))
 (define optname-table-export (N_ "Table for Exporting"))
 (define optname-infobox-display (N_ "Add options summary"))
 
@@ -510,6 +511,15 @@ in the Options panel."))
 
   (gnc:options-add-date-interval!
    options gnc:pagename-general optname-startdate optname-enddate "a")
+
+  (gnc:register-trep-option
+   (gnc:make-multichoice-option
+    gnc:pagename-general optname-date-source
+    "a5" (G_ "Specify date to filter by...")
+    'posted
+    (list (vector 'posted (G_ "Date Posted"))
+          (vector 'reconciled (G_ "Reconciled Date"))
+          (vector 'entered (G_ "Date Entered")))))
 
   (gnc:register-trep-option
    (gnc:make-complex-boolean-option
@@ -1933,7 +1943,8 @@ be excluded from periodic reporting.")
   ;; #:empty-report-message - a str or html-object displayed at the initial run
   ;; #:custom-split-filter - a split->bool function to add to the split filter
   ;; #:split->date - a split->time64 which overrides the default posted date filter
-  ;;     (see reconcile report)
+  ;;     if a derived report specifies this, the Date Filter option
+  ;;     becomes unused and should be hidden via gnc:option-make-internal!
   ;; #:split->date-include-false? - addendum to above, specifies filter behaviour if
   ;;     split->date returns #f. useful to include unreconciled splits in reconcile
   ;;     report. it can be useful for alternative date filtering, e.g. filter by
@@ -1990,6 +2001,9 @@ warning will be removed in GnuCash 5.0"))
          (enddate (gnc:time64-end-day-time
                    (gnc:date-option-absolute-time
                     (opt-val gnc:pagename-general optname-enddate))))
+         (date-source (if split->date
+                          'custom
+                          (opt-val gnc:pagename-general optname-date-source)))
          (transaction-matcher (opt-val pagename-filter optname-transaction-matcher))
          (transaction-filter-case-insensitive?
           (opt-val pagename-filter optname-transaction-matcher-caseinsensitive))
@@ -2132,7 +2146,7 @@ warning will be removed in GnuCash 5.0"))
       (qof-query-set-book query (gnc-get-current-book))
       (xaccQueryAddAccountMatch query c_account_1 QOF-GUID-MATCH-ANY QOF-QUERY-AND)
       (xaccQueryAddClearedMatch query cleared-filter QOF-QUERY-AND)
-      (unless split->date
+      (when (eq? date-source 'posted)
         (xaccQueryAddDateMatchTT query #t begindate #t enddate QOF-QUERY-AND))
       (when (boolean? closing-match)
         (xaccQueryAddClosingTransMatch query closing-match QOF-QUERY-AND))
@@ -2161,11 +2175,19 @@ warning will be removed in GnuCash 5.0"))
         (filter
          (lambda (split)
            (let* ((trans (xaccSplitGetParent split)))
-             (and (or (not split->date)
-                      (let ((date (split->date split)))
+             (and (case date-source
+                    ((posted) #t)
+                    ((reconciled)
+                     (if (char=? (xaccSplitGetReconcile split) #\y)
+                         (<= begindate (xaccSplitGetDateReconciled split) enddate)
+                         #t))
+                    ((entered) (<= begindate (xaccTransRetDateEntered trans) enddate))
+                    ((custom)
+                     (let ((date (split->date split)))
                         (if date
                             (<= begindate date enddate)
                             split->date-include-false?)))
+                    (else (gnc:warn "invalid date-source" date-source) #t))
                   (case filter-mode
                     ((none) #t)
                     ((include) (is-filter-member split c_account_2))


### PR DESCRIPTION
* Transaction Report upgrade - can select the date to be used for date filter. Defaults to posted date.
* Transaction Report can still filter with a different date e.g. payment date, by a derived report via the `#:split->date` argument.
* Reconcile Report gains ability to filter by Posted Date, which IMHO shouldn't have been changed in the first place.