### PR TITLE
Change g_assert() -> g_assert_true() in tests

### DIFF
--- a/common/test-core/unittest-support.c
+++ b/common/test-core/unittest-support.c
@@ -219,7 +219,7 @@ do_test_checked_handler (const char *log_domain, GLogLevelFlags log_level,
         gchar *level = test_log_level (log_level);
         g_printf ( "<%s> (%s) %s\n", level, log_domain, msg);
         g_free (level);
-        g_assert (log_level ^ G_LOG_FLAG_FATAL);
+        g_assert_true (log_level ^ G_LOG_FLAG_FATAL);
         return FALSE;
     }
     if (hits)
@@ -242,7 +242,7 @@ test_checked_substring_handler (const char *log_domain, GLogLevelFlags log_level
         gchar *level = test_log_level (log_level);
         g_printf ( "<%s> (%s) %s\n", level, log_domain, msg);
         g_free (level);
-        g_assert (log_level ^ G_LOG_FLAG_FATAL);
+        g_assert_true (log_level ^ G_LOG_FLAG_FATAL);
         return FALSE;
     }
     ++(tdata->hits);
@@ -272,7 +272,7 @@ test_log_handler (const char *log_domain, GLogLevelFlags log_level,
     gchar *level = test_log_level (log_level);
     g_printf ( "<%s> (%s) %s\n", level, log_domain, msg);
     g_free (level);
-    g_assert (log_level ^ G_LOG_FLAG_FATAL);
+    g_assert_true (log_level ^ G_LOG_FLAG_FATAL);
     return FALSE;
 }
 
@@ -330,7 +330,7 @@ mock_signal_handler (QofInstance *entity, QofEventId event_type,
             && signal->event_type == event_type)
     {
         if (signal->event_data)
-            g_assert (signal->event_data == event_data);
+            g_assert_true (signal->event_data == event_data);
         signal->hits += 1;
     }
 }

--- a/common/test-core/unittest-support.h
+++ b/common/test-core/unittest-support.h
@@ -351,8 +351,8 @@ gboolean test_object_checked_destroy (GObject *obj);
  */
 
 #define test_destroy(obj) \
-    g_assert (obj != NULL && G_IS_OBJECT (obj));		\
-    g_assert (test_object_checked_destroy (G_OBJECT (obj)))
+    g_assert_true (obj != NULL && G_IS_OBJECT (obj));		\
+    g_assert_true (test_object_checked_destroy (G_OBJECT (obj)))
 
 /** @} */
 /* For Scheme testing access:

--- a/gnucash/import-export/aqb/test/test-kvp.c
+++ b/gnucash/import-export/aqb/test/test-kvp.c
@@ -47,7 +47,7 @@ static char* get_filepath(const char* filename)
     g_test_message("Using file path %s\n", result);
 
     // Test whether the file really exists
-    g_assert(g_file_test(result, G_FILE_TEST_EXISTS));
+    g_assert_true(g_file_test(result, G_FILE_TEST_EXISTS));
 
     return result;
 }
@@ -71,16 +71,16 @@ test_qofsession_aqb_kvp( void )
         qof_session_begin (new_session, newfile, SESSION_READ_ONLY);
         io_err = qof_session_get_error (new_session);
         //printf("io_err1 = %d\n", io_err);
-        g_assert(io_err != ERR_BACKEND_NO_HANDLER); // Do not have no handler
+        g_assert_true(io_err != ERR_BACKEND_NO_HANDLER); // Do not have no handler
 
-        g_assert(io_err != ERR_BACKEND_NO_SUCH_DB); // DB must exist
-        g_assert(io_err != ERR_BACKEND_LOCKED);
-        g_assert(io_err == 0);
+        g_assert_true(io_err != ERR_BACKEND_NO_SUCH_DB); // DB must exist
+        g_assert_true(io_err != ERR_BACKEND_LOCKED);
+        g_assert_true(io_err == 0);
 
         qof_session_load (new_session, NULL);
         io_err = qof_session_get_error (new_session);
         //printf("io_err2 = %d\n", io_err);
-        g_assert(io_err == 0);
+        g_assert_true(io_err == 0);
 
         g_free(newfile);
         g_free(file1);
@@ -100,16 +100,16 @@ test_qofsession_aqb_kvp( void )
         qof_session_begin (new_session, newfile, SESSION_READ_ONLY);
         io_err = qof_session_get_error (new_session);
         //printf("io_err1 = %d\n", io_err);
-        g_assert(io_err != ERR_BACKEND_NO_HANDLER); // Do not have no handler
+        g_assert_true(io_err != ERR_BACKEND_NO_HANDLER); // Do not have no handler
 
-        g_assert(io_err != ERR_BACKEND_NO_SUCH_DB); // DB must exist
-        g_assert(io_err != ERR_BACKEND_LOCKED);
-        g_assert(io_err == 0);
+        g_assert_true(io_err != ERR_BACKEND_NO_SUCH_DB); // DB must exist
+        g_assert_true(io_err != ERR_BACKEND_LOCKED);
+        g_assert_true(io_err == 0);
 
         qof_session_load (new_session, NULL);
         io_err = qof_session_get_error (new_session);
         //printf("io_err2 = %d\n", io_err);
-        g_assert(io_err == 0);
+        g_assert_true(io_err == 0);
 
         {
             GList *templ_list;
@@ -129,11 +129,11 @@ test_qofsession_aqb_kvp( void )
             // Now we change the name into something else and verify it can be saved
             gnc_ab_trans_templ_set_name(templ, CHANGED_NAME);
             {
-                g_assert(!qof_instance_get_dirty(QOF_INSTANCE(book))); // not yet dirty
+                g_assert_true(!qof_instance_get_dirty(QOF_INSTANCE(book))); // not yet dirty
 
                 // Here we save the changed kvp
                 gnc_ab_set_book_template_list(book, templ_list);
-                g_assert(qof_instance_get_dirty(QOF_INSTANCE(book))); // yup, now dirty
+                g_assert_true(qof_instance_get_dirty(QOF_INSTANCE(book))); // yup, now dirty
                 gnc_ab_trans_templ_list_free(templ_list);
             }
 
@@ -153,7 +153,7 @@ test_qofsession_aqb_kvp( void )
             Account* account = gnc_book_get_root_account(book);
             struct tm *retrieved_date, *original_date;
 
-            g_assert(account);
+            g_assert_true(account);
 
             // The interesting test case here: Can we read the correct date
             // from the xml file?

--- a/libgnucash/backend/dbi/test/test-backend-dbi-basic.cpp
+++ b/libgnucash/backend/dbi/test/test-backend-dbi-basic.cpp
@@ -361,7 +361,7 @@ test_conn_index_functions (QofBackend* qof_be)
     {
         const char* errmsg;
         conn->provider()->drop_index (dbi_be->conn, index);
-        g_assert (DBI_ERROR_NONE == dbi_conn_error (conn->conn(), &errmsg));
+        g_assert_true (DBI_ERROR_NONE == dbi_conn_error (conn->conn(), &errmsg));
     }
 
 }
@@ -388,23 +388,23 @@ test_dbi_store_and_reload (Fixture* fixture, gconstpointer pData)
     auto book2{qof_book_new()};
     auto session_2 = qof_session_new (book2);
     qof_session_begin (session_2, url, SESSION_NEW_OVERWRITE);
-    g_assert (session_2 != NULL);
+    g_assert_true (session_2 != NULL);
     g_assert_cmpint (qof_session_get_error (session_2), == , ERR_BACKEND_NO_ERR);
     qof_session_swap_data (fixture->session, session_2);
     qof_book_mark_session_dirty (qof_session_get_book (session_2));
     qof_session_save (session_2, NULL);
-    g_assert (session_2 != NULL);
+    g_assert_true (session_2 != NULL);
     g_assert_cmpint (qof_session_get_error (session_2), == , ERR_BACKEND_NO_ERR);
 
     // Reload the session data
     auto book3{qof_book_new()};
     auto session_3 = qof_session_new (book3);
-    g_assert (session_3 != NULL);
+    g_assert_true (session_3 != NULL);
     qof_session_begin (session_3, url, SESSION_READ_ONLY);
-    g_assert (session_3 != NULL);
+    g_assert_true (session_3 != NULL);
     g_assert_cmpint (qof_session_get_error (session_3), == , ERR_BACKEND_NO_ERR);
     qof_session_load (session_3, NULL);
-    g_assert (session_3 != NULL);
+    g_assert_true (session_3 != NULL);
     g_assert_cmpint (qof_session_get_error (session_3), == , ERR_BACKEND_NO_ERR);
     // Compare with the original data
     compare_books (qof_session_get_book (session_2),
@@ -447,7 +447,7 @@ test_dbi_safe_save (Fixture* fixture, gconstpointer pData)
         g_warning ("Session Error: %d, %s", qof_session_get_error (session_1),
                    qof_session_get_error_message (session_1));
         g_test_message ("DB Session Creation Failed");
-        g_assert (FALSE);
+        g_assert_true (FALSE);
         goto cleanup;
     }
     qof_session_swap_data (fixture->session, session_1);
@@ -460,7 +460,7 @@ test_dbi_safe_save (Fixture* fixture, gconstpointer pData)
         g_warning ("Session Error: %s",
                    qof_session_get_error_message (session_1));
         g_test_message ("DB Session Safe Save Failed");
-        g_assert (FALSE);
+        g_assert_true (FALSE);
         goto cleanup;
     }
     /* Destroy the session and reload it */
@@ -473,7 +473,7 @@ test_dbi_safe_save (Fixture* fixture, gconstpointer pData)
         g_warning ("Session Error: %d, %s", qof_session_get_error (session_2),
                    qof_session_get_error_message (session_2));
         g_test_message ("DB Session re-creation Failed");
-        g_assert (FALSE);
+        g_assert_true (FALSE);
         goto cleanup;
     }
     qof_session_load (session_2, NULL);
@@ -520,7 +520,7 @@ test_dbi_version_control (Fixture* fixture, gconstpointer pData)
         g_warning ("Session Error: %d, %s", qof_session_get_error (sess),
                    qof_session_get_error_message (sess));
         g_test_message ("DB Session Creation Failed");
-        g_assert (FALSE);
+        g_assert_true (FALSE);
         goto cleanup;
     }
     qof_session_swap_data (fixture->session, sess);

--- a/libgnucash/backend/dbi/test/test-backend-dbi.cpp
+++ b/libgnucash/backend/dbi/test/test-backend-dbi.cpp
@@ -41,8 +41,8 @@ main (int   argc,
     g_test_init (&argc, &argv, NULL);       /* initialize test program */
     g_test_bug_base ("https://bugs.gnucash.org/show_bug.cgi?id="); /* init the bugzilla URL */
     cashobjects_register ();
-    g_assert (qof_load_backend_library (GNC_LIB_REL_PATH_1, GNC_LIB_NAME_1));
-    g_assert (qof_load_backend_library (GNC_LIB_REL_PATH_2, GNC_LIB_NAME_2));
+    g_assert_true (qof_load_backend_library (GNC_LIB_REL_PATH_1, GNC_LIB_NAME_1));
+    g_assert_true (qof_load_backend_library (GNC_LIB_REL_PATH_2, GNC_LIB_NAME_2));
 
     test_suite_gnc_backend_dbi ();
 

--- a/libgnucash/backend/dbi/test/test-dbi-stuff.cpp
+++ b/libgnucash/backend/dbi/test/test-dbi-stuff.cpp
@@ -61,7 +61,7 @@ compare_account_trees (QofBook* book_1, QofBook* book_2)
     Account* root_2 = gnc_book_get_root_account (book_2);
 
     xaccAccountSetHidden (root_2, xaccAccountGetHidden (root_1));
-    g_assert (xaccAccountEqual (root_1, root_2, FALSE));
+    g_assert_true (xaccAccountEqual (root_1, root_2, FALSE));
 }
 
 static void
@@ -72,7 +72,7 @@ compare_single_tx (QofInstance* inst, gpointer user_data)
     Transaction* tx_2 = xaccTransLookup (qof_instance_get_guid (inst),
                                          info->book_2);
 
-    g_assert (xaccTransEqual (tx_1, tx_2, TRUE, TRUE, TRUE, FALSE));
+    g_assert_true (xaccTransEqual (tx_1, tx_2, TRUE, TRUE, TRUE, FALSE));
 }
 
 static void
@@ -104,8 +104,8 @@ get_sx_by_guid (QofBook* book, const GncGUID* guid)
 #define TEST_GDATES_EQUAL(gd1, gd2) \
     if (g_date_valid (gd1))           \
     {                         \
-        g_assert (g_date_valid (gd2));        \
-        g_assert (g_date_compare (gd1, gd2) == 0);\
+        g_assert_true (g_date_valid (gd2));        \
+        g_assert_true (g_date_compare (gd1, gd2) == 0);\
     }
 
 static void
@@ -116,7 +116,7 @@ compare_recurrences (GList* rl_1, GList* rl_2)
     if (rl_1 == NULL)
         return;
 
-    g_assert (rl_2 != NULL);
+    g_assert_true (rl_2 != NULL);
     g_assert_cmpint (g_list_length (rl_1), == , g_list_length (rl_2));
     for (ritem1 = rl_1, ritem2 = rl_2; ritem1 != NULL && ritem2 != NULL;
          ritem1 = g_list_next (ritem1), ritem2 = g_list_next (ritem2))
@@ -139,7 +139,7 @@ compare_single_sx (QofInstance* inst, gpointer user_data)
     SchedXaction* sx_2 = get_sx_by_guid (info->book_2,
                                          qof_instance_get_guid (inst));
 
-    g_assert (sx_2 != NULL);
+    g_assert_true (sx_2 != NULL);
     g_assert_cmpstr (sx_1->name, == , sx_2->name);
     compare_recurrences (sx_2->schedule, sx_1->schedule);
     TEST_GDATES_EQUAL (&sx_2->last_date, &sx_1->last_date);
@@ -176,11 +176,11 @@ compare_single_lot (QofInstance* inst, gpointer user_data)
                                     info->book_2);
     GList* split1, *splits1, *splits2;
 
-    g_assert (xaccAccountEqual (gnc_lot_get_account (lot_1),
+    g_assert_true (xaccAccountEqual (gnc_lot_get_account (lot_1),
                                 gnc_lot_get_account (lot_2), FALSE));
     g_assert_cmpint (gnc_lot_is_closed (lot_1), == , gnc_lot_is_closed (lot_2));
 
-    g_assert (compare (qof_instance_get_slots (QOF_INSTANCE (lot_1)),
+    g_assert_true (compare (qof_instance_get_slots (QOF_INSTANCE (lot_1)),
                        qof_instance_get_slots (QOF_INSTANCE (lot_2))) == 0);
     splits1 = gnc_lot_get_split_list (lot_1);
     splits2 = gnc_lot_get_split_list (lot_2);
@@ -188,11 +188,11 @@ compare_single_lot (QofInstance* inst, gpointer user_data)
     for (split1 = splits1; split1 != NULL; split1 = g_list_next (split1))
     {
         Split* split2;
-        g_assert (GNC_IS_SPLIT (split1->data));
+        g_assert_true (GNC_IS_SPLIT (split1->data));
         split2 = xaccSplitLookup (qof_instance_get_guid (split1->data),
                                   info->book_2);
-        g_assert (GNC_IS_SPLIT (split2));
-        g_assert (xaccSplitEqual (static_cast<Split*> (split1->data),
+        g_assert_true (GNC_IS_SPLIT (split2));
+        g_assert_true (xaccSplitEqual (static_cast<Split*> (split1->data),
                                   split2, TRUE, TRUE, TRUE));
     }
 }
@@ -215,7 +215,7 @@ test_conn_index_functions (QofBackend* qof_be)
     {
         const char* errmsg;
         conn->provider()->drop_index (dbi_be->conn, index);
-        g_assert (DBI_ERROR_NONE == dbi_conn_error (conn->conn(), &errmsg));
+        g_assert_true (DBI_ERROR_NONE == dbi_conn_error (conn->conn(), &errmsg));
     }
 }
 #endif

--- a/libgnucash/backend/sql/test/utest-gnc-backend-sql.cpp
+++ b/libgnucash/backend/sql/test/utest-gnc-backend-sql.cpp
@@ -258,7 +258,7 @@ gnc_sql_commit_edit (GncSqlBackend *sql_be, QofInstance *inst)// C: 1 */
 static void
 test_dirty_cb (QofBook* book, gboolean dirty, gpointer data)
 {
-    g_assert (data != NULL);
+    g_assert_true (data != NULL);
     if (dirty)
         ++* (guint*)data;
     else if (* (guint*)data)
@@ -296,34 +296,34 @@ test_gnc_sql_commit_edit (void)
     gnc_account_create_root (book);
     qof_book_mark_session_dirty (book);
 
-    g_assert (qof_instance_get_dirty_flag (inst));
-    g_assert (qof_book_session_not_saved (book));
+    g_assert_true (qof_instance_get_dirty_flag (inst));
+    g_assert_true (qof_book_session_not_saved (book));
     g_assert_cmpint (dirty_called, == , 1);
     sql_be->commit(inst);
-    g_assert (!qof_instance_get_dirty_flag (inst));
-    g_assert (!qof_book_session_not_saved (book));
+    g_assert_true (!qof_instance_get_dirty_flag (inst));
+    g_assert_true (!qof_book_session_not_saved (book));
     g_assert_cmpint (dirty_called, == , 0);
     g_assert_cmpint (check1.hits, == , 2);
 
     qof_book_mark_session_dirty (book);
 
-    g_assert (!qof_instance_get_dirty_flag (QOF_INSTANCE (book)));
-    g_assert (qof_book_session_not_saved (book));
+    g_assert_true (!qof_instance_get_dirty_flag (QOF_INSTANCE (book)));
+    g_assert_true (qof_book_session_not_saved (book));
     g_assert_cmpint (dirty_called, == , 1);
     sql_be->commit(QOF_INSTANCE (book));
-    g_assert (!qof_instance_get_dirty_flag (QOF_INSTANCE (book)));
-    g_assert (qof_book_session_not_saved (book));
+    g_assert_true (!qof_instance_get_dirty_flag (QOF_INSTANCE (book)));
+    g_assert_true (qof_book_session_not_saved (book));
     g_assert_cmpint (dirty_called, == , 1);
     g_assert_cmpint (check1.hits, == , 2);
 
     qof_instance_set_dirty_flag (QOF_INSTANCE (book), TRUE);
 
-    g_assert (qof_instance_get_dirty_flag (QOF_INSTANCE (book)));
-    g_assert (qof_book_session_not_saved (book));
+    g_assert_true (qof_instance_get_dirty_flag (QOF_INSTANCE (book)));
+    g_assert_true (qof_book_session_not_saved (book));
     g_assert_cmpint (dirty_called, == , 1);
     sql_be->commit(QOF_INSTANCE (book));
-    g_assert (!qof_instance_get_dirty_flag (QOF_INSTANCE (book)));
-    g_assert (!qof_book_session_not_saved (book));
+    g_assert_true (!qof_instance_get_dirty_flag (QOF_INSTANCE (book)));
+    g_assert_true (!qof_book_session_not_saved (book));
     g_assert_cmpint (dirty_called, == , 0);
     g_assert_cmpint (check1.hits, == , 2);
 

--- a/libgnucash/core-utils/test/test-gnc-glib-utils.c
+++ b/libgnucash/core-utils/test/test-gnc-glib-utils.c
@@ -45,9 +45,9 @@ test_gnc_utf8_strip_invalid_and_controls (gconstpointer data)
                                  &check);
 
     gnc_utf8_strip_invalid_and_controls (str);
-    g_assert (g_utf8_validate(str, -1, NULL) == TRUE);
-    g_assert (strpbrk(str, controls) == NULL);
-    g_assert (g_utf8_strlen(str, -1) > 0);
+    g_assert_true (g_utf8_validate(str, -1, NULL) == TRUE);
+    g_assert_true (strpbrk(str, controls) == NULL);
+    g_assert_true (g_utf8_strlen(str, -1) > 0);
     g_log_remove_handler (NULL, handler);
     g_free (str);
     g_free (msg1);
@@ -60,10 +60,10 @@ test_g_list_stringjoin (gconstpointer data)
     gchar *ret;
 
     ret = gnc_g_list_stringjoin (NULL, NULL);
-    g_assert (ret == NULL);
+    g_assert_true (ret == NULL);
 
     ret = gnc_g_list_stringjoin (NULL, ":");
-    g_assert (ret == NULL);
+    g_assert_true (ret == NULL);
 
     test = g_list_prepend (test, "one");
 
@@ -120,18 +120,18 @@ test_gnc_list_length (gconstpointer data)
 {
     GList *lst = NULL;
 
-    g_assert (gnc_list_length_cmp (lst, 0) == 0);
-    g_assert (gnc_list_length_cmp (lst, 1) == -1);
+    g_assert_true (gnc_list_length_cmp (lst, 0) == 0);
+    g_assert_true (gnc_list_length_cmp (lst, 1) == -1);
 
     lst = g_list_prepend (lst, (gpointer)1);
-    g_assert (gnc_list_length_cmp (lst, 0) == 1);
-    g_assert (gnc_list_length_cmp (lst, 1) == 0);
-    g_assert (gnc_list_length_cmp (lst, 2) == -1);
+    g_assert_true (gnc_list_length_cmp (lst, 0) == 1);
+    g_assert_true (gnc_list_length_cmp (lst, 1) == 0);
+    g_assert_true (gnc_list_length_cmp (lst, 2) == -1);
 
     lst = g_list_prepend (lst, (gpointer)2);
-    g_assert (gnc_list_length_cmp (lst, 1) == 1);
-    g_assert (gnc_list_length_cmp (lst, 2) == 0);
-    g_assert (gnc_list_length_cmp (lst, 3) == -1);
+    g_assert_true (gnc_list_length_cmp (lst, 1) == 1);
+    g_assert_true (gnc_list_length_cmp (lst, 2) == 0);
+    g_assert_true (gnc_list_length_cmp (lst, 3) == -1);
 
     g_list_free (lst);
 }

--- a/libgnucash/engine/mocks/gmock-gobject.h
+++ b/libgnucash/engine/mocks/gmock-gobject.h
@@ -10,7 +10,7 @@ mock_g_object_new (GType object_type, const gchar *first_property_name, size_t s
     GTypeQuery query;
 
     g_type_query(object_type, &query);
-    g_assert(size == query.instance_size);
+    g_assert_true (size == query.instance_size);
     return g_object_new (object_type, first_property_name);
 }
 
@@ -21,7 +21,7 @@ mock_g_object_unref (gpointer object, size_t size)
     GTypeQuery query;
 
     g_type_query(object_type, &query);
-    g_assert(size == query.instance_size);
+    g_assert_true (size == query.instance_size);
     g_object_unref(object);
 }
 

--- a/libgnucash/engine/test-core/test-engine-stuff.cpp
+++ b/libgnucash/engine/test-core/test-engine-stuff.cpp
@@ -1294,11 +1294,11 @@ get_random_split(QofBook *book, Account *acct, Transaction *trn)
        also allowed to be zero, because that is caused by a small
        rate. */
     if (gnc_numeric_positive_p(val))
-        g_assert(!gnc_numeric_negative_p(amt)); /* non-negative amt */
+        g_assert_true(!gnc_numeric_negative_p(amt)); /* non-negative amt */
     else
-        g_assert(!gnc_numeric_positive_p(amt)); /* non-positive amt */
+        g_assert_true(!gnc_numeric_positive_p(amt)); /* non-positive amt */
 
-//    g_assert(amt.num < (2LL << 56));
+//    g_assert_true(amt.num < (2LL << 56));
     qof_instance_set_slots(QOF_INSTANCE (ret), get_random_kvp_frame());
     xaccTransCommitEdit(trn);
 

--- a/libgnucash/engine/test/test-engine-kvp-properties.c
+++ b/libgnucash/engine/test/test-engine-kvp-properties.c
@@ -158,7 +158,7 @@ test_account_kvp_properties (Fixture *fixture, gconstpointer pData)
 		      "ab-trans-retrieval", &trans_retr,
 		      NULL);
 
-    g_assert (qof_instance_is_dirty (QOF_INSTANCE (fixture->acct)));
+    g_assert_true (qof_instance_is_dirty (QOF_INSTANCE (fixture->acct)));
     qof_instance_mark_clean (QOF_INSTANCE (fixture->acct));
 
     qof_instance_get (QOF_INSTANCE (fixture->acct),
@@ -172,12 +172,12 @@ test_account_kvp_properties (Fixture *fixture, gconstpointer pData)
 		      NULL);
     g_assert_cmpint (next_id, ==, next_id_r);
     g_assert_cmpstr (online_id, ==, online_id_r);
-    g_assert (guid_equal (ofx_income_acct, ofx_income_acct_r));
+    g_assert_true (guid_equal (ofx_income_acct, ofx_income_acct_r));
     g_assert_cmpstr (ab_acct_id, ==, ab_acct_id_r);
     g_assert_cmpstr (ab_bank_code, ==, ab_bank_code_r);
     g_assert_cmpint (ab_acct_uid, ==, ab_acct_uid_r);
     g_assert_cmpint (trans_retr.t, ==, trans_retr_r->t);
-    g_assert (!qof_instance_is_dirty (QOF_INSTANCE (fixture->acct)));
+    g_assert_true (!qof_instance_is_dirty (QOF_INSTANCE (fixture->acct)));
 
     guid_free (ofx_income_acct);
     guid_free (ofx_income_acct_r);
@@ -199,7 +199,7 @@ test_trans_kvp_properties (Fixture *fixture, gconstpointer pData)
 		      "online-id", online_id,
 		      NULL);
 
-    g_assert (qof_instance_is_dirty (QOF_INSTANCE (fixture->trans)));
+    g_assert_true (qof_instance_is_dirty (QOF_INSTANCE (fixture->trans)));
     qof_instance_mark_clean (QOF_INSTANCE (fixture->trans));
 
     qof_instance_get (QOF_INSTANCE (fixture->trans),
@@ -207,10 +207,10 @@ test_trans_kvp_properties (Fixture *fixture, gconstpointer pData)
 		      "from-sched-xaction", &from_sx_r,
 		      "online-id", &online_id_r,
 		      NULL);
-    g_assert (guid_equal (invoice, invoice_r));
-    g_assert (guid_equal (from_sx, from_sx_r));
+    g_assert_true (guid_equal (invoice, invoice_r));
+    g_assert_true (guid_equal (from_sx, from_sx_r));
     g_assert_cmpstr (online_id, ==, online_id_r);
-    g_assert (!qof_instance_is_dirty (QOF_INSTANCE (fixture->trans)));
+    g_assert_true (!qof_instance_is_dirty (QOF_INSTANCE (fixture->trans)));
     guid_free (invoice);
     guid_free (invoice_r);
     guid_free (from_sx);
@@ -244,7 +244,7 @@ test_split_kvp_properties (Fixture *fixture, gconstpointer pData)
 		      "online-id", online_id,
 		      NULL);
 
-    g_assert (qof_instance_is_dirty (QOF_INSTANCE (fixture->split)));
+    g_assert_true (qof_instance_is_dirty (QOF_INSTANCE (fixture->split)));
     qof_instance_mark_clean (QOF_INSTANCE (fixture->split));
 
     qof_instance_get (QOF_INSTANCE (fixture->split),
@@ -257,13 +257,13 @@ test_split_kvp_properties (Fixture *fixture, gconstpointer pData)
 		      "online-id", &online_id_r,
 		      NULL);
     g_assert_cmpstr (debit_formula, ==, debit_formula_r);
-    g_assert (gnc_numeric_equal (debit_numeric, *debit_numeric_r));
+    g_assert_true (gnc_numeric_equal (debit_numeric, *debit_numeric_r));
     g_assert_cmpstr (credit_formula, ==, credit_formula_r);
-    g_assert (gnc_numeric_equal (credit_numeric, *credit_numeric_r));
-    g_assert (guid_equal (sx_account, sx_account_r));
+    g_assert_true (gnc_numeric_equal (credit_numeric, *credit_numeric_r));
+    g_assert_true (guid_equal (sx_account, sx_account_r));
     g_assert_cmpstr (sx_shares, ==, sx_shares_r);
     g_assert_cmpstr (online_id, ==, online_id_r);
-    g_assert (!qof_instance_is_dirty (QOF_INSTANCE (fixture->split)));
+    g_assert_true (!qof_instance_is_dirty (QOF_INSTANCE (fixture->split)));
     g_free (debit_formula_r);
     g_free (debit_numeric_r);
     g_free (credit_formula_r);
@@ -275,7 +275,7 @@ test_split_kvp_properties (Fixture *fixture, gconstpointer pData)
     qof_instance_get (QOF_INSTANCE (fixture->split),
 		      "sx-credit-formula", &credit_numeric_r,
 		      NULL);
-    g_assert (credit_numeric_r == NULL);
+    g_assert_true (credit_numeric_r == NULL);
     g_free (sx_shares_r);
     g_free (online_id_r);
     guid_free (sx_account);
@@ -299,7 +299,7 @@ test_lot_kvp_properties (Fixture *fixture, gconstpointer pData)
 		      GNC_OWNER_GUID, owner,
 		      NULL);
 
-    g_assert (qof_instance_is_dirty (QOF_INSTANCE (fixture->lot)));
+    g_assert_true (qof_instance_is_dirty (QOF_INSTANCE (fixture->lot)));
     qof_instance_mark_clean (QOF_INSTANCE (fixture->lot));
 
     qof_instance_get (QOF_INSTANCE (fixture->lot),
@@ -307,10 +307,10 @@ test_lot_kvp_properties (Fixture *fixture, gconstpointer pData)
 		      GNC_OWNER_TYPE, &owner_type_r,
 		      GNC_OWNER_GUID, &owner_r,
 		      NULL);
-    g_assert (guid_equal (invoice, invoice_r));
+    g_assert_true (guid_equal (invoice, invoice_r));
     g_assert_cmpint (owner_type, ==, owner_type_r);
-    g_assert (guid_equal (owner, owner_r));
-    g_assert (!qof_instance_is_dirty (QOF_INSTANCE (fixture->lot)));
+    g_assert_true (guid_equal (owner, owner_r));
+    g_assert_true (!qof_instance_is_dirty (QOF_INSTANCE (fixture->lot)));
     guid_free (invoice);
     guid_free (invoice_r);
     guid_free (owner);
@@ -333,7 +333,7 @@ test_customer_kvp_properties (Fixture *fixture, gconstpointer pData)
 		      "payment-last-account", pmt_acct,
 		      NULL);
 
-    g_assert (qof_instance_is_dirty (QOF_INSTANCE (fixture->cust)));
+    g_assert_true (qof_instance_is_dirty (QOF_INSTANCE (fixture->cust)));
     qof_instance_mark_clean (QOF_INSTANCE (fixture->cust));
 
     qof_instance_get (QOF_INSTANCE (fixture->cust),
@@ -343,8 +343,8 @@ test_customer_kvp_properties (Fixture *fixture, gconstpointer pData)
 		      NULL);
 
     g_assert_cmpstr (pdf_dir, ==, pdf_dir_r);
-    g_assert (guid_equal (inv_acct, inv_acct_r));
-    g_assert (guid_equal (pmt_acct, pmt_acct_r));
+    g_assert_true (guid_equal (inv_acct, inv_acct_r));
+    g_assert_true (guid_equal (pmt_acct, pmt_acct_r));
     guid_free (inv_acct);
     guid_free (inv_acct_r);
     guid_free (pmt_acct);
@@ -369,7 +369,7 @@ test_employee_kvp_properties (Fixture *fixture, gconstpointer pData)
 		      "payment-last-account", pmt_acct,
 		      NULL);
 
-    g_assert (qof_instance_is_dirty (QOF_INSTANCE (fixture->emp)));
+    g_assert_true (qof_instance_is_dirty (QOF_INSTANCE (fixture->emp)));
     qof_instance_mark_clean (QOF_INSTANCE (fixture->emp));
 
     qof_instance_get (QOF_INSTANCE (fixture->emp),
@@ -379,8 +379,8 @@ test_employee_kvp_properties (Fixture *fixture, gconstpointer pData)
 		      NULL);
 
     g_assert_cmpstr (pdf_dir, ==, pdf_dir_r);
-    g_assert (guid_equal (inv_acct, inv_acct_r));
-    g_assert (guid_equal (pmt_acct, pmt_acct_r));
+    g_assert_true (guid_equal (inv_acct, inv_acct_r));
+    g_assert_true (guid_equal (pmt_acct, pmt_acct_r));
     guid_free (inv_acct);
     guid_free (inv_acct_r);
     guid_free (pmt_acct);
@@ -400,7 +400,7 @@ test_job_kvp_properties (Fixture *fixture, gconstpointer pData)
 		      "export-pdf-dir", pdf_dir,
 		      NULL);
 
-    g_assert (qof_instance_is_dirty (QOF_INSTANCE (fixture->job)));
+    g_assert_true (qof_instance_is_dirty (QOF_INSTANCE (fixture->job)));
     qof_instance_mark_clean (QOF_INSTANCE (fixture->job));
 
     qof_instance_get (QOF_INSTANCE (fixture->job),
@@ -428,7 +428,7 @@ test_vendor_kvp_properties (Fixture *fixture, gconstpointer pData)
 		      "payment-last-account", pmt_acct,
 		      NULL);
 
-    g_assert (qof_instance_is_dirty (QOF_INSTANCE (fixture->vend)));
+    g_assert_true (qof_instance_is_dirty (QOF_INSTANCE (fixture->vend)));
     qof_instance_mark_clean (QOF_INSTANCE (fixture->vend));
 
     qof_instance_get (QOF_INSTANCE (fixture->vend),
@@ -438,8 +438,8 @@ test_vendor_kvp_properties (Fixture *fixture, gconstpointer pData)
 		      NULL);
 
     g_assert_cmpstr (pdf_dir, ==, pdf_dir_r);
-    g_assert (guid_equal (inv_acct, inv_acct_r));
-    g_assert (guid_equal (pmt_acct, pmt_acct_r));
+    g_assert_true (guid_equal (inv_acct, inv_acct_r));
+    g_assert_true (guid_equal (pmt_acct, pmt_acct_r));
     guid_free (inv_acct);
     guid_free (inv_acct_r);
     guid_free (pmt_acct);

--- a/libgnucash/engine/test/test-gnc-date.c
+++ b/libgnucash/engine/test/test-gnc-date.c
@@ -154,7 +154,7 @@ test_gnc_localtime (void)
         struct tm* ans;
         if (secs[ind] > max_secs)
         {
-            g_assert (time == NULL);
+            g_assert_true (time == NULL);
             continue;
         }
         tsecs = (time_t)(secs[ind]);
@@ -205,7 +205,7 @@ test_gnc_gmtime (void)
         struct tm* time = gnc_gmtime (&secs[ind]);
         if ((secs[ind] > max_secs))
         {
-            g_assert (time == NULL);
+            g_assert_true (time == NULL);
             continue;
         }
 
@@ -376,28 +376,28 @@ static void
 test_gnc_date_string_to_dateformat (void)
 {
     QofDateFormat fmt = 123;
-    g_assert (gnc_date_string_to_dateformat (NULL, &fmt));
+    g_assert_true (gnc_date_string_to_dateformat (NULL, &fmt));
     g_assert_cmpint (fmt, ==, 123);
-    g_assert (!gnc_date_string_to_dateformat ("us", &fmt));
+    g_assert_true (!gnc_date_string_to_dateformat ("us", &fmt));
     g_assert_cmpint (fmt, ==, QOF_DATE_FORMAT_US);
-    g_assert (!gnc_date_string_to_dateformat ("uk", &fmt));
+    g_assert_true (!gnc_date_string_to_dateformat ("uk", &fmt));
     g_assert_cmpint (fmt, ==, QOF_DATE_FORMAT_UK);
-    g_assert (!gnc_date_string_to_dateformat ("ce", &fmt));
+    g_assert_true (!gnc_date_string_to_dateformat ("ce", &fmt));
     g_assert_cmpint (fmt, ==, QOF_DATE_FORMAT_CE);
-    g_assert (!gnc_date_string_to_dateformat ("iso", &fmt));
+    g_assert_true (!gnc_date_string_to_dateformat ("iso", &fmt));
     g_assert_cmpint (fmt, ==, QOF_DATE_FORMAT_ISO);
-    g_assert (!gnc_date_string_to_dateformat ("utc", &fmt));
+    g_assert_true (!gnc_date_string_to_dateformat ("utc", &fmt));
     g_assert_cmpint (fmt, ==, QOF_DATE_FORMAT_UTC);
-    g_assert (!gnc_date_string_to_dateformat ("locale", &fmt));
+    g_assert_true (!gnc_date_string_to_dateformat ("locale", &fmt));
     g_assert_cmpint (fmt, ==, QOF_DATE_FORMAT_LOCALE);
-    g_assert (!gnc_date_string_to_dateformat ("custom", &fmt));
+    g_assert_true (!gnc_date_string_to_dateformat ("custom", &fmt));
     g_assert_cmpint (fmt, ==, QOF_DATE_FORMAT_CUSTOM);
-    g_assert (!gnc_date_string_to_dateformat ("unset", &fmt));
+    g_assert_true (!gnc_date_string_to_dateformat ("unset", &fmt));
     g_assert_cmpint (fmt, ==, QOF_DATE_FORMAT_UNSET);
     fmt = 123;
-    g_assert (gnc_date_string_to_dateformat ("", &fmt));
+    g_assert_true (gnc_date_string_to_dateformat ("", &fmt));
     g_assert_cmpint (fmt, ==, 123);
-    g_assert (gnc_date_string_to_dateformat ("foo", &fmt));
+    g_assert_true (gnc_date_string_to_dateformat ("foo", &fmt));
     g_assert_cmpint (fmt, ==, 123);
 
 }
@@ -411,7 +411,7 @@ test_gnc_date_monthformat_to_string (void)
     g_assert_cmpstr (gnc_date_monthformat_to_string (GNCDATE_MONTH_NUMBER), ==, "number");
     g_assert_cmpstr (gnc_date_monthformat_to_string (GNCDATE_MONTH_ABBREV), ==, "abbrev");
     g_assert_cmpstr (gnc_date_monthformat_to_string (GNCDATE_MONTH_NAME), ==, "name");
-    g_assert (gnc_date_monthformat_to_string (93) == NULL);
+    g_assert_true (gnc_date_monthformat_to_string (93) == NULL);
 }
 /* gnc_date_string_to_monthformat
 gboolean
@@ -421,18 +421,18 @@ static void
 test_gnc_date_string_to_monthformat (void)
 {
     GNCDateMonthFormat fmt = 123;
-    g_assert (gnc_date_string_to_monthformat (NULL, &fmt));
+    g_assert_true (gnc_date_string_to_monthformat (NULL, &fmt));
     g_assert_cmpint (fmt, ==, 123);
-    g_assert (!gnc_date_string_to_monthformat ("number", &fmt));
+    g_assert_true (!gnc_date_string_to_monthformat ("number", &fmt));
     g_assert_cmpint (fmt, ==, GNCDATE_MONTH_NUMBER);
-    g_assert (!gnc_date_string_to_monthformat ("abbrev", &fmt));
+    g_assert_true (!gnc_date_string_to_monthformat ("abbrev", &fmt));
     g_assert_cmpint (fmt, ==, GNCDATE_MONTH_ABBREV);
-    g_assert (!gnc_date_string_to_monthformat ("name", &fmt));
+    g_assert_true (!gnc_date_string_to_monthformat ("name", &fmt));
     g_assert_cmpint (fmt, ==, GNCDATE_MONTH_NAME);
     fmt = 123;
-    g_assert (gnc_date_string_to_monthformat ("", &fmt));
+    g_assert_true (gnc_date_string_to_monthformat ("", &fmt));
     g_assert_cmpint (fmt, ==, 123);
-    g_assert (gnc_date_string_to_monthformat ("foo", &fmt));
+    g_assert_true (gnc_date_string_to_monthformat ("foo", &fmt));
     g_assert_cmpint (fmt, ==, 123);
 }
 
@@ -1158,61 +1158,61 @@ test_qof_scan_date (void)
     year = tm.tm_year + 1900;
     month = tm.tm_mon + 1;
 
-    g_assert (!qof_scan_date (NULL, &day, &mo, &yr));
+    g_assert_true (!qof_scan_date (NULL, &day, &mo, &yr));
     g_assert_cmpint (day, ==, 0);
     g_assert_cmpint (mo, ==, 0);
     g_assert_cmpint (yr, ==, 0);
 
     qof_date_format_set (QOF_DATE_FORMAT_UTC);
-    g_assert (qof_scan_date ("1974-11-23", &day, &mo, &yr));
+    g_assert_true (qof_scan_date ("1974-11-23", &day, &mo, &yr));
     g_assert_cmpint (day, ==, 23);
     g_assert_cmpint (mo, ==, 11);
     g_assert_cmpint (yr, ==, 1974);
 
-    g_assert (qof_scan_date ("1961-2-2", &day, &mo, &yr));
+    g_assert_true (qof_scan_date ("1961-2-2", &day, &mo, &yr));
     g_assert_cmpint (day, ==, 2);
     g_assert_cmpint (mo, ==, 2);
     g_assert_cmpint (yr, ==, 1961);
 
-    g_assert (qof_scan_date ("2045-6-16", &day, &mo, &yr));
+    g_assert_true (qof_scan_date ("2045-6-16", &day, &mo, &yr));
     g_assert_cmpint (day, ==, 16);
     g_assert_cmpint (mo, ==, 6);
     g_assert_cmpint (yr, ==, 2045);
 
     qof_date_format_set (QOF_DATE_FORMAT_US);
-    g_assert (qof_scan_date ("11/23/1974", &day, &mo, &yr));
+    g_assert_true (qof_scan_date ("11/23/1974", &day, &mo, &yr));
     g_assert_cmpint (day, ==, 23);
     g_assert_cmpint (mo, ==, 11);
     g_assert_cmpint (yr, ==, 1974);
 
-    g_assert (qof_scan_date ("2/2/1961", &day, &mo, &yr));
+    g_assert_true (qof_scan_date ("2/2/1961", &day, &mo, &yr));
     g_assert_cmpint (day, ==, 2);
     g_assert_cmpint (mo, ==, 2);
     g_assert_cmpint (yr, ==, 1961);
 
-    g_assert (qof_scan_date ("6/16/2045", &day, &mo, &yr));
+    g_assert_true (qof_scan_date ("6/16/2045", &day, &mo, &yr));
     g_assert_cmpint (day, ==, 16);
     g_assert_cmpint (mo, ==, 6);
     g_assert_cmpint (yr, ==, 2045);
 
-    g_assert (qof_scan_date ("11월23년1974", &day, &mo, &yr));
+    g_assert_true (qof_scan_date ("11월23년1974", &day, &mo, &yr));
     g_assert_cmpint (day, ==, 23);
     g_assert_cmpint (mo, ==, 11);
     g_assert_cmpint (yr, ==, 1974);
 
-    g_assert (qof_scan_date ("11月23年1974", &day, &mo, &yr));
+    g_assert_true (qof_scan_date ("11月23年1974", &day, &mo, &yr));
     g_assert_cmpint (day, ==, 23);
     g_assert_cmpint (mo, ==, 11);
     g_assert_cmpint (yr, ==, 1974);
 
     qof_date_completion_set (QOF_DATE_COMPLETION_THISYEAR, 0);
 
-    g_assert (qof_scan_date ("11-23", &day, &mo, &yr));
+    g_assert_true (qof_scan_date ("11-23", &day, &mo, &yr));
     g_assert_cmpint (day, ==, 23);
     g_assert_cmpint (mo, ==, 11);
     g_assert_cmpint (yr, ==, year);
 
-    g_assert (qof_scan_date ("23-11", &day, &mo, &yr));
+    g_assert_true (qof_scan_date ("23-11", &day, &mo, &yr));
     g_assert_cmpint (day, ==, 23);
     g_assert_cmpint (mo, ==, 11);
     g_assert_cmpint (yr, ==, year);
@@ -1221,7 +1221,7 @@ test_qof_scan_date (void)
     {
         qof_date_completion_set (QOF_DATE_COMPLETION_SLIDING, month + 1);
 
-        g_assert (qof_scan_date ("12-23", &day, &mo, &yr));
+        g_assert_true (qof_scan_date ("12-23", &day, &mo, &yr));
         g_assert_cmpint (day, ==, 23);
         g_assert_cmpint (mo, ==, 12);
         g_assert_cmpint (yr, ==, year - 1);
@@ -1230,17 +1230,17 @@ test_qof_scan_date (void)
     }
 
     qof_date_format_set (QOF_DATE_FORMAT_UK);
-    g_assert (qof_scan_date ("23/11/1974", &day, &mo, &yr));
+    g_assert_true (qof_scan_date ("23/11/1974", &day, &mo, &yr));
     g_assert_cmpint (day, ==, 23);
     g_assert_cmpint (mo, ==, 11);
     g_assert_cmpint (yr, ==, 1974);
 
-    g_assert (qof_scan_date ("2/2/1961", &day, &mo, &yr));
+    g_assert_true (qof_scan_date ("2/2/1961", &day, &mo, &yr));
     g_assert_cmpint (day, ==, 2);
     g_assert_cmpint (mo, ==, 2);
     g_assert_cmpint (yr, ==, 1961);
 
-    g_assert (qof_scan_date ("16/6/2045", &day, &mo, &yr));
+    g_assert_true (qof_scan_date ("16/6/2045", &day, &mo, &yr));
     g_assert_cmpint (day, ==, 16);
     g_assert_cmpint (mo, ==, 6);
     g_assert_cmpint (yr, ==, 2045);
@@ -1249,14 +1249,14 @@ test_qof_scan_date (void)
     test_gnc_setlocale (LC_TIME, "en_GB");
     tm_set_dmy (&tm, 1974, 11, 23);
     strftime (buff, MAX_DATE_LENGTH, GNC_D_FMT, &tm);
-    g_assert (qof_scan_date (buff, &day, &mo, &yr));
+    g_assert_true (qof_scan_date (buff, &day, &mo, &yr));
     g_assert_cmpint (day, ==, tm.tm_mday);
     g_assert_cmpint (mo, ==, tm.tm_mon + 1);
     g_assert_cmpint (yr, ==, tm.tm_year + 1900);
 
     tm_set_dmy (&tm, 1961,2, 2);
     strftime (buff, MAX_DATE_LENGTH, GNC_D_FMT, &tm);
-    g_assert (qof_scan_date (buff, &day, &mo, &yr));
+    g_assert_true (qof_scan_date (buff, &day, &mo, &yr));
     g_assert_cmpint (day, ==, tm.tm_mday);
     g_assert_cmpint (mo, ==, tm.tm_mon + 1);
     /* Some locale date formats result in a 2-digit year, which strptime
@@ -1266,7 +1266,7 @@ test_qof_scan_date (void)
 
     tm_set_dmy (&tm, 2045, 6, 16);
     strftime (buff, MAX_DATE_LENGTH, GNC_D_FMT, &tm);
-    g_assert (qof_scan_date (buff, &day, &mo, &yr));
+    g_assert_true (qof_scan_date (buff, &day, &mo, &yr));
     g_assert_cmpint (day, ==, tm.tm_mday);
     g_assert_cmpint (mo, ==, tm.tm_mon + 1);
     g_assert_cmpint (yr, ==, tm.tm_year + 1900);
@@ -1326,7 +1326,7 @@ test_gnc_date_timestamp (void)
     gchar *timestr = gnc_date_timestamp ();
     struct tm tm0, tm1;
     gnc_localtime_r(&now, &tm0);
-    g_assert (strptime (timestr, "%Y%m%d%H%M%S", &tm1));
+    g_assert_true (strptime (timestr, "%Y%m%d%H%M%S", &tm1));
     g_assert_cmpint (tm0.tm_year, ==, tm1.tm_year);
     g_assert_cmpint (tm0.tm_mon, ==, tm1.tm_mon);
     g_assert_cmpint (tm0.tm_mday, ==, tm1.tm_mday);
@@ -1390,7 +1390,7 @@ test_gnc_time64_to_iso8601_buff (FixtureA *f, gconstpointer pData)
     memset (buff, 0, sizeof buff);
 
     end = gnc_time64_to_iso8601_buff (t, NULL);
-    g_assert (end == NULL);
+    g_assert_true (end == NULL);
 
     end = gnc_time64_to_iso8601_buff (f->t0, buff);
     g_assert_cmpint (end - buff, ==, strlen (buff));
@@ -1625,7 +1625,7 @@ test_gdate_to_time64 (FixtureB *f, gconstpointer pData)
               if (f->test[i].secs < INT64_MAX)
               {
                    gd2 = time64_to_gdate(r_t);
-                   g_assert (g_date_compare (&gd2, &gd) == 0);
+                   g_assert_true (g_date_compare (&gd2, &gd) == 0);
               }
          }
     }

--- a/libgnucash/engine/test/test-gnc-guid-old.cpp
+++ b/libgnucash/engine/test/test-gnc-guid-old.cpp
@@ -46,21 +46,21 @@ static const gchar * suitename {"/qof/gnc-guid"};
 /*Create a GUID and free it.*/
 static void test_create_gnc_guid (void){
     GncGUID * guid {guid_malloc ()};
-    g_assert (guid != nullptr);
+    g_assert_true (guid != nullptr);
     guid_replace (guid);
     /*We apparently don't need to free guid_null (based on its being const)*/
     const GncGUID * guidnull {guid_null ()};
-    g_assert (!guid_equal (guid, guidnull));
+    g_assert_true (!guid_equal (guid, guidnull));
     guid_free (guid);
 }
 
 /*We create a GUID, create a copy, and compare them to ensure they're not different.*/
 static void test_gnc_guid_copy (void) {
     GncGUID * guid {guid_malloc ()};
-    g_assert (guid != nullptr);
+    g_assert_true (guid != nullptr);
     guid_replace (guid);
     GncGUID * cp {guid_copy (guid)};
-    g_assert (guid_equal (guid, cp));
+    g_assert_true (guid_equal (guid, cp));
     guid_free (cp);
     guid_free (guid);
 }
@@ -71,23 +71,23 @@ static void test_gnc_guid_to_string (void) {
     GncGUID * guid {guid_malloc()};
     gchar guidstrp [GUID_ENCODING_LENGTH+1];
     gchar guidstrp2[GUID_ENCODING_LENGTH+1];
-    g_assert (guid != nullptr);
+    g_assert_true (guid != nullptr);
     guid_replace (guid);
     string message {" using guid_to_string (deprecated): "};
     guid_to_string_buff (guid,guidstrp);
     string guidstr {guidstrp};
-    g_assert (guidstr.size () == GUID_ENCODING_LENGTH);
+    g_assert_true (guidstr.size () == GUID_ENCODING_LENGTH);
     message += guidstr;
     g_test_message ("%s", message.c_str ());
     message = " using guid_to_string_buff: ";
     gchar * ret {guid_to_string_buff (guid, guidstrp2)};
-    g_assert (ret == guidstrp2 + GUID_ENCODING_LENGTH);
+    g_assert_true (ret == guidstrp2 + GUID_ENCODING_LENGTH);
     string guidstr2 {guidstrp2};
-    g_assert (guidstr2.size () == GUID_ENCODING_LENGTH);
+    g_assert_true (guidstr2.size () == GUID_ENCODING_LENGTH);
     message += guidstr2;
     g_test_message ("%s", message.c_str ());
 
-    g_assert (guidstr2 == guidstr);
+    g_assert_true (guidstr2 == guidstr);
     guid_free (guid);
 }
 
@@ -95,11 +95,11 @@ static void test_gnc_guid_to_string (void) {
 two GUIDs, then ensure that they are equal*/
 static void test_gnc_guid_equals (void) {
     GncGUID * guid1 {guid_malloc ()};
-    g_assert (guid1 != nullptr);
+    g_assert_true (guid1 != nullptr);
     GncGUID * guid2 {guid_malloc ()};
-    g_assert (guid2 != nullptr);
+    g_assert_true (guid2 != nullptr);
     GncGUID * guidold {guid_malloc ()};
-    g_assert (guidold != nullptr);
+    g_assert_true (guidold != nullptr);
 
     mt19937 m;
     uniform_int_distribution<unsigned> dist;
@@ -115,14 +115,14 @@ static void test_gnc_guid_equals (void) {
         for (unsigned spot {0}; spot < 4; ++spot)
             o << setw (8) << dist (m);
         string guids {o.str ()};
-        g_assert (guids.size() == GUID_ENCODING_LENGTH);
-        g_assert (string_to_guid (guids.c_str (), guid1));
-        g_assert (string_to_guid (guids.c_str (), guid2));
-        g_assert (guid_equal (guid1, guid2));
+        g_assert_true (guids.size() == GUID_ENCODING_LENGTH);
+        g_assert_true (string_to_guid (guids.c_str (), guid1));
+        g_assert_true (string_to_guid (guids.c_str (), guid2));
+        g_assert_true (guid_equal (guid1, guid2));
         /*Assuming that our distribution won't give the same
         GUID twice in a row.*/
-        g_assert (!guid_equal (guid1, guidold));
-        g_assert (string_to_guid (guids.c_str (), guidold));
+        g_assert_true (!guid_equal (guid1, guidold));
+        g_assert_true (string_to_guid (guids.c_str (), guidold));
     }
     guid_free (guidold);
     guid_free (guid2);
@@ -133,17 +133,17 @@ static void test_gnc_guid_equals (void) {
 a guid, ensuring that we end up with an equivalent structure*/
 static void test_gnc_guid_roundtrip (void) {
     GncGUID * guid1 {guid_malloc ()};
-    g_assert (guid1 != nullptr);
+    g_assert_true (guid1 != nullptr);
     GncGUID * guid2 {guid_malloc ()};
-    g_assert (guid2 != nullptr);
+    g_assert_true (guid2 != nullptr);
     guid_replace (guid1);
 
     gchar guidstrp [GUID_ENCODING_LENGTH+1];
     gchar * temp {guid_to_string_buff (guid1, guidstrp)};
-    g_assert (temp == guidstrp + GUID_ENCODING_LENGTH);
+    g_assert_true (temp == guidstrp + GUID_ENCODING_LENGTH);
 
-    g_assert (string_to_guid (guidstrp, guid2));
-    g_assert (guid_equal (guid1, guid2));
+    g_assert_true (string_to_guid (guidstrp, guid2));
+    g_assert_true (guid_equal (guid1, guid2));
     guid_free (guid2);
     guid_free (guid1);
 }
@@ -160,7 +160,7 @@ static void test_gnc_guid_replace (void)
     guid_replace (guid1);
     GncGUID * guid2 {guid_copy (guid1)};
     guid_replace (guid1);
-    g_assert (! guid_equal (guid1, guid2));
+    g_assert_true (! guid_equal (guid1, guid2));
 
     guid_free (guid2);
     guid_free (guid1);
@@ -175,13 +175,13 @@ static void test_gnc_guid_from_string (void) {
     const char * bogus {"01-23-45-6789a.cDeF0123z56789abcdef"};
 
     /* string_to_guid should return false if either parameter is null*/
-    g_assert (!string_to_guid (nullptr, guid));
-    g_assert (!string_to_guid (bogus, nullptr));
+    g_assert_true (!string_to_guid (nullptr, guid));
+    g_assert_true (!string_to_guid (bogus, nullptr));
 
-    g_assert (!string_to_guid (bogus, guid));
+    g_assert_true (!string_to_guid (bogus, guid));
 
     const char * good {"0123456789abcdef1234567890abcdef"};
-    g_assert (string_to_guid (good, guid));
+    g_assert_true (string_to_guid (good, guid));
 
     guid_free (guid);
 }

--- a/libgnucash/engine/test/test-qof-string-cache.c
+++ b/libgnucash/engine/test/test-qof-string-cache.c
@@ -62,19 +62,19 @@ test_qof_string_cache( void )
 
     strncpy(str, "str1", sizeof(str));
     str1_1 = qof_string_cache_insert(str);      /* Refcount = 1 */
-    g_assert(str1_1 != str);
+    g_assert_true(str1_1 != str);
     str1_2 = qof_string_cache_insert(str);      /* Refcount = 2 */
-    g_assert(str1_1 == str1_2);
+    g_assert_true(str1_1 == str1_2);
     qof_string_cache_remove(str);               /* Refcount = 1 */
     str1_3 = qof_string_cache_insert(str);      /* Refcount = 2 */
-    g_assert(str1_1 == str1_3);
+    g_assert_true(str1_1 == str1_3);
     qof_string_cache_remove(str);               /* Refcount = 1 */
     qof_string_cache_remove(str);               /* Refcount = 0 */
     strncpy(str, "str2", sizeof(str));
     qof_string_cache_insert(str);               /* Refcount = 1 */
     strncpy(str, "str1", sizeof(str));
     str1_4 = qof_string_cache_insert(str);      /* Refcount = 1 */
-    g_assert(str1_1 != str1_4);
+    g_assert_true(str1_1 != str1_4);
 }
 
 void

--- a/libgnucash/engine/test/test-qofbook.c
+++ b/libgnucash/engine/test/test-qofbook.c
@@ -81,11 +81,11 @@ mock_dirty_cb (QofBook *book, gboolean dirty, gpointer user_data)
 {
     test_struct.called = TRUE;
     g_test_message( "Checking if book is valid" );
-    g_assert( book );
-    g_assert( QOF_IS_BOOK( book ) );
+    g_assert_true( book );
+    g_assert_true( QOF_IS_BOOK( book ) );
     g_test_message( "Checking parameters" );
-    g_assert( dirty );
-    g_assert( user_data == test_struct.data );
+    g_assert_true( dirty );
+    g_assert_true( user_data == test_struct.data );
 }
 
 /* mock callback for qof_book_foreach_collection testing */
@@ -93,8 +93,8 @@ static void
 mock_foreach_collection (QofCollection *col, gpointer user_data)
 {
     g_test_message( "Checking if collection and data passed correctly" );
-    g_assert( col );
-    g_assert( user_data == col_struct.data );
+    g_assert_true( col );
+    g_assert_true( user_data == col_struct.data );
     if ( g_strcmp0( qof_collection_get_type(col), "my_type" ) == 0 )
         col_struct.col1_called = TRUE;
     else if ( g_strcmp0( qof_collection_get_type(col), "my_type2" ) == 0 )
@@ -106,8 +106,8 @@ static void
 mock_final_cb (QofBook *book, gpointer key, gpointer user_data)
 {
     test_struct.called = TRUE;
-    g_assert( book );
-    g_assert( QOF_IS_BOOK( book ) );
+    g_assert_true( book );
+    g_assert_true( QOF_IS_BOOK( book ) );
     g_test_message( "Checking parameters" );
     g_assert_cmpstr( (gchar*)key, == , "key" );
     g_assert_cmpstr( (gchar*)user_data, == , "data" );
@@ -116,10 +116,10 @@ mock_final_cb (QofBook *book, gpointer key, gpointer user_data)
 static void
 test_book_readonly( Fixture *fixture, gconstpointer pData )
 {
-    g_assert( fixture->book != NULL );
-    g_assert( !qof_book_is_readonly( fixture->book ) );
+    g_assert_true( fixture->book != NULL );
+    g_assert_true( !qof_book_is_readonly( fixture->book ) );
     qof_book_mark_readonly( fixture->book );
-    g_assert( qof_book_is_readonly( fixture->book ) );
+    g_assert_true( qof_book_is_readonly( fixture->book ) );
 }
 static void
 test_book_normalize_counter( void )
@@ -130,8 +130,8 @@ test_book_normalize_counter( void )
 
     /* Test for detection of missing format conversion */
     r = qof_book_normalize_counter_format("This string is missing the conversion specifier", &err_msg);
-    g_assert(!r);
-    g_assert(err_msg);
+    g_assert_true(!r);
+    g_assert_true(err_msg);
     if (!r && g_test_verbose())
     {
         g_test_message("Counter format normalization correctly failed: %s", err_msg);
@@ -146,7 +146,7 @@ test_book_normalize_counter( void )
         g_test_message("Counter format normalization erroneously failed: %s", err_msg);
     }
     g_assert_cmpstr( r, == , "Test - %" PRIi64);
-    g_assert(err_msg == NULL);
+    g_assert_true(err_msg == NULL);
     g_free(r);
 
     /* Test the Windows G_GINT64_FORMAT */
@@ -156,7 +156,7 @@ test_book_normalize_counter( void )
         g_test_message("Counter format normalization erroneously failed: %s", err_msg);
     }
     g_assert_cmpstr( r, == , "Test - %" PRIi64);
-    g_assert(err_msg == NULL);
+    g_assert_true(err_msg == NULL);
     g_free(r);
 
     /* Test the system's G_INT64_FORMAT */
@@ -166,7 +166,7 @@ test_book_normalize_counter( void )
         g_test_message("Counter format normalization erroneously failed: %s", err_msg);
     }
     g_assert_cmpstr( r, == , "Test - %" PRIi64);
-    g_assert(err_msg == NULL);
+    g_assert_true(err_msg == NULL);
     g_free(r);
 
     /* Test the posix' PRIi64 */
@@ -176,7 +176,7 @@ test_book_normalize_counter( void )
         g_test_message("Counter format normalization erroneously failed: %s", err_msg);
     }
     g_assert_cmpstr( r, == , "Test - %" PRIi64);
-    g_assert(err_msg == NULL);
+    g_assert_true(err_msg == NULL);
     g_free(r);
 
     /* Test the posix' PRIi64 with precision field */
@@ -186,7 +186,7 @@ test_book_normalize_counter( void )
         g_test_message("Counter format normalization erroneously failed: %s", err_msg);
     }
     g_assert_cmpstr( r, == , "Test - %.3" PRIi64);
-    g_assert(err_msg == NULL);
+    g_assert_true(err_msg == NULL);
     g_free(r);
 
     /* Test the posix' PRIi64 with width field */
@@ -196,7 +196,7 @@ test_book_normalize_counter( void )
         g_test_message("Counter format normalization erroneously failed: %s", err_msg);
     }
     g_assert_cmpstr( r, == , "Test - %5" PRIi64);
-    g_assert(err_msg == NULL);
+    g_assert_true(err_msg == NULL);
     g_free(r);
 
     /* Test the posix' PRIi64 with width and precision field */
@@ -206,7 +206,7 @@ test_book_normalize_counter( void )
         g_test_message("Counter format normalization erroneously failed: %s", err_msg);
     }
     g_assert_cmpstr( r, == , "Test - %5.4" PRIi64);
-    g_assert(err_msg == NULL);
+    g_assert_true(err_msg == NULL);
     g_free(r);
 
     /* Test the usual Linux/Unix G_GINT64_FORMAT */
@@ -216,7 +216,7 @@ test_book_normalize_counter( void )
         g_test_message("Counter format normalization erroneously failed: %s", err_msg);
     }
     g_assert_cmpstr( r, == , "Test - %" PRIi64);
-    g_assert(err_msg == NULL);
+    g_assert_true(err_msg == NULL);
     g_free(r);
 
     /* Test the Windows G_GINT64_FORMAT */
@@ -226,13 +226,13 @@ test_book_normalize_counter( void )
         g_test_message("Counter format normalization erroneously failed: %s", err_msg);
     }
     g_assert_cmpstr( r, == , "Test - %" PRIi64);
-    g_assert(err_msg == NULL);
+    g_assert_true(err_msg == NULL);
     g_free(r);
 
     /* Test an erroneous Windows G_GINT64_FORMAT */
     r = qof_book_normalize_counter_format_internal("Test - %li", "I64i", &err_msg);
-    g_assert(!r);
-    g_assert(err_msg);
+    g_assert_true(!r);
+    g_assert_true(err_msg);
     if (!r && g_test_verbose())
     {
         g_test_message("Counter format normalization correctly failed: %s", err_msg);
@@ -242,8 +242,8 @@ test_book_normalize_counter( void )
 
     /* Test an erroneous Linux G_GINT64_FORMAT */
     r = qof_book_normalize_counter_format_internal("Test - %I64i", "li", &err_msg);
-    g_assert(!r);
-    g_assert(err_msg);
+    g_assert_true(!r);
+    g_assert_true(err_msg);
     if (!r && g_test_verbose())
     {
         g_test_message("Counter format normalization correctly failed: %s", err_msg);
@@ -257,7 +257,7 @@ test_book_get_string_option( Fixture *fixture, gconstpointer pData )
     const char *opt_name = "Option Name";
     const char *opt_value = "Option Value";
     const char *opt_name_notset = "Not Set";
-    g_assert( fixture->book != NULL );
+    g_assert_true( fixture->book != NULL );
     qof_book_set_string_option( fixture->book, opt_name, opt_value);
     g_assert_cmpstr( qof_book_get_string_option( fixture->book, opt_name ), == , opt_value);
     g_assert_cmpstr( qof_book_get_string_option( fixture->book, opt_name_notset ), == , NULL );
@@ -268,21 +268,21 @@ test_book_set_string_option( Fixture *fixture, gconstpointer pData )
 {
     const char *opt_name = "Option Name";
     const char *opt_value = "Option Value";
-    g_assert( fixture->book != NULL );
+    g_assert_true( fixture->book != NULL );
     qof_book_set_string_option( fixture->book, opt_name, opt_value);
-    g_assert( qof_instance_is_dirty (QOF_INSTANCE (fixture->book)) );
+    g_assert_true( qof_instance_is_dirty (QOF_INSTANCE (fixture->book)) );
 }
 
 static void
 test_book_session_not_saved( Fixture *fixture, gconstpointer pData )
 {
-    g_assert( fixture->book != NULL );
-    g_assert( !qof_book_session_not_saved( fixture->book ) );
+    g_assert_true( fixture->book != NULL );
+    g_assert_true( !qof_book_session_not_saved( fixture->book ) );
     qof_book_mark_session_saved( fixture->book );
-    g_assert( !qof_book_session_not_saved( fixture->book ) );
+    g_assert_true( !qof_book_session_not_saved( fixture->book ) );
     gnc_account_create_root (fixture->book);
     qof_book_mark_session_dirty( fixture-> book );
-    g_assert( qof_book_session_not_saved( fixture->book ) );
+    g_assert_true( qof_book_session_not_saved( fixture->book ) );
 }
 
 static void
@@ -292,13 +292,13 @@ test_book_mark_session_saved( Fixture *fixture, gconstpointer pData )
 
     gnc_account_create_root (fixture->book);
     qof_book_mark_session_dirty( fixture-> book );
-    g_assert( qof_book_session_not_saved( fixture->book ) );
+    g_assert_true( qof_book_session_not_saved( fixture->book ) );
     dirty_time = qof_book_get_session_dirty_time( fixture->book );
     qof_book_mark_session_saved( fixture->book );
     clean_time = qof_book_get_session_dirty_time( fixture->book );
-    g_assert( !qof_book_session_not_saved( fixture->book ) );
-    g_assert( dirty_time != clean_time );
-    g_assert( clean_time == 0);
+    g_assert_true( !qof_book_session_not_saved( fixture->book ) );
+    g_assert_true( dirty_time != clean_time );
+    g_assert_true( clean_time == 0);
 }
 
 static void
@@ -314,17 +314,17 @@ test_book_get_counter( Fixture *fixture, gconstpointer pData )
 
     counter = qof_book_get_counter( NULL, counter_name );
     g_assert_cmpint( counter, == , -1 );
-    g_assert( g_strrstr( test_struct.msg, err_no_book ) != NULL );
+    g_assert_true( g_strrstr( test_struct.msg, err_no_book ) != NULL );
     g_free( test_struct.msg );
 
     counter = qof_book_get_counter( fixture->book, NULL );
     g_assert_cmpint( counter, == , -1 );
-    g_assert( g_strrstr( test_struct.msg, err_invalid_cnt ) != NULL );
+    g_assert_true( g_strrstr( test_struct.msg, err_invalid_cnt ) != NULL );
     g_free( test_struct.msg );
 
     counter = qof_book_get_counter( fixture->book, NULL );
     g_assert_cmpint( counter, == , -1 );
-    g_assert( g_strrstr( test_struct.msg, err_invalid_cnt ) != NULL );
+    g_assert_true( g_strrstr( test_struct.msg, err_invalid_cnt ) != NULL );
     g_free( test_struct.msg );
 
     counter = qof_book_get_counter( fixture->book, counter_name );
@@ -349,19 +349,19 @@ test_book_get_counter_format ( Fixture *fixture, gconstpointer pData )
     g_test_message( "Testing counter format when book is null" );
     r = qof_book_get_counter_format( NULL, counter_name );
     g_assert_cmpstr( r, == , NULL );
-    g_assert( g_strrstr( test_struct.msg, err_no_book ) != NULL );
+    g_assert_true( g_strrstr( test_struct.msg, err_no_book ) != NULL );
     g_free( test_struct.msg );
 
     g_test_message( "Testing counter format when counter name is null" );
     r = qof_book_get_counter_format( fixture->book, NULL );
     g_assert_cmpstr( r, == , NULL );
-    g_assert( g_strrstr( test_struct.msg, err_invalid_cnt ) != NULL );
+    g_assert_true( g_strrstr( test_struct.msg, err_invalid_cnt ) != NULL );
     g_free( test_struct.msg );
 
     g_test_message( "Testing counter format when counter name is empty string" );
     r = qof_book_get_counter_format( fixture->book, "" );
     g_assert_cmpstr( r, == , NULL );
-    g_assert( g_strrstr( test_struct.msg, err_invalid_cnt ) != NULL );
+    g_assert_true( g_strrstr( test_struct.msg, err_invalid_cnt ) != NULL );
     g_free( test_struct.msg );
 
     g_test_message( "Testing counter format with existing counter" );
@@ -390,21 +390,21 @@ test_book_increment_and_format_counter ( Fixture *fixture, gconstpointer pData )
     r = qof_book_increment_and_format_counter( NULL, counter_name );
     g_assert_cmpstr( r, == , NULL );
     g_free( r );
-    g_assert( g_strrstr( test_struct.msg, err_no_book ) != NULL );
+    g_assert_true( g_strrstr( test_struct.msg, err_no_book ) != NULL );
     g_free( test_struct.msg );
 
     g_test_message( "Testing increment and format when counter name is null" );
     r = qof_book_increment_and_format_counter( fixture->book, NULL );
     g_assert_cmpstr( r, == , NULL );
     g_free( r );
-    g_assert( g_strrstr( test_struct.msg, err_invalid_cnt ) != NULL );
+    g_assert_true( g_strrstr( test_struct.msg, err_invalid_cnt ) != NULL );
     g_free( test_struct.msg );
 
     g_test_message( "Testing increment and format when counter name is empty string" );
     r = qof_book_increment_and_format_counter( fixture->book, "" );
     g_assert_cmpstr( r, == , NULL );
     g_free( r );
-    g_assert( g_strrstr( test_struct.msg, err_invalid_cnt ) != NULL );
+    g_assert_true( g_strrstr( test_struct.msg, err_invalid_cnt ) != NULL );
     g_free( test_struct.msg );
 
     g_test_message( "Testing increment and format with new counter" );
@@ -412,7 +412,7 @@ test_book_increment_and_format_counter ( Fixture *fixture, gconstpointer pData )
     counter = qof_book_get_counter( fixture->book, counter_name );
     format = qof_book_get_counter_format( fixture->book, counter_name );
     g_assert_cmpint( counter, == , 1 );
-    g_assert( qof_instance_is_dirty (QOF_INSTANCE (fixture->book)) );
+    g_assert_true( qof_instance_is_dirty (QOF_INSTANCE (fixture->book)) );
     g_assert_cmpstr( r, == , g_strdup_printf( format, counter ));
     g_free( r );
 
@@ -437,7 +437,7 @@ test_book_get_default_report_guid ( Fixture *fixture, gconstpointer pData )
     g_test_message( "Testing default report guid when book is null" );
     r = qof_book_get_default_invoice_report_guid ( NULL );
     g_assert_cmpstr( r, == , NULL );
-    g_assert( g_strrstr( test_struct.msg, err_no_book ) != NULL );
+    g_assert_true( g_strrstr( test_struct.msg, err_no_book ) != NULL );
     g_free( test_struct.msg );
 
     g_test_message( "Testing default report guid for default value" );
@@ -457,7 +457,7 @@ test_book_get_default_report_name ( Fixture *fixture, gconstpointer pData )
     g_test_message( "Testing default report name when book is null" );
     r = qof_book_get_default_invoice_report_name ( NULL );
     g_assert_cmpstr( r, == , NULL );
-    g_assert( g_strrstr( test_struct.msg, err_no_book ) != NULL );
+    g_assert_true( g_strrstr( test_struct.msg, err_no_book ) != NULL );
     g_free( test_struct.msg );
 
     g_test_message( "Testing default report name for default value" );
@@ -477,7 +477,7 @@ test_book_get_default_report_timeout ( Fixture *fixture, gconstpointer pData )
     g_test_message( "Testing default report timeout when book is null" );
     r = qof_book_get_default_invoice_report_timeout ( NULL );
     g_assert_cmpint( r, == , 0 );
-    g_assert( g_strrstr( test_struct.msg, err_no_book ) != NULL );
+    g_assert_true( g_strrstr( test_struct.msg, err_no_book ) != NULL );
     g_free( test_struct.msg );
 
     g_test_message( "Testing default report timeout for default value" );
@@ -503,21 +503,21 @@ test_book_set_default_report ( Fixture *fixture, gconstpointer pData )
     qof_book_set_default_invoice_report ( NULL, test_guid1, test_name );
     r = qof_book_get_default_invoice_report_guid ( fixture->book );
     g_assert_cmpstr( r, == , NULL );
-    g_assert( g_strrstr( test_struct.msg, err_no_book ) != NULL );
+    g_assert_true( g_strrstr( test_struct.msg, err_no_book ) != NULL );
     g_free( test_struct.msg );
 
     g_test_message( "Testing setting default report when guid is null" );
     qof_book_set_default_invoice_report ( fixture->book, NULL, test_name );
     r = qof_book_get_default_invoice_report_guid ( fixture->book );
     g_assert_cmpstr( r, == , NULL );
-    g_assert( g_strrstr( test_struct.msg, err_no_guid ) != NULL );
+    g_assert_true( g_strrstr( test_struct.msg, err_no_guid ) != NULL );
     g_free( test_struct.msg );
 
     g_test_message( "Testing setting default report when name is null" );
     qof_book_set_default_invoice_report ( fixture->book, test_guid1, NULL );
     r = qof_book_get_default_invoice_report_guid ( fixture->book );
     g_assert_cmpstr( r, == , NULL );
-    g_assert( g_strrstr( test_struct.msg, err_no_name ) != NULL );
+    g_assert_true( g_strrstr( test_struct.msg, err_no_name ) != NULL );
     g_free( test_struct.msg );
 
     g_test_message( "Testing setting default report when name is empty string" );
@@ -538,20 +538,20 @@ test_book_set_default_report ( Fixture *fixture, gconstpointer pData )
 static void
 test_book_use_trading_accounts( Fixture *fixture, gconstpointer pData )
 {
-    g_assert( qof_book_use_trading_accounts( fixture-> book ) == FALSE );
+    g_assert_true( qof_book_use_trading_accounts( fixture-> book ) == FALSE );
 
     g_test_message( "Testing with existing trading accounts set to true - t" );
     qof_book_begin_edit (fixture->book);
     qof_instance_set (QOF_INSTANCE (fixture->book),
 		      "trading-accts", "t",
 		      NULL);
-    g_assert( qof_book_use_trading_accounts( fixture-> book ) == TRUE );
+    g_assert_true( qof_book_use_trading_accounts( fixture-> book ) == TRUE );
 
     g_test_message( "Testing with existing trading accounts and incorrect value - tt" );
     qof_instance_set (QOF_INSTANCE (fixture->book),
 		      "trading-accts", "tt",
 		      NULL);
-    g_assert( qof_book_use_trading_accounts( fixture-> book ) == FALSE );
+    g_assert_true( qof_book_use_trading_accounts( fixture-> book ) == FALSE );
     qof_book_commit_edit (fixture->book);
 
 }
@@ -560,32 +560,32 @@ static void
 test_book_get_num_days_autofreeze( Fixture *fixture, gconstpointer pData )
 {
     g_test_message( "Testing default: No auto-freeze days are set" );
-    g_assert( qof_book_uses_autoreadonly( fixture-> book ) == FALSE );
-    g_assert( qof_book_get_num_days_autoreadonly( fixture-> book ) == 0 );
+    g_assert_true( qof_book_uses_autoreadonly( fixture-> book ) == FALSE );
+    g_assert_true( qof_book_get_num_days_autoreadonly( fixture-> book ) == 0 );
 
-    g_assert( qof_book_uses_autoreadonly( fixture-> book ) == FALSE );
-    g_assert( qof_book_get_num_days_autoreadonly( fixture-> book ) == 0 );
+    g_assert_true( qof_book_uses_autoreadonly( fixture-> book ) == FALSE );
+    g_assert_true( qof_book_get_num_days_autoreadonly( fixture-> book ) == 0 );
 
     qof_book_begin_edit (fixture->book);
     qof_instance_set (QOF_INSTANCE (fixture->book),
 		      "autoreadonly-days", (gdouble)17,
 		      NULL);
-    g_assert( qof_book_uses_autoreadonly( fixture-> book ) == TRUE );
-    g_assert( qof_book_get_num_days_autoreadonly( fixture-> book ) == 17 );
+    g_assert_true( qof_book_uses_autoreadonly( fixture-> book ) == TRUE );
+    g_assert_true( qof_book_get_num_days_autoreadonly( fixture-> book ) == 17 );
 
     g_test_message( "Testing when setting this correctly to zero again" );
 
     qof_instance_set (QOF_INSTANCE (fixture->book),
 		      "autoreadonly-days", (gdouble)0,
 		      NULL);
-    g_assert( qof_book_uses_autoreadonly( fixture-> book ) == FALSE );
-    g_assert( qof_book_get_num_days_autoreadonly( fixture-> book ) == 0 );
+    g_assert_true( qof_book_uses_autoreadonly( fixture-> book ) == FALSE );
+    g_assert_true( qof_book_get_num_days_autoreadonly( fixture-> book ) == 0 );
 
     qof_instance_set (QOF_INSTANCE (fixture->book),
 		      "autoreadonly-days", (gdouble)32,
 		      NULL);
-    g_assert( qof_book_uses_autoreadonly( fixture-> book ) == TRUE );
-    g_assert( qof_book_get_num_days_autoreadonly( fixture-> book ) == 32 );
+    g_assert_true( qof_book_uses_autoreadonly( fixture-> book ) == TRUE );
+    g_assert_true( qof_book_get_num_days_autoreadonly( fixture-> book ) == 32 );
 
     qof_book_commit_edit (fixture->book);
 }
@@ -594,7 +594,7 @@ static void
 test_book_use_split_action_for_num_field( Fixture *fixture, gconstpointer pData )
 {
     g_test_message( "Testing default: No selection has been specified" );
-    g_assert( qof_book_use_split_action_for_num_field( fixture-> book ) == FALSE );
+    g_assert_true( qof_book_use_split_action_for_num_field( fixture-> book ) == FALSE );
 
     g_test_message( "Testing with existing use split action for num set to true - t" );
 
@@ -602,13 +602,13 @@ test_book_use_split_action_for_num_field( Fixture *fixture, gconstpointer pData 
     qof_instance_set (QOF_INSTANCE (fixture->book),
 		      "split-action-num-field", "t",
 		      NULL);
-    g_assert( qof_book_use_split_action_for_num_field( fixture-> book ) == TRUE );
+    g_assert_true( qof_book_use_split_action_for_num_field( fixture-> book ) == TRUE );
 
     g_test_message( "Testing with existing use split action for num and incorrect value - tt" );
     qof_instance_set (QOF_INSTANCE (fixture->book),
 		      "split-action-num-field", "tt",
 		      NULL);
-    g_assert( qof_book_use_split_action_for_num_field( fixture-> book ) == FALSE );
+    g_assert_true( qof_book_use_split_action_for_num_field( fixture-> book ) == FALSE );
     qof_book_commit_edit (fixture->book);
 }
 
@@ -621,19 +621,19 @@ test_book_mark_session_dirty( Fixture *fixture, gconstpointer pData )
 
     g_test_message( "Testing when book is NULL" );
     qof_book_mark_session_dirty( _empty );
-    g_assert( _empty == NULL );
+    g_assert_true( _empty == NULL );
 
     g_test_message( "Testing when book is not dirty and dirty_cb is null" );
     g_assert_cmpint( qof_book_get_session_dirty_time( fixture->book ), == , 0);
-    g_assert( fixture->book->dirty_cb == NULL );
-    g_assert( qof_book_session_not_saved( fixture->book ) == FALSE );
+    g_assert_true( fixture->book->dirty_cb == NULL );
+    g_assert_true( qof_book_session_not_saved( fixture->book ) == FALSE );
     before = gnc_time (NULL);
     gnc_account_create_root (fixture->book);
     qof_book_mark_session_dirty( fixture->book );
     after = gnc_time (NULL);
     g_assert_cmpint( qof_book_get_session_dirty_time( fixture->book ), >= , before);
     g_assert_cmpint( qof_book_get_session_dirty_time( fixture->book ), <= , after);
-    g_assert( qof_book_session_not_saved( fixture->book ) == TRUE );
+    g_assert_true( qof_book_session_not_saved( fixture->book ) == TRUE );
 
     g_test_message( "Testing when book is not dirty and dirty_cb is not null" );
     /* prepare conditions */
@@ -641,9 +641,9 @@ test_book_mark_session_dirty( Fixture *fixture, gconstpointer pData )
     qof_book_set_dirty_cb( fixture->book, mock_dirty_cb, (gpointer) (&param) );
     test_struct.data = (gpointer) (&param);
     test_struct.called = FALSE;
-    g_assert( fixture->book->dirty_cb != NULL );
+    g_assert_true( fixture->book->dirty_cb != NULL );
     g_assert_cmpint( qof_book_get_session_dirty_time( fixture->book ), == , 0);
-    g_assert( qof_book_session_not_saved( fixture->book ) == FALSE );
+    g_assert_true( qof_book_session_not_saved( fixture->book ) == FALSE );
     /* run FUT */
     before = gnc_time (NULL);
     qof_book_mark_session_dirty( fixture->book );
@@ -651,14 +651,14 @@ test_book_mark_session_dirty( Fixture *fixture, gconstpointer pData )
     /* test output */
     g_assert_cmpint( qof_book_get_session_dirty_time( fixture->book ), >= , before);
     g_assert_cmpint( qof_book_get_session_dirty_time( fixture->book ), <= , after);
-    g_assert( qof_book_session_not_saved( fixture->book ) == TRUE );
-    g_assert( test_struct.called );
+    g_assert_true( qof_book_session_not_saved( fixture->book ) == TRUE );
+    g_assert_true( test_struct.called );
 
     g_test_message( "Testing when book is dirty" );
-    g_assert( qof_book_session_not_saved( fixture->book ) == TRUE );
+    g_assert_true( qof_book_session_not_saved( fixture->book ) == TRUE );
     before = qof_book_get_session_dirty_time( fixture->book );
     qof_book_mark_session_dirty( fixture->book );
-    g_assert( qof_book_session_not_saved( fixture->book ) == TRUE );
+    g_assert_true( qof_book_session_not_saved( fixture->book ) == TRUE );
     after = qof_book_get_session_dirty_time( fixture->book );
     g_assert_cmpint( before, == , after );
 }
@@ -669,7 +669,7 @@ test_book_get_session_dirty_time( Fixture *fixture, gconstpointer pData )
     time64 before, after;
 
     g_test_message( "Testing time on saved book = 0" );
-    g_assert( qof_book_session_not_saved( fixture->book ) == FALSE );
+    g_assert_true( qof_book_session_not_saved( fixture->book ) == FALSE );
     g_assert_cmpint( qof_book_get_session_dirty_time( fixture->book ), == , 0);
 
     g_test_message( "Testing time on dirty book is correct" );
@@ -687,20 +687,20 @@ test_book_set_dirty_cb( Fixture *fixture, gconstpointer pData )
     const char * error_msg = "Already existing callback";
 
     g_test_message( "Testing when callback is previously not set" );
-    g_assert( fixture->book->dirty_cb == NULL );
+    g_assert_true( fixture->book->dirty_cb == NULL );
     qof_book_set_dirty_cb( fixture->book, mock_dirty_cb, (gpointer) (&test_struct) );
-    g_assert( fixture->book->dirty_cb == mock_dirty_cb );
-    g_assert( fixture->book->dirty_data == &test_struct );
+    g_assert_true( fixture->book->dirty_cb == mock_dirty_cb );
+    g_assert_true( fixture->book->dirty_data == &test_struct );
 
     /* need this as long as we have fatal warnings enabled */
     g_test_log_set_fatal_handler ( ( GTestLogFatalFunc )handle_faults, NULL );
 
     g_test_message( "Testing when callback was previously set" );
-    g_assert( fixture->book->dirty_cb != NULL );
+    g_assert_true( fixture->book->dirty_cb != NULL );
     qof_book_set_dirty_cb( fixture->book, NULL, NULL );
-    g_assert( g_strrstr( test_struct.msg, error_msg ) != NULL );
-    g_assert( fixture->book->dirty_cb == NULL );
-    g_assert( fixture->book->dirty_data == NULL );
+    g_assert_true( g_strrstr( test_struct.msg, error_msg ) != NULL );
+    g_assert_true( fixture->book->dirty_cb == NULL );
+    g_assert_true( fixture->book->dirty_data == NULL );
     g_free( test_struct.msg );
 }
 
@@ -708,13 +708,13 @@ static void
 test_book_shutting_down( Fixture *fixture, gconstpointer pData )
 {
     g_test_message( "Testing when book is null" );
-    g_assert( qof_book_shutting_down( NULL ) == FALSE );
+    g_assert_true( qof_book_shutting_down( NULL ) == FALSE );
     g_test_message( "Testing when shutting down is true" );
     fixture->book->shutting_down = TRUE;
-    g_assert( qof_book_shutting_down( fixture->book ) == TRUE );
+    g_assert_true( qof_book_shutting_down( fixture->book ) == TRUE );
     g_test_message( "Testing when shutting down is false" );
     fixture->book->shutting_down = FALSE;
-    g_assert( qof_book_shutting_down( fixture->book ) == FALSE );
+    g_assert_true( qof_book_shutting_down( fixture->book ) == FALSE );
 }
 
 static void
@@ -723,18 +723,18 @@ test_book_set_get_data( Fixture *fixture, gconstpointer pData )
     const char *key = "key";
     const char *data = "data";
 
-    g_assert( fixture->book->data_tables != NULL );
+    g_assert_true( fixture->book->data_tables != NULL );
     g_test_message( "Testing when book is null" );
     qof_book_set_data( NULL, key, (gpointer) data );
-    g_assert( qof_book_get_data( NULL, key ) == NULL );
+    g_assert_true( qof_book_get_data( NULL, key ) == NULL );
 
     g_test_message( "Testing when key is null" );
     qof_book_set_data( fixture->book, NULL, (gpointer) data );
-    g_assert( qof_book_get_data( fixture->book, NULL) == NULL );
+    g_assert_true( qof_book_get_data( fixture->book, NULL) == NULL );
 
     g_test_message( "Testing with book key not null, data null" );
     qof_book_set_data( fixture->book, key, NULL );
-    g_assert( qof_book_get_data( fixture->book, key ) == NULL );
+    g_assert_true( qof_book_get_data( fixture->book, key ) == NULL );
 
     g_test_message( "Testing with book key data not null" );
     qof_book_set_data( fixture->book, key, (gpointer) data );
@@ -748,22 +748,22 @@ test_book_get_collection( Fixture *fixture, gconstpointer pData )
     QofCollection *m_col, *m_col2;
 
     g_test_message( "Testing when book is null" );
-    g_assert( qof_book_get_collection( NULL, my_type ) == NULL );
+    g_assert_true( qof_book_get_collection( NULL, my_type ) == NULL );
 
     g_test_message( "Testing when entity type is null" );
-    g_assert( qof_book_get_collection( fixture->book, NULL ) == NULL );
+    g_assert_true( qof_book_get_collection( fixture->book, NULL ) == NULL );
 
     g_test_message( "Testing when collection does not exist" );
-    g_assert( fixture->book->hash_of_collections != NULL );
-    g_assert( g_hash_table_lookup ( fixture->book->hash_of_collections, my_type ) == NULL );
+    g_assert_true( fixture->book->hash_of_collections != NULL );
+    g_assert_true( g_hash_table_lookup ( fixture->book->hash_of_collections, my_type ) == NULL );
     m_col = qof_book_get_collection( fixture->book, my_type );
-    g_assert( m_col != NULL );
+    g_assert_true( m_col != NULL );
 
     g_test_message( "Testing with existing collection" );
-    g_assert( g_hash_table_lookup ( fixture->book->hash_of_collections, my_type ) != NULL );
+    g_assert_true( g_hash_table_lookup ( fixture->book->hash_of_collections, my_type ) != NULL );
     m_col2 = qof_book_get_collection( fixture->book, my_type );
-    g_assert( m_col2 != NULL );
-    g_assert( m_col == m_col2 );
+    g_assert_true( m_col2 != NULL );
+    g_assert_true( m_col == m_col2 );
 }
 
 
@@ -839,16 +839,16 @@ test_book_foreach_collection( Fixture *fixture, gconstpointer pData )
     col_struct.data = (gpointer) (&param);
     /* launch foreach make sure callback was not called and check warning msg */
     qof_book_foreach_collection( NULL, mock_foreach_collection, (gpointer)(&param) );
-    g_assert( !col_struct.col1_called );
-    g_assert( !col_struct.col2_called );
+    g_assert_true( !col_struct.col1_called );
+    g_assert_true( !col_struct.col2_called );
     g_assert_cmpstr( test_struct.msg, == , msg1);
     g_free( test_struct.msg );
 
     g_test_message( "Testing when cb is null" );
     /* launching with empty cb should still fail and produce warning */
     qof_book_foreach_collection( fixture->book, NULL, (gpointer)(&param) );
-    g_assert( !col_struct.col1_called );
-    g_assert( !col_struct.col2_called );
+    g_assert_true( !col_struct.col1_called );
+    g_assert_true( !col_struct.col2_called );
     g_assert_cmpstr( test_struct.msg, == , msg2);
     g_free( test_struct.msg );
     g_log_remove_handler (log_domain, hdlr);
@@ -857,8 +857,8 @@ test_book_foreach_collection( Fixture *fixture, gconstpointer pData )
     g_test_message( "Testing when book and cb not null, user_data provided" );
     /* both cols have to be called */
     qof_book_foreach_collection( fixture->book, mock_foreach_collection, (gpointer)(&param) );
-    g_assert( col_struct.col1_called );
-    g_assert( col_struct.col2_called );
+    g_assert_true( col_struct.col1_called );
+    g_assert_true( col_struct.col2_called );
 }
 
 static void
@@ -898,12 +898,12 @@ test_book_set_data_fin( void )
     g_assert_cmpint( g_hash_table_size( book->data_tables ), == , 1 );
     g_assert_cmpint( g_hash_table_size( book->data_table_finalizers ), == , 1 );
     g_assert_cmpstr( (const char *)qof_book_get_data( book, key ), == , data );
-    g_assert( g_hash_table_lookup ( book->data_table_finalizers, (gpointer)key ) == mock_final_cb );
+    g_assert_true( g_hash_table_lookup ( book->data_table_finalizers, (gpointer)key ) == mock_final_cb );
 
     /* get rid of book make sure final cb is called */
     test_struct.called = FALSE;
     qof_book_destroy( book );
-    g_assert( test_struct.called );
+    g_assert_true( test_struct.called );
 }
 
 static void
@@ -928,19 +928,19 @@ test_book_new_destroy( void )
 
     g_test_message( "Testing book creation and initial setup" );
     book = qof_book_new();
-    g_assert( book );
-    g_assert( QOF_IS_BOOK( book ) );
+    g_assert_true( book );
+    g_assert_true( QOF_IS_BOOK( book ) );
 
     g_test_message( "Testing book initial setup" );
-    g_assert( book->hash_of_collections );
-    g_assert( book->data_tables );
-    g_assert( book->data_table_finalizers );
+    g_assert_true( book->hash_of_collections );
+    g_assert_true( book->data_tables );
+    g_assert_true( book->data_table_finalizers );
     g_assert_cmpint( g_hash_table_size( book->hash_of_collections ), == , 1 );
-    g_assert( g_hash_table_lookup ( book->hash_of_collections, QOF_ID_BOOK ) != NULL );
+    g_assert_true( g_hash_table_lookup ( book->hash_of_collections, QOF_ID_BOOK ) != NULL );
     g_assert_cmpint( g_hash_table_size( book->data_tables ), == , 0 );
     g_assert_cmpint( g_hash_table_size( book->data_table_finalizers ), == , 0 );
     g_assert_cmpstr( &book->book_open, == , "y");
-    g_assert( !book->read_only );
+    g_assert_true( !book->read_only );
     g_assert_cmpint( book->version, == , 0 );
 
     /* set finalizer */
@@ -949,8 +949,8 @@ test_book_new_destroy( void )
 
     g_test_message( "Testing book destroy" );
     qof_book_destroy( book );
-    g_assert( qof_book_shutting_down( book ) );
-    g_assert( test_struct.called );
+    g_assert_true( qof_book_shutting_down( book ) );
+    g_assert_true( test_struct.called );
 }
 
 void

--- a/libgnucash/engine/test/test-qofinstance.cpp
+++ b/libgnucash/engine/test/test-qofinstance.cpp
@@ -60,8 +60,8 @@ public:
     void sync(QofBook* book) override {}
     void safe_sync(QofBook* book) override {}
     void begin(QofInstance* inst) override {
-        g_assert(inst);
-        g_assert(QOF_IS_INSTANCE(inst));
+        g_assert_true(inst);
+        g_assert_true(QOF_IS_INSTANCE(inst));
         commit_test.m_inst = inst;
     }
     void set_error(QofBackendError err) {
@@ -69,10 +69,10 @@ public:
         commit_test.m_err = err;
     }
     void commit(QofInstance* inst) override {
-        g_assert( inst );
-        g_assert( QOF_IS_INSTANCE( inst ) );
-        g_assert( commit_test.m_inst == inst );
-        g_assert( commit_test.m_be == this );
+        g_assert_true( inst );
+        g_assert_true( QOF_IS_INSTANCE( inst ) );
+        g_assert_true( commit_test.m_inst == inst );
+        g_assert_true( commit_test.m_be == this );
         commit_test.m_commit_called = true;
         if (qof_instance_is_dirty(inst))
             qof_instance_mark_clean(inst);
@@ -95,23 +95,23 @@ typedef struct
 
 static void
 on_error(QofInstance* inst, QofBackendError err) {
-    g_assert( inst );
-    g_assert( QOF_IS_INSTANCE( inst ) );
-    g_assert( commit_test.m_err == err );
+    g_assert_true( inst );
+    g_assert_true( QOF_IS_INSTANCE( inst ) );
+    g_assert_true( commit_test.m_err == err );
     commit_test.m_on_error_called = true;
 }
 static void
 on_done(QofInstance* inst) {
-    g_assert( inst );
-    g_assert( QOF_IS_INSTANCE( inst ) );
-    g_assert( commit_test.m_inst == inst );
+    g_assert_true( inst );
+    g_assert_true( QOF_IS_INSTANCE( inst ) );
+    g_assert_true( commit_test.m_inst == inst );
     commit_test.m_on_done_called = true;
 }
 static void
 on_free(QofInstance* inst) {
-    g_assert( inst );
-    g_assert( QOF_IS_INSTANCE( inst ) );
-    g_assert(commit_test.m_inst == inst );
+    g_assert_true( inst );
+    g_assert_true( QOF_IS_INSTANCE( inst ) );
+    g_assert_true(commit_test.m_inst == inst );
     commit_test.m_on_free_called = true;
 }
 
@@ -146,14 +146,14 @@ test_instance_set_get_book( Fixture *fixture, gconstpointer pData )
     /* set up */
     book = qof_book_new();
 
-    g_assert( QOF_IS_INSTANCE( fixture->inst ) );
+    g_assert_true( QOF_IS_INSTANCE( fixture->inst ) );
 
     g_test_message( "Setting and getting book" );
     qof_instance_set_book( fixture->inst, book );
-    g_assert( book == qof_instance_get_book( fixture->inst ) );
+    g_assert_true( book == qof_instance_get_book( fixture->inst ) );
 
     g_test_message( "Getting book when instance is null" );
-    g_assert( qof_instance_get_book( NULL ) == NULL );
+    g_assert_true( qof_instance_get_book( NULL ) == NULL );
 
     /* Clean up */
     qof_book_destroy( book );
@@ -167,21 +167,21 @@ test_instance_set_get_guid( Fixture *fixture, gconstpointer pData )
     /* on null instance deprecated getter returns empty guid
      * while instance_get_guid returns null
      */
-    g_assert( !qof_instance_get_guid( NULL ) );
-    g_assert( qof_entity_get_guid( NULL ) == guid_null() );
+    g_assert_true( !qof_instance_get_guid( NULL ) );
+    g_assert_true( qof_entity_get_guid( NULL ) == guid_null() );
 
     /* set up */
     gncGuid = guid_new();
-    g_assert( QOF_IS_INSTANCE( fixture->inst ) );
-    g_assert( gncGuid );
+    g_assert_true( QOF_IS_INSTANCE( fixture->inst ) );
+    g_assert_true( gncGuid );
 
     /* guid already exists after instance init */
     g_test_message( "Setting new guid" );
-    g_assert( qof_instance_get_guid( fixture->inst ) );
-    g_assert( !guid_equal( gncGuid, qof_instance_get_guid( fixture->inst ) ) );
+    g_assert_true( qof_instance_get_guid( fixture->inst ) );
+    g_assert_true( !guid_equal( gncGuid, qof_instance_get_guid( fixture->inst ) ) );
     qof_instance_set_guid( fixture->inst, gncGuid );
-    g_assert( guid_equal( gncGuid, qof_instance_get_guid( fixture->inst ) ) );
-    g_assert( guid_equal( gncGuid, qof_entity_get_guid( fixture->inst ) ) );
+    g_assert_true( guid_equal( gncGuid, qof_instance_get_guid( fixture->inst ) ) );
+    g_assert_true( guid_equal( gncGuid, qof_entity_get_guid( fixture->inst ) ) );
 
     /* Clean up */
     guid_free( gncGuid );
@@ -202,24 +202,24 @@ test_instance_new_destroy( void )
 
     g_test_message( "Testing qofinstance object initialization" );
     inst = static_cast<QofInstance*>(g_object_new(QOF_TYPE_INSTANCE, NULL));
-    g_assert( QOF_IS_INSTANCE( inst ) );
+    g_assert_true( QOF_IS_INSTANCE( inst ) );
     /* test class fields */
     klass = QOF_INSTANCE_GET_CLASS( inst );
-    g_assert( QOF_IS_INSTANCE_CLASS( klass ) );
-    g_assert( klass->get_display_name == NULL );
-    g_assert( klass->refers_to_object == NULL );
-    g_assert( klass->get_typed_referring_object_list == NULL );
+    g_assert_true( QOF_IS_INSTANCE_CLASS( klass ) );
+    g_assert_true( klass->get_display_name == NULL );
+    g_assert_true( klass->refers_to_object == NULL );
+    g_assert_true( klass->get_typed_referring_object_list == NULL );
     /* testing initial values */
-    g_assert( qof_instance_get_guid( inst ) );
-    g_assert( !qof_instance_get_collection( inst ) );
-    g_assert( qof_instance_get_book( inst ) == NULL );
-    g_assert( inst->kvp_data );
+    g_assert_true( qof_instance_get_guid( inst ) );
+    g_assert_true( !qof_instance_get_collection( inst ) );
+    g_assert_true( qof_instance_get_book( inst ) == NULL );
+    g_assert_true( inst->kvp_data );
     g_object_get( inst, "last-update", &time_priv, NULL);
     g_assert_cmpint( time_priv->t, == , 0 );
     g_assert_cmpint( qof_instance_get_editlevel( inst ), == , 0 );
-    g_assert( !qof_instance_get_destroying( inst ) );
-    g_assert( !qof_instance_get_dirty_flag( inst ) );
-    g_assert( qof_instance_get_infant( inst ) );
+    g_assert_true( !qof_instance_get_destroying( inst ) );
+    g_assert_true( !qof_instance_get_dirty_flag( inst ) );
+    g_assert_true( qof_instance_get_infant( inst ) );
     g_assert_cmpint( qof_instance_get_version( inst ), == , 0 );
     g_assert_cmpint( qof_instance_get_version_check( inst ), == , 0 );
     g_assert_cmpint( qof_instance_get_idata( inst ), == , 0 );
@@ -243,30 +243,30 @@ test_instance_init_data( void )
 
     /* set up */
     inst = static_cast<QofInstance*>(g_object_new( QOF_TYPE_INSTANCE, NULL ));
-    g_assert( QOF_IS_INSTANCE( inst ) );
+    g_assert_true( QOF_IS_INSTANCE( inst ) );
     book = qof_book_new();
-    g_assert( QOF_IS_BOOK( book ) );
+    g_assert_true( QOF_IS_BOOK( book ) );
     /* set fatal handler */
     g_test_log_set_fatal_handler ( ( GTestLogFatalFunc )fatal_handler, NULL );
 
     g_test_message( "Running test with correct initial data" );
     gncguid = qof_instance_get_guid( inst );
-    g_assert( gncguid );
+    g_assert_true( gncguid );
     guid_to_string_buff( gncguid, guid_id_before );
-    g_assert( qof_instance_get_book( inst ) == NULL );
-    g_assert( qof_instance_get_collection( inst ) == NULL );
+    g_assert_true( qof_instance_get_book( inst ) == NULL );
+    g_assert_true( qof_instance_get_collection( inst ) == NULL );
     /* run init */
     qof_instance_init_data( inst, test_type, book );
 
-    g_assert( qof_instance_get_book( inst ) == book );
+    g_assert_true( qof_instance_get_book( inst ) == book );
     guid_to_string_buff( gncguid, guid_id_after );
     g_assert_cmpstr( guid_id_before, != , guid_id_after );
-    g_assert( qof_instance_get_collection( inst ) != NULL );
+    g_assert_true( qof_instance_get_collection( inst ) != NULL );
     col = qof_book_get_collection( book, test_type );
-    g_assert( col );
-    g_assert( col == qof_instance_get_collection( inst ) );
+    g_assert_true( col );
+    g_assert_true( col == qof_instance_get_collection( inst ) );
     g_assert_cmpstr( inst->e_type, == , test_type );
-    g_assert( qof_collection_lookup_entity( qof_instance_get_collection( inst ), gncguid ) == inst );
+    g_assert_true( qof_collection_lookup_entity( qof_instance_get_collection( inst ), gncguid ) == inst );
 
     /* clean up */
     g_object_unref( inst );
@@ -279,26 +279,26 @@ test_instance_get_set_slots( Fixture *fixture, gconstpointer pData )
     KvpFrame *kvp_frame, *kvp_frame2;
 
     /* set up */
-    g_assert( fixture->inst );
+    g_assert_true( fixture->inst );
     kvp_frame = qof_instance_get_slots( fixture->inst );
-    g_assert( kvp_frame );
+    g_assert_true( kvp_frame );
 
     g_test_message( "Test when kvp frame is the same" );
     qof_instance_set_slots( fixture->inst, kvp_frame );
-    g_assert( kvp_frame == qof_instance_get_slots( fixture->inst ) );
-    g_assert( qof_instance_get_dirty_flag( fixture->inst ) );
+    g_assert_true( kvp_frame == qof_instance_get_slots( fixture->inst ) );
+    g_assert_true( qof_instance_get_dirty_flag( fixture->inst ) );
 
     g_test_message( "Test when kvp frame is not the same" );
     kvp_frame2 = new KvpFrame;
-    g_assert( kvp_frame != kvp_frame2 );
+    g_assert_true( kvp_frame != kvp_frame2 );
     qof_instance_set_slots( fixture->inst, kvp_frame2 );
-    g_assert( kvp_frame2 == qof_instance_get_slots( fixture->inst ) );
-    g_assert( qof_instance_get_dirty_flag( fixture->inst ) );
+    g_assert_true( kvp_frame2 == qof_instance_get_slots( fixture->inst ) );
+    g_assert_true( qof_instance_get_dirty_flag( fixture->inst ) );
 
     g_test_message( "Test when kvp frame is null" );
     qof_instance_set_slots( fixture->inst, NULL );
-    g_assert( NULL == qof_instance_get_slots( fixture->inst ) );
-    g_assert( qof_instance_get_dirty_flag( fixture->inst ) );
+    g_assert_true( NULL == qof_instance_get_slots( fixture->inst ) );
+    g_assert_true( qof_instance_get_dirty_flag( fixture->inst ) );
 
 }
 
@@ -361,19 +361,19 @@ test_instance_get_set_dirty( Fixture *fixture, gconstpointer pData )
     /* setup */
     col = qof_collection_new ( type );
     qof_instance_set_collection( fixture->inst, col );
-    g_assert( qof_instance_get_collection( fixture->inst ) );
+    g_assert_true( qof_instance_get_collection( fixture->inst ) );
 
     g_test_message( "Test get_dirty on empty instance returns false" );
-    g_assert( qof_instance_get_dirty( NULL ) == FALSE );
+    g_assert_true( qof_instance_get_dirty( NULL ) == FALSE );
 
     g_test_message( "Test dirty" );
-    g_assert( !qof_instance_get_dirty_flag( fixture->inst ) );
-    g_assert( !qof_collection_is_dirty( col ) );
-    g_assert( !qof_instance_get_dirty( fixture->inst ) );
+    g_assert_true( !qof_instance_get_dirty_flag( fixture->inst ) );
+    g_assert_true( !qof_collection_is_dirty( col ) );
+    g_assert_true( !qof_instance_get_dirty( fixture->inst ) );
     qof_instance_set_dirty( fixture->inst );
-    g_assert( qof_instance_get_dirty_flag( fixture->inst ) );
-    g_assert( !qof_collection_is_dirty( col ) );
-    g_assert( qof_instance_get_dirty( fixture->inst ) );
+    g_assert_true( qof_instance_get_dirty_flag( fixture->inst ) );
+    g_assert_true( !qof_collection_is_dirty( col ) );
+    g_assert_true( qof_instance_get_dirty( fixture->inst ) );
 
     /* clean up */
     qof_instance_set_collection( fixture->inst, NULL );
@@ -386,8 +386,8 @@ mock_get_display_name(const QofInstance* inst)
 {
     gchar *display_name;
 
-    g_assert( inst );
-    g_assert( QOF_INSTANCE_GET_CLASS( inst )->get_display_name == mock_get_display_name );
+    g_assert_true( inst );
+    g_assert_true( QOF_INSTANCE_GET_CLASS( inst )->get_display_name == mock_get_display_name );
     is_called = TRUE;
     display_name = g_strdup_printf("Mock display name %p", inst );
     return display_name;
@@ -401,26 +401,26 @@ test_instance_display_name( Fixture *fixture, gconstpointer pData )
     gchar *display_name, *default_display_name, *mock_display_name;
 
     /* setup */
-    g_assert( fixture->inst );
+    g_assert_true( fixture->inst );
     is_called = FALSE;
     col = qof_collection_new ( type );
-    g_assert( col );
+    g_assert_true( col );
     qof_instance_set_collection( fixture->inst, col );
-    g_assert( qof_instance_get_collection( fixture->inst ) );
+    g_assert_true( qof_instance_get_collection( fixture->inst ) );
     default_display_name = g_strdup_printf( "Object %s %p", type, fixture->inst );
     mock_display_name = g_strdup_printf( "Mock display name %p", fixture->inst );
 
     g_test_message( "Test instance when display name not set" );
-    g_assert( QOF_INSTANCE_GET_CLASS( fixture->inst )->get_display_name == NULL );
+    g_assert_true( QOF_INSTANCE_GET_CLASS( fixture->inst )->get_display_name == NULL );
     display_name = qof_instance_get_display_name( fixture->inst );
-    g_assert( !is_called );
+    g_assert_true( !is_called );
     g_assert_cmpstr( display_name, == , default_display_name );
     g_free( display_name );
 
     g_test_message( "Test instance when display name is set" );
     QOF_INSTANCE_GET_CLASS( fixture->inst )->get_display_name = mock_get_display_name;
     display_name = qof_instance_get_display_name( fixture->inst );
-    g_assert( is_called );
+    g_assert_true( is_called );
     g_assert_cmpstr( display_name, == , mock_display_name );
     g_free( display_name );
 
@@ -439,32 +439,32 @@ test_instance_begin_edit( Fixture *fixture, gconstpointer pData )
 
     /* setup */
     auto be = new QofInstMockBackend;
-    g_assert( be );
+    g_assert_true( be );
     book = qof_book_new();
-    g_assert( book );
-    g_assert( QOF_IS_BOOK( book ) );
+    g_assert_true( book );
+    g_assert_true( QOF_IS_BOOK( book ) );
     qof_book_set_backend( book, be );
-    g_assert( fixture->inst );
+    g_assert_true( fixture->inst );
     fixture->inst->e_type = "test type";
-    g_assert( qof_instance_get_dirty_flag( fixture->inst ) == FALSE );
+    g_assert_true( qof_instance_get_dirty_flag( fixture->inst ) == FALSE );
     g_assert_cmpint( qof_instance_get_editlevel( fixture->inst ), == , 0 );
 
     g_test_message( "Test when instance is null" );
     result = qof_begin_edit( NULL );
-    g_assert( result == FALSE );
+    g_assert_true( result == FALSE );
 
     g_test_message( "Test when instance's editlevel is >= 1" );
     qof_instance_increase_editlevel( fixture->inst );
     result = qof_begin_edit( fixture->inst );
-    g_assert( result == FALSE );
+    g_assert_true( result == FALSE );
     g_assert_cmpint( qof_instance_get_editlevel( fixture->inst ), == , 2 );
 
     g_test_message( "Test when instance's editlevel is <= 0 and backend not set" );
     qof_instance_reset_editlevel( fixture->inst );
     result = qof_begin_edit( fixture->inst );
-    g_assert( result == TRUE );
+    g_assert_true( result == TRUE );
     g_assert_cmpint( qof_instance_get_editlevel( fixture->inst ), == , 1 );
-    g_assert( qof_instance_get_dirty_flag( fixture->inst ) == TRUE );
+    g_assert_true( qof_instance_get_dirty_flag( fixture->inst ) == TRUE );
 
     g_test_message( "Test when instance's editlevel is <= 0 and backend is set" );
     result = FALSE;
@@ -472,9 +472,9 @@ test_instance_begin_edit( Fixture *fixture, gconstpointer pData )
     qof_instance_set_dirty_flag( fixture->inst, FALSE );
     qof_instance_set_book( fixture->inst, book );
     result = qof_begin_edit( fixture->inst );
-    g_assert( result == TRUE );
+    g_assert_true( result == TRUE );
     g_assert_cmpint( qof_instance_get_editlevel( fixture->inst ), == , 1 );
-    g_assert( qof_instance_get_dirty_flag( fixture->inst ) == FALSE );
+    g_assert_true( qof_instance_get_dirty_flag( fixture->inst ) == FALSE );
 
     /* clean up */
     qof_book_set_backend( book, NULL );
@@ -494,7 +494,7 @@ test_instance_commit_edit( Fixture *fixture, gconstpointer pData )
 
     g_test_message( "Test when instance set to null" );
     result = qof_commit_edit( NULL );
-    g_assert( !result );
+    g_assert_true( !result );
 
     g_test_message( "Test when instance's editlevel >= 2" );
     qof_instance_increase_editlevel( fixture->inst );
@@ -502,12 +502,12 @@ test_instance_commit_edit( Fixture *fixture, gconstpointer pData )
     g_assert_cmpint( qof_instance_get_editlevel( fixture->inst ), == , 2 );
     result = qof_commit_edit( fixture->inst );
     g_assert_cmpint( qof_instance_get_editlevel( fixture->inst ), == , 1 );
-    g_assert( !result );
+    g_assert_true( !result );
 
     g_test_message( "Test when instance's editlevel = 1" );
     result = qof_commit_edit( fixture->inst );
     g_assert_cmpint( qof_instance_get_editlevel( fixture->inst ), == , 0 );
-    g_assert( result );
+    g_assert_true( result );
 
     g_test_message( "Test when instance's editlevel < 0" );
     g_test_log_set_fatal_handler ( ( GTestLogFatalFunc )fatal_handler, NULL );
@@ -534,10 +534,10 @@ test_instance_commit_edit_part2( Fixture *fixture, gconstpointer pData )
 
     /* setup */
     auto be = new QofInstMockBackend;
-    g_assert( be );
+    g_assert_true( be );
     book = qof_book_new();
-    g_assert( book );
-    g_assert( QOF_IS_BOOK( book ) );
+    g_assert_true( book );
+    g_assert_true( QOF_IS_BOOK( book ) );
     qof_book_set_backend( book, be );
 
     /* init */
@@ -552,56 +552,56 @@ test_instance_commit_edit_part2( Fixture *fixture, gconstpointer pData )
     qof_instance_set_dirty_flag( fixture->inst, TRUE );
 
     g_test_message( "Test when instance's backend not set, callbacks not set" );
-    g_assert( qof_instance_get_infant( fixture->inst ) );
-    g_assert( !qof_instance_get_destroying( fixture->inst ) );
+    g_assert_true( qof_instance_get_infant( fixture->inst ) );
+    g_assert_true( !qof_instance_get_destroying( fixture->inst ) );
     result = qof_commit_edit_part2( fixture->inst, NULL, NULL, NULL );
-    g_assert( result );
-    g_assert( qof_instance_get_dirty_flag( fixture->inst ) );
-    g_assert( qof_instance_get_infant( fixture->inst ) );
-    g_assert( !commit_test.m_commit_called );
-    g_assert( !commit_test.m_commit_with_err_called );
-    g_assert( !commit_test.m_on_error_called );
-    g_assert( !commit_test.m_on_free_called );
-    g_assert( !commit_test.m_on_done_called );
+    g_assert_true( result );
+    g_assert_true( qof_instance_get_dirty_flag( fixture->inst ) );
+    g_assert_true( qof_instance_get_infant( fixture->inst ) );
+    g_assert_true( !commit_test.m_commit_called );
+    g_assert_true( !commit_test.m_commit_with_err_called );
+    g_assert_true( !commit_test.m_on_error_called );
+    g_assert_true( !commit_test.m_on_free_called );
+    g_assert_true( !commit_test.m_on_done_called );
 
     g_test_message( "Test when instance's backend not set, do_free is false" );
     qof_instance_set_destroying( fixture->inst, TRUE );
     result = qof_commit_edit_part2( fixture->inst, on_error, on_done, on_free );
-    g_assert( result );
-    g_assert( qof_instance_get_dirty_flag( fixture->inst ) );
-    g_assert( qof_instance_get_infant( fixture->inst ) );
-    g_assert( !commit_test.m_commit_called );
-    g_assert( !commit_test.m_commit_with_err_called );
-    g_assert( !commit_test.m_on_error_called );
-    g_assert( commit_test.m_on_free_called );
-    g_assert( !commit_test.m_on_done_called );
+    g_assert_true( result );
+    g_assert_true( qof_instance_get_dirty_flag( fixture->inst ) );
+    g_assert_true( qof_instance_get_infant( fixture->inst ) );
+    g_assert_true( !commit_test.m_commit_called );
+    g_assert_true( !commit_test.m_commit_with_err_called );
+    g_assert_true( !commit_test.m_on_error_called );
+    g_assert_true( commit_test.m_on_free_called );
+    g_assert_true( !commit_test.m_on_done_called );
 
     g_test_message( "Test when instance's backend not set, do_free is false" );
     qof_instance_set_destroying( fixture->inst, FALSE );
     commit_test.m_on_free_called = false;
     result = qof_commit_edit_part2( fixture->inst, on_error, on_done, on_free );
-    g_assert( result );
-    g_assert( qof_instance_get_dirty_flag( fixture->inst ) );
-    g_assert( qof_instance_get_infant( fixture->inst ) );
-    g_assert( !commit_test.m_commit_called );
-    g_assert( !commit_test.m_commit_with_err_called );
-    g_assert( !commit_test.m_on_error_called );
-    g_assert( !commit_test.m_on_free_called );
-    g_assert( commit_test.m_on_done_called );
+    g_assert_true( result );
+    g_assert_true( qof_instance_get_dirty_flag( fixture->inst ) );
+    g_assert_true( qof_instance_get_infant( fixture->inst ) );
+    g_assert_true( !commit_test.m_commit_called );
+    g_assert_true( !commit_test.m_commit_with_err_called );
+    g_assert_true( !commit_test.m_on_error_called );
+    g_assert_true( !commit_test.m_on_free_called );
+    g_assert_true( commit_test.m_on_done_called );
 
     g_test_message( "Test when instance's backend is set, all cb set, no error produced" );
     qof_instance_set_book( fixture->inst, book );
     qof_instance_set_destroying( fixture->inst, FALSE );
     commit_test.m_on_done_called = false;
     result = qof_commit_edit_part2( fixture->inst, on_error, on_done, on_free );
-    g_assert( result );
-    g_assert( !qof_instance_get_dirty_flag( fixture->inst ) );
-    g_assert( !qof_instance_get_infant( fixture->inst ) );
-    g_assert( commit_test.m_commit_called );
-    g_assert( !commit_test.m_commit_with_err_called );
-    g_assert( !commit_test.m_on_error_called );
-    g_assert( !commit_test.m_on_free_called );
-    g_assert( commit_test.m_on_done_called );
+    g_assert_true( result );
+    g_assert_true( !qof_instance_get_dirty_flag( fixture->inst ) );
+    g_assert_true( !qof_instance_get_infant( fixture->inst ) );
+    g_assert_true( commit_test.m_commit_called );
+    g_assert_true( !commit_test.m_commit_with_err_called );
+    g_assert_true( !commit_test.m_on_error_called );
+    g_assert_true( !commit_test.m_on_free_called );
+    g_assert_true( commit_test.m_on_done_called );
 
     g_test_message( "Test when instance's backend is set, all cb set, error produced" );
     commit_test.m_commit_called = false;
@@ -610,13 +610,13 @@ test_instance_commit_edit_part2( Fixture *fixture, gconstpointer pData )
     qof_instance_set_dirty_flag( fixture->inst, TRUE );
     qof_instance_set_destroying( fixture->inst, TRUE );
     result = qof_commit_edit_part2( fixture->inst, on_error, on_done, on_free );
-    g_assert( !result );
-    g_assert( !qof_instance_get_dirty_flag( fixture->inst ) );
-    g_assert( !qof_instance_get_destroying( fixture->inst ) );
-    g_assert( commit_test.m_commit_called );
-    g_assert( commit_test.m_on_error_called );
-    g_assert( !commit_test.m_on_free_called );
-    g_assert( !commit_test.m_on_done_called );
+    g_assert_true( !result );
+    g_assert_true( !qof_instance_get_dirty_flag( fixture->inst ) );
+    g_assert_true( !qof_instance_get_destroying( fixture->inst ) );
+    g_assert_true( commit_test.m_commit_called );
+    g_assert_true( commit_test.m_on_error_called );
+    g_assert_true( !commit_test.m_on_free_called );
+    g_assert_true( !commit_test.m_on_done_called );
 
     /* clean up */
     qof_book_set_backend( book, NULL );
@@ -639,10 +639,10 @@ static struct
 static gboolean
 mock_refers_to_object( const QofInstance* inst, const QofInstance* ref )
 {
-    g_assert( inst );
-    g_assert( ref );
-    g_assert( refers_test_struct.inst == inst );
-    g_assert( refers_test_struct.ref == ref );
+    g_assert_true( inst );
+    g_assert_true( ref );
+    g_assert_true( refers_test_struct.inst == inst );
+    g_assert_true( refers_test_struct.ref == ref );
     refers_test_struct.refers_to_object_called = TRUE;
     return TRUE;
 }
@@ -653,21 +653,21 @@ test_instance_refers_to_object( Fixture *fixture, gconstpointer pData )
     QofInstance * ref;
 
     ref = static_cast<QofInstance*>(g_object_new( QOF_TYPE_INSTANCE, NULL ));
-    g_assert( fixture->inst );
-    g_assert( ref );
-    g_assert( QOF_INSTANCE_GET_CLASS( fixture->inst )->refers_to_object == NULL );
+    g_assert_true( fixture->inst );
+    g_assert_true( ref );
+    g_assert_true( QOF_INSTANCE_GET_CLASS( fixture->inst )->refers_to_object == NULL );
     refers_test_struct.refers_to_object_called = FALSE;
     refers_test_struct.inst = fixture->inst;
     refers_test_struct.ref = ref;
 
     g_test_message( "Test when refers to object not set" );
-    g_assert( !qof_instance_refers_to_object( fixture->inst, ref ) );
-    g_assert( !refers_test_struct.refers_to_object_called );
+    g_assert_true( !qof_instance_refers_to_object( fixture->inst, ref ) );
+    g_assert_true( !refers_test_struct.refers_to_object_called );
 
     g_test_message( "Test when refers to object set" );
     QOF_INSTANCE_GET_CLASS( fixture->inst )->refers_to_object = mock_refers_to_object;
-    g_assert( qof_instance_refers_to_object( fixture->inst, ref ) );
-    g_assert( refers_test_struct.refers_to_object_called );
+    g_assert_true( qof_instance_refers_to_object( fixture->inst, ref ) );
+    g_assert_true( refers_test_struct.refers_to_object_called );
 
     g_object_unref( ref );
 }
@@ -682,10 +682,10 @@ static struct
 static gboolean
 mock_refers_to_object_from_col( const QofInstance* inst, const QofInstance* ref )
 {
-    g_assert( inst );
-    g_assert( ref );
-    g_assert( g_list_find( refers_test_struct_from_col.list, inst ) );
-    g_assert( refers_test_struct_from_col.ref == ref );
+    g_assert_true( inst );
+    g_assert_true( ref );
+    g_assert_true( g_list_find( refers_test_struct_from_col.list, inst ) );
+    g_assert_true( refers_test_struct_from_col.ref == ref );
     refers_test_struct_from_col.call_count++;
     refers_test_struct.refers_to_object_called = TRUE;
     return TRUE;
@@ -706,11 +706,11 @@ test_instance_get_referring_object_list_from_collection( void )
 
     /* setup book and ref instance */
     book = qof_book_new();
-    g_assert( book );
-    g_assert( QOF_IS_BOOK( book ) );
+    g_assert_true( book );
+    g_assert_true( QOF_IS_BOOK( book ) );
     ref =  static_cast<QofInstance*>(g_object_new( QOF_TYPE_INSTANCE, NULL ));
-    g_assert( ref );
-    g_assert( QOF_IS_INSTANCE( ref ) );
+    g_assert_true( ref );
+    g_assert_true( QOF_IS_INSTANCE( ref ) );
     QOF_INSTANCE_GET_CLASS( ref )->refers_to_object = NULL;
     refers_test_struct_from_col.call_count = 0;
     /* init list of entities of one type,
@@ -720,7 +720,7 @@ test_instance_get_referring_object_list_from_collection( void )
     for (i = 0; i < list_length; i++ )
     {
         auto inst = static_cast<QofInstance*>(g_object_new( QOF_TYPE_INSTANCE, NULL ));
-        g_assert( inst );
+        g_assert_true( inst );
         qof_instance_init_data( inst, type, book );
         inst_list = g_list_append ( inst_list, inst );
         g_assert_cmpint( g_list_length( inst_list ), == , (i + 1) );
@@ -729,9 +729,9 @@ test_instance_get_referring_object_list_from_collection( void )
 
     g_test_message( "Test when refers to object not set" );
     coll = qof_book_get_collection( book, type );
-    g_assert( coll );
+    g_assert_true( coll );
     result = qof_instance_get_referring_object_list_from_collection( coll, ref );
-    g_assert( !result );
+    g_assert_true( !result );
     g_assert_cmpint( refers_test_struct_from_col.call_count, == , 0 );
 
     g_test_message( "Test when refers to object is set" );
@@ -740,9 +740,9 @@ test_instance_get_referring_object_list_from_collection( void )
     refers_test_struct_from_col.ref = ref;
     result = qof_instance_get_referring_object_list_from_collection( coll, ref );
     if ( list_length == 0 )
-        g_assert( !result );
+        g_assert_true( !result );
     else
-        g_assert( result );
+        g_assert_true( result );
     g_assert_cmpint( g_list_length( inst_list ), == , g_list_length( result ) );
     g_assert_cmpint( g_list_length( inst_list ), == , refers_test_struct_from_col.call_count );
 
@@ -767,10 +767,10 @@ mock_get_typed_referring_object_list( const QofInstance* inst, const QofInstance
 {
     GList* result = NULL;
 
-    g_assert( inst );
-    g_assert( ref );
-    g_assert( get_typed_referring_object_list_struct.inst == inst );
-    g_assert( get_typed_referring_object_list_struct.ref == ref );
+    g_assert_true( inst );
+    g_assert_true( ref );
+    g_assert_true( get_typed_referring_object_list_struct.inst == inst );
+    g_assert_true( get_typed_referring_object_list_struct.ref == ref );
     get_typed_referring_object_list_struct.get_typed_referring_object_list_called = TRUE;
     return g_list_append( result, (gpointer) inst );
 }
@@ -787,9 +787,9 @@ test_instance_get_typed_referring_object_list( void )
     inst = static_cast<QofInstance*>(g_object_new( QOF_TYPE_INSTANCE, NULL ));
     ref = static_cast<QofInstance*>(g_object_new( QOF_TYPE_INSTANCE, NULL ));
     book = qof_book_new();
-    g_assert( inst );
-    g_assert( ref );
-    g_assert( book );
+    g_assert_true( inst );
+    g_assert_true( ref );
+    g_assert_true( book );
     QOF_INSTANCE_GET_CLASS( inst )->refers_to_object = NULL;
     QOF_INSTANCE_GET_CLASS( inst )->get_typed_referring_object_list = NULL;
     qof_instance_init_data( inst, "test type", book );
@@ -801,8 +801,8 @@ test_instance_get_typed_referring_object_list( void )
      */
     g_test_message( "Test when get typed referring object list is not set" );
     result = qof_instance_get_typed_referring_object_list( inst, ref );
-    g_assert( !result );
-    g_assert( !get_typed_referring_object_list_struct.get_typed_referring_object_list_called );
+    g_assert_true( !result );
+    g_assert_true( !get_typed_referring_object_list_struct.get_typed_referring_object_list_called );
     g_list_free( result );
 
     g_test_message( "Test when get typed referring object list is set" );
@@ -810,9 +810,9 @@ test_instance_get_typed_referring_object_list( void )
     get_typed_referring_object_list_struct.inst = inst;
     get_typed_referring_object_list_struct.ref = ref;
     result = qof_instance_get_typed_referring_object_list( inst, ref );
-    g_assert( result );
+    g_assert_true( result );
     g_assert_cmpint( g_list_length( result ), == , 1 );
-    g_assert( get_typed_referring_object_list_struct.get_typed_referring_object_list_called );
+    g_assert_true( get_typed_referring_object_list_struct.get_typed_referring_object_list_called );
     g_list_free( result );
 
     /* clean */
@@ -830,8 +830,8 @@ static struct
 static gboolean
 mock_simple_refers_to_object( const QofInstance* inst, const QofInstance* ref )
 {
-    g_assert( inst );
-    g_assert( ref );
+    g_assert_true( inst );
+    g_assert_true( ref );
     if ( inst->e_type == ref->e_type )
     {
         get_referring_object_list_struct.refers_to_object_call_count++;
@@ -843,8 +843,8 @@ mock_simple_refers_to_object( const QofInstance* inst, const QofInstance* ref )
 static GList*
 mock_simple_get_typed_referring_object_list(const QofInstance* inst, const QofInstance* ref)
 {
-    g_assert( inst );
-    g_assert( ref );
+    g_assert_true( inst );
+    g_assert_true( ref );
     get_referring_object_list_struct.get_typed_referring_object_list_count++;
     return qof_instance_get_referring_object_list_from_collection(qof_instance_get_collection(inst), ref);
 }
@@ -867,12 +867,12 @@ test_instance_get_referring_object_list( void )
 
     /* setup */
     book = qof_book_new();
-    g_assert( book );
-    g_assert( QOF_IS_BOOK( book ) );
+    g_assert_true( book );
+    g_assert_true( QOF_IS_BOOK( book ) );
     ref1 = static_cast<QofInstance*>(g_object_new( QOF_TYPE_INSTANCE, NULL ));
-    g_assert( ref1 );
+    g_assert_true( ref1 );
     ref2 = static_cast<QofInstance*>(g_object_new( QOF_TYPE_INSTANCE, NULL ));
-    g_assert( ref2 );
+    g_assert_true( ref2 );
     qof_instance_init_data( ref1, type1, book );
     qof_instance_init_data( ref2, type2, book );
     QOF_INSTANCE_GET_CLASS( ref1 )->refers_to_object = NULL;
@@ -888,7 +888,7 @@ test_instance_get_referring_object_list( void )
     for (i = 0; i < col1_length; i++ )
     {
         auto inst = static_cast<QofInstance*>(g_object_new( QOF_TYPE_INSTANCE, NULL ));
-        g_assert( inst );
+        g_assert_true( inst );
         qof_instance_init_data( inst, type1, book );
         inst_list1 = g_list_append ( inst_list1, inst );
         g_assert_cmpint( g_list_length( inst_list1 ), == , (i + 1) );
@@ -899,7 +899,7 @@ test_instance_get_referring_object_list( void )
     for (j = 0; j < col2_length; j++ )
     {
         auto inst = static_cast<QofInstance*>(g_object_new( QOF_TYPE_INSTANCE, NULL ));
-        g_assert( inst );
+        g_assert_true( inst );
         qof_instance_init_data( inst, type2, book );
         inst_list2 = g_list_append ( inst_list2, inst );
         g_assert_cmpint( g_list_length( inst_list2 ), == , (j + 1) );
@@ -909,12 +909,12 @@ test_instance_get_referring_object_list( void )
 
     g_test_message( "Test object list returned for ref1 instance by default" );
     result = qof_instance_get_referring_object_list( ref1 );
-    g_assert( !result );
+    g_assert_true( !result );
     g_assert_cmpint( get_referring_object_list_struct.refers_to_object_call_count, == , 0 );
 
     g_test_message( "Test object list returned for ref2 instance by default" );
     result = qof_instance_get_referring_object_list( ref2 );
-    g_assert( !result );
+    g_assert_true( !result );
     g_assert_cmpint( get_referring_object_list_struct.refers_to_object_call_count, == , 0 );
 
     /*
@@ -926,7 +926,7 @@ test_instance_get_referring_object_list( void )
     g_test_message( "Test object list returned for ref1 instance when refers_to_object is set" );
     QOF_INSTANCE_GET_CLASS( ref1 )->refers_to_object = mock_simple_refers_to_object;
     result = qof_instance_get_referring_object_list( ref1 );
-    g_assert( result );
+    g_assert_true( result );
     g_assert_cmpint( g_list_length( result ), == , col1_length + 1 );
     g_assert_cmpint( get_referring_object_list_struct.refers_to_object_call_count, == , col1_length + 1 );
     g_list_free( result );
@@ -934,7 +934,7 @@ test_instance_get_referring_object_list( void )
     g_test_message( "Test object list returned for ref2 instance when refers_to_object is set" );
     get_referring_object_list_struct.refers_to_object_call_count = 0;
     result = qof_instance_get_referring_object_list( ref2 );
-    g_assert( result );
+    g_assert_true( result );
     g_assert_cmpint( g_list_length( result ), == , col2_length + 1 );
     g_assert_cmpint( get_referring_object_list_struct.refers_to_object_call_count, == , col2_length + 1 );
     g_list_free( result );
@@ -944,7 +944,7 @@ test_instance_get_referring_object_list( void )
     get_referring_object_list_struct.refers_to_object_call_count = 0;
     get_referring_object_list_struct.get_typed_referring_object_list_count = 0;
     result = qof_instance_get_referring_object_list( ref1 );
-    g_assert( result );
+    g_assert_true( result );
     g_assert_cmpint( g_list_length( result ), == , col1_length + 1 );
     g_assert_cmpint( get_referring_object_list_struct.refers_to_object_call_count, == , col1_length + 1 );
     g_assert_cmpint( get_referring_object_list_struct.get_typed_referring_object_list_count, == , 2 );
@@ -954,7 +954,7 @@ test_instance_get_referring_object_list( void )
     get_referring_object_list_struct.refers_to_object_call_count = 0;
     get_referring_object_list_struct.get_typed_referring_object_list_count = 0;
     result = qof_instance_get_referring_object_list( ref2 );
-    g_assert( result );
+    g_assert_true( result );
     g_assert_cmpint( g_list_length( result ), == , col2_length + 1 );
     g_assert_cmpint( get_referring_object_list_struct.refers_to_object_call_count, == , col2_length + 1 );
     g_assert_cmpint( get_referring_object_list_struct.get_typed_referring_object_list_count, == , 2 );

--- a/libgnucash/engine/test/test-qofobject.c
+++ b/libgnucash/engine/test/test-qofobject.c
@@ -54,7 +54,7 @@ new_object( QofIdType e_type, const char *type_label, MockFields field)
     QofObject *object = NULL;
 
     object = g_new0( QofObject, 1 );
-    g_assert( object );
+    g_assert_true( object );
     object->interface_version = QOF_OBJECT_VERSION;
     object->e_type = e_type;
     object->type_label = type_label;
@@ -113,8 +113,8 @@ generate_and_register_objects( guint min_objects, MockFields mock_field )
     for (i = 0; i < list_length; i++ )
     {
         QofObject *object = new_object( types[i], "desc", mock_field );
-        g_assert( object );
-        g_assert( qof_object_register( object ) );
+        g_assert_true( object );
+        g_assert_true( qof_object_register( object ) );
         g_assert_cmpint( g_list_length( get_object_modules() ), == , (i + 1) );
     }
     g_assert_cmpint( list_length, == , g_list_length( get_object_modules() ) );
@@ -134,8 +134,8 @@ static struct
 static void
 mock_book_begin( QofBook *book )
 {
-    g_assert( book );
-    g_assert( book == book_begin_struct.books->data );
+    g_assert_true( book );
+    g_assert_true( book == book_begin_struct.books->data );
     book_begin_struct.books = book_begin_struct.books->next;
     book_begin_struct.call_count++;
 }
@@ -151,44 +151,44 @@ test_qof_object_register( Fixture *fixture, gconstpointer pData )
     for (i = 0; i < list_length; i++ )
     {
         QofBook *book = qof_book_new();
-        g_assert( book );
+        g_assert_true( book );
         books = g_list_prepend ( books, book );
         g_assert_cmpint( g_list_length( books ), == , (i + 1) );
     }
     g_assert_cmpint( list_length, == , g_list_length( books ) );
 
     g_test_message( "Test null check" );
-    g_assert( qof_object_register( NULL ) == FALSE );
+    g_assert_true( qof_object_register( NULL ) == FALSE );
 
     g_test_message( "Test new object register with book_begin specified" );
     fixture->qofobject->book_begin = mock_book_begin;
     book_begin_struct.books = books;
     book_begin_struct.call_count = 0;
-    g_assert( qof_object_register( fixture->qofobject ) == TRUE );
-    g_assert( qof_object_lookup( "my type object" ) == fixture->qofobject );
+    g_assert_true( qof_object_register( fixture->qofobject ) == TRUE );
+    g_assert_true( qof_object_lookup( "my type object" ) == fixture->qofobject );
     g_assert_cmpint( book_begin_struct.call_count, == , list_length );
 
     g_test_message( "Test registering the same object one more time" );
     book_begin_struct.call_count = 0;
-    g_assert( qof_object_register( fixture->qofobject ) == FALSE );
-    g_assert( qof_object_lookup( "my type object" ) == fixture->qofobject );
+    g_assert_true( qof_object_register( fixture->qofobject ) == FALSE );
+    g_assert_true( qof_object_lookup( "my type object" ) == fixture->qofobject );
     g_assert_cmpint( book_begin_struct.call_count, == , 0 );
 
     g_test_message( "Test new object register without book_begin specified" );
     simple_object = new_object( "my type simple", "simple desc", EMPTY );
-    g_assert( qof_object_register( simple_object ) == TRUE );
-    g_assert( qof_object_lookup( "my type simple" ) == simple_object );
+    g_assert_true( qof_object_register( simple_object ) == TRUE );
+    g_assert_true( qof_object_lookup( "my type simple" ) == simple_object );
     g_assert_cmpint( book_begin_struct.call_count, == , 0 );
 
     g_test_message( "Test register simple object one more time" );
-    g_assert( qof_object_register( simple_object ) == FALSE );
-    g_assert( qof_object_lookup( "my type simple" ) == simple_object );
+    g_assert_true( qof_object_register( simple_object ) == FALSE );
+    g_assert_true( qof_object_lookup( "my type simple" ) == simple_object );
 
     g_test_message( "Test book begin is called only one time when object is registered" );
     simple_object->book_begin = mock_book_begin;
     book_begin_struct.books = books;
     book_begin_struct.call_count = 0;
-    g_assert( qof_object_register( simple_object ) == FALSE );
+    g_assert_true( qof_object_register( simple_object ) == FALSE );
     g_assert_cmpint( book_begin_struct.call_count, == , 0 );
 
     g_list_foreach( books, (GFunc) qof_book_destroy, NULL );
@@ -200,27 +200,27 @@ static void
 test_qof_object_lookup( Fixture *fixture, gconstpointer pData )
 {
     g_test_message( "Test null check" );
-    g_assert( qof_object_lookup( NULL ) == NULL );
+    g_assert_true( qof_object_lookup( NULL ) == NULL );
 
     g_test_message( "Test existing object lookup" );
-    g_assert( qof_object_register( fixture->qofobject ) == TRUE );
-    g_assert( qof_object_lookup( "my type object" ) == fixture->qofobject );
+    g_assert_true( qof_object_register( fixture->qofobject ) == TRUE );
+    g_assert_true( qof_object_lookup( "my type object" ) == fixture->qofobject );
 
     g_test_message( "Test non existing object lookup" );
-    g_assert( qof_object_lookup( "anytype" ) == NULL );
+    g_assert_true( qof_object_lookup( "anytype" ) == NULL );
 }
 
 
 static void
 test_qof_object_get_type_label( Fixture *fixture, gconstpointer pData )
 {
-    g_assert( qof_object_get_type_label( NULL ) == NULL );
+    g_assert_true( qof_object_get_type_label( NULL ) == NULL );
 
     g_test_message( "Test with non existing object" );
-    g_assert( qof_object_get_type_label( "anytype" ) == NULL );
+    g_assert_true( qof_object_get_type_label( "anytype" ) == NULL );
 
     g_test_message( "Test with existing registered object" );
-    g_assert( qof_object_register( fixture->qofobject ) == TRUE );
+    g_assert_true( qof_object_register( fixture->qofobject ) == TRUE );
     g_assert_cmpstr( qof_object_get_type_label( "my type object" ), == , "object desc" );
 }
 
@@ -232,8 +232,8 @@ static struct
 static const char *
 mock_printable( gpointer instance )
 {
-    g_assert( instance );
-    g_assert( instance == printable_struct.param );
+    g_assert_true( instance );
+    g_assert_true( instance == printable_struct.param );
     return "printable was called";
 }
 
@@ -243,15 +243,15 @@ test_qof_object_printable( Fixture *fixture, gconstpointer pData )
     gint param;
 
     g_test_message( "Test null checks" );
-    g_assert( qof_object_printable( NULL, (gpointer)&param ) == NULL );
-    g_assert( qof_object_printable( "test", NULL ) == NULL );
+    g_assert_true( qof_object_printable( NULL, (gpointer)&param ) == NULL );
+    g_assert_true( qof_object_printable( "test", NULL ) == NULL );
 
     g_test_message( "Test with non registered object" );
-    g_assert( qof_object_printable( "test", (gpointer)&param ) == NULL );
+    g_assert_true( qof_object_printable( "test", (gpointer)&param ) == NULL );
 
     g_test_message( "Test with registered object and printable not set" );
-    g_assert( qof_object_register( fixture->qofobject ) == TRUE );
-    g_assert( qof_object_printable( "my type object", (gpointer)&param ) == NULL );
+    g_assert_true( qof_object_register( fixture->qofobject ) == TRUE );
+    g_assert_true( qof_object_printable( "my type object", (gpointer)&param ) == NULL );
 
     g_test_message( "Test with registered object and printable set" );
     fixture->qofobject->printable = mock_printable;
@@ -268,8 +268,8 @@ static struct
 static void
 mock_object_book_begin( QofBook *book )
 {
-    g_assert( book );
-    g_assert( book == object_book_begin_struct.book );
+    g_assert_true( book );
+    g_assert_true( book == object_book_begin_struct.book );
     object_book_begin_struct.call_count++;
 }
 
@@ -283,7 +283,7 @@ test_qof_object_book_begin( Fixture *fixture, gconstpointer pData )
     g_assert_cmpint( 0, == , g_list_length( get_book_list() ) );
     object_book_begin_struct.call_count = 0;
     book = g_object_new(QOF_TYPE_BOOK, NULL);
-    g_assert( book );
+    g_assert_true( book );
     qof_object_book_begin( book );
     g_assert_cmpint( 1, == , g_list_length( get_book_list() ) );
     g_assert_cmpint( g_list_index( get_book_list(), (gconstpointer) book), != , -1 );
@@ -296,7 +296,7 @@ test_qof_object_book_begin( Fixture *fixture, gconstpointer pData )
     g_test_message( "Test book begin with random objects registered and book begin set up" );
     g_assert_cmpint( 0, == , g_list_length( get_book_list() ) );
     book2 = g_object_new(QOF_TYPE_BOOK, NULL);
-    g_assert( book2 );
+    g_assert_true( book2 );
     object_book_begin_struct.book = book2;
     qof_object_book_begin( book2 );
     g_assert_cmpint( 1, == , g_list_length( get_book_list() ) );
@@ -314,7 +314,7 @@ test_qof_object_book_end( Fixture *fixture, gconstpointer pData )
 
     g_test_message( "Test book with no objects" );
     book = qof_book_new();
-    g_assert( book );
+    g_assert_true( book );
     object_book_begin_struct.call_count = 0;
     g_assert_cmpint( 1, == , g_list_length( get_book_list() ) );
     g_assert_cmpint( g_list_index( get_book_list(), (gconstpointer) book), != , -1 );
@@ -326,7 +326,7 @@ test_qof_object_book_end( Fixture *fixture, gconstpointer pData )
 
     g_test_message( "Test book end with random objects registered and book end set up" );
     book2 = qof_book_new();
-    g_assert( book2 );
+    g_assert_true( book2 );
     object_book_begin_struct.book = book2;
     g_assert_cmpint( 1, == , g_list_length( get_book_list() ) );
     g_assert_cmpint( g_list_index( get_book_list(), (gconstpointer) book2 ), != , -1 );
@@ -347,10 +347,10 @@ mock_object_dirty( const QofCollection *col )
 {
     QofObject *obj = NULL;
 
-    g_assert( col );
+    g_assert_true( col );
     obj = object_dirty_struct.objects->data;
     object_dirty_struct.objects = object_dirty_struct.objects->next;
-    g_assert( obj );
+    g_assert_true( obj );
     g_assert_cmpstr( qof_collection_get_type( col ), == , obj->e_type );
     object_dirty_struct.call_count++;
     return object_dirty_struct.result;
@@ -363,13 +363,13 @@ test_qof_object_is_dirty( Fixture *fixture, gconstpointer pData )
     gint32 list_length;
 
     g_test_message( "Test null check returns false" );
-    g_assert( qof_object_is_dirty( NULL ) == FALSE );
+    g_assert_true( qof_object_is_dirty( NULL ) == FALSE );
 
     g_test_message( "Test with no objects" );
     book = qof_book_new();
-    g_assert( book );
+    g_assert_true( book );
     object_dirty_struct.call_count = 0;
-    g_assert( qof_object_is_dirty( book ) == FALSE );
+    g_assert_true( qof_object_is_dirty( book ) == FALSE );
     g_assert_cmpint( object_dirty_struct.call_count, == , 0 );
 
     list_length = generate_and_register_objects( 1, MOCK_OBJECT_DIRTY );
@@ -377,14 +377,14 @@ test_qof_object_is_dirty( Fixture *fixture, gconstpointer pData )
     g_test_message( "Test with registered objects and suppose all collections are clean" );
     object_dirty_struct.objects = get_object_modules();
     object_dirty_struct.result = FALSE;
-    g_assert( qof_object_is_dirty( book ) == FALSE );
+    g_assert_true( qof_object_is_dirty( book ) == FALSE );
     g_assert_cmpint( object_dirty_struct.call_count, == , list_length );
 
     g_test_message( "Test with registered objects and suppose first collection is dirty" );
     object_dirty_struct.objects = get_object_modules();
     object_dirty_struct.result = TRUE;
     object_dirty_struct.call_count = 0;
-    g_assert( qof_object_is_dirty( book ) == TRUE );
+    g_assert_true( qof_object_is_dirty( book ) == TRUE );
     g_assert_cmpint( object_dirty_struct.call_count, == , 1 ); /* should break on first */
 
     qof_book_destroy( book );
@@ -401,10 +401,10 @@ mock_object_mark_clean( QofCollection *col )
 {
     QofObject *obj = NULL;
 
-    g_assert( col );
+    g_assert_true( col );
     obj = object_mark_clean_struct.objects->data;
     object_mark_clean_struct.objects = object_mark_clean_struct.objects->next;
-    g_assert( obj );
+    g_assert_true( obj );
     g_assert_cmpstr( qof_collection_get_type( col ), == , obj->e_type );
     object_mark_clean_struct.call_count++;
 }
@@ -417,7 +417,7 @@ test_qof_object_mark_clean( Fixture *fixture, gconstpointer pData )
 
     g_test_message( "Test with no objects" );
     book = qof_book_new();
-    g_assert( book );
+    g_assert_true( book );
     object_mark_clean_struct.call_count = 0;
     g_assert_cmpint( g_list_length( get_object_modules() ), == , 0 );
     qof_object_mark_clean( book );
@@ -446,10 +446,10 @@ mock_object_create( QofBook *book )
     QofInstance *inst = NULL;
 
     inst = g_object_new(QOF_TYPE_INSTANCE, NULL);
-    g_assert( inst );
-    g_assert( QOF_IS_INSTANCE( inst ) );
-    g_assert( book );
-    g_assert( book == object_create_struct.book );
+    g_assert_true( inst );
+    g_assert_true( QOF_IS_INSTANCE( inst ) );
+    g_assert_true( book );
+    g_assert_true( book == object_create_struct.book );
     object_create_struct.is_called = TRUE;
     object_create_struct.inst = inst;
     return inst;
@@ -462,17 +462,17 @@ test_qof_object_new_instance( Fixture *fixture, gconstpointer pData )
     QofInstance *inst = NULL;
 
     book = qof_book_new();
-    g_assert( book );
+    g_assert_true( book );
 
     g_test_message( "Test null check" );
-    g_assert( qof_object_new_instance( NULL, book ) == NULL );
+    g_assert_true( qof_object_new_instance( NULL, book ) == NULL );
 
     g_test_message( "Test non existing object type" );
-    g_assert( qof_object_new_instance( "non existing type", book ) == NULL );
+    g_assert_true( qof_object_new_instance( "non existing type", book ) == NULL );
 
     g_test_message( "Test with registered object type and create not set" );
-    g_assert( qof_object_register( fixture->qofobject ) );
-    g_assert( qof_object_new_instance( fixture->qofobject->e_type, book ) == NULL );
+    g_assert_true( qof_object_register( fixture->qofobject ) );
+    g_assert_true( qof_object_new_instance( fixture->qofobject->e_type, book ) == NULL );
 
     g_test_message( "Test with registered object type and create set" );
     object_create_struct.is_called = FALSE;
@@ -480,9 +480,9 @@ test_qof_object_new_instance( Fixture *fixture, gconstpointer pData )
     object_create_struct.inst = NULL;
     fixture->qofobject->create = mock_object_create;
     inst = qof_object_new_instance( fixture->qofobject->e_type, book );
-    g_assert( inst );
-    g_assert( object_create_struct.is_called == TRUE );
-    g_assert( object_create_struct.inst == inst );
+    g_assert_true( inst );
+    g_assert_true( object_create_struct.is_called == TRUE );
+    g_assert_true( object_create_struct.inst == inst );
 
     g_object_unref( inst );
     qof_book_destroy( book );
@@ -496,28 +496,28 @@ mock_object_foreach( const QofCollection *col, QofInstanceForeachCB cb, gpointer
 static void
 test_qof_object_compliance( Fixture *fixture, gconstpointer pData )
 {
-    g_assert( qof_object_register( fixture->qofobject ) );
+    g_assert_true( qof_object_register( fixture->qofobject ) );
 
     g_test_message( "Test when neither create nor foreach set" );
-    g_assert( qof_object_compliance( fixture->qofobject->e_type, FALSE ) == FALSE );
-    g_assert( qof_object_compliance( fixture->qofobject->e_type, TRUE ) == FALSE );
+    g_assert_true( qof_object_compliance( fixture->qofobject->e_type, FALSE ) == FALSE );
+    g_assert_true( qof_object_compliance( fixture->qofobject->e_type, TRUE ) == FALSE );
 
     g_test_message( "Test when only create set" );
     fixture->qofobject->create = mock_object_create;
-    g_assert( qof_object_compliance( fixture->qofobject->e_type, FALSE ) == FALSE );
-    g_assert( qof_object_compliance( fixture->qofobject->e_type, TRUE ) == FALSE );
+    g_assert_true( qof_object_compliance( fixture->qofobject->e_type, FALSE ) == FALSE );
+    g_assert_true( qof_object_compliance( fixture->qofobject->e_type, TRUE ) == FALSE );
 
     g_test_message( "Test when only foreach set" );
     fixture->qofobject->create = NULL;
     fixture->qofobject->foreach = mock_object_foreach;
-    g_assert( qof_object_compliance( fixture->qofobject->e_type, FALSE ) == FALSE );
-    g_assert( qof_object_compliance( fixture->qofobject->e_type, TRUE ) == FALSE );
+    g_assert_true( qof_object_compliance( fixture->qofobject->e_type, FALSE ) == FALSE );
+    g_assert_true( qof_object_compliance( fixture->qofobject->e_type, TRUE ) == FALSE );
 
     g_test_message( "Test when both set" );
     fixture->qofobject->create = mock_object_create;
     fixture->qofobject->foreach = mock_object_foreach;
-    g_assert( qof_object_compliance( fixture->qofobject->e_type, FALSE ) == TRUE );
-    g_assert( qof_object_compliance( fixture->qofobject->e_type, TRUE ) == TRUE );
+    g_assert_true( qof_object_compliance( fixture->qofobject->e_type, FALSE ) == TRUE );
+    g_assert_true( qof_object_compliance( fixture->qofobject->e_type, TRUE ) == TRUE );
 }
 
 static struct
@@ -530,10 +530,10 @@ static struct
 static void
 mock_foreach_type_cb( QofObject *object, gpointer user_data )
 {
-    g_assert( object );
-    g_assert( user_data );
-    g_assert( object == foreach_type_cb_struct.objects->data );
-    g_assert( user_data == foreach_type_cb_struct.user_data );
+    g_assert_true( object );
+    g_assert_true( user_data );
+    g_assert_true( object == foreach_type_cb_struct.objects->data );
+    g_assert_true( user_data == foreach_type_cb_struct.user_data );
     foreach_type_cb_struct.objects = foreach_type_cb_struct.objects->next;
     foreach_type_cb_struct.call_count++;
 }
@@ -576,12 +576,12 @@ mock_instance_foreach_cb( QofInstance *inst, gpointer user_data )
 static void
 mock_foreach( const QofCollection *col, QofInstanceForeachCB cb, gpointer user_data )
 {
-    g_assert( col );
-    g_assert( cb );
-    g_assert( user_data );
-    g_assert( col == foreach_cb_struct.col );
-    g_assert( user_data == foreach_cb_struct.user_data );
-    g_assert( cb == foreach_cb_struct.cb );
+    g_assert_true( col );
+    g_assert_true( cb );
+    g_assert_true( user_data );
+    g_assert_true( col == foreach_cb_struct.col );
+    g_assert_true( user_data == foreach_cb_struct.user_data );
+    g_assert_true( cb == foreach_cb_struct.cb );
     foreach_cb_struct.is_called = TRUE;
 }
 
@@ -594,12 +594,12 @@ test_qof_object_foreach( Fixture *fixture, gconstpointer pData )
 
     /* setup */
     book = qof_book_new();
-    g_assert( book );
+    g_assert_true( book );
     g_assert_cmpint( g_list_length( get_object_modules() ), == , 0 );
     qof_object_register( fixture->qofobject );
     g_assert_cmpint( g_list_length( get_object_modules() ), == , 1 );
     col = qof_book_get_collection( book, fixture->qofobject->e_type ); /* make col already exist */
-    g_assert( col );
+    g_assert_true( col );
 
     g_test_message( "Test foreach and data" );
     foreach_cb_struct.user_data = ( gpointer ) &user_data;
@@ -608,7 +608,7 @@ test_qof_object_foreach( Fixture *fixture, gconstpointer pData )
     foreach_cb_struct.cb = mock_instance_foreach_cb;
     fixture->qofobject->foreach = mock_foreach;
     qof_object_foreach( fixture->qofobject->e_type, book, mock_instance_foreach_cb, ( gpointer ) &user_data );
-    g_assert( foreach_cb_struct.is_called == TRUE );
+    g_assert_true( foreach_cb_struct.is_called == TRUE );
 
     qof_book_destroy( book );
 }
@@ -625,9 +625,9 @@ mock_foreach_for_sorted( const QofCollection *col, QofInstanceForeachCB cb, gpoi
 {
     GList *iter;
 
-    g_assert( col );
-    g_assert( cb );
-    g_assert( user_data );
+    g_assert_true( col );
+    g_assert_true( cb );
+    g_assert_true( user_data );
 
     for (iter = foreach_for_sorted_struct.instances; iter; iter = iter->next)
     {
@@ -638,10 +638,10 @@ mock_foreach_for_sorted( const QofCollection *col, QofInstanceForeachCB cb, gpoi
 static void
 mock_instance_foreach_cb_for_sorted( QofInstance *inst, gpointer user_data )
 {
-    g_assert( inst );
-    g_assert( user_data );
+    g_assert_true( inst );
+    g_assert_true( user_data );
     g_assert_cmpint( g_list_index( foreach_for_sorted_struct.instances, (gconstpointer) inst ), != , -1 );
-    g_assert( user_data == foreach_for_sorted_struct.user_data );
+    g_assert_true( user_data == foreach_for_sorted_struct.user_data );
     foreach_for_sorted_struct.call_count++;
 }
 
@@ -657,7 +657,7 @@ test_qof_object_foreach_sorted( Fixture *fixture, gconstpointer pData )
 
     /* setup */
     book = qof_book_new();
-    g_assert( book );
+    g_assert_true( book );
     g_assert_cmpint( g_list_length( get_object_modules() ), == , 0 );
     qof_object_register( fixture->qofobject );
     g_assert_cmpint( g_list_length( get_object_modules() ), == , 1 );
@@ -668,7 +668,7 @@ test_qof_object_foreach_sorted( Fixture *fixture, gconstpointer pData )
     for (i = 0; i < list_length; i++ )
     {
         QofInstance * inst = g_object_new( QOF_TYPE_INSTANCE, NULL );
-        g_assert( QOF_IS_INSTANCE( inst ) );
+        g_assert_true( QOF_IS_INSTANCE( inst ) );
         foreach_for_sorted_struct.instances = g_list_append( foreach_for_sorted_struct.instances, inst );
         qof_collection_insert_entity( col, inst );
     }

--- a/libgnucash/engine/test/test-qofsession-old.cpp
+++ b/libgnucash/engine/test/test-qofsession-old.cpp
@@ -69,7 +69,7 @@ setup( Fixture *fixture, gconstpointer pData )
 {
     fixture->session = qof_session_new (qof_book_new ());
     init_static_qofsession_pointers ();
-    g_assert (p_qof_session_clear_error && p_qof_session_destroy_backend && p_qof_session_load_backend);
+    g_assert_true (p_qof_session_clear_error && p_qof_session_destroy_backend && p_qof_session_load_backend);
 }
 
 static void
@@ -86,14 +86,14 @@ test_qof_session_new_destroy (void)
 {
     g_test_message ("Test session initialization");
     auto session = qof_session_new (qof_book_new ());
-    g_assert (session);
-    g_assert (qof_session_get_book (session));
+    g_assert_true (session);
+    g_assert_true (qof_session_get_book (session));
     auto book = qof_session_get_book (session);
-    g_assert (book);
-    g_assert (QOF_IS_BOOK (book));
-    g_assert (!strlen (qof_session_get_url (session)));
-    g_assert (!qof_session_get_backend (session));
-    g_assert (!qof_session_save_in_progress (session));
+    g_assert_true (book);
+    g_assert_true (QOF_IS_BOOK (book));
+    g_assert_true (!strlen (qof_session_get_url (session)));
+    g_assert_true (!qof_session_get_backend (session));
+    g_assert_true (!qof_session_save_in_progress (session));
     g_assert_cmpint (qof_session_get_error (session), == , ERR_BACKEND_NO_ERR);
 
     g_test_message ("Test session destroy");
@@ -111,7 +111,7 @@ test_session_safe_save( Fixture *fixture, gconstpointer pData )
     qof_session_safe_save( fixture->session, percentage_fn );
     g_assert_cmpint( ERR_BACKEND_DATA_CORRUPT, == ,
                      qof_session_get_error( fixture->session ));
-    g_assert (!strlen (qof_session_get_url (fixture->session)));
+    g_assert_true (!strlen (qof_session_get_url (fixture->session)));
 }
 
 static struct
@@ -133,7 +133,7 @@ struct QofMockLoadBackendProvider : public QofBackendProvider
 bool
 QofMockLoadBackendProvider::type_check (const char* uri)
 {
-    g_assert (uri);
+    g_assert_true (uri);
     g_assert_cmpstr (uri, ==, "my book");
     load_backend_struct.check_data_type_called = true;
     return load_backend_struct.data_compatible;
@@ -145,7 +145,7 @@ QofMockLoadBackendProvider::create_backend (void)
     QofBackend *be = NULL;
 
     be = g_new0 (QofBackend, 1);
-    g_assert (be);
+    g_assert_true (be);
     load_backend_struct.be = be;
     load_backend_struct.backend_new_called = TRUE;
     return be;
@@ -159,17 +159,17 @@ test_qof_session_load_backend (Fixture *fixture, gconstpointer pData)
     /* init */
 
     g_test_message ("Test when no provider is registered");
-    g_assert (!get_providers_initialized ());
-    g_assert (get_providers ().empty());
+    g_assert_true (!get_providers_initialized ());
+    g_assert_true (get_providers ().empty());
     p_qof_session_load_backend (fixture->session, "file");
-    g_assert (!get_providers_initialized ());
+    g_assert_true (!get_providers_initialized ());
     g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_NO_HANDLER);
     p_qof_session_clear_error (fixture->session);
 
     g_test_message ("Test with provider registered but access method not supported");
     auto prov = QofBackendProvider_ptr(new QofMockLoadBackendProvider("Mock Backend", "unsupported"));
     qof_backend_register_provider (std::move(prov));
-    g_assert (!get_providers().empty());
+    g_assert_true (!get_providers().empty());
     g_assert_cmpint (get_providers().size(), == , 1);
     p_qof_session_load_backend (fixture->session, "file");
     g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_NO_HANDLER);
@@ -183,7 +183,7 @@ test_qof_session_load_backend (Fixture *fixture, gconstpointer pData)
     load_backend_struct.check_data_type_called = FALSE;
     p_qof_session_set_uri (fixture->session, "my book");
     p_qof_session_load_backend (fixture->session, "file");
-    g_assert (load_backend_struct.check_data_type_called);
+    g_assert_true (load_backend_struct.check_data_type_called);
     g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_NO_HANDLER);
     p_qof_session_clear_error (fixture->session);
 
@@ -193,16 +193,16 @@ test_qof_session_load_backend (Fixture *fixture, gconstpointer pData)
     load_backend_struct.data_compatible = TRUE;
     load_backend_struct.check_data_type_called = FALSE;
     load_backend_struct.backend_new_called = FALSE;
-    g_assert (qof_book_get_backend (qof_session_get_book (fixture->session)) == NULL);
+    g_assert_true (qof_book_get_backend (qof_session_get_book (fixture->session)) == NULL);
     book = qof_session_get_book (fixture->session);
-    g_assert (book);
-    g_assert (qof_book_get_backend (book) == NULL);
+    g_assert_true (book);
+    g_assert_true (qof_book_get_backend (book) == NULL);
     p_qof_session_load_backend (fixture->session, "file");
-    g_assert (load_backend_struct.check_data_type_called);
-    g_assert (load_backend_struct.backend_new_called);
-    g_assert (load_backend_struct.be);
-    g_assert (load_backend_struct.be == qof_book_get_backend (qof_session_get_book (fixture->session)));
-    g_assert (qof_book_get_backend (book) == load_backend_struct.be);
+    g_assert_true (load_backend_struct.check_data_type_called);
+    g_assert_true (load_backend_struct.backend_new_called);
+    g_assert_true (load_backend_struct.be);
+    g_assert_true (load_backend_struct.be == qof_book_get_backend (qof_session_get_book (fixture->session)));
+    g_assert_true (qof_book_get_backend (book) == load_backend_struct.be);
     g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_NO_ERR);
 
     qof_backend_unregister_all_providers ();
@@ -220,11 +220,11 @@ static struct
 static void
 mock_load (QofBackend *be, QofBook *book, QofBackendLoadType type)
 {
-    g_assert (be);
-    g_assert (book);
-    g_assert (be == load_session_struct.be);
-    g_assert (book != load_session_struct.oldbook);
-    g_assert (qof_book_get_backend (book) == be);
+    g_assert_true (be);
+    g_assert_true (book);
+    g_assert_true (be == load_session_struct.be);
+    g_assert_true (book != load_session_struct.oldbook);
+    g_assert_true (qof_book_get_backend (book) == be);
     if (load_session_struct.error)
         qof_backend_set_error (be, ERR_BACKEND_DATA_CORRUPT); /* just any valid error */
     load_session_struct.load_called = TRUE;
@@ -242,35 +242,35 @@ test_qof_session_load (Fixture *fixture, gconstpointer pData)
     /* init */
     p_qof_session_set_uri (fixture->session, "my book");
     be = g_new0 (QofBackend, 1);
-    g_assert (be);
+    g_assert_true (be);
     qof_book_set_backend (qof_session_get_book (fixture->session), be);
     be->load = mock_load;
 
     g_test_message ("Test when no error is produced");
-    g_assert (be->percentage == NULL);
+    g_assert_true (be->percentage == NULL);
     load_session_struct.be = be;
     load_session_struct.oldbook = qof_session_get_book (fixture->session);
-    g_assert (qof_session_get_book (fixture->session));
+    g_assert_true (qof_session_get_book (fixture->session));
     load_session_struct.error = FALSE;
     load_session_struct.load_called = FALSE;
     qof_session_load (fixture->session, percentage_fn);
     newbook = qof_session_get_book (fixture->session);
-    g_assert (newbook);
-    g_assert (load_session_struct.oldbook != newbook);
-    g_assert (qof_session_get_book (fixture->session));
-    g_assert (load_session_struct.load_called);
+    g_assert_true (newbook);
+    g_assert_true (load_session_struct.oldbook != newbook);
+    g_assert_true (qof_session_get_book (fixture->session));
+    g_assert_true (load_session_struct.load_called);
 
     g_test_message ("Test when no is produced");
     load_session_struct.oldbook = qof_session_get_book (fixture->session);
-    g_assert (qof_session_get_book (fixture->session));
+    g_assert_true (qof_session_get_book (fixture->session));
     load_session_struct.error = TRUE;
     load_session_struct.load_called = FALSE;
     qof_session_load (fixture->session, percentage_fn);
     newbook = qof_session_get_book (fixture->session);
-    g_assert (newbook);
-    g_assert (load_session_struct.oldbook == newbook);
-    g_assert (qof_session_get_book (fixture->session));
-    g_assert (load_session_struct.load_called);
+    g_assert_true (newbook);
+    g_assert_true (load_session_struct.oldbook == newbook);
+    g_assert_true (qof_session_get_book (fixture->session));
+    g_assert_true (load_session_struct.load_called);
 }
 
 static struct
@@ -287,13 +287,13 @@ static void
 mock_session_begin (QofBackend *be, QofSession *session, const char *uri,
                     SessionOpenMode mode)
 {
-    g_assert (be);
-    g_assert (be == session_begin_struct.be);
-    g_assert (session);
-    g_assert (session == session_begin_struct.session);
-    g_assert (uri);
+    g_assert_true (be);
+    g_assert_true (be == session_begin_struct.be);
+    g_assert_true (session);
+    g_assert_true (session == session_begin_struct.session);
+    g_assert_true (uri);
     g_assert_cmpstr (uri, == , session_begin_struct.uri);
-    g_assert (mode == SESSION_BREAK_LOCK);
+    g_assert_true (mode == SESSION_BREAK_LOCK);
     if (session_begin_struct.produce_error)
     {
         qof_backend_set_error (be, ERR_BACKEND_DATA_CORRUPT);
@@ -312,7 +312,7 @@ struct QofMockSessBackendProvider : public QofBackendProvider
 bool
 QofMockSessBackendProvider::type_check (const char* uri)
 {
-    g_assert (uri);
+    g_assert_true (uri);
     return true;
 }
 
@@ -322,7 +322,7 @@ QofMockSessBackendProvider::create_backend (void)
     QofBackend *be = NULL;
 
     be = g_new0 (QofBackend, 1);
-    g_assert (be);
+    g_assert_true (be);
     be->session_begin = mock_session_begin;
     session_begin_struct.be = be;
     session_begin_struct.backend_new_called = TRUE;
@@ -338,7 +338,7 @@ test_qof_session_begin (Fixture *fixture, gconstpointer pData)
     SessionOpenMode mode{SESSION_BREAK_LOCK};
 
     be = g_new0 (QofBackend, 1);
-    g_assert (be);
+    g_assert_true (be);
     g_assert_cmpint (get_providers().size(), == , 0);
 
     /* run tests */
@@ -346,12 +346,12 @@ test_qof_session_begin (Fixture *fixture, gconstpointer pData)
     qof_book_set_backend (qof_session_get_book (fixture->session), be);
     p_qof_session_set_uri (fixture->session, "my book");
     qof_session_begin (fixture->session, "my book", mode);
-    g_assert (qof_book_get_backend (qof_session_get_book (fixture->session)) == be);
+    g_assert_true (qof_book_get_backend (qof_session_get_book (fixture->session)) == be);
 
     g_test_message ("Test when session uri is not set and uri passed is null backend is not changed");
     p_qof_session_set_uri (fixture->session, NULL);
     qof_session_begin (fixture->session, NULL, mode);
-    g_assert (qof_book_get_backend (qof_session_get_book (fixture->session)) == be);
+    g_assert_true (qof_book_get_backend (qof_session_get_book (fixture->session)) == be);
 
     g_test_message ("Test default access_method parsing");
     /* routine will destroy old backend
@@ -359,14 +359,14 @@ test_qof_session_begin (Fixture *fixture, gconstpointer pData)
      * as there is no backend registered error will be raised
      */
     qof_session_begin (fixture->session, "default_should_be_file", mode);
-    g_assert (qof_book_get_backend (qof_session_get_book (fixture->session)) == NULL);
-    g_assert (!strlen (qof_session_get_url (fixture->session)));
+    g_assert_true (qof_book_get_backend (qof_session_get_book (fixture->session)) == NULL);
+    g_assert_true (!strlen (qof_session_get_url (fixture->session)));
     g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_NO_HANDLER);
 
     g_test_message ("Test access_method parsing");
     qof_session_begin (fixture->session, "postgres://localhost:8080", mode);
-    g_assert (qof_book_get_backend (qof_session_get_book (fixture->session)) == NULL);
-    g_assert (!strlen (qof_session_get_url (fixture->session)));
+    g_assert_true (qof_book_get_backend (qof_session_get_book (fixture->session)) == NULL);
+    g_assert_true (!strlen (qof_session_get_url (fixture->session)));
     g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_NO_HANDLER);
 
     g_test_message ("Test with valid backend returned and session begin set; error is produced");
@@ -380,11 +380,11 @@ test_qof_session_begin (Fixture *fixture, gconstpointer pData)
     qof_backend_register_provider (std::move(prov));
 
     qof_session_begin (fixture->session, "postgres://localhost:8080", mode);
-    g_assert (qof_book_get_backend (qof_session_get_book (fixture->session)));
-    g_assert (session_begin_struct.be == qof_book_get_backend (qof_session_get_book (fixture->session)));
-    g_assert (session_begin_struct.backend_new_called == TRUE);
-    g_assert (session_begin_struct.session_begin_called == TRUE);
-    g_assert (!strlen (qof_session_get_url (fixture->session)));
+    g_assert_true (qof_book_get_backend (qof_session_get_book (fixture->session)));
+    g_assert_true (session_begin_struct.be == qof_book_get_backend (qof_session_get_book (fixture->session)));
+    g_assert_true (session_begin_struct.backend_new_called == TRUE);
+    g_assert_true (session_begin_struct.session_begin_called == TRUE);
+    g_assert_true (!strlen (qof_session_get_url (fixture->session)));
     g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_DATA_CORRUPT);
     g_assert_cmpstr (qof_session_get_error_message (fixture->session), == , "push any error");
 
@@ -393,11 +393,11 @@ test_qof_session_begin (Fixture *fixture, gconstpointer pData)
     session_begin_struct.session_begin_called = FALSE;
     session_begin_struct.produce_error = FALSE;
     qof_session_begin (fixture->session, "postgres://localhost:8080", ignore_lock, create, force);
-    g_assert (qof_book_get_backend (qof_session_get_book (fixture->session)));
-    g_assert (session_begin_struct.be == qof_book_get_backend (qof_session_get_book (fixture->session)));
-    g_assert (session_begin_struct.backend_new_called == TRUE);
-    g_assert (session_begin_struct.session_begin_called == TRUE);
-    g_assert (strlen (qof_session_get_url (fixture->session)));
+    g_assert_true (qof_book_get_backend (qof_session_get_book (fixture->session)));
+    g_assert_true (session_begin_struct.be == qof_book_get_backend (qof_session_get_book (fixture->session)));
+    g_assert_true (session_begin_struct.backend_new_called == TRUE);
+    g_assert_true (session_begin_struct.session_begin_called == TRUE);
+    g_assert_true (strlen (qof_session_get_url (fixture->session)));
     g_assert_cmpstr (qof_session_get_url (fixture->session), == , "postgres://localhost:8080");
     g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_NO_ERR);
 
@@ -418,10 +418,10 @@ static struct
 static void
 mock_sync (QofBackend *be, QofBook *book)
 {
-    g_assert (be);
-    g_assert (book);
-    g_assert (be == session_save_struct.be);
-    g_assert (book == session_save_struct.book);
+    g_assert_true (be);
+    g_assert_true (book);
+    g_assert_true (be == session_save_struct.be);
+    g_assert_true (book == session_save_struct.book);
     session_save_struct.sync_called = TRUE;
 }
 
@@ -433,42 +433,42 @@ test_qof_session_save (Fixture *fixture, gconstpointer pData)
     QofBackendProvider *prov = NULL;
 
     g_test_message ("Test when backend not set");
-    g_assert (qof_book_get_backend (qof_session_get_book (fixture->session)) == NULL);
+    g_assert_true (qof_book_get_backend (qof_session_get_book (fixture->session)) == NULL);
     book = qof_session_get_book (fixture->session);
-    g_assert (book);
+    g_assert_true (book);
     g_assert_cmpint (qof_session_get_error (fixture->session), !=, ERR_BACKEND_NO_HANDLER);
-    g_assert (!qof_session_save_in_progress (fixture->session));
+    g_assert_true (!qof_session_save_in_progress (fixture->session));
     qof_session_save (fixture->session, NULL);
     g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_NO_HANDLER);
-    g_assert (!qof_session_save_in_progress (fixture->session));
+    g_assert_true (!qof_session_save_in_progress (fixture->session));
 
     g_test_message ("Test when backend set; imitate error");
     be = g_new0 (QofBackend, 1);
-    g_assert (be);
+    g_assert_true (be);
     be->sync = mock_sync;
     qof_book_set_backend (qof_session_get_book (fixture->session), be);
-    g_assert (!qof_session_save_in_progress (fixture->session));
+    g_assert_true (!qof_session_save_in_progress (fixture->session));
     session_save_struct.sync_called = FALSE;
     session_save_struct.be = be;
     session_save_struct.book = book;
     qof_backend_set_error (be, ERR_BACKEND_DATA_CORRUPT);
     qof_backend_set_message (be, "push any error");
     qof_session_save (fixture->session, percentage_fn);
-    g_assert (qof_book_get_backend (book) == be);
-    g_assert (be->percentage == percentage_fn);
-    g_assert (session_save_struct.sync_called);
-    g_assert (!qof_session_save_in_progress (fixture->session));
+    g_assert_true (qof_book_get_backend (book) == be);
+    g_assert_true (be->percentage == percentage_fn);
+    g_assert_true (session_save_struct.sync_called);
+    g_assert_true (!qof_session_save_in_progress (fixture->session));
     g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_DATA_CORRUPT);
     g_assert_cmpstr (qof_session_get_error_message (fixture->session), == , "");
 
     g_test_message ("Test when backend set; successful save");
-    g_assert (!qof_session_save_in_progress (fixture->session));
+    g_assert_true (!qof_session_save_in_progress (fixture->session));
     session_save_struct.sync_called = FALSE;
     qof_session_save (fixture->session, percentage_fn);
-    g_assert (qof_book_get_backend (book) == be);
-    g_assert (be->percentage == percentage_fn);
-    g_assert (session_save_struct.sync_called);
-    g_assert (!qof_session_save_in_progress (fixture->session));
+    g_assert_true (qof_book_get_backend (book) == be);
+    g_assert_true (be->percentage == percentage_fn);
+    g_assert_true (session_save_struct.sync_called);
+    g_assert_true (!qof_session_save_in_progress (fixture->session));
     g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_NO_ERR);
 
     /* change backend testing
@@ -489,8 +489,8 @@ static struct
 static void
 mock_destroy_backend (QofBackend *be)
 {
-    g_assert (be);
-    g_assert (destroy_backend_struct.be == be);
+    g_assert_true (be);
+    g_assert_true (destroy_backend_struct.be == be);
     destroy_backend_struct.called = TRUE;
 }
 
@@ -501,21 +501,21 @@ test_qof_session_destroy_backend (Fixture *fixture, gconstpointer pData)
 
     g_test_message ("Test with destroy backend callback not set");
     be = g_new0 (QofBackend, 1);
-    g_assert (be);
+    g_assert_true (be);
     qof_book_set_backend (qof_session_get_book (fixture->session), be);
     p_qof_session_destroy_backend (fixture->session);
-    g_assert (!qof_book_get_backend (qof_session_get_book (fixture->session)));
+    g_assert_true (!qof_book_get_backend (qof_session_get_book (fixture->session)));
 
     g_test_message ("Test with destroy backend callback set");
     be = g_new0 (QofBackend, 1);
-    g_assert (be);
+    g_assert_true (be);
     be->destroy_backend = mock_destroy_backend;
     qof_book_set_backend (qof_session_get_book (fixture->session), be);
     destroy_backend_struct.called = FALSE;
     destroy_backend_struct.be = be;
     p_qof_session_destroy_backend (fixture->session);
-    g_assert (!qof_book_get_backend (qof_session_get_book (fixture->session)));
-    g_assert (destroy_backend_struct.called);
+    g_assert_true (!qof_book_get_backend (qof_session_get_book (fixture->session)));
+    g_assert_true (destroy_backend_struct.called);
 }
 
 static struct
@@ -527,8 +527,8 @@ static struct
 static void
 mock_session_end (QofBackend *be)
 {
-    g_assert (be);
-    g_assert (session_end_struct.be == be);
+    g_assert_true (be);
+    g_assert_true (session_end_struct.be == be);
     session_end_struct.called = TRUE;
 }
 
@@ -539,7 +539,7 @@ test_qof_session_end (Fixture *fixture, gconstpointer pData)
 
     g_test_message ("Test backend is closed, errors cleared and uri removed");
     be = g_new0 (QofBackend, 1);
-    g_assert (be);
+    g_assert_true (be);
     be->session_end = mock_session_end;
     be->last_err = ERR_BACKEND_DATA_CORRUPT;
     be->error_msg = g_strdup("push any error");
@@ -548,9 +548,9 @@ test_qof_session_end (Fixture *fixture, gconstpointer pData)
     session_end_struct.called = FALSE;
     session_end_struct.be = be;
     qof_session_end (fixture->session);
-    g_assert (session_end_struct.called);
+    g_assert_true (session_end_struct.called);
     g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_NO_ERR);
-    g_assert (!strlen (qof_session_get_url (fixture->session)));
+    g_assert_true (!strlen (qof_session_get_url (fixture->session)));
 }
 
 static struct
@@ -563,10 +563,10 @@ static struct
 static void
 mock_export (QofBackend *be, QofBook *book)
 {
-    g_assert (be);
-    g_assert (session_export_struct.be == be);
-    g_assert (book);
-    g_assert (session_export_struct.book == book);
+    g_assert_true (be);
+    g_assert_true (session_export_struct.be == be);
+    g_assert_true (book);
+    g_assert_true (session_export_struct.book == book);
     session_export_struct.called = TRUE;
 }
 
@@ -576,27 +576,27 @@ test_qof_session_export (Fixture *fixture, gconstpointer pData)
     QofBackend *be = NULL;
 
     auto real_session = qof_session_new (qof_book_new ());
-    g_assert (real_session);
+    g_assert_true (real_session);
 
     g_test_message ("Test null checks");
-    g_assert (!qof_session_export (NULL, real_session, percentage_fn));
-    g_assert (!qof_session_export (fixture->session, NULL, percentage_fn));
+    g_assert_true (!qof_session_export (NULL, real_session, percentage_fn));
+    g_assert_true (!qof_session_export (fixture->session, NULL, percentage_fn));
 
     g_test_message ("Test with backend not set");
     auto tmp_book = qof_session_get_book (fixture->session);
-    g_assert (tmp_book);
+    g_assert_true (tmp_book);
     auto be = qof_book_get_backend (tmp_book);
-    g_assert (!be);
-    g_assert (!qof_session_export (fixture->session, real_session, percentage_fn));
+    g_assert_true (!be);
+    g_assert_true (!qof_session_export (fixture->session, real_session, percentage_fn));
 
     g_test_message ("Test with backend set");
     be = g_new0 (QofBackend, 1);
-    g_assert (be);
+    g_assert_true (be);
     qof_book_set_backend (qof_session_get_book (fixture->session), be);
     qof_book_set_backend (tmp_book, be);
-    g_assert (!be->percentage);
-    g_assert (qof_session_export (fixture->session, real_session, percentage_fn));
-    g_assert (be->percentage == percentage_fn);
+    g_assert_true (!be->percentage);
+    g_assert_true (qof_session_export (fixture->session, real_session, percentage_fn));
+    g_assert_true (be->percentage == percentage_fn);
 
     g_test_message ("Test with backend export function set and error is produced");
     be->export_fn = mock_export;
@@ -604,17 +604,17 @@ test_qof_session_export (Fixture *fixture, gconstpointer pData)
     qof_backend_set_message (be, "push any error");
     session_export_struct.called = FALSE;
     auto real_book = qof_session_get_book (real_session);
-    g_assert (real_book);
+    g_assert_true (real_book);
     session_export_struct.be = be;
     session_export_struct.book = real_book;
-    g_assert (!qof_session_export (fixture->session, real_session, percentage_fn));
-    g_assert (session_export_struct.called);
+    g_assert_true (!qof_session_export (fixture->session, real_session, percentage_fn));
+    g_assert_true (session_export_struct.called);
 
     g_test_message ("Test with backend export function set and no error produced");
     p_qof_session_clear_error (fixture->session);
     session_export_struct.called = FALSE;
-    g_assert (qof_session_export (fixture->session, real_session, percentage_fn));
-    g_assert (session_export_struct.called);
+    g_assert_true (qof_session_export (fixture->session, real_session, percentage_fn));
+    g_assert_true (session_export_struct.called);
 
     qof_session_destroy (real_session);
 }
@@ -627,28 +627,28 @@ test_qof_session_swap_data (Fixture *fixture, gconstpointer pData)
     QofBook *book1 = NULL, *book2 = NULL;
 
     /* init */
-    g_assert (fixture->session);
+    g_assert_true (fixture->session);
     auto session2 = qof_session_new (qof_book_new ());
-    g_assert (session2);
-    g_assert (fixture->session != session2);
+    g_assert_true (session2);
+    g_assert_true (fixture->session != session2);
     be1 = g_new0 (QofBackend, 1);
-    g_assert (be1);
+    g_assert_true (be1);
     be2 = g_new0 (QofBackend, 1);
-    g_assert (be2);
+    g_assert_true (be2);
     qof_book_set_backend (qof_session_get_book (fixture->session), be1);
     qof_book_set_backend (qof_session_get_book (session2), be2);
     book1 = qof_session_get_book (fixture->session);
     book2 = qof_session_get_book (session2);
-    g_assert (book1);
-    g_assert (book2);
+    g_assert_true (book1);
+    g_assert_true (book2);
     qof_book_set_backend (book1, qof_book_get_backend (qof_session_get_book (fixture->session)));
     qof_book_set_backend (book2, qof_book_get_backend (qof_session_get_book (session2)));
 
 
     g_test_message ("Test book lists are swapped and backend for each book is swapped");
     qof_session_swap_data (fixture->session, session2);
-    g_assert (qof_session_get_book (fixture->session) == book2);
-    g_assert (qof_session_get_book (session2) == book1);
+    g_assert_true (qof_session_get_book (fixture->session) == book2);
+    g_assert_true (qof_session_get_book (session2) == book1);
 
     qof_session_destroy (session2);
 }
@@ -662,8 +662,8 @@ static struct
 static gboolean
 mock_events_fn (QofBackend *be)
 {
-    g_assert (be);
-    g_assert (be == events_struct.be);
+    g_assert_true (be);
+    g_assert_true (be == events_struct.be);
     events_struct.called = TRUE;
     return TRUE;
 }
@@ -678,10 +678,10 @@ static struct
 static void
 mock_all_data_load (QofBackend *be, QofBook *book, QofBackendLoadType type)
 {
-    g_assert (be);
-    g_assert (book);
-    g_assert (be == data_load_struct.be);
-    g_assert (book == data_load_struct.book);
+    g_assert_true (be);
+    g_assert_true (book);
+    g_assert_true (be == data_load_struct.be);
+    g_assert_true (book == data_load_struct.book);
     g_assert_cmpint (type, == , LOAD_TYPE_LOAD_ALL);
     qof_backend_set_error (be, ERR_BACKEND_DATA_CORRUPT);
     data_load_struct.called = TRUE;
@@ -693,7 +693,7 @@ test_qof_session_data_loaded (Fixture *fixture, gconstpointer pData)
     QofBackend *be = NULL;
 
     be = g_new0 (QofBackend, 1);
-    g_assert (be);
+    g_assert_true (be);
     be->load = mock_all_data_load;
     qof_book_set_backend (qof_session_get_book (fixture->session), be);
 
@@ -702,7 +702,7 @@ test_qof_session_data_loaded (Fixture *fixture, gconstpointer pData)
     data_load_struct.book = qof_session_get_book (fixture->session);
     data_load_struct.called = FALSE;
     qof_session_ensure_all_data_loaded (fixture->session);
-    g_assert (data_load_struct.called);
+    g_assert_true (data_load_struct.called);
     g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_DATA_CORRUPT);
     g_assert_cmpstr (qof_session_get_error_message (fixture->session), == , "");
 }
@@ -713,17 +713,17 @@ test_qof_session_get_book (Fixture *fixture, gconstpointer pData)
     QofBook *book = NULL;
 
     g_test_message ("Test null check");
-    g_assert (!qof_session_get_book (NULL));
+    g_assert_true (!qof_session_get_book (NULL));
 
     g_test_message ("Test open book is returned");
-    g_assert (qof_session_get_book (fixture->session));
+    g_assert_true (qof_session_get_book (fixture->session));
     book = qof_session_get_book (fixture->session);
-    g_assert (book);
+    g_assert_true (book);
     g_assert_cmpuint (book->book_open, == , 'y');
 
     g_test_message ("Test when book is closed null returned");
     qof_book_mark_closed (book);
-    g_assert (!qof_session_get_book (fixture->session));
+    g_assert_true (!qof_session_get_book (fixture->session));
 
 }
 
@@ -737,7 +737,7 @@ test_qof_session_get_error (Fixture *fixture, gconstpointer pData)
 
     g_test_message ("Test for backend error");
     be = g_new0 (QofBackend, 1);
-    g_assert (be);
+    g_assert_true (be);
     qof_backend_set_error (be, ERR_BACKEND_CANT_CONNECT);
     qof_book_set_backend (qof_session_get_book (fixture->session), be);
     g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_CANT_CONNECT);
@@ -749,7 +749,7 @@ test_qof_session_clear_error (Fixture *fixture, gconstpointer pData)
     QofBackend *be = NULL;
 
     be = g_new0 (QofBackend, 1);
-    g_assert (be);
+    g_assert_true (be);
 
     g_test_message ("Test session and backend errors are cleared");
     be->last_err = ERR_BACKEND_NO_SUCH_DB;
@@ -759,7 +759,7 @@ test_qof_session_clear_error (Fixture *fixture, gconstpointer pData)
     p_qof_session_clear_error (fixture->session);
     g_assert_cmpint (qof_session_get_error (fixture->session), == , ERR_BACKEND_NO_ERR);
     g_assert_cmpstr (qof_session_get_error_message (fixture->session), == , "");
-    g_assert (!strlen (qof_session_get_error_message (fixture->session)));
+    g_assert_true (!strlen (qof_session_get_error_message (fixture->session)));
     g_assert_cmpint (qof_backend_get_error (be), == , ERR_BACKEND_NO_ERR);
 }
 
@@ -777,16 +777,16 @@ mock_hook_fn (gpointer data, gpointer user_data)
 {
     QofSession *session;
 
-    g_assert (data);
-    g_assert (user_data);
+    g_assert_true (data);
+    g_assert_true (user_data);
     session = (QofSession*) data;
-    g_assert (session == hooks_struct.session);
+    g_assert_true (session == hooks_struct.session);
     if (hooks_struct.call_count == 0)
-        g_assert (hooks_struct.data1 == user_data);
+        g_assert_true (hooks_struct.data1 == user_data);
     if (hooks_struct.call_count == 1)
-        g_assert (hooks_struct.data2 == user_data);
+        g_assert_true (hooks_struct.data2 == user_data);
     if (hooks_struct.call_count == 2)
-        g_assert (hooks_struct.data3 == user_data);
+        g_assert_true (hooks_struct.data3 == user_data);
     hooks_struct.call_count++;
 }
 

--- a/libgnucash/engine/test/utest-Account.cpp
+++ b/libgnucash/engine/test/utest-Account.cpp
@@ -284,7 +284,7 @@ insert_split (Account *parent, Transaction *txn, SplitParms *p)
     auto acct = gnc_account_lookup_by_name (parent, p->account);
     auto lotlist = xaccAccountGetLotList (acct);
     GNCLot* lot = NULL;
-    g_assert (acct != NULL);
+    g_assert_true (acct != NULL);
     xaccSplitSetParent (split, txn);
     xaccSplitSetMemo (split, p->memo);
     xaccSplitSetReconcile (split, (p->reconciled ? p->reconciled : NREC));
@@ -337,7 +337,7 @@ setup (Fixture *fixture, gconstpointer pData)
         if (p.parent && strlen (p.parent) > 0)
         {
             auto parent = static_cast<Account*>(g_hash_table_lookup (accts, p.parent));
-            g_assert (parent != NULL);
+            g_assert_true (parent != NULL);
             gnc_account_append_child (parent, child);
         }
         else
@@ -422,18 +422,18 @@ test_gnc_set_account_separator ()
     const gunichar default_sep = ':';
     gunichar sep = gnc_get_account_separator ();
 
-    g_assert (sep == default_sep);
+    g_assert_true (sep == default_sep);
     memset (sep_str, 0, sizeof (sep_str));
     g_unichar_to_utf8 (fail_sep, sep_str);
     gnc_set_account_separator (sep_str);
     sep = gnc_get_account_separator ();
-    g_assert (sep != fail_sep);
-    g_assert (sep == default_sep);
+    g_assert_true (sep != fail_sep);
+    g_assert_true (sep == default_sep);
     memset (sep_str, 0, sizeof (sep_str));
     g_unichar_to_utf8 (pass_sep, sep_str);
     gnc_set_account_separator (sep_str);
     sep = gnc_get_account_separator ();
-    g_assert (sep == pass_sep);
+    g_assert_true (sep == pass_sep);
 }
 /* Note: gnc_account_name_violations and gnc_account_list_name_violations should work with unicode. Change the functions and the tests accordingly. */
 /* gnc_account_name_violations_errmsg
@@ -450,7 +450,7 @@ test_gnc_account_name_violations_errmsg ()
     auto message = gnc_account_name_violations_errmsg (separator, nonames);
     auto account_list = gnc_g_list_stringjoin (badnames, "\n");
     message = gnc_account_name_violations_errmsg (separator, nonames);
-    g_assert (message == NULL);
+    g_assert_true (message == NULL);
     auto validation_message = g_strdup_printf (
         "The separator character \"%s\" is used in one or more account "
         "names.\n\nThis will result in unexpected behaviour. "
@@ -481,11 +481,11 @@ test_gnc_account_list_name_violations (Fixture *fixture, gconstpointer pData)
      */
     GLogFunc oldlogger = g_log_set_default_handler ((GLogFunc)test_null_handler, check);
     g_test_log_set_fatal_handler ((GTestLogFatalFunc)test_checked_substring_handler, check);
-    g_assert (gnc_account_list_name_violations (NULL, NULL) == NULL);
+    g_assert_true (gnc_account_list_name_violations (NULL, NULL) == NULL);
     g_assert_cmpint (check->hits, ==, 1);
-    g_assert (gnc_account_list_name_violations (book, NULL) == NULL);
+    g_assert_true (gnc_account_list_name_violations (book, NULL) == NULL);
     g_assert_cmpint (check->hits, ==, 2);
-    g_assert (gnc_account_list_name_violations (NULL, sep) == NULL);
+    g_assert_true (gnc_account_list_name_violations (NULL, sep) == NULL);
     g_log_set_default_handler (oldlogger, NULL);
     results = gnc_account_list_name_violations (book, sep);
     g_assert_cmpuint (g_list_length (results), == , 2);
@@ -590,33 +590,33 @@ test_gnc_account_create_and_destroy (void)
     g_assert_cmpstr (fname, == , "");
     g_assert_cmpstr (code, == , "");
     g_assert_cmpstr (desc, == , "");
-    g_assert (!color);
-    g_assert (!notes);
-    g_assert (type == ACCT_TYPE_NONE);
-    g_assert (!commo);
-    g_assert (!commo_scu);
-    g_assert (!non_std_scu);
-    g_assert (!sort_dirty);
-    g_assert (!bal_dirty);
-    g_assert (gnc_numeric_zero_p (*end_bal));
-    g_assert (gnc_numeric_zero_p (*end_clr_bal));
-    g_assert (gnc_numeric_zero_p (*end_rec_bal));
-    g_assert (gnc_numeric_zero_p (*start_bal));
-    g_assert (gnc_numeric_zero_p (*start_clr_bal));
-    g_assert (gnc_numeric_zero_p (*start_rec_bal));
-    g_assert (!opening_balance);
-    g_assert (pol == xaccGetFIFOPolicy ());
-    g_assert (!mark);
-    g_assert (!tax_rel);
-    g_assert (!tax_code);
-    g_assert (!tax_src);
-    g_assert (copy_num == 1);
-    g_assert (!hide);
-    g_assert (!hold);
-    g_assert (gnc_account_get_parent (acc) == NULL);
-    g_assert (gnc_account_get_children (acc) == NULL);
-    g_assert (xaccAccountGetLotList (acc) == NULL);
-    g_assert (xaccAccountGetSplitList (acc) == NULL);
+    g_assert_true (!color);
+    g_assert_true (!notes);
+    g_assert_true (type == ACCT_TYPE_NONE);
+    g_assert_true (!commo);
+    g_assert_true (!commo_scu);
+    g_assert_true (!non_std_scu);
+    g_assert_true (!sort_dirty);
+    g_assert_true (!bal_dirty);
+    g_assert_true (gnc_numeric_zero_p (*end_bal));
+    g_assert_true (gnc_numeric_zero_p (*end_clr_bal));
+    g_assert_true (gnc_numeric_zero_p (*end_rec_bal));
+    g_assert_true (gnc_numeric_zero_p (*start_bal));
+    g_assert_true (gnc_numeric_zero_p (*start_clr_bal));
+    g_assert_true (gnc_numeric_zero_p (*start_rec_bal));
+    g_assert_true (!opening_balance);
+    g_assert_true (pol == xaccGetFIFOPolicy ());
+    g_assert_true (!mark);
+    g_assert_true (!tax_rel);
+    g_assert_true (!tax_code);
+    g_assert_true (!tax_src);
+    g_assert_true (copy_num == 1);
+    g_assert_true (!hide);
+    g_assert_true (!hold);
+    g_assert_true (gnc_account_get_parent (acc) == NULL);
+    g_assert_true (gnc_account_get_children (acc) == NULL);
+    g_assert_true (xaccAccountGetLotList (acc) == NULL);
+    g_assert_true (xaccAccountGetSplitList (acc) == NULL);
     g_free (name);
     g_free (fname);
     g_free (code);
@@ -676,13 +676,13 @@ test_gnc_book_set_get_root_account (Fixture *fixture, gconstpointer pData)
     GLogFunc oldlogger;
     QofBook *book2 = gnc_account_get_book (fixture->acct);
     acc1 = gnc_book_get_root_account (NULL);
-    g_assert (!acc1);
+    g_assert_true (!acc1);
     /* Check that an account is created, and that it isn't the same as the
      * one in fixture.
      */
     acc1 = gnc_book_get_root_account (book1);
-    g_assert (acc1);
-    g_assert (acc1 != fixture->acct);
+    g_assert_true (acc1);
+    g_assert_true (acc1 != fixture->acct);
     /* Now try to set the book's root account to the fixture
      * account. Should throw an error.
      */
@@ -690,17 +690,17 @@ test_gnc_book_set_get_root_account (Fixture *fixture, gconstpointer pData)
     g_test_log_set_fatal_handler ((GTestLogFatalFunc)test_checked_handler,
                                   check);
     gnc_book_set_root_account (book1, fixture->acct);
-    g_assert (gnc_book_get_root_account (book1) == acc1);
+    g_assert_true (gnc_book_get_root_account (book1) == acc1);
     g_assert_cmpint (check->hits, ==, 1);
     g_log_set_default_handler (oldlogger, NULL);
     /* Check that if we set the same root, it stays set */
     gnc_book_set_root_account (book2, fixture->acct);
-    g_assert (gnc_book_get_root_account (book2) == fixture->acct);
+    g_assert_true (gnc_book_get_root_account (book2) == fixture->acct);
     /* Create a new account in book1 and check that we can set it to root */
     acc2 = xaccMallocAccount (book1);
     gnc_book_set_root_account (book1, acc2);
-    g_assert (gnc_book_get_root_account (book1) != acc1);
-    g_assert (gnc_book_get_root_account (book1) == acc2);
+    g_assert_true (gnc_book_get_root_account (book1) != acc1);
+    g_assert_true (gnc_book_get_root_account (book1) == acc2);
     /* Clean up */
     /* acc1 gets freed by setting the root account to acc2
         g_object_unref (acc1);
@@ -718,7 +718,7 @@ test_xaccMallocAccount (void)
     Account *acc;
     TestSignal signal = test_signal_new (NULL, QOF_EVENT_CREATE, NULL);
     acc = xaccMallocAccount (book);
-    g_assert (acc != NULL);
+    g_assert_true (acc != NULL);
     test_signal_assert_hits (signal, 1);
     test_signal_free (signal);
     g_object_unref (acc);
@@ -738,12 +738,12 @@ test_gnc_account_create_root (void)
     AccountTestFunctions *func = _utest_account_fill_functions ();
     /* Can't use gnc_book_get_root_account, it creates one if it doesn't
      * yet exist */
-    g_assert (func->coll_get_root_account (coll) == NULL);
+    g_assert_true (func->coll_get_root_account (coll) == NULL);
     acc = gnc_account_create_root (book);
-    g_assert (acc);
+    g_assert_true (acc);
     g_object_get (acc, "name", &name, NULL);
     g_assert_cmpstr (name, == , "Root Account");
-    g_assert (gnc_book_get_root_account (book) == acc);
+    g_assert_true (gnc_book_get_root_account (book) == acc);
     g_object_unref (acc);
     qof_book_destroy (book);
     g_free (func);
@@ -767,28 +767,28 @@ test_xaccCloneAccount (Fixture *fixture, gconstpointer pData)
                                                 check);
     g_test_log_set_fatal_handler ((GTestLogFatalFunc)test_checked_substring_handler, check);
     clone = xaccCloneAccount (NULL, book);
-    g_assert (clone == NULL);
+    g_assert_true (clone == NULL);
     g_assert_cmpint (check->hits, ==, 1);
     g_free(check->msg);
     check->msg = g_strdup(msg2);
     clone = xaccCloneAccount (fixture->acct, NULL);
-    g_assert (clone == NULL);
+    g_assert_true (clone == NULL);
     g_assert_cmpint (check->hits, ==, 2);
     g_log_set_default_handler (oldlogger, NULL);
     /* Now test the real clone */
     clone = xaccCloneAccount (fixture->acct, book);
-    g_assert (clone);
+    g_assert_true (clone);
     acct_p = fixture->func->get_private (fixture->acct);
     clone_p = fixture->func->get_private (clone);
-    g_assert (clone_p->type == acct_p->type);
-    g_assert (clone_p->accountName == acct_p->accountName);
-    g_assert (clone_p->accountCode == acct_p->accountCode);
-    g_assert (clone_p->description == acct_p->description);
-    g_assert (compare (clone->inst.kvp_data,
+    g_assert_true (clone_p->type == acct_p->type);
+    g_assert_true (clone_p->accountName == acct_p->accountName);
+    g_assert_true (clone_p->accountCode == acct_p->accountCode);
+    g_assert_true (clone_p->description == acct_p->description);
+    g_assert_true (compare (clone->inst.kvp_data,
                        fixture->acct->inst.kvp_data) == 0);
-    g_assert (gnc_commodity_equal (clone_p->commodity, acct_p->commodity));
-    g_assert (clone_p->commodity_scu == acct_p->commodity_scu);
-    g_assert (clone_p->non_standard_scu == acct_p->non_standard_scu);
+    g_assert_true (gnc_commodity_equal (clone_p->commodity, acct_p->commodity));
+    g_assert_true (clone_p->commodity_scu == acct_p->commodity_scu);
+    g_assert_true (clone_p->non_standard_scu == acct_p->non_standard_scu);
     /* Clean Up */
     test_error_struct_free(check);
     g_object_unref (clone);
@@ -891,11 +891,11 @@ test_xaccFreeAccount (Fixture *fixture, gconstpointer pData)
     }
     xaccAccountSetCommodity (parent, commodity);
     /* Check that we've got children, lots, and splits to remove */
-    g_assert (p_priv->children != NULL);
-    g_assert (p_priv->lots != NULL);
-    g_assert (p_priv->splits != NULL);
-    g_assert (p_priv->parent != NULL);
-    g_assert (p_priv->commodity != NULL);
+    g_assert_true (p_priv->children != NULL);
+    g_assert_true (p_priv->lots != NULL);
+    g_assert_true (p_priv->splits != NULL);
+    g_assert_true (p_priv->parent != NULL);
+    g_assert_true (p_priv->commodity != NULL);
     g_assert_cmpint (check1->hits, ==, 0);
     g_assert_cmpint (check2->hits, ==, 0);
     /* Now set the other private parts to something so that they can be set back */
@@ -1006,11 +1006,11 @@ test_xaccAccountCommitEdit (Fixture *fixture, gconstpointer pData)
     }
     xaccAccountSetCommodity (parent, commodity);
     /* Check that we've got children, lots, and splits to remove */
-    g_assert (p_priv->children != NULL);
-    g_assert (p_priv->lots != NULL);
-    g_assert (p_priv->splits != NULL);
-    g_assert (p_priv->parent != NULL);
-    g_assert (p_priv->commodity != NULL);
+    g_assert_true (p_priv->children != NULL);
+    g_assert_true (p_priv->lots != NULL);
+    g_assert_true (p_priv->splits != NULL);
+    g_assert_true (p_priv->parent != NULL);
+    g_assert_true (p_priv->commodity != NULL);
     g_assert_cmpint (check1->hits, ==, 0);
     g_assert_cmpint (check2->hits, ==, 0);
 
@@ -1022,11 +1022,11 @@ test_xaccAccountCommitEdit (Fixture *fixture, gconstpointer pData)
     /* Make sure that the account didn't get destroyed */
     test_signal_assert_hits (sig1, 1);
     test_signal_assert_hits (sig2, 0);
-    g_assert (p_priv->children != NULL);
-    g_assert (p_priv->lots != NULL);
-    g_assert (p_priv->splits != NULL);
-    g_assert (p_priv->parent != NULL);
-    g_assert (p_priv->commodity != NULL);
+    g_assert_true (p_priv->children != NULL);
+    g_assert_true (p_priv->lots != NULL);
+    g_assert_true (p_priv->splits != NULL);
+    g_assert_true (p_priv->parent != NULL);
+    g_assert_true (p_priv->commodity != NULL);
     g_assert_cmpint (check1->hits, ==, 0);
     g_assert_cmpint (check2->hits, ==, 0);
     /* xaccAccountDestroy destroys the account by calling
@@ -1097,22 +1097,22 @@ test_gnc_account_kvp_setters_getters (Fixture *fixture, gconstpointer pData)
     int prev_months, prev_days;
 
     // equity_type getter/setter
-    g_assert (xaccAccountGetIsOpeningBalance (account) == FALSE);
+    g_assert_true (xaccAccountGetIsOpeningBalance (account) == FALSE);
 
     xaccAccountSetIsOpeningBalance (account, TRUE);
-    g_assert (xaccAccountGetIsOpeningBalance (account) == TRUE);
+    g_assert_true (xaccAccountGetIsOpeningBalance (account) == TRUE);
 
     xaccAccountSetIsOpeningBalance (account, FALSE);
-    g_assert (xaccAccountGetIsOpeningBalance (account) == FALSE);
+    g_assert_true (xaccAccountGetIsOpeningBalance (account) == FALSE);
 
     // sortreversed getter/setter
-    g_assert (xaccAccountGetSortReversed (account) == FALSE);
+    g_assert_true (xaccAccountGetSortReversed (account) == FALSE);
 
     xaccAccountSetSortReversed (account, TRUE);
-    g_assert (xaccAccountGetSortReversed (account) == TRUE);
+    g_assert_true (xaccAccountGetSortReversed (account) == TRUE);
 
     xaccAccountSetSortReversed (account, FALSE);
-    g_assert (xaccAccountGetSortReversed (account) == FALSE);
+    g_assert_true (xaccAccountGetSortReversed (account) == FALSE);
 
     // color getter/setter
     g_assert_cmpstr (xaccAccountGetColor (account), ==, nullptr);
@@ -1238,59 +1238,59 @@ test_gnc_account_kvp_setters_getters (Fixture *fixture, gconstpointer pData)
     g_assert_cmpstr (xaccAccountGetNotes (account), ==, nullptr);
 
     // Balance Limits getter/setter
-    g_assert (xaccAccountGetHigherBalanceLimit (account, &balance_limit) == false);
-    g_assert (xaccAccountGetLowerBalanceLimit (account, &balance_limit) == false);
-    g_assert (xaccAccountGetIncludeSubAccountBalances (account) == false);
+    g_assert_true (xaccAccountGetHigherBalanceLimit (account, &balance_limit) == false);
+    g_assert_true (xaccAccountGetLowerBalanceLimit (account, &balance_limit) == false);
+    g_assert_true (xaccAccountGetIncludeSubAccountBalances (account) == false);
 
     xaccAccountSetHigherBalanceLimit (account, h_balance);
     xaccAccountSetLowerBalanceLimit (account, l_balance);
     xaccAccountSetIncludeSubAccountBalances (account, true);
 
-    g_assert (xaccAccountGetHigherBalanceLimit (account, &balance_limit) == true);
+    g_assert_true (xaccAccountGetHigherBalanceLimit (account, &balance_limit) == true);
     g_assert_cmpint (gnc_numeric_compare (h_balance, balance_limit), ==, 0);
 
-    g_assert (xaccAccountGetLowerBalanceLimit (account, &balance_limit) == true);
+    g_assert_true (xaccAccountGetLowerBalanceLimit (account, &balance_limit) == true);
     g_assert_cmpint (gnc_numeric_compare (l_balance, balance_limit), ==, 0);
 
-    g_assert (xaccAccountGetIncludeSubAccountBalances (account) == true);
+    g_assert_true (xaccAccountGetIncludeSubAccountBalances (account) == true);
 
     xaccAccountSetIncludeSubAccountBalances (account, false);
 
     xaccAccountClearHigherBalanceLimit (account);
     xaccAccountClearLowerBalanceLimit (account);
 
-    g_assert (xaccAccountGetHigherBalanceLimit (account, &balance_limit) == false);
-    g_assert (xaccAccountGetLowerBalanceLimit (account, &balance_limit) == false);
-    g_assert (xaccAccountGetIncludeSubAccountBalances (account) == false);
+    g_assert_true (xaccAccountGetHigherBalanceLimit (account, &balance_limit) == false);
+    g_assert_true (xaccAccountGetLowerBalanceLimit (account, &balance_limit) == false);
+    g_assert_true (xaccAccountGetIncludeSubAccountBalances (account) == false);
 
     // Reconcile getter/setter
     date = date - (60*60*24*7); // -7 days
     xaccAccountSetReconcileLastDate (account, date);
     xaccAccountGetReconcileLastDate (account, &returned_date);
-    g_assert (date == returned_date);
+    g_assert_true (date == returned_date);
 
     date = date + (60*60*24*2); // +2 days
     xaccAccountSetReconcilePostponeDate (account, date);
     xaccAccountGetReconcilePostponeDate (account, &returned_date);
-    g_assert (date == returned_date);
+    g_assert_true (date == returned_date);
 
-    g_assert (xaccAccountGetReconcilePostponeBalance (account, &returned_post_balance) == false);
+    g_assert_true (xaccAccountGetReconcilePostponeBalance (account, &returned_post_balance) == false);
     xaccAccountSetReconcilePostponeBalance (account, post_balance);
-    g_assert (xaccAccountGetReconcilePostponeBalance (account, &returned_post_balance) == true);
+    g_assert_true (xaccAccountGetReconcilePostponeBalance (account, &returned_post_balance) == true);
     g_assert_cmpint (gnc_numeric_compare (post_balance, returned_post_balance), ==, 0);
 
     xaccAccountClearReconcilePostpone (account);
-    g_assert (xaccAccountGetReconcilePostponeBalance (account, &returned_post_balance) == false);
+    g_assert_true (xaccAccountGetReconcilePostponeBalance (account, &returned_post_balance) == false);
 
-    g_assert (xaccAccountGetReconcileLastInterval (account, &prev_months, &prev_days) == false);
+    g_assert_true (xaccAccountGetReconcileLastInterval (account, &prev_months, &prev_days) == false);
     xaccAccountSetReconcileLastInterval (account, 2, 6);
-    g_assert (xaccAccountGetReconcileLastInterval (account, &prev_months, &prev_days) == true);
-    g_assert (prev_months == 2);
-    g_assert (prev_days == 6);
+    g_assert_true (xaccAccountGetReconcileLastInterval (account, &prev_months, &prev_days) == true);
+    g_assert_true (prev_months == 2);
+    g_assert_true (prev_days == 6);
 
-    g_assert (xaccAccountGetReconcileChildrenStatus (account) == false); //default
+    g_assert_true (xaccAccountGetReconcileChildrenStatus (account) == false); //default
     xaccAccountSetReconcileChildrenStatus (account, true);
-    g_assert (xaccAccountGetReconcileChildrenStatus (account) == true);
+    g_assert_true (xaccAccountGetReconcileChildrenStatus (account) == true);
 
     // STOCK_ACCOUNT tests from now on
     xaccAccountSetType (account, ACCT_TYPE_STOCK);
@@ -1396,22 +1396,22 @@ test_gnc_account_insert_remove_split (Fixture *fixture, gconstpointer pData)
     g_test_log_set_fatal_handler ((GTestLogFatalFunc)test_list_substring_handler, NULL);
 
     /* Check that the call fails with invalid account and split (throws) */
-    g_assert (!gnc_account_insert_split (NULL, split1));
+    g_assert_true (!gnc_account_insert_split (NULL, split1));
     g_assert_cmpuint (g_list_length (priv->splits), == , 0);
-    g_assert (!priv->sort_dirty);
-    g_assert (!priv->balance_dirty);
+    g_assert_true (!priv->sort_dirty);
+    g_assert_true (!priv->balance_dirty);
     test_signal_assert_hits (sig1, 0);
     test_signal_assert_hits (sig2, 0);
-    g_assert (!gnc_account_insert_split (fixture->acct, NULL));
+    g_assert_true (!gnc_account_insert_split (fixture->acct, NULL));
     g_assert_cmpuint (g_list_length (priv->splits), == , 0);
-    g_assert (!priv->sort_dirty);
-    g_assert (!priv->balance_dirty);
+    g_assert_true (!priv->sort_dirty);
+    g_assert_true (!priv->balance_dirty);
     test_signal_assert_hits (sig1, 0);
     test_signal_assert_hits (sig2, 0);
-    /* g_assert (!gnc_account_insert_split (fixture->acct, (Split*)priv)); */
+    /* g_assert_true (!gnc_account_insert_split (fixture->acct, (Split*)priv)); */
     /* g_assert_cmpuint (g_list_length (priv->splits), == , 0); */
-    /* g_assert (!priv->sort_dirty); */
-    /* g_assert (!priv->balance_dirty); */
+    /* g_assert_true (!priv->sort_dirty); */
+    /* g_assert_true (!priv->balance_dirty); */
     /* test_signal_assert_hits (sig1, 0); */
     /* test_signal_assert_hits (sig2, 0); */
     g_assert_cmpint (check1->hits, ==, 1);
@@ -1421,33 +1421,33 @@ test_gnc_account_insert_remove_split (Fixture *fixture, gconstpointer pData)
     test_clear_error_list ();
 
     /* Check that it works the first time */
-    g_assert (gnc_account_insert_split (fixture->acct, split1));
+    g_assert_true (gnc_account_insert_split (fixture->acct, split1));
     g_assert_cmpuint (g_list_length (priv->splits), == , 1);
-    g_assert (!priv->sort_dirty);
-    g_assert (priv->balance_dirty);
+    g_assert_true (!priv->sort_dirty);
+    g_assert_true (priv->balance_dirty);
     test_signal_assert_hits (sig1, 1);
     test_signal_assert_hits (sig2, 1);
     /* Check that it fails if the split has already been added once */
-    g_assert (!gnc_account_insert_split (fixture->acct, split1));
+    g_assert_true (!gnc_account_insert_split (fixture->acct, split1));
     /* Free up hdlr2 and set up hdlr2 */
     test_signal_free (sig2);
     sig3 = test_signal_new (&fixture->acct->inst, GNC_EVENT_ITEM_ADDED, split2);
     /* Now add a second split to the account and check that sort_dirty isn't set. We have to bump the editlevel to force this. */
-    g_assert (gnc_account_insert_split (fixture->acct, split2));
+    g_assert_true (gnc_account_insert_split (fixture->acct, split2));
     g_assert_cmpuint (g_list_length (priv->splits), == , 2);
-    g_assert (!priv->sort_dirty);
-    g_assert (priv->balance_dirty);
+    g_assert_true (!priv->sort_dirty);
+    g_assert_true (priv->balance_dirty);
     test_signal_assert_hits (sig1, 2);
     test_signal_assert_hits (sig3, 1);
     /* One more add, incrementing the editlevel to get sort_dirty set. */
     test_signal_free (sig3);
     sig3 = test_signal_new (&fixture->acct->inst, GNC_EVENT_ITEM_ADDED, split3);
     qof_instance_increase_editlevel (fixture->acct);
-    g_assert (gnc_account_insert_split (fixture->acct, split3));
+    g_assert_true (gnc_account_insert_split (fixture->acct, split3));
     qof_instance_decrease_editlevel (fixture->acct);
     g_assert_cmpuint (g_list_length (priv->splits), == , 3);
-    g_assert (priv->sort_dirty);
-    g_assert (priv->balance_dirty);
+    g_assert_true (priv->sort_dirty);
+    g_assert_true (priv->balance_dirty);
     test_signal_assert_hits (sig1, 3);
     test_signal_assert_hits (sig3, 1);
     /* Finally delete a split. It's going to recompute the balance, so
@@ -1455,18 +1455,18 @@ test_gnc_account_insert_remove_split (Fixture *fixture, gconstpointer pData)
     test_signal_free (sig3);
     sig3 = test_signal_new (&fixture->acct->inst, GNC_EVENT_ITEM_REMOVED,
                             split3);
-    g_assert (gnc_account_remove_split (fixture->acct, split3));
+    g_assert_true (gnc_account_remove_split (fixture->acct, split3));
     g_assert_cmpuint (g_list_length (priv->splits), == , 2);
-    g_assert (priv->sort_dirty);
-    g_assert (!priv->balance_dirty);
+    g_assert_true (priv->sort_dirty);
+    g_assert_true (!priv->balance_dirty);
     test_signal_assert_hits (sig1, 4);
     test_signal_assert_hits (sig3, 1);
     /* And do it again to make sure that it fails when the split has
      * already been removed */
-    g_assert (!gnc_account_remove_split (fixture->acct, split3));
+    g_assert_true (!gnc_account_remove_split (fixture->acct, split3));
     g_assert_cmpuint (g_list_length (priv->splits), == , 2);
-    g_assert (priv->sort_dirty);
-    g_assert (!priv->balance_dirty);
+    g_assert_true (priv->sort_dirty);
+    g_assert_true (!priv->balance_dirty);
     test_signal_assert_hits (sig1, 4);
     test_signal_assert_hits (sig3, 1);
 
@@ -1527,19 +1527,19 @@ test_xaccAccountInsertRemoveLot (Fixture *fixture, gconstpointer pData)
     g_assert_cmpuint (g_list_length (a_priv->lots), == , 0);
     g_assert_cmpuint (g_list_length (p_priv->lots), == , 0);
     xaccAccountInsertLot (fixture->acct, lot);
-    g_assert (gnc_lot_get_account (lot) == fixture->acct);
+    g_assert_true (gnc_lot_get_account (lot) == fixture->acct);
     g_assert_cmpuint (g_list_length (a_priv->lots), == , 1);
     test_signal_assert_hits (sig1, 1);
     test_signal_assert_hits (sig2, 1);
     /* Make sure that inserting again doesn't do anything */
     xaccAccountInsertLot (fixture->acct, lot);
-    g_assert (gnc_lot_get_account (lot) == fixture->acct);
+    g_assert_true (gnc_lot_get_account (lot) == fixture->acct);
     g_assert_cmpuint (g_list_length (a_priv->lots), == , 1);
     test_signal_assert_hits (sig1, 1);
     test_signal_assert_hits (sig2, 1);
     /* Check that inserting the lot into a different account changes the lot */
     xaccAccountInsertLot (parent, lot);
-    g_assert (gnc_lot_get_account (lot) == parent);
+    g_assert_true (gnc_lot_get_account (lot) == parent);
     g_assert_cmpuint (g_list_length (a_priv->lots), == , 0);
     g_assert_cmpuint (g_list_length (p_priv->lots), == , 1);
     test_signal_assert_hits (sig1, 2);
@@ -1550,7 +1550,7 @@ test_xaccAccountInsertRemoveLot (Fixture *fixture, gconstpointer pData)
     /* The following test should fail, but it doesn't because of an
      * error in the routine: When removing a lot from an account, the
      * account reference in the lot object should be NULLed. */
-    g_assert (gnc_lot_get_account (lot) != NULL);
+    g_assert_true (gnc_lot_get_account (lot) != NULL);
     g_assert_cmpuint (g_list_length (a_priv->lots), == , 0);
     g_assert_cmpuint (g_list_length (p_priv->lots), == , 0);
     test_signal_assert_hits (sig3, 1);
@@ -1562,7 +1562,7 @@ test_xaccAccountInsertRemoveLot (Fixture *fixture, gconstpointer pData)
     gnc_lot_set_account (lot, NULL);
     xaccAccountInsertLot (parent, lot);
     g_assert_cmpuint (g_list_length (p_priv->lots), == , 1);
-    g_assert (gnc_lot_get_account (lot) == parent);
+    g_assert_true (gnc_lot_get_account (lot) == parent);
     gnc_lot_destroy (lot);
     /* Destroying the lot should remove it from the account. */
     g_assert_cmpuint (g_list_length (p_priv->lots), == , 0);
@@ -1602,7 +1602,7 @@ test_xaccAccountRecomputeBalance (Fixture *fixture, gconstpointer pData)
                 clr_bal = gnc_numeric_zero ();
     SetupData *sdata = (SetupData*)pData;
     TxnParms* t_arr;
-    g_assert (sdata != NULL);
+    g_assert_true (sdata != NULL);
     t_arr = (TxnParms*)sdata->txns;
     for (unsigned int ind = 0; ind < sdata->num_txns; ind++)
     {
@@ -1613,15 +1613,15 @@ test_xaccAccountRecomputeBalance (Fixture *fixture, gconstpointer pData)
         if (p.reconciled == YREC || p.reconciled == FREC)
             rec_bal = gnc_numeric_add_fixed (rec_bal, p.amount);
     }
-    g_assert (gnc_numeric_zero_p (priv->starting_balance));
-    g_assert (gnc_numeric_zero_p (priv->balance));
+    g_assert_true (gnc_numeric_zero_p (priv->starting_balance));
+    g_assert_true (gnc_numeric_zero_p (priv->balance));
     priv->balance_dirty = TRUE;
     xaccAccountRecomputeBalance (fixture->acct);
-    g_assert (gnc_numeric_zero_p (priv->starting_balance));
-    g_assert (gnc_numeric_eq (priv->balance, bal));
-    g_assert (gnc_numeric_eq (priv->cleared_balance, clr_bal));
-    g_assert (gnc_numeric_eq (priv->reconciled_balance, rec_bal));
-    g_assert (!priv->balance_dirty);
+    g_assert_true (gnc_numeric_zero_p (priv->starting_balance));
+    g_assert_true (gnc_numeric_eq (priv->balance, bal));
+    g_assert_true (gnc_numeric_eq (priv->cleared_balance, clr_bal));
+    g_assert_true (gnc_numeric_eq (priv->reconciled_balance, rec_bal));
+    g_assert_true (!priv->balance_dirty);
 }
 
 /* xaccAccountOrder
@@ -1634,10 +1634,10 @@ test_xaccAccountOrder ( )
     QofBook *book = qof_book_new ();
 
 
-    g_assert (xaccAccountOrder (aa, ab) == 0);
+    g_assert_true (xaccAccountOrder (aa, ab) == 0);
     aa = xaccMallocAccount (book);
-    g_assert (xaccAccountOrder (aa, ab) == -1);
-    g_assert (xaccAccountOrder (ab, aa) == 1);
+    g_assert_true (xaccAccountOrder (aa, ab) == -1);
+    g_assert_true (xaccAccountOrder (ab, aa) == 1);
 
     ab = xaccMallocAccount (book);
     qof_instance_increase_editlevel (aa);
@@ -1730,16 +1730,16 @@ test_qofAccountSetParent (Fixture *fixture, gconstpointer pData)
     Account *root = gnc_account_get_root (fixture->acct);
     Account *old_parent = gnc_account_get_parent (fixture->acct);
     AccountTestFunctions *func = _utest_account_fill_functions ();
-    g_assert (root != old_parent);
+    g_assert_true (root != old_parent);
     /* qofAccountSetParent doesn't check to see if the parent is already
      * set, nor does gnc_account_append_child, which is the passed-through
      * function.
      */
     func->qofAccountSetParent (fixture->acct, QOF_INSTANCE (root));
-    g_assert (root == gnc_account_get_parent (fixture->acct));
-    g_assert (qof_instance_get_dirty (QOF_INSTANCE (fixture->acct)));
-    g_assert (qof_instance_get_dirty (QOF_INSTANCE (root)));
-    g_assert (qof_instance_get_dirty (QOF_INSTANCE (old_parent)));
+    g_assert_true (root == gnc_account_get_parent (fixture->acct));
+    g_assert_true (qof_instance_get_dirty (QOF_INSTANCE (fixture->acct)));
+    g_assert_true (qof_instance_get_dirty (QOF_INSTANCE (root)));
+    g_assert_true (qof_instance_get_dirty (QOF_INSTANCE (old_parent)));
 }
 /* gnc_account_append_child
 void
@@ -1772,16 +1772,16 @@ test_gnc_account_append_remove_child (Fixture *fixture, gconstpointer pData)
     sig3 = test_signal_new (QOF_INSTANCE (account), QOF_EVENT_CREATE, NULL);
 
     gnc_account_append_child (froot, account);
-    g_assert (gnc_account_get_parent (account) == froot);
+    g_assert_true (gnc_account_get_parent (account) == froot);
     test_signal_assert_hits (sig1, 1);
     test_signal_assert_hits (sig2, 0);
     test_signal_assert_hits (sig3, 0);
     g_assert_cmpint (check_warn->hits, ==, 0);
     g_assert_cmpint (check_err->hits, ==, 0);
-    g_assert (qof_instance_get_dirty (QOF_INSTANCE (froot)));
-    g_assert (qof_instance_get_dirty (QOF_INSTANCE (account)));
-    g_assert (g_list_find (frpriv->children, account));
-    g_assert (qof_collection_lookup_entity (
+    g_assert_true (qof_instance_get_dirty (QOF_INSTANCE (froot)));
+    g_assert_true (qof_instance_get_dirty (QOF_INSTANCE (account)));
+    g_assert_true (g_list_find (frpriv->children, account));
+    g_assert_true (qof_collection_lookup_entity (
                   qof_book_get_collection (fbook, GNC_ID_ACCOUNT),
                   acct_guid));
     auto loglevelr = static_cast<GLogLevelFlags>(G_LOG_LEVEL_WARNING |
@@ -1793,21 +1793,21 @@ test_gnc_account_append_remove_child (Fixture *fixture, gconstpointer pData)
     gnc_account_append_child (fixture->acct, account);
     g_log_remove_handler (logdomain, log_handler);
     g_assert_cmpstr (msg1, == , check_warn->msg);
-    g_assert (gnc_account_get_parent (account) == fixture->acct);
+    g_assert_true (gnc_account_get_parent (account) == fixture->acct);
     test_signal_assert_hits (sig1, 2);
     test_signal_assert_hits (sig2, 1);
     test_signal_assert_hits (sig3, 1);
     g_assert_cmpint (check_warn->hits, ==, 1);
     g_assert_cmpint (check_err->hits, ==, 0);
-    g_assert (!qof_collection_lookup_entity (
+    g_assert_true (!qof_collection_lookup_entity (
                   qof_book_get_collection (fbook, GNC_ID_ACCOUNT),
                   acct_guid));
-    g_assert (qof_collection_lookup_entity (
+    g_assert_true (qof_collection_lookup_entity (
                   qof_book_get_collection (book, GNC_ID_ACCOUNT),
                   acct_guid));
-    g_assert (qof_instance_get_dirty (QOF_INSTANCE (fixture->acct)));
-    g_assert (g_list_find (frpriv->children, account) == NULL);
-    g_assert (g_list_find (apriv->children, account));
+    g_assert_true (qof_instance_get_dirty (QOF_INSTANCE (fixture->acct)));
+    g_assert_true (g_list_find (frpriv->children, account) == NULL);
+    g_assert_true (g_list_find (apriv->children, account));
 
     test_signal_free (sig1);
     test_signal_free (sig2);
@@ -1826,8 +1826,8 @@ test_gnc_account_append_remove_child (Fixture *fixture, gconstpointer pData)
     g_assert_cmpint (check_warn->hits, ==, 1);
 
     gnc_account_remove_child (fixture->acct, account);
-    g_assert (gnc_account_get_parent (account) == NULL);
-    g_assert (g_list_find (apriv->children, account) == NULL);
+    g_assert_true (gnc_account_get_parent (account) == NULL);
+    g_assert_true (g_list_find (apriv->children, account) == NULL);
     test_signal_assert_hits (sig1, 1);
     test_signal_assert_hits (sig2, 1);
     g_assert_cmpint (check_warn->hits, ==, 1);
@@ -1912,12 +1912,12 @@ test_gnc_account_get_descendants (Fixture *fixture, gconstpointer pData)
 
     GList *list = gnc_account_get_descendants (
                       gnc_account_get_root (fixture->acct));
-    g_assert (list != NULL);
+    g_assert_true (list != NULL);
     g_assert_cmpuint (g_list_length (list), == , 34);
     g_assert_cmpint (g_list_index (list, fixture->acct), == , 33);
     g_list_free (list);
     list = gnc_account_get_descendants (fixture->acct);
-    g_assert (list == NULL);
+    g_assert_true (list == NULL);
 }
 /* gnc_account_get_descendants_sorted
 GList *
@@ -1927,7 +1927,7 @@ test_gnc_account_get_descendants_sorted (Fixture *fixture, gconstpointer pData)
 {
     GList *list = gnc_account_get_descendants_sorted (
                       gnc_account_get_root (fixture->acct));
-    g_assert (list != NULL);
+    g_assert_true (list != NULL);
     g_list_foreach (list, print_account, NULL);
     g_assert_cmpuint (g_list_length (list), == , 34);
     g_assert_cmpint (g_list_index (list, fixture->acct), == , 10);
@@ -1943,21 +1943,21 @@ test_gnc_account_lookup_by_name (Fixture *fixture, gconstpointer pData)
     gchar *code;
     root = gnc_account_get_root (fixture->acct);
     target = gnc_account_lookup_by_name (root, "income");
-    g_assert (target != NULL);
+    g_assert_true (target != NULL);
     g_object_get (target, "code", &code, NULL);
     g_assert_cmpstr (code, == , "4000");
     target = gnc_account_lookup_by_name (target, "int");
-    g_assert (target != NULL);
+    g_assert_true (target != NULL);
     g_free (code);
     g_object_get (target, "code", &code, NULL);
     g_assert_cmpstr (code, == , "4160");
     target = gnc_account_lookup_by_name (root, "bank");
-    g_assert (target != NULL);
+    g_assert_true (target != NULL);
     g_free (code);
     g_object_get (target, "code", &code, NULL);
     g_assert_cmpstr (code, == , "2300");
     target = gnc_account_lookup_by_name (target, "int");
-    g_assert (target == NULL);
+    g_assert_true (target == NULL);
     g_free (code);
 
 }
@@ -1973,7 +1973,7 @@ test_gnc_account_lookup_by_name_duplicated (Fixture *fixture, gconstpointer pDat
     gchar *code;
     root = gnc_account_get_root (fixture->acct);
     target = gnc_account_lookup_by_name (root, "B");
-    g_assert (target != NULL);
+    g_assert_true (target != NULL);
     g_object_get (target, "code", &code, NULL);
     g_assert_cmpstr (code, == , "1B");
     g_free (code);
@@ -1989,16 +1989,16 @@ test_gnc_account_lookup_by_code (Fixture *fixture, gconstpointer pData)
     gchar *name;
     root = gnc_account_get_root (fixture->acct);
     target = gnc_account_lookup_by_code (root, "3100");
-    g_assert (target != NULL);
+    g_assert_true (target != NULL);
     g_object_get (target, "name", &name, NULL);
     g_assert_cmpstr (name, == , "ordinary");
     g_free (name);
     target = gnc_account_lookup_by_code (target, "3150");
-    g_assert (target != NULL);
+    g_assert_true (target != NULL);
     g_object_get (target, "name", &name, NULL);
     g_assert_cmpstr (name, == , "utilities");
     target = gnc_account_lookup_by_code (target, "2100");
-    g_assert (target == NULL);
+    g_assert_true (target == NULL);
     g_free (name);
 }
 /* gnc_account_lookup_by_full_name_helper
@@ -2018,16 +2018,16 @@ test_gnc_account_lookup_by_full_name_helper ( Fixture *fixture,
 
     root = gnc_account_get_root (fixture->acct);
     target = func->gnc_account_lookup_by_full_name_helper (root, const_cast<char**>(names1));
-    g_assert (target != NULL);
+    g_assert_true (target != NULL);
     g_object_get (target, "code", &code, NULL);
     g_assert_cmpstr (code, == , "4160");
     g_free (code);
     target = func->gnc_account_lookup_by_full_name_helper (root, const_cast<char**>(names2));
-    g_assert (target != NULL);
+    g_assert_true (target != NULL);
     g_object_get (target, "code", &code, NULL);
     g_assert_cmpstr (code, == , "4210");
     target = func->gnc_account_lookup_by_full_name_helper (root, const_cast<char**>(names3));
-    g_assert (target == NULL);
+    g_assert_true (target == NULL);
     g_free (code);
 }
 /* gnc_account_lookup_by_full_name
@@ -2044,16 +2044,16 @@ test_gnc_account_lookup_by_full_name (Fixture *fixture, gconstpointer pData)
 
     root = gnc_account_get_root (fixture->acct);
     target = gnc_account_lookup_by_full_name (root, names1);
-    g_assert (target != NULL);
+    g_assert_true (target != NULL);
     g_object_get (target, "code", &code, NULL);
     g_assert_cmpstr (code, == , "4160");
     g_free (code);
     target = gnc_account_lookup_by_full_name (root, names2);
-    g_assert (target != NULL);
+    g_assert_true (target != NULL);
     g_object_get (target, "code", &code, NULL);
     g_assert_cmpstr (code, == , "4210");
     target = gnc_account_lookup_by_full_name (root, names3);
-    g_assert (target == NULL);
+    g_assert_true (target == NULL);
     g_free (code);
 }
 
@@ -2061,7 +2061,7 @@ static void
 thunk (Account *s, gpointer data)
 {
     guint *counter = (guint*)data;
-    g_assert (GNC_IS_ACCOUNT (s));
+    g_assert_true (GNC_IS_ACCOUNT (s));
     ++(*counter);
 }
 
@@ -2070,7 +2070,7 @@ thunk2 (Account *s, gpointer data)
 {
     guint *counter = (guint*)data;
     gchar *name;
-    g_assert (GNC_IS_ACCOUNT (s));
+    g_assert_true (GNC_IS_ACCOUNT (s));
     g_object_get (G_OBJECT (s), "name", &name, NULL);
     if (!g_strcmp0 (name, "int"))
     {
@@ -2107,10 +2107,10 @@ test_gnc_account_foreach_child_until (Fixture *fixture, gconstpointer pData)
     guint counter = 0;
     result = gnc_account_foreach_child_until (first, thunk2, &counter);
     g_assert_cmpint (counter, ==, 2);
-    g_assert (result == NULL);
+    g_assert_true (result == NULL);
     counter = 0;
     result = gnc_account_foreach_child_until (second, thunk2, &counter);
-    g_assert (result == expected);
+    g_assert_true (result == expected);
     g_assert_cmpint (counter, ==, 3);
     }*/
 /* gnc_account_foreach_descendant
@@ -2138,10 +2138,10 @@ test_gnc_account_foreach_descendant_until (Fixture *fixture, gconstpointer pData
     unsigned int counter = 0;
     auto result = static_cast<Account*>(gnc_account_foreach_descendant_until (first, thunk2, &counter));
     g_assert_cmpint (counter, == , 11);
-    g_assert (result == NULL);
+    g_assert_true (result == NULL);
     counter = 0;
     result = static_cast<Account*>(gnc_account_foreach_descendant_until (second, thunk2, &counter));
-    g_assert (result == expected);
+    g_assert_true (result == expected);
     g_assert_cmpint (counter, == , 6);
 }
 /* More getter/setters:
@@ -2169,15 +2169,15 @@ test_gnc_account_get_full_name (Fixture *fixture, gconstpointer pData)
 {
     gchar *result;
     result = gnc_account_get_full_name (NULL);
-    g_assert (result != NULL);
+    g_assert_true (result != NULL);
     g_assert_cmpstr (result, == , "");
     g_free (result);
     result = gnc_account_get_full_name (gnc_account_get_root (fixture->acct));
-    g_assert (result != NULL);
+    g_assert_true (result != NULL);
     g_assert_cmpstr (result, == , "");
     g_free (result);
     result = gnc_account_get_full_name (fixture->acct);
-    g_assert (result != NULL);
+    g_assert_true (result != NULL);
     g_assert_cmpstr (result, == , "foo:baz:waldo");
     g_free (result);
 
@@ -2201,7 +2201,7 @@ test_xaccAccountGetProjectedMinimumBalance (Fixture *fixture, gconstpointer pDat
     TxnParms* t_arr;
     int ind;
     gint min_ind = 4;
-    g_assert (sdata != NULL);
+    g_assert_true (sdata != NULL);
     t_arr = (TxnParms*)sdata->txns;
     for (ind = 0; ind < min_ind; ind++)
     {
@@ -2231,7 +2231,7 @@ test_xaccAccountGetBalanceAsOfDate (Fixture *fixture, gconstpointer pData)
     int ind;
     gint min_ind = 2;
     gint offset = 24 * 3600 * 3; /* 3 days in seconds */
-    g_assert (sdata != NULL);
+    g_assert_true (sdata != NULL);
     t_arr = (TxnParms*)sdata->txns;
     for (ind = 0; ind < min_ind; ind++)
     {
@@ -2258,7 +2258,7 @@ test_xaccAccountGetPresentBalance (Fixture *fixture, gconstpointer pData)
     TxnParms* t_arr;
     int ind;
     gint min_ind = 3;
-    g_assert (sdata != NULL);
+    g_assert_true (sdata != NULL);
     t_arr = (TxnParms*)sdata->txns;
     for (ind = 0; ind < min_ind; ind++)
     {
@@ -2332,21 +2332,21 @@ test_xaccAccountFindOpenLots (Fixture *fixture, gconstpointer pData)
     Account *acct = gnc_account_lookup_by_name (root, "baz");
     LotList* lots;
 
-    g_assert (acct);
+    g_assert_true (acct);
     lots = xaccAccountFindOpenLots (acct, NULL, NULL, NULL);
-    g_assert (g_list_length (lots) == 2);
+    g_assert_true (g_list_length (lots) == 2);
     if (lots) g_list_free (lots);
     lots = xaccAccountFindOpenLots (acct, bogus_lot_match_func_true,
                                     NULL, NULL);
-    g_assert (g_list_length (lots) == 2);
+    g_assert_true (g_list_length (lots) == 2);
     if (lots) g_list_free (lots);
     lots = xaccAccountFindOpenLots (acct, bogus_lot_match_func_false,
                                     NULL, NULL);
-    g_assert (g_list_length (lots) == 0);
+    g_assert_true (g_list_length (lots) == 0);
     if (lots) g_list_free (lots);
     lots = xaccAccountFindOpenLots (acct, NULL, NULL, bogus_lot_sort_func);
     g_assert_cmpint (count_sorts, == , 1);
-    g_assert (g_list_length (lots) == 2);
+    g_assert_true (g_list_length (lots) == 2);
     if (lots) g_list_free (lots);
     count_sorts = 0;
 }
@@ -2369,7 +2369,7 @@ test_xaccAccountForEachLot (Fixture *fixture, gconstpointer pData)
     Account *acct = gnc_account_lookup_by_name (root, "baz");
     guint count_calls = 0;
 
-    g_assert (acct);
+    g_assert_true (acct);
     xaccAccountForEachLot (acct, bogus_for_each_lot_func, &count_calls);
     g_assert_cmpint (count_calls, == , 3);
     xaccAccountForEachLot (acct, bogus_for_each_lot_func, &count_calls);
@@ -2402,13 +2402,13 @@ test_xaccAccountHasAncestor (Fixture *fixture, gconstpointer pData)
     Account *income = gnc_account_lookup_by_name (root, "income");
     Account *expense = gnc_account_lookup_by_name (root, "expense");
 
-    g_assert (root);
-    g_assert (ltcg);
-    g_assert (income);
-    g_assert (expense);
-    g_assert (xaccAccountHasAncestor (fixture->acct, root));
-    g_assert (xaccAccountHasAncestor (ltcg, income));
-    g_assert (!xaccAccountHasAncestor (ltcg, expense));
+    g_assert_true (root);
+    g_assert_true (ltcg);
+    g_assert_true (income);
+    g_assert_true (expense);
+    g_assert_true (xaccAccountHasAncestor (fixture->acct, root));
+    g_assert_true (xaccAccountHasAncestor (ltcg, income));
+    g_assert_true (!xaccAccountHasAncestor (ltcg, expense));
 
 }
 inline GNCAccountType& operator++(GNCAccountType& x)
@@ -2446,7 +2446,7 @@ test_xaccAccountType_Stuff (void)
         const gchar *typestr;
         gchar *typestr_uc;
 
-        g_assert (type_name);
+        g_assert_true (type_name);
         g_assert_cmpint (xaccAccountStringToEnum (type_name), == , type);
         if (type < 0 || type >= NUM_ACCOUNT_TYPES)
             continue;
@@ -2480,9 +2480,9 @@ test_xaccAccountType_Stuff (void)
 	qof_instance_decrease_editlevel (acc);
         if (type == ACCT_TYPE_STOCK || type == ACCT_TYPE_MUTUAL ||
                 type == ACCT_TYPE_CURRENCY)
-            g_assert (xaccAccountIsPriced (acc));
+            g_assert_true (xaccAccountIsPriced (acc));
         else
-            g_assert (!xaccAccountIsPriced (acc));
+            g_assert_true (!xaccAccountIsPriced (acc));
 
     }
     g_object_unref (acc);
@@ -2490,7 +2490,7 @@ test_xaccAccountType_Stuff (void)
     loghandler = g_log_set_handler (logdomain, loglevel,
                                     (GLogFunc)test_null_handler, check1);
     g_test_log_set_fatal_handler ((GTestLogFatalFunc)test_checked_handler, check1);
-    g_assert (!xaccAccountTypeEnumAsString (ACCT_TYPE_LAST));
+    g_assert_true (!xaccAccountTypeEnumAsString (ACCT_TYPE_LAST));
     g_assert_cmpint (check1->hits, ==, 1);
 
     g_log_remove_handler (logdomain, loghandler);
@@ -2498,14 +2498,14 @@ test_xaccAccountType_Stuff (void)
     loghandler = g_log_set_handler (logdomain, loglevel,
                                     (GLogFunc)test_null_handler, check2);
     g_test_log_set_fatal_handler ((GTestLogFatalFunc)test_checked_handler, check2);
-    g_assert (!xaccAccountStringToType (NULL, &type));
+    g_assert_true (!xaccAccountStringToType (NULL, &type));
     g_assert_cmpint (check2->hits, ==, 1);
 
     g_log_remove_handler (logdomain, loghandler);
     loghandler = g_log_set_handler (logdomain, loglevel,
                                     (GLogFunc)test_null_handler, check3);
     g_test_log_set_fatal_handler ((GTestLogFatalFunc)test_checked_handler, check3);
-    g_assert (!xaccAccountStringToType ("LAST", &type));
+    g_assert_true (!xaccAccountStringToType ("LAST", &type));
     g_assert_cmpint (check3->hits, ==, 1);
 
     g_log_remove_handler (logdomain, loghandler);
@@ -2588,9 +2588,9 @@ test_xaccAccountType_Compatibility (void)
             g_assert_cmpint (compat, == , trading_compat);
         for (auto parent = ACCT_TYPE_NONE; parent < ACCT_TYPE_LAST; ++parent)
             if (parent != ACCT_TYPE_NONE && (1 << parent) & compat)
-                g_assert (xaccAccountTypesCompatible (parent, type));
+                g_assert_true (xaccAccountTypesCompatible (parent, type));
             else
-                g_assert (!xaccAccountTypesCompatible (parent, type));
+                g_assert_true (!xaccAccountTypesCompatible (parent, type));
 
         compat = xaccAccountTypesCompatibleWith (type);
         if (type <= ACCT_TYPE_LIABILITY ||
@@ -2632,7 +2632,7 @@ test_xaccAccountFindSplitByDesc (Fixture *fixture, gconstpointer pData)
     Account *baz = gnc_account_lookup_by_name (root, "baz");
     gchar *memo;
     Split *split = xaccAccountFindSplitByDesc (baz, "pepper");
-    g_assert (split);
+    g_assert_true (split);
     g_object_get (split, "memo", &memo, NULL);
     g_assert_cmpstr (memo, == , "pepper_baz");
     g_free (memo);
@@ -2647,7 +2647,7 @@ test_xaccAccountFindTransByDesc (Fixture *fixture, gconstpointer pData)
     Account *baz = gnc_account_lookup_by_name (root, "baz");
     gchar *desc;
     Transaction *txn = xaccAccountFindTransByDesc (baz, "pepper");
-    g_assert (txn);
+    g_assert_true (txn);
     g_object_get (txn, "description", &desc, NULL);
     g_assert_cmpstr (desc, == , "pepper");
     g_free (desc);
@@ -2816,7 +2816,7 @@ test_xaccAccountForEachTransaction (Fixture *fixture, gconstpointer pData )
     gint result;
     result = xaccAccountForEachTransaction (root, thunk3, &td);
     g_assert_cmpint (td.count, == , 0);
-    g_assert (money);
+    g_assert_true (money);
     result = xaccAccountForEachTransaction (money, thunk3, &td);
     g_assert_cmpint (td.count, == , 9);
     g_assert_cmpint (result, == , 0);

--- a/libgnucash/engine/test/utest-Budget.c
+++ b/libgnucash/engine/test/utest-Budget.c
@@ -36,9 +36,9 @@ test_gnc_set_budget_name()
     QofBook *book = qof_book_new();
     GncBudget* budget = gnc_budget_new(book);
 
-    g_assert(strcmp(gnc_budget_get_name(budget), "Unnamed Budget") == 0);
+    g_assert_true(strcmp(gnc_budget_get_name(budget), "Unnamed Budget") == 0);
     gnc_budget_set_name(budget, "New Budget");
-    g_assert(strcmp(gnc_budget_get_name(budget), "New Budget") == 0);
+    g_assert_true(strcmp(gnc_budget_get_name(budget), "New Budget") == 0);
 
     gnc_budget_destroy(budget);
 }
@@ -49,9 +49,9 @@ test_gnc_set_budget_description()
     QofBook *book = qof_book_new();
     GncBudget* budget = gnc_budget_new(book);
 
-    g_assert(strcmp(gnc_budget_get_description(budget), "") == 0);
+    g_assert_true(strcmp(gnc_budget_get_description(budget), "") == 0);
     gnc_budget_set_description(budget, "New Budget");
-    g_assert(strcmp(gnc_budget_get_description(budget), "New Budget") == 0);
+    g_assert_true(strcmp(gnc_budget_get_description(budget), "New Budget") == 0);
 
     gnc_budget_destroy(budget);
 }
@@ -85,7 +85,7 @@ test_gnc_set_budget_num_periods_data_retention ()
 
     /* create value at period 16 */
     gnc_budget_set_account_period_value(budget, acc, 15, gnc_numeric_create(100,1));
-    g_assert (gnc_budget_is_account_period_value_set(budget, acc, 15));
+    g_assert_true (gnc_budget_is_account_period_value_set(budget, acc, 15));
 
     /* create note at period 12 */
     gnc_budget_set_account_period_note(budget, acc, 11, "undefined");
@@ -97,7 +97,7 @@ test_gnc_set_budget_num_periods_data_retention ()
     gnc_budget_set_num_periods(budget, 20);
 
     /* value and note are lost */
-    g_assert (!gnc_budget_is_account_period_value_set(budget, acc, 15));
+    g_assert_true (!gnc_budget_is_account_period_value_set(budget, acc, 15));
     note = gnc_budget_get_account_period_note (budget, acc, 11);
     g_assert_cmpstr (note, ==, NULL);
 
@@ -172,11 +172,11 @@ test_gnc_set_budget_account_period_value()
 
     acc = gnc_account_create_root(book);
 
-    g_assert(!gnc_budget_is_account_period_value_set(budget, acc, 0));
+    g_assert_true(!gnc_budget_is_account_period_value_set(budget, acc, 0));
     gnc_budget_set_account_period_value(budget, acc, 0, gnc_numeric_create(100,1));
-    g_assert(gnc_budget_is_account_period_value_set(budget, acc, 0));
+    g_assert_true(gnc_budget_is_account_period_value_set(budget, acc, 0));
     val = gnc_budget_get_account_period_value(budget, acc, 0);
-    g_assert (gnc_numeric_equal (val, gnc_numeric_create (100, 1)));
+    g_assert_true (gnc_numeric_equal (val, gnc_numeric_create (100, 1)));
 
     /* Budget has 12 periods by default, numbered from 0 to 11. Setting
      * period 12 should throw an error. */

--- a/libgnucash/engine/test/utest-Entry.c
+++ b/libgnucash/engine/test/utest-Entry.c
@@ -84,41 +84,41 @@ test_entry_basics ( Fixture *fixture, gconstpointer pData )
     gboolean is_cn = FALSE;
 
     GncEntry *entry = gncEntryCreate(fixture->book);
-    g_assert(entry);
+    g_assert_true(entry);
 
     g_test_message( "Test basic setters/getters" );
     g_test_message( "  Date" );
     gncEntrySetDate (entry, ts1);
     ts2 = gncEntryGetDate (entry);
-    g_assert(ts2 == ts1);
+    g_assert_true(ts2 == ts1);
     g_test_message( "  DateEntered" );
     gncEntrySetDateEntered (entry, ts1);
     ts2 = gncEntryGetDateEntered (entry);
-    g_assert(ts2 == ts1);
+    g_assert_true(ts2 == ts1);
     g_test_message( "  Description" );
     gncEntrySetDescription (entry, desc);
-    g_assert(g_strcmp0 (gncEntryGetDescription (entry), desc) == 0);
+    g_assert_true(g_strcmp0 (gncEntryGetDescription (entry), desc) == 0);
     g_test_message( "  Action" );
     gncEntrySetAction (entry, action);
-    g_assert(g_strcmp0 (gncEntryGetAction (entry), action) == 0);
+    g_assert_true(g_strcmp0 (gncEntryGetAction (entry), action) == 0);
     g_test_message( "  Notes" );
     gncEntrySetNotes (entry, note);
-    g_assert(g_strcmp0 (gncEntryGetNotes (entry), note) == 0);
+    g_assert_true(g_strcmp0 (gncEntryGetNotes (entry), note) == 0);
     g_test_message( "  Quantity" );
     gncEntrySetQuantity (entry, quantity);
-    g_assert(gnc_numeric_eq (gncEntryGetQuantity (entry), quantity));
+    g_assert_true(gnc_numeric_eq (gncEntryGetQuantity (entry), quantity));
     g_test_message( "  DocQuantity (with is_cn = FALSE)" );
     gncEntrySetDocQuantity (entry, quantity, is_cn);
-    g_assert(gnc_numeric_eq (gncEntryGetDocQuantity (entry, is_cn), quantity));
-    g_assert(gnc_numeric_eq (gncEntryGetQuantity (entry), quantity));
+    g_assert_true(gnc_numeric_eq (gncEntryGetDocQuantity (entry, is_cn), quantity));
+    g_assert_true(gnc_numeric_eq (gncEntryGetQuantity (entry), quantity));
     g_test_message( "  DocQuantity (with is_cn = TRUE)");
     is_cn = TRUE;
     gncEntrySetDocQuantity (entry, quantity, is_cn);
-    g_assert(gnc_numeric_eq (gncEntryGetDocQuantity (entry, is_cn), quantity));
-    g_assert(gnc_numeric_eq (gncEntryGetQuantity (entry), gnc_numeric_neg (quantity)));
+    g_assert_true(gnc_numeric_eq (gncEntryGetDocQuantity (entry, is_cn), quantity));
+    g_assert_true(gnc_numeric_eq (gncEntryGetQuantity (entry), gnc_numeric_neg (quantity)));
     g_test_message( "  InvAccount" );
     gncEntrySetInvAccount (entry, fixture->account);
-    g_assert(gncEntryGetInvAccount (entry) == fixture->account);
+    g_assert_true(gncEntryGetInvAccount (entry) == fixture->account);
 
 }
 
@@ -148,21 +148,21 @@ test_entry_rounding ( Fixture *fixture, gconstpointer pData )
     gncEntrySetQuantity(entry, gnc_numeric_create (2, 1));
     gncEntrySetInvPrice(entry, gnc_numeric_create (3, 1));
     /* Check unrounded result */
-    g_assert(gnc_numeric_equal (gncEntryGetDocValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (6, 1)));
-    g_assert(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (6, 10)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (6, 1)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (6, 10)));
     /* Check rounded result */
-    g_assert(gnc_numeric_equal (gncEntryGetDocValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (6, 1)));
-    g_assert(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (6, 10)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (6, 1)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (6, 10)));
 
     // Test with numbers that do require rounding
     /* Tax 10% (high precision GncNumeric), tax included */
     gncEntrySetInvTaxIncluded(entry, TRUE);
     /* Check unrounded result */
-    g_assert(gnc_numeric_equal (gncEntryGetDocValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (60, 11)));
-    g_assert(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (60, 110)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (60, 11)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (60, 110)));
     /* Check rounded result */
-    g_assert(gnc_numeric_equal (gncEntryGetDocValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (545455, 100000)));
-    g_assert(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (54545, 100000)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (545455, 100000)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (54545, 100000)));
 
     // Use different taxtable percentage precision
     /* Tax 10% (low precision GncNumeric), tax included */
@@ -170,11 +170,11 @@ test_entry_rounding ( Fixture *fixture, gconstpointer pData )
     gncEntrySetInvTaxTable(entry, NULL);
     gncEntrySetInvTaxTable(entry, taxtable);
     /* Check unrounded result */
-    g_assert(gnc_numeric_equal (gncEntryGetDocValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (60, 11)));
-    g_assert(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (60, 110)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (60, 11)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (60, 110)));
     /* Check rounded result */
-    g_assert(gnc_numeric_equal (gncEntryGetDocValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (545455, 100000)));
-    g_assert(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (54545, 100000)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (545455, 100000)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (54545, 100000)));
 
     // Test with odd tax percentage (Taken from a mailing list example)
     /* Tax 13% (high precision GncNumeric), tax not included */
@@ -185,11 +185,11 @@ test_entry_rounding ( Fixture *fixture, gconstpointer pData )
     gncEntrySetQuantity(entry, gnc_numeric_create (1, 1));
     gncEntrySetInvPrice(entry, gnc_numeric_create (27750, 100));
     /* Check unrounded result */
-    g_assert(gnc_numeric_equal (gncEntryGetDocValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (27750, 100)));
-    g_assert(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (36075, 1000)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (27750, 100)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (36075, 1000)));
     /* Check rounded result */
-    g_assert(gnc_numeric_equal (gncEntryGetDocValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (27750, 100)));
-    g_assert(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (36075, 1000)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (27750, 100)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (36075, 1000)));
     /* Note on the above expected result: the standard gncEntry denom is 100000 if the entry has no invoice or
      * bill set. So with the example above no rounding is required yet */
 
@@ -200,11 +200,11 @@ test_entry_rounding ( Fixture *fixture, gconstpointer pData )
     gncEntrySetInvTaxTable(entry, NULL);
     gncEntrySetInvTaxTable(entry, taxtable);
     /* Check unrounded result */
-    g_assert(gnc_numeric_equal (gncEntryGetDocValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (27750, 100)));
-    g_assert(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (36075, 1000)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (27750, 100)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (36075, 1000)));
     /* Check rounded result */
-    g_assert(gnc_numeric_equal (gncEntryGetDocValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (27750, 100)));
-    g_assert(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (36075, 1000)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (27750, 100)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (36075, 1000)));
     /* Note on the above expected result: the standard gncEntry denom is 100000 if the entry has no invoice or
      * bill set. So with the example above no rounding is required yet */
 
@@ -218,21 +218,21 @@ test_entry_rounding ( Fixture *fixture, gconstpointer pData )
     gncEntrySetQuantity(entry, gnc_numeric_create (2, 1));
     gncEntrySetInvPrice(entry, gnc_numeric_create (3, 1));
     /* Check unrounded result */
-    g_assert(gnc_numeric_equal (gncEntryGetDocValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (6, 1)));
-    g_assert(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (6, 10)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (6, 1)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (6, 10)));
     /* Check rounded result */
-    g_assert(gnc_numeric_equal (gncEntryGetDocValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (6, 1)));
-    g_assert(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (6, 10)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (6, 1)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (6, 10)));
 
     // Test with numbers that do require rounding
     /* Tax 10% (high precision GncNumeric), tax included */
     gncEntrySetInvTaxIncluded(entry, TRUE);
     /* Check unrounded result */
-    g_assert(gnc_numeric_equal (gncEntryGetDocValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (60, 11)));
-    g_assert(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (60, 110)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (60, 11)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (60, 110)));
     /* Check rounded result */
-    g_assert(gnc_numeric_equal (gncEntryGetDocValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (545, 100)));
-    g_assert(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (55, 100)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (545, 100)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (55, 100)));
 
     // Use different taxtable percentage precision
     /* Tax 10% (low precision GncNumeric), tax included */
@@ -240,11 +240,11 @@ test_entry_rounding ( Fixture *fixture, gconstpointer pData )
     gncEntrySetInvTaxTable(entry, NULL);
     gncEntrySetInvTaxTable(entry, taxtable);
     /* Check unrounded result */
-    g_assert(gnc_numeric_equal (gncEntryGetDocValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (60, 11)));
-    g_assert(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (60, 110)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (60, 11)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (60, 110)));
     /* Check rounded result */
-    g_assert(gnc_numeric_equal (gncEntryGetDocValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (545, 100)));
-    g_assert(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (55, 100)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (545, 100)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (55, 100)));
 
     // Test with odd tax percentage (Taken from a mailing list example)
     /* Tax 13% (high precision GncNumeric), tax not included */
@@ -255,11 +255,11 @@ test_entry_rounding ( Fixture *fixture, gconstpointer pData )
     gncEntrySetQuantity(entry, gnc_numeric_create (1, 1));
     gncEntrySetInvPrice(entry, gnc_numeric_create (27750, 100));
     /* Check unrounded result */
-    g_assert(gnc_numeric_equal (gncEntryGetDocValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (27750, 100)));
-    g_assert(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (36075, 1000)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (27750, 100)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (36075, 1000)));
     /* Check rounded result */
-    g_assert(gnc_numeric_equal (gncEntryGetDocValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (27750, 100)));
-    g_assert(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (3608, 100)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (27750, 100)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (3608, 100)));
     /* Note on the above expected result: the standard gncEntry denom is 100000 if the entry has no invoice or
      * bill set. So with the example above no rounding is required yet */
 
@@ -270,11 +270,11 @@ test_entry_rounding ( Fixture *fixture, gconstpointer pData )
     gncEntrySetInvTaxTable(entry, NULL);
     gncEntrySetInvTaxTable(entry, taxtable);
     /* Check unrounded result */
-    g_assert(gnc_numeric_equal (gncEntryGetDocValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (27750, 100)));
-    g_assert(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (36075, 1000)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (27750, 100)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, FALSE, TRUE, FALSE), gnc_numeric_create (36075, 1000)));
     /* Check rounded result */
-    g_assert(gnc_numeric_equal (gncEntryGetDocValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (27750, 100)));
-    g_assert(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (3608, 100)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (27750, 100)));
+    g_assert_true(gnc_numeric_equal (gncEntryGetDocTaxValue(entry, TRUE, TRUE, FALSE), gnc_numeric_create (3608, 100)));
     /* Note on the above expected result: the standard gncEntry denom is 100000 if the entry has no invoice or
      * bill set. So with the example above no rounding is required yet */
 

--- a/libgnucash/engine/test/utest-Invoice.c
+++ b/libgnucash/engine/test/utest-Invoice.c
@@ -288,22 +288,22 @@ test_invoice_post ( Fixture *fixture, gconstpointer pData )
 {
     time64 ts1 = gnc_time(NULL);
     time64 ts2 = ts1;
-    g_assert(fixture->invoice);
-    g_assert(!gncInvoiceGetIsCreditNote(fixture->invoice));
-    g_assert(gncInvoiceGetActive(fixture->invoice));
-    g_assert(gncInvoiceGetPostedAcc(fixture->invoice) == NULL);
+    g_assert_true(fixture->invoice);
+    g_assert_true(!gncInvoiceGetIsCreditNote(fixture->invoice));
+    g_assert_true(gncInvoiceGetActive(fixture->invoice));
+    g_assert_true(gncInvoiceGetPostedAcc(fixture->invoice) == NULL);
 
     gncInvoiceSetCurrency(fixture->invoice, fixture->commodity);
 
     gncInvoiceSetOwner(fixture->invoice, &fixture->owner);
 
     g_test_message( "Will now post the invoice" );
-    g_assert(!gncInvoiceIsPosted(fixture->invoice));
+    g_assert_true(!gncInvoiceIsPosted(fixture->invoice));
     gncInvoicePostToAccount(fixture->invoice, fixture->account, ts1, ts2, "memo", TRUE, FALSE);
-    g_assert(gncInvoiceIsPosted(fixture->invoice));
+    g_assert_true(gncInvoiceIsPosted(fixture->invoice));
 
     gncInvoiceUnpost(fixture->invoice, TRUE);
-    g_assert(!gncInvoiceIsPosted(fixture->invoice));
+    g_assert_true(!gncInvoiceIsPosted(fixture->invoice));
 }
 
 
@@ -341,8 +341,8 @@ test_invoice_posted_trans ( Fixture *fixture, gconstpointer pData )
     gnc_numeric total = gncInvoiceGetTotal(fixture->invoice);
     gnc_numeric acct_balance, acct2_balance;
 
-    g_assert (account_has_one_split (fixture->account));
-    g_assert (account_has_one_split (fixture->account2));
+    g_assert_true (account_has_one_split (fixture->account));
+    g_assert_true (account_has_one_split (fixture->account2));
 
     acct_balance = xaccAccountGetBalance(fixture->account);
     acct2_balance = xaccAccountGetBalance(fixture->account2);
@@ -350,13 +350,13 @@ test_invoice_posted_trans ( Fixture *fixture, gconstpointer pData )
     // Handle sign reversals (document values vs balance values)
     if (data->is_cn != !data->is_cust_doc)
     {
-        g_assert (gnc_numeric_equal (gnc_numeric_neg(acct_balance), total));
-        g_assert (gnc_numeric_equal (acct2_balance, total));
+        g_assert_true (gnc_numeric_equal (gnc_numeric_neg(acct_balance), total));
+        g_assert_true (gnc_numeric_equal (acct2_balance, total));
     }
     else
     {
-        g_assert (gnc_numeric_equal (acct_balance, total));
-        g_assert (gnc_numeric_equal (gnc_numeric_neg(acct2_balance), total));
+        g_assert_true (gnc_numeric_equal (acct_balance, total));
+        g_assert_true (gnc_numeric_equal (gnc_numeric_neg(acct2_balance), total));
     }
 }
 

--- a/libgnucash/engine/test/utest-Split.cpp
+++ b/libgnucash/engine/test/utest-Split.cpp
@@ -124,22 +124,22 @@ static void
 test_gnc_split_init ()
 {
     Split *split = static_cast<Split*>(g_object_new (GNC_TYPE_SPLIT, NULL));
-    g_assert (split->acc == NULL);
-    g_assert (split->orig_acc == NULL);
-    g_assert (split->parent == NULL);
-    g_assert (split->lot == NULL);
+    g_assert_true (split->acc == NULL);
+    g_assert_true (split->orig_acc == NULL);
+    g_assert_true (split->parent == NULL);
+    g_assert_true (split->lot == NULL);
     g_assert_cmpstr (split->action, ==, "");
     g_assert_cmpstr (split->memo, ==, "");
     g_assert_cmpint (split->reconciled, ==, NREC);
-    g_assert (gnc_numeric_zero_p (split->amount));
-    g_assert (gnc_numeric_zero_p (split->value));
-    g_assert (gnc_numeric_zero_p (split->balance));
-    g_assert (gnc_numeric_zero_p (split->cleared_balance));
-    g_assert (gnc_numeric_zero_p (split->reconciled_balance));
+    g_assert_true (gnc_numeric_zero_p (split->amount));
+    g_assert_true (gnc_numeric_zero_p (split->value));
+    g_assert_true (gnc_numeric_zero_p (split->balance));
+    g_assert_true (gnc_numeric_zero_p (split->cleared_balance));
+    g_assert_true (gnc_numeric_zero_p (split->reconciled_balance));
     g_assert_cmpint (split->gains, ==, GAINS_STATUS_UNKNOWN);
-    g_assert (split->gains_split == NULL);
+    g_assert_true (split->gains_split == NULL);
     /* Make sure that the parent's init has been run */
-    g_assert (split->inst.kvp_data != NULL);
+    g_assert_true (split->inst.kvp_data != NULL);
 
     g_object_unref (split);
 }
@@ -169,7 +169,7 @@ test_gnc_split_dispose ()
 
     g_object_run_dispose (G_OBJECT (split));
 
-    g_assert (instance->e_type == NULL);
+    g_assert_true (instance->e_type == NULL);
 
     g_object_unref (split);
     qof_book_destroy (book);
@@ -236,13 +236,13 @@ test_gnc_split_set_get_property ()
 
     g_assert_cmpstr (r_action, ==, "foo");
     g_assert_cmpstr (r_memo, ==, "bar");
-    g_assert (gnc_numeric_equal (*r_value, value));
+    g_assert_true (gnc_numeric_equal (*r_value, value));
     /* Setting the transaction causes the amount to be scrubbed into the value */
-    g_assert (gnc_numeric_equal (*r_amount, value));
+    g_assert_true (gnc_numeric_equal (*r_amount, value));
     g_assert_cmpint (rtime->t, ==, time);
-    g_assert (txn == rtxn);
-    g_assert (acc == racc);
-    g_assert (lot == rlot);
+    g_assert_true (txn == rtxn);
+    g_assert_true (acc == racc);
+    g_assert_true (lot == rlot);
 
     /* The official destroy functions all step on each other. We'll take a
      * few leaks to save trouble; it will all work fine once the
@@ -277,7 +277,7 @@ static void
 test_xaccMallocSplit (Fixture *fixture, gconstpointer pData)
 {
     /* We use this in the setup, so we can just verify that it works. */
-    g_assert (fixture->split != NULL);
+    g_assert_true (fixture->split != NULL);
 }
 /* xaccDupeSplit
 Split *
@@ -289,28 +289,28 @@ test_xaccDupeSplit (Fixture *fixture, gconstpointer pData)
     Split *f_split = fixture->split;
     Split *split = xaccDupeSplit (f_split);
 
-    g_assert (split != fixture->split);
-    g_assert (qof_instance_get_guid (split) != qof_instance_get_guid (f_split));
-    g_assert (guid_equal (qof_instance_get_guid (split), qof_instance_get_guid (f_split)));
-    g_assert (qof_instance_get_book (split) == qof_instance_get_book (f_split));
-    g_assert (split->parent == f_split->parent);
-    g_assert (split->acc == f_split->acc);
-    g_assert (split->orig_acc == f_split->orig_acc);
-    g_assert (split->lot == f_split->lot);
+    g_assert_true (split != fixture->split);
+    g_assert_true (qof_instance_get_guid (split) != qof_instance_get_guid (f_split));
+    g_assert_true (guid_equal (qof_instance_get_guid (split), qof_instance_get_guid (f_split)));
+    g_assert_true (qof_instance_get_book (split) == qof_instance_get_book (f_split));
+    g_assert_true (split->parent == f_split->parent);
+    g_assert_true (split->acc == f_split->acc);
+    g_assert_true (split->orig_acc == f_split->orig_acc);
+    g_assert_true (split->lot == f_split->lot);
     g_assert_cmpstr (split->memo, ==, f_split->memo);
     g_assert_cmpstr (split->action, ==, f_split->action);
-    g_assert (compare (split->inst.kvp_data, f_split->inst.kvp_data) == 0);
+    g_assert_true (compare (split->inst.kvp_data, f_split->inst.kvp_data) == 0);
     g_assert_cmpint (split->reconciled, ==, f_split->reconciled);
     g_assert_cmpint (split->date_reconciled, ==, f_split->date_reconciled);
-    g_assert (gnc_numeric_equal (split->value, f_split->value));
-    g_assert (gnc_numeric_equal (split->amount, f_split->amount));
+    g_assert_true (gnc_numeric_equal (split->value, f_split->value));
+    g_assert_true (gnc_numeric_equal (split->amount, f_split->amount));
     /* xaccDupeSplit intentionally doesn't copy the balances */
-    g_assert (gnc_numeric_zero_p (split->balance));
-    g_assert (gnc_numeric_zero_p (split->cleared_balance));
-    g_assert (gnc_numeric_zero_p (split->reconciled_balance));
+    g_assert_true (gnc_numeric_zero_p (split->balance));
+    g_assert_true (gnc_numeric_zero_p (split->cleared_balance));
+    g_assert_true (gnc_numeric_zero_p (split->reconciled_balance));
     /* FIXME: gains and gains_split are not copied */
     g_assert_cmpint (split->gains, !=, f_split->gains);
-    g_assert (split->gains_split != f_split->gains_split);
+    g_assert_true (split->gains_split != f_split->gains_split);
 
 }
 /* xaccSplitCloneNoKvp
@@ -323,27 +323,27 @@ test_xaccSplitCloneNoKvp (Fixture *fixture, gconstpointer pData)
     Split *f_split = fixture->split;
     Split *split = xaccSplitCloneNoKvp (f_split);
 
-    g_assert (split != fixture->split);
-    g_assert (qof_instance_get_guid (split) != qof_instance_get_guid (f_split));
+    g_assert_true (split != fixture->split);
+    g_assert_true (qof_instance_get_guid (split) != qof_instance_get_guid (f_split));
     g_assert_cmpint (guid_compare (qof_instance_get_guid (split), qof_instance_get_guid (f_split)), !=, 0);
-    g_assert (qof_instance_get_book (split) == qof_instance_get_book (f_split));
-    g_assert (split->parent == NULL);
-    g_assert (split->acc == f_split->acc);
+    g_assert_true (qof_instance_get_book (split) == qof_instance_get_book (f_split));
+    g_assert_true (split->parent == NULL);
+    g_assert_true (split->acc == f_split->acc);
     /* Clone doesn't copy the orig_acc */
-    g_assert (split->orig_acc == NULL);
-    g_assert (split->lot == f_split->lot);
+    g_assert_true (split->orig_acc == NULL);
+    g_assert_true (split->lot == f_split->lot);
     g_assert_cmpstr (split->memo, ==, f_split->memo);
     g_assert_cmpstr (split->action, ==, f_split->action);
-    g_assert (split->inst.kvp_data->empty());
+    g_assert_true (split->inst.kvp_data->empty());
     g_assert_cmpint (split->reconciled, ==, f_split->reconciled);
     g_assert_cmpint (split->date_reconciled, == , f_split->date_reconciled);
-    g_assert (gnc_numeric_equal (split->value, f_split->value));
-    g_assert (gnc_numeric_equal (split->amount, f_split->amount));
-    g_assert (gnc_numeric_equal (split->balance, f_split->balance));
-    g_assert (gnc_numeric_equal (split->cleared_balance, f_split->cleared_balance));
-    g_assert (gnc_numeric_equal (split->reconciled_balance, f_split->reconciled_balance));
+    g_assert_true (gnc_numeric_equal (split->value, f_split->value));
+    g_assert_true (gnc_numeric_equal (split->amount, f_split->amount));
+    g_assert_true (gnc_numeric_equal (split->balance, f_split->balance));
+    g_assert_true (gnc_numeric_equal (split->cleared_balance, f_split->cleared_balance));
+    g_assert_true (gnc_numeric_equal (split->reconciled_balance, f_split->reconciled_balance));
     g_assert_cmpint (split->gains, ==, GAINS_STATUS_UNKNOWN);
-    g_assert (split->gains_split == NULL);
+    g_assert_true (split->gains_split == NULL);
 }
 // Not Used
 /* xaccSplitDump
@@ -444,31 +444,31 @@ test_xaccSplitEqual (Fixture *fixture, gconstpointer pData)
                                (GLogFunc)test_list_handler, &checkA);
     /* Note that check_splits is just passed through to xaccTransEqual, so we don't vary it here. */
     /* Test that a NULL comparison fails */
-    g_assert (xaccSplitEqual (fixture->split, NULL, TRUE, TRUE, TRUE) == FALSE);
-    g_assert (xaccSplitEqual (NULL, split1, TRUE, TRUE, TRUE) == FALSE);
+    g_assert_true (xaccSplitEqual (fixture->split, NULL, TRUE, TRUE, TRUE) == FALSE);
+    g_assert_true (xaccSplitEqual (NULL, split1, TRUE, TRUE, TRUE) == FALSE);
     g_assert_cmpint (checkA.hits, ==, 2);
     g_assert_cmpint (checkB.hits, ==, 0);
     g_assert_cmpint (checkC.hits, ==, 0);
     g_assert_cmpint (checkD.hits, ==, 0);
     checkA.msg = msg02;
     /* Clone creates splits with different GUIDs: Make sure that it fails comparison */
-    g_assert (xaccSplitEqual (fixture->split, split1, TRUE, TRUE, TRUE) == FALSE);
+    g_assert_true (xaccSplitEqual (fixture->split, split1, TRUE, TRUE, TRUE) == FALSE);
     /* Test that the parent comparison fails */
-    g_assert (xaccSplitEqual (fixture->split, split1, FALSE, TRUE, TRUE) == FALSE);
+    g_assert_true (xaccSplitEqual (fixture->split, split1, FALSE, TRUE, TRUE) == FALSE);
     /* Now set split1's parent so that it passes -- we're also checking that the GUID check is disabled when we pass FALSE to check_guids */
     g_assert_cmpint (checkA.hits, ==, 3);
     g_assert_cmpint (checkB.hits, ==, 1);
     g_assert_cmpint (checkC.hits, ==, 1);
     g_assert_cmpint (checkD.hits, ==, 0);
     split1->parent = fixture->split->parent;
-    g_assert (xaccSplitEqual (fixture->split, split1, FALSE, TRUE, TRUE) == TRUE);
+    g_assert_true (xaccSplitEqual (fixture->split, split1, FALSE, TRUE, TRUE) == TRUE);
     /* Now set the GUIDs equal and see that the comparison passes */
     qof_instance_increase_editlevel (split1->parent);
     g_object_set (G_OBJECT (split1),
                   "guid", qof_instance_get_guid (QOF_INSTANCE(fixture->split)),
                   NULL);
     qof_instance_increase_editlevel (split1->parent);
-    g_assert (xaccSplitEqual (fixture->split, split1, TRUE, TRUE, TRUE) == TRUE);
+    g_assert_true (xaccSplitEqual (fixture->split, split1, TRUE, TRUE, TRUE) == TRUE);
     g_assert_cmpint (checkA.hits, ==, 3);
     g_assert_cmpint (checkB.hits, ==, 1);
     g_assert_cmpint (checkC.hits, ==, 1);
@@ -479,7 +479,7 @@ test_xaccSplitEqual (Fixture *fixture, gconstpointer pData)
                              fixture->split->memo, fixture->split->memo,
                              split1->memo, split1->memo);
     checkA.msg = msg03;
-    g_assert (xaccSplitEqual (fixture->split, split1, TRUE, TRUE, TRUE) == FALSE);
+    g_assert_true (xaccSplitEqual (fixture->split, split1, TRUE, TRUE, TRUE) == FALSE);
     g_assert_cmpint (checkA.hits, ==, 4);
     g_assert_cmpint (checkB.hits, ==, 1);
     g_assert_cmpint (checkC.hits, ==, 1);
@@ -487,11 +487,11 @@ test_xaccSplitEqual (Fixture *fixture, gconstpointer pData)
     split1->memo = fixture->split->memo;
     split1->action = "bar";
     checkA.msg = msg04;
-    g_assert (xaccSplitEqual (fixture->split, split1, TRUE, TRUE, TRUE) == FALSE);
+    g_assert_true (xaccSplitEqual (fixture->split, split1, TRUE, TRUE, TRUE) == FALSE);
     g_log_remove_handler (logdomain, hdlr);
     hdlr  = g_log_set_handler (logdomain, loglevel,
                                (GLogFunc)test_list_handler, &checkA);
-    g_assert (xaccSplitEqual (fixture->split, split1, TRUE, TRUE, TRUE) == FALSE);
+    g_assert_true (xaccSplitEqual (fixture->split, split1, TRUE, TRUE, TRUE) == FALSE);
     g_assert_cmpint (checkA.hits, ==, 6);
     g_assert_cmpint (checkB.hits, ==, 1);
     g_assert_cmpint (checkC.hits, ==, 1);
@@ -499,28 +499,28 @@ test_xaccSplitEqual (Fixture *fixture, gconstpointer pData)
     /* Split2 doesn't have balances copied from fixture->split, so the balance test fails */
     checkB.msg = msg12;
     checkC.msg = msg13;
-    g_assert (xaccSplitEqual (fixture->split, split2, TRUE, TRUE, TRUE) == FALSE);
+    g_assert_true (xaccSplitEqual (fixture->split, split2, TRUE, TRUE, TRUE) == FALSE);
     g_assert_cmpint (checkA.hits, ==, 6);
     g_assert_cmpint (checkB.hits, ==, 2);
     g_assert_cmpint (checkC.hits, ==, 1);
     g_assert_cmpint (checkD.hits, ==, 0);
 
     split2->balance = fixture->split->balance;
-    g_assert (xaccSplitEqual (fixture->split, split2, TRUE, TRUE, TRUE) == FALSE);
+    g_assert_true (xaccSplitEqual (fixture->split, split2, TRUE, TRUE, TRUE) == FALSE);
     g_assert_cmpint (checkA.hits, ==, 6);
     g_assert_cmpint (checkB.hits, ==, 2);
     g_assert_cmpint (checkC.hits, ==, 2);
     g_assert_cmpint (checkD.hits, ==, 0);
 
     split2->cleared_balance = fixture->split->cleared_balance;
-    g_assert (xaccSplitEqual (fixture->split, split2, TRUE, TRUE, TRUE) == FALSE);
+    g_assert_true (xaccSplitEqual (fixture->split, split2, TRUE, TRUE, TRUE) == FALSE);
     g_assert_cmpint (checkA.hits, ==, 6);
     g_assert_cmpint (checkB.hits, ==, 2);
     g_assert_cmpint (checkC.hits, ==, 2);
     g_assert_cmpint (checkD.hits, ==, 1);
 
     test_clear_error_list ();
-    g_assert (xaccSplitEqual (fixture->split, split2, TRUE, FALSE, TRUE) == TRUE);
+    g_assert_true (xaccSplitEqual (fixture->split, split2, TRUE, FALSE, TRUE) == TRUE);
     g_object_unref (split1);
     g_object_unref (split2);
     test_clear_error_list ();
@@ -591,14 +591,14 @@ test_xaccSplitCommitEdit (Fixture *fixture, gconstpointer pData)
                   NULL);
     g_assert_cmpint (sort_dirty, ==, TRUE);
     g_assert_cmpint (balance_dirty, ==, FALSE);
-    g_assert (qof_instance_is_dirty (QOF_INSTANCE (fixture->split->parent)));
-    g_assert (qof_instance_is_dirty (QOF_INSTANCE (fixture->split)));
+    g_assert_true (qof_instance_is_dirty (QOF_INSTANCE (fixture->split->parent)));
+    g_assert_true (qof_instance_is_dirty (QOF_INSTANCE (fixture->split)));
     test_signal_assert_hits (sig1, 1);
     test_signal_assert_hits (sig2, 3);
     g_assert_cmpint (error.hits, ==, 0);
     g_assert_cmpint (error.lasterr, ==, ERR_BACKEND_NO_ERR);
-    g_assert (fixture->split->orig_acc == fixture->split->acc);
-    g_assert (fixture->split->orig_parent == fixture->split->parent);
+    g_assert_true (fixture->split->orig_acc == fixture->split->acc);
+    g_assert_true (fixture->split->orig_parent == fixture->split->parent);
     g_assert_cmpint (checkA.hits, ==, 4);
     g_assert_cmpint (checkB.hits, ==, 2);
 
@@ -618,16 +618,16 @@ test_xaccSplitCommitEdit (Fixture *fixture, gconstpointer pData)
                   NULL);
     g_assert_cmpint (sort_dirty, ==, TRUE);
     g_assert_cmpint (balance_dirty, ==, FALSE);
-    g_assert (!qof_instance_is_dirty (QOF_INSTANCE (fixture->split->parent)));
-    g_assert (qof_instance_is_dirty (QOF_INSTANCE (fixture->split)));
+    g_assert_true (!qof_instance_is_dirty (QOF_INSTANCE (fixture->split->parent)));
+    g_assert_true (qof_instance_is_dirty (QOF_INSTANCE (fixture->split)));
     test_signal_assert_hits (sig1, 1);
     test_signal_assert_hits (sig2, 4);
     g_assert_cmpint (checkA.hits, ==, 4);
     g_assert_cmpint (checkB.hits, ==, 2);
     g_assert_cmpint (error.hits, ==, 0);
     g_assert_cmpint (error.lasterr, ==, ERR_BACKEND_NO_ERR);
-    g_assert (fixture->split->orig_acc == fixture->split->acc);
-    g_assert (fixture->split->orig_parent == fixture->split->parent);
+    g_assert_true (fixture->split->orig_acc == fixture->split->acc);
+    g_assert_true (fixture->split->orig_parent == fixture->split->parent);
 
 
     g_log_remove_handler (logdomain, hdlr);
@@ -663,16 +663,16 @@ test_xaccSplitRollbackEdit (Fixture *fixture, gconstpointer pData)
     sig3 = test_signal_new (QOF_INSTANCE (txn1),
                             GNC_EVENT_ITEM_ADDED, NULL);
     fixture->split->orig_acc = NULL;
-    g_assert (fixture->split->acc != fixture->split->orig_acc);
+    g_assert_true (fixture->split->acc != fixture->split->orig_acc);
     fixture->split->orig_parent = NULL;
 
     xaccSplitRollbackEdit (fixture->split);
     test_signal_assert_hits (sig1, 1);
     test_signal_assert_hits (sig2, 0);
     test_signal_assert_hits (sig3, 0);
-    g_assert (fixture->split->acc == NULL);
-    g_assert (fixture->split->parent == NULL);
-    g_assert (fixture->split->orig_parent == NULL);
+    g_assert_true (fixture->split->acc == NULL);
+    g_assert_true (fixture->split->parent == NULL);
+    g_assert_true (fixture->split->orig_parent == NULL);
 
     fixture->split->acc = acc;
     fixture->split->orig_acc = acc;
@@ -681,14 +681,14 @@ test_xaccSplitRollbackEdit (Fixture *fixture, gconstpointer pData)
     qof_instance_set_destroying (fixture->split, TRUE);
 
     xaccSplitRollbackEdit (fixture->split);
-    g_assert (fixture->split->acc == acc);
-    g_assert (fixture->split->parent == txn1);
-    g_assert (fixture->split->orig_parent == txn1);
+    g_assert_true (fixture->split->acc == acc);
+    g_assert_true (fixture->split->parent == txn1);
+    g_assert_true (fixture->split->orig_parent == txn1);
     test_signal_assert_hits (sig1, 1);
     test_signal_assert_hits (sig2, 1);
     test_signal_assert_hits (sig3, 1);
-    g_assert (fixture->split->parent == fixture->split->orig_parent);
-    g_assert (fixture->split->parent == txn1);
+    g_assert_true (fixture->split->parent == fixture->split->orig_parent);
+    g_assert_true (fixture->split->parent == txn1);
 
     test_signal_free (sig1);
     test_signal_free (sig2);
@@ -704,11 +704,11 @@ test_xaccSplitLookup (Fixture *fixture, gconstpointer pData)
     QofBook *book = xaccSplitGetBook (fixture->split);
     const GncGUID *guid = xaccSplitGetGUID (fixture->split);
     Split *split = xaccSplitLookup (NULL, book);
-    g_assert (split == NULL);
+    g_assert_true (split == NULL);
     split = xaccSplitLookup (guid, NULL);
-    g_assert (split == NULL);
+    g_assert_true (split == NULL);
     split = xaccSplitLookup (guid, book);
-    g_assert (split == fixture->split);
+    g_assert_true (split == fixture->split);
 }
 /* xaccSplitDetermineGainStatus
 void
@@ -723,26 +723,26 @@ test_xaccSplitDetermineGainStatus (Fixture *fixture, gconstpointer pData)
     g_assert_cmpint (gains, !=, GAINS_STATUS_UNKNOWN);
     xaccSplitDetermineGainStatus (fixture->split);
     g_assert_cmpint (fixture->split->gains, ==, gains);
-    g_assert (fixture->split->gains_split == g_split);
+    g_assert_true (fixture->split->gains_split == g_split);
 
-    g_assert (g_split != NULL);
+    g_assert_true (g_split != NULL);
     fixture->split->gains = GAINS_STATUS_UNKNOWN;
     xaccSplitDetermineGainStatus (fixture->split);
     g_assert_cmpint (fixture->split->gains, ==, GAINS_STATUS_A_VDIRTY | GAINS_STATUS_DATE_DIRTY);
-    g_assert (fixture->split->gains_split == g_split);
+    g_assert_true (fixture->split->gains_split == g_split);
 
     fixture->split->gains = GAINS_STATUS_UNKNOWN;
     fixture->split->gains_split = NULL;
-    g_assert (fixture->split->inst.kvp_data->get_slot({"gains_source"}) == NULL);
+    g_assert_true (fixture->split->inst.kvp_data->get_slot({"gains_source"}) == NULL);
     xaccSplitDetermineGainStatus (fixture->split);
-    g_assert (fixture->split->gains_split == NULL);
+    g_assert_true (fixture->split->gains_split == NULL);
     g_assert_cmpint (fixture->split->gains, ==, GAINS_STATUS_A_VDIRTY | GAINS_STATUS_DATE_DIRTY);
 
     fixture->split->inst.kvp_data->set({"gains-source"}, new KvpValue(guid_copy(g_guid)));
-    g_assert (fixture->split->gains_split == NULL);
+    g_assert_true (fixture->split->gains_split == NULL);
     fixture->split->gains = GAINS_STATUS_UNKNOWN;
     xaccSplitDetermineGainStatus (fixture->split);
-    g_assert (fixture->split->gains_split == g_split);
+    g_assert_true (fixture->split->gains_split == g_split);
     g_assert_cmpint (fixture->split->gains, ==, GAINS_STATUS_GAINS);
 }
 /* get_currency_denom
@@ -791,13 +791,13 @@ test_xaccSplitSetSharePriceAndAmount (Fixture *fixture, gconstpointer pData)
     xaccSplitSetSharePriceAndAmount (fixture->split, price, amt);
     g_assert_cmpint (fixture->split->value.num, ==, 16272);
     g_assert_cmpint (fixture->split->amount.num, ==, 10000);
-    g_assert (qof_instance_is_dirty (QOF_INSTANCE (fixture->split)));
+    g_assert_true (qof_instance_is_dirty (QOF_INSTANCE (fixture->split)));
     price.denom = 1000;
 
     xaccSplitSetSharePriceAndAmount (fixture->split, price, amt);
     g_assert_cmpint (fixture->split->value.num, ==, 1627);
     g_assert_cmpint (fixture->split->amount.num, ==, 10000);
-    g_assert (qof_instance_is_dirty (QOF_INSTANCE (fixture->split)));
+    g_assert_true (qof_instance_is_dirty (QOF_INSTANCE (fixture->split)));
 }
 /* Used as a QofObject setter. Does the same as xaccSplitSetSharePrice
  * without the beginEdit/commitEdit and marking dirty.
@@ -818,7 +818,7 @@ test_xaccSplitSetSharePrice (Fixture *fixture, gconstpointer pData)
     xaccSplitSetSharePrice (fixture->split, price);
     g_assert_cmpint (fixture->split->value.num, ==, 522);
     g_assert_cmpint (fixture->split->amount.num, ==, 321);
-    g_assert (qof_instance_is_dirty (QOF_INSTANCE (fixture->split)));
+    g_assert_true (qof_instance_is_dirty (QOF_INSTANCE (fixture->split)));
 }
 /* Used as a QofObject setter. Does the same as xaccSplitSetAmount
  * without the beginEdit/commitEdit and marking dirty.
@@ -839,7 +839,7 @@ test_xaccSplitSetAmount (Fixture *fixture, gconstpointer pData)
     xaccSplitSetAmount (fixture->split, amt);
     g_assert_cmpint (fixture->split->value.num, ==, 123);
     g_assert_cmpint (fixture->split->amount.num, ==, 10000);
-    g_assert (qof_instance_is_dirty (QOF_INSTANCE (fixture->split)));
+    g_assert_true (qof_instance_is_dirty (QOF_INSTANCE (fixture->split)));
 }
 /* Used as a QofObject setter. Does the same as xaccSplitSetValue
  * without the beginEdit/commitEdit and marking dirty.
@@ -860,7 +860,7 @@ test_xaccSplitSetValue (Fixture *fixture, gconstpointer pData)
     xaccSplitSetValue (fixture->split, value);
     g_assert_cmpint (fixture->split->value.num, ==, 1627);
     g_assert_cmpint (fixture->split->amount.num, ==, 321);
-    g_assert (qof_instance_is_dirty (QOF_INSTANCE (fixture->split)));
+    g_assert_true (qof_instance_is_dirty (QOF_INSTANCE (fixture->split)));
 }
 /* xaccSplitGetBalance // C: 8 in 3 SCM: 4 in 3
  * xaccSplitGetClearedBalance // Not Used
@@ -893,7 +893,7 @@ test_xaccSplitSetBaseValue (Fixture *fixture, gconstpointer pData)
     /* No parent account */
     fixture->split->acc = NULL;
     xaccSplitSetBaseValue (fixture->split, value, fixture->comm);
-    g_assert (!qof_instance_is_dirty (QOF_INSTANCE (fixture->split)));
+    g_assert_true (!qof_instance_is_dirty (QOF_INSTANCE (fixture->split)));
     xaccTransRollbackEdit (fixture->split->parent);
     g_assert_cmpint (check.hits, ==, 1);
     /* Base currency ==  currency, != commodity */
@@ -903,7 +903,7 @@ test_xaccSplitSetBaseValue (Fixture *fixture, gconstpointer pData)
     g_assert_cmpint (fixture->split->value.denom, ==, 240);
     g_assert_cmpint (fixture->split->amount.num, ==, 321);
     g_assert_cmpint (fixture->split->amount.denom, ==, 1000);
-    g_assert (qof_instance_is_dirty (QOF_INSTANCE (fixture->split)));
+    g_assert_true (qof_instance_is_dirty (QOF_INSTANCE (fixture->split)));
     g_assert_cmpint (check.hits, ==, 1);
 
     /* Base currency == currency, == commodity */
@@ -912,12 +912,12 @@ test_xaccSplitSetBaseValue (Fixture *fixture, gconstpointer pData)
     fixture->split->amount = old_amt;
     xaccAccountSetCommodity(fixture->split->acc, fixture->curr);
     xaccSplitSetBaseValue (fixture->split, value, fixture->curr);
-//    g_assert (gnc_numeric_equal (fixture->split->amount, old_amt));
+//    g_assert_true (gnc_numeric_equal (fixture->split->amount, old_amt));
     g_assert_cmpint (fixture->split->value.num, ==, 360);
     g_assert_cmpint (fixture->split->value.denom, ==, 240);
     g_assert_cmpint (fixture->split->amount.num, ==, 360);
     g_assert_cmpint (fixture->split->amount.denom, ==, 240);
-    g_assert (qof_instance_is_dirty (QOF_INSTANCE (fixture->split)));
+    g_assert_true (qof_instance_is_dirty (QOF_INSTANCE (fixture->split)));
     g_assert_cmpint (check.hits, ==, 1);
     /* Base currency != currency, == commodity */
     qof_instance_mark_clean (QOF_INSTANCE (fixture->split));
@@ -925,10 +925,10 @@ test_xaccSplitSetBaseValue (Fixture *fixture, gconstpointer pData)
     fixture->split->amount = old_amt;
     xaccAccountSetCommodity(fixture->split->acc, fixture->comm);
     xaccSplitSetBaseValue (fixture->split, value, fixture->comm);
-    g_assert (gnc_numeric_equal (fixture->split->value, old_val));
+    g_assert_true (gnc_numeric_equal (fixture->split->value, old_val));
     g_assert_cmpint (fixture->split->amount.num, ==, 1500);
     g_assert_cmpint (fixture->split->amount.denom, ==, 1000);
-    g_assert (qof_instance_is_dirty (QOF_INSTANCE (fixture->split)));
+    g_assert_true (qof_instance_is_dirty (QOF_INSTANCE (fixture->split)));
     g_assert_cmpint (check.hits, ==, 1);
 
     /* Base currency != currency, != commodity */
@@ -942,7 +942,7 @@ test_xaccSplitSetBaseValue (Fixture *fixture, gconstpointer pData)
     fixture->split->orig_parent = fixture->split->parent;
     xaccAccountSetCommodity(fixture->split->acc, fixture->comm);
     xaccSplitSetBaseValue (fixture->split, value, gnaira);
-    g_assert (!qof_instance_is_dirty (QOF_INSTANCE (fixture->split)));
+    g_assert_true (!qof_instance_is_dirty (QOF_INSTANCE (fixture->split)));
     g_assert_cmpint (check.hits, ==, 2);
 
     g_free (check.msg);
@@ -1005,11 +1005,11 @@ test_xaccSplitConvertAmount (void)
     /* accounts are equal, return the amount */
     xaccTransCommitEdit (txn);
     result = xaccSplitConvertAmount (split, acc);
-    g_assert (gnc_numeric_equal (result, gnaira_amt));
+    g_assert_true (gnc_numeric_equal (result, gnaira_amt));
 
     /* commodities are equal, return the amount */
     result = xaccSplitConvertAmount (split, o_acc);
-    g_assert (gnc_numeric_equal (result, gnaira_amt));
+    g_assert_true (gnc_numeric_equal (result, gnaira_amt));
 
     /* commodities are different, but transaction is balanced: Returns the
      * value of o_split
@@ -1026,13 +1026,13 @@ test_xaccSplitConvertAmount (void)
     g_test_log_set_fatal_handler ((GTestLogFatalFunc)test_checked_handler,
                                   &check);
     result = xaccSplitConvertAmount (split, ya_acc);
-    g_assert (gnc_numeric_zero_p (result));
+    g_assert_true (gnc_numeric_zero_p (result));
     g_assert_cmpint (check.hits, ==, 1);
 
     /* Transaction isn't balanced, split has 0 value, returns that */
     split->value = gnc_numeric_zero ();
     result = xaccSplitConvertAmount (split, o_acc);
-    g_assert (gnc_numeric_zero_p (result));
+    g_assert_true (gnc_numeric_zero_p (result));
     g_assert_cmpint (check.hits, ==, 1);
 
     /* Transaction isn't balanced, compute a conversion */
@@ -1151,7 +1151,7 @@ test_xaccSplitOrder (Fixture *fixture, gconstpointer pData)
 		      "split-action-num-field", "t",
 		      NULL);
     qof_book_commit_edit (book);
-    g_assert(qof_book_use_split_action_for_num_field(xaccSplitGetBook(split)) == TRUE);
+    g_assert_true(qof_book_use_split_action_for_num_field(xaccSplitGetBook(split)) == TRUE);
 
     g_assert_cmpint (xaccSplitOrder (split, o_split), ==, -1);
 
@@ -1167,7 +1167,7 @@ test_xaccSplitOrder (Fixture *fixture, gconstpointer pData)
 		      "split-action-num-field", "f",
 		      NULL);
     qof_book_commit_edit (book);
-    g_assert(qof_book_use_split_action_for_num_field(xaccSplitGetBook(split)) == FALSE);
+    g_assert_true(qof_book_use_split_action_for_num_field(xaccSplitGetBook(split)) == FALSE);
     split->parent = NULL;
     /* This should return > 0 because o_split has no memo string */
     g_assert_cmpint (xaccSplitOrder (split, o_split), >, 0);
@@ -1313,23 +1313,23 @@ test_get_corr_account_split (Fixture *fixture, gconstpointer pData)
                                                       GNC_HOW_RND_NEVER));
     split5->value = fixture->split->value;
 
-    g_assert (!fixture->func->get_corr_account_split(fixture->split, &result));
-    g_assert (result == NULL);
+    g_assert_true (!fixture->func->get_corr_account_split(fixture->split, &result));
+    g_assert_true (result == NULL);
 
     xaccTransBeginEdit (txn);
     xaccSplitSetParent (split2, txn);
     xaccTransCommitEdit (txn);
 
-    g_assert (fixture->func->get_corr_account_split(fixture->split, &result));
-    g_assert (result == split2);
+    g_assert_true (fixture->func->get_corr_account_split(fixture->split, &result));
+    g_assert_true (result == split2);
 
     xaccTransBeginEdit (txn);
     xaccSplitSetParent (split1, txn);
     xaccSplitSetParent (split3, txn);
     xaccTransCommitEdit (txn);
 
-    g_assert (!fixture->func->get_corr_account_split(fixture->split, &result));
-    g_assert (result == NULL);
+    g_assert_true (!fixture->func->get_corr_account_split(fixture->split, &result));
+    g_assert_true (result == NULL);
 
     /* Test for bug 752035 */
     xaccTransBeginEdit (txn);
@@ -1340,12 +1340,12 @@ test_get_corr_account_split (Fixture *fixture, gconstpointer pData)
     xaccSplitSetParent (split5, txn);
     xaccTransCommitEdit (txn);
 
-    g_assert (!fixture->func->get_corr_account_split(fixture->split, &result));
-    g_assert (result == NULL);
+    g_assert_true (!fixture->func->get_corr_account_split(fixture->split, &result));
+    g_assert_true (result == NULL);
     g_assert_cmpint (check->hits, ==, 0);
 
-    g_assert (!fixture->func->get_corr_account_split(NULL, &result));
-    g_assert (result == NULL);
+    g_assert_true (!fixture->func->get_corr_account_split(NULL, &result));
+    g_assert_true (result == NULL);
     g_assert_cmpint (check->hits, ==, 1);
 
     test_destroy (split1);
@@ -1644,11 +1644,11 @@ test_xaccSplitSetParent (Fixture *fixture, gconstpointer pData)
     xaccTransSetCurrency (txn2, fixture->curr);
     split->orig_parent = txn1;
     xaccSplitSetParent (split, txn2);
-    g_assert (split->parent == txn2);
-    g_assert (split->orig_parent == txn1);
+    g_assert_true (split->parent == txn2);
+    g_assert_true (split->orig_parent == txn1);
     test_signal_assert_hits (sig1, 1);
     test_signal_assert_hits (sig2, 1);
-    g_assert (qof_instance_is_dirty (QOF_INSTANCE (split)));
+    g_assert_true (qof_instance_is_dirty (QOF_INSTANCE (split)));
     g_assert_cmpint (check.hits, ==, 1);
 
     test_signal_free (sig1);
@@ -1677,26 +1677,26 @@ test_xaccSplitGetSharePrice (Fixture *fixture, gconstpointer pData)
                                   &check);
 
     result = xaccSplitGetSharePrice (NULL);
-    g_assert (gnc_numeric_equal (result, expected));
+    g_assert_true (gnc_numeric_equal (result, expected));
 
     expected = gnc_numeric_div (split->value, split->amount,
                                 GNC_DENOM_AUTO,
                                 GNC_HOW_RND_ROUND_HALF_UP);
 
     result = xaccSplitGetSharePrice (split);
-    g_assert (gnc_numeric_equal (result, expected));
+    g_assert_true (gnc_numeric_equal (result, expected));
     g_assert_cmpint (check.hits, ==, 0);
 
     expected = gnc_numeric_create (0, 1);
     split->amount = gnc_numeric_zero ();
     result = xaccSplitGetSharePrice (split);
-    g_assert (gnc_numeric_equal (result, expected));
+    g_assert_true (gnc_numeric_equal (result, expected));
     g_assert_cmpint (check.hits, ==, 0);
 
     split->value = gnc_numeric_zero ();
     expected = gnc_numeric_create (0, 1);
     result = xaccSplitGetSharePrice (split);
-    g_assert (gnc_numeric_equal (result, expected));
+    g_assert_true (gnc_numeric_equal (result, expected));
     g_assert_cmpint (check.hits, ==, 0);
 
     /* Now invent some value/amount pairs which cause numeric errors to test the limits */
@@ -1716,7 +1716,7 @@ test_xaccSplitGetSharePrice (Fixture *fixture, gconstpointer pData)
                                  split->amount.denom);
     expected = gnc_numeric_create (0, 1);
     result = xaccSplitGetSharePrice (split);
-    g_assert (gnc_numeric_equal (result, expected));
+    g_assert_true (gnc_numeric_equal (result, expected));
     g_assert_cmpint (check.hits, ==, 2);
     g_free (check.msg);
     */
@@ -1735,7 +1735,7 @@ test_xaccSplitGetSharePrice (Fixture *fixture, gconstpointer pData)
                                  split->amount.denom);
     expected = gnc_numeric_create (0, 1);
     result = xaccSplitGetSharePrice (split);
-    g_assert (gnc_numeric_equal (result, expected));
+    g_assert_true (gnc_numeric_equal (result, expected));
     g_assert_cmpint (check.hits, ==, 2);
     g_free (check.msg);
 
@@ -1754,7 +1754,7 @@ test_xaccSplitGetSharePrice (Fixture *fixture, gconstpointer pData)
                                  split->amount.denom);
     expected = gnc_numeric_create (0, 1);
     result = xaccSplitGetSharePrice (split);
-    g_assert (gnc_numeric_equal (result, expected));
+    g_assert_true (gnc_numeric_equal (result, expected));
     g_assert_cmpint (check.hits, ==, 4);
     g_free (check.msg);
 
@@ -1773,7 +1773,7 @@ test_xaccSplitMakeStockSplit (Fixture *fixture, gconstpointer pData)
 
     xaccSplitMakeStockSplit (split);
     g_assert_cmpstr (xaccSplitGetType (split), ==, "stock-split");
-    g_assert (qof_instance_is_dirty (QOF_INSTANCE (split)));
+    g_assert_true (qof_instance_is_dirty (QOF_INSTANCE (split)));
 }
 /* xaccSplitGetOtherSplit
 Split *
@@ -1790,43 +1790,43 @@ test_xaccSplitGetOtherSplit (Fixture *fixture, gconstpointer pData)
     Account *acc2 = xaccMallocAccount (book);
     KvpValue *kvpnow = new KvpValue (gnc_time (NULL));
 
-    g_assert (xaccSplitGetOtherSplit (NULL) == NULL);
-    g_assert (xaccSplitGetOtherSplit (split1) == NULL);
+    g_assert_true (xaccSplitGetOtherSplit (NULL) == NULL);
+    g_assert_true (xaccSplitGetOtherSplit (split1) == NULL);
 
-    g_assert (xaccTransUseTradingAccounts (txn) == FALSE);
-    g_assert (split->inst.kvp_data->get_slot({"lot-split"}) == NULL);
+    g_assert_true (xaccTransUseTradingAccounts (txn) == FALSE);
+    g_assert_true (split->inst.kvp_data->get_slot({"lot-split"}) == NULL);
     g_assert_cmpint (xaccTransCountSplits (txn), !=, 2);
-    g_assert (xaccSplitGetOtherSplit (split) == NULL);
+    g_assert_true (xaccSplitGetOtherSplit (split) == NULL);
 
     split1->value = gnc_numeric_neg (split->value);
     xaccSplitSetParent (split1, txn);
-    g_assert (xaccSplitGetOtherSplit (split) == split1);
+    g_assert_true (xaccSplitGetOtherSplit (split) == split1);
 
     xaccSplitSetParent (split2, txn);
-    g_assert (xaccSplitGetOtherSplit (split) == NULL);
+    g_assert_true (xaccSplitGetOtherSplit (split) == NULL);
 
     split->inst.kvp_data->set({"lot-split"}, kvpnow);
-    g_assert (split->inst.kvp_data->get_slot({"lot-split"}));
-    g_assert (xaccSplitGetOtherSplit (split) == NULL);
+    g_assert_true (split->inst.kvp_data->get_slot({"lot-split"}));
+    g_assert_true (xaccSplitGetOtherSplit (split) == NULL);
 
     split1->inst.kvp_data->set({"lot-split"}, kvpnow);
-    g_assert (split1->inst.kvp_data->get_slot({"lot-split"}));
-    g_assert (xaccSplitGetOtherSplit (split) == split2);
+    g_assert_true (split1->inst.kvp_data->get_slot({"lot-split"}));
+    g_assert_true (xaccSplitGetOtherSplit (split) == split2);
 
     split->inst.kvp_data->set({"lot-split"}, NULL);
-    g_assert (split->inst.kvp_data->get_slot({"lot-split"}) == NULL);
+    g_assert_true (split->inst.kvp_data->get_slot({"lot-split"}) == NULL);
     split1->inst.kvp_data->set({"lot-split"}, NULL);
-    g_assert (split1->inst.kvp_data->get_slot({"lot-split"}) == NULL);
+    g_assert_true (split1->inst.kvp_data->get_slot({"lot-split"}) == NULL);
     qof_book_begin_edit (book);
     qof_instance_set (QOF_INSTANCE (book),
 		      "trading-accts", "t",
 		      NULL);
     qof_book_commit_edit (book);
-    g_assert (xaccTransUseTradingAccounts (txn));
-    g_assert (xaccSplitGetOtherSplit (split) == NULL);
+    g_assert_true (xaccTransUseTradingAccounts (txn));
+    g_assert_true (xaccSplitGetOtherSplit (split) == NULL);
     split2->acc = acc2;
     xaccAccountSetType (acc2, ACCT_TYPE_TRADING);
-    g_assert (xaccSplitGetOtherSplit (split) == split1);
+    g_assert_true (xaccSplitGetOtherSplit (split) == split1);
 
     test_destroy (split1);
     test_destroy (split2);
@@ -1842,21 +1842,21 @@ test_xaccSplitVoid (Fixture *fixture, gconstpointer pData)
 {
     gnc_numeric value = fixture->split->value;
     gnc_numeric amount = fixture->split->amount;
-    g_assert (gnc_numeric_zero_p (xaccSplitVoidFormerAmount (fixture->split)));
-    g_assert (gnc_numeric_zero_p (xaccSplitVoidFormerValue (fixture->split)));
+    g_assert_true (gnc_numeric_zero_p (xaccSplitVoidFormerAmount (fixture->split)));
+    g_assert_true (gnc_numeric_zero_p (xaccSplitVoidFormerValue (fixture->split)));
     xaccSplitVoid (fixture->split);
-    g_assert (gnc_numeric_zero_p (fixture->split->value));
-    g_assert (gnc_numeric_zero_p (fixture->split->amount));
-    g_assert (gnc_numeric_equal (xaccSplitVoidFormerAmount (fixture->split),
+    g_assert_true (gnc_numeric_zero_p (fixture->split->value));
+    g_assert_true (gnc_numeric_zero_p (fixture->split->amount));
+    g_assert_true (gnc_numeric_equal (xaccSplitVoidFormerAmount (fixture->split),
                                  amount));
-    g_assert (gnc_numeric_equal (xaccSplitVoidFormerValue (fixture->split),
+    g_assert_true (gnc_numeric_equal (xaccSplitVoidFormerValue (fixture->split),
                                  value));
     g_assert_cmpint (fixture->split->reconciled, ==, VREC);
     xaccSplitUnvoid (fixture->split);
-    g_assert (gnc_numeric_equal (fixture->split->value, value));
-    g_assert (gnc_numeric_equal (fixture->split->amount, amount));
-    g_assert (gnc_numeric_zero_p (xaccSplitVoidFormerAmount (fixture->split)));
-    g_assert (gnc_numeric_zero_p (xaccSplitVoidFormerValue (fixture->split)));
+    g_assert_true (gnc_numeric_equal (fixture->split->value, value));
+    g_assert_true (gnc_numeric_equal (fixture->split->amount, amount));
+    g_assert_true (gnc_numeric_zero_p (xaccSplitVoidFormerAmount (fixture->split)));
+    g_assert_true (gnc_numeric_zero_p (xaccSplitVoidFormerValue (fixture->split)));
     g_assert_cmpint (fixture->split->reconciled, ==, NREC);
 }
 

--- a/libgnucash/engine/test/utest-Transaction.cpp
+++ b/libgnucash/engine/test/utest-Transaction.cpp
@@ -255,15 +255,15 @@ test_xaccTransStillHasSplit (Fixture *fixture, gconstpointer pData)
 {
     QofBook *book = qof_instance_get_book (QOF_INSTANCE (fixture->txn));
     auto split = xaccMallocSplit (book);
-    g_assert (!xaccTransStillHasSplit (fixture->txn, split));
+    g_assert_true (!xaccTransStillHasSplit (fixture->txn, split));
     xaccSplitSetParent (split, fixture->txn);
-    g_assert (xaccTransStillHasSplit (fixture->txn, split));
+    g_assert_true (xaccTransStillHasSplit (fixture->txn, split));
     qof_instance_set_destroying (split, TRUE);
-    g_assert (!xaccTransStillHasSplit (fixture->txn, split));
+    g_assert_true (!xaccTransStillHasSplit (fixture->txn, split));
     qof_instance_set_destroying (split, FALSE);
-    g_assert (xaccTransStillHasSplit (fixture->txn, split));
+    g_assert_true (xaccTransStillHasSplit (fixture->txn, split));
     xaccSplitSetParent (split, NULL);
-    g_assert (!xaccTransStillHasSplit (fixture->txn, split));
+    g_assert_true (!xaccTransStillHasSplit (fixture->txn, split));
 
     test_destroy (split);
 }
@@ -291,15 +291,15 @@ test_mark_trans (Fixture *fixture, gconstpointer pData)
     for (splits = (fixture->txn)->splits; splits; splits = splits->next)
     {
         if (!splits->data) continue;
-        g_assert (!qof_instance_get_dirty_flag (splits->data));
+        g_assert_true (!qof_instance_get_dirty_flag (splits->data));
         check_split_dirty (static_cast<Split*>(splits->data), FALSE);
     }
     fixture->func->mark_trans (fixture->txn);
-    g_assert (!qof_instance_get_dirty_flag (fixture->txn));
+    g_assert_true (!qof_instance_get_dirty_flag (fixture->txn));
     for (splits = (fixture->txn)->splits; splits; splits = splits->next)
     {
         if (!splits->data) continue;
-        g_assert (!qof_instance_get_dirty_flag (splits->data));
+        g_assert_true (!qof_instance_get_dirty_flag (splits->data));
         check_split_dirty (static_cast<Split*>(splits->data), TRUE);
     }
 }
@@ -336,12 +336,12 @@ test_gnc_transaction_init ()
     auto txn = static_cast<Transaction*>(g_object_new (GNC_TYPE_TRANSACTION, NULL));
     g_assert_cmpstr (txn->num, ==, "");
     g_assert_cmpstr (txn->description, ==, "");
-    g_assert (txn->common_currency == NULL);
-    g_assert (txn->splits == NULL);
+    g_assert_true (txn->common_currency == NULL);
+    g_assert_true (txn->splits == NULL);
     g_assert_cmpint (txn->date_entered, ==, 0);
     g_assert_cmpint (txn->date_posted, ==, 0);
     g_assert_cmpint (txn->marker, ==, 0);
-    g_assert (txn->orig == NULL);
+    g_assert_true (txn->orig == NULL);
 
     test_destroy (txn);
 }
@@ -363,19 +363,19 @@ test_gnc_transaction_dispose ()
     txn->splits = g_list_append (txn->splits, split);
     txn->common_currency = curr;
 
-    g_assert (txn->splits != NULL);
-    g_assert (s_ref != NULL);
-    g_assert (c_ref != NULL);
+    g_assert_true (txn->splits != NULL);
+    g_assert_true (s_ref != NULL);
+    g_assert_true (c_ref != NULL);
 
     g_object_run_dispose (G_OBJECT (txn));
     /* If gnc_transaction_dispose was written correctly, txn->splits and
      * txn->curr would be null and all of the splits would be destroyed,
      * so all of these would be equal instead of unequal.
      */
-    g_assert (txn->splits != NULL);
-    g_assert (txn->common_currency != NULL);
-    g_assert (s_ref != NULL);
-    g_assert (c_ref != NULL);
+    g_assert_true (txn->splits != NULL);
+    g_assert_true (txn->common_currency != NULL);
+    g_assert_true (s_ref != NULL);
+    g_assert_true (c_ref != NULL);
     /* And these would be unnecessary -- in fact, they would assert */
     test_destroy (split);
     test_destroy (curr);
@@ -409,7 +409,7 @@ test_gnc_transaction_set_get_property (Fixture *fixture, gconstpointer pData)
     Time64 *t_entered, *t_posted;
     g_assert_cmpstr (txn->num, ==, "");
     g_assert_cmpstr (txn->description, ==, "");
-    g_assert (txn->common_currency == NULL);
+    g_assert_true (txn->common_currency == NULL);
     g_assert_cmpint (txn->date_entered, ==, 0);
     g_assert_cmpint (txn->date_posted, ==, 0);
     /* Kick up the edit counter to keep from committing */
@@ -424,9 +424,9 @@ test_gnc_transaction_set_get_property (Fixture *fixture, gconstpointer pData)
 
     g_assert_cmpstr (txn->num, ==, num);
     g_assert_cmpstr (txn->description, ==, desc);
-    g_assert (txn->common_currency == curr);
-    g_assert (txn->date_entered == now);
-    g_assert (txn->date_posted == now);
+    g_assert_true (txn->common_currency == curr);
+    g_assert_true (txn->date_entered == now);
+    g_assert_true (txn->date_posted == now);
 
     g_object_get (G_OBJECT (txn),
                   "num", &t_num,
@@ -438,7 +438,7 @@ test_gnc_transaction_set_get_property (Fixture *fixture, gconstpointer pData)
 
     g_assert_cmpstr (t_num, ==, num);
     g_assert_cmpstr (t_desc, ==, desc);
-    g_assert (t_curr == curr);
+    g_assert_true (t_curr == curr);
     g_assert_cmpint (t_entered->t, ==, now);
     g_assert_cmpint (t_posted->t, ==, now);
     xaccTransRollbackEdit (txn);
@@ -469,12 +469,12 @@ test_xaccMallocTransaction (Fixture *fixture, gconstpointer pData)
                      (GLogFunc)test_checked_handler);
     test_signal_assert_hits (sig1, 0);
     txn = xaccMallocTransaction (NULL);
-    g_assert (txn == NULL);
+    g_assert_true (txn == NULL);
     g_assert_cmpint (check->hits, ==, 1);
     test_signal_assert_hits (sig1, 0);
 
     txn = xaccMallocTransaction (book);
-    g_assert (txn != NULL);
+    g_assert_true (txn != NULL);
     g_assert_cmpint (check->hits, ==, 1);
     test_signal_assert_hits (sig1, 1);
 
@@ -512,28 +512,28 @@ test_xaccTransSortSplits (Fixture *fixture, gconstpointer pData)
     }
 
     node = txn->splits;
-    g_assert (node->data == split1);
+    g_assert_true (node->data == split1);
     node = g_list_next (node);
-    g_assert (node->data == split2);
+    g_assert_true (node->data == split2);
     node = g_list_next (node);
-    g_assert (node->data == split[0]);
+    g_assert_true (node->data == split[0]);
     node = g_list_next (node);
-    g_assert (node->data == split[1]);
+    g_assert_true (node->data == split[1]);
     node = g_list_next (node);
-    g_assert (node->data == split[2]);
+    g_assert_true (node->data == split[2]);
 
     xaccTransSortSplits (txn);
 
     node = txn->splits;
-    g_assert (node->data == split1);
+    g_assert_true (node->data == split1);
     node = g_list_next (node);
-    g_assert (node->data == split[0]);
+    g_assert_true (node->data == split[0]);
     node = g_list_next (node);
-    g_assert (node->data == split[1]);
+    g_assert_true (node->data == split[1]);
     node = g_list_next (node);
-    g_assert (node->data == split2);
+    g_assert_true (node->data == split2);
     node = g_list_next (node);
-    g_assert (node->data == split[2]);
+    g_assert_true (node->data == split[2]);
 
     xaccTransCommitEdit (txn);
 }
@@ -562,24 +562,24 @@ test_dupe_trans (Fixture *fixture, gconstpointer pData)
     for (newnode = newtxn->splits; newnode && oldnode;
             newnode = g_list_next (newnode))
     {
-        g_assert (xaccSplitEqual (static_cast<Split*>(newnode->data),
+        g_assert_true (xaccSplitEqual (static_cast<Split*>(newnode->data),
                                   static_cast<Split*>(oldnode->data),
                                   TRUE, FALSE, TRUE));
         oldnode = g_list_next (oldnode);
     }
-    g_assert (newnode == NULL);
-    g_assert (oldnode == NULL);
-    g_assert (newtxn->date_posted == posted);
-    g_assert (newtxn->date_entered == entered);
-    g_assert (qof_instance_version_cmp (QOF_INSTANCE (newtxn),
+    g_assert_true (newnode == NULL);
+    g_assert_true (oldnode == NULL);
+    g_assert_true (newtxn->date_posted == posted);
+    g_assert_true (newtxn->date_entered == entered);
+    g_assert_true (qof_instance_version_cmp (QOF_INSTANCE (newtxn),
                                         QOF_INSTANCE (oldtxn)) == 0);
-    g_assert (newtxn->orig == NULL);
-    g_assert (newtxn->common_currency == fixture->curr);
-    g_assert (newtxn->inst.e_type == NULL);
-    g_assert (guid_equal (qof_instance_get_guid (QOF_INSTANCE (newtxn)),
+    g_assert_true (newtxn->orig == NULL);
+    g_assert_true (newtxn->common_currency == fixture->curr);
+    g_assert_true (newtxn->inst.e_type == NULL);
+    g_assert_true (guid_equal (qof_instance_get_guid (QOF_INSTANCE (newtxn)),
                           guid_null ()));
-    g_assert (qof_instance_get_book (QOF_INSTANCE (newtxn)) == old_book);
-    g_assert (compare (oldtxn->inst.kvp_data, newtxn->inst.kvp_data) == 0);
+    g_assert_true (qof_instance_get_book (QOF_INSTANCE (newtxn)) == old_book);
+    g_assert_true (compare (oldtxn->inst.kvp_data, newtxn->inst.kvp_data) == 0);
 
     test_destroy (newtxn);
 }
@@ -613,24 +613,24 @@ test_xaccTransClone (Fixture *fixture, gconstpointer pData)
     for (newnode = newtxn->splits; newnode && oldnode;
             newnode = g_list_next (newnode))
     {
-        g_assert (xaccSplitEqual (static_cast<Split*>(newnode->data),
+        g_assert_true (xaccSplitEqual (static_cast<Split*>(newnode->data),
                                   static_cast<Split*>(oldnode->data),
                                   FALSE, FALSE, FALSE));
         oldnode = g_list_next (oldnode);
     }
-    g_assert (newnode == NULL);
-    g_assert (oldnode == NULL);
-    g_assert (newtxn->date_posted == posted);
-    g_assert (newtxn->date_entered == entered);
-    g_assert (qof_instance_version_cmp (QOF_INSTANCE (newtxn),
+    g_assert_true (newnode == NULL);
+    g_assert_true (oldnode == NULL);
+    g_assert_true (newtxn->date_posted == posted);
+    g_assert_true (newtxn->date_entered == entered);
+    g_assert_true (qof_instance_version_cmp (QOF_INSTANCE (newtxn),
                                         QOF_INSTANCE (oldtxn)) == 0);
     g_assert_cmpint (qof_instance_get_version_check (newtxn), ==,
                      qof_instance_get_version_check (oldtxn));
-    g_assert (newtxn->orig == NULL);
-    g_assert (newtxn->common_currency == fixture->curr);
+    g_assert_true (newtxn->orig == NULL);
+    g_assert_true (newtxn->common_currency == fixture->curr);
 
-    g_assert (qof_instance_get_book (QOF_INSTANCE (newtxn)) == old_book);
-    g_assert (compare (oldtxn->inst.kvp_data, newtxn->inst.kvp_data) == 0);
+    g_assert_true (qof_instance_get_book (QOF_INSTANCE (newtxn)) == old_book);
+    g_assert_true (compare (oldtxn->inst.kvp_data, newtxn->inst.kvp_data) == 0);
 
     test_destroy (newtxn);
 }
@@ -658,10 +658,10 @@ test_xaccTransCopyFromClipBoard (Fixture *fixture, gconstpointer pData)
 
     xaccAccountSetCommodity (acc1, fixture->comm);
     xaccTransCopyFromClipBoard (txn, to_txn, fixture->acc1, acc1, FALSE);
-    g_assert (gnc_commodity_equal (txn->common_currency,
+    g_assert_true (gnc_commodity_equal (txn->common_currency,
                                    to_txn->common_currency));
-    g_assert (to_txn->date_entered == now);
-    g_assert (to_txn->date_posted == txn->date_posted);
+    g_assert_true (to_txn->date_entered == now);
+    g_assert_true (to_txn->date_posted == txn->date_posted);
     g_assert_cmpstr (txn->num, ==, to_txn->num);
     /* Notes also tests that KVP is copied */
     g_assert_cmpstr (xaccTransGetNotes (txn), ==, xaccTransGetNotes (to_txn));
@@ -684,10 +684,10 @@ test_xaccTransCopyFromClipBoard_no_start (Fixture *fixture, gconstpointer pData)
 
     xaccAccountSetCommodity (acc1, fixture->comm);
     xaccTransCopyFromClipBoard (txn, to_txn, fixture->acc1, acc1, TRUE);
-    g_assert (gnc_commodity_equal (txn->common_currency,
+    g_assert_true (gnc_commodity_equal (txn->common_currency,
                                    to_txn->common_currency));
-    g_assert (to_txn->date_entered == now);
-    g_assert (to_txn->date_posted == never);
+    g_assert_true (to_txn->date_entered == now);
+    g_assert_true (to_txn->date_posted == never);
     g_assert_cmpstr (to_txn->num, ==, txn->num);
     /* Notes also tests that KVP is copied */
     g_assert_cmpstr (xaccTransGetNotes (txn), ==, xaccTransGetNotes (to_txn));
@@ -719,14 +719,14 @@ test_xaccFreeTransaction (Fixture *fixture, gconstpointer pData)
 
     fixture->func->xaccFreeTransaction (txn);
 
-    g_assert (split == NULL);
-    g_assert (txn->splits == NULL);
+    g_assert_true (split == NULL);
+    g_assert_true (txn->splits == NULL);
     g_assert_cmpint (GPOINTER_TO_INT(txn->num), ==, 1);
-    g_assert (txn->description == NULL);
+    g_assert_true (txn->description == NULL);
     g_assert_cmpint (txn->date_entered, ==, 0);
     g_assert_cmpint (txn->date_posted, ==, 0);
     g_assert_cmpint (GPOINTER_TO_INT(orig->num), ==, 1);
-    g_assert (txn->orig == NULL);
+    g_assert_true (txn->orig == NULL);
     test_destroy (orig);
 
     g_test_log_set_fatal_handler ((GTestLogFatalFunc) test_log_handler, NULL);
@@ -773,10 +773,10 @@ test_xaccTransEqual (Fixture *fixture, gconstpointer pData)
     fixture->hdlrs = test_log_set_handler (fixture->hdlrs, check,
                                            (GLogFunc)test_list_handler);
     /* Booleans are check_guids, check_splits, check_balances, assume_ordered */
-    g_assert (xaccTransEqual (NULL, NULL, TRUE, TRUE, TRUE, TRUE));
-    g_assert (!xaccTransEqual (txn0, NULL, TRUE, TRUE, TRUE, TRUE));
-    g_assert (!xaccTransEqual (NULL, txn0, TRUE, TRUE, TRUE, TRUE));
-    g_assert (xaccTransEqual (txn0, txn0, TRUE, TRUE, TRUE, TRUE));
+    g_assert_true (xaccTransEqual (NULL, NULL, TRUE, TRUE, TRUE, TRUE));
+    g_assert_true (!xaccTransEqual (txn0, NULL, TRUE, TRUE, TRUE, TRUE));
+    g_assert_true (!xaccTransEqual (NULL, txn0, TRUE, TRUE, TRUE, TRUE));
+    g_assert_true (xaccTransEqual (txn0, txn0, TRUE, TRUE, TRUE, TRUE));
 
     qof_instance_set_book (txn1, book2);
     qof_instance_set_guid (txn1, guid_f_txn);
@@ -788,9 +788,9 @@ test_xaccTransEqual (Fixture *fixture, gconstpointer pData)
 
     g_free (check->msg);
     check->msg = g_strdup ("[xaccTransEqual] GUIDs differ");
-    g_assert (!xaccTransEqual (clone, txn0, TRUE, TRUE, TRUE, TRUE));
+    g_assert_true (!xaccTransEqual (clone, txn0, TRUE, TRUE, TRUE, TRUE));
     qof_instance_set_guid (clone, guid_f_txn);
-    g_assert (xaccTransEqual (clone, txn0, TRUE, FALSE, TRUE, TRUE));
+    g_assert_true (xaccTransEqual (clone, txn0, TRUE, FALSE, TRUE, TRUE));
     g_assert_cmpint (check->hits, ==, 1);
     xaccTransBeginEdit (clone);
     cleanup->msg = g_strdup_printf (cleanup_fmt, clone->orig);
@@ -800,7 +800,7 @@ test_xaccTransEqual (Fixture *fixture, gconstpointer pData)
     g_free (cleanup->msg);
     g_free (check->msg);
     check->msg = g_strdup_printf ("[xaccTransEqual] commodities differ %s vs %s", gnc_commodity_get_unique_name (fixture->comm), gnc_commodity_get_unique_name (fixture->curr));
-    g_assert (!xaccTransEqual (clone, txn0, TRUE, FALSE, TRUE, TRUE));
+    g_assert_true (!xaccTransEqual (clone, txn0, TRUE, FALSE, TRUE, TRUE));
     g_assert_cmpint (check->hits, ==, 2);
 
     gnc_time64_to_iso8601_buff (clone->date_posted, posted);
@@ -814,7 +814,7 @@ test_xaccTransEqual (Fixture *fixture, gconstpointer pData)
     g_free (cleanup->msg);
     g_free (check->msg);
     check->msg = g_strdup_printf ("[xaccTransEqual] date posted differs: '%s' vs '%s'", entered, posted);
-    g_assert (!xaccTransEqual (clone, txn0, TRUE, FALSE, TRUE, TRUE));
+    g_assert_true (!xaccTransEqual (clone, txn0, TRUE, FALSE, TRUE, TRUE));
     g_assert_cmpint (check->hits, ==, 3);
 
     xaccTransBeginEdit (clone);
@@ -825,7 +825,7 @@ test_xaccTransEqual (Fixture *fixture, gconstpointer pData)
     g_free (cleanup->msg);
     g_free (check->msg);
     check->msg = g_strdup_printf ("[xaccTransEqual] date entered differs: '%s' vs '%s'", posted, entered);
-    g_assert (!xaccTransEqual (clone, txn0, TRUE, FALSE, TRUE, TRUE));
+    g_assert_true (!xaccTransEqual (clone, txn0, TRUE, FALSE, TRUE, TRUE));
     g_assert_cmpint (check->hits, ==, 4);
 
     xaccTransBeginEdit (clone);
@@ -836,15 +836,15 @@ test_xaccTransEqual (Fixture *fixture, gconstpointer pData)
     g_free (cleanup->msg);
     g_free (check->msg);
     check->msg = g_strdup ("[xaccTransEqual] num differs: 123 vs 123");
-    g_assert (!xaccTransEqual (clone, txn0, TRUE, FALSE, TRUE, TRUE));
+    g_assert_true (!xaccTransEqual (clone, txn0, TRUE, FALSE, TRUE, TRUE));
     g_assert_cmpint (check->hits, ==, 5);
-    g_assert (xaccTransEqual (txn1, clone, TRUE, FALSE, TRUE, TRUE));
+    g_assert_true (xaccTransEqual (txn1, clone, TRUE, FALSE, TRUE, TRUE));
     g_assert_cmpint (check->hits, ==, 5);
 
     txn1->num = CACHE_INSERT("321");
     g_free (check->msg);
     check->msg = g_strdup ("[xaccTransEqual] num differs: 321 vs 123");
-    g_assert (!xaccTransEqual (txn1, txn0, TRUE, FALSE, TRUE, TRUE));
+    g_assert_true (!xaccTransEqual (txn1, txn0, TRUE, FALSE, TRUE, TRUE));
     g_assert_cmpint (check->hits, ==, 6);
 
     g_free ((char*)clone->num);
@@ -854,11 +854,11 @@ test_xaccTransEqual (Fixture *fixture, gconstpointer pData)
     clone->description = CACHE_INSERT("salt pork");
     g_free (check->msg);
     check->msg = g_strdup ("[xaccTransEqual] descriptions differ: salt pork vs Waldo Pepper");
-    g_assert (!xaccTransEqual (clone, txn0, TRUE, FALSE, TRUE, TRUE));
+    g_assert_true (!xaccTransEqual (clone, txn0, TRUE, FALSE, TRUE, TRUE));
     g_assert_cmpint (check->hits, ==, 7);
-    g_assert (xaccTransEqual (txn1, txn0, TRUE, FALSE, TRUE, TRUE));
+    g_assert_true (xaccTransEqual (txn1, txn0, TRUE, FALSE, TRUE, TRUE));
     g_assert_cmpint (check->hits, ==, 7);
-    g_assert (!xaccTransEqual (clone, txn1, TRUE, FALSE, TRUE, TRUE));
+    g_assert_true (!xaccTransEqual (clone, txn1, TRUE, FALSE, TRUE, TRUE));
     g_assert_cmpint (check->hits, ==, 8);
 
     xaccTransBeginEdit (clone);
@@ -872,7 +872,7 @@ test_xaccTransEqual (Fixture *fixture, gconstpointer pData)
     g_free (check->msg);
     check->msg = g_strdup ("[xaccTransEqual] kvp frames differ:\nnotes/Salt pork sausage (char *)\nqux/quux/corge/654.321 (double)\n\n\n\n\nvs\n\nnotes/Salt pork sausage (char *)\nqux/quux/corge/123.456 (double)\n\n\n");
 
-    g_assert (!xaccTransEqual (clone, txn0, TRUE, FALSE, TRUE, TRUE));
+    g_assert_true (!xaccTransEqual (clone, txn0, TRUE, FALSE, TRUE, TRUE));
 
     g_assert_cmpint (check->hits, ==, 9);
     xaccTransBeginEdit (clone);
@@ -890,8 +890,8 @@ test_xaccTransEqual (Fixture *fixture, gconstpointer pData)
     check2->msg = g_strdup_printf (
                      "[xaccTransEqual] splits %s and %s differ", split_guid1, split_guid0);
 
-    g_assert (!xaccTransEqual (clone, txn0, TRUE, TRUE, TRUE, TRUE));
-    g_assert (xaccTransEqual (clone, txn0, FALSE, FALSE, FALSE, TRUE));
+    g_assert_true (!xaccTransEqual (clone, txn0, TRUE, TRUE, TRUE, TRUE));
+    g_assert_true (xaccTransEqual (clone, txn0, FALSE, FALSE, FALSE, TRUE));
     g_assert_cmpint (check->hits, ==, 10);
     g_assert_cmpint (check2->hits, ==, 1);
 
@@ -899,8 +899,8 @@ test_xaccTransEqual (Fixture *fixture, gconstpointer pData)
     check2->msg = g_strdup_printf (
                      "[xaccTransEqual] splits %s and %s differ", split_guid0, split_guid0);
     qof_instance_set_guid (split1, qof_instance_get_guid (split0));
-    g_assert (!xaccTransEqual (clone, txn0, TRUE, TRUE, TRUE, TRUE));
-    g_assert (xaccTransEqual (clone, txn0, TRUE, FALSE, FALSE, TRUE));
+    g_assert_true (!xaccTransEqual (clone, txn0, TRUE, TRUE, TRUE, TRUE));
+    g_assert_true (xaccTransEqual (clone, txn0, TRUE, FALSE, FALSE, TRUE));
     g_assert_cmpint (check->hits, ==, 10);
     g_assert_cmpint (check2->hits, ==, 2);
 
@@ -922,8 +922,8 @@ test_xaccTransEqual (Fixture *fixture, gconstpointer pData)
         check3->msg = g_strdup_printf("[xaccSplitEqualCheckBal] balances differ: %s vs %s", bal11, bal01);
 
         test_add_error (check3);
-        g_assert (!xaccTransEqual (txn1, txn0, TRUE, TRUE, TRUE, TRUE));
-        g_assert (xaccTransEqual (txn1, txn0, TRUE, TRUE, FALSE, TRUE));
+        g_assert_true (!xaccTransEqual (txn1, txn0, TRUE, TRUE, TRUE, TRUE));
+        g_assert_true (xaccTransEqual (txn1, txn0, TRUE, TRUE, FALSE, TRUE));
         g_assert_cmpint (check->hits, ==, 11);
         g_assert_cmpint (check2->hits, ==, 3);
         g_assert_cmpint (check3->hits, ==, 0);
@@ -932,7 +932,7 @@ test_xaccTransEqual (Fixture *fixture, gconstpointer pData)
         split11->balance = split01->balance;
         split10->noclosing_balance = split00->noclosing_balance;
         split11->noclosing_balance = split01->noclosing_balance;
-        g_assert (xaccTransEqual (txn1, txn0, TRUE, TRUE, TRUE, TRUE));
+        g_assert_true (xaccTransEqual (txn1, txn0, TRUE, TRUE, TRUE, TRUE));
     }
     g_free (check3->msg);
     g_free (check2->msg);
@@ -953,7 +953,7 @@ test_xaccTransLookup (Fixture *fixture, gconstpointer pData)
 {
     Transaction *txn = fixture->txn;
     QofInstance *inst = QOF_INSTANCE (txn);
-    g_assert (xaccTransLookup (qof_instance_get_guid (inst),
+    g_assert_true (xaccTransLookup (qof_instance_get_guid (inst),
                                qof_instance_get_book (inst)) == txn);
 }
 /* xaccTransGetImbalanceValue
@@ -965,7 +965,7 @@ test_xaccTransGetImbalanceValue (Fixture *fixture, gconstpointer pData)
 {
     QofBook *book = qof_instance_get_book (QOF_INSTANCE (fixture->txn));
     auto split1 = xaccMallocSplit (book);
-    g_assert (gnc_numeric_equal (xaccTransGetImbalanceValue (fixture->txn),
+    g_assert_true (gnc_numeric_equal (xaccTransGetImbalanceValue (fixture->txn),
                                  gnc_numeric_zero ()));
     split1->acc = fixture->acc1;
     split1->memo = CACHE_INSERT ("foo");
@@ -975,7 +975,7 @@ test_xaccTransGetImbalanceValue (Fixture *fixture, gconstpointer pData)
     xaccTransBeginEdit (fixture->txn);
     xaccSplitSetParent (split1, fixture->txn);
 
-    g_assert (gnc_numeric_equal (xaccTransGetImbalanceValue (fixture->txn),
+    g_assert_true (gnc_numeric_equal (xaccTransGetImbalanceValue (fixture->txn),
                                  split1->value));
     xaccTransCommitEdit (fixture->txn);
 }
@@ -989,7 +989,7 @@ test_xaccTransGetImbalance (Fixture *fixture, gconstpointer pData)
     QofBook *book = qof_instance_get_book (QOF_INSTANCE (fixture->txn));
     auto split1 = xaccMallocSplit (book);
     MonetaryList *mlist;
-    g_assert (xaccTransGetImbalance (NULL) == NULL);
+    g_assert_true (xaccTransGetImbalance (NULL) == NULL);
     mlist = xaccTransGetImbalance (fixture->txn);
     g_assert_cmpint (g_list_length (mlist), ==, 0);
 
@@ -1032,7 +1032,7 @@ test_xaccTransGetImbalance_trading (Fixture *fixture,
     xaccAccountSetType (acc1, ACCT_TYPE_TRADING);
     xaccAccountSetType (acc2, ACCT_TYPE_TRADING);
     /* The setup transaction is unbalanced in a trading-accounts environment. */
-    g_assert (!xaccTransIsBalanced (fixture->txn));
+    g_assert_true (!xaccTransIsBalanced (fixture->txn));
     /* Make it look like a proper trading accounts transactionm */
     split1->acc = acc1;
     split1->memo = CACHE_INSERT ("foo");
@@ -1079,8 +1079,8 @@ test_xaccTransIsBalanced (Fixture *fixture, gconstpointer pData)
 {
     QofBook *book = qof_instance_get_book (QOF_INSTANCE (fixture->txn));
     auto split1 = xaccMallocSplit (book);
-    g_assert (!xaccTransIsBalanced (NULL));
-    g_assert (xaccTransIsBalanced (fixture->txn));
+    g_assert_true (!xaccTransIsBalanced (NULL));
+    g_assert_true (xaccTransIsBalanced (fixture->txn));
 
     split1->acc = fixture->acc1;
     split1->memo = CACHE_INSERT ("foo");
@@ -1089,7 +1089,7 @@ test_xaccTransIsBalanced (Fixture *fixture, gconstpointer pData)
     split1->value = gnc_numeric_create (3200, 240);
     xaccTransBeginEdit (fixture->txn);
     xaccSplitSetParent (split1, fixture->txn);
-    g_assert (! xaccTransIsBalanced (fixture->txn));
+    g_assert_true (! xaccTransIsBalanced (fixture->txn));
     xaccTransCommitEdit (fixture->txn);
 }
 
@@ -1114,7 +1114,7 @@ test_xaccTransIsBalanced_trading (Fixture *fixture, gconstpointer pData)
     xaccAccountSetType (acc1, ACCT_TYPE_TRADING);
     xaccAccountSetType (acc2, ACCT_TYPE_TRADING);
     /* The setup transaction is unbalanced in a trading-accounts environment. */
-    g_assert (!xaccTransIsBalanced (fixture->txn));
+    g_assert_true (!xaccTransIsBalanced (fixture->txn));
     split1->acc = acc1;
     split1->memo = CACHE_INSERT ("foo");
     split1->action = CACHE_INSERT ("bar");
@@ -1127,15 +1127,15 @@ test_xaccTransIsBalanced_trading (Fixture *fixture, gconstpointer pData)
     split2->value = gnc_numeric_create (-3000, 240);
     xaccTransBeginEdit (fixture->txn);
     xaccSplitSetParent (split1, fixture->txn);
-    g_assert (!xaccTransIsBalanced (fixture->txn));
+    g_assert_true (!xaccTransIsBalanced (fixture->txn));
     xaccSplitSetParent (split2, fixture->txn);
-    g_assert (!xaccTransIsBalanced (fixture->txn));
+    g_assert_true (!xaccTransIsBalanced (fixture->txn));
     split2->amount = gnc_numeric_create (-11000, 100);
     split2->value = gnc_numeric_create (-3200, 240);
-    g_assert (!xaccTransIsBalanced (fixture->txn));
+    g_assert_true (!xaccTransIsBalanced (fixture->txn));
     split2->amount = gnc_numeric_create (-10000, 100);
     split2->value = gnc_numeric_create (-3200, 240);
-    g_assert (xaccTransIsBalanced (fixture->txn));
+    g_assert_true (xaccTransIsBalanced (fixture->txn));
     xaccTransRollbackEdit (fixture->txn);
 
     test_destroy (acc2);
@@ -1150,10 +1150,10 @@ test_xaccTransGetAccountValue (Fixture *fixture, gconstpointer pData)
 {
     gnc_numeric val1 = {3200, 240}, val2 = {-3200, 240};
 
-    g_assert (gnc_numeric_zero_p (xaccTransGetAccountValue (fixture->txn, NULL)));
-    g_assert (gnc_numeric_zero_p (xaccTransGetAccountValue (NULL, fixture->acc1)));
-    g_assert (gnc_numeric_eq (xaccTransGetAccountValue (fixture->txn, fixture->acc1), val1));
-    g_assert (gnc_numeric_eq (xaccTransGetAccountValue (fixture->txn, fixture->acc2), val2));
+    g_assert_true (gnc_numeric_zero_p (xaccTransGetAccountValue (fixture->txn, NULL)));
+    g_assert_true (gnc_numeric_zero_p (xaccTransGetAccountValue (NULL, fixture->acc1)));
+    g_assert_true (gnc_numeric_eq (xaccTransGetAccountValue (fixture->txn, fixture->acc1), val1));
+    g_assert_true (gnc_numeric_eq (xaccTransGetAccountValue (fixture->txn, fixture->acc2), val2));
 
 }
 /* xaccTransGetAccountAmount
@@ -1165,10 +1165,10 @@ test_xaccTransGetAccountAmount (Fixture *fixture, gconstpointer pData)
 {
     gnc_numeric amt1 = {100000, 1000}, amt2 = {-3200, 240};
 
-    g_assert (gnc_numeric_zero_p (xaccTransGetAccountAmount (fixture->txn, NULL)));
-    g_assert (gnc_numeric_zero_p (xaccTransGetAccountAmount (NULL, fixture->acc1)));
-    g_assert (gnc_numeric_eq (xaccTransGetAccountAmount (fixture->txn, fixture->acc1), amt1));
-    g_assert (gnc_numeric_eq (xaccTransGetAccountAmount (fixture->txn, fixture->acc2), amt2));
+    g_assert_true (gnc_numeric_zero_p (xaccTransGetAccountAmount (fixture->txn, NULL)));
+    g_assert_true (gnc_numeric_zero_p (xaccTransGetAccountAmount (NULL, fixture->acc1)));
+    g_assert_true (gnc_numeric_eq (xaccTransGetAccountAmount (fixture->txn, fixture->acc1), amt1));
+    g_assert_true (gnc_numeric_eq (xaccTransGetAccountAmount (fixture->txn, fixture->acc2), amt2));
 
 }
 /* xaccTransGetRateForCommodity
@@ -1184,23 +1184,23 @@ test_xaccTransGetRateForCommodity (Fixture *fixture, gconstpointer pData)
     QofBook *book = qof_instance_get_book (QOF_INSTANCE (fixture->txn));
     auto split0 = xaccMallocSplit (book);
     auto split1 = xaccTransFindSplitByAccount(fixture->txn, fixture->acc1);
-    g_assert (!xaccTransGetRateForCommodity (NULL, fixture->comm,
+    g_assert_true (!xaccTransGetRateForCommodity (NULL, fixture->comm,
               split0, &rate));
-    g_assert (!xaccTransGetRateForCommodity (fixture->txn, NULL,
+    g_assert_true (!xaccTransGetRateForCommodity (fixture->txn, NULL,
               split0, &rate));
-    g_assert (!xaccTransGetRateForCommodity (fixture->txn, fixture->comm,
+    g_assert_true (!xaccTransGetRateForCommodity (fixture->txn, fixture->comm,
               NULL, &rate));
-    g_assert (xaccTransGetRateForCommodity (fixture->txn, fixture->curr,
+    g_assert_true (xaccTransGetRateForCommodity (fixture->txn, fixture->curr,
                                             split0, &rate));
-    g_assert (gnc_numeric_equal (rate, gnc_numeric_create (1, 1)));
+    g_assert_true (gnc_numeric_equal (rate, gnc_numeric_create (1, 1)));
     rate = gnc_numeric_zero ();
-    g_assert (!xaccTransGetRateForCommodity (fixture->txn, fixture->comm,
+    g_assert_true (!xaccTransGetRateForCommodity (fixture->txn, fixture->comm,
               split0, &rate));
-    g_assert (gnc_numeric_zero_p (rate));
+    g_assert_true (gnc_numeric_zero_p (rate));
 
-    g_assert (xaccTransGetRateForCommodity (fixture->txn, fixture->comm,
+    g_assert_true (xaccTransGetRateForCommodity (fixture->txn, fixture->comm,
                                             split1, &rate));
-    g_assert (gnc_numeric_equal (rate, gnc_numeric_create (1800, 240)));
+    g_assert_true (gnc_numeric_equal (rate, gnc_numeric_create (1800, 240)));
 
 }
 /* xaccTransGetAccountConvRate
@@ -1219,11 +1219,11 @@ test_xaccTransGetAccountConvRate (Fixture *fixture, gconstpointer pData)
     fixture->hdlrs = test_log_set_fatal_handler (fixture->hdlrs, check,
                      (GLogFunc)test_checked_handler);
 
-    g_assert (gnc_numeric_equal (xaccTransGetAccountConvRate (fixture->txn,
+    g_assert_true (gnc_numeric_equal (xaccTransGetAccountConvRate (fixture->txn,
                                  fixture->acc2),
                                  gnc_numeric_create (1, 1)));
 
-    g_assert (gnc_numeric_equal (xaccTransGetAccountConvRate (fixture->txn,
+    g_assert_true (gnc_numeric_equal (xaccTransGetAccountConvRate (fixture->txn,
                                  fixture->acc1),
                                  gnc_numeric_create (1800, 240)));
     g_assert_cmpint (check->hits, ==, 0);
@@ -1262,11 +1262,11 @@ test_xaccTransGetAccountBalance (Fixture *fixture, gconstpointer pData)
     g_assert_cmpint (check->hits, ==, 2);
 
     rate = xaccTransGetAccountBalance (fixture->txn, fixture->acc1);
-    g_assert (gnc_numeric_equal (rate, gnc_numeric_create (100000, 1000)));
+    g_assert_true (gnc_numeric_equal (rate, gnc_numeric_create (100000, 1000)));
     g_assert_cmpint (check->hits, ==, 2);
 
     rate = xaccTransGetAccountBalance (fixture->txn, fixture->acc2);
-    g_assert (gnc_numeric_equal (rate, gnc_numeric_create (-3200, 240)));
+    g_assert_true (gnc_numeric_equal (rate, gnc_numeric_create (-3200, 240)));
     g_assert_cmpint (check->hits, ==, 2);
 
 }
@@ -1289,7 +1289,7 @@ test_xaccTransSetCurrency (Fixture *fixture, gconstpointer pData)
     /* Prevent commit in xaccTransSetCurrency() */
     xaccTransBeginEdit(fixture->txn);
     xaccTransSetCurrency (fixture->txn, curr);
-    g_assert (fixture->txn->common_currency == curr);
+    g_assert_true (fixture->txn->common_currency == curr);
     g_assert_cmpint (xaccSplitGetValue (split1).denom, ==,
                      gnc_commodity_get_fraction (curr));
     g_assert_cmpint (xaccSplitGetValue (split1).num, ==,
@@ -1319,32 +1319,32 @@ test_xaccTransBeginEdit ()
 
 
     g_assert_cmpint (0, ==, qof_instance_get_editlevel (QOF_INSTANCE (txn)));
-    g_assert (txn->orig == NULL);
+    g_assert_true (txn->orig == NULL);
     xaccTransBeginEdit (txn);
     g_assert_cmpint (1, ==, qof_instance_get_editlevel (QOF_INSTANCE (txn)));
     dupe = txn->orig;
-    g_assert (txn->orig != NULL);
+    g_assert_true (txn->orig != NULL);
     g_assert_cmpint (1, ==, check1->hits);
     g_assert_cmpint (1, ==, check2->hits);
     xaccTransBeginEdit (txn);
     g_assert_cmpint (2, ==, qof_instance_get_editlevel (QOF_INSTANCE (txn)));
-    g_assert (txn->orig == dupe);
+    g_assert_true (txn->orig == dupe);
     g_assert_cmpint (1, ==, check1->hits);
     g_assert_cmpint (1, ==, check2->hits);
     xaccTransRollbackEdit (txn);
     xaccTransRollbackEdit (txn);
     g_assert_cmpint (0, ==, qof_instance_get_editlevel (QOF_INSTANCE (txn)));
-    g_assert (txn->orig == NULL);
+    g_assert_true (txn->orig == NULL);
     qof_book_mark_readonly (book);
     xaccTransBeginEdit (txn);
     dupe = txn->orig;
     g_assert_cmpint (1, ==, qof_instance_get_editlevel (QOF_INSTANCE (txn)));
-    g_assert (txn->orig == dupe);
+    g_assert_true (txn->orig == dupe);
     g_assert_cmpint (1, ==, check1->hits);
     g_assert_cmpint (2, ==, check2->hits);
     xaccTransRollbackEdit (txn);
     g_assert_cmpint (0, ==, qof_instance_get_editlevel (QOF_INSTANCE (txn)));
-    g_assert (txn->orig == NULL);
+    g_assert_true (txn->orig == NULL);
 
     g_log_remove_handler (logdomain, hdlr);
     test_clear_error_list ();
@@ -1365,17 +1365,17 @@ test_xaccTransDestroy (Fixture *fixture, gconstpointer pData)
     Transaction *dupe = xaccTransClone (txn);
 
     xaccTransBeginEdit (txn);
-    g_assert (!qof_instance_get_destroying (QOF_INSTANCE (txn)));
-    g_assert (xaccTransEqual (txn, dupe, FALSE, TRUE, FALSE, TRUE));
+    g_assert_true (!qof_instance_get_destroying (QOF_INSTANCE (txn)));
+    g_assert_true (xaccTransEqual (txn, dupe, FALSE, TRUE, FALSE, TRUE));
     xaccTransDestroy (txn);
-    g_assert (qof_instance_get_destroying (QOF_INSTANCE (txn)));
-    g_assert (xaccTransEqual (txn, dupe, FALSE, TRUE, FALSE, TRUE));
+    g_assert_true (qof_instance_get_destroying (QOF_INSTANCE (txn)));
+    g_assert_true (xaccTransEqual (txn, dupe, FALSE, TRUE, FALSE, TRUE));
     xaccTransRollbackEdit (txn);
     qof_book_mark_readonly (book);
     xaccTransBeginEdit (txn);
     xaccTransDestroy (txn);
-    g_assert (qof_instance_get_destroying (QOF_INSTANCE (txn)));
-    g_assert (xaccTransEqual (txn, dupe, FALSE, TRUE, FALSE, TRUE));
+    g_assert_true (qof_instance_get_destroying (QOF_INSTANCE (txn)));
+    g_assert_true (xaccTransEqual (txn, dupe, FALSE, TRUE, FALSE, TRUE));
     xaccTransRollbackEdit (txn);
 
     test_destroy (dupe);
@@ -1394,8 +1394,8 @@ test_destroy_gains (GainsFixture *fixture, gconstpointer pData)
     auto base_split = static_cast<Split*>(g_list_nth_data (base->txn->splits, 1));
     xaccTransBeginEdit (fixture->gains_txn); /* Protect it from being actually destroyed */
     base->func->destroy_gains (base->txn);
-    g_assert (qof_instance_get_destroying (QOF_INSTANCE (fixture->gains_txn)));
-    g_assert (base_split->gains_split == NULL);
+    g_assert_true (qof_instance_get_destroying (QOF_INSTANCE (fixture->gains_txn)));
+    g_assert_true (base_split->gains_split == NULL);
     xaccTransCommitEdit (fixture->gains_txn);
 }
 /* do_destroy
@@ -1421,10 +1421,10 @@ test_do_destroy (GainsFixture *fixture, gconstpointer pData)
 
     base->func->do_destroy (base->txn);
     g_assert_cmpint (test_signal_return_hits (sig), ==, 1);
-    g_assert (base->txn->description == NULL);
+    g_assert_true (base->txn->description == NULL);
     g_assert_cmpint (GPOINTER_TO_INT(base->txn->num), ==, 1);
-    g_assert (qof_instance_get_destroying (QOF_INSTANCE (fixture->gains_txn)));
-    g_assert (base_split == NULL);
+    g_assert_true (qof_instance_get_destroying (QOF_INSTANCE (fixture->gains_txn)));
+    g_assert_true (base_split == NULL);
 
     test_signal_free (sig);
 }
@@ -1439,9 +1439,9 @@ static void
 test_was_trans_emptied (Fixture *fixture, gconstpointer pData)
 {
     GList *list = fixture->txn->splits;
-    g_assert (!fixture->func->was_trans_emptied (fixture->txn));
+    g_assert_true (!fixture->func->was_trans_emptied (fixture->txn));
     fixture->txn->splits = NULL;
-    g_assert (fixture->func->was_trans_emptied (fixture->txn));
+    g_assert_true (fixture->func->was_trans_emptied (fixture->txn));
     /* Restore the list so teardown can free the splits */
     fixture->txn->splits = list;
 }
@@ -1514,7 +1514,7 @@ test_trans_cleanup_commit (Fixture *fixture, gconstpointer pData)
     qof_instance_set_destroying (QOF_INSTANCE (destr_split), TRUE);
     /*Reverse the splits list so we can check later that it got sorted */
     fixture->txn->splits = g_list_reverse (fixture->txn->splits);
-    g_assert (fixture->txn->splits->data != split0);
+    g_assert_true (fixture->txn->splits->data != split0);
     fixture->func->trans_cleanup_commit (fixture->txn);
 
     g_assert_cmpint (test_signal_return_hits (sig_d_remove), ==, 1);
@@ -1525,9 +1525,9 @@ test_trans_cleanup_commit (Fixture *fixture, gconstpointer pData)
     g_assert_cmpint (test_signal_return_hits (sig_a_changed), ==, 1);
     g_assert_cmpint (g_list_index (fixture->txn->splits, destr_split), ==, -1);
     g_assert_cmpint (g_list_index (fixture->txn->splits, bogus_split), ==, -1);
-    g_assert (fixture->txn->orig == NULL);
-    g_assert (fixture->txn->splits->data == split0);
-    g_assert (qof_instance_get_destroying (destr_split));
+    g_assert_true (fixture->txn->orig == NULL);
+    g_assert_true (fixture->txn->splits->data == split0);
+    g_assert_true (qof_instance_get_destroying (destr_split));
     /* Note that the function itself aborts if qof_instance_editlevel != 0 */
 
     /* load things back up and test the txn-is-the-parent path */
@@ -1675,30 +1675,30 @@ test_xaccTransRollbackEdit (Fixture *fixture, gconstpointer pData)
     g_object_ref (split_11);
     qof_instance_increase_editlevel (QOF_INSTANCE (txn)); /* So it's 2 */
     xaccTransRollbackEdit (txn);
-    g_assert (txn->orig == orig);
+    g_assert_true (txn->orig == orig);
     qof_instance_reset_editlevel (QOF_INSTANCE (txn)); /* Now it's 0 */
     xaccTransRollbackEdit (txn);
-    g_assert (txn->orig == orig);
+    g_assert_true (txn->orig == orig);
     qof_instance_increase_editlevel (QOF_INSTANCE (txn)); /* And back to 1 */
     xaccTransRollbackEdit (txn);
-    g_assert (txn->orig == NULL);
+    g_assert_true (txn->orig == NULL);
     g_assert_cmpstr (txn->num, ==, "123");
     g_assert_cmpint (GPOINTER_TO_INT(orig->num), ==, 1);
     g_assert_cmpstr (txn->description, ==, "Waldo Pepper");
-    g_assert (txn->inst.kvp_data == base_frame);
-    g_assert (txn->common_currency == fixture->curr);
-    g_assert (txn->date_posted == orig_post);
-    g_assert (txn->date_entered == orig_entered);
+    g_assert_true (txn->inst.kvp_data == base_frame);
+    g_assert_true (txn->common_currency == fixture->curr);
+    g_assert_true (txn->date_posted == orig_post);
+    g_assert_true (txn->date_entered == orig_entered);
     g_assert_cmpuint (test_signal_return_hits (sig_account), ==, 1);
     g_assert_cmpuint (g_list_length (txn->splits), ==, 2);
     g_assert_cmpint (GPOINTER_TO_INT(split_02->memo), ==, 1);
-    g_assert (xaccSplitEqual (static_cast<Split*>(txn->splits->data), split_10,
+    g_assert_true (xaccSplitEqual (static_cast<Split*>(txn->splits->data), split_10,
                               FALSE, FALSE, FALSE));
-    g_assert (xaccSplitEqual (static_cast<Split*>(txn->splits->next->data),
+    g_assert_true (xaccSplitEqual (static_cast<Split*>(txn->splits->next->data),
                               split_10, FALSE, FALSE, FALSE));
     g_assert_cmpstr (mbe->m_last_call.c_str(), ==, "rollback");
     g_assert_cmpuint (qof_instance_get_editlevel (QOF_INSTANCE (txn)), ==, 0);
-    g_assert (qof_instance_get_destroying (txn) == FALSE);
+    g_assert_true (qof_instance_get_destroying (txn) == FALSE);
     test_signal_free (sig_account);
     g_object_unref (split_10);
     g_object_unref (split_11);
@@ -1904,22 +1904,22 @@ test_xaccTransVoid (Fixture *fixture, gconstpointer pData)
                      ==, "Transaction Voided");
     for (split = fixture->txn->splits; split; split=g_list_next (split))
     {
-        g_assert (gnc_numeric_zero_p (((Split*)(split->data))->value));
-        g_assert (gnc_numeric_zero_p (((Split*)(split->data))->amount));
+        g_assert_true (gnc_numeric_zero_p (((Split*)(split->data))->value));
+        g_assert_true (gnc_numeric_zero_p (((Split*)(split->data))->amount));
     }
 
     xaccTransUnvoid (fixture->txn);
 
     g_assert_cmpstr (frame->get_slot({trans_notes_str})->get<const char*>(), ==,
                      txn_notes);
-    g_assert (frame->get_slot({void_former_notes_str}) == NULL);
-    g_assert (frame->get_slot({void_reason_str}) == NULL);
-    g_assert (frame->get_slot({void_time_str}) == NULL);
-    g_assert (frame->get_slot({TRANS_READ_ONLY_REASON}) == NULL);
+    g_assert_true (frame->get_slot({void_former_notes_str}) == NULL);
+    g_assert_true (frame->get_slot({void_reason_str}) == NULL);
+    g_assert_true (frame->get_slot({void_time_str}) == NULL);
+    g_assert_true (frame->get_slot({TRANS_READ_ONLY_REASON}) == NULL);
     for (split = fixture->txn->splits; split; split=g_list_next (split))
     {
-        g_assert (!gnc_numeric_zero_p (((Split*)(split->data))->value));
-        g_assert (!gnc_numeric_zero_p (((Split*)(split->data))->amount));
+        g_assert_true (!gnc_numeric_zero_p (((Split*)(split->data))->value));
+        g_assert_true (!gnc_numeric_zero_p (((Split*)(split->data))->amount));
     }
 
     g_free (txn_notes);
@@ -1936,10 +1936,10 @@ test_xaccTransReverse (Fixture *fixture, gconstpointer pData)
     auto frame = fixture->txn->inst.kvp_data;
     GList *orig_splits = NULL, *rev_splits = NULL;
 
-    g_assert (guid_equal (frame->get_slot({TRANS_REVERSED_BY})->get<GncGUID*>(),
+    g_assert_true (guid_equal (frame->get_slot({TRANS_REVERSED_BY})->get<GncGUID*>(),
                           xaccTransGetGUID (rev)));
 
-    g_assert (!qof_instance_is_dirty (QOF_INSTANCE (rev))); //Cleared by commit
+    g_assert_true (!qof_instance_is_dirty (QOF_INSTANCE (rev))); //Cleared by commit
     g_assert_cmpint (g_list_length (fixture->txn->splits), ==,
                      g_list_length (rev->splits));
     for (orig_splits = fixture->txn->splits,
@@ -1950,9 +1950,9 @@ test_xaccTransReverse (Fixture *fixture, gconstpointer pData)
     {
         auto orig_split = static_cast<Split*>(orig_splits->data);
         auto rev_split = static_cast<Split*>(rev_splits->data);
-        g_assert (gnc_numeric_equal (orig_split->amount,
+        g_assert_true (gnc_numeric_equal (orig_split->amount,
                                      gnc_numeric_neg (rev_split->amount)));
-        g_assert (gnc_numeric_equal (orig_split->value,
+        g_assert_true (gnc_numeric_equal (orig_split->value,
                                      gnc_numeric_neg (rev_split->value)));
         g_assert_cmpint (xaccSplitGetReconcile (rev_split), ==, NREC);
     }
@@ -1981,7 +1981,7 @@ test_xaccTransScrubGainsDate_no_dirty (GainsFixture *fixture,
 
     fixture->base.func->xaccTransScrubGainsDate (fixture->base.txn);
 
-    g_assert (fixture->base.txn->date_posted != fixture->gains_txn->date_posted);
+    g_assert_true (fixture->base.txn->date_posted != fixture->gains_txn->date_posted);
     g_assert_cmphex (base_split->gains & GAINS_STATUS_DATE_DIRTY, ==, 0);
     g_assert_cmphex (base_split->gains_split->gains & GAINS_STATUS_DATE_DIRTY,
                      ==, 0);
@@ -1999,7 +1999,7 @@ test_xaccTransScrubGainsDate_base_dirty (GainsFixture *fixture,
 
     fixture->base.func->xaccTransScrubGainsDate (fixture->base.txn);
 
-    g_assert (fixture->base.txn->date_posted == fixture->gains_txn->date_posted);
+    g_assert_true (fixture->base.txn->date_posted == fixture->gains_txn->date_posted);
     g_assert_cmphex (base_split->gains & GAINS_STATUS_DATE_DIRTY, ==, 0);
     g_assert_cmphex (base_split->gains_split->gains & GAINS_STATUS_DATE_DIRTY,
                      ==, 0);
@@ -2017,7 +2017,7 @@ test_xaccTransScrubGainsDate_gains_dirty (GainsFixture *fixture,
 
     fixture->base.func->xaccTransScrubGainsDate (fixture->base.txn);
 
-    g_assert (fixture->base.txn->date_posted == fixture->gains_txn->date_posted);
+    g_assert_true (fixture->base.txn->date_posted == fixture->gains_txn->date_posted);
     g_assert_cmphex (base_split->gains & GAINS_STATUS_DATE_DIRTY, ==, 0);
     g_assert_cmphex (base_split->gains_split->gains & GAINS_STATUS_DATE_DIRTY,
                      ==, 0);

--- a/libgnucash/engine/test/utest-gnc-pricedb.c
+++ b/libgnucash/engine/test/utest-gnc-pricedb.c
@@ -691,23 +691,23 @@ test_gnc_price_list_equal (PriceDBFixture *fixture, gconstpointer pData)
     gnc_commodity *aud = c->aud;
 
     /* p1 and p2 are both NULL */
-    g_assert (gnc_price_list_equal (p1, p2));
+    g_assert_true (gnc_price_list_equal (p1, p2));
 
     p1 = gnc_pricedb_lookup_latest_any_currency(fixture->pricedb, aud);
 
     /* p1 is PriceList, p2 is NULL */
-    g_assert (!gnc_price_list_equal (p1, p2));
+    g_assert_true (!gnc_price_list_equal (p1, p2));
 
     p2 = p1;
 
     /* p1 and p2 both point to the same PriceList */
-    g_assert (gnc_price_list_equal (p1, p2));
+    g_assert_true (gnc_price_list_equal (p1, p2));
 
     p2 = gnc_pricedb_lookup_latest_any_currency(fixture->pricedb, aud);
 
     /* p1 and p2 are different PriceLists, but are identical in contents */
-    g_assert (p1 != p2);
-    g_assert (gnc_price_list_equal (p1, p2));
+    g_assert_true (p1 != p2);
+    g_assert_true (gnc_price_list_equal (p1, p2));
 
     gnc_price_list_destroy (p1);
     gnc_price_list_destroy (p2);
@@ -831,7 +831,7 @@ static void test_gnc_pricedb_remove_old_prices (PriceDBFixture *fixture, gconstp
 
     g_assert_cmpint (gnc_pricedb_get_num_prices(fixture->pricedb), ==, 42);
 
-    g_assert (gnc_pricedb_remove_old_prices(fixture->pricedb, comm_list,
+    g_assert_true (gnc_pricedb_remove_old_prices(fixture->pricedb, comm_list,
                                            fiscal_end_date, t_cut1,
                                            PRICE_REMOVE_SOURCE_USER, // source is USER
                                            PRICE_REMOVE_KEEP_NONE)); // keep none
@@ -839,35 +839,35 @@ static void test_gnc_pricedb_remove_old_prices (PriceDBFixture *fixture, gconstp
     g_assert_cmpint (gnc_pricedb_get_num_prices(fixture->pricedb), ==, 39);
 
     // there should be no prices before cutoff, returns false
-    g_assert (!gnc_pricedb_remove_old_prices(fixture->pricedb, comm_list,
+    g_assert_true (!gnc_pricedb_remove_old_prices(fixture->pricedb, comm_list,
                                            NULL, t_cut,
                                            PRICE_REMOVE_SOURCE_FQ,   // source is FQ
                                            PRICE_REMOVE_KEEP_NONE)); // keep none
 
     g_assert_cmpint (gnc_pricedb_get_num_prices(fixture->pricedb), ==, 39);
 
-    g_assert (gnc_pricedb_remove_old_prices(fixture->pricedb, comm_list,
+    g_assert_true (gnc_pricedb_remove_old_prices(fixture->pricedb, comm_list,
                                            fiscal_end_date, t_cut1,
                                            source_all,                      // source is ALL
                                            PRICE_REMOVE_KEEP_LAST_WEEKLY)); // keep last of week
 
     g_assert_cmpint (gnc_pricedb_get_num_prices(fixture->pricedb), ==, 38);
 
-    g_assert (gnc_pricedb_remove_old_prices(fixture->pricedb, comm_list,
+    g_assert_true (gnc_pricedb_remove_old_prices(fixture->pricedb, comm_list,
                                            fiscal_end_date, t_cut2,
                                            PRICE_REMOVE_SOURCE_FQ,           // source is FQ
                                            PRICE_REMOVE_KEEP_LAST_MONTHLY)); // keep last of month
 
     g_assert_cmpint (gnc_pricedb_get_num_prices(fixture->pricedb), ==, 37);
 
-    g_assert (gnc_pricedb_remove_old_prices(fixture->pricedb, comm_list,
+    g_assert_true (gnc_pricedb_remove_old_prices(fixture->pricedb, comm_list,
                                            fiscal_end_date, t_cut2,
                                            source_all,                         // source is all
                                            PRICE_REMOVE_KEEP_LAST_QUARTERLY)); // keep last of quarter
 
     g_assert_cmpint (gnc_pricedb_get_num_prices(fixture->pricedb), ==, 35);
 
-    g_assert (gnc_pricedb_remove_old_prices(fixture->pricedb, comm_list,
+    g_assert_true (gnc_pricedb_remove_old_prices(fixture->pricedb, comm_list,
                                            fiscal_end_date, t_cut2,
                                            source_all,                      // source is all
                                            PRICE_REMOVE_KEEP_LAST_PERIOD)); // keep last of period
@@ -905,12 +905,12 @@ test_gnc_pricedb_lookup_latest (PriceDBFixture *fixture, gconstpointer pData)
                                                          fixture->com->eur);
     time64 t = gnc_dmy2time64(12, 11, 2014);
     time64 price_time = gnc_price_get_time64(price);
-    g_assert(gnc_price_get_commodity(price) == fixture->com->gbp);
-    g_assert(gnc_price_get_currency(price) == fixture->com->eur);
+    g_assert_true(gnc_price_get_commodity(price) == fixture->com->gbp);
+    g_assert_true(gnc_price_get_currency(price) == fixture->com->eur);
     g_assert_cmpint(price_time, ==, t);
     price2 = gnc_pricedb_lookup_latest(fixture->pricedb, fixture->com->eur,
                                       fixture->com->gbp);
-    g_assert(price2 == price);
+    g_assert_true(price2 == price);
     gnc_price_unref(price);
     gnc_price_unref(price2);
 }
@@ -1073,9 +1073,9 @@ gnc_pricedb_has_prices(GNCPriceDB *db,// C: 4 in 3 SCM: 1  Local: 0:0:0
 static void
 test_gnc_pricedb_has_prices (PriceDBFixture *fixture, gconstpointer pData)
 {
-    g_assert(gnc_pricedb_has_prices(fixture->pricedb, fixture->com->usd,
+    g_assert_true(gnc_pricedb_has_prices(fixture->pricedb, fixture->com->usd,
                                     fixture->com->dkk));
-    g_assert(!gnc_pricedb_has_prices(fixture->pricedb, fixture->com->usd,
+    g_assert_true(!gnc_pricedb_has_prices(fixture->pricedb, fixture->com->usd,
                                      fixture->com->gbp));
 }
 /* gnc_pricedb_get_prices
@@ -1118,7 +1118,7 @@ test_gnc_pricedb_lookup_day_t64 (PriceDBFixture *fixture, gconstpointer pData)
     price = gnc_pricedb_lookup_day_t64(fixture->pricedb,
                                    fixture->com->usd,
                                    fixture->com->gbp, t);
-    g_assert(price == NULL);
+    g_assert_true(price == NULL);
     g_log_set_default_handler (hdlr, 0);
 }
 

--- a/test-templates/test-suite.c
+++ b/test-templates/test-suite.c
@@ -87,7 +87,7 @@ test_performance_function( void )
 /* Assert macros that you can use in your test functions. "cmp" is a
  * comparison operator, one of ==, !=, <, >, <=, >=.
  *
- *  g_assert( boolean_expression )
+ *  g_assert_true( boolean_expression )
  *  g_assert_not_reached()
  *  g_assert_cmpstr( gchar *s1, cmp, gchar *s2 )
  *  g_assert_cmpint( int s1, cmp, int s2 )


### PR DESCRIPTION
g_assert() can be compiled out, so should not be used for tests

Minimum glib has been increased to 2.56 since
https://bugs.gnucash.org/show_bug.cgi?id=792008