### PR TITLE
Use const references for for-loops to avoid unnecessary copies

### DIFF
--- a/gnucash/gnome/dialog-report-column-view.cpp
+++ b/gnucash/gnome/dialog-report-column-view.cpp
@@ -146,7 +146,7 @@ update_available_lists(gnc_column_view_edit * view)
     auto store = GTK_LIST_STORE(model);
     gtk_list_store_clear(store);
 
-    for (auto guid : view->available_list)
+    for (const auto& guid : view->available_list)
     {
        auto rpt_guid{scm_from_utf8_string(guid.c_str())};
        auto name =

--- a/gnucash/import-export/csv-imp/assistant-csv-price-import.cpp
+++ b/gnucash/import-export/csv-imp/assistant-csv-price-import.cpp
@@ -801,7 +801,7 @@ void CsvImpPriceAssist::preview_populate_settings_combo()
 
     // Append the default entry
     auto presets = get_import_presets_price ();
-    for (auto preset : presets)
+    for (const auto& preset : presets)
     {
         GtkTreeIter iter;
         gtk_list_store_append (GTK_LIST_STORE(model), &iter);

--- a/libgnucash/app-utils/gnc-quotes.cpp
+++ b/libgnucash/app-utils/gnc-quotes.cpp
@@ -154,7 +154,7 @@ m_version{}, m_sources{}, m_api_key{}
     if (rv)
     {
         std::string err{bl::translate("Failed to initialize Finance::Quote: ")};
-        for (auto err_line : errors)
+        for (const auto& err_line : errors)
             err += err_line.empty() ? "" : err_line + "\n";
         throw(GncQuoteSourceError(err));
     }
@@ -427,13 +427,13 @@ get_quotes(const std::string& json_str, const std::unique_ptr<GncQuoteSource>& q
 
     if (rv == 0)
     {
-        for (auto line : quotes)
+        for (const auto& line : quotes)
             answer.append(line + "\n");
     }
     else
     {
         std::string err_str;
-        for (auto line: errors)
+        for (const auto& line: errors)
         {
             if (line == "invalid_json\n")
                 PERR("Finanace Quote Wrapper was unable to parse %s",
@@ -831,7 +831,7 @@ get_commodity_data(const bpt::ptree& pt, const std::string& comm)
 static void
 show_quotes(const bpt::ptree& pt, const StrVec& commodities, bool verbose)
 {
-    for (auto comm : commodities)
+    for (const auto& comm : commodities)
     {
         auto comm_pt{get_commodity_data(pt, comm)};
 
@@ -854,7 +854,7 @@ static void
 show_currency_quotes(const bpt::ptree& pt, const StrVec& commodities, bool verbose)
 {
     auto to_cur{commodities.front()};
-    for (auto comm : commodities)
+    for (const auto& comm : commodities)
     {
         if (comm == to_cur)
             continue;

--- a/libgnucash/backend/dbi/gnc-backend-dbi.cpp
+++ b/libgnucash/backend/dbi/gnc-backend-dbi.cpp
@@ -178,7 +178,7 @@ UriStrings::quote_dbname(DbType t) const noexcept
 static void
 set_options(dbi_conn conn, const PairVec& options)
 {
-    for (auto option : options)
+    for (const auto& option : options)
     {
         auto opt = option.first.c_str();
         auto val = option.second.c_str();

--- a/libgnucash/backend/sql/gnc-sql-backend.cpp
+++ b/libgnucash/backend/sql/gnc-sql-backend.cpp
@@ -232,7 +232,7 @@ GncSqlBackend::ObjectBackendRegistry::load_remaining(GncSqlBackend* sql_be)
     auto num_types = m_registry.size();
     auto num_done = fixed_load_order.size() + business_fixed_load_order.size();
 
-    for (auto entry : m_registry)
+    for (const auto& entry : m_registry)
     {
         std::string type;
         GncSqlObjectBackendPtr obe = nullptr;
@@ -292,7 +292,7 @@ GncSqlBackend::load (QofBook* book, QofBackendLoadType loadType)
         auto num_done = 0;
 
         /* Load any initial stuff. Some of this needs to happen in a certain order */
-        for (auto type : fixed_load_order)
+        for (const auto& type : fixed_load_order)
         {
             num_done++;
             auto obe = m_backend_registry.get_object_backend(type);
@@ -302,7 +302,7 @@ GncSqlBackend::load (QofBook* book, QofBackendLoadType loadType)
                 obe->load_all(this);
             }
         }
-        for (auto type : business_fixed_load_order)
+        for (const auto& type : business_fixed_load_order)
         {
             num_done++;
             auto obe = m_backend_registry.get_object_backend(type);
@@ -903,7 +903,7 @@ GncSqlBackend::build_insert_statement (const char* table_name,
     }
 
     sql << ") VALUES(";
-    for (auto col_value : values)
+    for (const auto& col_value : values)
     {
         if (col_value != *values.begin())
             sql << ",";

--- a/libgnucash/core-utils/gnc-filepath-utils.cpp
+++ b/libgnucash/core-utils/gnc-filepath-utils.cpp
@@ -701,7 +701,7 @@ static std::string migrate_gnc_datahome()
                                          % gnc_userconfig_home.string().c_str();
 
         migration_msg << std::endl;
-        for (auto success_file : succeeded)
+        for (const auto& success_file : succeeded)
             migration_msg << "- " << success_file << std::endl;
     }
     if (!conf_exist_vec.empty())
@@ -711,7 +711,7 @@ static std::string migrate_gnc_datahome()
                                         "The following files have become obsolete and will be ignored:",
                                         conf_exist_vec.size())
                       << std::endl;
-        for (auto obs_file : conf_exist_vec)
+        for (const auto& obs_file : conf_exist_vec)
             migration_msg << "- " << obs_file << std::endl;
     }
     if (!failed.empty())
@@ -721,7 +721,7 @@ static std::string migrate_gnc_datahome()
                                                     "The following files could not be moved to {1}:",
                                                           failed.size())}) % gnc_userconfig_home.string().c_str()
                       << std::endl;
-        for (auto failed_file : failed)
+        for (const auto& failed_file : failed)
             migration_msg << "- " << failed_file << std::endl;
     }
 

--- a/libgnucash/engine/gnc-timezone.cpp
+++ b/libgnucash/engine/gnc-timezone.cpp
@@ -775,6 +775,6 @@ TimeZoneProvider::get(int year) const noexcept
 void
 TimeZoneProvider::dump() const noexcept
 {
-    for (auto zone : m_zone_vector)
+    for (const auto& zone : m_zone_vector)
 	std::cout << zone.first << ": " << zone.second->to_posix_string() << "\n";
 }

--- a/libgnucash/engine/qoflog.cpp
+++ b/libgnucash/engine/qoflog.cpp
@@ -338,7 +338,7 @@ qof_log_check(QofLogModule domain, QofLogLevel level)
 
     auto domain_vec = split_domain(domain);
 
-    for (auto part : domain_vec)
+    for (const auto& part : domain_vec)
     {
         auto iter = std::find_if(module->m_children.begin(),
                                module->m_children.end(),


### PR DESCRIPTION
Found by clazy - clazy-range-loop-reference