### PR TITLE
Bug 798809 - Multicolumn report error when reopened after saving.

### DIFF
--- a/gnucash/report/report-core.scm
+++ b/gnucash/report/report-core.scm
@@ -582,7 +582,7 @@ not found.")))
              "      (let*\n"
              "        (\n"
              "          (option (gnc-lookup-option (gnc:optiondb options) \"__general\" \"report-list\"))\n"
-             "          (saved-report-list (GncOption-set-value option))\n"
+             "          (saved-report-list (GncOption-get-value option))\n"
              "        )\n"
              "        (\n"
              "          (lambda (option)\n"


### PR DESCRIPTION
GncOption-set-value needed to be GncOption-get-value