### PR TITLE
Demonstrate fx handling in budget report

### DIFF
--- a/libgnucash/engine/Account.h
+++ b/libgnucash/engine/Account.h
@@ -618,6 +618,8 @@ typedef enum
 
     gnc_numeric xaccAccountGetNoclosingBalanceChangeForPeriod (
         Account *acc, time64 date1, time64 date2, gboolean recurse);
+    gnc_numeric xaccAccountGetNoclosingBalanceChangeInCurrencyForPeriod (
+        Account *acc, time64 date1, time64 date2, gboolean recurse);          
     gnc_numeric xaccAccountGetBalanceChangeForPeriod (
         Account *acc, time64 date1, time64 date2, gboolean recurse);
 

--- a/libgnucash/engine/Recurrence.c
+++ b/libgnucash/engine/Recurrence.c
@@ -426,7 +426,7 @@ recurrenceGetAccountPeriodValue(const Recurrence *r, Account *acc, guint n)
     g_return_val_if_fail(r && acc, gnc_numeric_zero());
     t1 = recurrenceGetPeriodTime(r, n, FALSE);
     t2 = recurrenceGetPeriodTime(r, n, TRUE);
-    return xaccAccountGetNoclosingBalanceChangeForPeriod (acc, t1, t2, TRUE);
+    return xaccAccountGetNoclosingBalanceChangeInCurrencyForPeriod (acc, t1, t2, TRUE);
 }
 
 void


### PR DESCRIPTION
This demonstrates a fix to https://bugs.gnucash.org/show_bug.cgi?id=798716

It shows the structure of new functionality to add, since *I think* the current functions do not allow this.

In essence, for budget reporting, the balance difference of an account should be computed in the local currency first, and then the change should be converted to a parent currency. The results for all sub-accounts are "rolled up" the account hierarchy in the same way as usual, using `gnc_account_foreach_descendant`.

It will need formatting to match style policies and coding guidelines.