### PR TITLE
Bug 403979 - Balance column shows only low order digits when too narrow

### DIFF
--- a/gnucash/register/register-gnome/gnucash-sheet-private.c
+++ b/gnucash/register/register-gnome/gnucash-sheet-private.c
@@ -514,6 +514,26 @@ draw_cell (GnucashSheet *sheet, SheetBlock *block,
     }
 #endif
 
+    if ((text != NULL) && (*text != '\0') && g_strcmp0 (PRICE_CELL_TYPE_NAME,
+         gnc_table_get_cell_type_name (table, virt_loc)) == 0)
+    {
+        int text_width;
+        int text_border_padding;
+
+        pango_layout_get_pixel_size (layout, &text_width, NULL);
+
+        text_border_padding = gnc_item_edit_get_margin (item_edit, left_right) +
+                              gnc_item_edit_get_padding_border (item_edit, left_right);
+
+        if (text_width + text_border_padding > width)
+        {
+            int pango_width = (width - text_border_padding) * PANGO_SCALE;
+
+            pango_layout_set_width (layout, pango_width); //pango units
+            pango_layout_set_ellipsize (layout, PANGO_ELLIPSIZE_END);
+        }
+    }
+
     /* If this is the currently open transaction and
        there is no text in this cell */
     if ((table->current_cursor_loc.vcell_loc.virt_row ==


### PR DESCRIPTION
I came across this bug and thought it may be of use so had a go at implementing it, did not take much and I was curious to see what it would look like.
Basically if a PRICE_CELL_TYPE is too narrow to display the whole number, the digits are replaced with '*'s

![column-width](https://user-images.githubusercontent.com/15702727/204016900-be1edca2-adf4-4919-8dfe-144a43841251.png)
I think I may of been caught out by this along time ago.
Worth while?
