### PR TITLE
[assistant-stock-transaction] check account irrespective of numeric field

### DIFF
--- a/gnucash/gnome/assistant-stock-transaction.cpp
+++ b/gnucash/gnome/assistant-stock-transaction.cpp
@@ -656,6 +656,8 @@ StockTransactionEntry::validate_amount(Logger& logger) const
         g_free (buf);
     };
 
+    if (!gnc_numeric_zero_p(m_value) && !m_account)
+        add_error(N_("The %s amount has no associated account."), m_action);
 
     if (gnc_numeric_check (m_value))
     {
@@ -669,9 +671,6 @@ StockTransactionEntry::validate_amount(Logger& logger) const
 
     if (!m_allow_zero && !gnc_numeric_positive_p (m_value))
         add_error (N_("Amount for %s must be positive."), m_action);
-
-    if (!gnc_numeric_zero_p(m_value) && !m_account)
-        add_error(N_("The %s amount has no associated account."), m_action);
 }
 
 const char *
@@ -1004,6 +1003,9 @@ StockTransactionFeesEntry::validate_amount(Logger& logger) const
     };
 
 
+    if (!gnc_numeric_zero_p(m_value) && !m_account && !m_capitalize)
+        add_error(N_("The %s amount has no associated account."), m_action);
+
     if (gnc_numeric_check (m_value))
     {
         if (!m_allow_zero)
@@ -1016,9 +1018,6 @@ StockTransactionFeesEntry::validate_amount(Logger& logger) const
 
     if (!m_allow_zero && !gnc_numeric_positive_p (m_value))
         add_error (N_("Amount for %s must be positive."), m_action);
-
-    if (!gnc_numeric_zero_p(m_value) && !m_account && !m_capitalize)
-        add_error(N_("The %s amount has no associated account."), m_action);
 }
 
 void


### PR DESCRIPTION
checking account should occur even if numeric field is invalid.

further issues:
1. run an assistant session, with valid amounts/accounts. the final page should show 'ready to create'. press back and erase some numeric fields (i.e. the GtkEntry is now blank). complete the assistant again. the numeric field is still retaining the old number.
2. (just reverted as 095d32f73b) a fees page amount being empty shouldn't lead to an exception. it should undergo validation in the final page, erroring out if appropriate. In my original design, fees are always optional. empty = no fee deducted, positive number = fee deducted, negative number = invalid; non-number = invalid (? unsure).