### PR TITLE
Speed up during import when discarding transactions already imported

### DIFF
--- a/gnucash/import-export/aqb/gnc-ab-utils.c
+++ b/gnucash/import-export/aqb/gnc-ab-utils.c
@@ -872,6 +872,7 @@ txn_accountinfo_cb (AB_IMEXPORTER_ACCOUNTINFO *element, gpointer user_data)
                                                txn_transaction_cb, data,
                                                AB_Transaction_TypeStatement, 0);
     }
+    gnc_gen_trans_list_purge_existing (data->generic_importer);
     return NULL;
 }
 

--- a/gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp
+++ b/gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp
@@ -2183,6 +2183,8 @@ CsvImpTransAssist::assist_match_page_prepare ()
             draft_trans->trans = nullptr;
         }
     }
+
+    gnc_gen_trans_list_purge_existing(gnc_csv_importer_gui);
     /* Show the matcher dialog */
     gnc_gen_trans_list_show_all (gnc_csv_importer_gui);
 }

--- a/gnucash/import-export/import-main-matcher.h
+++ b/gnucash/import-export/import-main-matcher.h
@@ -200,6 +200,19 @@ void gnc_gen_trans_list_add_trans_with_ref_id (GNCImportMainMatcher *gui,
                                                guint32 ref_id);
 
 
+/** Performs housekeeping for the previous related functions
+ * gnc_gen_trans_list_add_trans etc -- these functions will add (or
+ * mark for destroy) transactions for import. This function will
+ * actually efficiently destroy the transactions already imported.
+ *
+ * @param gui The Transaction Importer to use.
+ *
+ *
+ * @param ref_id Reference id which links an external object to the transaction.
+ */
+
+void gnc_gen_trans_list_purge_existing (GNCImportMainMatcher *gui);
+
 /** Run this dialog and return only after the user pressed Ok, Cancel,
   or closed the window. This means that all actual importing will
   have been finished upon returning.

--- a/gnucash/import-export/ofx/gnc-ofx-import.cpp
+++ b/gnucash/import-export/ofx/gnc-ofx-import.cpp
@@ -1339,6 +1339,7 @@ runMatcher (ofx_info* info, char * selected_filename, gboolean go_to_next_file)
             info->num_trans_processed ++;
         }
     }
+    gnc_gen_trans_list_purge_existing (info->gnc_ofx_importer_gui);
     g_list_free (info->trans_list);
     g_hash_table_destroy (trans_hash);
     info->trans_list = g_list_reverse (trans_list_remain);


### PR DESCRIPTION
If a transaction `online_id` already exists, the code will destroy the transaction. Defer all destruction until all transactions processed, and efficiently destroy them within an xaccAccountBegin/CommitEdit block.

To test: import a large OFX. Import them all. Now reimport the same file. Previously there'd be a significant delay before displaying "All transactions already present".