### PR TITLE
L10N:nl: Better Invoice Number translation

### DIFF
--- a/po/nl.po
+++ b/po/nl.po
@@ -23694,7 +23694,7 @@ msgstr "Opmaaksjabloon"
 
 #: gnucash/report/report-core.scm:165
 msgid "Invoice Number"
-msgstr "Verkoopfactuurnummer"
+msgstr "Factuurnummer"
 
 #: gnucash/report/report-core.scm:211
 msgid ""


### PR DESCRIPTION
In Dutch it is weird to say "Sales Invoice Number", instead you use
"Invoice Number". Also, the old value messed up the PDF layout because
it was so long.

5345 translated messages, 29 fuzzy translations, 6 untranslated messages.