### PR TITLE
Fix first-day-of-week detexion in dense calendar (Upcoming Transactions)

### DIFF
--- a/gnucash/gnome-utils/gnc-dense-cal.c
+++ b/gnucash/gnome-utils/gnc-dense-cal.c
@@ -496,30 +496,7 @@ gnc_dense_cal_init(GncDenseCal *dcal)
     dcal->initialized = TRUE;
 
 
-    dcal->week_starts_monday = 0;
-    {
-        gchar **parts;
-        const char *week_start_str;
-
-        /* Use this renaming macro to avoid extraction of the message
-           string into the gnucash.pot file when calling xgettext. */
-#define dgettext_noextract dgettext
-        /* Translators: This string must not show up in gnucash.pot as
-           it is looked up in the "gtk20" translation domain
-           instead. */
-        week_start_str = dgettext_noextract("gtk20", "calendar:week_start:0");
-#undef dgettext_noextract
-
-        parts = g_strsplit(week_start_str, ":", 3);
-        if (parts[0] != NULL
-                && parts[1] != NULL
-                && parts[2] != NULL)
-        {
-            if (strcmp("1", parts[2]) == 0)
-                dcal->week_starts_monday = 1;
-        }
-        g_strfreev(parts);
-    }
+    dcal->week_starts_monday = gnc_start_of_week() == 2;
 
     gtk_widget_show_all(GTK_WIDGET(dcal));
 }


### PR DESCRIPTION
GnuCash depends on GTK3, and not GTK2. Thus:
```
$ gettext -d gtk20 calendar:week_start:0; echo
calendar:week_start:0
$ LC_LANG=pl_PL.UTF-8 gettext -d gtk20 calendar:week_start:0; echo
calendar:week_start:0

$ gettext -d gtk30 calendar:week_start:0; echo
calendar:week_start:1
$ LC_LANG=pl_PL.UTF-8 gettext -d gtk30 calendar:week_start:0; echo
calendar:week_start:1
```
because the "gtk20" catalog, provided by GTK2, doesn't exist.

Before:
![image](https://github.com/Gnucash/gnucash/assets/6709544/12f4b48c-5132-4371-89b2-dce512d94457)

After:
![image](https://github.com/Gnucash/gnucash/assets/6709544/f0917ec7-3073-49fe-8414-496a2ab7cd93)


This corresponds to https://bugs.gnucash.org/show_bug.cgi?id=797623 and  https://bugs.gnucash.org/show_bug.cgi?id=752395