### PR TITLE
Html report chart field continued...

### DIFF
--- a/gnucash/report/html-chart.scm
+++ b/gnucash/report/html-chart.scm
@@ -454,8 +454,6 @@ document.getElementById(chartid).onclick = function(evt) {
          ;; clashing on multi-column reports
          (id (symbol->string (gensym "chart"))))
 
-    (push (gnc:html-js-include "chartjs/Chart.bundle.min.js"))
-
     ;; the following hidden h3 is used to query style and copy onto chartjs
     (push "<h3 style='display:none'></h3>")
     (push (format #f "<div style='width:~a;height:~a;'>\n"

--- a/gnucash/report/html-document.scm
+++ b/gnucash/report/html-document.scm
@@ -30,6 +30,7 @@
 (use-modules (gnucash report html-style-sheet))
 (use-modules (gnucash report html-table))
 (use-modules (gnucash report html-text))
+(use-modules (gnucash report html-utilities))
 (use-modules (gnucash report report-utilities))
 (use-modules (gnucash utilities))
 (use-modules (ice-9 match))
@@ -151,13 +152,13 @@
           (else (cons (object->string e) accum)))))
 
 ;; returns the html document as a string, I think.
-(define* (gnc:html-document-render doc #:optional (headers? #t))
+(define* (gnc:html-document-render doc #:optional (headers? #t) chart?)
   (let ((stylesheet (gnc:html-document-style-sheet doc))
         (style-text (gnc:html-document-style-text doc)))
 
     (if stylesheet
         ;; if there's a style sheet, let it do the rendering
-        (gnc:html-style-sheet-render stylesheet doc headers?)
+        (gnc:html-style-sheet-render stylesheet doc headers? chart?)
 
         ;; otherwise, do the trivial render.
         (let* ((retval '())
@@ -185,6 +186,8 @@
                 (push (list "</style>" style-text "<style type=\"text/css\">\n")))
             (if (not (string-null? title))
                 (push (list "</title>" title "<title>\n")))
+            (when chart?
+              (push (gnc:html-js-include "chartjs/Chart.bundle.min.js")))
             (push "</head>")
 
             ;; this lovely little number just makes sure that <body>

--- a/gnucash/report/html-document.scm
+++ b/gnucash/report/html-document.scm
@@ -152,13 +152,13 @@
           (else (cons (object->string e) accum)))))
 
 ;; returns the html document as a string, I think.
-(define* (gnc:html-document-render doc #:optional (headers? #t) chart?)
+(define* (gnc:html-document-render doc #:optional (headers? #t) chart? export?)
   (let ((stylesheet (gnc:html-document-style-sheet doc))
         (style-text (gnc:html-document-style-text doc)))
 
     (if stylesheet
         ;; if there's a style sheet, let it do the rendering
-        (gnc:html-style-sheet-render stylesheet doc headers? chart?)
+        (gnc:html-style-sheet-render stylesheet doc headers? chart? export?)
 
         ;; otherwise, do the trivial render.
         (let* ((retval '())
@@ -186,8 +186,10 @@
                 (push (list "</style>" style-text "<style type=\"text/css\">\n")))
             (if (not (string-null? title))
                 (push (list "</title>" title "<title>\n")))
-            (when chart?
-              (push (gnc:html-js-include "chartjs/Chart.bundle.min.js")))
+            (if chart?
+              (if export?
+                (push (gnc:html-js-embed "chartjs/Chart.bundle.min.js"))
+                (push (gnc:html-js-include "chartjs/Chart.bundle.min.js"))))
             (push "</head>")
 
             ;; this lovely little number just makes sure that <body>

--- a/gnucash/report/html-style-sheet.scm
+++ b/gnucash/report/html-style-sheet.scm
@@ -205,7 +205,7 @@
 ;;  html-style-sheet-render 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define* (gnc:html-style-sheet-render sheet doc #:optional headers?)
+(define* (gnc:html-style-sheet-render sheet doc #:optional headers? chart? export?)
   ;; render the document (returns an <html-document>)
   (let ((newdoc ((gnc:html-style-sheet-renderer sheet) 
                  (gnc:html-style-sheet-options sheet)
@@ -238,7 +238,7 @@
     ;; render the ssdocument (using the trivial stylesheet).  since
     ;; the objects from 'doc' are now in newdoc, this renders the whole
     ;; package.
-    (gnc:html-document-render newdoc headers?)))
+    (gnc:html-document-render newdoc headers? chart? export?)))
 
 (define (gnc:get-html-style-sheets)
   (sort (map cdr (hash-map->list cons *gnc:_style-sheets_*))

--- a/gnucash/report/html-utilities.scm
+++ b/gnucash/report/html-utilities.scm
@@ -35,6 +35,7 @@
 (use-modules (gnucash report html-text))
 (use-modules (gnucash report html-table))
 (use-modules (ice-9 match))
+(use-modules (ice-9 textual-ports))
 (use-modules (web uri))
 
 (export gnc:html-make-empty-cell)
@@ -70,6 +71,7 @@
 (export gnc:html-make-empty-data-warning)
 (export gnc:html-make-options-link)
 (export gnc:html-js-include)
+(export gnc:html-js-embed)
 (export gnc:html-css-include)
 
 ;; returns a list with n #f (empty cell) values
@@ -395,6 +397,14 @@
   (format #f
           "<script language=\"javascript\" type=\"text/javascript\" src=~s></script>\n"
           (make-uri (gnc-resolve-file-path file))))
+
+(define (gnc:html-js-embed file)
+  (let* ((js-port (open-input-file (gnc-resolve-file-path file)))
+         (js-embed (get-string-all js-port)))
+    (close-port js-port)
+    (format #f
+            "<script language=\"javascript\" type=\"text/javascript\">~a</script>\n"
+            js-embed)))
 
 (define (gnc:html-css-include file)
   (format #f

--- a/gnucash/report/report-core.scm
+++ b/gnucash/report/report-core.scm
@@ -172,7 +172,7 @@
   (make-new-record-template version name report-guid parent-type options-generator
                             options-cleanup-cb options-changed-cb
                             renderer in-menu? menu-path menu-name
-                            menu-tip hook export-types export-thunk)
+                            menu-tip hook export-types export-thunk chart?)
   report-template?
   (version report-template-version)
   (report-guid report-template-report-guid report-template-set-report-guid!)
@@ -187,11 +187,12 @@
   (menu-name report-template-menu-name)
   (menu-tip report-template-menu-tip)
   (hook report-template-hook)
+  (chart? report-template-chart?)
   (export-types report-template-export-types)
   (export-thunk report-template-export-thunk))
 
 (define (make-report-template)
-  (make-new-record-template #f #f #f #f #f #f #f #f #t #f #f #f #f #f #f))
+  (make-new-record-template #f #f #f #f #f #f #f #f #t #f #f #f #f #f #f #f))
 (define gnc:report-template-version report-template-version)
 (define gnc:report-template-report-guid report-template-report-guid)
 (define gnc:report-template-set-report-guid! report-template-set-report-guid!)
@@ -742,12 +743,13 @@ not found.")))
         (and template
              (let* ((renderer (gnc:report-template-renderer template))
                     (stylesheet (gnc:report-stylesheet report))
+                    (chart? (report-template-chart? template))
                     (doc (renderer report))
                     (html (cond
                            ((string? doc) doc)
                            (else
                             (gnc:html-document-set-style-sheet! doc stylesheet)
-                            (gnc:html-document-render doc headers?)))))
+                            (gnc:html-document-render doc headers? chart?)))))
                (gnc:report-set-ctext! report html) ;; cache the html
                (gnc:report-set-dirty?! report #f)  ;; mark it clean
                html)))))

--- a/gnucash/report/reports/example/average-balance.scm
+++ b/gnucash/report/reports/example/average-balance.scm
@@ -491,4 +491,7 @@
  'report-guid "d5adcc61c62e4b8684dd8907448d7900"
  'menu-path (list gnc:menuname-example)
  'options-generator options-generator
+ 'chart? (lambda (report_obj)
+          (let* ((options (gnc:report-options report_obj)))
+            (gnc-optiondb-lookup-value options gnc:pagename-display "Show plot")))
  'renderer renderer)

--- a/gnucash/report/reports/example/daily-reports.scm
+++ b/gnucash/report/reports/example/daily-reports.scm
@@ -301,6 +301,7 @@
     'menu-name (caddr l)
     'menu-tip (car (cdddr l))
     'options-generator (lambda () (options-generator (cadr l)))
+    'chart? #t
     'renderer (lambda (report-obj)
                 (piechart-renderer report-obj
                                    (car l)

--- a/gnucash/report/reports/example/sample-graphs.scm
+++ b/gnucash/report/reports/example/sample-graphs.scm
@@ -185,5 +185,13 @@
  ;; The options generator function defined above.
  'options-generator options-generator
 
+ ;; A flag that informs the renderer whether or not to include
+ ;; the chart.js library in the html header.
+ ;; Can be set directly to a #t or #f value or
+ ;; if it changes based on report options, it can be set to
+ ;; a procedure that will be called with the report object
+ ;; to retrieve a #t or #f value
+ 'chart? #t
+
  ;; The rendering function defined above.
  'renderer test-graphing-renderer)

--- a/gnucash/report/reports/standard/account-piecharts.scm
+++ b/gnucash/report/reports/standard/account-piecharts.scm
@@ -588,6 +588,7 @@ balance at a given time"))
     'options-generator (lambda () (options-generator acct-types
                                                      income-expense?
                                                      depth-based?))
+    'chart? #t
     'renderer (lambda (report-obj)
                 (piechart-renderer report-obj name uuid
                                    acct-types income-expense? depth-based?

--- a/gnucash/report/reports/standard/balance-forecast.scm
+++ b/gnucash/report/reports/standard/balance-forecast.scm
@@ -306,4 +306,5 @@ date point, a projected minimum balance including scheduled transactions."))
   'report-guid "321d940d487d4ccbb4bd0467ffbadbf2"
   'menu-path (list gnc:menuname-asset-liability)
   'options-generator options-generator
+  'chart? #t
   'renderer document-renderer)

--- a/gnucash/report/reports/standard/budget-barchart.scm
+++ b/gnucash/report/reports/standard/budget-barchart.scm
@@ -325,4 +325,5 @@
  'report-guid "415cd38d39054d9e9c4040455290c2b1"
  'menu-path (list gnc:menuname-budget)
  'options-generator (lambda () (options-generator))
+ 'chart? #t
  'renderer (lambda (report-obj) (net-renderer report-obj)))

--- a/gnucash/report/reports/standard/cashflow-barchart.scm
+++ b/gnucash/report/reports/standard/cashflow-barchart.scm
@@ -351,4 +351,5 @@
  'menu-tip (N_ "Shows a barchart with cash flow over time")
  'menu-path (list gnc:menuname-income-expense)
  'options-generator cashflow-barchart-options-generator
+ 'chart? #t
  'renderer cashflow-barchart-renderer)

--- a/gnucash/report/reports/standard/category-barchart.scm
+++ b/gnucash/report/reports/standard/category-barchart.scm
@@ -703,6 +703,7 @@ Please deselect the accounts with negative balances."))
      'menu-name menuname
      'menu-tip menutip
      'options-generator (lambda () (options-generator account-types inc-exp?))
+     'chart? #t
      'export-types '(("CSV" . csv))
      'export-thunk (lambda (report-obj export-type)
                      (category-barchart-renderer

--- a/gnucash/report/reports/standard/investment-lots.scm
+++ b/gnucash/report/reports/standard/investment-lots.scm
@@ -2031,4 +2031,7 @@
  'report-guid "ab2acc24afd14630a551f98f1a35fa81"
  'menu-path (list gnc:menuname-asset-liability)
  'options-generator options-generator
+ 'chart? (lambda (report_obj)
+          (let* ((options (gnc:report-options report_obj)))
+            (gnc-optiondb-lookup-value options pagename-chart optname-show-chart)))
  'renderer investment-lots-renderer)

--- a/gnucash/report/reports/standard/net-charts.scm
+++ b/gnucash/report/reports/standard/net-charts.scm
@@ -472,6 +472,7 @@
  'report-guid net-worth-barchart-uuid
  'menu-path (list gnc:menuname-asset-liability)
  'options-generator (lambda () (options-generator #f #f))
+ 'chart? #t
  'renderer (lambda (report-obj) (net-renderer report-obj #f #f #f))
  'export-types '(("CSV" . csv))
  'export-thunk (lambda (report-obj export-type)
@@ -484,6 +485,7 @@
  'menu-name (N_ "Income & Expense Barchart")
  'menu-path (list gnc:menuname-income-expense)
  'options-generator (lambda () (options-generator #t #f))
+ 'chart? #t
  'renderer (lambda (report-obj) (net-renderer report-obj #t #f #f))
  'export-types '(("CSV" . csv))
  'export-thunk (lambda (report-obj export-type)
@@ -495,6 +497,7 @@
  'report-guid net-worth-linechart-uuid
  'menu-path (list gnc:menuname-asset-liability)
  'options-generator (lambda () (options-generator #f #t))
+ 'chart? #t
  'renderer (lambda (report-obj) (net-renderer report-obj #f #t #f))
  'export-types '(("CSV" . csv))
  'export-thunk (lambda (report-obj export-type)
@@ -509,6 +512,7 @@
  'menu-name (N_ "Income & Expense Linechart")
  'menu-path (list gnc:menuname-income-expense)
  'options-generator (lambda () (options-generator #t #t))
+ 'chart? #t
  'renderer (lambda (report-obj) (net-renderer report-obj #t #t #f))
  'export-types '(("CSV" . csv))
  'export-thunk (lambda (report-obj export-type)

--- a/gnucash/report/reports/standard/price-scatter.scm
+++ b/gnucash/report/reports/standard/price-scatter.scm
@@ -302,4 +302,5 @@ Unfortunately, the plotting tool can't handle that.")))
  'menu-path (list gnc:menuname-asset-liability)
  'menu-name (N_ "Price Scatterplot")
  'options-generator options-generator
+ 'chart? #t
  'renderer renderer)

--- a/gnucash/report/reports/standard/view-column.scm
+++ b/gnucash/report/reports/standard/view-column.scm
@@ -29,6 +29,7 @@
 (define-module (gnucash reports standard view-column))
 (use-modules (gnucash engine))
 (use-modules (ice-9 match))
+(use-modules (srfi srfi-1))
 (use-modules (gnucash utilities))
 (use-modules (gnucash core-utils))
 (use-modules (gnucash app-utils))
@@ -176,6 +177,14 @@
         (((child rowspan colspan _) . rest)
          (loop rest (cons (list child rowspan colspan #f) new-reports)))))))
 
+(define (include-chart? report)
+  (let* ((options (gnc:report-options report))
+         (reports
+          (gnc-optiondb-lookup-value options "__general" "report-list"))
+         (has-chart? (lambda (child)
+                        (gnc:report-chart? (gnc-report-find (car child))))))
+    (any has-chart? reports)))
+
 ;; define the view now.
 (gnc:define-report
  'version 1
@@ -186,4 +195,5 @@
  'renderer render-view
  'options-generator make-options
  'options-cleanup-cb cleanup-options
- 'options-changed-cb options-changed-cb)
+ 'options-changed-cb options-changed-cb
+ 'chart? include-chart?)


### PR DESCRIPTION
@christopherlam Taking it from your work at #1688

It works well with the chart.js now either included or embedded (if export flag is set) only once in the html head, including with the multi-column report

Of note: in gnucash/gnome/gnc-plugin-page-report.cpp I am no longer using the old `gnc_html_export_to_file` from the gnc_html object. The rendering in report-core.scm is already cached so there no need to go treat the regular and export rendering differently (except for the flag). In the export flag is not set, report-core.scm will simply reuse the previous already cached rendering (that is not new).

Still TO DO (if we decide to go this route):
+ html export also needs to be implemented in gnucash-cli, simlar to how it's done in gnc-plugin-page-report.cpp

DONE
+ ~~`gnucash/report/reports/standard/dashboard.scm` uses a weird definition not calling gnc:define-report so I have no idea how to set the chart? flag for that report~~ This was never a problem since dashboard is just a custom multicolumn
+ ~~The 2 chart tests `gnucash/report/test/test-html-chart.scm` and `gnucash/report/reports/standard/test/test-cashflow-barchart.scm` fail. How do we modify the test engine to address the need for a chart? flag there as well?~~ This was caused by a small typo in cashflow-barchart.scm