### PR TITLE
Use the default version of Python 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,11 @@
 
 cmake_minimum_required (VERSION 3.14.5)
 
+# CMake 3.15+ Python3_FIND_STRATEGY=LOCATION
+if (POLICY CMP0094)
+  cmake_policy(SET CMP0094 NEW)
+endif()
+
 project (gnucash
     VERSION 5.4
 )
@@ -492,6 +497,9 @@ endif()
 
 if (WITH_PYTHON)
   set (PYTHON_MIN_VERSION 3.6.0)
+  if (NOT DEFINED Python3_FIND_UNVERSIONED_NAMES)
+    set (Python3_FIND_UNVERSIONED_NAMES FIRST)
+  endif()
   find_package (Python3 ${PYTHON_MIN_VERSION} COMPONENTS Interpreter Development)
   if (NOT Python3_FOUND)
     message(SEND_ERROR "Python support enabled, but Python3 interpreter and/or libaries not found.")


### PR DESCRIPTION
Python scripts that run with the default version of Python 3 by executing with `/usr/bin/python3` that try to `import gnucash` can't find it if it has been built for a different version.

Instead of using other installed versions of Python 3 that happen to be present, default to using the default "unversioned" version.

It doesn't look like CMake are going to fix the default behaviour, so every project has to do this:
https://gitlab.kitware.com/cmake/cmake/-/issues/24878
https://gitlab.kitware.com/cmake/cmake/-/issues/24126
https://gitlab.kitware.com/cmake/cmake/-/merge_requests/8287

This is only supported on CMake 3.20 or newer, so users of older versions will still get the broken behaviour.

The default behaviour for `Python3_FIND_STRATEGY` also changes depending on which version of CMake is used, and needs to be set to `LOCATION` for the change to `Python3_FIND_UNVERSIONED_NAMES` to have any effect:
https://cmake.org/cmake/help/latest/policy/CMP0094.html