### PR TITLE
Bug741674 - Template accounts appearing in search register and gl

### DIFF
--- a/gnucash/gnome/dialog-find-transactions.c
+++ b/gnucash/gnome/dialog-find-transactions.c
@@ -193,35 +193,7 @@ gnc_ui_find_transactions_dialog_create(GtkWindow *parent, GNCLedgerDisplay * ori
     {
         start_q = qof_query_create ();
         qof_query_set_book (start_q, gnc_get_current_book ());
-
-        /* In lieu of not "mis-using" some portion of the infrastructure by writing
-         * a bunch of new code, we just filter out the accounts of the template
-         * transactions.  While these are in a separate Account trees just for this
-         * reason, the query engine makes no distinction between Account trees.
-         * See Gnome Bug 86302.
-         * 	-- jsled
-         *
-         * copied from gnc-ledger-display.c:gnc_ledger_display_gl()  -- warlord
-         *
-         * <jsled> Alternatively, you could look for a GNC_SX_ACCOUNT [SchedAction.h]
-         * key in the KVP frame of the split.
-         */
-        {
-            Account *tRoot;
-            GList *al;
-
-            tRoot = gnc_book_get_template_root( gnc_get_current_book() );
-            al = gnc_account_get_descendants( tRoot );
-
-            if (g_list_length(al) != 0)
-                xaccQueryAddAccountMatch( start_q, al, QOF_GUID_MATCH_NONE, QOF_QUERY_AND );
-
-            g_list_free (al);
-            al = NULL;
-            tRoot = NULL;
-        }
-
-        ftd->q = start_q;		/* save this to destroy it later */
+        ftd->q = start_q; // save this to destroy it later
     }
 
     ftd->parent = parent;

--- a/gnucash/register/ledger-core/gnc-ledger-display.c
+++ b/gnucash/register/ledger-core/gnc-ledger-display.c
@@ -70,6 +70,8 @@ struct gnc_ledger_display
     GNCLedgerDisplayDestroy destroy;
     GNCLedgerDisplayGetParent get_parent;
 
+    GHashTable *excluded_template_acc_hash;
+
     gpointer user_data;
 
     gint number_of_subaccounts;
@@ -168,7 +170,7 @@ gnc_ledger_display_get_query (GNCLedgerDisplay* ld)
 }
 
 static void
-exclude_template_accounts (Query* q)
+exclude_template_accounts (Query* q, GHashTable *excluded_template_acc_hash)
 {
     Account* tRoot;
     GList* al;
@@ -176,6 +178,21 @@ exclude_template_accounts (Query* q)
     tRoot = gnc_book_get_template_root (gnc_get_current_book());
     al = gnc_account_get_descendants (tRoot);
 
+    if (gnc_list_length_cmp (al, 0) && excluded_template_acc_hash)
+    {
+        GList *node, *next;
+
+        for (node = al; node; node = next)
+        {
+            Account *acc = node->data;
+            next = g_list_next (node);
+
+            if (g_hash_table_lookup (excluded_template_acc_hash, acc) != NULL)
+                al = g_list_delete_link (al, node);
+            else
+                g_hash_table_insert (excluded_template_acc_hash, acc, acc);
+        }
+    }
     if (gnc_list_length_cmp (al, 0))
         xaccQueryAddAccountMatch (q, al, QOF_GUID_MATCH_NONE, QOF_QUERY_AND);
 
@@ -427,12 +444,15 @@ gnc_ledger_display_gl (void)
     time64 start;
     struct tm tm;
     GNCLedgerDisplay* ld;
+    GHashTable *exclude_template_accounts_hash;
 
     ENTER (" ");
 
     query = qof_query_create_for (GNC_ID_SPLIT);
 
     qof_query_set_book (query, gnc_get_current_book());
+
+    exclude_template_accounts_hash = g_hash_table_new (g_direct_hash, g_direct_equal);
 
     /* In lieu of not "mis-using" some portion of the infrastructure by writing
      * a bunch of new code, we just filter out the accounts of the template
@@ -441,7 +461,7 @@ gnc_ledger_display_gl (void)
      * See Gnome Bug 86302.
      *         -- jsled */
     // Exclude any template accounts for search register and gl
-     exclude_template_accounts (query);
+     exclude_template_accounts (query, exclude_template_accounts_hash);
 
     gnc_tm_get_today_start (&tm);
     tm.tm_mon--; /* Default the register to the last month's worth of transactions. */
@@ -453,6 +473,8 @@ gnc_ledger_display_gl (void)
 
     ld = gnc_ledger_display_internal (NULL, query, LD_GL, GENERAL_JOURNAL,
                                       REG_STYLE_JOURNAL, FALSE, FALSE, FALSE);
+
+    ld->excluded_template_acc_hash = exclude_template_accounts_hash;
     LEAVE ("%p", ld);
 
     qof_query_destroy (query);
@@ -611,7 +633,7 @@ refresh_handler (GHashTable* changes, gpointer user_data)
 
     // Exclude any template accounts for search register and gl
     if (!ld->reg->is_template && (ld->reg->type == SEARCH_LEDGER || ld->ld_type == LD_GL))
-        exclude_template_accounts (ld->query);
+        exclude_template_accounts (ld->query, ld->excluded_template_acc_hash);
 
     /* Its not clear if we should re-run the query, or if we should
      * just use qof_query_last_run().  Its possible that the dates
@@ -642,6 +664,10 @@ close_handler (gpointer user_data)
 
     gnc_split_register_destroy (ld->reg);
     ld->reg = NULL;
+
+    // Destroy the excluded template account hash
+    if (ld->excluded_template_acc_hash)
+        g_hash_table_destroy (ld->excluded_template_acc_hash);
 
     qof_query_destroy (ld->query);
     ld->query = NULL;
@@ -718,6 +744,8 @@ gnc_ledger_display_query (Query* query, SplitRegisterType type,
 
     ld = gnc_ledger_display_internal (NULL, query, LD_GL, type, style,
                                       FALSE, FALSE, FALSE);
+
+    ld->excluded_template_acc_hash = g_hash_table_new (g_direct_hash, g_direct_equal);
     LEAVE ("%p", ld);
     return ld;
 }
@@ -811,6 +839,7 @@ gnc_ledger_display_internal (Account* lead_account, Query* q,
     ld->destroy = NULL;
     ld->get_parent = NULL;
     ld->user_data = NULL;
+    ld->excluded_template_acc_hash = NULL;
 
     limit = gnc_prefs_get_float (GNC_PREFS_GROUP_GENERAL_REGISTER,
                                  GNC_PREF_MAX_TRANS);
@@ -906,7 +935,7 @@ gnc_ledger_display_refresh (GNCLedgerDisplay* ld)
 
     // Exclude any template accounts for search register and gl
     if (!ld->reg->is_template && (ld->reg->type == SEARCH_LEDGER || ld->ld_type == LD_GL))
-        exclude_template_accounts (ld->query);
+        exclude_template_accounts (ld->query, ld->excluded_template_acc_hash);
 
     gnc_ledger_display_refresh_internal (ld, qof_query_run (ld->query));
     LEAVE (" ");


### PR DESCRIPTION
This is a proposed fix for the bug mentioned. The first commit I think is OK but am wondering if the second commit needs to be changed.

The second commit uses a hash table to remember the template accounts that have been excluded already. I am comparing the template account pointer to do this and am wondering if it should be based on the guid string. The template account pointer should be around while program is running but when the schedule is deleted, the template accounts will also be deleted.
As I am just comparing the pointer, will this matter?