### PR TITLE
KvpValue::Type::LIST and KvpFrame <-> SCM

### DIFF
--- a/bindings/guile/test/CMakeLists.txt
+++ b/bindings/guile/test/CMakeLists.txt
@@ -61,6 +61,7 @@ set (scm_tests_with_srfi64_SOURCES
   test-core-utils.scm
   test-business-core.scm
   test-scm-engine.scm
+  test-scm-kvpvalue.scm
   )
 
 if (HAVE_SRFI64)

--- a/bindings/guile/test/test-scm-kvpvalue.scm
+++ b/bindings/guile/test/test-scm-kvpvalue.scm
@@ -1,0 +1,68 @@
+(use-modules (srfi srfi-64))
+(use-modules (tests srfi64-extras))
+(use-modules (gnucash engine))
+(use-modules (gnucash app-utils))
+
+(define (run-test)
+  (test-runner-factory gnc:test-runner)
+  (test-begin "test-app-utils")
+  (test-kvp-access)
+  (test-end "test-app-utils"))
+
+(define (setup book)
+  (qof-book-set-option book "bla" '("top" "lvl1a"))
+  (qof-book-set-option book "arg" '("top" "lvl1b"))
+  (qof-book-set-option book "baf" '("top" "lvl1c" "lvl2" "lvl3")))
+
+(define (teardown)
+  (gnc-clear-current-session))
+
+(define (test-kvp-access)
+  (define book (gnc-get-current-book))
+  (test-begin "kvp-access from guile")
+
+  (setup book)
+
+  (test-equal "top/lvl1a"
+    "bla"
+    (qof-book-get-option book '("top" "lvl1a")))
+
+  (test-equal "top/lvl1b"
+    "arg"
+    (qof-book-get-option book '("top" "lvl1b")))
+
+  (test-equal "top/lvl1c/lvl2/lvl3"
+    "baf"
+    (qof-book-get-option book '("top" "lvl1c" "lvl2" "lvl3")))
+
+  (test-equal "top/lvl1c/lvl2"
+    '(("lvl3" . "baf"))
+    (qof-book-get-option book '("top" "lvl1c" "lvl2")))
+
+  (test-equal "top/lvl1c"
+    '(("lvl2" ("lvl3" . "baf")))
+    (qof-book-get-option book '("top" "lvl1c")))
+
+  ;; this tests the reading & writing of KvpFrame, copying branch
+  ;; from top/lvl1c to top/lvl1d
+  (qof-book-set-option book
+                       (qof-book-get-option book '("top" "lvl1c"))
+                       '("top" "lvl1d"))
+
+  (test-equal "top/lvl1d, after copying from top/lvl1c"
+    '(("lvl2" ("lvl3" . "baf")))
+    (qof-book-get-option book '("top" "lvl1d")))
+
+  (test-equal "top/lvl1c/lvl2/error"
+    #f
+    (qof-book-get-option book '("top" "lvl1c" "lvl2" "error")))
+
+  (test-equal "top"
+    '(("lvl1a" . "bla")
+      ("lvl1b" . "arg")
+      ("lvl1c" ("lvl2" ("lvl3" . "baf")))
+      ("lvl1d" ("lvl2" ("lvl3" . "baf"))))
+    (qof-book-get-option book '("top")))
+
+  (test-end "kvp-access from guile")
+  (teardown))

--- a/libgnucash/engine/kvp-frame.cpp
+++ b/libgnucash/engine/kvp-frame.cpp
@@ -78,6 +78,8 @@ KvpFrame::get_child_frame_or_nullptr (Path const & path) noexcept
     if (map_iter == m_valuemap.end ())
         return nullptr;
     auto child = map_iter->second->get <KvpFrame *> ();
+    if (!child)
+        return nullptr;
     Path send;
     std::copy (path.begin () + 1, path.end (), std::back_inserter (send));
     return child->get_child_frame_or_nullptr (send);

--- a/libgnucash/engine/kvp-frame.hpp
+++ b/libgnucash/engine/kvp-frame.hpp
@@ -226,6 +226,9 @@ struct KvpFrameImpl
     bool empty() const noexcept { return m_valuemap.empty(); }
     friend int compare(const KvpFrameImpl&, const KvpFrameImpl&) noexcept;
 
+    map_type::iterator begin() { return m_valuemap.begin(); }
+    map_type::iterator end() { return m_valuemap.end(); }
+
     private:
     map_type m_valuemap;
 


### PR DESCRIPTION
* ~gncEntry precision bugs~ moved to #1312 
* creates a lispy kvp-frame representation
* avoids segfault when navigating non-existent frame:

```scheme

  (let ((book (gnc-get-current-book)))
    (define (try path)
      (format #t "retrieve ~s ~s\n"
              path (qof-book-get-option book path)))
    (qof-book-set-option book "bla" '("top" "lvl1a"))
    (qof-book-set-option book "arg" '("top" "lvl1b"))
    (qof-book-set-option book "baf" '("top" "lvl1c" "lvl2" "lvl3"))
    (qof-book-set-option book '"baf" '("top" "lvl1c" "lvl2" "lvl3"))
    (qof-book-set-option book #("arg" "1" "2" 3) '("top" "lvl1d"))
    (qof-book-set-option book
                         '(("a" . "alpha")
                           ("b" . "beta")
                           ("c" . "charlie"))
                         '("top" "lvl1e"))
    (try '("top"))
    (try '("top" "lvl1a"))
    (try '("top" "lvl1b"))
    (try '("top" "lvl1c"))
    (try '("top" "lvl1c" "lvl2"))
    (try '("top" "lvl1c" "lvl2" "lvl3"))
    (try '("top" "lvl1c" "lvl2" "error"))
    (try '("top" "lvl1d"))
    (try '("top" "lvl1e"))
    (try '("top" "lvl1e" "a"))
    (try '("top" "error")))
```

outputs

```
retrieve ("top") (("lvl1a" . "bla") ("lvl1b" . "arg") ("lvl1c" ("lvl2" ("lvl3" . "baf"))) ("lvl1d" . #("arg" "1" "2" 3)) ("lvl1e" ("a" . "alpha") ("b" . "beta") ("c" . "charlie")))
retrieve ("top" "lvl1a") "bla"
retrieve ("top" "lvl1b") "arg"
retrieve ("top" "lvl1c") (("lvl2" ("lvl3" . "baf")))
retrieve ("top" "lvl1c" "lvl2") (("lvl3" . "baf"))
retrieve ("top" "lvl1c" "lvl2" "lvl3") "baf"
retrieve ("top" "lvl1c" "lvl2" "error") #f
retrieve ("top" "lvl1d") #("arg" "1" "2" 3)
retrieve ("top" "lvl1e") (("a" . "alpha") ("b" . "beta") ("c" . "charlie"))
retrieve ("top" "lvl1e" "a") "alpha"
retrieve ("top" "error") #f
```
