### PR TITLE
Fix: Avoid infinite recursive calls

### DIFF
--- a/gnucash/register/register-gnome/gnucash-item-edit.c
+++ b/gnucash/register/register-gnome/gnucash-item-edit.c
@@ -306,6 +306,9 @@ gnc_item_edit_focus_out (GncItemEdit *item_edit)
     g_return_if_fail (item_edit != NULL);
     g_return_if_fail (GNC_IS_ITEM_EDIT(item_edit));
 
+    if (item_edit->show_popup)
+        return; // Prevent recursion
+
     ev.type = GDK_FOCUS_CHANGE;
     ev.window = gtk_widget_get_window (GTK_WIDGET(item_edit->sheet));
     ev.in = FALSE;


### PR DESCRIPTION
When I try to use IME (e.g. fcitx) to narrow down a combo box (e.g. Description, Transfer in Account), infinite recursion occurs via `popup_set_focus` and GnuCash falls down with SIGSEGV.