### PR TITLE
Stock acct metadata

### DIFF
--- a/libgnucash/engine/Account.h
+++ b/libgnucash/engine/Account.h
@@ -312,6 +312,11 @@ typedef enum
     void xaccAccountSetSortReversed (Account *account, gboolean sortreversed);
     /** Set the account's notes */
     void xaccAccountSetNotes (Account *account, const char *notes);
+
+    /** Set the account's associated account e.g. stock account -> dividend account */
+    void xaccAccountSetAssociatedAccount (Account *acc, const char *tag,
+                                          const Account *assoc_acct);
+
     /** Set the last num field of an Account */
     void xaccAccountSetLastNum (Account *account, const char *num);
     /** Set the account's lot order policy */
@@ -416,6 +421,9 @@ typedef enum
     gboolean xaccAccountGetSortReversed (const Account *account);
     /** Get the account's notes */
     const char * xaccAccountGetNotes (const Account *account);
+
+    /** Get the account's associated account e.g. stock account -> dividend account */
+    Account* xaccAccountGetAssociatedAccount (const Account *acc, const char *tag);
     /** Get the last num field of an Account */
     const char * xaccAccountGetLastNum (const Account *account);
     /** Get the account's lot order policy */

--- a/libgnucash/engine/test/utest-Account.cpp
+++ b/libgnucash/engine/test/utest-Account.cpp
@@ -1237,6 +1237,25 @@ test_gnc_account_kvp_setters_getters (Fixture *fixture, gconstpointer pData)
     xaccAccountSetNotes (account, nullptr);
     g_assert_cmpstr (xaccAccountGetNotes (account), ==, nullptr);
 
+    // Associated Account getter/setter
+    g_assert_null (xaccAccountGetAssociatedAccount (account, "test"));
+
+    g_test_expect_message ("gnc.engine", G_LOG_LEVEL_CRITICAL,
+                           "*xaccAccountSetAssociatedAccount*assertion*tag && *tag*");
+    xaccAccountSetAssociatedAccount (account, nullptr, account);
+    g_test_assert_expected_messages();
+
+    g_test_expect_message ("gnc.engine", G_LOG_LEVEL_CRITICAL,
+                           "*xaccAccountSetAssociatedAccount*assertion*GNC_IS_ACCOUNT(acc)*");
+    xaccAccountSetAssociatedAccount (nullptr, "test", account);
+    g_test_assert_expected_messages();
+
+    xaccAccountSetAssociatedAccount (account, "test", account);
+    g_assert_true (xaccAccountGetAssociatedAccount (account, "test") == account);
+
+    xaccAccountSetAssociatedAccount (account, "test", nullptr);
+    g_assert_null (xaccAccountGetAssociatedAccount (account, "test"));
+
     // Balance Limits getter/setter
     g_assert_true (xaccAccountGetHigherBalanceLimit (account, &balance_limit) == false);
     g_assert_true (xaccAccountGetLowerBalanceLimit (account, &balance_limit) == false);


### PR DESCRIPTION
stock-acct can have metadata to save and retrieve the associated proceeds/dividend/capgains/fees accounts.