### PR TITLE
B sb 20121012 sepa internal transfer

### DIFF
--- a/gnucash/import-export/aqb/dialog-ab-trans.c
+++ b/gnucash/import-export/aqb/dialog-ab-trans.c
@@ -406,16 +406,6 @@ gnc_ab_trans_dialog_new(GtkWidget *parent, GNC_AB_ACCOUNT_SPEC *ab_acc,
 #if (AQBANKING_VERSION_INT >= 60400)
     case SEPA_INTERNAL_TRANSFER:
         gtk_label_set_text(GTK_LABEL (heading_label),
-                           /* Translators: Strings from this file are
-                              needed only in countries that have one of
-                              aqbanking's Online Banking techniques
-                              available. This is 'OFX DirectConnect'
-                              (U.S. and others), 'HBCI' (Germany),
-                              or 'YellowNet' (Switzerland). If none of
-                              these techniques are available in your
-                              country, you may safely ignore strings
-                              from the import-export/hbci
-                              subdirectory. */
                            _("Enter a SEPA Internal Transfer"));
         gtk_label_set_text(GTK_LABEL(recp_account_heading),
                            _("Recipient IBAN (International Account Number)"));
@@ -438,7 +428,7 @@ gnc_ab_trans_dialog_new(GtkWidget *parent, GNC_AB_ACCOUNT_SPEC *ab_acc,
     	gtk_widget_set_can_focus(del_templ_button, FALSE);
         gtk_label_set_text(GTK_LABEL(template_label),
                            _("Target Accounts"));
-        gtk_expander_set_expanded(template_expander,TRUE);
+        gtk_expander_set_expanded(template_expander, TRUE);
         break;
 #endif
 

--- a/gnucash/import-export/aqb/dialog-ab-trans.h
+++ b/gnucash/import-export/aqb/dialog-ab-trans.h
@@ -56,6 +56,9 @@ enum _GncABTransType
     SINGLE_INTERNAL_TRANSFER
     , SEPA_TRANSFER
     , SEPA_DEBITNOTE
+#if (AQBANKING_VERSION_INT >= 60400)
+    , SEPA_INTERNAL_TRANSFER
+#endif
 };
 /**
   * Returns true if the given GncABTransType is an European (SEPA) transaction

--- a/gnucash/import-export/aqb/gnc-ab-transfer.c
+++ b/gnucash/import-export/aqb/gnc-ab-transfer.c
@@ -114,10 +114,26 @@ gnc_ab_maketrans(GtkWidget *parent, Account *gnc_acc,
         goto cleanup;
     }
 
+#if (AQBANKING_VERSION_INT >= 60400)
+    if (trans_type == SEPA_INTERNAL_TRANSFER)
+    {
+        /* Generate list of template transactions from the reference accounts*/
+        templates = gnc_ab_trans_templ_list_new_from_ref_accounts (ab_acc);
+        if (templates == NULL)
+        {
+            g_warning ("gnc_ab_gettrans: No reference accounts found");
+            gnc_error_dialog (GTK_WINDOW (parent), _("No reference accounts found."));
+            goto cleanup;
+        }
+    }
+    else
+#endif
+    {
     /* Get list of template transactions */
-    templates = gnc_ab_trans_templ_list_new_from_book(
-         gnc_account_get_book(gnc_acc));
-
+        templates = gnc_ab_trans_templ_list_new_from_book(
+             gnc_account_get_book(gnc_acc));
+    }
+    
     /* Create new ABTransDialog */
     td = gnc_ab_trans_dialog_new(parent, ab_acc,
                                  xaccAccountGetCommoditySCU(gnc_acc),
@@ -156,14 +172,21 @@ gnc_ab_maketrans(GtkWidget *parent, Account *gnc_acc,
         /* Let the user enter the values */
         result = gnc_ab_trans_dialog_run_until_ok(td);
 
-        /* Save the templates */
+				
         templates = gnc_ab_trans_dialog_get_templ(td, &changed);
-        if (changed)
+#if (AQBANKING_VERSION_INT >= 60400)
+        if (trans_type != SEPA_INTERNAL_TRANSFER && changed)
+#else
+	      if (changed)
+#endif
+        {
+        		/* Save the templates */
             save_templates(parent, gnc_acc, templates,
                            (result == GNC_RESPONSE_NOW));
-        g_list_free(templates);
-        templates = NULL;
-
+        }
+				g_list_free(templates);
+        templates = NULL;        
+        
         if (result != GNC_RESPONSE_NOW && result != GNC_RESPONSE_LATER)
         {
             aborted = TRUE;
@@ -220,6 +243,13 @@ gnc_ab_maketrans(GtkWidget *parent, Account *gnc_acc,
                 xfer_dialog, _("Online Banking European (SEPA) Transfer"));
             gnc_xfer_dialog_lock_from_account_tree(xfer_dialog);
             break;
+#if (AQBANKING_VERSION_INT >= 60400)
+        case SEPA_INTERNAL_TRANSFER:
+            gnc_xfer_dialog_set_title (
+                xfer_dialog, _("Online Banking European (SEPA) Internal Transfer"));
+            gnc_xfer_dialog_lock_from_account_tree (xfer_dialog);
+            break;
+#endif
         case SEPA_DEBITNOTE:
             gnc_xfer_dialog_set_title(
                 xfer_dialog, _("Online Banking European (SEPA) Debit Note"));

--- a/gnucash/import-export/aqb/gnc-ab-transfer.c
+++ b/gnucash/import-export/aqb/gnc-ab-transfer.c
@@ -171,20 +171,19 @@ gnc_ab_maketrans(GtkWidget *parent, Account *gnc_acc,
 
         /* Let the user enter the values */
         result = gnc_ab_trans_dialog_run_until_ok(td);
-
 				
         templates = gnc_ab_trans_dialog_get_templ(td, &changed);
 #if (AQBANKING_VERSION_INT >= 60400)
         if (trans_type != SEPA_INTERNAL_TRANSFER && changed)
 #else
-	      if (changed)
+	if (changed)
 #endif
         {
-        		/* Save the templates */
+           /* Save the templates */
             save_templates(parent, gnc_acc, templates,
                            (result == GNC_RESPONSE_NOW));
         }
-				g_list_free(templates);
+        g_list_free(templates);
         templates = NULL;        
         
         if (result != GNC_RESPONSE_NOW && result != GNC_RESPONSE_LATER)

--- a/gnucash/import-export/aqb/gnc-ab-utils.c
+++ b/gnucash/import-export/aqb/gnc-ab-utils.c
@@ -1341,41 +1341,35 @@ GList*
 gnc_ab_trans_templ_list_new_from_ref_accounts(GNC_AB_ACCOUNT_SPEC *ab_acc)
 {
     GList *retval = NULL;
-    AB_REFERENCE_ACCOUNT *ra = NULL;
+    AB_REFERENCE_ACCOUNT *ra;
     AB_REFERENCE_ACCOUNT_LIST *ral;
-    int16_t numAccounts;
-    int16_t counter;
-    GWEN_BUFFER *accNameForTemplate;
-    const char *accName;
-    const char *iban;
-    gnc_numeric zero=gnc_numeric_zero();
+    GWEN_BUFFER *accNameForTemplate = GWEN_Buffer_new(0,120,0,0);
+    gnc_numeric zero = gnc_numeric_zero();
 
-		/* get the target account list */
+    /* get the target account list */
     ral = AB_AccountSpec_GetRefAccountList(ab_acc);
-    numAccounts = AB_ReferenceAccount_List_GetCount(ral);
     ra = AB_ReferenceAccount_List_First(ral);
-    accNameForTemplate = GWEN_Buffer_new(0,120,0,0);
     
     /* fill the template list with the target accounts */
     while (ra)
     {
-	      GncABTransTempl *new_templ;
-	      GWEN_Buffer_Reset(accNameForTemplate);
-	      iban = AB_ReferenceAccount_GetIban(ra);
-	      accName = AB_ReferenceAccount_GetAccountName(ra);
-	      if (accName) {
-	        GWEN_Buffer_AppendString(accNameForTemplate, accName);
-	        GWEN_Buffer_AppendString(accNameForTemplate, ": ");
-	      }
-	      GWEN_Buffer_AppendString(accNameForTemplate, iban);
-	      new_templ = gnc_ab_trans_templ_new();
-	      gnc_ab_trans_templ_set_name(new_templ,GWEN_Buffer_GetStart(accNameForTemplate));
-	      gnc_ab_trans_templ_set_recp_name(new_templ,AB_ReferenceAccount_GetOwnerName(ra));
-	      gnc_ab_trans_templ_set_recp_account(new_templ,AB_ReferenceAccount_GetIban(ra));
-	      gnc_ab_trans_templ_set_recp_bankcode(new_templ,AB_ReferenceAccount_GetBic(ra));
-	      gnc_ab_trans_templ_set_amount(new_templ,zero);
-	      retval = g_list_prepend (retval, new_templ);
-	      ra = AB_ReferenceAccount_List_Next(ra);
+        GncABTransTempl *new_templ = gnc_ab_trans_templ_new();
+        const char *iban = AB_ReferenceAccount_GetIban(ra);
+	const char *accName = AB_ReferenceAccount_GetAccountName(ra);
+	GWEN_Buffer_Reset(accNameForTemplate);
+	if (accName)
+	{
+	    GWEN_Buffer_AppendString(accNameForTemplate, accName);
+	    GWEN_Buffer_AppendString(accNameForTemplate, ": ");
+	}
+	GWEN_Buffer_AppendString(accNameForTemplate, iban);
+	gnc_ab_trans_templ_set_name(new_templ, GWEN_Buffer_GetStart(accNameForTemplate));
+	gnc_ab_trans_templ_set_recp_name(new_templ, AB_ReferenceAccount_GetOwnerName(ra));
+	gnc_ab_trans_templ_set_recp_account(new_templ, AB_ReferenceAccount_GetIban(ra));
+	gnc_ab_trans_templ_set_recp_bankcode(new_templ, AB_ReferenceAccount_GetBic(ra));
+	gnc_ab_trans_templ_set_amount(new_templ, zero);
+	retval = g_list_prepend (retval, new_templ);
+	ra = AB_ReferenceAccount_List_Next(ra);
     }
     retval = g_list_reverse (retval);
 

--- a/gnucash/import-export/aqb/gnc-ab-utils.c
+++ b/gnucash/import-export/aqb/gnc-ab-utils.c
@@ -35,7 +35,11 @@
 #include <gwenhywfar/gwenhywfar.h>
 #include <aqbanking/banking.h>
 #ifdef AQBANKING6
-# include <aqbanking/types/balance.h>
+#include <aqbanking/types/balance.h>
+#if (AQBANKING_VERSION_INT >= 60400)
+#include <aqbanking/types/refaccount.h>
+#include <gnc-aqbanking-templates.h>
+#endif
 #endif
 #include "window-reconcile.h"
 #include "Transaction.h"
@@ -1331,3 +1335,52 @@ gnc_ab_get_permanent_certs(void)
     g_return_val_if_fail(rv >= 0, NULL);
     return perm_certs;
 }
+
+#if (AQBANKING_VERSION_INT >= 60400)
+GList*
+gnc_ab_trans_templ_list_new_from_ref_accounts(GNC_AB_ACCOUNT_SPEC *ab_acc)
+{
+    GList *retval = NULL;
+    AB_REFERENCE_ACCOUNT *ra = NULL;
+    AB_REFERENCE_ACCOUNT_LIST *ral;
+    int16_t numAccounts;
+    int16_t counter;
+    GWEN_BUFFER *accNameForTemplate;
+    const char *accName;
+    const char *iban;
+    gnc_numeric zero=gnc_numeric_zero();
+
+		/* get the target account list */
+    ral = AB_AccountSpec_GetRefAccountList(ab_acc);
+    numAccounts = AB_ReferenceAccount_List_GetCount(ral);
+    ra = AB_ReferenceAccount_List_First(ral);
+    accNameForTemplate = GWEN_Buffer_new(0,120,0,0);
+    
+    /* fill the template list with the target accounts */
+    while (ra)
+    {
+	      GncABTransTempl *new_templ;
+	      GWEN_Buffer_Reset(accNameForTemplate);
+	      iban = AB_ReferenceAccount_GetIban(ra);
+	      accName = AB_ReferenceAccount_GetAccountName(ra);
+	      if (accName) {
+	        GWEN_Buffer_AppendString(accNameForTemplate, accName);
+	        GWEN_Buffer_AppendString(accNameForTemplate, ": ");
+	      }
+	      GWEN_Buffer_AppendString(accNameForTemplate, iban);
+	      new_templ = gnc_ab_trans_templ_new();
+	      gnc_ab_trans_templ_set_name(new_templ,GWEN_Buffer_GetStart(accNameForTemplate));
+	      gnc_ab_trans_templ_set_recp_name(new_templ,AB_ReferenceAccount_GetOwnerName(ra));
+	      gnc_ab_trans_templ_set_recp_account(new_templ,AB_ReferenceAccount_GetIban(ra));
+	      gnc_ab_trans_templ_set_recp_bankcode(new_templ,AB_ReferenceAccount_GetBic(ra));
+	      gnc_ab_trans_templ_set_amount(new_templ,zero);
+	      retval = g_list_prepend (retval, new_templ);
+	      ra = AB_ReferenceAccount_List_Next(ra);
+    }
+    retval = g_list_reverse (retval);
+
+    GWEN_Buffer_free(accNameForTemplate);
+
+    return retval;
+}
+#endif

--- a/gnucash/import-export/aqb/gnc-ab-utils.h
+++ b/gnucash/import-export/aqb/gnc-ab-utils.h
@@ -287,6 +287,18 @@ GWEN_DB_NODE *gnc_ab_get_permanent_certs(void);
  */
 gchar* gnc_ab_create_online_id(const gchar *bankcode, const gchar *accountnumber);
 
+
+#if (AQBANKING_VERSION_INT >= 60400)
+/**
+ * Obtain the list of templates based on the aqbanking account spec's target accounts.
+ *
+ * @param ab_abb aqbanking account spec.
+ * @return A GList of newly allocated GncABTransTempls
+ */
+GList*
+gnc_ab_trans_templ_list_new_from_ref_accounts(GNC_AB_ACCOUNT_SPEC *ab_acc);
+#endif
+
 G_END_DECLS
 
 /** @} */

--- a/gnucash/import-export/aqb/gnc-plugin-aqbanking-ui.xml
+++ b/gnucash/import-export/aqb/gnc-plugin-aqbanking-ui.xml
@@ -21,6 +21,7 @@
           <menuitem name="ABGetTrans"           action="ABGetTransAction"/>
           <separator name="OnlineActionsSep1"/>
           <menuitem name="ABIssueSepaTrans"         action="ABIssueSepaTransAction"/>
+          <menuitem name="ABIssueSepaIntTrans"         action="ABIssueSepaIntTransAction"/>
           <menuitem name="ABIssueIntTrans"      action="ABIssueIntTransAction"/>
           <!--menuitem name="ABIssueSepaDirectDebit"         action="ABIssueSepaDirectDebitAction"/-->
           <separator name="OnlineActionsSep2"/>

--- a/gnucash/import-export/aqb/gnc-plugin-aqbanking.c
+++ b/gnucash/import-export/aqb/gnc-plugin-aqbanking.c
@@ -72,6 +72,7 @@ static void gnc_plugin_ab_cmd_setup(GtkAction *action, GncMainWindowActionData *
 static void gnc_plugin_ab_cmd_get_balance(GtkAction *action, GncMainWindowActionData *data);
 static void gnc_plugin_ab_cmd_get_transactions(GtkAction *action, GncMainWindowActionData *data);
 static void gnc_plugin_ab_cmd_issue_sepatransaction(GtkAction *action, GncMainWindowActionData *data);
+static void gnc_plugin_ab_cmd_issue_sepainternaltransaction(GtkAction *action, GncMainWindowActionData *data);
 static void gnc_plugin_ab_cmd_issue_inttransaction(GtkAction *action, GncMainWindowActionData *data);
 static void gnc_plugin_ab_cmd_issue_sepa_direct_debit(GtkAction *action, GncMainWindowActionData *data);
 static void gnc_plugin_ab_cmd_view_logwindow(GtkToggleAction *action, GncMainWindow *window);
@@ -113,6 +114,12 @@ static GtkActionEntry gnc_plugin_actions [] =
 		N_("Issue _SEPA Transaction..."), NULL,
         N_("Issue a new international European (SEPA) transaction online through Online Banking"),
         G_CALLBACK(gnc_plugin_ab_cmd_issue_sepatransaction)
+    },
+    {
+        "ABIssueSepaIntTransAction", NULL,
+        N_("Issue SEPA I_nternal Transaction..."), NULL,
+        N_("Issue a new internal European (SEPA) transaction online through Online Banking"),
+        G_CALLBACK(gnc_plugin_ab_cmd_issue_sepainternaltransaction)
     },
     {
         "ABIssueIntTransAction", NULL, N_("_Internal Transaction..."), NULL,
@@ -179,10 +186,21 @@ static const gchar *need_account_actions[] =
     "ABGetBalanceAction",
     "ABGetTransAction",
     "ABIssueSepaTransAction",
+#if (AQBANKING_VERSION_INT >= 60400)
+    "ABIssueSepaIntTransAction",
+#endif
     "ABIssueIntTransAction",
     "ABIssueSepaDirectDebitAction",
     NULL
 };
+
+#if (AQBANKING_VERSION_INT < 60400)
+static const gchar *inactive_account_actions[] =
+{
+    "ABIssueSepaIntTransAction",
+    NULL
+};
+#endif
 
 static const gchar *readonly_inactive_actions[] =
 {
@@ -379,6 +397,12 @@ gnc_plugin_ab_account_selected(GncPluginPage *plugin_page, Account *account,
                                    && accountid && *accountid));
         gnc_plugin_update_actions(action_group, need_account_actions,
                                   "visible", TRUE);
+#if (AQBANKING_VERSION_INT < 60400)
+        gnc_plugin_update_actions(action_group, inactive_account_actions,
+                                  "sensitive", FALSE);
+        gnc_plugin_update_actions(action_group, inactive_account_actions,
+                                  "visible", FALSE);
+#endif
     }
     else
     {
@@ -548,6 +572,39 @@ gnc_plugin_ab_cmd_issue_sepatransaction(GtkAction *action,
 
     LEAVE(" ");
 }
+
+#if (AQBANKING_VERSION_INT >= 60400)
+static void
+gnc_plugin_ab_cmd_issue_sepainternaltransaction(GtkAction *action,
+                                    GncMainWindowActionData *data)
+{
+    Account *account;
+
+    ENTER("action %p, main window data %p", action, data);
+    account = main_window_to_account(data->window);
+    if (account == NULL)
+    {
+        PINFO("No AqBanking account selected");
+        LEAVE("no account");
+        return;
+    }
+
+    gnc_main_window = data->window;
+    gnc_ab_maketrans(GTK_WIDGET(data->window), account, SEPA_INTERNAL_TRANSFER);
+
+    LEAVE(" ");
+}
+#else
+static void
+gnc_plugin_ab_cmd_issue_sepainternaltransaction(GtkAction *action,
+                                    GncMainWindowActionData *data)
+{
+
+    ENTER("action %p, main window data %p", action, data);
+    PINFO("Sepa Internal Transfer not supported by your aqbanking version!");
+    LEAVE("Sepa Internal Transfer not supported!");
+}
+#endif
 
 static void
 gnc_plugin_ab_cmd_issue_inttransaction(GtkAction *action,


### PR DESCRIPTION
Adapts the aqbanking importer functionality to support the SEPA internal transfer (SEPA Übertrag) available from aqbanking version 6.4.0, uses the transfer form, bank info cannot be entered directly, but the template list is used to list the possible target accounts provided by aqbanking. If no target account exists an error message is shown. Everything is encapsulated by #if AQBANKING_VERSION_INT >= 60400 blocks.