### PR TITLE
Bug 777472 - reconcile does not work if transaction selected

### DIFF
--- a/gnucash/gnome/gnc-plugin-page-account-tree.c
+++ b/gnucash/gnome/gnc-plugin-page-account-tree.c
@@ -1782,6 +1782,17 @@ gnc_plugin_page_account_tree_cmd_reconcile (GSimpleAction *simple,
     account = gnc_plugin_page_account_tree_get_current_account (page);
     g_return_if_fail (account != NULL);
 
+    /* To prevent mistakes involving saving an edited transaction after
+     * finishing a reconciliation (reverting the reconcile state), we could look
+     * at all open registers and determine if any of them have a transaction
+     * being edited that involves the account to be reconciled.
+     *
+     * However, the reconcile window isn't modal so it's still possible to start
+     * editing a transaction after opening it. Assume the user knows what
+     * they're doing if they start a reconciliation from the account tree and
+     * don't attempt to stop them.
+     */
+
     window = GNC_PLUGIN_PAGE (page)->window;
     recnData = recnWindow (window, account);
     gnc_ui_reconcile_window_raise (recnData);

--- a/gnucash/gnome/gnc-plugin-page-register.c
+++ b/gnucash/gnome/gnc-plugin-page-register.c
@@ -4327,6 +4327,17 @@ gnc_plugin_page_register_cmd_reconcile (GSimpleAction *simple,
 
     g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER (page));
 
+    /* To prevent mistakes involving saving an edited transaction after
+     * finishing a reconciliation (reverting the reconcile state), require
+     * pending activity on the current register to be finished.
+     *
+     * The reconcile window isn't modal so it's still possible to start editing
+     * a transaction after opening it, but at that point the user should know
+     * what they're doing is unsafe.
+     */
+    if (!gnc_plugin_page_register_finish_pending (GNC_PLUGIN_PAGE (page)))
+        return;
+
     account = gnc_plugin_page_register_get_account (page);
 
     window = gnc_window_get_gtk_window (GNC_WINDOW (GNC_PLUGIN_PAGE (


### PR DESCRIPTION
If there's an existing transaction with pending edits when starting reconciliation, that transaction can appear in the list of transactions and be modified by the reconciliation but as soon as navigation to another transaction occurs the pending edit will be saved, overwriting the change to mark it as reconciled. The result is that reconciliation appears to have failed or not marked the transaction as reconciled.

This commonly happens when marking several transactions as cleared before performing reconciliation. If the last transaction is still being edited it will typically be saved after the reconciliation finishes and overwrite any change made.

<s>Potential modification or removal of transactions affecting reconciliation could be detected by looking for pending edits to transactions involving the account being reconciled but it's not trivial to determine if a pending edit in another register would add the transaction to the account being reconciled.

Check that there's no outstanding activity in any register pages before starting a reconciliation. It is still possible to start modifying a transaction after the reconciliation window is open but this will stop the most common issue with the process.</s>

Check that there's no outstanding activity in the current register page before starting a reconciliation.

It is still possible to start modifying a transaction after the reconciliation window is open but this will stop the most common issue with the process.

Starting a reconciliation from the account tree is left unprotected.