### PR TITLE
By default, filter out online_wiggle in test-gnc-quotes

### DIFF
--- a/libgnucash/app-utils/test/CMakeLists.txt
+++ b/libgnucash/app-utils/test/CMakeLists.txt
@@ -48,7 +48,8 @@ set(test_gnc_quotes_LIBS
         ${Boost_PROPERTY_TREE_LIBRARY}
         ${Boost_SYSTEM_LIBRARY}
         )
-gnc_add_test(test-gnc-quotes "${test_gnc_quotes_SOURCES}" test_gnc_quotes_INCLUDES test_gnc_quotes_LIBS)
+gnc_add_test(test-gnc-quotes "${test_gnc_quotes_SOURCES}" test_gnc_quotes_INCLUDES test_gnc_quotes_LIBS
+        "GTEST_FILTER=-GncQuotesTest.online_wiggle")
 
 set(GUILE_DEPENDS
   scm-test-engine


### PR DESCRIPTION
The test relies on a lot of external dependencies
- installed finance-quote-wrapper
- alpha vantage key
- network
- working remote server

Running ./bin/test-gnc-quotes from the command line will still include online_wiggle