### PR TITLE
Fix tests

### DIFF
--- a/common/cmake_modules/GncAddTest.cmake
+++ b/common/cmake_modules/GncAddTest.cmake
@@ -149,7 +149,11 @@ function(gnc_add_scheme_test _TARGET _SOURCE_FILE)
                   (format #t \"%load-compiled-path = ~s~%\" %load-compiled-path)
                   (error \"Loading guile/site file from outside build tree!\" filename))))
       (load-from-path \"${_TARGET}\")
-      (exit (run-test))"
+      (let ((result (run-test)))
+           (if (boolean? result)
+             (exit result)
+             (exit (test-runner-fail-count result))))
+"
     )
   endif()
   get_guile_env()


### PR DESCRIPTION
Tests were passing incorrectly.

This branch removes the srfi-64 test runner customisation, using the default `test-runner-simple`. The test output is less nice, but it does not incorrectly signal test passes.

I'm not sure of the effect upon the guile coverage tests.

@jralls