### PR TITLE
[gnc-numeric.cpp] shortcut parsing num/denom as gnc_numeric

### DIFF
--- a/libgnucash/engine/test/gtest-gnc-numeric.cpp
+++ b/libgnucash/engine/test/gtest-gnc-numeric.cpp
@@ -206,6 +206,9 @@ TEST(gncnumeric_constructors, test_string_constructor)
     EXPECT_THROW(GncNumeric overflow("12345678987654321.123456"),
                  std::overflow_error);
     EXPECT_NO_THROW(GncNumeric overflow("12345678987654321.123456", true));
+    EXPECT_NO_THROW(GncNumeric limit64a("-9223372036854775808/9223372036854775807"));
+    EXPECT_THROW(GncNumeric limit64b("-9223372036854775809/9223372036854775807"), std::out_of_range);
+    EXPECT_THROW(GncNumeric limit64c("-9223372036854775808/9223372036854775808"), std::out_of_range);
     GncNumeric overflow("12345678987654321.123456", true);
     EXPECT_EQ(6028163568190586486, overflow.num());
     EXPECT_EQ(488, overflow.denom());


### PR DESCRIPTION
The gnc_numeric is written as "num/denom" with no whitespace, and denom > 0. This function takes advantage of https://en.cppreference.com/w/cpp/utility/from_chars to parse it.

Benchmarks from my console cli session. From 7.5s to 5.5s i.e. 25% speedup!

```shell
chris@pop-os:~/sources/gnucash [env]$ # WITH fast_char
chris@pop-os:~/sources/gnucash [env]$ time stable-install/bin/gnucash-cli ~/GNC/OZ-xml.gnucash -R show --name "Transaction Report"
This is a development version. It may or may not work.
Report bugs and other problems to gnucash-devel@gnucash.org
You can also lookup and file bug reports at https://bugs.gnucash.org
To find the last stable version, please refer to https://www.gnucash.org/
hello from config-user.scm

* name: Transaction Report
  guid: 2fe3b9833af044abb929a88d5a59620f

real	0m5.711s
user	0m5.629s
sys	0m0.217s
chris@pop-os:~/sources/gnucash [env]$ time stable-install/bin/gnucash-cli ~/GNC/OZ-xml.gnucash -R show --name "Transaction Report"
This is a development version. It may or may not work.
Report bugs and other problems to gnucash-devel@gnucash.org
You can also lookup and file bug reports at https://bugs.gnucash.org
To find the last stable version, please refer to https://www.gnucash.org/
hello from config-user.scm

* name: Transaction Report
  guid: 2fe3b9833af044abb929a88d5a59620f

real	0m5.540s
user	0m5.485s
sys	0m0.203s
chris@pop-os:~/sources/gnucash [env]$ time stable-install/bin/gnucash-cli ~/GNC/OZ-xml.gnucash -R show --name "Transaction Report"
This is a development version. It may or may not work.
Report bugs and other problems to gnucash-devel@gnucash.org
You can also lookup and file bug reports at https://bugs.gnucash.org
To find the last stable version, please refer to https://www.gnucash.org/
hello from config-user.scm

* name: Transaction Report
  guid: 2fe3b9833af044abb929a88d5a59620f

real	0m5.658s
user	0m5.570s
sys	0m0.234s
chris@pop-os:~/sources/gnucash [env]$ # without fast_char
chris@pop-os:~/sources/gnucash [env]$ time stable-install/bin/gnucash-cli ~/GNC/OZ-xml.gnucash -R show --name "Transaction Report"
This is a development version. It may or may not work.
Report bugs and other problems to gnucash-devel@gnucash.org
You can also lookup and file bug reports at https://bugs.gnucash.org
To find the last stable version, please refer to https://www.gnucash.org/
hello from config-user.scm

* name: Transaction Report
  guid: 2fe3b9833af044abb929a88d5a59620f

real	0m7.635s
user	0m7.570s
sys	0m0.216s
chris@pop-os:~/sources/gnucash [env]$ time stable-install/bin/gnucash-cli ~/GNC/OZ-xml.gnucash -R show --name "Transaction Report"
This is a development version. It may or may not work.
Report bugs and other problems to gnucash-devel@gnucash.org
You can also lookup and file bug reports at https://bugs.gnucash.org
To find the last stable version, please refer to https://www.gnucash.org/
hello from config-user.scm

* name: Transaction Report
  guid: 2fe3b9833af044abb929a88d5a59620f

real	0m7.559s
user	0m7.441s
sys	0m0.237s
chris@pop-os:~/sources/gnucash [env]$ time stable-install/bin/gnucash-cli ~/GNC/OZ-xml.gnucash -R show --name "Transaction Report"
This is a development version. It may or may not work.
Report bugs and other problems to gnucash-devel@gnucash.org
You can also lookup and file bug reports at https://bugs.gnucash.org
To find the last stable version, please refer to https://www.gnucash.org/
hello from config-user.scm

* name: Transaction Report
  guid: 2fe3b9833af044abb929a88d5a59620f

real	0m7.619s
user	0m7.548s
sys	0m0.204s
```