### PR TITLE
refinement #1162 to allow edit multiple rows

### DIFF
--- a/gnucash/gtkbuilder/dialog-import.glade
+++ b/gnucash/gtkbuilder/dialog-import.glade
@@ -866,6 +866,145 @@
       <action-widget response="-7">matcher_help_close</action-widget>
     </action-widgets>
   </object>
+  <object class="GtkDialog" id="transaction_edit_dialog">
+    <property name="can-focus">False</property>
+    <property name="title" translatable="yes">Edit imported transaction details</property>
+    <property name="default-width">320</property>
+    <property name="type-hint">dialog</property>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
+            <child>
+              <object class="GtkButton" id="button1">
+                <property name="label" translatable="yes">_Cancel</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="use-underline">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button2">
+                <property name="label" translatable="yes">_OK</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="use-underline">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <!-- n-columns=2 n-rows=3 -->
+          <object class="GtkGrid">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="row-spacing">3</property>
+            <property name="column-spacing">6</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="halign">end</property>
+                <property name="label" translatable="yes">Description</property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="halign">end</property>
+                <property name="label" translatable="yes">Notes</property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="halign">end</property>
+                <property name="label" translatable="yes">Memo</property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkEntry" id="desc_entry">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="hexpand">True</property>
+              </object>
+              <packing>
+                <property name="left-attach">1</property>
+                <property name="top-attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkEntry" id="notes_entry">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="hexpand">True</property>
+              </object>
+              <packing>
+                <property name="left-attach">1</property>
+                <property name="top-attach">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkEntry" id="memo_entry">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="hexpand">True</property>
+              </object>
+              <packing>
+                <property name="left-attach">1</property>
+                <property name="top-attach">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="-6">button1</action-widget>
+      <action-widget response="-5">button2</action-widget>
+    </action-widgets>
+  </object>
   <object class="GtkBox" id="transaction_matcher_content">
     <property name="visible">True</property>
     <property name="can-focus">False</property>

--- a/gnucash/gtkbuilder/dialog-import.glade
+++ b/gnucash/gtkbuilder/dialog-import.glade
@@ -927,7 +927,9 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">end</property>
-                <property name="label" translatable="yes">Description</property>
+                <property name="label" translatable="yes">_Description</property>
+                <property name="use-underline">True</property>
+                <property name="mnemonic-widget">desc_entry</property>
               </object>
               <packing>
                 <property name="left-attach">0</property>
@@ -939,7 +941,9 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">end</property>
-                <property name="label" translatable="yes">Notes</property>
+                <property name="label" translatable="yes">_Notes</property>
+                <property name="use-underline">True</property>
+                <property name="mnemonic-widget">notes_entry</property>
               </object>
               <packing>
                 <property name="left-attach">0</property>
@@ -951,7 +955,9 @@
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">end</property>
-                <property name="label" translatable="yes">Memo</property>
+                <property name="label" translatable="yes">_Memo</property>
+                <property name="use-underline">True</property>
+                <property name="mnemonic-widget">memo_entry</property>
               </object>
               <packing>
                 <property name="left-attach">0</property>

--- a/gnucash/import-export/import-main-matcher.c
+++ b/gnucash/import-export/import-main-matcher.c
@@ -1378,6 +1378,8 @@ gnc_gen_trans_view_popup_menu (GtkTreeView *treeview,
                       info);
     gtk_menu_shell_append (GTK_MENU_SHELL(menu), menuitem);
 
+    gtk_menu_attach_to_widget (GTK_MENU (menu), GTK_WIDGET (treeview), NULL);
+
     gtk_widget_show_all (menu);
     /* Note: event can be NULL here when called from view_onPopupMenu; */
     gtk_menu_popup_at_pointer (GTK_MENU(menu), (GdkEvent*)event);

--- a/gnucash/import-export/import-main-matcher.c
+++ b/gnucash/import-export/import-main-matcher.c
@@ -1291,8 +1291,8 @@ gnc_gen_trans_view_popup_menu (GtkTreeView *treeview,
 
     ENTER ("");
     menu = gtk_menu_new();
-    menuitem = gtk_menu_item_new_with_label (
-                   _("Assign a transfer account to the selection."));
+    menuitem = gtk_menu_item_new_with_mnemonic
+        (_("_Assign a transfer account to the selection"));
     g_signal_connect (menuitem, "activate",
                       G_CALLBACK(
                       gnc_gen_trans_assign_transfer_account_to_selection_cb),
@@ -1338,7 +1338,7 @@ gnc_gen_trans_view_popup_menu (GtkTreeView *treeview,
         rowinfo_free (rowinfo);
     }
 
-    menuitem = gtk_menu_item_new_with_label (_("Edit description, notes, memo."));
+    menuitem = gtk_menu_item_new_with_mnemonic (_("_Edit description, notes, memo"));
     gtk_widget_set_sensitive (menuitem,
                               info->edit_desc || info->edit_notes || info->edit_memo);
     g_signal_connect (menuitem, "activate",
@@ -1346,7 +1346,7 @@ gnc_gen_trans_view_popup_menu (GtkTreeView *treeview,
                       info);
     gtk_menu_shell_append (GTK_MENU_SHELL(menu), menuitem);
 
-    menuitem = gtk_menu_item_new_with_label (_("Reset edits."));
+    menuitem = gtk_menu_item_new_with_mnemonic (_("_Reset all edits"));
     gtk_widget_set_sensitive (menuitem, has_edits);
     g_signal_connect (menuitem, "activate",
                       G_CALLBACK (gnc_gen_trans_reset_edits_cb),

--- a/gnucash/import-export/import-main-matcher.c
+++ b/gnucash/import-export/import-main-matcher.c
@@ -130,8 +130,7 @@ static void gnc_gen_trans_assign_transfer_account_to_selection_cb (GtkMenuItem *
                                                                    GNCImportMainMatcher *info);
 static void gnc_gen_trans_view_popup_menu (GtkTreeView *treeview,
                                            GdkEvent *event,
-                                           GNCImportMainMatcher *info,
-                                           gboolean show_edit_actions);
+                                           GNCImportMainMatcher *info);
 static gboolean gnc_gen_trans_onButtonPressed_cb (GtkTreeView *treeview,
                                                   GdkEvent *event,
                                                   GNCImportMainMatcher *info);
@@ -1112,8 +1111,7 @@ gnc_gen_trans_row_changed_cb (GtkTreeSelection *selection,
 static void
 gnc_gen_trans_view_popup_menu (GtkTreeView *treeview,
                                GdkEvent *event,
-                               GNCImportMainMatcher *info,
-                               gboolean show_edit_actions)
+                               GNCImportMainMatcher *info)
 {
     GtkWidget *menu, *menuitem;
     GdkEventButton *event_button;
@@ -1227,7 +1225,7 @@ gnc_gen_trans_onButtonPressed_cb (GtkTreeView *treeview,
                 GtkTreeModel *model;
                 selected = gtk_tree_selection_get_selected_rows (selection, &model);
                 if (get_action_for_path (selected->data, model) == GNCImport_ADD)
-                    gnc_gen_trans_view_popup_menu (treeview, event, info, TRUE);
+                    gnc_gen_trans_view_popup_menu (treeview, event, info);
                 g_list_free_full (selected, (GDestroyNotify)gtk_tree_path_free);
             }
             LEAVE("return TRUE");
@@ -1248,7 +1246,7 @@ gnc_gen_trans_onPopupMenu_cb (GtkTreeView *treeview,
     selection = gtk_tree_view_get_selection (treeview);
     if (gtk_tree_selection_count_selected_rows (selection) > 0)
     {
-      gnc_gen_trans_view_popup_menu (treeview, NULL, info, TRUE);
+      gnc_gen_trans_view_popup_menu (treeview, NULL, info);
       LEAVE ("TRUE");
       return TRUE;
     }

--- a/gnucash/import-export/import-main-matcher.c
+++ b/gnucash/import-export/import-main-matcher.c
@@ -1114,7 +1114,6 @@ gnc_gen_trans_view_popup_menu (GtkTreeView *treeview,
                                GNCImportMainMatcher *info)
 {
     GtkWidget *menu, *menuitem;
-    GdkEventButton *event_button;
     GtkTreeModel *model;
     GtkTreeSelection *selection;
     GList *selected_rows;
@@ -1156,40 +1155,28 @@ gnc_gen_trans_view_popup_menu (GtkTreeView *treeview,
         rowinfo_free (rowinfo);
     }
 
-    if (edit_desc)
-    {
-        menuitem = gtk_menu_item_new_with_label (
-                                                 _("Edit description."));
-        g_signal_connect (menuitem, "activate",
-                          G_CALLBACK (gnc_gen_trans_edit_description_cb),
-                          info);
-        DEBUG("Callback to edit description");
-        gtk_menu_shell_append (GTK_MENU_SHELL(menu), menuitem);
-    }
+    menuitem = gtk_menu_item_new_with_label (_("Edit description."));
+    gtk_widget_set_sensitive (menuitem, edit_desc);
+    g_signal_connect (menuitem, "activate",
+                      G_CALLBACK (gnc_gen_trans_edit_description_cb),
+                      info);
+    gtk_menu_shell_append (GTK_MENU_SHELL(menu), menuitem);
 
-    if (edit_memo)
-    {
-        menuitem = gtk_menu_item_new_with_label (
-                                                 _("Edit memo."));
-        g_signal_connect (menuitem, "activate",
-                          G_CALLBACK (gnc_gen_trans_edit_memo_cb),
-                          info);
-        DEBUG("Callback to edit memo");
-        gtk_menu_shell_append (GTK_MENU_SHELL(menu), menuitem);
-    }
+    menuitem = gtk_menu_item_new_with_label (_("Edit memo."));
+    gtk_widget_set_sensitive (menuitem, edit_memo);
+    g_signal_connect (menuitem, "activate",
+                      G_CALLBACK (gnc_gen_trans_edit_memo_cb),
+                      info);
+    gtk_menu_shell_append (GTK_MENU_SHELL(menu), menuitem);
 
-    if (edit_notes)
-    {
-        menuitem = gtk_menu_item_new_with_label (
-                                                 _("Edit notes."));
-        g_signal_connect (menuitem, "activate",
-                          G_CALLBACK (gnc_gen_trans_edit_notes_cb),
-                          info);
-        DEBUG("Callback to edit notes");
-        gtk_menu_shell_append (GTK_MENU_SHELL(menu), menuitem);
-    }
+    menuitem = gtk_menu_item_new_with_label (_("Edit notes."));
+    gtk_widget_set_sensitive (menuitem, edit_notes);
+    g_signal_connect (menuitem, "activate",
+                      G_CALLBACK (gnc_gen_trans_edit_notes_cb),
+                      info);
+    gtk_menu_shell_append (GTK_MENU_SHELL(menu), menuitem);
+
     gtk_widget_show_all (menu);
-    event_button = (GdkEventButton *) event;
     /* Note: event can be NULL here when called from view_onPopupMenu; */
     gtk_menu_popup_at_pointer (GTK_MENU(menu), (GdkEvent*)event);
 

--- a/gnucash/import-export/import-main-matcher.c
+++ b/gnucash/import-export/import-main-matcher.c
@@ -164,14 +164,6 @@ static gboolean query_tooltip_tree_view_cb (GtkWidget *widget, gint x, gint y,
                                             gpointer user_data);
 /* end local prototypes */
 
-static
-gboolean delete_hash (gpointer key, gpointer value, gpointer user_data)
-{
-    // Value is a hash table that needs to be destroyed.
-    g_hash_table_destroy (value);
-    return TRUE;
-}
-
 static void
 update_all_balances (GNCImportMainMatcher *info)
 {
@@ -239,10 +231,7 @@ gnc_gen_trans_list_delete (GNCImportMainMatcher *info)
     update_all_balances (info);
 
     gnc_import_PendingMatches_delete (info->pending_matches);
-    g_hash_table_foreach_remove (info->acct_id_hash, delete_hash, NULL);
     g_hash_table_destroy (info->acct_id_hash);
-    info->acct_id_hash = NULL;
-
     g_hash_table_destroy (info->desc_hash);
     g_hash_table_destroy (info->notes_hash);
     g_hash_table_destroy (info->memo_hash);
@@ -1593,7 +1582,8 @@ gnc_gen_trans_init_view (GNCImportMainMatcher *info,
     g_signal_connect (view, "popup-menu",
                       G_CALLBACK(gnc_gen_trans_onPopupMenu_cb), info);
 
-    info->acct_id_hash = g_hash_table_new (g_direct_hash, g_direct_equal);
+    info->acct_id_hash = g_hash_table_new_full (g_direct_hash, g_direct_equal, NULL,
+                                                (GDestroyNotify)g_hash_table_destroy);
 }
 
 static void


### PR DESCRIPTION
Today I wanted to mass-rename when importing, and could not.

This commit will allow renaming desc/notes/memo, but only enabled if rows' desc/notes/memo are identical.

The disabling works piecemeal i.e. if selection has identical description but varied memo and notes, then only the description will be allowed mass renaming.

@jeanlaroche from #1162 