### PR TITLE
[dialog-bi-import.c] insert "" in ListStore when regex match fails

### DIFF
--- a/gnucash/import-export/bi-import/dialog-bi-import.c
+++ b/gnucash/import-export/bi-import/dialog-bi-import.c
@@ -68,7 +68,7 @@
                 g_strstrip( temp ); \
                 gtk_list_store_set (store, &iter, column, temp, -1); \
                 g_free (temp); \
-            }
+            } else gtk_list_store_set (store, &iter, column, "", -1);
 
 static QofLogModule log_module = G_LOG_DOMAIN; //G_LOG_BUSINESS;
 static char * un_escape(char *str);


### PR DESCRIPTION
because the liststore data isn't being null-checked. It's easier to insert "" when the regex match fails thereby allowing strlen e.g. strlen(date_posted) to return 0 instead of segfaulting.

allows import from https://lists.gnucash.org/pipermail/gnucash-user/2024-March/111275.html to succeed.