### PR TITLE
Chart Y axis scaling can cause some bar charts to become misleading

### DIFF
--- a/gnucash/report/html-chart.scm
+++ b/gnucash/report/html-chart.scm
@@ -64,6 +64,7 @@
 (export gnc:html-chart-set-stacking?!)
 (export gnc:html-chart-set-grid?!)
 (export gnc:html-chart-set-y-axis-label!)
+(export gnc:html-chart-set-y-axis-begin-at-zero!)
 (export gnc:html-chart-add-data-series!)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -331,6 +332,9 @@
 
 (define (gnc:html-chart-set-y-axis-label! chart label)
   (gnc:html-chart-set! chart '(options scales yAxes (0) scaleLabel labelString) label))
+
+(define (gnc:html-chart-set-y-axis-begin-at-zero! chart yzero?)
+  (gnc:html-chart-set! chart '(options scales yAxes (0) ticks beginAtZero) yzero?))
 
 (define (gnc:html-chart-get chart path)
   (let ((options (gnc:html-chart-get-options-internal chart)))

--- a/gnucash/report/reports/standard/cashflow-barchart.scm
+++ b/gnucash/report/reports/standard/cashflow-barchart.scm
@@ -263,6 +263,7 @@
           (gnc:html-chart-set-height! chart height)
           (gnc:html-chart-set-y-axis-label!
            chart (gnc-commodity-get-mnemonic report-currency))
+          (gnc:html-chart-set-y-axis-begin-at-zero! chart #t)
           (gnc:html-chart-set-currency-iso!
            chart (gnc-commodity-get-mnemonic report-currency))
           (gnc:html-chart-set-currency-symbol!

--- a/gnucash/report/reports/standard/net-charts.scm
+++ b/gnucash/report/reports/standard/net-charts.scm
@@ -318,6 +318,7 @@
                             (qof-print-date to-date-t64))))
        (gnc:html-chart-set-y-axis-label!
         chart (gnc-commodity-get-mnemonic report-currency))
+       (gnc:html-chart-set-y-axis-begin-at-zero! chart (not linechart?))
        (gnc:html-chart-set-grid?! chart y-grid)
        (gnc:html-chart-set-currency-iso!
         chart (gnc-commodity-get-mnemonic report-currency))


### PR DESCRIPTION
I guess I've been lucky, but all my quarters' cash flow has been positive. (Yay me)
Unfortunately, this causes the "Cash Flow Barchart" and other similar reports to start their Y axes at various non-zero auto-scaled values, which causes these reports to look misleading at a glance.

This PR adds a `gnc:html-chart-set-y-axis-begin-at-zero!` function that can be used in reports to toggle the `beginAtZero` chart property. I also updated the charts I have issues with to use it.

I'd be happy to update more reports, but these are the ones I'm familiar with. I'm also willing to add check boxes to the report options to make this behavior optional. Another option would be to simply enable this behavior for all bar charts, but this method seems less disruptive. Let me know what you need.