### PR TITLE
Bug 799281 - Deleting a transaction may trigger a crash

### DIFF
--- a/libgnucash/engine/qofid.cpp
+++ b/libgnucash/engine/qofid.cpp
@@ -216,6 +216,7 @@ qof_collection_lookup_entity (const QofCollection *col, const GncGUID * guid)
     if (guid == NULL) return NULL;
     ent = static_cast<QofInstance*>(g_hash_table_lookup (col->hash_of_entities,
 							 guid));
+    if (qof_instance_get_destroying(ent)) return NULL;	
     return ent;
 }
 

--- a/libgnucash/engine/qofid.cpp
+++ b/libgnucash/engine/qofid.cpp
@@ -216,7 +216,7 @@ qof_collection_lookup_entity (const QofCollection *col, const GncGUID * guid)
     if (guid == NULL) return NULL;
     ent = static_cast<QofInstance*>(g_hash_table_lookup (col->hash_of_entities,
 							 guid));
-    if (qof_instance_get_destroying(ent)) return NULL;	
+    if (ent != NULL && qof_instance_get_destroying(ent)) return NULL;	
     return ent;
 }
 


### PR DESCRIPTION
Update qof_collection_lookup_entity() to prevent returning instances marked to be destroyed.