### PR TITLE
Register description fixes / changes

### DIFF
--- a/gnucash/register/register-gnome/completioncell-gnome.c
+++ b/gnucash/register/register-gnome/completioncell-gnome.c
@@ -666,6 +666,10 @@ gnc_completion_cell_modify_verify (BasicCell* bcell,
          box->stop_searching = FALSE;
     }
 
+    // Are were deleting or inserting in the middle.
+    if (change == NULL || *cursor_position < bcell->value_chars)
+        *start_selection = *end_selection = *cursor_position;
+
     populate_list_store (cell, newval);
 
     if (g_strcmp0 (newval, "") == 0)

--- a/gnucash/register/register-gnome/completioncell-gnome.c
+++ b/gnucash/register/register-gnome/completioncell-gnome.c
@@ -565,6 +565,10 @@ select_first_entry_in_list (PopBox* box)
     if (!gtk_tree_model_iter_next (model, &iter))
         return;
 
+    // reset horizontal scrolling
+    gtk_tree_view_column_queue_resize (gtk_tree_view_get_column (
+                                       box->item_list->tree_view, TEXT_COL));
+
     gtk_tree_model_get (model, &iter, TEXT_COL, &string, -1);
 
     gnc_item_list_select (box->item_list, string);

--- a/gnucash/register/register-gnome/completioncell-gnome.c
+++ b/gnucash/register/register-gnome/completioncell-gnome.c
@@ -670,7 +670,9 @@ gnc_completion_cell_modify_verify (BasicCell* bcell,
     if (change == NULL || *cursor_position < bcell->value_chars)
         *start_selection = *end_selection = *cursor_position;
 
-    populate_list_store (cell, newval);
+    gchar *start_of_text = g_utf8_substring (newval, 0, *cursor_position);
+    populate_list_store (cell, start_of_text);
+    g_free (start_of_text);
 
     if (g_strcmp0 (newval, "") == 0)
     {


### PR DESCRIPTION
This PR has a couple of fixes / changes to the description completion.

The first deals with updating the cursor position when deleting selected text.

The second changes the match text when editing to be from the start of the description to the cursor allowing similar entries to be shown, originally it was the whole of the description.

The third resets the horizontal scrolling position on subsequent popups.

The last one changes the horizontal scroll position to show the matching text. So if you have a matches in the list at the start and at the end of a long description as you move down with the arrow keys it will scroll to the left and right appropriately. This also helps when editing long description text as the popup list should be in the same area.

I am in two minds about this, I think it does what was asked but need other people to test. The other option could be to allow the description popup to use all the space to the right like the transfer field by doing the following...

Change the line 129 in split-register-load.c to...

    gnc_completion_cell_set_autosize (cell, FALSE);
