### PR TITLE
Fix minor potential memory leak

### DIFF
--- a/libgnucash/core-utils/gnc-path.c
+++ b/libgnucash/core-utils/gnc-path.c
@@ -145,7 +145,7 @@ gchar *gnc_path_get_localedir()
     {
         g_free (prefix);
         g_free (locale_subdir);
-        return LOCALEDIR;
+        return g_strdup (LOCALEDIR);
     }
     else
     {


### PR DESCRIPTION
Returning the literal string will cause the caller to free unallocated memory.