### PR TITLE
Fix crash after upgrading v4 graph reports to v5

### DIFF
--- a/bindings/guile/gnc-optiondb.i
+++ b/bindings/guile/gnc-optiondb.i
@@ -1369,7 +1369,11 @@ inline SCM return_scm_value(ValueType value)
                                   GncOptionRangeValue<int>>)
                     {
                         if (scm_is_pair(new_value))
-                            option.set_value(scm_to_int(scm_cdr(new_value)));
+                        {
+                            // in Gnucash 4, the value might have been saved as floating point
+                            auto double_value = scm_to_double(scm_cdr(new_value));
+                            option.set_value(static_cast<int>(double_value));
+                        }
                         else
                             option.set_value(scm_to_int(new_value));
                         return;


### PR DESCRIPTION
Backtrace:
In ice-9/boot-9.scm:
  1752:10  5 (with-exception-handler _ _ #:unwind? _ #:unwind-for-type _)
...
In unknown file:
           0 (GncOption-set-value #<pointer 0x555da480fe78> (percent . 50.0))

ERROR: In procedure GncOption-set-value:
Wrong type (expecting exact integer): 50.0