### PR TITLE
Bug 798886 - [Transaction Report] Subtotal upper headings do not follow font style of lower headings

### DIFF
--- a/gnucash/report/trep-engine.scm
+++ b/gnucash/report/trep-engine.scm
@@ -1445,12 +1445,12 @@ be excluded from periodic reporting.")
             (gnc:html-make-empty-cells left-indent)
             (if export?
                 (cons
-                 (gnc:make-html-table-cell data)
+                 (gnc:make-html-table-cell/markup "total-label-cell" data)
                  (gnc:html-make-empty-cells
                   (+ right-indent width-left-columns -1)))
                 (list
-                 (gnc:make-html-table-cell/size
-                  1 (+ right-indent width-left-columns) data)))
+                 (gnc:make-html-table-cell/size/markup
+                  1 (+ right-indent width-left-columns) "total-label-cell" data)))
             (map
              (lambda (cell)
                (match (vector-ref cell 5)


### PR DESCRIPTION
Added "total-label-cell" market to upper headings to match lower headings

This is a small bug that has really, well, bugged me. I usually fix it on my own copy but here is a PR to finally get it in.

**This is what it looks like BEFORE the fix**. Notice the font size of "Cash in Wallet" and "Checking Account" as well as Month subheadings.
![image](https://user-images.githubusercontent.com/267163/234177619-1342294a-9bab-4f9b-9094-1d5a1292f8ba.png)

**This is what it looks like after the fix**. Font sizes can now be set via the stylesheets as they are for lower subtotal headings. Eventually it would be nice to have separate cell and row styles for upper and lower, as well as for primary and secondary (row style is different but font isn't), but for now this is already an improvement.
![image](https://user-images.githubusercontent.com/267163/234178014-84c1fd29-a159-4b32-a82f-7be82446d08e.png)


