### PR TITLE
Sixtp string converters use from_char

### DIFF
--- a/libgnucash/backend/xml/sixtp-dom-parsers.cpp
+++ b/libgnucash/backend/xml/sixtp-dom-parsers.cpp
@@ -98,46 +98,32 @@ dom_tree_to_integer_kvp_value (xmlNodePtr node)
     return ret;
 }
 
+template <typename T>
+static bool
+dom_tree_to_num (xmlNodePtr node, std::function<bool(const char*, T*)>string_to_num, T* num_ptr)
+{
+    auto text = dom_tree_to_text (node);
+    auto ret = string_to_num (text, num_ptr);
+    g_free (text);
+    return ret;
+}
+
 gboolean
 dom_tree_to_integer (xmlNodePtr node, gint64* daint)
 {
-    gchar* text;
-    gboolean ret;
-
-    text = dom_tree_to_text (node);
-
-    ret = string_to_gint64 (text, daint);
-
-    g_free (text);
-
-    return ret;
+    return dom_tree_to_num<gint64>(node, string_to_gint64, daint);
 }
 
 gboolean
 dom_tree_to_guint16 (xmlNodePtr node, guint16* i)
 {
-    gboolean ret;
-    guint j = 0;
-
-    ret = dom_tree_to_guint (node, &j);
-    *i = (guint16) j;
-    return ret;
+    return dom_tree_to_num<guint16>(node, string_to_guint16, i);
 }
 
 gboolean
 dom_tree_to_guint (xmlNodePtr node, guint* i)
 {
-    gchar* text, *endptr;
-    gboolean ret;
-
-    text = dom_tree_to_text (node);
-    /* In spite of the strange string_to_gint64 function, I'm just
-       going to use strtoul here until someone shows me the error of
-       my ways. -CAS */
-    *i = (guint) strtoul (text, &endptr, 0);
-    ret = (endptr != text);
-    g_free (text);
-    return ret;
+    return dom_tree_to_num<guint>(node, string_to_guint, i);
 }
 
 gboolean

--- a/libgnucash/backend/xml/sixtp-utils.h
+++ b/libgnucash/backend/xml/sixtp-utils.h
@@ -63,7 +63,9 @@ gboolean string_to_double (const char* str, double* result);
 
 gboolean string_to_gint64 (const gchar* str, gint64* v);
 
-gboolean string_to_gint32 (const gchar* str, gint32* v);
+gboolean string_to_guint16 (const gchar* str, guint16* v);
+
+gboolean string_to_guint (const gchar* str, guint* v);
 
 gboolean hex_string_to_binary (const gchar* str,  void** v, guint64* data_len);
 

--- a/libgnucash/backend/xml/test/test-string-converters.cpp
+++ b/libgnucash/backend/xml/test/test-string-converters.cpp
@@ -25,10 +25,12 @@
 #include "test-engine-stuff.h"
 
 #include "test-file-stuff.h"
+#include "sixtp-utils.h"
 #include "sixtp-dom-parsers.h"
 #include "sixtp-dom-generators.h"
 #include "test-stuff.h"
 
+#include <optional>
 
 #define GNC_V2_STRING "gnc-v2"
 const gchar* gnc_v2_xml_version_string = GNC_V2_STRING;
@@ -79,6 +81,85 @@ test_bad_string (void)
     xmlFreeNode (test_node);
 }
 
+template <class T>
+using TestcaseVec = std::vector<std::pair<const char*, std::optional<T>>>;
+
+template <class T>
+const TestcaseVec<T> test_cases_common = {
+    { "1"                     ,   1 },
+    { "  \t 2   \t\v\n\f\r  " ,   2 },
+    { "              0      " ,   0 },
+    { "123"                   , 123 },
+    { "123z"                  ,  {} },
+    { "a123"                  ,  {} },
+    { " 23"                   ,  23 },
+    { "\t23"                  ,  23 },
+    { "44 "                   ,  44 },
+    { "44\t"                  ,  44 },
+    { " 56   "                ,  56 },
+    { "\t56\t"                ,  56 },
+    { "1 2"                   ,  {} },
+    { "1 2 \t"                ,  {} },
+};
+
+const TestcaseVec<gint64> test_cases_gint64 = {
+    { "-44"                   , -44 },
+    { "9223372036854775807"   ,  9223372036854775807 }, // maxint64
+    { "9223372036854775808"   ,  {} },                  // overflow
+    { "-9223372036854775807"  , -9223372036854775807 }, // minint64
+};
+
+const TestcaseVec<guint> test_cases_guint = {
+    { "-44"                   ,  {} },                // no negative allowed
+    { "4294967295"            ,  4294967295 },        // max_uint
+    { "4294967296"            ,  {} },                // overflow
+};
+
+const TestcaseVec<guint16> test_cases_guint16 = {
+    { "-44"                   ,  {} },                // no negative allowed
+    { "65535"                 ,  65535 },             // max_int16
+    { "65536"                 ,  {} },                // overflow
+};
+
+const TestcaseVec<double> test_cases_double = {
+    { "-3.5"                   ,  -3.5 },
+    { ".5"                     ,   0.5 },
+    { "1e10"                   ,  1e10 },
+    { "-1e10"                  , -1e10 },
+    { "1e-10"                  ,  1e-10 },
+    { "-1e-10"                 ,  -1e-10 },
+    { "1.7976931348623158e+308", 1.7976931348623158e+308 }, // max_double
+    { "1.7976931348623159e+308", {}   },                    // overflow
+};
+
+template <typename T>
+static void
+test_string_to_num (const char *func_name, const TestcaseVec<T>& test_cases,
+                    const std::function<bool(const char*,T*)> &func)
+{
+    auto do_test = [&](std::pair<const char*, std::optional<T>> test_pair)
+    {
+        T num = 0;
+        auto [test_str, test_int] = test_pair;
+        auto rv = func (test_str, &num);
+        // Output for debugging
+        // std::cout << "test_str = [" << test_str << "], test_int = ";
+        // if (test_int)
+        //     std::cout << *test_int;
+        // else
+        //     std::cout << "{}";
+        // std::cout << ", num = [" << num << "], rv = " << rv << std::endl;
+        do_test_args (rv == test_int.has_value(), func_name,
+                      __FILE__, __LINE__, "with string %s", test_str);
+        if (rv)
+            do_test_args (num == *test_int, func_name,
+                          __FILE__, __LINE__, "with string %s", test_str);
+    };
+
+    std::for_each (test_cases_common<T>.begin(), test_cases_common<T>.end(), do_test);
+    std::for_each (test_cases.begin(), test_cases.end(), do_test);
+}
+
 int
 main (int argc, char** argv)
 {
@@ -86,6 +167,13 @@ main (int argc, char** argv)
     fflush (stdout);
     test_string_converters ();
     test_bad_string ();
+#if __cpp_lib_to_chars >= 201611L
+    // because older strtod code is more liberal and parses "123z" as 123.0
+    test_string_to_num<double> ("string_to_double", test_cases_double, string_to_double);
+#endif
+    test_string_to_num<gint64> ("string_to_gint64", test_cases_gint64, string_to_gint64);
+    test_string_to_num<guint16>("string_to_guint16",test_cases_guint16,string_to_guint16);
+    test_string_to_num<guint>  ("string_to_guint",  test_cases_guint,  string_to_guint);
     fflush (stdout);
     print_test_results ();
     exit (get_rv ());


### PR DESCRIPTION
This speeds up `string_to_int{32|64}` by 40% and introduces `string_to_guint`, but IRL speedup is less impressive because xml stores most numbers in gnc_numeric "num/denom" format.

This also IIUC fixes some maxint bugs in previous code, ~see commit with test illustrating bug, and the test case fixed in later commits.~

EDIT: ~looks like mac clang cannot use `from_chars` for float~ the `string_to_float` will test cpp features and use `strtod` if required.

Benchmarks:
```
Benchmarks running tests 4E6 times:

using sscanf

$ bin/test-string-converters
 elapsed=7.33942s
Executed 92000006 tests. All tests passed.
$ bin/test-string-converters
 elapsed=7.3811s
Executed 92000006 tests. All tests passed.
$ bin/test-string-converters
 elapsed=7.3455s
Executed 92000006 tests. All tests passed.

with std::from_chars

$ bin/test-string-converters
 elapsed=4.47369s
Executed 92000006 tests. All tests passed.
$ bin/test-string-converters
 elapsed=4.46908s
Executed 92000006 tests. All tests passed.
$ bin/test-string-converters
 elapsed=4.47067s
Executed 92000006 tests. All tests passed.
$ bin/test-string-converters
 elapsed=4.48706s
Executed 92000006 tests. All tests passed.
```