### PR TITLE
OFX Investment transaction import

### DIFF
--- a/gnucash/import-export/import-main-matcher.c
+++ b/gnucash/import-export/import-main-matcher.c
@@ -2190,21 +2190,6 @@ refresh_model_row (GNCImportMainMatcher *gui,
 }
 
 void
-gnc_gen_trans_list_add_trans (GNCImportMainMatcher *gui, Transaction *trans)
-{
-    Account* acc = NULL;
-    Split* split = NULL;
-    int i=0;
-
-    split = xaccTransGetSplit (trans, 0);
-    acc = xaccSplitGetAccount (split);
-    defer_bal_computation (gui, acc);
-
-    gnc_gen_trans_list_add_trans_with_ref_id (gui, trans, 0);
-    return;
-}/* end gnc_import_add_trans() */
-
-void
 gnc_gen_trans_list_show_reconcile_after_close_button (GNCImportMainMatcher *info,
                                                       gboolean reconcile_after_close,
                                                       gboolean active)
@@ -2218,6 +2203,22 @@ gnc_gen_trans_list_get_reconcile_after_close_button (GNCImportMainMatcher *info)
 {
     return info->reconcile_after_close;
 }
+
+
+void
+gnc_gen_trans_list_add_trans (GNCImportMainMatcher *gui, Transaction *trans)
+{
+    Account* acc = NULL;
+    Split* split = NULL;
+    int i=0;
+
+    split = xaccTransGetSplit (trans, 0);
+    acc = xaccSplitGetAccount (split);
+    defer_bal_computation (gui, acc);
+
+    gnc_gen_trans_list_add_trans_with_ref_id (gui, trans, 0);
+    return;
+}/* end gnc_import_add_trans() */
 
 void
 gnc_gen_trans_list_add_trans_with_ref_id (GNCImportMainMatcher *gui, Transaction *trans, guint32 ref_id)

--- a/gnucash/import-export/ofx/gnc-ofx-import.c
+++ b/gnucash/import-export/ofx/gnc-ofx-import.c
@@ -65,6 +65,9 @@ static QofLogModule log_module = GNC_MOD_IMPORT;
 
 static gboolean auto_create_commodity = FALSE;
 static Account *ofx_parent_account = NULL;
+
+typedef struct OfxTransactionData OfxTransactionData;
+
 // Structure we use to gather information about statement balance/account etc.
 typedef struct _ofx_info
 {
@@ -126,9 +129,9 @@ set_associated_income_account(Account* investment_account,
 
 int ofx_proc_statement_cb (struct OfxStatementData data, void * statement_user_data);
 int ofx_proc_security_cb (const struct OfxSecurityData data, void * security_user_data);
-int ofx_proc_transaction_cb (struct OfxTransactionData data, void *user_data);
+int ofx_proc_transaction_cb (OfxTransactionData data, void *user_data);
 int ofx_proc_account_cb (struct OfxAccountData data, void * account_user_data);
-static double ofx_get_investment_amount (const struct OfxTransactionData* data);
+static double ofx_get_investment_amount (const OfxTransactionData* data);
 
 static const gchar *gnc_ofx_ttype_to_string(TransactionType t)
 {
@@ -314,7 +317,7 @@ int ofx_proc_security_cb(const struct OfxSecurityData data, void * security_user
     return 0;
 }
 
-static void gnc_ofx_set_split_memo(const struct OfxTransactionData* data, Split *split)
+static void gnc_ofx_set_split_memo(const OfxTransactionData* data, Split *split)
 {
     g_assert(data);
     g_assert(split);
@@ -412,7 +415,7 @@ fix_ofx_bug_39 (time64 t)
     return t;
 }
 
-int ofx_proc_transaction_cb(struct OfxTransactionData data, void *user_data)
+int ofx_proc_transaction_cb(OfxTransactionData data, void *user_data)
 {
     char dest_string[255];
     time64 current_time = gnc_time (NULL);
@@ -1079,7 +1082,7 @@ int ofx_proc_account_cb(struct OfxAccountData data, void * account_user_data)
     return 0;
 }
 
-double ofx_get_investment_amount(const struct OfxTransactionData* data)
+double ofx_get_investment_amount(const OfxTransactionData* data)
 {
     double amount = data->amount;
 #ifdef HAVE_LIBOFX_VERSION_0_10

--- a/gnucash/import-export/ofx/gnc-ofx-import.c
+++ b/gnucash/import-export/ofx/gnc-ofx-import.c
@@ -825,7 +825,9 @@ add_investment_split(Transaction* transaction, Account* account,
         xaccSplitSetMemo(split,
                          sanitize_string (data->security_data_ptr->memo));
     }
-    if (data->fi_id_valid)
+    if (data->fi_id_valid &&
+        xaccAccountTypesCompatible(xaccAccountGetType(account),
+                                   ACCT_TYPE_ASSET))
     {
         gnc_import_set_split_online_id(split,
                                        sanitize_string (data->fi_id));

--- a/gnucash/import-export/ofx/gnc-ofx-import.c
+++ b/gnucash/import-export/ofx/gnc-ofx-import.c
@@ -649,13 +649,19 @@ static Account*
 choose_investment_account_helper(OfxTransactionData *data, ofx_info *info,
                                  InvestmentAcctData *inv_data)
 {
-    Account *investment_account =
+    Account *investment_account, *parent_account;
+
+    if (xaccAccountGetCommodity(info->last_investment_account) == inv_data->commodity)
+        parent_account = info->last_investment_account;
+    else
+        parent_account = ofx_parent_account;
+
+    investment_account =
         gnc_import_select_account(GTK_WIDGET(info->parent),
                                   inv_data->online_id,
                                   TRUE, inv_data->acct_text,
                                   inv_data->commodity, ACCT_TYPE_STOCK,
-                                  info->last_investment_account,
-                                  &inv_data->choosing);
+                                  parent_account, &inv_data->choosing);
     if (investment_account &&
         xaccAccountGetCommodity(investment_account) == inv_data->commodity)
     {


### PR DESCRIPTION
An alternate and much more involved fix for [Bug 798681](https://bugs.gnucash.org/show_bug.cgi?id=798681). It first heavily refactors ofx_proc_transaction_cb by extracting several functions to make each single-purpose and short enough to easily reason about. The last commit reorders the split creation so that the import account splits are first in all cases except a reinvest, which doesn't have an import account split. 