### PR TITLE
[utest-gnc-pricedb] fix test failure due to callback type mismatch

### DIFF
--- a/libgnucash/engine/test/utest-gnc-pricedb.c
+++ b/libgnucash/engine/test/utest-gnc-pricedb.c
@@ -1499,14 +1499,17 @@ gboolean
 gnc_pricedb_foreach_price(GNCPriceDB *db,// C: 2 in 2  Local: 6:0:0
 */
 
-static void prepend_price_time64 (GNCPrice *p, GList **lst)
+static gboolean prepend_price_time64 (GNCPrice *p, GList **lst)
 {
     *lst = g_list_prepend (*lst, GUINT_TO_POINTER(gnc_price_get_time64 (p)));
+    return TRUE;
 }
 
-static void inc_counter (GNCPrice *p, guint *count)
+static gboolean inc_counter (GNCPrice *p, guint *count)
 {
+
     (*count)++;
+    return TRUE;
 }
 
 static void


### PR DESCRIPTION
I found the test `test_gnc_pricedb_foreach_price` can fail randomly, I believe this is because the callback to `gnc_pricedb_foreach_price` is supposed to return a `gboolean`.

Currently, depending on the compiler, this can randomly exit the iterator early here
https://github.com/Gnucash/gnucash/blob/5.4/libgnucash/engine/gnc-pricedb.cpp#L2633-L2635