### PR TITLE
Add spacing for long Invoice ID's

### DIFF
--- a/gnucash/report/reports/standard/invoice.scm
+++ b/gnucash/report/reports/standard/invoice.scm
@@ -40,7 +40,7 @@
 .entries-table > table { width: 100% }
 .company-table > table * { padding: 0px; }
 .client-table > table * { padding: 0px; }
-.invoice-details-table > table * { padding: 0px; }
+.invoice-details-table > table * { padding: 0px; text-indent: 0.2em; }
 @media print { .main-table > table { width: 100%; }}
 ")
 
@@ -564,7 +564,7 @@ for styling the invoice. Please see the exported report for the CSS class names.
               (begin
                 (gnc:html-table-append-row! invoice-details-table
                                             (list
-                                             (G_ "Reference:&nbsp;")
+                                             (G_ "Reference:")
                                              (gnc:make-html-div/markup
                                               "div-align-right"
                                               (multiline-to-html-text billing-id))))

--- a/gnucash/report/reports/standard/invoice.scm
+++ b/gnucash/report/reports/standard/invoice.scm
@@ -564,7 +564,7 @@ for styling the invoice. Please see the exported report for the CSS class names.
               (begin
                 (gnc:html-table-append-row! invoice-details-table
                                             (list
-                                             (G_ "Reference:")
+                                             (G_ "Reference:&nbsp;")
                                              (gnc:make-html-div/markup
                                               "div-align-right"
                                               (multiline-to-html-text billing-id))))


### PR DESCRIPTION
This just simply adds a space between "Reference:" and long Invoice ID's printed on the invoice. If it is long enough it appears on the invoice as:

`Reference:MyInvoiceID`

Without the space:

![Screenshot 2023-12-22 165516](https://github.com/Gnucash/gnucash/assets/18019245/69716152-7db7-4b52-9e95-013d35fd8f94)

---

With the space:

![Screenshot 2023-12-22 165350](https://github.com/Gnucash/gnucash/assets/18019245/4d0ff4ba-7518-439c-983f-07ca7c5a9b17)
