### PR TITLE
Bug 797725 - Untranslatable string "For Period Covering ~a to ~a"

### DIFF
--- a/bindings/guile/core-utils.scm
+++ b/bindings/guile/core-utils.scm
@@ -111,7 +111,7 @@
 (set-exception-printer! 'unbound-variable print-unbound-variable-error)
 
 ;; format.
-(define %regex (make-regexp "[$][{]([[:alnum:]]+)[}]"))
+(define %regex (make-regexp "[$][{]([[:alnum:]\\-]+)[}]"))
 (define (gnc:format str . bindings)
   (define hash (make-hash-table))
   (define (substitute m)

--- a/gnucash/report/reports/standard/account-summary.scm
+++ b/gnucash/report/reports/standard/account-summary.scm
@@ -297,14 +297,17 @@
          (exchange-fn (gnc:case-exchange-fn price-source report-commodity to-date)))
 
     (gnc:html-document-set-title!
-     doc (string-append
-          company-name " " report-title " "
-          (if sx?
-              ;; Translators: This is part of the report title, which is capitalzed in English, but not all other languages
-              (format #f (G_ "For Period Covering ~a to ~a")
-                      (qof-print-date from-date)
-                      (qof-print-date to-date))
-              (qof-print-date to-date))))
+     doc
+     (if sx?
+         (gnc:format (G_ "${company-name} ${report-title} For Period Covering ${start} to ${end}")
+                     'company-name company-name
+                     'report-title report-title
+                     'start (qof-print-date from-date)
+                     'end (qof-print-date to-date))
+         (gnc:format (G_ "${company-name} ${report-title} ${date}")
+                     'company-name company-name
+                     'report-title report-title
+                     'date (qof-print-date to-date))))
 
     (if (null? accounts)
 

--- a/gnucash/report/reports/standard/equity-statement.scm
+++ b/gnucash/report/reports/standard/equity-statement.scm
@@ -283,12 +283,11 @@
       (gnc:account-get-comm-balance-at-date account end-date #f))
 
     (gnc:html-document-set-title! 
-     doc (format #f
-		  (string-append "~a ~a "
-				 (G_ "For Period Covering ~a to ~a"))
-		  company-name report-title
-                  (qof-print-date start-date-printable)
-                  (qof-print-date end-date)))
+     doc (gnc:format (G_ "${company-name} ${report-title} For Period Covering ${start} to ${end}")
+                     'company-name company-name
+                     'report-title report-title
+                     'start (qof-print-date start-date-printable)
+                     'end (qof-print-date end-date)))
     
     (if (null? accounts)
 	

--- a/gnucash/report/reports/standard/income-statement.scm
+++ b/gnucash/report/reports/standard/income-statement.scm
@@ -377,10 +377,11 @@
       (gnc:html-table-append-ruler! table (* 2 tree-depth)))
 
     (gnc:html-document-set-title!
-     doc (format #f (string-append "~a ~a " (G_ "For Period Covering ~a to ~a"))
-                  company-name report-title
-                  (qof-print-date start-date-printable)
-                  (qof-print-date end-date)))
+     doc (gnc:format (G_ "${company-name} ${report-title} For Period Covering ${start} to ${end}")
+                     'company-name company-name
+                     'report-title report-title
+                     'start (qof-print-date start-date-printable)
+                     'end (qof-print-date end-date)))
 
     (if (null? accounts)
 

--- a/gnucash/report/reports/standard/trial-balance.scm
+++ b/gnucash/report/reports/standard/trial-balance.scm
@@ -374,15 +374,17 @@
          (period-for (string-append " " (G_ "for Period"))))
 
     (gnc:html-document-set-title!
-     doc (if (eq? report-variant 'current)
-             (format #f "~a ~a ~a"
-                     company-name report-title
-                     (qof-print-date end-date))
-             (format #f (string-append "~a ~a "
-                                       (G_ "For Period Covering ~a to ~a"))
-                     company-name report-title
-                     (qof-print-date start-date-printable)
-                     (qof-print-date end-date))))
+     doc
+     (if (eq? report-variant 'current)
+         (gnc:format (G_ "${company-name} ${report-title} ${date}")
+                     'company-name company-name
+                     'report-title report-title
+                     'date (qof-print-date end-date))
+         (gnc:format (G_ "${company-name} ${report-title} For Period Covering ${start} to ${end}")
+                     'company-name company-name
+                     'report-title report-title
+                     'start (qof-print-date start-date-printable)
+                     'end (qof-print-date end-date))))
 
     (if (null? accounts)
 


### PR DESCRIPTION
use `(gnc:format)` strings.