### PR TITLE
Bug 798967 - Cannot Save to Any Path After Upgrading to 5.2

### DIFF
--- a/libgnucash/backend/xml/io-gncxml-v2.cpp
+++ b/libgnucash/backend/xml/io-gncxml-v2.cpp
@@ -1612,7 +1612,7 @@ gnc_book_write_to_xml_file_v2 (QofBook* book, const char* filename,
     /* Optionally wait for parallel compression threads */
     if (thread)
     {
-        if (g_thread_join (thread) != nullptr)
+        if (g_thread_join (thread) == nullptr)
             success = false;
     }
 


### PR DESCRIPTION
Fix inverted if statement condition for save success flag