### PR TITLE
Bug 798990 - Notes No Longer Autofills

### DIFF
--- a/gnucash/register/ledger-core/split-register-load.c
+++ b/gnucash/register/ledger-core/split-register-load.c
@@ -354,6 +354,10 @@ update_info (SRInfo* info, SplitRegister* reg)
         gnc_split_register_get_current_trans_split (reg, NULL);
     info->cursor_hint_cursor_class =
         gnc_split_register_get_current_cursor_class (reg);
+
+    if (!info->first_pass && !info->quickfill_setup)
+        info->quickfill_setup = TRUE;
+
     info->hint_set_by_traverse = FALSE;
     info->traverse_to_new = FALSE;
     info->exact_traversal = FALSE;
@@ -746,15 +750,14 @@ gnc_split_register_load (SplitRegister* reg, GList* slist,
             }
         }
 
-        /* If this is the first load of the register,
-         * fill up the quickfill cells. */
-        if (info->first_pass)
+        /* On first load the split list is empty so fill up the quickfill cells
+         * only on the next load. */
+        if (!info->first_pass && !info->quickfill_setup)
             add_quickfill_completions (reg->table->layout, trans, split, has_last_num);
 
         gnc_completion_cell_add_menu_item (
             (CompletionCell*) gnc_table_layout_get_cell (reg->table->layout, DESC_CELL),
              xaccTransGetDescription (trans));
-
 
         if (trans == find_trans)
             new_trans_row = vcell_loc.virt_row;

--- a/gnucash/register/ledger-core/split-register-p.h
+++ b/gnucash/register/ledger-core/split-register-p.h
@@ -100,6 +100,9 @@ struct sr_info
     /** true if we are loading the register for the first time */
     gboolean first_pass;
 
+    /** true if we have setup the quickfills */
+    gboolean quickfill_setup;
+
     /** true if the user has already confirmed changes of a reconciled
      * split */
     gboolean change_confirmed;

--- a/gnucash/register/ledger-core/split-register-util.c
+++ b/gnucash/register/ledger-core/split-register-util.c
@@ -55,6 +55,7 @@ gnc_split_register_init_info (SplitRegister *reg)
     info->last_date_entered = gnc_time64_get_today_start ();
 
     info->first_pass = TRUE;
+    info->quickfill_setup = FALSE;
     info->full_refresh = TRUE;
     info->separator_changed = TRUE;
 


### PR DESCRIPTION
With the change to delay loading the non focused registers, the notes and memo quick fills are empty. This is due to trying to populate the quick fill on the first load when there are no splits so change populating the quick fill lists to the subsequent load only.

This works on my Linux VM machine and is the only thing I thought of. Will test on my Windows build machine once it has finished a backup.