### PR TITLE
Bug799179 SLR Troubles

### DIFF
--- a/gnucash/gnome/dialog-sx-since-last-run.c
+++ b/gnucash/gnome/dialog-sx-since-last-run.c
@@ -103,10 +103,7 @@ static void gnc_sx_slr_tree_model_adapter_dispose (GObject *obj);
 static void gnc_sx_slr_tree_model_adapter_finalize (GObject *obj);
 
 GncSxInstanceModel* gnc_sx_slr_tree_model_adapter_get_instance_model (GncSxSlrTreeModelAdapter *slr_model);
-GncSxInstances* gnc_sx_slr_tree_model_adapter_get_sx_instances (GncSxSlrTreeModelAdapter *model, GtkTreeIter *iter);
-static GncSxInstances* _gnc_sx_slr_tree_model_adapter_get_sx_instances (GncSxSlrTreeModelAdapter *model,
-                                                                        GtkTreeIter *iter,
-                                                                        gboolean check_depth);
+
 /** @return null if the iter is not actually an GncSxInstance. **/
 GncSxInstance* gnc_sx_slr_model_get_instance (GncSxSlrTreeModelAdapter *model, GtkTreeIter *iter);
 static GncSxInstance* _gnc_sx_slr_model_get_instance (GncSxSlrTreeModelAdapter *model,
@@ -558,48 +555,6 @@ GncSxInstanceModel*
 gnc_sx_slr_tree_model_adapter_get_instance_model (GncSxSlrTreeModelAdapter *slr_model)
 {
     return slr_model->instances;
-}
-
-GncSxInstances*
-gnc_sx_slr_tree_model_adapter_get_sx_instances (GncSxSlrTreeModelAdapter *model, GtkTreeIter *iter)
-{
-    return _gnc_sx_slr_tree_model_adapter_get_sx_instances (model, iter, TRUE);
-}
-
-static GncSxInstances*
-_gnc_sx_slr_tree_model_adapter_get_sx_instances (GncSxSlrTreeModelAdapter *model, GtkTreeIter *iter, gboolean check_depth)
-{
-    GtkTreePath *model_path = gtk_tree_model_get_path (GTK_TREE_MODEL(model), iter);
-    gint *indices, instances_index;
-    GncSxInstances *instances = NULL;
-    GtkTreeIter new_iter;
-
-    debug_path (DEBUG, "model path is:", model_path);
-
-    if (check_depth && gtk_tree_path_get_depth (model_path) != 1)
-    {
-        DEBUG("path depth not equal to 1");
-        gtk_tree_path_free (model_path);
-        return NULL;
-    }
-
-    indices = gtk_tree_path_get_indices (model_path);
-    instances_index = indices[0];
-
-    gtk_tree_path_free (model_path);
-
-    model_path = gtk_tree_path_new_from_indices (instances_index, -1);
-
-    debug_path (DEBUG, "new model path is:", model_path);
-
-    if (gtk_tree_model_get_iter (GTK_TREE_MODEL(model), &new_iter, model_path))
-        gtk_tree_model_get (GTK_TREE_MODEL(model), &new_iter, SLR_MODEL_COL_INSTANCE_PTR, &instances, -1);
-
-    gtk_tree_path_free (model_path);
-
-    DEBUG("instances is %p", instances);
-
-    return instances;
 }
 
 GncSxInstance*

--- a/gnucash/gschemas/org.gnucash.GnuCash.dialogs.sxs.gschema.xml.in
+++ b/gnucash/gschemas/org.gnucash.GnuCash.dialogs.sxs.gschema.xml.in
@@ -37,6 +37,11 @@
       <summary>Set the sort direction in the "since last run" dialog.</summary>
       <description>This settings sets the sort direction in the "since last run" dialog.</description>
     </key>
+    <key name="sort-depth" type="i">
+      <default>1</default>
+      <summary>The depth used in the tree to sort in the "since last run" dialog.</summary>
+      <description>The depth used in the tree to sort in the "since last run" dialog.</description>
+    </key>
   </schema>
   <schema id="org.gnucash.GnuCash.dialogs.sxs.transaction-editor" path="/org/gnucash/GnuCash/dialogs/scheduled-trans/transaction-editor/">
     <key name="create-auto" type="b">


### PR DESCRIPTION
I think this will fix the SLR troubles...

In the original code the GtkTreeModel is populated from a GList of GncSxInstances. The path of the GtkTreeModel entry is split in to indices and various parts are used to do a lookup in the GList. As I was not adding the empty instances, the two lists will be out of sink and depending on where the missing instances were affected what fault was highlighted in the SLR.

To fix this, I added another column to the model that holds a pointer to instances, instance and variable depending on the depth and these values are used to look up the required objects.

The second commit removes an unused function, I did notice there are some 'g_warning' entries so I suppose they should be changed to 'PWARN' entries.

To test this I changed the order of schedules in my XML test file so it resulted in this for 5.4 ...

![old-slr](https://github.com/Gnucash/gnucash/assets/15702727/d20dbc9e-6a61-434f-ab13-581b68f0c979)

And after this change ...

![new-slr](https://github.com/Gnucash/gnucash/assets/15702727/3df70295-412f-4173-88b7-dc5dbf061ec6)

I have been able to change any of the entries with correct results but I thought that last time !!!

What I did notice but this existed before these changes is...
If you have entries after one that is in a state 'Postponed' and try to update them, they are not removed from the SLR as shown below when I changed 'Test-24/01/2024' to create and provided a value for 'Avar-28/12/2023', pressed OK and rerun SLR which resulted in the following...
![slr-q](https://github.com/Gnucash/gnucash/assets/15702727/832c362e-af80-4c13-b858-65a5b1b3e2a6)

So I am wondering if this is a 'BUG' and should the following be applied in another PR/commit...
If entry changed to 'Postponed', all entries after should be changed to 'Postponed'
If entry changed from 'Postponed', all entries before should also be changed to that state.
This may also apply for 'Reminder' changes.



