### PR TITLE
Bug 798695 - Deleting everything from the "Transfer" cell after suggestions pop-up restricts search to the first 30 accounts

### DIFF
--- a/gnucash/register/register-gnome/combocell-gnome.c
+++ b/gnucash/register/register-gnome/combocell-gnome.c
@@ -633,6 +633,20 @@ gnc_combo_cell_type_ahead_search (const gchar* newval,
     gtk_list_store_clear (box->tmp_store);
     unblock_list_signals (cell);
 
+    if (strlen (newval) == 0) {
+        /* Deleting everything in the cell shouldn't provide a search result for
+         * "" because that will just be the first MAX_NUM_MATCHES accounts which
+         * isn't very useful.
+         *
+         * Skip the search show the popup again with all accounts. Clear the
+         * temp store or the cell will be pre-filled with the first account.
+         */
+        gnc_item_list_set_temp_store (box->item_list, NULL);
+        gnc_item_edit_show_popup (box->item_edit);
+        box->list_popped = TRUE;
+        goto cleanup;
+    }
+
     while (valid && num_found < MAX_NUM_MATCHES)
     {
         gchar* str_data = NULL;
@@ -659,6 +673,8 @@ gnc_combo_cell_type_ahead_search (const gchar* newval,
         gnc_item_edit_show_popup (box->item_edit);
         box->list_popped = TRUE;
     }
+
+cleanup:
     g_regex_unref (regex);
     return match_str;
 }
@@ -1213,4 +1229,3 @@ gnc_combo_cell_set_autosize (ComboCell* cell, gboolean autosize)
 
     box->autosize = autosize;
 }
-


### PR DESCRIPTION
The combo box list is capable of displaying all accounts if expanded without starting searching, so changing the search string to "" shouldn't only return a small subset of accounts with no way to fix it.

Skip the search and return all accounts in the combo box as it normally does if the account list is opened without searching for something.