### PR TITLE
Bug 798461 - balance sheet shows positions with zero balances despite report options

### DIFF
--- a/gnucash/report/html-acct-table.scm
+++ b/gnucash/report/html-acct-table.scm
@@ -1023,6 +1023,8 @@
                                               (omit-bal . #f)))
                                   (bal-sym (assq-ref bal-syms bal-method))
                                   (comm-amt (get-val env bal-sym)))
+                         (when (eq? zero-mode 'omit-balance)
+                           (comm-amt 'remove-zeros #f #f))
                          (cond
                           ((and (eq? zero-mode 'omit-balance)
                                 (gnc-commodity-collector-allzero? comm-amt)) #f)

--- a/gnucash/report/report-utilities.scm
+++ b/gnucash/report/report-utilities.scm
@@ -365,6 +365,8 @@
              (total (if pair ((cadr pair) 'total #f) 0)))
         (gnc:make-gnc-monetary c (if sign? (- total) total))))
 
+    (define (not-zero? l) (not (zero? ((cadr l) 'total #f))))
+
     ;; Dispatch function
     (lambda (action commodity amount)
       (case action
@@ -377,6 +379,7 @@
         ((reset) (set! commoditylist '()))
         ((getpair) (getpair commodity amount))
         ((getmonetary) (getmonetary commodity amount))
+        ((remove-zeros) (set! commoditylist (filter not-zero? commoditylist)))
         ((list) commoditylist) ; this one is only for internal use
         (else (gnc:warn "bad commodity-collector action: " action))))))
 

--- a/gnucash/report/test/test-report-utilities.scm
+++ b/gnucash/report/test/test-report-utilities.scm
@@ -261,6 +261,17 @@
       (coll-A 'add GBP -1)
       (test-equal "gnc-commodity-collector does not round inappropriately"
         '(("GBP" . 0))
+        (collector->list coll-A))
+
+      ;; the following tests the remove-zeros action
+      (coll-A 'add USD 1)
+      (coll-A 'add EUR 0)
+      (test-equal "gnc-commodity-collector before remove-zeros"
+        '(("EUR" . 0) ("USD" . 1) ("GBP" . 0))
+        (collector->list coll-A))
+      (coll-A 'remove-zeros #f #f)
+      (test-equal "gnc-commodity-collector after remove-zeros"
+        '(("USD" . 1))
         (collector->list coll-A)))
     (teardown)))
 


### PR DESCRIPTION
This occurs when accounts with different currencies or commodities are being rolled up to a higher level of subaccounts. Fixed by removing commodities with zero totals from commoditylist when "omit zero balance figures" option is selected.

Code's author is Christopher Lam.