### PR TITLE
L10n:nl: Better tax name translations for invoices

### DIFF
--- a/po/nl.po
+++ b/po/nl.po
@@ -27114,7 +27114,7 @@ msgstr "Winst- en verliesrekening"
 #: gnucash/report/reports/standard/taxinvoice.scm:108
 #: gnucash/report/reports/standard/taxinvoice.scm:181
 msgid "Tax Amount"
-msgstr "Belastingbedrag"
+msgstr "BTW"
 
 #: gnucash/report/reports/standard/invoice.scm:112
 msgid "Client or vendor name, address and ID"
@@ -28067,7 +28067,7 @@ msgstr "Kortingsbedrag"
 #: gnucash/report/reports/standard/taxinvoice.scm:107
 #: gnucash/report/reports/standard/taxinvoice.scm:179
 msgid "Tax Rate"
-msgstr "Belastingtarief"
+msgstr "BTW%"
 
 #: gnucash/report/reports/standard/receipt.scm:61
 #: gnucash/report/reports/standard/receipt.scm:134
@@ -28307,7 +28307,7 @@ msgstr "kolom: Datum"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:75
 msgid "column: Tax Rate"
-msgstr "kolom: Belastingtarief"
+msgstr "kolom: BTW"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:76
 msgid "column: Units"


### PR DESCRIPTION
Most Dutch invoices do not talk about taxes and tax rates, but about VAT and VAT%. This change has the added benefit that the invoice PDF layout is much better:

Tax invoice pdf before:
![Screenshot from 2022-01-18 14-29-11](https://user-images.githubusercontent.com/121169/149947367-2ccc480a-caad-41b1-a9a6-6c00b92814de.png)

Tax invoice pdf after:
![Screenshot from 2022-01-18 14-28-41](https://user-images.githubusercontent.com/121169/149947381-3551a078-c804-4eed-bbe8-ca0e409807c0.png)

