### PR TITLE
If a currency pair is not found, make a detour via EUR (maint branch)

### DIFF
--- a/libgnucash/quotes/gnc-fq-dump.in
+++ b/libgnucash/quotes/gnc-fq-dump.in
@@ -198,6 +198,16 @@ if ($exchange eq "currency") {
             $result = $inv_res;
         }
     }
+    # If quotes aren't directly available, try a detour via EUR
+    # TODO reverse direction as above, detour via USD etc...
+    unless (defined($result)) {
+        my $eur_res_from = $q->currency($from, "EUR");
+        my $eur_res_to = $q->currency($to, "EUR");
+        if (defined($eur_res_from) and defined($eur_res_to)) {
+            $result = $eur_res_from / $eur_res_to;
+        }
+    }
+    # end
     if (defined($result)) {
       printf "1 $from = $result $to\n";
     } else {

--- a/libgnucash/quotes/gnc-fq-helper.in
+++ b/libgnucash/quotes/gnc-fq-helper.in
@@ -358,6 +358,16 @@ while(<>) {
             $price = $inv_price;
         }
     }
+    # If quotes aren't directly available, try a detour via EUR
+    # TODO reverse direction as above, detour via USD etc...
+    unless (defined($price)) {
+        my $eur_price_from = $quoter->currency($from_currency, "EUR");
+        my $eur_price_to = $quoter->currency($to_currency, "EUR");
+        if (defined($eur_price_from) and defined($eur_price_to)) {
+            $price = $eur_price_from / $eur_price_to;
+        }
+    }
+    # end
 
     $quote_data{$from_currency, "success"} = defined($price);
     $quote_data{$from_currency, "symbol"} = $from_currency;


### PR DESCRIPTION
Some pairs, e.g. XAU-CHF, are not directly available. Make a detour via EUR then. This could of course be improved to try other detour currencies etc...