### PR TITLE
[Master] C++options posible fixes

### DIFF
--- a/gnucash/gnome-utils/dialog-options.cpp
+++ b/gnucash/gnome-utils/dialog-options.cpp
@@ -1319,6 +1319,11 @@ void
 BothDateEntry::toggle_relative(bool use_absolute)
 {
     m_use_absolute = use_absolute;
+
+    gtk_widget_set_sensitive(GTK_WIDGET(m_abs_entry->get_widget()),
+                             m_use_absolute);
+    gtk_widget_set_sensitive(GTK_WIDGET(m_rel_entry->get_widget()),
+                             !m_use_absolute);
 }
 
 void
@@ -1334,6 +1339,8 @@ BothDateEntry::set_entry_from_option(GncOption& option)
                                  !m_use_absolute);
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(m_abs_button),
                                  m_use_absolute);
+
+    toggle_relative(m_use_absolute);
 }
 
 void

--- a/gnucash/gnome-utils/dialog-options.cpp
+++ b/gnucash/gnome-utils/dialog-options.cpp
@@ -2021,12 +2021,19 @@ public:
         GncOptionGtkUIItem{widget, GncOptionUIType::NUMBER_RANGE} {}
     void set_ui_item_from_option(GncOption& option) noexcept override
     {
-        gtk_spin_button_set_value(GTK_SPIN_BUTTON(get_widget()),
-                                  option.get_value<double>());
+        if (option.is_alternate())
+            gtk_spin_button_set_value(GTK_SPIN_BUTTON(get_widget()),
+                                      option.get_value<int>());
+        else
+            gtk_spin_button_set_value(GTK_SPIN_BUTTON(get_widget()),
+                                      option.get_value<double>());
     }
     void set_option_from_ui_item(GncOption& option) noexcept override
     {
-        option.set_value<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get_widget())));
+        if (option.is_alternate())
+            option.set_value<int>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get_widget())));
+        else
+            option.set_value<double>(gtk_spin_button_get_value(GTK_SPIN_BUTTON(get_widget())));
     }
 };
 
@@ -2042,7 +2049,19 @@ create_range_spinner(GncOption& option)
     gdouble upper_bound = G_MAXDOUBLE;
     gdouble step_size = 1.0;
 
-    option.get_limits(upper_bound, lower_bound, step_size);
+    if (option.is_alternate())
+    {
+        int tmp_lower_bound = G_MININT;
+        int tmp_upper_bound = G_MAXINT;
+        int tmp_step_size = 1.0;
+        option.get_limits<int>(tmp_upper_bound, tmp_lower_bound, tmp_step_size);
+        lower_bound =(double)tmp_lower_bound;
+        upper_bound = (double)tmp_upper_bound;
+        step_size = (double)tmp_step_size;
+    }
+    else
+        option.get_limits<double>(upper_bound, lower_bound, step_size);
+
     auto adj = GTK_ADJUSTMENT(gtk_adjustment_new(lower_bound, lower_bound,
                                                  upper_bound, step_size,
                                                  step_size * 5.0,

--- a/gnucash/gnome-utils/dialog-options.cpp
+++ b/gnucash/gnome-utils/dialog-options.cpp
@@ -1248,7 +1248,6 @@ RelativeDateEntry::set_option_from_entry(GncOption& option)
 void
 RelativeDateEntry::block_signals(bool block)
 {
-    auto entry{G_OBJECT(GNC_DATE_EDIT(m_entry)->date_entry)};
     if (block)
         g_signal_handler_block(m_entry, m_handler_id);
     else

--- a/gnucash/gnome-utils/dialog-options.cpp
+++ b/gnucash/gnome-utils/dialog-options.cpp
@@ -2691,10 +2691,12 @@ public:
     {
         GtkTreeIter iter;
         auto widget{GTK_COMBO_BOX(get_widget())};
-        gtk_combo_box_get_active_iter(widget, &iter);
-        auto tree_model{gtk_combo_box_get_model(widget)};
-        auto budget{gnc_tree_model_budget_get_budget(tree_model, &iter)};
-        option.set_value(qof_instance_cast(budget));
+        if (gtk_combo_box_get_active_iter(widget, &iter))
+        {
+            auto tree_model{gtk_combo_box_get_model(widget)};
+            auto budget{gnc_tree_model_budget_get_budget(tree_model, &iter)};
+            option.set_value(qof_instance_cast(budget));
+        }
     }
 };
 

--- a/gnucash/gnome-utils/dialog-options.cpp
+++ b/gnucash/gnome-utils/dialog-options.cpp
@@ -1365,7 +1365,7 @@ class GncOptionDateUIItem : public GncOptionGtkUIItem
 {
 public:
     GncOptionDateUIItem(GncDateEntryPtr entry, GncOptionUIType type) :
-        GncOptionGtkUIItem{nullptr, type}, m_entry{std::move(entry)} { }
+        GncOptionGtkUIItem{entry->get_widget(), type}, m_entry{std::move(entry)} { }
     ~GncOptionDateUIItem() = default;
     void clear_ui_item() override { m_entry = nullptr; }
     void set_ui_item_from_option(GncOption& option) noexcept override

--- a/gnucash/gnome-utils/dialog-options.cpp
+++ b/gnucash/gnome-utils/dialog-options.cpp
@@ -1986,11 +1986,6 @@ create_list_widget(GncOption& option, char *name)
 
     g_object_set (G_OBJECT(hbox), "margin", 3, NULL);
 
-    option.set_ui_item(std::make_unique<GncGtkListUIItem>(GTK_WIDGET(view)));
-    option.set_ui_item_from_option();
-
-    gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(view), FALSE, FALSE, 0);
-
     return frame;
 }
 

--- a/gnucash/gnome-utils/dialog-options.cpp
+++ b/gnucash/gnome-utils/dialog-options.cpp
@@ -647,7 +647,7 @@ component_close_handler (gpointer data)
 /** Constructs a GncOptionsDialog
  *
  * Based on the description in the GtkBuilder file. Initializes signals.
- * Two component classes might be used, DIALOG_BOOK_OPTIONS_CM_CLASS or DIALOG_OPTIONS_CM_CLASS of which the latter is the default. 
+ * Two component classes might be used, DIALOG_BOOK_OPTIONS_CM_CLASS or DIALOG_OPTIONS_CM_CLASS of which the latter is the default.
  *
  * @param modal: If true the "Apply" button is hidden. It doesn't make the dialog run in its own event loop so it's not truly modal.
  * @param title: The title that will appear in the dialog's title bar.
@@ -2642,9 +2642,9 @@ create_option_widget<GncOptionUIType::PLOT_SIZE> (GncOption& option,
     g_signal_connect(G_OBJECT(value_percent), "changed",
                      G_CALLBACK(gnc_option_changed_widget_cb), &option);
     g_signal_connect(G_OBJECT(px_butt), "toggled",
-                         G_CALLBACK(gnc_rd_option_px_set_cb), &option);
+                     G_CALLBACK(gnc_rd_option_px_set_cb), &option);
     g_signal_connect(G_OBJECT(p_butt), "toggled",
-                         G_CALLBACK(gnc_rd_option_p_set_cb), &option);
+                     G_CALLBACK(gnc_rd_option_p_set_cb), &option);
 
     gtk_container_add(GTK_CONTAINER(*enclosing), hbox);
     gtk_widget_show_all(*enclosing);

--- a/gnucash/gnome-utils/dialog-options.cpp
+++ b/gnucash/gnome-utils/dialog-options.cpp
@@ -304,18 +304,12 @@ gnc_option_set_ui_widget(GncOption& option, GtkGrid *page_box, gint grid_row)
     }
     if (!packed && (enclosing != NULL))
     {
-        /* Pack option widget into an extra eventbox because otherwise the
-           "documentation" tooltip is not displayed. */
-        GtkWidget *eventbox = gtk_event_box_new();
-
-        gtk_container_add (GTK_CONTAINER (eventbox), enclosing);
-
         /* attach the option widget to the second column of the grid */
-        gtk_grid_attach (GTK_GRID(page_box), eventbox,
+        gtk_grid_attach (GTK_GRID(page_box), enclosing,
                          1, grid_row, // left, top
                          1, 1);  // width, height
 
-        gtk_widget_set_tooltip_text (eventbox, documentation);
+        gtk_widget_set_tooltip_text (enclosing, documentation);
     }
 
     if (value != NULL)
@@ -1462,15 +1456,10 @@ create_date_option_widget(GncOption& option, GtkGrid *page_box,
 
     gtk_widget_set_halign (GTK_WIDGET(*enclosing), GTK_ALIGN_START);
 
-    /* Pack option widget into an extra eventbox because otherwise the
-       "documentation" tooltip is not displayed. */
-    auto eventbox = gtk_event_box_new();
-    gtk_container_add (GTK_CONTAINER (eventbox), *enclosing);
-
-    gtk_grid_attach (GTK_GRID(page_box), eventbox, 1, grid_row, 1, 1);
+    gtk_grid_attach (GTK_GRID(page_box), *enclosing, 1, grid_row, 1, 1);
     *packed = TRUE;
 
-    gtk_widget_set_tooltip_text (eventbox, documentation);
+    gtk_widget_set_tooltip_text (*enclosing, documentation);
 
     auto ui_item{dynamic_cast<GncOptionDateUIItem*>(option.get_ui_item())};
     if (auto date_ui{ui_item ? ui_item->get_entry() : nullptr})
@@ -2020,15 +2009,10 @@ create_option_widget<GncOptionUIType::LIST> (GncOption& option,
 
     align_label (name_label);
 
-    /* Pack option widget into an extra eventbox because otherwise the
-       "documentation" tooltip is not displayed. */
-    auto eventbox = gtk_event_box_new();
-    gtk_container_add (GTK_CONTAINER (eventbox), *enclosing);
-
-    gtk_grid_attach (GTK_GRID(page_box), eventbox, 1, grid_row, 1, 1);
+    gtk_grid_attach (GTK_GRID(page_box), *enclosing, 1, grid_row, 1, 1);
     *packed = TRUE;
 
-    gtk_widget_set_tooltip_text(eventbox, documentation);
+    gtk_widget_set_tooltip_text(*enclosing, documentation);
 
     gtk_widget_show(*enclosing);
     return value;

--- a/gnucash/gnome-utils/dialog-options.cpp
+++ b/gnucash/gnome-utils/dialog-options.cpp
@@ -976,15 +976,16 @@ public:
     void set_ui_item_from_option(GncOption& option) noexcept override
     {
         auto widget{GNC_CURRENCY_EDIT(get_widget())};
-        auto instance{option.get_value<const QofInstance*>()};
-        if (instance)
-            gnc_currency_edit_set_currency(widget, GNC_COMMODITY(instance));
+        auto currency{option.get_value<gnc_commodity*>()};
+
+        if (currency)
+            gnc_currency_edit_set_currency(widget, GNC_COMMODITY(currency));
     }
     void set_option_from_ui_item(GncOption& option) noexcept override
     {
         auto widget{GNC_CURRENCY_EDIT(get_widget())};
         auto currency = gnc_currency_edit_get_currency(widget);
-        option.set_value(qof_instance_cast(currency));
+        option.set_value<gnc_commodity*>(currency);
     }
 };
 
@@ -1016,15 +1017,16 @@ public:
     void set_ui_item_from_option(GncOption& option) noexcept override
     {
         auto widget{GNC_GENERAL_SELECT(get_widget())};
-        auto instance{option.get_value<const QofInstance*>()};
-        if (instance)
-            gnc_general_select_set_selected(widget, GNC_COMMODITY(instance));
+        auto commodity{option.get_value<gnc_commodity*>()};
+
+        if (commodity)
+            gnc_general_select_set_selected(widget, GNC_COMMODITY(commodity));
     }
     void set_option_from_ui_item(GncOption& option) noexcept override
     {
         auto widget{GNC_GENERAL_SELECT(get_widget())};
         auto commodity{gnc_general_select_get_selected(widget)};
-        option.set_value(qof_instance_cast(commodity));
+        option.set_value<gnc_commodity*>(GNC_COMMODITY(commodity));
     }
 };
 

--- a/gnucash/gnome-utils/dialog-options.cpp
+++ b/gnucash/gnome-utils/dialog-options.cpp
@@ -1893,6 +1893,7 @@ public:
     {
         auto widget{GTK_TREE_VIEW(get_widget())};
         auto selection{gtk_tree_view_get_selection(widget)};
+        g_signal_handlers_block_by_func(selection, (gpointer)list_changed_cb, &option);
         gtk_tree_selection_unselect_all(selection);
         for (auto index : option.get_value<GncMultichoiceOptionIndexVec>())
         {
@@ -1900,6 +1901,7 @@ public:
             gtk_tree_selection_select_path(selection, path);
             gtk_tree_path_free(path);
         }
+        g_signal_handlers_unblock_by_func(selection, (gpointer)list_changed_cb, &option);
     }
     void set_option_from_ui_item(GncOption& option) noexcept override
     {

--- a/gnucash/gnome-utils/dialog-options.cpp
+++ b/gnucash/gnome-utils/dialog-options.cpp
@@ -506,7 +506,6 @@ void GncOptionsDialog::call_apply_cb() noexcept
     if (m_apply_cb)
         (m_apply_cb)(this, m_apply_cb_data);
     m_close_cb = close_cb;
-    gnc_save_window_size (GNC_PREFS_GROUP, GTK_WINDOW(m_window));
     set_sensitive(false);
 }
 
@@ -518,7 +517,6 @@ void GncOptionsDialog::call_help_cb() noexcept
 
 void GncOptionsDialog::call_close_cb() noexcept
 {
-    gnc_save_window_size (GNC_PREFS_GROUP, GTK_WINDOW(m_window));
     if (m_close_cb)
     {
         gtk_window_close(GTK_WINDOW(m_window));
@@ -556,6 +554,7 @@ dialog_help_button_cb(GtkWidget * widget, GncOptionsDialog *win)
 static void
 dialog_cancel_button_cb(GtkWidget * widget, GncOptionsDialog *win)
 {
+    gnc_save_window_size (GNC_PREFS_GROUP, GTK_WINDOW(win->get_widget()));
     win->call_close_cb();
 }
 
@@ -563,6 +562,7 @@ dialog_cancel_button_cb(GtkWidget * widget, GncOptionsDialog *win)
 static void
 dialog_apply_button_cb(GtkWidget * widget, GncOptionsDialog *win)
 {
+    gnc_save_window_size (GNC_PREFS_GROUP, GTK_WINDOW(win->get_widget()));
     win->call_apply_cb();
 }
 
@@ -645,7 +645,6 @@ static void
 component_close_handler (gpointer data)
 {
     GncOptionsDialog *win = static_cast<decltype(win)>(data);
-    gnc_save_window_size (GNC_PREFS_GROUP, GTK_WINDOW(win->get_widget()));
     dialog_cancel_button_cb (NULL, win);
 }
 

--- a/gnucash/gnome-utils/dialog-options.cpp
+++ b/gnucash/gnome-utils/dialog-options.cpp
@@ -214,7 +214,9 @@ dialog_changed_internal (GtkWidget *widget, bool sensitive)
     auto option_win =
         static_cast<GncOptionsDialog*>(g_object_get_data(G_OBJECT(toplevel),
                                                      "optionwin"));
-    option_win->set_sensitive(sensitive);
+
+    if (option_win) // this null when part of assistant
+        option_win->set_sensitive(sensitive);
 }
 
 void

--- a/gnucash/gnome-utils/dialog-options.cpp
+++ b/gnucash/gnome-utils/dialog-options.cpp
@@ -2186,15 +2186,15 @@ public:
         GncOptionGtkUIItem{widget, GncOptionUIType::FONT} {}
     void set_ui_item_from_option(GncOption& option) noexcept override
     {
-        GtkFontButton *font_button = GTK_FONT_BUTTON(get_widget());
-        gtk_font_button_set_font_name(font_button,
+        GtkFontChooser *font_chooser = GTK_FONT_CHOOSER(get_widget());
+        gtk_font_chooser_set_font(font_chooser,
                                       option.get_value<std::string>().c_str());
 
     }
     void set_option_from_ui_item(GncOption& option) noexcept override
     {
-        GtkFontButton *font_button = GTK_FONT_BUTTON(get_widget());
-        option.set_value(std::string{gtk_font_button_get_font_name(font_button)});
+        GtkFontChooser *font_chooser = GTK_FONT_CHOOSER(get_widget());
+        option.set_value(std::string{gtk_font_chooser_get_font(font_chooser)});
     }
 };
 

--- a/gnucash/gnome-utils/dialog-options.cpp
+++ b/gnucash/gnome-utils/dialog-options.cpp
@@ -1828,13 +1828,13 @@ create_option_widget<GncOptionUIType::ACCOUNT_SEL> (GncOption& option,
     gnc_account_sel_set_acct_filters(GNC_ACCOUNT_SEL(widget),
                                      acct_type_list, NULL);
     g_list_free(acct_type_list);
-    g_signal_connect(widget, "account_sel_changed",
-                     G_CALLBACK(gnc_option_changed_widget_cb), &option);
 
-
-// gnc_account_sel doesn't emit a changed signal
+    // gnc_account_sel doesn't emit a changed signal
     option.set_ui_item(std::make_unique<GncGtkAccountSelUIItem>(widget));
     option.set_ui_item_from_option();
+
+    g_signal_connect(widget, "account_sel_changed",
+                     G_CALLBACK(gnc_option_changed_widget_cb), &option);
 
     *enclosing = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
     gtk_box_set_homogeneous (GTK_BOX (*enclosing), FALSE);

--- a/gnucash/gnome/assistant-hierarchy.cpp
+++ b/gnucash/gnome/assistant-hierarchy.cpp
@@ -130,18 +130,23 @@ typedef struct
 
 } hierarchy_data;
 
-void on_prepare (GtkAssistant  *assistant, GtkWidget *page,
-                 hierarchy_data  *data);
+extern "C"
+{
+void on_prepare (GtkAssistant *assistant, GtkWidget *page,
+                 hierarchy_data *data);
+
+void on_cancel (GtkAssistant *gtkassistant, hierarchy_data *data);
+void on_finish (GtkAssistant *gtkassistant, hierarchy_data *data);
+
+void select_all_clicked (GtkButton *button,
+                         hierarchy_data *data);
+void clear_all_clicked (GtkButton *button,
+                        hierarchy_data *data);
+}
+
 void on_choose_account_categories_prepare (hierarchy_data  *data);
-void select_all_clicked (GtkButton       *button,
-                         hierarchy_data  *data);
-void clear_all_clicked (GtkButton       *button,
-                        hierarchy_data  *data);
 void on_final_account_prepare (hierarchy_data  *data);
 void on_select_currency_prepare (hierarchy_data  *data);
-void on_cancel (GtkAssistant      *gtkassistant, hierarchy_data *data);
-void on_finish (GtkAssistant  *gtkassistant, hierarchy_data *data);
-
 
 static void add_one_category (GncExampleAccount *acc, hierarchy_data *data);
 static void categories_page_enable_next (hierarchy_data *data);

--- a/gnucash/gnome/business-options-gnome.cpp
+++ b/gnucash/gnome/business-options-gnome.cpp
@@ -167,6 +167,9 @@ public:
         if (taxtable)
             gnc_simple_combo_set_value(GTK_COMBO_BOX(get_widget()),
                                        GNC_TAXTABLE(taxtable));
+        else
+            gnc_simple_combo_set_value(GTK_COMBO_BOX(get_widget()),
+                                       nullptr);
     }
     void set_option_from_ui_item(GncOption& option) noexcept override
     {

--- a/gnucash/report/options-utilities.scm
+++ b/gnucash/report/options-utilities.scm
@@ -157,7 +157,7 @@
    (gnc:make-number-plot-size-option
     pagename name-width
     (string-append sort-tag "a")
-    (N_ "Width of plot in pixels.") default-width
+    (N_ "Width of plot, 10 - 100 in percent, above in pixels.") default-width
     100 20000 0 5))
 
   (gnc:register-option
@@ -165,7 +165,7 @@
    (gnc:make-number-plot-size-option
     pagename name-height
     (string-append sort-tag "b")
-    (N_ "Height of plot in pixels.") default-height
+    (N_ "Height of plot, 10 - 100 in percent, above in pixels.") default-height
     100 20000 0 5)))
 
 ;; A multicoice option for the marker of a scatter plot.

--- a/libgnucash/app-utils/gnc-option-impl.cpp
+++ b/libgnucash/app-utils/gnc-option-impl.cpp
@@ -587,7 +587,7 @@ qof_instance_from_guid(GncGUID* guid, GncOptionUIType type)
             qof_type = "gncInvoice";
             break;
         case GncOptionUIType::TAX_TABLE:
-            qof_type = "gncTaxtable";
+            qof_type = "gncTaxTable";
             break;
         case GncOptionUIType::ACCOUNT_LIST:
         case GncOptionUIType::ACCOUNT_SEL:

--- a/libgnucash/app-utils/gnc-option-impl.cpp
+++ b/libgnucash/app-utils/gnc-option-impl.cpp
@@ -224,7 +224,7 @@ GncOptionCommodityValue::reset_default_value()
 bool
 GncOptionCommodityValue::is_changed() const noexcept
 {
-    return m_namespace == m_default_namespace && m_mnemonic == m_default_mnemonic;
+    return m_namespace != m_default_namespace || m_mnemonic != m_default_mnemonic;
 }
 
 bool

--- a/libgnucash/app-utils/gnc-option-impl.hpp
+++ b/libgnucash/app-utils/gnc-option-impl.hpp
@@ -335,8 +335,9 @@ public:
         OptionClassifier{section, name, key, doc_string},
         m_value{value >= min && value <= max ? value : min},
         m_default_value{value >= min && value <= max ? value : min},
-        m_min{min}, m_max{max}, m_step{step} {}
-
+        m_min{min}, m_max{max}, m_step{step} {
+           if constexpr(is_same_decayed_v<ValueType, int>)
+                set_alternate(true);}
     GncOptionRangeValue<ValueType>(const GncOptionRangeValue<ValueType>&) = default;
     GncOptionRangeValue<ValueType>(GncOptionRangeValue<ValueType>&&) = default;
     GncOptionRangeValue<ValueType>& operator=(const GncOptionRangeValue<ValueType>&) = default;
@@ -369,10 +370,7 @@ public:
     GncOptionUIType get_ui_type() const noexcept { return m_ui_type; }
     void make_internal() { m_ui_type = GncOptionUIType::INTERNAL; }
     bool is_alternate() const noexcept { return m_alternate; }
-    void set_alternate(bool value) noexcept {
-        if (m_ui_type == GncOptionUIType::PLOT_SIZE)
-            m_alternate = value;
-    }
+    void set_alternate(bool value) noexcept { m_alternate = value; }
     std::string serialize() const noexcept;
     bool deserialize(const std::string& str) noexcept;
 private:

--- a/libgnucash/app-utils/gnc-optiondb.i
+++ b/libgnucash/app-utils/gnc-optiondb.i
@@ -1346,8 +1346,7 @@ inline SCM return_scm_value(ValueType value)
                             if (scm_is_string(new_value))
                             {
                                  auto strval{scm_to_utf8_string(new_value)};
-                                 auto val{qof_instance_from_string(strval, option.get_ui_type())};
-                                 option.set_value(GNC_COMMODITY(val));
+                                 option.deserialize(strval);
                                  return;
                             }
                             option.set_value(scm_to_value<gnc_commodity*>(new_value));

--- a/libgnucash/app-utils/options.scm
+++ b/libgnucash/app-utils/options.scm
@@ -255,7 +255,7 @@
 (define-public (gnc:make-number-plot-size-option section name key docstring default min max dec-places step)
   (issue-deprecation-warning "gnc:make-number-plot-size-option is deprecated. Make and register the option in one command with gnc-register-plot-size-range-option.")
   ;; Ignore what the call asks for, only 10-100% makes sense.
-  (gnc-make-plot-size-option section name key docstring 100 10 100 1))
+  (gnc-make-plot-size-option section name key docstring 100 10 2000 1))
 (define-public (gnc:make-query-option section name default)
   (issue-deprecation-warning "gnc:make-query-option is deprecated. Make and register the option in one command with gnc-register-query-option.")
   (let ((defv (if (list? default) default (gnc-query2scm default))))


### PR DESCRIPTION
@jralls  I have been looking at the new C++ options in master and have tried to fix a couple of additional errors I found so created this PR. Apart from the 'FancyDate' one, there is one I have come across that can not see where it is going wrong.

That is 'Plot Size', first off I did not realize it had changed so looking in wrong area. In the dialog, the plot size widget is 309 characters wide. I see that gnc_make_plot_size_option is getting the correct 'int' values but when it tries to create a GncOptionUIType::NUMBER_RANGE calling create_range_spinner,  the values returned do not match with the upper_bound being the very large number.