### PR TITLE
[dialog-report-column-view.cpp] new/delete instead of g_new/malloc

### DIFF
--- a/bindings/guile/gnc-engine-guile.cpp
+++ b/bindings/guile/gnc-engine-guile.cpp
@@ -386,17 +386,16 @@ gnc_query_scm2path (SCM path_scm)
     if (!scm_is_list (path_scm))
         return nullptr;
 
-    while (!scm_is_null (path_scm))
+    for (; !scm_is_null (path_scm); path_scm = scm_cdr (path_scm))
     {
         SCM key_scm = SCM_CAR (path_scm);
-        char *key;
 
         if (!scm_is_string (key_scm))
             break;
 
-        key = gnc_scm_to_utf8_string(key_scm);
-        path = g_slist_prepend (path, key);
-        path_scm = SCM_CDR (path_scm);
+        auto key = gnc_scm_to_utf8_string(key_scm);
+        path = g_slist_prepend (path, (gpointer)qof_string_cache_insert(key));
+        g_free (key);
     }
 
     return g_slist_reverse (path);
@@ -405,12 +404,7 @@ gnc_query_scm2path (SCM path_scm)
 static void
 gnc_query_path_free (GSList *path)
 {
-    GSList *node;
-
-    for (node = path; node; node = node->next)
-        g_free (node->data);
-
-    g_slist_free (path);
+    g_slist_free_full (path, (GDestroyNotify)qof_string_cache_remove);
 }
 
 

--- a/gnucash/gnome/dialog-report-column-view.cpp
+++ b/gnucash/gnome/dialog-report-column-view.cpp
@@ -61,7 +61,7 @@ using StrVec = std::vector<std::string>;
 
 struct gncp_column_view_edit
 {
-    GncOptionsDialog * optwin;
+    std::unique_ptr<GncOptionsDialog> optwin;
     GtkTreeView  * available;
     GtkTreeView  * contents;
 
@@ -103,10 +103,9 @@ gnc_column_view_set_option(GncOptionDB* odb, const char* section,
 static void
 gnc_column_view_edit_destroy(gnc_column_view_edit * view)
 {
-    delete view->optwin;
     scm_gc_unprotect_object(view->view);
     gnc_option_db_destroy(view->odb);
-    g_free(view);
+    delete view;
 }
 
 static StrVec
@@ -322,10 +321,10 @@ gnc_column_view_edit_options(GncOptionDB* odb, SCM view)
     }
     else
     {
-        gnc_column_view_edit * r = g_new0(gnc_column_view_edit, 1);
+        auto r = new gnc_column_view_edit;
         GtkBuilder *builder;
 
-        r->optwin = new GncOptionsDialog(nullptr, GTK_WINDOW(gnc_ui_get_main_window (nullptr)));
+        r->optwin = std::make_unique<GncOptionsDialog>(nullptr, GTK_WINDOW(gnc_ui_get_main_window (nullptr)));
 
         /* Hide the generic dialog page list. */
         gtk_widget_hide(r->optwin->get_page_list());


### PR DESCRIPTION
because the struct has cpp (eg vector) objects which would otherwise leak.