### PR TITLE
recurrencePeriodTypeToString and recurrenceWeekendAdjustToString g_strdup only when necessary

### DIFF
--- a/libgnucash/backend/sql/gnc-recurrence-sql.cpp
+++ b/libgnucash/backend/sql/gnc-recurrence-sql.cpp
@@ -379,14 +379,13 @@ upgrade_recurrence_table_1_2 (GncSqlBackend* sql_be)
 
     /* Step 2: insert a default value in the newly created column */
     {
-        gchar* weekend_adj_str = recurrenceWeekendAdjustToString (WEEKEND_ADJ_NONE);
+        const gchar* weekend_adj_str = recurrenceWeekendAdjustToString (WEEKEND_ADJ_NONE);
         std::stringstream sql;
         sql << "UPDATE " << TABLE_NAME << " SET " <<
             weekend_adjust_col_table[0]->name() << "='" <<
             weekend_adj_str << "'";
         auto stmt = sql_be->create_statement_from_sql(sql.str());
         sql_be->execute_nonselect_statement(stmt);
-        g_free (weekend_adj_str);
     }
 
     /* Step 3: rewrite the table, requiring the weekend_adj column to be non-null */

--- a/libgnucash/engine/Recurrence.c
+++ b/libgnucash/engine/Recurrence.c
@@ -518,10 +518,10 @@ recurrenceListToString(const GList *r)
     return g_string_free(str, FALSE);
 }
 
-gchar *
+const gchar *
 recurrencePeriodTypeToString(PeriodType pt)
 {
-    return VALID_PERIOD_TYPE(pt) ? g_strdup(period_type_strings[pt]) : NULL;
+    return VALID_PERIOD_TYPE(pt) ? period_type_strings[pt] : NULL;
 }
 
 PeriodType
@@ -535,10 +535,10 @@ recurrencePeriodTypeFromString(const gchar *str)
     return -1;
 }
 
-gchar *
+const gchar *
 recurrenceWeekendAdjustToString(WeekendAdjust wadj)
 {
-    return VALID_WEEKEND_ADJ(wadj) ? g_strdup(weekend_adj_strings[wadj]) : NULL;
+    return VALID_WEEKEND_ADJ(wadj) ? weekend_adj_strings[wadj] : NULL;
 }
 
 WeekendAdjust

--- a/libgnucash/engine/Recurrence.h
+++ b/libgnucash/engine/Recurrence.h
@@ -155,9 +155,9 @@ void recurrenceListNextInstance(const GList *r, const GDate *refDate,
                                 GDate *nextDate);
 
 /* These four functions are only for xml storage, not user presentation. */
-gchar *recurrencePeriodTypeToString(PeriodType pt);
+const gchar *recurrencePeriodTypeToString(PeriodType pt);
 PeriodType recurrencePeriodTypeFromString(const gchar *str);
-gchar *recurrenceWeekendAdjustToString(WeekendAdjust wadj);
+const gchar *recurrenceWeekendAdjustToString(WeekendAdjust wadj);
 WeekendAdjust recurrenceWeekendAdjustFromString(const gchar *str);
 
 /* For debugging.  Caller owns the returned string.  Not intl. */


### PR DESCRIPTION
for sql use only. xml use assumes they return a const char*.

I can't set up libsql on my machine and cannot verify this strdup is necessary. From https://github.com/Gnucash/gnucash/pull/1802#issuecomment-1791602981