### PR TITLE
Bug 797879 - [Transaction Report] running balance column not consistent with amount column for SAME transaction date

### DIFF
--- a/gnucash/report/trep-engine.scm
+++ b/gnucash/report/trep-engine.scm
@@ -2178,7 +2178,7 @@ be excluded from periodic reporting.")
          query
          (keylist-get-info (sortkey-list BOOK-SPLIT-ACTION) primary-key 'sortkey)
          (keylist-get-info (sortkey-list BOOK-SPLIT-ACTION) secondary-key 'sortkey)
-         '())
+         (list QUERY-DEFAULT-SORT))
         (qof-query-set-sort-increasing
          query (eq? primary-order 'ascend) (eq? secondary-order 'ascend)
          #t))


### PR DESCRIPTION
Added QUERY-DEFAULT-SORT as second parameter to query sortkey to ensure transactions are sorted as per register within the same TRANS-DATE-POSTED

The problem only occurs with the query sort, not the custom sort. For the trep-engine, sorting by date is a regular query sort unless a primary subtotal per date key (e.g. per month or year) is chosen. In that second case it shifts to a custom sort (the sort is done in the report) which is not experiencing this problem. 

Hence it's only a query sort issue illustrated below. Correct register sort is on the left, incorrect date ascending sort on the right.

![running-balance-ro-vs-da](https://user-images.githubusercontent.com/267163/233910323-49d1ece6-2591-42bd-94bc-2a1f9583866d.png)

Looking further it seems the problem is with the sortkey for date as set for the query. Currently it is set to 

SPLIT-TRANS TRANS-DATE-POSTED 

which means sorted by posted date then split order within each transaction (I assume). It seems that it's not enough. Evidently we need to tell the query engine to use the register sort within the same date otherwise it uses some way to sort within a same date. The register sort is call QUERY-DEFAULT-SORT so I added that.

SPLIT-TRANS QUERY-DEFAULT-SORT TRANS-DATE-POSTED

It seems to fix the problem as per my test. After this chage, date descending matches register sort, and date ascending matches the exact opposite of register sort, and the running balance is much happier.