### PR TITLE
Fix invalid-$DISPLAY error being non-text

### DIFF
--- a/gnucash/gnucash.cpp
+++ b/gnucash/gnucash.cpp
@@ -296,7 +296,8 @@ main(int argc, char ** argv)
         << "\n"
         // Translators: Do not translate $DISPLAY! It is an environment variable for X11
         << _("Error: could not initialize graphical user interface and option add-price-quotes was not set.\n"
-        "Perhaps you need to set the $DISPLAY environment variable?");
+        "Perhaps you need to set the $DISPLAY environment variable?")
+        << "\n";
         return 1;
     }
 


### PR DESCRIPTION
Given
```
nabijaczleweli@tarta:~$ DISPLAY=komputerek-x40.:0 gnucash
Run 'g --help' to see a full list of available command line options.
Error: could not initialise graphical user interface and option add-price-quotes was not set.
Perhaps you need to set the $DISPLAY environment variable?nabijaczleweli@tarta:~$
we can obviously see the error output isn't a text file.
```

Half-mechanically updated with
```sh
sed -i '/eed to set the $DISPLAY environmen/s/?/?\\n/' $(git grep -l 'eed to set the $DISPLAY environmen')
```
and then
```sh
vi $(git grep -l 'eed to set the $DISPLAY environmen')
```