### PR TITLE
Python bindings: Provide wrapper for qof numeric predicate, import full set of QOF enums to gnucash

### DIFF
--- a/bindings/python/example_scripts/qof.py
+++ b/bindings/python/example_scripts/qof.py
@@ -9,8 +9,11 @@
 
 import datetime
 from random import randint
-from gnucash import Session, SessionOpenMode, Account, Transaction, Split, GncNumeric, Query
-from gnucash import QOF_COMPARE_GTE, QOF_COMPARE_GT, QOF_QUERY_AND, QOF_QUERY_OR, QOF_STRING_MATCH_NORMAL
+from gnucash import Session, SessionOpenMode, Account, Transaction, Split, \
+                    GncNumeric, Query
+from gnucash import QOF_COMPARE_GTE, QOF_COMPARE_GT, QOF_QUERY_AND, \
+                    QOF_QUERY_OR, QOF_STRING_MATCH_NORMAL, QOF_COMPARE_CONTAINS, \
+                    QOF_NUMERIC_MATCH_ANY
 from gnucash import gnucash_core_c
 from gnucash import gnucash_core
 
@@ -129,7 +132,6 @@ with Session(uri, SessionOpenMode.SESSION_NEW_STORE) as ses:
     print("Query transactions with date > 1950: " + str(len(transactions_2)) + " (Should be about 50).")
 
     # query description
-    QOF_COMPARE_CONTAINS = 7
     isRegex = False
     terms = [(['desc'], gnucash_core.QueryStringPredicate(QOF_COMPARE_CONTAINS, "Transaction 5", QOF_STRING_MATCH_NORMAL, isRegex), QOF_QUERY_AND)]
     transactions_3 = query_transactions(book, terms)
@@ -138,21 +140,18 @@ with Session(uri, SessionOpenMode.SESSION_NEW_STORE) as ses:
     # SPLITS
     #
     # query memo
-    QOF_COMPARE_CONTAINS = 7
     isRegex = False
     terms = [(['memo'], gnucash_core.QueryStringPredicate(QOF_COMPARE_CONTAINS, "A22", QOF_STRING_MATCH_NORMAL, isRegex), QOF_QUERY_AND)]
     splits_1 = query_splits(book, terms)
     print("Query splits with memo containing 'A22': " + str(len(splits_1)) + " (Should be 1).")
 
     # query description
-    QOF_COMPARE_CONTAINS = 7
     isRegex = False
     terms = [(['trans', 'desc'], gnucash_core.QueryStringPredicate(QOF_COMPARE_CONTAINS, "Transaction 5", QOF_STRING_MATCH_NORMAL, isRegex), QOF_QUERY_AND)]
     splits_2 = query_splits(book, terms)
     print("Query splits with transaction description containing 'Transaction 5': " + str(len(splits_2)) + " (Should be 22).")
 
     # query memo and desc
-    QOF_COMPARE_CONTAINS = 7
     isRegex = False
     terms = [(['memo'], gnucash_core.QueryStringPredicate(QOF_COMPARE_CONTAINS, "A22", QOF_STRING_MATCH_NORMAL, isRegex), QOF_QUERY_AND)]
     terms += [(['trans', 'desc'], gnucash_core.QueryStringPredicate(QOF_COMPARE_CONTAINS, "Transaction 55", QOF_STRING_MATCH_NORMAL, isRegex), QOF_QUERY_OR)]

--- a/bindings/python/example_scripts/qof.py
+++ b/bindings/python/example_scripts/qof.py
@@ -160,7 +160,6 @@ with Session(uri, SessionOpenMode.SESSION_NEW_STORE) as ses:
 
     # query split value
     threshold = GncNumeric(5000, 100)
-    QOF_NUMERIC_MATCH_ANY = 3
     terms = [(["amount"], gnucash_core.QueryNumericPredicate(QOF_COMPARE_GT, QOF_NUMERIC_MATCH_ANY, threshold), QOF_QUERY_AND)]
     splits_3 = query_splits(book, terms)
     print("Query splits with amount > " + str(threshold) + ": " + str(len(splits_3)) + " (Should be about 50).")

--- a/bindings/python/example_scripts/qof.py
+++ b/bindings/python/example_scripts/qof.py
@@ -161,7 +161,7 @@ with Session(uri, SessionOpenMode.SESSION_NEW_STORE) as ses:
 
     # query split value
     threshold = GncNumeric(5000, 100)
-    QOF_NUMERIC_MATCH_ANY = 1
-    terms = [(["amount"], gnucash_core_c.qof_query_numeric_predicate(QOF_COMPARE_GT, QOF_NUMERIC_MATCH_ANY, threshold.instance), QOF_QUERY_AND)]
+    QOF_NUMERIC_MATCH_ANY = 3
+    terms = [(["amount"], gnucash_core.QueryNumericPredicate(QOF_COMPARE_GT, QOF_NUMERIC_MATCH_ANY, threshold), QOF_QUERY_AND)]
     splits_3 = query_splits(book, terms)
     print("Query splits with amount > " + str(threshold) + ": " + str(len(splits_3)) + " (Should be about 50).")

--- a/bindings/python/example_scripts/qof.py
+++ b/bindings/python/example_scripts/qof.py
@@ -162,4 +162,4 @@ with Session(uri, SessionOpenMode.SESSION_NEW_STORE) as ses:
     threshold = GncNumeric(5000, 100)
     terms = [(["amount"], gnucash_core.QueryNumericPredicate(QOF_COMPARE_GT, QOF_NUMERIC_MATCH_ANY, threshold), QOF_QUERY_AND)]
     splits_3 = query_splits(book, terms)
-    print("Query splits with amount > " + str(threshold) + ": " + str(len(splits_3)) + " (Should be about 50).")
+    print("Query splits with amount > " + str(threshold) + ": " + str(len(splits_3)) + " (Should be about 100).")

--- a/bindings/python/example_scripts/rest-api/gnucash_rest.py
+++ b/bindings/python/example_scripts/rest-api/gnucash_rest.py
@@ -63,6 +63,9 @@ from gnucash import \
     QOF_COMPARE_NEQ
 
 from gnucash import \
+    QOF_DATE_MATCH_NORMAL
+
+from gnucash import \
     INVOICE_TYPE
 
 from gnucash import \
@@ -914,8 +917,6 @@ def getAccountSplits(book, guid, date_posted_from, date_posted_to):
     query.set_book(book)
 
     SPLIT_TRANS= 'trans'
-
-    QOF_DATE_MATCH_NORMAL = 1
 
     TRANS_DATE_POSTED = 'date-posted'
 

--- a/bindings/python/gnucash_core.py
+++ b/bindings/python/gnucash_core.py
@@ -967,3 +967,9 @@ class QueryGuidPredicate(GnuCashCoreClass):
 
 QueryGuidPredicate.add_constructor_and_methods_with_prefix(
     'qof_query_', 'guid_predicate')
+
+class QueryNumericPredicate(GnuCashCoreClass):
+    pass
+
+QueryNumericPredicate.add_constructor_and_methods_with_prefix(
+    'qof_query_', 'numeric_predicate')

--- a/bindings/python/gnucash_core.py
+++ b/bindings/python/gnucash_core.py
@@ -908,7 +908,29 @@ from gnucash.gnucash_core_c import \
     QOF_COMPARE_EQUAL, \
     QOF_COMPARE_GT, \
     QOF_COMPARE_GTE, \
-    QOF_COMPARE_NEQ
+    QOF_COMPARE_NEQ, \
+    QOF_COMPARE_CONTAINS, \
+    QOF_COMPARE_NCONTAINS
+
+from gnucash.gnucash_core_c import \
+    QOF_DATE_MATCH_NORMAL, \
+    QOF_DATE_MATCH_DAY
+
+from gnucash.gnucash_core_c import \
+    QOF_NUMERIC_MATCH_DEBIT, \
+    QOF_NUMERIC_MATCH_CREDIT, \
+    QOF_NUMERIC_MATCH_ANY
+
+from gnucash.gnucash_core_c import \
+    QOF_GUID_MATCH_ANY, \
+    QOF_GUID_MATCH_NONE, \
+    QOF_GUID_MATCH_NULL, \
+    QOF_GUID_MATCH_ALL, \
+    QOF_GUID_MATCH_LIST_ANY
+
+from gnucash.gnucash_core_c import \
+    QOF_CHAR_MATCH_ANY, \
+    QOF_CHAR_MATCH_NONE
 
 from gnucash.gnucash_core_c import \
     INVOICE_TYPE


### PR DESCRIPTION
Python bindings already have some wrapping objects for
qof predicates. This adds the one missing for GncNumeric
comparisons.

Additionally fixes a wrong number for QOF_NUMERIC_MATCH_ANY
in example file.

[Provide the complete set of QOF enums in gnucash](https://github.com/Gnucash/gnucash/pull/1290/commits/62f8acf6ae265ceac29a01b290b450b9a4cf8cfd) and
[Modify examples to make use of it](https://github.com/Gnucash/gnucash/pull/1290/commits/395c7a705248615a70cb8b2ea334d309daee875f)