### PR TITLE
Bug 765920 - Running balance on report is not accurate when report is sorted in in different ways.

### DIFF
--- a/gnucash/report/reports/standard/test/test-transaction.scm
+++ b/gnucash/report/reports/standard/test/test-transaction.scm
@@ -477,7 +477,7 @@
        (lambda (name)
          (set-option! options "Display" name #f))
        (list "Date" "Reconciled Date" "Num" "Description" "Memo" "Notes"
-             "Account Name" "Other Account Name" "Shares" "Price" "Running Balance"
+             "Account Name" "Other Account Name" "Shares" "Price" "Account Balance"
              "Totals"))
       (let ((sxml (options->sxml options "all columns off")))
         (test-assert "all display columns off, except amount and subtotals are enabled, there should be 2 columns"
@@ -535,12 +535,12 @@
        (lambda (name)
          (set-option! options "Display" name #t))
        (list "Date" "Reconciled Date" "Num" "Description" "Memo" "Notes"
-             "Account Name" "Other Account Name" "Shares" "Price" "Running Balance"
+             "Account Name" "Other Account Name" "Shares" "Price" "Account Balance"
              "Totals" "Use Full Other Account Name" "Use Full Account Name"))
       (let* ((sxml (options->sxml options "all columns on")))
         (test-equal "all display columns on, displays correct columns"
           (list "Date" "Reconciled Date" "Num" "Description" "Memo/Notes" "Account"
-                "Transfer from/to" "Shares" "Price" "Amount" "Running Balance")
+                "Transfer from/to" "Shares" "Price" "Amount" "Account Balance")
           (get-row-col sxml 0 #f))
         (test-assert "reconciled dates must be 01/03/70 or whitespace"
           (and-map
@@ -679,6 +679,27 @@
         (test-equal "dual amount column, first transaction correct"
           (list "$103 income" "Root.Asset.Bank" "$103.00" "$103.00")
           (cdr (get-row-col sxml 1 #f))))
+
+      ;; test account balance displayed as running balance
+      (set! options (default-testing-options))
+      (set-option! options "Display" "Account Balance" #t)
+      (let* ((sxml (options->sxml options "running balance, default options")))
+        (test-equal "running balance, default sort"
+          (list "Date" "Num" "Description" "Memo/Notes" "Account" "Amount" "Running Balance")
+          (get-row-col sxml 0 #f))
+        (test-equal "running balance, showing Balance b/f"
+          (list "Bank: Balance b/f" "-$99.00")
+          (get-row-col sxml 1 #f)))
+
+      (set-option! options "Sorting" "Primary Key" 'account-code)
+      (set-option! options "Sorting" "Secondary Key" 'date)
+      (let* ((sxml (options->sxml options "running balance, primary sort by account code, secondary sort by date")))
+        (test-equal "running balance, secondary sort by date"
+          (list "Date" "Num" "Description" "Memo/Notes" "Account" "Amount" "Running Balance")
+          (get-row-col sxml 0 #f))
+        (test-equal "running balance, showing Balance b/f"
+          (list "Bank: Balance b/f" "-$99.00")
+          (get-row-col sxml 1 #f)))
       )
 
     (test-end "display options")

--- a/libgnucash/engine/gnc-optiondb.cpp
+++ b/libgnucash/engine/gnc-optiondb.cpp
@@ -115,6 +115,8 @@ const OptionAliases Aliases::c_option_aliases
     // ... replaced to …, Dec 2022
     {"Filter By...", {nullptr, "Filter By…"}},
     {"Specify date to filter by...", {nullptr, "Specify date to filter by…"}},
+    // trep-engine:
+    {"Running Balance", {nullptr, "Account Balance"}},
 };
 
 static bool


### PR DESCRIPTION
### Summary:
- Renamed option to "Account Balance at Transaction" to avoid confusion with running total.
- Added helper function to ensure running balance and balance forward are only shown when transaction are grouped by account and sorted as in register. In that case column heading remains "Running Balance" and balance forward is shown. Otherwwise column heading is renamed "Account Balance" and balance forward is not shown.
- Also added missing code for Common Currency conversion.

### More details:
This bug relates to the running account balance option being available and rendered even when the transactions selected and sort order do not allow for a coherent running account balance pulled from the underlying account, including a balance forward amount shown at the top, before the first transaction on the account. The resulting “running balance” is very confusing as the numbers do not actually add up from one line to the next.

A running balance pulled from the underlying account should only be shown when most of the report defaults are maintained. A new helper function in this PR ensures this is the case based on the following criteria:

- The primary sort is set to account name (as per default) or account code (which only works if unique codes are used for each account, otherwise the result is still nonsensical and the current fix does not check that)
- The primary subtotals are displayed (as per default) so the accounts are listed separately with a break between them.
- The secondary sort is set to register order (as per default) or date ascending to match the transaction order on the underlying account. Date ascending is allowed to offer a secondary date grouping subtotal which is compatible with the running balance.
- Detail level is set to “one transaction per line” (as per default). If “one split per line” is selected, the account balance is pulled from the corresponding account every 2 lines, hence breaking up the running balance.
- Date filter is set to date posted (as per default). The code that fetches the balance forward needs a transaction start date for the report which the other date filter options cannot provide.
- Filtering on transactions is kept as per default. Filtering on account is fine. Because closing transactions are excluded by default, we are not excluding that option. However, if closing transactions are present (and not shown as per default) then the running balance will jump back to zero as it crosses the (hidden) closing transaction threshold. 

In an earlier PR #1460 , it was discussed to possibly ONLY make the running balance option available in the options when relevant as per above. However one challenge is the disabling (graying) of the option in the option dialog. Because so many underlying options trigger the unavailability of the running balance, and because the code disabling options has to be triggered from each of the other options causing it to be unavailable, it creates a lot of additional code to write and maintain, including converting several simple options that currently have no triggering functions to more complex ones. It seems like a lot of code to maintain for such a side issue.

An alternative proposed at the time avoid that problem. The option (in the dialog) is renamed from “Running Balance” to “Account Balance at Transaction”. However, when the account balance is in fact running (as per the criteria above), the column heading is kept as “Running Balance” and the balance forward is shown. When the balance is not running (as per the criteria above) then the column heading is shown as “Account Balance”.

The renaming also clarifies a related issue. Some users that have commented on the bug report appear think this feature is meant to creates a running total based on the report transactions. The renaming to “Account Balance at Transaction” makes it less likely this will be confused with a running total. A running total feature would be useful however, and I will be submitting a PR later on with a running total enhancement that will implement that feature, separately from this PR.

Finally this PR also adds missing code related to Common Currency conversion for the Account Balance. 
