### PR TITLE
Bug 799090 - Right Clicking scheduled transaction

### DIFF
--- a/gnucash/gnome/gnc-plugin-page-sx-list.c
+++ b/gnucash/gnome/gnc-plugin-page-sx-list.c
@@ -390,19 +390,19 @@ treeview_popup (GtkTreeView *treeview, GdkEvent *event, GncPluginPageSxList *pag
 
     menu = gtk_menu_new();
 
-    menuitem = gtk_menu_item_new_with_mnemonic (_("_New"));
+    menuitem = gtk_menu_item_new_with_mnemonic (_("_New Schedule"));
     full_action_name = g_strconcat (group_name, ".SxListNewAction", NULL);
     gtk_actionable_set_action_name (GTK_ACTIONABLE(menuitem), full_action_name);
     g_free (full_action_name);
     gtk_menu_shell_append (GTK_MENU_SHELL(menu), menuitem);
 
-    menuitem = gtk_menu_item_new_with_mnemonic (_("_Edit"));
+    menuitem = gtk_menu_item_new_with_mnemonic (_("_Edit Schedule"));
     full_action_name = g_strconcat (group_name, ".SxListEditAction", NULL);
     gtk_actionable_set_action_name (GTK_ACTIONABLE(menuitem), full_action_name);
     g_free (full_action_name);
     gtk_menu_shell_append (GTK_MENU_SHELL(menu), menuitem);
 
-    menuitem = gtk_menu_item_new_with_mnemonic (_("_Delete"));
+    menuitem = gtk_menu_item_new_with_mnemonic (_("_Delete Schedule"));
     full_action_name = g_strconcat (group_name, ".SxListDeleteAction", NULL);
     gtk_actionable_set_action_name (GTK_ACTIONABLE(menuitem), full_action_name);
     g_free (full_action_name);

--- a/gnucash/gnome/gnc-plugin-page-sx-list.c
+++ b/gnucash/gnome/gnc-plugin-page-sx-list.c
@@ -425,6 +425,20 @@ treeview_button_press (GtkTreeView *treeview, GdkEvent *event,
         GdkEventButton *event_button = (GdkEventButton*)event;
         if (event_button->button == GDK_BUTTON_SECONDARY)
         {
+            GtkTreePath *path = NULL;
+            if (gtk_tree_view_get_path_at_pos (priv->tree_view, event_button->x, event_button->y,
+                                               &path, NULL, NULL, NULL))
+            {
+                GtkTreeSelection *selection = gtk_tree_view_get_selection (priv->tree_view);
+
+                if (!gtk_tree_selection_path_is_selected (selection, path))
+                {
+                    gtk_tree_selection_unselect_all (selection);
+                    gtk_tree_selection_select_path (selection, path);
+                }
+            }
+            gtk_tree_path_free (path);
+
             treeview_popup (tree_view, event, page);
             return TRUE;
         }

--- a/gnucash/ui/gnc-plugin-page-sx-list.ui
+++ b/gnucash/ui/gnc-plugin-page-sx-list.ui
@@ -44,19 +44,19 @@
 
   <menu id="SchedulePlaceholder0">
     <item>
-      <attribute name="label" translatable="yes">_New</attribute>
+      <attribute name="label" translatable="yes">_New Schedule</attribute>
       <attribute name="action">GncPluginPageSxListActions.SxListNewAction</attribute>
       <attribute name="tooltip" translatable="yes">Create a new scheduled transaction</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
     <item>
-      <attribute name="label" translatable="yes">_Edit</attribute>
+      <attribute name="label" translatable="yes">_Edit Schedule</attribute>
       <attribute name="action">GncPluginPageSxListActions.SxListEditAction</attribute>
       <attribute name="tooltip" translatable="yes">Edit the selected scheduled transaction</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
     <item>
-      <attribute name="label" translatable="yes">_Delete</attribute>
+      <attribute name="label" translatable="yes">_Delete Schedule</attribute>
       <attribute name="action">GncPluginPageSxListActions.SxListDeleteAction</attribute>
       <attribute name="tooltip" translatable="yes">Delete the selected scheduled transaction</attribute>
       <attribute name="temp" translatable="no">yes</attribute>


### PR DESCRIPTION
The first commit fixes the bug by changing the right click action to...
If you right click on an unselected row, it does an unselect of all rows and then selects the one under the mouse to apply the popup action to. If you right click on a selected row, all selected rows are used in the popup action.

The second commit changes the delete warning message to list all the schedules selected for deletion.

The last commit is some thing I noticed when looking at the bug, the tool tip for the 'Edit' schedule was not being displayed in the status bar. This was down to a conflict with the main 'Edit' menu entry and can be easily fixed by renaming the scheduled transaction menu entries to 'Edit Schedule'/New Schedule' and 'Delete Schedule' which also brings them in line with the account menu entries.

I think this is good to go unless changes are required so will push end of week.

