### PR TITLE
Register description cell

### DIFF
--- a/gnucash/register/ledger-core/split-register-layout.c
+++ b/gnucash/register/ledger-core/split-register-layout.c
@@ -675,7 +675,7 @@ gnc_split_register_layout_add_cells (SplitRegister* reg,
 
     gnc_register_add_cell (layout,
                            DESC_CELL,
-                           QUICKFILL_CELL_TYPE_NAME,
+                           COMBO_CELL_TYPE_NAME,
                            C_ ("sample", "Description of a transaction"),
                            CELL_ALIGN_LEFT,
                            TRUE,

--- a/gnucash/register/ledger-core/split-register-load.c
+++ b/gnucash/register/ledger-core/split-register-load.c
@@ -50,6 +50,7 @@ static QofLogModule log_module = GNC_MOD_LEDGER;
 static void gnc_split_register_load_xfer_cells (SplitRegister* reg,
                                                 Account* base_account);
 
+static void gnc_split_register_load_desc_cells (SplitRegister* reg);
 static void
 gnc_split_register_load_recn_cells (SplitRegister* reg)
 {
@@ -239,10 +240,6 @@ _find_split_with_parent_txn (gconstpointer a, gconstpointer b)
 static void add_quickfill_completions (TableLayout* layout, Transaction* trans,
                                        Split* split, gboolean has_last_num)
 {
-    gnc_quickfill_cell_add_completion (
-        (QuickFillCell*) gnc_table_layout_get_cell (layout, DESC_CELL),
-        xaccTransGetDescription (trans));
-
     gnc_quickfill_cell_add_completion (
         (QuickFillCell*) gnc_table_layout_get_cell (layout, NOTES_CELL),
         xaccTransGetNotes (trans));
@@ -528,6 +525,7 @@ gnc_split_register_load (SplitRegister* reg, GList* slist,
 
         /* load up account names into the transfer combobox menus */
         gnc_split_register_load_xfer_cells (reg, default_account);
+        gnc_split_register_load_desc_cells (reg);
         gnc_split_register_load_doclink_cells (reg);
         gnc_split_register_load_recn_cells (reg);
         gnc_split_register_load_type_cells (reg);
@@ -661,6 +659,10 @@ gnc_split_register_load (SplitRegister* reg, GList* slist,
          * fill up the quickfill cells. */
         if (info->first_pass)
             add_quickfill_completions (reg->table->layout, trans, split, has_last_num);
+
+        gnc_combo_cell_add_menu_item_unique (
+            (ComboCell*) gnc_table_layout_get_cell (reg->table->layout, DESC_CELL),
+            xaccTransGetDescription (trans));
 
         if (trans == find_trans)
             new_trans_row = vcell_loc.virt_row;
@@ -851,4 +853,15 @@ gnc_split_register_load_xfer_cells (SplitRegister* reg, Account* base_account)
     gnc_combo_cell_use_list_store_cache (cell, store);
 }
 
+static void
+gnc_split_register_load_desc_cells (SplitRegister* reg)
+{
+    ComboCell* cell;
+    GtkListStore* store = gtk_list_store_new (1, G_TYPE_STRING);
+
+    cell = (ComboCell*)
+           gnc_table_layout_get_cell (reg->table->layout, DESC_CELL);
+
+    gnc_combo_cell_use_list_store_cache (cell, store);
+}
 /* ====================== END OF FILE ================================== */

--- a/gnucash/register/ledger-core/split-register-load.c
+++ b/gnucash/register/ledger-core/split-register-load.c
@@ -862,6 +862,8 @@ gnc_split_register_load_desc_cells (SplitRegister* reg)
     cell = (ComboCell*)
            gnc_table_layout_get_cell (reg->table->layout, DESC_CELL);
 
+    gnc_combo_cell_use_type_ahead_only (cell);
+
     gnc_combo_cell_use_list_store_cache (cell, store);
 }
 /* ====================== END OF FILE ================================== */

--- a/gnucash/register/ledger-core/split-register.c
+++ b/gnucash/register/ledger-core/split-register.c
@@ -2666,6 +2666,11 @@ gnc_split_register_config_cells (SplitRegister* reg)
         ((ComboCell*)
          gnc_table_layout_get_cell (reg->table->layout, ACTN_CELL), TRUE);
 
+    /* the description cell */
+    gnc_combo_cell_set_autosize
+        ((ComboCell*)
+         gnc_table_layout_get_cell (reg->table->layout, DESC_CELL), TRUE);
+
     /* Use GNC_COMMODITY_MAX_FRACTION for prices and "exchange rates"  */
     gnc_price_cell_set_fraction
         ((PriceCell*)
@@ -2692,6 +2697,11 @@ gnc_split_register_config_cells (SplitRegister* reg)
     gnc_combo_cell_set_strict
         ((ComboCell*)
          gnc_table_layout_get_cell (reg->table->layout, ACTN_CELL), FALSE);
+
+    /* The description cell should accept strings not in the list */
+    gnc_combo_cell_set_strict
+        ((ComboCell*)
+         gnc_table_layout_get_cell (reg->table->layout, DESC_CELL), FALSE);
 
     /* number format for share quantities in stock ledgers */
     switch (reg->type)

--- a/gnucash/register/register-core/combocell.h
+++ b/gnucash/register/register-core/combocell.h
@@ -108,5 +108,9 @@ void gnc_combo_cell_use_quickfill_cache (ComboCell* cell,
                                          QuickFill* shared_qf);
 void gnc_combo_cell_use_list_store_cache (ComboCell* cell, gpointer data);
 
+/** Set the combocell to use only type ahead search. This will make the
+ *  search to be more like a modified entry completion. */
+void gnc_combo_cell_use_type_ahead_only (ComboCell* cell);
+
 /** @} */
 #endif

--- a/gnucash/register/register-core/combocell.h
+++ b/gnucash/register/register-core/combocell.h
@@ -63,6 +63,10 @@ void         gnc_combo_cell_clear_menu (ComboCell* cell);
 void         gnc_combo_cell_add_menu_item (ComboCell* cell,
                                            const char* menustr);
 
+/** Add a unique menu item to the list. */
+void gnc_combo_cell_add_menu_item_unique (ComboCell* cell,
+                                          const char* menustr);
+
 /** Add a 'account name' menu item to the list. When testing for
  *  equality with the currently selected item, this function will
  *  ignore the characters normally used to separate account names. */

--- a/gnucash/register/register-gnome/combocell-gnome.c
+++ b/gnucash/register/register-gnome/combocell-gnome.c
@@ -75,6 +75,8 @@ typedef struct _PopBox
     GList* ignore_strings;
 
     GHashTable *item_hash;
+
+    gboolean use_type_ahead_only;
 } PopBox;
 
 
@@ -167,6 +169,8 @@ gnc_combo_cell_init (ComboCell* cell)
     box->ignore_strings = NULL;
 
     box->item_hash = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+
+    box->use_type_ahead_only = FALSE;
 }
 
 static void
@@ -694,7 +698,7 @@ gnc_combo_cell_modify_verify (BasicCell* _cell,
     /* If item_list is using temp then we're already partly matched by
      * type-ahead and a quickfill_match won't work.
      */
-    if (!gnc_item_list_using_temp (box->item_list))
+    if (!gnc_item_list_using_temp (box->item_list) && !box->use_type_ahead_only)
     {
         // If we were deleting or inserting in the middle, just accept.
         if (change == NULL || *cursor_position < _cell->value_chars)
@@ -924,6 +928,19 @@ gnc_combo_cell_direct_update (BasicCell* bcell,
     *end_selection = -1;
 
     return TRUE;
+}
+
+void
+gnc_combo_cell_use_type_ahead_only (ComboCell* cell)
+{
+    PopBox* box;
+
+    if (cell == NULL) return;
+
+    box = cell->cell.gui_private;
+
+    box->use_type_ahead_only = TRUE;
+
 }
 
 static void

--- a/gnucash/register/register-gnome/gnucash-item-edit.c
+++ b/gnucash/register/register-gnome/gnucash-item-edit.c
@@ -1089,6 +1089,12 @@ gnc_item_edit_show_popup (GncItemEdit *item_edit)
     // Lets check popup height is the true height
     item_edit->popup_returned_height = popup_h;
 
+    gtk_widget_get_allocation (GTK_WIDGET(item_edit), &alloc);
+
+    // the calendar will be 0
+    if ((popup_w != 0) && (popup_w < alloc.width))
+        popup_w = alloc.width;
+
     if (popup_h == popup_max_height)
         gtk_widget_set_size_request (item_edit->popup_item, popup_w - 1, popup_h);
     else

--- a/gnucash/register/register-gnome/gnucash-item-list.c
+++ b/gnucash/register/register-gnome/gnucash-item-list.c
@@ -247,7 +247,7 @@ gnc_item_list_autosize (GncItemList* item_list)
     g_return_val_if_fail (item_list != NULL, 0);
     g_return_val_if_fail (IS_GNC_ITEM_LIST (item_list), 0);
 
-    return 100;
+    return 150;
 }
 
 void


### PR DESCRIPTION
I think this may be of use and seem to recall it being requested.
This PR changes the register description cell from an entry cell to a combo cell which lists all the previous descriptions.
To make the search more akin to a modified completion, a function was added to combocell that sets the cell to use only the type ahead search. Below is an image of the description cell popped...
![reg-combo](https://user-images.githubusercontent.com/15702727/194861067-7ccf3684-722d-4262-921c-56a21ed0e7e6.png)

As is, there is a difference to a normal register and the journal. The journal with default settings, lists only the descriptions of the last 30 days where as the normal registers have all entries. This could be changed by adding the if clause at line 663 in split-register-load.c
`if (!info->first_pass)`
which will limit the descriptions to be the same as the register view. Not sure which is better ?

This changes the description cell only but could be done for notes and memo cells if warranted or maybe all could be controlled via preference settings on the 'Register Defaults' page.

I do not think the change has had an impact on loading times but I do not have a lot of transaction with different descriptions so maybe some one else could give it spin.