### PR TITLE
[import-main-matcher] speed up input dialog

### DIFF
--- a/gnucash/import-export/import-main-matcher.c
+++ b/gnucash/import-export/import-main-matcher.c
@@ -1147,6 +1147,19 @@ input_new_fields (GNCImportMainMatcher *info, RowInfo *rowinfo,
 }
 
 static void
+update_stringinfo_list (GNCImportMainMatcher *info, GList **list, char *str)
+{
+    char *new_string;
+    if (!str || !str[0] ||
+        g_list_find_custom (*list, str, (GCompareFunc)stringinfo_eq))
+        return;
+    new_string = g_strdup (str);
+    info->new_strings = g_list_prepend (info->new_strings, new_string);
+    *list = g_list_insert_sorted (*list, make_stringinfo (new_string),
+                                  (GCompareFunc) stringinfo_cmp);
+}
+
+static void
 gnc_gen_trans_edit_fields (GtkMenuItem *menuitem, GNCImportMainMatcher *info)
 {
     GtkTreeView *treeview;
@@ -1188,29 +1201,13 @@ gnc_gen_trans_edit_fields (GtkMenuItem *menuitem, GNCImportMainMatcher *info)
                                     DOWNLOADED_COL_DESCRIPTION_STYLE, style,
                                     -1);
                 xaccTransSetDescription (row->trans, new_desc);
-                if (*new_desc && !g_list_find_custom (info->desc_list, new_desc,
-                                                      (GCompareFunc)stringinfo_eq))
-                {
-                    char *new_string = g_strdup (new_desc);
-                    info->new_strings = g_list_prepend (info->new_strings, new_string);
-                    info->desc_list = g_list_insert_sorted
-                        (info->desc_list, make_stringinfo (new_string),
-                         (GCompareFunc) stringinfo_cmp);
-                }
+                update_stringinfo_list (info, &info->desc_list, new_desc);
             }
 
             if (info->edit_notes)
             {
                 xaccTransSetNotes (row->trans, new_notes);
-                if (*new_notes && !g_list_find_custom (info->notes_list, new_notes,
-                                                      (GCompareFunc)stringinfo_eq))
-                {
-                    char *new_string = g_strdup (new_notes);
-                    info->new_strings = g_list_prepend (info->new_strings, new_string);
-                    info->notes_list = g_list_insert_sorted
-                        (info->notes_list, make_stringinfo (new_string),
-                         (GCompareFunc) stringinfo_cmp);
-                }
+                update_stringinfo_list (info, &info->notes_list, new_notes);
             }
 
             if (info->edit_memo)
@@ -1222,15 +1219,7 @@ gnc_gen_trans_edit_fields (GtkMenuItem *menuitem, GNCImportMainMatcher *info)
                                     DOWNLOADED_COL_MEMO_STYLE, style,
                                     -1);
                 xaccSplitSetMemo (row->split, new_memo);
-                if (*new_memo && !g_list_find_custom (info->memo_list, new_memo,
-                                                      (GCompareFunc)stringinfo_eq))
-                {
-                    char *new_string = g_strdup (new_memo);
-                    info->new_strings = g_list_prepend (info->new_strings, new_string);
-                    info->memo_list = g_list_insert_sorted
-                        (info->memo_list, make_stringinfo (new_string),
-                         (GCompareFunc) stringinfo_cmp);
-                }
+                update_stringinfo_list (info, &info->memo_list, new_memo);
             }
         }
         g_free (new_desc);


### PR DESCRIPTION
From #1371 

A moderate sized datafile will have a significant slowdown when sorting GtkListStore when creating editing input dialog.

Instead of storing hash tables into main struct, store sorted GLists instead. Thus there's no need for `gtk_tree_sortable_set_sort_column_id` anymore.