### PR TITLE
[engine.i] even faster gnc_get_match_commodity_splits

### DIFF
--- a/libgnucash/engine/Account.cpp
+++ b/libgnucash/engine/Account.cpp
@@ -1151,6 +1151,22 @@ gnc_account_foreach_split (const Account *acc, std::function<void(Split*)> func,
         std::for_each(splits.begin(), splits.end(), func);
 }
 
+void
+gnc_account_foreach_split_until_date (const Account *acc, time64 end_date,
+                                      std::function<void(Split*)> f)
+{
+    if (!GNC_IS_ACCOUNT (acc))
+        return;
+
+    auto after_date = [](time64 end_date, auto s) -> bool
+    { return (xaccTransGetDate (xaccSplitGetParent (s)) > end_date); };
+
+    auto splits{GET_PRIVATE(acc)->splits};
+    auto after_date_iter = std::upper_bound (splits.begin(), splits.end(), end_date, after_date);
+    std::for_each (splits.begin(), after_date_iter, f);
+}
+
+
 Split*
 gnc_account_find_split (const Account *acc, std::function<bool(const Split*)> predicate,
                         bool reverse)

--- a/libgnucash/engine/Account.hpp
+++ b/libgnucash/engine/Account.hpp
@@ -43,6 +43,9 @@ const SplitsVec xaccAccountGetSplits (const Account*);
 
 void gnc_account_foreach_split (const Account*, std::function<void(Split*)>, bool);
 
+void gnc_account_foreach_split_until_date (const Account *acc, time64 end_date,
+                                           std::function<void(Split*)> f);
+
 /** scans account split list (in forward or reverse order) until
  *    predicate split->bool returns true. Maybe return the split.
  *


### PR DESCRIPTION
`gnc_get_match_commodity_splits` needs to scan the account splitlists to find suitable splits upto `end_date`. We can stop scanning each account at `end_date` because the splitlists are sorted by date. This saves significant time because majority of splits can by bypassed in the early report dates.

My primary book net worth linechart benchmarks -- fastest speeds from 1.05s to 0.54s, now practically unnoticeable