### PR TITLE
Mac tests

### DIFF
--- a/.github/workflows/mac-tests.yaml
+++ b/.github/workflows/mac-tests.yaml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 permissions: {}
 jobs:
   ci_tests_mac:
-    runs-on: macos-10.15
+    runs-on: macos-11
     name: macOS CI Tests
     env:
       TZ: America/Los_Angeles

--- a/util/ci/macos-ci-deps/README.md
+++ b/util/ci/macos-ci-deps/README.md
@@ -11,7 +11,7 @@ Procedure:
 * Set up a Gtk-OSX build environment following the [GnuCash Quartz Build instructions](https://wiki.gnucash.org/wiki/MacOS/Quartz).
 * Retrieve [jhbuildrc-custom](https://github.com/gnucash/gnucash-on-osx/jhbuildrc-custom) and put it in ~/.config.
 * Set `modules = _modules_deps` on the appropriate line of `jhbuildrc-custom`.
-* If you are not running the same version of macOS as the Github actions virtual environment change the `setup_SDK()` line at the bottom of `jhbuildrc-custom` to `setup_SDK('10.15')`, substituting the VM's macOS version for '10.15'.
+* If you are not running the same version of macOS as the Github actions virtual environment change the `setup_SDK()` line at the bottom of `jhbuildrc-custom` to `setup_SDK('11')`, substituting the VM's macOS version for '11'.
 * Create the directory `/Users/runner/` and make yourself the owner:
   ```
   sudo mkdir /Users/runner


### PR DESCRIPTION
I got
```
mac-tests: .github#L1
The macOS-10.15 environment is deprecated, consider switching to macos-11(macos-latest), macos-12 instead. For more details see https://github.com/actions/virtual-environments/issues/5583
```
on my last real commit.

With this change the test succeeds again.

I don't know, if you have to do updates on the Mac bundle, too.