### PR TITLE
Gnc numeric operators

### DIFF
--- a/libgnucash/engine/test/gtest-gnc-numeric.cpp
+++ b/libgnucash/engine/test/gtest-gnc-numeric.cpp
@@ -427,6 +427,28 @@ TEST(gncnumeric_functions, test_cmp)
     EXPECT_EQ(1, a.cmp(INT64_C(12500)));
 }
 
+TEST(gncnumeric_functions, test_operators)
+{
+    GncNumeric a(123456789, 9876), b(567894321, 6543);
+    auto c = a;
+    EXPECT_TRUE (b > a);
+    EXPECT_TRUE (a < b);
+    EXPECT_TRUE (b >= a);
+    EXPECT_TRUE (a <= b);
+    EXPECT_TRUE (a == c);
+    EXPECT_TRUE (b != c);
+
+    auto zero = INT64_C(0);
+    EXPECT_TRUE (b > zero);
+    EXPECT_TRUE (zero < a);
+    EXPECT_TRUE (b >= zero);
+    EXPECT_TRUE (zero <= b);
+    EXPECT_TRUE (a != zero);
+    EXPECT_TRUE (zero != a);
+    EXPECT_FALSE (a == zero);
+    EXPECT_FALSE (zero == a);
+}
+
 TEST(gncnumeric_functions, test_invert)
 {
     GncNumeric a(123456789, 9876), b, c;


### PR DESCRIPTION
@jralls the `GncNumeric` <=> `int64_t` comparison operators don't compile.


test-gnc-numeric.cpp:443:23: note: candidate 2: 'operator>=(double, int)' (built-in)
```
  443 |     EXPECT_TRUE (b >= 0);
      |                       ^
```
test-gnc-numeric.cpp:444:23: error: ISO C++ says that these are ambiguous, even though the worst conversion for the first is better than the worst conversion for the second: [-Werror]
