### PR TITLE
Silence the boost (<1.76) warning message

### DIFF
--- a/libgnucash/app-utils/gnc-quotes.cpp
+++ b/libgnucash/app-utils/gnc-quotes.cpp
@@ -27,6 +27,11 @@
 #include <vector>
 #include <string>
 #include <iostream>
+#include <boost/version.hpp>
+#if BOOST_VERSION < 107600
+// json_parser uses a deprecated version of bind.hpp
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
+#endif
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/process.hpp>


### PR DESCRIPTION
from .../gnucash-4.8/libgnucash/app-utils/gnc-quotes.cpp:33: /usr/include/boost/bind.hpp:36:1: note: ‘#pragma message:

    The practice of declaring the Bind placeholders (_1, _2, ...) in the
    global namespace is deprecated.
    Please use <boost/bind/bind.hpp> + using namespace boost::placeholders,
    or define BOOST_BIND_GLOBAL_PLACEHOLDERS to retain the current behavior.’
    
The issue was fixed in boost 1.76, but, e.g ubuntu 22.04 has boost 1.74