### PR TITLE
Remove references to old boost versions

### DIFF
--- a/libgnucash/engine/kvp-value.hpp
+++ b/libgnucash/engine/kvp-value.hpp
@@ -26,10 +26,7 @@
 
 #include <config.h>
 #include "qof.h"
-#include <boost/version.hpp>
-#if BOOST_VERSION == 105600
-#include <boost/type_traits/is_nothrow_move_assignable.hpp>
-#endif
+
 #include <boost/variant.hpp>
 
 //Must be a struct because it's exposed to C so that it can in turn be

--- a/libgnucash/engine/test/test-gnc-guid.cpp
+++ b/libgnucash/engine/test/test-gnc-guid.cpp
@@ -30,7 +30,6 @@
 #include <string>
 #include <iostream>
 #include <gtest/gtest.h>
-#include <boost/version.hpp>
 
 TEST (GncGUID, creation)
 {
@@ -79,12 +78,8 @@ TEST (GncGUID, from_string)
     {
         fail = true;
     }
-    /* Currently, boost uuid string parsing is mostly very permissive, but it has some
-     * odd pet peeves. See https://svn.boost.org/trac/boost/ticket/12253 for more.*/
-    if (BOOST_VERSION >= 106600)
-        EXPECT_TRUE (fail) << "Parsing the bogus string should throw";
-    else
-        EXPECT_FALSE (fail) << "Perhaps boost uuid is fixed.";
+
+    EXPECT_TRUE (fail) << "Parsing the bogus string should throw";
 }
 
 TEST (GncGUID, round_trip)


### PR DESCRIPTION
we already require 1.67