### PR TITLE
Bug 799039 - gnc:strify produces unusual results or crashes GnuCash when fed an option from gnc-lookup-option

### DIFF
--- a/gnucash/report/report-utilities.scm
+++ b/gnucash/report/report-utilities.scm
@@ -1080,6 +1080,10 @@
             (map gnc:strify (coll 'format gnc:make-gnc-monetary #f))))
   (define (value-collector->str coll)
     (format #f "coll<~a>" (coll 'total #f)))
+  (define (option-get-description option)
+    (format #f "Option<~a/~a>"
+            (GncOption-get-section option)
+            (GncOption-get-name option)))
   (define (procedure->str proc)
     (format #f "Proc<~a>"
             (or (procedure-name proc) "unk")))
@@ -1141,6 +1145,7 @@
                              (if (eq? (car d) 'absolute)
                                  (qof-print-date (cdr d))
                                  (gnc:strify (cdr d)))))
+      (try option-get-description)
       (try monetary-collector->str)
       (try value-collector->str)
       (try procedure->str)


### PR DESCRIPTION
`gnc:strify` to handle options without crashing.

Here's the swigged output. Other than the weird `delete [] result` rather than `g_free (result)` this works well.

```cpp

static SCM
_wrap_gnc_option_get_description (SCM s_0)
{
#define FUNC_NAME "gnc-option-get-description"
  GncOption *arg1 = (GncOption *) 0 ;
  SCM gswig_result;
  SWIGUNUSED int gswig_list_p = 0;
  char *result = 0 ;
  
  arg1 = scm_is_true(s_0) ? static_cast<GncOption*>(scm_to_pointer(s_0)) : nullptr;
  result = (char *)gnc_option_get_description((GncOption const *)arg1);
  {
    gswig_result = SCM_UNSPECIFIED;
    if (result) {
      gswig_result = scm_from_utf8_string((const char *)result);
    }
    if (!result || !scm_is_true(gswig_result)) {
      gswig_result = scm_c_make_string(0, SCM_UNDEFINED);
    }
  }
  
  delete [] result;
  
  return gswig_result;
#undef FUNC_NAME
}
```