### PR TITLE
Mark 2 regular expressions as raw strings

### DIFF
--- a/gnucash/python/pycons/console.py
+++ b/gnucash/python/pycons/console.py
@@ -164,7 +164,7 @@ class Console (Gtk.ScrolledWindow):
                                 weight=Pango.Weight.BOLD,
                                 font='Mono 10')
         self.buffer.create_tag('0')
-        self.color_pat = re.compile('\x01?\x1b\[(.*?)m\x02?')
+        self.color_pat = re.compile(r'\x01?\x1b\[(.*?)m\x02?')
         for code in ansi_colors:
             self.buffer.create_tag(code,
                                    foreground=ansi_colors[code],

--- a/gnucash/python/pycons/shell.py
+++ b/gnucash/python/pycons/shell.py
@@ -47,7 +47,7 @@ class Shell:
         self.command = ''
         self.globals = ns_globals
         self.locals = ns_locals
-        self.complete_sep = re.compile('[\s\{\}\[\]\(\)]')
+        self.complete_sep = re.compile(r'[\s\{\}\[\]\(\)]')
         self.prompt = sys.ps1
 
 


### PR DESCRIPTION
When running gnucash with python 3.12, I see these warnings on startup:
```
/usr/share/gnucash/python/pycons/console.py:167: SyntaxWarning: invalid escape sequence '\['
  self.color_pat = re.compile('\x01?\x1b\[(.*?)m\x02?')
/usr/share/gnucash/python/pycons/shell.py:50: SyntaxWarning: invalid escape sequence '\s'
  self.complete_sep = re.compile('[\s\{\}\[\]\(\)]')
```
Mark both strings as raw strings so the escapes are passed through to the regular expression engine.
