### PR TITLE
Fix libgnucash/engine/mocks/fake-qofquery.cpp: error: pointer used after ‘void operator delete(void*, std::size_t)’ [-Werror=use-after-free]

### DIFF
--- a/libgnucash/engine/mocks/fake-qofquery.cpp
+++ b/libgnucash/engine/mocks/fake-qofquery.cpp
@@ -59,8 +59,8 @@ public:
     {
         ASSERT_TRUE(query_used((QofQuery*)query));
         auto it = std::find(m_queriesUsed.begin(), m_queriesUsed.end(), query);
-        m_queriesUsed.erase(it);
         m_queriesConsumed.push_back(*it);
+        m_queriesUsed.erase(it);
     }
 
     /* Remove a formerly added QofFakeQueryObject from the pool */


### PR DESCRIPTION
Hi everyone! When I've tried to compile tests on gnucash-4.12 to bump version in gentoo, I've hit the following error.

```
[370/398] /usr/sbin/x86_64-pc-linux-gnu-g++ -DBOOST_ATOMIC_DYN_LINK -DBOOST_ATOMIC_NO_LIB -DBOOST_CHRONO_DYN_LINK -DBOOST_CHRONO_NO_LIB -DBOOST_DATE_TIME_DYN_LINK -DBOOST_DATE_TIME_NO_LIB -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_FILESYSTEM_NO_LIB -DBOOST_LOCALE_DYN_LINK -DBOOST_LOCALE_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_REGEX_DYN_LINK -DBOOST_REGEX_NO_LIB -DBOOST_SYSTEM_DYN_LINK -DBOOST_SYSTEM_NO_LIB -DBOOST_THREAD_DYN_LINK -DBOOST_THREAD_NO_LIB -DHAVE_CONFIG_H -DHAVE_GUILE22 -D_GNU_SOURCE -I/var/tmp/portage/app-office/gnucash-4.12/work/gnucash-4.12_build/common -I/var/tmp/portage/app-office/gnucash-4.12/work/gnucash-4.12/common -I/var/tmp/portage/app-office/gnucash-4.12/work/gnucash-4.12/gnucash/import-export -I/var/tmp/portage/app-office/gnucash-4.12/work/gnucash-4.12/libgnucash/app-utils -I/var/tmp/portage/app-office/gnucash-4.12/work/gnucash-4.12/libgnucash/app-utils/mocks -I/var/tmp/portage/app-office/gnucash-4.12/work/gnucash-4.12/libgnucash/core-utils -I/var/tmp/portage/app-office/gnucash-4.12/work/gnucash-4.12/libgnucash/engine -I/var/tmp/portage/app-office/gnucash-4.12/work/gnucash-4.12/libgnucash/engine/mocks -isystem /usr/include/gtk-3.0 -isystem /usr/include/pango-1.0 -isystem /usr/include/glib-2.0 -isystem /usr/lib64/glib-2.0/include -isystem /usr/lib64/libffi/include -isystem /usr/include/harfbuzz -isystem /usr/include/freetype2 -isystem /usr/include/libmount -isystem /usr/include/blkid -isystem /usr/include/fribidi -isystem /usr/include/cairo -isystem /usr/include/lzo -isystem /usr/include/libpng16 -isystem /usr/include/pixman-1 -isystem /usr/include/gdk-pixbuf-2.0 -isystem /usr/include/gio-unix-2.0 -isystem /usr/include/atk-1.0 -isystem /usr/include/at-spi2-atk/2.0 -isystem /usr/include/at-spi-2.0 -isystem /usr/include/dbus-1.0 -isystem /usr/lib64/dbus-1.0/include  -Wno-error=deprecated-declarations  -Werror -Wall -Wmissing-declarations -Wno-unused -Wno-error=parentheses -march=native -O2 -pipe -frecord-gcc-switches -pthread -std=c++17 -MD -MT gnucash/import-export/test/CMakeFiles/test-import-backend.dir/__/__/__/libgnucash/engine/mocks/fake-qofquery.cpp.o -MF gnucash/import-export/test/CMakeFiles/test-import-backend.dir/__/__/__/libgnucash/engine/mocks/fake-qofquery.cpp.o.d -o gnucash/import-export/test/CMakeFiles/test-import-backend.dir/__/__/__/libgnucash/engine/mocks/fake-qofquery.cpp.o -c /var/tmp/portage/app-office/gnucash-4.12/work/gnucash-4.12/libgnucash/engine/mocks/fake-qofquery.cpp
FAILED: gnucash/import-export/test/CMakeFiles/test-import-backend.dir/__/__/__/libgnucash/engine/mocks/fake-qofquery.cpp.o 
/usr/sbin/x86_64-pc-linux-gnu-g++ -DBOOST_ATOMIC_DYN_LINK -DBOOST_ATOMIC_NO_LIB -DBOOST_CHRONO_DYN_LINK -DBOOST_CHRONO_NO_LIB -DBOOST_DATE_TIME_DYN_LINK -DBOOST_DATE_TIME_NO_LIB -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_FILESYSTEM_NO_LIB -DBOOST_LOCALE_DYN_LINK -DBOOST_LOCALE_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_REGEX_DYN_LINK -DBOOST_REGEX_NO_LIB -DBOOST_SYSTEM_DYN_LINK -DBOOST_SYSTEM_NO_LIB -DBOOST_THREAD_DYN_LINK -DBOOST_THREAD_NO_LIB -DHAVE_CONFIG_H -DHAVE_GUILE22 -D_GNU_SOURCE -I/var/tmp/portage/app-office/gnucash-4.12/work/gnucash-4.12_build/common -I/var/tmp/portage/app-office/gnucash-4.12/work/gnucash-4.12/common -I/var/tmp/portage/app-office/gnucash-4.12/work/gnucash-4.12/gnucash/import-export -I/var/tmp/portage/app-office/gnucash-4.12/work/gnucash-4.12/libgnucash/app-utils -I/var/tmp/portage/app-office/gnucash-4.12/work/gnucash-4.12/libgnucash/app-utils/mocks -I/var/tmp/portage/app-office/gnucash-4.12/work/gnucash-4.12/libgnucash/core-utils -I/var/tmp/portage/app-office/gnucash-4.12/work/gnucash-4.12/libgnucash/engine -I/var/tmp/portage/app-office/gnucash-4.12/work/gnucash-4.12/libgnucash/engine/mocks -isystem /usr/include/gtk-3.0 -isystem /usr/include/pango-1.0 -isystem /usr/include/glib-2.0 -isystem /usr/lib64/glib-2.0/include -isystem /usr/lib64/libffi/include -isystem /usr/include/harfbuzz -isystem /usr/include/freetype2 -isystem /usr/include/libmount -isystem /usr/include/blkid -isystem /usr/include/fribidi -isystem /usr/include/cairo -isystem /usr/include/lzo -isystem /usr/include/libpng16 -isystem /usr/include/pixman-1 -isystem /usr/include/gdk-pixbuf-2.0 -isystem /usr/include/gio-unix-2.0 -isystem /usr/include/atk-1.0 -isystem /usr/include/at-spi2-atk/2.0 -isystem /usr/include/at-spi-2.0 -isystem /usr/include/dbus-1.0 -isystem /usr/lib64/dbus-1.0/include  -Wno-error=deprecated-declarations  -Werror -Wall -Wmissing-declarations -Wno-unused -Wno-error=parentheses -march=native -O2 -pipe -frecord-gcc-switches -pthread -std=c++17 -MD -MT gnucash/import-export/test/CMakeFiles/test-import-backend.dir/__/__/__/libgnucash/engine/mocks/fake-qofquery.cpp.o -MF gnucash/import-export/test/CMakeFiles/test-import-backend.dir/__/__/__/libgnucash/engine/mocks/fake-qofquery.cpp.o.d -o gnucash/import-export/test/CMakeFiles/test-import-backend.dir/__/__/__/libgnucash/engine/mocks/fake-qofquery.cpp.o -c /var/tmp/portage/app-office/gnucash-4.12/work/gnucash-4.12/libgnucash/engine/mocks/fake-qofquery.cpp
In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/12/include/g++-v12/x86_64-pc-linux-gnu/bits/c++allocator.h:33,
                 from /usr/lib/gcc/x86_64-pc-linux-gnu/12/include/g++-v12/bits/allocator.h:46,
                 from /usr/lib/gcc/x86_64-pc-linux-gnu/12/include/g++-v12/list:61,
                 from /var/tmp/portage/app-office/gnucash-4.12/work/gnucash-4.12/libgnucash/engine/mocks/fake-qofquery.cpp:9:
In member function ‘void std::__new_allocator<_Tp>::construct(_Up*, _Args&& ...) [with _Up = QofFakeQuery*; _Args = {QofFakeQuery* const&}; _Tp = std::_List_node<QofFakeQuery*>]’,
    inlined from ‘static void std::allocator_traits<std::allocator<_Tp1> >::construct(allocator_type&, _Up*, _Args&& ...) [with _Up = QofFakeQuery*; _Args = {QofFakeQuery* const&}; _Tp = std::_List_node<QofFakeQuery*>]’ at /usr/lib/gcc/x86_64-pc-linux-gnu/12/include/g++-v12/bits/alloc_traits.h:516:17,
    inlined from ‘std::__cxx11::list<_Tp, _Alloc>::_Node* std::__cxx11::list<_Tp, _Alloc>::_M_create_node(_Args&& ...) [with _Args = {QofFakeQuery* const&}; _Tp = QofFakeQuery*; _Alloc = std::allocator<QofFakeQuery*>]’ at /usr/lib/gcc/x86_64-pc-linux-gnu/12/include/g++-v12/bits/stl_list.h:713:33,
    inlined from ‘void std::__cxx11::list<_Tp, _Alloc>::_M_insert(iterator, _Args&& ...) [with _Args = {QofFakeQuery* const&}; _Tp = QofFakeQuery*; _Alloc = std::allocator<QofFakeQuery*>]’ at /usr/lib/gcc/x86_64-pc-linux-gnu/12/include/g++-v12/bits/stl_list.h:2005:32,
    inlined from ‘void std::__cxx11::list<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = QofFakeQuery*; _Alloc = std::allocator<QofFakeQuery*>]’ at /usr/lib/gcc/x86_64-pc-linux-gnu/12/include/g++-v12/bits/stl_list.h:1306:24,
    inlined from ‘void QofFakeQueryPool::release_query(QofFakeQuery*)’ at /var/tmp/portage/app-office/gnucash-4.12/work/gnucash-4.12/libgnucash/engine/mocks/fake-qofquery.cpp:63:36:
/usr/lib/gcc/x86_64-pc-linux-gnu/12/include/g++-v12/bits/new_allocator.h:175:11: error: pointer used after ‘void operator delete(void*, std::size_t)’ [-Werror=use-after-free]
  175 |         { ::new((void *)__p) _Up(std::forward<_Args>(__args)...); }
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In member function ‘void std::__new_allocator<_Tp>::deallocate(_Tp*, size_type) [with _Tp = std::_List_node<QofFakeQuery*>]’,
    inlined from ‘static void std::allocator_traits<std::allocator<_Tp1> >::deallocate(allocator_type&, pointer, size_type) [with _Tp = std::_List_node<QofFakeQuery*>]’ at /usr/lib/gcc/x86_64-pc-linux-gnu/12/include/g++-v12/bits/alloc_traits.h:496:23,
    inlined from ‘void std::__cxx11::_List_base<_Tp, _Alloc>::_M_put_node(typename _Node_alloc_traits::pointer) [with _Tp = QofFakeQuery*; _Alloc = std::allocator<QofFakeQuery*>]’ at /usr/lib/gcc/x86_64-pc-linux-gnu/12/include/g++-v12/bits/stl_list.h:522:39,
    inlined from ‘void std::__cxx11::list<_Tp, _Alloc>::_M_erase(iterator) [with _Tp = QofFakeQuery*; _Alloc = std::allocator<QofFakeQuery*>]’ at /usr/lib/gcc/x86_64-pc-linux-gnu/12/include/g++-v12/bits/stl_list.h:2024:13,
    inlined from ‘std::__cxx11::list<_Tp, _Alloc>::iterator std::__cxx11::list<_Tp, _Alloc>::erase(const_iterator) [with _Tp = QofFakeQuery*; _Alloc = std::allocator<QofFakeQuery*>]’ at /usr/lib/gcc/x86_64-pc-linux-gnu/12/include/g++-v12/bits/list.tcc:158:15,
    inlined from ‘void QofFakeQueryPool::release_query(QofFakeQuery*)’ at /var/tmp/portage/app-office/gnucash-4.12/work/gnucash-4.12/libgnucash/engine/mocks/fake-qofquery.cpp:62:28:
/usr/lib/gcc/x86_64-pc-linux-gnu/12/include/g++-v12/bits/new_allocator.h:158:33: note: call to ‘void operator delete(void*, std::size_t)’ here
  158 |         _GLIBCXX_OPERATOR_DELETE(_GLIBCXX_SIZED_DEALLOC(__p, __n));
      |                                 ^
cc1plus: all warnings being treated as errors
```

When I've asked on IRC, @simon pointed be out about that little problem. Changing position of line 62 and 63 did the trick and that's why I've decided to ask for patching it upstream.

EDIT: The error appears with gcc-12: I haven't tested with other gcc/clang.

Signed-off-by: Marco Scardovi <mscardovi@icloud.com>