### PR TITLE
stock assistant - add units column, remove zero-fee line

### DIFF
--- a/gnucash/gnome/assistant-stock-transaction.cpp
+++ b/gnucash/gnome/assistant-stock-transaction.cpp
@@ -638,8 +638,6 @@ check_page (GtkListStore *list, gnc_numeric& debit, gnc_numeric& credit,
             FieldMask splitfield, Account *acct, GtkWidget *memo, GtkWidget *gae,
             gnc_commodity *comm, const char* page, StringVec& errors)
 {
-    if (splitfield == FieldMask::DISABLED)
-        return;
     const char* missing_str = N_("(missing)");
     const gchar* amtstr;
     gnc_numeric amount;
@@ -766,26 +764,32 @@ to ensure proper recording."), new_date_str, last_split_date_str);
             add_error_str (errors, N_("Cannot cover buy more units than owed"));
     }
 
-    check_page (list, debit, credit, info->txn_type->stock_value, info->acct,
-                info->stock_memo_edit, info->stock_value_edit, info->currency,
-                NC_ ("Stock Assistant: Page name", "stock value"), errors);
+    if (info->txn_type->stock_value != FieldMask::DISABLED)
+        check_page (list, debit, credit, info->txn_type->stock_value, info->acct,
+                    info->stock_memo_edit, info->stock_value_edit, info->currency,
+                    NC_ ("Stock Assistant: Page name", "stock value"), errors);
 
-    check_page (list, debit, credit, info->txn_type->cash_value,
-                gas_account (info->cash_account), info->cash_memo_edit,
-                info->cash_value, info->currency,
-                NC_ ("Stock Assistant: Page name", "cash"), errors);
+    if (info->txn_type->cash_value != FieldMask::DISABLED)
+        check_page (list, debit, credit, info->txn_type->cash_value,
+                    gas_account (info->cash_account), info->cash_memo_edit,
+                    info->cash_value, info->currency,
+                    NC_ ("Stock Assistant: Page name", "cash"), errors);
 
-    auto capitalize_fees = gtk_toggle_button_get_active
-        (GTK_TOGGLE_BUTTON (info->capitalize_fees_checkbox));
-    check_page (list, debit, credit, info->txn_type->fees_value,
-                capitalize_fees ? info->acct : gas_account (info->fees_account),
-                info->fees_memo_edit, info->fees_value, info->currency,
-                NC_ ("Stock Assistant: Page name", "fees"), errors);
+    if (info->txn_type->fees_value != FieldMask::DISABLED)
+    {
+        auto capitalize_fees = gtk_toggle_button_get_active
+            (GTK_TOGGLE_BUTTON (info->capitalize_fees_checkbox));
+        check_page (list, debit, credit, info->txn_type->fees_value,
+                    capitalize_fees ? info->acct : gas_account (info->fees_account),
+                    info->fees_memo_edit, info->fees_value, info->currency,
+                    NC_ ("Stock Assistant: Page name", "fees"), errors);
+    }
 
-    check_page (list, debit, credit, info->txn_type->dividend_value,
-                gas_account (info->dividend_account),
-                info->dividend_memo_edit, info->dividend_value, info->currency,
-                NC_ ("Stock Assistant: Page name", "dividend"), errors);
+    if (info->txn_type->dividend_value != FieldMask::DISABLED)
+        check_page (list, debit, credit, info->txn_type->dividend_value,
+                    gas_account (info->dividend_account),
+                    info->dividend_memo_edit, info->dividend_value, info->currency,
+                    NC_ ("Stock Assistant: Page name", "dividend"), errors);
 
     // the next two checks will involve the two capgains splits:
     // income side and stock side. The capgains_value ^

--- a/gnucash/gnome/assistant-stock-transaction.cpp
+++ b/gnucash/gnome/assistant-stock-transaction.cpp
@@ -75,7 +75,7 @@ enum split_cols
 {
     SPLIT_COL_ACCOUNT = 0,
     SPLIT_COL_MEMO,
-    SPLIT_COL_MEMO_ESCAPED,
+    SPLIT_COL_TOOLTIP,
     SPLIT_COL_DEBIT,
     SPLIT_COL_CREDIT,
     NUM_SPLIT_COLS
@@ -695,7 +695,7 @@ check_page (GtkListStore *list, gnc_numeric& debit, gnc_numeric& credit,
     gtk_list_store_set (list, &iter,
                         SPLIT_COL_ACCOUNT, acctstr,
                         SPLIT_COL_MEMO, memostr,
-                        SPLIT_COL_MEMO_ESCAPED, memostr_escaped,
+                        SPLIT_COL_TOOLTIP, memostr_escaped,
                         SPLIT_COL_DEBIT, debit_side ? amtstr : "",
                         SPLIT_COL_CREDIT, !debit_side ? amtstr : "",
                         -1);
@@ -1253,7 +1253,7 @@ stock_assistant_create (StockTransactionInfo *info)
     g_signal_connect (G_OBJECT(info->window), "destroy",
                       G_CALLBACK (stock_assistant_window_destroy_cb), info);
     gtk_tree_view_set_tooltip_column (GTK_TREE_VIEW (info->finish_split_view),
-                                      SPLIT_COL_MEMO_ESCAPED);
+                                      SPLIT_COL_TOOLTIP);
 
     gtk_assistant_set_forward_page_func (GTK_ASSISTANT(info->window),
                                          (GtkAssistantPageFunc)forward_page_func,

--- a/gnucash/gnome/assistant-stock-transaction.cpp
+++ b/gnucash/gnome/assistant-stock-transaction.cpp
@@ -667,6 +667,8 @@ check_page (SummaryLineInfo& line, gnc_numeric& debit, gnc_numeric& credit,
             FieldMask splitfield, Account *acct, GtkWidget *memo, GtkWidget *gae,
             gnc_commodity *comm, const char* page, StringVec& errors)
 {
+    // Translators: (missing) denotes that the amount or account is
+    // not provided, or incorrect, in the Stock Transaction Assistant.
     const char* missing_str = N_("(missing)");
     gnc_numeric amount;
 


### PR DESCRIPTION
* add stock units column indicating gain/loss of number of units
* don't show Fee line if zero; a zero-fee split isn't generated.