### PR TITLE
Bug799258 gnc:make-date-exchange-time-fn as a better gnc:make-exchange-time-fn

### DIFF
--- a/gnucash/report/reports/standard/balsheet-pnl.scm
+++ b/gnucash/report/reports/standard/balsheet-pnl.scm
@@ -738,15 +738,9 @@ also show overall period profit & loss."))
 
          ;; generate an exchange-fn for date, and cache its result.
          (get-date-exchange-fn
-          (let ((h (make-hash-table))
-                (commodities (gnc:accounts-get-commodities accounts #f)))
-            (lambda (date)
-              (or (hashv-ref h date)
-                  (let ((exchangefn (gnc:case-exchange-time-fn
-                                     price-source common-currency commodities
-                                     date #f #f)))
-                    (hashv-set! h date exchangefn)
-                    exchangefn)))))
+          (gnc:make-date-exchange-time-fn price-source common-currency
+                                          (gnc:accounts-get-commodities accounts #f)
+                                          enddate #f #f))
 
          ;; from col-idx, find effective date to retrieve pricedb
          ;; entry or to limit transactions to calculate average-cost

--- a/gnucash/report/reports/standard/net-charts.scm
+++ b/gnucash/report/reports/standard/net-charts.scm
@@ -212,7 +212,7 @@
       (fold
        (lambda (mon acc)
          (+ acc (gnc-numeric-convert
-                 (gnc:gnc-monetary-amount (exchange-fn mon report-currency date))
+                 (gnc:gnc-monetary-amount ((exchange-fn date) mon report-currency date))
                  (gnc-commodity-get-fraction report-currency)
                  GNC-RND-ROUND)))
        0 (c 'format gnc:make-gnc-monetary #f)))
@@ -281,9 +281,9 @@
                           (gnc-accounts-and-all-descendants accounts)
                           report-currency))
     (gnc:report-percent-done 10)
-    (set! exchange-fn (gnc:case-exchange-time-fn
-                       price-source report-currency
-                       commodity-list to-date-t64
+    (set! exchange-fn (gnc:make-date-exchange-time-fn
+                       price-source report-currency (gnc:accounts-get-commodities accounts #f)
+                       to-date-t64
                        10 40))
     (gnc:report-percent-done 50)
 


### PR DESCRIPTION
creates a better `gnc:make-exchange-time-fn` which doesn't search transactions dated after the date selected.

heavily memory intensive.