### PR TITLE
Further amendment to use new/delete to handle vector<string>

### DIFF
--- a/gnucash/import-export/aqb/gnc-ab-utils.c
+++ b/gnucash/import-export/aqb/gnc-ab-utils.c
@@ -872,7 +872,6 @@ txn_accountinfo_cb (AB_IMEXPORTER_ACCOUNTINFO *element, gpointer user_data)
                                                txn_transaction_cb, data,
                                                AB_Transaction_TypeStatement, 0);
     }
-    gnc_gen_trans_list_purge_existing (data->generic_importer);
     return NULL;
 }
 

--- a/gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp
+++ b/gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp
@@ -2183,8 +2183,6 @@ CsvImpTransAssist::assist_match_page_prepare ()
             draft_trans->trans = nullptr;
         }
     }
-
-    gnc_gen_trans_list_purge_existing(gnc_csv_importer_gui);
     /* Show the matcher dialog */
     gnc_gen_trans_list_show_all (gnc_csv_importer_gui);
 }

--- a/gnucash/import-export/import-main-matcher.cpp
+++ b/gnucash/import-export/import-main-matcher.cpp
@@ -2224,6 +2224,10 @@ gnc_gen_trans_list_add_trans_internal (GNCImportMainMatcher *gui, Transaction *t
     g_assert (gui);
     g_assert (trans);
 
+    Split *split = xaccTransGetSplit (trans, 0);
+    Account *acc = xaccSplitGetAccount (split);
+    defer_bal_computation (gui, acc);
+
     if (gnc_import_exists_online_id (trans, gui->acct_id_hash))
     {
         /* If it does, abort the process for this transaction, since
@@ -2233,10 +2237,6 @@ gnc_gen_trans_list_add_trans_internal (GNCImportMainMatcher *gui, Transaction *t
         xaccTransCommitEdit(trans);
         return;
     }
-
-    Split *split = xaccTransGetSplit (trans, 0);
-    Account *acc = xaccSplitGetAccount (split);
-    defer_bal_computation (gui, acc);
 
     GNCImportTransInfo *transaction_info = gnc_import_TransInfo_new (trans, NULL);
     gnc_import_TransInfo_set_ref_id (transaction_info, ref_id);

--- a/gnucash/import-export/import-main-matcher.cpp
+++ b/gnucash/import-export/import-main-matcher.cpp
@@ -39,8 +39,6 @@
 #include <stdbool.h>
 
 #include <vector>
-#include <unordered_set>
-#include <algorithm>
 
 #include "import-main-matcher.h"
 
@@ -80,7 +78,6 @@ struct _main_matcher_info
     GtkWidget               *show_matched_info;
     GtkWidget               *append_text; // Update+Clear: Append import Desc/Notes to matched Desc/Notes
     GtkWidget               *reconcile_after_close;
-    std::vector<Transaction*> transactions_to_delete; // transactions to delete immediately instead of importing
     bool add_toggled;     // flag to indicate that add has been toggled to stop selection
     gint id;
     GSList* temp_trans_list;  // Temporary list of imported transactions
@@ -2232,7 +2229,8 @@ gnc_gen_trans_list_add_trans_internal (GNCImportMainMatcher *gui, Transaction *t
         /* If it does, abort the process for this transaction, since
            it is already in the system. */
         DEBUG("%s", "Transaction with same online ID exists, destroying current transaction");
-        gui->transactions_to_delete.push_back (trans);
+        xaccTransDestroy(trans);
+        xaccTransCommitEdit(trans);
         return;
     }
 
@@ -2246,31 +2244,6 @@ gnc_gen_trans_list_add_trans_internal (GNCImportMainMatcher *gui, Transaction *t
     // It's much faster to gather the imported transactions into a GSList than
     // directly into the treeview.
     gui->temp_trans_list = g_slist_prepend (gui->temp_trans_list, transaction_info);
-}
-
-void
-gnc_gen_trans_list_purge_existing (GNCImportMainMatcher *gui)
-{
-    g_return_if_fail (gui);
-    std::unordered_set<Account*> accset;
-    std::for_each (gui->transactions_to_delete.begin(), gui->transactions_to_delete.end(),
-                   [&accset](const Transaction* txn)
-                   {
-                       for (auto n = xaccTransGetSplitList (txn); n; n = n->next)
-                       {
-                           auto acc{xaccSplitGetAccount (static_cast<const Split*>(n->data))};
-                           if (accset.insert(acc).second)
-                               xaccAccountBeginEdit (acc);
-                       }
-                   });
-    std::for_each (gui->transactions_to_delete.begin(), gui->transactions_to_delete.end(),
-                   [](Transaction* txn)
-                   {
-                       xaccTransDestroy (txn);
-                       xaccTransCommitEdit (txn);
-                   });
-    std::for_each (accset.begin(), accset.end(), xaccAccountCommitEdit);
-    gui->transactions_to_delete.clear();
 }
 
 void

--- a/gnucash/import-export/import-main-matcher.h
+++ b/gnucash/import-export/import-main-matcher.h
@@ -200,16 +200,6 @@ void gnc_gen_trans_list_add_trans_with_ref_id (GNCImportMainMatcher *gui,
                                                guint32 ref_id);
 
 
-/** Performs housekeeping for the previous related functions
- * gnc_gen_trans_list_add_trans etc -- these functions will add (or
- * mark for destroy) transactions for import. This function will
- * actually efficiently destroy the transactions already imported.
- *
- * @param gui The Transaction Importer to use.
- */
-
-void gnc_gen_trans_list_purge_existing (GNCImportMainMatcher *gui);
-
 /** Run this dialog and return only after the user pressed Ok, Cancel,
   or closed the window. This means that all actual importing will
   have been finished upon returning.

--- a/gnucash/import-export/ofx/gnc-ofx-import.cpp
+++ b/gnucash/import-export/ofx/gnc-ofx-import.cpp
@@ -1339,7 +1339,6 @@ runMatcher (ofx_info* info, char * selected_filename, gboolean go_to_next_file)
             info->num_trans_processed ++;
         }
     }
-    gnc_gen_trans_list_purge_existing (info->gnc_ofx_importer_gui);
     g_list_free (info->trans_list);
     g_hash_table_destroy (trans_hash);
     info->trans_list = g_list_reverse (trans_list_remain);


### PR DESCRIPTION
I guess the `_main_matcher_info` should be inited via `new`/`delete` instead of `g_new0`/`g_free` because of the vector.