### PR TITLE
Implement option for more aggressive match for Other Split

### DIFF
--- a/gnucash/report/trep-engine.scm
+++ b/gnucash/report/trep-engine.scm
@@ -211,13 +211,13 @@ in the Options panel."))
               (cons 'sortkey (list SPLIT-CORR-ACCT-NAME))
               (cons 'split-sortvalue xaccSplitGetCorrAccountFullName)
               (cons 'text (G_ "Other Account Name"))
-              (cons 'renderer-fn (compose xaccSplitGetAccount xaccSplitGetOtherSplit)))
+              (cons 'renderer-fn (compose xaccSplitGetAccount xaccSplitGetOtherSplitExtended)))
 
         (list 'corresponding-acc-code
               (cons 'sortkey (list SPLIT-CORR-ACCT-CODE))
               (cons 'split-sortvalue xaccSplitGetCorrAccountCode)
               (cons 'text (G_ "Other Account Code"))
-              (cons 'renderer-fn (compose xaccSplitGetAccount xaccSplitGetOtherSplit)))
+              (cons 'renderer-fn (compose xaccSplitGetAccount xaccSplitGetOtherSplitExtended)))
 
         (list 'amount
               (cons 'sortkey (list SPLIT-VALUE))
@@ -1243,7 +1243,7 @@ be excluded from periodic reporting.")
                                                 (xaccSplitGetParent split)))
                                           (account-namestring
                                            (xaccSplitGetAccount
-                                            (xaccSplitGetOtherSplit split))
+                                            (xaccSplitGetOtherSplitExtended split))
                                            (column-uses? 'other-account-code)
                                            (column-uses? 'other-account-name)
                                            (column-uses? 'other-account-full-name)))))))

--- a/libgnucash/engine/Split.h
+++ b/libgnucash/engine/Split.h
@@ -393,6 +393,17 @@ void xaccSplitMergePeerSplits (Split *split, const Split *other_split);
  */
 Split * xaccSplitGetOtherSplit (const Split *split);
 
+/**
+ * xaccSplitGetOtherSplitExtended() is similar to accSplitGetOtherSplit()
+ * but more aggressive in its match.
+ * Multiple splits on the same credit/debit side as main split are excluded.
+ * Splits with zero value are exluded unless main split is zero as well.
+ * A Split on the other side with same value (opposite sign) is matched
+ * unless there is more than one.
+ * If not split is found with these extra rules, it still returns NULL.
+ */
+Split * xaccSplitGetOtherSplitExtended (const Split *split);
+
 /** The xaccIsPeerSplit() is a convenience routine that returns TRUE
  * (a non-zero value) if the two splits share a common parent
  * transaction, else it returns FALSE (zero).


### PR DESCRIPTION
## Current situation
`xaccSplitGetOtherSplit` in `/libgnucash/engine/Split.c` is the function that currently retrieve the "other split" when provided a split. The other split account is used in register to show the transfer account as well as in various reports (such as the transaction report). Currently the match is conservative. If there is more than 2 splits, xaccSplitGetOtherSplit returns NULL and *Split Transaction* is typically displayed. In the register, the user can see the detail by opening the split view. In reports, not so much (although some have a split view it isn't quite as usable as the transaction view for some reports).

There are already 2 exceptions to the NULL return value when there are more than 2 splits:
1. Trading accounts are ignored, so that the transfer account can be shown in the transaction view even if additional trading account splits exists
2. Split that have been cut by the lot feature are regrouped, also to avoid the *split transaction* message

## Proposed changes
I'd like to propose an additional function called `xaccSplitGetOtherSplitExtended` that offers a more aggressive match to "other split" that what we currently have. This would not replace `xaccSplitGetOtherSplit` in all places but instead could be used in places where a more aggressive match is useful and doesn't have negative side effects, such as in reports. In the register, the current conservative match is probably prudent as it forces the user to open the split view instead of updating the split account in the transaction line without looking at the other splits as well.

In addition to the existing rules, the following rules are added for a more aggressive match:
 * Multiple splits on the same credit/debit side as main split are excluded.
 * Splits with zero value are excluded unless main split is zero as well.
 * A Split on the other side with same value (opposite sign) is matched unless there is more than one with same value.
 * If no obvious single split is found with these extra rules, it still returns NULL of course

## Example
Here is an example of this more aggressive match implemented in the transaction report. 

**First this view shows the example splits as entered in the register:**
![image](https://github.com/Gnucash/gnucash/assets/267163/24aaf363-2b31-47d3-b444-9edb651a7e7f)
![image](https://github.com/Gnucash/gnucash/assets/267163/78274a82-8184-4946-be1f-97ce4b85a61f)

**This is the transaction report with the more aggressive match:**
![image](https://github.com/Gnucash/gnucash/assets/267163/a96ef08c-adc1-4db3-80e8-5811493bb185)
![image](https://github.com/Gnucash/gnucash/assets/267163/91c3ea5c-ddb8-4d52-bae8-1e83e91732f1)

**For comparison, same report with the current match:**
![image](https://github.com/Gnucash/gnucash/assets/267163/beccf5fa-d58b-419a-8ed6-f889807fc9cc)
![image](https://github.com/Gnucash/gnucash/assets/267163/41e01285-9828-4f36-b46d-92a4ef4bf49a)


