### PR TITLE
gnc:string<? uses glib instead of guile string compare

### DIFF
--- a/bindings/core-utils.i
+++ b/bindings/core-utils.i
@@ -104,6 +104,8 @@ const char * gnc_locale_default_iso_currency_code (void);
 %newobject gnc_locale_name;
 gchar *gnc_locale_name (void);
 
+int g_utf8_collate (const char *a, const char *b);
+
 #if defined(SWIGGUILE)
 %init {
     {

--- a/bindings/guile/core-utils.scm
+++ b/bindings/guile/core-utils.scm
@@ -75,8 +75,8 @@
      (issue-deprecation-warning "Using _ to call gettext is disallowed in guile-3 and will be removed in the future. Use G_ instead.")
      (gnc:gettext x))))
 
-(define gnc:string-locale<? string-locale<?)
-(define gnc:string-locale>? string-locale>?)
+(define (gnc:string-locale<? a b) (< (g-utf8-collate a b) 0))
+(define (gnc:string-locale>? a b) (> (g-utf8-collate a b) 0))
 
 ;; Custom unbound-variable exception printer: instead of generic "In
 ;; procedure module-lookup: Unbound variable: varname", it will first


### PR DESCRIPTION
for [Bug 798991](https://bugs.gnucash.org/show_bug.cgi?id=798991) - Incorrect Account Name Order in Transaction Report

needs win32 build and test on localised environment...