### PR TITLE
Push -Wno-error=deprecated-declarations from C*_FLAGS down to the target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -591,13 +591,11 @@ set(CMAKE_C_EXTENSIONS ON)
 
 if (UNIX)
   set( CMAKE_C_FLAGS "-Werror -Wall -Wmissing-prototypes -Wmissing-declarations ${CMAKE_C_FLAGS}")
-  set( CMAKE_C_FLAGS "-Wno-error=deprecated-declarations ${CMAKE_C_FLAGS}")
   set( CMAKE_CXX_FLAGS "-Werror -Wall -Wmissing-declarations ${CMAKE_CXX_FLAGS}")
-  set( CMAKE_CXX_FLAGS "-Wno-error=deprecated-declarations ${CMAKE_CXX_FLAGS}")
   set( CMAKE_C_FLAGS_RELEASE "-O3 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 ${CMAKE_C_FLAGS}")
 endif()
 if (MINGW)
-  set( CMAKE_C_FLAGS "-Werror -Wall -Wmissing-prototypes -Wmissing-declarations -Wno-error=deprecated-declarations ${CMAKE_C_FLAGS}")
+  set( CMAKE_C_FLAGS "-Werror -Wall -Wmissing-prototypes -Wmissing-declarations ${CMAKE_C_FLAGS}")
   set( CMAKE_CXX_FLAGS "-DWINVER=0x0500 -D_EMULATE_GLIBC=0 ${CMAKE_CXX_FLAGS}") # Workaround for bug in gtest on mingw, see https://github.com/google/googletest/issues/893 and https://github.com/google/googletest/issues/920
 endif()
 

--- a/gnucash/gnome-utils/gnc-keyring.c
+++ b/gnucash/gnome-utils/gnc-keyring.c
@@ -37,6 +37,8 @@
 #include <Security/Security.h>
 #include <CoreFoundation/CoreFoundation.h>
 #include <Carbon/Carbon.h>
+// SecKeychain* are deprecated
+#pragma GCC diagnostic warning "-Wdeprecated-declarations"
 #endif
 
 /* This static indicates the debugging module that this .o belongs to. */

--- a/libgnucash/backend/xml/gnc-xml-backend.cpp
+++ b/libgnucash/backend/xml/gnc-xml-backend.cpp
@@ -372,12 +372,17 @@ GncXmlBackend::write_to_file (bool make_backup)
     strcpy (tmp_name, m_fullpath.c_str());
     strcat (tmp_name, ".tmp-XXXXXX");
 
-    /* Clang static analyzer flags this as a security risk, which is
+    /* Clang static analyzer and GNU ld flag mktemp as a security risk, which is
      * theoretically true, but we can't use mkstemp because we need to
      * open the file ourselves because of compression. None of the alternatives
      * is any more secure.
+     *
+     * Xcode marks mktemp as deprecated
      */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wdeprecated-declarations"
     if (!mktemp (tmp_name))
+#pragma GCC diagnostic pop
     {
         g_free (tmp_name);
         set_error(ERR_BACKEND_MISC);


### PR DESCRIPTION
- Apple Xcode deprecates SecKeychain* and mktemp
- ~~Leave mingw - it uses guile2~~
- mingw no longer needs it, according to the build logs at
  https://code.gnucash.org/builds/win32/build-logs/master