### PR TITLE
Use correct literal suffix for `size_type`.

### DIFF
--- a/gnucash/import-export/import-main-matcher.cpp
+++ b/gnucash/import-export/import-main-matcher.cpp
@@ -847,7 +847,7 @@ gnc_gen_trans_assign_transfer_account_to_selection_cb (GtkMenuItem *menuitem,
     bool is_selection = true;
     auto debugging_enabled{qof_log_check (G_LOG_DOMAIN, QOF_LOG_DEBUG)};
 
-    DEBUG("Rows in selection = %ld", selected_refs.size());
+    DEBUG("Rows in selection = %zu", selected_refs.size());
 
     for (const auto& ref : selected_refs)
     {


### PR DESCRIPTION
`std::vector<T,Allocator>::size` returns `size_type`. `%ld` works fine on 64 bit arches, but fails on 32 bit.

Ref.: https://en.cppreference.com/w/cpp/container/vector/size
      https://en.cppreference.com/w/cpp/types/size_t