### PR TITLE
Since Last Run changes

### DIFF
--- a/gnucash/gnome/dialog-sx-since-last-run.c
+++ b/gnucash/gnome/dialog-sx-since-last-run.c
@@ -957,6 +957,12 @@ variable_value_changed_cb (GtkCellRendererText *cell,
         g_free (value_copy);
         return;
     }
+
+    if (inst->state == SX_INSTANCE_STATE_REMINDER)
+    {
+        gnc_sx_instance_model_change_instance_state (dialog->editing_model->instances, inst,
+                                                     SX_INSTANCE_STATE_TO_CREATE);
+    }
     gnc_sx_instance_model_set_variable (dialog->editing_model->instances, inst, var, &parsed_num);
 }
 

--- a/gnucash/gnome/dialog-sx-since-last-run.c
+++ b/gnucash/gnome/dialog-sx-since-last-run.c
@@ -435,6 +435,10 @@ gsslrtma_populate_tree_store (GncSxSlrTreeModelAdapter *model)
             }
         }
 
+        // if there are no instances for the instance skip adding
+        if (g_list_length (instances->instance_list) == 0)
+            continue;
+
         if (!gtk_tree_model_iter_nth_child (GTK_TREE_MODEL(model->real), &sx_tree_iter, NULL, ++instances_index))
         {
             gtk_tree_store_append (model->real, &sx_tree_iter, NULL);

--- a/gnucash/gnome/dialog-sx-since-last-run.h
+++ b/gnucash/gnome/dialog-sx-since-last-run.h
@@ -34,7 +34,6 @@
 #define GNC_PREFS_GROUP_STARTUP "dialogs.sxs.since-last-run"
 #define GNC_PREF_RUN_AT_FOPEN   "show-at-file-open"
 #define GNC_PREF_SHOW_AT_FOPEN  "show-notify-window-at-file-open"
-#define GNC_PREF_SET_REVIEW     "review-transactions"
 
 typedef struct _GncSxSlrTreeModelAdapter GncSxSlrTreeModelAdapter;
 typedef struct _GncSxSinceLastRunDialog GncSxSinceLastRunDialog;

--- a/gnucash/gschemas/org.gnucash.GnuCash.dialogs.sxs.gschema.xml.in
+++ b/gnucash/gschemas/org.gnucash.GnuCash.dialogs.sxs.gschema.xml.in
@@ -27,8 +27,17 @@
       <summary>Set "Review Created Transactions" as the default for the "since last run" dialog.</summary>
       <description>This setting controls whether as default the "review created transactions" is set for the "since last run" dialog.</description>
     </key>
+    <key name="sort-column" type="i">
+      <default>0</default>
+      <summary>Set the sort column in the "since last run" dialog.</summary>
+      <description>This settings sets the sort column in the "since last run" dialog.</description>
+    </key>
+    <key name="sort-ascending" type="b">
+      <default>true</default>
+      <summary>Set the sort direction in the "since last run" dialog.</summary>
+      <description>This settings sets the sort direction in the "since last run" dialog.</description>
+    </key>
   </schema>
-
   <schema id="org.gnucash.GnuCash.dialogs.sxs.transaction-editor" path="/org/gnucash/GnuCash/dialogs/scheduled-trans/transaction-editor/">
     <key name="create-auto" type="b">
       <default>false</default>

--- a/gnucash/gtkbuilder/dialog-sx.glade
+++ b/gnucash/gtkbuilder/dialog-sx.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.22"/>
   <object class="GtkDialog" id="account_deletion_dialog">
@@ -1554,6 +1554,7 @@
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="vexpand">True</property>
+                <property name="hscrollbar-policy">never</property>
                 <property name="shadow-type">in</property>
                 <child>
                   <object class="GtkTreeView" id="instance_view">


### PR DESCRIPTION
Some possible bug fixes

The first commit, Bug799241 allows the description and status tree view columns to be sorted. With the description column it is sorted by the date of the first instance in the list and then the description of the schedule. From testing it works OK but can be tweaked if required.
The second commit just allows for the sorting to be saved.

The third commit, Bug607000 removes all the schedules that have any empty status from the view, there is no pending operation.

The fourth commit, Bug798760 allows the OK button to complete the value entry field instead of loosing any changes. A second part to this was for a reminder that required a value, if a value was entered it automatically changes the status to 'To Create'.

The last commit, Bug798025 I was originally going to close but had this idea which I am not sure about. It is all about when the cell renderer text entry is focused / active, the underlying tree view can be scrolled which can lead to confusion as all the entry values are marked 'Need Value'. This commit blocks the scrolling of the tree view while an entry is being made.
