### PR TITLE
start plugging leaks from qof_instance_get

### DIFF
--- a/gnucash/import-export/aqb/assistant-ab-initial.c
+++ b/gnucash/import-export/aqb/assistant-ab-initial.c
@@ -755,7 +755,7 @@ save_kvp_acc_cb(gpointer key, gpointer value, gpointer user_data)
     const gchar *ab_bankcode, *gnc_bankcode;
 #ifdef AQBANKING6
     gchar *ab_online_id;
-    const gchar *gnc_online_id;
+    gchar *gnc_online_id;
 #endif
 
     g_return_if_fail(ab_acc && gnc_acc);
@@ -796,6 +796,7 @@ save_kvp_acc_cb(gpointer key, gpointer value, gpointer user_data)
     if (ab_online_id && (!gnc_online_id || (strcmp(ab_online_id, gnc_online_id) != 0)))
         gnc_import_set_acc_online_id(gnc_acc, ab_online_id);
     g_free(ab_online_id);
+    g_free (gnc_online_id);
 #endif
 }
 

--- a/gnucash/import-export/import-account-matcher.c
+++ b/gnucash/import-export/import-account-matcher.c
@@ -101,7 +101,7 @@ static AccountPickerDialog* gnc_import_new_account_picker(void)
 static gpointer test_acct_online_id_match(Account *acct, gpointer data)
 {
     AccountOnlineMatch *match = (AccountOnlineMatch*)data;
-    const char *acct_online_id = gnc_import_get_acc_online_id(acct);
+    char *acct_online_id = gnc_import_get_acc_online_id(acct);
     int acct_len, match_len;
 
     if (acct_online_id == NULL || match->online_id == NULL)
@@ -126,7 +126,7 @@ static gpointer test_acct_online_id_match(Account *acct, gpointer data)
         }
         else
         {
-            const char *partial_online_id =
+            char *partial_online_id =
                 gnc_import_get_acc_online_id(match->partial_match);
             int partial_len = strlen(partial_online_id);
             if (partial_online_id[partial_len - 1] == ' ')
@@ -157,9 +157,11 @@ static gpointer test_acct_online_id_match(Account *acct, gpointer data)
                 g_free (name1);
                 g_free (name2);
             }
+            g_free (partial_online_id);
         }
     }
 
+    g_free (acct_online_id);
     return NULL;
 }
 

--- a/gnucash/import-export/import-backend.c
+++ b/gnucash/import-export/import-backend.c
@@ -1057,8 +1057,10 @@ gnc_import_process_trans_item (GncImportMatchMap *matchmap,
                the match will be remembered */
             if (gnc_import_split_has_online_id(trans_info->first_split))
             {
-                gnc_import_set_split_online_id(selected_match->split,
-                                               gnc_import_get_split_online_id(trans_info->first_split));
+                char *online_id = gnc_import_get_split_online_id
+                    (trans_info->first_split);
+                gnc_import_set_split_online_id(selected_match->split, online_id);
+                g_free (online_id);
             }
 
             /* Done editing. */
@@ -1112,9 +1114,12 @@ gnc_import_process_trans_item (GncImportMatchMap *matchmap,
             /* Copy the online id to the reconciled transaction, so
             		 the match will be remembered */
             if (gnc_import_split_has_online_id(trans_info->first_split))
-                gnc_import_set_split_online_id
-                (selected_match->split,
-                 gnc_import_get_split_online_id(trans_info->first_split));
+            {
+                char *online_id = gnc_import_get_split_online_id
+                    (trans_info->first_split);
+                gnc_import_set_split_online_id (selected_match->split, online_id);
+                g_free (online_id);
+            }
 
             /* Done editing. */
             /*DEBUG("CommitEdit selected_match")*/
@@ -1152,8 +1157,8 @@ static gint check_trans_online_id(Transaction *trans1, void *user_data)
     Account *account;
     Split *split1;
     Split *split2 = user_data;
-    const gchar *online_id1;
-    const gchar *online_id2;
+    gchar *online_id1, *online_id2;
+    gint retval;
 
     account = xaccSplitGetAccount(split2);
     split1 = xaccTransFindSplitByAccount(trans1, account);
@@ -1164,24 +1169,18 @@ static gint check_trans_online_id(Transaction *trans1, void *user_data)
        instead of the transactions */
     g_assert(split1 != NULL);
 
-    if (gnc_import_split_has_online_id(split1))
-        online_id1 = gnc_import_get_split_online_id(split1);
-    else
-        online_id1 = gnc_import_get_trans_online_id(trans1);
+    online_id1 = gnc_import_get_split_online_id (split1);
+
+    if (!online_id1 || !online_id1[0])
+        online_id1 = gnc_import_get_trans_online_id (trans1);
 
     online_id2 = gnc_import_get_split_online_id(split2);
 
-    if ((online_id1 == NULL) ||
-            (online_id2 == NULL) ||
-            (strcmp(online_id1, online_id2) != 0))
-    {
-        return 0;
-    }
-    else
-    {
-        /*printf("test_trans_online_id(): Duplicate found\n");*/
-        return 1;
-    }
+    retval = (!online_id1 || !online_id2 || strcmp (online_id1, online_id2)) ? 0 : 1;
+
+    g_free (online_id1);
+    g_free (online_id2);
+    return retval;
 }
 
 /** Checks whether the given transaction's online_id already exists in
@@ -1191,30 +1190,38 @@ gboolean gnc_import_exists_online_id (Transaction *trans, GHashTable* acct_id_ha
     gboolean online_id_exists = FALSE;
     Account *dest_acct;
     Split *source_split;
+    char *source_online_id;
 
     /* Look for an online_id in the first split */
     source_split = xaccTransGetSplit(trans, 0);
     g_assert(source_split);
 
+    source_online_id = gnc_import_get_split_online_id (source_split);
+
     // No online id, no point in continuing. We'd crash if we tried.
-    if (!gnc_import_get_split_online_id (source_split))
+    if (!source_online_id)
         return FALSE;
-    // Create a hash per account of a hash of all split IDs. Then the test below will be fast if
-    // we have many transactions to import.
+
+    // Create a hash per account of a hash of all split IDs. Then the
+    // test below will be fast if we have many transactions to import.
     dest_acct = xaccSplitGetAccount (source_split);
     if (!g_hash_table_contains (acct_id_hash, dest_acct))
     {
-        GHashTable* new_hash = g_hash_table_new (g_str_hash, g_str_equal);
-        GList* split_list = xaccAccountGetSplitList(dest_acct);
+        GHashTable* new_hash = g_hash_table_new_full
+            (g_str_hash, g_str_equal, g_free, NULL);
         g_hash_table_insert (acct_id_hash, dest_acct, new_hash);
-        for (;split_list;split_list=split_list->next)
+        for (GList *n = xaccAccountGetSplitList (dest_acct) ; n; n=n->next)
         {
-            if (gnc_import_split_has_online_id (split_list->data))
-                g_hash_table_add (new_hash, (void*) gnc_import_get_split_online_id (split_list->data));
+            if (gnc_import_split_has_online_id (n->data))
+            {
+                char *id = gnc_import_get_split_online_id (n->data);
+                g_hash_table_insert (new_hash, (void*) id, GINT_TO_POINTER (1));
+                /* note we don't want to free id yet */
+            }
         }
     }
     online_id_exists = g_hash_table_contains (g_hash_table_lookup (acct_id_hash, dest_acct),
-                                              gnc_import_get_split_online_id (source_split));
+                                              source_online_id);
     
     /* If it does, abort the process for this transaction, since it is
        already in the system. */
@@ -1224,6 +1231,7 @@ gboolean gnc_import_exists_online_id (Transaction *trans, GHashTable* acct_id_ha
         xaccTransDestroy(trans);
         xaccTransCommitEdit(trans);
     }
+    g_free (source_online_id);
     return online_id_exists;
 }
 

--- a/gnucash/import-export/import-utilities.c
+++ b/gnucash/import-export/import-utilities.c
@@ -40,7 +40,8 @@
  * Account, Transaction and Split
 \********************************************************************/
 
-const gchar * gnc_import_get_acc_online_id (Account * account)
+gchar *
+gnc_import_get_acc_online_id (Account * account)
 {
     gchar *id = NULL;
     qof_instance_get (QOF_INSTANCE (account), "online-id", &id, NULL);
@@ -49,7 +50,8 @@ const gchar * gnc_import_get_acc_online_id (Account * account)
 
 /* Used in the midst of editing a transaction; make it save the
  * account data. */
-void gnc_import_set_acc_online_id (Account *account, const gchar *id)
+void
+gnc_import_set_acc_online_id (Account *account, const gchar *id)
 {
     g_return_if_fail (account != NULL);
     xaccAccountBeginEdit (account);
@@ -57,15 +59,17 @@ void gnc_import_set_acc_online_id (Account *account, const gchar *id)
     xaccAccountCommitEdit (account);
 }
 
-const gchar * gnc_import_get_trans_online_id (Transaction * transaction)
+gchar *
+gnc_import_get_trans_online_id (Transaction * transaction)
 {
     gchar *id = NULL;
     qof_instance_get (QOF_INSTANCE (transaction), "online-id", &id, NULL);
     return id;
 }
+
 /* Not actually used */
-void gnc_import_set_trans_online_id (Transaction *transaction,
-				     const gchar *id)
+void
+gnc_import_set_trans_online_id (Transaction *transaction, const gchar *id)
 {
     g_return_if_fail (transaction != NULL);
     xaccTransBeginEdit (transaction);
@@ -73,33 +77,40 @@ void gnc_import_set_trans_online_id (Transaction *transaction,
     xaccTransCommitEdit (transaction);
 }
 
-gboolean gnc_import_trans_has_online_id(Transaction * transaction)
+gboolean
+gnc_import_trans_has_online_id (Transaction * transaction)
 {
-    const gchar * online_id;
-    online_id = gnc_import_get_trans_online_id(transaction);
-    return (online_id != NULL && strlen(online_id) > 0);
+    gchar *online_id = gnc_import_get_trans_online_id(transaction);
+    gboolean retval = (online_id && *online_id);
+    g_free (online_id);
+    return retval;
 }
 
-const gchar * gnc_import_get_split_online_id (Split * split)
+gchar *
+gnc_import_get_split_online_id (Split * split)
 {
     gchar *id = NULL;
     qof_instance_get (QOF_INSTANCE (split), "online-id", &id, NULL);
     return id;
 }
+
 /* Used several places in a transaction edit where many other
  * parameters are also being set, so individual commits wouldn't be
  * appropriate. Besides, there isn't a function for one.*/
-void gnc_import_set_split_online_id (Split *split, const gchar *id)
+void
+gnc_import_set_split_online_id (Split *split, const gchar *id)
 {
     g_return_if_fail (split != NULL);
     qof_instance_set (QOF_INSTANCE (split), "online-id", id, NULL);
 }
 
-gboolean gnc_import_split_has_online_id(Split * split)
+gboolean
+gnc_import_split_has_online_id (Split * split)
 {
-    const gchar * online_id;
-    online_id = gnc_import_get_split_online_id(split);
-    return (online_id != NULL && strlen(online_id) > 0);
+    gchar *online_id = gnc_import_get_split_online_id(split);
+    gboolean retval = (online_id && *online_id);
+    g_free (online_id);
+    return retval;
 }
 
 /* @} */

--- a/gnucash/import-export/import-utilities.h
+++ b/gnucash/import-export/import-utilities.h
@@ -45,7 +45,7 @@
     Accounts.
 	@{
 */
-const gchar * gnc_import_get_acc_online_id(Account * account);
+gchar * gnc_import_get_acc_online_id(Account * account);
 void gnc_import_set_acc_online_id(Account * account,
                                   const gchar * string_value);
 /** @} */
@@ -54,7 +54,7 @@ void gnc_import_set_acc_online_id(Account * account,
     Transactions.
 	@{
 */
-const gchar * gnc_import_get_trans_online_id(Transaction * transaction);
+gchar * gnc_import_get_trans_online_id(Transaction * transaction);
 void gnc_import_set_trans_online_id(Transaction * transaction,
                                     const gchar * string_value);
 /** @} */
@@ -66,7 +66,7 @@ gboolean gnc_import_trans_has_online_id(Transaction * transaction);
     Splits.
 	@{
 */
-const gchar * gnc_import_get_split_online_id(Split * split);
+gchar * gnc_import_get_split_online_id(Split * split);
 void gnc_import_set_split_online_id(Split * split,
                                     const gchar * string_value);
 /** @} */


### PR DESCRIPTION
`qof_instance_get` comes from `g_object_get` which returns copies and must be freed via `g_free` or `g_object_unref`. see https://docs.gtk.org/gobject/method.Object.get.htmle-Object-Type.html#g-object-get

ditto `gtk_tree_model_get`.

This means the signatures for `gnc_import_get_split_online_id` and friends are wrong -- they're not `const` and must be `g_free`d after use. I guess fixing this means changing the signature throughout?