### PR TITLE
Edit local symbol for uzbek sum (UZS)

### DIFF
--- a/libgnucash/engine/iso-4217-currencies.xml
+++ b/libgnucash/engine/iso-4217-currencies.xml
@@ -2692,7 +2692,7 @@
   exchange-code="860"
   parts-per-unit="100"
   smallest-fraction="100"
-  local-symbol="so‘m "
+  local-symbol="so'm "
 />
 <!-- "VEB" - "Venezuela Bolívar"
   2008-01-01 "VEF" 1000

--- a/libgnucash/engine/iso-4217-currencies.xml
+++ b/libgnucash/engine/iso-4217-currencies.xml
@@ -2692,7 +2692,7 @@
   exchange-code="860"
   parts-per-unit="100"
   smallest-fraction="100"
-  local-symbol="som"
+  local-symbol="so‘m "
 />
 <!-- "VEB" - "Venezuela Bolívar"
   2008-01-01 "VEF" 1000


### PR DESCRIPTION
Uzbek sum has not a symbol yet, and unit name is used. It's international form is `sum`.
But it's actually called `so'm` and should be written after digit part.