### PR TITLE
gncEntry and invoice plugin page

### DIFF
--- a/gnucash/register/ledger-core/gncEntryLedger.c
+++ b/gnucash/register/ledger-core/gncEntryLedger.c
@@ -265,22 +265,6 @@ gnc_entry_ledger_config_cells (GncEntryLedger *ledger)
     ((ComboCell *)
      gnc_table_layout_get_cell (ledger->table->layout, ENTRY_ACTN_CELL), FALSE);
 
-    /* Use GNC_COMMODITY_MAX_FRACTION for all prices and quantities */
-    gnc_price_cell_set_fraction
-    ((PriceCell *)
-     gnc_table_layout_get_cell (ledger->table->layout, ENTRY_PRIC_CELL),
-     GNC_COMMODITY_MAX_FRACTION);
-
-    gnc_price_cell_set_fraction
-    ((PriceCell *)
-     gnc_table_layout_get_cell (ledger->table->layout, ENTRY_DISC_CELL),
-     GNC_COMMODITY_MAX_FRACTION);
-
-    gnc_price_cell_set_fraction
-    ((PriceCell *) gnc_table_layout_get_cell (ledger->table->layout,
-            ENTRY_QTY_CELL),
-     GNC_COMMODITY_MAX_FRACTION);
-
     /* add menu items for the action and payment cells */
     gnc_entry_ledger_config_action (ledger);
 }

--- a/gnucash/report/reports/standard/invoice.scm
+++ b/gnucash/report/reports/standard/invoice.scm
@@ -447,7 +447,9 @@ for styling the invoice. Please see the exported report for the CSS class names.
           (addif (quantity-col used-columns)
                  (gnc:make-html-table-cell/markup
                   "number-cell"
-                  (gncEntryGetDocQuantity entry credit-note?)))
+                  (xaccPrintAmount
+                   (gncEntryGetDocQuantity entry credit-note?)
+                   (gnc-default-print-info #f))))
 
           (addif (price-col used-columns)
                  (gnc:make-html-table-cell/markup

--- a/libgnucash/engine/gnc-numeric.cpp
+++ b/libgnucash/engine/gnc-numeric.cpp
@@ -1090,7 +1090,7 @@ gnc_numeric_to_decimal(gnc_numeric *a, guint8 *max_decimal_places)
     }
     catch (const std::exception& err)
     {
-        PWARN("%s", err.what());
+        PINFO ("%s", err.what());
         return FALSE;
     }
 }


### PR DESCRIPTION
* removes rounding for Discount, Quantity allowing input of unrounded numbers
* invoice report shows numbers as fraction or decimal appropriately
* silence gnc-numeric warning