### PR TITLE
[dialog-price-edit-db.cpp] Copy the latest price when creating a new entry from a commodity selection

### DIFF
--- a/gnucash/gnome/dialog-price-edit-db.cpp
+++ b/gnucash/gnome/dialog-price-edit-db.cpp
@@ -532,9 +532,23 @@ gnc_prices_dialog_add_clicked (GtkWidget *widget, gpointer data)
     {
         if (!gnc_list_length_cmp (comm_list, 1)) // make sure it is only one parent
         {
-            price = gnc_price_create (pdb_dialog->book);
-            auto comm = static_cast<gnc_commodity *> (comm_list->data);
-            gnc_price_set_commodity (price, comm);
+            auto comm = GNC_COMMODITY (comm_list->data);
+            auto latest_price = gnc_pricedb_lookup_latest_any_currency (pdb_dialog->price_db, comm);
+
+            if (latest_price)
+            {
+                price = GNC_PRICE (latest_price->data);
+                gnc_price_ref (price);
+
+                gnc_price_list_destroy (latest_price);
+            }
+
+            if (!price)
+            {
+                price = gnc_price_create (pdb_dialog->book);
+                gnc_price_set_commodity (price, comm);
+            }
+
             unref_price = TRUE;
         }
         g_list_free (comm_list);


### PR DESCRIPTION
When a price entry is selected, it's contents get copied 1:1 to the newly created price to facilitate faster entry based on existing values (e.g. the type).
When selecting a commodity instead, the user is presented with an empty price entry where only the commodity is set.

IMO the user ends up with the same values (except the price of course) as the latest entry.
So we check whether we have a (latest) entry and use that as the template,
so that e.g. the type gets copied, too.
This spares the user some clicks.