### PR TITLE
Bug 798956 - On Flatpak, broken link to Chart.bundle.min.js in chart report html

### DIFF
--- a/gnucash/gnome/gnc-plugin-page-report.cpp
+++ b/gnucash/gnome/gnc-plugin-page-report.cpp
@@ -1532,14 +1532,27 @@ gnc_get_export_type_choice (SCM export_types, GtkWindow *parent)
 
     if (!bad)
     {
+        const gchar * html_type = _("HTML");
+        gboolean custom_html_export = FALSE;
+
         choices = g_list_reverse (choices);
 
-        choices = g_list_prepend (choices, g_strdup (_("HTML")));
+        for (node = choices; node; node = node->next)
+            if (g_strcmp0 (static_cast<char*>(node->data), html_type) == 0)
+            {
+                custom_html_export = TRUE;
+                break;
+            }
+
+        if (!custom_html_export)
+            choices = g_list_prepend (choices, g_strdup (html_type));
 
         choice = gnc_choose_radio_option_dialog
             (GTK_WIDGET (parent), _("Choose export format"),
              _("Choose the export format for this report:"),
              nullptr, 0, choices);
+
+        if (custom_html_export && (choice >= 0)) ++choice;
     }
     else
         choice = -1;

--- a/gnucash/report/html-chart.scm
+++ b/gnucash/report/html-chart.scm
@@ -65,6 +65,8 @@
 (export gnc:html-chart-set-grid?!)
 (export gnc:html-chart-set-y-axis-label!)
 (export gnc:html-chart-add-data-series!)
+(export gnc:html-chart-embed-js?)
+(export gnc:html-chart-set-embed-js?!)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
@@ -157,7 +159,8 @@
   (custom-x-axis-ticks? html-chart-custom-x-axis-ticks?
                         html-chart-set-custom-x-axis-ticks?)
   (custom-y-axis-ticks? html-chart-custom-y-axis-ticks?
-                        html-chart-set-custom-y-axis-ticks?))
+                        html-chart-set-custom-y-axis-ticks?)
+  (embed-js? html-chart-embed-js? html-chart-set-embed-js?))
 
 (define gnc:make-html-chart-internal make-html-chart)
 (define gnc:html-chart? html-chart?)
@@ -175,6 +178,8 @@
 (define gnc:html-chart-set-custom-x-axis-ticks?! html-chart-set-custom-x-axis-ticks?)
 (define gnc:html-chart-custom-y-axis-ticks? html-chart-custom-y-axis-ticks?)
 (define gnc:html-chart-set-custom-y-axis-ticks?! html-chart-set-custom-y-axis-ticks?)
+(define gnc:html-chart-embed-js? html-chart-embed-js?)
+(define gnc:html-chart-set-embed-js?! html-chart-set-embed-js?)
 (define gnc:html-chart-get-options-internal html-chart-chart-options)
 (define gnc:html-chart-set-options-internal! html-chart-set-chart-options)
 
@@ -453,8 +458,9 @@ document.getElementById(chartid).onclick = function(evt) {
          ;; Use a unique chart-id for each chart. This prevents charts
          ;; clashing on multi-column reports
          (id (symbol->string (gensym "chart"))))
-
-    (push (gnc:html-js-include "chartjs/Chart.bundle.min.js"))
+    (if (gnc:html-chart-embed-js? chart)
+        (push (gnc:html-js-embed "chartjs/Chart.bundle.min.js"))
+        (push (gnc:html-js-include "chartjs/Chart.bundle.min.js")))
 
     ;; the following hidden h3 is used to query style and copy onto chartjs
     (push "<h3 style='display:none'></h3>")

--- a/gnucash/report/html-utilities.scm
+++ b/gnucash/report/html-utilities.scm
@@ -35,6 +35,7 @@
 (use-modules (gnucash report html-text))
 (use-modules (gnucash report html-table))
 (use-modules (ice-9 match))
+(use-modules (ice-9 textual-ports))
 (use-modules (web uri))
 
 (export gnc:html-make-empty-cell)
@@ -70,6 +71,7 @@
 (export gnc:html-make-empty-data-warning)
 (export gnc:html-make-options-link)
 (export gnc:html-js-include)
+(export gnc:html-js-embed)
 (export gnc:html-css-include)
 
 ;; returns a list with n #f (empty cell) values
@@ -395,6 +397,14 @@
   (format #f
           "<script language=\"javascript\" type=\"text/javascript\" src=~s></script>\n"
           (make-uri (gnc-resolve-file-path file))))
+
+(define (gnc:html-js-embed file)
+  (let* ((js-port (open-input-file (gnc-resolve-file-path file)))
+         (js-embed (get-string-all js-port)))
+    (close-port js-port)
+    (format #f
+            "<script language=\"javascript\" type=\"text/javascript\">~a</script>\n"
+            js-embed)))
 
 (define (gnc:html-css-include file)
   (format #f

--- a/gnucash/report/reports/standard/category-barchart.scm
+++ b/gnucash/report/reports/standard/category-barchart.scm
@@ -607,6 +607,9 @@ Please deselect the accounts with negative balances."))
             (gnc:html-chart-set-format-style!
              chart (if ratio-chart? "percent" "currency"))
 
+            (if (eq? export-type 'html)
+              (gnc:html-chart-set-embed-js?! chart #t))
+
             (gnc:report-percent-done 98)
             (gnc:html-document-add-object! document chart)
 
@@ -682,7 +685,11 @@ Please deselect the accounts with negative balances."))
                                 (list (apply + row))
                                 '())))
                          (map (cut gnc-print-time64 <> iso-date) dates-list)
-                         list-of-rows)))))))))))))
+                         list-of-rows))))))
+             ((eq? export-type 'html)
+              (gnc:html-document-set-export-string
+                 document
+                 (gnc:html-document-render document))))))))))
 
     (unless (gnc:html-document-export-string document)
       (gnc:html-document-set-export-error document (G_ "No exportable data")))
@@ -703,7 +710,7 @@ Please deselect the accounts with negative balances."))
      'menu-name menuname
      'menu-tip menutip
      'options-generator (lambda () (options-generator account-types inc-exp?))
-     'export-types '(("CSV" . csv))
+     'export-types (list (cons (G_ "HTML") 'html) (cons "CSV" 'csv))
      'export-thunk (lambda (report-obj export-type)
                      (category-barchart-renderer
                       report-obj reportname uuid account-types inc-exp? reverse-bal?


### PR DESCRIPTION
Just sharing my work so far for some feedback because I am not sure whether this even makes sense.

If we want to embed Chart.bundle.min.js in the html for reports using it, we have two choices. We either do it in the regular report rendering into the tmp html produced by simply viewing the report OR we only do it when exporting. The first option is much easier since right now the option to export to html isn't actually rendering anything, it's reusing the existing tmp file. 

Yet for the sake of it I decided to give the second option a try. Right now just testing with one report category-barchart.scm. 

It's easy enoough to use the existing export feature (in that report used for CSV export) and add a second HTML export which calls the embedding js code instead of the regular renderer just calling include js. 

I have to do a little step dance in `gnc-plugin-page-report.cpp` in the procedure that shows the available options since the default HTML export is added in that procedure to whatever other custom export types the report is defining, and treated separately from regular exports; that means we need to bypass the default HTML export when an actual custom HTML export is offered otherwise we would end up with 2 HTML export options (one just reusing the existing html file, the other rerendering with the embedded js). **TODO**: now I realize my code doesn't take into account the case where the custom HTML rendering is the only option and therefore chosen by default without the dialog box even showing up, so that's still a TODO.

The alternative is we simply always call `gnc:html-js-embed` instead of `gnc:html-js-include` and simply create larger tmp files that will be the way we want them if export to html is used. I really don't know the downside of this except for bigger tmp files, but how much does that matter? Yet it feels ugly. Bit it cuts down on a lot of the gymnastics involved with removing the default HTML option.

Finally handling multi-column reports will create its own problems and I have not adressed that here. We could simply call the custom html export for each subreport offering it, but then we will end up with the same js embedded for each report in the multi-column report, creating an unnecessary large file. It might have to be the price to pay for now.
