### PR TITLE
Bug 798768 - Improve docs for gnucash.trace location

### DIFF
--- a/doc/gnucash-cli.1.in
+++ b/doc/gnucash-cli.1.in
@@ -60,7 +60,7 @@ Enable extra/development/debugging features.
 Log level overrides, of the form "log.ger.path={debug,info,warn,crit,error}"
 This option can be specified multiple times.
 .IP --logto
-File to log into; defaults to "/tmp/gnucash.trace"; can be "stderr" or "stdout".
+File to log into; defaults to "$TMPDIR/gnucash.trace"; can be "stderr" or "stdout".
 .SH FILES
 .I ~/.gnucash/config.auto
 .RS

--- a/doc/gnucash.1.in
+++ b/doc/gnucash.1.in
@@ -33,7 +33,7 @@ Enable extra/development/debugging features.
 Log level overrides, of the form "log.ger.path={debug,info,warn,crit,error}"
 This option can be specified multiple times.
 .IP --logto
-File to log into; defaults to "/tmp/gnucash.trace"; can be "stderr" or "stdout".
+File to log into; defaults to "$TMPDIR/gnucash.trace"; can be "stderr" or "stdout".
 .IP --nofile
 Do not load the last file opened
 .IP "--add-price-quotes FILE"

--- a/gnucash/gnucash-core-app.cpp
+++ b/gnucash/gnucash-core-app.cpp
@@ -309,7 +309,7 @@ Gnucash::CoreApp::add_common_program_options (void)
         ("paths", bpo::bool_switch(&m_show_paths),
          _("Show paths"))
         ("logto", bpo::value (&m_log_to_filename),
-         _("File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or \"stdout\"."));
+         _("File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or \"stdout\"."));
 
     bpo::options_description hidden_options(_("Hidden Options"));
     hidden_options.add_options()

--- a/po/ar.po
+++ b/po/ar.po
@@ -10496,9 +10496,9 @@ msgstr "عرض الرسم"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
-msgstr "ملف لتسجيل \"/tmp/gnucash.trace\"; can be \"stderr\" or \"stdout\"."
+msgstr "ملف لتسجيل \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or \"stdout\"."
 
 #: gnucash/gnucash-core-app.cpp:313
 #, fuzzy

--- a/po/as.po
+++ b/po/as.po
@@ -10505,10 +10505,10 @@ msgstr "ক্ষেত্ৰখন দেখুৱাওক"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"ডিফল্টলৈ লগ কৰিবলগীয়া ফাইল \"/tmp/gnucash.trace\"; \"stderr\" বা \"stdout\" ও "
+"ডিফল্টলৈ লগ কৰিবলগীয়া ফাইল \"$TMPDIR/gnucash.trace\"; \"stderr\" বা \"stdout\" ও "
 "হব পাৰে."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/az.po
+++ b/po/az.po
@@ -10342,7 +10342,7 @@ msgstr "Qısa Yollar"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -10631,10 +10631,10 @@ msgstr "Показване на графика"
 # FIXME много ; Да се променят ли?
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"Журнален файл; стандартно в \"/tmp/gnucash.trace\"; може да е \"stderr\" или "
+"Журнален файл; стандартно в \"$TMPDIR/gnucash.trace\"; може да е \"stderr\" или "
 "\"stdout\"."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/brx.po
+++ b/po/brx.po
@@ -10492,10 +10492,10 @@ msgstr "दब्लाइ दिन्थि"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"..आव लग खालामनो फाइल; \"/tmp/gnucash.trace\" आव डिफल्ट; \"stderr\" एबा "
+"..आव लग खालामनो फाइल; \"$TMPDIR/gnucash.trace\" आव डिफल्ट; \"stderr\" एबा "
 "\"stdout\"जानो हागौ।"
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/ca.po
+++ b/po/ca.po
@@ -10547,10 +10547,10 @@ msgstr "Mostra el diagrama"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"Fitxer de registre, per defecte és /tmp/gnucash.trace. També pot ser "
+"Fitxer de registre, per defecte és $TMPDIR/gnucash.trace. També pot ser "
 "«stderr» o «stdout»."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/cs.po
+++ b/po/cs.po
@@ -10626,10 +10626,10 @@ msgstr "Zobrazit graf"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"Soubor, do kterého ladit; implicitně \"/tmp/gnucash.trace\"; může být "
+"Soubor, do kterého ladit; implicitně \"$TMPDIR/gnucash.trace\"; může být "
 "\"stderr\" nebo \"stdout\"."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/da.po
+++ b/po/da.po
@@ -10705,7 +10705,7 @@ msgstr "Vis diagram"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -10636,7 +10636,7 @@ msgstr "Dateipfade anzeigen"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
 "Datei, in welche die Logmeldungen geschrieben werden; Voreinstellung »/tmp/"

--- a/po/doi.po
+++ b/po/doi.po
@@ -10597,10 +10597,10 @@ msgstr "प्लॉट दस्सो"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"ओह् फ़ाइल जिस च लॉग कीता जाना ऐ ; \"/tmp/gnucash.trace\"; च डिफाल्ट \"stderr\" "
+"ओह् फ़ाइल जिस च लॉग कीता जाना ऐ ; \"$TMPDIR/gnucash.trace\"; च डिफाल्ट \"stderr\" "
 "जां \"stdout\" होई सकदा ऐ ।"
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/en_AU.po
+++ b/po/en_AU.po
@@ -10386,10 +10386,10 @@ msgstr "Show paths"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -10386,10 +10386,10 @@ msgstr "Show paths"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/en_NZ.po
+++ b/po/en_NZ.po
@@ -10386,10 +10386,10 @@ msgstr "Show paths"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/es.po
+++ b/po/es.po
@@ -10686,10 +10686,10 @@ msgstr "Mostrar traza"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"El fichero bitácora interna; por defecto a «/tmp/gnucash.trace»; puede ser "
+"El fichero bitácora interna; por defecto a «$TMPDIR/gnucash.trace»; puede ser "
 "«stderr» o «stdout»."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/es_NI.po
+++ b/po/es_NI.po
@@ -11040,7 +11040,7 @@ msgstr "Mostrar diagrama"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
 

--- a/po/et.po
+++ b/po/et.po
@@ -9881,7 +9881,7 @@ msgstr ""
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
 

--- a/po/eu.po
+++ b/po/eu.po
@@ -10948,7 +10948,7 @@ msgstr "Erakutsi grafikoa"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -10476,10 +10476,10 @@ msgstr "نمایش قطعه"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"پرونده برای نگهداری سابقه؛ پیش‌گزیده به «/tmp/gnucash.trace»; می‌تواند "
+"پرونده برای نگهداری سابقه؛ پیش‌گزیده به «$TMPDIR/gnucash.trace»; می‌تواند "
 "«stderr» یا «stdout» باشد."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/fi.po
+++ b/po/fi.po
@@ -10047,7 +10047,7 @@ msgstr "Näytä kuvaaja"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -11615,10 +11615,10 @@ msgstr "Afficher les chemins"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"Fichier de sortie du journal ; par défaut dans \"/tmp/gnucash.trace\" ; "
+"Fichier de sortie du journal ; par défaut dans \"$TMPDIR/gnucash.trace\" ; "
 "options possibles \"stderr\" ou \"stdout\"."
 
 # po/guile_strings.txt:221

--- a/po/gu.po
+++ b/po/gu.po
@@ -10560,10 +10560,10 @@ msgstr "પ્લોટ દર્શાવો"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"જેમાં લોગ કરવામાં આવશે તે ફાઈલ; \"/tmp/gnucash.trace\"માં ડિફોલ્ટ કરો; \"stderr\" કે "
+"જેમાં લોગ કરવામાં આવશે તે ફાઈલ; \"$TMPDIR/gnucash.trace\"માં ડિફોલ્ટ કરો; \"stderr\" કે "
 "\"stdout\" હોઈ શકે છે."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/he.po
+++ b/po/he.po
@@ -10216,10 +10216,10 @@ msgstr "הצגת נתיבים"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"קובץ יומן־רישום לכתיבה; ברירת המחדל היא ל־'‎/tmp/gnucash.trace'; האפשרויות הן "
+"קובץ יומן־רישום לכתיבה; ברירת המחדל היא ל־'‎$TMPDIR/gnucash.trace'; האפשרויות הן "
 "'stderr' או 'stdout'."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/hi.po
+++ b/po/hi.po
@@ -10467,10 +10467,10 @@ msgstr "प्लॉट दिखाएं "
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"वह फ़ाइल जिसमें लॉग किया जाना है; \"/tmp/gnucash.trace\"; में डिफॉल्ट \"stderr\" या "
+"वह फ़ाइल जिसमें लॉग किया जाना है; \"$TMPDIR/gnucash.trace\"; में डिफॉल्ट \"stderr\" या "
 "\"stdout\" हो सकता है."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/hr.po
+++ b/po/hr.po
@@ -10396,10 +10396,10 @@ msgstr "Prikaži staze"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"Datoteka za log-podatke; standardna datoteka je „/tmp/gnucash.trace“; može "
+"Datoteka za log-podatke; standardna datoteka je „$TMPDIR/gnucash.trace“; može "
 "biti „stderr“ ili „stdout“."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/hu.po
+++ b/po/hu.po
@@ -10566,9 +10566,9 @@ msgstr "Rajz megjelenítése"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
-msgstr "Log-fájl \"/tmp/gnucash.trace\"; lehet \"stderr\" vagy \"stdout\" is."
+msgstr "Log-fájl \"$TMPDIR/gnucash.trace\"; lehet \"stderr\" vagy \"stdout\" is."
 
 #: gnucash/gnucash-core-app.cpp:313
 #, fuzzy

--- a/po/id.po
+++ b/po/id.po
@@ -10418,10 +10418,10 @@ msgstr "Tampilkan path"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"Berkas untuk menyimpan log; berkas baku adalah \"/tmp/gnucash.trace\"; bisa "
+"Berkas untuk menyimpan log; berkas baku adalah \"$TMPDIR/gnucash.trace\"; bisa "
 "berupa \"stderr\" atau \"stdout\"."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/it.po
+++ b/po/it.po
@@ -10660,10 +10660,10 @@ msgstr "Visualizza percorsi"
 # linea di comando
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"File su cui registrare il log; predefinito: «/tmp/gnucash.trace»; può essere "
+"File su cui registrare il log; predefinito: «$TMPDIR/gnucash.trace»; può essere "
 "«stderr» or «stdout»."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/ja.po
+++ b/po/ja.po
@@ -10270,10 +10270,10 @@ msgstr "パスを表示する"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"ログを格納するファイル: デフォルトは \"/tmp/gnucash.trace\"。\"stderr\" ある"
+"ログを格納するファイル: デフォルトは \"$TMPDIR/gnucash.trace\"。\"stderr\" ある"
 "いは \"stdout\" を設定することも可能。"
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/kn.po
+++ b/po/kn.po
@@ -10553,10 +10553,10 @@ msgstr "ರೇಖಾನಕ್ಷೆಯನ್ನು ತೋರಿಸು"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"ದಾಖಲಿಸಬೇಕಿರುವ ಕಡತ; ಪೂರ್ವನಿಯೋಜಿತವು \"/tmp/gnucash.trace\" ಆಗಿರುತ್ತದೆ; \"stderr"
+"ದಾಖಲಿಸಬೇಕಿರುವ ಕಡತ; ಪೂರ್ವನಿಯೋಜಿತವು \"$TMPDIR/gnucash.trace\" ಆಗಿರುತ್ತದೆ; \"stderr"
 "\" ಅಥವ \"stdout\" ಆಗಿರಬಹುದು."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/ko.po
+++ b/po/ko.po
@@ -10202,10 +10202,10 @@ msgstr "파일 경로 표시하기"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"파일 로그의 기본값은 \"/tmp/gnucash.trace\"; \"stderr\" 또는 \"stdout\"이 될 "
+"파일 로그의 기본값은 \"$TMPDIR/gnucash.trace\"; \"stderr\" 또는 \"stdout\"이 될 "
 "수 있습니다."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/kok.po
+++ b/po/kok.po
@@ -10397,10 +10397,10 @@ msgstr "प्लॉट दाखयात"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"लॉग करपाक फायल; मूळाव्यान \"/tmp/gnucash.trace\"; \"stderr\" वो \"stdout\" "
+"लॉग करपाक फायल; मूळाव्यान \"$TMPDIR/gnucash.trace\"; \"stderr\" वो \"stdout\" "
 "आसपाक शकता."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/kok@latin.po
+++ b/po/kok@latin.po
@@ -10516,10 +10516,10 @@ msgstr "suvat dakhoi"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"log in korcheak fail kor; hankam default \"/tmp/gnucash.trace\";zanv ieta "
+"log in korcheak fail kor; hankam default \"$TMPDIR/gnucash.trace\";zanv ieta "
 "\"stderr\" or \"stdout\"."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/ks.po
+++ b/po/ks.po
@@ -10507,10 +10507,10 @@ msgstr "पुलाट हॊयीव"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"फायील यथ मंज़ लाग करुन छु; \"/tmp/gnucash.trace\"कुन डीफालट; हयीको \"stderr\" या "
+"फायील यथ मंज़ लाग करुन छु; \"$TMPDIR/gnucash.trace\"कुन डीफालट; हयीको \"stderr\" या "
 "\"stdout\" एिसीथ."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/lt.po
+++ b/po/lt.po
@@ -10564,10 +10564,10 @@ msgstr "Rodyti grafiką"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"Failas žurnalo rašymui; numatyta į „/tmp/gnucash.trace“; gali būti „stderr“ "
+"Failas žurnalo rašymui; numatyta į „$TMPDIR/gnucash.trace“; gali būti „stderr“ "
 "arba „stdout“."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/lv.po
+++ b/po/lv.po
@@ -10511,10 +10511,10 @@ msgstr "Rādīt skici"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"Fails, kurā žurnalēt; pēc noklusējuma \"/tmp/gnucash.trace\"; can be \"stderr"
+"Fails, kurā žurnalēt; pēc noklusējuma \"$TMPDIR/gnucash.trace\"; can be \"stderr"
 "\" or \"stdout\"."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/mai.po
+++ b/po/mai.po
@@ -10473,10 +10473,10 @@ msgstr "प्लाट देखाउ"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"ओ फाइल जकरामे लाग कएल जाएनाइ अछि; \"/tmp/gnucash.trace\"; मे पूर्वनिर्धारित "
+"ओ फाइल जकरामे लाग कएल जाएनाइ अछि; \"$TMPDIR/gnucash.trace\"; मे पूर्वनिर्धारित "
 "\"stderr\" अथवा \"stdout\" भ' सकैत अछि."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/mk.po
+++ b/po/mk.po
@@ -9835,7 +9835,7 @@ msgstr ""
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
 

--- a/po/mni.po
+++ b/po/mni.po
@@ -10444,10 +10444,10 @@ msgstr "ꯄ꯭ꯂꯣꯠ ꯎꯠꯂꯣ"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"ꯂꯣꯒ ꯇꯧꯅꯕ ꯐꯥꯏꯜ; \"/tmp/gnucash.trace\";ꯗꯤꯐꯣꯜꯠꯁ \"stderr\" ꯅꯇ꯭ꯔꯒ \"stdout\" ꯑꯣꯏꯕ "
+"ꯂꯣꯒ ꯇꯧꯅꯕ ꯐꯥꯏꯜ; \"$TMPDIR/gnucash.trace\";ꯗꯤꯐꯣꯜꯠꯁ \"stderr\" ꯅꯇ꯭ꯔꯒ \"stdout\" ꯑꯣꯏꯕ "
 "ꯌꯥꯏ."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/mni@bengali.po
+++ b/po/mni@bengali.po
@@ -10547,10 +10547,10 @@ msgstr "প্লোত উৎলো"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"লোগ তৌনবা ফাইল; \"/tmp/gnucash.trace\";দিফোল্তস \"stderr\" নত্রগা \"stdout\" "
+"লোগ তৌনবা ফাইল; \"$TMPDIR/gnucash.trace\";দিফোল্তস \"stderr\" নত্রগা \"stdout\" "
 "ওইবা য়াই."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/mr.po
+++ b/po/mr.po
@@ -10442,10 +10442,10 @@ msgstr "प्लॉट दाखवा"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"च्या मध्ये लॉग करण्यासाठी फाइल करा; डिफॉल्ट्स \"/tmp/gnucash.trace\" वर; \"stderr"
+"च्या मध्ये लॉग करण्यासाठी फाइल करा; डिफॉल्ट्स \"$TMPDIR/gnucash.trace\" वर; \"stderr"
 "\" or \"stdout\" असू शकते"
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/nb.po
+++ b/po/nb.po
@@ -10549,7 +10549,7 @@ msgstr "Vis plott"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
 

--- a/po/ne.po
+++ b/po/ne.po
@@ -10558,7 +10558,7 @@ msgstr "प्लट देखाउनुहोस्"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -10520,10 +10520,10 @@ msgstr "Grafiek weergeven"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"Bestand voor logmeldingen; standaard is “/tmp/gnucash.trace”; mag ook "
+"Bestand voor logmeldingen; standaard is “$TMPDIR/gnucash.trace”; mag ook "
 "“stderr” of “stdout” zijn."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/pl.po
+++ b/po/pl.po
@@ -10547,10 +10547,10 @@ msgstr "Pokaż ścieżki"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"Plik dziennika; domyślnie do \"/tmp/gnucash.trace\"; może być \"stderr\" lub "
+"Plik dziennika; domyślnie do \"$TMPDIR/gnucash.trace\"; może być \"stderr\" lub "
 "\"stdout\"."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/pt.po
+++ b/po/pt.po
@@ -10393,10 +10393,10 @@ msgstr "Mostrar caminhos"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"Ficheiro onde escrever; predefinido como \"/tmp/gnucash.trace\"; pode ser "
+"Ficheiro onde escrever; predefinido como \"$TMPDIR/gnucash.trace\"; pode ser "
 "\"stderr\" ou \"stdout\"."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -10466,7 +10466,7 @@ msgstr "Mostrar os caminhos"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
 "O arquivo para salvar o log; o padrão é \"/tmp/gnucash.strace\"; pode ser "

--- a/po/ro.po
+++ b/po/ro.po
@@ -10839,10 +10839,10 @@ msgstr "Arată graficul"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"Fișierul de autentificat; implicit \"/tmp/gnucash.trace\"; poate fi \"stderr"
+"Fișierul de autentificat; implicit \"$TMPDIR/gnucash.trace\"; poate fi \"stderr"
 "\" sau \"stdout\"."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/ru.po
+++ b/po/ru.po
@@ -10539,10 +10539,10 @@ msgstr "Показать график"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"Файл лога, по умолчанию это \"/tmp/gnucash.trace\", но возможно \"stderr\" "
+"Файл лога, по умолчанию это \"$TMPDIR/gnucash.trace\", но возможно \"stderr\" "
 "или \"stdout\"."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/rw.po
+++ b/po/rw.po
@@ -11261,7 +11261,7 @@ msgstr "Kwerekana imbonerahamwe"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
 

--- a/po/sk.po
+++ b/po/sk.po
@@ -10242,10 +10242,10 @@ msgstr "Ukázať zobrazenie"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"Súbor, do ktorého zaznamenávať; štandardne \"/tmp/gnucash.trace\"; môže byť "
+"Súbor, do ktorého zaznamenávať; štandardne \"$TMPDIR/gnucash.trace\"; môže byť "
 "\"stderr\" alebo \"stdout\"."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/sr.po
+++ b/po/sr.po
@@ -10541,10 +10541,10 @@ msgstr "Прикажи график"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"Датотека за дневник; основно је „/tmp/gnucash.trace“; може бити „stderr“ или "
+"Датотека за дневник; основно је „$TMPDIR/gnucash.trace“; може бити „stderr“ или "
 "„stdout“."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/sv.po
+++ b/po/sv.po
@@ -10407,10 +10407,10 @@ msgstr "Visa sökvägar"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"Fil att logga till; förval är \"/tmp/gnucash.trace\"; kan vara \"stderr\" "
+"Fil att logga till; förval är \"$TMPDIR/gnucash.trace\"; kan vara \"stderr\" "
 "eller \"stdout\"."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/ta.po
+++ b/po/ta.po
@@ -10502,10 +10502,10 @@ msgstr "பிளாட்டை காட்டு"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"பதிவு செய்ய வேண்டிய கோப்பு; \"/tmp/gnucash.trace\" முன்னிருப்புக்கு; \"stderr\" "
+"பதிவு செய்ய வேண்டிய கோப்பு; \"$TMPDIR/gnucash.trace\" முன்னிருப்புக்கு; \"stderr\" "
 "அல்லது \"stdout\" ஆக இருக்கலாம்."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/te.po
+++ b/po/te.po
@@ -10391,10 +10391,10 @@ msgstr "ప్లాట్‌ను చూపించు"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"\"/tmp/gnucash.trace\"; can be \"stderr\" or \"stdout\"కు అప్రమేయాలు; లోనికి "
+"\"$TMPDIR/gnucash.trace\"; can be \"stderr\" or \"stdout\"కు అప్రమేయాలు; లోనికి "
 "ప్రవేశించడానికి ఫైల్ చేయి"
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/tr.po
+++ b/po/tr.po
@@ -10485,10 +10485,10 @@ msgstr "Plan göster"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"Loglanacak dosya; varsayılan \"/tmp/gnucash.trace\"; \"stderr\" veya \"stdout"
+"Loglanacak dosya; varsayılan \"$TMPDIR/gnucash.trace\"; \"stderr\" veya \"stdout"
 "\" olabilir."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/uk.po
+++ b/po/uk.po
@@ -10505,10 +10505,10 @@ msgstr "Показати шляхи"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"Файл журналу; типово «/tmp/gnucash.trace»; можна вказувати «stderr» чи "
+"Файл журналу; типово «$TMPDIR/gnucash.trace»; можна вказувати «stderr» чи "
 "«stdout»."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/ur.po
+++ b/po/ur.po
@@ -10514,10 +10514,10 @@ msgstr "پلاٹ دكھاؤ"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"وہ فائل جس میں لاگ كیا جانا ہے ; \"/tmp/gnucash.trace\"; میں ڈیفالٹ \"stderr"
+"وہ فائل جس میں لاگ كیا جانا ہے ; \"$TMPDIR/gnucash.trace\"; میں ڈیفالٹ \"stderr"
 "\" یا \"stdout\" ہو سكتا ہے۔"
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/vi.po
+++ b/po/vi.po
@@ -10581,10 +10581,10 @@ msgstr "Hiện đồ thị"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"Tập tin vào đó cần ghi lưu, mặc định là « /tmp/gnucash.trace », cũng có thể "
+"Tập tin vào đó cần ghi lưu, mặc định là « $TMPDIR/gnucash.trace », cũng có thể "
 "là thiết bị lỗi chuẩn hay thiết bị xuất chuẩn."
 
 #: gnucash/gnucash-core-app.cpp:313

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -10088,10 +10088,10 @@ msgstr "显示路径"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"日志文件输出；默认为“/tmp/gnucash.trace”；可以修改为“stderr”或“stdout”。"
+"日志文件输出；默认为“$TMPDIR/gnucash.trace”；可以修改为“stderr”或“stdout”。"
 
 #: gnucash/gnucash-core-app.cpp:313
 msgid "Hidden Options"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -10151,10 +10151,10 @@ msgstr "顯示圖表"
 
 #: gnucash/gnucash-core-app.cpp:311
 msgid ""
-"File to log into; defaults to \"/tmp/gnucash.trace\"; can be \"stderr\" or "
+"File to log into; defaults to \"$TMPDIR/gnucash.trace\"; can be \"stderr\" or "
 "\"stdout\"."
 msgstr ""
-"日誌寫入的檔案；預為為 \"/tmp/gnucash.trace\"；可以是 \"stderr\" 或\"stdout"
+"日誌寫入的檔案；預為為 \"$TMPDIR/gnucash.trace\"；可以是 \"stderr\" 或\"stdout"
 "\"。"
 
 #: gnucash/gnucash-core-app.cpp:313


### PR DESCRIPTION
Used glib documentation as source of truth:
https://docs.gtk.org/glib/func.get_tmp_dir.html

Note that it is still not 100% accurate buecause on Windows the `TEMP` variable is used.

See also https://bugs.gnucash.org/show_bug.cgi?id=798768