### PR TITLE
Support touch scroll in register; remove legacy scroll interactions

### DIFF
--- a/gnucash/register/register-gnome/gnucash-sheet.h
+++ b/gnucash/register/register-gnome/gnucash-sheet.h
@@ -57,7 +57,7 @@ typedef struct
 
 
 GType      gnucash_sheet_get_type (void);
-GtkWidget *gnucash_sheet_new (Table *table);
+GtkWidget *gnucash_sheet_new (Table *table, GtkAdjustment *hadj, GtkAdjustment *vadj);
 
 void gnucash_sheet_table_load (GnucashSheet *sheet, gboolean do_scroll);
 

--- a/gnucash/register/register-gnome/gnucash-sheetP.h
+++ b/gnucash/register/register-gnome/gnucash-sheetP.h
@@ -91,7 +91,6 @@ struct _GnucashSheet
     guint delete_signal;
 
     GtkAdjustment *hadj, *vadj;
-    GtkWidget *hscrollbar, *vscrollbar;
 
     GFunc moved_cb;
     gpointer moved_cb_data;


### PR DESCRIPTION
Just as an experiment, I'd like to compare how standard scrolling behavior feels in the register view.  I find the current fast and quantized scroll to be disconcerting, but I recognize that a lot of thought, and trial and error, have already gone into the existing custom scroll interactions.

This patch replaces custom scrolling with a ScrolledWindow container and its default handlers.

Reviewers: if you like this simplification, please suggest any legacy scrolling behaviors which should be reinstated.