### PR TITLE
Bug 797507 - GnuCash Splash screen may disappear before the main window appears

### DIFF
--- a/gnucash/gnome-utils/gnc-splash.c
+++ b/gnucash/gnome-utils/gnc-splash.c
@@ -48,7 +48,8 @@ splash_destroy_cb (GtkWidget *object, gpointer user_data)
 static gboolean
 button_press_cb(GtkWidget *widget, GdkEventButton *event, gpointer unused)
 {
-    gnc_destroy_splash_screen();
+    if (splash)
+        gtk_window_iconify (GTK_WINDOW (splash));
     return TRUE;
 }
 


### PR DESCRIPTION
[Bug 339876](https://bugs.gnucash.org/show_bug.cgi?id=339876) complains that the splash screen is useless because the desktop environment should indicate that the application is loading. This is only partly true because the desktop environment can't indicate the progress made when the application takes several seconds to load. There is now a preference to disable the splash screen.

[Bug 350993](https://bugs.gnucash.org/show_bug.cgi?id=350993) states that the splash screen should remain until the main window is completely ready (which it currently does). There's also a complaint that the splash screen is annoying because it obscures other windows. The solution to this would be to allow it to be moved or minimise it.

[Bug 366418](https://bugs.gnucash.org/show_bug.cgi?id=366418) asks for the splash screen to disappear when clicked, without really explaining why (except that other applications can do it). This is the current implementation.

Clicking the splash screen is effectively a temporary "disable splash screen" because it closes it. This avoids the "obscures other windows" problem but it makes it unclear what is going on because it actively works against the desktop environment by making it appear as if the application has exited.

We can avoid that problem by minimising the splash screen instead of closing it. This is primarily a splash screen not a loading screen (and it can't be aborted, despite what closing it might imply). Without a redesign it will look odd for it to have a title bar.

Minimise the splash screen when clicked instead of closing it early. It will then be possible to restore the splash screen window instead of losing it completely.