### PR TITLE
[guid.hpp] GUID::from_string and is_valid_string takes a const char*

### DIFF
--- a/libgnucash/engine/guid.cpp
+++ b/libgnucash/engine/guid.cpp
@@ -331,8 +331,10 @@ GUID::to_string () const noexcept
 }
 
 GUID
-GUID::from_string (std::string const & str)
+GUID::from_string (const char* str)
 {
+    if (!str)
+        throw guid_syntax_exception {};
     try
     {
         static boost::uuids::string_generator strgen;
@@ -345,7 +347,7 @@ GUID::from_string (std::string const & str)
 }
 
 bool
-GUID::is_valid_guid (std::string const & str)
+GUID::is_valid_guid (const char* str)
 {
     try
     {

--- a/libgnucash/engine/guid.hpp
+++ b/libgnucash/engine/guid.hpp
@@ -24,6 +24,7 @@
 
 #include <boost/uuid/uuid.hpp>
 #include <stdexcept>
+#include <string>
 
 #include "guid.h"
 
@@ -48,8 +49,10 @@ struct GUID
     operator GncGUID () const noexcept;
     static GUID create_random () noexcept;
     static GUID const & null_guid () noexcept;
-    static GUID from_string (std::string const &);
-    static bool is_valid_guid (std::string const &);
+    static GUID from_string (const char*);
+    static GUID from_string (std::string const& s) { return from_string (s.c_str()); };
+    static bool is_valid_guid (const char*);
+    static bool is_valid_guid (std::string const &s) { return is_valid_guid (s.c_str()); };
     std::string to_string () const noexcept;
     auto begin () const noexcept -> decltype (implementation.begin ());
     auto end () const noexcept -> decltype (implementation.end ());


### PR DESCRIPTION
- because boost::uuids::string_generator has operator()(const char*)
- thereby we can avoid allocating std::string.

benchmarks are better than #1885, but not much. my best loading times are now 3.65s.

EDIT: benchmarks with 4e6 uuid generated in 4-5s reveal a consistent 4% speedup.