### PR TITLE
Maint leaks

### DIFF
--- a/libgnucash/app-utils/gnc-sx-instance-model.c
+++ b/libgnucash/app-utils/gnc-sx-instance-model.c
@@ -88,41 +88,45 @@ static void _gnc_sx_instance_event_handler(QofInstance *ent, QofEventId event_ty
 static gnc_commodity* get_transaction_currency(SxTxnCreationData *creation_data, SchedXaction *sx, Transaction *template_txn);
 /* ------------------------------------------------------------ */
 
-static gboolean
-scrub_sx_split_numeric (Split* split, const char *debcred)
+typedef struct
 {
-    const gboolean is_credit = g_strcmp0 (debcred, "credit") == 0;
-    const char *formula = is_credit ?
-        "sx-credit-formula" : "sx-debit-formula";
-    const char *numeric = is_credit ?
-        "sx-credit-numeric" : "sx-debit-numeric";
+    const char *name;
+    gnc_numeric amount;
+} ScrubItem;
+
+static void
+scrub_sx_split_numeric (Split* split, gboolean is_credit, GList **changes)
+{
+    const char *formula = is_credit ? "sx-credit-formula" : "sx-debit-formula";
+    const char *numeric = is_credit ? "sx-credit-numeric" : "sx-debit-numeric";
     char *formval;
     gnc_numeric *numval = NULL;
     GHashTable *parser_vars = g_hash_table_new (g_str_hash, g_str_equal);
     char *error_loc;
     gnc_numeric amount = gnc_numeric_zero ();
     gboolean parse_result = FALSE;
-    gboolean num_val_changed = FALSE;
-    qof_instance_get (QOF_INSTANCE (split),
-		  formula, &formval,
-		  numeric, &numval,
-		  NULL);
-    parse_result =
-        gnc_exp_parser_parse_separate_vars (formval, &amount,
-                                            &error_loc, parser_vars);
+
+    qof_instance_get (QOF_INSTANCE (split), formula, &formval,
+                      numeric, &numval, NULL);
+
+    parse_result = gnc_exp_parser_parse_separate_vars (formval, &amount,
+                                                       &error_loc, parser_vars);
+
     if (!parse_result || g_hash_table_size (parser_vars) != 0)
         amount = gnc_numeric_zero ();
+
     g_hash_table_unref (parser_vars);
+
     if (!numval || !gnc_numeric_eq (amount, *numval))
     {
-        qof_instance_set (QOF_INSTANCE (split),
-                          numeric, &amount,
-                          NULL);
-        num_val_changed = TRUE;
+        ScrubItem *change = g_new (ScrubItem, 1);
+        change->name = numeric;
+        change->amount = amount;
+        *changes = g_list_prepend (*changes, change);
     }
+
     g_free (formval);
     g_free (numval);
-    return num_val_changed;
 }
 
 /* Fixes error in pre-2.6.16 where the numeric slot wouldn't get changed if the
@@ -133,14 +137,20 @@ gnc_sx_scrub_split_numerics (gpointer psplit, gpointer puser)
 {
     Split *split = GNC_SPLIT (psplit);
     Transaction *trans = xaccSplitGetParent (split);
-    gboolean changed;
+    GList *changes = NULL;
+    scrub_sx_split_numeric (split, TRUE, &changes);
+    scrub_sx_split_numeric (split, FALSE, &changes);
+    if (!changes)
+        return;
+
     xaccTransBeginEdit (trans);
-    changed = scrub_sx_split_numeric (split, "credit") +
-        scrub_sx_split_numeric (split, "debit");
-    if (!changed)
-        xaccTransRollbackEdit (trans);
-    else
-        xaccTransCommitEdit (trans);
+    for (GList *n = changes; n; n = n->next)
+    {
+        ScrubItem *change = n->data;
+        qof_instance_set (QOF_INSTANCE (split), change->name, &change->amount, NULL);
+    }
+    xaccTransCommitEdit (trans);
+    g_list_free_full (changes, g_free);
 }
 
 static void

--- a/libgnucash/app-utils/gnc-sx-instance-model.c
+++ b/libgnucash/app-utils/gnc-sx-instance-model.c
@@ -101,7 +101,8 @@ scrub_sx_split_numeric (Split* split, gboolean is_credit, GList **changes)
     const char *numeric = is_credit ? "sx-credit-numeric" : "sx-debit-numeric";
     char *formval;
     gnc_numeric *numval = NULL;
-    GHashTable *parser_vars = g_hash_table_new (g_str_hash, g_str_equal);
+    GHashTable *parser_vars = g_hash_table_new_full
+        (g_str_hash, g_str_equal, g_free, (GDestroyNotify)gnc_sx_variable_free);
     char *error_loc;
     gnc_numeric amount = gnc_numeric_zero ();
     gboolean parse_result = FALSE;
@@ -205,6 +206,9 @@ GHashTable*
 gnc_sx_instance_get_variables_for_parser(GHashTable *instance_var_hash)
 {
     GHashTable *parser_vars;
+
+    /* fixme: the following GHashTable should g_free keys and
+       gnc_sx_variable_free the values, however this breaks SX formulas */
     parser_vars = g_hash_table_new(g_str_hash, g_str_equal);
     g_hash_table_foreach(instance_var_hash, (GHFunc)_sx_var_to_raw_numeric, parser_vars);
     return parser_vars;


### PR DESCRIPTION
scrubber refactored to avoid 3Kb leak. see valgrind below. Instead of trying to fix `xaccTransRollbackEdit` it's best to avoid calling it altogether.

```
==173547== 
==173547== 3,440 (928 direct, 2,512 indirect) bytes in 4 blocks are definitely lost in loss record 20,325 of 20,717
==173547==    at 0x5ADAF9D: g_type_create_instance (in /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.7200.1)
==173547==    by 0x5AC1F4C: ??? (in /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.7200.1)
==173547==    by 0x5AC31AC: g_object_new_with_properties (in /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.7200.1)
==173547==    by 0x5AC3CB0: g_object_new (in /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.7200.1)
==173547==    by 0x5E6391F: xaccDupeSplit (Split.c:557)
==173547==    by 0x5E6A4FE: dupe_trans (Transaction.c:617)
==173547==    by 0x5E6CCDB: xaccTransBeginEdit (Transaction.c:1470)
==173547==    by 0x5B771CD: gnc_sx_scrub_split_numerics (gnc-sx-instance-model.c:137)
==173547==    by 0x4C3FF5F: g_list_foreach (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.7200.1)
==173547==    by 0x4FCEEF5: gnc_post_file_open (gnc-file.c:1037)
==173547==    by 0x4FCF224: gnc_file_open_file (gnc-file.c:1168)
==173547==    by 0x13F380: scm_run_gnucash(void*, int, char**) (gnucash.cpp:184)
==173547== 
```