### PR TITLE
Trep subtotal links

### DIFF
--- a/gnucash/report/trep-engine.scm
+++ b/gnucash/report/trep-engine.scm
@@ -2071,18 +2071,20 @@ be excluded from periodic reporting.")
       (if (null? cell) ""
           (gnc:make-html-table-cell/markup
            "number-cell"
-           (monetary-div
-            (list-ref-safe (get-subtotal-table-cell-data (car cell)) commodity-idx)
-            divisor)))))
+           (gnc:make-html-text
+            (let ((subtotal (list-ref-safe (get-subtotal-table-cell-data (car cell)) commodity-idx)))
+              (if divisor
+                  (monetary-div subtotal divisor)
+                  subtotal)))))))
   (define (make-row row commodity-idx)
     (append
      (list (cond
             ((positive? commodity-idx) "")
             ((eq? row 'row-total) (G_ "Grand Total"))
             (else (cdr row))))
-     (map (lambda (col) (make-table-cell row col commodity-idx 1))
+     (map (lambda (col) (make-table-cell row col commodity-idx #f))
           list-of-cols)
-     (list (make-table-cell row 'col-total commodity-idx 1))
+     (list (make-table-cell row 'col-total commodity-idx #f))
      (if row-average-enabled?
          (list (make-table-cell
                 row 'col-total commodity-idx (length list-of-cols)))


### PR DESCRIPTION
There's more to add in the trep.

Subtotal Table can be modified from a boring 2D grid of numbers into a super interactive table with links to the relevant subtotal in the main report. eg the "-$50.60" links to the "Total For 08/10/2023 to 14/10/2023 		$50.60" row. It would be nicer to link to the header instead of the footer but is much more difficult.

![image](https://github.com/Gnucash/gnucash/assets/1975870/4e932936-ee42-44c0-9c9c-932811bafe6f)
