### PR TITLE
Gsettting Changes

### DIFF
--- a/gnucash/gschemas/pref_transformations.xml
+++ b/gnucash/gschemas/pref_transformations.xml
@@ -2152,16 +2152,20 @@
 <obsolete old-path="org.gnucash.window.pages.account-tree.summary"
           old-key="end-period"/>
 
+</release>
+
+
+<release version="5000">
+
 <deprecate old-path="org.gnucash.GnuCash.dialogs.business.invoice"
            old-key="invoice-printreport" />
 
 </release>
 
-<!--
 <release version="6000">
 
 <obsolete old-path="org.gnucash.GnuCash.dialogs.business.invoice"
           old-key="invoice-printreport"/>
 
 </release>
--->
+

--- a/libgnucash/app-utils/gnc-gsettings.cpp
+++ b/libgnucash/app-utils/gnc-gsettings.cpp
@@ -688,7 +688,7 @@ void gnc_gsettings_load_backend (void)
 
 static GVariant *
 gnc_gsettings_get_user_value (const gchar *schema,
-                         const gchar *key)
+                              const gchar *key)
 {
     GSettings *settings_ptr = gnc_gsettings_get_settings_ptr (schema);
     g_return_val_if_fail (G_IS_SETTINGS (settings_ptr), NULL);

--- a/libgnucash/app-utils/gnc-gsettings.cpp
+++ b/libgnucash/app-utils/gnc-gsettings.cpp
@@ -870,9 +870,12 @@ void gnc_gsettings_version_upgrade (void)
     auto ogG_maj_min = gnc_gsettings_get_user_value (GNC_PREFS_GROUP_GENERAL, GNC_PREF_VERSION);
     auto og_maj_min = gnc_gsettings_get_user_value (GSET_SCHEMA_OLD_PREFIX "." GNC_PREFS_GROUP_GENERAL, GNC_PREF_VERSION);
 
+    auto cur_maj_min = PROJECT_VERSION_MAJOR * 1000 + PROJECT_VERSION_MINOR;
+
     if (!ogG_maj_min && !og_maj_min) // new install
     {
-        LEAVE("");
+        gnc_gsettings_set_int (GNC_PREFS_GROUP_GENERAL, GNC_PREF_VERSION, cur_maj_min);
+        LEAVE ("Setting Previous compatibility level to current version: %i", cur_maj_min);
         return;
     }
 
@@ -886,8 +889,6 @@ void gnc_gsettings_version_upgrade (void)
     }
     if (og_maj_min)
         g_variant_unref (og_maj_min);
-
-    auto cur_maj_min = PROJECT_VERSION_MAJOR * 1000 + PROJECT_VERSION_MINOR;
 
     PINFO ("Previous setting compatibility level: %i, Current version: %i", old_maj_min, cur_maj_min);
 

--- a/libgnucash/app-utils/gnc-gsettings.cpp
+++ b/libgnucash/app-utils/gnc-gsettings.cpp
@@ -638,6 +638,21 @@ gnc_gsettings_reset_schema (const gchar *schema_str)
     g_strfreev (keys);
 }
 
+static void
+gnc_settings_dump_schema_paths (void)
+{
+    gchar **non_relocatable;
+
+    auto schema_source {g_settings_schema_source_get_default()};
+    g_settings_schema_source_list_schemas (schema_source, true,
+                                           &non_relocatable, nullptr);
+
+    for (gint i = 0; non_relocatable[i] != nullptr; i++)
+        PINFO("Schema entry %d is '%s'", i, non_relocatable[i]);
+
+    g_strfreev (non_relocatable);
+}
+
 void gnc_gsettings_load_backend (void)
 {
     ENTER("");
@@ -676,6 +691,9 @@ void gnc_gsettings_load_backend (void)
     prefsbackend->reset_group = gnc_gsettings_reset_schema;
     prefsbackend->block_all = gnc_gsettings_block_all;
     prefsbackend->unblock_all = gnc_gsettings_unblock_all;
+
+    if (qof_log_check (log_module, QOF_LOG_DEBUG))
+        gnc_settings_dump_schema_paths ();
 
     /* Run any data model changes for the backend before it's used
      * by anyone */

--- a/libgnucash/app-utils/gnc-gsettings.cpp
+++ b/libgnucash/app-utils/gnc-gsettings.cpp
@@ -844,7 +844,7 @@ void gnc_gsettings_version_upgrade (void)
      * this version of GnuCash will be executed.
      *
      * Starting with GnuCash 4.7 the code expects all preferences to be stored
-     * under prefix org.gnucash instead of org.gnucash.GnuCash, including our
+     * under prefix org.gnucash.GnuCash instead of org.gnucash, including our
      * GNC_PREF_VERSION setting.
      * As the logic to determine whether or not settings conversions are needed
      * depends on this preference, we have to test for its value in two


### PR DESCRIPTION
This changes the `gnc_gsettings_version_upgrade` process so that release versions greater than the current GnuCash version in the `pref_transformations.xml` file are not processed. It also fixes a windows bug that was failing on the glib error...
`WARN <GLib-GIO> subscribe() failed: only 64 different paths may be watched.`

The way I have done this is that after each migrate/obsolete pass, the function `clear_gset_object`(will rename this to `clear_gsettings_object`), is called which finds the GSettings object in the schema_hash, removes it and then unref's the object to release the schema path.

The down side on this is that a two GSettings objects are created and removed for each migrate and one created and removed for each obsolete.

Not sure if this is an issue, another way I did think of is to have two static GSettings objects and compare the `schema-id` to see if it can be reused for the next change, if not unref it and create a new one, may also need a couple of duplicate functions to use them, not sure have not tried it.