### PR TITLE
Bug 798879 - RFE: [Transaction Report] add Running Total option

### DIFF
--- a/gnucash/report/reports/standard/income-gst-statement.scm
+++ b/gnucash/report/reports/standard/income-gst-statement.scm
@@ -226,6 +226,7 @@ with *EUGOODS* in the account description."))
   (GncOptionDBPtr-make-internal options gnc:pagename-display "Amount")
   (GncOptionDBPtr-make-internal options gnc:pagename-display "Sign Reverses")
   (GncOptionDBPtr-make-internal options gnc:pagename-display "Running Balance")
+  (GncOptionDBPtr-make-internal options gnc:pagename-display "Running Totals")
   ;; No multilines allowed
   (GncOptionDBPtr-make-internal options gnc:pagename-display "Detail Level")
   (GncOptionDBPtr-make-internal options pagename-sorting "Show Informal Debit/Credit Headers")

--- a/gnucash/report/reports/standard/test/test-transaction.scm
+++ b/gnucash/report/reports/standard/test/test-transaction.scm
@@ -487,7 +487,7 @@
          (set-option! options "Display" name #f))
        (list "Date" "Reconciled Date" "Num" "Description" "Memo" "Notes"
              "Account Name" "Other Account Name" "Shares" "Price" "Account Balance"
-             "Totals"))
+             "Grand Total"))
       (let ((sxml (options->sxml options "all columns off")))
         (test-assert "all display columns off, except amount and subtotals are enabled, there should be 2 columns"
           (= (length ((sxpath '(// (table 1) // (tr 1) // th)) sxml))
@@ -545,7 +545,7 @@
          (set-option! options "Display" name #t))
        (list "Date" "Reconciled Date" "Num" "Description" "Memo" "Notes"
              "Account Name" "Other Account Name" "Shares" "Price" "Account Balance"
-             "Totals" "Use Full Other Account Name" "Use Full Account Name"))
+             "Grand Total" "Use Full Other Account Name" "Use Full Account Name"))
       (set-option! options "Display" "Running Totals" 'grand)
       (let* ((sxml (options->sxml options "all columns on")))
         (test-equal "all display columns on, displays correct columns"
@@ -571,7 +571,7 @@
       (set-option! options "General" "Start Date" (cons 'absolute (gnc-dmy2time64 13 02 1971)))
       (set-option! options "General" "End Date" (cons 'absolute (gnc-dmy2time64 15 02 1971)))
       (set-option! options "Display" "Detail Level" 'multi-line)
-      (set-option! options "Display" "Totals" #f)
+      (set-option! options "Display" "Grand Total" #f)
       (set-option! options "Sorting" "Primary Subtotal" #f)
       (set-option! options "Sorting" "Primary Subtotal for Date Key" 'none)
       (set-option! options "Sorting" "Secondary Subtotal" #f)
@@ -735,7 +735,7 @@
       (set-option! options "General" "End Date" (cons 'absolute (gnc-dmy2time64 31 12 1970)))
       ;;(set-option! options "Accounts" "Accounts" (gnc-account-get-descendants (gnc-account-get-root bank)))
       (set-option! options "Accounts" "Accounts" (list bank))
-      (set-option! options "Display" "Totals" #f)
+      (set-option! options "Display" "Grand Total" #f)
       (set-option! options "Display" "Other Account Name" #t)
       (set-option! options "Filter" "Void Transactions" 'both)
       (set-option! options "Sorting" "Primary Subtotal" #f)
@@ -797,7 +797,7 @@
       (set-option! options "Sorting" "Primary Subtotal" #t)
       (set-option! options "Sorting" "Secondary Key" 'date)
       (set-option! options "Sorting" "Secondary Subtotal for Date Key" 'monthly)
-      (set-option! options "Display" "Totals" #t)
+      (set-option! options "Display" "Grand Total" #t)
       (set-option! options "Sorting" "Secondary Subtotal for Date Key" 'quarterly)
       (set-option! options "Sorting" "Show subtotals only (hide transactional data)" #t)
       (let* ((sxml (options->sxml options "sorting=account-name, date-quarterly, subtotals only")))
@@ -807,7 +807,7 @@
 
       (set! options (default-testing-options))
       (set-option! options "Accounts" "Accounts" (gnc-account-get-descendants (gnc-account-get-root bank)))
-      (set-option! options "Display" "Totals" #t)
+      (set-option! options "Display" "Grand Total" #t)
       (set-option! options "Display" "Amount" 'double)
       (set-option! options "Currency" "Show original currency amount" #t)
       (set-option! options "General" "Table for Exporting" #f)
@@ -827,7 +827,7 @@
           (get-row-col sxml 91 #f)))
 
       (set-option! options "Accounts" "Accounts" (list bank))
-      (set-option! options "Display" "Totals" #f)
+      (set-option! options "Display" "Grand Total" #f)
       (set-option! options "Sorting" "Show subtotals only (hide transactional data)" #t)
       (let* ((sxml (options->sxml options "sorting=date quarterly")))
         (test-equal "quarterly subtotals are correct"
@@ -868,7 +868,7 @@
 
       ;; test running subtotals
       (set! options (default-testing-options))
-      (set-option! options "Display" "Totals" #f)
+      (set-option! options "Display" "Grand Total" #f)
       (set-option! options "Display" "Running Totals" 'sub)
       (set-option! options "Sorting" "Primary Key" 'account-name)
       (set-option! options "Sorting" "Primary Subtotal" #t)
@@ -918,7 +918,7 @@
         (set-option! options "Display" name #t))
       (list "Date" "Reconciled Date" "Num" "Description" "Memo" "Notes"
             "Account Name" "Other Account Name" "Shares" "Price" "Account Balance"
-            "Totals" "Use Full Other Account Name" "Use Full Account Name"))
+            "Grand Total" "Use Full Other Account Name" "Use Full Account Name"))
       (set-option! options "Display" "Running Totals" 'all)
       (set-option! options "Sorting" "Primary Key" 'account-name)
       (set-option! options "Sorting" "Primary Subtotal" #t)

--- a/gnucash/report/reports/standard/test/test-transaction.scm
+++ b/gnucash/report/reports/standard/test/test-transaction.scm
@@ -909,7 +909,35 @@
         (test-equal "No running total columns are present"
           (list "Date" "Num" "Description" "Memo/Notes" "Account" "Amount")
           (get-row-col sxml 0 #f)))
-      )
+
+      ;; test that only columns with subtotals are displayed when
+      ;; "Show subtotals only (hide transactional data)" is selected
+      (set! options (default-testing-options))
+      (for-each
+      (lambda (name)
+        (set-option! options "Display" name #t))
+      (list "Date" "Reconciled Date" "Num" "Description" "Memo" "Notes"
+            "Account Name" "Other Account Name" "Shares" "Price" "Account Balance"
+            "Totals" "Use Full Other Account Name" "Use Full Account Name"))
+      (set-option! options "Display" "Running Totals" 'all)
+      (set-option! options "Sorting" "Primary Key" 'account-name)
+      (set-option! options "Sorting" "Primary Subtotal" #t)
+      (set-option! options "Sorting" "Secondary Key" 'date)
+      (set-option! options "Sorting" "Secondary Subtotal for Date Key" 'monthly)
+      (set-option! options "Sorting" "Show subtotals only (hide transactional data)" #t)
+      (set-option! options "Currency" "Common Currency" #t)
+      (set-option! options "Currency" "Show original currency amount" #t)
+      (let* ((sxml (options->sxml options "show subtotals only, single column")))
+        (test-equal "all display columns on with single amount; show subtotals only, so only amount columns are shown"
+          (list "Amount (USD)" "Amount")
+          (get-row-col sxml 0 #f)))
+
+      (set-option! options "Display" "Amount" 'double)
+      (let* ((sxml (options->sxml options "show subtotals only, dual column")))
+        (test-equal "all display columns on with dual amount; show subtotals only, so only debit/credit columns are shown"
+          (list "Debit (USD)" "Credit (USD)" "Debit" "Credit")
+          (get-row-col sxml 0 #f)))
+    )
 
     (test-end "sorting options")
 

--- a/gnucash/report/trep-engine.scm
+++ b/gnucash/report/trep-engine.scm
@@ -1636,14 +1636,19 @@ be excluded from periodic reporting.")
       ;; this part will check whether custom-calculated-cells were specified. this
       ;; describes a custom function which consumes an options list, and generates
       ;; an association list similar to default-calculated-cells as above.
-      (if custom-calculated-cells
-          (let ((cc (custom-calculated-cells options)))
-            (cond
-             ((not (pair? cc)) (gnc:error "welp" cc) default-calculated-cells)
-             ((vector? (car cc)) (upgrade-vector-to-assoclist cc))
-             ((any invalid-cell? cc) (gnc:error "welp" cc) default-calculated-cells)
-             (else cc)))
-          default-calculated-cells))
+      (let ((cc (if custom-calculated-cells
+                    (let ((ccc (custom-calculated-cells options)))
+                      (cond
+                        ((not (pair? ccc)) (gnc:error "welp" ccc)
+                          default-calculated-cells)
+                        ((vector? (car ccc)) (upgrade-vector-to-assoclist ccc))
+                        ((any invalid-cell? ccc) (gnc:error "welp" ccc)
+                          default-calculated-cells)
+                        (else ccc)))
+                    default-calculated-cells)))
+        ;; Only keep cells with subtotals when "Show subtotals only" is selected
+        ;; otherwise leave all calculated-cells as is.
+        (if (column-uses? 'subtotals-only) (filter cell-with-subtotals? cc) cc)))
 
     (define headings-left-columns
       (map (cut assq-ref <> 'heading) left-columns))

--- a/gnucash/report/trep-engine.scm
+++ b/gnucash/report/trep-engine.scm
@@ -74,6 +74,7 @@
 ;;Display
 (define optname-detail-level (N_ "Detail Level"))
 (define optname-grid (N_ "Subtotal Table"))
+(define optname-grand-total (N_ "Grand Total"))
 ;; Translators: a running total is a total that is continually adjusted on every line.
 ;; To be consistent, also consider how the term "Running Balance" is translated.
 ;; "Running Totals" is the plural form as it refers to the running total and running subtotals.
@@ -926,7 +927,7 @@ be excluded from periodic reporting.")
       ;; note the "Amount" multichoice option in between here
       (list optname-grid                        "m5" (G_ "Display a subtotal summary table.") #f)
       (list (N_ "Account Balance")              "n"  (G_ "Display the balance of the underlying account on each line?") #f)
-      (list (N_ "Totals")                       "o"  (G_ "Display the totals?") #t)))
+      (list optname-grand-total                 "o"  (G_ "Display a grand total section at the bottom?") #t)))
 
     (when BOOK-SPLIT-ACTION
       (gnc-register-simple-boolean-option options
@@ -1321,7 +1322,7 @@ be excluded from periodic reporting.")
 
         (if (or (column-uses? 'subtotals-only)
                 (and (null? left-cols-list)
-                     (or (opt-val gnc:pagename-display "Totals")
+                     (or (opt-val gnc:pagename-display optname-grand-total)
                          (primary-get-info 'renderer-fn)
                          (secondary-get-info 'renderer-fn))))
             `(((heading . "") (renderer-fn . ,(const #f))))
@@ -2005,7 +2006,7 @@ be excluded from periodic reporting.")
 
       (if (null? splits)
 
-          (when (opt-val gnc:pagename-display "Totals")
+          (when (opt-val gnc:pagename-display optname-grand-total)
             (gnc:html-table-append-row/markup!
              table def:grand-total-style
              (list

--- a/libgnucash/engine/gnc-optiondb.cpp
+++ b/libgnucash/engine/gnc-optiondb.cpp
@@ -117,6 +117,7 @@ const OptionAliases Aliases::c_option_aliases
     {"Specify date to filter by...", {nullptr, "Specify date to filter by…"}},
     // trep-engine:
     {"Running Balance", {nullptr, "Account Balance"}},
+    {"Totals", {nullptr, "Grand Total"}},
 };
 
 static bool


### PR DESCRIPTION
### Summary
Running total are calculated based on report transactions sort order as shown. Can be displayed on the main total as well as the primary and secondary subtotal levels. Compatible with multi-currency options and multi-line (splits) display.
### Context
The idea came when I was trying to use the running balance feature to create running totals and realized it wasn't doing what I wanted (although it's a usefull feature in itself). What I wanted was a running total based on the transactions in the report in  whatever order and filtering I had selected. 

I started to work on in gnucash version 4. My code was improved based on useful (and very patient) feedback I received on a couple of previous PR (code in the [first one](https://github.com/Gnucash/gnucash/pull/1459) was pretty bad, [second one](https://github.com/Gnucash/gnucash/pull/1460) better) and is now presented with additional improvements for version 5. It is a work in progress requiring more pairs of eyes both in terms of code but also presentation. Because it changes trep-engine, care must also be taken to not impact other reports and custom reports based on it, so additional testing will be done there as well. In the meantime I am opening this draft PR to get additional feedback.
### The Feature
The running totals work on all 3 levels: Grand Total, Primary Subtotal and Secondary Subtotal. They can be enabled or disabled separetely. In the screenshot below all 3 are enabled at once (with a small dataset to keep the screenshot manageable).
![image](https://user-images.githubusercontent.com/267163/234471992-a454af28-b14b-4dc2-a0c1-6056e5762f38.png)

The options to enables them are right under each of their respective options (so in the Display section for the grand total and the Sorting section for the subtotals). 
![image](https://user-images.githubusercontent.com/267163/234471056-938aec35-4de1-41b9-b998-4e61f2f15f8d.png)

![image](https://user-images.githubusercontent.com/267163/234470958-82dff96f-bd9d-49c3-9ef7-cd2edab5d825.png)

The running totals are calculated as per the grouping and ordering presented in the report, not the underlying data. It is for the user to decide whether a particular grouping and ordering is relevant (such as combining transactions from several accounts in the same list ordered by date). But the running totals will follow whatever grouping and sorting option the user chooses. 

Here is an example of a running total calculated by combining transactions from both wallet and checking accounts mixed together with an unusual descending date sort order. This examples is meant to highlight that the relevance of the nature and order of transaction data presented is left to the user, the running total is not judgmental in that regard.
![image](https://user-images.githubusercontent.com/267163/234472608-5533dcd0-285f-4506-9dc8-667d6328c87e.png)

The feature is fully compliant with the multi currency display (including showing converted and original amounts, each with their own set of running total and subtotals columns). 
![image](https://user-images.githubusercontent.com/267163/234474966-c070c9f0-c309-44d9-9b98-4368fe7fd6ee.png)


### Caveats

1. Although fully compliant with the multi currency display, in the multicurrency columns, only the running total of the current split’s currency is shown on each line, while all currency are shown in the final total at the bottom on the corresponding amount column (current behavior). Showing all currencies on each transaction line would not only require significant code change but also most likely clutter the report. Additionally, the total is not currently shown on the running total columns themselves as that would require significant additional changes to how subtotals are calculated and displayed. Minimizing the effect is the fact that running totals are only enables when their corresponding total or subtotal is enabled.
2. The running totals get their data from the splits, not the other calculated columns themselves. If one were to transform the data in a custom calculator-function for the amount columns, then of course the running total calculator-functions would need to be updated accordingly with their own custom calculator-functions. That is to be expected and fully supported by the trep-engine’s custom-calculated-cells feature. 
3. The running totals suffer from the same issue as the subtotals as related to the “Sign Reverses” option. Just as they are for the subtotals, signs are not reversed for the running totals since they have to match the totals on the last transaction of their respective level. The issues around the “Sign Reverses” option have been discussed other places and if anything is ever decided as relating to either that option or changes to the subtotals then the same would be done to the running totals. However there is nothing that can be done here differently until that other issue is resolved.

### Technical brief and code review
Although this introduces close to 200 lines of new code and a few lines of modified code, most additions are pretty benign boilerplate to create new options, new columns, etc. following existing code structures, and with plenty of comments to help with long-term maintainability.

There is only one major change (discussed in detail below) which calls for the introduction of a second argument in the calculated-cells calculator-functions (while preserving the support of calculator-functions with a single argument) with related code change in the add-split-row renderer.

A second smaller change was made to selecting which number columns are formatted with a link to the underlying transaction in the register is also discussed below (discussed further down).

A third small change is in removing columns that do not have subtotals enabled from calculated-cells when “Show subtotals only” is selected. This should have been done when that feature was developed, and the missing code caused empty columns to be displayed in that view (including the existing account balance column) an issue made more apparent with the new running total columns.

### Changes to add-split-row and the related calculator-functions
Add-split-row is the procedure that is called to add each row of data to the report. It received a split and runs it through the calculator-function for each cell. 

In the definition part of the report, the columns are divided in two groups:

1. the left-columns (date, description, notes, etc.), and 
2. the calculated-cells (also referred as right-columns) that contain the numeric data calculated from the split amount or retrieved based on it (single amount, credit, debit, running balance, etc).

One key difference between the left-columns and calculated-cells is that the function that are called to retrieve the content of the left-columns are provided with a second parameter called transaction-row? which differentiates the splits in a multiline situation (when "Display – Detail Level – One Split per Line” is selected). The flag is set to #t when the current split is the “main” split related to the account and #f when the current split is another split. This allows the left-columns to only show the date and description when the main split is shown, and leaves that information blank when not (since it is the same for the splits).

Unlike the left-columns, the calculator-functions for the calculated-cells do not have that argument. They only get the split with no way to tell if it’s a main split or “other” split. This is a problem for the running totals in a multiline environment since they should only be computed and shown on the main split, not the other splits. In fact the same problem exists on the Running Balance which for now is disabled in the multiline context. 

Hence my code changes implement this additional argument for the calculator-functions (calculator-function split transaction-row?) while preserving the ability to have calculator-functions with only one argument (calculator-function split) for legacy purpose. 

This results in one of the main code additions and changes in add-split-row

```
             ;; Returns the number of required arguments of a function
             (fn-arity (lambda (fn) (car (procedure-minimum-arity fn))))
             ;; Calls the calculator-function for the provided cell with either
             ;; two arguments (calculator-function split transaction-row?) or only
             ;; one argument  (calculator-function split) for legacy support.
             (calc-fn (lambda (cell split transaction-row?)
                              (if (= (fn-arity (vector-ref cell 1)) 1)
                                  ((vector-ref cell 1) split)
                                  ((vector-ref cell 1) split transaction-row?))))
```
The code uses a guile-specific procedure called procedure-minimum-arity. It is not widely documented because not standard RnRS scheme but it was introduced in Guile version 2.0.0 (it is mentioned in the changelog for that version) and is till supported as of the current version 3.0.9. It’s pretty straightforward as explained by (help procedure-minimum-arity)
`procedure-minimum-arity' is a procedure in the (guile) module.

- Scheme Procedure: procedure-minimum-arity proc
     Return the "minimum arity" of a procedure.

     If the procedure has only one arity, that arity is returned as a
     list of three values: the number of required arguments, the number
     of optional arguments, and a boolean indicating whether or not the
     procedure takes rest arguments.

     For a case-lambda procedure, the arity returned is the one with the
     lowest minimum number of arguments, and the highest maximum number
     of arguments.

     If it was not possible to determine the arity of the procedure,
     `#f' is returned.

See the specific commit for this procedure: https://git.savannah.gnu.org/cgit/guile.git/commit/?id=cb2ce548441824fe1284fc80a3a95394a9fc03d0

For our purpose we can ignore optional and rest argument, and are only looking at the number of required argument, assuming either 1 (for legacy purpose) or otherwise expecting 2 as the else. Hence we simply retrieve the car of the procedure-minimum-arity for the provided calculator-functions to decide to either call it with 1 or 2 arguments. This therefore requires no changes to existing calculator-functions in trep-engine or trep-engine-based report but allows for addition of new calculator-functions with the 2 arguments.

I feel the addition of the transaction-row? argument is a worthwhile addition to the calculated-cells to bring them in line with the left-columns even outside of this current feature. For instance it could also be used to fix the running balance display in the multiline context or used by custom reports for other reasons.

### Alternative to changes to add-row-split and calculator-functions’ number of arguments
If this change is considered to bold, the alternative would be to disable running totals in the multiline context for now, although that brings the smaller challenge of disabling “on the fly” the subtotal options in the ui (in the sorting section) when the “One Split per Line” is selected in the display section. I don’t think there is any way to do this right now while the dialog is active, or at least there is no hook I could find when changing tabs in the dialog (I could only get it done when it is opened the next time, or apply is clicked, or when a related option is clicked in the sorting window). That said the actual option can be disabled in the actual report output regardless of option graying in the dialog. So this is purely for the visual in the dialog and could possibly be left active with additional info in the option popup message stating it doesn’t work when “One Split per Line” is selected. 

### Changes to which number columns are formatted as links
The current implementation offers the “Enable Links” option in the display section. When enabled, it is applied to each cell that has a number in it. One limitation of this approach is that it is even applied to number cells whose calculated number is different from the transaction amount in the register (for instance a converted amount, or a running total). Also it can clutter the report visually since the link is essentially the same for each cell in a given row, pointing to the split in the register.

Ideally there would be an additional flag in the column definition to decide whether a link should or shouldn’t be present on that column, but that would require additional changes for such a small feature with potential impact on custom reports. The alternative I propose is to limit links (when enabled) to columns already marked as displaying a subtotal so as to declutter the report. To avoid an edge case of being left with no links on the report (which could happen if no columns with subtotals are enabled), the code reverts back to putting links on any number column in case no columns with subtotals are enabled.