### PR TITLE
Test qof plug leaks

### DIFF
--- a/libgnucash/engine/test/test-qofbook.c
+++ b/libgnucash/engine/test/test-qofbook.c
@@ -64,6 +64,9 @@ setup( Fixture *fixture, gconstpointer pData )
 static void
 teardown( Fixture *fixture, gconstpointer pData )
 {
+    Account *root = gnc_book_get_root_account (fixture->book);
+    xaccAccountBeginEdit (root);
+    xaccAccountDestroy (root);
     qof_book_destroy( fixture->book );
 }
 

--- a/libgnucash/engine/test/test-qofsession.cpp
+++ b/libgnucash/engine/test/test-qofsession.cpp
@@ -36,8 +36,20 @@ static bool sync_called {false};
 static bool load_error {true};
 static bool data_loaded {false};
 
+struct DestroyAccount
+{
+    void operator()(Account *acct)
+    {
+        xaccAccountBeginEdit (acct);
+        xaccAccountDestroy (acct);
+    }
+};
+
+using AccountPtr = std::unique_ptr<Account, DestroyAccount>;
+
 class QofSessionMockBackend : public QofBackend
 {
+    AccountPtr m_root;
 public:
     QofSessionMockBackend() = default;
     QofSessionMockBackend(const QofSessionMockBackend&) = delete;
@@ -56,7 +68,7 @@ void QofSessionMockBackend::load (QofBook *book, QofBackendLoadType)
     if (load_error)
         set_error(ERR_BACKEND_NO_BACKEND);
     else
-        gnc_account_create_root (book);
+        m_root = AccountPtr{gnc_account_create_root (book)};
     data_loaded = true;
 }
 


### PR DESCRIPTION
keeps valgrind happy but:
1. test-qofbook.c -- shouldn't `qof_book_destroy` take care of destroying root?
2. test-qofsession.cpp -- works but of doubtful elegance.