### PR TITLE
Bug 798995 - Keystrokes ignored during ledger entry

### DIFF
--- a/gnucash/register/register-gnome/combocell-gnome.c
+++ b/gnucash/register/register-gnome/combocell-gnome.c
@@ -920,29 +920,20 @@ gnc_combo_cell_gui_move (BasicCell* bcell)
 }
 
 static int
-popup_get_height (G_GNUC_UNUSED GtkWidget* widget,
+popup_get_height (GtkWidget* widget,
                   int space_available,
-                  int row_height,
+                  G_GNUC_UNUSED int row_height,
                   gpointer user_data)
 {
     PopBox* box = user_data;
     GtkScrolledWindow* scrollwin = GNC_ITEM_LIST(widget)->scrollwin;
-    GtkWidget *hsbar = gtk_scrolled_window_get_hscrollbar (scrollwin);
-    GtkStyleContext *context = gtk_widget_get_style_context (hsbar);
-    /* Note: gtk_scrolled_window_get_overlay_scrolling (scrollwin) always returns
-       TRUE so look for style class "overlay-indicator" on the scrollbar. */
-    gboolean overlay = gtk_style_context_has_class (context, "overlay-indicator");
-    int count, height;
+    int height;
 
-    count = gnc_item_list_num_entries (box->item_list);
-    height = count * (gnc_item_list_get_cell_height (box->item_list) + 2);
-
-    if (!overlay)
-    {
-        gint minh, nath;
-        gtk_widget_get_preferred_height (hsbar, &minh, &nath);
-        height = height + minh;
-    }
+    // if popup_allocation_height set use that
+    if (box->item_edit->popup_allocation_height != -1)
+        height = box->item_edit->popup_allocation_height;
+    else
+        height = gnc_item_list_get_popup_height (GNC_ITEM_LIST(widget));
 
     if (height < space_available)
     {

--- a/gnucash/register/register-gnome/completioncell-gnome.c
+++ b/gnucash/register/register-gnome/completioncell-gnome.c
@@ -644,6 +644,7 @@ populate_list_store (CompletionCell* cell, const gchar* str)
     PopBox* box = cell->cell.gui_private;
 
     box->in_list_select = FALSE;
+    box->item_edit->popup_allocation_height = -1;
 
     if (box->stop_searching)
         return;
@@ -904,27 +905,20 @@ gnc_completion_cell_gui_move (BasicCell* bcell)
 }
 
 static int
-popup_get_height (G_GNUC_UNUSED GtkWidget* widget,
+popup_get_height (GtkWidget* widget,
                   int space_available,
-                  int row_height,
+                  G_GNUC_UNUSED int row_height,
                   gpointer user_data)
 {
     PopBox* box = user_data;
     GtkScrolledWindow* scrollwin = GNC_ITEM_LIST(widget)->scrollwin;
-    GtkWidget *hsbar = gtk_scrolled_window_get_hscrollbar (scrollwin);
-    GtkStyleContext *context = gtk_widget_get_style_context (hsbar);
-    /* Note: gtk_scrolled_window_get_overlay_scrolling (scrollwin) always returns
-       TRUE so look for style class "overlay-indicator" on the scrollbar. */
-    gboolean overlay = gtk_style_context_has_class (context, "overlay-indicator");
-    int count = gnc_item_list_num_entries (box->item_list);
-    int height = count * (gnc_item_list_get_cell_height (box->item_list) + 2);
+    int height;
 
-    if (!overlay)
-    {
-        gint minh, nath;
-        gtk_widget_get_preferred_height (hsbar, &minh, &nath);
-        height = height + minh;
-    }
+    // if popup_allocation_height set use that
+    if (box->item_edit->popup_allocation_height != -1)
+        height = box->item_edit->popup_allocation_height;
+    else
+        height = gnc_item_list_get_popup_height (GNC_ITEM_LIST(widget));
 
     if (height < space_available)
     {

--- a/gnucash/register/register-gnome/gnucash-item-edit.c
+++ b/gnucash/register/register-gnome/gnucash-item-edit.c
@@ -319,6 +319,7 @@ gnc_item_edit_init (GncItemEdit *item_edit)
     item_edit->popup_user_data = NULL;
     item_edit->popup_returned_height = 0;
     item_edit->popup_height_signal_id = 0;
+    item_edit->popup_allocation_height = -1;
 
     item_edit->style = NULL;
     item_edit->button_width = MIN_BUTT_WIDTH;
@@ -944,15 +945,15 @@ gnc_item_edit_destroying (GtkWidget *item_edit, gpointer data)
 static void
 check_popup_height_is_true (GtkWidget    *widget,
                             GdkRectangle *allocation,
-                            gpointer user_data)
+                            gpointer      user_data)
 {
     GncItemEdit *item_edit = GNC_ITEM_EDIT(user_data);
 
-    // if a larger font is specified in css for the sheet, the popup returned height value
-    // on first pop does not reflect the true height but the minimum height so just to be
-    // sure check this value against the allocated one.
+    // the popup returned height value on first pop sometimes does not reflect the true height
+    // but the minimum height so just to be sure check this value against the allocated one.
     if (allocation->height != item_edit->popup_returned_height)
     {
+        item_edit->popup_allocation_height = allocation->height;
         gtk_container_remove (GTK_CONTAINER(item_edit->sheet), item_edit->popup_item);
 
         g_idle_add_full (G_PRIORITY_HIGH_IDLE,
@@ -1104,6 +1105,8 @@ gnc_item_edit_hide_popup (GncItemEdit *item_edit)
 
     gtk_toggle_button_set_active
         (GTK_TOGGLE_BUTTON(item_edit->popup_toggle.tbutton), FALSE);
+
+    item_edit->popup_allocation_height = -1;
 
     gtk_widget_grab_focus (GTK_WIDGET(item_edit->sheet));
 }

--- a/gnucash/register/register-gnome/gnucash-item-edit.h
+++ b/gnucash/register/register-gnome/gnucash-item-edit.h
@@ -91,6 +91,7 @@ typedef struct
     PopupGetWidth    popup_get_width;
     gpointer         popup_user_data;
     gint             popup_returned_height;
+    gint             popup_allocation_height;
     gulong           popup_height_signal_id;
 
     GtkBorder        padding;

--- a/gnucash/register/register-gnome/gnucash-item-list.c
+++ b/gnucash/register/register-gnome/gnucash-item-list.c
@@ -468,7 +468,7 @@ tree_view_selection_changed (GtkTreeSelection* selection,
 }
 
 
-gint
+static gint
 gnc_item_list_get_cell_height (GncItemList *item_list)
 {
 
@@ -479,6 +479,26 @@ gnc_item_list_get_cell_height (GncItemList *item_list)
                                            &nat_height);
 
     return min_height;
+}
+
+gint
+gnc_item_list_get_popup_height (GncItemList *item_list)
+{
+    GtkWidget *hsbar = gtk_scrolled_window_get_hscrollbar (GTK_SCROLLED_WINDOW(item_list->scrollwin));
+    GtkStyleContext *context = gtk_widget_get_style_context (hsbar);
+    /* Note: gtk_scrolled_window_get_overlay_scrolling (scrollwin) always returns
+       TRUE so look for style class "overlay-indicator" on the scrollbar. */
+    gboolean overlay = gtk_style_context_has_class (context, "overlay-indicator");
+    int count = gnc_item_list_num_entries (item_list);
+    int height = count * (gnc_item_list_get_cell_height (item_list) + 2);
+
+    if (!overlay)
+    {
+        gint minh, nath;
+        gtk_widget_get_preferred_height (hsbar, &minh, &nath);
+        height = height + minh;
+    }
+    return height;
 }
 
 

--- a/gnucash/register/register-gnome/gnucash-item-list.h
+++ b/gnucash/register/register-gnome/gnucash-item-list.h
@@ -71,7 +71,7 @@ GtkWidget *gnc_item_list_new (GtkListStore *shared_store);
 
 gint gnc_item_list_num_entries (GncItemList *item_list);
 
-gint gnc_item_list_get_cell_height (GncItemList *item_list);
+gint gnc_item_list_get_popup_height (GncItemList *item_list);
 
 void gnc_item_list_clear (GncItemList *item_list);
 


### PR DESCRIPTION
Some themes add additional pixels to list rows and dialogs, in this case with 'TraditionalOK' 2 pixels are added to each entry in the list and 2 to the popup. This make the calculation for the pop up height wrong and so when compared to the allocation height it is different so tries to resolve by re-popping the list and this causes an endless loop.

To fix this, use the calculated height which works for Adwaita but if this is different to the popup allocation height use that.

I have tested this on the reported OS, Fedora38 with the reported 'TraditionalOK' theme and also on an Xfce VM with the 'Clearlooks-Phenix' theme. Also built and tested on Windows and all seems to be OK.