### PR TITLE
Fixes based on clang static analysis

### DIFF
--- a/gnucash/gnome-utils/dialog-account.c
+++ b/gnucash/gnome-utils/dialog-account.c
@@ -2232,7 +2232,7 @@ gnc_account_renumber_update_examples (RenumberDialog *data)
     gtk_label_set_text (GTK_LABEL(data->example1), str);
     g_free (str);
 
-    if (strlen (prefix))
+    if (prefix && *prefix)
         str = g_strdup_printf ("%s-%0*d", prefix, num_digits,
                                interval * data->num_children);
     else

--- a/gnucash/gnome-utils/gnc-main-window.cpp
+++ b/gnucash/gnome-utils/gnc-main-window.cpp
@@ -3751,7 +3751,6 @@ gnc_main_window_update_menu_and_toolbar (GncMainWindow *window,
     const gchar *menu_qualifier;
 
     GMenuModel *menu_model_part;
-    GncMenuModelSearch *gsm = g_new0 (GncMenuModelSearch, 1);
 #ifdef MAC_INTEGRATION
     auto theApp{static_cast<GtkosxApplication *>(g_object_new(GTKOSX_TYPE_APPLICATION, nullptr))};
 #endif
@@ -3792,6 +3791,7 @@ gnc_main_window_update_menu_and_toolbar (GncMainWindow *window,
     gnc_menubar_model_remove_items_with_attrib (priv->menubar_model,
                                                 GNC_MENU_ATTRIBUTE_TEMPORARY);
 
+    GncMenuModelSearch *gsm = g_new0 (GncMenuModelSearch, 1);
     for (gint i = 0; ui_updates[i]; i++)
     {
         gchar *menu_name;

--- a/gnucash/gnome/window-autoclear.c
+++ b/gnucash/gnome/window-autoclear.c
@@ -123,7 +123,7 @@ gnc_autoclear_window_ok_cb (GtkWidget *widget,
                             AutoClearWindow *data)
 {
     GList *toclear_list = NULL;
-    gnc_numeric toclear_value;
+    gnc_numeric toclear_value = gnc_numeric_error (GNC_ERROR_ARG);
     gchar *errmsg = NULL;
     GError* error = NULL;
 

--- a/gnucash/import-export/qif-imp/dialog-account-picker.c
+++ b/gnucash/import-export/qif-imp/dialog-account-picker.c
@@ -360,7 +360,7 @@ dialog_response_cb (GtkDialog *dialog, gint response_id, gpointer user_data)
     QIFAccountPickerDialog * wind = user_data;
     GtkTreeModel *model;
     GtkTreeIter iter;
-    gboolean placeholder;
+    gboolean placeholder = TRUE;
 
     if (gtk_tree_selection_get_selected (gtk_tree_view_get_selection
                                         (wind->treeview), &model, &iter))

--- a/gnucash/register/ledger-core/split-register-load.c
+++ b/gnucash/register/ledger-core/split-register-load.c
@@ -902,6 +902,7 @@ gnc_split_register_load (SplitRegister* reg, GList* slist,
     {
         VirtualCellLocation vc_loc;
         vc_loc.virt_row = 0;
+        vc_loc.virt_col = 0;
         gnc_split_register_show_trans (reg, vc_loc);
     }
     else

--- a/gnucash/register/ledger-core/split-register.c
+++ b/gnucash/register/ledger-core/split-register.c
@@ -1593,7 +1593,7 @@ gnc_split_register_save_to_copy_buffer (SplitRegister *reg,
 
         if (!other_fs)
         {
-            if (g_list_length (ft->m_splits) == 1)
+            if (ft && g_list_length (ft->m_splits) == 1)
             {
                 Split* temp_split;
 

--- a/gnucash/register/register-gnome/gnucash-style.c
+++ b/gnucash/register/register-gnome/gnucash-style.c
@@ -277,7 +277,7 @@ set_dimensions_pass_two (GnucashSheet *sheet, int default_width)
 
     width = 0;
     num_cols = cursor->num_cols;
-    widths = g_new (int, num_cols);
+    widths = g_new0 (int, num_cols);
 
     /* find header widths */
     for (col = 0; col < num_cols; col++)

--- a/libgnucash/app-utils/gnc-quotes.cpp
+++ b/libgnucash/app-utils/gnc-quotes.cpp
@@ -329,7 +329,10 @@ void
 GncQuotesImpl::report (const char* source, const StrVec& commodities,
                        bool verbose)
 {
-    bool is_currency{source && strcmp(source, "currency") == 0};
+    if (!source)
+        throw (GncQuoteException(bl::translate("GncQuotes::Report called with no source.")));
+
+    bool is_currency{strcmp(source, "currency") == 0};
     m_failures.clear();
     if (commodities.empty())
     {

--- a/libgnucash/backend/xml/gnc-bill-term-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-bill-term-xml-v2.cpp
@@ -151,11 +151,7 @@ static gboolean
 set_numeric (xmlNodePtr node, GncBillTerm* term,
              void (*func) (GncBillTerm*, gnc_numeric))
 {
-    gnc_numeric* num = dom_tree_to_gnc_numeric (node);
-    g_return_val_if_fail (num, FALSE);
-
-    func (term, *num);
-    g_free (num);
+    func (term, dom_tree_to_gnc_numeric (node));
     return TRUE;
 }
 

--- a/libgnucash/backend/xml/gnc-customer-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-customer-xml-v2.cpp
@@ -289,14 +289,8 @@ static gboolean
 customer_discount_handler (xmlNodePtr node, gpointer cust_pdata)
 {
     struct customer_pdata* pdata = static_cast<decltype (pdata)> (cust_pdata);
-    gnc_numeric* val;
 
-    val = dom_tree_to_gnc_numeric (node);
-    g_return_val_if_fail (val, FALSE);
-
-    gncCustomerSetDiscount (pdata->customer, *val);
-    g_free (val);
-
+    gncCustomerSetDiscount (pdata->customer, dom_tree_to_gnc_numeric (node));
     return TRUE;
 }
 
@@ -304,14 +298,8 @@ static gboolean
 customer_credit_handler (xmlNodePtr node, gpointer cust_pdata)
 {
     struct customer_pdata* pdata = static_cast<decltype (pdata)> (cust_pdata);
-    gnc_numeric* val;
 
-    val = dom_tree_to_gnc_numeric (node);
-    g_return_val_if_fail (val, FALSE);
-
-    gncCustomerSetCredit (pdata->customer, *val);
-    g_free (val);
-
+    gncCustomerSetCredit (pdata->customer, dom_tree_to_gnc_numeric (node));
     return TRUE;
 }
 

--- a/libgnucash/backend/xml/gnc-employee-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-employee-xml-v2.cpp
@@ -229,13 +229,8 @@ static gboolean
 employee_workday_handler (xmlNodePtr node, gpointer employee_pdata)
 {
     struct employee_pdata* pdata = static_cast<decltype (pdata)> (employee_pdata);
-    gnc_numeric* val;
 
-    val = dom_tree_to_gnc_numeric (node);
-    g_return_val_if_fail (val, FALSE);
-    gncEmployeeSetWorkday (pdata->employee, *val);
-    g_free (val);
-
+    gncEmployeeSetWorkday (pdata->employee, dom_tree_to_gnc_numeric (node));
     return TRUE;
 }
 
@@ -243,13 +238,8 @@ static gboolean
 employee_rate_handler (xmlNodePtr node, gpointer employee_pdata)
 {
     struct employee_pdata* pdata = static_cast<decltype (pdata)> (employee_pdata);
-    gnc_numeric* val;
 
-    val = dom_tree_to_gnc_numeric (node);
-    g_return_val_if_fail (val, FALSE);
-    gncEmployeeSetRate (pdata->employee, *val);
-    g_free (val);
-
+    gncEmployeeSetRate (pdata->employee, dom_tree_to_gnc_numeric (node));
     return TRUE;
 }
 

--- a/libgnucash/backend/xml/gnc-entry-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-entry-xml-v2.cpp
@@ -250,11 +250,7 @@ static inline gboolean
 set_numeric (xmlNodePtr node, GncEntry* entry,
              void (*func) (GncEntry* entry, gnc_numeric num))
 {
-    gnc_numeric* num = dom_tree_to_gnc_numeric (node);
-    g_return_val_if_fail (num, FALSE);
-
-    func (entry, *num);
-    g_free (num);
+    func (entry, dom_tree_to_gnc_numeric (node));
     return TRUE;
 }
 

--- a/libgnucash/backend/xml/gnc-invoice-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-invoice-xml-v2.cpp
@@ -382,11 +382,8 @@ static gboolean
 invoice_tochargeamt_handler (xmlNodePtr node, gpointer invoice_pdata)
 {
     struct invoice_pdata* pdata = static_cast<decltype (pdata)> (invoice_pdata);
-    gnc_numeric* num = dom_tree_to_gnc_numeric (node);
-    g_return_val_if_fail (num, FALSE);
 
-    gncInvoiceSetToChargeAmount (pdata->invoice, *num);
-    g_free (num);
+    gncInvoiceSetToChargeAmount (pdata->invoice, dom_tree_to_gnc_numeric (node));
     return TRUE;
 }
 

--- a/libgnucash/backend/xml/gnc-pricedb-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-pricedb-xml-v2.cpp
@@ -130,10 +130,7 @@ price_parse_xml_sub_node (GNCPrice* p, xmlNodePtr sub_node, QofBook* book)
     }
     else if (g_strcmp0 ("price:value", (char*)sub_node->name) == 0)
     {
-        gnc_numeric* value = dom_tree_to_gnc_numeric (sub_node);
-        if (!value) return FALSE;
-        gnc_price_set_value (p, *value);
-        g_free (value);
+        gnc_price_set_value (p, dom_tree_to_gnc_numeric (sub_node));
     }
     gnc_price_commit_edit (p);
     return TRUE;

--- a/libgnucash/backend/xml/gnc-tax-table-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-tax-table-xml-v2.cpp
@@ -183,11 +183,8 @@ static gboolean
 ttentry_amount_handler (xmlNodePtr node, gpointer ttentry_pdata)
 {
     struct ttentry_pdata* pdata = static_cast<decltype (pdata)> (ttentry_pdata);
-    gnc_numeric* num = dom_tree_to_gnc_numeric (node);
-    g_return_val_if_fail (num, FALSE);
 
-    gncTaxTableEntrySetAmount (pdata->ttentry, *num);
-    g_free (num);
+    gncTaxTableEntrySetAmount (pdata->ttentry, dom_tree_to_gnc_numeric (node));
     return TRUE;
 }
 

--- a/libgnucash/backend/xml/gnc-transaction-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-transaction-xml-v2.cpp
@@ -217,14 +217,8 @@ static inline gboolean
 set_spl_gnc_num (xmlNodePtr node, Split* spl,
                  void (*func) (Split* spl, gnc_numeric gn))
 {
-    gnc_numeric* num = dom_tree_to_gnc_numeric (node);
-    g_return_val_if_fail (num, FALSE);
-
-    func (spl, *num);
-
-    g_free (num);
-
-    return FALSE;
+    func (spl, dom_tree_to_gnc_numeric (node));
+    return TRUE;
 }
 
 static gboolean

--- a/libgnucash/backend/xml/io-gncxml-v1.cpp
+++ b/libgnucash/backend/xml/io-gncxml-v1.cpp
@@ -2967,10 +2967,7 @@ price_parse_xml_sub_node (GNCPrice* p, xmlNodePtr sub_node, QofBook* book)
     }
     else if (g_strcmp0 ("price:value", (char*)sub_node->name) == 0)
     {
-        gnc_numeric* value = dom_tree_to_gnc_numeric (sub_node);
-        if (!value) return FALSE;
-        gnc_price_set_value (p, *value);
-        g_free (value);
+        gnc_price_set_value (p, dom_tree_to_gnc_numeric (sub_node));
     }
     gnc_price_commit_edit (p);
     return TRUE;

--- a/libgnucash/backend/xml/io-gncxml-v2.cpp
+++ b/libgnucash/backend/xml/io-gncxml-v2.cpp
@@ -1602,14 +1602,19 @@ gnc_book_write_to_xml_file_v2 (QofBook* book, const char* filename,
         return false;
 
     /* Try to write as much as possible */
-    success = (gnc_book_write_to_xml_filehandle_v2 (book, file));
+    if (!gnc_book_write_to_xml_filehandle_v2 (book, file))
+        success = false;
 
     /* Close the output stream */
-    success = ! (fclose (file));
+    if (fclose (file))
+        success = false;
 
     /* Optionally wait for parallel compression threads */
     if (thread)
-        success =  g_thread_join (thread) != nullptr;
+    {
+        if (g_thread_join (thread) != nullptr)
+            success = false;
+    }
 
     return success;
 }

--- a/libgnucash/backend/xml/sixtp-dom-parsers.cpp
+++ b/libgnucash/backend/xml/sixtp-dom-parsers.cpp
@@ -188,19 +188,7 @@ dom_tree_to_double_kvp_value (xmlNodePtr node)
 static KvpValue*
 dom_tree_to_numeric_kvp_value (xmlNodePtr node)
 {
-    gnc_numeric* danum;
-    KvpValue* ret = NULL;
-
-    danum = dom_tree_to_gnc_numeric (node);
-
-    if (danum)
-    {
-        ret = new KvpValue {*danum};
-    }
-
-    g_free (danum);
-
-    return ret;
+    return new KvpValue {dom_tree_to_gnc_numeric (node)};
 }
 
 static KvpValue*
@@ -514,19 +502,19 @@ dom_tree_to_text (xmlNodePtr tree)
     return result;
 }
 
-gnc_numeric*
+gnc_numeric
 dom_tree_to_gnc_numeric (xmlNodePtr node)
 {
     gchar* content = dom_tree_to_text (node);
     if (!content)
-        return NULL;
+        return gnc_numeric_zero ();
 
-    gnc_numeric *ret = g_new (gnc_numeric, 1);
+    gnc_numeric num;
+    if (!string_to_gnc_numeric (content, &num))
+        num = gnc_numeric_zero ();
 
-    if (!string_to_gnc_numeric (content, ret))
-	*ret = gnc_numeric_zero ();
     g_free (content);
-    return ret;
+    return num;
 }
 
 

--- a/libgnucash/backend/xml/sixtp-dom-parsers.h
+++ b/libgnucash/backend/xml/sixtp-dom-parsers.h
@@ -42,7 +42,7 @@ Recurrence* dom_tree_to_recurrence (xmlNodePtr node);
 time64 dom_tree_to_time64 (xmlNodePtr node);
 gboolean dom_tree_valid_time64 (time64 ts, const xmlChar* name);
 GDate* dom_tree_to_gdate (xmlNodePtr node);
-gnc_numeric* dom_tree_to_gnc_numeric (xmlNodePtr node);
+gnc_numeric dom_tree_to_gnc_numeric (xmlNodePtr node);
 gchar* dom_tree_to_text (xmlNodePtr tree);
 gboolean string_to_binary (const gchar* str,  void** v, guint64* data_len);
 gboolean dom_tree_create_instance_slots (xmlNodePtr node, QofInstance* inst);

--- a/libgnucash/backend/xml/test/test-dom-converters1.cpp
+++ b/libgnucash/backend/xml/test/test-dom-converters1.cpp
@@ -163,7 +163,6 @@ static const char*
 test_gnc_nums_internal (gnc_numeric to_test)
 {
     const char* ret = NULL;
-    gnc_numeric* to_compare = NULL;
     xmlNodePtr to_gen = NULL;
 
     to_gen = gnc_numeric_to_dom_tree ("test-num", &to_test);
@@ -173,24 +172,13 @@ test_gnc_nums_internal (gnc_numeric to_test)
     }
     else
     {
-        to_compare = dom_tree_to_gnc_numeric (to_gen);
-        if (!to_compare)
+        gnc_numeric to_compare = dom_tree_to_gnc_numeric (to_gen);
+        if (!gnc_numeric_equal (to_test, to_compare))
         {
-            ret = "no gnc_numeric parsed";
-        }
-        else
-        {
-            if (!gnc_numeric_equal (to_test, *to_compare))
-            {
-                ret = "numerics compared different";
-            }
+            ret = "numerics compared different";
         }
     }
 
-    if (to_compare)
-    {
-        g_free (to_compare);
-    }
     if (to_gen)
     {
         xmlFreeNode (to_gen);

--- a/libgnucash/backend/xml/test/test-xml-transaction.cpp
+++ b/libgnucash/backend/xml/test/test-xml-transaction.cpp
@@ -70,14 +70,12 @@ find_appropriate_node (xmlNodePtr node, Split* spl)
         {
             if (g_strcmp0 ((char*)mark2->name, "split:value") == 0)
             {
-                gnc_numeric* num = dom_tree_to_gnc_numeric (mark2);
+                gnc_numeric num = dom_tree_to_gnc_numeric (mark2);
 
-                if (gnc_numeric_equal (*num, xaccSplitGetValue (spl)))
+                if (gnc_numeric_equal (num, xaccSplitGetValue (spl)))
                 {
                     amount_good = TRUE;
                 }
-
-                g_free (num);
             }
             else if (g_strcmp0 ((char*)mark2->name, "split:account") == 0)
             {
@@ -143,44 +141,40 @@ equals_node_val_vs_split_internal (xmlNodePtr node, Split* spl)
         }
         else if (g_strcmp0 ((char*)mark->name, "split:value") == 0)
         {
-            gnc_numeric* num = dom_tree_to_gnc_numeric (mark);
+            gnc_numeric num = dom_tree_to_gnc_numeric (mark);
             gnc_numeric val = xaccSplitGetValue (spl);
 
-            if (!gnc_numeric_equal (*num, val))
+            if (!gnc_numeric_equal (num, val))
             {
-                g_free (num);
                 return g_strdup_printf ("values differ: %" G_GINT64_FORMAT "/%"
                                         G_GINT64_FORMAT " v %" G_GINT64_FORMAT
                                         "/%" G_GINT64_FORMAT,
-                                        (*num).num, (*num).denom,
+                                        num.num, num.denom,
                                         val.num, val.denom);
             }
-            g_free (num);
         }
         else if (g_strcmp0 ((char*)mark->name, "split:quantity") == 0)
         {
-            gnc_numeric* num = dom_tree_to_gnc_numeric (mark);
+            gnc_numeric num = dom_tree_to_gnc_numeric (mark);
             gnc_numeric val = xaccSplitGetAmount (spl);
 
-            if (!gnc_numeric_equal (*num, val))
+            if (!gnc_numeric_equal (num, val))
             {
                 return g_strdup_printf ("quantities differ under _equal: %"
                                         G_GINT64_FORMAT "/%" G_GINT64_FORMAT
                                         " v %" G_GINT64_FORMAT "/%"
                                         G_GINT64_FORMAT,
-                                        (*num).num, (*num).denom,
+                                        num.num, num.denom,
                                         val.num, val.denom);
             }
-            if (!gnc_numeric_equal (*num, val))
+            if (!gnc_numeric_equal (num, val))
             {
-                g_free (num);
                 return g_strdup_printf ("quantities differ: %" G_GINT64_FORMAT
                                         "/%" G_GINT64_FORMAT " v %"
                                         G_GINT64_FORMAT "/%" G_GINT64_FORMAT,
-                                        (*num).num, (*num).denom,
+                                        num.num, num.denom,
                                         val.num, val.denom);
             }
-            g_free (num);
         }
         else if (g_strcmp0 ((char*)mark->name, "split:account") == 0)
         {

--- a/libgnucash/engine/test/utest-Account.cpp
+++ b/libgnucash/engine/test/utest-Account.cpp
@@ -2587,7 +2587,7 @@ test_xaccAccountType_Compatibility (void)
         else if (type == ACCT_TYPE_TRADING)
             g_assert_cmpint (compat, == , trading_compat);
         for (auto parent = ACCT_TYPE_NONE; parent < ACCT_TYPE_LAST; ++parent)
-            if (1 << parent & compat)
+            if (parent != ACCT_TYPE_NONE && (1 << parent) & compat)
                 g_assert (xaccAccountTypesCompatible (parent, type));
             else
                 g_assert (!xaccAccountTypesCompatible (parent, type));


### PR DESCRIPTION
I wanted to see if clang's static analysis could find the recent null pointer dereference bug... it couldn't but it found several other issues:

Bugs:
* [Fix return value of gnc_book_write_to_xml_file_v2()](https://github.com/Gnucash/gnucash/commit/4b83068c6b64d41e82cee1c48caa5a73e94fe8f9)
* [Check source parameter to GncQuotesImpl::report() is not null](https://github.com/Gnucash/gnucash/commit/fe526a6043459763dba2701ff74fdb7717e193e4)
* [Initialise toclear_value in gnc_autoclear_window_ok_cb()](https://github.com/Gnucash/gnucash/commit/b8591de88e5595c0f72a995a532ad86cac81bee9) (not sure how to reproduce this, the impact looks like an invalid value could get set to an uninitialised `gnc_numeric` (if it was valid) instead of being left unmodified when providing an error message)
* [Fix memory leak in gnc_main_window_update_menu_and_toolbar()](https://github.com/Gnucash/gnucash/commit/2b47fe48f474fb76e9c761b86a1a88c3bd773e66)
* [Fix null pointer dereference in gnc_split_register_save_to_copy_buffer()](https://github.com/Gnucash/gnucash/commit/89ea0ca2398b7df8a0de9ffb43a2095c2d95de12) (copied a modified split but couldn't reproduce this - changing the account name on a newly created account affects the `account` cell not the `transfer` cell?)

Bug in tests:
* [Avoid unnecessary memory allocation in dom_tree_to_gnc_numeric()](https://github.com/Gnucash/gnucash/commit/d7568b2dcaafda3b5db092d4d78a99d2246d294a) (fixes use after free by avoiding allocation)

Won't cause a problem today but passes an uninitialised value that may affect future code:
* [Fix use of uninitialised value in gnc_split_register_load()](https://github.com/Gnucash/gnucash/commit/e1448d796b15b7a80b32d0b2c7a58cb9d24ff41c)

Should never happen but inconsistent null checks/missing initialisation of values:
* [Add missing null pointer check in gnc_account_renumber_update_examples()](https://github.com/Gnucash/gnucash/commit/96dd88c79ede5cd84a1976ff3e2db91925097c9d)
* [Initialise all column widths in set_dimensions_pass_two()](https://github.com/Gnucash/gnucash/commit/5b860d2fa9dfb788a86e23b4666a5a18007f3e95)

Warning in tests:
* [Avoid the potential negative left shift in test_xaccAccountType_Compa…](https://github.com/Gnucash/gnucash/commit/d36557ebbecabfbf6d011458aea104dc78820c6f)

Unresolved:
* [Bug 798966](https://bugs.gnucash.org/show_bug.cgi?id=798966) - Uninitialised variable used in [dialog-account-picker.c:dialog_response_cb()](https://github.com/Gnucash/gnucash/blob/ba7b26066ee8313b4580604958ce284950ac06be/gnucash/import-export/qif-imp/dialog-account-picker.c#L363-L372)