### PR TITLE
more leaks because qof_instance_get returns a new char*

### DIFF
--- a/gnucash/gnome/dialog-sx-editor.c
+++ b/gnucash/gnome/dialog-sx-editor.c
@@ -669,13 +669,18 @@ gnc_sxed_split_calculate_formula (GncSxEditorDialog *sxed, Split *s,
                       key, &str,
                       NULL);
     if (str == NULL || strlen (str) == 0)
+    {
+        if (str)
+            g_free (str);
         return TRUE; /* No formula no foul */
+    }
     if (gnc_sx_parse_vars_from_formula (str, vars, &tmp) < 0)
     {
         gchar *err = g_strdup_printf (_("Couldn't parse %s for split \"%s\"."),
                                       key, xaccSplitGetMemo (s));
         gnc_error_dialog (GTK_WINDOW (sxed->dialog), "%s", err);
         g_free (err);
+        g_free (str);
 
         return FALSE;
     }
@@ -685,6 +690,7 @@ gnc_sxed_split_calculate_formula (GncSxEditorDialog *sxed, Split *s,
     else
         tcds->debitSum = gnc_numeric_add (tcds->debitSum, tmp, 100,
                                           GNC_DENOM_AUTO | GNC_HOW_DENOM_LCD);
+    g_free (str);
     return TRUE;
 }
 

--- a/gnucash/import-export/import-account-matcher.c
+++ b/gnucash/import-export/import-account-matcher.c
@@ -105,7 +105,11 @@ static gpointer test_acct_online_id_match(Account *acct, gpointer data)
     int acct_len, match_len;
 
     if (acct_online_id == NULL || match->online_id == NULL)
+    {
+        if (acct_online_id)
+            g_free (acct_online_id);
         return NULL;
+    }
 
     acct_len = strlen(acct_online_id);
     match_len = strlen(match->online_id);
@@ -118,7 +122,10 @@ static gpointer test_acct_online_id_match(Account *acct, gpointer data)
     if (strncmp (acct_online_id, match->online_id, acct_len) == 0)
     {
         if (strncmp(acct_online_id, match->online_id, match_len) == 0)
+        {
+            g_free (acct_online_id);
             return (gpointer *) acct;
+        }
         if (match->partial_match == NULL)
         {
             match->partial_match = acct;

--- a/gnucash/import-export/import-backend.c
+++ b/gnucash/import-export/import-backend.c
@@ -1172,7 +1172,11 @@ static gint check_trans_online_id(Transaction *trans1, void *user_data)
     online_id1 = gnc_import_get_split_online_id (split1);
 
     if (!online_id1 || !online_id1[0])
+    {
+        if (online_id1)
+            g_free (online_id1);
         online_id1 = gnc_import_get_trans_online_id (trans1);
+    }
 
     online_id2 = gnc_import_get_split_online_id(split2);
 

--- a/gnucash/register/ledger-core/split-register-model.c
+++ b/gnucash/register/ledger-core/split-register-model.c
@@ -2311,6 +2311,7 @@ gnc_template_register_get_xfrm_entry (VirtualLocation virt_loc,
     account = xaccAccountLookup (guid, gnc_get_current_book());
     name = account ? gnc_get_account_name_for_split_register (account,
                                                               reg->show_leaf_accounts) : NULL;
+    guid_free (guid);
     return name;
 }
 
@@ -2322,8 +2323,10 @@ gnc_template_register_get_fdebt_entry (VirtualLocation virt_loc,
 {
     SplitRegister* reg = user_data;
     Split* split = gnc_split_register_get_split (reg, virt_loc.vcell_loc);
-    char* formula = NULL;
+    static char* formula = NULL;
 
+    g_free (formula);
+    formula = NULL;
     if (split)
     {
         qof_instance_get (QOF_INSTANCE (split),
@@ -2356,8 +2359,10 @@ gnc_template_register_get_fcred_entry (VirtualLocation virt_loc,
 {
     SplitRegister* reg = user_data;
     Split* split = gnc_split_register_get_split (reg, virt_loc.vcell_loc);
-    char* formula = NULL;
+    static char* formula = NULL;
 
+    g_free (formula);
+    formula = NULL;
     if (split)
     {
         qof_instance_get (QOF_INSTANCE (split),

--- a/libgnucash/app-utils/gnc-sx-instance-model.c
+++ b/libgnucash/app-utils/gnc-sx-instance-model.c
@@ -120,6 +120,7 @@ scrub_sx_split_numeric (Split* split, const char *debcred)
                           NULL);
         num_val_changed = TRUE;
     }
+    g_free (formval);
     g_free (numval);
     return num_val_changed;
 }
@@ -1053,6 +1054,8 @@ _get_sx_formula_value(const SchedXaction* sx,
          * localization problems with separators. */
 	numeric->num = numeric_val->num;
 	numeric->denom = numeric_val->denom;
+        g_free (formula_str);
+        g_free (numeric_val);
         return;
     }
 
@@ -1082,6 +1085,8 @@ _get_sx_formula_value(const SchedXaction* sx,
             g_hash_table_destroy(parser_vars);
         }
     }
+    g_free (formula_str);
+    g_free (numeric_val);
 }
 
 static void


### PR DESCRIPTION
more leaks. all because `qof_instance_get` for chars and structs need to be freed separately.