### PR TITLE
Bug 798952 - Unable to set day threshold or counters in properties

### DIFF
--- a/libgnucash/engine/gnc-optiondb.cpp
+++ b/libgnucash/engine/gnc-optiondb.cpp
@@ -547,7 +547,7 @@ GncOptionDB::load_from_kvp(QofBook* book) noexcept
                             set_double();
                             break;
                         case KvpValue::Type::INT64:
-                            option.set_value(kvp->get<int64_t>());
+                            option.set_value(static_cast<int>(kvp->get<int64_t>()));
                             break;
                         case KvpValue::Type::STRING:
                             fill_option_from_string_kvp(option, kvp);
@@ -889,7 +889,7 @@ gnc_register_counter_option(GncOptionDB* db, const char* section,
                             const char* doc_string, int value)
 {
     GncOption option{GncOptionRangeValue<int>{section, name, key, doc_string,
-                value, 1, 999999999, 1}};
+                value, 0, 999999999, 1}};
     option.set_alternate(true);
     db->register_option(section, std::move(option));
 }
@@ -1205,7 +1205,7 @@ gnc_option_db_book_options(GncOptionDB* odb)
     gnc_register_counter_option(odb, counter_section,
                                 N_("Expense voucher number"), "gncExpVouchera",
                                 N_("The previous expense voucher number generated. This number will be incremented to generate the next voucher number."),
-                                0LL);
+                                0);
     gnc_register_counter_format_option(odb, counter_section,
                                        N_("Expense voucher number format"),
                                        "gncExpVoucherb",


### PR DESCRIPTION
Make sure counter values are retrieved as int; allow counters back to zero; fix voucher default value.

@jralls please double check this. I think this fixes some of the issues we are still having with the counters not being retrieved in the properties and at least brings it back to 5.1 level.

However it doesn't fix the following that was already a problem in 5.1: when setting the counters to zero or when setting the counter format to empty string, it doesn't save. Counters 1 and above will save, but not 0. As for format, any string will save but not setting it empty. Hence clicking on default and saving won't work because default = zero counters with no format strings. As I said this was already like that in 5.1, so it's not related to these latest changes that were implemented for this bug.