### PR TITLE
Fix various typos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ foreach(install_dir ${CMAKE_INSTALL_FULL_BINDIR}
   string(FIND ${install_dir} ${CMAKE_INSTALL_PREFIX} in_prefix)
   if(NOT (in_prefix EQUAL 0))
     set(ENABLE_BINRELOC OFF)
-    message(WARNING "${install_dir} is set outside of the intallation prefix ${CMAKE_INSTALL_PREFIX}. That will break relocation so ENABLE_BINRELOC is set to off. With relocation disabled GnuCash will run only in its configured install location. You must set GNC_UNINSTALLED=1 and GNC_BUILDDIR=/path/to/builddir to run from the build directory. GnuCash will not run from a DESTDIR.")
+    message(WARNING "${install_dir} is set outside of the installation prefix ${CMAKE_INSTALL_PREFIX}. That will break relocation so ENABLE_BINRELOC is set to off. With relocation disabled GnuCash will run only in its configured install location. You must set GNC_UNINSTALLED=1 and GNC_BUILDDIR=/path/to/builddir to run from the build directory. GnuCash will not run from a DESTDIR.")
     break()
   endif()
 endforeach()

--- a/cmake/configure-appdata.cmake
+++ b/cmake/configure-appdata.cmake
@@ -18,7 +18,7 @@
 # - SRC_DIR (top level source code directory)
 # - SRC (full path to gnucash.appdata.xml.in)
 # - DST (full path to destination for gnucash.appdata.xml)
-# - REL_FILE (path to file containg (packaging) release info)
+# - REL_FILE (path to file containing (packaging) release info)
 # - VCS_INFO_FILE (full path to gnc-vcs-info.h - can be in source tree (release builds) or build tree (git builds))
 # - GNUCASH_BUILD_ID (optional, extra version information supplied by packagers)
 

--- a/common/cmake_modules/GncAddSchemeTargets.cmake
+++ b/common/cmake_modules/GncAddSchemeTargets.cmake
@@ -135,8 +135,8 @@ endmacro(find_guile_dirs)
 # If keyword TEST is specified this target will be treated as a test target.
 # That is its compiled files won't be installed and will be added to the set
 # of tests to run via the "check" target. If TEST is not set the targets are
-# considerd normal targets and will be added to the list of files to install.
-# They will be installed in the guile compied directory relative to the prefix
+# considered normal targets and will be added to the list of files to install.
+# They will be installed in the guile compiled directory relative to the prefix
 # set up for this build, with the OUTPUT_DIR appended to it. For example:
 # /usr/local/lib/x86_64-linux-gnu/guile/2.0/site-cache/gnucash
 function(gnc_add_scheme_targets _TARGET)

--- a/common/cmake_modules/GncAddSwigCommand.cmake
+++ b/common/cmake_modules/GncAddSwigCommand.cmake
@@ -6,7 +6,7 @@
 
 # gnc_add_swig_guile_command is used to generate guile swig wrappers
 # - _target is the name of a global target that will be set for this wrapper file,
-#    this can be used elsewhere to create a depencency on this wrapper
+#    this can be used elsewhere to create a dependency on this wrapper
 # - _out_var will be set to the full path to the generated wrapper file
 # - _output is the name of the wrapper file to generate
 # - _input is the swig interface file (*.i) to generate this wrapper from
@@ -47,7 +47,7 @@ endmacro (gnc_add_swig_guile_command)
 # gnc_add_swig_python_command is used to generate python swig wrappers
 # from the tarball will be used instead
 # - _target is the name of a global target that will be set for this wrapper file,
-#    this can be used elsewhere to create a depencency on this wrapper
+#    this can be used elsewhere to create a dependency on this wrapper
 # - _out_var will be set to the full path to the generated wrapper file
 # - _py_out_var is the same but for the python module that's generated together with the wrapper
 # - _output is the name of the wrapper file to generate

--- a/common/debug/valgrind/valgrind-libgda.supp
+++ b/common/debug/valgrind/valgrind-libgda.supp
@@ -37,7 +37,7 @@
 #     if Free: name of free-ing fn)
 
 {
-	libgda permanant memory for gda_paramlist_dtd
+	libgda permanent memory for gda_paramlist_dtd
 	Memcheck:Leak
 	fun:malloc
 	fun:xmlStrndup

--- a/common/test-core/test-stuff.h
+++ b/common/test-core/test-stuff.h
@@ -86,7 +86,7 @@ void print_test_results(void);
  * Use this to set whether successful tests
  * should print a message.
  * Default is false.
- * Successful test messages are useful while initally constructing the
+ * Successful test messages are useful while initially constructing the
  * test suite, but when it's completed, no news is good news.
  * A successful test run will be indicated by the message
  * from print_test_results().

--- a/common/test-core/unittest-support.h
+++ b/common/test-core/unittest-support.h
@@ -339,7 +339,7 @@ gboolean test_object_checked_destroy (GObject *obj);
 /**
  * Ensures that a GObject is still alive at the time
  * it's called and that it is finalized. The first assertion will
- * trigger if you pass it a ponter which isn't a GObject -- which
+ * trigger if you pass it a pointer which isn't a GObject -- which
  * could be the case if the object has already been finalized. Then it
  * calls test_object_checked_destroy() on it, asserting if the
  * finalize method wasn't called (which indicates a leak).

--- a/contrib/rapid2gnucash.py
+++ b/contrib/rapid2gnucash.py
@@ -23,7 +23,7 @@ Convert a CSV file exported from Rapid Electronics (UK) to a form importable by 
 Line format is:
 line number,product code,quantity,availability,product description,unit price,discounts,line total,delivery,sub total,vat,grand total
 
-Useage: rapid2gnucash.py  DOWNLOADED_BASKET.csv "ORDER_NUMBER" <"Expense account">  >  output.csv
+Usage: rapid2gnucash.py  DOWNLOADED_BASKET.csv "ORDER_NUMBER" <"Expense account">  >  output.csv
 
 We need to remove first line and totals
 
@@ -46,7 +46,7 @@ try:
 	INV_ID=sys.argv[2]
 except:
 	print "No order number  specified."
-	print "Useage: rapid2gnucash.py  DOWNLOADED_BASKET.csv \"ORDER_NUMBER\""
+	print "Usage: rapid2gnucash.py  DOWNLOADED_BASKET.csv \"ORDER_NUMBER\""
 	quit(1)
 try:
 	ACCOUNT=sys.argv[3]

--- a/doc/examples/taxreport.gnucash
+++ b/doc/examples/taxreport.gnucash
@@ -2116,7 +2116,7 @@
   <act:parent type="guid">ce8a0ff9cfc2c79c99e6c65d5e258a55</act:parent>
 </gnc:account>
 <gnc:account version="2.0.0">
-  <act:name>Pension Contrbution</act:name>
+  <act:name>Pension Contribution</act:name>
   <act:id type="guid">91e7e5e4cd2374c9aca8024cdc1c4997</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
@@ -2929,7 +2929,7 @@
 </gnc:account>
 <gnc:account version="2.0.0">
   <act:name>Federal 
-Witholding</act:name>
+Withholding</act:name>
   <act:id type="guid">2ea59a43e4fa1b7225e3b8896c74713d</act:id>
   <act:type>EXPENSE</act:type>
   <act:commodity>
@@ -3555,7 +3555,7 @@ Witholding</act:name>
   <trn:date-entered>
     <ts:date>2000-09-17 20:34:05 +0200</ts:date>
   </trn:date-entered>
-  <trn:description>Fed Tax Witholding</trn:description>
+  <trn:description>Fed Tax Withholding</trn:description>
   <trn:splits>
     <trn:split>
       <split:id type="guid">7faf50cecbe6d64bd04275aa35974d02</split:id>

--- a/gnucash/gnome-utils/gnc-cell-view.c
+++ b/gnucash/gnome-utils/gnc-cell-view.c
@@ -226,7 +226,7 @@ gcv_start_editing (GtkCellEditable *cell_editable,
     GncCellView *cv = GNC_CELL_VIEW(cell_editable);
     GtkTextIter siter, eiter;
 
-    // Remove the text_view tooltip after 5secs to stop it recuring
+    // Remove the text_view tooltip after 5secs to stop it recurring
     cv->tooltip_id = g_timeout_add (5000, (GSourceFunc) gcv_remove_tooltip, cv);
 
     gtk_text_buffer_get_bounds (cv->buffer, &siter, &eiter);

--- a/gnucash/gnome-utils/gnc-frequency.h
+++ b/gnucash/gnome-utils/gnc-frequency.h
@@ -97,7 +97,7 @@ void gnc_frequency_set_frequency_label_text (GncFrequency *gf, const gchar *txt)
 
 /**
  * Set the label text for the date entry widget. In the current
- * impelmentation, the default label text is "Start Date"
+ * implementation, the default label text is "Start Date"
  */
 void gnc_frequency_set_date_label_text (GncFrequency *gf, const gchar *txt);
 

--- a/gnucash/gnome-utils/gnc-main-window.c
+++ b/gnucash/gnome-utils/gnc-main-window.c
@@ -1410,7 +1410,7 @@ gnc_main_window_quit(GncMainWindow *window)
     {
         GList *w, *next;
 
-        /* This is not a typical list iteration. There is a possability
+        /* This is not a typical list iteration. There is a possibility
          * that the window maybe removed from the active_windows list so
          * we have to cache the 'next' pointer before executing any code
          * in the loop. */

--- a/gnucash/gnome/dialog-print-check.c
+++ b/gnucash/gnome/dialog-print-check.c
@@ -315,7 +315,7 @@ struct _print_check_dialog
 };
 
 
-/* This function walks ths list of available check formats looking for a
+/* This function walks the list of available check formats looking for a
  * specific format as specified by guid number.  If found, a pointer to it is
  * returned to the caller.  Additionally, if the caller passed a pointer to a
  * GtkTreeIter, then the iter for that entry will also be returned.

--- a/gnucash/gnome/dialog-sx-editor.c
+++ b/gnucash/gnome/dialog-sx-editor.c
@@ -751,7 +751,7 @@ check_transaction_splits (Transaction *txn, gpointer data)
                                                sd->tcds))
         {
             gchar *message = g_strdup_printf
-                (_("Split with memo %s has an unparseable Credit Formula."),
+                (_("Split with memo %s has an unparsable Credit Formula."),
                  xaccSplitGetMemo (s));
             split_error_warning_dialog (sd->sxed->dialog,
                                         _("Unparsable Formula in Split"),
@@ -767,7 +767,7 @@ check_transaction_splits (Transaction *txn, gpointer data)
 
         {
             gchar *message = g_strdup_printf
-                (_("Split with memo %s has an unparseable Debit Formula."),
+                (_("Split with memo %s has an unparsable Debit Formula."),
                  xaccSplitGetMemo (s));
             split_error_warning_dialog (sd->sxed->dialog,
                                         _("Unparsable Formula in Split"),

--- a/gnucash/gnome/window-reconcile2.c
+++ b/gnucash/gnome/window-reconcile2.c
@@ -569,7 +569,7 @@ gnc_save_reconcile_interval (Account *account, time64 statement_date)
 
     /*
      * See if we need to remember days(weeks) or months.  The only trick
-     * value is 28 days which could be wither 4 weeks or 1 month.
+     * value is 28 days which could be either 4 weeks or 1 month.
      */
     if (days == 28)
     {

--- a/gnucash/gschemas/pref_transformations.xml
+++ b/gnucash/gschemas/pref_transformations.xml
@@ -22,7 +22,7 @@
 
     <release version="encoded_version">
        ...
-    </releaase>
+    </release>
 
     encoded_version = gnucash_major  * 1000 + gnucash_minor
     For example for gnucash 4.7 encoded_version becomes 4 * 1000 + 7 = 4007

--- a/gnucash/import-export/import-backend.c
+++ b/gnucash/import-export/import-backend.c
@@ -461,7 +461,7 @@ TransactionGetTokens(GNCImportTransInfo *info)
     tokens = tokenize_string(tokens, text);
 
     /* The day of week the transaction occurred is a good indicator of
-     * what account this transaction belongs in.  Get the date and covert
+     * what account this transaction belongs in.  Get the date and convert
      * it to day of week as a token
      */
     transtime = xaccTransGetDate(transaction);

--- a/gnucash/import-export/import-main-matcher.c
+++ b/gnucash/import-export/import-main-matcher.c
@@ -333,7 +333,7 @@ get_trans_info (GtkTreeModel* model, GtkTreeIter* iter)
                         -1);
     return transaction_info;
 }
-/* This fuction find the top matching register transaction for the imported transaction pointed to by iter
+/* This function finds the top matching register transaction for the imported transaction pointed to by iter
  * It then goes through the list of all other imported transactions and creates a list of the ones that
  * have the same register transaction as their top match (i.e., are in conflict). It finds the best of them
  * (match-score-wise) and returns the rest as a list. The imported transactions in that list will get their

--- a/gnucash/import-export/qif-imp/test/test-qif-merge-groups.scm
+++ b/gnucash/import-export/qif-imp/test/test-qif-merge-groups.scm
@@ -87,7 +87,7 @@
           2
           (length (assoc-ref matches new-txn2)))
 
-        (test-equal "test-gnc:account-tree-find-duplicates - 3nd txn matches none"
+        (test-equal "test-gnc:account-tree-find-duplicates - 3rd txn matches none"
           #f
           (assoc-ref matches new-txn3))
 

--- a/gnucash/python/pycons/pycons
+++ b/gnucash/python/pycons/pycons
@@ -113,7 +113,7 @@ def replace (console, canvas, anchor):
 
 # ----------------------------------------------------------------------- refresh
 def refresh(console):
-    """ Refreshs all active canvas  """
+    """ Refreshes all active canvas  """
 
     figures = console.figures
     for fig in figures:
@@ -213,7 +213,7 @@ def insert (console, figure):
 
 # ----------------------------------------------------------------------- refresh
 def refresh(console):
-    """ Refreshs all active canvas  """
+    """ Refreshes all active canvas  """
     figures = console.figures
     for fig in figures:
         figure, canvas, anchor = fig

--- a/gnucash/register/ledger-core/split-register.c
+++ b/gnucash/register/ledger-core/split-register.c
@@ -1490,7 +1490,7 @@ gnc_split_register_save_to_copy_buffer (SplitRegister *reg,
 
     /* use the changed flag to avoid heavy-weight updates
      * of the split & transaction fields. This will help
-     * cut down on unneccessary register redraws. */
+     * cut down on unnecessary register redraws. */
     if (!gnc_table_current_cursor_changed (reg->table, FALSE))
         return FALSE;
 

--- a/libgnucash/app-utils/gnc-ui-util.h
+++ b/libgnucash/app-utils/gnc-ui-util.h
@@ -446,7 +446,7 @@ gchar * gnc_filter_text_for_control_chars (const gchar *incoming_text);
  *
  * @param symbol to remove
  *
- * @param cursor_position the posistion of cursor in the incoming text
+ * @param cursor_position the position of cursor in the incoming text
  *
  * @return nothing
 */
@@ -460,7 +460,7 @@ void gnc_filter_text_set_cursor_position (const gchar *incoming_text,
  *
  * @param symbol to remove
  *
- * @param cursor_position the posistion of cursor in the incoming text
+ * @param cursor_position the position of cursor in the incoming text
  *
  * @return The incoming text with symbol removed to be freed by the caller
 */

--- a/libgnucash/app-utils/options.scm
+++ b/libgnucash/app-utils/options.scm
@@ -496,7 +496,7 @@ the option '~a'."))
        #f)
 
      ;; generate-restore-form
-     ;; "return 'ascii represention of a function'
+     ;; "return 'ascii representation of a function'
      ;; that will set the option passed as its lone parameter
      ;; to the value it was when the picker was first displayed"
      ;;

--- a/libgnucash/backend/xml/test/test-files/xml1/abcall.gml
+++ b/libgnucash/backend/xml/test/test-files/xml1/abcall.gml
@@ -194,7 +194,7 @@
         </split>
         <split>
           <guid>686e0a76ab0ae02b10526729d4309509</guid>
-          <memo>soem as invst</memo>
+          <memo>some as invst</memo>
           <reconcile-state>n</reconcile-state>
           <value>-190000/100</value>
           <quantity>-190000/100</quantity>

--- a/libgnucash/backend/xml/test/test-files/xml2/abcall.gml2
+++ b/libgnucash/backend/xml/test/test-files/xml2/abcall.gml2
@@ -236,7 +236,7 @@
     </trn:split>
     <trn:split>
       <split:id type="guid">686e0a76ab0ae02b10526729d4309509</split:id>
-      <split:memo>soem as invst</split:memo>
+      <split:memo>some as invst</split:memo>
       <split:reconciled-state>n</split:reconciled-state>
       <split:value>-190000/100</split:value>
       <split:quantity>-190000/100</split:quantity>

--- a/libgnucash/engine/Scrub.c
+++ b/libgnucash/engine/Scrub.c
@@ -654,7 +654,7 @@ xaccTransClearTradingSplits (Transaction *trans)
 
     xaccTransBeginEdit (trans);
     /* destroy_splits doesn't actually free the splits but this gets
-     * the list ifself freed.
+     * the list itself freed.
      */
     g_list_free_full (trading_splits, destroy_split);
     xaccTransCommitEdit (trans);

--- a/libgnucash/engine/gnc-numeric.cpp
+++ b/libgnucash/engine/gnc-numeric.cpp
@@ -123,8 +123,8 @@ GncNumeric::GncNumeric(const std::string& str, bool autoround)
     static const std::string hex_frag("(0x[a-f0-9]+)");
     static const std::string slash( "[ \\t]*/[ \\t]*");
     /* The llvm standard C++ library refused to recognize the - in the
-     * numer_frag patter with the default ECMAScript syntax so we use the awk
-     * syntax.
+     * numer_frag pattern with the default ECMAScript syntax so we use the
+     * awk syntax.
      */
     static const regex numeral(numer_frag);
     static const regex hex(hex_frag);

--- a/libgnucash/engine/policy-p.h
+++ b/libgnucash/engine/policy-p.h
@@ -44,7 +44,7 @@
  *  The PolicyGetLot() routine returns a lot into which the
  *     indicated split should be placed.
  *
- *  The PolicyGetSplit() routine returns an unassinged split
+ *  The PolicyGetSplit() routine returns an unassigned split
  *     from the account that is appropriate for placing into the
  *     indicated lot.  For the FIFO policy, that would be the
  *     earliest split that is not in any account, and is of the

--- a/libgnucash/engine/qofquery.h
+++ b/libgnucash/engine/qofquery.h
@@ -115,7 +115,7 @@ typedef enum
 #define QOF_PARAM_VERSION "version"
 
 /* --------------------------------------------------------- */
-/** \name Query Subsystem Initialization and Shudown  */
+/** \name Query Subsystem Initialization and Shutdown  */
 // @{
 /** Subsystem initialization and shutdown. Call init() once
  *  to initialize the query subsystem; call shutdown() to free

--- a/libgnucash/engine/test/gtest-gnc-datetime.cpp
+++ b/libgnucash/engine/test/gtest-gnc-datetime.cpp
@@ -572,7 +572,7 @@ TEST(gnc_datetime_functions, test_date)
 /* This test works only in the America/LosAngeles time zone and
  * there's no straightforward way to make it more flexible. It ensures
  * that DST in that timezone transitions correctly for each day of the
- * week in which March begines.
+ * week in which March begins.
 
  TEST(gnc_datetime_functions, test_timezone_offset)
 {


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,./po,*.min.js,./ChangeLog*,./NEWS,./borrowed,./doc/README*,./AUTHORS,./libgnucash/tax/us/txf-de*,./data/accounts -L ans,ba,cas,dragable,gae,iff,iif,mut,nd,numer,parm,parms,startd,stoll`