### PR TITLE
Update subdir location for backend libraries

### DIFF
--- a/libgnucash/backend/xml/gnc-xml-backend.cpp
+++ b/libgnucash/backend/xml/gnc-xml-backend.cpp
@@ -297,7 +297,7 @@ GncXmlBackend::load(QofBook* book, QofBackendLoadType loadType)
 void
 GncXmlBackend::sync(QofBook* book)
 {
-        /* We make an important assumption here, that we might want to change
+    /* We make an important assumption here, that we might want to change
      * in the future: when the user says 'save', we really save the one,
      * the only, the current open book, and nothing else. In any case the plans
      * for multiple books have been removed in the meantime and there is just one
@@ -652,7 +652,7 @@ GncXmlBackend::get_file_lock (SessionOpenMode mode)
         case EEXIST:
             be_err = ERR_BACKEND_LOCKED;
             break;
-        default: 
+        default:
             PWARN ("Unable to create the lockfile %s: %s",
                    m_lockfile.c_str(), strerror(errno));
             set_message("Lockfile creation failed. Please see the tracefile for details.");

--- a/libgnucash/engine/gnc-engine.c
+++ b/libgnucash/engine/gnc-engine.c
@@ -74,9 +74,9 @@ gnc_engine_init_part2()
     } libs[] =
     {
 #if defined( HAVE_DBI_DBI_H )
-        { "", "gncmod-backend-dbi", TRUE },
+        { "gnucash", "gncmod-backend-dbi", TRUE },
 #endif
-        { "", "gncmod-backend-xml", TRUE },
+        { "gnucash", "gncmod-backend-xml", TRUE },
         { NULL, NULL, FALSE }
     }, *lib;
 


### PR DESCRIPTION
gnucash version 5 branch changed the location of module libraries
inside CMakeFile.txt
Let's adopt to make the linker happy again.