### PR TITLE
Fix  CoreApp() constructor misuse

### DIFF
--- a/gnucash/gnucash-core-app.cpp
+++ b/gnucash/gnucash-core-app.cpp
@@ -167,7 +167,7 @@ gnc_log_init (const std::vector <std::string> log_flags,
     }
 }
 
-Gnucash::CoreApp::CoreApp ()
+Gnucash::CoreApp::CoreApp (const char* app_name) : m_app_name {app_name}
 {
     #ifdef ENABLE_BINRELOC
     {
@@ -210,14 +210,6 @@ Gnucash::CoreApp::CoreApp ()
     std::cerr.imbue (gnc_get_boost_locale());
     std::cout.imbue (gnc_get_boost_locale());
     g_free(localedir);
-}
-
-Gnucash::CoreApp::CoreApp (const char* app_name)
-{
-
-    CoreApp();
-
-    m_app_name = std::string(app_name);
 
     // Now that gettext is properly initialized, set our help tagline.
     m_tagline = _("- GnuCash, accounting for personal and small business finance");

--- a/gnucash/gnucash-core-app.hpp
+++ b/gnucash/gnucash-core-app.hpp
@@ -39,7 +39,6 @@ namespace bpo = boost::program_options;
 class CoreApp
 {
 public:
-    CoreApp ();
     CoreApp (const char* app_name);
 
     void parse_command_line (int argc, char **argv);


### PR DESCRIPTION
- spotted by [bugprone-undelegated-constructor] [bugprone-unused-raii]

gnucash/gnucash-core-app.cpp:218:5: warning: did you intend to call a delegated constructor? A temporary object is created here instead [bugprone-undelegated-constructor]
    CoreApp();
    ^
gnucash/gnucash-core-app.cpp:218:5: warning: object destroyed immediately after creation; did you mean to name the object? [bugprone-unused-raii]
    CoreApp();
    ^      ~~
            give_me_a_name