### PR TITLE
xaccTransGetTxnType must return even P if non-APAR is zero-value

### DIFF
--- a/libgnucash/engine/Transaction.c
+++ b/libgnucash/engine/Transaction.c
@@ -2484,7 +2484,7 @@ xaccTransRetDateDue(const Transaction *trans)
 char
 xaccTransGetTxnType (Transaction *trans)
 {
-    gboolean has_nonAPAR_amount = FALSE;
+    gboolean has_nonAPAR_split = FALSE;
 
     if (!trans) return TXN_TYPE_NONE;
 
@@ -2499,9 +2499,8 @@ xaccTransGetTxnType (Transaction *trans)
         if (!acc)
             continue;
 
-        if (!xaccAccountIsAPARType (xaccAccountGetType (acc)) &&
-            !gnc_numeric_zero_p (xaccSplitGetValue (n->data)))
-            has_nonAPAR_amount = TRUE;
+        if (!xaccAccountIsAPARType (xaccAccountGetType (acc)))
+            has_nonAPAR_split = TRUE;
         else if (trans->txn_type == TXN_TYPE_NONE)
         {
             GNCLot *lot = xaccSplitGetLot (n->data);
@@ -2515,7 +2514,7 @@ xaccTransGetTxnType (Transaction *trans)
         }
     }
 
-    if (!has_nonAPAR_amount && (trans->txn_type == TXN_TYPE_PAYMENT))
+    if (!has_nonAPAR_split && (trans->txn_type == TXN_TYPE_PAYMENT))
         trans->txn_type = TXN_TYPE_LINK;
 
     return trans->txn_type;

--- a/libgnucash/engine/test/utest-Invoice.c
+++ b/libgnucash/engine/test/utest-Invoice.c
@@ -369,6 +369,12 @@ test_xaccTransGetTxnTypeInvoice (Fixture *fixture, gconstpointer pData)
     g_assert_cmpint (TXN_TYPE_INVOICE, ==, xaccTransGetTxnType (fixture->trans));
 
     g_assert_cmpint (TXN_TYPE_PAYMENT, ==, xaccTransGetTxnType (fixture->trans2));
+
+    xaccTransVoid (fixture->trans2, "Cancel payment");
+
+    g_assert_cmpint (TXN_TYPE_PAYMENT, ==, xaccTransGetTxnType (fixture->trans2));
+
+    xaccTransUnvoid (fixture->trans2);
 }
 
 


### PR DESCRIPTION
Amendment to #1201: A txn_type==P transaction which is later voided will be incorrectly changed to txn_type==L.

~Will create tests soon.~

Tests completed.