### PR TITLE
Bug 798406 - 4.9 inappropriately converts dollars to shares at $1 a piece in pure cash transactions

### DIFF
--- a/libgnucash/engine/Split.c
+++ b/libgnucash/engine/Split.c
@@ -1196,6 +1196,10 @@ void
 xaccSplitSetSharePrice (Split *s, gnc_numeric price)
 {
     if (!s) return;
+
+    if (gnc_numeric_zero_p (price))
+        return;
+
     ENTER (" ");
     xaccTransBeginEdit (s->parent);
 
@@ -1927,22 +1931,18 @@ gnc_numeric
 xaccSplitGetSharePrice (const Split * split)
 {
     gnc_numeric amt, val, price;
-    if (!split) return gnc_numeric_create(1, 1);
+    if (!split) return gnc_numeric_create(0, 1);
 
 
-    /* if amount == 0 and value == 0, then return 1.
-     * if amount == 0 and value != 0 then return 0.
+    /* if amount == 0, return 0
      * otherwise return value/amount
      */
 
     amt = xaccSplitGetAmount(split);
     val = xaccSplitGetValue(split);
     if (gnc_numeric_zero_p(amt))
-    {
-        if (gnc_numeric_zero_p(val))
-            return gnc_numeric_create(1, 1);
         return gnc_numeric_create(0, 1);
-    }
+
     price = gnc_numeric_div(val, amt,
                             GNC_DENOM_AUTO,
                             GNC_HOW_RND_ROUND_HALF_UP);

--- a/libgnucash/engine/test/utest-Split.cpp
+++ b/libgnucash/engine/test/utest-Split.cpp
@@ -1669,7 +1669,7 @@ static void
 test_xaccSplitGetSharePrice (Fixture *fixture, gconstpointer pData)
 {
     gnc_numeric result, quotient;
-    gnc_numeric expected = gnc_numeric_create (1, 1);
+    gnc_numeric expected = gnc_numeric_create (0, 1);
     Split *split = fixture->split;
     /* Warning: this is a define in Split.c */
     char *logdomain = "gnc.engine";
@@ -1699,7 +1699,7 @@ test_xaccSplitGetSharePrice (Fixture *fixture, gconstpointer pData)
     g_assert_cmpint (check.hits, ==, 0);
 
     split->value = gnc_numeric_zero ();
-    expected = gnc_numeric_create (1, 1);
+    expected = gnc_numeric_create (0, 1);
     result = xaccSplitGetSharePrice (split);
     g_assert (gnc_numeric_equal (result, expected));
     g_assert_cmpint (check.hits, ==, 0);


### PR DESCRIPTION
`xaccSplitGetSharePrice` returns price==0 instead of price==1 and don't save price==0 into pricedb.