### PR TITLE
Put hostname (if available) and PID in XML backend lock file

### DIFF
--- a/libgnucash/backend/dbi/gnc-backend-dbi.hpp
+++ b/libgnucash/backend/dbi/gnc-backend-dbi.hpp
@@ -24,15 +24,8 @@
 #define GNC_BACKEND_DBI_HPP
 
 #include <dbi/dbi.h>
-#ifdef G_OS_WIN32
-#include <winsock2.h>
-#define GETPID() GetCurrentProcessId()
-#else
-#include <limits.h>
-#include <unistd.h>
-#define GETPID() getpid()
-#endif
 
+#include "../gnc-backend.hpp"
 #include <gnc-sql-backend.hpp>
 #include <gnc-sql-connection.hpp>
 

--- a/libgnucash/backend/gnc-backend.hpp
+++ b/libgnucash/backend/gnc-backend.hpp
@@ -1,0 +1,34 @@
+/********************************************************************
+ * gnc-backend.hpp: header stuff used by multiple backends          *
+ *                                                                  *
+ * This program is free software; you can redistribute it and/or    *
+ * modify it under the terms of the GNU General Public License as   *
+ * published by the Free Software Foundation; either version 2 of   *
+ * the License, or (at your option) any later version.              *
+ *                                                                  *
+ * This program is distributed in the hope that it will be useful,  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    *
+ * GNU General Public License for more details.                     *
+ *                                                                  *
+ * You should have received a copy of the GNU General Public License*
+ * along with this program; if not, contact:                        *
+ *                                                                  *
+ * Free Software Foundation           Voice:  +1-617-542-5942       *
+ * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652       *
+ * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
+\********************************************************************/
+
+#ifndef GNC_BACKEND_HPP
+#define GNC_BACKEND_HPP
+
+#ifdef G_OS_WIN32
+#include <winsock2.h>
+#define GETPID() GetCurrentProcessId()
+#else
+#include <limits.h>
+#include <unistd.h>
+#define GETPID() getpid()
+#endif
+
+#endif //GNC_BACKEND_HPP


### PR DESCRIPTION
Write the host name (if `gethostname` is available) and the PID of the GnuCash process into the XML backend lock file.

User story: I synchronize my GnuCash data across multiple computers using a cloud file synchronization service and run GnuCash on all of these computers. When I forget to close GnuCash on one computer and try to launch it on another, the lock file prevents me from doing that, but now I need to figure out which computer it's running on so I can close it there. Writing the host name and PID into the lock file make this easy to do, so I don't have to check each of my computers one by one to figure out where it's running.
