### PR TITLE
Bug769256 - Change New Account Dialog

### DIFF
--- a/gnucash/gnome-utils/dialog-account.c
+++ b/gnucash/gnome-utils/dialog-account.c
@@ -1390,6 +1390,16 @@ opening_equity_cb (GtkWidget *w, gpointer data)
     gtk_widget_set_sensitive (aw->transfer_account_scroll, !use_equity);
 }
 
+static void
+gnc_name_entry_realize (GtkWidget *widget, gpointer user_data)
+{
+    GtkWidget *commodity_box = user_data;
+    GtkAllocation alloc;
+
+    gtk_widget_get_allocation (widget, &alloc);
+    gtk_widget_set_size_request (commodity_box, -1, alloc.height);
+}
+
 /********************************************************************\
  * gnc_account_window_create                                        *
  *   creates a window to create a new account.                      *
@@ -1454,11 +1464,18 @@ gnc_account_window_create (GtkWindow *parent, AccountWindow *aw)
     // If the account has transactions, prevent changes by displaying a label and tooltip
     if (xaccAccountGetSplitList (aw_get_account (aw)) != NULL)
     {
+        GtkStyleContext *stylectxt = gtk_widget_get_style_context (GTK_WIDGET(box));
         const gchar *sec_name = gnc_commodity_get_printname (xaccAccountGetCommodity (
                                                              aw_get_account (aw)));
         GtkWidget *label = gtk_label_new (sec_name);
         gtk_widget_set_tooltip_text (label, tt);
         gtk_box_pack_start (GTK_BOX(box), label, FALSE, FALSE, 0);
+
+        g_signal_connect (G_OBJECT(aw->name_entry), "realize",
+                          G_CALLBACK(gnc_name_entry_realize), box);
+        gtk_style_context_add_class (stylectxt, GTK_STYLE_CLASS_FRAME);
+        gtk_widget_set_margin_start (label, 6);
+        gtk_widget_set_margin_end (label, 6);
         gtk_widget_show (label);
     }
     else

--- a/gnucash/gnome-utils/gnc-tree-model-account-types.h
+++ b/gnucash/gnome-utils/gnc-tree-model-account-types.h
@@ -131,11 +131,21 @@ guint32 gnc_tree_model_account_types_get_selection(GtkTreeSelection *sel);
 GNCAccountType
 gnc_tree_model_account_types_get_selection_single(GtkTreeSelection *sel);
 
+/* Gets the selected account type.  If no types are active, returns
+   ACCT_TYPE_NONE. */
+GNCAccountType
+gnc_tree_model_account_types_get_active_combo (GtkComboBox *combo);
+
 /* Set the selection state of the tree selection to match the bitmask
    of account-type enums in 'selected'.  This will also scroll to a
    selected row in the TreeView.*/
 void gnc_tree_model_account_types_set_selection(GtkTreeSelection *sel,
         guint32 selected);
+
+/* Set the active entry to match the bitmask of account-type enums in
+   'selected' */
+void gnc_tree_model_account_types_set_active_combo (GtkComboBox *combo,
+                                                    guint32 selected);
 
 
 /**************** Method 2 functions **************/

--- a/gnucash/gtkbuilder/dialog-account.glade
+++ b/gnucash/gtkbuilder/dialog-account.glade
@@ -1177,29 +1177,47 @@
             <property name="can-focus">True</property>
             <property name="border-width">5</property>
             <child>
-              <object class="GtkBox" id="vbox301">
+              <!-- n-columns=1 n-rows=3 -->
+              <object class="GtkGrid" id="grid300">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
+                <property name="margin-top">6</property>
+                <property name="margin-bottom">6</property>
                 <property name="hexpand">True</property>
-                <property name="vexpand">True</property>
-                <property name="border-width">6</property>
-                <property name="orientation">vertical</property>
-                <property name="spacing">18</property>
                 <child>
-                  <!-- n-columns=1 n-rows=2 -->
-                  <object class="GtkGrid" id="grid300">
+                  <object class="GtkLabel" id="label300">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Identification</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <!-- n-columns=2 n-rows=9 -->
+                  <object class="GtkGrid" id="grid301">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="hexpand">True</property>
+                    <property name="row-spacing">3</property>
+                    <property name="column-spacing">6</property>
                     <child>
-                      <object class="GtkLabel" id="label300">
+                      <object class="GtkLabel" id="label301">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="halign">start</property>
-                        <property name="label" translatable="yes">Identification</property>
-                        <attributes>
-                          <attribute name="weight" value="bold"/>
-                        </attributes>
+                        <property name="halign">end</property>
+                        <property name="label" translatable="yes">Account _name</property>
+                        <property name="use-underline">True</property>
+                        <property name="mnemonic-widget">name_entry</property>
+                        <property name="ellipsize">middle</property>
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
@@ -1207,406 +1225,265 @@
                       </packing>
                     </child>
                     <child>
-                      <!-- n-columns=2 n-rows=12 -->
-                      <object class="GtkGrid" id="grid301">
+                      <object class="GtkLabel" id="label302">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="hexpand">True</property>
-                        <property name="row-spacing">3</property>
-                        <property name="column-spacing">6</property>
-                        <child>
-                          <object class="GtkLabel" id="label301">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="halign">end</property>
-                            <property name="label" translatable="yes">Account _name</property>
-                            <property name="use-underline">True</property>
-                            <property name="mnemonic-widget">name_entry</property>
-                            <property name="ellipsize">middle</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">0</property>
-                            <property name="top-attach">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="label302">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="halign">end</property>
-                            <property name="label" translatable="yes">_Account code</property>
-                            <property name="use-underline">True</property>
-                            <property name="mnemonic-widget">code_entry</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">0</property>
-                            <property name="top-attach">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="label304">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="halign">end</property>
-                            <property name="label" translatable="yes">_Description</property>
-                            <property name="use-underline">True</property>
-                            <property name="mnemonic-widget">description_entry</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">0</property>
-                            <property name="top-attach">2</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="security_label">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="halign">end</property>
-                            <property name="label" translatable="yes">_Security/currency</property>
-                            <property name="use-underline">True</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">0</property>
-                            <property name="top-attach">3</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkBox" id="commodity_hbox">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <child>
-                              <placeholder/>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="top-attach">3</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="label305">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="halign">end</property>
-                            <property name="label" translatable="yes">Smallest _fraction</property>
-                            <property name="use-underline">True</property>
-                            <property name="mnemonic-widget">account_scu</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">0</property>
-                            <property name="top-attach">4</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="label306">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="halign">end</property>
-                            <property name="label" translatable="yes">Account _Color</property>
-                            <property name="use-underline">True</property>
-                            <property name="mnemonic-widget">color_entry_button</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">0</property>
-                            <property name="top-attach">5</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkBox" id="color_hbox">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="spacing">2</property>
-                            <property name="homogeneous">True</property>
-                            <child>
-                              <object class="GtkColorButton" id="color_entry_button">
-                                <property name="visible">True</property>
-                                <property name="can-focus">True</property>
-                                <property name="receives-default">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkButton" id="color_default_button">
-                                <property name="label" translatable="yes">Default</property>
-                                <property name="visible">True</property>
-                                <property name="can-focus">True</property>
-                                <property name="receives-default">True</property>
-                                <signal name="clicked" handler="gnc_account_color_default_cb" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="top-attach">5</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="label307">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="halign">end</property>
-                            <property name="valign">start</property>
-                            <property name="label" translatable="yes">No_tes</property>
-                            <property name="use-underline">True</property>
-                            <property name="mnemonic-widget">notes_text</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">0</property>
-                            <property name="top-attach">6</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkEntry" id="name_entry">
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="has-focus">True</property>
-                            <property name="hexpand">True</property>
-                            <property name="activates-default">True</property>
-                            <signal name="changed" handler="gnc_account_name_changed_cb" swapped="no"/>
-                            <signal name="insert-text" handler="gnc_account_name_insert_text_cb" swapped="no"/>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="top-attach">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkEntry" id="code_entry">
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="activates-default">True</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="top-attach">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkEntry" id="description_entry">
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="activates-default">True</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="top-attach">2</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkScrolledWindow" id="scrolledwindow300">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="shadow-type">in</property>
-                            <property name="min-content-height">60</property>
-                            <child>
-                              <object class="GtkTextView" id="notes_text">
-                                <property name="visible">True</property>
-                                <property name="can-focus">True</property>
-                                <property name="margin-start">3</property>
-                                <property name="margin-end">3</property>
-                                <property name="wrap-mode">word</property>
-                                <property name="accepts-tab">False</property>
-                              </object>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="top-attach">6</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkEventBox" id="eventbox300">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="tooltip-text" translatable="yes">Smallest fraction of this commodity that can be referenced.</property>
-                            <child>
-                              <object class="GtkComboBox" id="account_scu">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="model">fraction_liststore</property>
-                                <child>
-                                  <object class="GtkCellRendererText" id="acct_scu_renderer"/>
-                                  <attributes>
-                                    <attribute name="text">0</attribute>
-                                  </attributes>
-                                </child>
-                              </object>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="top-attach">4</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkCheckButton" id="placeholder_button">
-                            <property name="label" translatable="yes">Placeholde_r</property>
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="receives-default">False</property>
-                            <property name="tooltip-text" translatable="yes">This account is present solely as a placeholder in the hierarchy. Transactions may not be posted to this account, only to sub-accounts of this account.</property>
-                            <property name="halign">start</property>
-                            <property name="use-underline">True</property>
-                            <property name="draw-indicator">True</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="top-attach">9</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkCheckButton" id="hidden_button">
-                            <property name="label" translatable="yes">H_idden</property>
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="receives-default">False</property>
-                            <property name="tooltip-text" translatable="yes">This account (and any sub-accounts) will be hidden in the account tree and will not appear in the popup account list in the register. To reset this option, you will first need to open the "Filter By..." dialog for the account tree and check the "show hidden accounts" option. Doing so will allow you to select the account and reopen this dialog.</property>
-                            <property name="halign">start</property>
-                            <property name="use-underline">True</property>
-                            <property name="draw-indicator">True</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="top-attach">8</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkCheckButton" id="auto_interest_button">
-                            <property name="label" translatable="yes">Auto _interest transfer</property>
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="receives-default">False</property>
-                            <property name="tooltip-text" translatable="yes">Prior to reconciling an account which charges or pays interest, prompt the user to enter a transaction for the interest charge or payment. Currently only enabled for Bank, Credit, Mutual, Asset, Receivable, Payable, and Liability accounts.</property>
-                            <property name="halign">start</property>
-                            <property name="use-underline">True</property>
-                            <property name="draw-indicator">True</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="top-attach">10</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkCheckButton" id="tax_related_button">
-                            <property name="label" translatable="yes">Ta_x related</property>
-                            <property name="visible">True</property>
-                            <property name="sensitive">False</property>
-                            <property name="can-focus">True</property>
-                            <property name="receives-default">False</property>
-                            <property name="tooltip-text" translatable="yes" comments="Translators: use the same words here as in 'Ta_x Report Options'.">Use Edit-&gt;Tax Report Options to set the tax-related flag and assign a tax code to this account.</property>
-                            <property name="halign">start</property>
-                            <property name="use-underline">True</property>
-                            <property name="draw-indicator">True</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="top-attach">7</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkCheckButton" id="opening_balance_button">
-                            <property name="label" translatable="yes">Opening balance</property>
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="receives-default">False</property>
-                            <property name="tooltip-text" translatable="yes">This account holds opening balance transactions. Only one account per commodity can hold opening balance transactions.</property>
-                            <property name="draw-indicator">True</property>
-                          </object>
-                          <packing>
-                            <property name="left-attach">1</property>
-                            <property name="top-attach">11</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
-                        <child>
-                          <placeholder/>
-                        </child>
+                        <property name="halign">end</property>
+                        <property name="label" translatable="yes">_Account code</property>
+                        <property name="use-underline">True</property>
+                        <property name="mnemonic-widget">code_entry</property>
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
                         <property name="top-attach">1</property>
                       </packing>
                     </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <!-- n-columns=2 n-rows=2 -->
-                  <object class="GtkGrid" id="grid302">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="row-spacing">3</property>
-                    <property name="column-spacing">12</property>
                     <child>
-                      <object class="GtkLabel" id="type_label">
+                      <object class="GtkLabel" id="label304">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="halign">start</property>
-                        <property name="label" translatable="yes">&lt;b&gt;Acco_unt Type&lt;/b&gt;</property>
-                        <property name="use-markup">True</property>
+                        <property name="halign">end</property>
+                        <property name="label" translatable="yes">_Description</property>
                         <property name="use-underline">True</property>
-                        <property name="mnemonic-widget">type_view</property>
+                        <property name="mnemonic-widget">description_entry</property>
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
+                        <property name="top-attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="security_label">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">end</property>
+                        <property name="label" translatable="yes">_Security/currency</property>
+                        <property name="use-underline">True</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">5</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="commodity_hbox">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <child>
+                          <placeholder/>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">5</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label305">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">end</property>
+                        <property name="label" translatable="yes">Smallest _fraction</property>
+                        <property name="use-underline">True</property>
+                        <property name="mnemonic-widget">account_scu</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">6</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label306">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">end</property>
+                        <property name="label" translatable="yes">Account _Color</property>
+                        <property name="use-underline">True</property>
+                        <property name="mnemonic-widget">color_entry_button</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">7</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="color_hbox">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="spacing">2</property>
+                        <property name="homogeneous">True</property>
+                        <child>
+                          <object class="GtkColorButton" id="color_entry_button">
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="color_default_button">
+                            <property name="label" translatable="yes">Default</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">True</property>
+                            <signal name="clicked" handler="gnc_account_color_default_cb" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">7</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label307">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">end</property>
+                        <property name="valign">start</property>
+                        <property name="label" translatable="yes">No_tes</property>
+                        <property name="use-underline">True</property>
+                        <property name="mnemonic-widget">notes_text</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">8</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkEntry" id="name_entry">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="has-focus">True</property>
+                        <property name="hexpand">True</property>
+                        <property name="activates-default">True</property>
+                        <signal name="changed" handler="gnc_account_name_changed_cb" swapped="no"/>
+                        <signal name="insert-text" handler="gnc_account_name_insert_text_cb" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
                         <property name="top-attach">0</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkLabel" id="label8">
+                      <object class="GtkEntry" id="code_entry">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="label">    </property>
+                        <property name="can-focus">True</property>
+                        <property name="activates-default">True</property>
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
                         <property name="top-attach">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkEntry" id="description_entry">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="activates-default">True</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkScrolledWindow" id="scrolledwindow300">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="shadow-type">in</property>
+                        <property name="min-content-height">60</property>
+                        <child>
+                          <object class="GtkTextView" id="notes_text">
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="margin-start">3</property>
+                            <property name="margin-end">3</property>
+                            <property name="wrap-mode">word</property>
+                            <property name="accepts-tab">False</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">8</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkEventBox" id="eventbox300">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="tooltip-text" translatable="yes">Smallest fraction of this commodity that can be referenced.</property>
+                        <child>
+                          <object class="GtkComboBox" id="account_scu">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="model">fraction_liststore</property>
+                            <child>
+                              <object class="GtkCellRendererText" id="acct_scu_renderer"/>
+                              <attributes>
+                                <attribute name="text">0</attribute>
+                              </attributes>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">6</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="parent_label">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="halign">start</property>
+                        <property name="halign">end</property>
+                        <property name="valign">start</property>
                         <property name="label" translatable="yes">_Parent Account</property>
                         <property name="use-underline">True</property>
-                        <attributes>
-                          <attribute name="weight" value="bold"/>
-                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">end</property>
+                        <property name="label" translatable="yes">Acco_unt Type</property>
+                        <property name="use-underline">True</property>
+                        <property name="mnemonic-widget">account_type_combo</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBox" id="account_type_combo">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
-                        <property name="top-attach">0</property>
+                        <property name="top-attach">4</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkScrolledWindow" id="parent_scroll">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
+                        <property name="can-focus">True</property>
                         <property name="hexpand">True</property>
                         <property name="vexpand">True</property>
                         <property name="shadow-type">in</property>
@@ -1616,59 +1493,112 @@
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
+                        <property name="top-attach">3</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <!-- n-columns=3 n-rows=2 -->
+                  <object class="GtkGrid" id="grid302">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">center</property>
+                    <property name="margin-top">6</property>
+                    <child>
+                      <object class="GtkCheckButton" id="placeholder_button">
+                        <property name="label" translatable="yes">Placeholde_r</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">False</property>
+                        <property name="tooltip-text" translatable="yes">This account is present solely as a placeholder in the hierarchy. Transactions may not be posted to this account, only to sub-accounts of this account.</property>
+                        <property name="halign">start</property>
+                        <property name="use-underline">True</property>
+                        <property name="draw-indicator">True</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="auto_interest_button">
+                        <property name="label" translatable="yes">Auto _interest transfer</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">False</property>
+                        <property name="tooltip-text" translatable="yes">Prior to reconciling an account which charges or pays interest, prompt the user to enter a transaction for the interest charge or payment. Currently only enabled for Bank, Credit, Mutual, Asset, Receivable, Payable, and Liability accounts.</property>
+                        <property name="halign">start</property>
+                        <property name="use-underline">True</property>
+                        <property name="draw-indicator">True</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">2</property>
+                        <property name="top-attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="hidden_button">
+                        <property name="label" translatable="yes">H_idden</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">False</property>
+                        <property name="tooltip-text" translatable="yes">This account (and any sub-accounts) will be hidden in the account tree and will not appear in the popup account list in the register. To reset this option, you will first need to open the "Filter By..." dialog for the account tree and check the "show hidden accounts" option. Doing so will allow you to select the account and reopen this dialog.</property>
+                        <property name="halign">start</property>
+                        <property name="use-underline">True</property>
+                        <property name="draw-indicator">True</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="opening_balance_button">
+                        <property name="label" translatable="yes">Opening balance</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">False</property>
+                        <property name="tooltip-text" translatable="yes">This account holds opening balance transactions. Only one account per commodity can hold opening balance transactions.</property>
+                        <property name="halign">start</property>
+                        <property name="draw-indicator">True</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">2</property>
                         <property name="top-attach">1</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" id="type_vbox">
+                      <object class="GtkCheckButton" id="tax_related_button">
+                        <property name="label" translatable="yes">Ta_x related</property>
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="orientation">vertical</property>
-                        <child>
-                          <object class="GtkScrolledWindow" id="scrolledwindow32">
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="hscrollbar-policy">never</property>
-                            <property name="shadow-type">in</property>
-                            <child>
-                              <object class="GtkTreeView" id="type_view">
-                                <property name="visible">True</property>
-                                <property name="can-focus">True</property>
-                                <property name="halign">start</property>
-                                <property name="vexpand">True</property>
-                                <property name="headers-visible">False</property>
-                                <child internal-child="selection">
-                                  <object class="GtkTreeSelection" id="treeview-selection1"/>
-                                </child>
-                              </object>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
+                        <property name="sensitive">False</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">False</property>
+                        <property name="tooltip-text" translatable="yes" comments="Translators: use the same words here as in 'Ta_x Report Options'.">Use Edit-&gt;Tax Report Options to set the tax-related flag and assign a tax code to this account.</property>
+                        <property name="halign">start</property>
+                        <property name="use-underline">True</property>
+                        <property name="draw-indicator">True</property>
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
                         <property name="top-attach">1</property>
                       </packing>
                     </child>
+                    <child>
+                      <placeholder/>
+                    </child>
                   </object>
                   <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">2</property>
                   </packing>
                 </child>
-                <style>
-                  <class name="gnc-class-account"/>
-                </style>
               </object>
-              <packing>
-                <property name="tab-expand">True</property>
-              </packing>
             </child>
             <child type="tab">
               <object class="GtkLabel" id="label308">


### PR DESCRIPTION
Came across this bug regarding the account dialog layout and thought I would see what the changes would look like.

The main change is changing the account type field from a tree view to a combo and repositioning it. The parent account tree view has been set to expand to the available space. The bug also mentions changing the parent account field to a combo but I do not like that idea as I think it looks better as a tree.
Added some images below, the first one is when editing, the second is a new account and the third is the type popped...
Is it an improvement ?
Any further changes required before pushing ?

![Screenshot_2022-10-10_13-27-07](https://user-images.githubusercontent.com/15702727/194869775-dcc43161-91bc-4be5-96f3-12ff597a93c8.png)
![account-edit1](https://user-images.githubusercontent.com/15702727/194869839-9813139b-ae33-4719-83dc-81a7676bda1b.png)
![account-edit2](https://user-images.githubusercontent.com/15702727/194869853-1f5c778e-a1de-4990-b866-e556f8c34de9.png)
