### PR TITLE
account->splits is a vector

### DIFF
--- a/gnucash/gnome-utils/dialog-transfer.cpp
+++ b/gnucash/gnome-utils/dialog-transfer.cpp
@@ -44,6 +44,7 @@
 #include "gnc-ui.h"
 #include "Transaction.h"
 #include "Account.h"
+#include "Account.hpp"
 #include "engine-helpers.h"
 #include "QuickFill.h"
 #include <gnc-commodity.h>
@@ -472,10 +473,8 @@ gnc_xfer_dialog_reload_quickfill( XferDialog *xferData )
     gnc_quickfill_destroy( xferData->qf );
     xferData->qf = gnc_quickfill_new();
 
-    auto splitlist = xaccAccountGetSplitList( account );
-    for ( GList *node = splitlist; node; node = node->next )
+    for (const auto& split : xaccAccountGetSplits (account))
     {
-        auto split = static_cast<Split *> (node->data);
         auto trans = xaccSplitGetParent (split);
         gnc_quickfill_insert( xferData->qf,
                               xaccTransGetDescription (trans), QUICKFILL_LIFO);

--- a/gnucash/gnome/assistant-stock-transaction.cpp
+++ b/gnucash/gnome/assistant-stock-transaction.cpp
@@ -37,6 +37,7 @@
 #include <sstream>
 
 #include "Account.h"
+#include "Account.hpp"
 #include "Transaction.h"
 #include "engine-helpers.h"
 #include "dialog-utils.h"
@@ -1262,9 +1263,8 @@ StockAssistantModel::set_txn_type (guint type_idx)
 };
 
 static void
-check_txn_date(GList* last_split_node, time64 txn_date, Logger& logger)
+check_txn_date(Split* last_split, time64 txn_date, Logger& logger)
 {
-    auto last_split = static_cast<const Split *>(last_split_node->data);
     auto last_split_date = xaccTransGetDate(xaccSplitGetParent(last_split));
     if (txn_date <= last_split_date) {
         auto last_split_date_str = qof_print_date(last_split_date);
@@ -1301,9 +1301,9 @@ StockAssistantModel::generate_list_of_splits() {
     // transactions dated after the date specified, it is very likely
     // the later stock transactions will be invalidated. warn the user
     // to review them.
-    auto last_split_node = g_list_last (xaccAccountGetSplitList (m_acct));
-    if (last_split_node)
-        check_txn_date(last_split_node, m_transaction_date, m_logger);
+    auto last_split_node = xaccAccountGetSplits (m_acct).rbegin();
+    if (last_split_node != xaccAccountGetSplits (m_acct).rend())
+        check_txn_date(*last_split_node, m_transaction_date, m_logger);
 
     if (m_stock_entry->enabled()  || m_stock_entry->has_amount())
     {

--- a/gnucash/gnome/test/gtest-assistant-stock-transaction.cpp
+++ b/gnucash/gnome/test/gtest-assistant-stock-transaction.cpp
@@ -231,9 +231,8 @@ static void dump_acct (Account *acct)
     std::cout << '\n' << std::setw(20) << std::right << xaccAccountGetName (acct)
               << " Bal=" << std::setw(10) << std::right << GncNumeric (xaccAccountGetBalance (acct))
               << std::endl;
-    for (auto n = xaccAccountGetSplitList (acct); n; n = n->next)
+    for (const auto& s : xaccAccountGetSplits (acct))
     {
-        auto s = static_cast<Split*>(n->data);
         bal += xaccSplitGetAmount (s);
         std::cout << std::setw(20) << std::right << GncDateTime (xaccTransGetDate (xaccSplitGetParent (s))).format_iso8601()
                   << " amt=" << std::setw(10) << std::right << GncNumeric (xaccSplitGetAmount (s))

--- a/gnucash/import-export/import-backend.cpp
+++ b/gnucash/import-export/import-backend.cpp
@@ -38,6 +38,7 @@
 #include "import-backend.h"
 #include "import-utilities.h"
 #include "Account.h"
+#include "Account.hpp"
 #include "Query.h"
 #include "gnc-engine.h"
 #include "engine-helpers.h"
@@ -996,9 +997,9 @@ hash_account_online_ids (Account *account)
 {
      auto acct_hash = g_hash_table_new_full
           (g_str_hash, g_str_equal, g_free, nullptr);
-     for (GList *n = xaccAccountGetSplitList (account) ; n; n = n->next)
+     for (const auto& split : xaccAccountGetSplits (account))
      {
-        auto id = gnc_import_get_split_online_id (static_cast<Split *>(n->data));
+        auto id = gnc_import_get_split_online_id (split);
         if (id && *id)
             g_hash_table_insert (acct_hash, (void*) id, GINT_TO_POINTER (1));
      }

--- a/gnucash/import-export/import-main-matcher.cpp
+++ b/gnucash/import-export/import-main-matcher.cpp
@@ -44,6 +44,7 @@
 
 #include "import-main-matcher.h"
 
+#include "Account.hpp"
 #include "dialog-transfer.h"
 #include "dialog-utils.h"
 #include "gnc-glib-utils.h"
@@ -468,9 +469,8 @@ load_hash_tables (GNCImportMainMatcher *info)
     }
     for (GList *m = accounts_list; m; m = m->next)
     {
-        for (GList *n = xaccAccountGetSplitList (static_cast<Account*>(m->data)); n; n = n->next)
+        for (const auto& s : xaccAccountGetSplits (static_cast<Account*>(m->data)))
         {
-            auto s = static_cast<const Split*>(n->data);
             const Transaction *t = xaccSplitGetParent (s);
 
             const gchar *key = xaccTransGetDescription (t);

--- a/libgnucash/engine/Account.cpp
+++ b/libgnucash/engine/Account.cpp
@@ -34,6 +34,7 @@
 #include <string.h>
 
 #include "AccountP.hpp"
+#include "Account.hpp"
 #include "Split.h"
 #include "Transaction.h"
 #include "TransactionP.h"
@@ -333,7 +334,7 @@ gnc_account_init(Account* acc)
     priv->lower_balance_limit = {};
     priv->include_sub_account_balances = {};
 
-    priv->splits = nullptr;
+    priv->splits = {};
     priv->sort_dirty = FALSE;
 }
 
@@ -1370,22 +1371,19 @@ xaccFreeAccount (Account *acc)
     /* NB there shouldn't be any splits by now ... they should
      * have been all been freed by CommitEdit().  We can remove this
      * check once we know the warning isn't occurring any more. */
-    if (priv->splits)
+    if (priv->splits.size())
     {
-        GList *slist;
         PERR (" instead of calling xaccFreeAccount(), please call\n"
               " xaccAccountBeginEdit(); xaccAccountDestroy();\n");
 
         qof_instance_reset_editlevel(acc);
 
-        slist = g_list_copy(priv->splits);
-        for (lp = slist; lp; lp = lp->next)
+        std::vector<Split*> slist = priv->splits;
+        for (const auto& s : slist)
         {
-            Split *s = (Split *) lp->data;
             g_assert(xaccSplitGetAccount(s) == acc);
             xaccSplitDestroy (s);
         }
-        g_list_free(slist);
 /* Nothing here (or in xaccAccountCommitEdit) nullptrs priv->splits, so this asserts every time.
         g_assert(priv->splits == nullptr);
 */
@@ -1471,6 +1469,7 @@ destroy_pending_splits_for_account(QofInstance *ent, gpointer acc)
             xaccSplitDestroy(split);
 }
 
+
 void
 xaccAccountCommitEdit (Account *acc)
 {
@@ -1485,7 +1484,6 @@ xaccAccountCommitEdit (Account *acc)
     priv = GET_PRIVATE(acc);
     if (qof_instance_get_destroying(acc))
     {
-        GList *lp, *slist;
         QofCollection *col;
 
         qof_instance_increase_editlevel(acc);
@@ -1502,18 +1500,13 @@ xaccAccountCommitEdit (Account *acc)
            themselves will be destroyed by the transaction code */
         if (!qof_book_shutting_down(book))
         {
-            slist = g_list_copy(priv->splits);
-            for (lp = slist; lp; lp = lp->next)
-            {
-                Split *s = static_cast<Split *>(lp->data);
+            std::vector<Split*> slist = priv->splits;
+            for (const auto& s : slist)
                 xaccSplitDestroy (s);
-            }
-            g_list_free(slist);
         }
         else
         {
-            g_list_free(priv->splits);
-            priv->splits = nullptr;
+            priv->splits = {};
         }
 
         /* It turns out there's a case where this assertion does not hold:
@@ -1530,7 +1523,7 @@ xaccAccountCommitEdit (Account *acc)
             qof_collection_foreach(col, destroy_pending_splits_for_account, acc);
 
             /* the lots should be empty by now */
-            for (lp = priv->lots; lp; lp = lp->next)
+            for (auto lp = priv->lots; lp; lp = lp->next)
             {
                 GNCLot *lot = static_cast<GNCLot*>(lp->data);
                 gnc_lot_destroy (lot);
@@ -1824,38 +1817,25 @@ xaccAccountEqual(const Account *aa, const Account *ab, gboolean check_guids)
     /* no parent; always compare downwards. */
 
     {
-        GList *la = priv_aa->splits;
-        GList *lb = priv_ab->splits;
+        auto it_a = priv_aa->splits.begin();
+        auto it_b = priv_ab->splits.begin();
 
-        if ((la && !lb) || (!la && lb))
+        for (; it_a != priv_aa->splits.end() && it_b != priv_ab->splits.end(); ++it_a, ++it_b)
         {
-            PWARN ("only one has splits");
-            return FALSE;
+            Split *sa = *it_a;
+            Split *sb = *it_b;
+
+            if (!xaccSplitEqual(sa, sb, check_guids, TRUE, FALSE))
+            {
+                PWARN ("splits differ");
+                return false;
+            }
         }
 
-        if (la && lb)
+        if (it_a != priv_aa->splits.end() || it_b != priv_ab->splits.end())
         {
-            /* presume that the splits are in the same order */
-            while (la && lb)
-            {
-                Split *sa = (Split *) la->data;
-                Split *sb = (Split *) lb->data;
-
-                if (!xaccSplitEqual(sa, sb, check_guids, TRUE, FALSE))
-                {
-                    PWARN ("splits differ");
-                    return(FALSE);
-                }
-
-                la = la->next;
-                lb = lb->next;
-            }
-
-            if ((la != nullptr) || (lb != nullptr))
-            {
-                PWARN ("number of splits differs");
-                return(FALSE);
-            }
+            PWARN ("number of splits differs");
+            return(FALSE);
         }
     }
 
@@ -1924,30 +1904,29 @@ gboolean gnc_account_get_defer_bal_computation (Account *acc)
 /********************************************************************\
 \********************************************************************/
 
+static bool split_sort_cmp (const Split* a, const Split* b)
+{
+    return xaccSplitOrder (a, b) < 0;
+}
+
 gboolean
 gnc_account_insert_split (Account *acc, Split *s)
 {
     AccountPrivate *priv;
-    GList *node;
 
     g_return_val_if_fail(GNC_IS_ACCOUNT(acc), FALSE);
     g_return_val_if_fail(GNC_IS_SPLIT(s), FALSE);
 
     priv = GET_PRIVATE(acc);
-    node = g_list_find(priv->splits, s);
-    if (node)
+    if (std::find (priv->splits.begin(), priv->splits.end(), s) != priv->splits.end())
         return FALSE;
 
+    priv->splits.push_back (s);
+
     if (qof_instance_get_editlevel(acc) == 0)
-    {
-        priv->splits = g_list_insert_sorted(priv->splits, s,
-                                            (GCompareFunc)xaccSplitOrder);
-    }
+        std::sort (priv->splits.begin(), priv->splits.end(), split_sort_cmp);
     else
-    {
-        priv->splits = g_list_prepend(priv->splits, s);
-        priv->sort_dirty = TRUE;
-    }
+        priv->sort_dirty = true;
 
     //FIXME: find better event
     qof_event_gen (&acc->inst, QOF_EVENT_MODIFY, nullptr);
@@ -1964,17 +1943,17 @@ gboolean
 gnc_account_remove_split (Account *acc, Split *s)
 {
     AccountPrivate *priv;
-    GList *node;
 
     g_return_val_if_fail(GNC_IS_ACCOUNT(acc), FALSE);
     g_return_val_if_fail(GNC_IS_SPLIT(s), FALSE);
 
     priv = GET_PRIVATE(acc);
-    node = g_list_find(priv->splits, s);
-    if (nullptr == node)
+
+    auto it = std::find (priv->splits.begin(), priv->splits.end(), s);
+    if (it == priv->splits.end())
         return FALSE;
 
-    priv->splits = g_list_delete_link(priv->splits, node);
+    priv->splits.erase (it);
     //FIXME: find better event type
     qof_event_gen(&acc->inst, QOF_EVENT_MODIFY, nullptr);
     // And send the account-based event, too
@@ -1995,7 +1974,7 @@ xaccAccountSortSplits (Account *acc, gboolean force)
     priv = GET_PRIVATE(acc);
     if (!priv->sort_dirty || (!force && qof_instance_get_editlevel(acc) > 0))
         return;
-    priv->splits = g_list_sort(priv->splits, (GCompareFunc)xaccSplitOrder);
+    std::sort (priv->splits.begin(), priv->splits.end(), split_sort_cmp);
     priv->sort_dirty = FALSE;
     priv->balance_dirty = TRUE;
 }
@@ -2168,7 +2147,7 @@ xaccAccountInsertLot (Account *acc, GNCLot *lot)
 /********************************************************************\
 \********************************************************************/
 static void
-xaccPreSplitMove (Split *split, gpointer dummy)
+xaccPreSplitMove (Split *split)
 {
     xaccTransBeginEdit (xaccSplitGetParent (split));
 }
@@ -2195,7 +2174,7 @@ xaccAccountMoveAllSplits (Account *accfrom, Account *accto)
 
     /* optimizations */
     from_priv = GET_PRIVATE(accfrom);
-    if (!from_priv->splits || accfrom == accto)
+    if (from_priv->splits.empty() || accfrom == accto)
         return;
 
     /* check for book mix-up */
@@ -2205,7 +2184,8 @@ xaccAccountMoveAllSplits (Account *accfrom, Account *accto)
     xaccAccountBeginEdit(accfrom);
     xaccAccountBeginEdit(accto);
     /* Begin editing both accounts and all transactions in accfrom. */
-    g_list_foreach(from_priv->splits, (GFunc)xaccPreSplitMove, nullptr);
+    std::for_each (from_priv->splits.begin(), from_priv->splits.end(),
+                   xaccPreSplitMove);
 
     /* Concatenate accfrom's lists of splits and lots to accto's lists. */
     //to_priv->splits = g_list_concat(to_priv->splits, from_priv->splits);
@@ -2222,10 +2202,11 @@ xaccAccountMoveAllSplits (Account *accfrom, Account *accto)
      * Convert each split's amount to accto's commodity.
      * Commit to editing each transaction.
      */
-    g_list_foreach(from_priv->splits, (GFunc)xaccPostSplitMove, (gpointer)accto);
+    std::for_each (from_priv->splits.begin(), from_priv->splits.end(),
+                   [](const auto& s){ xaccPostSplitMove (s, nullptr); });
 
     /* Finally empty accfrom. */
-    g_assert(from_priv->splits == nullptr);
+    g_assert(from_priv->splits.empty());
     g_assert(from_priv->lots == nullptr);
     xaccAccountCommitEdit(accfrom);
     xaccAccountCommitEdit(accto);
@@ -2270,7 +2251,6 @@ xaccAccountRecomputeBalance (Account * acc)
     gnc_numeric  noclosing_balance;
     gnc_numeric  cleared_balance;
     gnc_numeric  reconciled_balance;
-    GList *lp;
 
     if (nullptr == acc) return;
 
@@ -2287,9 +2267,8 @@ xaccAccountRecomputeBalance (Account * acc)
 
     PINFO ("acct=%s starting baln=%" G_GINT64_FORMAT "/%" G_GINT64_FORMAT,
            priv->accountName, balance.num, balance.denom);
-    for (lp = priv->splits; lp; lp = lp->next)
+    for (const auto& split : priv->splits)
     {
-        Split *split = (Split *) lp->data;
         gnc_numeric amt = xaccSplitGetAmount (split);
 
         balance = gnc_numeric_add_fixed(balance, amt);
@@ -2313,7 +2292,6 @@ xaccAccountRecomputeBalance (Account * acc)
         split->noclosing_balance = noclosing_balance;
         split->cleared_balance = cleared_balance;
         split->reconciled_balance = reconciled_balance;
-
     }
 
     priv->balance = balance;
@@ -2609,7 +2587,6 @@ void
 xaccAccountSetCommodity (Account * acc, gnc_commodity * com)
 {
     AccountPrivate *priv;
-    GList *lp;
 
     /* errors */
     g_return_if_fail(GNC_IS_ACCOUNT(acc));
@@ -2628,9 +2605,8 @@ xaccAccountSetCommodity (Account * acc, gnc_commodity * com)
     priv->non_standard_scu = FALSE;
 
     /* iterate over splits */
-    for (lp = priv->splits; lp; lp = lp->next)
+    for (const auto& s : priv->splits)
     {
-        Split *s = (Split *) lp->data;
         Transaction *trans = xaccSplitGetParent (s);
 
         xaccTransBeginEdit (trans);
@@ -3543,7 +3519,6 @@ gnc_numeric
 xaccAccountGetProjectedMinimumBalance (const Account *acc)
 {
     AccountPrivate *priv;
-    GList *node;
     time64 today;
     gnc_numeric lowest = gnc_numeric_zero ();
     int seen_a_transaction = 0;
@@ -3552,9 +3527,9 @@ xaccAccountGetProjectedMinimumBalance (const Account *acc)
 
     priv = GET_PRIVATE(acc);
     today = gnc_time64_get_today_end();
-    for (node = g_list_last(priv->splits); node; node = node->prev)
+    for (auto it = priv->splits.rbegin(); it != priv->splits.rend(); it++)
     {
-        Split *split = static_cast<Split*>(node->data);
+        Split *split = *it;
 
         if (!seen_a_transaction)
         {
@@ -3593,11 +3568,11 @@ GetBalanceAsOfDate (Account *acc, time64 date, gboolean ignclosing)
     xaccAccountSortSplits (acc, TRUE); /* just in case, normally a noop */
     xaccAccountRecomputeBalance (acc); /* just in case, normally a noop */
 
-    for (GList *lp = GET_PRIVATE(acc)->splits; lp; lp = lp->next)
+    for (const auto& split : GET_PRIVATE(acc)->splits)
     {
-        if (xaccTransGetDate (xaccSplitGetParent ((Split *)lp->data)) >= date)
+        if (xaccTransGetDate (xaccSplitGetParent (split)) >= date)
             break;
-        latest = (Split *)lp->data;
+        latest = split;
     }
 
     if (!latest)
@@ -3628,9 +3603,8 @@ xaccAccountGetReconciledBalanceAsOfDate (Account *acc, time64 date)
 
     g_return_val_if_fail(GNC_IS_ACCOUNT(acc), gnc_numeric_zero());
 
-    for (GList *node = GET_PRIVATE(acc)->splits; node; node = node->next)
+    for (const auto& split : GET_PRIVATE(acc)->splits)
     {
-        Split *split = (Split*) node->data;
         if ((xaccSplitGetReconcile (split) == YREC) &&
             (xaccSplitGetDateReconciled (split) <= date))
             balance = gnc_numeric_add_fixed (balance, xaccSplitGetAmount (split));
@@ -4044,16 +4018,24 @@ SplitList *
 xaccAccountGetSplitList (const Account *acc)
 {
     g_return_val_if_fail(GNC_IS_ACCOUNT(acc), nullptr);
-    xaccAccountSortSplits((Account*)acc, FALSE);  // normally a noop
-    return GET_PRIVATE(acc)->splits;
+    auto priv{GET_PRIVATE(acc)};
+    return std::accumulate (priv->splits.rbegin(), priv->splits.rend(),
+                            static_cast<GList*>(nullptr), g_list_prepend);
 }
 
+const std::vector<Split*>
+xaccAccountGetSplits (const Account *account)
+{
+    if (!GNC_IS_ACCOUNT(account))
+        return {};
+    return GET_PRIVATE(account)->splits;
+}
 
 gboolean gnc_account_and_descendants_empty (Account *acc)
 {
     g_return_val_if_fail (GNC_IS_ACCOUNT (acc), FALSE);
     auto priv = GET_PRIVATE (acc);
-    if (priv->splits != nullptr) return FALSE;
+    if (!priv->splits.empty()) return FALSE;
     for (auto *n = priv->children; n; n = n->next)
     {
 	if (!gnc_account_and_descendants_empty (static_cast<Account*>(n->data)))
@@ -5390,7 +5372,6 @@ finder_help_function(const Account *acc, const char *description,
                      Split **split, Transaction **trans )
 {
     AccountPrivate *priv;
-    GList *slp;
 
     /* First, make sure we set the data to nullptr BEFORE we start */
     if (split) *split = nullptr;
@@ -5403,9 +5384,9 @@ finder_help_function(const Account *acc, const char *description,
      * list is in date order, and the most recent matches should be
      * returned!?  */
     priv = GET_PRIVATE(acc);
-    for (slp = g_list_last(priv->splits); slp; slp = slp->prev)
+    for (auto it = priv->splits.rbegin(); it != priv->splits.rend(); it++)
     {
-        Split *lsplit = static_cast<Split*>(slp->data);
+        auto lsplit = *it;
         Transaction *ltrans = xaccSplitGetParent(lsplit);
 
         if (g_strcmp0 (description, xaccTransGetDescription (ltrans)) == 0)
@@ -5522,8 +5503,8 @@ gnc_account_merge_children (Account *parent)
             gnc_account_merge_children (acc_a);
 
             /* consolidate transactions */
-            while (priv_b->splits)
-                xaccSplitSetAccount (static_cast <Split*> (priv_b->splits->data), acc_a);
+            while (!priv_b->splits.empty())
+                xaccSplitSetAccount (priv_b->splits[0], acc_a);
 
             /* move back one before removal. next iteration around the loop
              * will get the node after node_b */
@@ -5541,14 +5522,11 @@ gnc_account_merge_children (Account *parent)
 /* Transaction Traversal functions                                  */
 
 
-void
-xaccSplitsBeginStagedTransactionTraversals (GList *splits)
+static void
+xaccSplitsBeginStagedTransactionTraversals (std::vector<Split*> splits)
 {
-    GList *lp;
-
-    for (lp = splits; lp; lp = lp->next)
+    for (const auto& s : splits)
     {
-        Split *s = static_cast <Split*> (lp->data);
         Transaction *trans = s->parent;
 
         if (trans)
@@ -5560,12 +5538,9 @@ xaccSplitsBeginStagedTransactionTraversals (GList *splits)
 void
 xaccAccountBeginStagedTransactionTraversals (const Account *account)
 {
-    AccountPrivate *priv;
-
     if (!account)
         return;
-    priv = GET_PRIVATE(account);
-    xaccSplitsBeginStagedTransactionTraversals(priv->splits);
+    xaccSplitsBeginStagedTransactionTraversals(GET_PRIVATE (account)->splits);
 }
 
 gboolean
@@ -5582,7 +5557,7 @@ xaccTransactionTraverse (Transaction *trans, int stage)
     return FALSE;
 }
 
-static void do_one_split (Split *s, gpointer data)
+static void do_one_split (Split *s)
 {
     Transaction *trans = s->parent;
     trans->marker = 0;
@@ -5591,7 +5566,7 @@ static void do_one_split (Split *s, gpointer data)
 static void do_one_account (Account *account, gpointer data)
 {
     AccountPrivate *priv = GET_PRIVATE(account);
-    g_list_foreach(priv->splits, (GFunc)do_one_split, nullptr);
+    std::for_each (priv->splits.begin(), priv->splits.end(), do_one_split);
 }
 
 /* Replacement for xaccGroupBeginStagedTransactionTraversals */
@@ -5612,24 +5587,21 @@ xaccAccountStagedTransactionTraversal (const Account *acc,
                                        void *cb_data)
 {
     AccountPrivate *priv;
-    GList *split_p;
-    GList *next;
     Transaction *trans;
-    Split *s;
     int retval;
 
     if (!acc) return 0;
 
     priv = GET_PRIVATE(acc);
-    for (split_p = priv->splits; split_p; split_p = next)
+    for (auto it = priv->splits.begin(); it != priv->splits.end();)
     {
         /* Get the next element in the split list now, just in case some
          * naughty thunk destroys the one we're using. This reduces, but
          * does not eliminate, the possibility of undefined results if
          * a thunk removes splits from this account. */
-        next = g_list_next(split_p);
+        auto next = std::next (it);
 
-        s = static_cast <Split*> (split_p->data);
+        auto s = *it;
         trans = s->parent;
         if (trans && (trans->marker < stage))
         {
@@ -5640,6 +5612,8 @@ xaccAccountStagedTransactionTraversal (const Account *acc,
                 if (retval) return retval;
             }
         }
+
+        it = next;
     }
 
     return 0;
@@ -5652,16 +5626,14 @@ gnc_account_tree_staged_transaction_traversal (const Account *acc,
         void *cb_data)
 {
     const AccountPrivate *priv;
-    GList *acc_p, *split_p;
     Transaction *trans;
-    Split *s;
     int retval;
 
     if (!acc) return 0;
 
     /* depth first traversal */
     priv = GET_PRIVATE(acc);
-    for (acc_p = priv->children; acc_p; acc_p = g_list_next(acc_p))
+    for (auto acc_p = priv->children; acc_p; acc_p = g_list_next(acc_p))
     {
         retval = gnc_account_tree_staged_transaction_traversal(static_cast <Account*> (acc_p->data),
                 stage, thunk, cb_data);
@@ -5669,9 +5641,8 @@ gnc_account_tree_staged_transaction_traversal (const Account *acc,
     }
 
     /* Now this account */
-    for (split_p = priv->splits; split_p; split_p = g_list_next(split_p))
+    for (const auto& s : priv->splits)
     {
-        s = static_cast <Split*> (split_p->data);
         trans = s->parent;
         if (trans && (trans->marker < stage))
         {

--- a/libgnucash/engine/Account.h
+++ b/libgnucash/engine/Account.h
@@ -1491,12 +1491,6 @@ typedef enum
      */
     void gnc_account_tree_begin_staged_transaction_traversals(Account *acc);
 
-    /** xaccSplitsBeginStagedTransactionTraversals() resets the traversal
-     *    marker for each transaction which is a parent of one of the
-     *    splits in the list.
-     */
-    void xaccSplitsBeginStagedTransactionTraversals(SplitList *splits);
-
     /** xaccAccountBeginStagedTransactionTraversals() resets the traversal
      *    marker for each transaction which is a parent of one of the
      *    splits in the account.

--- a/libgnucash/engine/Account.hpp
+++ b/libgnucash/engine/Account.hpp
@@ -1,0 +1,45 @@
+/**********************************************************************
+ * Account.hpp
+ *                                                                    *
+ * This program is free software; you can redistribute it and/or      *
+ * modify it under the terms of the GNU General Public License as     *
+ * published by the Free Software Foundation; either version 2 of     *
+ * the License, or (at your option) any later version.                *
+ *                                                                    *
+ * This program is distributed in the hope that it will be useful,    *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of     *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the      *
+ * GNU General Public License for more details.                       *
+ *                                                                    *
+ * You should have received a copy of the GNU General Public License  *
+ * along with this program; if not, contact:                          *
+ *                                                                    *
+ * Free Software Foundation           Voice:  +1-617-542-5942         *
+ * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652         *
+ * Boston, MA  02110-1301,  USA       gnu@gnu.org                     *
+ *                                                                    *
+ *********************************************************************/
+
+/** @addtogroup Engine
+    @{ */
+/** @addtogroup Account
+
+    @{ */
+/** @file Account.hpp
+ *  @brief Account public routines (C++ api)
+ */
+
+#ifndef GNC_ACCOUNT_HPP
+#define GNC_ACCOUNT_HPP
+
+#include <vector>
+
+#include <Account.h>
+
+using SplitsVec = std::vector<Split*>;
+
+const SplitsVec xaccAccountGetSplits (const Account*);
+
+#endif /* GNC_COMMODITY_HPP */
+/** @} */
+/** @} */

--- a/libgnucash/engine/AccountP.hpp
+++ b/libgnucash/engine/AccountP.hpp
@@ -39,6 +39,7 @@
 #ifndef XACC_ACCOUNT_P_H
 #define XACC_ACCOUNT_P_H
 
+#include <vector>
 #include <optional>
 
 #include "Account.h"
@@ -118,7 +119,7 @@ typedef struct AccountPrivate
  
     gboolean balance_dirty;     /* balances in splits incorrect */
 
-    GList *splits;              /* list of split pointers */
+    std::vector<Split*> splits;              /* list of split pointers */
     gboolean sort_dirty;        /* sort order of splits is bad */
 
     LotList   *lots;		/* list of lot pointers */

--- a/libgnucash/engine/Scrub.cpp
+++ b/libgnucash/engine/Scrub.cpp
@@ -47,6 +47,7 @@
 
 #include "Account.h"
 #include "AccountP.hpp"
+#include "Account.hpp"
 #include "Scrub.h"
 #include "Transaction.h"
 #include "TransactionP.h"
@@ -91,8 +92,8 @@ gnc_get_ongoing_scrub (void)
 
 static void add_transactions (const Account *account, GHashTable **ht)
 {
-    for (GList *m = xaccAccountGetSplitList (account); m; m = g_list_next (m))
-        g_hash_table_add (*ht, xaccSplitGetParent (GNC_SPLIT(m->data)));
+    for (const auto& s : xaccAccountGetSplits (account))
+        g_hash_table_add (*ht, xaccSplitGetParent (s));
 }
 
 static GList*
@@ -226,12 +227,11 @@ xaccAccountTreeScrubSplits (Account *account)
 void
 xaccAccountScrubSplits (Account *account)
 {
-    GList *node;
     scrub_depth++;
-    for (node = xaccAccountGetSplitList (account); node; node = node->next)
+    for (const auto& s : xaccAccountGetSplits (account))
     {
         if (abort_now) break;
-        xaccSplitScrub (GNC_SPLIT(node->data));
+        xaccSplitScrub (s);
     }
     scrub_depth--;
 }

--- a/libgnucash/engine/Scrub2.cpp
+++ b/libgnucash/engine/Scrub2.cpp
@@ -37,6 +37,7 @@
 #include "qof.h"
 #include "Account.h"
 #include "AccountP.hpp"
+#include "Account.hpp"
 #include "Transaction.h"
 #include "TransactionP.h"
 #include "Scrub2.h"
@@ -57,19 +58,14 @@ static QofLogModule log_module = GNC_MOD_LOT;
 void
 xaccAccountAssignLots (Account *acc)
 {
-    SplitList *splits, *node;
-
     if (!acc) return;
 
     ENTER ("acc=%s", xaccAccountGetName(acc));
     xaccAccountBeginEdit (acc);
 
 restart_loop:
-    splits = xaccAccountGetSplitList(acc);
-    for (node = splits; node; node = node->next)
+    for (const auto& split : xaccAccountGetSplits (acc))
     {
-        Split * split = GNC_SPLIT(node->data);
-
         /* If already in lot, then no-op */
         if (split->lot) continue;
 

--- a/libgnucash/engine/cap-gains.cpp
+++ b/libgnucash/engine/cap-gains.cpp
@@ -58,6 +58,7 @@ ToDo:
 #include <glib.h>
 #include <glib/gi18n.h>
 
+#include "Account.hpp"
 #include "AccountP.hpp"
 #include "Scrub2.h"
 #include "Scrub3.h"
@@ -79,7 +80,6 @@ gboolean
 xaccAccountHasTrades (const Account *acc)
 {
     gnc_commodity *acc_comm;
-    SplitList *splits, *node;
 
     if (!acc) return FALSE;
 
@@ -88,10 +88,8 @@ xaccAccountHasTrades (const Account *acc)
 
     acc_comm = xaccAccountGetCommodity(acc);
 
-    splits = xaccAccountGetSplitList(acc);
-    for (node = splits; node; node = node->next)
+    for (const auto& s : xaccAccountGetSplits (acc))
     {
-        Split *s = GNC_SPLIT(node->data);
         Transaction *t = s->parent;
 	if (s->gains == GAINS_STATUS_GAINS) continue;
         if (acc_comm != t->common_currency) return TRUE;

--- a/libgnucash/engine/policy.cpp
+++ b/libgnucash/engine/policy.cpp
@@ -101,11 +101,8 @@ DirectionPolicyGetSplit (GNCPolicy *pcy, GNCLot *lot, short reverse)
      * hasn't been assigned to a lot.  Return that split.
      * Make use of the fact that the splits in an account are
      * already in date order; so we don't have to sort. */
-    node = xaccAccountGetSplitList (lot_account);
-    if (reverse)
-    {
-        node = g_list_last (node);
-    }
+    auto splits = xaccAccountGetSplitList (lot_account);
+    node = reverse ? g_list_last (splits) : splits;
     while (node)
     {
         gboolean is_match;
@@ -145,6 +142,7 @@ donext:
             node = node->next;
         }
     }
+    g_list_free (splits);
     return nullptr;
 }
 

--- a/libgnucash/engine/test-core/test-engine-stuff.cpp
+++ b/libgnucash/engine/test-core/test-engine-stuff.cpp
@@ -1074,7 +1074,6 @@ make_random_changes_to_level (QofBook *book, Account *parent)
     account = static_cast<Account*>(get_random_list_element (accounts));
 
     splits = xaccAccountGetSplitList (account);
-    splits = g_list_copy (splits);
 
     for (node = splits; node; node = node->next)
     {

--- a/libgnucash/engine/test/utest-Account.cpp
+++ b/libgnucash/engine/test/utest-Account.cpp
@@ -882,7 +882,7 @@ test_xaccFreeAccount (Fixture *fixture, gconstpointer pData)
     /* Check that we've got children, lots, and splits to remove */
     g_assert_true (p_priv->children != NULL);
     g_assert_true (p_priv->lots != NULL);
-    g_assert_true (p_priv->splits != NULL);
+    g_assert_true (p_priv->splits.size());
     g_assert_true (p_priv->parent != NULL);
     g_assert_true (p_priv->commodity != NULL);
     g_assert_cmpint (check1->hits, ==, 0);
@@ -983,7 +983,7 @@ test_xaccAccountCommitEdit (Fixture *fixture, gconstpointer pData)
     /* Check that we've got children, lots, and splits to remove */
     g_assert_true (p_priv->children != NULL);
     g_assert_true (p_priv->lots != NULL);
-    g_assert_true (p_priv->splits != NULL);
+    g_assert_true (p_priv->splits.size());
     g_assert_true (p_priv->parent != NULL);
     g_assert_true (p_priv->commodity != NULL);
     g_assert_cmpint (check1->hits, ==, 0);
@@ -998,7 +998,7 @@ test_xaccAccountCommitEdit (Fixture *fixture, gconstpointer pData)
     test_signal_assert_hits (sig2, 0);
     g_assert_true (p_priv->children != NULL);
     g_assert_true (p_priv->lots != NULL);
-    g_assert_true (p_priv->splits != NULL);
+    g_assert_true (p_priv->splits.size());
     g_assert_true (p_priv->parent != NULL);
     g_assert_true (p_priv->commodity != NULL);
     g_assert_cmpint (check1->hits, ==, 0);
@@ -1393,19 +1393,19 @@ test_gnc_account_insert_remove_split (Fixture *fixture, gconstpointer pData)
 
     /* Check that the call fails with invalid account and split (throws) */
     g_assert_true (!gnc_account_insert_split (NULL, split1));
-    g_assert_cmpuint (g_list_length (priv->splits), == , 0);
+    g_assert_cmpuint (priv->splits.size(), == , 0);
     g_assert_true (!priv->sort_dirty);
     g_assert_true (!priv->balance_dirty);
     test_signal_assert_hits (sig1, 0);
     test_signal_assert_hits (sig2, 0);
     g_assert_true (!gnc_account_insert_split (fixture->acct, NULL));
-    g_assert_cmpuint (g_list_length (priv->splits), == , 0);
+    g_assert_cmpuint (priv->splits.size(), == , 0);
     g_assert_true (!priv->sort_dirty);
     g_assert_true (!priv->balance_dirty);
     test_signal_assert_hits (sig1, 0);
     test_signal_assert_hits (sig2, 0);
     /* g_assert_true (!gnc_account_insert_split (fixture->acct, (Split*)priv)); */
-    /* g_assert_cmpuint (g_list_length (priv->splits), == , 0); */
+    /* g_assert_cmpuint (priv->splits.size(), == , 0); */
     /* g_assert_true (!priv->sort_dirty); */
     /* g_assert_true (!priv->balance_dirty); */
     /* test_signal_assert_hits (sig1, 0); */
@@ -1418,7 +1418,7 @@ test_gnc_account_insert_remove_split (Fixture *fixture, gconstpointer pData)
 
     /* Check that it works the first time */
     g_assert_true (gnc_account_insert_split (fixture->acct, split1));
-    g_assert_cmpuint (g_list_length (priv->splits), == , 1);
+    g_assert_cmpuint (priv->splits.size(), == , 1);
     g_assert_true (!priv->sort_dirty);
     g_assert_true (priv->balance_dirty);
     test_signal_assert_hits (sig1, 1);
@@ -1430,7 +1430,7 @@ test_gnc_account_insert_remove_split (Fixture *fixture, gconstpointer pData)
     sig3 = test_signal_new (&fixture->acct->inst, GNC_EVENT_ITEM_ADDED, split2);
     /* Now add a second split to the account and check that sort_dirty isn't set. We have to bump the editlevel to force this. */
     g_assert_true (gnc_account_insert_split (fixture->acct, split2));
-    g_assert_cmpuint (g_list_length (priv->splits), == , 2);
+    g_assert_cmpuint (priv->splits.size(), == , 2);
     g_assert_true (!priv->sort_dirty);
     g_assert_true (priv->balance_dirty);
     test_signal_assert_hits (sig1, 2);
@@ -1441,7 +1441,7 @@ test_gnc_account_insert_remove_split (Fixture *fixture, gconstpointer pData)
     qof_instance_increase_editlevel (fixture->acct);
     g_assert_true (gnc_account_insert_split (fixture->acct, split3));
     qof_instance_decrease_editlevel (fixture->acct);
-    g_assert_cmpuint (g_list_length (priv->splits), == , 3);
+    g_assert_cmpuint (priv->splits.size(), == , 3);
     g_assert_true (priv->sort_dirty);
     g_assert_true (priv->balance_dirty);
     test_signal_assert_hits (sig1, 3);
@@ -1452,7 +1452,7 @@ test_gnc_account_insert_remove_split (Fixture *fixture, gconstpointer pData)
     sig3 = test_signal_new (&fixture->acct->inst, GNC_EVENT_ITEM_REMOVED,
                             split3);
     g_assert_true (gnc_account_remove_split (fixture->acct, split3));
-    g_assert_cmpuint (g_list_length (priv->splits), == , 2);
+    g_assert_cmpuint (priv->splits.size(), == , 2);
     g_assert_true (priv->sort_dirty);
     g_assert_true (!priv->balance_dirty);
     test_signal_assert_hits (sig1, 4);
@@ -1460,7 +1460,7 @@ test_gnc_account_insert_remove_split (Fixture *fixture, gconstpointer pData)
     /* And do it again to make sure that it fails when the split has
      * already been removed */
     g_assert_true (!gnc_account_remove_split (fixture->acct, split3));
-    g_assert_cmpuint (g_list_length (priv->splits), == , 2);
+    g_assert_cmpuint (priv->splits.size(), == , 2);
     g_assert_true (priv->sort_dirty);
     g_assert_true (!priv->balance_dirty);
     test_signal_assert_hits (sig1, 4);


### PR DESCRIPTION
and `xaccAccountGetSplitList` still returns a `GList*`.

compared to #1887 the best benchmarks are now 3.491s