### PR TITLE
Remove redundant uses of cmake -E env

### DIFF
--- a/common/cmake_modules/GncAddGSchemaTargets.cmake
+++ b/common/cmake_modules/GncAddGSchemaTargets.cmake
@@ -12,8 +12,7 @@ macro(add_gschema_targets _gschema_INPUTS)
     list(APPEND _gschema_VALIDS ${_VALID_FILE})
     add_custom_command(
         OUTPUT ${_VALID_FILE}
-        COMMAND ${CMAKE_COMMAND} -E env
-          ${GLIB_COMPILE_SCHEMAS} --strict --dry-run --schema-file=${_OUTPUT_FILE}
+        COMMAND ${GLIB_COMPILE_SCHEMAS} --strict --dry-run --schema-file=${_OUTPUT_FILE}
         COMMAND ${CMAKE_COMMAND} -E touch ${_VALID_FILE}
         DEPENDS ${_OUTPUT_FILE}
     )

--- a/common/cmake_modules/GncAddTest.cmake
+++ b/common/cmake_modules/GncAddTest.cmake
@@ -84,9 +84,7 @@ function(gnc_add_test _TARGET _SOURCE_FILES TEST_INCLUDE_VAR_NAME TEST_LIBS_VAR_
   target_link_libraries(${_TARGET} ${TEST_LIBS})
   target_include_directories(${_TARGET} PRIVATE ${TEST_INCLUDE_DIRS})
   if (${HAVE_ENV_VARS})
-    add_test(${_TARGET} ${CMAKE_COMMAND} -E env "GNC_UNINSTALLED=YES;GNC_BUILDDIR=${CMAKE_BINARY_DIR};${ARGN}"
-      ${CMAKE_BINARY_DIR}/bin/${_TARGET}
-    )
+    add_test(${_TARGET} ${CMAKE_BINARY_DIR}/bin/${_TARGET})
     set_tests_properties(${_TARGET} PROPERTIES ENVIRONMENT "GNC_UNINSTALLED=YES;GNC_BUILDDIR=${CMAKE_BINARY_DIR};${ARGN}")
   else()
     if (CMAKE_GENERATOR STREQUAL Xcode)
@@ -108,8 +106,7 @@ endfunction()
 
 
 function(gnc_add_scheme_test _TARGET _SOURCE_FILE)
-  add_test(${_TARGET} ${CMAKE_COMMAND} -E env
-    ${GUILE_EXECUTABLE} --debug -c "
+  add_test(${_TARGET} ${GUILE_EXECUTABLE} --debug -c "
     (set! %load-hook
           (lambda (filename)
             (when (and filename

--- a/common/cmake_modules/MakeDist.cmake
+++ b/common/cmake_modules/MakeDist.cmake
@@ -63,7 +63,7 @@ function(make_dist PACKAGE_PREFIX GNUCASH_SOURCE_DIR BUILD_SOURCE_DIR BUILDING_F
         COMMAND ${CMAKE_COMMAND} -E copy ${PACKAGE_PREFIX}.tar ${PACKAGE_PREFIX}.tar.save
     )
     execute_process_and_check_result(
-            COMMAND ${CMAKE_COMMAND} -E env gzip -f ${PACKAGE_PREFIX}.tar
+            COMMAND gzip -f ${PACKAGE_PREFIX}.tar
             WORKING_DIRECTORY .
             ERROR_MSG "gzip command to create ${PACKAGE_PREFIX}.tar.gz failed."
     )
@@ -73,7 +73,7 @@ function(make_dist PACKAGE_PREFIX GNUCASH_SOURCE_DIR BUILD_SOURCE_DIR BUILDING_F
         COMMAND ${CMAKE_COMMAND} -E rename ${PACKAGE_PREFIX}.tar.save ${PACKAGE_PREFIX}.tar
     )
     execute_process_and_check_result(
-            COMMAND ${CMAKE_COMMAND} -E env bzip2 -f ${PACKAGE_PREFIX}.tar
+            COMMAND bzip2 -f ${PACKAGE_PREFIX}.tar
             WORKING_DIRECTORY .
             ERROR_MSG "bzip2 command to create ${PACKAGE_PREFIX}.tar.bz2 failed."
     )

--- a/common/cmake_modules/MakeDistCheck.cmake
+++ b/common/cmake_modules/MakeDistCheck.cmake
@@ -54,28 +54,28 @@ function(run_dist_check PACKAGE_PREFIX EXT)
 
     # Run ninja in the build directory
     execute_process_and_check_result(
-            COMMAND ${CMAKE_COMMAND} -E env ${NINJA_COMMAND}
+            COMMAND ${NINJA_COMMAND}
             WORKING_DIRECTORY ${BUILD_DIR}
             ERROR_MSG "Ninja build failed."
     )
 
     # Run ninja install
     execute_process_and_check_result(
-            COMMAND ${CMAKE_COMMAND} -E env ${NINJA_COMMAND} install
+            COMMAND ${NINJA_COMMAND} install
             WORKING_DIRECTORY ${BUILD_DIR}
             ERROR_MSG "Ninja install failed."
     )
 
     # Run ninja check in the build directory
     execute_process_and_check_result(
-            COMMAND ${CMAKE_COMMAND} -E env ${NINJA_COMMAND} check
+            COMMAND ${NINJA_COMMAND} check
             WORKING_DIRECTORY ${BUILD_DIR}
             ERROR_MSG "Ninja check failed."
     )
 
     # Run ninja dist
     execute_process_and_check_result(
-            COMMAND ${CMAKE_COMMAND} -E env ${NINJA_COMMAND} dist
+            COMMAND ${NINJA_COMMAND} dist
             WORKING_DIRECTORY ${BUILD_DIR}
             ERROR_MSG "Ninja dist failed."
     )

--- a/gnucash/gnome/CMakeLists.txt
+++ b/gnucash/gnome/CMakeLists.txt
@@ -180,8 +180,7 @@ if (NOT BUILDING_FROM_VCS)
 else()
     add_custom_command (
         OUTPUT ${GNC_APPDATA_IN}
-        COMMAND ${CMAKE_COMMAND} -E env
-            ${GETTEXT_MSGFMT_EXECUTABLE}
+        COMMAND ${GETTEXT_MSGFMT_EXECUTABLE}
                 --xml --template ${CMAKE_CURRENT_SOURCE_DIR}/gnucash.appdata.xml.in.in
                 -d ${CMAKE_SOURCE_DIR}/po
                 -o ${GNC_APPDATA_IN}

--- a/gnucash/gschemas/CMakeLists.txt
+++ b/gnucash/gschemas/CMakeLists.txt
@@ -44,7 +44,7 @@ if (COMPILE_GSCHEMAS)
 
     add_custom_command(
         OUTPUT ${SCHEMADIR_BUILD}/gschemas.compiled
-        COMMAND ${CMAKE_COMMAND} -E env ${GLIB_COMPILE_SCHEMAS} --strict ${SCHEMADIR_BUILD}
+        COMMAND ${GLIB_COMPILE_SCHEMAS} --strict ${SCHEMADIR_BUILD}
         DEPENDS ${gschema_depends}
     )
 

--- a/libgnucash/backend/xml/test/CMakeLists.txt
+++ b/libgnucash/backend/xml/test/CMakeLists.txt
@@ -94,8 +94,7 @@ set(test-real-data-env
   TEST_PATH=${CMAKE_BINARY_DIR}/bin
 )
 add_test(NAME test-real-data
-   COMMAND ${CMAKE_COMMAND} -E env
-    ${SHELL} ${CMAKE_CURRENT_SOURCE_DIR}/test-real-data.sh
+   COMMAND ${SHELL} ${CMAKE_CURRENT_SOURCE_DIR}/test-real-data.sh
    CONFIGURATIONS Debug;Release
 )
 set_tests_properties(test-real-data PROPERTIES ENVIRONMENT "${test-real-data-env}")

--- a/libgnucash/quotes/CMakeLists.txt
+++ b/libgnucash/quotes/CMakeLists.txt
@@ -15,7 +15,7 @@ foreach(file finance-quote-wrapper)
   list(APPEND _MAN_FILES ${_MAN_OUTPUT})
   add_custom_command(
       OUTPUT ${_MAN_OUTPUT}
-      COMMAND ${CMAKE_COMMAND} -E env ${PERL_EXECUTABLE} ${POD2MAN_EXECUTABLE} ${_POD_INPUT} ${_MAN_OUTPUT}
+      COMMAND ${PERL_EXECUTABLE} ${POD2MAN_EXECUTABLE} ${_POD_INPUT} ${_MAN_OUTPUT}
       DEPENDS ${_POD_INPUT}
   )
 endforeach(file)

--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -19,8 +19,7 @@ foreach (lingua ${ALL_LINGUAS})
 
   add_custom_command(
       OUTPUT ${_MO_FILE}
-      COMMAND ${CMAKE_COMMAND} -E env
-        ${GETTEXT_MSGFMT_EXECUTABLE}
+      COMMAND ${GETTEXT_MSGFMT_EXECUTABLE}
             -o ${_MO_FILE} ${CMAKE_CURRENT_SOURCE_DIR}/${lingua}.po
       DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${lingua}.po
   )


### PR DESCRIPTION
- In GncAddTest, set_tests_properties() is already setting the env
- In the other uses, there is no change to the environment