### PR TITLE
Iter to stl

### DIFF
--- a/gnucash/gnome-utils/gnc-tree-container.hpp
+++ b/gnucash/gnome-utils/gnc-tree-container.hpp
@@ -74,6 +74,12 @@ template <typename ModelType>
 class GncTreeIter
 {
 public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = ModelType;
+    using difference_type = ModelType;
+    using pointer = ModelType*;
+    using reference = ModelType&;
+
     GncTreeIter(GtkTreeModel* model, std::optional<GtkTreeIter> iter) : m_model(model), m_iter(iter) {}
 
     GncTreeIter(GtkTreeModel* model) : m_model (model)
@@ -98,6 +104,13 @@ public:
             throw "no value, cannot dereference";
         return ModelType (m_model, *m_iter);
     }
+
+    GtkTreeIter& get_gtk_tree_iter ()
+    {
+        if (!m_iter.has_value())
+            throw "no value, cannot dereference";
+        return *m_iter;
+    };
 
     bool has_value() { return m_iter.has_value(); };
 
@@ -135,6 +148,13 @@ public:
     TreeModelIterator begin() { return TreeModelIterator(m_model); };
 
     TreeModelIterator end() { return TreeModelIterator(m_model, std::nullopt); };
+
+    TreeModelIterator append()
+    {
+        GtkTreeIter iter;
+        gtk_list_store_append (GTK_LIST_STORE(m_model), &iter);
+        return TreeModelIterator(m_model, iter);
+    };
 
     bool empty() { return begin() == end(); };
 

--- a/gnucash/import-export/import-match-picker.cpp
+++ b/gnucash/import-export/import-match-picker.cpp
@@ -31,11 +31,14 @@
 #include <gtk/gtk.h>
 #include <glib/gi18n.h>
 
+#include "gnc-tree-container.hpp"
 #include "import-match-picker.h"
 #include "qof.h"
 #include "gnc-ui-util.h"
 #include "dialog-utils.h"
 #include "gnc-prefs.h"
+
+#include <algorithm>
 
 /********************************************************************\
  *   Constants   *
@@ -98,32 +101,22 @@ downloaded_transaction_append(GNCImportMatchPicker * matcher,
     g_return_if_fail (matcher);
     g_return_if_fail (transaction_info);
 
-    auto found = false;
     auto store = GTK_LIST_STORE(gtk_tree_view_get_model(matcher->downloaded_view));
     auto split = gnc_import_TransInfo_get_fsplit(transaction_info);
     auto trans = gnc_import_TransInfo_get_trans(transaction_info);
+    auto container = GncTreeContainer<GncTreeData> (GTK_TREE_MODEL(store));
 
-    /* Has the transaction already been added? */
-    GtkTreeIter iter;
-    if (gtk_tree_model_get_iter_first(GTK_TREE_MODEL(store), &iter))
-    {
-        do
-        {
-            GNCImportTransInfo *local_info;
-            gtk_tree_model_get(GTK_TREE_MODEL(store), &iter,
-                               DOWNLOADED_COL_INFO_PTR, &local_info,
-                               -1);
-            if (local_info == transaction_info)
-            {
-                found = TRUE;
-                break;
-            }
-        }
-        while (gtk_tree_model_iter_next(GTK_TREE_MODEL(store), &iter));
-    }
-    if (!found)
-        gtk_list_store_append(store, &iter);
+    auto it_matches = [&transaction_info](auto it)
+    { return it.template get<GNCImportTransInfo*>(DOWNLOADED_COL_INFO_PTR) == transaction_info; };
 
+    // find the GncTreeIter whose DOWNLOADED_COL_INFO_PTR matches transaction_info
+    auto iter = std::find_if (container.begin(), container.end(), it_matches);
+
+    // not found. append a new GtkTreeIter in container.
+    if (iter == container.end())
+        iter = container.append();
+
+    // now iter is a GncTreeIter; iter.get_gtk_tree_iter() is the GtkTreeIter
     auto account = xaccAccountGetName(xaccSplitGetAccount(split));
     auto date = qof_print_date(xaccTransGetDate(trans));
     auto amount = g_strdup (xaccPrintAmount(xaccSplitGetAmount(split), gnc_split_amount_print_info(split, TRUE)));
@@ -137,7 +130,7 @@ downloaded_transaction_append(GNCImportMatchPicker * matcher,
     auto imbalance = g_strdup (xaccPrintAmount (xaccTransGetImbalanceValue(trans),
                                                 gnc_commodity_print_info (xaccTransGetCurrency (trans), TRUE)));
 
-    gtk_list_store_set (store, &iter,
+    gtk_list_store_set (store, &iter.get_gtk_tree_iter(),
                         DOWNLOADED_COL_ACCOUNT, account,
                         DOWNLOADED_COL_DATE, date,
                         DOWNLOADED_COL_AMOUNT, amount,
@@ -147,7 +140,7 @@ downloaded_transaction_append(GNCImportMatchPicker * matcher,
                         DOWNLOADED_COL_INFO_PTR, transaction_info,
                         -1);
 
-    gtk_tree_selection_select_iter (gtk_tree_view_get_selection(matcher->downloaded_view), &iter);
+    gtk_tree_selection_select_iter (gtk_tree_view_get_selection(matcher->downloaded_view), &iter.get_gtk_tree_iter());
 
     g_free (date);
     g_free (amount);


### PR DESCRIPTION
More iter changes.

- to fully be compatible with `std::find_if` and friends, the `GncTreeIter` seems to need iterator traits inherited from `std::iterator`. See the class definition
- `GncTreeContainer` adds an `append()` methods which adds a new `GtkTreeIter` and returns its `GncTreeIter`.
- `GncTreeIter` adds a `get_gtk_tree_iter` to return the `GtkTreeIter` to be useful when `find_if` returns the `GncTreeIter`. This creates another method to access the GtkTreeIter; one from the GncTreeIter and another from GncTreeData. The benefit is this allows:
```cpp
 auto iter = std::find_if (...);
 gtk_list_store_set (store, &iter.get_gtk_tree_iter(), ...)
```
instead of the uglier
```cpp
 auto iter = std::find_if (...);
 gtk_list_store_set (store, &(*iter).get_iter(), ...)
```
- Adds an example `std::find_if` use in `import-match-picker.cpp`.