### PR TITLE
Bug 798796 - Account list incomplete in report options

### DIFF
--- a/gnucash/report/reports/standard/advanced-portfolio.scm
+++ b/gnucash/report/reports/standard/advanced-portfolio.scm
@@ -129,7 +129,7 @@ by preventing negative stock balances.<br/>")
       (filter gnc:account-is-stock?
               (gnc-account-get-descendants-sorted
                (gnc-get-current-root-account)))
-      (list ACCT-TYPE-ASSET ACCT-TYPE-STOCK ACCT-TYPE-MUTUAL))
+      (list ACCT-TYPE-ASSET ACCT-TYPE-BANK ACCT-TYPE-STOCK ACCT-TYPE-MUTUAL))
 
     (gnc-register-simple-boolean-option options
       gnc:pagename-accounts optname-zero-shares "e"

--- a/gnucash/report/reports/standard/investment-lots.scm
+++ b/gnucash/report/reports/standard/investment-lots.scm
@@ -147,7 +147,7 @@
       (filter gnc:account-is-stock?
               (gnc-account-get-descendants-sorted
                (gnc-get-current-root-account)))
-    (list ACCT-TYPE-ASSET ACCT-TYPE-STOCK ACCT-TYPE-MUTUAL))
+    (list ACCT-TYPE-ASSET ACCT-TYPE-BANK ACCT-TYPE-STOCK ACCT-TYPE-MUTUAL))
 
     (gnc-register-simple-boolean-option options
         gnc:pagename-accounts

--- a/gnucash/report/reports/standard/portfolio.scm
+++ b/gnucash/report/reports/standard/portfolio.scm
@@ -65,7 +65,7 @@
       (gnc:filter-accountlist-type
        (list ACCT-TYPE-STOCK ACCT-TYPE-MUTUAL)
        (gnc-account-get-descendants-sorted (gnc-get-current-root-account)))
-      (list ACCT-TYPE-ASSET ACCT-TYPE-STOCK ACCT-TYPE-MUTUAL))
+      (list ACCT-TYPE-ASSET ACCT-TYPE-BANK ACCT-TYPE-STOCK ACCT-TYPE-MUTUAL))
 
     (gnc-register-simple-boolean-option options
       gnc:pagename-accounts optname-zero-shares "e"


### PR DESCRIPTION
Allow stock/fund accounts that are descendants of Bank accounts to be selected for the Advanced Portfolio, Investment Lots and Investment Portfolio reports.