### PR TITLE
Restore the ability to set the plot size in pixels

### DIFF
--- a/libgnucash/engine/gnc-optiondb.cpp
+++ b/libgnucash/engine/gnc-optiondb.cpp
@@ -817,9 +817,8 @@ gnc_register_number_plot_size_option(GncOptionDB* db,
                                      const char* key, const char* doc_string,
                                      int value)
 {
-    // Pixel values don't make much sense so always use percent.
     GncOption option{GncOptionRangeValue<int>{section, name, key, doc_string,
-                value, 10, 100, 1}};
+                value, 10, std::numeric_limits<int>::max(), 1}};
     db->register_option(section, std::move(option));
 }
 


### PR DESCRIPTION
FWIW, I use this.

- Text never scales, and IMHO it looks better if the graph behaves the same
- Rescaling is sluggish on older machines
- The behaviour now matches the tooltip

It is unfortunate that the UI is not very discoverable