### PR TITLE
WIP: Incorporate new Finance::Quote get_features() to automatically configure quote sources

### DIFF
--- a/gnucash/gnome-utils/dialog-commodity.c
+++ b/gnucash/gnome-utils/dialog-commodity.c
@@ -771,7 +771,7 @@ gnc_ui_source_menu_create(QuoteSourceType type)
             source = gnc_quote_source_lookup_by_ti(type, i);
             if (source == NULL)
                 break;
-            name = gnc_quote_source_get_user_name(source);
+            name = gnc_quote_source_get_name(source);
             supported = gnc_quote_source_get_supported(source);
             gtk_list_store_append(store, &iter);
             gtk_list_store_set(store, &iter,

--- a/gnucash/gnome-utils/gnc-tree-model-commodity.c
+++ b/gnucash/gnome-utils/gnc-tree-model-commodity.c
@@ -602,7 +602,7 @@ gnc_tree_model_commodity_get_value (GtkTreeModel *tree_model,
         if (gnc_commodity_get_quote_flag (commodity))
         {
             source = gnc_commodity_get_quote_source (commodity);
-            g_value_set_string (value, gnc_quote_source_get_internal_name(source));
+            g_value_set_string (value, gnc_quote_source_get_name(source));
         }
         else
         {

--- a/gnucash/gnucash.cpp
+++ b/gnucash/gnucash.cpp
@@ -178,9 +178,13 @@ scm_run_gnucash (void *data, [[maybe_unused]] int argc, [[maybe_unused]] char **
         gnc_update_splash_screen (checking, GNC_SPLASH_PERCENTAGE_UNKNOWN);
         GncQuotes quotes;
         auto found = (bl::format (std::string{_("Found Finance::Quote version {1}.")}) % quotes.version()).str();
-        auto quote_sources = quotes.sources_as_glist();
-        gnc_quote_source_set_fq_installed (quotes.version().c_str(), quote_sources);
-        g_list_free_full (quote_sources, g_free);
+        auto currency_quote_sources = quotes.currency_sources_as_glist();
+        auto single_quote_sources = quotes.single_sources_as_glist();
+        auto multiple_quote_sources = quotes.multiple_sources_as_glist();
+        gnc_quote_source_set_fq_installed (quotes.version().c_str(), currency_quote_sources, single_quote_sources, multiple_quote_sources);
+        g_list_free_full (currency_quote_sources, g_free);
+        g_list_free_full (single_quote_sources, g_free);
+        g_list_free_full (multiple_quote_sources, g_free);
         gnc_update_splash_screen (found.c_str(), GNC_SPLASH_PERCENTAGE_UNKNOWN);
     }
     catch (const GncQuoteException& err)

--- a/libgnucash/app-utils/gnc-quotes.cpp
+++ b/libgnucash/app-utils/gnc-quotes.cpp
@@ -80,9 +80,6 @@ struct GncQuoteSourceError : public std::runtime_error
 CommVec
 gnc_quotes_get_quotable_commodities(const gnc_commodity_table * table);
 
-/**
- * GncQuotesSource provides an API for quote retrieval used by GncQuotesImpl.
- **/
 class GncQuoteSource
 {
 public:
@@ -94,11 +91,6 @@ public:
     virtual QuoteResult get_quotes(const std::string& json_str) const = 0;
 };
 
-/**
- * GncQuotesImpl defines the Quote API used by the core of GnuCash.  A quote source
- * such as Finance::Quote implements the GncQuotesSource API and this class translates
- * between that API and the public API this class defines for the rest of GnuCash.
- **/
 class GncQuotesImpl
 {
 public:
@@ -144,9 +136,6 @@ private:
     gnc_commodity *m_dflt_curr;
 };
 
-/**
- * GncFQQuotesSource implements the GncQuotesSources API for Finance::Quote. 
- **/
 class GncFQQuoteSource final : public GncQuoteSource
 {
     const bfs::path c_cmd;

--- a/libgnucash/app-utils/gnc-quotes.hpp
+++ b/libgnucash/app-utils/gnc-quotes.hpp
@@ -103,18 +103,49 @@ public:
      */
     const std::string& version() noexcept;
 
-    /** Get the available Finance::Quote sources as a std::vector
+    /** Get currency sources as a std::vector. Finance::Quote has a default
+     * currency module but may support multiple currency modules.
      *
-     * @return The quote sources configured in Finance::Quote
+     * @return The currency sources configured in Finance::Quote
      */
-    const QuoteSources& sources() noexcept;
+    const QuoteSources& currency_sources() noexcept;
 
-    /** Get the available Finance::Quote sources as a GList
+    /** Get currency sources as a GList
      *
-     * @return A double-linked list containing the names of the installed quote sources.
+     * @return A double-linked list containing the names of the installed currency sources.
      * @note the list and its contents are owned by the caller and should be freed with `g_list_free_full(list, g_free)`.
      */
-    GList* sources_as_glist () ;
+    GList* currency_sources_as_glist ();
+
+    /** Get quote sources that use a single upstream source as a std::vector. Finance::Quote
+     * has "modules" (which gather quotes from a single upstream source) and "methods" (which
+     * use a combination of modules to retrieve quotes, trying one and then
+     * falling back to other modules if the first fails.
+     *
+     * @return The single sources configured in Finance::Quote
+     */
+    const QuoteSources& single_sources() noexcept;
+    
+    /** Get single_sources as a GList.  See single_sources() for description of single sources.
+     *
+     * @return A double-linked list containing the names of the installed Fiannce::Quote modules.
+     * @note the list and its contents are owned by the caller and should be freed with `g_list_free_full(list, g_free)`.
+     */
+    GList* single_sources_as_glist ();
+
+    /** Get list of quotes souces that use multiple upstream sources.  See single_sources() for more details.
+     *
+     * @return A double-linked list containing the names of the available Fiannce::Quote methods.
+     * @note the list and its contents are owned by the caller and should be freed with `g_list_free_full(list, g_free)`.
+     */
+    const QuoteSources& multiple_sources() noexcept;
+    
+    /** Get multiple_sources as a GList.  See multiple_sources() for description of multiple sources.
+     *
+     * @return A double-linked list containing the names of the available Fiannce::Quote methods.
+     * @note the list and its contents are owned by the caller and should be freed with `g_list_free_full(list, g_free)`.
+     */
+    GList* multiple_sources_as_glist ();
 
     /** Report if there were quotes requested but not retrieved.
      *

--- a/libgnucash/app-utils/gnc-quotes.hpp
+++ b/libgnucash/app-utils/gnc-quotes.hpp
@@ -139,8 +139,7 @@ public:
 
     /** Get list of quotes souces that use multiple upstream sources.  See single_sources() for more details.
      *
-     * @return A double-linked list containing the names of the available Fiannce::Quote methods.
-     * @note the list and its contents are owned by the caller and should be freed with `g_list_free_full(list, g_free)`.
+     * @return The sources in Finance::Quote that use multiple sources
      */
     const QuoteSources& multiple_sources() noexcept;
     

--- a/libgnucash/app-utils/gnc-quotes.hpp
+++ b/libgnucash/app-utils/gnc-quotes.hpp
@@ -117,10 +117,14 @@ public:
      */
     GList* currency_sources_as_glist ();
 
-    /** Get quote sources that use a single upstream source as a std::vector. Finance::Quote
-     * has "modules" (which gather quotes from a single upstream source) and "methods" (which
-     * use a combination of modules to retrieve quotes, trying one and then
-     * falling back to other modules if the first fails.
+    /** Get quote sources that use a single upstream source as a std::vector.
+     * Finance::Quote has "modules" that gather quotes from a single upstream
+     * source and "methods" that use one or more modules to retrieve quotes
+     * (trying one and then falling back to other modules if the first fails).
+     * 
+     * A module typically provides a method with the same name (eg the AlphaVantage
+     * module provides the alphavantage method as well as being one of the sources
+     * for the nasdaq method).
      *
      * @return The single sources configured in Finance::Quote
      */

--- a/libgnucash/backend/sql/gnc-commodity-sql.cpp
+++ b/libgnucash/backend/sql/gnc-commodity-sql.cpp
@@ -98,7 +98,7 @@ get_quote_source_name (gpointer pObject)
     g_return_val_if_fail (GNC_IS_COMMODITY (pObject), NULL);
 
     pCommodity = GNC_COMMODITY (pObject);
-    return (gpointer)gnc_quote_source_get_internal_name (
+    return (gpointer)gnc_quote_source_get_name (
                gnc_commodity_get_quote_source (pCommodity));
 }
 
@@ -115,7 +115,7 @@ set_quote_source_name (gpointer pObject, gpointer pValue)
     if (pValue == NULL) return;
 
     pCommodity = GNC_COMMODITY (pObject);
-    quote_source = gnc_quote_source_lookup_by_internal (quote_source_name);
+    quote_source = gnc_quote_source_lookup_by_name (quote_source_name);
     gnc_commodity_set_quote_source (pCommodity, quote_source);
 }
 

--- a/libgnucash/backend/xml/gnc-commodity-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-commodity-xml-v2.cpp
@@ -101,7 +101,7 @@ gnc_commodity_dom_tree_create (const gnc_commodity* com)
         source = gnc_commodity_get_quote_source (com);
         if (source)
             xmlAddChild (ret, text_to_dom_tree (cmdty_quote_source,
-                                                gnc_quote_source_get_internal_name (source)));
+                                                gnc_quote_source_get_name (source)));
         string = gnc_commodity_get_quote_tz (com);
         if (string)
             xmlAddChild (ret, text_to_dom_tree (cmdty_quote_tz, string));
@@ -156,9 +156,9 @@ set_commodity_value (xmlNodePtr node, gnc_commodity* com)
         char* string;
 
         string = (char*) xmlNodeGetContent (node->xmlChildrenNode);
-        source = gnc_quote_source_lookup_by_internal (string);
+        source = gnc_quote_source_lookup_by_name (string);
         if (!source)
-            source = gnc_quote_source_add_new (string, FALSE);
+            source = gnc_quote_source_add_new (string, SOURCE_UNKNOWN);
         gnc_commodity_set_quote_source (com, source);
         xmlFree (string);
     }

--- a/libgnucash/engine/Scrub.c
+++ b/libgnucash/engine/Scrub.c
@@ -1334,9 +1334,9 @@ move_quote_source (Account *account, gpointer data)
         PINFO("to %8s from %s", gnc_commodity_get_mnemonic(com),
               xaccAccountGetName(account));
         gnc_commodity_set_quote_flag(com, TRUE);
-        quote_source = gnc_quote_source_lookup_by_internal(source);
+        quote_source = gnc_quote_source_lookup_by_name(source);
         if (!quote_source)
-            quote_source = gnc_quote_source_add_new(source, FALSE);
+            quote_source = gnc_quote_source_add_new(source, SOURCE_UNKNOWN);
         gnc_commodity_set_quote_source(com, quote_source);
         gnc_commodity_set_quote_tz(com, tz);
     }

--- a/libgnucash/engine/gnc-commodity.c
+++ b/libgnucash/engine/gnc-commodity.c
@@ -154,7 +154,6 @@ struct gnc_quote_source_s
     QuoteSourceType type;
     gint index;
     char *user_name;		/* User friendly name incl. region code*/
-    char *old_internal_name;	/* Name used internally (deprecated) */
     char *internal_name;	/* Name used internally and by finance::quote. */
 };
 
@@ -167,7 +166,7 @@ struct gnc_quote_source_s
  * Apply changes here also to the FQ appendix of help.
  */
 static gnc_quote_source currency_quote_source =
-{ TRUE, 0, 0, "Currency", "CURRENCY", "currency" };
+{ TRUE, 0, 0, "Currency", "currency" };
 
 /* The single quote method is usually the module name, but
  * sometimes it gets the suffix "_direct"
@@ -175,92 +174,92 @@ static gnc_quote_source currency_quote_source =
  */
 static gnc_quote_source single_quote_sources[] =
 {
-    { FALSE, 0, 0, "Alphavantage, US", "ALPHAVANTAGE", "alphavantage" },
-    { FALSE, 0, 0, "Amsterdam Euronext eXchange, NL", "AEX", "aex" },
-    { FALSE, 0, 0, "American International Assurance, HK", "AIAHK", "aiahk" },
-    { FALSE, 0, 0, "Association of Mutual Funds in India", "AMFIINDIA", "amfiindia" },
-    { FALSE, 0, 0, "Athens Stock Exchange, GR", "ASEGR", "asegr" },
-    { FALSE, 0, 0, "Australian Stock Exchange, AU", "ASX", "asx" },
-    { FALSE, 0, 0, "BAMOSZ funds, HU", "BAMOSZ", "bamosz" },
-    { FALSE, 0, 0, "BMO NesbittBurns, CA", "BMONESBITTBURNS", "bmonesbittburns" },
-    { FALSE, 0, 0, "Bucharest Stock Exchange, RO", "BSERO", "bsero" },
-    { FALSE, 0, 0, "Budapest Stock Exchange (BET), ex-BUX, HU", "BSE", "bse" },
-    { FALSE, 0, 0, "Canada Mutual", "CANADAMUTUAL", "canadamutual" },
-    { FALSE, 0, 0, "Citywire Funds, GB", "citywire", "citywire" },
-    { FALSE, 0, 0, "Colombo Stock Exchange, LK", "CSE", "cse" },
-    { FALSE, 0, 0, "Cominvest, ex-Adig, DE", "COMINVEST", "cominvest" },
-    { FALSE, 0, 0, "Deka Investments, DE", "DEKA", "deka" },
-    { FALSE, 0, 0, "Dutch", "DUTCH", "dutch" },
-    { FALSE, 0, 0, "DWS, DE", "DWS", "dwsfunds" },
-    { FALSE, 0, 0, "Equinox Unit Trusts, ZA", "ZA_unittrusts", "za_unittrusts" },
-    { FALSE, 0, 0, "Fidelity Direct", "FIDELITY_DIRECT", "fidelity_direct" },
-    { FALSE, 0, 0, "Fidelity Fixed", "FIDELITY_DIRECT", "fidelityfixed" },
-    { FALSE, 0, 0, "Finance Canada", "FINANCECANADA", "financecanada" },
-    { FALSE, 0, 0, "Financial Times Funds service, GB", "FTFUNDS", "ftfunds" },
-    { FALSE, 0, 0, "Finanzpartner, DE", "FINANZPARTNER", "finanzpartner" },
-    { FALSE, 0, 0, "First Trust Portfolios, US", "FTPORTFOLIOS", "ftportfolios" },
-    { FALSE, 0, 0, "Fund Library, CA", "FUNDLIBRARY", "fundlibrary" },
-    { FALSE, 0, 0, "GoldMoney spot rates, JE", "GOLDMONEY", "goldmoney" },
-    { FALSE, 0, 0, "Greece", "GREECE", "greece" },
-    { FALSE, 0, 0, "Helsinki stock eXchange, FI", "HEX", "hex" },
-    { FALSE, 0, 0, "Hungary", "HU", "hu" },
-    { FALSE, 0, 0, "India Mutual", "INDIAMUTUAL", "indiamutual" },
-    { FALSE, 0, 0, "Man Investments, AU", "maninv", "maninv" },
-    { FALSE, 0, 0, "Morningstar, GB", "MSTARUK", "mstaruk" },
-    { FALSE, 0, 0, "Morningstar, JP", "MORNINGSTARJP", "morningstarjp" },
-    { FALSE, 0, 0, "Morningstar, SE", "MORNINGSTAR", "morningstar" },
-    { FALSE, 0, 0, "Motley Fool, US", "FOOL", "fool" },
-    { FALSE, 0, 0, "New Zealand stock eXchange, NZ", "NZX", "nzx" },
-    { FALSE, 0, 0, "Paris Stock Exchange/Boursorama, FR", "BOURSO", "bourso" },
-    { FALSE, 0, 0, "Paris Stock Exchange/LeRevenu, FR", "LEREVENU", "lerevenu" },
-    { FALSE, 0, 0, "Platinum Asset Management, AU", "PLATINUM", "platinum" },
-    { FALSE, 0, 0, "Romania", "romania", "romania" },
-    { FALSE, 0, 0, "SIX Swiss Exchange funds, CH", "SIXFUNDS", "sixfunds" },
-    { FALSE, 0, 0, "SIX Swiss Exchange shares, CH", "SIXSHARES", "sixshares" },
-    { FALSE, 0, 0, "Skandinaviska Enskilda Banken, SE", "SEB_FUNDS", "seb_funds" },
-    { FALSE, 0, 0, "Sharenet, ZA", "ZA", "za" },
-    { FALSE, 0, 0, "StockHouse Canada", "STOCKHOUSE_FUND", "stockhousecanada_fund" },
-    { FALSE, 0, 0, "TD Waterhouse Funds, CA", "TDWATERHOUSE", "tdwaterhouse" },
-    { FALSE, 0, 0, "TD Efunds, CA", "TDEFUNDS", "tdefunds" },
-    { FALSE, 0, 0, "TIAA-CREF, US", "TIAACREF", "tiaacref" },
-    { FALSE, 0, 0, "Toronto Stock eXchange, CA", "TSX", "tsx" },
-    { FALSE, 0, 0, "T. Rowe Price", "TRPRICE", "troweprice" },
-    { FALSE, 0, 0, "T. Rowe Price, US", "TRPRICE_DIRECT", "troweprice_direct" },
-    { FALSE, 0, 0, "Trustnet via tnetuk.pm, GB", "TNETUK", "tnetuk" },
-    { FALSE, 0, 0, "Trustnet via trustnet.pm, GB", "TRUSTNET", "trustnet" },
-    { FALSE, 0, 0, "U.K. Unit Trusts", "UKUNITTRUSTS", "uk_unit_trusts" },
-    { FALSE, 0, 0, "Union Investment, DE", "UNIONFUNDS", "unionfunds" },
-    { FALSE, 0, 0, "US Treasury Bonds", "usfedbonds", "usfedbonds" },
-    { FALSE, 0, 0, "US Govt. Thrift Savings Plan", "TSP", "tsp" },
-    { FALSE, 0, 0, "Vanguard", "VANGUARD", "vanguard" }, /* Method of Alphavantage */
-    { FALSE, 0, 0, "VWD, DE (unmaintained)", "VWD", "vwd" },
-    { FALSE, 0, 0, "Yahoo as JSON", "YAHOO_JSON", "yahoo_json" },
-    { FALSE, 0, 0, "Yahoo as YQL", "YAHOO_YQL", "yahoo_yql" },
+    { FALSE, 0, 0, "Alphavantage, US", "alphavantage" },
+    { FALSE, 0, 0, "Amsterdam Euronext eXchange, NL", "aex" },
+    { FALSE, 0, 0, "American International Assurance, HK", "aiahk" },
+    { FALSE, 0, 0, "Association of Mutual Funds in India", "amfiindia" },
+    { FALSE, 0, 0, "Athens Stock Exchange, GR", "asegr" },
+    { FALSE, 0, 0, "Australian Stock Exchange, AU", "asx" },
+    { FALSE, 0, 0, "BAMOSZ funds, HU", "bamosz" },
+    { FALSE, 0, 0, "BMO NesbittBurns, CA", "bmonesbittburns" },
+    { FALSE, 0, 0, "Bucharest Stock Exchange, RO", "bsero" },
+    { FALSE, 0, 0, "Budapest Stock Exchange (BET), ex-BUX, HU", "bse" },
+    { FALSE, 0, 0, "Canada Mutual", "canadamutual" },
+    { FALSE, 0, 0, "Citywire Funds, GB", "citywire" },
+    { FALSE, 0, 0, "Colombo Stock Exchange, LK", "cse" },
+    { FALSE, 0, 0, "Cominvest, ex-Adig, DE", "cominvest" },
+    { FALSE, 0, 0, "Deka Investments, DE", "deka" },
+    { FALSE, 0, 0, "Dutch", "dutch" },
+    { FALSE, 0, 0, "DWS, DE", "dwsfunds" },
+    { FALSE, 0, 0, "Equinox Unit Trusts, ZA", "za_unittrusts" },
+    { FALSE, 0, 0, "Fidelity Direct", "fidelity_direct" },
+    { FALSE, 0, 0, "Fidelity Fixed", "fidelityfixed" },
+    { FALSE, 0, 0, "Finance Canada", "financecanada" },
+    { FALSE, 0, 0, "Financial Times Funds service, GB", "ftfunds" },
+    { FALSE, 0, 0, "Finanzpartner, DE", "finanzpartner" },
+    { FALSE, 0, 0, "First Trust Portfolios, US", "ftportfolios" },
+    { FALSE, 0, 0, "Fund Library, CA", "fundlibrary" },
+    { FALSE, 0, 0, "GoldMoney spot rates, JE", "goldmoney" },
+    { FALSE, 0, 0, "Greece", "greece" },
+    { FALSE, 0, 0, "Helsinki stock eXchange, FI", "hex" },
+    { FALSE, 0, 0, "Hungary", "hu" },
+    { FALSE, 0, 0, "India Mutual", "indiamutual" },
+    { FALSE, 0, 0, "Man Investments, AU", "maninv" },
+    { FALSE, 0, 0, "Morningstar, GB", "mstaruk" },
+    { FALSE, 0, 0, "Morningstar, JP", "morningstarjp" },
+    { FALSE, 0, 0, "Morningstar, SE", "morningstar" },
+    { FALSE, 0, 0, "Motley Fool, US", "fool" },
+    { FALSE, 0, 0, "New Zealand stock eXchange, NZ", "nzx" },
+    { FALSE, 0, 0, "Paris Stock Exchange/Boursorama, FR", "bourso" },
+    { FALSE, 0, 0, "Paris Stock Exchange/LeRevenu, FR", "lerevenu" },
+    { FALSE, 0, 0, "Platinum Asset Management, AU", "platinum" },
+    { FALSE, 0, 0, "Romania", "romania" },
+    { FALSE, 0, 0, "SIX Swiss Exchange funds, CH", "sixfunds" },
+    { FALSE, 0, 0, "SIX Swiss Exchange shares, CH", "sixshares" },
+    { FALSE, 0, 0, "Skandinaviska Enskilda Banken, SE", "seb_funds" },
+    { FALSE, 0, 0, "Sharenet, ZA", "za" },
+    { FALSE, 0, 0, "StockHouse Canada", "stockhousecanada_fund" },
+    { FALSE, 0, 0, "TD Waterhouse Funds, CA", "tdwaterhouse" },
+    { FALSE, 0, 0, "TD Efunds, CA", "tdefunds" },
+    { FALSE, 0, 0, "TIAA-CREF, US", "tiaacref" },
+    { FALSE, 0, 0, "Toronto Stock eXchange, CA", "tsx" },
+    { FALSE, 0, 0, "T. Rowe Price", "troweprice" },
+    { FALSE, 0, 0, "T. Rowe Price, US", "troweprice_direct" },
+    { FALSE, 0, 0, "Trustnet via tnetuk.pm, GB", "tnetuk" },
+    { FALSE, 0, 0, "Trustnet via trustnet.pm, GB", "trustnet" },
+    { FALSE, 0, 0, "U.K. Unit Trusts", "uk_unit_trusts" },
+    { FALSE, 0, 0, "Union Investment, DE", "unionfunds" },
+    { FALSE, 0, 0, "US Treasury Bonds", "usfedbonds" },
+    { FALSE, 0, 0, "US Govt. Thrift Savings Plan", "tsp" },
+    { FALSE, 0, 0, "Vanguard", "vanguard" }, /* Method of Alphavantage */
+    { FALSE, 0, 0, "VWD, DE (unmaintained)", "vwd" },
+    { FALSE, 0, 0, "Yahoo as JSON", "yahoo_json" },
+    { FALSE, 0, 0, "Yahoo as YQL", "yahoo_yql" },
 };
 
 static gnc_quote_source multiple_quote_sources[] =
 {
-    { FALSE, 0, 0, "Australia (ASX, ...)", "AUSTRALIA", "australia" },
-    { FALSE, 0, 0, "Canada (Alphavantage, TSX, ...)", "CANADA", "canada" },
-    { FALSE, 0, 0, "Canada Mutual (Fund Library, StockHouse, ...)", "CANADAMUTUAL", "canadamutual" },
-    { FALSE, 0, 0, "Dutch (AEX, ...)", "DUTCH", "dutch" },
-    { FALSE, 0, 0, "Europe (asegr,.bsero, hex ...)", "EUROPE", "europe" },
-    { FALSE, 0, 0, "Greece (ASE, ...)", "GREECE", "greece" },
-    { FALSE, 0, 0, "Hungary (Bamosz, BET, ...)", "HU", "hu" },
-    { FALSE, 0, 0, "India Mutual (AMFI, ...)", "INDIAMUTUAL", "indiamutual" },
-    { FALSE, 0, 0, "Fidelity (Fidelity, ...)", "FIDELITY", "fidelity" },
-    { FALSE, 0, 0, "Finland (HEX, ...)", "FINLAND", "finland" },
-    { FALSE, 0, 0, "First Trust (First Trust, ...)", "FTPORTFOLIOS", "ftportfolios" },
-    { FALSE, 0, 0, "France (bourso, ĺerevenu, ...)", "FRANCE", "france" },
-    { FALSE, 0, 0, "Nasdaq (alphavantage, fool, ...)", "NASDAQ", "nasdaq" },
-    { FALSE, 0, 0, "New Zealand (NZX, ...)", "NZ", "nz" },
-    { FALSE, 0, 0, "NYSE (alphavantage, fool, ...)", "NYSE", "nyse" },
-    { FALSE, 0, 0, "South Africa (Sharenet, ...)", "ZA", "za" },
-    { FALSE, 0, 0, "Romania (BSE-RO, ...)", "romania", "romania" },
-    { FALSE, 0, 0, "T. Rowe Price", "TRPRICE", "troweprice" },
-    { FALSE, 0, 0, "U.K. Funds (citywire, FTfunds, MStar, tnetuk, ...)", "ukfunds", "ukfunds" },
-    { FALSE, 0, 0, "U.K. Unit Trusts (trustnet, ...)", "UKUNITTRUSTS", "uk_unit_trusts" },
-    { FALSE, 0, 0, "USA (Alphavantage, Fool, ...)", "USA", "usa" },
+    { FALSE, 0, 0, "Australia (ASX, ...)", "australia" },
+    { FALSE, 0, 0, "Canada (Alphavantage, TSX, ...)", "canada" },
+    { FALSE, 0, 0, "Canada Mutual (Fund Library, StockHouse, ...)", "canadamutual" },
+    { FALSE, 0, 0, "Dutch (AEX, ...)", "dutch" },
+    { FALSE, 0, 0, "Europe (asegr,.bsero, hex ...)", "europe" },
+    { FALSE, 0, 0, "Greece (ASE, ...)", "greece" },
+    { FALSE, 0, 0, "Hungary (Bamosz, BET, ...)", "hu" },
+    { FALSE, 0, 0, "India Mutual (AMFI, ...)", "indiamutual" },
+    { FALSE, 0, 0, "Fidelity (Fidelity, ...)", "fidelity" },
+    { FALSE, 0, 0, "Finland (HEX, ...)", "finland" },
+    { FALSE, 0, 0, "First Trust (First Trust, ...)", "ftportfolios" },
+    { FALSE, 0, 0, "France (bourso, ĺerevenu, ...)", "france" },
+    { FALSE, 0, 0, "Nasdaq (alphavantage, fool, ...)", "nasdaq" },
+    { FALSE, 0, 0, "New Zealand (NZX, ...)", "nz" },
+    { FALSE, 0, 0, "NYSE (alphavantage, fool, ...)", "nyse" },
+    { FALSE, 0, 0, "South Africa (Sharenet, ...)", "za" },
+    { FALSE, 0, 0, "Romania (BSE-RO, ...)", "romania" },
+    { FALSE, 0, 0, "T. Rowe Price", "troweprice" },
+    { FALSE, 0, 0, "U.K. Funds (citywire, FTfunds, MStar, tnetuk, ...)", "ukfunds" },
+    { FALSE, 0, 0, "U.K. Unit Trusts (trustnet, ...)", "uk_unit_trusts" },
+    { FALSE, 0, 0, "USA (Alphavantage, Fool, ...)", "usa" },
 };
 
 static const int num_single_quote_sources =
@@ -367,7 +366,6 @@ gnc_quote_source_add_new (const char *source_name, gboolean supported)
     /* This name is permanent and must be kept the same if/when support
      * for this price source is integrated into gnucash (i.e. for a
      * nice user name). */
-    new_source->old_internal_name = g_strdup(source_name);
     new_source->internal_name = g_strdup(source_name);
     new_quote_sources = g_list_append(new_quote_sources, new_source);
     return new_source;
@@ -438,14 +436,10 @@ gnc_quote_source_lookup_by_internal(const char * name)
 
     if (g_strcmp0(name, currency_quote_source.internal_name) == 0)
         return &currency_quote_source;
-    if (g_strcmp0(name, currency_quote_source.old_internal_name) == 0)
-        return &currency_quote_source;
 
     for (i = 0; i < num_single_quote_sources; i++)
     {
         if (g_strcmp0(name, single_quote_sources[i].internal_name) == 0)
-            return &single_quote_sources[i];
-        if (g_strcmp0(name, single_quote_sources[i].old_internal_name) == 0)
             return &single_quote_sources[i];
     }
 
@@ -453,16 +447,12 @@ gnc_quote_source_lookup_by_internal(const char * name)
     {
         if (g_strcmp0(name, multiple_quote_sources[i].internal_name) == 0)
             return &multiple_quote_sources[i];
-        if (g_strcmp0(name, multiple_quote_sources[i].old_internal_name) == 0)
-            return &multiple_quote_sources[i];
     }
 
     for (i = 0, node = new_quote_sources; node; node = node->next, i++)
     {
         source = node->data;
         if (g_strcmp0(name, source->internal_name) == 0)
-            return source;
-        if (g_strcmp0(name, source->old_internal_name) == 0)
             return source;
     }
 

--- a/libgnucash/engine/gnc-commodity.c
+++ b/libgnucash/engine/gnc-commodity.c
@@ -206,12 +206,24 @@ gnc_quote_source_fq_version (void)
 gint gnc_quote_source_num_entries(QuoteSourceType type)
 {
     switch (type) {
-        case SOURCE_CURRENCY: return g_list_length(currency_quote_sources); break;
-        case SOURCE_FQ_CURRENCY: return g_list_length(fq_currency_quote_sources); break;
-        case SOURCE_SINGLE: return g_list_length(single_quote_sources); break;
-        case SOURCE_MULTI: return g_list_length(multiple_quote_sources); break;
-        case SOURCE_UNKNOWN: return g_list_length(unknown_quote_sources); break;
-        default: return 0; break;
+        case SOURCE_CURRENCY:
+            return g_list_length(currency_quote_sources);
+            break;
+        case SOURCE_FQ_CURRENCY:
+            return g_list_length(fq_currency_quote_sources);
+            break;
+        case SOURCE_SINGLE:
+            return g_list_length(single_quote_sources);
+            break;
+        case SOURCE_MULTI:
+            return g_list_length(multiple_quote_sources);
+            break;
+        case SOURCE_UNKNOWN:
+            return g_list_length(unknown_quote_sources);
+            break;
+        default:
+            return 0;
+            break;
     }
 }
 
@@ -273,11 +285,21 @@ gnc_quote_source_lookup_by_ti (QuoteSourceType type, gint index)
 
     switch (type)
     {
-        case SOURCE_CURRENCY: source_list = currency_quote_sources; break;
-        case SOURCE_FQ_CURRENCY: source_list = fq_currency_quote_sources; break;
-        case SOURCE_SINGLE: source_list = single_quote_sources; break;
-        case SOURCE_MULTI: source_list = multiple_quote_sources; break;
-        case SOURCE_UNKNOWN: source_list = unknown_quote_sources; break;
+        case SOURCE_CURRENCY:
+            source_list = currency_quote_sources;
+            break;
+        case SOURCE_FQ_CURRENCY:
+            source_list = fq_currency_quote_sources;
+            break;
+        case SOURCE_SINGLE:
+            source_list = single_quote_sources;
+            break;
+        case SOURCE_MULTI:
+            source_list = multiple_quote_sources;
+            break;
+        case SOURCE_UNKNOWN:
+            source_list = unknown_quote_sources;
+            break;
     }
 
     if (NULL != source_list)
@@ -303,11 +325,21 @@ gnc_quote_source_lookup_by_name_and_type(const char * name, QuoteSourceType type
 
     GList *source_list = NULL;
     switch (type) {
-        case SOURCE_CURRENCY: source_list = currency_quote_sources; break;
-        case SOURCE_FQ_CURRENCY: source_list = fq_currency_quote_sources; break;
-        case SOURCE_SINGLE: source_list = single_quote_sources; break;
-        case SOURCE_MULTI: source_list = multiple_quote_sources; break;
-        case SOURCE_UNKNOWN: source_list = unknown_quote_sources; break;
+        case SOURCE_CURRENCY:
+            source_list = currency_quote_sources;
+            break;
+        case SOURCE_FQ_CURRENCY:
+            source_list = fq_currency_quote_sources;
+            break;
+        case SOURCE_SINGLE:
+            source_list = single_quote_sources;
+            break;
+        case SOURCE_MULTI:
+            source_list = multiple_quote_sources;
+            break;
+        case SOURCE_UNKNOWN:
+            source_list = unknown_quote_sources;
+            break;
     }
 
     for (GList* node = source_list; node; node = node->next) {

--- a/libgnucash/engine/gnc-commodity.c
+++ b/libgnucash/engine/gnc-commodity.c
@@ -230,7 +230,7 @@ gint gnc_quote_source_num_entries(QuoteSourceType type)
 /********************************************************************
  * gnc_quote_source_add_new
  *
- * Add a new price source. Called from withing this source file to 
+ * Add a new price source. Called from within this source file to 
  * register F::Q sources as well as when an unknown source is found 
  * in the user's data.
  ********************************************************************/

--- a/libgnucash/engine/gnc-commodity.c
+++ b/libgnucash/engine/gnc-commodity.c
@@ -150,124 +150,15 @@ static char *fq_version = NULL;
 
 struct gnc_quote_source_s
 {
-    gboolean supported;
     QuoteSourceType type;
     gint index;
-    char *user_name;		/* User friendly name incl. region code*/
-    char *internal_name;	/* Name used internally and by finance::quote. */
+    char *name;
 };
 
-/* To update the following lists scan
- * from github.com/finance-quote/finance-quote
- * in lib/Finance/Quote/ all *.pm for "methods"
- * because many of them have more than one -
- * ideally after each release of them.
- *
- * Apply changes here also to the FQ appendix of help.
- */
-static gnc_quote_source currency_quote_source =
-{ TRUE, 0, 0, "Currency", "currency" };
-
-/* The single quote method is usually the module name, but
- * sometimes it gets the suffix "_direct"
- * and the failover method is without suffix.
- */
-static gnc_quote_source single_quote_sources[] =
-{
-    { FALSE, 0, 0, "Alphavantage, US", "alphavantage" },
-    { FALSE, 0, 0, "Amsterdam Euronext eXchange, NL", "aex" },
-    { FALSE, 0, 0, "American International Assurance, HK", "aiahk" },
-    { FALSE, 0, 0, "Association of Mutual Funds in India", "amfiindia" },
-    { FALSE, 0, 0, "Athens Stock Exchange, GR", "asegr" },
-    { FALSE, 0, 0, "Australian Stock Exchange, AU", "asx" },
-    { FALSE, 0, 0, "BAMOSZ funds, HU", "bamosz" },
-    { FALSE, 0, 0, "BMO NesbittBurns, CA", "bmonesbittburns" },
-    { FALSE, 0, 0, "Bucharest Stock Exchange, RO", "bsero" },
-    { FALSE, 0, 0, "Budapest Stock Exchange (BET), ex-BUX, HU", "bse" },
-    { FALSE, 0, 0, "Canada Mutual", "canadamutual" },
-    { FALSE, 0, 0, "Citywire Funds, GB", "citywire" },
-    { FALSE, 0, 0, "Colombo Stock Exchange, LK", "cse" },
-    { FALSE, 0, 0, "Cominvest, ex-Adig, DE", "cominvest" },
-    { FALSE, 0, 0, "Deka Investments, DE", "deka" },
-    { FALSE, 0, 0, "Dutch", "dutch" },
-    { FALSE, 0, 0, "DWS, DE", "dwsfunds" },
-    { FALSE, 0, 0, "Equinox Unit Trusts, ZA", "za_unittrusts" },
-    { FALSE, 0, 0, "Fidelity Direct", "fidelity_direct" },
-    { FALSE, 0, 0, "Fidelity Fixed", "fidelityfixed" },
-    { FALSE, 0, 0, "Finance Canada", "financecanada" },
-    { FALSE, 0, 0, "Financial Times Funds service, GB", "ftfunds" },
-    { FALSE, 0, 0, "Finanzpartner, DE", "finanzpartner" },
-    { FALSE, 0, 0, "First Trust Portfolios, US", "ftportfolios" },
-    { FALSE, 0, 0, "Fund Library, CA", "fundlibrary" },
-    { FALSE, 0, 0, "GoldMoney spot rates, JE", "goldmoney" },
-    { FALSE, 0, 0, "Greece", "greece" },
-    { FALSE, 0, 0, "Helsinki stock eXchange, FI", "hex" },
-    { FALSE, 0, 0, "Hungary", "hu" },
-    { FALSE, 0, 0, "India Mutual", "indiamutual" },
-    { FALSE, 0, 0, "Man Investments, AU", "maninv" },
-    { FALSE, 0, 0, "Morningstar, GB", "mstaruk" },
-    { FALSE, 0, 0, "Morningstar, JP", "morningstarjp" },
-    { FALSE, 0, 0, "Morningstar, SE", "morningstar" },
-    { FALSE, 0, 0, "Motley Fool, US", "fool" },
-    { FALSE, 0, 0, "New Zealand stock eXchange, NZ", "nzx" },
-    { FALSE, 0, 0, "Paris Stock Exchange/Boursorama, FR", "bourso" },
-    { FALSE, 0, 0, "Paris Stock Exchange/LeRevenu, FR", "lerevenu" },
-    { FALSE, 0, 0, "Platinum Asset Management, AU", "platinum" },
-    { FALSE, 0, 0, "Romania", "romania" },
-    { FALSE, 0, 0, "SIX Swiss Exchange funds, CH", "sixfunds" },
-    { FALSE, 0, 0, "SIX Swiss Exchange shares, CH", "sixshares" },
-    { FALSE, 0, 0, "Skandinaviska Enskilda Banken, SE", "seb_funds" },
-    { FALSE, 0, 0, "Sharenet, ZA", "za" },
-    { FALSE, 0, 0, "StockHouse Canada", "stockhousecanada_fund" },
-    { FALSE, 0, 0, "TD Waterhouse Funds, CA", "tdwaterhouse" },
-    { FALSE, 0, 0, "TD Efunds, CA", "tdefunds" },
-    { FALSE, 0, 0, "TIAA-CREF, US", "tiaacref" },
-    { FALSE, 0, 0, "Toronto Stock eXchange, CA", "tsx" },
-    { FALSE, 0, 0, "T. Rowe Price", "troweprice" },
-    { FALSE, 0, 0, "T. Rowe Price, US", "troweprice_direct" },
-    { FALSE, 0, 0, "Trustnet via tnetuk.pm, GB", "tnetuk" },
-    { FALSE, 0, 0, "Trustnet via trustnet.pm, GB", "trustnet" },
-    { FALSE, 0, 0, "U.K. Unit Trusts", "uk_unit_trusts" },
-    { FALSE, 0, 0, "Union Investment, DE", "unionfunds" },
-    { FALSE, 0, 0, "US Treasury Bonds", "usfedbonds" },
-    { FALSE, 0, 0, "US Govt. Thrift Savings Plan", "tsp" },
-    { FALSE, 0, 0, "Vanguard", "vanguard" }, /* Method of Alphavantage */
-    { FALSE, 0, 0, "VWD, DE (unmaintained)", "vwd" },
-    { FALSE, 0, 0, "Yahoo as JSON", "yahoo_json" },
-    { FALSE, 0, 0, "Yahoo as YQL", "yahoo_yql" },
-};
-
-static gnc_quote_source multiple_quote_sources[] =
-{
-    { FALSE, 0, 0, "Australia (ASX, ...)", "australia" },
-    { FALSE, 0, 0, "Canada (Alphavantage, TSX, ...)", "canada" },
-    { FALSE, 0, 0, "Canada Mutual (Fund Library, StockHouse, ...)", "canadamutual" },
-    { FALSE, 0, 0, "Dutch (AEX, ...)", "dutch" },
-    { FALSE, 0, 0, "Europe (asegr,.bsero, hex ...)", "europe" },
-    { FALSE, 0, 0, "Greece (ASE, ...)", "greece" },
-    { FALSE, 0, 0, "Hungary (Bamosz, BET, ...)", "hu" },
-    { FALSE, 0, 0, "India Mutual (AMFI, ...)", "indiamutual" },
-    { FALSE, 0, 0, "Fidelity (Fidelity, ...)", "fidelity" },
-    { FALSE, 0, 0, "Finland (HEX, ...)", "finland" },
-    { FALSE, 0, 0, "First Trust (First Trust, ...)", "ftportfolios" },
-    { FALSE, 0, 0, "France (bourso, ĺerevenu, ...)", "france" },
-    { FALSE, 0, 0, "Nasdaq (alphavantage, fool, ...)", "nasdaq" },
-    { FALSE, 0, 0, "New Zealand (NZX, ...)", "nz" },
-    { FALSE, 0, 0, "NYSE (alphavantage, fool, ...)", "nyse" },
-    { FALSE, 0, 0, "South Africa (Sharenet, ...)", "za" },
-    { FALSE, 0, 0, "Romania (BSE-RO, ...)", "romania" },
-    { FALSE, 0, 0, "T. Rowe Price", "troweprice" },
-    { FALSE, 0, 0, "U.K. Funds (citywire, FTfunds, MStar, tnetuk, ...)", "ukfunds" },
-    { FALSE, 0, 0, "U.K. Unit Trusts (trustnet, ...)", "uk_unit_trusts" },
-    { FALSE, 0, 0, "USA (Alphavantage, Fool, ...)", "usa" },
-};
-
-static const int num_single_quote_sources =
-    sizeof(single_quote_sources) / sizeof(gnc_quote_source);
-static const int num_multiple_quote_sources =
-    sizeof(multiple_quote_sources) / sizeof(gnc_quote_source);
-static GList *new_quote_sources = NULL;
-
+static GList *currency_quote_sources = NULL;
+static GList *single_quote_sources = NULL;
+static GList *multiple_quote_sources = NULL;
+static GList *unknown_quote_sources = NULL;
 
 /********************************************************************
  * gnc_quote_source_fq_installed
@@ -301,73 +192,51 @@ gnc_quote_source_fq_version (void)
  ********************************************************************/
 gint gnc_quote_source_num_entries(QuoteSourceType type)
 {
-    if  (type == SOURCE_CURRENCY)
-        return 1;
-
-    if  (type == SOURCE_SINGLE)
-        return num_single_quote_sources;
-
-    if (type == SOURCE_MULTI)
-        return num_multiple_quote_sources;
-
-    return g_list_length(new_quote_sources);
-}
-
-/********************************************************************
- * gnc_quote_source_init_tables
- *
- * Update the type/index values for prices sources.
- ********************************************************************/
-static void
-gnc_quote_source_init_tables (void)
-{
-    gint i;
-
-    for (i = 0; i < num_single_quote_sources; i++)
-    {
-        single_quote_sources[i].type = SOURCE_SINGLE;
-        single_quote_sources[i].index = i;
+    switch (type) {
+        case SOURCE_CURRENCY: return g_list_length(currency_quote_sources); break;
+        case SOURCE_SINGLE: return g_list_length(single_quote_sources); break;
+        case SOURCE_MULTI: return g_list_length(multiple_quote_sources); break;
+        case SOURCE_UNKNOWN: return g_list_length(unknown_quote_sources); break;
+        default: return 0; break;
     }
-
-    for (i = 0; i < num_multiple_quote_sources; i++)
-    {
-        multiple_quote_sources[i].type = SOURCE_MULTI;
-        multiple_quote_sources[i].index = i;
-    }
-
-    currency_quote_source.type = SOURCE_CURRENCY;
-    currency_quote_source.index = 0;
 }
-
 
 /********************************************************************
  * gnc_quote_source_add_new
  *
- * Add a new price source. Called when unknown source names are found
- * either in the F::Q installation (a newly available source) or in
- * the user's data file (a source that has vanished but needs to be
- * tracked.)
+ * Add a new price source. Called from withing this source file to 
+ * register F::Q sources as well as when an unknown source is found 
+ * in the user's data.
  ********************************************************************/
 gnc_quote_source *
-gnc_quote_source_add_new (const char *source_name, gboolean supported)
+gnc_quote_source_add_new (const char *source_name, QuoteSourceType type)
 {
     gnc_quote_source *new_source;
 
     DEBUG("Creating new source %s", (source_name == NULL ? "(null)" : source_name));
     new_source = malloc(sizeof(gnc_quote_source));
-    new_source->supported = supported;
-    new_source->type = SOURCE_UNKNOWN;
-    new_source->index = g_list_length(new_quote_sources);
+    new_source->type = type;
+    new_source->name = g_strdup(source_name);
 
-    /* This name can be changed if/when support for this price source is
-     * integrated into gnucash. */
-    new_source->user_name = g_strdup(source_name);
+    switch (type) {
+        case SOURCE_CURRENCY:
+            new_source->index = g_list_length(currency_quote_sources);
+            currency_quote_sources = g_list_append(currency_quote_sources, new_source);
+            break;
+        case SOURCE_SINGLE:
+            new_source->index = g_list_length(single_quote_sources);
+            single_quote_sources = g_list_append(single_quote_sources, new_source);
+            break;
+        case SOURCE_MULTI:
+            new_source->index = g_list_length(multiple_quote_sources);
+            multiple_quote_sources = g_list_append(multiple_quote_sources, new_source);
+            break;
+        case SOURCE_UNKNOWN:
+            new_source->index = g_list_length(unknown_quote_sources);
+            unknown_quote_sources = g_list_append(unknown_quote_sources, new_source);
+            break;
+    }
 
-    /* This name is permanent and must be kept the same if/when support
-     * for this price source is integrated into gnucash (i.e. for a
-     * nice user name). */
-    new_source->internal_name = g_strdup(source_name);
-    new_quote_sources = g_list_append(new_quote_sources, new_source);
     return new_source;
 }
 
@@ -379,80 +248,52 @@ gnc_quote_source_add_new (const char *source_name, gboolean supported)
 gnc_quote_source *
 gnc_quote_source_lookup_by_ti (QuoteSourceType type, gint index)
 {
-    gnc_quote_source *source;
-    GList *node;
-
     ENTER("type/index is %d/%d", type, index);
+    
+    GList *source_list = NULL;
+    GList *node = NULL;
+
     switch (type)
     {
-    case SOURCE_CURRENCY:
-        LEAVE("found %s", currency_quote_source.user_name);
-        return &currency_quote_source;
-        break;
-
-    case SOURCE_SINGLE:
-        if (index < num_single_quote_sources)
-        {
-            LEAVE("found %s", single_quote_sources[index].user_name);
-            return &single_quote_sources[index];
-        }
-        break;
-
-    case SOURCE_MULTI:
-        if (index < num_multiple_quote_sources)
-        {
-            LEAVE("found %s", multiple_quote_sources[index].user_name);
-            return &multiple_quote_sources[index];
-        }
-        break;
-
-    case SOURCE_UNKNOWN:
-    default:
-        node = g_list_nth(new_quote_sources, index);
-        if (node)
-        {
-            source = node->data;
-            LEAVE("found %s", source->user_name);
-            return source;
-        }
-        break;
+        case SOURCE_CURRENCY: source_list = currency_quote_sources; break;
+        case SOURCE_SINGLE: source_list = single_quote_sources; break;
+        case SOURCE_MULTI: source_list = multiple_quote_sources; break;
+        case SOURCE_UNKNOWN: source_list = unknown_quote_sources; break;
     }
 
-    LEAVE("not found");
-    return NULL;
+    if (NULL != source_list)
+        node = g_list_nth(source_list, index);
+
+    if (NULL == node) {
+        LEAVE("not found");
+        return NULL;
+    }
+
+    gnc_quote_source *source = node->data;
+    LEAVE("found %s", source->name);
+    return source;
 }
 
 gnc_quote_source *
-gnc_quote_source_lookup_by_internal(const char * name)
+gnc_quote_source_lookup_by_name(const char * name, QuoteSourceType type)
 {
-    gnc_quote_source *source;
-    GList *node;
-    gint i;
-
     if ((name == NULL) || (g_strcmp0(name, "") == 0))
     {
         return NULL;
     }
 
-    if (g_strcmp0(name, currency_quote_source.internal_name) == 0)
-        return &currency_quote_source;
-
-    for (i = 0; i < num_single_quote_sources; i++)
-    {
-        if (g_strcmp0(name, single_quote_sources[i].internal_name) == 0)
-            return &single_quote_sources[i];
+    GList *source_list = NULL;
+    switch (type) {
+        case SOURCE_CURRENCY: source_list = currency_quote_sources; break;
+        case SOURCE_SINGLE: source_list = single_quote_sources; break;
+        case SOURCE_MULTI: source_list = multiple_quote_sources; break;
+        case SOURCE_UNKNOWN: source_list = unknown_quote_sources; break;
     }
 
-    for (i = 0; i < num_multiple_quote_sources; i++)
-    {
-        if (g_strcmp0(name, multiple_quote_sources[i].internal_name) == 0)
-            return &multiple_quote_sources[i];
-    }
+    for (GList* node = sources_list; node; node = node->next) {
+        gnc_quote_source *source = node->data;
 
-    for (i = 0, node = new_quote_sources; node; node = node->next, i++)
-    {
-        source = node->data;
-        if (g_strcmp0(name, source->internal_name) == 0)
+        if (g_strcmp0(name, source->name) == 0)
             return source;
     }
 
@@ -502,13 +343,14 @@ gnc_quote_source_get_supported (const gnc_quote_source *source)
         LEAVE("bad source");
         return FALSE;
     }
+    gboolean supported = source && source->type != SOURCE_UNKNOWN;
 
-    LEAVE("%ssupported", source && source->supported ? "" : "not ");
-    return source->supported;
+    LEAVE("%s", supported ? "supported" : "not supported");
+    return supported;
 }
 
 const char *
-gnc_quote_source_get_user_name (const gnc_quote_source *source)
+gnc_quote_source_get_name (const gnc_quote_source *source)
 {
     ENTER("%p", source);
     if (!source)
@@ -516,42 +358,20 @@ gnc_quote_source_get_user_name (const gnc_quote_source *source)
         LEAVE("bad source");
         return NULL;
     }
-    LEAVE("user name %s", source->user_name);
-    return source->user_name;
+    LEAVE("name %s", source->name);
+    return source->name;
 }
 
-const char *
-gnc_quote_source_get_internal_name (const gnc_quote_source *source)
+/**
+ * gnc_quote_source_set_fq_installed registers names for the
+ * various F::Q source types.
+ **/
+void gnc_quote_source_set_fq_installed (const char* version_string,
+                                        const GList *currency_sources_list,
+                                        const GList *single_sources_list,
+                                        const GList *multiple_sources_list)
 {
-    ENTER("%p", source);
-    if (!source)
-    {
-        LEAVE("bad source");
-        return NULL;
-    }
-    LEAVE("internal name %s", source->internal_name);
-    return source->internal_name;
-}
-
-
-/********************************************************************
- * gnc_quote_source_set_fq_installed
- *
- * Update gnucash internal tables on what Finance::Quote sources are
- * installed.
- ********************************************************************/
-void
-gnc_quote_source_set_fq_installed (const char* version_string,
-                                   const GList *sources_list)
-{
-    gnc_quote_source *source;
-    char *source_name;
     const GList *node;
-
-    ENTER(" ");
-
-    if (!sources_list)
-        return;
 
     if (fq_version)
     {
@@ -562,21 +382,12 @@ gnc_quote_source_set_fq_installed (const char* version_string,
     if (version_string)
         fq_version = g_strdup (version_string);
 
-    for (node = sources_list; node; node = node->next)
-    {
-        source_name = node->data;
-
-        source = gnc_quote_source_lookup_by_internal(source_name);
-        if (source != NULL)
-        {
-            DEBUG("Found source %s: %s", source_name, source->user_name);
-            source->supported = TRUE;
-            continue;
-        }
-
-        gnc_quote_source_add_new(source_name, TRUE);
-    }
-    LEAVE(" ");
+    for (node = currency_quote_sources; node; node = node->next)
+        gnc_quote_source_add_new(node->data, SOURCE_CURRENCY);
+    for (node = single_quote_sources; node; node = node->next)
+        gnc_quote_source_add_new(node->data, SOURCE_SINGLE);
+    for (node = multiple_quote_sources; node; node = node->next)
+        gnc_quote_source_add_new(node->data, SOURCE_MULTI);
 }
 
 /********************************************************************
@@ -891,7 +702,7 @@ gnc_commodity_new(QofBook *book, const char * fullname,
         if (gnc_commodity_namespace_is_iso(name_space))
         {
             gnc_commodity_set_quote_source(retval,
-                                           gnc_quote_source_lookup_by_internal("currency") );
+                                           gnc_quote_source_lookup_by_name("alphavantage", SOURCE_CURRENCY) );
         }
     }
     gnc_commodity_set_fullname(retval, fullname);
@@ -1155,7 +966,7 @@ gnc_commodity_get_default_quote_source(const gnc_commodity *cm)
     if (cm && gnc_commodity_is_iso(cm))
         return &currency_quote_source;
     /* Should make this a user option at some point. */
-    return gnc_quote_source_lookup_by_internal("alphavantage");
+    return gnc_quote_source_lookup_by_name("alphavantage", SOURCE_SINGLE);
 }
 
 /********************************************************************

--- a/libgnucash/engine/gnc-commodity.c
+++ b/libgnucash/engine/gnc-commodity.c
@@ -356,18 +356,9 @@ gnc_quote_source_lookup_by_name_and_type(const char * name, QuoteSourceType type
 gnc_quote_source *
 gnc_quote_source_lookup_by_name(const char * name)
 {
-    // "currency" is the internal GNC name that causes the F::Q wrapper to call the currency conversion routine
-    if (g_strcmp0(name, "currency") == 0)
-        return gnc_quote_source_lookup_by_name_and_type(name, SOURCE_CURRENCY);
-
-    // Otherwise, the source must be in one of the following since SOURCE_FQ_CURRENCY is not currently in use
-    gnc_quote_source *source = NULL;
-    if (NULL != (source = gnc_quote_source_lookup_by_name_and_type(name, SOURCE_SINGLE)))
-        return source;
-    if (NULL != (source = gnc_quote_source_lookup_by_name_and_type(name, SOURCE_MULTI)))
-        return source;
-    if (NULL != (source = gnc_quote_source_lookup_by_name_and_type(name, SOURCE_UNKNOWN)))
-        return source;
+    for (QuoteSourceType type = SOURCE_SINGLE; type <= SOURCE_CURRENCY; type++)
+      if (source = gnc_quote_source_lookup_by_name_and_type (name, type))
+          return source;    
 
     return NULL;
 }

--- a/libgnucash/engine/gnc-commodity.c
+++ b/libgnucash/engine/gnc-commodity.c
@@ -356,8 +356,9 @@ gnc_quote_source_lookup_by_name_and_type(const char * name, QuoteSourceType type
 gnc_quote_source *
 gnc_quote_source_lookup_by_name(const char * name)
 {
+    gnc_quote_source *source;
     for (QuoteSourceType type = SOURCE_SINGLE; type <= SOURCE_CURRENCY; type++)
-      if (source = gnc_quote_source_lookup_by_name_and_type (name, type))
+      if ((source = gnc_quote_source_lookup_by_name_and_type (name, type)))
           return source;    
 
     return NULL;

--- a/libgnucash/engine/gnc-commodity.h
+++ b/libgnucash/engine/gnc-commodity.h
@@ -158,17 +158,19 @@ gboolean gnc_quote_source_fq_installed (void);
  */
 const char* gnc_quote_source_fq_version (void);
 
-/** Update gnucash internal tables based on what Finance::Quote
- *  sources are installed.  Sources that have been explicitly coded
- *  into gnucash are marked sensitive/insensitive based upon whether
- *  they are present. New sources that gnucash doesn't know about are
- *  added to its internal tables.
+/** Register the available currency, single, and multiple sources
+ * that Finance::Quote reports are available.  The "unkown" source
+ * type is used for quote sources that are in the user's data but
+ * are not available in the current version of Finance::Quote.
  *
- *  @param sources_list A list of strings containing the source names
- *  as they are known to F::Q.
+ *  @param currency_sources_list A list of strings for currency sources
+ *  @param single_sources_list A list of strings for F::Q modules (single sources)
+ *  @param multiple_sources_list A list of strings for F::Q methods (multiple sources)
  */
 void gnc_quote_source_set_fq_installed (const char* version_string,
-                                        const GList *sources_list);
+                                        const GList *currency_sources_list,
+                                        const GList *single_sources_list,
+                                        const GList *multiple_sources_list);
 
 /** Return the number of entries for a given type of quote source.
  *
@@ -178,29 +180,28 @@ void gnc_quote_source_set_fq_installed (const char* version_string,
  */
 gint gnc_quote_source_num_entries(QuoteSourceType type);
 
-/** Create a new quote source. This is called by the F::Q startup code
- *  or the XML parsing code to add new entries to the list of
- *  available quote sources.
+/** Create a new quote source.  This is called from gnc_quote_source_set_fq_installed()
+ *  and from the book parsing code when an unknown source is found.
  *
  *  @param name The internal name for this new quote source.
  *
- *  @param supported TRUE if this quote source is supported by F::Q.
- *  Should only be set by the F::Q startup routine.
+ *  @param type indicates the source type
  *
  *  @return A pointer to the newly created quote source.
  */
-gnc_quote_source *gnc_quote_source_add_new(const char * name, gboolean supported);
+gnc_quote_source *gnc_quote_source_add_new(const char * name, QuoteSourceType type);
 
-/** Given the internal (gnucash or F::Q) name of a quote source, find
+/** Given the F::Q name of a quote source, find
  *  the data structure identified by this name.
  *
- *  @param internal_name The name of this quote source.
+ *  @param name The name of this quote source
+ *  @param type The type of the quote source
  *
  *  @return A pointer to the price quote source that has the specified
  *  internal name.
  */
 /*@ dependent @*/
-gnc_quote_source *gnc_quote_source_lookup_by_internal(const char * internal_name);
+gnc_quote_source *gnc_quote_source_lookup_by_name(const char * name, QuoteSourceType type);
 
 /** Given the type/index of a quote source, find the data structure
  *  identified by this pair.
@@ -227,7 +228,7 @@ gboolean gnc_quote_source_get_supported (const gnc_quote_source *source);
 /** Given a gnc_quote_source data structure, return the type of this
  *  particular quote source. (SINGLE, MULTI, UNKNOWN)
  *
- *  @param source The quote source in question.
+ *  @param source The quote source in question.y
  *
  *  @return The type of this quote source.
  */
@@ -242,27 +243,15 @@ QuoteSourceType gnc_quote_source_get_type (const gnc_quote_source *source);
  */
 gint gnc_quote_source_get_index (const gnc_quote_source *source);
 
-/** Given a gnc_quote_source data structure, return the user friendly
- *  name of this quote source.  E.G. "Yahoo Australia" or "Australia
- *  (Yahoo, ASX, ...)"
+/** Given a gnc_quote_source data structure, return the F::Q name for 
+ *  the source.
  *
  *  @param source The quote source in question.
  *
- *  @return The user friendly name.
+ *  @return The quote source name
  */
 /*@ dependent @*/
-const char *gnc_quote_source_get_user_name (const gnc_quote_source *source);
-
-/** Given a gnc_quote_source data structure, return the internal name
- *  of this quote source.  This is the name used by both gnucash and
- *  by Finance::Quote.  E.G. "yahoo_australia" or "australia"
- *
- *  @param source The quote source in question.
- *
- *  @return The internal name.
- */
-/*@ dependent @*/
-const char *gnc_quote_source_get_internal_name (const gnc_quote_source *source);
+const char *gnc_quote_source_get_name (const gnc_quote_source *source);
 
 /** @} */
 

--- a/libgnucash/engine/gnc-commodity.h
+++ b/libgnucash/engine/gnc-commodity.h
@@ -134,12 +134,11 @@ typedef enum
     SOURCE_MULTI,		/**< This quote source may pull from multiple
 			 *   web sites.  For example, the australia
 			 *   source may pull from ASX, yahoo, etc. */
-    SOURCE_UNKNOWN,	/**< This is a locally installed quote source
-			 *   that gnucash knows nothing about. May
-			 *   pull from single or multiple
-			 *   locations. */
+    SOURCE_UNKNOWN,	/**< This is a quote source observed in user's data
+             *   file but not known to F::Q. */
+    SOURCE_FQ_CURRENCY, /**< An F::Q currency source. */
     SOURCE_MAX,
-    SOURCE_CURRENCY = SOURCE_MAX, /**< The special currency quote source. */
+    SOURCE_CURRENCY = SOURCE_MAX, /**< The special currency quote source called "currency". */
 } QuoteSourceType;
 
 /** This function indicates whether or not the Finance::Quote module
@@ -191,8 +190,8 @@ gint gnc_quote_source_num_entries(QuoteSourceType type);
  */
 gnc_quote_source *gnc_quote_source_add_new(const char * name, QuoteSourceType type);
 
-/** Given the F::Q name of a quote source, find
- *  the data structure identified by this name.
+/** Given the F::Q name of a quote source and the type, find
+ *  the corresponding data structure.
  *
  *  @param name The name of this quote source
  *  @param type The type of the quote source
@@ -201,7 +200,21 @@ gnc_quote_source *gnc_quote_source_add_new(const char * name, QuoteSourceType ty
  *  internal name.
  */
 /*@ dependent @*/
-gnc_quote_source *gnc_quote_source_lookup_by_name(const char * name, QuoteSourceType type);
+
+gnc_quote_source *gnc_quote_source_lookup_by_name_and_type(const char * name, QuoteSourceType type);
+
+/** Given the F::Q name of a quote source, find
+ *  the data structure identified by this name. The name "currency"
+ *  is a special case, referring to the internal name for calling
+ *  F::Q currency conversion.
+ *
+ *  @param name The name of this quote source
+ *
+ *  @return A pointer to the price quote source that has the specified
+ *  internal name.
+ */
+/*@ dependent @*/
+gnc_quote_source *gnc_quote_source_lookup_by_name(const char * name);
 
 /** Given the type/index of a quote source, find the data structure
  *  identified by this pair.

--- a/libgnucash/quotes/finance-quote-wrapper.in
+++ b/libgnucash/quotes/finance-quote-wrapper.in
@@ -27,6 +27,7 @@
 
 use strict;
 use English;
+use Getopt::Long;
 
 =head1 NAME
 
@@ -72,7 +73,7 @@ non-zero - failure
 =cut
 
 sub check_modules {
-  my @modules = qw(Finance::Quote JSON::Parse Getopt::Std);
+  my @modules = qw(Finance::Quote JSON::Parse Getopt::Long);
   my @missing;
 
   foreach my $mod (@modules) {
@@ -128,6 +129,8 @@ Usage:
     finance-quote-wrapper -v
   Fetch quotes (input should be passed as JSON via stdin):
     finance-quote-wrapper -f
+  Return Finanance::Quote features as JSON
+    finance-quote-wrapper -i
 END
         print STDERR $message;
     }
@@ -190,96 +193,90 @@ sub parse_commodities {
 #---------------------------------------------------------------------------
 # Runtime.
 
+sub fetch {
+    JSON::Parse->import(qw(valid_json parse_json));
+    
+    my $json_input = do { local $/; <STDIN> };
+    
+    if (!valid_json($json_input)) {
+        if (-t STDERR)
+        {
+            print STDERR "Could not parse input as valid JSON.\n";
+            print STDERR "Received input:\n$json_input\n";
+        }
+        else
+        {
+            print STDERR "invalid_json\n";
+        }
+        exit 1;
+    }
+    
+    my $requests = parse_json ($json_input);
+    
+    my $defaultcurrency = $$requests{'defaultcurrency'};
+    # This shouldn't be possible if we're called from GnuCash, so only warn in interactive use.
+    if (!$defaultcurrency) {
+        $defaultcurrency = "USD";
+        if (-t STDERR)
+        {
+            print STDERR "Warning: no default currency was specified, assuming 'USD'\n";
+        }
+    }
+    
+    # Create a stockquote object.
+    my $quoter = Finance::Quote->new();
+    my $prgnam = "gnc-fq-helper";
+    
+    # Disable default currency conversions.
+    $quoter->set_currency();
+    
+    my $key;
+    my $values;
+    my %results;
+    while (($key, $values) = each %$requests)
+    {
+        next if ($key eq "defaultcurrency");
+        if ($key eq "currency")  {
+            my %curr_results = parse_currencies ($quoter, $values, $defaultcurrency, %results);
+            if (%curr_results) {
+                %results = (%results, %curr_results);
+            }
+        }
+        else
+        {
+            my %comm_results = parse_commodities ($quoter, $key, $values, %results);
+            if (%comm_results) {
+                %results = (%results, %comm_results);
+            }
+        }
+    }
+    
+    if (%results) {
+        use JSON;
+        my $jsonval = encode_json \%results;
+        print "$jsonval\n";
+    }
+    
+    STDOUT->flush();
+}
+
+sub features {
+    use JSON;
+    my %info = Finance::Quote::get_features();
+    print encode_json \%info;
+    STDOUT->flush();
+}
+
 # Check for and load non-standard modules
 check_modules ();
 
-my %opts;
-my $status = getopts('hvf', \%opts);
-if (!$status)
-{
-    print_usage();
-    exit 1;
-}
+GetOptions('h' => sub {print_usage(); exit 1;},
+	   'v' => sub {print_version(); exit 0;},
+	   'f' => sub {fetch(); exit 0;},
+           'i' => sub {features(); exit 0;});
 
-if (exists $opts{'v'})
-{
-    print_version();
-}
-elsif (exists $opts{'h'})
-{
-    print_usage();
-    exit 0;
-}
-elsif (!exists $opts{'f'})
-{
-    print_usage();
-    exit 1;
-}
-
-JSON::Parse->import(qw(valid_json parse_json));
-
-my $json_input = do { local $/; <STDIN> };
-
-if (!valid_json($json_input)) {
-    if (-t STDERR)
-    {
-        print STDERR "Could not parse input as valid JSON.\n";
-        print STDERR "Received input:\n$json_input\n";
-    }
-    else
-    {
-        print STDERR "invalid_json\n";
-    }
-    exit 1;
-}
-
-my $requests = parse_json ($json_input);
-
-my $defaultcurrency = $$requests{'defaultcurrency'};
-# This shouldn't be possible if we're called from GnuCash, so only warn in interactive use.
-if (!$defaultcurrency) {
-    $defaultcurrency = "USD";
-    if (-t STDERR)
-    {
-        print STDERR "Warning: no default currency was specified, assuming 'USD'\n";
-    }
-}
-
-# Create a stockquote object.
-my $quoter = Finance::Quote->new();
-my $prgnam = "gnc-fq-helper";
-
-# Disable default currency conversions.
-$quoter->set_currency();
-
-my $key;
-my $values;
-my %results;
-while (($key, $values) = each %$requests)
-{
-    next if ($key eq "defaultcurrency");
-    if ($key eq "currency")  {
-        my %curr_results = parse_currencies ($quoter, $values, $defaultcurrency, %results);
-        if (%curr_results) {
-            %results = (%results, %curr_results);
-        }
-    }
-    else
-    {
-        my %comm_results = parse_commodities ($quoter, $key, $values, %results);
-        if (%comm_results) {
-            %results = (%results, %comm_results);
-        }
-    }
-}
-
-if (%results) {
-    use JSON;
-    my $jsonval = encode_json \%results;
-    print "$jsonval\n";
-}
-
-STDOUT->flush();
+print_usage();
+exit 1;
 
 ## Local Variables:
 ## mode: perl

--- a/libgnucash/quotes/finance-quote-wrapper.in
+++ b/libgnucash/quotes/finance-quote-wrapper.in
@@ -262,7 +262,11 @@ sub fetch {
 
 sub features {
     use JSON;
+    # Get FQ Features as JSON
     my %info = Finance::Quote::get_features();
+    # Add a version key
+    $info{'version'} = $Finance::Quote::VERSION;
+    # Print info as json
     print encode_json \%info;
     STDOUT->flush();
 }

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -656,7 +656,6 @@ libgnucash/engine/gnc-option-impl.cpp
 libgnucash/engine/gncOrder.c
 libgnucash/engine/gncOwner.c
 libgnucash/engine/gnc-pricedb.cpp
-libgnucash/engine/gnc-quote-source.cpp
 libgnucash/engine/gnc-rational.cpp
 libgnucash/engine/gnc-session.c
 libgnucash/engine/gncTaxTable.c


### PR DESCRIPTION
# Background

This work in progress PR is a continuation of a discussion started on [GNG-dev](https://lists.gnucash.org/pipermail/gnucash-devel/2023-January/046534.html) in January.

This PR will:
- Use the new Finance::Quote `get_features()` to populate both the list of single quote sources and quote methods that use multiple sources
- Any security quote source discovered in a user's datafile that is not found in the `get_features()` list will be registered in the "unknown" source list in GnuCash
- Establish data structures in GnuCash to hold additional information returned by `get_features()` such are required API keys for certain sources

A future PR will implement GUI features that expose the additional information to users and enable setting of fields such as API keys.

# What is Implemented

- Add command line option to finance-quote-wrapper to call FQ::get_features() and return result on STDOUT as json
- C++ code that parses the features json blob from finance-quote-wrapper into map of map of list of strings

# Next Steps

- Implement `get` functions to retrieve single source, multi-source, and currency methods from the parsed json to populate menu lists in the GUI
- Add additional documentation to clarify changes
