### PR TITLE
Add account charts for locale es_AR.

### DIFF
--- a/data/accounts/CMakeLists.txt
+++ b/data/accounts/CMakeLists.txt
@@ -13,6 +13,7 @@ add_subdirectory(de_DE)
 add_subdirectory(el_GR)
 add_subdirectory(en_GB)
 add_subdirectory(en_IN)
+add_subdirectory(es_AR)
 add_subdirectory(es_ES)
 add_subdirectory(es_MX)
 add_subdirectory(fi_FI)
@@ -46,7 +47,7 @@ add_subdirectory(zh_TW)
 set_local_dist(dist_list CMakeLists.txt )
 
 set(accounts_DIST ${C_DIST} ${CA_DIST} ${CS_DIST} ${DA_DIST} ${DE_AT_DIST} ${DE_CH_DIST} ${DE_DE_DIST} ${EL_GR_DIST}
-                  ${EN_GB_DIST} ${EN_IN_DIST} ${ES_ES_DIST} ${ES_MX_DIST} ${FI_FI_DIST} ${FR_BE_DIST} ${FR_CA_DIST}
+                  ${EN_GB_DIST} ${EN_IN_DIST} ${ES_AR_DIST} ${ES_ES_DIST} ${ES_MX_DIST} ${FI_FI_DIST} ${FR_BE_DIST} ${FR_CA_DIST}
                   ${FR_CH_DIST} ${FR_FR_DIST} ${HE_DIST} ${HR_DIST} ${HU_DIST} ${IT_DIST} ${JA_DIST} ${KO_DIST} ${LT_DIST}
                   ${LV_DIST} ${NB_DIST} ${NL_DIST} ${PL_DIST} ${PT_BR_DIST} ${PT_PT_DIST} ${RU_DIST} ${SK_DIST}
                   ${SV_AX_DIST} ${SV_FI_DIST} ${SV_SE_DIST} ${TR_TR_DIST} ${ZH_CN_DIST}

--- a/data/accounts/es_AR/CMakeLists.txt
+++ b/data/accounts/es_AR/CMakeLists.txt
@@ -1,0 +1,25 @@
+
+
+set(account_DATA
+  acctchrt_brokerage.gnucash-xea
+  acctchrt_business.gnucash-xea
+  acctchrt_carloan.gnucash-xea
+  acctchrt_cdmoneymkt.gnucash-xea
+  acctchrt_checkbook.gnucash-xea
+  acctchrt_childcare.gnucash-xea
+  acctchrt_common.gnucash-xea
+  acctchrt_currency.gnucash-xea
+  acctchrt_fixedassets.gnucash-xea
+  acctchrt_homeloan.gnucash-xea
+  acctchrt_homeown.gnucash-xea
+  acctchrt_otherloan.gnucash-xea
+  acctchrt_renter.gnucash-xea
+  acctchrt_spouseinc.gnucash-xea)
+
+set_dist_list(ES_AR_DIST ${account_DATA} CMakeLists.txt)
+
+install(FILES ${account_DATA} DESTINATION ${ACCOUNTS_INSTALL_DIR}/es_AR)
+
+foreach(acct_file ${account_DATA})
+    configure_file(${acct_file} ${ACCOUNTS_BUILD_DIR}/es_AR/${acct_file} COPYONLY)
+endforeach()

--- a/data/accounts/es_AR/acctchrt_brokerage.gnucash-xea
+++ b/data/accounts/es_AR/acctchrt_brokerage.gnucash-xea
@@ -1,0 +1,228 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gnc-account-example 
+  xmlns="http://www.gnucash.org/XML/"
+  xmlns:act="http://www.gnucash.org/XML/act"
+  xmlns:addr="http://www.gnucash.org/XML/addr"
+  xmlns:bgt="http://www.gnucash.org/XML/bgt"
+  xmlns:billterm="http://www.gnucash.org/XML/billterm"
+  xmlns:book="http://www.gnucash.org/XML/book"
+  xmlns:bt-days="http://www.gnucash.org/XML/bt-days"
+  xmlns:bt-prox="http://www.gnucash.org/XML/bt-prox"
+  xmlns:cd="http://www.gnucash.org/XML/cd"
+  xmlns:cmdty="http://www.gnucash.org/XML/cmdty"
+  xmlns:cust="http://www.gnucash.org/XML/cust"
+  xmlns:employee="http://www.gnucash.org/XML/employee"
+  xmlns:entry="http://www.gnucash.org/XML/entry"
+  xmlns:fs="http://www.gnucash.org/XML/fs"
+  xmlns:gnc="http://www.gnucash.org/XML/gnc"
+  xmlns:gnc-act="http://www.gnucash.org/XML/gnc-act"
+  xmlns:invoice="http://www.gnucash.org/XML/invoice"
+  xmlns:job="http://www.gnucash.org/XML/job"
+  xmlns:lot="http://www.gnucash.org/XML/lot"
+  xmlns:order="http://www.gnucash.org/XML/order"
+  xmlns:owner="http://www.gnucash.org/XML/owner"
+  xmlns:price="http://www.gnucash.org/XML/price"
+  xmlns:recurrence="http://www.gnucash.org/XML/recurrence"
+  xmlns:slot="http://www.gnucash.org/XML/slot"
+  xmlns:split="http://www.gnucash.org/XML/split"
+  xmlns:sx="http://www.gnucash.org/XML/sx"
+  xmlns:taxtable="http://www.gnucash.org/XML/taxtable"
+  xmlns:trn="http://www.gnucash.org/XML/trn"
+  xmlns:ts="http://www.gnucash.org/XML/ts"
+  xmlns:tte="http://www.gnucash.org/XML/tte"
+  xmlns:vendor="http://www.gnucash.org/XML/vendor">
+    <gnc-act:title>
+     Cuentas de Inversión
+    </gnc-act:title>
+    <gnc-act:short-description>
+      Cuenta de corredor de bolsa con las cuentas de inversiones asociadas
+    </gnc-act:short-description>
+    <gnc-act:long-description>
+    Deberás escoger esta lista de cuentas si tenés inversiones (acciones, bonos, fondos de inversión, fondos indexados, intereses, dividendos).
+    </gnc-act:long-description>
+<gnc:account version="2.0.0">
+  <act:name>Root Account</act:name>
+  <act:id type="new">1972cce2e2364f95b2b0bc014502661d</act:id>
+  <act:type>ROOT</act:type>
+  <act:commodity-scu>0</act:commodity-scu>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Activo</act:name>
+  <act:id type="new">52b5942b5beaec856eaca5a75ee71592</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Activo</act:description>
+  <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Inversiones</act:name>
+  <act:id type="new">7ff59d92615cce4d8388d7e179ee3ff6</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Inversiones</act:description>
+  <act:parent type="new">52b5942b5beaec856eaca5a75ee71592</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Cuenta de inversión</act:name>
+  <act:id type="new">f15ec9568727f08a5ebd8f3e66483876</act:id>
+  <act:type>BANK</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Cuenta de inversión</act:description>
+  <act:parent type="new">7ff59d92615cce4d8388d7e179ee3ff6</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Bonos</act:name>
+  <act:id type="new">8196bf0015c25f501338f07a87c512d8</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Bonos</act:description>
+  <act:parent type="new">f15ec9568727f08a5ebd8f3e66483876</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Acciones</act:name>
+  <act:id type="new">7d7db9bed07f21fc0b1f50674702aff0</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Acciones</act:description>
+  <act:parent type="new">f15ec9568727f08a5ebd8f3e66483876</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Fondo de índice</act:name>
+  <act:id type="new">fe9db8a7eedf2990e9846f634a922143</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Fondo de índice</act:description>
+  <act:parent type="new">f15ec9568727f08a5ebd8f3e66483876</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Fondo de inversión</act:name>
+  <act:id type="new">9da28c1aa7789e84bdc8484ba8f527b3</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Fondo de inversión</act:description>
+  <act:parent type="new">f15ec9568727f08a5ebd8f3e66483876</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Ingresos</act:name>
+  <act:id type="new">9da3c880bd04b9db49eb7f5b06403bda</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Ingresos</act:description>
+  <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Ingresos por dividendos</act:name>
+  <act:id type="new">1af1f4894aeab96d840e66254d023b88</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Ingresos por dividendos</act:description>
+  <act:parent type="new">9da3c880bd04b9db49eb7f5b06403bda</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Ingresos por intereses</act:name>
+  <act:id type="new">7943bc59ffbb9a7be4afcd2996147119</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Ingresos por intereses</act:description>
+  <act:parent type="new">9da3c880bd04b9db49eb7f5b06403bda</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Intereses de bonos</act:name>
+  <act:id type="new">8ceb4752a11e2d342b9009b343fdba38</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Intereses de bonos</act:description>
+  <act:parent type="new">7943bc59ffbb9a7be4afcd2996147119</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Egresos</act:name>
+  <act:id type="new">6de23244232785031501171abcc1d4aa</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Egresos</act:description>
+  <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Comisiones</act:name>
+  <act:id type="new">77fdffddc79c662c93c482cefa5a4744</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Comisiones</act:description>
+  <act:parent type="new">6de23244232785031501171abcc1d4aa</act:parent>
+</gnc:account>
+</gnc-account-example>

--- a/data/accounts/es_AR/acctchrt_business.gnucash-xea
+++ b/data/accounts/es_AR/acctchrt_business.gnucash-xea
@@ -1,0 +1,860 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gnc-account-example 
+  xmlns="http://www.gnucash.org/XML/"
+  xmlns:act="http://www.gnucash.org/XML/act"
+  xmlns:addr="http://www.gnucash.org/XML/addr"
+  xmlns:bgt="http://www.gnucash.org/XML/bgt"
+  xmlns:billterm="http://www.gnucash.org/XML/billterm"
+  xmlns:book="http://www.gnucash.org/XML/book"
+  xmlns:bt-days="http://www.gnucash.org/XML/bt-days"
+  xmlns:bt-prox="http://www.gnucash.org/XML/bt-prox"
+  xmlns:cd="http://www.gnucash.org/XML/cd"
+  xmlns:cmdty="http://www.gnucash.org/XML/cmdty"
+  xmlns:cust="http://www.gnucash.org/XML/cust"
+  xmlns:employee="http://www.gnucash.org/XML/employee"
+  xmlns:entry="http://www.gnucash.org/XML/entry"
+  xmlns:fs="http://www.gnucash.org/XML/fs"
+  xmlns:gnc="http://www.gnucash.org/XML/gnc"
+  xmlns:gnc-act="http://www.gnucash.org/XML/gnc-act"
+  xmlns:invoice="http://www.gnucash.org/XML/invoice"
+  xmlns:job="http://www.gnucash.org/XML/job"
+  xmlns:lot="http://www.gnucash.org/XML/lot"
+  xmlns:order="http://www.gnucash.org/XML/order"
+  xmlns:owner="http://www.gnucash.org/XML/owner"
+  xmlns:price="http://www.gnucash.org/XML/price"
+  xmlns:recurrence="http://www.gnucash.org/XML/recurrence"
+  xmlns:slot="http://www.gnucash.org/XML/slot"
+  xmlns:split="http://www.gnucash.org/XML/split"
+  xmlns:sx="http://www.gnucash.org/XML/sx"
+  xmlns:taxtable="http://www.gnucash.org/XML/taxtable"
+  xmlns:trn="http://www.gnucash.org/XML/trn"
+  xmlns:ts="http://www.gnucash.org/XML/ts"
+  xmlns:tte="http://www.gnucash.org/XML/tte"
+  xmlns:vendor="http://www.gnucash.org/XML/vendor">
+
+<gnc-act:title>
+  Cuentas Empresariales
+</gnc-act:title>
+<gnc-act:short-description>
+  Lista completa de cuentas para un negocio.
+</gnc-act:short-description>
+<gnc-act:long-description>
+  Usuarios dueños de un negocio preferirán esta a otras opciones. Incluye las cuentas necesarias para llevar la contabilidad de la mayoría de los negocios, como Cuentas a Pagar, Cuentas por Cobrar, Ingresos y Egresos.
+</gnc-act:long-description>
+<gnc-act:exclude-from-select-all>1</gnc-act:exclude-from-select-all>
+
+<gnc:account version="2.0.0">
+  <act:name>Root Account</act:name>
+  <act:id type="new">4daebd948ebd4d74bcc7876818b15fd0</act:id>
+  <act:type>ROOT</act:type>
+  <act:commodity-scu>0</act:commodity-scu>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Activo</act:name>
+  <act:id type="new">cc057da0cd914a5689609bf4a8bdc316</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Activo</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="new">4daebd948ebd4d74bcc7876818b15fd0</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Caja y Bancos</act:name>
+  <act:id type="new">714c8c0241f04706babbeb8c323bd84f</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Activo Corriente</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="new">cc057da0cd914a5689609bf4a8bdc316</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Banco Cuenta Corriente</act:name>
+  <act:id type="new">9b4507766c614c0584683d619b98d6dd</act:id>
+  <act:type>BANK</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Banco Cuenta Corriente</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>notes</slot:key>
+      <slot:value type="string">Creá una subcuenta para cada Cuenta Corriente que tengas.</slot:value>
+    </slot>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">false</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="new">714c8c0241f04706babbeb8c323bd84f</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Banco Caja de Ahorro</act:name>
+  <act:id type="new">9f70ff56341143b0b859bc1de15312e2</act:id>
+  <act:type>BANK</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Banco Caja de Ahorro</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>last-num</slot:key>
+      <slot:value type="string">130</slot:value>
+    </slot>
+    <slot>
+      <slot:key>notes</slot:key>
+      <slot:value type="string">Creá una subcuenta para cada Caja de Ahorro que tengas.</slot:value>
+    </slot>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">false</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="new">714c8c0241f04706babbeb8c323bd84f</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Caja</act:name>
+  <act:id type="new">a1b9391a6ed24fbeb06f4f335eb5d69f</act:id>
+  <act:type>CASH</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Caja</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>notes</slot:key>
+      <slot:value type="string"></slot:value>
+    </slot>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">false</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="new">714c8c0241f04706babbeb8c323bd84f</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Valores a Depositar</act:name>
+  <act:id type="new">ae986fcecf3a47d6af550bba13727838</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Valores a Depositar</act:description>
+  <act:parent type="new">714c8c0241f04706babbeb8c323bd84f</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Créditos por Ventas</act:name>
+  <act:id type="new">6b50d09becfb4da988a57ce0e8457ea0</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Créditos por Ventas</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>notes</slot:key>
+      <slot:value type="string"></slot:value>
+    </slot>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="new">cc057da0cd914a5689609bf4a8bdc316</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Deudores por Ventas</act:name>
+  <act:id type="new">a4fe1215af2f42338fed5e4e8a09b5c5</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Deudores por Ventas</act:description>
+  <act:parent type="new">6b50d09becfb4da988a57ce0e8457ea0</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Documentos a Cobrar</act:name>
+  <act:id type="new">ceac142e738a4ef0aede8de6cf0c74ef</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Documentos a Cobrar</act:description>
+  <act:parent type="new">6b50d09becfb4da988a57ce0e8457ea0</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Otros Créditos</act:name>
+  <act:id type="new">84bd6af761d04e5c9522327b5c868db7</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="new">cc057da0cd914a5689609bf4a8bdc316</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Intereses a Cobrar</act:name>
+  <act:id type="new">e1821ff70d0445fdbf57451c0d1a7a38</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Intereses a Cobrar</act:description>
+  <act:parent type="new">84bd6af761d04e5c9522327b5c868db7</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>IVA - Saldo a Favor</act:name>
+  <act:id type="new">8b59b7e108a44f05a9e30072117a0c13</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>IVA - Saldo a Favor</act:description>
+  <act:parent type="new">84bd6af761d04e5c9522327b5c868db7</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>IVA - Crédito Fiscal</act:name>
+  <act:id type="new">cfa7a9f1efd3498c97b44e2c90022cda</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>IVA - Crédito Fiscal</act:description>
+  <act:parent type="new">84bd6af761d04e5c9522327b5c868db7</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Deudores Varios</act:name>
+  <act:id type="new">0c47fe5cf5e94c819e8b3616e5828bdf</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Deudores Varios</act:description>
+  <act:parent type="new">84bd6af761d04e5c9522327b5c868db7</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Bienes de Cambio</act:name>
+  <act:id type="new">fbba7626c5e64e3aa3d5d25bfd8f5abc</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Bienes de Cambio</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="new">cc057da0cd914a5689609bf4a8bdc316</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Mercaderías</act:name>
+  <act:id type="new">cf2043c48e7f465b8517c48d51374402</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Mercaderías</act:description>
+  <act:parent type="new">fbba7626c5e64e3aa3d5d25bfd8f5abc</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Pasivo</act:name>
+  <act:id type="new">9d6f959b8794477b9c53935ee46762d0</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Pasivo</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="new">4daebd948ebd4d74bcc7876818b15fd0</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Cuentas por Pagar</act:name>
+  <act:id type="new">34d12be2257e45d793382a084ded2b15</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Cuentas por Pagar</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>notes</slot:key>
+      <slot:value type="string"></slot:value>
+    </slot>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="new">9d6f959b8794477b9c53935ee46762d0</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Proveedores</act:name>
+  <act:id type="new">b525ee134c4c4af5981ed69755dd0e3d</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Proveedores</act:description>
+  <act:parent type="new">34d12be2257e45d793382a084ded2b15</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Documentos a Pagar</act:name>
+  <act:id type="new">ceba965eb9b74be48459be4be739c356</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Documentos a Pagar</act:description>
+  <act:parent type="new">34d12be2257e45d793382a084ded2b15</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Sueldos</act:name>
+  <act:id type="new">df34223abb9e4007b91890cd04192caa</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Sueldos</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="new">9d6f959b8794477b9c53935ee46762d0</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Sueldos y Jornales a Pagar</act:name>
+  <act:id type="new">3db8a7f3ad1b40bca1cf234b88d23bc2</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Sueldos y Jornales a Pagar</act:description>
+  <act:parent type="new">df34223abb9e4007b91890cd04192caa</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Contribuciones Sociales a Pagar</act:name>
+  <act:id type="new">4c8576509ae645b581bf20c0265bc2c1</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Contribuciones Sociales a Pagar</act:description>
+  <act:parent type="new">df34223abb9e4007b91890cd04192caa</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Sueldo Anual Complementario a Pagar</act:name>
+  <act:id type="new">13593c44d59f465d99c6e6dadccd9da2</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Sueldo Anual Complementario a Pagar</act:description>
+  <act:parent type="new">df34223abb9e4007b91890cd04192caa</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Cargas Fiscales</act:name>
+  <act:id type="new">42cecb6cc8ab498fbe35b78b9db83e89</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Cargas Fiscales</act:description>
+  <act:parent type="new">9d6f959b8794477b9c53935ee46762d0</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>IVA - Débito Fiscal</act:name>
+  <act:id type="new">af59155e5cdc4b249e1bdac8477805bb</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>IVA - Débito Fiscal</act:description>
+  <act:parent type="new">42cecb6cc8ab498fbe35b78b9db83e89</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>IVA - Saldo a Favor</act:name>
+  <act:id type="new">51a21f89b2fd4711953f7cfc7a3db2ea</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>IVA - Saldo a Favor</act:description>
+  <act:parent type="new">42cecb6cc8ab498fbe35b78b9db83e89</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Otros Pasivos</act:name>
+  <act:id type="new">147166e5117a4ee2a665e12cba5af612</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Otros Pasivos</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="new">9d6f959b8794477b9c53935ee46762d0</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Acreedores Varios</act:name>
+  <act:id type="new">3aeeb1fe14c647b094f67a8a194d8dd8</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Acreedores Varios</act:description>
+  <act:parent type="new">147166e5117a4ee2a665e12cba5af612</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Ingresos</act:name>
+  <act:id type="new">59d316be7bc5420cb5c1e51e4c3d41be</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Ingresos</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="new">4daebd948ebd4d74bcc7876818b15fd0</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Ventas</act:name>
+  <act:id type="new">a4578581877340b6bb4bb5abb96dd54e</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Ventas</act:description>
+  <act:parent type="new">59d316be7bc5420cb5c1e51e4c3d41be</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Otros Ingresos</act:name>
+  <act:id type="new">c9786f2462144b9aba1d598f5867e509</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Otros Ingresos</act:description>
+  <act:parent type="new">59d316be7bc5420cb5c1e51e4c3d41be</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Intereses Ganados</act:name>
+  <act:id type="new">01a6e30b82894ec0b8aa7fbb5d9cd7ce</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Intereses Ganados</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>notes</slot:key>
+      <slot:value type="string"></slot:value>
+    </slot>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">false</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="new">59d316be7bc5420cb5c1e51e4c3d41be</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Egresos</act:name>
+  <act:id type="new">817b0e2d4e0d445398028aae994824ba</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Egresos</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="new">4daebd948ebd4d74bcc7876818b15fd0</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Costo de Mercaderías Vendidas</act:name>
+  <act:id type="new">6abc980a25b54aeb8e6bf1dc7304cdf7</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Costo de Mercaderías Vendidas</act:description>
+  <act:parent type="new">817b0e2d4e0d445398028aae994824ba</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Gastos de Administración</act:name>
+  <act:id type="new">3614a7bd4f3f4d6491d044325ac81108</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Gastos de Administración</act:description>
+  <act:parent type="new">817b0e2d4e0d445398028aae994824ba</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Artículos de Librería</act:name>
+  <act:id type="new">59b196d1e1714a8e8294e527f1c91505</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Artículos de Librería</act:description>
+  <act:parent type="new">817b0e2d4e0d445398028aae994824ba</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Contribuciones Sociales</act:name>
+  <act:id type="new">c28ebde0b4d34edfb0dbdb95ab81ab02</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Contribuciones Sociales</act:description>
+  <act:parent type="new">817b0e2d4e0d445398028aae994824ba</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Fletes</act:name>
+  <act:id type="new">039825a6e104464fb50d9184d7d50cbe</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Fletes</act:description>
+  <act:parent type="new">817b0e2d4e0d445398028aae994824ba</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Gastos Bancarios</act:name>
+  <act:id type="new">e3ae8bb886104104b8fffc230baddfc2</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Gastos Bancarios</act:description>
+  <act:parent type="new">817b0e2d4e0d445398028aae994824ba</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Gastos Generales</act:name>
+  <act:id type="new">be0e8eb988094490b2cd20647d987403</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Gastos Generales</act:description>
+  <act:parent type="new">817b0e2d4e0d445398028aae994824ba</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Servicios</act:name>
+  <act:id type="new">48367bd7d0f94c23a4ca415bff072050</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Luz, gas, teléfono, ...</act:description>
+  <act:parent type="new">817b0e2d4e0d445398028aae994824ba</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Sueldo Anual Complementario</act:name>
+  <act:id type="new">7f7f761bd1d548489fde43e287f73aa5</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Sueldo Anual Complementario</act:description>
+  <act:parent type="new">817b0e2d4e0d445398028aae994824ba</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Sueldos y Jornales</act:name>
+  <act:id type="new">79f5ef7eb5824eb89204ee1c05bf37e1</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Sueldos y Jornales</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>notes</slot:key>
+      <slot:value type="string"></slot:value>
+    </slot>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">false</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="new">817b0e2d4e0d445398028aae994824ba</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Impuestos</act:name>
+  <act:id type="new">5da28f004efd44cd980623799bc9f12a</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Impuestos</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="new">817b0e2d4e0d445398028aae994824ba</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Impuestos Provinciales</act:name>
+  <act:id type="new">419b877f1b0a46c49a483cef43425291</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Impuestos Provinciales</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>notes</slot:key>
+      <slot:value type="string">Agregá subcuentas para los impuestos provinciales.</slot:value>
+    </slot>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="new">5da28f004efd44cd980623799bc9f12a</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Impuesto a los Ingresos Brutos</act:name>
+  <act:id type="new">323fecd2789d45718ff83e88c11c76c2</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Impuesto a los Ingresos Brutos</act:description>
+  <act:parent type="new">5da28f004efd44cd980623799bc9f12a</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Impuesto a las Ganancias</act:name>
+  <act:id type="new">5f89b607c45d45559fe8763d91cb204d</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Impuesto a las Ganancias</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>notes</slot:key>
+      <slot:value type="string"></slot:value>
+    </slot>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">false</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="new">5da28f004efd44cd980623799bc9f12a</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Impuestos y Tasas</act:name>
+  <act:id type="new">5a36c522d4094e93a590b77cda93bbec</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Impuestos y Tasas</act:description>
+  <act:parent type="new">5da28f004efd44cd980623799bc9f12a</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Intereses Perdidos</act:name>
+  <act:id type="new">9d001391350d499aa39f8b1d8c2f7a3b</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Intereses Perdidos</act:description>
+  <act:parent type="new">817b0e2d4e0d445398028aae994824ba</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Ajustes</act:name>
+  <act:id type="new">39f2b9433dc54df2b81205cf7ff78223</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Ajustes</act:description>
+  <act:parent type="new">817b0e2d4e0d445398028aae994824ba</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Patrimonio Neto</act:name>
+  <act:id type="new">b5f290c96b33423da0da9eb51eb4378a</act:id>
+  <act:type>EQUITY</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Patrimonio Neto</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="new">4daebd948ebd4d74bcc7876818b15fd0</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Capital Inicial</act:name>
+  <act:id type="new">3f54d877d0aa4220a2b926e26fc9414e</act:id>
+  <act:type>EQUITY</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Capital Inicial</act:description>
+  <act:slots>
+    <slot>
+      <slot:key>equity-type</slot:key>
+      <slot:value type="string">opening-balance</slot:value>
+    </slot>
+  </act:slots>
+  <act:parent type="new">b5f290c96b33423da0da9eb51eb4378a</act:parent>
+</gnc:account>
+
+</gnc-account-example>

--- a/data/accounts/es_AR/acctchrt_carloan.gnucash-xea
+++ b/data/accounts/es_AR/acctchrt_carloan.gnucash-xea
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gnc-account-example 
+  xmlns="http://www.gnucash.org/XML/"
+  xmlns:act="http://www.gnucash.org/XML/act"
+  xmlns:addr="http://www.gnucash.org/XML/addr"
+  xmlns:bgt="http://www.gnucash.org/XML/bgt"
+  xmlns:billterm="http://www.gnucash.org/XML/billterm"
+  xmlns:book="http://www.gnucash.org/XML/book"
+  xmlns:bt-days="http://www.gnucash.org/XML/bt-days"
+  xmlns:bt-prox="http://www.gnucash.org/XML/bt-prox"
+  xmlns:cd="http://www.gnucash.org/XML/cd"
+  xmlns:cmdty="http://www.gnucash.org/XML/cmdty"
+  xmlns:cust="http://www.gnucash.org/XML/cust"
+  xmlns:employee="http://www.gnucash.org/XML/employee"
+  xmlns:entry="http://www.gnucash.org/XML/entry"
+  xmlns:fs="http://www.gnucash.org/XML/fs"
+  xmlns:gnc="http://www.gnucash.org/XML/gnc"
+  xmlns:gnc-act="http://www.gnucash.org/XML/gnc-act"
+  xmlns:invoice="http://www.gnucash.org/XML/invoice"
+  xmlns:job="http://www.gnucash.org/XML/job"
+  xmlns:lot="http://www.gnucash.org/XML/lot"
+  xmlns:order="http://www.gnucash.org/XML/order"
+  xmlns:owner="http://www.gnucash.org/XML/owner"
+  xmlns:price="http://www.gnucash.org/XML/price"
+  xmlns:recurrence="http://www.gnucash.org/XML/recurrence"
+  xmlns:slot="http://www.gnucash.org/XML/slot"
+  xmlns:split="http://www.gnucash.org/XML/split"
+  xmlns:sx="http://www.gnucash.org/XML/sx"
+  xmlns:taxtable="http://www.gnucash.org/XML/taxtable"
+  xmlns:trn="http://www.gnucash.org/XML/trn"
+  xmlns:ts="http://www.gnucash.org/XML/ts"
+  xmlns:tte="http://www.gnucash.org/XML/tte"
+  xmlns:vendor="http://www.gnucash.org/XML/vendor">
+    <gnc-act:title>
+      Prenda de auto
+    </gnc-act:title>
+    <gnc-act:short-description>
+      Cuentas para pago de prenda de auto e intereses asociados
+    </gnc-act:short-description>
+    <gnc-act:long-description>
+      Debería seleccionar esta lista de cuentas si está pagando en cuotas su auto (prenda de auto, intereses por prenda de auto).
+    </gnc-act:long-description>
+<gnc:account version="2.0.0">
+  <act:name>Root Account</act:name>
+  <act:id type="new">1972cce2e2364f95b2b0bc014502661d</act:id>
+  <act:type>ROOT</act:type>
+  <act:commodity-scu>0</act:commodity-scu>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Pasivo</act:name>
+  <act:id type="new">33a326fe16ae360f777a94b3f5bdfbdc</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Pasivo</act:description>
+  <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Préstamos</act:name>
+  <act:id type="new">023e2343114b3d695feaeb96904e0da6</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Préstamos</act:description>
+  <act:parent type="new">33a326fe16ae360f777a94b3f5bdfbdc</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Prenda Automotor</act:name>
+  <act:id type="new">3e5f44fd7bfaa9cae737a4113a749e36</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Prenda Automotor</act:description>
+  <act:parent type="new">023e2343114b3d695feaeb96904e0da6</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Egresos</act:name>
+  <act:id type="new">acacdcb998e45fb741766622e8542f0b</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Egresos</act:description>
+  <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Intereses</act:name>
+  <act:id type="new">9e8495e80ebfb762089be917dff7ab72</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Intereses</act:description>
+  <act:parent type="new">acacdcb998e45fb741766622e8542f0b</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Intereses Prenda Automotor</act:name>
+  <act:id type="new">e9bd8477e27361238d2f53c4fe7594ab</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Intereses Prenda Automotor</act:description>
+  <act:parent type="new">9e8495e80ebfb762089be917dff7ab72</act:parent>
+</gnc:account>
+</gnc-account-example>

--- a/data/accounts/es_AR/acctchrt_cdmoneymkt.gnucash-xea
+++ b/data/accounts/es_AR/acctchrt_cdmoneymkt.gnucash-xea
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gnc-account-example 
+  xmlns="http://www.gnucash.org/XML/"
+  xmlns:act="http://www.gnucash.org/XML/act"
+  xmlns:addr="http://www.gnucash.org/XML/addr"
+  xmlns:bgt="http://www.gnucash.org/XML/bgt"
+  xmlns:billterm="http://www.gnucash.org/XML/billterm"
+  xmlns:book="http://www.gnucash.org/XML/book"
+  xmlns:bt-days="http://www.gnucash.org/XML/bt-days"
+  xmlns:bt-prox="http://www.gnucash.org/XML/bt-prox"
+  xmlns:cd="http://www.gnucash.org/XML/cd"
+  xmlns:cmdty="http://www.gnucash.org/XML/cmdty"
+  xmlns:cust="http://www.gnucash.org/XML/cust"
+  xmlns:employee="http://www.gnucash.org/XML/employee"
+  xmlns:entry="http://www.gnucash.org/XML/entry"
+  xmlns:fs="http://www.gnucash.org/XML/fs"
+  xmlns:gnc="http://www.gnucash.org/XML/gnc"
+  xmlns:gnc-act="http://www.gnucash.org/XML/gnc-act"
+  xmlns:invoice="http://www.gnucash.org/XML/invoice"
+  xmlns:job="http://www.gnucash.org/XML/job"
+  xmlns:lot="http://www.gnucash.org/XML/lot"
+  xmlns:order="http://www.gnucash.org/XML/order"
+  xmlns:owner="http://www.gnucash.org/XML/owner"
+  xmlns:price="http://www.gnucash.org/XML/price"
+  xmlns:recurrence="http://www.gnucash.org/XML/recurrence"
+  xmlns:slot="http://www.gnucash.org/XML/slot"
+  xmlns:split="http://www.gnucash.org/XML/split"
+  xmlns:sx="http://www.gnucash.org/XML/sx"
+  xmlns:taxtable="http://www.gnucash.org/XML/taxtable"
+  xmlns:trn="http://www.gnucash.org/XML/trn"
+  xmlns:ts="http://www.gnucash.org/XML/ts"
+  xmlns:tte="http://www.gnucash.org/XML/tte"
+  xmlns:vendor="http://www.gnucash.org/XML/vendor">
+    <gnc-act:title>
+      Pagarés y mercado monetario
+    </gnc-act:title>
+    <gnc-act:short-description>
+     Cuentas para pagarés, e inversiones de mercado monetario
+    </gnc-act:short-description>
+    <gnc-act:long-description>
+    Deberías seleccionar esta lista de cuentas si manejás pagarés o cuentas de mercado monetario (pagarés, intereses de pagarés, mercado monetario, intereses de mercado monetario).
+  </gnc-act:long-description>    
+<gnc:account version="2.0.0">
+  <act:name>Root Account</act:name>
+  <act:id type="new">1972cce2e2364f95b2b0bc014502661d</act:id>
+  <act:type>ROOT</act:type>
+  <act:commodity-scu>0</act:commodity-scu>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Activo</act:name>
+  <act:id type="new">7b1a39efc6234d1db148baa722c9471e</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Activo</act:description>
+  <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Activo Corriente</act:name>
+  <act:id type="new">1880e89ec9fe82622b8648df481dd2b7</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Activo Corriente</act:description>
+  <act:parent type="new">7b1a39efc6234d1db148baa722c9471e</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Pagaré de banco</act:name>
+  <act:id type="new">c1620f9c3082e33d8fd559e17f90a122</act:id>
+  <act:type>BANK</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Pagaré de banco</act:description>
+  <act:parent type="new">1880e89ec9fe82622b8648df481dd2b7</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Mercado monetario</act:name>
+  <act:id type="new">3a01e5b0132ba26803b49732a3242654</act:id>
+  <act:type>BANK</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Mercado monetario</act:description>
+  <act:parent type="new">1880e89ec9fe82622b8648df481dd2b7</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Ingresos</act:name>
+  <act:id type="new">4b3e36f325569b80efc7d3331bdf851b</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Ingresos</act:description>
+  <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Ingresos por intereses</act:name>
+  <act:id type="new">fd131cae797d1fb83c2e2bf57254eca5</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Ingresos por intereses</act:description>
+  <act:parent type="new">4b3e36f325569b80efc7d3331bdf851b</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Interés de pagarés</act:name>
+  <act:id type="new">28d311f0f38da5e35628e76ad8bcc853</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Interés de pagarés</act:description>
+  <act:parent type="new">fd131cae797d1fb83c2e2bf57254eca5</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Interés de mercado monetario</act:name>
+  <act:id type="new">dc537946f39e84ccef7ce38f016249af</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Interés de mercado monetario</act:description>
+  <act:parent type="new">fd131cae797d1fb83c2e2bf57254eca5</act:parent>
+</gnc:account>
+</gnc-account-example>

--- a/data/accounts/es_AR/acctchrt_checkbook.gnucash-xea
+++ b/data/accounts/es_AR/acctchrt_checkbook.gnucash-xea
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gnc-account-example 
+  xmlns="http://www.gnucash.org/XML/"
+  xmlns:act="http://www.gnucash.org/XML/act"
+  xmlns:addr="http://www.gnucash.org/XML/addr"
+  xmlns:bgt="http://www.gnucash.org/XML/bgt"
+  xmlns:billterm="http://www.gnucash.org/XML/billterm"
+  xmlns:book="http://www.gnucash.org/XML/book"
+  xmlns:bt-days="http://www.gnucash.org/XML/bt-days"
+  xmlns:bt-prox="http://www.gnucash.org/XML/bt-prox"
+  xmlns:cd="http://www.gnucash.org/XML/cd"
+  xmlns:cmdty="http://www.gnucash.org/XML/cmdty"
+  xmlns:cust="http://www.gnucash.org/XML/cust"
+  xmlns:employee="http://www.gnucash.org/XML/employee"
+  xmlns:entry="http://www.gnucash.org/XML/entry"
+  xmlns:fs="http://www.gnucash.org/XML/fs"
+  xmlns:gnc="http://www.gnucash.org/XML/gnc"
+  xmlns:gnc-act="http://www.gnucash.org/XML/gnc-act"
+  xmlns:invoice="http://www.gnucash.org/XML/invoice"
+  xmlns:job="http://www.gnucash.org/XML/job"
+  xmlns:lot="http://www.gnucash.org/XML/lot"
+  xmlns:order="http://www.gnucash.org/XML/order"
+  xmlns:owner="http://www.gnucash.org/XML/owner"
+  xmlns:price="http://www.gnucash.org/XML/price"
+  xmlns:recurrence="http://www.gnucash.org/XML/recurrence"
+  xmlns:slot="http://www.gnucash.org/XML/slot"
+  xmlns:split="http://www.gnucash.org/XML/split"
+  xmlns:sx="http://www.gnucash.org/XML/sx"
+  xmlns:taxtable="http://www.gnucash.org/XML/taxtable"
+  xmlns:trn="http://www.gnucash.org/XML/trn"
+  xmlns:ts="http://www.gnucash.org/XML/ts"
+  xmlns:tte="http://www.gnucash.org/XML/tte"
+  xmlns:vendor="http://www.gnucash.org/XML/vendor">
+    <gnc-act:title>
+      Talonario de Cuenta Corriente
+    </gnc-act:title>
+    <gnc-act:short-description>
+     Un conjunto mínimo de cuentas para usar GnuCash.
+    </gnc-act:short-description>
+    <gnc-act:long-description>
+     Usá esto si solo querés realizar un balance de tu cuenta corriente. Más tarde podés llevar un balance más detallado de cada egreso e ingreso, si lo necesitás.
+    </gnc-act:long-description>
+<gnc:account version="2.0.0">
+  <act:name>Root Account</act:name>
+  <act:id type="new">1972cce2e2364f95b2b0bc014502661d</act:id>
+  <act:type>ROOT</act:type>
+  <act:commodity-scu>0</act:commodity-scu>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Activo</act:name>
+  <act:id type="new">bde24bbbe01829aff3dac8d038e174cc</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Activo</act:description>
+  <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Activo Corriente</act:name>
+  <act:id type="new">d90864ec1d660176244b05a0e43e621a</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Activo Corriente</act:description>
+  <act:parent type="new">bde24bbbe01829aff3dac8d038e174cc</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Cuenta Corriente</act:name>
+  <act:id type="new">ab2dc28552256b8d1ef4fdea4ba45717</act:id>
+  <act:type>BANK</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Cuenta Corriente</act:description>
+  <act:parent type="new">d90864ec1d660176244b05a0e43e621a</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Ingresos</act:name>
+  <act:id type="new">e96c0691c219f5f55590e20fb9a3309b</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Ingresos</act:description>
+  <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Egresos</act:name>
+  <act:id type="new">3b95fbbcc06ef20d61aa082b84938287</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Egresos</act:description>
+  <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Patrimonio Neto</act:name>
+  <act:id type="new">b8b72887da1adf889f171923d23efbdd</act:id>
+  <act:type>EQUITY</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Patrimonio Neto</act:description>
+  <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Capital Inicial</act:name>
+  <act:id type="new">bdb4dd9be2b98f03a0b400036452232c</act:id>
+  <act:type>EQUITY</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:commodity-scu>100</act:commodity-scu>
+  <act:description>Capital Inicial</act:description>
+  <act:parent type="new">b8b72887da1adf889f171923d23efbdd</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>equity-type</slot:key>
+      <slot:value type="string">opening-balance</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+</gnc-account-example>

--- a/data/accounts/es_AR/acctchrt_childcare.gnucash-xea
+++ b/data/accounts/es_AR/acctchrt_childcare.gnucash-xea
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gnc-account-example 
+  xmlns="http://www.gnucash.org/XML/"
+  xmlns:act="http://www.gnucash.org/XML/act"
+  xmlns:addr="http://www.gnucash.org/XML/addr"
+  xmlns:bgt="http://www.gnucash.org/XML/bgt"
+  xmlns:billterm="http://www.gnucash.org/XML/billterm"
+  xmlns:book="http://www.gnucash.org/XML/book"
+  xmlns:bt-days="http://www.gnucash.org/XML/bt-days"
+  xmlns:bt-prox="http://www.gnucash.org/XML/bt-prox"
+  xmlns:cd="http://www.gnucash.org/XML/cd"
+  xmlns:cmdty="http://www.gnucash.org/XML/cmdty"
+  xmlns:cust="http://www.gnucash.org/XML/cust"
+  xmlns:employee="http://www.gnucash.org/XML/employee"
+  xmlns:entry="http://www.gnucash.org/XML/entry"
+  xmlns:fs="http://www.gnucash.org/XML/fs"
+  xmlns:gnc="http://www.gnucash.org/XML/gnc"
+  xmlns:gnc-act="http://www.gnucash.org/XML/gnc-act"
+  xmlns:invoice="http://www.gnucash.org/XML/invoice"
+  xmlns:job="http://www.gnucash.org/XML/job"
+  xmlns:lot="http://www.gnucash.org/XML/lot"
+  xmlns:order="http://www.gnucash.org/XML/order"
+  xmlns:owner="http://www.gnucash.org/XML/owner"
+  xmlns:price="http://www.gnucash.org/XML/price"
+  xmlns:recurrence="http://www.gnucash.org/XML/recurrence"
+  xmlns:slot="http://www.gnucash.org/XML/slot"
+  xmlns:split="http://www.gnucash.org/XML/split"
+  xmlns:sx="http://www.gnucash.org/XML/sx"
+  xmlns:taxtable="http://www.gnucash.org/XML/taxtable"
+  xmlns:trn="http://www.gnucash.org/XML/trn"
+  xmlns:ts="http://www.gnucash.org/XML/ts"
+  xmlns:tte="http://www.gnucash.org/XML/tte"
+  xmlns:vendor="http://www.gnucash.org/XML/vendor">
+    <gnc-act:title>
+      Gastos de guardería
+    </gnc-act:title>
+    <gnc-act:short-description>
+      Cuenta para gestionar gastos de guardería
+    </gnc-act:short-description>
+    <gnc-act:long-description>
+      Deberá seleccionar esta lista de cuentas si tiene gastos de guardería.
+    </gnc-act:long-description>
+<gnc:account version="2.0.0">
+  <act:name>Root Account</act:name>
+  <act:id type="new">1972cce2e2364f95b2b0bc014502661d</act:id>
+  <act:type>ROOT</act:type>
+  <act:commodity-scu>0</act:commodity-scu>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Egresos</act:name>
+  <act:id type="new">ee8238ee2c2ce590160761df09b99b72</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Egresos</act:description>
+  <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Guardería</act:name>
+  <act:id type="new">8999739a6bfc46088a3ea5ec45e5f8a4</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Guardería</act:description>
+  <act:parent type="new">ee8238ee2c2ce590160761df09b99b72</act:parent>
+</gnc:account>
+</gnc-account-example>

--- a/data/accounts/es_AR/acctchrt_common.gnucash-xea
+++ b/data/accounts/es_AR/acctchrt_common.gnucash-xea
@@ -1,0 +1,813 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gnc-account-example 
+  xmlns="http://www.gnucash.org/XML/"
+  xmlns:act="http://www.gnucash.org/XML/act"
+  xmlns:addr="http://www.gnucash.org/XML/addr"
+  xmlns:bgt="http://www.gnucash.org/XML/bgt"
+  xmlns:billterm="http://www.gnucash.org/XML/billterm"
+  xmlns:book="http://www.gnucash.org/XML/book"
+  xmlns:bt-days="http://www.gnucash.org/XML/bt-days"
+  xmlns:bt-prox="http://www.gnucash.org/XML/bt-prox"
+  xmlns:cd="http://www.gnucash.org/XML/cd"
+  xmlns:cmdty="http://www.gnucash.org/XML/cmdty"
+  xmlns:cust="http://www.gnucash.org/XML/cust"
+  xmlns:employee="http://www.gnucash.org/XML/employee"
+  xmlns:entry="http://www.gnucash.org/XML/entry"
+  xmlns:fs="http://www.gnucash.org/XML/fs"
+  xmlns:gnc="http://www.gnucash.org/XML/gnc"
+  xmlns:gnc-act="http://www.gnucash.org/XML/gnc-act"
+  xmlns:invoice="http://www.gnucash.org/XML/invoice"
+  xmlns:job="http://www.gnucash.org/XML/job"
+  xmlns:lot="http://www.gnucash.org/XML/lot"
+  xmlns:order="http://www.gnucash.org/XML/order"
+  xmlns:owner="http://www.gnucash.org/XML/owner"
+  xmlns:price="http://www.gnucash.org/XML/price"
+  xmlns:recurrence="http://www.gnucash.org/XML/recurrence"
+  xmlns:slot="http://www.gnucash.org/XML/slot"
+  xmlns:split="http://www.gnucash.org/XML/split"
+  xmlns:sx="http://www.gnucash.org/XML/sx"
+  xmlns:taxtable="http://www.gnucash.org/XML/taxtable"
+  xmlns:trn="http://www.gnucash.org/XML/trn"
+  xmlns:ts="http://www.gnucash.org/XML/ts"
+  xmlns:tte="http://www.gnucash.org/XML/tte"
+  xmlns:vendor="http://www.gnucash.org/XML/vendor">
+
+<gnc-act:title>
+  Cuentas Comunes
+</gnc-act:title>
+<gnc-act:short-description>
+  Un conjunto de las cuentas básicas más usadas.
+</gnc-act:short-description>
+<gnc-act:long-description>
+  La mayoría de los usuarios deseará elegir este conjunto de cuentas de uso personal. Incluye las cuentas más usadas (cuenta corriente, caja de ahorro, caja, tarjeta de crédito, ingresos, egresos, gastos comunes).
+</gnc-act:long-description>
+<gnc-act:start-selected>1</gnc-act:start-selected>
+
+<gnc:account version="2.0.0">
+  <act:name>Root Account</act:name>
+  <act:id type="new">1972cce2e2364f95b2b0bc014502661d</act:id>
+  <act:type>ROOT</act:type>
+  <act:commodity-scu>0</act:commodity-scu>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Activo</act:name>
+  <act:id type="new">98f262dfab9a2b99ac42919dcf58d304</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Activo</act:description>
+  <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Activo Corriente</act:name>
+  <act:id type="new">a1dd5f225156f110689c204fefded0ab</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Activo Corriente</act:description>
+  <act:parent type="new">98f262dfab9a2b99ac42919dcf58d304</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Cuenta Corriente</act:name>
+  <act:id type="new">b477aa9e0d4eb67c34e1e35903fb3f99</act:id>
+  <act:type>BANK</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Cuenta Corriente</act:description>
+  <act:parent type="new">a1dd5f225156f110689c204fefded0ab</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Caja de Ahorro</act:name>
+  <act:id type="new">eeae5a1892e88adbc3b369c76ee4e889</act:id>
+  <act:type>BANK</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Caja de Ahorro</act:description>
+  <act:parent type="new">a1dd5f225156f110689c204fefded0ab</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Caja</act:name>
+  <act:id type="new">07b454b9dd6f68c4b613c5f1ef76f884</act:id>
+  <act:type>CASH</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Caja (efectivo)</act:description>
+  <act:parent type="new">a1dd5f225156f110689c204fefded0ab</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Pasivo</act:name>
+  <act:id type="new">19a911feed9b41b8b01be036a2aed9fe</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Pasivo</act:description>
+  <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Tarjeta de Crédito</act:name>
+  <act:id type="new">efc3caac2619666c53e6e27f02d5e716</act:id>
+  <act:type>CREDIT</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Tarjeta de Crédito</act:description>
+  <act:parent type="new">19a911feed9b41b8b01be036a2aed9fe</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Ingresos</act:name>
+  <act:id type="new">a7ab23dd2d41616042034d5a012a0850</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Ingresos</act:description>
+  <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Adicionales</act:name>
+  <act:id type="new">59b72cd943a2ca6f077748bba9a942cd</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Adicionales</act:description>
+  <act:parent type="new">a7ab23dd2d41616042034d5a012a0850</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Regalos Recibidos</act:name>
+  <act:id type="new">1adcf2c65d7a66f32144ccd9ce4f438f</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Regalos Recibidos</act:description>
+  <act:parent type="new">a7ab23dd2d41616042034d5a012a0850</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Intereses Ganados</act:name>
+  <act:id type="new">c47361e40d9478ec11758097e64d693c</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Intereses Ganados</act:description>
+  <act:parent type="new">a7ab23dd2d41616042034d5a012a0850</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Intereses de Cuenta Corriente</act:name>
+  <act:id type="new">73481e2da7461fc34e7003b7ec560bdf</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Intereses de Cuenta Corriente</act:description>
+  <act:parent type="new">c47361e40d9478ec11758097e64d693c</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Otros Intereses</act:name>
+  <act:id type="new">be17363347a8578c48cecd06bc8b7aa8</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Otros Intereses</act:description>
+  <act:parent type="new">c47361e40d9478ec11758097e64d693c</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Intereses de Caja de Ahorro</act:name>
+  <act:id type="new">2802ac0d1bff1c09a903f2ad6fde2725</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Intereses de Caja de Ahorro</act:description>
+  <act:parent type="new">c47361e40d9478ec11758097e64d693c</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Otros Ingresos</act:name>
+  <act:id type="new">49525ad0fb4ced06b9874d365d53f505</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Otros Ingresos</act:description>
+  <act:parent type="new">a7ab23dd2d41616042034d5a012a0850</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Sueldo</act:name>
+  <act:id type="new">a750b99cb8487a5e47daedcd3a69fe85</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Sueldo</act:description>
+  <act:parent type="new">a7ab23dd2d41616042034d5a012a0850</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Egresos</act:name>
+  <act:id type="new">1884bbd7394883ebafec8b9e2eb091a4</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Egresos</act:description>
+  <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Ajustes</act:name>
+  <act:id type="new">72f85277a7a7f8b4de175405e20d83bd</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Ajustes</act:description>
+  <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Rodados</act:name>
+  <act:id type="new">56df186f1ce6114ddca7b9e5d03af390</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Rodados (autos, motos, etc.)</act:description>
+  <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Patente</act:name>
+  <act:id type="new">2ff007a389bd23d8970afeba2d58c9a8</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Patente</act:description>
+  <act:parent type="new">56df186f1ce6114ddca7b9e5d03af390</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Combustible</act:name>
+  <act:id type="new">e64b5eecf86ce4e27a64c477a4c77477</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Nafta, diésel, GNC, etc.</act:description>
+  <act:parent type="new">56df186f1ce6114ddca7b9e5d03af390</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Estacionamiento</act:name>
+  <act:id type="new">d72262c1c0e2c3388183ebb44a98b011</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Estacionamiento</act:description>
+  <act:parent type="new">56df186f1ce6114ddca7b9e5d03af390</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Arreglos y Mantenimiento</act:name>
+  <act:id type="new">665dd78f0cc75dd331f556949337de68</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Arreglos y Mantenimiento</act:description>
+  <act:parent type="new">56df186f1ce6114ddca7b9e5d03af390</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Gastos Bancarios</act:name>
+  <act:id type="new">fb6c8e25a50737e70fffde432a2355ee</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Gastos Bancarios</act:description>
+  <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Libros</act:name>
+  <act:id type="new">36479bbc17680f4b9663a9842736153f</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Libros</act:description>
+  <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Cable</act:name>
+  <act:id type="new">a1393344fb199f08f751ac3154694e87</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Cable</act:description>
+  <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Donaciones</act:name>
+  <act:id type="new">ec8eec3d46c69aa861fda836e11346c0</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Donaciones</act:description>
+  <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Ropa</act:name>
+  <act:id type="new">c27a040a73eac2688d85d29b5b5309c8</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Ropa</act:description>
+  <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Computadoras</act:name>
+  <act:id type="new">fc4390b6214ad1576c5ffffc2b3c268c</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Computadoras</act:description>
+  <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Restaurantes</act:name>
+  <act:id type="new">0a59a3347e4ff02b862de41ef59d7351</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Restaurantes</act:description>
+  <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Educación</act:name>
+  <act:id type="new">5b5ac050529b0f553752babe4a6a35d2</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Educación</act:description>
+  <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Entretenimiento</act:name>
+  <act:id type="new">0ebd1d5f40d9e9e8bb1a4bf539650dd1</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Entretenimiento</act:description>
+  <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+    <act:name>Música/Películas</act:name>
+  <act:id type="new">4570ea8f4ac5cbd7d8927c905f0978ae</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Música y Películas</act:description>
+  <act:parent type="new">0ebd1d5f40d9e9e8bb1a4bf539650dd1</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Recreación</act:name>
+  <act:id type="new">7db9b0aa3bc348da9900f95fc67541a1</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Recreación</act:description>
+  <act:parent type="new">0ebd1d5f40d9e9e8bb1a4bf539650dd1</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Viajes</act:name>
+  <act:id type="new">def0eac939dbd668f503d84860de8d6e</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Viajes</act:description>
+  <act:parent type="new">0ebd1d5f40d9e9e8bb1a4bf539650dd1</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Regalos</act:name>
+  <act:id type="new">f86b1cebc619455ada23952a0e810909</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Regalos</act:description>
+  <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Comida</act:name>
+  <act:id type="new">83bc2bd915ab6b74c7107b55f8783523</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Comida</act:description>
+  <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Hobbies</act:name>
+  <act:id type="new">89f6400a94cd87fea0b056faf6ab7744</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Hobbies</act:description>
+  <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Seguros</act:name>
+  <act:id type="new">5bda5ff833bc395dc1b00f95c66ce555</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Seguros</act:description>
+  <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Seguro de Auto</act:name>
+  <act:id type="new">cd72695526906a15ba1a1d9a7680b8e7</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Seguro de Auto</act:description>
+  <act:parent type="new">5bda5ff833bc395dc1b00f95c66ce555</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Seguro de Salud</act:name>
+  <act:id type="new">d80613194a52340c9e5eb62e853c72cf</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Obra social, prepaga, etc.</act:description>
+  <act:parent type="new">5bda5ff833bc395dc1b00f95c66ce555</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Seguro de Vida</act:name>
+  <act:id type="new">70a327f54be53ef187a52b1d8df70fdd</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Seguro de Vida</act:description>
+  <act:parent type="new">5bda5ff833bc395dc1b00f95c66ce555</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Lavandería</act:name>
+  <act:id type="new">1006551b2458631dfc8507b7451c9631</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Lavandería</act:description>
+  <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Gastos Médicos</act:name>
+  <act:id type="new">62752930dd1b2b4c90c6d198bd2ff33f</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Gastos Médicos</act:description>
+  <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Otros Gastos</act:name>
+  <act:id type="new">759deef82e73587bf48a7dd76aa6abe8</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Otros Gastos</act:description>
+  <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Sevicios Online</act:name>
+  <act:id type="new">2170a1a631cc3b6fc32813fa49a12f77</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Servicios Online</act:description>
+  <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Teléfono</act:name>
+  <act:id type="new">1d9d7265e25c6c84dda514d2e8899e87</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Teléfono</act:description>
+  <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Transporte Público</act:name>
+  <act:id type="new">64aa760163c7768518e49a104d1c171f</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Transporte Público</act:description>
+  <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Suscripciones</act:name>
+  <act:id type="new">0336712690d36bcb02e0ce59b5d7653b</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Suscripciones</act:description>
+  <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Provisiones</act:name>
+  <act:id type="new">e2b34f49d4cf916cf4d45525e1e7319d</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Provisiones</act:description>
+  <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Impuestos</act:name>
+  <act:id type="new">2c53a8a0c8b36f7de3f4052653886c2b</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Impuestos</act:description>
+  <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Impuesto a las Ganancias</act:name>
+  <act:id type="new">090a786357463ec7fbee8066cb999097</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Impuesto a las Ganancias</act:description>
+  <act:parent type="new">2c53a8a0c8b36f7de3f4052653886c2b</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Otros Impuestos</act:name>
+  <act:id type="new">51875f8aaa0e4f2295a2ae13cf780b2e</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Otros Impuestos</act:description>
+  <act:parent type="new">2c53a8a0c8b36f7de3f4052653886c2b</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Impuestos Provinciales</act:name>
+  <act:id type="new">cd1f1b512ed51a069fd83a5ffcaf6e11</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Impuestos Provinciales</act:description>
+  <act:parent type="new">2c53a8a0c8b36f7de3f4052653886c2b</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Impuestos Municipales</act:name>
+  <act:id type="new">c252f10f3d57dd05c500856164b1729e</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Impuestos Municipales</act:description>
+  <act:parent type="new">2c53a8a0c8b36f7de3f4052653886c2b</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Servicios</act:name>
+  <act:id type="new">57635fa5f71dee8ffc207c277250e773</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Servicios</act:description>
+  <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Electricidad</act:name>
+  <act:id type="new">2fe462e202e2daffd845359b08a7eefe</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Electricidad</act:description>
+  <act:parent type="new">57635fa5f71dee8ffc207c277250e773</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Tasas Municipales</act:name>
+  <act:id type="new">2d0315d7b2f8f11a8a8b32d805bca6eb</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>ABL o similares</act:description>
+  <act:parent type="new">57635fa5f71dee8ffc207c277250e773</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Gas</act:name>
+  <act:id type="new">dcc33ce7edf402e327318aa1890d35ea</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Gas</act:description>
+  <act:parent type="new">57635fa5f71dee8ffc207c277250e773</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Agua Corriente</act:name>
+  <act:id type="new">8cdc91b733444f9f0dfae9773b8f408c</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Agua Corriente</act:description>
+  <act:parent type="new">57635fa5f71dee8ffc207c277250e773</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Patrimonio Neto</act:name>
+  <act:id type="new">3ab6a6d97b216c11333e48aa2b749a91</act:id>
+  <act:type>EQUITY</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Patrimonio Neto</act:description>
+  <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Capital Inicial</act:name>
+  <act:id type="new">a0a622a30410f75eba35d2875a843da8</act:id>
+  <act:type>EQUITY</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Capital Inicial</act:description>
+  <act:parent type="new">3ab6a6d97b216c11333e48aa2b749a91</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>equity-type</slot:key>
+      <slot:value type="string">opening-balance</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+
+</gnc-account-example>

--- a/data/accounts/es_AR/acctchrt_currency.gnucash-xea
+++ b/data/accounts/es_AR/acctchrt_currency.gnucash-xea
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gnc-account-example 
+  xmlns="http://www.gnucash.org/XML/"
+  xmlns:act="http://www.gnucash.org/XML/act"
+  xmlns:addr="http://www.gnucash.org/XML/addr"
+  xmlns:bgt="http://www.gnucash.org/XML/bgt"
+  xmlns:billterm="http://www.gnucash.org/XML/billterm"
+  xmlns:book="http://www.gnucash.org/XML/book"
+  xmlns:bt-days="http://www.gnucash.org/XML/bt-days"
+  xmlns:bt-prox="http://www.gnucash.org/XML/bt-prox"
+  xmlns:cd="http://www.gnucash.org/XML/cd"
+  xmlns:cmdty="http://www.gnucash.org/XML/cmdty"
+  xmlns:cust="http://www.gnucash.org/XML/cust"
+  xmlns:employee="http://www.gnucash.org/XML/employee"
+  xmlns:entry="http://www.gnucash.org/XML/entry"
+  xmlns:fs="http://www.gnucash.org/XML/fs"
+  xmlns:gnc="http://www.gnucash.org/XML/gnc"
+  xmlns:gnc-act="http://www.gnucash.org/XML/gnc-act"
+  xmlns:invoice="http://www.gnucash.org/XML/invoice"
+  xmlns:job="http://www.gnucash.org/XML/job"
+  xmlns:lot="http://www.gnucash.org/XML/lot"
+  xmlns:order="http://www.gnucash.org/XML/order"
+  xmlns:owner="http://www.gnucash.org/XML/owner"
+  xmlns:price="http://www.gnucash.org/XML/price"
+  xmlns:recurrence="http://www.gnucash.org/XML/recurrence"
+  xmlns:slot="http://www.gnucash.org/XML/slot"
+  xmlns:split="http://www.gnucash.org/XML/split"
+  xmlns:sx="http://www.gnucash.org/XML/sx"
+  xmlns:taxtable="http://www.gnucash.org/XML/taxtable"
+  xmlns:trn="http://www.gnucash.org/XML/trn"
+  xmlns:ts="http://www.gnucash.org/XML/ts"
+  xmlns:tte="http://www.gnucash.org/XML/tte"
+  xmlns:vendor="http://www.gnucash.org/XML/vendor">
+    <gnc-act:title>
+      Cuenta de conversión monetaria
+    </gnc-act:title>
+    <gnc-act:short-description>
+      Cuenta para convertir y comerciar con moneda extranjera
+    </gnc-act:short-description>
+    <gnc-act:long-description>
+     Deseará seleccionar esta lista de cuentas si comercia con monedas extranjeras.
+
+     Nota: La cuenta se encuentra en USD; edite la cuenta a la moneda extranjera que use.
+  </gnc-act:long-description>    
+<gnc:account version="2.0.0">
+  <act:name>Root Account</act:name>
+  <act:id type="new">1972cce2e2364f95b2b0bc014502661d</act:id>
+  <act:type>ROOT</act:type>
+  <act:commodity-scu>0</act:commodity-scu>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Activo</act:name>
+  <act:id type="new">b3c65be1c5d163746ddc0c506f3f4619</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Activo</act:description>
+  <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Inversiones</act:name>
+  <act:id type="new">d9c796b35784533aee4309e28a3cbfc5</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Inversiones</act:description>
+  <act:parent type="new">b3c65be1c5d163746ddc0c506f3f4619</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Moneda Extranjera</act:name>
+  <act:id type="new">9206632307989cb5b244ad5da5d3131b</act:id>
+  <act:type>CURRENCY</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>USD</cmdty:id>
+  </act:commodity>
+  <act:description>Moneda Extranjera</act:description>
+  <act:parent type="new">d9c796b35784533aee4309e28a3cbfc5</act:parent>
+</gnc:account>
+</gnc-account-example>

--- a/data/accounts/es_AR/acctchrt_fixedassets.gnucash-xea
+++ b/data/accounts/es_AR/acctchrt_fixedassets.gnucash-xea
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gnc-account-example 
+  xmlns="http://www.gnucash.org/XML/"
+  xmlns:act="http://www.gnucash.org/XML/act"
+  xmlns:addr="http://www.gnucash.org/XML/addr"
+  xmlns:bgt="http://www.gnucash.org/XML/bgt"
+  xmlns:billterm="http://www.gnucash.org/XML/billterm"
+  xmlns:book="http://www.gnucash.org/XML/book"
+  xmlns:bt-days="http://www.gnucash.org/XML/bt-days"
+  xmlns:bt-prox="http://www.gnucash.org/XML/bt-prox"
+  xmlns:cd="http://www.gnucash.org/XML/cd"
+  xmlns:cmdty="http://www.gnucash.org/XML/cmdty"
+  xmlns:cust="http://www.gnucash.org/XML/cust"
+  xmlns:employee="http://www.gnucash.org/XML/employee"
+  xmlns:entry="http://www.gnucash.org/XML/entry"
+  xmlns:fs="http://www.gnucash.org/XML/fs"
+  xmlns:gnc="http://www.gnucash.org/XML/gnc"
+  xmlns:gnc-act="http://www.gnucash.org/XML/gnc-act"
+  xmlns:invoice="http://www.gnucash.org/XML/invoice"
+  xmlns:job="http://www.gnucash.org/XML/job"
+  xmlns:lot="http://www.gnucash.org/XML/lot"
+  xmlns:order="http://www.gnucash.org/XML/order"
+  xmlns:owner="http://www.gnucash.org/XML/owner"
+  xmlns:price="http://www.gnucash.org/XML/price"
+  xmlns:recurrence="http://www.gnucash.org/XML/recurrence"
+  xmlns:slot="http://www.gnucash.org/XML/slot"
+  xmlns:split="http://www.gnucash.org/XML/split"
+  xmlns:sx="http://www.gnucash.org/XML/sx"
+  xmlns:taxtable="http://www.gnucash.org/XML/taxtable"
+  xmlns:trn="http://www.gnucash.org/XML/trn"
+  xmlns:ts="http://www.gnucash.org/XML/ts"
+  xmlns:tte="http://www.gnucash.org/XML/tte"
+  xmlns:vendor="http://www.gnucash.org/XML/vendor">
+    <gnc-act:title>
+      Activos fijos
+    </gnc-act:title>
+    <gnc-act:short-description>
+      Cuentas para gestionar varios activos fijos
+    </gnc-act:short-description>
+    <gnc-act:long-description>
+      Deberá seleccionar esta cuenta si tiene varios activos fijos (casa, vehículo, casa de vacaciones, otros activos).
+    </gnc-act:long-description>
+<gnc:account version="2.0.0">
+  <act:name>Root Account</act:name>
+  <act:id type="new">1972cce2e2364f95b2b0bc014502661d</act:id>
+  <act:type>ROOT</act:type>
+  <act:commodity-scu>0</act:commodity-scu>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Activo</act:name>
+  <act:id type="new">64b6276c060185131cecbd1ac6218440</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Activo</act:description>
+  <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Activo fijo</act:name>
+  <act:id type="new">9b171f77000bf68dd1ebbaf58336656d</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Activo fijo</act:description>
+  <act:parent type="new">64b6276c060185131cecbd1ac6218440</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Casa</act:name>
+  <act:id type="new">9205ad6b6482903e5a696602d491c8f5</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Casa</act:description>
+  <act:parent type="new">9b171f77000bf68dd1ebbaf58336656d</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Otros activos</act:name>
+  <act:id type="new">ad3b239297277c9ef3840c0433cecb18</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Otros activos</act:description>
+  <act:parent type="new">9b171f77000bf68dd1ebbaf58336656d</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Vehículo</act:name>
+  <act:id type="new">5913089ffc36df6f0a5d96a5d7a444c0</act:id>
+  <act:type>ASSET</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Vehículo</act:description>
+  <act:parent type="new">9b171f77000bf68dd1ebbaf58336656d</act:parent>
+</gnc:account>
+</gnc-account-example>

--- a/data/accounts/es_AR/acctchrt_homeloan.gnucash-xea
+++ b/data/accounts/es_AR/acctchrt_homeloan.gnucash-xea
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gnc-account-example 
+  xmlns="http://www.gnucash.org/XML/"
+  xmlns:act="http://www.gnucash.org/XML/act"
+  xmlns:addr="http://www.gnucash.org/XML/addr"
+  xmlns:bgt="http://www.gnucash.org/XML/bgt"
+  xmlns:billterm="http://www.gnucash.org/XML/billterm"
+  xmlns:book="http://www.gnucash.org/XML/book"
+  xmlns:bt-days="http://www.gnucash.org/XML/bt-days"
+  xmlns:bt-prox="http://www.gnucash.org/XML/bt-prox"
+  xmlns:cd="http://www.gnucash.org/XML/cd"
+  xmlns:cmdty="http://www.gnucash.org/XML/cmdty"
+  xmlns:cust="http://www.gnucash.org/XML/cust"
+  xmlns:employee="http://www.gnucash.org/XML/employee"
+  xmlns:entry="http://www.gnucash.org/XML/entry"
+  xmlns:fs="http://www.gnucash.org/XML/fs"
+  xmlns:gnc="http://www.gnucash.org/XML/gnc"
+  xmlns:gnc-act="http://www.gnucash.org/XML/gnc-act"
+  xmlns:invoice="http://www.gnucash.org/XML/invoice"
+  xmlns:job="http://www.gnucash.org/XML/job"
+  xmlns:lot="http://www.gnucash.org/XML/lot"
+  xmlns:order="http://www.gnucash.org/XML/order"
+  xmlns:owner="http://www.gnucash.org/XML/owner"
+  xmlns:price="http://www.gnucash.org/XML/price"
+  xmlns:recurrence="http://www.gnucash.org/XML/recurrence"
+  xmlns:slot="http://www.gnucash.org/XML/slot"
+  xmlns:split="http://www.gnucash.org/XML/split"
+  xmlns:sx="http://www.gnucash.org/XML/sx"
+  xmlns:taxtable="http://www.gnucash.org/XML/taxtable"
+  xmlns:trn="http://www.gnucash.org/XML/trn"
+  xmlns:ts="http://www.gnucash.org/XML/ts"
+  xmlns:tte="http://www.gnucash.org/XML/tte"
+  xmlns:vendor="http://www.gnucash.org/XML/vendor">
+    <gnc-act:title>
+      Préstamo hipotecario
+    </gnc-act:title>
+    <gnc-act:short-description>
+      Cuentas para préstamo hipotecario e interés asociado
+    </gnc-act:short-description>
+    <gnc-act:long-description>
+      Deseará escoger esta lista de cuentas si tiene contratado un préstamo hipotecario (préstamo hipotecario, interés hipoteca).
+  </gnc-act:long-description>    
+<gnc:account version="2.0.0">
+  <act:name>Root Account</act:name>
+  <act:id type="new">1972cce2e2364f95b2b0bc014502661d</act:id>
+  <act:type>ROOT</act:type>
+  <act:commodity-scu>0</act:commodity-scu>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Pasivo</act:name>
+  <act:id type="new">6664763bd1ea41462cba5ef856d9c00c</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Pasivo</act:description>
+  <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Préstamos</act:name>
+  <act:id type="new">2e6e2d91551cff7b1fd8d6eb34c12117</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Préstamos</act:description>
+  <act:parent type="new">6664763bd1ea41462cba5ef856d9c00c</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Préstamo hipotecario</act:name>
+  <act:id type="new">4df1b393c218d9047dd22d33d2737e83</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Préstamo hipotecario</act:description>
+  <act:parent type="new">2e6e2d91551cff7b1fd8d6eb34c12117</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Egresos</act:name>
+  <act:id type="new">2f076f5ae073173a11d33420cd39fa4d</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Egresos</act:description>
+  <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Intereses</act:name>
+  <act:id type="new">3dc58d8a51b5deaa22e0c65d81e90346</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Intereses</act:description>
+  <act:parent type="new">2f076f5ae073173a11d33420cd39fa4d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Interés de hipoteca</act:name>
+  <act:id type="new">c1e23fa813d3c8c4a8ea1228a7615b79</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Interés de hipoteca</act:description>
+  <act:parent type="new">3dc58d8a51b5deaa22e0c65d81e90346</act:parent>
+</gnc:account>
+</gnc-account-example>

--- a/data/accounts/es_AR/acctchrt_homeown.gnucash-xea
+++ b/data/accounts/es_AR/acctchrt_homeown.gnucash-xea
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gnc-account-example 
+  xmlns="http://www.gnucash.org/XML/"
+  xmlns:act="http://www.gnucash.org/XML/act"
+  xmlns:addr="http://www.gnucash.org/XML/addr"
+  xmlns:bgt="http://www.gnucash.org/XML/bgt"
+  xmlns:billterm="http://www.gnucash.org/XML/billterm"
+  xmlns:book="http://www.gnucash.org/XML/book"
+  xmlns:bt-days="http://www.gnucash.org/XML/bt-days"
+  xmlns:bt-prox="http://www.gnucash.org/XML/bt-prox"
+  xmlns:cd="http://www.gnucash.org/XML/cd"
+  xmlns:cmdty="http://www.gnucash.org/XML/cmdty"
+  xmlns:cust="http://www.gnucash.org/XML/cust"
+  xmlns:employee="http://www.gnucash.org/XML/employee"
+  xmlns:entry="http://www.gnucash.org/XML/entry"
+  xmlns:fs="http://www.gnucash.org/XML/fs"
+  xmlns:gnc="http://www.gnucash.org/XML/gnc"
+  xmlns:gnc-act="http://www.gnucash.org/XML/gnc-act"
+  xmlns:invoice="http://www.gnucash.org/XML/invoice"
+  xmlns:job="http://www.gnucash.org/XML/job"
+  xmlns:lot="http://www.gnucash.org/XML/lot"
+  xmlns:order="http://www.gnucash.org/XML/order"
+  xmlns:owner="http://www.gnucash.org/XML/owner"
+  xmlns:price="http://www.gnucash.org/XML/price"
+  xmlns:recurrence="http://www.gnucash.org/XML/recurrence"
+  xmlns:slot="http://www.gnucash.org/XML/slot"
+  xmlns:split="http://www.gnucash.org/XML/split"
+  xmlns:sx="http://www.gnucash.org/XML/sx"
+  xmlns:taxtable="http://www.gnucash.org/XML/taxtable"
+  xmlns:trn="http://www.gnucash.org/XML/trn"
+  xmlns:ts="http://www.gnucash.org/XML/ts"
+  xmlns:tte="http://www.gnucash.org/XML/tte"
+  xmlns:vendor="http://www.gnucash.org/XML/vendor">
+    <gnc-act:title>
+      Gastos de propietario de casa
+    </gnc-act:title>
+    <gnc-act:short-description>
+      Gastos asociados a la propiedad de una casa
+    </gnc-act:short-description>
+    <gnc-act:long-description>
+      Deberás seleccionar esta lista de cuentas si tenés una casa. Proporciona un grupo de cuentas para controlar los gastos domésticos (seguro, impuestos, reparaciones).
+    </gnc-act:long-description>
+<gnc:account version="2.0.0">
+  <act:name>Root Account</act:name>
+  <act:id type="new">1972cce2e2364f95b2b0bc014502661d</act:id>
+  <act:type>ROOT</act:type>
+  <act:commodity-scu>0</act:commodity-scu>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Egresos</act:name>
+  <act:id type="new">84732f5fdd27b6463d75bf958e3a4b06</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Egresos</act:description>
+  <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Reparaciones domésticas</act:name>
+  <act:id type="new">fa27de57090e107fa99fe1db53790f23</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Reparaciones domésticas</act:description>
+  <act:parent type="new">84732f5fdd27b6463d75bf958e3a4b06</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Seguros</act:name>
+  <act:id type="new">4677fe36914ebcf23758f3bf20686b4a</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Seguros</act:description>
+  <act:parent type="new">84732f5fdd27b6463d75bf958e3a4b06</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Seguro de hogar</act:name>
+  <act:id type="new">3b5909f31bda0e0f76149fd600e0cb1d</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Seguro de hogar</act:description>
+  <act:parent type="new">4677fe36914ebcf23758f3bf20686b4a</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Impuestos</act:name>
+  <act:id type="new">a931b8ffe2917ff9a069333623da96ca</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Impuestos</act:description>
+  <act:parent type="new">84732f5fdd27b6463d75bf958e3a4b06</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Contribución</act:name>
+  <act:id type="new">3994b8f5a6a8b2a0a48126fa955e03f7</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Bienes Personales</act:description>
+  <act:parent type="new">a931b8ffe2917ff9a069333623da96ca</act:parent>
+</gnc:account>
+</gnc-account-example>

--- a/data/accounts/es_AR/acctchrt_otherloan.gnucash-xea
+++ b/data/accounts/es_AR/acctchrt_otherloan.gnucash-xea
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gnc-account-example 
+  xmlns="http://www.gnucash.org/XML/"
+  xmlns:act="http://www.gnucash.org/XML/act"
+  xmlns:addr="http://www.gnucash.org/XML/addr"
+  xmlns:bgt="http://www.gnucash.org/XML/bgt"
+  xmlns:billterm="http://www.gnucash.org/XML/billterm"
+  xmlns:book="http://www.gnucash.org/XML/book"
+  xmlns:bt-days="http://www.gnucash.org/XML/bt-days"
+  xmlns:bt-prox="http://www.gnucash.org/XML/bt-prox"
+  xmlns:cd="http://www.gnucash.org/XML/cd"
+  xmlns:cmdty="http://www.gnucash.org/XML/cmdty"
+  xmlns:cust="http://www.gnucash.org/XML/cust"
+  xmlns:employee="http://www.gnucash.org/XML/employee"
+  xmlns:entry="http://www.gnucash.org/XML/entry"
+  xmlns:fs="http://www.gnucash.org/XML/fs"
+  xmlns:gnc="http://www.gnucash.org/XML/gnc"
+  xmlns:gnc-act="http://www.gnucash.org/XML/gnc-act"
+  xmlns:invoice="http://www.gnucash.org/XML/invoice"
+  xmlns:job="http://www.gnucash.org/XML/job"
+  xmlns:lot="http://www.gnucash.org/XML/lot"
+  xmlns:order="http://www.gnucash.org/XML/order"
+  xmlns:owner="http://www.gnucash.org/XML/owner"
+  xmlns:price="http://www.gnucash.org/XML/price"
+  xmlns:recurrence="http://www.gnucash.org/XML/recurrence"
+  xmlns:slot="http://www.gnucash.org/XML/slot"
+  xmlns:split="http://www.gnucash.org/XML/split"
+  xmlns:sx="http://www.gnucash.org/XML/sx"
+  xmlns:taxtable="http://www.gnucash.org/XML/taxtable"
+  xmlns:trn="http://www.gnucash.org/XML/trn"
+  xmlns:ts="http://www.gnucash.org/XML/ts"
+  xmlns:tte="http://www.gnucash.org/XML/tte"
+  xmlns:vendor="http://www.gnucash.org/XML/vendor">
+    <gnc-act:title>
+      Otros préstamos
+    </gnc-act:title>
+    <gnc-act:short-description>
+      Cuentas para controlar otros préstamos, junto con su interés asociado
+    </gnc-act:short-description>
+    <gnc-act:long-description>
+      Deberás seleccionar esta lista de cuentas si tenés un préstamo distinto a un préstamo hipotecario (otro préstamo, interés de otro préstamo).
+    </gnc-act:long-description>
+<gnc:account version="2.0.0">
+  <act:name>Root Account</act:name>
+  <act:id type="new">1972cce2e2364f95b2b0bc014502661d</act:id>
+  <act:type>ROOT</act:type>
+  <act:commodity-scu>0</act:commodity-scu>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Pasivo</act:name>
+  <act:id type="new">8ec79e80d9abf58d78ce3129d3fe3365</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Pasivo</act:description>
+  <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Préstamos</act:name>
+  <act:id type="new">b5624a9d1a1b797b87b815774faccfe4</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Préstamos</act:description>
+  <act:parent type="new">8ec79e80d9abf58d78ce3129d3fe3365</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Otros préstamos</act:name>
+  <act:id type="new">eb79670a4c9b0faab87485b7b2a4abe4</act:id>
+  <act:type>LIABILITY</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Otros préstamos</act:description>
+  <act:parent type="new">b5624a9d1a1b797b87b815774faccfe4</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Egresos</act:name>
+  <act:id type="new">565e52a122e8acc9a67a36e61357e2ae</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Egresos</act:description>
+  <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Intereses</act:name>
+  <act:id type="new">4a02c14e992ea79076837c164aa6fc8d</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Intereses</act:description>
+  <act:parent type="new">565e52a122e8acc9a67a36e61357e2ae</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Otros intereses</act:name>
+  <act:id type="new">f01de45e290ecc29b64d9cb8a733af68</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Intereses asociados a otros préstamos</act:description>
+  <act:parent type="new">4a02c14e992ea79076837c164aa6fc8d</act:parent>
+</gnc:account>
+</gnc-account-example>

--- a/data/accounts/es_AR/acctchrt_renter.gnucash-xea
+++ b/data/accounts/es_AR/acctchrt_renter.gnucash-xea
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gnc-account-example 
+  xmlns="http://www.gnucash.org/XML/"
+  xmlns:act="http://www.gnucash.org/XML/act"
+  xmlns:addr="http://www.gnucash.org/XML/addr"
+  xmlns:bgt="http://www.gnucash.org/XML/bgt"
+  xmlns:billterm="http://www.gnucash.org/XML/billterm"
+  xmlns:book="http://www.gnucash.org/XML/book"
+  xmlns:bt-days="http://www.gnucash.org/XML/bt-days"
+  xmlns:bt-prox="http://www.gnucash.org/XML/bt-prox"
+  xmlns:cd="http://www.gnucash.org/XML/cd"
+  xmlns:cmdty="http://www.gnucash.org/XML/cmdty"
+  xmlns:cust="http://www.gnucash.org/XML/cust"
+  xmlns:employee="http://www.gnucash.org/XML/employee"
+  xmlns:entry="http://www.gnucash.org/XML/entry"
+  xmlns:fs="http://www.gnucash.org/XML/fs"
+  xmlns:gnc="http://www.gnucash.org/XML/gnc"
+  xmlns:gnc-act="http://www.gnucash.org/XML/gnc-act"
+  xmlns:invoice="http://www.gnucash.org/XML/invoice"
+  xmlns:job="http://www.gnucash.org/XML/job"
+  xmlns:lot="http://www.gnucash.org/XML/lot"
+  xmlns:order="http://www.gnucash.org/XML/order"
+  xmlns:owner="http://www.gnucash.org/XML/owner"
+  xmlns:price="http://www.gnucash.org/XML/price"
+  xmlns:recurrence="http://www.gnucash.org/XML/recurrence"
+  xmlns:slot="http://www.gnucash.org/XML/slot"
+  xmlns:split="http://www.gnucash.org/XML/split"
+  xmlns:sx="http://www.gnucash.org/XML/sx"
+  xmlns:taxtable="http://www.gnucash.org/XML/taxtable"
+  xmlns:trn="http://www.gnucash.org/XML/trn"
+  xmlns:ts="http://www.gnucash.org/XML/ts"
+  xmlns:tte="http://www.gnucash.org/XML/tte"
+  xmlns:vendor="http://www.gnucash.org/XML/vendor">
+    <gnc-act:title>
+      Gastos de inquilino
+    </gnc-act:title>
+    <gnc-act:short-description>
+      Gastos asociados a alquilar una casa
+    </gnc-act:short-description>
+    <gnc-act:long-description>
+      Deseará escoger esta lista de cuentas si alquila una casa o departamente (alquiler, seguro de inquilino).
+    </gnc-act:long-description>
+<gnc:account version="2.0.0">
+  <act:name>Root Account</act:name>
+  <act:id type="new">1972cce2e2364f95b2b0bc014502661d</act:id>
+  <act:type>ROOT</act:type>
+  <act:commodity-scu>0</act:commodity-scu>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Egresos</act:name>
+  <act:id type="new">9a2b4520f113372f4e576f5b6dc129c6</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Egresos</act:description>
+  <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Seguros</act:name>
+  <act:id type="new">b79b231807a98cd562c46cf0454e9f25</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Seguros</act:description>
+  <act:parent type="new">9a2b4520f113372f4e576f5b6dc129c6</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Seguro de inquilino</act:name>
+  <act:id type="new">a4c93c964b8322d534e35b7054cbda4d</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Seguro de inquilino</act:description>
+  <act:parent type="new">b79b231807a98cd562c46cf0454e9f25</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Alquiler</act:name>
+  <act:id type="new">c1638a9a48d4d0e1b17d99219a18f34b</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Alquiler</act:description>
+  <act:parent type="new">9a2b4520f113372f4e576f5b6dc129c6</act:parent>
+</gnc:account>
+</gnc-account-example>

--- a/data/accounts/es_AR/acctchrt_spouseinc.gnucash-xea
+++ b/data/accounts/es_AR/acctchrt_spouseinc.gnucash-xea
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gnc-account-example 
+  xmlns="http://www.gnucash.org/XML/"
+  xmlns:act="http://www.gnucash.org/XML/act"
+  xmlns:addr="http://www.gnucash.org/XML/addr"
+  xmlns:bgt="http://www.gnucash.org/XML/bgt"
+  xmlns:billterm="http://www.gnucash.org/XML/billterm"
+  xmlns:book="http://www.gnucash.org/XML/book"
+  xmlns:bt-days="http://www.gnucash.org/XML/bt-days"
+  xmlns:bt-prox="http://www.gnucash.org/XML/bt-prox"
+  xmlns:cd="http://www.gnucash.org/XML/cd"
+  xmlns:cmdty="http://www.gnucash.org/XML/cmdty"
+  xmlns:cust="http://www.gnucash.org/XML/cust"
+  xmlns:employee="http://www.gnucash.org/XML/employee"
+  xmlns:entry="http://www.gnucash.org/XML/entry"
+  xmlns:fs="http://www.gnucash.org/XML/fs"
+  xmlns:gnc="http://www.gnucash.org/XML/gnc"
+  xmlns:gnc-act="http://www.gnucash.org/XML/gnc-act"
+  xmlns:invoice="http://www.gnucash.org/XML/invoice"
+  xmlns:job="http://www.gnucash.org/XML/job"
+  xmlns:lot="http://www.gnucash.org/XML/lot"
+  xmlns:order="http://www.gnucash.org/XML/order"
+  xmlns:owner="http://www.gnucash.org/XML/owner"
+  xmlns:price="http://www.gnucash.org/XML/price"
+  xmlns:recurrence="http://www.gnucash.org/XML/recurrence"
+  xmlns:slot="http://www.gnucash.org/XML/slot"
+  xmlns:split="http://www.gnucash.org/XML/split"
+  xmlns:sx="http://www.gnucash.org/XML/sx"
+  xmlns:taxtable="http://www.gnucash.org/XML/taxtable"
+  xmlns:trn="http://www.gnucash.org/XML/trn"
+  xmlns:ts="http://www.gnucash.org/XML/ts"
+  xmlns:tte="http://www.gnucash.org/XML/tte"
+  xmlns:vendor="http://www.gnucash.org/XML/vendor">
+    <gnc-act:title>
+      Ingresos de cónyuge
+    </gnc-act:title>
+    <gnc-act:short-description>
+     Cuentas para controlar los ingresos del cónyuge de manera separada
+    </gnc-act:short-description>
+    <gnc-act:long-description>
+     Deberás seleccionar esta lista de cuentas si tu cónyuge trabaja (sueldo (cónyuge), impuestos (cónyuge)).
+    </gnc-act:long-description>
+<gnc:account version="2.0.0">
+  <act:name>Root Account</act:name>
+  <act:id type="new">1972cce2e2364f95b2b0bc014502661d</act:id>
+  <act:type>ROOT</act:type>
+  <act:commodity-scu>0</act:commodity-scu>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Ingresos</act:name>
+  <act:id type="new">b4fadf6188d7f1ae7e7aa4fa27f5cc95</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Ingresos</act:description>
+  <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Sueldo (Cónyuge)</act:name>
+  <act:id type="new">7c4495ff132d100b0aa339ce683200dd</act:id>
+  <act:type>INCOME</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Sueldo (Cónyuge)</act:description>
+  <act:parent type="new">b4fadf6188d7f1ae7e7aa4fa27f5cc95</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Egresos</act:name>
+  <act:id type="new">1884bbd7394883ebafec8b9e2eb091a4</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Egresos</act:description>
+  <act:parent type="new">1972cce2e2364f95b2b0bc014502661d</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Impuestos (Cónyuge)</act:name>
+  <act:id type="new">3cd0ca7d6b0e5f44e4cde2851c3ff387</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Impuestos (Cónyuge)</act:description>
+  <act:parent type="new">1884bbd7394883ebafec8b9e2eb091a4</act:parent>
+  <act:slots>
+    <slot>
+      <slot:key>placeholder</slot:key>
+      <slot:value type="string">true</slot:value>
+    </slot>
+  </act:slots>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Impuesto a las Ganancias</act:name>
+  <act:id type="new">78df9cf06ee197272a695a4c3044f749</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Impuesto a las Ganancias</act:description>
+  <act:parent type="new">3cd0ca7d6b0e5f44e4cde2851c3ff387</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Retenciones</act:name>
+  <act:id type="new">eba0c095658c7c3a4f4294db9c7392f3</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Retenciones</act:description>
+  <act:parent type="new">3cd0ca7d6b0e5f44e4cde2851c3ff387</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Otros impuestos</act:name>
+  <act:id type="new">dea0cf67026749c9a5aa97be4e5cd052</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Otros impuestos</act:description>
+  <act:parent type="new">3cd0ca7d6b0e5f44e4cde2851c3ff387</act:parent>
+</gnc:account>
+<gnc:account version="2.0.0">
+  <act:name>Municipales</act:name>
+  <act:id type="new">aa14dbcd622024495a8a972b0f37d13a</act:id>
+  <act:type>EXPENSE</act:type>
+  <act:commodity>
+    <cmdty:space>ISO4217</cmdty:space>
+    <cmdty:id>ARS</cmdty:id>
+  </act:commodity>
+  <act:description>Municipales</act:description>
+  <act:parent type="new">3cd0ca7d6b0e5f44e4cde2851c3ff387</act:parent>
+</gnc:account>
+</gnc-account-example>


### PR DESCRIPTION
I am in the process of creating account charts for Argentina. The PR is a Draft for now, I will mark it as ready for review when all translations are completed.

Translated:
- [x] acctchrt_brokerage.gnucash-xea
- [x] acctchrt_business.gnucash-xea
- [x] acctchrt_carloan.gnucash-xea
- [x] acctchrt_cdmoneymkt.gnucash-xea
- [x] acctchrt_checkbook.gnucash-xea
- [x] acctchrt_childcare.gnucash-xea
- [x] acctchrt_common.gnucash-xea
- [x] acctchrt_currency.gnucash-xea
- [x] acctchrt_eduloan.gnucash-xea
- [x] acctchrt_fixedassets.gnucash-xea
- [x] acctchrt_homeloan.gnucash-xea
- [x] acctchrt_homeown.gnucash-xea
- [x] acctchrt_otherloan.gnucash-xea
- [x] acctchrt_renter.gnucash-xea
- [x] acctchrt_retiremt.gnucash-xea
- [x] acctchrt_spouseinc.gnucash-xea
- [x] acctchrt_spouseretire.gnucash-xea