### PR TITLE
Bug 798564 - GnuCash is slow when there are a lot of open tabs/registers

### DIFF
--- a/gnucash/gnome-utils/gnc-main-window.cpp
+++ b/gnucash/gnome-utils/gnc-main-window.cpp
@@ -3035,7 +3035,8 @@ gnc_main_window_connect (GncMainWindow *window,
     priv = GNC_MAIN_WINDOW_GET_PRIVATE(window);
     notebook = GTK_NOTEBOOK (priv->notebook);
 
-    if (gnc_prefs_get_bool (GNC_PREFS_GROUP_GENERAL, GNC_PREF_TAB_OPEN_ADJACENT))
+    if (!priv->restoring_pages
+            && gnc_prefs_get_bool (GNC_PREFS_GROUP_GENERAL, GNC_PREF_TAB_OPEN_ADJACENT))
         current_position = g_list_index (priv->installed_pages, priv->current_page) + 1;
 
     priv->installed_pages = g_list_insert (priv->installed_pages, page, current_position);
@@ -3044,7 +3045,8 @@ gnc_main_window_connect (GncMainWindow *window,
                                    tab_hbox, menu_label, current_position);
     gtk_notebook_set_tab_reorderable (notebook, page->notebook_page, TRUE);
     gnc_plugin_page_inserted (page);
-    gtk_notebook_set_current_page (notebook, current_position);
+    if (!priv->restoring_pages)
+        gtk_notebook_set_current_page (notebook, current_position);
 
     if (GNC_PLUGIN_PAGE_GET_CLASS(page)->window_changed)
         (GNC_PLUGIN_PAGE_GET_CLASS(page)->window_changed)(page, GTK_WIDGET(window));
@@ -3187,7 +3189,8 @@ gnc_main_window_open_page (GncMainWindow *window,
 
     if (gnc_main_window_page_exists(page))
     {
-        gnc_main_window_display_page(page);
+        if (!gnc_main_window_is_restoring_pages (window))
+            gnc_main_window_display_page (page);
         return;
     }
 

--- a/gnucash/gnome-utils/gnc-plugin-page.c
+++ b/gnucash/gnome-utils/gnc-plugin-page.c
@@ -888,7 +888,8 @@ gnc_plugin_page_inserted_cb (GncPluginPage *page, gpointer user_data)
                                               page);
 
     // on initial load try and set the page focus
-    (GNC_PLUGIN_PAGE_GET_CLASS(page)->focus_page)(page, TRUE);
+    if (!gnc_main_window_is_restoring_pages (GNC_MAIN_WINDOW(page->window)))
+        (GNC_PLUGIN_PAGE_GET_CLASS(page)->focus_page)(page, TRUE);
 }
 
 

--- a/gnucash/gnome/gnc-plugin-page-register.c
+++ b/gnucash/gnome/gnc-plugin-page-register.c
@@ -1202,8 +1202,6 @@ gnc_plugin_page_register_create_widget (GncPluginPage* plugin_page)
         LEAVE ("existing widget %p", priv->widget);
         return priv->widget;
     }
-    // on create, the page will be the current page so set the focus flag
-    priv->page_focus = TRUE;
 
     priv->widget = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
     gtk_box_set_homogeneous (GTK_BOX (priv->widget), FALSE);

--- a/gnucash/gnome/gnc-plugin-page-register.c
+++ b/gnucash/gnome/gnc-plugin-page-register.c
@@ -1176,6 +1176,8 @@ gnc_plugin_page_register_focus (GncPluginPage* plugin_page,
 
     // set the sheet focus setting
     gnc_split_reg_set_sheet_focus (gsr, priv->page_focus);
+
+    gnc_ledger_display_set_focus (priv->ledger, priv->page_focus);
 }
 
 static GtkWidget*
@@ -1742,7 +1744,6 @@ gnc_plugin_page_register_recreate_page (GtkWidget* window,
 
     /* enable the refresh */
     priv->enable_refresh = TRUE;
-    gnc_ledger_display_refresh (priv->ledger);
     LEAVE (" ");
     return page;
 }

--- a/gnucash/register/ledger-core/gnc-ledger-display.c
+++ b/gnucash/register/ledger-core/gnc-ledger-display.c
@@ -66,6 +66,8 @@ struct gnc_ledger_display
 
     gboolean loading;
     gboolean use_double_line_default;
+    gboolean visible; /* focus */
+    gboolean needs_refresh;
 
     GNCLedgerDisplayDestroy destroy;
     GNCLedgerDisplayGetParent get_parent;
@@ -617,7 +619,15 @@ refresh_handler (GHashTable* changes, gpointer user_data)
         }
     }
 
-    gnc_ledger_display_refresh (ld);
+    if (ld->visible)
+    {
+        DEBUG ("immediate refresh because ledger is visible");
+        gnc_ledger_display_refresh (ld);
+    }
+    else
+    {
+        ld->needs_refresh = TRUE;
+    }
     LEAVE (" ");
 }
 
@@ -808,6 +818,8 @@ gnc_ledger_display_internal (Account* lead_account, Query* q,
     ld->query = NULL;
     ld->ld_type = ld_type;
     ld->loading = FALSE;
+    ld->visible = FALSE;
+    ld->needs_refresh = TRUE;
     ld->destroy = NULL;
     ld->get_parent = NULL;
     ld->user_data = NULL;
@@ -837,10 +849,13 @@ gnc_ledger_display_internal (Account* lead_account, Query* q,
 
     gnc_split_register_set_data (ld->reg, ld, gnc_ledger_display_parent);
 
-    /* We don't need to recreate the query, so skip that refresh step by
-     * bypassing gnc_ledger_display_refresh().
+    /* Must call this before gnc_table_realize_gui() gets called or all the
+     * combo boxes will be empty. Use an empty list of splits instad of running
+     * the query when we're not in focus yet.
      */
-    gnc_ledger_display_refresh_internal (ld);
+    ld->loading = TRUE;
+    gnc_split_register_load (ld->reg, NULL, gnc_ledger_display_leader (ld));
+    ld->loading = FALSE;
     return ld;
 }
 
@@ -894,6 +909,7 @@ gnc_ledger_display_refresh_internal (GNCLedgerDisplay* ld)
     gnc_split_register_load (ld->reg, splits,
                              gnc_ledger_display_leader (ld));
 
+    ld->needs_refresh = FALSE;
     ld->loading = FALSE;
 }
 
@@ -941,6 +957,20 @@ gnc_ledger_display_refresh (GNCLedgerDisplay* ld)
 
     gnc_ledger_display_refresh_internal (ld);
     LEAVE (" ");
+}
+
+void gnc_ledger_display_set_focus (GNCLedgerDisplay* ld, gboolean focus)
+{
+    if (!ld)
+        return;
+
+    ld->visible = focus;
+
+    if (ld->visible && ld->needs_refresh)
+    {
+        DEBUG ("deferred refresh because ledger is now visible");
+        gnc_ledger_display_refresh (ld);
+    }
 }
 
 void

--- a/gnucash/register/ledger-core/gnc-ledger-display.h
+++ b/gnucash/register/ledger-core/gnc-ledger-display.h
@@ -121,6 +121,9 @@ GNCLedgerDisplay* gnc_ledger_display_find_by_query (Query* q);
 void gnc_ledger_display_refresh (GNCLedgerDisplay* ledger_display);
 void gnc_ledger_display_refresh_by_split_register (SplitRegister* reg);
 
+/** Mark the ledger as being in focus (refresh immediately) or not. */
+void gnc_ledger_display_set_focus (GNCLedgerDisplay* ld, gboolean focus);
+
 /** close the window */
 void gnc_ledger_display_close (GNCLedgerDisplay* ledger_display);
 


### PR DESCRIPTION
Every time a change to a transaction is saved by navigating away from it, the UI freezes for almost a second.

Register refreshes should be deferred on tabs that are not visible until those tabs are focused again.

Use focus information to suppress the last part of the refresh_handler() if the ledger isn't currently visible. When it becomes visible again, run the deferred refresh step.

----

When loading the book on startup, GnuCash takes a long time. This is partly because gnc_restore_all_state() is loading data for every register page and I have 35+ registers open.

Don't automatically focus pages when they are recreated. This has to disregard a preference to get them to be in the right order so it is specifically only for recreates (and not a "background" or "without focus" way of creating pages).
    
Change the register page so that it doesn't assume it will be in focus on creation. Don't immediately load or refresh the ledger (this will happen the first time it is focused instead).
    
The previously active page is still focused automatically when loading is finished and this will load the ledger if it's a register.
