### PR TITLE
Bug 798392 - Reports do not display when Reports JavaScript dependencies are located at a filepath that includes special characters like hash ("#")

### DIFF
--- a/bindings/core-utils.i
+++ b/bindings/core-utils.i
@@ -69,14 +69,14 @@ gchar * gnc_path_get_localedir(void);
 %newobject gnc_path_get_stdreportsdir;
 gchar * gnc_path_get_stdreportsdir(void);
 
-%newobject gnc_path_find_localized_html_file;
-gchar * gnc_path_find_localized_html_file(const gchar *);
-
 %newobject gnc_build_userdata_path;
 gchar * gnc_build_userdata_path(const gchar *);
 
 %newobject gnc_file_path_absolute;
 gchar *gnc_file_path_absolute (const gchar *, const gchar *);
+
+%newobject gnc_resolve_file_path;
+gchar *gnc_resolve_file_path (const gchar *);
 
 %newobject gnc_build_scm_path;
 gchar * gnc_build_scm_path(const gchar *);

--- a/gnucash/report/html-chart.scm
+++ b/gnucash/report/html-chart.scm
@@ -444,8 +444,7 @@ document.getElementById(chartid).onclick = function(evt) {
          ;; clashing on multi-column reports
          (id (symbol->string (gensym "chart"))))
 
-    (push (gnc:html-js-include
-           (gnc-path-find-localized-html-file "chartjs/Chart.bundle.min.js")))
+    (push (gnc:html-js-include "chartjs/Chart.bundle.min.js"))
 
     ;; the following hidden h3 is used to query style and copy onto chartjs
     (push "<h3 style='display:none'></h3>")

--- a/gnucash/report/html-utilities.scm
+++ b/gnucash/report/html-utilities.scm
@@ -425,12 +425,12 @@
 (define (gnc:html-js-include file)
   (format #f
           "<script language=\"javascript\" type=\"text/javascript\" src=~s></script>\n"
-          (make-uri (gnc-path-find-localized-html-file file))))
+          (make-uri (gnc-resolve-file-path file))))
 
 (define (gnc:html-css-include file)
   (format #f
-          "<link rel=\"stylesheet\" type=\"text/css\" href=\"file:///~a\" />\n"
-          (gnc-path-find-localized-html-file file)))
+          "<link rel=\"stylesheet\" type=\"text/css\" href=~s />\n"
+          (make-uri (gnc-resolve-file-path file))))
 
 
 

--- a/gnucash/report/html-utilities.scm
+++ b/gnucash/report/html-utilities.scm
@@ -35,7 +35,6 @@
 (use-modules (gnucash report html-text))
 (use-modules (gnucash report html-table))
 (use-modules (ice-9 match))
-(use-modules (sxml simple))
 (use-modules (web uri))
 
 (export gnc:html-make-empty-cell)

--- a/gnucash/report/html-utilities.scm
+++ b/gnucash/report/html-utilities.scm
@@ -35,6 +35,8 @@
 (use-modules (gnucash report html-text))
 (use-modules (gnucash report html-table))
 (use-modules (ice-9 match))
+(use-modules (sxml simple))
+(use-modules (web uri))
 
 (export gnc:html-make-empty-cell)
 (export gnc:html-make-empty-cells)
@@ -405,10 +407,22 @@
     (G_ "No data")
     (G_ "The selected accounts contain no data/transactions (or only zeroes) for the selected time period")))
 
+(define unreserved-chars-rfc3986
+  (char-set-union
+   (string->char-set "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+   (string->char-set ":/?#[]@")         ;gen-delims
+   (string->char-set "-._~")))
+
+(define (make-uri path)
+  (string-append
+   "file://"
+   (uri-encode (gnc:substring-replace path "\\" "/")
+               #:unescaped-chars unreserved-chars-rfc3986)))
+
 (define (gnc:html-js-include file)
   (format #f
-          "<script language=\"javascript\" type=\"text/javascript\" src=\"file:///~a\"></script>\n"
-          (gnc-path-find-localized-html-file file)))
+          "<script language=\"javascript\" type=\"text/javascript\" src=~s></script>\n"
+          (make-uri (gnc-path-find-localized-html-file file))))
 
 (define (gnc:html-css-include file)
   (format #f

--- a/gnucash/report/html-utilities.scm
+++ b/gnucash/report/html-utilities.scm
@@ -413,11 +413,14 @@
    (string->char-set ":/?#[]@")         ;gen-delims
    (string->char-set "-._~")))
 
+;;path must be absolute. On Windows an absolute path begins with a
+;;drive letter followed by a colon.
 (define (make-uri path)
-  (string-append
-   "file://"
-   (uri-encode (gnc:substring-replace path "\\" "/")
+  (let ((uri-path (uri-encode (gnc:substring-replace path "\\" "/")
                #:unescaped-chars unreserved-chars-rfc3986)))
+  (string-append
+   (if (char=? (string-ref uri-path 0) #\/) "file://" "file:///")
+   uri-path)))
 
 (define (gnc:html-js-include file)
   (format #f

--- a/gnucash/report/test/test-html-utilities-srfi64.scm
+++ b/gnucash/report/test/test-html-utilities-srfi64.scm
@@ -1,5 +1,5 @@
 (use-modules (gnucash app-utils))
-(use-modules (gnucash report))
+(use-modules (gnucash report html-utilities))
 (use-modules (tests test-engine-extras))
 (use-modules (tests test-report-extras))
 (use-modules (tests srfi64-extras))
@@ -9,7 +9,10 @@
   (test-runner-factory gnc:test-runner)
   (test-begin "test-html-utilities-srfi64.scm")
   (test-gnc:assign-colors)
+  (test-html-includes)
   (test-end "test-html-utilities-srfi64.scm"))
+
+(define make-uri (@@ (gnucash report html-utilities) make-uri))
 
 (define (test-gnc:assign-colors)
   (test-begin "test-gnc:assign-colors")
@@ -18,3 +21,11 @@
     (length (gnc:assign-colors 99)))
   (test-end "test-gnc:assign-colors"))
 
+(define (test-html-includes)
+  (test-begin "test-html-includes")
+
+  (test-equal "windows path into rfc3986 uri"
+    "file://C:/Program%20Files%20%28x86%29/gnucash/share/gnucash/chartjs/Chart.bundle.min.js"
+    (make-uri "C:\\Program Files (x86)\\gnucash/share\\gnucash\\chartjs/Chart.bundle.min.js"))
+
+  (test-end "test-html-includes"))

--- a/gnucash/report/test/test-html-utilities-srfi64.scm
+++ b/gnucash/report/test/test-html-utilities-srfi64.scm
@@ -25,7 +25,7 @@
   (test-begin "test-html-includes")
 
   (test-equal "windows path into rfc3986 uri"
-    "file://C:/Program%20Files%20%28x86%29/gnucash/share/gnucash/chartjs/Chart.bundle.min.js"
+    "file:///C:/Program%20Files%20%28x86%29/gnucash/share/gnucash/chartjs/Chart.bundle.min.js"
     (make-uri "C:\\Program Files (x86)\\gnucash/share\\gnucash\\chartjs/Chart.bundle.min.js"))
 
   (test-end "test-html-includes"))


### PR DESCRIPTION
using a guile's uri.scm sanitizing function with expanded charset.

More test cases are available from https://github.com/Sporkmonger/Addressable/blob/master/spec/addressable/uri_spec.rb