### PR TITLE
Bug 798570 - Totals for the income, expenses and remaining to budget incorrect for one specific date

### DIFF
--- a/gnucash/gnome/gnc-budget-view.c
+++ b/gnucash/gnome/gnc-budget-view.c
@@ -1547,11 +1547,13 @@ The function will step through to only display the columns that are set
 void
 gnc_budget_view_refresh (GncBudgetView *budget_view)
 {
-	// Column identifiers
-	const gint GNC_BUDGET_VIEW_CODE_COL = 1;
-	const gint GNC_BUDGET_VIEW_DESC_COL = 2;
-	const gint GNC_BUDGET_VIEW_START_PERIODS_COL = 3;
-	// The Totals column will be after the periods columns.
+    // Column identifiers
+    enum {
+        code_column         = 1,
+        description_column  = 2,
+        startPeriods_column = 3
+        // The Totals column will be after the periods columns.
+    };
 
     GncBudgetViewPrivate *priv;
     gint num_periods;
@@ -1595,13 +1597,13 @@ gnc_budget_view_refresh (GncBudgetView *budget_view)
     // set visibility of the account code columns
     code_col = gnc_tree_view_find_column_by_name (GNC_TREE_VIEW(priv->tree_view), "account-code");
     gtk_tree_view_column_set_visible (code_col, priv->show_account_code);
-    code_col = gtk_tree_view_get_column (GTK_TREE_VIEW(priv->totals_tree_view), GNC_BUDGET_VIEW_CODE_COL);
+    code_col = gtk_tree_view_get_column (GTK_TREE_VIEW(priv->totals_tree_view), code_column);
     gtk_tree_view_column_set_visible (code_col, priv->show_account_code);
 
     // set visibility of the account description columns
     desc_col = gnc_tree_view_find_column_by_name (GNC_TREE_VIEW(priv->tree_view), "description");
     gtk_tree_view_column_set_visible (desc_col, priv->show_account_desc);
-    desc_col = gtk_tree_view_get_column (GTK_TREE_VIEW(priv->totals_tree_view), GNC_BUDGET_VIEW_DESC_COL);
+    desc_col = gtk_tree_view_get_column (GTK_TREE_VIEW(priv->totals_tree_view), description_column);
     gtk_tree_view_column_set_visible (desc_col, priv->show_account_desc);
 
     /* If we're creating new columns to be appended to already existing
@@ -1614,7 +1616,7 @@ gnc_budget_view_refresh (GncBudgetView *budget_view)
         gtk_tree_view_remove_column (GTK_TREE_VIEW(priv->tree_view), col);
         priv->total_col = NULL;
         col = gtk_tree_view_get_column (GTK_TREE_VIEW(priv->totals_tree_view),
-        		GNC_BUDGET_VIEW_START_PERIODS_COL + num_periods_visible);
+        	startPeriods_column + num_periods_visible);
         gtk_tree_view_remove_column (GTK_TREE_VIEW(priv->totals_tree_view), col);
     }
 

--- a/gnucash/gnome/gnc-budget-view.c
+++ b/gnucash/gnome/gnc-budget-view.c
@@ -1547,6 +1547,12 @@ The function will step through to only display the columns that are set
 void
 gnc_budget_view_refresh (GncBudgetView *budget_view)
 {
+	// Column identifiers
+	const gint GNC_BUDGET_VIEW_CODE_COL = 1;
+	const gint GNC_BUDGET_VIEW_DESC_COL = 2;
+	const gint GNC_BUDGET_VIEW_START_PERIODS_COL = 3;
+	// The Totals column will be after the periods columns.
+
     GncBudgetViewPrivate *priv;
     gint num_periods;
     gint num_periods_visible;
@@ -1589,13 +1595,13 @@ gnc_budget_view_refresh (GncBudgetView *budget_view)
     // set visibility of the account code columns
     code_col = gnc_tree_view_find_column_by_name (GNC_TREE_VIEW(priv->tree_view), "account-code");
     gtk_tree_view_column_set_visible (code_col, priv->show_account_code);
-    code_col = gtk_tree_view_get_column (GTK_TREE_VIEW(priv->totals_tree_view), 1);
+    code_col = gtk_tree_view_get_column (GTK_TREE_VIEW(priv->totals_tree_view), GNC_BUDGET_VIEW_CODE_COL);
     gtk_tree_view_column_set_visible (code_col, priv->show_account_code);
 
     // set visibility of the account description columns
     desc_col = gnc_tree_view_find_column_by_name (GNC_TREE_VIEW(priv->tree_view), "description");
     gtk_tree_view_column_set_visible (desc_col, priv->show_account_desc);
-    desc_col = gtk_tree_view_get_column (GTK_TREE_VIEW(priv->totals_tree_view), 2);
+    desc_col = gtk_tree_view_get_column (GTK_TREE_VIEW(priv->totals_tree_view), GNC_BUDGET_VIEW_DESC_COL);
     gtk_tree_view_column_set_visible (desc_col, priv->show_account_desc);
 
     /* If we're creating new columns to be appended to already existing
@@ -1607,7 +1613,8 @@ gnc_budget_view_refresh (GncBudgetView *budget_view)
         col = priv->total_col;
         gtk_tree_view_remove_column (GTK_TREE_VIEW(priv->tree_view), col);
         priv->total_col = NULL;
-        col = gtk_tree_view_get_column (GTK_TREE_VIEW(priv->totals_tree_view), num_periods_visible + 1);
+        col = gtk_tree_view_get_column (GTK_TREE_VIEW(priv->totals_tree_view),
+        		GNC_BUDGET_VIEW_START_PERIODS_COL + num_periods_visible);
         gtk_tree_view_remove_column (GTK_TREE_VIEW(priv->totals_tree_view), col);
     }
 


### PR DESCRIPTION
https://bugs.gnucash.org/show_bug.cgi?id=798570

In a budget, if you increase the number of periods (ex. from 12 months to 26 fortnights), the code attempts to delete the "totals column" (the last column which shows totals for the entire budget), then add the extra columns and then add the totals column back.  When deleting the totals column in the "totals row" (the bottom rows which show totals for each period), the wrong column was being deleted.  The "totals column" would remain which displays the entire budget totals instead of just the given period, then columns added and a second "totals column" was added.  Calculating the column to delete was not taking into account the 2 hidden by default columns (code and description).