### PR TITLE
Correct misleading description of SX action

### DIFF
--- a/gnucash/ui/gnc-plugin-page-register.ui
+++ b/gnucash/ui/gnc-plugin-page-register.ui
@@ -14,14 +14,14 @@
     <item>
       <attribute name="label" translatable="yes">Assign as payment…</attribute>
       <attribute name="action">gnc-plugin-business-actions.RegisterAssignPayment</attribute>
-      <attribute name="tooltip" translatable="yes">Assign the selected transaction as payment</attribute>
+      <attribute name="tooltip" translatable="yes">Assign the selected transaction as payment.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
       <attribute name="hidden-when">action-disabled</attribute>
     </item>
     <item>
       <attribute name="label" translatable="yes">Edit payment…</attribute>
       <attribute name="action">gnc-plugin-business-actions.RegisterEditPayment</attribute>
-      <attribute name="tooltip" translatable="yes">Edit the payment this transaction is a part of</attribute>
+      <attribute name="tooltip" translatable="yes">Edit the payment this transaction is a part of.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
       <attribute name="hidden-when">action-disabled</attribute>
     </item>
@@ -32,14 +32,14 @@
       <attribute name="label" translatable="yes">_Edit Account</attribute>
       <attribute name="action">GncPluginPageRegisterActions.EditEditAccountAction</attribute>
       <attribute name="accel">&lt;Primary&gt;e</attribute>
-      <attribute name="tooltip" translatable="yes">Edit the selected account</attribute>
+      <attribute name="tooltip" translatable="yes">Edit the selected account.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
     <item>
       <attribute name="label" translatable="yes">F_ind Account</attribute>
       <attribute name="action">GncPluginPageRegisterActions.EditFindAccountAction</attribute>
       <attribute name="accel">&lt;Primary&gt;i</attribute>
-      <attribute name="tooltip" translatable="yes">Find an account</attribute>
+      <attribute name="tooltip" translatable="yes">Find an account.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
   </menu>
@@ -49,7 +49,7 @@
       <attribute name="label" translatable="yes">_Find…</attribute>
       <attribute name="action">GncPluginPageRegisterActions.EditFindTransactionsAction</attribute>
       <attribute name="accel">&lt;Primary&gt;f</attribute>
-      <attribute name="tooltip" translatable="yes">Find transactions with a search</attribute>
+      <attribute name="tooltip" translatable="yes">Find transactions with a search.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
   </menu>
@@ -60,7 +60,7 @@
       <attribute name="label" translatable="yes">Ta_x Report Options</attribute>
       <attribute name="action">GncPluginPageRegisterActions.EditTaxOptionsAction</attribute>
 <!-- Translators: currently implemented are, US: income tax and DE: VAT, So adjust this string -->
-      <attribute name="tooltip" translatable="yes">Setup relevant accounts for tax reports, e.g. US income tax</attribute>
+      <attribute name="tooltip" translatable="yes">Setup relevant accounts for tax reports, e.g. US income tax.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
   </menu>
@@ -71,7 +71,7 @@
       <attribute name="label" translatable="yes">_Basic Ledger</attribute>
       <attribute name="action">GncPluginPageRegisterActions.ViewStyleRadioAction</attribute>
       <attribute name="target" type="i">0</attribute>
-      <attribute name="tooltip" translatable="yes">Show transactions on one or two lines</attribute>
+      <attribute name="tooltip" translatable="yes">Show transactions on one or two lines.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
     <item>
@@ -79,7 +79,7 @@
       <attribute name="label" translatable="yes">_Auto-Split Ledger</attribute>
       <attribute name="action">GncPluginPageRegisterActions.ViewStyleRadioAction</attribute>
       <attribute name="target" type="i">1</attribute>
-      <attribute name="tooltip" translatable="yes">Show transactions on one or two lines and expand the current transaction</attribute>
+      <attribute name="tooltip" translatable="yes">Show transactions on one or two lines and expand the current transaction.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
     <item>
@@ -87,7 +87,7 @@
       <attribute name="label" translatable="yes">Transaction _Journal</attribute>
       <attribute name="action">GncPluginPageRegisterActions.ViewStyleRadioAction</attribute>
       <attribute name="target" type="i">2</attribute>
-      <attribute name="tooltip" translatable="yes">Show expanded transactions with all splits</attribute>
+      <attribute name="tooltip" translatable="yes">Show expanded transactions with all splits.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
   </menu>
@@ -120,7 +120,7 @@
       <attribute name="label" translatable="yes">_Refresh</attribute>
       <attribute name="action">GncPluginPageRegisterActions.ViewRefreshAction</attribute>
       <attribute name="accel">&lt;Primary&gt;r</attribute>
-      <attribute name="tooltip" translatable="yes">Refresh this window</attribute>
+      <attribute name="tooltip" translatable="yes">Refresh this window.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
   </menu>
@@ -129,37 +129,37 @@
     <item>
       <attribute name="label" translatable="yes">Cu_t Transaction</attribute>
       <attribute name="action">GncPluginPageRegisterActions.CutTransactionAction</attribute>
-      <attribute name="tooltip" translatable="yes">Cut the selected transaction into clipboard</attribute>
+      <attribute name="tooltip" translatable="yes">Cut the selected transaction into clipboard.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
     <item>
       <attribute name="label" translatable="yes">_Copy Transaction</attribute>
       <attribute name="action">GncPluginPageRegisterActions.CopyTransactionAction</attribute>
-      <attribute name="tooltip" translatable="yes">Copy the selected transaction into clipboard</attribute>
+      <attribute name="tooltip" translatable="yes">Copy the selected transaction into clipboard.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
     <item>
       <attribute name="label" translatable="yes">_Paste Transaction</attribute>
       <attribute name="action">GncPluginPageRegisterActions.PasteTransactionAction</attribute>
-      <attribute name="tooltip" translatable="yes">Paste the transaction from the clipboard</attribute>
+      <attribute name="tooltip" translatable="yes">Paste the transaction from the clipboard.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
     <item>
       <attribute name="label" translatable="yes">Dup_licate Transaction</attribute>
       <attribute name="action">GncPluginPageRegisterActions.DuplicateTransactionAction</attribute>
-      <attribute name="tooltip" translatable="yes">Make a copy of the current transaction</attribute>
+      <attribute name="tooltip" translatable="yes">Make a copy of the current transaction.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
     <item>
       <attribute name="label" translatable="yes">_Delete Transaction</attribute>
       <attribute name="action">GncPluginPageRegisterActions.DeleteTransactionAction</attribute>
-      <attribute name="tooltip" translatable="yes">Delete the current transaction</attribute>
+      <attribute name="tooltip" translatable="yes">Delete the current transaction.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
     <item>
       <attribute name="label" translatable="yes">Remo_ve Other Splits</attribute>
       <attribute name="action">GncPluginPageRegisterActions.RemoveTransactionSplitsAction</attribute>
-      <attribute name="tooltip" translatable="yes">Remove all splits in the current transaction</attribute>
+      <attribute name="tooltip" translatable="yes">Remove all splits in the current transaction.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
   </menu>
@@ -168,13 +168,13 @@
     <item>
       <attribute name="label" translatable="yes">_Enter Transaction</attribute>
       <attribute name="action">GncPluginPageRegisterActions.RecordTransactionAction</attribute>
-      <attribute name="tooltip" translatable="yes">Record the current transaction</attribute>
+      <attribute name="tooltip" translatable="yes">Record the current transaction.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
     <item>
       <attribute name="label" translatable="yes">Ca_ncel Transaction</attribute>
       <attribute name="action">GncPluginPageRegisterActions.CancelTransactionAction</attribute>
-      <attribute name="tooltip" translatable="yes">Cancel the current transaction</attribute>
+      <attribute name="tooltip" translatable="yes">Cancel the current transaction.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
   </menu>
@@ -183,19 +183,19 @@
     <item>
       <attribute name="label" translatable="yes">_Void Transaction</attribute>
       <attribute name="action">GncPluginPageRegisterActions.VoidTransactionAction</attribute>
-      <attribute name="tooltip" translatable="yes">Void the current transaction</attribute>
+      <attribute name="tooltip" translatable="yes">Void the current transaction.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
     <item>
       <attribute name="label" translatable="yes">_Unvoid Transaction</attribute>
       <attribute name="action">GncPluginPageRegisterActions.UnvoidTransactionAction</attribute>
-      <attribute name="tooltip" translatable="yes">Unvoid the current transaction</attribute>
+      <attribute name="tooltip" translatable="yes">Unvoid the current transaction.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
     <item>
       <attribute name="label" translatable="yes">Add _Reversing Transaction</attribute>
       <attribute name="action">GncPluginPageRegisterActions.ReverseTransactionAction</attribute>
-      <attribute name="tooltip" translatable="yes">Add a reversing transaction</attribute>
+      <attribute name="tooltip" translatable="yes">Add a reversing transaction.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
   </menu>
@@ -204,13 +204,13 @@
     <item>
       <attribute name="label" translatable="yes">_Manage Document Link…</attribute>
       <attribute name="action">GncPluginPageRegisterActions.LinkTransactionAction</attribute>
-      <attribute name="tooltip" translatable="yes">Add, change, or unlink the document linked with the current transaction</attribute>
+      <attribute name="tooltip" translatable="yes">Add, change, or unlink the document linked with the current transaction.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
     <item>
       <attribute name="label" translatable="yes">_Open Linked Document</attribute>
       <attribute name="action">GncPluginPageRegisterActions.LinkedTransactionOpenAction</attribute>
-      <attribute name="tooltip" translatable="yes">Open the linked document for the current transaction</attribute>
+      <attribute name="tooltip" translatable="yes">Open the linked document for the current transaction.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
   </menu>
@@ -219,7 +219,7 @@
     <item>
       <attribute name="label" translatable="yes">Jump to Invoice</attribute>
       <attribute name="action">GncPluginPageRegisterActions.JumpLinkedInvoiceAction</attribute>
-      <attribute name="tooltip" translatable="yes">Jump to the linked bill, invoice, or voucher</attribute>
+      <attribute name="tooltip" translatable="yes">Jump to the linked bill, invoice, or voucher.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
   </menu>
@@ -229,19 +229,19 @@
       <attribute name="label" translatable="yes">_Transfer…</attribute>
       <attribute name="action">GncPluginPageRegisterActions.ActionsTransferAction</attribute>
       <attribute name="accel">&lt;Primary&gt;t</attribute>
-      <attribute name="tooltip" translatable="yes">Transfer funds from one account to another</attribute>
+      <attribute name="tooltip" translatable="yes">Transfer funds from one account to another.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
     <item>
       <attribute name="label" translatable="yes">_Reconcile…</attribute>
       <attribute name="action">GncPluginPageRegisterActions.ActionsReconcileAction</attribute>
-      <attribute name="tooltip" translatable="yes">Reconcile the selected account</attribute>
+      <attribute name="tooltip" translatable="yes">Reconcile the selected account.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
     <item>
       <attribute name="label" translatable="yes">_Auto-clear…</attribute>
       <attribute name="action">GncPluginPageRegisterActions.ActionsAutoClearAction</attribute>
-      <attribute name="tooltip" translatable="yes">Automatically clear individual transactions, so as to reach a certain cleared amount</attribute>
+      <attribute name="tooltip" translatable="yes">Automatically clear individual transactions, so as to reach a certain cleared amount.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
     <item>
@@ -253,13 +253,13 @@
     <item>
       <attribute name="label" translatable="yes">Stoc_k Split…</attribute>
       <attribute name="action">GncPluginPageRegisterActions.ActionsStockSplitAction</attribute>
-      <attribute name="tooltip" translatable="yes">Record a stock split or a stock merger</attribute>
+      <attribute name="tooltip" translatable="yes">Record a stock split or a stock merger.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
     <item>
       <attribute name="label" translatable="yes">View _Lots…</attribute>
       <attribute name="action">GncPluginPageRegisterActions.ActionsLotsAction</attribute>
-      <attribute name="tooltip" translatable="yes">Bring up the lot viewer/editor window</attribute>
+      <attribute name="tooltip" translatable="yes">Bring up the lot viewer/editor window.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
   </menu>
@@ -269,32 +269,32 @@
       <attribute name="label" translatable="yes">_Blank Transaction</attribute>
       <attribute name="action">GncPluginPageRegisterActions.BlankTransactionAction</attribute>
       <attribute name="accel">&lt;Primary&gt;b</attribute>
-      <attribute name="tooltip" translatable="yes">Move to the blank transaction in the register</attribute>
+      <attribute name="tooltip" translatable="yes">Move to the blank transaction in the register.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
     <item>
       <attribute name="label" translatable="yes">_Go to Date</attribute>
       <attribute name="action">GncPluginPageRegisterActions.GotoDateAction</attribute>
       <attribute name="accel">&lt;Primary&gt;g</attribute>
-      <attribute name="tooltip" translatable="yes">Move to the split at the specified date</attribute>
+      <attribute name="tooltip" translatable="yes">Move to the split at the specified date.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
     <item>
       <attribute name="label" translatable="yes">S_plit Transaction</attribute>
       <attribute name="action">GncPluginPageRegisterActions.SplitTransactionAction</attribute>
-      <attribute name="tooltip" translatable="yes">Show all splits in the current transaction</attribute>
+      <attribute name="tooltip" translatable="yes">Show all splits in the current transaction.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
     <item>
       <attribute name="label" translatable="yes">Edit E_xchange Rate</attribute>
       <attribute name="action">GncPluginPageRegisterActions.EditExchangeRateAction</attribute>
-      <attribute name="tooltip" translatable="yes">Edit the exchange rate for the current transaction</attribute>
+      <attribute name="tooltip" translatable="yes">Edit the exchange rate for the current transaction.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
     <item>
       <attribute name="label" translatable="yes">Sche_dule…</attribute>
       <attribute name="action">GncPluginPageRegisterActions.ScheduleTransactionAction</attribute>
-      <attribute name="tooltip" translatable="yes">Create a Scheduled Transaction with the current transaction as a template or edit the Scheduled Transaction that current transaction was created by</attribute>
+      <attribute name="tooltip" translatable="yes">Create a Scheduled Transaction with the current transaction as a template or edit the Scheduled Transaction that current transaction was created by.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
     <item>
@@ -303,7 +303,7 @@
      with focus on the current transaction's entry in that register. -->
       <attribute name="label" translatable="yes">_Jump to the other account</attribute>
       <attribute name="action">GncPluginPageRegisterActions.JumpTransactionAction</attribute>
-      <attribute name="tooltip" translatable="yes">Open a new register tab for the other account with focus on this transaction</attribute>
+      <attribute name="tooltip" translatable="yes">Open a new register tab for the other account with focus on this transaction.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
   </menu>
@@ -331,13 +331,13 @@
     <item>
       <attribute name="label" translatable="yes">Account Report</attribute>
       <attribute name="action">GncPluginPageRegisterActions.ReportsAccountReportAction</attribute>
-      <attribute name="tooltip" translatable="yes">Open a register report for this Account</attribute>
+      <attribute name="tooltip" translatable="yes">Open a register report for this Account.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
     <item>
       <attribute name="label" translatable="yes">Account Report - Single Transaction</attribute>
       <attribute name="action">GncPluginPageRegisterActions.ReportsAcctTransReportAction</attribute>
-      <attribute name="tooltip" translatable="yes">Open a register report for the selected Transaction</attribute>
+      <attribute name="tooltip" translatable="yes">Open a register report for the selected Transaction.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
   </menu>
@@ -356,100 +356,100 @@
       <item>
         <attribute name="label" translatable="yes">Re_name Page</attribute>
         <attribute name="action">mainwin.ActionsRenamePageAction</attribute>
-        <attribute name="tooltip" translatable="yes">Rename this page</attribute>
+        <attribute name="tooltip" translatable="yes">Rename this page.</attribute>
       </item>
     </section>
     <section>
       <item>
         <attribute name="label" translatable="yes">Dup_licate Transaction</attribute>
         <attribute name="action">GncPluginPageRegisterActions.DuplicateTransactionAction</attribute>
-        <attribute name="tooltip" translatable="yes">Make a copy of the current transaction</attribute>
+        <attribute name="tooltip" translatable="yes">Make a copy of the current transaction.</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">_Delete Transaction</attribute>
         <attribute name="action">GncPluginPageRegisterActions.DeleteTransactionAction</attribute>
-        <attribute name="tooltip" translatable="yes">Delete the current transaction</attribute>
+        <attribute name="tooltip" translatable="yes">Delete the current transaction.</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">Remo_ve Other Splits</attribute>
         <attribute name="action">GncPluginPageRegisterActions.RemoveTransactionSplitsAction</attribute>
-        <attribute name="tooltip" translatable="yes">Remove all splits in the current transaction</attribute>
+        <attribute name="tooltip" translatable="yes">Remove all splits in the current transaction.</attribute>
       </item>
     </section>
     <section>
       <item>
         <attribute name="label" translatable="yes">_Enter Transaction</attribute>
         <attribute name="action">GncPluginPageRegisterActions.RecordTransactionAction</attribute>
-        <attribute name="tooltip" translatable="yes">Record the current transaction</attribute>
+        <attribute name="tooltip" translatable="yes">Record the current transaction.</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">Ca_ncel Transaction</attribute>
         <attribute name="action">GncPluginPageRegisterActions.CancelTransactionAction</attribute>
-        <attribute name="tooltip" translatable="yes">Cancel the current transaction</attribute>
+        <attribute name="tooltip" translatable="yes">Cancel the current transaction.</attribute>
       </item>
     </section>
     <section>
       <item>
         <attribute name="label" translatable="yes">_Manage Document Link…</attribute>
         <attribute name="action">GncPluginPageRegisterActions.LinkTransactionAction</attribute>
-        <attribute name="tooltip" translatable="yes">Add, change, or unlink the document linked with the current transaction</attribute>
+        <attribute name="tooltip" translatable="yes">Add, change, or unlink the document linked with the current transaction.</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">_Open Linked Document</attribute>
         <attribute name="action">GncPluginPageRegisterActions.LinkedTransactionOpenAction</attribute>
-        <attribute name="tooltip" translatable="yes">Open the linked document for the current transaction</attribute>
+        <attribute name="tooltip" translatable="yes">Open the linked document for the current transaction.</attribute>
       </item>
     </section>
     <section>
       <item>
         <attribute name="label" translatable="yes">Jump to Invoice</attribute>
         <attribute name="action">GncPluginPageRegisterActions.JumpLinkedInvoiceAction</attribute>
-        <attribute name="tooltip" translatable="yes">Jump to the linked bill, invoice, or voucher</attribute>
+        <attribute name="tooltip" translatable="yes">Jump to the linked bill, invoice, or voucher.</attribute>
       </item>
     </section>
     <section>
       <item>
         <attribute name="label" translatable="yes">_Blank Transaction</attribute>
         <attribute name="action">GncPluginPageRegisterActions.BlankTransactionAction</attribute>
-        <attribute name="tooltip" translatable="yes">Move to the blank transaction in the register</attribute>
+        <attribute name="tooltip" translatable="yes">Move to the blank transaction in the register.</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">_Go to Date</attribute>
         <attribute name="action">GncPluginPageRegisterActions.GotoDateAction</attribute>
-        <attribute name="tooltip" translatable="yes">Move to the split at the specified date</attribute>
+        <attribute name="tooltip" translatable="yes">Move to the split at the specified date.</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">S_plit Transaction</attribute>
         <attribute name="action">GncPluginPageRegisterActions.SplitTransactionAction</attribute>
-        <attribute name="tooltip" translatable="yes">Show all splits in the current transaction</attribute>
+        <attribute name="tooltip" translatable="yes">Show all splits in the current transaction.</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">Edit E_xchange Rate</attribute>
         <attribute name="action">GncPluginPageRegisterActions.EditExchangeRateAction</attribute>
-        <attribute name="tooltip" translatable="yes">Edit the exchange rate for the current transaction</attribute>
+        <attribute name="tooltip" translatable="yes">Edit the exchange rate for the current transaction.</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">Sche_dule…</attribute>
         <attribute name="action">GncPluginPageRegisterActions.ScheduleTransactionAction</attribute>
-        <attribute name="tooltip" translatable="yes">Create a Scheduled Transaction with the current transaction as a template or edit the Scheduled Transaction that current transaction was created by</attribute>
+        <attribute name="tooltip" translatable="yes">Create a Scheduled Transaction with the current transaction as a template or edit the Scheduled Transaction that current transaction was created by.</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">_Jump to the other account</attribute>
         <attribute name="action">GncPluginPageRegisterActions.JumpTransactionAction</attribute>
-        <attribute name="tooltip" translatable="yes">Open a new register tab for the other account with focus on this transaction</attribute>
+        <attribute name="tooltip" translatable="yes">Open a new register tab for the other account with focus on this transaction.</attribute>
       </item>
     </section>
     <section>
       <item>
         <attribute name="label" translatable="yes">Assign as payment…</attribute>
         <attribute name="action">gnc-plugin-business-actions.RegisterAssignPayment</attribute>
-        <attribute name="tooltip" translatable="yes">Assign the selected transaction as payment</attribute>
+        <attribute name="tooltip" translatable="yes">Assign the selected transaction as payment.</attribute>
         <attribute name="hidden-when">action-disabled</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">Edit payment…</attribute>
         <attribute name="action">gnc-plugin-business-actions.RegisterEditPayment</attribute>
-        <attribute name="tooltip" translatable="yes">Edit the payment this transaction is a part of</attribute>
+        <attribute name="tooltip" translatable="yes">Edit the payment this transaction is a part of.</attribute>
         <attribute name="hidden-when">action-disabled</attribute>
       </item>
     </section>
@@ -468,100 +468,100 @@
       <item>
         <attribute name="label" translatable="yes">Re_name Page</attribute>
         <attribute name="action">mainwin.ActionsRenamePageAction</attribute>
-        <attribute name="tooltip" translatable="yes">Rename this page</attribute>
+        <attribute name="tooltip" translatable="yes">Rename this page.</attribute>
       </item>
     </section>
     <section>
       <item>
         <attribute name="label" translatable="yes">Dup_licate Split</attribute>
         <attribute name="action">GncPluginPageRegisterActions.DuplicateTransactionAction</attribute>
-        <attribute name="tooltip" translatable="yes">Make a copy of the current split</attribute>
+        <attribute name="tooltip" translatable="yes">Make a copy of the current split.</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">_Delete Split</attribute>
         <attribute name="action">GncPluginPageRegisterActions.DeleteTransactionAction</attribute>
-        <attribute name="tooltip" translatable="yes">Delete the current split</attribute>
+        <attribute name="tooltip" translatable="yes">Delete the current split.</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">Remo_ve Other Splits</attribute>
         <attribute name="action">GncPluginPageRegisterActions.RemoveTransactionSplitsAction</attribute>
-        <attribute name="tooltip" translatable="yes">Remove all splits in the current transaction</attribute>
+        <attribute name="tooltip" translatable="yes">Remove all splits in the current transaction.</attribute>
       </item>
     </section>
     <section>
       <item>
         <attribute name="label" translatable="yes">_Enter Transaction</attribute>
         <attribute name="action">GncPluginPageRegisterActions.RecordTransactionAction</attribute>
-        <attribute name="tooltip" translatable="yes">Record the current transaction</attribute>
+        <attribute name="tooltip" translatable="yes">Record the current transaction.</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">Ca_ncel Transaction</attribute>
         <attribute name="action">GncPluginPageRegisterActions.CancelTransactionAction</attribute>
-        <attribute name="tooltip" translatable="yes">Cancel the current transaction</attribute>
+        <attribute name="tooltip" translatable="yes">Cancel the current transaction.</attribute>
       </item>
     </section>
     <section>
       <item>
         <attribute name="label" translatable="yes">_Manage Document Link…</attribute>
         <attribute name="action">GncPluginPageRegisterActions.LinkTransactionAction</attribute>
-        <attribute name="tooltip" translatable="yes">Add, change, or unlink the document linked with the current transaction</attribute>
+        <attribute name="tooltip" translatable="yes">Add, change, or unlink the document linked with the current transaction.</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">_Open Linked Document</attribute>
         <attribute name="action">GncPluginPageRegisterActions.LinkedTransactionOpenAction</attribute>
-        <attribute name="tooltip" translatable="yes">Open the linked document for the current transaction</attribute>
+        <attribute name="tooltip" translatable="yes">Open the linked document for the current transaction.</attribute>
       </item>
     </section>
     <section>
       <item>
         <attribute name="label" translatable="yes">Jump to Invoice</attribute>
         <attribute name="action">GncPluginPageRegisterActions.JumpLinkedInvoiceAction</attribute>
-        <attribute name="tooltip" translatable="yes">Jump to the linked bill, invoice, or voucher</attribute>
+        <attribute name="tooltip" translatable="yes">Jump to the linked bill, invoice, or voucher.</attribute>
       </item>
     </section>
     <section>
       <item>
         <attribute name="label" translatable="yes">_Blank Transaction</attribute>
         <attribute name="action">GncPluginPageRegisterActions.BlankTransactionAction</attribute>
-        <attribute name="tooltip" translatable="yes">Move to the blank transaction in the register</attribute>
+        <attribute name="tooltip" translatable="yes">Move to the blank transaction in the register.</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">_Go to Date</attribute>
         <attribute name="action">GncPluginPageRegisterActions.GotoDateAction</attribute>
-        <attribute name="tooltip" translatable="yes">Move to the split at the specified date</attribute>
+        <attribute name="tooltip" translatable="yes">Move to the split at the specified date.</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">S_plit Transaction</attribute>
         <attribute name="action">GncPluginPageRegisterActions.SplitTransactionAction</attribute>
-        <attribute name="tooltip" translatable="yes">Show all splits in the current transaction</attribute>
+        <attribute name="tooltip" translatable="yes">Show all splits in the current transaction.</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">Edit E_xchange Rate</attribute>
         <attribute name="action">GncPluginPageRegisterActions.EditExchangeRateAction</attribute>
-        <attribute name="tooltip" translatable="yes">Edit the exchange rate for the current transaction</attribute>
+        <attribute name="tooltip" translatable="yes">Edit the exchange rate for the current transaction.</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">Sche_dule…</attribute>
         <attribute name="action">GncPluginPageRegisterActions.ScheduleTransactionAction</attribute>
-        <attribute name="tooltip" translatable="yes">Create a Scheduled Transaction with the current transaction as a template or edit the Scheduled Transaction that current transaction was created by</attribute>
+        <attribute name="tooltip" translatable="yes">Create a Scheduled Transaction with the current transaction as a template or edit the Scheduled Transaction that current transaction was created by.</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">_Jump to the other account</attribute>
         <attribute name="action">GncPluginPageRegisterActions.JumpTransactionAction</attribute>
-        <attribute name="tooltip" translatable="yes">Open a new register tab for the other account with focus on this transaction</attribute>
+        <attribute name="tooltip" translatable="yes">Open a new register tab for the other account with focus on this transaction.</attribute>
       </item>
     </section>
     <section>
       <item>
         <attribute name="label" translatable="yes">Assign as payment…</attribute>
         <attribute name="action">gnc-plugin-business-actions.RegisterAssignPayment</attribute>
-        <attribute name="tooltip" translatable="yes">Assign the selected transaction as payment</attribute>
+        <attribute name="tooltip" translatable="yes">Assign the selected transaction as payment.</attribute>
         <attribute name="hidden-when">action-disabled</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">Edit payment…</attribute>
         <attribute name="action">gnc-plugin-business-actions.RegisterEditPayment</attribute>
-        <attribute name="tooltip" translatable="yes">Edit the payment this transaction is a part of</attribute>
+        <attribute name="tooltip" translatable="yes">Edit the payment this transaction is a part of.</attribute>
         <attribute name="hidden-when">action-disabled</attribute>
       </item>
     </section>
@@ -573,36 +573,36 @@
       <item>
         <attribute name="label" translatable="yes">Dup_licate Transaction</attribute>
         <attribute name="action">GncPluginPageRegisterActions.DuplicateTransactionAction</attribute>
-        <attribute name="tooltip" translatable="yes">Make a copy of the current transaction</attribute>
+        <attribute name="tooltip" translatable="yes">Make a copy of the current transaction.</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">_Delete Transaction</attribute>
         <attribute name="action">GncPluginPageRegisterActions.DeleteTransactionAction</attribute>
-        <attribute name="tooltip" translatable="yes">Delete the current transaction</attribute>
+        <attribute name="tooltip" translatable="yes">Delete the current transaction.</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">Remo_ve Other Splits</attribute>
         <attribute name="action">GncPluginPageRegisterActions.RemoveTransactionSplitsAction</attribute>
-        <attribute name="tooltip" translatable="yes">Remove all splits in the current transaction</attribute>
+        <attribute name="tooltip" translatable="yes">Remove all splits in the current transaction.</attribute>
       </item>
     </section>
     <section>
       <item>
         <attribute name="label" translatable="yes">_Enter Transaction</attribute>
         <attribute name="action">GncPluginPageRegisterActions.RecordTransactionAction</attribute>
-        <attribute name="tooltip" translatable="yes">Record the current transaction</attribute>
+        <attribute name="tooltip" translatable="yes">Record the current transaction.</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">Ca_ncel Transaction</attribute>
         <attribute name="action">GncPluginPageRegisterActions.CancelTransactionAction</attribute>
-        <attribute name="tooltip" translatable="yes">Cancel the current transaction</attribute>
+        <attribute name="tooltip" translatable="yes">Cancel the current transaction.</attribute>
       </item>
     </section>
     <section>
       <item>
         <attribute name="label" translatable="yes">_Blank Transaction</attribute>
         <attribute name="action">GncPluginPageRegisterActions.BlankTransactionAction</attribute>
-        <attribute name="tooltip" translatable="yes">Move to the blank transaction in the register</attribute>
+        <attribute name="tooltip" translatable="yes">Move to the blank transaction in the register.</attribute>
       </item>
     </section>
   </menu>
@@ -612,36 +612,36 @@
       <item>
         <attribute name="label" translatable="yes">Dup_licate Split</attribute>
         <attribute name="action">GncPluginPageRegisterActions.DuplicateTransactionAction</attribute>
-        <attribute name="tooltip" translatable="yes">Make a copy of the current split</attribute>
+        <attribute name="tooltip" translatable="yes">Make a copy of the current split.</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">_Delete Split</attribute>
         <attribute name="action">GncPluginPageRegisterActions.DeleteTransactionAction</attribute>
-        <attribute name="tooltip" translatable="yes">Delete the current split</attribute>
+        <attribute name="tooltip" translatable="yes">Delete the current split.</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">Remo_ve Other Splits</attribute>
         <attribute name="action">GncPluginPageRegisterActions.RemoveTransactionSplitsAction</attribute>
-        <attribute name="tooltip" translatable="yes">Remove all splits in the current transaction</attribute>
+        <attribute name="tooltip" translatable="yes">Remove all splits in the current transaction.</attribute>
       </item>
     </section>
     <section>
       <item>
         <attribute name="label" translatable="yes">_Enter Transaction</attribute>
         <attribute name="action">GncPluginPageRegisterActions.RecordTransactionAction</attribute>
-        <attribute name="tooltip" translatable="yes">Record the current transaction</attribute>
+        <attribute name="tooltip" translatable="yes">Record the current transaction.</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">Ca_ncel Transaction</attribute>
         <attribute name="action">GncPluginPageRegisterActions.CancelTransactionAction</attribute>
-        <attribute name="tooltip" translatable="yes">Cancel the current transaction</attribute>
+        <attribute name="tooltip" translatable="yes">Cancel the current transaction.</attribute>
       </item>
     </section>
     <section>
       <item>
         <attribute name="label" translatable="yes">_Blank Transaction</attribute>
         <attribute name="action">GncPluginPageRegisterActions.BlankTransactionAction</attribute>
-        <attribute name="tooltip" translatable="yes">Move to the blank transaction in the register</attribute>
+        <attribute name="tooltip" translatable="yes">Move to the blank transaction in the register.</attribute>
       </item>
     </section>
   </menu>

--- a/gnucash/ui/gnc-plugin-page-register.ui
+++ b/gnucash/ui/gnc-plugin-page-register.ui
@@ -294,7 +294,7 @@
     <item>
       <attribute name="label" translatable="yes">Sche_dule…</attribute>
       <attribute name="action">GncPluginPageRegisterActions.ScheduleTransactionAction</attribute>
-      <attribute name="tooltip" translatable="yes">Create a Scheduled Transaction with the current transaction as a template</attribute>
+      <attribute name="tooltip" translatable="yes">Create a Scheduled Transaction with the current transaction as a template or edit the Scheduled Transaction that current transaction was created by</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
     <item>
@@ -431,7 +431,7 @@
       <item>
         <attribute name="label" translatable="yes">Sche_dule…</attribute>
         <attribute name="action">GncPluginPageRegisterActions.ScheduleTransactionAction</attribute>
-        <attribute name="tooltip" translatable="yes">Create a Scheduled Transaction with the current transaction as a template</attribute>
+        <attribute name="tooltip" translatable="yes">Create a Scheduled Transaction with the current transaction as a template or edit the Scheduled Transaction that current transaction was created by</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">_Jump to the other account</attribute>
@@ -543,7 +543,7 @@
       <item>
         <attribute name="label" translatable="yes">Sche_dule…</attribute>
         <attribute name="action">GncPluginPageRegisterActions.ScheduleTransactionAction</attribute>
-        <attribute name="tooltip" translatable="yes">Create a Scheduled Transaction with the current transaction as a template</attribute>
+        <attribute name="tooltip" translatable="yes">Create a Scheduled Transaction with the current transaction as a template or edit the Scheduled Transaction that current transaction was created by</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">_Jump to the other account</attribute>
@@ -846,7 +846,7 @@
         <property name="can-focus">False</property>
         <property name="label" translatable="yes">Sche_dule…</property>
         <property name="action-name">GncPluginPageRegisterActions.ScheduleTransactionAction</property>
-        <property name="tooltip-text" translatable="yes">Create a Scheduled Transaction with the current transaction as a template</property>
+        <property name="tooltip-text" translatable="yes">Create a Scheduled Transaction with the current transaction as a template or edit the Scheduled Transaction that current transaction was created by</property>
         <property name="use-underline">True</property>
         <property name="icon-name">gnc-sx-new</property>
       </object>


### PR DESCRIPTION
Correct misleading description about creating Scheduled Transaction. Using this action on a user-created transaction creates a new Scheduled Transaction, but using this action on a transaction that was created by Schedule just opens its Scheduled Transaction.