### PR TITLE
[account.cpp] restore breadthwise search for 2 functions

### DIFF
--- a/libgnucash/engine/Account.cpp
+++ b/libgnucash/engine/Account.cpp
@@ -3048,6 +3048,30 @@ gnc_account_get_descendants_sorted (const Account *account)
     return g_list_reverse (list);
 }
 
+// because gnc_account_lookup_by_name and gnc_account_lookup_by_code
+// are described in Account.h searching breadth-first until 4.6, and
+// accidentally modified to search depth-first from 4.7
+// onwards. Restore breath-first searching in 4.11 onwards to match
+// previous behaviour and function description in Account.h
+static gpointer
+account_foreach_descendant_breadthfirst_until (const Account *acc,
+                                               AccountCb2 thunk,
+                                               gpointer user_data)
+{
+    gpointer result {nullptr};
+
+    g_return_val_if_fail (GNC_IS_ACCOUNT(acc), nullptr);
+    g_return_val_if_fail (thunk, nullptr);
+
+    for (auto node = GET_PRIVATE(acc)->children; !result && node; node = node->next)
+        result = thunk (static_cast<Account*>(node->data), user_data);
+
+    for (auto node = GET_PRIVATE(acc)->children; !result && node; node = node->next)
+        result = account_foreach_descendant_breadthfirst_until (static_cast<Account*>(node->data), thunk, user_data);
+
+    return result;
+}
+
 static gpointer
 is_acct_name (Account *account, gpointer user_data)
 {
@@ -3058,7 +3082,7 @@ is_acct_name (Account *account, gpointer user_data)
 Account *
 gnc_account_lookup_by_name (const Account *parent, const char * name)
 {
-    return (Account*)gnc_account_foreach_descendant_until (parent, is_acct_name, (char*)name);
+    return (Account*)account_foreach_descendant_breadthfirst_until (parent, is_acct_name, (char*)name);
 }
 
 static gpointer
@@ -3071,7 +3095,7 @@ is_acct_code (Account *account, gpointer user_data)
 Account *
 gnc_account_lookup_by_code (const Account *parent, const char * code)
 {
-    return (Account*)gnc_account_foreach_descendant_until (parent, is_acct_code, (char*)code);
+    return (Account*)account_foreach_descendant_breadthfirst_until (parent, is_acct_code, (char*)code);
 }
 
 static gpointer

--- a/libgnucash/engine/test/utest-Account.cpp
+++ b/libgnucash/engine/test/utest-Account.cpp
@@ -195,6 +195,17 @@ static AccountParms complex_accts[] =
 
 };
 
+static AccountParms complex_accts_duplicated[] =
+{
+    {ACCT_TYPE_EXPENSE, "A", "root", "1A", "", "", "", "", NULL},
+    {ACCT_TYPE_EXPENSE, "B", "root", "1B", "", "", "", "", NULL},
+    {ACCT_TYPE_EXPENSE, "C", "root", "1C", "", "", "", "", NULL},
+    {ACCT_TYPE_EXPENSE, "D", "A", "2D", "", "", "", "", NULL},
+    {ACCT_TYPE_EXPENSE, "E", "B", "2E", "", "", "", "", NULL},
+    {ACCT_TYPE_EXPENSE, "F", "C", "2F", "", "", "", "", NULL},
+    {ACCT_TYPE_EXPENSE, "B", "D", "3B", "", "", "", "", NULL},
+};
+
 static TxnParms lot_txns[] =
 {
     {
@@ -256,6 +267,10 @@ static TxnParms lot_txns[] =
 static SetupData complex = {G_N_ELEMENTS (complex_accts),
                             (AccountParms**)(&complex_accts), 0, NULL
                            };
+
+static SetupData complex_duplicated = {G_N_ELEMENTS (complex_accts_duplicated),
+    (AccountParms**)(&complex_accts_duplicated), 0, NULL
+};
 
 static SetupData complex_data = {G_N_ELEMENTS (complex_accts),
                                  (AccountParms**)(&complex_accts),
@@ -1885,6 +1900,24 @@ test_gnc_account_lookup_by_name (Fixture *fixture, gconstpointer pData)
     g_free (code);
 
 }
+
+/* gnc_account_lookup_by_name
+Account *
+gnc_account_lookup_by_name_duplicated (const Account *parent, const char * name)
+ */
+static void
+test_gnc_account_lookup_by_name_duplicated (Fixture *fixture, gconstpointer pData)
+{
+    Account *root, *target;
+    gchar *code;
+    root = gnc_account_get_root (fixture->acct);
+    target = gnc_account_lookup_by_name (root, "B");
+    g_assert (target != NULL);
+    g_object_get (target, "code", &code, NULL);
+    g_assert_cmpstr (code, == , "1B");
+    g_free (code);
+}
+
 /* gnc_account_lookup_by_code
 Account *
 gnc_account_lookup_by_code (const Account *parent, const char * code)// C: 5 in 3 */
@@ -2789,6 +2822,7 @@ test_suite_account (void)
     GNC_TEST_ADD (suitename, "gnc account get descendants", Fixture, &complex, setup, test_gnc_account_get_descendants,  teardown );
     GNC_TEST_ADD (suitename, "gnc account get descendants sorted", Fixture, &complex, setup, test_gnc_account_get_descendants_sorted,  teardown );
     GNC_TEST_ADD (suitename, "gnc account lookup by name", Fixture, &complex, setup, test_gnc_account_lookup_by_name,  teardown );
+    GNC_TEST_ADD (suitename, "gnc account lookup by name - duplicated", Fixture, &complex_duplicated, setup, test_gnc_account_lookup_by_name_duplicated,  teardown );
     GNC_TEST_ADD (suitename, "gnc account lookup by code", Fixture, &complex, setup, test_gnc_account_lookup_by_code,  teardown );
     GNC_TEST_ADD (suitename, "gnc account lookup by full name helper", Fixture, &complex, setup, test_gnc_account_lookup_by_full_name_helper,  teardown );
     GNC_TEST_ADD (suitename, "gnc account lookup by full name", Fixture, &complex, setup, test_gnc_account_lookup_by_full_name,  teardown );


### PR DESCRIPTION
gnc_account_lookup_by_name and gnc_account_lookup_by_code were searching breadthwise.

as reported in https://github.com/Gnucash/gnucash/pull/1101#issuecomment-1098146573