### PR TITLE
Add blank transaction at the top - the last piece for 5.1

### DIFF
--- a/gnucash/gtkbuilder/dialog-preferences.glade
+++ b/gnucash/gtkbuilder/dialog-preferences.glade
@@ -2762,13 +2762,13 @@ many months before the current month</property>
                 </child>
                 <child>
                   <object class="GtkCheckButton" id="pref/general.register/future-after-blank-transaction">
-                    <property name="label" translatable="yes">_Future transactions after blank transaction</property>
+                    <property name="label" translatable="yes">_Placement of future transactions</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
                     <property name="has-tooltip">True</property>
-                    <property name="tooltip-markup">If checked, transactions with a date in the future will be displayed at the bottom of the register after the blank transaction. If clear, the blank transaction will be at the bottom of the register after all transactions.</property>
-                    <property name="tooltip-text" translatable="yes">If checked, transactions with a date in the future will be displayed at the bottom of the register after the blank transaction. If clear, the blank transaction will be at the bottom of the register after all transactions.</property>
+                    <property name="tooltip-markup">If checked, transactions with a date in the future will be displayed at the bottom of the register after the blank transaction unless in reverse sort order when they are displayed at the top before the blank transaction. If clear, the blank transaction will be at the bottom of the register after all transactions unless in reverse sort order when it will be at the top.</property>
+                    <property name="tooltip-text" translatable="yes">If checked, transactions with a date in the future will be displayed at the bottom of the register after the blank transaction unless in reverse sort order when they are displayed at the top before the blank transaction. If clear, the blank transaction will be at the bottom of the register after all transactions unless in reverse sort order when it will be at the top.</property>
                     <property name="halign">start</property>
                     <property name="use-underline">True</property>
                     <property name="draw-indicator">True</property>

--- a/gnucash/ui/gnc-plugin-page-register.ui
+++ b/gnucash/ui/gnc-plugin-page-register.ui
@@ -269,7 +269,7 @@
       <attribute name="label" translatable="yes">_Blank Transaction</attribute>
       <attribute name="action">GncPluginPageRegisterActions.BlankTransactionAction</attribute>
       <attribute name="accel">&lt;Primary&gt;b</attribute>
-      <attribute name="tooltip" translatable="yes">Move to the blank transaction at the bottom of the register</attribute>
+      <attribute name="tooltip" translatable="yes">Move to the blank transaction in the register</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
     <item>
@@ -411,7 +411,7 @@
       <item>
         <attribute name="label" translatable="yes">_Blank Transaction</attribute>
         <attribute name="action">GncPluginPageRegisterActions.BlankTransactionAction</attribute>
-        <attribute name="tooltip" translatable="yes">Move to the blank transaction at the bottom of the register</attribute>
+        <attribute name="tooltip" translatable="yes">Move to the blank transaction in the register</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">_Go to Date</attribute>
@@ -523,7 +523,7 @@
       <item>
         <attribute name="label" translatable="yes">_Blank Transaction</attribute>
         <attribute name="action">GncPluginPageRegisterActions.BlankTransactionAction</attribute>
-        <attribute name="tooltip" translatable="yes">Move to the blank transaction at the bottom of the register</attribute>
+        <attribute name="tooltip" translatable="yes">Move to the blank transaction in the register</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">_Go to Date</attribute>
@@ -602,7 +602,7 @@
       <item>
         <attribute name="label" translatable="yes">_Blank Transaction</attribute>
         <attribute name="action">GncPluginPageRegisterActions.BlankTransactionAction</attribute>
-        <attribute name="tooltip" translatable="yes">Move to the blank transaction at the bottom of the register</attribute>
+        <attribute name="tooltip" translatable="yes">Move to the blank transaction in the register</attribute>
       </item>
     </section>
   </menu>
@@ -641,7 +641,7 @@
       <item>
         <attribute name="label" translatable="yes">_Blank Transaction</attribute>
         <attribute name="action">GncPluginPageRegisterActions.BlankTransactionAction</attribute>
-        <attribute name="tooltip" translatable="yes">Move to the blank transaction at the bottom of the register</attribute>
+        <attribute name="tooltip" translatable="yes">Move to the blank transaction in the register</attribute>
       </item>
     </section>
   </menu>
@@ -801,7 +801,7 @@
         <property name="can-focus">False</property>
         <property name="label" translatable="yes">_Blank Transaction</property>
         <property name="action-name">GncPluginPageRegisterActions.BlankTransactionAction</property>
-        <property name="tooltip-text" translatable="yes">Move to the blank transaction at the bottom of the register</property>
+        <property name="tooltip-text" translatable="yes">Move to the blank transaction in the register</property>
         <property name="use-underline">True</property>
         <property name="icon-name">go-jump</property>
       </object>


### PR DESCRIPTION
This adds the blank transaction at the top of the register when in reverse sort order which I think makes sense and there may be a bug for it.

As part of this, the toolbar icon and keyboard short cut did not seem appropriate so have changed them to 'go-jump' and 'CNTRL-B', this can be changed if there is a better combination. This would then free up 'CNTRL+Page_Down' for tab navigation which I think there is also a bug report for but have not looked if other changes are needed for this.

Unfortunately I did not realise that the tool tip was so specific so that needed changing and subsequently found the preference 'Future transactions after blank transaction' would also need changing, might need some better tool tip text for that one.

I have tested this and all seems to work OK but would appreciate if some one else could give it a try.

So what to do...
This introduces another copy of the same block of code for the blank transaction, I will try and refactor that and maybe create a structure to pass all the function parameters.

The string changes will need to wait till after the freeze but could the rest be applied?
