### PR TITLE
Bug798475 - GNCAccountSel could have shortcuts

### DIFF
--- a/gnucash/gnome-utils/dialog-book-close.c
+++ b/gnucash/gnome-utils/dialog-book-close.c
@@ -351,7 +351,6 @@ void gnc_ui_close_book (QofBook* book, GtkWindow *parent)
     equity_list = g_list_prepend(equity_list, GINT_TO_POINTER(ACCT_TYPE_EQUITY));
     box = GTK_WIDGET(gtk_builder_get_object (builder, "income_acct_box"));
     cbw->income_acct_widget = gnc_account_sel_new();
-    gnc_account_sel_set_hexpand (GNC_ACCOUNT_SEL(cbw->income_acct_widget), TRUE);
     gnc_account_sel_set_acct_filters(GNC_ACCOUNT_SEL(cbw->income_acct_widget),
                                      equity_list, NULL);
     gnc_account_sel_set_new_account_ability(GNC_ACCOUNT_SEL(cbw->income_acct_widget), TRUE);
@@ -360,7 +359,6 @@ void gnc_ui_close_book (QofBook* book, GtkWindow *parent)
     /* expense acct */
     box = GTK_WIDGET(gtk_builder_get_object (builder, "expense_acct_box"));
     cbw->expense_acct_widget = gnc_account_sel_new();
-    gnc_account_sel_set_hexpand (GNC_ACCOUNT_SEL(cbw->expense_acct_widget), TRUE);
     gnc_account_sel_set_acct_filters(GNC_ACCOUNT_SEL(cbw->expense_acct_widget),
                                      equity_list, NULL);
     gnc_account_sel_set_new_account_ability(GNC_ACCOUNT_SEL(cbw->expense_acct_widget), TRUE);

--- a/gnucash/gnome-utils/gnc-account-sel.c
+++ b/gnucash/gnome-utils/gnc-account-sel.c
@@ -79,6 +79,7 @@ enum
     PROP_0,
     PROP_HIDE_PLACEHOLDER,
     PROP_HIDE_HIDDEN,
+    PROP_HORIZONTAL_EXPAND,
 };
 
 static guint account_sel_signals [LAST_SIGNAL] = { 0 };
@@ -170,6 +171,11 @@ gas_set_property (GObject *object, guint param_id,
             gas->hide_hidden = g_value_get_boolean (value);
             break;
 
+        case PROP_HORIZONTAL_EXPAND:
+            gtk_widget_set_hexpand (GTK_WIDGET(gas), g_value_get_boolean (value));
+            gtk_widget_set_hexpand (GTK_WIDGET(gas->combo), g_value_get_boolean (value));
+            break;
+
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID(object, param_id, pspec);
             break;
@@ -195,6 +201,10 @@ gas_get_property (GObject *object, guint param_id,
 
         case PROP_HIDE_HIDDEN:
             g_value_set_boolean (value, gas->hide_hidden);
+            break;
+
+        case PROP_HORIZONTAL_EXPAND:
+            g_value_set_boolean (value, gtk_widget_get_hexpand (GTK_WIDGET(gas)));
             break;
 
         default:
@@ -226,6 +236,12 @@ gnc_account_sel_class_init (GNCAccountSelClass *klass)
         object_class, PROP_HIDE_HIDDEN,
         g_param_spec_boolean("hide-hidden", "Hide Hidden",
                              "Hidden accounts are hidden", TRUE,
+                             G_PARAM_READWRITE));
+
+    g_object_class_install_property (
+        object_class, PROP_HIDE_HIDDEN,
+        g_param_spec_boolean("horizontal-expand", "Horizontal Expand",
+                             "Should GAS take all horizontal space", TRUE,
                              G_PARAM_READWRITE));
 
     account_sel_signals [ACCOUNT_SEL_CHANGED] =
@@ -568,6 +584,10 @@ gnc_account_sel_init (GNCAccountSel *gas)
                               G_CALLBACK(combo_changed_cb), gas);
     gtk_container_add (GTK_CONTAINER(gas), widget);
 
+    // set the default horizontal expansion to TRUE
+    gtk_widget_set_hexpand (GTK_WIDGET(gas), TRUE);
+    gtk_widget_set_hexpand (GTK_WIDGET(gas->combo), TRUE);
+
     entry = gtk_bin_get_child (GTK_BIN(gas->combo));
     gtk_entry_set_icon_from_icon_name (GTK_ENTRY(entry), GTK_ENTRY_ICON_SECONDARY,
                                        "preferences-system-symbolic");
@@ -596,13 +616,6 @@ gnc_account_sel_init (GNCAccountSel *gas)
         qof_event_register_handler (gnc_account_sel_event_cb, gas);
 
     gas->initDone = TRUE;
-}
-
-void
-gnc_account_sel_set_hexpand (GNCAccountSel *gas, gboolean expand)
-{
-    gtk_widget_set_hexpand (GTK_WIDGET(gas), expand);
-    gtk_widget_set_hexpand (GTK_WIDGET(gas->combo), expand);
 }
 
 typedef struct

--- a/gnucash/gnome-utils/gnc-account-sel.c
+++ b/gnucash/gnome-utils/gnc-account-sel.c
@@ -80,6 +80,7 @@ enum
     PROP_HIDE_PLACEHOLDER,
     PROP_HIDE_HIDDEN,
     PROP_HORIZONTAL_EXPAND,
+    PROP_COMBO_ENTRY_WIDTH,
 };
 
 static guint account_sel_signals [LAST_SIGNAL] = { 0 };
@@ -176,6 +177,23 @@ gas_set_property (GObject *object, guint param_id,
             gtk_widget_set_hexpand (GTK_WIDGET(gas->combo), g_value_get_boolean (value));
             break;
 
+        case PROP_COMBO_ENTRY_WIDTH:
+            {
+                GtkEntry *entry = GTK_ENTRY(gtk_bin_get_child (GTK_BIN(gas->combo)));
+                gboolean expand = FALSE;
+                gint width = g_value_get_int (value);
+
+                if (width == -1)
+                    expand = TRUE;
+
+                gtk_widget_set_hexpand (GTK_WIDGET(gas), expand);
+                gtk_widget_set_hexpand (GTK_WIDGET(gas->combo), expand);
+
+                gtk_entry_set_width_chars (entry, width);
+                gtk_widget_queue_resize (GTK_WIDGET(gas));
+            }
+            break;
+
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID(object, param_id, pspec);
             break;
@@ -205,6 +223,13 @@ gas_get_property (GObject *object, guint param_id,
 
         case PROP_HORIZONTAL_EXPAND:
             g_value_set_boolean (value, gtk_widget_get_hexpand (GTK_WIDGET(gas)));
+            break;
+
+        case PROP_COMBO_ENTRY_WIDTH:
+            {
+                GtkEntry *entry = GTK_ENTRY(gtk_bin_get_child (GTK_BIN(gas->combo)));
+                g_value_set_int (value, gtk_entry_get_width_chars (entry));
+            }
             break;
 
         default:
@@ -243,6 +268,12 @@ gnc_account_sel_class_init (GNCAccountSelClass *klass)
         g_param_spec_boolean("horizontal-expand", "Horizontal Expand",
                              "Should GAS take all horizontal space", TRUE,
                              G_PARAM_READWRITE));
+
+    g_object_class_install_property(
+        object_class, PROP_COMBO_ENTRY_WIDTH,
+        g_param_spec_int("entry-width", "Number of Charactors",
+                         "Set the width of the combo entry",
+                         -1, 100, -1, G_PARAM_READWRITE));
 
     account_sel_signals [ACCOUNT_SEL_CHANGED] =
         g_signal_new ("account_sel_changed",

--- a/gnucash/gnome-utils/gnc-account-sel.h
+++ b/gnucash/gnome-utils/gnc-account-sel.h
@@ -48,7 +48,7 @@ typedef struct
     void (*account_sel_changed) (GNCAccountSel *gas);
 } GNCAccountSelClass;
 
-GType      gnc_account_sel_get_type (void);
+GType      gnc_account_sel_get_type (void) G_GNUC_CONST;
 GtkWidget* gnc_account_sel_new (void);
 
 /**
@@ -56,13 +56,14 @@ GtkWidget* gnc_account_sel_new (void);
  * list, then it doesn't change the state of the GAS.  If the account is
  * NULL, then the first list selection is made if set_default_acct is TRUE.
  **/
-void       gnc_account_sel_set_account (GNCAccountSel *gas, Account *acct,
-                                        gboolean set_default_acct);
+void gnc_account_sel_set_account (GNCAccountSel *gas, Account *acct,
+                                  gboolean set_default_acct);
+
 /**
  * Returns the currently-selected Account.  If, for some reason the selection
  * is in a bad state, NULL will be returned.
  **/
-Account*   gnc_account_sel_get_account (GNCAccountSel *gas);
+Account* gnc_account_sel_get_account (GNCAccountSel *gas);
 
 /**
  * The GNCAccountSel can be setup to filter the accounts displayed.
@@ -70,8 +71,18 @@ Account*   gnc_account_sel_get_account (GNCAccountSel *gas);
  * @param commodityFilters A GList of gnc_commodity types which are allowed.
  * The list is copied, of course.
  **/
-void gnc_account_sel_set_acct_filters (GNCAccountSel *gas, GList *typeFilters,
+void gnc_account_sel_set_acct_filters (GNCAccountSel *gas,
+                                       GList *typeFilters,
                                        GList *commodityFilters);
+
+/**
+ * The GNCAccountSel can be setup to filter the accounts displayed.
+ * @param gas The GNCAccountSel widget.
+ * @param excludeFilter A GList of accounts to be excluded.
+ * The list is copied, of course.
+ **/
+void gnc_account_sel_set_acct_exclude_filter (GNCAccountSel *gas,
+                                              GList *excludeFilter);
 
 /**
  * Conditional inclusion of a new-account button to the right of the
@@ -86,7 +97,12 @@ void gnc_account_sel_set_new_account_ability (GNCAccountSel *gas, gboolean state
  **/
 void gnc_account_sel_set_new_account_modal (GNCAccountSel *gas, gboolean state);
 
-gint gnc_account_sel_get_num_account (GNCAccountSel *gas);
-void gnc_account_sel_purge_account (GNCAccountSel *gas, Account *acc, gboolean recursive);
+/**
+ * Get the number of accounts visible.
+ *
+ * @param gas The GNCAccountSel widget.
+ * @return The number of visible accounts from the filter model.
+ **/
+gint gnc_account_sel_get_visible_account_num (GNCAccountSel *gas);
 
 #endif /* GNC_ACCOUNT_SEL_H */

--- a/gnucash/gnome-utils/gnc-account-sel.h
+++ b/gnucash/gnome-utils/gnc-account-sel.h
@@ -38,25 +38,7 @@
 #define GNC_ACCOUNT_SEL_CLASS(klass)  G_TYPE_CHECK_CLASS_CAST (klass, GNC_TYPE_ACCOUNT_SEL, GNCAccountSelClass)
 #define GNC_IS_ACCOUNT_SEL(obj)       G_TYPE_CHECK_INSTANCE_TYPE (obj, GNC_TYPE_ACCOUNT_SEL)
 
-typedef struct
-{
-    GtkBox hbox;
-    gboolean initDone;
-    gboolean isModal;
-    GtkListStore *store;
-    GtkComboBox *combo;
-    GList *acctTypeFilters;
-    GList *acctCommodityFilters;
-    gint eventHandlerId;
-    /* The state of this pointer also serves as a flag about what state
-     * the widget is in WRT the new-account-button ability. */
-    GtkWidget *newAccountButton;
-    gint currentSelection;
-
-#if 0 /* completion not implemented. */
-    GCompletion *completion;
-#endif /* 0 - completion not implemented */
-} GNCAccountSel;
+typedef struct _GNCAccountSel GNCAccountSel;
 
 typedef struct
 {

--- a/gnucash/gnome-utils/gnc-account-sel.h
+++ b/gnucash/gnome-utils/gnc-account-sel.h
@@ -88,6 +88,5 @@ void gnc_account_sel_set_new_account_modal (GNCAccountSel *gas, gboolean state);
 
 gint gnc_account_sel_get_num_account (GNCAccountSel *gas);
 void gnc_account_sel_purge_account (GNCAccountSel *gas, Account *acc, gboolean recursive);
-void gnc_account_sel_set_hexpand (GNCAccountSel *gas, gboolean expand);
 
 #endif /* GNC_ACCOUNT_SEL_H */

--- a/gnucash/gnome/assistant-loan.cpp
+++ b/gnucash/gnome/assistant-loan.cpp
@@ -734,6 +734,7 @@ gnc_loan_assistant_create( LoanAssistantData *ldd )
                           G_CALLBACK(loan_opt_escrow_toggle_cb), ldd );
         gtk_widget_set_sensitive( GTK_WIDGET(ldd->optEscrowHBox), FALSE );
         ldd->optEscrowGAS = GNC_ACCOUNT_SEL(gnc_account_sel_new());
+        g_object_set (ldd->optEscrowGAS, "entry-width", 50, NULL);
         gnc_account_sel_set_new_account_modal (GNC_ACCOUNT_SEL(ldd->optEscrowGAS), true);
         gnc_account_sel_set_new_account_ability( ldd->optEscrowGAS, TRUE );
         gtk_container_add( GTK_CONTAINER(ldd->optEscrowHBox),

--- a/gnucash/gnome/assistant-loan.cpp
+++ b/gnucash/gnome/assistant-loan.cpp
@@ -641,7 +641,6 @@ gnc_loan_assistant_create( LoanAssistantData *ldd )
                                   gas_data[i].height);
 
                 gtk_widget_set_halign (GTK_WIDGET(gas), GTK_ALIGN_FILL);
-                gnc_account_sel_set_hexpand (GNC_ACCOUNT_SEL(gas), true);
                 gnc_account_sel_set_new_account_modal (GNC_ACCOUNT_SEL(gas), true);
                 g_object_set (GTK_WIDGET(gas), "margin", 2, nullptr);
                 *(gas_data[i].loc) = gas;
@@ -735,7 +734,6 @@ gnc_loan_assistant_create( LoanAssistantData *ldd )
                           G_CALLBACK(loan_opt_escrow_toggle_cb), ldd );
         gtk_widget_set_sensitive( GTK_WIDGET(ldd->optEscrowHBox), FALSE );
         ldd->optEscrowGAS = GNC_ACCOUNT_SEL(gnc_account_sel_new());
-        gnc_account_sel_set_hexpand (GNC_ACCOUNT_SEL(ldd->optEscrowGAS), true);
         gnc_account_sel_set_new_account_modal (GNC_ACCOUNT_SEL(ldd->optEscrowGAS), true);
         gnc_account_sel_set_new_account_ability( ldd->optEscrowGAS, TRUE );
         gtk_container_add( GTK_CONTAINER(ldd->optEscrowHBox),

--- a/gnucash/gnome/dialog-date-close.c
+++ b/gnucash/gnome/dialog-date-close.c
@@ -239,7 +239,6 @@ gnc_dialog_dates_acct_question_parented (GtkWidget *parent, const char *message,
 
     acct_box = GTK_WIDGET(gtk_builder_get_object (builder, "acct_hbox"));
     ddc->acct_combo = gnc_account_sel_new();
-    gnc_account_sel_set_hexpand (GNC_ACCOUNT_SEL(ddc->acct_combo), TRUE);
     gtk_box_pack_start (GTK_BOX(acct_box), ddc->acct_combo, TRUE, TRUE, 0);
 
     date_box = GTK_WIDGET(gtk_builder_get_object (builder, "date_hbox"));
@@ -360,7 +359,6 @@ gnc_dialog_date_acct_parented (GtkWidget *parent, const char *message,
     ddc->acct_combo = gnc_account_sel_new();
     if (*acct)
         gnc_account_sel_set_account (GNC_ACCOUNT_SEL(ddc->acct_combo), *acct, FALSE);
-    gnc_account_sel_set_hexpand (GNC_ACCOUNT_SEL(ddc->acct_combo), TRUE);
     gtk_box_pack_start (GTK_BOX(acct_box), ddc->acct_combo, TRUE, TRUE, 0);
 
     date_box = GTK_WIDGET(gtk_builder_get_object (builder, "date_hbox"));

--- a/gnucash/gnome/dialog-employee.c
+++ b/gnucash/gnome/dialog-employee.c
@@ -479,7 +479,6 @@ gnc_employee_new_window (GtkWindow *parent,
     edit = gnc_account_sel_new();
     acct_types = g_list_prepend(NULL, (gpointer)ACCT_TYPE_CREDIT);
     gnc_account_sel_set_acct_filters (GNC_ACCOUNT_SEL(edit), acct_types, NULL);
-    gnc_account_sel_set_hexpand (GNC_ACCOUNT_SEL(edit), TRUE);
     g_list_free (acct_types);
 
     ew->ccard_acct_sel = edit;

--- a/gnucash/gnome/gnc-plugin-page-account-tree.c
+++ b/gnucash/gnome/gnc-plugin-page-account-tree.c
@@ -1398,6 +1398,11 @@ gppat_setup_account_selector (GtkBuilder *builder, GtkWidget *dialog,
 
     gtk_box_pack_start (GTK_BOX(box), selector, TRUE, TRUE, 0);
     gnc_account_sel_set_hexpand (GNC_ACCOUNT_SEL(selector), TRUE);
+
+    // placeholder accounts are OK for this GAS
+    if (g_strcmp0 (sel_name, DELETE_DIALOG_SA_MAS) == 0)
+        g_object_set (selector, "hide-placeholder", FALSE, NULL);
+
     g_object_set_data(G_OBJECT(dialog), sel_name, selector);
 
     gppat_populate_gas_list(dialog, GNC_ACCOUNT_SEL(selector), TRUE);

--- a/gnucash/gnome/gnc-plugin-page-account-tree.c
+++ b/gnucash/gnome/gnc-plugin-page-account-tree.c
@@ -1397,7 +1397,6 @@ gppat_setup_account_selector (GtkBuilder *builder, GtkWidget *dialog,
     GtkWidget *box = GTK_WIDGET(gtk_builder_get_object (builder, hbox));
 
     gtk_box_pack_start (GTK_BOX(box), selector, TRUE, TRUE, 0);
-    gnc_account_sel_set_hexpand (GNC_ACCOUNT_SEL(selector), TRUE);
 
     // placeholder accounts are OK for this GAS
     if (g_strcmp0 (sel_name, DELETE_DIALOG_SA_MAS) == 0)

--- a/gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp
+++ b/gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp
@@ -572,7 +572,6 @@ CsvImpTransAssist::CsvImpTransAssist ()
         acct_selector = gnc_account_sel_new();
         auto account_hbox = GTK_WIDGET(gtk_builder_get_object (builder, "account_hbox"));
         gtk_box_pack_start (GTK_BOX(account_hbox), acct_selector, TRUE, TRUE, 6);
-        gnc_account_sel_set_hexpand (GNC_ACCOUNT_SEL(acct_selector), true);
         gtk_widget_show (acct_selector);
 
         g_signal_connect(G_OBJECT(acct_selector), "account_sel_changed",


### PR DESCRIPTION
@christopherlam 
Chris, I think the first commit does what you asked for, can you give it a spin. I could not see a way of reusing the same code as the register but may have another look.

The second commit is what I suggested in your PR #1321 for using a secondary icon. I set the default for the GNCAccountSel to hide placeholders and hidden accounts but if the combo is set with such an account the settings are changed appropriately to show it.
Below is an image of what it looks like...
![acc-sel](https://user-images.githubusercontent.com/15702727/167890114-845c8133-a8ed-4e5f-959e-11d4ac0884c0.png)
What do you think, worthwhile or not