### PR TITLE
[gnc-features.cpp] convert to cpp

### DIFF
--- a/libgnucash/engine/CMakeLists.txt
+++ b/libgnucash/engine/CMakeLists.txt
@@ -93,6 +93,7 @@ set (engine_HEADERS
   qof-backend.hpp
   qofbackend.h
   qofbook.h
+  qofbook.hpp
   qofbookslots.h
   qofchoice.h
   qofclass.h
@@ -145,7 +146,7 @@ set (engine_SOURCES
   gnc-datetime.cpp
   gnc-engine.c
   gnc-event.c
-  gnc-features.c
+  gnc-features.cpp
   gnc-hooks.c
   gnc-int128.cpp
   gnc-lot.c

--- a/libgnucash/engine/qofbook.cpp
+++ b/libgnucash/engine/qofbook.cpp
@@ -1214,28 +1214,6 @@ static void commit_err (G_GNUC_UNUSED QofInstance *inst, QofBackendError errcode
 }
 
 #define GNC_FEATURES "features"
-static void
-add_feature_to_hash (const gchar *key, KvpValue *value, GHashTable * user_data)
-{
-    gchar *descr = g_strdup(value->get<const char*>());
-    g_hash_table_insert (user_data, (gchar*)key, descr);
-}
-
-GHashTable *
-qof_book_get_features (QofBook *book)
-{
-    KvpFrame *frame = qof_instance_get_slots (QOF_INSTANCE (book));
-    GHashTable *features = g_hash_table_new_full (g_str_hash, g_str_equal,
-                                                  NULL, g_free);
-
-    auto slot = frame->get_slot({GNC_FEATURES});
-    if (slot != nullptr)
-    {
-        frame = slot->get<KvpFrame*>();
-        frame->for_each_slot_temp(&add_feature_to_hash, features);
-    }
-    return features;
-}
 
 void
 qof_book_set_feature (QofBook *book, const gchar *key, const gchar *descr)

--- a/libgnucash/engine/qofbook.hpp
+++ b/libgnucash/engine/qofbook.hpp
@@ -1,0 +1,38 @@
+/********************************************************************\
+ * This program is free software; you can redistribute it and/or    *
+ * modify it under the terms of the GNU General Public License as   *
+ * published by the Free Software Foundation; either version 2 of   *
+ * the License, or (at your option) any later version.              *
+ *                                                                  *
+ * This program is distributed in the hope that it will be useful,  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    *
+ * GNU General Public License for more details.                     *
+ *                                                                  *
+ * You should have received a copy of the GNU General Public License*
+ * along with this program; if not, contact:                        *
+ *                                                                  *
+ * Free Software Foundation           Voice:  +1-617-542-5942       *
+ * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652       *
+ * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
+ *                                                                  *
+\********************************************************************/
+
+#ifndef __QOF_BOOK__HPP__
+#define __QOF_BOOK__HPP__
+
+#include <vector>
+#include <unordered_map>
+#include <string>
+
+#include "qof.h"
+
+using FeaturesTable = std::unordered_map<std::string,std::string>;
+
+std::vector<std::string>
+qof_book_get_unknown_features (QofBook *book, const FeaturesTable& features);
+bool qof_book_test_feature (QofBook*, const char*);
+
+#endif /* QOF_BOOK_HPP */
+/** @} */
+/** @} */

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -641,7 +641,7 @@ libgnucash/engine/gncEmployee.c
 libgnucash/engine/gnc-engine.c
 libgnucash/engine/gncEntry.c
 libgnucash/engine/gnc-event.c
-libgnucash/engine/gnc-features.c
+libgnucash/engine/gnc-features.cpp
 libgnucash/engine/gnc-hooks.c
 libgnucash/engine/gncIDSearch.c
 libgnucash/engine/gnc-int128.cpp


### PR DESCRIPTION
A useful glib->stl conversion

- don't need to create/destroy GHashTable for each feature query
- plugs leak: `g_hash_table_unref (features_used)` was not always called properly
- to check 1 feature, don't need to traverse whole GHashTable