### PR TITLE
[dialog-sx-since-last-run] Fix handling of last run dialog on file open

### DIFF
--- a/gnucash/gnome/dialog-sx-since-last-run.c
+++ b/gnucash/gnome/dialog-sx-since-last-run.c
@@ -851,15 +851,16 @@ gnc_sx_sxsincelast_book_opened (void)
     if (summary.need_dialog)
     {
         gnc_ui_sx_since_last_run_dialog (gnc_ui_get_main_window (NULL), inst_model, auto_created_txns);
+        /* gnc_ui_sx_since_last_run_dialog now owns this list */
         auto_created_txns = NULL;
     }
     else
     {
-        if (summary.num_auto_create_no_notify_instances != 0)
-        {
-            if (!gnc_prefs_get_bool (GNC_PREFS_GROUP_STARTUP, GNC_PREF_SHOW_AT_FOPEN))
-                return;
+        g_list_free (auto_created_txns);
 
+        if (summary.num_auto_create_no_notify_instances != 0
+                && gnc_prefs_get_bool (GNC_PREFS_GROUP_STARTUP, GNC_PREF_SHOW_AT_FOPEN))
+        {
             gnc_info_dialog
             (gnc_ui_get_main_window (NULL),
              ngettext
@@ -871,8 +872,9 @@ gnc_sx_sxsincelast_book_opened (void)
               summary.num_auto_create_no_notify_instances);
         }
     }
-    g_list_free (auto_created_txns);
+
     g_object_unref (G_OBJECT(inst_model));
+
     if (creation_errors)
         creation_error_dialog (&creation_errors);
 }
@@ -1146,54 +1148,54 @@ dialog_response_cb (GtkDialog *dialog, gint response_id, GncSxSinceLastRunDialog
         // - [ ] instance state constraints
         // - [x] required variable binding
         // - [?] ability to create transactions
-    {
-        GList *unbound_variables;
-        gint unbound_len;
-        unbound_variables = gnc_sx_instance_model_check_variables (app_dialog->editing_model->instances);
-        unbound_len = g_list_length (unbound_variables);
-        PINFO ("%d variables unbound", unbound_len);
-        if (unbound_len > 0)
         {
-            // focus first variable
-            GncSxVariableNeeded *first_unbound;
-            GtkTreePath *variable_path;
-            GtkTreeViewColumn *variable_col;
-            gint variable_view_column = 2;
-            gboolean start_editing = TRUE;
+            GList *unbound_variables;
+            gint unbound_len;
+            unbound_variables = gnc_sx_instance_model_check_variables (app_dialog->editing_model->instances);
+            unbound_len = g_list_length (unbound_variables);
+            PINFO ("%d variables unbound", unbound_len);
+            if (unbound_len > 0)
+            {
+                // focus first variable
+                GncSxVariableNeeded *first_unbound;
+                GtkTreePath *variable_path;
+                GtkTreeViewColumn *variable_col;
+                gint variable_view_column = 2;
+                gboolean start_editing = TRUE;
 
-            first_unbound = (GncSxVariableNeeded*)unbound_variables->data;
-            variable_path = _get_path_for_variable (app_dialog->editing_model, first_unbound->instance, first_unbound->variable);
-            variable_col = gtk_tree_view_get_column (app_dialog->instance_view, variable_view_column);
+                first_unbound = (GncSxVariableNeeded*)unbound_variables->data;
+                variable_path = _get_path_for_variable (app_dialog->editing_model, first_unbound->instance, first_unbound->variable);
+                variable_col = gtk_tree_view_get_column (app_dialog->instance_view, variable_view_column);
 
-            gtk_tree_view_set_cursor (app_dialog->instance_view, variable_path, variable_col, start_editing);
+                gtk_tree_view_set_cursor (app_dialog->instance_view, variable_path, variable_col, start_editing);
 
-            gtk_tree_view_scroll_to_cell (app_dialog->instance_view, variable_path, variable_col,
-                                          TRUE, 0.5, 0.5);
+                gtk_tree_view_scroll_to_cell (app_dialog->instance_view, variable_path, variable_col,
+                                              TRUE, 0.5, 0.5);
 
-            gtk_tree_path_free (variable_path);
-            g_list_foreach (unbound_variables, (GFunc)g_free, NULL);
-            g_list_free (unbound_variables);
-            return;
+                gtk_tree_path_free (variable_path);
+                g_list_foreach (unbound_variables, (GFunc)g_free, NULL);
+                g_list_free (unbound_variables);
+                return;
+            }
         }
-    }
-    gnc_suspend_gui_refresh ();
-    gnc_sx_slr_model_effect_change (app_dialog->editing_model, FALSE, &app_dialog->created_txns, &creation_errors);
-    gnc_resume_gui_refresh ();
-    gnc_gui_refresh_all (); // force a refresh of all registers
-    if (creation_errors)
-        creation_error_dialog (&creation_errors);
+        gnc_suspend_gui_refresh ();
+        gnc_sx_slr_model_effect_change (app_dialog->editing_model, FALSE, &app_dialog->created_txns, &creation_errors);
+        gnc_resume_gui_refresh ();
+        gnc_gui_refresh_all (); // force a refresh of all registers
+        if (creation_errors)
+            creation_error_dialog (&creation_errors);
 
-    if (gtk_toggle_button_get_active (app_dialog->review_created_txns_toggle)
-            && g_list_length (app_dialog->created_txns) > 0)
-    {
-        _show_created_transactions (app_dialog, app_dialog->created_txns);
-    }
-    g_list_free (app_dialog->created_txns);
-    app_dialog->created_txns = NULL;
+        if (gtk_toggle_button_get_active (app_dialog->review_created_txns_toggle)
+                && g_list_length (app_dialog->created_txns) > 0)
+        {
+            _show_created_transactions (app_dialog, app_dialog->created_txns);
+        }
 
     /* FALL THROUGH */
     case GTK_RESPONSE_CANCEL:
     case GTK_RESPONSE_DELETE_EVENT:
+        g_list_free (app_dialog->created_txns);
+        app_dialog->created_txns = NULL;
         gnc_close_gui_component (app_dialog->component_id);
         break;
     default:


### PR DESCRIPTION
When the "since last run" notification dialog is disabled on file open, it leaks a reference to GncSxInstanceModel and any creation errors won't be displayed. Avoid returning from the function too early.