### PR TITLE
Bug 798922 - No withdrawal/deposit fields in csv import dialog

### DIFF
--- a/gnucash/gtkbuilder/assistant-csv-trans-import.glade
+++ b/gnucash/gtkbuilder/assistant-csv-trans-import.glade
@@ -43,12 +43,29 @@
         <property name="margin-end">12</property>
         <property name="label" translatable="yes">This assistant will help you import a delimited file containing a list of transactions. It supports both token separated files (such as comma separated or semi-colon separated) and fixed width data.
 
-For a successful import three columns have to be available in the import data:
-• a Date column
-• a Description column
-• a Deposit or Withdrawal column
+For a successful import at least three columns have to be available in the import data:
+• a Date column,
+• a Description column,
+• an Amount column.
 
 If there is no Account data available, a base account can be selected to which all data will be imported.
+
+After selecting a base account, the Amount column headings will guide you in selecting the correct label for you data column(s) depending on the number of amount columns in your data and signs used (positive or negative).
+
+For instance, when selecting a bank account as a base account, the column heading labelled "Amount: +Deposit -Withdrawal" could be used on a single column containing both positive deposit amounts and negative withdrawal amounts, or on a column with positive deposit amounts only. The same label could then be used on a second column with negative withdrawal amounts only. However, if that second column comes with POSITIVE withdrawal amounts, then the opposite column heading labelled "Amount: +Withdrawal -Deposit" would need be used for that column.
+
+When separate Account data is provided for each transaction, then the heading(s) to select for the Amount data depends on whether it follows this standard sign format or its opposite:
+• for bank and cash accounts, deposits are positive and withdrawals are negative;
+• for credit card accounts, charges are negative and payments/refunds are positive;
+• for mortgages and loans, debt proceeds are negative and repayments are positive;
+• for brokerage accounts, "shares bought" are positive and "shares sold" are negative;
+• for other account types, refer to the concept guide, chapter 2 (available in the help menu).
+
+If it follows that format, select the "Amount (sign-standard)" heading; otherwise select "Amount (sign-reversed)".
+
+Note that when "formal accounting labels" are selected in Preferences, the formal "Debit/Credit" labels are used in Amount column headings:
+• "Amount: +Debit -Credit" for the sign-standard label, accepting positive debit amounts and negative credit amounts,
+• "Amount: +Credit -Debit" for the sign-reversed label, accepting positive credit amounts and negative debit amounts.
 
 Apart from a choice of delimiter, there are several options to tweak the importer. For example a number of lines can be skipped at the start or the end of the data, as well as odd rows. Several date and number formats are supported. The file encoding can be defined.
 

--- a/gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp
+++ b/gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp
@@ -41,6 +41,7 @@
 #include "gnc-uri-utils.h"
 #include "gnc-ui-util.h"
 #include "dialog-utils.h"
+#include "gnc-prefs.h"
 
 #include "gnc-component-manager.h"
 
@@ -1530,9 +1531,23 @@ CsvImpTransAssist::preview_style_column (uint32_t col_num, GtkTreeModel* model)
 /* Helper to create a shared store for the header comboboxes in the preview treeview.
  * It holds the possible column types */
 static GtkTreeModel*
-make_column_header_model (bool multi_split)
+make_column_header_model (bool multi_split, const Account* acct=NULL)
 {
     auto combostore = gtk_list_store_new (2, G_TYPE_STRING, G_TYPE_INT);
+
+    /* Set labels for Amount columns as per global label preference and account type */
+    if (gnc_prefs_get_bool(GNC_PREFS_GROUP_GENERAL, GNC_PREF_ACCOUNTING_LABELS))
+    {
+        gnc_csv_col_type_strs[GncTransPropType::AMOUNT] = _("Amount: +Debit -Credit");
+        gnc_csv_col_type_strs[GncTransPropType::AMOUNT_NEG] = _("Amount: +Credit -Debit");
+    }
+    else
+    {
+        GNCAccountType acct_type = xaccAccountGetType (acct);
+        gnc_csv_col_type_strs[GncTransPropType::AMOUNT] = gnc_imp_amount_strs[acct_type];
+        gnc_csv_col_type_strs[GncTransPropType::AMOUNT_NEG] = gnc_imp_amtneg_strs[acct_type];
+    }
+
     for (auto col_type : gnc_csv_col_type_strs)
     {
         /* Only add column types that make sense in
@@ -1624,7 +1639,7 @@ void CsvImpTransAssist::preview_refresh_table ()
     }
 
     /* Reset column attributes as they are undefined after recreating the model */
-    auto combostore = make_column_header_model (tx_imp->multi_split());
+    auto combostore = make_column_header_model (tx_imp->multi_split(), tx_imp->base_account());
     for (uint32_t i = 0; i < ntcols; i++)
         preview_style_column (i, combostore);
 

--- a/gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp
+++ b/gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp
@@ -52,6 +52,46 @@ namespace bl = boost::locale;
 
 G_GNUC_UNUSED static QofLogModule log_module = GNC_MOD_IMPORT;
 
+/* This map contains a set of strings representing the AMOUNT column informal
+ * names for different account types. */
+std::map<GNCAccountType, const char*> gnc_imp_amount_strs = {
+    { ACCT_TYPE_NONE,       N_("Amount (sign-standard)") },
+    { ACCT_TYPE_BANK,       N_("Amount: +Deposit -Withdrawal") },
+    { ACCT_TYPE_CASH,       N_("Amount: +Receive -Spend") },
+    { ACCT_TYPE_CREDIT,     N_("Amount: +Payment -Charge") },
+    { ACCT_TYPE_ASSET,      N_("Amount: +Increase -Decrease") },
+    { ACCT_TYPE_LIABILITY,  N_("Amount: +Decrease -Increase") },
+    { ACCT_TYPE_STOCK,      N_("Amount: +Buy -Sell") },
+    { ACCT_TYPE_MUTUAL,     N_("Amount: +Buy -Sell") },
+    { ACCT_TYPE_CURRENCY,   N_("Amount: +Buy -Sell") },
+    { ACCT_TYPE_INCOME,     N_("Amount: +Charge -Income") },
+    { ACCT_TYPE_EXPENSE,    N_("Amount: +Expense -Rebate") },
+    { ACCT_TYPE_PAYABLE,    N_("Amount: +Payment -Bill") },
+    { ACCT_TYPE_RECEIVABLE, N_("Amount: +Invoice -Payment") },
+    { ACCT_TYPE_TRADING,    N_("Amount: +Decrease -Increase") },
+    { ACCT_TYPE_EQUITY,     N_("Amount: +Decrease -Increase") },
+};
+
+/* This map contains a set of strings representing the AMOUNT_NEG column informal
+ * names for different account types. */
+std::map<GNCAccountType, const char*> gnc_imp_amtneg_strs = {
+    { ACCT_TYPE_NONE,       N_("Amount (sign-reversed)") },
+    { ACCT_TYPE_BANK,       N_("Amount: +Withdrawal -Deposit") },
+    { ACCT_TYPE_CASH,       N_("Amount: +Spend -Receive") },
+    { ACCT_TYPE_CREDIT,     N_("Amount: +Charge -Payment") },
+    { ACCT_TYPE_ASSET,      N_("Amount: +Decrease -Increase") },
+    { ACCT_TYPE_LIABILITY,  N_("Amount: +Increase -Decrease") },
+    { ACCT_TYPE_STOCK,      N_("Amount: +Sell -Buy") },
+    { ACCT_TYPE_MUTUAL,     N_("Amount: +Sell -Buy") },
+    { ACCT_TYPE_CURRENCY,   N_("Amount: +Sell -Buy") },
+    { ACCT_TYPE_INCOME,     N_("Amount: +Income -Charge") },
+    { ACCT_TYPE_EXPENSE,    N_("Amount: +Rebate -Expense") },
+    { ACCT_TYPE_PAYABLE,    N_("Amount: +Bill -Payment") },
+    { ACCT_TYPE_RECEIVABLE, N_("Amount: +Payment -Invoice") },
+    { ACCT_TYPE_TRADING,    N_("Amount: +Increase -Decrease") },
+    { ACCT_TYPE_EQUITY,     N_("Amount: +Increase -Decrease") },
+};
+
 /* This map contains a set of strings representing the different column types. */
 std::map<GncTransPropType, const char*> gnc_csv_col_type_strs = {
         { GncTransPropType::NONE, N_("None") },
@@ -64,10 +104,10 @@ std::map<GncTransPropType, const char*> gnc_csv_col_type_strs = {
         { GncTransPropType::VOID_REASON, N_("Void Reason") },
         { GncTransPropType::ACTION, N_("Action") },
         { GncTransPropType::ACCOUNT, N_("Account") },
-        { GncTransPropType::AMOUNT, N_("Amount") },
-        { GncTransPropType::AMOUNT_NEG, N_("Amount (Negated)") },
+        { GncTransPropType::AMOUNT,  gnc_imp_amount_strs[ACCT_TYPE_NONE] },
+        { GncTransPropType::AMOUNT_NEG, gnc_imp_amtneg_strs[ACCT_TYPE_NONE] },
         { GncTransPropType::VALUE, N_("Value") },
-        { GncTransPropType::VALUE_NEG, N_("Value (Negated)") },
+        { GncTransPropType::VALUE_NEG, N_("Value (sign-reversed)") },
         { GncTransPropType::PRICE, N_("Price") },
         { GncTransPropType::MEMO, N_("Memo") },
         { GncTransPropType::REC_STATE, N_("Reconciled") },
@@ -75,7 +115,7 @@ std::map<GncTransPropType, const char*> gnc_csv_col_type_strs = {
         { GncTransPropType::TACTION, N_("Transfer Action") },
         { GncTransPropType::TACCOUNT, N_("Transfer Account") },
         { GncTransPropType::TAMOUNT, N_("Transfer Amount") },
-        { GncTransPropType::TAMOUNT_NEG, N_("Transfer Amount (Negated)") },
+        { GncTransPropType::TAMOUNT_NEG, N_("Transfer Amount (sign-reversed)") },
         { GncTransPropType::TMEMO, N_("Transfer Memo") },
         { GncTransPropType::TREC_STATE, N_("Transfer Reconciled") },
         { GncTransPropType::TREC_DATE, N_("Transfer Reconcile Date") }
@@ -659,10 +699,10 @@ StrVec GncPreSplit::verify_essentials()
     if (m_pre_trans->is_multi_currency())
     {
         if (m_pre_trans->m_multi_split && !m_price && !m_value && !m_value_neg)
-            err_msg.emplace_back( _("Choice of accounts makes this a multi-currency transaction but price or (negated) value column is missing or invalid."));
+            err_msg.emplace_back( _("Choice of accounts makes this a multi-currency transaction but price or value column is missing or invalid."));
         else if (!m_pre_trans->m_multi_split &&
             !m_price && !m_value && !m_value_neg && !m_tamount && !m_tamount_neg )
-            err_msg.emplace_back( _("Choice of account makes this a multi-currency transaction but price, (negated) value or (negated) transfer column is missing or invalid."));
+            err_msg.emplace_back( _("Choice of account makes this a multi-currency transaction but price, value or transfer column is missing or invalid."));
     }
 
     return err_msg;

--- a/gnucash/import-export/csv-imp/gnc-imp-props-tx.hpp
+++ b/gnucash/import-export/csv-imp/gnc-imp-props-tx.hpp
@@ -89,6 +89,13 @@ using ErrPair = std::pair<GncTransPropType, std::string>;
  *  changes to enum class GncTransPropType ! */
 extern std::map<GncTransPropType, const char*> gnc_csv_col_type_strs;
 
+/** Maps all account types to a string representation for
+ *  the AMOUNT and AMOUNT_NEG informal labels
+ *  Attention: these definitions should be adjusted for any
+ *  changes to enum class GNCAccountType in Account.h */
+extern std::map<GNCAccountType, const char*> gnc_imp_amount_strs;
+extern std::map<GNCAccountType, const char*> gnc_imp_amtneg_strs;
+
 /** Functor to check if the above map has an element of which
  *  the value equals name. To be used with std::find_if.
  */


### PR DESCRIPTION
**Set Amount column labels as per base account type and global preference for formal accounting labels.**
+ generic headings set to "Amount (sign-standard)" and "Amount (sign-reversed)"
+ for formal labels, headings set to "Account: +Debit -Credit" and "Amount: +Credit -Debit"
+ when base account is selected, headings are customized
+ e.g. for Bank account, headings are set to "Amount: +Deposit -Withdrawal" and "Amount: +Withdrawal -Deposit"
+ [See other base account labels in code](https://github.com/Gnucash/gnucash/pull/1699/commits/7e759d95422dd59f4eb1271f911bafc2a0995488#diff-cb38e23796dd773e0243e5f319ab581b3dadf7f6c85c9083adf7624dd6fe2b6a)

**Clarify instructions re:Amount columns on start page.**
![image](https://github.com/Gnucash/gnucash/assets/267163/1ad09cd3-4be9-4a74-9092-b5fff6b4fddc)

**TODO**

+ There are still some messages with the old (negated) language that I need to change
+ As per @nomis  comment: When formal labels are selected, the main start page message should be simplified.
+ As per @nomis  comment: Whatever decision is made as to how account columns are presented, a similar logic would then apply to value and transfer amount columns