### PR TITLE
Restore register description quickfill

### DIFF
--- a/gnucash/register/ledger-core/split-register-load.c
+++ b/gnucash/register/ledger-core/split-register-load.c
@@ -878,8 +878,6 @@ gnc_split_register_load_desc_cells (SplitRegister* reg)
     cell = (ComboCell*)
            gnc_table_layout_get_cell (reg->table->layout, DESC_CELL);
 
-    gnc_combo_cell_use_type_ahead_only (cell);
-
     gnc_combo_cell_use_list_store_cache (cell, store);
 }
 /* ====================== END OF FILE ================================== */


### PR DESCRIPTION
Here is a PR to restore the register quickfill to how it was.

I have been testing some changes that would of fixed most of the bugs but I do not think I will have enough time to fully test and complete the changes before the weekend so probably worth reverting my changes and clear half a dozen bugs.

What I have achieved with the test file from [Bug 798788](https://bugs.gnucash.org/show_bug.cgi?id=798788) which has 16804 transaction with 16804 unique descriptions that are 128 characters long.
Register load time, 0.22 seconds
Completion test from start of description, say pressing 9 resulted in a sorted list store with 265 descriptions in 0.12 seconds
Completion test any part of description, say pressing 9 resulted in a sorted list store with 10920 descriptions in 1.25 seconds

I achieved this by creating a new cell type and loading the descriptions in to a hash table and once the first character was typed create the sorted list store.
With the use of a secondary entry icon, I am able to choose to do the search from the start or any place and with a new preference a default could be set.


