### PR TITLE
Updated wording for assistant-stock-transaction.cpp

### DIFF
--- a/gnucash/gnome/assistant-stock-transaction.cpp
+++ b/gnucash/gnome/assistant-stock-transaction.cpp
@@ -168,7 +168,7 @@ static const TxnTypeVec long_types
         FieldMask::DISABLED,               // dividend_amt
         FieldMask::DISABLED,               // capg_amt
         // Translators: this is a stock transaction describing
-        // purchase of stock.
+        // new purchase of stock.
         N_("Buy"),
         N_("Buying stock long.")
     },
@@ -180,8 +180,8 @@ static const TxnTypeVec long_types
         false,                  // fees_capitalize
         FieldMask::DISABLED,               // dividend_amt
         FieldMask::ENABLED_CREDIT | FieldMask::ALLOW_ZERO | FieldMask::ALLOW_NEGATIVE, // capgains_amt
-        // Translators: this is a stock transaction describing sale of
-        // stock, and recording capital gain/loss
+        // Translators: this is a stock transaction describing new
+        // sale of stock, and recording capital gain/loss
         N_("Sell"),
         N_("Selling stock long, and record capital gain/loss.")
     },
@@ -285,8 +285,8 @@ static const TxnTypeVec long_types
         FieldMask::DISABLED,               // dividend_amt
         FieldMask::ENABLED_CREDIT | FieldMask::ALLOW_ZERO | FieldMask::ALLOW_NEGATIVE, // capgains_amt
         // Translators: this is a stock transaction describing a
-        // reverse split. Some fractional stock is returned as cash.
-        N_("Reverse split with cash in lieu for fractional unit remainders"),
+        // reverse split. Some remainder stock units are returned as cash.
+        N_("Reverse split with cash in lieu for remainder units"),
         N_("Company redeems units, thereby increasing the stock price by a multiple, while keeping the total monetary value of the overall investment constant. Any remainder units are sold/redeemed for cash, with a capital gain/loss realized.")
     },
 };
@@ -420,9 +420,9 @@ static const TxnTypeVec short_types
         FieldMask::DISABLED,               // dividend_amt
         FieldMask::ENABLED_DEBIT | FieldMask::ALLOW_ZERO | FieldMask::ALLOW_NEGATIVE,          // capg_amt
         // Translators: this is a stock transaction describing a
-        // reverse split when shorting stock. Fractional remaining
-        // stock is retrieved as cash.
-        N_("Reverse split with cash in lieu for fractionals"),
+        // reverse split when shorting stock. Remainder stock
+        // units are retrieved as cash.
+        N_("Reverse split with cash in lieu remainder units"),
         N_("Company redeems units, thereby increasing the stock price by a multiple, while keeping the total monetary value of the overall investment constant. Any remainder units are closed and covered with a cash payment, with a capital gain/loss realized.")
     },
 };

--- a/gnucash/gnome/assistant-stock-transaction.cpp
+++ b/gnucash/gnome/assistant-stock-transaction.cpp
@@ -262,7 +262,7 @@ static const TxnTypeVec long_types
         // Translators: this is a stock transaction describing a stock
         // split
         N_("Stock split"),
-        N_("Company issues additional units, thereby reducing the stock price by a divisor, while keeping the $ value of shares constant.")
+        N_("Company issues additional units, thereby reducing the stock price by a divisor, while keeping the total monetary value the overall investment constant.")
     },
     {
         FieldMask::ENABLED_CREDIT,         // stock_amt
@@ -274,7 +274,7 @@ static const TxnTypeVec long_types
         FieldMask::DISABLED,               // capg_amt
         // Translators: this is a stock transaction describing a reverse split
         N_("Reverse split"),
-        N_("Company redeems units, thereby increasing the stock price by a multiple, while keeping the $ value of shares constant.")
+        N_("Company redeems units, thereby increasing the stock price by a multiple, while keeping the monetary value of the overall investment constant.")
     },
     {
         FieldMask::ENABLED_CREDIT,         // stock_amt
@@ -287,7 +287,7 @@ static const TxnTypeVec long_types
         // Translators: this is a stock transaction describing a
         // reverse split. Some fractional stock is returned as cash.
         N_("Reverse split with cash in lieu for fractional unit remainders"),
-        N_("Company redeems units, thereby increasing the stock price by a multiple, while keeping the $ value of shares constant. Any remainder units are sold/redeemed for cash, with a capital gain/loss realized.")
+        N_("Company redeems units, thereby increasing the stock price by a multiple, while keeping the monetary value of overall investment constant. Any remainder units are sold/redeemed for cash, with a capital gain/loss realized.")
     },
 };
 
@@ -370,7 +370,7 @@ static const TxnTypeVec short_types
         // Translators: this is a stock transaction describing return
         // of capital retrieved from holder when shorting stock
         N_("Compensatory return of capital"),
-        N_("Company returns capital, and the short stock holder must make a compensatory payment for the returned capital. This reduces the cost basis (less negative towards $0) without affecting # units.")
+        N_("Company returns capital, and the short stock holder must make a compensatory payment for the returned capital. This reduces the cost basis (less negative, towards 0.00 value) without affecting # units.")
     },
     {
         FieldMask::DISABLED,               // stock_amt
@@ -383,7 +383,7 @@ static const TxnTypeVec short_types
         // Translators: this is a stock transaction describing a
         // notional distribution when shorting stock
         N_("Compensatory notional distribution"),
-        N_("Company issues a notional distribution, and the short stock holder must make a compensatory payment for the notional distribution. This is recorded as a loss/negative dividend income amount, and increases the cost basis (more negative away from $0) without affecting # units.")
+        N_("Company issues a notional distribution, and the short stock holder must make a compensatory payment for the notional distribution. This is recorded as a loss/negative dividend income amount, and increases the cost basis (more negative, away from 0.00 value) without affecting # units.")
     },
     {
         FieldMask::ENABLED_CREDIT,         // stock_amt
@@ -396,7 +396,7 @@ static const TxnTypeVec short_types
         // Translators: this is a stock transaction describing a stock
         // split when shorting stock
         N_("Stock split"),
-        N_("Company issues additional units, thereby reducing the stock price by a divisor, while keeping the $ value of shares constant.")
+        N_("Company issues additional units, thereby reducing the stock price by a divisor, while keeping the monetary value of the overall investment constant.")
     },
     {
         FieldMask::ENABLED_DEBIT,          // stock_amt
@@ -409,7 +409,7 @@ static const TxnTypeVec short_types
         // Translators: this is a stock transaction describing a
         // reverse split when shorting stock.
         N_("Reverse split"),
-        N_("Company redeems units, thereby increasing the stock price by a multiple, while keeping the $ value of shares constant.")
+        N_("Company redeems units, thereby increasing the stock price by a multiple, while keeping the monetary value of the overall investment constant.")
     },
     {
         FieldMask::ENABLED_DEBIT,          // stock_amt
@@ -423,7 +423,7 @@ static const TxnTypeVec short_types
         // reverse split when shorting stock. Fractional remaining
         // stock is retrieved as cash.
         N_("Reverse split with cash in lieu for fractionals"),
-        N_("Company redeems units, thereby increasing the stock price by a multiple, while keeping the $ value of shares constant. Any remainder units are closed and covered with a cash payment, with a capital gain/loss realized.")
+        N_("Company redeems units, thereby increasing the stock price by a multiple, while keeping the monetary value of the overall investment constant. Any remainder units are closed and covered with a cash payment, with a capital gain/loss realized.")
     },
 };
 

--- a/gnucash/gnome/assistant-stock-transaction.cpp
+++ b/gnucash/gnome/assistant-stock-transaction.cpp
@@ -262,7 +262,7 @@ static const TxnTypeVec long_types
         // Translators: this is a stock transaction describing a stock
         // split
         N_("Stock split"),
-        N_("Company issues additional units, thereby reducing the stock price by a divisor, while keeping the total monetary value the overall investment constant.")
+        N_("Company issues additional units, thereby reducing the stock price by a divisor, while keeping the total monetary value of the overall investment constant.")
     },
     {
         FieldMask::ENABLED_CREDIT,         // stock_amt
@@ -274,7 +274,7 @@ static const TxnTypeVec long_types
         FieldMask::DISABLED,               // capg_amt
         // Translators: this is a stock transaction describing a reverse split
         N_("Reverse split"),
-        N_("Company redeems units, thereby increasing the stock price by a multiple, while keeping the monetary value of the overall investment constant.")
+        N_("Company redeems units, thereby increasing the stock price by a multiple, while keeping the total monetary value of the overall investment constant.")
     },
     {
         FieldMask::ENABLED_CREDIT,         // stock_amt
@@ -287,7 +287,7 @@ static const TxnTypeVec long_types
         // Translators: this is a stock transaction describing a
         // reverse split. Some fractional stock is returned as cash.
         N_("Reverse split with cash in lieu for fractional unit remainders"),
-        N_("Company redeems units, thereby increasing the stock price by a multiple, while keeping the monetary value of overall investment constant. Any remainder units are sold/redeemed for cash, with a capital gain/loss realized.")
+        N_("Company redeems units, thereby increasing the stock price by a multiple, while keeping the total monetary value of the overall investment constant. Any remainder units are sold/redeemed for cash, with a capital gain/loss realized.")
     },
 };
 
@@ -396,7 +396,7 @@ static const TxnTypeVec short_types
         // Translators: this is a stock transaction describing a stock
         // split when shorting stock
         N_("Stock split"),
-        N_("Company issues additional units, thereby reducing the stock price by a divisor, while keeping the monetary value of the overall investment constant.")
+        N_("Company issues additional units, thereby reducing the stock price by a divisor, while keeping the total monetary value of the overall investment constant.")
     },
     {
         FieldMask::ENABLED_DEBIT,          // stock_amt
@@ -409,7 +409,7 @@ static const TxnTypeVec short_types
         // Translators: this is a stock transaction describing a
         // reverse split when shorting stock.
         N_("Reverse split"),
-        N_("Company redeems units, thereby increasing the stock price by a multiple, while keeping the monetary value of the overall investment constant.")
+        N_("Company redeems units, thereby increasing the stock price by a multiple, while keeping the total monetary value of the overall investment constant.")
     },
     {
         FieldMask::ENABLED_DEBIT,          // stock_amt
@@ -423,7 +423,7 @@ static const TxnTypeVec short_types
         // reverse split when shorting stock. Fractional remaining
         // stock is retrieved as cash.
         N_("Reverse split with cash in lieu for fractionals"),
-        N_("Company redeems units, thereby increasing the stock price by a multiple, while keeping the monetary value of the overall investment constant. Any remainder units are closed and covered with a cash payment, with a capital gain/loss realized.")
+        N_("Company redeems units, thereby increasing the stock price by a multiple, while keeping the total monetary value of the overall investment constant. Any remainder units are closed and covered with a cash payment, with a capital gain/loss realized.")
     },
 };
 

--- a/gnucash/gnome/assistant-stock-transaction.cpp
+++ b/gnucash/gnome/assistant-stock-transaction.cpp
@@ -138,9 +138,9 @@ static const TxnTypeVec starting_types
         FieldMask::DISABLED,               // dividend_amt
         FieldMask::DISABLED,               // capg_amt
         // Translators: this is a stock transaction describing an
-        // Initial stock purchase
+        // Initial stock long purchase
         N_("Open buy"),
-        N_("Initial stock purchase")
+        N_("Initial stock long purchase.")
     },
     {
         FieldMask::ENABLED_CREDIT,         // stock_amt
@@ -151,9 +151,9 @@ static const TxnTypeVec starting_types
         FieldMask::DISABLED,               // dividend_amt
         FieldMask::DISABLED,               // capg_amt
         // Translators: this is a stock transaction describing an
-        // initial stock short-sale
+        // initial stock short sale
         N_("Open short"),
-        N_("Initial stock short-sale")
+        N_("Initial stock short sale.")
     }
 };
 
@@ -170,7 +170,7 @@ static const TxnTypeVec long_types
         // Translators: this is a stock transaction describing
         // purchase of stock.
         N_("Buy"),
-        N_("Buying stock.")
+        N_("Buying stock long.")
     },
     {
         FieldMask::ENABLED_CREDIT,         // stock_amt
@@ -183,7 +183,7 @@ static const TxnTypeVec long_types
         // Translators: this is a stock transaction describing sale of
         // stock, and recording capital gain/loss
         N_("Sell"),
-        N_("Selling stock, and record capital gain/loss")
+        N_("Selling stock long, and record capital gain/loss.")
     },
     {
         FieldMask::DISABLED,               // stock_amt
@@ -196,7 +196,7 @@ static const TxnTypeVec long_types
         // Translators: this is a stock transaction describing
         // dividends issued to holder
         N_("Dividend"),
-        N_("Company issues dividends to holder")
+        N_("Company issues cash dividends to holder.")
     },
     {
         FieldMask::ENABLED_DEBIT,          // stock_amt
@@ -207,10 +207,10 @@ static const TxnTypeVec long_types
         FieldMask::ENABLED_CREDIT,         // dividend_amt
         FieldMask::DISABLED,               // capg_amt
         // Translators: this is a stock transaction describing
-        // dividend issued to holder, and is reinvested. Some
+        // dividend issued to holder, and it may be reinvested. Some
         // dividends are distributed as cash.
-        N_("Dividend reinvestment (with remainder)"),
-        N_("Company issues dividend which is reinvested. Some dividends are paid to holder")
+        N_("Dividend reinvestment"),
+        N_("Company issues dividend, which may be reinvested. Non-reinvested dividends are paid out as cash.")
     },
     {
         FieldMask::ENABLED_DEBIT,          // stock_amt
@@ -222,7 +222,7 @@ static const TxnTypeVec long_types
         FieldMask::DISABLED,               // capg_amt
         // Translators: this is a stock transaction describing
         // dividend which is wholly reinvested.
-        N_("Dividend reinvestment (without remainder)"),
+        N_("Dividend reinvestment (without remainder) - N/A"),
         N_("Company issues dividend which is wholly reinvested.")
     },
     {
@@ -235,8 +235,8 @@ static const TxnTypeVec long_types
         FieldMask::DISABLED,               // capg_amt
         // Translators: this is a stock transaction describing return
         // of capital
-        N_("Return of Capital"),
-        N_("Stock returns capital to holder")
+        N_("Return of capital"),
+        N_("Company returns capital, reducing the cost basis without affecting # units.")
     },
     {
         FieldMask::DISABLED,               // stock_amt
@@ -249,7 +249,7 @@ static const TxnTypeVec long_types
         // Translators: this is a stock transaction describing a
         // notional distribution
         N_("Notional distribution"),
-        N_("Stock returns a notional distribution")
+        N_("Company issues a notional distribution, which is recorded as dividend income and increases the cost basis without affecting # units.")
     },
     {
         FieldMask::ENABLED_DEBIT,          // stock_amt
@@ -262,7 +262,7 @@ static const TxnTypeVec long_types
         // Translators: this is a stock transaction describing a stock
         // split
         N_("Stock split"),
-        N_("Stock price is fractionally reduced")
+        N_("Company issues additional units, thereby reducing the stock price by a divisor, while keeping the $ value of shares constant.")
     },
     {
         FieldMask::ENABLED_CREDIT,         // stock_amt
@@ -274,7 +274,7 @@ static const TxnTypeVec long_types
         FieldMask::DISABLED,               // capg_amt
         // Translators: this is a stock transaction describing a reverse split
         N_("Reverse split"),
-        N_("Stock price is fractionally increased.")
+        N_("Company redeems units, thereby increasing the stock price by a multiple, while keeping the $ value of shares constant.")
     },
     {
         FieldMask::ENABLED_CREDIT,         // stock_amt
@@ -286,8 +286,8 @@ static const TxnTypeVec long_types
         FieldMask::ENABLED_CREDIT | FieldMask::ALLOW_ZERO | FieldMask::ALLOW_NEGATIVE, // capgains_amt
         // Translators: this is a stock transaction describing a
         // reverse split. Some fractional stock is returned as cash.
-        N_("Reverse split with cash in lieu for fractionals"),
-        N_("Stock price is fractionally increased. Fractional remaining stock is returned as cash.")
+        N_("Reverse split with cash in lieu for fractional unit remainders"),
+        N_("Company redeems units, thereby increasing the stock price by a multiple, while keeping the $ value of shares constant. Any remainder units are sold/redeemed for cash, with a capital gain/loss realized.")
     },
 };
 
@@ -304,7 +304,7 @@ static const TxnTypeVec short_types
         // Translators: this is a stock transaction describing
         // shorting of stock.
         N_("Short sell"),
-        N_("Shorting stock.")
+        N_("Selling stock short.")
     },
     {
         FieldMask::ENABLED_DEBIT,          // stock_amt
@@ -317,7 +317,7 @@ static const TxnTypeVec short_types
         // Translators: this is a stock transaction describing cover
         // buying stock, and recording capital gain/loss
         N_("Buy to cover short"),
-        N_("Buy back stock to cover short and record capital gain/loss")
+        N_("Buy back stock to cover short position, and record capital gain/loss.")
     },
     {
         FieldMask::DISABLED,               // stock_amt
@@ -329,8 +329,8 @@ static const TxnTypeVec short_types
         FieldMask::DISABLED,               // capg_amt
         // Translators: this is a stock transaction describing
         // dividends retrieved from holder when shorting stock
-        N_("Compensatory Dividend"),
-        N_("Company issues dividends to holder when shorting stock")
+        N_("Compensatory dividend"),
+        N_("Company issues dividends, and the short stock holder must make a compensatory payment for the dividend.")
     },
     {
         FieldMask::ENABLED_CREDIT,         // stock_amt
@@ -343,7 +343,7 @@ static const TxnTypeVec short_types
         // Translators: this is a stock transaction describing
         // dividends retrieved from holder when shorting stock. Some
         // dividends are recovered from holder
-        N_("Dividend reinvestment (with remainder)"),
+        N_("Dividend reinvestment (with remainder) - N/A"),
         N_("Company issues dividends to holder when shorting stock. Some dividends are recovered from holder")
     },
     {
@@ -356,7 +356,7 @@ static const TxnTypeVec short_types
         FieldMask::DISABLED,               // capg_amt
         // Translators: this is a stock transaction describing
         // dividends retrieved from holder when shorting stock,
-        N_("Dividend reinvestment (without remainder)"),
+        N_("Dividend reinvestment (without remainder) - N/A"),
         N_("Company issues dividend when shorting stock, which are wholly recovered from holder.")
     },
     {
@@ -369,8 +369,8 @@ static const TxnTypeVec short_types
         FieldMask::DISABLED,               // capg_amt
         // Translators: this is a stock transaction describing return
         // of capital retrieved from holder when shorting stock
-        N_("Compensatory Return of Capital"),
-        N_("Return retrieves capital from holder when shorting stock")
+        N_("Compensatory return of capital"),
+        N_("Company returns capital, and the short stock holder must make a compensatory payment for the returned capital. This reduces the cost basis (less negative towards $0) without affecting # units.")
     },
     {
         FieldMask::DISABLED,               // stock_amt
@@ -382,8 +382,8 @@ static const TxnTypeVec short_types
         FieldMask::DISABLED,               // capg_amt
         // Translators: this is a stock transaction describing a
         // notional distribution when shorting stock
-        N_("Compensatory Notional distribution"),
-        N_("Stock retrieves a notional distribution")
+        N_("Compensatory notional distribution"),
+        N_("Company issues a notional distribution, and the short stock holder must make a compensatory payment for the notional distribution. This is recorded as a loss/negative dividend income amount, and increases the cost basis (more negative away from $0) without affecting # units.")
     },
     {
         FieldMask::ENABLED_CREDIT,         // stock_amt
@@ -396,7 +396,7 @@ static const TxnTypeVec short_types
         // Translators: this is a stock transaction describing a stock
         // split when shorting stock
         N_("Stock split"),
-        N_("Stock price is fractionally reduced when shorting stock")
+        N_("Company issues additional units, thereby reducing the stock price by a divisor, while keeping the $ value of shares constant.")
     },
     {
         FieldMask::ENABLED_DEBIT,          // stock_amt
@@ -409,7 +409,7 @@ static const TxnTypeVec short_types
         // Translators: this is a stock transaction describing a
         // reverse split when shorting stock.
         N_("Reverse split"),
-        N_("Stock price is fractionally increased when shorting stock.")
+        N_("Company redeems units, thereby increasing the stock price by a multiple, while keeping the $ value of shares constant.")
     },
     {
         FieldMask::ENABLED_DEBIT,          // stock_amt
@@ -423,7 +423,7 @@ static const TxnTypeVec short_types
         // reverse split when shorting stock. Fractional remaining
         // stock is retrieved as cash.
         N_("Reverse split with cash in lieu for fractionals"),
-        N_("Stock price is fractionally increased when shorting stock. Fractional remaining stock is retrieved as cash.")
+        N_("Company redeems units, thereby increasing the stock price by a multiple, while keeping the $ value of shares constant. Any remainder units are closed and covered with a cash payment, with a capital gain/loss realized.")
     },
 };
 

--- a/gnucash/gnome/assistant-stock-transaction.cpp
+++ b/gnucash/gnome/assistant-stock-transaction.cpp
@@ -201,7 +201,7 @@ static const TxnTypeVec long_types
     {
         FieldMask::ENABLED_DEBIT,          // stock_amt
         FieldMask::ENABLED_DEBIT,          // stock_val
-        FieldMask::ENABLED_DEBIT,          // cash_amt
+        FieldMask::ENABLED_DEBIT | FieldMask::ALLOW_ZERO,          // cash_amt
         FieldMask::ENABLED_DEBIT | FieldMask::ALLOW_ZERO,          // fees_amt
         true,                   // fees_capitalize
         FieldMask::ENABLED_CREDIT,         // dividend_amt
@@ -210,7 +210,7 @@ static const TxnTypeVec long_types
         // dividend issued to holder, and it may be reinvested. Some
         // dividends are distributed as cash.
         N_("Dividend reinvestment"),
-        N_("Company issues dividend, which may be reinvested. Non-reinvested dividends are paid out as cash.")
+        N_("Company issues dividend, which may be reinvested. Remaining non-reinvested dividends (if any) are paid out as a cash dividend.")
     },
     {
         FieldMask::ENABLED_DEBIT,          // stock_amt


### PR DESCRIPTION
On the long side of the transaction list, dividend reinvestments with and without remainder can be merged.

On the short side of the transaction list, the 2 dividend reinvestment transactions are not relevant and should be deleted.  There is no such thing as a "compensatory dividend reinvestment".

Refer to https://bugs.gnucash.org/show_bug.cgi?id=798004#c49