### PR TITLE
Fix typos in libgnucash/

### DIFF
--- a/libgnucash/doc/finutil.html
+++ b/libgnucash/doc/finutil.html
@@ -696,7 +696,7 @@ set by the user to use the financial calculator functions.
 [Hh](elp) to Display This Help
 [Qq](uit)? to Quit
 [Ss](tatus)? to Display Status of Computations
-[Uu](ser) Display User Defined Variables
+[Uu](set) Display User Defined Variables
 
 Variables to set:
 n    == number of periodic payments
@@ -756,7 +756,7 @@ Effective       Date: Tue Jun 04 00:00:00 1996(2450239)
 Initial Payment Date: Thu Aug 01 00:00:00 1996(2450297)
 <>
 </pre>
-<li>[Uu](ser) Display User Defined Variables
+<li>[Uu](set) Display User Defined Variables
 <br>If any variables have been defined by the user, this command displays their names and
 values.
 </ol>


### PR DESCRIPTION
Found via `codespell -q 3 -L ans,ba,parm,parms,numer`