### PR TITLE
[doclinkcell.c] cache use_glyphs output

### DIFF
--- a/gnucash/register/register-core/doclinkcell.c
+++ b/gnucash/register/register-core/doclinkcell.c
@@ -260,34 +260,38 @@ gnc_doclink_cell_set_read_only (Doclinkcell *cell, gboolean read_only)
     cell->read_only = read_only;
 }
 
+static gboolean
+test_use_glyphs (void)
+{
+    static gboolean cached = FALSE;
+    static gboolean use_glyphs = TRUE;
+
+    if (!cached)
+    {
+        GtkWidget *label = gtk_label_new (NULL);
+        gchar *test_text = g_strconcat (GLYPH_LINK, ",", GLYPH_PAPERCLIP, NULL);
+        PangoLayout *test_layout = gtk_widget_create_pango_layout (label, test_text);
+
+        pango_layout_set_text (test_layout, test_text, strlen (test_text));
+
+        use_glyphs = (pango_layout_get_unknown_glyphs_count (test_layout) != 0);
+        cached = TRUE;
+
+        g_object_unref (test_layout);
+        g_free (test_text);
+    }
+    return use_glyphs;
+}
+
+
 void
 gnc_doclink_cell_set_use_glyphs (Doclinkcell *cell)
 {
-#ifdef MAC_INTEGRATION
-    cell->use_glyphs = FALSE;
-#else 
-    gboolean use_glyphs = TRUE;
-    gchar *test_text;
-    GtkWidget *label;
-    PangoLayout *test_layout;
-    gint count;
-
     g_return_if_fail (cell != NULL);
 
-    label = gtk_label_new (NULL);
-    test_text = g_strconcat (GLYPH_LINK, ",", GLYPH_PAPERCLIP, NULL);
-    test_layout = gtk_widget_create_pango_layout (GTK_WIDGET (label), test_text);
-
-    pango_layout_set_text (test_layout, test_text, strlen (test_text));
-
-    count = pango_layout_get_unknown_glyphs_count (test_layout);
-
-    if (count != 0)
-        use_glyphs = FALSE;
-
-    g_object_unref (test_layout);
-    g_free (test_text);
-
-    cell->use_glyphs = use_glyphs;
+#ifdef MAC_INTEGRATION
+    cell->use_glyphs = FALSE;
+#else
+    cell->use_glyphs = test_use_glyphs();
 #endif
 }


### PR DESCRIPTION
This function `gnc_assoc_cell_set_use_glyphs` calls `pango_layout_get_unknown_glyphs_count` which seems to leak badly. In any case this function does not actually use `cell` at all, except to set its `use_glyphs` property. So, may I suggest moving the detection routine into a static function and cache its result.

```
==104710== 7,584 (512 direct, 7,072 indirect) bytes in 1 blocks are definitely lost in loss record 20,433 of 20,632
==104710==    at 0x484DCD3: realloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==104710==    by 0x76FFAC0: ??? (in /usr/lib/x86_64-linux-gnu/libfontconfig.so.1.12.0)
==104710==    by 0x7702590: ??? (in /usr/lib/x86_64-linux-gnu/libfontconfig.so.1.12.0)
==104710==    by 0x7198A6D: ??? (in /usr/lib/x86_64-linux-gnu/libcairo.so.2.11600.0)
==104710==    by 0x70CD8CC: ??? (in /usr/lib/x86_64-linux-gnu/libpangocairo-1.0.so.0.5000.6)
==104710==    by 0x760530D: ??? (in /usr/lib/x86_64-linux-gnu/libpangoft2-1.0.so.0.5000.6)
==104710==    by 0x65C2250: ??? (in /usr/lib/x86_64-linux-gnu/libpango-1.0.so.0.5000.6)
==104710==    by 0x65D53EE: ??? (in /usr/lib/x86_64-linux-gnu/libpango-1.0.so.0.5000.6)
==104710==    by 0x65C9DC1: pango_layout_get_unknown_glyphs_count (in /usr/lib/x86_64-linux-gnu/libpango-1.0.so.0.5000.6)
==104710==    by 0x709DB99: gnc_doclink_cell_set_use_glyphs (doclinkcell.c:283)
==104710==    by 0x707350C: gnc_split_register_load (split-register-load.c:428)
==104710==    by 0x705F790: gnc_ledger_display_refresh_internal (gnc-ledger-display.c:913)
==104710== 
```