### PR TITLE
Scrub speedup

### DIFF
--- a/libgnucash/engine/Scrub.c
+++ b/libgnucash/engine/Scrub.c
@@ -332,6 +332,28 @@ xaccSplitScrub (Split *split)
 /* ================================================================ */
 
 void
+xaccTransScrubSplits (Transaction *trans)
+{
+    if (!trans) return;
+
+    gnc_commodity *currency = xaccTransGetCurrency (trans);
+    if (!currency)
+        PERR ("Transaction doesn't have a currency!");
+
+    xaccTransBeginEdit(trans);
+    /* The split scrub expects the transaction to have a currency! */
+
+    for (GList *n = xaccTransGetSplitList (trans); n; n = g_list_next (n))
+        xaccSplitScrub (n->data);
+
+    xaccTransCommitEdit(trans);
+}
+
+
+/* ================================================================ */
+
+
+void
 xaccAccountTreeScrubImbalance (Account *acc, QofPercentageFunc percentagefunc)
 {
     if (!acc) return;

--- a/libgnucash/engine/Transaction.c
+++ b/libgnucash/engine/Transaction.c
@@ -2868,23 +2868,6 @@ xaccTransGetReversedBy(const Transaction *trans)
     return retval;
 }
 
-void
-xaccTransScrubSplits (Transaction *trans)
-{
-    gnc_commodity *currency;
-
-    if (!trans) return;
-
-    xaccTransBeginEdit(trans);
-    /* The split scrub expects the transaction to have a currency! */
-    currency = xaccTransGetCurrency (trans);
-    if (!currency)
-        PERR ("Transaction doesn't have a currency!");
-
-    FOR_EACH_SPLIT(trans, xaccSplitScrub(s));
-    xaccTransCommitEdit(trans);
-}
-
 /* ============================================================== */
 /** The xaccTransScrubGainsDate() routine is used to keep the posted date
  *    of gains splits in sync with the posted date of the transaction


### PR DESCRIPTION
Instead of #1651 which does reduce the number of scrubs dramatically, this branch will augment `xaccSplitScrub` to take a `dry_run` option returning true/false if a scrub must take place.

Most splits wouldn't need scrubbing therefore the slow Begin/Commit can be skipped.