### PR TITLE
Correct check amount when printed from subaccount

### DIFF
--- a/gnucash/gnome/dialog-payment.c
+++ b/gnucash/gnome/dialog-payment.c
@@ -1041,7 +1041,7 @@ gnc_payment_ok_cb (G_GNUC_UNUSED GtkWidget *widget, gpointer data)
         Split *split = xaccTransFindSplitByAccount (pw->tx_info->txn, pw->xfer_acct);
         GList *splits = NULL;
         splits = g_list_append(splits, split);
-        gnc_ui_print_check_dialog_create(NULL, splits);
+        gnc_ui_print_check_dialog_create(NULL, splits, NULL);
         g_list_free (splits);
     }
 

--- a/gnucash/gnome/dialog-print-check.h
+++ b/gnucash/gnome/dialog-print-check.h
@@ -29,6 +29,7 @@
 typedef struct _print_check_dialog PrintCheckDialog;
 
 void gnc_ui_print_check_dialog_create(GtkWidget *parent,
-                                      GList *splits);
+                                      GList *splits,
+                                      Account* account);
 
 #endif

--- a/gnucash/gnome/gnc-plugin-page-register.c
+++ b/gnucash/gnome/gnc-plugin-page-register.c
@@ -3458,7 +3458,7 @@ gnc_plugin_page_register_cmd_print_check (GSimpleAction *simple,
     Transaction*    trans;
     GList*          splits = NULL, *item;
     GNCLedgerDisplayType ledger_type;
-    Account*        account;
+    Account*        account, *subaccount = NULL;
     GtkWidget*      window;
 
     ENTER ("(action %p, page %p)", simple, page);
@@ -3474,13 +3474,19 @@ gnc_plugin_page_register_cmd_print_check (GSimpleAction *simple,
         account  = gnc_plugin_page_register_get_account (page);
         split    = gnc_split_register_get_current_split (reg);
         trans    = xaccSplitGetParent (split);
+        if (ledger_type == LD_SUBACCOUNT)
+        {
+            /* Set up subaccount printing, where the check amount matches the
+             * value displayed in the register. */
+            subaccount = account;
+        }
 
         if (split && trans)
         {
             if (xaccSplitGetAccount (split) == account)
             {
                 splits = g_list_prepend (splits, split);
-                gnc_ui_print_check_dialog_create (window, splits);
+                gnc_ui_print_check_dialog_create (window, splits, subaccount);
                 g_list_free (splits);
             }
             else
@@ -3491,7 +3497,7 @@ gnc_plugin_page_register_cmd_print_check (GSimpleAction *simple,
                 if (split)
                 {
                     splits = g_list_prepend (splits, split);
-                    gnc_ui_print_check_dialog_create (window, splits);
+                    gnc_ui_print_check_dialog_create (window, splits, subaccount);
                     g_list_free (splits);
                 }
             }
@@ -3544,7 +3550,7 @@ gnc_plugin_page_register_cmd_print_check (GSimpleAction *simple,
                 }
             }
         }
-        gnc_ui_print_check_dialog_create (window, splits);
+        gnc_ui_print_check_dialog_create (window, splits, NULL);
     }
     else
     {


### PR DESCRIPTION
Previously, GnuCash would include only a single split's amount as the check amount. If a "bank" account has multiple subaccounts for budgeting reasons, and a transaction involves both "internal" (e.g. from one bank subaccount to another bank subaccount) and external transfers, then even when a "subaccount" register showing the top-level bank account is printed from, the check will have the amount of the first split rather than the total of all splits which are from subaccounts.

This change communicates the parent account (when viewed from a "subaccount" register) to the check printing dialog so that the check amount matches the amount displayed in the register.

e.g.
![image](https://github.com/Gnucash/gnucash/assets/207428/774bf958-08d7-4f2e-af24-2a133b39499c)
Before:
<img width="671" alt="image" src="https://github.com/Gnucash/gnucash/assets/207428/c679a15e-b56e-4450-8278-de4ad5bfa93c">

After:
<img width="665" alt="image" src="https://github.com/Gnucash/gnucash/assets/207428/63d87df4-00af-4f59-b0b1-c5839847e0f5">
