### PR TITLE
Bug798759 saving register 'with sub-account' registers 

### DIFF
--- a/gnucash/gnome/gnc-plugin-page-register.c
+++ b/gnucash/gnome/gnc-plugin-page-register.c
@@ -2145,17 +2145,15 @@ gnc_plugin_page_register_check_for_empty_group (GKeyFile *state_file, const gcha
 }
 
 static gchar*
-gnc_plugin_page_register_get_filter_gcm (Account* leader)
+gnc_plugin_page_register_get_filter_gcm (GNCSplitReg *gsr)
 {
     GKeyFile* state_file = gnc_state_get_current();
     gchar* state_section;
-    gchar acct_guid[GUID_ENCODING_LENGTH + 1];
     GError* error = NULL;
     char* filter = NULL;
 
     // get the filter from the .gcm file
-    guid_to_string_buff (xaccAccountGetGUID (leader), acct_guid);
-    state_section = g_strconcat (STATE_SECTION_REG_PREFIX, " ", acct_guid, NULL);
+    state_section = gsr_get_register_state_section (gsr);
     filter = g_key_file_get_string (state_file, state_section,
                                     KEY_PAGE_FILTER, &error);
 
@@ -2173,7 +2171,6 @@ gnc_plugin_page_register_get_filter (GncPluginPage* plugin_page)
 {
     GncPluginPageRegisterPrivate* priv;
     GNCLedgerDisplayType ledger_type;
-    Account* leader;
     char* filter = NULL;
 
     g_return_val_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page),
@@ -2182,10 +2179,9 @@ gnc_plugin_page_register_get_filter (GncPluginPage* plugin_page)
     priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
 
     ledger_type = gnc_ledger_display_type (priv->ledger);
-    leader = gnc_ledger_display_leader (priv->ledger);
 
     // load from gcm file
-    filter = gnc_plugin_page_register_get_filter_gcm (leader);
+    filter = gnc_plugin_page_register_get_filter_gcm (priv->gsr);
 
     if (filter)
         return filter;
@@ -2195,17 +2191,15 @@ gnc_plugin_page_register_get_filter (GncPluginPage* plugin_page)
 }
 
 static void
-gnc_plugin_page_register_set_filter_gcm (Account* leader, const gchar* filter,
+gnc_plugin_page_register_set_filter_gcm (GNCSplitReg *gsr, const gchar* filter,
                                          gchar* default_filter)
 {
     GKeyFile* state_file = gnc_state_get_current();
     gchar* state_section;
     gchar* filter_text;
-    gchar acct_guid[GUID_ENCODING_LENGTH + 1];
 
     // save the filter to the .gcm file also
-    guid_to_string_buff (xaccAccountGetGUID (leader), acct_guid);
-    state_section = g_strconcat (STATE_SECTION_REG_PREFIX, " ", acct_guid, NULL);
+    state_section = gsr_get_register_state_section (gsr);
     if (!filter || (g_strcmp0 (filter, default_filter) == 0))
     {
         if (g_key_file_has_key (state_file, state_section, KEY_PAGE_FILTER, NULL))
@@ -2230,37 +2224,33 @@ gnc_plugin_page_register_set_filter (GncPluginPage* plugin_page,
 {
     GncPluginPageRegisterPrivate* priv;
     GNCLedgerDisplayType ledger_type;
-    Account* leader;
     gchar* default_filter;
 
     priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
 
     ledger_type = gnc_ledger_display_type (priv->ledger);
-    leader = gnc_ledger_display_leader (priv->ledger);
 
     default_filter = g_strdup_printf ("%s,%s,%s,%s", DEFAULT_FILTER,
                                       "0", "0", get_filter_default_num_of_days (ledger_type));
 
     // save to gcm file
-    gnc_plugin_page_register_set_filter_gcm (leader, filter, default_filter);
+    gnc_plugin_page_register_set_filter_gcm (priv->gsr, filter, default_filter);
 
     g_free (default_filter);
     return;
 }
 
 static gchar*
-gnc_plugin_page_register_get_sort_order_gcm (Account* leader)
+gnc_plugin_page_register_get_sort_order_gcm (GNCSplitReg *gsr)
 {
     GKeyFile* state_file = gnc_state_get_current();
     gchar* state_section;
     gchar* sort_text;
-    gchar acct_guid[GUID_ENCODING_LENGTH + 1];
     GError* error = NULL;
     char* sort_order = NULL;
 
     // get the sort_order from the .gcm file
-    guid_to_string_buff (xaccAccountGetGUID (leader), acct_guid);
-    state_section = g_strconcat (STATE_SECTION_REG_PREFIX, " ", acct_guid, NULL);
+    state_section = gsr_get_register_state_section (gsr);
     sort_text = g_key_file_get_string (state_file, state_section, KEY_PAGE_SORT,
                                        &error);
 
@@ -2279,7 +2269,6 @@ static gchar*
 gnc_plugin_page_register_get_sort_order (GncPluginPage* plugin_page)
 {
     GncPluginPageRegisterPrivate* priv;
-    Account* leader;
     char* sort_order = NULL;
 
     g_return_val_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page),
@@ -2287,26 +2276,21 @@ gnc_plugin_page_register_get_sort_order (GncPluginPage* plugin_page)
 
     priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
 
-    leader = gnc_ledger_display_leader (priv->ledger);
-
     // load from gcm file
-    sort_order = gnc_plugin_page_register_get_sort_order_gcm (leader);
-
+    sort_order = gnc_plugin_page_register_get_sort_order_gcm (priv->gsr);
 
     return sort_order ? sort_order : g_strdup (DEFAULT_SORT_ORDER);
 }
 
 static void
-gnc_plugin_page_register_set_sort_order_gcm (Account* leader,
+gnc_plugin_page_register_set_sort_order_gcm (GNCSplitReg *gsr,
                                              const gchar* sort_order)
 {
     GKeyFile* state_file = gnc_state_get_current();
     gchar* state_section;
-    gchar acct_guid[GUID_ENCODING_LENGTH + 1];
 
     // save sort_order to the .gcm file also
-    guid_to_string_buff (xaccAccountGetGUID (leader), acct_guid);
-    state_section = g_strconcat (STATE_SECTION_REG_PREFIX, " ", acct_guid, NULL);
+    state_section = gsr_get_register_state_section (gsr);
     if (!sort_order || (g_strcmp0 (sort_order, DEFAULT_SORT_ORDER) == 0))
     {
         if (g_key_file_has_key (state_file, state_section, KEY_PAGE_SORT, NULL))
@@ -2324,28 +2308,23 @@ gnc_plugin_page_register_set_sort_order (GncPluginPage* plugin_page,
                                          const gchar* sort_order)
 {
     GncPluginPageRegisterPrivate* priv;
-    Account* leader;
 
     priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
 
-    leader = gnc_ledger_display_leader (priv->ledger);
-
     // save to gcm file
-    gnc_plugin_page_register_set_sort_order_gcm (leader, sort_order);
+    gnc_plugin_page_register_set_sort_order_gcm (priv->gsr, sort_order);
 }
 
 static gboolean
-gnc_plugin_page_register_get_sort_reversed_gcm (Account* leader)
+gnc_plugin_page_register_get_sort_reversed_gcm (GNCSplitReg *gsr)
 {
     GKeyFile* state_file = gnc_state_get_current();
     gchar* state_section;
-    gchar acct_guid[GUID_ENCODING_LENGTH + 1];
     GError* error = NULL;
     gboolean sort_reversed = FALSE;
 
     // get the sort_reversed from the .gcm file
-    guid_to_string_buff (xaccAccountGetGUID (leader), acct_guid);
-    state_section = g_strconcat (STATE_SECTION_REG_PREFIX, " ", acct_guid, NULL);
+    state_section = gsr_get_register_state_section (gsr);
     sort_reversed = g_key_file_get_boolean (state_file, state_section,
                                             KEY_PAGE_SORT_REV, &error);
 
@@ -2360,31 +2339,27 @@ static gboolean
 gnc_plugin_page_register_get_sort_reversed (GncPluginPage* plugin_page)
 {
     GncPluginPageRegisterPrivate* priv;
-    Account* leader;
     gboolean sort_reversed = FALSE;
 
     g_return_val_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (plugin_page), FALSE);
 
     priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
 
-    leader = gnc_ledger_display_leader (priv->ledger);
-
     // load from gcm file
-    sort_reversed = gnc_plugin_page_register_get_sort_reversed_gcm (leader);
+    sort_reversed = gnc_plugin_page_register_get_sort_reversed_gcm (priv->gsr);
     return sort_reversed;
 }
 
 static void
-gnc_plugin_page_register_set_sort_reversed_gcm (Account* leader,
+gnc_plugin_page_register_set_sort_reversed_gcm (GNCSplitReg *gsr,
                                                 gboolean reverse_order)
 {
     GKeyFile* state_file = gnc_state_get_current();
     gchar* state_section;
-    gchar acct_guid[GUID_ENCODING_LENGTH + 1];
 
     // save reverse_order to the .gcm file also
-    guid_to_string_buff (xaccAccountGetGUID (leader), acct_guid);
-    state_section = g_strconcat (STATE_SECTION_REG_PREFIX, " ", acct_guid, NULL);
+    state_section = gsr_get_register_state_section (gsr);
+
     if (!reverse_order)
     {
         if (g_key_file_has_key (state_file, state_section, KEY_PAGE_SORT_REV, NULL))
@@ -2404,13 +2379,11 @@ gnc_plugin_page_register_set_sort_reversed (GncPluginPage* plugin_page,
                                             gboolean reverse_order)
 {
     GncPluginPageRegisterPrivate* priv;
-    Account* leader;
 
     priv = GNC_PLUGIN_PAGE_REGISTER_GET_PRIVATE (plugin_page);
-    leader = gnc_ledger_display_leader (priv->ledger);
 
     // save to gcm file
-    gnc_plugin_page_register_set_sort_reversed_gcm (leader, reverse_order);
+    gnc_plugin_page_register_set_sort_reversed_gcm (priv->gsr, reverse_order);
 }
 
 static gchar*
@@ -5264,7 +5237,7 @@ gnc_plugin_page_help_changed_cb (GNCSplitReg* gsr,
     }
 
     // only update status text if on current page
-    if (GNC_IS_MAIN_WINDOW(window) && (gnc_main_window_get_current_page 
+    if (GNC_IS_MAIN_WINDOW(window) && (gnc_main_window_get_current_page
        (GNC_MAIN_WINDOW(window)) != GNC_PLUGIN_PAGE(register_page)))
        return;
 

--- a/gnucash/gnome/gnc-split-reg.c
+++ b/gnucash/gnome/gnc-split-reg.c
@@ -2152,11 +2152,14 @@ gnc_split_reg_set_sort_reversed(GNCSplitReg *gsr, gboolean rev, gboolean refresh
      *       In other words, qof_query_set_sort_increasing should
      *       always use the inverse of rev.
      */
+    SplitRegister *reg = gnc_ledger_display_get_split_register (gsr->ledger);
     Query *query = gnc_ledger_display_get_query( gsr->ledger );
+
+    gnc_split_register_set_reverse_sort (reg, rev);
+
     qof_query_set_sort_increasing (query, !rev, !rev, !rev);
     gsr->sort_rev = rev;
-    Account *acct = gnc_ledger_display_leader (gsr->ledger);
-    xaccAccountSetSortReversed(acct, rev);
+
     if (refresh)
         gnc_ledger_display_refresh( gsr->ledger );
 }

--- a/gnucash/gnome/gnc-split-reg.h
+++ b/gnucash/gnome/gnc-split-reg.h
@@ -299,6 +299,14 @@ void gsr_default_reinit_handler( GNCSplitReg *gsr, gpointer data );
 void gsr_default_expand_handler( GNCSplitReg *gsr, gpointer data );
 void gsr_default_schedule_handler( GNCSplitReg *gsr, gpointer data );
 
+/** Get the register state section
+ *
+ *  @param gsr A pointer to GNCSplitReg
+ * 
+ *  @return The register state section, to be freed by caller
+ **/
+gchar *gsr_get_register_state_section (GNCSplitReg *gsr);
+
 void gnc_split_reg_set_moved_cb( GNCSplitReg *gsr, GFunc cb, gpointer cb_data );
 
 #endif /* GNC_SPLIT_REG_H */

--- a/gnucash/register/ledger-core/split-register-load.c
+++ b/gnucash/register/ledger-core/split-register-load.c
@@ -644,6 +644,9 @@ gnc_split_register_load (SplitRegister* reg, GList* slist,
                     save_loc.phys_col_offset = 0;
                 }
 
+                // used in the setting the rows insensitive
+                table->model->blank_trans_row = vcell_loc.virt_row;
+
                 gnc_split_register_add_transaction (reg,
                                                     blank_trans, blank_split,
                                                     lead_cursor, split_cursor,
@@ -725,6 +728,9 @@ gnc_split_register_load (SplitRegister* reg, GList* slist,
             save_loc.phys_row_offset = 0;
             save_loc.phys_col_offset = 0;
         }
+
+        // used in the setting the rows insensitive
+        table->model->blank_trans_row = vcell_loc.virt_row;
 
         gnc_split_register_add_transaction (reg, blank_trans, blank_split,
                                             lead_cursor, split_cursor,

--- a/gnucash/register/ledger-core/split-register-load.c
+++ b/gnucash/register/ledger-core/split-register-load.c
@@ -377,7 +377,6 @@ gnc_split_register_load (SplitRegister* reg, GList* slist,
     gboolean need_divider_upper = FALSE;
     gboolean found_divider_upper = FALSE;
     gboolean found_divider = FALSE;
-    bool reverse_sort = xaccAccountGetSortReversed(default_account);
     gboolean has_last_num = FALSE;
     gboolean multi_line;
     gboolean dynamic;
@@ -610,8 +609,8 @@ gnc_split_register_load (SplitRegister* reg, GList* slist,
             use_autoreadonly &&
             !found_divider_upper)
         {
-            if (((reverse_sort && xaccTransGetDate(trans) < autoreadonly_time) ||
-                 (!reverse_sort && xaccTransGetDate (trans) >= autoreadonly_time)))
+            if (((table->model->reverse_sort && xaccTransGetDate(trans) < autoreadonly_time) ||
+                 (!table->model->reverse_sort && xaccTransGetDate (trans) >= autoreadonly_time)))
             {
                 table->model->dividing_row_upper = vcell_loc.virt_row;
                 found_divider_upper = TRUE;
@@ -623,8 +622,8 @@ gnc_split_register_load (SplitRegister* reg, GList* slist,
         }
 
         if (info->show_present_divider && !found_divider &&
-            ((reverse_sort && xaccTransGetDate(trans) < present) ||
-             (!reverse_sort && xaccTransGetDate (trans) > present)))
+            ((table->model->reverse_sort && xaccTransGetDate (trans) < present) ||
+             (!table->model->reverse_sort && xaccTransGetDate (trans) > present)))
         {
             table->model->dividing_row = vcell_loc.virt_row;
             found_divider = TRUE;

--- a/gnucash/register/ledger-core/split-register.c
+++ b/gnucash/register/ledger-core/split-register.c
@@ -2943,6 +2943,13 @@ gnc_split_register_config (SplitRegister* reg,
 }
 
 void
+gnc_split_register_set_reverse_sort (SplitRegister* reg, gboolean reverse_sort)
+{
+    g_return_if_fail (reg);
+    gnc_table_model_set_reverse_sort (reg->table->model, reverse_sort);
+}
+
+void
 gnc_split_register_set_auto_complete (SplitRegister* reg,
                                       gboolean do_auto_complete)
 {

--- a/gnucash/register/ledger-core/split-register.h
+++ b/gnucash/register/ledger-core/split-register.h
@@ -323,6 +323,15 @@ void gnc_split_register_config (SplitRegister* reg,
                                 SplitRegisterStyle style,
                                 gboolean use_double_line);
 
+/** Sets a split register's reverse sort order based on register
+ *
+ *  @param reg a ::SplitRegister
+ *
+ *  @param reverse_sort @c TRUE reverse sort order, @c FALSE default
+ */
+void gnc_split_register_set_reverse_sort (SplitRegister* reg,
+                                          gboolean reverse_sort);
+
 /** Sets whether a register uses auto-completion.
  *
  *  @param reg a ::SplitRegister

--- a/gnucash/register/register-core/table-model.c
+++ b/gnucash/register/register-core/table-model.c
@@ -145,6 +145,8 @@ gnc_table_model_new (void)
     model->dividing_row = -1;
     model->dividing_row_lower = -1;
 
+    model->blank_trans_row = -1;
+
     return model;
 }
 

--- a/gnucash/register/register-core/table-model.c
+++ b/gnucash/register/register-core/table-model.c
@@ -200,6 +200,14 @@ gnc_table_model_read_only (TableModel *model)
 }
 
 void
+gnc_table_model_set_reverse_sort (TableModel *model,
+                                  gboolean reverse_sort)
+{
+    g_return_if_fail (model);
+    model->reverse_sort = reverse_sort;
+}
+
+void
 gnc_table_model_set_entry_handler (TableModel *model,
                                    TableGetEntryHandler entry_handler,
                                    const char * cell_name)

--- a/gnucash/register/register-core/table-model.h
+++ b/gnucash/register/register-core/table-model.h
@@ -122,6 +122,10 @@ typedef struct
      * and edits should not be allowed. */
     gboolean read_only;
 
+    /* If true, denotes that this table is being displayed
+     * in the reverse direction. */
+    gboolean reverse_sort;
+
     /* If positive, denotes a row that marks a boundary that should
      * be visually distinguished. */
     int dividing_row;
@@ -144,6 +148,9 @@ void         gnc_table_model_destroy (TableModel *model);
 void         gnc_table_model_set_read_only (TableModel *model,
         gboolean read_only);
 gboolean     gnc_table_model_read_only (TableModel *model);
+
+void         gnc_table_model_set_reverse_sort (TableModel *model,
+                                               gboolean read_only);
 
 void gnc_table_model_set_entry_handler
 (TableModel *model,

--- a/gnucash/register/register-core/table-model.h
+++ b/gnucash/register/register-core/table-model.h
@@ -136,6 +136,9 @@ typedef struct
      * be visually distinguished. */
     int dividing_row_lower;
 
+    /* If positive, denotes the row position of the blank trans */
+    int blank_trans_row;
+
     VirtCellDataAllocator cell_data_allocator;
     VirtCellDataDeallocator cell_data_deallocator;
     VirtCellDataCopy cell_data_copy;

--- a/gnucash/register/register-gnome/gnucash-sheet-private.c
+++ b/gnucash/register/register-gnome/gnucash-sheet-private.c
@@ -375,6 +375,13 @@ draw_divider_line (cairo_t *cr, VirtualLocation virt_loc,
 }
 
 static void
+set_cell_insensitive (GtkStyleContext *stylectxt)
+{
+    if (!gtk_style_context_has_class (stylectxt, GTK_STYLE_CLASS_BACKGROUND))
+        gtk_style_context_set_state (stylectxt, GTK_STATE_FLAG_INSENSITIVE);
+}
+
+static void
 draw_cell (GnucashSheet *sheet, SheetBlock *block,
            VirtualLocation virt_loc, cairo_t *cr,
            int x, int y, int width, int height)
@@ -409,10 +416,7 @@ draw_cell (GnucashSheet *sheet, SheetBlock *block,
     gnucash_get_style_classes (sheet, stylectxt, color_type, use_neg_class);
 
     if (sheet->read_only)
-    {
-        if (!gtk_style_context_has_class (stylectxt, GTK_STYLE_CLASS_BACKGROUND))
-            gtk_style_context_set_state (stylectxt, GTK_STATE_FLAG_INSENSITIVE);
-    }
+        set_cell_insensitive (stylectxt);
     else
     {
         if (gtk_style_context_has_class (stylectxt, GTK_STYLE_CLASS_BACKGROUND))
@@ -421,11 +425,27 @@ draw_cell (GnucashSheet *sheet, SheetBlock *block,
 
     // Are we in a read-only row? Then make the background color somewhat more grey.
     if ((virt_loc.phys_row_offset < block->style->nrows)
-                && (table->model->dividing_row_upper >= 0)
-                && (virt_loc.vcell_loc.virt_row < table->model->dividing_row_upper))
+         && (table->model->dividing_row_upper >= 0))
     {
-        if (!gtk_style_context_has_class (stylectxt, GTK_STYLE_CLASS_BACKGROUND))
-            gtk_style_context_set_state (stylectxt, GTK_STATE_FLAG_INSENSITIVE);
+        if (table->model->reverse_sort)
+        {
+            if ((table->model->blank_trans_row < table->model->dividing_row_upper)
+                 && (virt_loc.vcell_loc.virt_row >= table->model->dividing_row_upper))
+            {
+                set_cell_insensitive (stylectxt); // future trans after blank
+            }
+
+            if ((virt_loc.vcell_loc.virt_row >= table->model->dividing_row_upper)
+                 && (virt_loc.vcell_loc.virt_row < table->model->blank_trans_row))
+            {
+                set_cell_insensitive (stylectxt);
+            }
+        }
+        else // normal order
+        {
+            if (virt_loc.vcell_loc.virt_row < table->model->dividing_row_upper)
+                set_cell_insensitive (stylectxt);
+        }
     }
 
     gtk_render_background (stylectxt, cr, x, y, width, height);


### PR DESCRIPTION
Register widths are saved in the .gcm file under sections based on the account guid. When you have for example an 'Assets' register open and the 'with sub-account' register page 'Assets+' open, they will both save there settings to the same section as there is only one guid.

To fix this, add a '+' to the end of the guid for the sub-account section as done for the title.

Also, I have modified @jralls commit earlier on to not use xaccAccountSetSortReversed as the 'sort order / sort by and filter by' are all stored in the register. This also fixes the general journal as there is no default account and if saved open segfaults Gnucash on restart.

Currently there is a function to remove those settings from used accounts and store them in the .gcm file, if I remember I added that at the beginning of 4.0 so maybe in 5.0 that can be removed but not sure how to handle the depreciation of the account functions.

The last commit fixes setting the cells insensitive when the register is in reverse order and also when the preference setting to move future transactions after the blank transaction. Could not think of another way of doing this.


