### PR TITLE
Allow to select saved report on print invoice button.

### DIFF
--- a/gnucash/gnome/dialog-custom-report.h
+++ b/gnucash/gnome/dialog-custom-report.h
@@ -38,8 +38,12 @@
  *  reports
  */
 
+typedef void (*GncCustomReportSelected) (GncMainWindow * window, const char *report_uuid, gpointer userdata);
+
 void
 gnc_ui_custom_report(GncMainWindow * window);
+void
+gnc_ui_custom_report_select(GncMainWindow * window, GncCustomReportSelected callback, gpointer userdata);
 void
 gnc_ui_custom_report_edit_name(GncMainWindow * window, SCM scm_guid);
 

--- a/gnucash/gnome/dialog-invoice.h
+++ b/gnucash/gnome/dialog-invoice.h
@@ -34,6 +34,7 @@ typedef struct _invoice_window InvoiceWindow;
 #include "gncOwner.h"
 #include "dialog-search.h"
 #include "dialog-query-view.h"
+#include "gnc-main-window.h"
 
 typedef enum
 {
@@ -92,7 +93,6 @@ void gnc_invoice_update_doclink_for_window (GncInvoice *invoice,
 GncInvoiceType gnc_invoice_get_type_from_window(InvoiceWindow *iw);
 
 #ifdef __GNC_PLUGIN_PAGE_H
-#include "gnc-main-window.h"
 GncPluginPage *gnc_invoice_recreate_page (GncMainWindow *window, GKeyFile *key_file, const gchar *group_name);
 void gnc_invoice_save_page (InvoiceWindow *iw, GKeyFile *key_file, const gchar *group_name);
 #endif
@@ -106,6 +106,7 @@ GtkWidget *gnc_invoice_get_notes(InvoiceWindow *iw);
 void gnc_invoice_window_destroy_cb (GtkWidget *widget, gpointer data);
 
 void gnc_invoice_window_new_invoice_cb (GtkWindow* parent, gpointer data);
+void gnc_invoice_window_print_invoice_report_cb(GncMainWindow *parent, const char* reportname, gpointer data);
 void gnc_invoice_window_printCB (GtkWindow* parent, gpointer data);
 void gnc_invoice_window_cut_cb (GtkWidget *widget, gpointer data);
 void gnc_invoice_window_copy_cb (GtkWidget *widget, gpointer data);

--- a/gnucash/gnome/gnc-plugin-business.c
+++ b/gnucash/gnome/gnc-plugin-business.c
@@ -1120,13 +1120,15 @@ static const char* invoice_printreport_values[] =
     "0769e242be474010b4acf264a5512e6e", // "Tax Invoice"
     "67112f318bef4fc496bdc27d106bbda4", // "Easy Invoice"
     "3ce293441e894423a2425d7a22dd1ac6", // "Fancy Invoice"
+    "",                                 // "Ask for a saved report"
     NULL
 };
+#define INVOICE_PRINTREPORT_VALUES_SIZE 5
 
 const char *gnc_plugin_business_get_invoice_printreport(void)
 {
     int value = gnc_prefs_get_int (GNC_PREFS_GROUP_INVOICE, GNC_PREF_INV_PRINT_RPT);
-    if (value >= 0 && value < 4)
+    if (value >= 0 && value < INVOICE_PRINTREPORT_VALUES_SIZE)
         return invoice_printreport_values[value];
     else
         return NULL;

--- a/gnucash/gnome/gnc-plugin-business.h
+++ b/gnucash/gnome/gnc-plugin-business.h
@@ -64,6 +64,12 @@ void gnc_invoice_remind_bills_due (GtkWindow *parent);
 void gnc_invoice_remind_invoices_due (GtkWindow *parent);
 void gnc_invoice_remind_bills_due_cb (void);
 void gnc_invoice_remind_invoices_due_cb (void);
+
+/**
+ * Get the GUID of the chosen print report in the preferences. Returns NULL if
+ * setting is not set and returns an empty string if the user chose to get asked
+ * each time for a saved report to use.
+ */
 const char *gnc_plugin_business_get_invoice_printreport(void);
 
 

--- a/gnucash/gtkbuilder/business-prefs.glade
+++ b/gnucash/gtkbuilder/business-prefs.glade
@@ -34,6 +34,9 @@
       <row>
         <col id="0" translatable="yes">Fancy Invoice</col>
       </row>
+      <row>
+        <col id="0" translatable="yes">Ask for a saved report</col>
+      </row>
     </data>
   </object>
   <object class="GtkWindow" id="preferences_window">


### PR DESCRIPTION
Use case : I want to be able to select a saved report I made to print
my invoices without having to open the saved report, change the option
and choose the invoice number. I also want to be able to print some of
my invoices using a specific template I made for quotes.

This change opens up the saved invoice dialog when the print invoice
button is clicked (only if the settings are set for this) and when I
select the saved report, the invoice report is created with the given
defaults and the correct invoice number.