### PR TITLE
boost->std::optional

### DIFF
--- a/gnucash/gnucash-cli.cpp
+++ b/gnucash/gnucash-cli.cpp
@@ -35,7 +35,7 @@
 #include <gnc-prefs.h>
 
 #include <boost/locale.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 #ifdef __MINGW32__
 #include <boost/nowide/args.hpp>
 #endif
@@ -59,13 +59,13 @@ namespace Gnucash {
         void configure_program_options (void);
 
         std::vector<std::string> m_quotes_cmd;
-        boost::optional <std::string> m_namespace;
+        std::optional <std::string> m_namespace;
         bool m_verbose = false;
 
-        boost::optional <std::string> m_report_cmd;
-        boost::optional <std::string> m_report_name;
-        boost::optional <std::string> m_export_type;
-        boost::optional <std::string> m_output_file;
+        std::optional <std::string> m_report_cmd;
+        std::optional <std::string> m_report_name;
+        std::optional <std::string> m_export_type;
+        std::optional <std::string> m_output_file;
     };
 
 }

--- a/gnucash/gnucash-commands.hpp
+++ b/gnucash/gnucash-commands.hpp
@@ -27,9 +27,9 @@
 
 #include <string>
 #include <vector>
-#include <boost/optional.hpp>
+#include <optional>
 
-using bo_str = boost::optional <std::string>;
+using bo_str = std::optional <std::string>;
 using StrVec = std::vector<std::string>;
 
 namespace Gnucash {

--- a/gnucash/gnucash-core-app.cpp
+++ b/gnucash/gnucash-core-app.cpp
@@ -111,7 +111,7 @@ Gnucash::gnc_load_scm_config (MessageCb update_message_cb)
 
 static void
 gnc_log_init (const std::vector <std::string> log_flags,
-              const boost::optional <std::string> &log_to_filename)
+              const std::optional <std::string> &log_to_filename)
 {
     if (log_to_filename && !log_to_filename->empty())
     {

--- a/gnucash/gnucash-core-app.hpp
+++ b/gnucash/gnucash-core-app.hpp
@@ -27,7 +27,7 @@
 #ifdef __MINGW32__
 #undef _GLIBCXX_USE_C99_MATH_TR1 // Avoid cmath missing function decl.
 #endif
-#include <boost/optional.hpp>
+#include <optional>
 #include <boost/program_options.hpp>
 #include <string>
 #include <vector>
@@ -47,8 +47,8 @@ public:
 protected:
     std::string m_app_name;
     std::string m_tagline;
-    boost::optional <std::string> m_log_to_filename;
-    boost::optional <std::string> m_file_to_load;
+    std::optional <std::string> m_log_to_filename;
+    std::optional <std::string> m_file_to_load;
 
     bpo::options_description m_opt_desc_all;
     std::unique_ptr<bpo::options_description> m_opt_desc_display;
@@ -64,7 +64,7 @@ private:
     bool m_show_paths = false;
     bool m_debug = false;
     bool m_extra = false;
-    boost::optional <std::string> m_gsettings_prefix;
+    std::optional <std::string> m_gsettings_prefix;
     std::vector <std::string> m_log_flags;
 
     char *sys_locale = nullptr;

--- a/gnucash/gnucash.cpp
+++ b/gnucash/gnucash.cpp
@@ -59,7 +59,7 @@
 #include <top-level.h>
 
 #include <boost/locale.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 #ifdef __MINGW32__
 #include <boost/nowide/args.hpp>
 #endif


### PR DESCRIPTION
A few usages weren't converted in libgnucash/app-utils because these belong to dependencies.