### PR TITLE
File/Open should default to *.gnucash files only

### DIFF
--- a/gnucash/gnome-utils/dialog-file-access.c
+++ b/gnucash/gnome-utils/dialog-file-access.c
@@ -22,6 +22,7 @@
  * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
 \********************************************************************/
 
+#include <stdbool.h>
 #include <config.h>
 
 #include <gtk/gtk.h>
@@ -33,6 +34,7 @@
 #include "dialog-utils.h"
 #include "dialog-file-access.h"
 #include "gnc-file.h"
+#include "gnc-filepath-utils.h"
 #include "gnc-plugin-file-history.h"
 #include "gnc-session.h"
 
@@ -243,6 +245,15 @@ get_default_database( void )
     return default_db;
 }
 
+typedef bool (*CharToBool)(const char*);
+
+static bool datafile_filter (const GtkFileFilterInfo* filter_info,
+                             CharToBool filename_checker)
+{
+    return filter_info && filter_info->filename &&
+        filename_checker (filter_info->filename);
+}
+
 static void free_file_access_window (FileAccessWindow *faw)
 {
     g_free (faw->starting_dir);
@@ -339,6 +350,31 @@ gnc_ui_file_access (GtkWindow *parent, int type)
     fileChooser = GTK_FILE_CHOOSER_WIDGET(gtk_file_chooser_widget_new( fileChooserAction ));
     faw->fileChooser = GTK_FILE_CHOOSER(fileChooser);
     gtk_box_pack_start( GTK_BOX(file_chooser), GTK_WIDGET(fileChooser), TRUE, TRUE, 6 );
+
+    /* set up .gnucash filters for Datafile operations */
+    GtkFileFilter *filter = gtk_file_filter_new ();
+    gtk_file_filter_set_name (filter, _("All files"));
+    gtk_file_filter_add_pattern (filter, "*");
+    gtk_file_chooser_add_filter (faw->fileChooser, filter);
+
+    filter = gtk_file_filter_new ();
+    /* Translators: *.gnucash and *.xac are file patterns and must not
+       be translated*/
+    gtk_file_filter_set_name (filter, _("Datafiles only (*.gnucash, *.xac)"));
+    gtk_file_filter_add_custom (filter, GTK_FILE_FILTER_FILENAME,
+                                (GtkFileFilterFunc)datafile_filter,
+                                gnc_filename_is_datafile, NULL);
+    gtk_file_chooser_add_filter (faw->fileChooser, filter);
+    gtk_file_chooser_set_filter (faw->fileChooser, filter);
+
+    filter = gtk_file_filter_new ();
+    /* Translators: *.gnucash.*.gnucash, *.xac.*.xac are file
+       patterns and must not be translated*/
+    gtk_file_filter_set_name (filter, _("Backups only (*.gnucash.*.gnucash, *.xac.*.xac)"));
+    gtk_file_filter_add_custom (filter, GTK_FILE_FILTER_FILENAME,
+                                (GtkFileFilterFunc)datafile_filter,
+                                gnc_filename_is_backup, NULL);
+    gtk_file_chooser_add_filter (faw->fileChooser, filter);
 
     /* Set the default directory */
     if (type == FILE_ACCESS_OPEN || type == FILE_ACCESS_SAVE_AS)

--- a/libgnucash/core-utils/gnc-filepath-utils.cpp
+++ b/libgnucash/core-utils/gnc-filepath-utils.cpp
@@ -66,6 +66,7 @@
 #include "gnc-locale-utils.hpp"
 #include <boost/filesystem.hpp>
 #include <boost/locale.hpp>
+#include <regex>
 #include <iostream>
 #include <numeric>
 
@@ -1324,6 +1325,23 @@ gnc_list_all_paths (void)
         return g_list_prepend (a, ep);
     };
     return std::accumulate (paths.rbegin(), paths.rend(), (GList*) nullptr, accum);
+}
+
+static const std::regex
+backup_regex (".*[.](?:xac|gnucash)[.][0-9]{14}[.](?:xac|gnucash)$");
+
+gboolean gnc_filename_is_backup (const char *filename)
+{
+    return std::regex_match (filename, backup_regex);
+}
+
+static const std::regex
+datafile_regex (".*[.](?:xac|gnucash)$");
+
+gboolean gnc_filename_is_datafile (const char *filename)
+{
+    return !gnc_filename_is_backup (filename) &&
+        std::regex_match (filename, datafile_regex);
 }
 
 /* =============================== END OF FILE ========================== */

--- a/libgnucash/core-utils/gnc-filepath-utils.h
+++ b/libgnucash/core-utils/gnc-filepath-utils.h
@@ -194,6 +194,10 @@ typedef struct
  */
 GList *gnc_list_all_paths (void);
 
+gboolean gnc_filename_is_backup (const char *filename);
+
+gboolean gnc_filename_is_datafile (const char *filename);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libgnucash/core-utils/test/gtest-path-utilities.cpp
+++ b/libgnucash/core-utils/test/gtest-path-utilities.cpp
@@ -121,3 +121,14 @@ TEST_F(PathTest, gnc_path_get_sysconfdir)
     g_free(sysconfpath);
 #endif
 }
+
+TEST_F (PathTest, gnc_filename_is_backup)
+{
+    EXPECT_EQ (gnc_filename_is_backup (""), false);
+    EXPECT_EQ (gnc_filename_is_backup ("a.gnucash"), false);
+    EXPECT_EQ (gnc_filename_is_backup ("a.gnucash.20201131010203.gnucash"), true);
+
+    EXPECT_EQ (gnc_filename_is_datafile (""), false);
+    EXPECT_EQ (gnc_filename_is_datafile ("a.gnucash"), true);
+    EXPECT_EQ (gnc_filename_is_datafile ("a.gnucash.20201131010203.gnucash"), false);
+}


### PR DESCRIPTION
Why should File/Open show all `*.*` files initially? Limit to `*.gnucash` and exclude `*.gnucash.*.gnucash` files