### PR TITLE
commodity-utilities.scm -> c++

### DIFF
--- a/bindings/engine.i
+++ b/bindings/engine.i
@@ -73,6 +73,8 @@ GLIST_HELPER_INOUT(AccountList, SWIGTYPE_p_Account);
 GLIST_HELPER_INOUT(PriceList, SWIGTYPE_p_GNCPrice);
 // TODO: free PriceList?
 GLIST_HELPER_INOUT(CommodityList, SWIGTYPE_p_gnc_commodity);
+VECTOR_HELPER_INOUT(SplitsVec, SWIGTYPE_p_Split, Split);
+VECTOR_HELPER_INOUT(AccountVec, SWIGTYPE_p_Account, Account);
 
 %typemap(newfree) char * "g_free($1);"
 

--- a/common/base-typemaps.i
+++ b/common/base-typemaps.i
@@ -162,6 +162,29 @@ typedef char gchar;
   $result = scm_reverse(list);
 }
 %enddef
+
+
+%define VECTOR_HELPER_INOUT(VectorType, ElemSwigType, ElemType)
+%typemap(in) VectorType {
+  std::vector<ElemType*> accum;
+  for (auto node = $input; !scm_is_null (node); node = scm_cdr (node))
+  {
+      auto p_scm = scm_car (node);
+      auto p = (scm_is_false (p_scm) || scm_is_null (p_scm)) ? static_cast<ElemType*>(nullptr) :
+          static_cast<ElemType*>(SWIG_MustGetPtr(p_scm, ElemSwigType, 1, 0));
+      accum.push_back (p);
+  }
+  accum.swap ($1);
+}
+
+%typemap(out) VectorType {
+  SCM list = SCM_EOL;
+  std::for_each ($1.rbegin(), $1.rend(), [&list](auto n)
+                 { list = scm_cons(SWIG_NewPointerObj(n, ElemSwigType, 0), list); });
+  $result = list;
+}
+%enddef
+
 #elif defined(SWIGPYTHON) /* Typemaps for Python */
 
 %import "glib.h"

--- a/gnucash/report/reports/standard/balsheet-pnl.scm
+++ b/gnucash/report/reports/standard/balsheet-pnl.scm
@@ -736,17 +736,10 @@ also show overall period profit & loss."))
               (cons acc (map col-datum-get-split-balance-with-closing cols-data))))
            accounts-cols-data))
 
-         ;; generate an exchange-fn for date, and cache its result.
-         (get-date-exchange-fn
-          (let ((h (make-hash-table))
-                (commodities (gnc:accounts-get-commodities accounts #f)))
-            (lambda (date)
-              (or (hashv-ref h date)
-                  (let ((exchangefn (gnc:case-exchange-time-fn
-                                     price-source common-currency commodities
-                                     date #f #f)))
-                    (hashv-set! h date exchangefn)
-                    exchangefn)))))
+         ;; generate an exchange-fn
+         (exchange-fn (gnc:case-exchange-time-fn price-source common-currency
+                                                 (gnc:accounts-get-commodities accounts #f)
+                                                 #f #f #f))
 
          ;; from col-idx, find effective date to retrieve pricedb
          ;; entry or to limit transactions to calculate average-cost
@@ -772,8 +765,7 @@ also show overall period profit & loss."))
                        (gnc:gnc-monetary-commodity monetary)
                        common-currency))
                  (has-price? (gnc:gnc-monetary-commodity monetary))
-                 (let* ((col-date (col-idx->price-date col-idx))
-                        (exchange-fn (get-date-exchange-fn col-date)))
+                 (let ((col-date (col-idx->price-date col-idx)))
                    (exchange-fn monetary common-currency col-date)))))
 
          ;; the following function generates an gnc:html-text object

--- a/gnucash/report/test/test-commodity-utils.scm
+++ b/gnucash/report/test/test-commodity-utils.scm
@@ -655,7 +655,7 @@
                           (gnc-dmy2time64-neutral 20 02 2016)
                           #f #f)))
         (test-equal "gnc:case-exchange-time-fn weighted-average 20/02/2012"
-          307/5
+          0
           (gnc:gnc-monetary-amount
            (exchange-fn
             (gnc:make-gnc-monetary AAPL 1)
@@ -663,7 +663,7 @@
             (gnc-dmy2time64-neutral 20 02 2012))))
 
         (test-equal "gnc:case-exchange-time-fn weighted-average 20/02/2014"
-          9366/125
+          307/5
           (gnc:gnc-monetary-amount
            (exchange-fn
             (gnc:make-gnc-monetary AAPL 1)
@@ -687,7 +687,7 @@
             (gnc-dmy2time64-neutral 11 08 2014))))
 
         (test-equal "gnc:case-exchange-time-fn weighted-average 22/10/2015"
-          27663/325
+          9366/125
           (gnc:gnc-monetary-amount
            (exchange-fn
             (gnc:make-gnc-monetary AAPL 1)
@@ -708,7 +708,7 @@
                           (gnc-dmy2time64-neutral 20 02 2016)
                           #f #f)))
         (test-equal "gnc:case-exchange-time-fn average-cost 20/02/2012"
-          14127/175
+          0
           (gnc:gnc-monetary-amount
            (exchange-fn
             (gnc:make-gnc-monetary AAPL 1)


### PR DESCRIPTION
step 1 of many for speed up currency conversions for bug 799258: make `gnc_get_match_commodity_splits` a cpp function. why does report eg asset chart fail?

```
* 00:18:52  WARN <gnc.gui> [gnc_run_report_with_error_handling()] Error in report: In ice-9/boot-9.scm:
  1752:10 11 (with-exception-handler _ _ #:unwind? _ # _)
In unknown file:
          10 (apply-smob/0 #<thunk 7a3fdf514300>)
In c-interface.scm:
     34:5  9 (gnc:call-with-error-handling _ _)
In ice-9/boot-9.scm:
  1747:15  8 (with-exception-handler #<procedure 7a3fcb9258a0 at ic…> …)
  1752:10  7 (with-exception-handler _ _ #:unwind? _ # _)
In c-interface.scm:
    38:40  6 (_)
In report-core.scm:
   748:25  5 (gnc:report-render-html #<<report> type: "e9cf815f79db…> …)
In standard/category-barchart.scm:
   282:26  4 (category-barchart-renderer #<<report> type: "e9cf815f…> …)
In commodity-utilities.scm:
   824:31  3 (gnc:case-exchange-time-fn _ _ _ _ _ _)
   192:29  2 (gnc:get-commoditylist-totalavg-prices (#<swig-poin…> …) …)
In unknown file:
           1 (gnc-get-match-commodity-splits (#<swig-pointer Acc…> …) …)
In ice-9/boot-9.scm:
  1685:16  0 (raise-exception _ #:continuable? _)

In procedure gnc-get-match-commodity-splits: Wrong type argument in position 1: (#<swig-pointer Account * 17a7080> #<swig-pointer Account * 17a6e00> #<swig-pointer Account * 17a9b90> #<swig-pointer Account * 17a9d80> #<swig-pointer Account * 17a73d0> #<swig-pointer Account * 17abc90> #<swig-pointer Account * 17ac340> #<swig-pointer Account * 17a75c0> #<swig-pointer Account * 17aa240> #<swig-pointer Account * 17a77b0> #<swig-pointer Account * 17a7c40> #<swig-pointer Account * 17a8890> #<swig-pointer Account * 17a7eb0> #<swig-pointer Account * 17a8cf0> #<swig-pointer Account * 17ac7b0> #<swig-pointer Account * 17acde0> #<swig-pointer Account * 17a8f60> #<swig-pointer Account * 17a8280> #<swig-pointer Account * 17acfd0> #<swig-pointer Account * 17ad1c0> #<swig-pointer Account * 17ad3b0> #<swig-pointer Account * 17ad790> #<swig-pointer Account * 17ad5a0> #<swig-pointer Account * 17ad980> #<swig-pointer Account * 17adb70> #<swig-pointer Account * 17add60> #<swig-pointer Account * 17adf50>)
```