### PR TITLE
[gnc-engine-guile] exports gnc_string_to_numeric

### DIFF
--- a/bindings/guile/test/test-scm-engine.scm
+++ b/bindings/guile/test/test-scm-engine.scm
@@ -6,9 +6,45 @@
   (test-runner-factory gnc:test-runner)
   (test-begin "test-engine")
   (test-engine)
+  (test-gnc-numeric-from-string)
   (test-end "test-engine"))
 
 (define (test-engine)
   (test-begin "testing function availability")
 
   (test-end "testing deprecated functions"))
+
+(define (test-gnc-numeric-from-string)
+  (test-equal "gnc-numeric-from-string 1"
+    1
+    (gnc-numeric-from-string "1"))
+
+  (test-equal "gnc-numeric-from-string 3/4"
+    3/4
+    (gnc-numeric-from-string "3/4"))
+
+  (test-equal "gnc-numeric-from-string 12 3/4"
+    51/4
+    (gnc-numeric-from-string "12 3/4"))
+
+  (test-equal "gnc-numeric-from-string 2.5"
+    5/2
+    (gnc-numeric-from-string "2.5"))
+
+  (test-equal "gnc-numeric-from-string .5"
+    1/2
+    (gnc-numeric-from-string ".5"))
+
+  (test-equal "gnc-numeric-from-string 1/3"
+    1/3
+    (gnc-numeric-from-string "1/3"))
+
+  ;; should error out; however "1 3" is parsed as 1.
+  (test-skip 1)
+  (test-equal "gnc-numeric-from-string 1 3"
+    #f
+    (gnc-numeric-from-string "1 3"))
+
+  (test-equal "gnc-numeric-from-string #f"
+    #f
+    (gnc-numeric-from-string "#f")))

--- a/bindings/python/gnucash_core.py
+++ b/bindings/python/gnucash_core.py
@@ -49,8 +49,8 @@ from gnucash.gnucash_core_c import gncInvoiceLookup, gncInvoiceGetInvoiceFromTxn
     gnc_search_customer_on_id, gnc_search_bill_on_id , \
     gnc_search_vendor_on_id, gncInvoiceNextID, gncCustomerNextID, \
     gncVendorNextID, gncTaxTableGetTables, gnc_numeric_zero, \
-    gnc_numeric_create, double_to_gnc_numeric, string_to_gnc_numeric, \
-    gnc_numeric_to_string
+    gnc_numeric_create, double_to_gnc_numeric, gnc_numeric_from_string, \
+    gnc_numeric_to_string, gnc_numeric_check
 
 from gnucash.deprecation import (
     deprecated_args_session,
@@ -432,8 +432,8 @@ class GncNumeric(GnuCashCoreClass):
             elif isinstance(arg, float):
                 return double_to_gnc_numeric(arg, GNC_DENOM_AUTO, GNC_HOW_DENOM_FIXED | GNC_HOW_RND_NEVER)
             elif isinstance(arg, str):
-                instance = gnc_numeric_zero()
-                if not string_to_gnc_numeric(arg, instance):
+                instance = gnc_numeric_from_string(arg)
+                if gnc_numeric_check(instance):
                     raise TypeError('Failed to convert to GncNumeric: ' + str(args))
                 return instance
             elif isinstance(arg, GncNumeric):

--- a/gnucash/gnome/dialog-fincalc.c
+++ b/gnucash/gnome/dialog-fincalc.c
@@ -194,9 +194,8 @@ gui_to_fi (FinCalcDialog *fcd)
     text = gtk_entry_get_text (GTK_ENTRY(entry));
     if (text && *text)
     {
-        gnc_numeric out;
-        gboolean result = string_to_gnc_numeric (text, &out);
-        if (result)
+        gnc_numeric out = gnc_numeric_from_string (text);
+        if (!gnc_numeric_check (out))
             npp = gnc_numeric_convert (out, 1, GNC_HOW_RND_TRUNC);
         else
             npp = gnc_numeric_zero ();

--- a/gnucash/import-export/log-replay/gnc-log-replay.c
+++ b/gnucash/import-export/log-replay/gnc-log-replay.c
@@ -233,12 +233,12 @@ static split_record interpret_split_record( char *record_line)
     }
     if (strlen(tok_ptr = my_strtok(NULL, "\t")) != 0)
     {
-        string_to_gnc_numeric(tok_ptr, &(record.amount));
+        record.amount = gnc_numeric_from_string (tok_ptr);
         record.amount_present = TRUE;
     }
     if (strlen(tok_ptr = my_strtok(NULL, "\t")) != 0)
     {
-        string_to_gnc_numeric(tok_ptr, &(record.value));
+        record.value = gnc_numeric_from_string (tok_ptr);
         record.value_present = TRUE;
     }
     if (strlen(tok_ptr = my_strtok(NULL, "\t")) != 0)

--- a/libgnucash/app-utils/gnc-exp-parser.c
+++ b/libgnucash/app-utils/gnc-exp-parser.c
@@ -98,10 +98,9 @@ gnc_exp_parser_real_init ( gboolean addPredefined )
             for (key = keys; key && *key; key++)
             {
                 str_value = g_key_file_get_string(key_file, GEP_GROUP_NAME, *key, NULL);
-                if (str_value && string_to_gnc_numeric(str_value, &value))
-                {
+                value = gnc_numeric_from_string (str_value);
+                if (!gnc_numeric_check (value))
                     gnc_exp_parser_set_value (*key, gnc_numeric_reduce (value));
-                }
             }
             g_strfreev(keys);
             g_key_file_free(key_file);

--- a/libgnucash/backend/xml/io-gncxml-v1.cpp
+++ b/libgnucash/backend/xml/io-gncxml-v1.cpp
@@ -472,6 +472,13 @@ simple_kvp_value_parser_new (sixtp_end_handler end_handler)
 
  */
 
+static gboolean
+string_to_gnc_numeric(const gchar* str, gnc_numeric *n)
+{
+    *n = gnc_numeric_from_string (str);
+    return (!gnc_numeric_check (*n));
+}
+
 /* ------------------------------------------------------------ */
 /* generic type copnversion for kvp types */
 #define KVP_CVT_VALUE(TYPE)                 \

--- a/libgnucash/backend/xml/sixtp-dom-parsers.cpp
+++ b/libgnucash/backend/xml/sixtp-dom-parsers.cpp
@@ -509,8 +509,8 @@ dom_tree_to_gnc_numeric (xmlNodePtr node)
     if (!content)
         return gnc_numeric_zero ();
 
-    gnc_numeric num;
-    if (!string_to_gnc_numeric (content, &num))
+    gnc_numeric num = gnc_numeric_from_string (content);
+    if (gnc_numeric_check (num))
         num = gnc_numeric_zero ();
 
     g_free (content);

--- a/libgnucash/backend/xml/sixtp-utils.cpp
+++ b/libgnucash/backend/xml/sixtp-utils.cpp
@@ -611,7 +611,8 @@ generic_gnc_numeric_end_handler (gpointer data_for_children,
         num = g_new (gnc_numeric, 1);
         if (num)
         {
-            if (string_to_gnc_numeric (txt, num))
+            *num = gnc_numeric_from_string (txt);
+            if (!gnc_numeric_check (*num))
             {
                 ok = TRUE;
                 *result = num;

--- a/libgnucash/engine/gnc-numeric.h
+++ b/libgnucash/engine/gnc-numeric.h
@@ -296,10 +296,9 @@ gnc_numeric double_to_gnc_numeric(double n, gint64 denom,
                                   gint how);
 
 /** Read a gnc_numeric from str, skipping any leading whitespace.
- *  Return TRUE on success and store the resulting value in "n".
- *  Return NULL on error. */
-gboolean string_to_gnc_numeric(const gchar* str, gnc_numeric *n);
-
+ *  Returns the resulting gnc_numeric.
+ *  Return GNC_ERROR_ARG on error. */
+gnc_numeric gnc_numeric_from_string (const gchar* str);
 /** Create a gnc_numeric object that signals the error condition
  *  noted by error_code, rather than a number.
  */

--- a/libgnucash/engine/test/gtest-gnc-numeric.cpp
+++ b/libgnucash/engine/test/gtest-gnc-numeric.cpp
@@ -180,6 +180,28 @@ TEST(gncnumeric_constructors, test_string_constructor)
     GncNumeric neg_embedded("The number is -123456/456");
     EXPECT_EQ(-123456, neg_embedded.num());
     EXPECT_EQ(456, neg_embedded.denom());
+    ASSERT_NO_THROW(GncNumeric integer_fraction("The number is 1234 567/890"));
+    GncNumeric integer_fraction("The number is 1234 567/890");
+    EXPECT_EQ(1098827, integer_fraction.num());
+    EXPECT_EQ(890, integer_fraction.denom());
+    ASSERT_NO_THROW(GncNumeric neg_integer_fraction("The number is -1234 567/890"));
+    GncNumeric neg_integer_fraction("The number is -1234 567/890");
+    EXPECT_EQ(-1098827, neg_integer_fraction.num());
+    EXPECT_EQ(890, neg_integer_fraction.denom());
+    GncNumeric integer_large_fraction("The number is 1234 4567/890");
+    EXPECT_EQ(1102827, integer_large_fraction.num());
+    EXPECT_EQ(890, integer_large_fraction.denom());
+    GncNumeric neg_integer_large_fraction("The number is -1234 4567/890");
+    EXPECT_EQ(-1102827, neg_integer_large_fraction.num());
+    EXPECT_EQ(890, neg_integer_large_fraction.denom());
+    ASSERT_NO_THROW(GncNumeric zero_integer_fraction("The number is 0 567/890"));
+    GncNumeric zero_integer_fraction("The number is 0 567/890");
+    EXPECT_EQ(567, zero_integer_fraction.num());
+    EXPECT_EQ(890, zero_integer_fraction.denom());
+    ASSERT_NO_THROW(GncNumeric neg_zero_integer_fraction("The number is -0 567/890"));
+    GncNumeric neg_zero_integer_fraction("The number is -0 567/890");
+    EXPECT_EQ(-567, neg_zero_integer_fraction.num());
+    EXPECT_EQ(890, neg_zero_integer_fraction.denom());
     EXPECT_THROW(GncNumeric throw_zero_denom("123/0"), std::invalid_argument);
     EXPECT_THROW(GncNumeric overflow("12345678987654321.123456"),
                  std::overflow_error);


### PR DESCRIPTION
which can return #f on error, or a number on successful parse.

- [x] doesn't seem to handle "integer fraction" form eg `10 3/4`.