### PR TITLE
[gnucash-style] free dimensions properly

### DIFF
--- a/gnucash/register/register-gnome/gnucash-sheet.c
+++ b/gnucash/register/register-gnome/gnucash-sheet.c
@@ -2521,9 +2521,8 @@ gnucash_sheet_new (Table *table)
     sheet->item_editor = gnc_item_edit_new (sheet);
 
     /* some register data */
-    sheet->dimensions_hash_table = g_hash_table_new_full (g_int_hash,
-                                   g_int_equal,
-                                   g_free, g_free);
+    sheet->dimensions_hash_table = g_hash_table_new_full (g_int_hash, g_int_equal,
+                                                          g_free, NULL);
 
     /* add tooltips to sheet */
     gtk_widget_set_has_tooltip (GTK_WIDGET(sheet), TRUE);

--- a/gnucash/register/register-gnome/gnucash-style.c
+++ b/gnucash/register/register-gnome/gnucash-style.c
@@ -102,15 +102,8 @@ style_dimensions_destroy (BlockDimensions *dimensions)
     if (dimensions == NULL)
         return;
 
-    dimensions->refcount--;
-
-    if (dimensions->refcount == 0)
-    {
-        g_table_destroy (dimensions->cell_dimensions);
-        dimensions->cell_dimensions = NULL;
-
-        g_free(dimensions);
-    }
+    g_table_destroy (dimensions->cell_dimensions);
+    g_free (dimensions);
 }
 
 


### PR DESCRIPTION
Previous code was trying to reference count dimensions upon destroy. However it was buggy: when refcount==1, both `style_dimensions_destroy` and `gnucash_sheet_style_destroy` were decrementing refcount, therefore the it never reached zero to trigger g_table_destroy and g_free.

The dimensions are held as GHashTable values, and were eventually g_freed; but the GTable was never destroyed.