### PR TITLE
Icu list formatter

### DIFF
--- a/gnucash/gnome/gnc-plugin-page-register.c
+++ b/gnucash/gnome/gnc-plugin-page-register.c
@@ -3230,7 +3230,7 @@ gnc_plugin_page_register_set_filter_tooltip (GncPluginPageRegister* page)
 
         if (show)
         {
-            char *str = gnc_g_list_stringjoin (show, ", ");
+            char *str = gnc_list_formatter (show);
             t_list = g_list_prepend
                 (t_list, g_strdup_printf ("%s %s", _("Show:"), str));
             g_free (str);
@@ -3238,7 +3238,7 @@ gnc_plugin_page_register_set_filter_tooltip (GncPluginPageRegister* page)
 
         if (hide)
         {
-            char *str = gnc_g_list_stringjoin (hide, ", ");
+            char *str = gnc_list_formatter (hide);
             t_list = g_list_prepend
                 (t_list, g_strdup_printf ("%s %s", _("Hide:"), str));
             g_free (str);

--- a/gnucash/import-export/import-main-matcher.cpp
+++ b/gnucash/import-export/import-main-matcher.cpp
@@ -1876,7 +1876,7 @@ get_peer_acct_names (Split *split)
         g_free (name);
     }
     names = g_list_sort (names, (GCompareFunc)g_utf8_collate);
-    gchar *retval = gnc_g_list_stringjoin (names, ", ");
+    auto retval = gnc_list_formatter (names);
     g_list_free_full (names, g_free);
     g_list_free (accounts_seen);
     return retval;

--- a/libgnucash/engine/gnc-date.cpp
+++ b/libgnucash/engine/gnc-date.cpp
@@ -46,6 +46,7 @@
 
 #include <cinttypes>
 #include <unicode/calendar.h>
+#include <unicode/listformatter.h>
 
 #include "gnc-date.h"
 #include "gnc-date-p.h"
@@ -1651,4 +1652,30 @@ gnc_date_load_funcs (void)
 {
     Testfuncs *tf = g_slice_new (Testfuncs);
     return tf;
+}
+
+
+gchar*
+gnc_list_formatter (GList *strings)
+{
+    g_return_val_if_fail (strings, nullptr);
+
+    UErrorCode status = U_ZERO_ERROR;
+    auto formatter = icu::ListFormatter::createInstance(status);
+    std::vector<icu::UnicodeString> strvec;
+    icu::UnicodeString result;
+    std::string retval;
+
+    for (auto n = strings; n; n = g_list_next (n))
+        strvec.push_back (static_cast<char*>(n->data));
+
+    formatter->format (strvec.data(), strvec.size(), result, status);
+
+    if (U_FAILURE(status))
+        PERR ("Unicode error");
+    else
+        result.toUTF8String(retval);
+
+    delete formatter;
+    return g_strdup (retval.c_str());
 }

--- a/libgnucash/engine/gnc-date.h
+++ b/libgnucash/engine/gnc-date.h
@@ -813,6 +813,17 @@ void gnc_gdate_set_prev_fiscal_year_start (GDate *date, const GDate *year_end);
  *  fiscal year.  The year field of this argument is ignored. */
 void gnc_gdate_set_prev_fiscal_year_end (GDate *date, const GDate *year_end);
 
+
+
+/** This function takes a GList of char*, and uses locale-sensitive
+ *  list formatter.
+ *
+ *  @param strings The GList* of char*.
+ *
+ * @returns a newly allocated char*
+ */
+gchar* gnc_list_formatter (GList* strings);
+
 //@}
 
 //@}


### PR DESCRIPTION
locale-sensitive list_of_strings to string... :smile: (inserted into gnc-date.cpp for convenient access to icu). now looking for a locale-sensitive quoter better than "string". Maybe we need to localise `_("\"%s\"")` @fellen ?

en_AU
![image](https://github.com/Gnucash/gnucash/assets/1975870/9aab470f-aebe-490c-a348-04b6da07f97c)

fr_FR
![image](https://github.com/Gnucash/gnucash/assets/1975870/e099bc24-0bb0-4043-b1c8-0c864f4a3738)

ja_JP
![image](https://github.com/Gnucash/gnucash/assets/1975870/3a4132b8-3a1c-440e-9108-23d72b3f8433)

zh_TW
![image](https://github.com/Gnucash/gnucash/assets/1975870/40e93f72-083a-4965-ad4f-0075a7d4e2c3)

hi_IN
![image](https://github.com/Gnucash/gnucash/assets/1975870/262f0d0e-5af9-42fe-98d4-7f8d7b4e2171)
