### PR TITLE
Bug 798501 - Balance wrong date end of account period

### DIFF
--- a/libgnucash/engine/gnc-date.cpp
+++ b/libgnucash/engine/gnc-date.cpp
@@ -1532,17 +1532,13 @@ gnc_gdate_set_quarter_start (GDate *date)
 void
 gnc_gdate_set_quarter_end (GDate *date)
 {
-    gint months;
+     const GDateMonth months[] = {G_DATE_MARCH, G_DATE_JUNE,
+                                  G_DATE_SEPTEMBER, G_DATE_DECEMBER};
+     const GDateDay days[] = {31, 30, 30, 31};
+     int quarter = (g_date_get_month (date) - 1) / 3;
 
-    /* Set the date to the first day of the specified month. */
-    g_date_set_day(date, 1);
-
-    /* Add 1-3 months to get the first day of the next quarter.*/
-    months = (g_date_get_month(date) - G_DATE_JANUARY) % 3;
-    g_date_add_months(date, 3 - months);
-
-    /* Now back up one day */
-    g_date_subtract_days(date, 1);
+     g_date_set_month (date, months[quarter]);
+     g_date_set_day (date, days[quarter]);
 }
 
 void
@@ -1555,8 +1551,8 @@ gnc_gdate_set_prev_quarter_start (GDate *date)
 void
 gnc_gdate_set_prev_quarter_end (GDate *date)
 {
-    gnc_gdate_set_quarter_end(date);
     g_date_subtract_months(date, 3);
+    gnc_gdate_set_quarter_end(date);
 }
 
 /* ================================================= */

--- a/libgnucash/engine/gnc-date.h
+++ b/libgnucash/engine/gnc-date.h
@@ -702,7 +702,7 @@ void gnc_gdate_set_prev_month_end (GDate *date);
 
 /** This function modifies a GDate to set it to the first day of the
  *  quarter in which it falls.  For example, if this function is called
- *  with a date of 2003-09-24 the date will be modified to 2003-09-01.
+ *  with a date of 2003-09-24 the date will be modified to 2003-07-01.
  *
  *  @param date The GDate to modify. */
 void gnc_gdate_set_quarter_start (GDate *date);
@@ -710,7 +710,7 @@ void gnc_gdate_set_quarter_start (GDate *date);
 
 /** This function modifies a GDate to set it to the last day of the
  *  quarter in which it falls.  For example, if this function is called
- *  with a date of 2003-09-24 the date will be modified to 2003-12-31.
+ *  with a date of 2003-09-24 the date will be modified to 2003-09-30.
  *
  *  @param date The GDate to modify. */
 void gnc_gdate_set_quarter_end (GDate *date);
@@ -719,7 +719,7 @@ void gnc_gdate_set_quarter_end (GDate *date);
 /** This function modifies a GDate to set it to the first day of the
  *  quarter prior to the one in which it falls.  For example, if this
  *  function is called with a date of 2003-09-24 the date will be
- *  modified to 2003-06-01.
+ *  modified to 2003-04-01.
  *
  *  @param date The GDate to modify. */
 void gnc_gdate_set_prev_quarter_start (GDate *date);
@@ -728,7 +728,7 @@ void gnc_gdate_set_prev_quarter_start (GDate *date);
 /** This function modifies a GDate to set it to the last day of the
  *  quarter prior to the one in which it falls.  For example, if this
  *  function is called with a date of 2003-09-24 the date will be
- *  modified to 2003-07-31.
+ *  modified to 2003-06-30.
  *
  *  @param date The GDate to modify. */
 void gnc_gdate_set_prev_quarter_end (GDate *date);


### PR DESCRIPTION
With the accounting period preference settings set to 'Start/End of previous quarter' and balance sheet report using 'End of accounting period' the date is wrong, currently is 30/03/2022 when it should be 31/03/2022.

I fixed this by changing `gnc_gdate_set_prev_quarter_end` to make sure date is month end.
I think it looks correct/OK to me but after a second opinion as I am not really up on financial matters.

For the way the date was calculated... 
`gnc_gdate_set_prev_quarter_end` calls `gnc_gdate_set_quarter_end` and this function changes the date in the following way...
starts of as 01/04/2022
changes to 01/07/2022
changes to 30/06/2022
and then `gnc_gdate_set_prev_quarter_end` would subtract 3 months to get
30/03/2022
