### PR TITLE
Bug 799108 - "Since Last Run" crashes if there are any errors creating a scheduled transaction

### DIFF
--- a/gnucash/gnome/dialog-sx-since-last-run.c
+++ b/gnucash/gnome/dialog-sx-since-last-run.c
@@ -759,8 +759,8 @@ gnc_sx_slr_tree_model_adapter_new (GncSxInstanceModel *instances)
     return rtn;
 }
 
-static void
-creation_error_dialog (GList **creation_errors)
+void
+gnc_ui_sx_creation_error_dialog (GList **creation_errors)
 {
     GtkWidget *dialog = NULL;
     gchar *message = NULL;
@@ -833,7 +833,7 @@ gnc_sx_sxsincelast_book_opened (void)
     g_object_unref (G_OBJECT(inst_model));
 
     if (creation_errors)
-        creation_error_dialog (&creation_errors);
+        gnc_ui_sx_creation_error_dialog (&creation_errors);
 }
 
 static void
@@ -1128,7 +1128,7 @@ dialog_response_cb (GtkDialog *dialog, gint response_id, GncSxSinceLastRunDialog
         gnc_resume_gui_refresh ();
         gnc_gui_refresh_all (); // force a refresh of all registers
         if (creation_errors)
-            creation_error_dialog (&creation_errors);
+            gnc_ui_sx_creation_error_dialog (&creation_errors);
 
         if (gtk_toggle_button_get_active (app_dialog->review_created_txns_toggle)
                 && g_list_length (app_dialog->created_txns) > 0)

--- a/gnucash/gnome/dialog-sx-since-last-run.h
+++ b/gnucash/gnome/dialog-sx-since-last-run.h
@@ -52,4 +52,6 @@ GncSxSinceLastRunDialog*  gnc_ui_sx_since_last_run_dialog (GtkWindow *parent,
                                                            GncSxInstanceModel *sx_instances,
                                                            GList *auto_created_txn_guids);
 
+void gnc_ui_sx_creation_error_dialog (GList **creation_errors);
+
 #endif

--- a/gnucash/gnome/gnc-plugin-basic-commands.c
+++ b/gnucash/gnome/gnc-plugin-basic-commands.c
@@ -475,6 +475,7 @@ gnc_main_window_cmd_actions_since_last_run (GSimpleAction *simple,
     GncSxInstanceModel *sx_instances;
     GncSxSummary summary;
     GList *auto_created_txns = NULL;
+    GList *creation_errors = NULL;
     const char *nothing_to_do_msg =
         _( "There are no Scheduled Transactions to be entered at this time." );
 
@@ -490,7 +491,8 @@ gnc_main_window_cmd_actions_since_last_run (GSimpleAction *simple,
 
     sx_instances = gnc_sx_get_current_instances();
     gnc_sx_instance_model_summarize(sx_instances, &summary);
-    gnc_sx_instance_model_effect_change(sx_instances, TRUE, &auto_created_txns, NULL);
+    gnc_sx_instance_model_effect_change(sx_instances, TRUE, &auto_created_txns,
+                                        &creation_errors);
 
     if (auto_created_txns)
         gnc_gui_refresh_all();
@@ -521,6 +523,9 @@ gnc_main_window_cmd_actions_since_last_run (GSimpleAction *simple,
     }
     g_list_free (auto_created_txns);
     g_object_unref (G_OBJECT(sx_instances));
+
+    if (creation_errors)
+        gnc_ui_sx_creation_error_dialog (&creation_errors);
 }
 
 static void

--- a/libgnucash/app-utils/gnc-sx-instance-model.c
+++ b/libgnucash/app-utils/gnc-sx-instance-model.c
@@ -1478,9 +1478,12 @@ gnc_sx_instance_model_effect_change(GncSxInstanceModel *model,
                         gnc_sx_instance_model_change_instance_state
                             (model, inst, SX_INSTANCE_STATE_CREATED);
                     }
-                    else
+                    else if (creation_errors)
+                    {
                         *creation_errors = g_list_concat (*creation_errors,
                                                           instance_errors);
+                        instance_errors = NULL;
+                    }
                     break;
                 case SX_INSTANCE_STATE_REMINDER:
                     // do nothing
@@ -1490,6 +1493,9 @@ gnc_sx_instance_model_effect_change(GncSxInstanceModel *model,
                     g_assert_not_reached();
                     break;
             }
+
+            if (instance_errors)
+                g_list_free_full (instance_errors, g_free);
         }
 
         xaccSchedXactionSetLastOccurDate(instances->sx, last_occur_date);


### PR DESCRIPTION
Pass a `creation_errors` list to `gnc_sx_instance_model_effect_change()` so that errors creating SX can be stored, and then display them.