### PR TITLE
Add action group to View menu for the tab position

### DIFF
--- a/gnucash/ui/gnc-main-window-ui.xml
+++ b/gnucash/ui/gnc-main-window-ui.xml
@@ -51,6 +51,12 @@
       <menuitem name="ViewToolbar" action="ViewToolbarAction"/>
       <menuitem name="ViewSummary" action="ViewSummaryAction"/>
       <menuitem name="ViewStatusbar" action="ViewStatusbarAction"/>
+      <menu name="ViewTabPosition" action="ViewTabPositionAction">
+        <menuitem name="ViewTabPositionTop" action="ViewTabPositionTopAction"/>
+        <menuitem name="ViewTabPositionBottom" action="ViewTabPositionBottomAction"/>
+        <menuitem name="ViewTabPositionLeft" action="ViewTabPositionLeftAction"/>
+        <menuitem name="ViewTabPositionRight" action="ViewTabPositionRightAction"/>
+      </menu>
       <separator name="ViewSep1"/>
       <placeholder name="ViewContentPlaceholder"/>
       <separator name="ViewSep2"/>


### PR DESCRIPTION
This makes it easier to change the tab position quickly without opening the preferences window.

With many tabs open there's more space to display all tabs vertically but when resizing GnuCash to half the display size they use up too much horizontal space which can be fixed by temporarily making the tabs horizontal.

----
PR to master: #1350