### PR TITLE
Bug 798775 - Why is General Journal called "Register" in the tabs?

### DIFF
--- a/gnucash/report/reports/standard/general-journal.scm
+++ b/gnucash/report/reports/standard/general-journal.scm
@@ -102,6 +102,7 @@
       (list (N_ "Running Balance") #f)
       (list (N_ "Totals") #f)))
 
+    (set-option! gnc:pagename-general gnc:optname-reportname (G_ reportname))
     (set-option! gnc:pagename-general "Title" (G_ reportname))
     options))
 


### PR DESCRIPTION
Set default report name to General Journal in options to overwrite default report name from underlying register report.

Maybe there is a reason why the report name is kept at "register" for the General Journal and if so please ignore this PR. But otherwise if it's just an oversight, this one line commit should fix this bug.