### PR TITLE
[gtest-qofevent.cpp] basic test for qofevent

### DIFF
--- a/libgnucash/engine/qofevent-p.h
+++ b/libgnucash/engine/qofevent-p.h
@@ -27,15 +27,6 @@
 #include "qofevent.h"
 #include "qofid.h"
 
-/* for backwards compatibility - to be moved back to qofevent.c in libqof2 */
-typedef struct
-{
-    QofEventHandler handler;
-    gpointer user_data;
-
-    gint handler_id;
-} HandlerInfo;
-
 /* generates an event even when events are suspended! */
 void qof_event_force (QofInstance *entity, QofEventId event_id, gpointer event_data);
 

--- a/libgnucash/engine/qofevent.cpp
+++ b/libgnucash/engine/qofevent.cpp
@@ -22,18 +22,31 @@
  *                                                                  *
  ********************************************************************/
 
+#include <vector>
+#include <algorithm>
 #include <config.h>
-#include <glib.h>
 
 #include "qof.h"
 #include "qofevent-p.h"
+
+struct HandlerInfo
+{
+    QofEventHandler handler;
+    gpointer user_data;
+    gint handler_id;
+    HandlerInfo (QofEventHandler handler, gpointer user_data, gint handler_id)
+        : handler (handler)
+        , user_data (user_data)
+        , handler_id (handler_id) {};
+    ~HandlerInfo () {};
+};
 
 /* Static Variables ************************************************/
 static guint   suspend_counter   = 0;
 static gint    next_handler_id   = 1;
 static guint   handler_run_level = 0;
 static guint   pending_deletes   = 0;
-static GList   *handlers  =   NULL;
+static std::vector<HandlerInfo> handlers;
 
 /* This static indicates the debugging module that this .o belongs to.  */
 static QofLogModule log_module = QOF_MOD_ENGINE;
@@ -43,26 +56,17 @@ static QofLogModule log_module = QOF_MOD_ENGINE;
 static gint
 find_next_handler_id(void)
 {
-    HandlerInfo *hi;
-    gint handler_id;
-    GList *node;
-
     /* look for a free handler id */
-    handler_id = next_handler_id;
-    node = handlers;
+    auto handler_id = next_handler_id;
 
-    while (node)
+ restart:
+    for (const auto& hi : handlers)
     {
-        hi = static_cast<HandlerInfo*>(node->data);
-
-        if (hi->handler_id == handler_id)
+        if (hi.handler_id == handler_id)
         {
             handler_id++;
-            node = handlers;
-            continue;
+            goto restart;
         }
-
-        node = node->next;
     }
     /* Update id for next registration */
     next_handler_id = handler_id + 1;
@@ -72,8 +76,6 @@ find_next_handler_id(void)
 gint
 qof_event_register_handler (QofEventHandler handler, gpointer user_data)
 {
-    HandlerInfo *hi;
-    gint handler_id;
 
     ENTER ("(handler=%p, data=%p)", handler, user_data);
 
@@ -85,16 +87,9 @@ qof_event_register_handler (QofEventHandler handler, gpointer user_data)
     }
 
     /* look for a free handler id */
-    handler_id = find_next_handler_id();
+    auto handler_id = find_next_handler_id();
 
-    /* Found one, add the handler */
-    hi = g_new0 (HandlerInfo, 1);
-
-    hi->handler = handler;
-    hi->user_data = user_data;
-    hi->handler_id = handler_id;
-
-    handlers = g_list_prepend (handlers, hi);
+    handlers.emplace_back (handler, user_data, handler_id);
     LEAVE ("(handler=%p, data=%p) handler_id=%d", handler, user_data, handler_id);
     return handler_id;
 }
@@ -102,43 +97,33 @@ qof_event_register_handler (QofEventHandler handler, gpointer user_data)
 void
 qof_event_unregister_handler (gint handler_id)
 {
-    GList *node;
-
     ENTER ("(handler_id=%d)", handler_id);
-    for (node = handlers; node; node = node->next)
+
+    auto iter = std::find_if (handlers.begin(), handlers.end(),
+                              [&handler_id](const auto& it)
+                              { return it.handler_id == handler_id; });
+    if (iter == handlers.end())
     {
-        HandlerInfo *hi = static_cast<HandlerInfo*>(node->data);
-
-        if (hi->handler_id != handler_id)
-            continue;
-
-        /* Normally, we could actually remove the handler's node from the
-           list, but we may be unregistering the event handler as a result
-           of a generated event, such as QOF_EVENT_DESTROY.  In that case,
-           we're in the middle of walking the GList and it is wrong to
-           modify the list. So, instead, we just NULL the handler. */
-        if (hi->handler)
-            LEAVE ("(handler_id=%d) handler=%p data=%p", handler_id,
-                   hi->handler, hi->user_data);
-
-        /* safety -- clear the handler in case we're running events now */
-        hi->handler = NULL;
-
-        if (handler_run_level == 0)
-        {
-            handlers = g_list_remove_link (handlers, node);
-            g_list_free_1 (node);
-            g_free (hi);
-        }
-        else
-        {
-            pending_deletes++;
-        }
-
+        PERR ("no such handler: %d", handler_id);
         return;
     }
 
-    PERR ("no such handler: %d", handler_id);
+    /* Normally, we could actually remove the handler from the vector,
+       but we may be unregistering the event handler as a result of a
+       generated event, such as QOF_EVENT_DESTROY.  In that case,
+       we're in the middle of walking the std::vector and it is wrong
+       to modify the vector. So, instead, we just NULL the handler. */
+    if (iter->handler)
+        LEAVE ("(handler_id=%d) handler=%p data=%p", handler_id,
+               iter->handler, iter->user_data);
+
+    /* safety -- clear the handler in case we're running events now */
+    iter->handler = nullptr;
+
+    if (handler_run_level == 0)
+        handlers.erase (iter);
+    else
+        pending_deletes++;
 }
 
 void
@@ -168,9 +153,6 @@ static void
 qof_event_generate_internal (QofInstance *entity, QofEventId event_id,
                              gpointer event_data)
 {
-    GList *node;
-    GList *next_node = NULL;
-
     g_return_if_fail(entity);
 
     switch (event_id)
@@ -183,17 +165,12 @@ qof_event_generate_internal (QofInstance *entity, QofEventId event_id,
     }
 
     handler_run_level++;
-    for (node = handlers; node; node = next_node)
+    for (const auto &hi : handlers)
     {
-        HandlerInfo *hi = static_cast<HandlerInfo*>(node->data);
-
-        next_node = node->next;
-        if (hi->handler)
-        {
-            PINFO("id=%d hi=%p han=%p data=%p", hi->handler_id, hi,
-                  hi->handler, event_data);
-            hi->handler (entity, event_id, hi->user_data, event_data);
-        }
+        if (!hi.handler)
+            continue;
+        PINFO("id=%d hi=%p han=%p data=%p", hi.handler_id, &hi, hi.handler, event_data);
+        hi.handler (entity, event_id, hi.user_data, event_data);
     }
     handler_run_level--;
 
@@ -202,18 +179,8 @@ qof_event_generate_internal (QofInstance *entity, QofEventId event_id,
      */
     if (handler_run_level == 0 && pending_deletes)
     {
-        for (node = handlers; node; node = next_node)
-        {
-            HandlerInfo *hi = static_cast<HandlerInfo*>(node->data);
-            next_node = node->next;
-            if (hi->handler == NULL)
-            {
-                /* remove this node from the list, then free this node */
-                handlers = g_list_remove_link (handlers, node);
-                g_list_free_1 (node);
-                g_free (hi);
-            }
-        }
+        std::remove_if (handlers.begin(), handlers.end(),
+                        [](const auto& hi){ return (!hi.handler); });
         pending_deletes = 0;
     }
 }

--- a/libgnucash/engine/test/CMakeLists.txt
+++ b/libgnucash/engine/test/CMakeLists.txt
@@ -197,6 +197,11 @@ gtest-qofquerycore.cpp)
 gnc_add_test(test-qofquerycore "${test_qofquerycore_SOURCES}"
   gtest_engine_INCLUDES gtest_old_engine_LIBS)
 
+set(test_qofevent_SOURCES
+gtest-qofevent.cpp)
+gnc_add_test(test-qofevent "${test_qofevent_SOURCES}"
+  gtest_engine_INCLUDES gtest_old_engine_LIBS)
+
 
 set(test_engine_SOURCES_DIST
         dummy.cpp
@@ -208,6 +213,7 @@ set(test_engine_SOURCES_DIST
         gtest-gnc-datetime.cpp
         gtest-import-map.cpp
         gtest-qofquerycore.cpp
+        gtest-qofevent.cpp
         test-account-object.cpp
         test-address.c
         test-business.c

--- a/libgnucash/engine/test/gtest-qofevent.cpp
+++ b/libgnucash/engine/test/gtest-qofevent.cpp
@@ -1,0 +1,137 @@
+/********************************************************************\
+ * gtest-qofevent.cpp -- Unit tests for qofevent.cpp                *
+ *                                                                  *
+ * Copyright 2018 Christopher Lam                                   *
+ *                                                                  *
+ * This program is free software; you can redistribute it and/or    *
+ * modify it under the terms of the GNU General Public License as   *
+ * published by the Free Software Foundation; either version 2 of   *
+ * the License, or (at your option) any later version.              *
+ *                                                                  *
+ * This program is distributed in the hope that it will be useful,  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    *
+ * GNU General Public License for more details.                     *
+ *                                                                  *
+ * You should have received a copy of the GNU General Public License*
+ * along with this program; if not, contact:                        *
+ *                                                                  *
+ * Free Software Foundation           Voice:  +1-617-542-5942       *
+ * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652       *
+ * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
+ *                                                                  *
+ \ *********************************************************************/
+
+#include <config.h>
+#include <glib.h>
+#include "../test-core/test-engine-stuff.h"
+#include "../qofevent.h"
+#include "../qofevent-p.h"
+#include <gtest/gtest.h>
+
+static void
+easy_handler (QofInstance *ent,  QofEventId event_type,
+            gpointer handler_data, gpointer event_data)
+{
+    int *data = static_cast<int*>(handler_data);
+    int increment = GPOINTER_TO_INT(event_data);
+    *data = *data + increment;
+}
+
+TEST (qofevent, events)
+{
+    QofInstance entity;         // qofevents needs a non-null entity.
+    int data = 1;
+
+    // initial setup. first handler_id is 1. data is initialized at 1.
+    int id1 = qof_event_register_handler (easy_handler, &data);
+    EXPECT_EQ (id1, 1);
+    EXPECT_EQ (data, 1);
+
+    // increment data by 2. data is now 3.
+    qof_event_gen (&entity, QOF_EVENT_ALL, GINT_TO_POINTER(2));
+    EXPECT_EQ (data, 3);
+
+    // try increment data by 2. but entity is NULL. data is unchanged.
+    qof_event_gen (NULL, QOF_EVENT_ALL, GINT_TO_POINTER(2));
+    EXPECT_EQ (data, 3);
+
+    // try increment data by 2. but event is NONE. data is unchanged.
+    qof_event_gen (&entity, QOF_EVENT_NONE, GINT_TO_POINTER(2));
+    EXPECT_EQ (data, 3);
+
+    // increment data by 2. data is now 5.
+    qof_event_gen (&entity, QOF_EVENT_ALL, GINT_TO_POINTER(2));
+    EXPECT_EQ (data, 5);
+
+    // suspend, try increment data by 2. data unchanged at 5.
+    qof_event_suspend ();
+    qof_event_gen (&entity, QOF_EVENT_ALL, GINT_TO_POINTER(2));
+    EXPECT_EQ (data, 5);
+
+    // although suspended, force events. data changed to 7.
+    qof_event_force (&entity, QOF_EVENT_ALL, GINT_TO_POINTER(2));
+    EXPECT_EQ (data, 7);
+
+    // resume, try increment data by 2. data changed to 9.
+    qof_event_resume ();
+    qof_event_gen (&entity, QOF_EVENT_ALL, GINT_TO_POINTER(2));
+    EXPECT_EQ (data, 9);
+
+    // no more handler. running events means data is no longer updated.
+    qof_event_unregister_handler (id1);
+    qof_event_gen (&entity, QOF_EVENT_ALL, GINT_TO_POINTER(2));
+    EXPECT_EQ (data, 9);
+
+    // test handler id is incremented to 2
+    int id2 = qof_event_register_handler (easy_handler, &data);
+    EXPECT_EQ (id2, 2);
+
+    // test handler id is incremented to 3
+    int id3 = qof_event_register_handler (easy_handler, &data);
+    EXPECT_EQ (id3, 3);
+    qof_event_unregister_handler (id3);
+    qof_event_unregister_handler (id2);
+
+    // although handler_id 1 to 3 are unregistered, the next handler_id is still 4.
+    int id4 = qof_event_register_handler (easy_handler, &data);
+    EXPECT_EQ (id4, 4);
+
+    // note: uncommenting the following line seems to be crucial
+    // for macos tests...
+    // qof_event_unregister_handler (id4);
+}
+
+static void
+compound_handler (QofInstance *ent,  QofEventId event_type,
+                  gpointer handler_data, gpointer event_data)
+{
+    QofInstance entity;
+    int *data = static_cast<int*>(handler_data);
+    int increment = GPOINTER_TO_INT(event_data);
+
+    int id = qof_event_register_handler (easy_handler, &data);
+    // this deletion will not take place until all handlers have run
+    qof_event_unregister_handler (id);
+
+    *data = *data + increment;
+}
+
+TEST (qofevent, compound_events)
+{
+    QofInstance entity;         // qofevents needs a non-null entity.
+    int data = 1;
+
+    // initial setup. first handler_id is 1. data is initialized at 1.
+    int id1 = qof_event_register_handler (compound_handler, &data);
+    EXPECT_EQ (id1, 5);
+    EXPECT_EQ (data, 1);
+
+    // increment data by 2. calling compound_handler will cause the
+    // deletion to be postponed
+    qof_event_gen (&entity, QOF_EVENT_ALL, GINT_TO_POINTER(2));
+    EXPECT_EQ (data, 3);
+
+    qof_event_unregister_handler (id1);
+}
+

--- a/libgnucash/engine/test/gtest-qofevent.cpp
+++ b/libgnucash/engine/test/gtest-qofevent.cpp
@@ -99,7 +99,7 @@ TEST (qofevent, events)
 
     // note: uncommenting the following line seems to be crucial
     // for macos tests...
-    // qof_event_unregister_handler (id4);
+    qof_event_unregister_handler (id4);
 }
 
 static void


### PR DESCRIPTION
includes unusual macos tests discrepancy... when `TEST (qofevent, events)` completes I'd forgotten to unregister the last `id4` handler, which means `TEST (qofevent, compound_events)` would run with `id4` still registered. With ubuntu the `compound` tests increments data once, but on mac it increments data twice. The commented-out line 102 is crucial for macos tests. I think mac is right.