### PR TITLE
Restore test-gnc-option

### DIFF
--- a/libgnucash/engine/test/CMakeLists.txt
+++ b/libgnucash/engine/test/CMakeLists.txt
@@ -200,6 +200,11 @@ gtest-qofevent.cpp)
 gnc_add_test(test-qofevent "${test_qofevent_SOURCES}"
   gtest_engine_INCLUDES gtest_old_engine_LIBS)
 
+set(test_gnc_option_SOURCES
+  gtest-gnc-option.cpp
+  gtest-gnc-optiondb.cpp)
+gnc_add_test(test-gnc-option "${test_gnc_option_SOURCES}"
+  gtest_engine_INCLUDES gtest_old_engine_LIBS)
 
 set(test_engine_SOURCES_DIST
         gtest-gnc-euro.cpp

--- a/libgnucash/engine/test/gtest-gnc-option.cpp
+++ b/libgnucash/engine/test/gtest-gnc-option.cpp
@@ -536,7 +536,6 @@ protected:
             return account;
         };
         auto assets = create_account(m_root, ACCT_TYPE_ASSET, "Assets");
-        auto liabilities = create_account(m_root, ACCT_TYPE_LIABILITY, "Liabilities");
         auto expenses = create_account(m_root, ACCT_TYPE_EXPENSE, "Expenses");
         create_account(assets, ACCT_TYPE_BANK, "Bank");
         auto broker = create_account(assets, ACCT_TYPE_ASSET, "Broker");
@@ -568,12 +567,6 @@ protected:
     QofBook* m_book;
     Account* m_root;
 };
-
-static bool
-operator==(const GncGUID& l, const GncGUID& r)
-{
-    return guid_equal(&l, &r);
-}
 
 TEST_F(GncOptionAccountTest, test_test_constructor_and_destructor)
 {
@@ -777,9 +770,9 @@ TEST_F(GncMultichoiceOption, test_permissible_value_stuff)
             EXPECT_STREQ("waldo", m_option.permissible_value(1));
             EXPECT_STREQ("sausage", m_option.permissible_value_name(2));
         });
-    EXPECT_THROW({ auto result = m_option.permissible_value(7); },
+    EXPECT_THROW({ m_option.permissible_value(7); },
                  std::out_of_range);
-    EXPECT_THROW({ auto result = m_option.permissible_value_name(9); },
+    EXPECT_THROW({ m_option.permissible_value_name(9); },
         std::out_of_range);
     EXPECT_EQ(std::numeric_limits<uint16_t>::max(),
               m_option.permissible_value_index("xyzzy"));

--- a/libgnucash/engine/test/gtest-gnc-optiondb.cpp
+++ b/libgnucash/engine/test/gtest-gnc-optiondb.cpp
@@ -118,7 +118,6 @@ struct GncOptionDBAccountTest : public ::testing::Test
             return account;
         };
         auto assets = create_account(m_root, ACCT_TYPE_ASSET, "Assets");
-        auto liabilities = create_account(m_root, ACCT_TYPE_LIABILITY, "Liabilities");
         auto expenses = create_account(m_root, ACCT_TYPE_EXPENSE, "Expenses");
         create_account(assets, ACCT_TYPE_BANK, "Bank");
         auto broker = create_account(assets, ACCT_TYPE_ASSET, "Broker");
@@ -288,12 +287,6 @@ TEST_F(GncOptionDBTest, test_register_start_date_option)
 
 }
 
-static bool
-operator==(const GncGUID& l, const GncGUID& r)
-{
-    return guid_equal(&l, &r);
-}
-
 class GncOptionDBIOTest : public ::testing::Test
 {
 protected:
@@ -315,7 +308,6 @@ protected:
             return account;
         };
         auto assets = create_account(m_root, ACCT_TYPE_ASSET, "Assets");
-        auto liabilities = create_account(m_root, ACCT_TYPE_LIABILITY, "Liabilities");
         auto expenses = create_account(m_root, ACCT_TYPE_EXPENSE, "Expenses");
         create_account(assets, ACCT_TYPE_BANK, "Bank");
         auto broker = create_account(assets, ACCT_TYPE_ASSET, "Broker");
@@ -384,14 +376,12 @@ TEST_F(GncOptionDBIOTest, test_option_kvp_save)
     auto bar = "bar";
     auto sausage = "sausage";
     auto grault = "grault";
-    auto garply = "garply";
     GSList foo_bar_tail{(void*)bar, nullptr};
     GSList foo_bar_head{(void*)foo, &foo_bar_tail};
     GSList foo_sausage_tail{(void*)sausage, nullptr};
     GSList foo_sausage_head{(void*)foo, &foo_sausage_tail};
     GSList qux_grault_tail{(void*)grault, nullptr};
     GSList qux_grault_head{(void*)foo, &qux_grault_tail};
-    GSList qux_garply_tail{(void*)garply, nullptr};
     GSList qux_garply_head{(void*)foo, &qux_grault_tail};
     m_db->set_option("foo", "sausage", std::string{"pepper"});
     m_db->save_to_kvp(m_book, true);


### PR DESCRIPTION
- removed in merge 3e5fcc8709100c299998b9377fa6db13c1c27fb9

To get it to compile

- remove unused variables
- remove duplicate operator==(GncGUID)