### PR TITLE
glib to stl

### DIFF
--- a/libgnucash/engine/qof-string-cache.h
+++ b/libgnucash/engine/qof-string-cache.h
@@ -58,23 +58,15 @@ extern "C"
  * just decrement the reference count.  Basically you should use this
  * instead of g_free.
  *
- * Just in case it's not clear: The remove function must NOT be called
- * for the string you passed INTO the insert function.  It must be
- * called for the _cached_ string that is _returned_ by the insert
- * function.
- *
  * Note that all the work is done when inserting or removing.  Once
- * cached the strings are just plain C strings.
+ * cached the strings are std::string objects.
  *
- * The string cache is demand-created on first use.
+ * The string cache is always available.
  *
  **/
 
-/** Initialize the string cache */
-void qof_string_cache_init(void);
-
-/** Destroy the qof_string_cache */
-void qof_string_cache_destroy(void);
+/** Clear the string cache */
+void qof_string_cache_clear (void);
 
 /** You can use this function as a destroy notifier for a GHashTable
    that uses common strings as keys (or values, for that matter.)

--- a/libgnucash/engine/qofclass-p.h
+++ b/libgnucash/engine/qofclass-p.h
@@ -32,9 +32,6 @@
 
 #include "qofclass.h"
 
-void qof_class_init(void);
-void qof_class_shutdown (void);
-
 QofSortFunc qof_class_get_default_sort (QofIdTypeConst obj_name);
 
 /* @} */

--- a/libgnucash/engine/qofevent-p.h
+++ b/libgnucash/engine/qofevent-p.h
@@ -27,15 +27,6 @@
 #include "qofevent.h"
 #include "qofid.h"
 
-/* for backwards compatibility - to be moved back to qofevent.c in libqof2 */
-typedef struct
-{
-    QofEventHandler handler;
-    gpointer user_data;
-
-    gint handler_id;
-} HandlerInfo;
-
 /* generates an event even when events are suspended! */
 void qof_event_force (QofInstance *entity, QofEventId event_id, gpointer event_data);
 

--- a/libgnucash/engine/qofevent.cpp
+++ b/libgnucash/engine/qofevent.cpp
@@ -22,18 +22,31 @@
  *                                                                  *
  ********************************************************************/
 
+#include <vector>
+#include <algorithm>
 #include <config.h>
-#include <glib.h>
 
 #include "qof.h"
 #include "qofevent-p.h"
+
+struct HandlerInfo
+{
+    QofEventHandler handler;
+    gpointer user_data;
+    gint handler_id;
+    HandlerInfo (QofEventHandler handler, gpointer user_data, gint handler_id)
+        : handler (handler)
+        , user_data (user_data)
+        , handler_id (handler_id) {};
+    ~HandlerInfo () {};
+};
 
 /* Static Variables ************************************************/
 static guint   suspend_counter   = 0;
 static gint    next_handler_id   = 1;
 static guint   handler_run_level = 0;
 static guint   pending_deletes   = 0;
-static GList   *handlers  =   NULL;
+static std::vector<HandlerInfo> handlers;
 
 /* This static indicates the debugging module that this .o belongs to.  */
 static QofLogModule log_module = QOF_MOD_ENGINE;
@@ -43,26 +56,17 @@ static QofLogModule log_module = QOF_MOD_ENGINE;
 static gint
 find_next_handler_id(void)
 {
-    HandlerInfo *hi;
-    gint handler_id;
-    GList *node;
-
     /* look for a free handler id */
-    handler_id = next_handler_id;
-    node = handlers;
+    auto handler_id = next_handler_id;
 
-    while (node)
+ restart:
+    for (const auto& hi : handlers)
     {
-        hi = static_cast<HandlerInfo*>(node->data);
-
-        if (hi->handler_id == handler_id)
+        if (hi.handler_id == handler_id)
         {
             handler_id++;
-            node = handlers;
-            continue;
+            goto restart;
         }
-
-        node = node->next;
     }
     /* Update id for next registration */
     next_handler_id = handler_id + 1;
@@ -72,8 +76,6 @@ find_next_handler_id(void)
 gint
 qof_event_register_handler (QofEventHandler handler, gpointer user_data)
 {
-    HandlerInfo *hi;
-    gint handler_id;
 
     ENTER ("(handler=%p, data=%p)", handler, user_data);
 
@@ -85,16 +87,9 @@ qof_event_register_handler (QofEventHandler handler, gpointer user_data)
     }
 
     /* look for a free handler id */
-    handler_id = find_next_handler_id();
+    auto handler_id = find_next_handler_id();
 
-    /* Found one, add the handler */
-    hi = g_new0 (HandlerInfo, 1);
-
-    hi->handler = handler;
-    hi->user_data = user_data;
-    hi->handler_id = handler_id;
-
-    handlers = g_list_prepend (handlers, hi);
+    handlers.emplace_back (handler, user_data, handler_id);
     LEAVE ("(handler=%p, data=%p) handler_id=%d", handler, user_data, handler_id);
     return handler_id;
 }
@@ -102,43 +97,33 @@ qof_event_register_handler (QofEventHandler handler, gpointer user_data)
 void
 qof_event_unregister_handler (gint handler_id)
 {
-    GList *node;
-
     ENTER ("(handler_id=%d)", handler_id);
-    for (node = handlers; node; node = node->next)
+
+    auto iter = std::find_if (handlers.begin(), handlers.end(),
+                              [&handler_id](const auto& it)
+                              { return it.handler_id == handler_id; });
+    if (iter == handlers.end())
     {
-        HandlerInfo *hi = static_cast<HandlerInfo*>(node->data);
-
-        if (hi->handler_id != handler_id)
-            continue;
-
-        /* Normally, we could actually remove the handler's node from the
-           list, but we may be unregistering the event handler as a result
-           of a generated event, such as QOF_EVENT_DESTROY.  In that case,
-           we're in the middle of walking the GList and it is wrong to
-           modify the list. So, instead, we just NULL the handler. */
-        if (hi->handler)
-            LEAVE ("(handler_id=%d) handler=%p data=%p", handler_id,
-                   hi->handler, hi->user_data);
-
-        /* safety -- clear the handler in case we're running events now */
-        hi->handler = NULL;
-
-        if (handler_run_level == 0)
-        {
-            handlers = g_list_remove_link (handlers, node);
-            g_list_free_1 (node);
-            g_free (hi);
-        }
-        else
-        {
-            pending_deletes++;
-        }
-
+        PERR ("no such handler: %d", handler_id);
         return;
     }
 
-    PERR ("no such handler: %d", handler_id);
+    /* Normally, we could actually remove the handler from the vector,
+       but we may be unregistering the event handler as a result of a
+       generated event, such as QOF_EVENT_DESTROY.  In that case,
+       we're in the middle of walking the std::vector and it is wrong
+       to modify the vector. So, instead, we just NULL the handler. */
+    if (iter->handler)
+        LEAVE ("(handler_id=%d) handler=%p data=%p", handler_id,
+               iter->handler, iter->user_data);
+
+    /* safety -- clear the handler in case we're running events now */
+    iter->handler = nullptr;
+
+    if (handler_run_level == 0)
+        handlers.erase (iter);
+    else
+        pending_deletes++;
 }
 
 void
@@ -168,9 +153,6 @@ static void
 qof_event_generate_internal (QofInstance *entity, QofEventId event_id,
                              gpointer event_data)
 {
-    GList *node;
-    GList *next_node = NULL;
-
     g_return_if_fail(entity);
 
     switch (event_id)
@@ -183,18 +165,16 @@ qof_event_generate_internal (QofInstance *entity, QofEventId event_id,
     }
 
     handler_run_level++;
-    for (node = handlers; node; node = next_node)
-    {
-        HandlerInfo *hi = static_cast<HandlerInfo*>(node->data);
-
-        next_node = node->next;
-        if (hi->handler)
-        {
-            PINFO("id=%d hi=%p han=%p data=%p", hi->handler_id, hi,
-                  hi->handler, event_data);
-            hi->handler (entity, event_id, hi->user_data, event_data);
-        }
-    }
+    std::for_each (handlers.rbegin(), handlers.rend(),
+                   [&](const auto& hi)
+                   {
+                       if (hi.handler)
+                       {
+                           PINFO("id=%d hi=%p han=%p data=%p", hi.handler_id,
+                                 &hi, hi.handler, event_data);
+                           hi.handler (entity, event_id, hi.user_data, event_data);
+                       };
+                   });
     handler_run_level--;
 
     /* If we're the outermost event runner and we have pending deletes
@@ -202,18 +182,8 @@ qof_event_generate_internal (QofInstance *entity, QofEventId event_id,
      */
     if (handler_run_level == 0 && pending_deletes)
     {
-        for (node = handlers; node; node = next_node)
-        {
-            HandlerInfo *hi = static_cast<HandlerInfo*>(node->data);
-            next_node = node->next;
-            if (hi->handler == NULL)
-            {
-                /* remove this node from the list, then free this node */
-                handlers = g_list_remove_link (handlers, node);
-                g_list_free_1 (node);
-                g_free (hi);
-            }
-        }
+        std::remove_if (handlers.begin(), handlers.end(),
+                        [](const auto& hi){ return (!hi.handler); });
         pending_deletes = 0;
     }
 }

--- a/libgnucash/engine/qofquery.cpp
+++ b/libgnucash/engine/qofquery.cpp
@@ -1344,13 +1344,11 @@ void qof_query_init (void)
 {
     ENTER (" ");
     qof_query_core_init ();
-    qof_class_init ();
     LEAVE ("Completed initialization of QofQuery");
 }
 
 void qof_query_shutdown (void)
 {
-    qof_class_shutdown ();
     qof_query_core_shutdown ();
 }
 

--- a/libgnucash/engine/qofutil.cpp
+++ b/libgnucash/engine/qofutil.cpp
@@ -259,7 +259,6 @@ void
 qof_init (void)
 {
     qof_log_init();
-    qof_string_cache_init();
     qof_object_initialize ();
     qof_query_init ();
     qof_book_register ();
@@ -271,7 +270,6 @@ qof_close(void)
     qof_query_shutdown ();
     qof_object_shutdown ();
     QofBackend::release_backends();
-    qof_string_cache_destroy ();
     qof_log_shutdown();
 }
 

--- a/libgnucash/engine/test/test-qof-string-cache.c
+++ b/libgnucash/engine/test/test-qof-string-cache.c
@@ -40,13 +40,13 @@ typedef struct
 G_GNUC_UNUSED static void
 setup( Fixture *fixture, gconstpointer pData )
 {
-    qof_string_cache_init();
+    return;
 }
 
 G_GNUC_UNUSED static void
 teardown( Fixture *fixture, gconstpointer pData )
 {
-    qof_string_cache_destroy();
+    return;
 }
 
 static void


### PR DESCRIPTION
~2~3 down... many more to go. There's some runtime advantages; the `unordered_map`s are populated during compilation in both qofchoice and qofclass. Most map keys are short strings; SSO makes using `std::string` *much* nicer than `char*`.