### PR TITLE
combine 2 account.cpp fns into 1

### DIFF
--- a/gnucash/gnome-utils/dialog-preferences.c
+++ b/gnucash/gnome-utils/dialog-preferences.c
@@ -123,22 +123,13 @@ GSList *add_ins = NULL;
 static gchar *gnc_account_separator_is_valid (const gchar *separator,
                                               gchar **normalized_separator)
 {
-    QofBook *book;
-    GList *conflict_accts = NULL;
-    gchar *message = NULL;
-
     if (!gnc_current_session_exist())
         return NULL;
 
-    book = gnc_get_current_book ();
+    QofBook *book = gnc_get_current_book ();
     *normalized_separator = gnc_normalize_account_separator (separator);
-    conflict_accts = gnc_account_list_name_violations (book, *normalized_separator);
-    if (conflict_accts)
-        message = gnc_account_name_violations_errmsg (*normalized_separator,
-                                                      conflict_accts);
 
-    g_list_free_full (conflict_accts, g_free);
-    return message;
+    return gnc_account_violations_message (book, *normalized_separator);
 }
 
 /** This function is called whenever the account separator is changed

--- a/gnucash/gnome-utils/gnc-file.c
+++ b/gnucash/gnome-utils/gnc-file.c
@@ -700,13 +700,7 @@ static char*
 get_account_sep_warning (QofBook *book)
 {
     const char *sep = gnc_get_account_separator_string ();
-    GList *violation_accts = gnc_account_list_name_violations (book, sep);
-    if (!violation_accts)
-        return NULL;
-
-    gchar *rv = gnc_account_name_violations_errmsg (sep, violation_accts);
-    g_list_free_full (violation_accts, g_free);
-    return rv;
+    return gnc_account_violations_message (book, sep);
 }
 
 /* private utilities for file open; done in two stages */

--- a/libgnucash/engine/Account.cpp
+++ b/libgnucash/engine/Account.cpp
@@ -231,54 +231,6 @@ gnc_set_account_separator (const gchar *separator)
     account_separator[count] = '\0';
 }
 
-gchar *gnc_account_name_violations_errmsg (const gchar *separator, GList* invalid_account_names)
-{
-    gchar *message = NULL;
-
-    if ( !invalid_account_names )
-        return NULL;
-
-    auto account_list {gnc_g_list_stringjoin (invalid_account_names, "\n")};
-
-    /* Translators: The first %s will be the account separator character,
-       the second %s is a list of account names.
-       The resulting string will be displayed to the user if there are
-       account names containing the separator character. */
-    message = g_strdup_printf(
-                  _("The separator character \"%s\" is used in one or more account names.\n\n"
-                    "This will result in unexpected behaviour. "
-                    "Either change the account names or choose another separator character.\n\n"
-                    "Below you will find the list of invalid account names:\n"
-                    "%s"), separator, account_list );
-    g_free ( account_list );
-    return message;
-}
-
-struct ViolationData
-{
-    GList *list;
-    const gchar *separator;
-};
-
-static void
-check_acct_name (Account *acct, gpointer user_data)
-{
-    auto cb {static_cast<ViolationData*>(user_data)};
-    auto name {xaccAccountGetName (acct)};
-    if (g_strstr_len (name, -1, cb->separator))
-        cb->list = g_list_prepend (cb->list, g_strdup (name));
-}
-
-GList *gnc_account_list_name_violations (QofBook *book, const gchar *separator)
-{
-    g_return_val_if_fail (separator != NULL, nullptr);
-    if (!book) return nullptr;
-    ViolationData cb = { nullptr, separator };
-    gnc_account_foreach_descendant (gnc_book_get_root_account (book),
-                                    (AccountCb)check_acct_name, &cb);
-    return cb.list;
-}
-
 struct AcctNameViolation
 {
     std::vector<std::string> list;

--- a/libgnucash/engine/Account.h
+++ b/libgnucash/engine/Account.h
@@ -288,6 +288,18 @@ typedef enum
      */
     GList *gnc_account_list_name_violations (QofBook *book, const gchar *separator);
 
+    /** Runs through all the accounts and returns a translatable error
+     *  message showing which account names clash with the current
+     *  account separator.
+     *
+     *  @param book Pointer to the book with accounts to verify
+     *  @param separator The separator character to verify against
+     *
+     *  @return An error message that can be displayed to the user or logged.
+     *          This message string should be freed with g_free when no longer
+     *          needed. Returns nullptr if there are no invalid account names.
+     */
+    gchar *gnc_account_violations_message (QofBook *book, const char *sep);
     /* ------------------ */
 
     /** @name Account general setters/getters

--- a/libgnucash/engine/Account.h
+++ b/libgnucash/engine/Account.h
@@ -262,32 +262,6 @@ typedef enum
 
     gboolean gnc_account_and_descendants_empty (Account *acc);
 
-    /** Composes a translatable error message showing which account
-     *  names clash with the current account separator. Can be called
-     *  after gnc_account_list_name_violations to have a consistent
-     *  error message in different parts of GnuCash
-     *
-     *  @param separator The separator character that was verified against
-     *  @param invalid_account_names A GList of invalid account names.
-     *
-     *  @return An error message that can be displayed to the user or logged.
-     *          This message string should be freed with g_free when no longer
-     *          needed.
-     */
-    gchar *gnc_account_name_violations_errmsg (const gchar *separator, GList* invalid_account_names);
-
-    /** Runs through all the accounts and returns a list of account names
-     *  that contain the provided separator character. This can be used to
-     *  check if certain account names are invalid.
-     *
-     *  @param book Pointer to the book with accounts to verify
-     *  @param separator The separator character to verify against
-     *
-     *  @return A GList of invalid account names. Should be freed with
-     *          g_list_free_full (value, g_free) when no longer needed.
-     */
-    GList *gnc_account_list_name_violations (QofBook *book, const gchar *separator);
-
     /** Runs through all the accounts and returns a translatable error
      *  message showing which account names clash with the current
      *  account separator.


### PR DESCRIPTION
I figure that Account.cpp returning a `char*` is preferable to returning a `GList*`. These two functions are complementary and could be combined.