### PR TITLE
Python gnc numeric example

### DIFF
--- a/bindings/python/example_scripts/GncNumeric.py
+++ b/bindings/python/example_scripts/GncNumeric.py
@@ -40,6 +40,15 @@ print(n4, "==", g4, ":", n4 == g4)
 print('Same float with higher precision: %.32f' % n4)
 print()
 
+# Create from float
+n5 = 2245.67
+g5 = GncNumeric(n5)
+print("5 - create from float")
+print(n5, "(", type(n5), ") =>", g5)
+print(n5, "==", g5, ":", n5 == g5)
+print('Same float with higher precision: %.32f' % n5)
+print()
+
 # Compare float, string and int
 print("Compare GncNumeric from float (4) to GncNumeric from string (2)")
 print(g2, "==", g4, ":", g2 == g4)
@@ -67,6 +76,18 @@ print()
 
 # Convert GncNumeric from float to remove errors
 print("Convert float to different denominator to remove conversion errors")
-g5 = g4.convert(1000, GNC_HOW_RND_ROUND)
-print(g4, "(", type(g4), ") =>", g5)
+g4b = g4.convert(1000, GNC_HOW_RND_ROUND)
+print(g4, "(", type(g4), ") =>", g4b)
+print()
+
+# Create from float with specified significant figures
+print(f"Create from float (Example 5, ={n5}) with specified significant figures")
+for sigfigs in range(0,20):
+    print(sigfigs, GncNumeric(n5, GNC_DENOM_AUTO, GNC_HOW_DENOM_SIGFIGS(sigfigs)))
+print()
+
+# Convert GncNumeric from float to remove errors
+print("Convert float to different denominator to remove conversion errors")
+g5b = g5.convert(1000, GNC_HOW_RND_ROUND)
+print(g5, "(", type(g5), ") =>", g5b)
 

--- a/bindings/python/example_scripts/GncNumeric.py
+++ b/bindings/python/example_scripts/GncNumeric.py
@@ -53,10 +53,16 @@ print("Compare GncNumeric from string (2) to GncNumeric from int (3)")
 print(g2, "==", g3, ":", g2 == g3)
 print()
 
-# Create from float with specified precision
-print("Create from float with specified precision")
-for n in range(0,20):
-    print(GncNumeric(n4, GNC_DENOM_AUTO, GNC_HOW_DENOM_SIGFIG | n * 0x100))
+def GNC_HOW_DENOM_SIGFIGS(n):
+    """Leaned on the C Macro"""
+    return GNC_HOW_DENOM_SIGFIG | (n << 8 & GNC_NUMERIC_SIGFIGS_MASK)
+
+GNC_NUMERIC_SIGFIGS_MASK = 0x0000ff00
+
+# Create from float with specified significant figures
+print(f"Create from float (Example 4, ={n4}) with specified significant figures")
+for sigfigs in range(0,20):
+    print(sigfigs, GncNumeric(n4, GNC_DENOM_AUTO, GNC_HOW_DENOM_SIGFIGS(sigfigs)))
 print()
 
 # Convert GncNumeric from float to remove errors

--- a/bindings/python/example_scripts/GncNumeric.py
+++ b/bindings/python/example_scripts/GncNumeric.py
@@ -37,6 +37,7 @@ g4 = GncNumeric(n4)
 print("4 - create from float")
 print(n4, "(", type(n4), ") =>", g4)
 print(n4, "==", g4, ":", n4 == g4)
+print('Same float with higher precision: %.32f' % n4)
 print()
 
 # Compare float, string and int

--- a/bindings/python/example_scripts/GncNumeric.py
+++ b/bindings/python/example_scripts/GncNumeric.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+##  @file
+#   @brief Some examples for GncNumeric to illustrate conversion and comparison
+#   @author Christoph Holtermann
+#   @date 2022-03-20
+#   @ingroup python_bindings_examples
+
+from gnucash import GncNumeric
+from gnucash import GNC_DENOM_AUTO, GNC_HOW_DENOM_SIGFIG, GNC_HOW_RND_ROUND
+
+# Create from int
+n1 = 1
+g1 = GncNumeric(n1)
+print("1 - create from int")
+print(n1, "(", type(n1), ") =>", g1)
+print(n1, "==", g1, ":", n1 == g1)
+print()
+
+# Create from String
+n2 = "1.1"
+g2 = GncNumeric(n2)
+print("2 - create from string")
+print(n2, "(", type(n2), ") =>", g2)
+print()
+
+# Create from two ints
+n3 = (11,10)
+g3 = GncNumeric(*n3)
+print("3 - create from two ints")
+print(n3, "(", type(n3), ") =>", g3)
+print()
+
+# Create from float
+n4 = 2.2
+g4 = GncNumeric(n4)
+print("4 - create from float")
+print(n4, "(", type(n4), ") =>", g4)
+print(n4, "==", g4, ":", n4 == g4)
+print()
+
+# Compare float, string and int
+print("Compare GncNumeric from float (4) to GncNumeric from string (2)")
+print(g2, "==", g4, ":", g2 == g4)
+print()
+
+print("Compare GncNumeric from float (4) to GncNumeric from int (3)")
+print(g3, "==", g4, ":", g3 == g4)
+print()
+
+print("Compare GncNumeric from string (2) to GncNumeric from int (3)")
+print(g2, "==", g3, ":", g2 == g3)
+print()
+
+# Create from float with specified precision
+print("Create from float with specified precision")
+for n in range(0,20):
+    print(GncNumeric(n4, GNC_DENOM_AUTO, GNC_HOW_DENOM_SIGFIG | n * 0x100))
+print()
+
+# Convert GncNumeric from float to remove errors
+print("Convert float to different denominator to remove conversion errors")
+g5 = g4.convert(1000, GNC_HOW_RND_ROUND)
+print(g4, "(", type(g4), ") =>", g5)
+


### PR DESCRIPTION
This is intended to be as an example file for GncNumeric to provide a better understanding (for me and others) of how gnucash handles numerics. It still has issues discussed in https://github.com/Gnucash/gnucash/pull/1298. I'd like to pick up that conversation. Just now the file has not changed in respect to the aforementioned PR. I will work on it this week and add changes to this PR.

One main topic is the conversion of float to GncNumeric. The basic practical question for me is how to achieve to have a specific decimal value like "2.2" as a GncNumeric. The way I'd expect it to work is GncNumeric(2.2) but this uses a float which does not have the exact value of 2.2 as has been showed by @jralls in https://github.com/Gnucash/gnucash/pull/1298#discussion_r830545454.

So I'm looking for practical ways to have exact decimal values represented in GncNumeric coming from python script or shell and to show possible problems. In this end this PR should show a practical solution but as now has flaws as John Ralls has pointed out.

The significance of the significant figures and their practical value and handling needs to be worked out.