### PR TITLE
use gtk_entry_get_text instead of gtk_editable_get_chars

### DIFF
--- a/gnucash/gnome-utils/gnc-account-sel.c
+++ b/gnucash/gnome-utils/gnc-account-sel.c
@@ -204,10 +204,11 @@ gas_populate_list (GNCAccountSel *gas)
     GtkEntry *entry;
     gint i, active = -1;
     GList *accts, *ptr;
-    gchar *currentSel, *name;
+    const gchar *currentSel;
+    gchar *name;
 
     entry = GTK_ENTRY(gtk_bin_get_child (GTK_BIN(gas->combo)));
-    currentSel = gtk_editable_get_chars (GTK_EDITABLE(entry), 0, -1 );
+    currentSel = gtk_entry_get_text (entry);
 
     g_signal_handlers_block_by_func (gas->combo, combo_changed_cb , gas);
 
@@ -244,8 +245,6 @@ gas_populate_list (GNCAccountSel *gas)
     g_signal_handlers_unblock_by_func (gas->combo, combo_changed_cb , gas);
 
     g_list_free (atnd.outList);
-    if (currentSel)
-        g_free (currentSel);
 }
 
 static void

--- a/gnucash/gnome/dialog-customer.c
+++ b/gnucash/gnome/dialog-customer.c
@@ -213,44 +213,25 @@ static void gnc_ui_to_customer (CustomerWindow *cw, GncCustomer *cust)
     if (cw->dialog_type == NEW_CUSTOMER)
         qof_event_gen(QOF_INSTANCE(cust), QOF_EVENT_ADD, NULL);
 
-    gncCustomerSetID (cust, gtk_editable_get_chars
-                      (GTK_EDITABLE (cw->id_entry), 0, -1));
-    gncCustomerSetName (cust, gtk_editable_get_chars
-                        (GTK_EDITABLE (cw->company_entry), 0, -1));
+    gncCustomerSetID (cust, gtk_entry_get_text (GTK_ENTRY (cw->id_entry)));
+    gncCustomerSetName (cust, gtk_entry_get_text (GTK_ENTRY (cw->company_entry)));
 
-    gncAddressSetName (addr, gtk_editable_get_chars
-                       (GTK_EDITABLE (cw->name_entry), 0, -1));
-    gncAddressSetAddr1 (addr, gtk_editable_get_chars
-                        (GTK_EDITABLE (cw->addr1_entry), 0, -1));
-    gncAddressSetAddr2 (addr, gtk_editable_get_chars
-                        (GTK_EDITABLE (cw->addr2_entry), 0, -1));
-    gncAddressSetAddr3 (addr, gtk_editable_get_chars
-                        (GTK_EDITABLE (cw->addr3_entry), 0, -1));
-    gncAddressSetAddr4 (addr, gtk_editable_get_chars
-                        (GTK_EDITABLE (cw->addr4_entry), 0, -1));
-    gncAddressSetPhone (addr, gtk_editable_get_chars
-                        (GTK_EDITABLE (cw->phone_entry), 0, -1));
-    gncAddressSetFax (addr, gtk_editable_get_chars
-                      (GTK_EDITABLE (cw->fax_entry), 0, -1));
-    gncAddressSetEmail (addr, gtk_editable_get_chars
-                        (GTK_EDITABLE (cw->email_entry), 0, -1));
-
-    gncAddressSetName (shipaddr, gtk_editable_get_chars
-                       (GTK_EDITABLE (cw->shipname_entry), 0, -1));
-    gncAddressSetAddr1 (shipaddr, gtk_editable_get_chars
-                        (GTK_EDITABLE (cw->shipaddr1_entry), 0, -1));
-    gncAddressSetAddr2 (shipaddr, gtk_editable_get_chars
-                        (GTK_EDITABLE (cw->shipaddr2_entry), 0, -1));
-    gncAddressSetAddr3 (shipaddr, gtk_editable_get_chars
-                        (GTK_EDITABLE (cw->shipaddr3_entry), 0, -1));
-    gncAddressSetAddr4 (shipaddr, gtk_editable_get_chars
-                        (GTK_EDITABLE (cw->shipaddr4_entry), 0, -1));
-    gncAddressSetPhone (shipaddr, gtk_editable_get_chars
-                        (GTK_EDITABLE (cw->shipphone_entry), 0, -1));
-    gncAddressSetFax (shipaddr, gtk_editable_get_chars
-                      (GTK_EDITABLE (cw->shipfax_entry), 0, -1));
-    gncAddressSetEmail (shipaddr, gtk_editable_get_chars
-                        (GTK_EDITABLE (cw->shipemail_entry), 0, -1));
+    gncAddressSetName (addr, gtk_entry_get_text (GTK_ENTRY (cw->name_entry)));
+    gncAddressSetAddr1 (addr, gtk_entry_get_text (GTK_ENTRY (cw->addr1_entry)));
+    gncAddressSetAddr2 (addr, gtk_entry_get_text (GTK_ENTRY (cw->addr2_entry)));
+    gncAddressSetAddr3 (addr, gtk_entry_get_text (GTK_ENTRY (cw->addr3_entry)));
+    gncAddressSetAddr4 (addr, gtk_entry_get_text (GTK_ENTRY (cw->addr4_entry)));
+    gncAddressSetPhone (addr, gtk_entry_get_text (GTK_ENTRY (cw->phone_entry)));
+    gncAddressSetFax (addr, gtk_entry_get_text (GTK_ENTRY (cw->fax_entry)));
+    gncAddressSetEmail (addr, gtk_entry_get_text (GTK_ENTRY (cw->email_entry)));
+    gncAddressSetName (shipaddr, gtk_entry_get_text (GTK_ENTRY (cw->shipname_entry)));
+    gncAddressSetAddr1 (shipaddr, gtk_entry_get_text (GTK_ENTRY (cw->shipaddr1_entry)));
+    gncAddressSetAddr2 (shipaddr, gtk_entry_get_text (GTK_ENTRY (cw->shipaddr2_entry)));
+    gncAddressSetAddr3 (shipaddr, gtk_entry_get_text (GTK_ENTRY (cw->shipaddr3_entry)));
+    gncAddressSetAddr4 (shipaddr, gtk_entry_get_text (GTK_ENTRY (cw->shipaddr4_entry)));
+    gncAddressSetPhone (shipaddr, gtk_entry_get_text (GTK_ENTRY (cw->shipphone_entry)));
+    gncAddressSetFax (shipaddr, gtk_entry_get_text (GTK_ENTRY (cw->shipfax_entry)));
+    gncAddressSetEmail (shipaddr, gtk_entry_get_text (GTK_ENTRY (cw->shipemail_entry)));
 
     gncCustomerSetActive (cust, gtk_toggle_button_get_active
                           (GTK_TOGGLE_BUTTON (cw->active_check)));

--- a/gnucash/gnome/dialog-doclink.c
+++ b/gnucash/gnome/dialog-doclink.c
@@ -109,12 +109,12 @@ gnc_doclink_open_uri (GtkWindow *parent, const gchar *uri)
 /* =================================================================== */
 
 static void
-location_ok_cb (GtkEditable *editable, gpointer user_data)
+location_ok_cb (GtkEntry *entry, gpointer user_data)
 {
     GtkWidget *ok_button = user_data;
     gboolean have_scheme = FALSE;
-    gchar *text = gtk_editable_get_chars (editable, 0, -1);
-    GtkWidget *warning_hbox = g_object_get_data (G_OBJECT(editable), "whbox");
+    const gchar *text = gtk_entry_get_text (entry);
+    GtkWidget *warning_hbox = g_object_get_data (G_OBJECT(entry), "whbox");
 
     if (text && *text)
     {
@@ -126,7 +126,6 @@ location_ok_cb (GtkEditable *editable, gpointer user_data)
     }
     gtk_widget_set_visible (warning_hbox, !have_scheme);
     gtk_widget_set_sensitive (ok_button, have_scheme);
-    g_free (text);
 }
 
 static void
@@ -216,7 +215,7 @@ uri_type_selected_cb (GtkToggleButton *button, GtkWidget *widget)
     {
         if (g_strcmp0 (gtk_buildable_get_name (
                              GTK_BUILDABLE(parent_hbox)), "location_hbox") == 0)
-            location_ok_cb (GTK_EDITABLE(widget), ok_button);
+            location_ok_cb (GTK_ENTRY (widget), ok_button);
         else
             file_ok_cb (GTK_BUTTON(widget), ok_button);
 

--- a/gnucash/gnome/dialog-employee.c
+++ b/gnucash/gnome/dialog-employee.c
@@ -129,32 +129,20 @@ static void gnc_ui_to_employee (EmployeeWindow *ew, GncEmployee *employee)
     if (ew->dialog_type == NEW_EMPLOYEE)
         qof_event_gen(QOF_INSTANCE(employee), QOF_EVENT_ADD, NULL);
 
-    gncEmployeeSetID (employee, gtk_editable_get_chars
-                      (GTK_EDITABLE (ew->id_entry), 0, -1));
-    gncEmployeeSetUsername (employee, gtk_editable_get_chars
-                            (GTK_EDITABLE (ew->username_entry), 0, -1));
+    gncEmployeeSetID (employee, gtk_entry_get_text (GTK_ENTRY (ew->id_entry)));
+    gncEmployeeSetUsername (employee, gtk_entry_get_text (GTK_ENTRY (ew->username_entry)));
 
-    gncAddressSetName (addr, gtk_editable_get_chars
-                       (GTK_EDITABLE (ew->name_entry), 0, -1));
-    gncAddressSetAddr1 (addr, gtk_editable_get_chars
-                        (GTK_EDITABLE (ew->addr1_entry), 0, -1));
-    gncAddressSetAddr2 (addr, gtk_editable_get_chars
-                        (GTK_EDITABLE (ew->addr2_entry), 0, -1));
-    gncAddressSetAddr3 (addr, gtk_editable_get_chars
-                        (GTK_EDITABLE (ew->addr3_entry), 0, -1));
-    gncAddressSetAddr4 (addr, gtk_editable_get_chars
-                        (GTK_EDITABLE (ew->addr4_entry), 0, -1));
-    gncAddressSetPhone (addr, gtk_editable_get_chars
-                        (GTK_EDITABLE (ew->phone_entry), 0, -1));
-    gncAddressSetFax (addr, gtk_editable_get_chars
-                      (GTK_EDITABLE (ew->fax_entry), 0, -1));
-    gncAddressSetEmail (addr, gtk_editable_get_chars
-                        (GTK_EDITABLE (ew->email_entry), 0, -1));
-
+    gncAddressSetName (addr, gtk_entry_get_text (GTK_ENTRY (ew->name_entry)));
+    gncAddressSetAddr1 (addr, gtk_entry_get_text (GTK_ENTRY (ew->addr1_entry)));
+    gncAddressSetAddr2 (addr, gtk_entry_get_text (GTK_ENTRY (ew->addr2_entry)));
+    gncAddressSetAddr3 (addr, gtk_entry_get_text (GTK_ENTRY (ew->addr3_entry)));
+    gncAddressSetAddr4 (addr, gtk_entry_get_text (GTK_ENTRY (ew->addr4_entry)));
+    gncAddressSetPhone (addr, gtk_entry_get_text (GTK_ENTRY (ew->phone_entry)));
+    gncAddressSetFax (addr, gtk_entry_get_text (GTK_ENTRY (ew->fax_entry)));
+    gncAddressSetEmail (addr, gtk_entry_get_text (GTK_ENTRY (ew->email_entry)));
     gncEmployeeSetActive (employee, gtk_toggle_button_get_active
                           (GTK_TOGGLE_BUTTON (ew->active_check)));
-    gncEmployeeSetLanguage (employee, gtk_editable_get_chars
-                            (GTK_EDITABLE (ew->language_entry), 0, -1));
+    gncEmployeeSetLanguage (employee, gtk_entry_get_text (GTK_ENTRY (ew->language_entry)));
 
     /* Parse and set the workday and rate amounts */
     gncEmployeeSetWorkday (employee, gnc_amount_edit_get_amount

--- a/gnucash/gnome/dialog-invoice.c
+++ b/gnucash/gnome/dialog-invoice.c
@@ -399,10 +399,8 @@ static void gnc_ui_to_invoice (InvoiceWindow *iw, GncInvoice *invoice)
     /* Only set these values for NEW/MOD INVOICE types */
     if (iw->dialog_type != EDIT_INVOICE)
     {
-        gncInvoiceSetID (invoice, gtk_editable_get_chars
-                         (GTK_EDITABLE (iw->id_entry), 0, -1));
-        gncInvoiceSetBillingID (invoice, gtk_editable_get_chars
-                                (GTK_EDITABLE (iw->billing_id_entry), 0, -1));
+        gncInvoiceSetID (invoice, gtk_entry_get_text (GTK_ENTRY (iw->id_entry)));
+        gncInvoiceSetBillingID (invoice, gtk_entry_get_text (GTK_ENTRY (iw->billing_id_entry)));
         gncInvoiceSetTerms (invoice, iw->terms);
 
         gncInvoiceSetDateOpened (invoice, time);

--- a/gnucash/gnome/dialog-job.c
+++ b/gnucash/gnome/dialog-job.c
@@ -105,12 +105,9 @@ static void gnc_ui_to_job (JobWindow *jw, GncJob *job)
 
     qof_event_gen(QOF_INSTANCE(job), QOF_EVENT_ADD, NULL);
 
-    gncJobSetID (job, gtk_editable_get_chars (GTK_EDITABLE (jw->id_entry),
-                 0, -1));
-    gncJobSetName (job, gtk_editable_get_chars (GTK_EDITABLE (jw->name_entry),
-                   0, -1));
-    gncJobSetReference (job, gtk_editable_get_chars
-                        (GTK_EDITABLE (jw->desc_entry), 0, -1));
+    gncJobSetID (job, gtk_entry_get_text (GTK_ENTRY (jw->id_entry)));
+    gncJobSetName (job, gtk_entry_get_text (GTK_ENTRY (jw->name_entry)));
+    gncJobSetReference (job, gtk_entry_get_text (GTK_ENTRY (jw->desc_entry)));
     gncJobSetRate (job, gnc_amount_edit_get_amount
                         (GNC_AMOUNT_EDIT (jw->rate_entry)));
     gncJobSetActive (job, gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON

--- a/gnucash/gnome/dialog-order.c
+++ b/gnucash/gnome/dialog-order.c
@@ -133,16 +133,14 @@ static void gnc_ui_to_order (OrderWindow *ow, GncOrder *order)
     gnc_suspend_gui_refresh ();
     gncOrderBeginEdit (order);
 
-    gncOrderSetID (order, gtk_editable_get_chars
-                   (GTK_EDITABLE (ow->id_entry), 0, -1));
+    gncOrderSetID (order, gtk_entry_get_text (GTK_ENTRY (ow->id_entry)));
 
     text_buffer = gtk_text_view_get_buffer (GTK_TEXT_VIEW(ow->notes_text));
     gtk_text_buffer_get_bounds (text_buffer, &start, &end);
     text = gtk_text_buffer_get_text (text_buffer, &start, &end, FALSE);
     gncOrderSetNotes (order, text);
 
-    gncOrderSetReference (order, gtk_editable_get_chars
-                          (GTK_EDITABLE (ow->ref_entry), 0, -1));
+    gncOrderSetReference (order, gtk_entry_get_text (GTK_ENTRY (ow->ref_entry)));
 
     tt = gnc_date_edit_get_date (GNC_DATE_EDIT (ow->opened_date));
     gncOrderSetDateOpened (order, tt);

--- a/gnucash/gnome/dialog-sx-editor.c
+++ b/gnucash/gnome/dialog-sx-editor.c
@@ -264,7 +264,7 @@ editor_ok_button_clicked_cb (GtkButton *b, GncSxEditorDialog *sxed)
 static gboolean
 gnc_sxed_check_name_changed (GncSxEditorDialog *sxed)
 {
-    char *name = gtk_editable_get_chars (GTK_EDITABLE (sxed->nameEntry), 0, -1);
+    const char *name = gtk_entry_get_text (GTK_ENTRY (sxed->nameEntry));
 
     if (strlen (name) == 0)
         return TRUE;

--- a/gnucash/gnome/dialog-vendor.c
+++ b/gnucash/gnome/dialog-vendor.c
@@ -146,27 +146,17 @@ static void gnc_ui_to_vendor (VendorWindow *vw, GncVendor *vendor)
     if (vw->dialog_type == NEW_VENDOR)
         qof_event_gen(QOF_INSTANCE(vendor), QOF_EVENT_ADD, NULL);
 
-    gncVendorSetID (vendor, gtk_editable_get_chars
-                    (GTK_EDITABLE (vw->id_entry), 0, -1));
-    gncVendorSetName (vendor, gtk_editable_get_chars
-                      (GTK_EDITABLE (vw->company_entry), 0, -1));
+    gncVendorSetID (vendor, gtk_entry_get_text (GTK_ENTRY (vw->id_entry)));
+    gncVendorSetName (vendor, gtk_entry_get_text (GTK_ENTRY (vw->company_entry)));
 
-    gncAddressSetName (addr, gtk_editable_get_chars
-                       (GTK_EDITABLE (vw->name_entry), 0, -1));
-    gncAddressSetAddr1 (addr, gtk_editable_get_chars
-                        (GTK_EDITABLE (vw->addr1_entry), 0, -1));
-    gncAddressSetAddr2 (addr, gtk_editable_get_chars
-                        (GTK_EDITABLE (vw->addr2_entry), 0, -1));
-    gncAddressSetAddr3 (addr, gtk_editable_get_chars
-                        (GTK_EDITABLE (vw->addr3_entry), 0, -1));
-    gncAddressSetAddr4 (addr, gtk_editable_get_chars
-                        (GTK_EDITABLE (vw->addr4_entry), 0, -1));
-    gncAddressSetPhone (addr, gtk_editable_get_chars
-                        (GTK_EDITABLE (vw->phone_entry), 0, -1));
-    gncAddressSetFax (addr, gtk_editable_get_chars
-                      (GTK_EDITABLE (vw->fax_entry), 0, -1));
-    gncAddressSetEmail (addr, gtk_editable_get_chars
-                        (GTK_EDITABLE (vw->email_entry), 0, -1));
+    gncAddressSetName (addr, gtk_entry_get_text (GTK_ENTRY (vw->name_entry)));
+    gncAddressSetAddr1 (addr, gtk_entry_get_text (GTK_ENTRY (vw->addr1_entry)));
+    gncAddressSetAddr2 (addr, gtk_entry_get_text (GTK_ENTRY (vw->addr2_entry)));
+    gncAddressSetAddr3 (addr, gtk_entry_get_text (GTK_ENTRY (vw->addr3_entry)));
+    gncAddressSetAddr4 (addr, gtk_entry_get_text (GTK_ENTRY (vw->addr4_entry)));
+    gncAddressSetPhone (addr, gtk_entry_get_text (GTK_ENTRY (vw->phone_entry)));
+    gncAddressSetFax (addr, gtk_entry_get_text (GTK_ENTRY (vw->fax_entry)));
+    gncAddressSetEmail (addr, gtk_entry_get_text (GTK_ENTRY (vw->email_entry)));
 
     gncVendorSetActive (vendor, gtk_toggle_button_get_active
                         (GTK_TOGGLE_BUTTON (vw->active_check)));


### PR DESCRIPTION
The former returns a `const char*` which does not need to be freed. I think this is self-explanatory.