### PR TITLE
Html report chart field

### DIFF
--- a/gnucash/report/html-chart.scm
+++ b/gnucash/report/html-chart.scm
@@ -454,8 +454,6 @@ document.getElementById(chartid).onclick = function(evt) {
          ;; clashing on multi-column reports
          (id (symbol->string (gensym "chart"))))
 
-    (push (gnc:html-js-include "chartjs/Chart.bundle.min.js"))
-
     ;; the following hidden h3 is used to query style and copy onto chartjs
     (push "<h3 style='display:none'></h3>")
     (push (format #f "<div style='width:~a;height:~a;'>\n"

--- a/gnucash/report/html-document.scm
+++ b/gnucash/report/html-document.scm
@@ -30,6 +30,7 @@
 (use-modules (gnucash report html-style-sheet))
 (use-modules (gnucash report html-table))
 (use-modules (gnucash report html-text))
+(use-modules (gnucash report html-utilities))
 (use-modules (gnucash report report-utilities))
 (use-modules (gnucash utilities))
 (use-modules (ice-9 match))
@@ -151,13 +152,13 @@
           (else (cons (object->string e) accum)))))
 
 ;; returns the html document as a string, I think.
-(define* (gnc:html-document-render doc #:optional (headers? #t))
+(define* (gnc:html-document-render doc #:optional (headers? #t) chart?)
   (let ((stylesheet (gnc:html-document-style-sheet doc))
         (style-text (gnc:html-document-style-text doc)))
 
     (if stylesheet
         ;; if there's a style sheet, let it do the rendering
-        (gnc:html-style-sheet-render stylesheet doc headers?)
+        (gnc:html-style-sheet-render stylesheet doc headers? chart?)
 
         ;; otherwise, do the trivial render.
         (let* ((retval '())
@@ -185,6 +186,8 @@
                 (push (list "</style>" style-text "<style type=\"text/css\">\n")))
             (if (not (string-null? title))
                 (push (list "</title>" title "<title>\n")))
+            (when chart?
+              (push (gnc:html-js-include "chartjs/Chart.bundle.min.js")))
             (push "</head>")
 
             ;; this lovely little number just makes sure that <body>

--- a/gnucash/report/report-core.scm
+++ b/gnucash/report/report-core.scm
@@ -172,7 +172,7 @@
   (make-new-record-template version name report-guid parent-type options-generator
                             options-cleanup-cb options-changed-cb
                             renderer in-menu? menu-path menu-name
-                            menu-tip hook export-types export-thunk)
+                            menu-tip hook export-types export-thunk chart?)
   report-template?
   (version report-template-version)
   (report-guid report-template-report-guid report-template-set-report-guid!)
@@ -187,11 +187,12 @@
   (menu-name report-template-menu-name)
   (menu-tip report-template-menu-tip)
   (hook report-template-hook)
+  (chart? report-template-chart?)
   (export-types report-template-export-types)
   (export-thunk report-template-export-thunk))
 
 (define (make-report-template)
-  (make-new-record-template #f #f #f #f #f #f #f #f #t #f #f #f #f #f #f))
+  (make-new-record-template #f #f #f #f #f #f #f #f #t #f #f #f #f #f #f #f))
 (define gnc:report-template-version report-template-version)
 (define gnc:report-template-report-guid report-template-report-guid)
 (define gnc:report-template-set-report-guid! report-template-set-report-guid!)
@@ -742,12 +743,13 @@ not found.")))
         (and template
              (let* ((renderer (gnc:report-template-renderer template))
                     (stylesheet (gnc:report-stylesheet report))
+                    (chart? (report-template-chart? template))
                     (doc (renderer report))
                     (html (cond
                            ((string? doc) doc)
                            (else
                             (gnc:html-document-set-style-sheet! doc stylesheet)
-                            (gnc:html-document-render doc headers?)))))
+                            (gnc:html-document-render doc headers? chart?)))))
                (gnc:report-set-ctext! report html) ;; cache the html
                (gnc:report-set-dirty?! report #f)  ;; mark it clean
                html)))))

--- a/gnucash/report/reports/standard/category-barchart.scm
+++ b/gnucash/report/reports/standard/category-barchart.scm
@@ -703,6 +703,7 @@ Please deselect the accounts with negative balances."))
      'menu-name menuname
      'menu-tip menutip
      'options-generator (lambda () (options-generator account-types inc-exp?))
+     'chart? #t
      'export-types '(("CSV" . csv))
      'export-thunk (lambda (report-obj export-type)
                      (category-barchart-renderer


### PR DESCRIPTION
#1681 and #1685 differing view -- insert chartjs in `<head>` section, depending on whether the report template definition requires it.

Re: exporting html - currently it calls the exporter in gnc-html; I'm not sure how the html exporter works. It may be an idea to simply call the document renderer again with a new parameter `#:export #t` --- @dawansv 