### PR TITLE
Bug 798956 Broken link to Chart.bundle.min.js - alternate solution

### DIFF
--- a/gnucash/report/html-chart.scm
+++ b/gnucash/report/html-chart.scm
@@ -456,6 +456,10 @@ document.getElementById(chartid).onclick = function(evt) {
 
     (push (gnc:html-js-include "chartjs/Chart.bundle.min.js"))
 
+    ;; Alternate location for Chart.bundle.min.js in case local file is not available.
+    ;; Make sure to update version number in url when upgrading local Chart.bundle.min.js
+    (push (gnc:html-js-include-alternate "https://cdn.jsdelivr.net/npm/chart.js@2.9.4/dist/Chart.bundle.min.js" "window.Chart"))
+
     ;; the following hidden h3 is used to query style and copy onto chartjs
     (push "<h3 style='display:none'></h3>")
     (push (format #f "<div style='width:~a;height:~a;'>\n"

--- a/gnucash/report/html-utilities.scm
+++ b/gnucash/report/html-utilities.scm
@@ -70,6 +70,7 @@
 (export gnc:html-make-empty-data-warning)
 (export gnc:html-make-options-link)
 (export gnc:html-js-include)
+(export gnc:html-js-include-alternate)
 (export gnc:html-css-include)
 
 ;; returns a list with n #f (empty cell) values
@@ -395,6 +396,12 @@
   (format #f
           "<script language=\"javascript\" type=\"text/javascript\" src=~s></script>\n"
           (make-uri (gnc-resolve-file-path file))))
+
+(define (gnc:html-js-include-alternate url test)
+  (format #f
+          "<script language=\"javascript\" type=\"text/javascript\">~a || \
+document.write('<script language=\"javascript\" type=\"text/javascript\" src=~s><\\/script>');</script>\n"
+          test url))
 
 (define (gnc:html-css-include file)
   (format #f


### PR DESCRIPTION
Add alternate CDN location to local Chart.bundle.min.js

See #1681 for earlier discussion about this

Tested on linux built, but please wait after 5.2 to commit this because it needs to be tested on Windows (unlikely to break but better safe than sorry)