### PR TITLE
Move function from scheme to cpp

### DIFF
--- a/bindings/engine-common.i
+++ b/bindings/engine-common.i
@@ -48,10 +48,14 @@ AccountList * gnc_account_get_descendants (const Account *account);
 %newobject gnc_account_get_descendants_sorted;
 AccountList * gnc_account_get_descendants_sorted (const Account *account);
 
+%newobject gnc_accounts_and_all_descendants;
+AccountList * gnc_accounts_and_all_descendants (AccountList *accounts);
+
 %ignore gnc_account_get_children;
 %ignore gnc_account_get_children_sorted;
 %ignore gnc_account_get_descendants;
 %ignore gnc_account_get_descendants_sorted;
+%ignore gnc_accounts_and_all_descendants;
 %include <Account.h>
 
 %include <Transaction.h>

--- a/gnucash/report/html-acct-table.scm
+++ b/gnucash/report/html-acct-table.scm
@@ -697,7 +697,7 @@
           (for-each
            (lambda (acct)
              (this-collector 'merge (get-balance acct-balances acct) #f))
-           (gnc:accounts-and-all-descendants (list account)))
+           (cons account (gnc-account-get-descendants-sorted account)))
           this-collector))
 
       (let lp ((accounts (if less-p (sort accts less-p) accts))

--- a/gnucash/report/html-acct-table.scm
+++ b/gnucash/report/html-acct-table.scm
@@ -555,6 +555,7 @@
   (gnc:string-locale<? (xaccAccountGetName a)
                        (xaccAccountGetName b)))
 (define (gnc:account-path-less-p a b)
+  (issue-deprecation-warning "gnc:account-path-less-p is deprecated. use gnc:account-full-name<? instead")
   (gnc:string-locale<? (gnc-account-get-full-name a)
                        (gnc-account-get-full-name b)))
 

--- a/gnucash/report/report-utilities.scm
+++ b/gnucash/report/report-utilities.scm
@@ -234,9 +234,10 @@
 
 ;; Return accountslist *and* their descendant accounts
 (define (gnc:accounts-and-all-descendants accountslist)
-  (sort-and-delete-duplicates
-   (apply append accountslist (map gnc-account-get-descendants accountslist))
-   gnc:account-path-less-p equal?))
+  (issue-deprecation-warning "gnc:accounts-and-all-descendants is \
+now deprecated, use gnc-accounts-and-all-descendants instead. sort \
+with gnc:account-full-name<? if necessary.")
+  (sort (gnc-accounts-and-all-descendants accountslist) gnc:account-full-name<?))
 
 ;;; Here's a statistics collector...  Collects max, min, total, and makes
 ;;; it easy to get at the mean.

--- a/gnucash/report/reports/example/average-balance.scm
+++ b/gnucash/report/reports/example/average-balance.scm
@@ -296,7 +296,7 @@
          (accounts   (get-option gnc:pagename-accounts (N_ "Accounts")))
          (dosubs?    (get-option gnc:pagename-accounts optname-subacct))
          (accounts (if dosubs?
-                       (gnc:accounts-and-all-descendants accounts)
+                       (gnc-accounts-and-all-descendants accounts)
                        accounts))
          (plot-type  (get-option gnc:pagename-display (N_ "Plot Type")))
          (show-plot? (get-option gnc:pagename-display (N_ "Show plot")))

--- a/gnucash/report/reports/example/daily-reports.scm
+++ b/gnucash/report/reports/example/daily-reports.scm
@@ -186,7 +186,7 @@
           ;; needed so as to amortize the cpu time properly.
 	  (gnc:report-percent-done 1)
 	  (set! commodity-list (gnc:accounts-get-commodities
-                                (gnc:accounts-and-all-descendants accounts)
+                                (gnc-accounts-and-all-descendants accounts)
                                 report-currency))
           (gnc:report-percent-done 5)
           (set! exchange-fn (gnc:case-exchange-time-fn
@@ -208,7 +208,7 @@
           (gnc:report-percent-done 25)
           (if dosubs?
                (set! accounts
-                 (gnc:accounts-and-all-descendants accounts)))
+                 (gnc-accounts-and-all-descendants accounts)))
           (gnc:report-percent-done 30)
 
           (xaccQueryAddAccountMatch

--- a/gnucash/report/reports/standard/account-summary.scm
+++ b/gnucash/report/reports/standard/account-summary.scm
@@ -444,7 +444,7 @@
             (gnc:html-document-add-object!
              doc (gnc:html-make-rates-table
                   report-commodity price-fn
-                  (gnc:accounts-and-all-descendants accounts))))))
+                  (gnc-accounts-and-all-descendants accounts))))))
 
     (gnc:report-finished)
     doc))

--- a/gnucash/report/reports/standard/budget.scm
+++ b/gnucash/report/reports/standard/budget.scm
@@ -686,7 +686,7 @@
                                                    optname-period-collapse-after)))
          (doc (gnc:make-html-document))
          (accounts (if show-subaccts?
-                       (gnc:accounts-and-all-descendants accounts)
+                       (gnc-accounts-and-all-descendants accounts)
                        accounts)))
     ;; end of defines
 

--- a/gnucash/report/reports/standard/cash-flow.scm
+++ b/gnucash/report/reports/standard/cash-flow.scm
@@ -156,7 +156,7 @@
 
          ;;add subaccounts if requested
          (accounts (if show-subaccts?
-                       (gnc:accounts-and-all-descendants accounts)
+                       (gnc-accounts-and-all-descendants accounts)
                        accounts))
          (accounts (sort accounts gnc:account-full-name<?)))
 

--- a/gnucash/report/reports/standard/category-barchart.scm
+++ b/gnucash/report/reports/standard/category-barchart.scm
@@ -294,7 +294,7 @@ developing over time"))
 
      (else
       (let* ((commodity-list (gnc:accounts-get-commodities
-                              (gnc:accounts-and-all-descendants accounts)
+                              (gnc-accounts-and-all-descendants accounts)
                               report-currency))
              (exchange-fn (gnc:case-exchange-time-fn
                            price-source report-currency
@@ -394,7 +394,7 @@ developing over time"))
                       #:nosplit->elt (gnc:make-gnc-monetary comm 0)))))
            ;; all selected accounts (of report-specific type), *and*
            ;; their descendants (of any type) need to be scanned.
-           (gnc:accounts-and-all-descendants accounts)))
+           (gnc-accounts-and-all-descendants accounts)))
 
         ;; Creates the <balance-list> to be used in the function
         ;; below.

--- a/gnucash/report/reports/standard/net-charts.scm
+++ b/gnucash/report/reports/standard/net-charts.scm
@@ -299,7 +299,7 @@
 
     (gnc:report-percent-done 1)
     (set! commodity-list (gnc:accounts-get-commodities
-                          (gnc:accounts-and-all-descendants accounts)
+                          (gnc-accounts-and-all-descendants accounts)
                           report-currency))
     (gnc:report-percent-done 10)
     (set! exchange-fn (gnc:case-exchange-time-fn

--- a/gnucash/report/reports/standard/portfolio.scm
+++ b/gnucash/report/reports/standard/portfolio.scm
@@ -195,7 +195,7 @@
     ;(gnc:debug "accounts" accounts)
     (if (not (null? accounts))
         (let* ((commodity-list (gnc:accounts-get-commodities
-                                (gnc:accounts-and-all-descendants accounts)
+                                (gnc-accounts-and-all-descendants accounts)
                                 currency))
                (pricedb (gnc-pricedb-get-db (gnc-get-current-book)))
 	       (exchange-fn (gnc:case-exchange-fn price-source currency to-date))

--- a/gnucash/report/reports/standard/test/test-income-gst.scm
+++ b/gnucash/report/reports/standard/test/test-income-gst.scm
@@ -232,10 +232,10 @@
     (define (default-testing-options)
       (let ((options (gnc:make-report-options rpt-uuid)))
         (set-option! options "Accounts" "Sales"
-                     (gnc:accounts-and-all-descendants
+                     (gnc-accounts-and-all-descendants
                       (list (get-acct "Income"))))
         (set-option! options "Accounts" "Purchases"
-                     (gnc:accounts-and-all-descendants
+                     (gnc-accounts-and-all-descendants
                       (list (get-acct "Expenses"))))
         (set-option! options "Accounts" "Tax Accounts"
                      (list (get-acct "Purchases VAT")

--- a/gnucash/report/test/test-report-utilities.scm
+++ b/gnucash/report/test/test-report-utilities.scm
@@ -546,9 +546,11 @@
             (account-lookup "GBP Savings")
             (account-lookup "Expenses")
             (account-lookup "Fuel"))
-      (gnc:accounts-and-all-descendants
-       (list (account-lookup "Expenses")
-             (account-lookup "GBP Bank"))))
+      (sort
+       (gnc-accounts-and-all-descendants
+        (list (account-lookup "Expenses")
+              (account-lookup "GBP Bank")))
+       gnc:account-full-name<?))
 
     (teardown)))
 

--- a/libgnucash/engine/Account.h
+++ b/libgnucash/engine/Account.h
@@ -1620,6 +1620,7 @@ void dxaccAccountSetQuoteTZ (Account *account, const char *tz);
 const char * dxaccAccountGetQuoteTZ (const Account *account);
 /** @} */
 
+GList * gnc_accounts_and_all_descendants (GList *accounts);
 
 /** @name Account parameter names
  @{


### PR DESCRIPTION
Much more efficient. Avoids generating GLists of accounts' descendants repeatedly prior to deleting duplicates.