### PR TITLE
[gnc-main-window] Fix null pointer dereference when opening existing pages

### DIFF
--- a/gnucash/gnome-utils/gnc-main-window.cpp
+++ b/gnucash/gnome-utils/gnc-main-window.cpp
@@ -3189,8 +3189,7 @@ gnc_main_window_open_page (GncMainWindow *window,
 
     if (gnc_main_window_page_exists(page))
     {
-        if (!gnc_main_window_is_restoring_pages (window))
-            gnc_main_window_display_page (page);
+        gnc_main_window_display_page (page);
         return;
     }
 


### PR DESCRIPTION
When the page already exists in a window then we can't be restoring pages so stop checking. The "window" variable will be nullptr if we're trying to open the page "in any window".

This bug was introduced in the changes for bug 798564.