### PR TITLE
Bug799051 - Shortcut Ctrl + Tab not working in 5.3

### DIFF
--- a/gnucash/register/register-gnome/completioncell-gnome.c
+++ b/gnucash/register/register-gnome/completioncell-gnome.c
@@ -752,6 +752,24 @@ gnc_completion_cell_modify_verify (BasicCell* bcell,
     gnc_basic_cell_set_value_internal (bcell, newval);
 }
 
+static char*
+get_entry_from_hash_if_size_is_one (CompletionCell* cell)
+{
+    if (!cell)
+        return NULL;
+
+    PopBox* box = cell->cell.gui_private;
+
+    if (box->item_hash && (g_hash_table_size (box->item_hash) == 1))
+    {
+        GList *keys = g_hash_table_get_keys (box->item_hash);
+        char *ret = g_strdup (keys->data);
+        g_list_free (keys);
+        return ret;
+    }
+    return NULL;
+}
+
 static gboolean
 gnc_completion_cell_direct_update (BasicCell* bcell,
                                    int* cursor_position,
@@ -771,6 +789,19 @@ gnc_completion_cell_direct_update (BasicCell* bcell,
     case GDK_KEY_Tab:
     case GDK_KEY_ISO_Left_Tab:
         {
+            if (event->state & GDK_CONTROL_MASK)
+            {
+                char* hash_string = get_entry_from_hash_if_size_is_one (cell);
+
+                if (hash_string)
+                {
+                    gnc_basic_cell_set_value_internal (bcell, hash_string);
+                    *cursor_position = strlen (hash_string);
+                }
+                g_free (hash_string);
+                return TRUE;
+            }
+
             char* string = gnc_item_list_get_selection (box->item_list);
 
             if (!string)


### PR DESCRIPTION
In a register description cell pressing Ctrl+Tab would populate the description cell if the list had only one entry, i.e. all the register transaction descriptions were the same. This was removed by mistake so this commit adds it back.

I think this is OK, have tested it on my Linux VM and will test on my Windows build machine once a backup has finished.