### PR TITLE
First day of the week changes

### DIFF
--- a/gnucash/gnome-utils/gnc-dense-cal-model.c
+++ b/gnucash/gnome-utils/gnc-dense-cal-model.c
@@ -1,34 +1,35 @@
-/*
- * gnc-dense-cal-model.c
- *
- * Copyright (C) 2006 Joshua Sled <jsled@asynchronous.org>
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of version 2 and/or version 3 of the GNU General Public License as
- * published by the Free Software Foundation.
- *
- * As a special exception, permission is granted to link the binary module
- * resultant from this code with the OpenSSL project's "OpenSSL" library (or
- * modified versions of it that use the same license as the "OpenSSL"
- * library), and distribute the linked executable.  You must obey the GNU
- * General Public License in all respects for all of the code used other than
- * "OpenSSL". If you modify this file, you may extend this exception to your
- * version of the file, but you are not obligated to do so. If you do not
- * wish to do so, delete this exception statement from your version of this
- * file.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
+/********************************************************************\
+ * gnc-dense-cal-model.c                                            *
+ * Copyright (C) 2006 Joshua Sled <jsled@asynchronous.org>          *
+ *                                                                  *
+ * This program is free software; you can redistribute it and/or    *
+ * modify it under the terms of the GNU General Public License as   *
+ * published by the Free Software Foundation, under version 2 and   *
+ *  / or version 3 of the License.                                  *
+ *                                                                  *
+ * As a special exception, permission is granted to link the binary *
+ * module resultant from this code with the OpenSSL project's       *
+ * "OpenSSL" library (or modified versions of it that use the same  *
+ * license as the "OpenSSL" library), and distribute the linked     *
+ * executable. You must obey the GNU General Public License in all  *
+ * respects for all of the code used other than "OpenSSL". If you   *
+ * modify this file, you may extend this exception to your version  *
+ * of the file, but you are not obligated to do so. If you do not   *
+ * wish to do so, delete this exception statement from your version *
+ * of this file.                                                    *
+ *                                                                  *
+ * This program is distributed in the hope that it will be useful,  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    *
+ * GNU General Public License for more details.                     *
+ *                                                                  *
  * You should have received a copy of the GNU General Public License*
- * along with this program; if not, contact:
- *
- * Free Software Foundation           Voice:  +1-617-542-5942
- * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652
- * Boston, MA  02110-1301,  USA       gnu@gnu.org
- */
+ * along with this program; if not, contact:                        *
+ *                                                                  *
+ * Free Software Foundation           Voice:  +1-617-542-5942       *
+ * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652       *
+ * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
+\********************************************************************/
 
 
 #include <config.h>
@@ -41,7 +42,7 @@ enum { GDCM_ADDED, GDCM_UPDATE, GDCM_REMOVE, LAST_SIGNAL };
 static guint gnc_dense_cal_model_signals[LAST_SIGNAL] = { 0 };
 
 static void
-gnc_dense_cal_model_default_init(GncDenseCalModelInterface *g_class)
+gnc_dense_cal_model_default_init (GncDenseCalModelInterface *g_class)
 {
     gnc_dense_cal_model_signals[GDCM_ADDED] = g_signal_new("added",
                        G_TYPE_FROM_CLASS(g_class),
@@ -80,34 +81,37 @@ gnc_dense_cal_model_default_init(GncDenseCalModelInterface *g_class)
                       );
 }
 
-G_DEFINE_INTERFACE (GncDenseCalModel, gnc_dense_cal_model, G_TYPE_OBJECT)
+G_DEFINE_INTERFACE(GncDenseCalModel, gnc_dense_cal_model, G_TYPE_OBJECT)
 
 GList*
-gnc_dense_cal_model_get_contained(GncDenseCalModel *model)
+gnc_dense_cal_model_get_contained (GncDenseCalModel *model)
 {
     return (*GNC_DENSE_CAL_MODEL_GET_IFACE(model)->get_contained)(model);
 }
 
 gchar*
-gnc_dense_cal_model_get_name(GncDenseCalModel *model, guint tag)
+gnc_dense_cal_model_get_name (GncDenseCalModel *model, guint tag)
 {
     return (*GNC_DENSE_CAL_MODEL_GET_IFACE(model)->get_name)(model, tag);
 }
 
 gchar*
-gnc_dense_cal_model_get_info(GncDenseCalModel *model, guint tag)
+gnc_dense_cal_model_get_info (GncDenseCalModel *model, guint tag)
 {
     return (*GNC_DENSE_CAL_MODEL_GET_IFACE(model)->get_info)(model, tag);
 }
 
 gint
-gnc_dense_cal_model_get_instance_count(GncDenseCalModel *model, guint tag)
+gnc_dense_cal_model_get_instance_count (GncDenseCalModel *model, guint tag)
 {
     return (*GNC_DENSE_CAL_MODEL_GET_IFACE(model)->get_instance_count)(model, tag);
 }
 
 void
-gnc_dense_cal_model_get_instance(GncDenseCalModel *model, guint tag, gint instance_index, GDate *date)
+gnc_dense_cal_model_get_instance (GncDenseCalModel *model,
+                                  guint tag,
+                                  gint instance_index,
+                                  GDate *date)
 {
     (*GNC_DENSE_CAL_MODEL_GET_IFACE(model)->get_instance)(model, tag, instance_index, date);
 }

--- a/gnucash/gnome-utils/gnc-dense-cal-model.h
+++ b/gnucash/gnome-utils/gnc-dense-cal-model.h
@@ -1,24 +1,24 @@
-/*
- * gnc-dense-cal-model.h
- *
- * Copyright (C) 2006 Joshua Sled <jsled@asynchronous.org>
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of version 2 and/or version 3 of the GNU General Public License as
- * published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
+/********************************************************************\
+ * gnc-dense-cal-model.h                                            *
+ * Copyright (C) 2006 Joshua Sled <jsled@asynchronous.org>          *
+ *                                                                  *
+ * This program is free software; you can redistribute it and/or    *
+ * modify it under the terms of the GNU General Public License as   *
+ * published by the Free Software Foundation, under version 2 and   *
+ *  / or version 3 of the License.                                  *
+ *                                                                  *
+ * This program is distributed in the hope that it will be useful,  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    *
+ * GNU General Public License for more details.                     *
+ *                                                                  *
  * You should have received a copy of the GNU General Public License*
- * along with this program; if not, contact:
- *
- * Free Software Foundation           Voice:  +1-617-542-5942
- * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652
- * Boston, MA  02110-1301,  USA       gnu@gnu.org
- */
+ * along with this program; if not, contact:                        *
+ *                                                                  *
+ * Free Software Foundation           Voice:  +1-617-542-5942       *
+ * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652       *
+ * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
+\********************************************************************/
 
 #ifndef _GNC_DENSE_CAL_MODEL_H
 #define _GNC_DENSE_CAL_MODEL_H
@@ -29,8 +29,8 @@
 
 G_BEGIN_DECLS
 
-#define GNC_TYPE_DENSE_CAL_MODEL (gnc_dense_cal_model_get_type())
-G_DECLARE_INTERFACE (GncDenseCalModel, gnc_dense_cal_model, GNC, DENSE_CAL_MODEL, GObject)
+#define GNC_TYPE_DENSE_CAL_MODEL (gnc_dense_cal_model_get_type ())
+G_DECLARE_INTERFACE(GncDenseCalModel, gnc_dense_cal_model, GNC, DENSE_CAL_MODEL, GObject)
 
 struct _GncDenseCalModelInterface
 {
@@ -45,11 +45,14 @@ struct _GncDenseCalModelInterface
 };
 
 /** @return Caller-owned GList (but not elements).  The Model-user will free. **/
-GList* gnc_dense_cal_model_get_contained(GncDenseCalModel *model);
-gchar* gnc_dense_cal_model_get_name(GncDenseCalModel *model, guint tag);
-gchar* gnc_dense_cal_model_get_info(GncDenseCalModel *model, guint tag);
-gint gnc_dense_cal_model_get_instance_count(GncDenseCalModel *model, guint tag);
-void gnc_dense_cal_model_get_instance(GncDenseCalModel *model, guint tag, gint instance_index, GDate *date);
+GList* gnc_dense_cal_model_get_contained (GncDenseCalModel *model);
+gchar* gnc_dense_cal_model_get_name (GncDenseCalModel *model, guint tag);
+gchar* gnc_dense_cal_model_get_info (GncDenseCalModel *model, guint tag);
+gint gnc_dense_cal_model_get_instance_count (GncDenseCalModel *model, guint tag);
+void gnc_dense_cal_model_get_instance (GncDenseCalModel *model,
+                                       guint tag,
+                                       gint instance_index,
+                                       GDate *date);
 
 G_END_DECLS
 

--- a/gnucash/gnome-utils/gnc-dense-cal-store.c
+++ b/gnucash/gnome-utils/gnc-dense-cal-store.c
@@ -1,34 +1,35 @@
-/*
- * gnc-dense-cal-store.h
- *
- * Copyright (C) 2006 Joshua Sled <jsled@asynchronous.org>
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of version 2 and/or version 3 of the GNU General Public License as
- * published by the Free Software Foundation.
- *
- * As a special exception, permission is granted to link the binary module
- * resultant from this code with the OpenSSL project's "OpenSSL" library (or
- * modified versions of it that use the same license as the "OpenSSL"
- * library), and distribute the linked executable.  You must obey the GNU
- * General Public License in all respects for all of the code used other than
- * "OpenSSL". If you modify this file, you may extend this exception to your
- * version of the file, but you are not obligated to do so. If you do not
- * wish to do so, delete this exception statement from your version of this
- * file.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, contact:
- *
- * Free Software Foundation           Voice:  +1-617-542-5942
- * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652
- * Boston, MA  02110-1301,  USA       gnu@gnu.org
- */
+/********************************************************************\
+ * gnc-dense-cal-store.h                                            *
+ * Copyright (C) 2006 Joshua Sled <jsled@asynchronous.org>          *
+ *                                                                  *
+ * This program is free software; you can redistribute it and/or    *
+ * modify it under the terms of the GNU General Public License as   *
+ * published by the Free Software Foundation, under version 2 and   *
+ *  / or version 3 of the License.                                  *
+ *                                                                  *
+ * As a special exception, permission is granted to link the binary *
+ * module resultant from this code with the OpenSSL project's       *
+ * "OpenSSL" library (or modified versions of it that use the same  *
+ * license as the "OpenSSL" library), and distribute the linked     *
+ * executable. You must obey the GNU General Public License in all  *
+ * respects for all of the code used other than "OpenSSL". If you   *
+ * modify this file, you may extend this exception to your version  *
+ * of the file, but you are not obligated to do so. If you do not   *
+ * wish to do so, delete this exception statement from your version *
+ * of this file.                                                    *
+ *                                                                  *
+ * This program is distributed in the hope that it will be useful,  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    *
+ * GNU General Public License for more details.                     *
+ *                                                                  *
+ * You should have received a copy of the GNU General Public License*
+ * along with this program; if not, contact:                        *
+ *                                                                  *
+ * Free Software Foundation           Voice:  +1-617-542-5942       *
+ * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652       *
+ * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
+\********************************************************************/
 
 #include <config.h>
 #include <glib.h>
@@ -54,20 +55,20 @@ struct _GncDenseCalStore
     GDate **cal_marks;
 };
 
-static void gnc_dense_cal_store_iface_init(GncDenseCalModelInterface *iface);
-static void gnc_dense_cal_store_finalize(GObject *obj);
+static void gnc_dense_cal_store_iface_init (GncDenseCalModelInterface *iface);
+static void gnc_dense_cal_store_finalize (GObject *obj);
 
-static GList* gdcs_get_contained(GncDenseCalModel *model);
-static gchar* gdcs_get_name(GncDenseCalModel *model, guint tag);
-static gchar* gdcs_get_info(GncDenseCalModel *model, guint tag);
-static gint gdcs_get_instance_count(GncDenseCalModel *model, guint tag);
-static void gdcs_get_instance(GncDenseCalModel *model, guint tag, gint instance_index, GDate *date);
+static GList* gdcs_get_contained (GncDenseCalModel *model);
+static gchar* gdcs_get_name (GncDenseCalModel *model, guint tag);
+static gchar* gdcs_get_info (GncDenseCalModel *model, guint tag);
+static gint gdcs_get_instance_count (GncDenseCalModel *model, guint tag);
+static void gdcs_get_instance (GncDenseCalModel *model, guint tag, gint instance_index, GDate *date);
 
-G_DEFINE_TYPE_WITH_CODE (GncDenseCalStore, gnc_dense_cal_store, G_TYPE_OBJECT,
-    G_IMPLEMENT_INTERFACE (GNC_TYPE_DENSE_CAL_MODEL, gnc_dense_cal_store_iface_init))
+G_DEFINE_TYPE_WITH_CODE(GncDenseCalStore, gnc_dense_cal_store, G_TYPE_OBJECT,
+    G_IMPLEMENT_INTERFACE(GNC_TYPE_DENSE_CAL_MODEL, gnc_dense_cal_store_iface_init))
 
 static void
-gnc_dense_cal_store_class_init(GncDenseCalStoreClass *klass)
+gnc_dense_cal_store_class_init (GncDenseCalStoreClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
 
@@ -75,12 +76,12 @@ gnc_dense_cal_store_class_init(GncDenseCalStoreClass *klass)
 }
 
 static void
-gnc_dense_cal_store_init(GncDenseCalStore *self)
+gnc_dense_cal_store_init (GncDenseCalStore *self)
 {
 }
 
 static void
-gnc_dense_cal_store_iface_init(GncDenseCalModelInterface *iface)
+gnc_dense_cal_store_iface_init (GncDenseCalModelInterface *iface)
 {
     iface->get_contained = gdcs_get_contained;
     iface->get_name = gdcs_get_name;
@@ -90,79 +91,75 @@ gnc_dense_cal_store_iface_init(GncDenseCalModelInterface *iface)
 }
 
 GncDenseCalStore*
-gnc_dense_cal_store_new(int num_marks)
+gnc_dense_cal_store_new (int num_marks)
 {
-    GncDenseCalStore *model = g_object_new(GNC_TYPE_DENSE_CAL_STORE, NULL);
+    GncDenseCalStore *model = g_object_new (GNC_TYPE_DENSE_CAL_STORE, NULL);
     model->num_marks = num_marks;
-    model->cal_marks = g_new0(GDate*, num_marks);
+    model->cal_marks = g_new0 (GDate*, num_marks);
     {
-        int i = 0;
-        for (i = 0; i < model->num_marks; i++)
+        for (int i = 0; i < model->num_marks; i++)
         {
             model->cal_marks[i] = g_date_new();
         }
     }
     model->num_real_marks = 0;
-    g_date_clear(&model->start_date, 1);
+    g_date_clear (&model->start_date, 1);
     gnc_gdate_set_today (&model->start_date);
     model->end_type = NEVER_END;
-    g_date_clear(&model->end_date, 1);
+    g_date_clear (&model->end_date, 1);
     gnc_gdate_set_today (&model->end_date);
     model->n_occurrences = 0;
     return model;
 }
 
 void
-gnc_dense_cal_store_clear(GncDenseCalStore *model)
+gnc_dense_cal_store_clear (GncDenseCalStore *model)
 {
     model->num_real_marks = 0;
-    g_signal_emit_by_name(model, "update", GUINT_TO_POINTER(1));
+    g_signal_emit_by_name (model, "update", GUINT_TO_POINTER(1));
 }
 
 void
-gnc_dense_cal_store_update_name(GncDenseCalStore *model, const gchar *name)
+gnc_dense_cal_store_update_name (GncDenseCalStore *model, const gchar *name)
 {
     if (model->name != NULL)
-    {
-        g_free(model->name);
-    }
-    model->name = g_strdup(name);
+        g_free (model->name);
+
+    model->name = g_strdup (name);
     //g_signal_emit_by_name(model, "update", GUINT_TO_POINTER(1));
 }
 
 void
-gnc_dense_cal_store_update_info(GncDenseCalStore *model, const gchar *info)
+gnc_dense_cal_store_update_info (GncDenseCalStore *model, const gchar *info)
 {
     if (model->info != NULL)
-    {
-        g_free(model->info);
-    }
-    model->info = g_strdup(info);
+        g_free (model->info);
+
+    model->info = g_strdup (info);
     //g_signal_emit_by_name(model, "update", GUINT_TO_POINTER(1));
 }
 
 static void
-gdcs_generic_update_recurrences(GncDenseCalStore *trans, GDate *start, GList *recurrences)
+gdcs_generic_update_recurrences (GncDenseCalStore *trans, GDate *start, GList *recurrences)
 {
-    int i;
+    int i = 0;
     GDate date, next;
 
     date = *start;
-    recurrenceListNextInstance(recurrences, &date, &next);
+    recurrenceListNextInstance (recurrences, &date, &next);
 
-    i = 0;
     while ((i < trans->num_marks)
-            && g_date_valid(&next)
+            && g_date_valid (&next)
             /* Do checking against end restriction. */
             && ((trans->end_type == NEVER_END)
                 || (trans->end_type == END_ON_DATE
-                    && g_date_compare(&next, &trans->end_date) <= 0)
+                    && g_date_compare (&next, &trans->end_date) <= 0)
                 || (trans->end_type == END_AFTER_N_OCCS
                     && i < trans->n_occurrences)))
     {
         *trans->cal_marks[i++] = next;
         date = next;
-        recurrenceListNextInstance(recurrences, &date, &next);
+        recurrenceListNextInstance (recurrences, &date, &next);
     }
     trans->num_real_marks = i;
     /* cstim: Previously this was i-1 but that's just plain wrong for
@@ -170,42 +167,50 @@ gdcs_generic_update_recurrences(GncDenseCalStore *trans, GDate *start, GList *re
      * the number of (rest) occurrences exactly! Subtracting one means
      * we will miss the last one. */
 
-    g_signal_emit_by_name(trans, "update", GUINT_TO_POINTER(1));
+    g_signal_emit_by_name (trans, "update", GUINT_TO_POINTER(1));
 }
 
 void
-gnc_dense_cal_store_update_recurrences_no_end(GncDenseCalStore *model, GDate *start, GList *recurrences)
+gnc_dense_cal_store_update_recurrences_no_end (GncDenseCalStore *model,
+                                               GDate *start,
+                                               GList *recurrences)
 {
     model->end_type = NEVER_END;
-    gdcs_generic_update_recurrences(model, start, recurrences);
+    gdcs_generic_update_recurrences (model, start, recurrences);
 }
 
 void
-gnc_dense_cal_store_update_recurrences_count_end(GncDenseCalStore *model, GDate *start, GList *recurrences, int num_occur)
+gnc_dense_cal_store_update_recurrences_count_end (GncDenseCalStore *model,
+                                                  GDate *start,
+                                                  GList *recurrences,
+                                                  int num_occur)
 {
     model->end_type = END_AFTER_N_OCCS;
     model->n_occurrences = num_occur;
-    gdcs_generic_update_recurrences(model, start, recurrences);
+    gdcs_generic_update_recurrences (model, start, recurrences);
 }
 
 void
-gnc_dense_cal_store_update_recurrences_date_end(GncDenseCalStore *model, GDate *start, GList *recurrences, GDate *end_date)
+gnc_dense_cal_store_update_recurrences_date_end (GncDenseCalStore *model,
+                                                 GDate *start,
+                                                 GList *recurrences,
+                                                 GDate *end_date)
 {
     model->end_type = END_ON_DATE;
     model->end_date = *end_date;
-    gdcs_generic_update_recurrences(model, start, recurrences);
+    gdcs_generic_update_recurrences (model, start, recurrences);
 }
 
 static GList*
-gdcs_get_contained(GncDenseCalModel *model)
+gdcs_get_contained (GncDenseCalModel *model)
 {
     GList *rtn = NULL;
-    rtn = g_list_append(rtn, GUINT_TO_POINTER(1));
+    rtn = g_list_append (rtn, GUINT_TO_POINTER(1));
     return rtn;
 }
 
 static gchar*
-gdcs_get_name(GncDenseCalModel *model, guint tag)
+gdcs_get_name (GncDenseCalModel *model, guint tag)
 {
     GncDenseCalStore *mdl = GNC_DENSE_CAL_STORE(model);
     // assert(tag == 1)
@@ -213,15 +218,15 @@ gdcs_get_name(GncDenseCalModel *model, guint tag)
 }
 
 static gchar*
-gdcs_get_info(GncDenseCalModel *model, guint tag)
+gdcs_get_info (GncDenseCalModel *model, guint tag)
 {
     GncDenseCalStore *mdl = GNC_DENSE_CAL_STORE(model);
     // assert(tag == 1)
-    return g_strdup(mdl->info);
+    return g_strdup (mdl->info);
 }
 
 static gint
-gdcs_get_instance_count(GncDenseCalModel *model, guint tag)
+gdcs_get_instance_count (GncDenseCalModel *model, guint tag)
 {
     GncDenseCalStore *mdl = GNC_DENSE_CAL_STORE(model);
     // assert(tag == 1)
@@ -229,7 +234,7 @@ gdcs_get_instance_count(GncDenseCalModel *model, guint tag)
 }
 
 static void
-gdcs_get_instance(GncDenseCalModel *model, guint tag, gint instance_index, GDate *date)
+gdcs_get_instance (GncDenseCalModel *model, guint tag, gint instance_index, GDate *date)
 {
     GncDenseCalStore *mdl = GNC_DENSE_CAL_STORE(model);
     // assert(tag == 1)
@@ -238,36 +243,35 @@ gdcs_get_instance(GncDenseCalModel *model, guint tag, gint instance_index, GDate
 }
 
 static void
-gnc_dense_cal_store_finalize(GObject *obj)
+gnc_dense_cal_store_finalize (GObject *obj)
 {
-    int i;
     GncDenseCalStore *store;
-    g_return_if_fail(obj != NULL);
+    g_return_if_fail (obj != NULL);
 
     store = GNC_DENSE_CAL_STORE(obj);
 
     if (store->name != NULL)
     {
-        g_free(store->name);
+        g_free (store->name);
         store->name = NULL;
     }
 
     if (store->info != NULL)
     {
-        g_free(store->info);
+        g_free (store->info);
         store->info = NULL;
     }
 
-    for (i = 0; i < store->num_marks; i++)
+    for (int i = 0; i < store->num_marks; i++)
     {
-        g_free(store->cal_marks[i]);
+        g_free (store->cal_marks[i]);
         store->cal_marks[i] = NULL;
     }
     if (store->cal_marks != NULL)
     {
-        g_free(store->cal_marks);
+        g_free (store->cal_marks);
         store->cal_marks = NULL;
     }
 
-    G_OBJECT_CLASS(gnc_dense_cal_store_parent_class)->finalize(obj);
+    G_OBJECT_CLASS(gnc_dense_cal_store_parent_class)->finalize (obj);
 }

--- a/gnucash/gnome-utils/gnc-dense-cal-store.h
+++ b/gnucash/gnome-utils/gnc-dense-cal-store.h
@@ -1,24 +1,24 @@
-/*
- * gnc-dense-cal-store.h
- *
- * Copyright (C) 2006 Joshua Sled <jsled@asynchronous.org>
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of version 2 and/or version 3 of the GNU General Public License as
- * published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
+/********************************************************************\
+ * gnc-dense-cal-store.h                                            *
+ * Copyright (C) 2006 Joshua Sled <jsled@asynchronous.org>          *
+ *                                                                  *
+ * This program is free software; you can redistribute it and/or    *
+ * modify it under the terms of the GNU General Public License as   *
+ * published by the Free Software Foundation, under version 2 and   *
+ *  / or version 3 of the License.                                  *
+ *                                                                  *
+ * This program is distributed in the hope that it will be useful,  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    *
+ * GNU General Public License for more details.                     *
+ *                                                                  *
  * You should have received a copy of the GNU General Public License*
- * along with this program; if not, contact:
- *
- * Free Software Foundation           Voice:  +1-617-542-5942
- * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652
- * Boston, MA  02110-1301,  USA       gnu@gnu.org
- */
+ * along with this program; if not, contact:                        *
+ *                                                                  *
+ * Free Software Foundation           Voice:  +1-617-542-5942       *
+ * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652       *
+ * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
+\********************************************************************/
 
 #ifndef _GNC_DENSE_CAL_STORE_H
 #define _GNC_DENSE_CAL_STORE_H
@@ -31,19 +31,27 @@
 
 G_BEGIN_DECLS
 
-#define GNC_TYPE_DENSE_CAL_STORE (gnc_dense_cal_store_get_type())
-G_DECLARE_FINAL_TYPE (GncDenseCalStore, gnc_dense_cal_store, GNC, DENSE_CAL_STORE, GObject)
+#define GNC_TYPE_DENSE_CAL_STORE (gnc_dense_cal_store_get_type ())
+G_DECLARE_FINAL_TYPE(GncDenseCalStore, gnc_dense_cal_store, GNC, DENSE_CAL_STORE, GObject)
 
 typedef enum { NEVER_END, END_ON_DATE, END_AFTER_N_OCCS, BAD_END } gdcs_end_type;
 
-GncDenseCalStore* gnc_dense_cal_store_new(int num_marks);
-void gnc_dense_cal_store_clear(GncDenseCalStore *model);
-void gnc_dense_cal_store_update_name(GncDenseCalStore *model, const gchar* name);
-void gnc_dense_cal_store_update_info(GncDenseCalStore *model, const gchar* info);
+GncDenseCalStore* gnc_dense_cal_store_new (int num_marks);
+void gnc_dense_cal_store_clear (GncDenseCalStore *model);
+void gnc_dense_cal_store_update_name (GncDenseCalStore *model, const gchar* name);
+void gnc_dense_cal_store_update_info (GncDenseCalStore *model, const gchar* info);
 
-void gnc_dense_cal_store_update_recurrences_no_end(GncDenseCalStore *model, GDate *start, GList *recurrences);
-void gnc_dense_cal_store_update_recurrences_count_end(GncDenseCalStore *model, GDate *start, GList *recurrences, int num_occur);
-void gnc_dense_cal_store_update_recurrences_date_end(GncDenseCalStore *model, GDate *start, GList *recurrences, GDate *end_date);
+void gnc_dense_cal_store_update_recurrences_no_end (GncDenseCalStore *model,
+                                                    GDate *start,
+                                                    GList *recurrences);
+void gnc_dense_cal_store_update_recurrences_count_end (GncDenseCalStore *model,
+                                                       GDate *start,
+                                                       GList *recurrences,
+                                                       int num_occur);
+void gnc_dense_cal_store_update_recurrences_date_end (GncDenseCalStore *model,
+                                                      GDate *start,
+                                                      GList *recurrences,
+                                                      GDate *end_date);
 
 G_END_DECLS
 

--- a/gnucash/gnome-utils/gnc-dense-cal.c
+++ b/gnucash/gnome-utils/gnc-dense-cal.c
@@ -35,7 +35,7 @@
 #include "dialog-utils.h"
 #include <qoflog.h>
 
-static const QofLogModule log_module = G_LOG_DOMAIN;
+static const QofLogModule log_module = "gnc.gui.dense-cal";
 
 /**
  * Marking ...
@@ -72,9 +72,6 @@ static const int DENSE_CAL_DEFAULT_WIDTH = 15;
 static const int DENSE_CAL_DEFAULT_HEIGHT = 105;
 static const int MINOR_BORDER_SIZE = 1;
 static const int COL_BORDER_SIZE = 3;
-
-#undef G_LOG_DOMAIN
-#define G_LOG_DOMAIN "gnc.gui.dense-cal"
 
 static void gnc_dense_cal_finalize (GObject *object);
 static void gnc_dense_cal_dispose (GObject *object);

--- a/gnucash/gnome-utils/gnc-dense-cal.c
+++ b/gnucash/gnome-utils/gnc-dense-cal.c
@@ -76,74 +76,76 @@ static const int COL_BORDER_SIZE = 3;
 #undef G_LOG_DOMAIN
 #define G_LOG_DOMAIN "gnc.gui.dense-cal"
 
-static void gnc_dense_cal_finalize(GObject *object);
-static void gnc_dense_cal_dispose(GObject *object);
-static void gnc_dense_cal_realize(GtkWidget *widget, gpointer user_data);
-static void gnc_dense_cal_configure(GtkWidget *widget, GdkEventConfigure *event, gpointer user_data);
-static void gnc_dense_cal_draw_to_buffer(GncDenseCal *dcal);
-static gboolean gnc_dense_cal_draw(GtkWidget *widget, cairo_t *cr, gpointer user_data);
+static void gnc_dense_cal_finalize (GObject *object);
+static void gnc_dense_cal_dispose (GObject *object);
+static void gnc_dense_cal_realize (GtkWidget *widget, gpointer user_data);
+static void gnc_dense_cal_configure (GtkWidget *widget,
+                                     GdkEventConfigure *event,
+                                     gpointer user_data);
+static void gnc_dense_cal_draw_to_buffer (GncDenseCal *dcal);
+static gboolean gnc_dense_cal_draw (GtkWidget *widget, cairo_t *cr, gpointer user_data);
 
-static void gdc_reconfig(GncDenseCal *dcal);
+static void gdc_reconfig (GncDenseCal *dcal);
 
-static void gdc_free_all_mark_data(GncDenseCal *dcal);
+static void gdc_free_all_mark_data (GncDenseCal *dcal);
 
-static void _gdc_compute_min_size(GncDenseCal *dcal,
-                                  guint *min_width, guint *min_height);
-static void _gdc_set_cal_min_size_req(GncDenseCal *dcal);
-static gint gnc_dense_cal_motion_notify(GtkWidget      *widget,
-                                        GdkEventMotion *event);
-static gint gnc_dense_cal_button_press(GtkWidget *widget,
-                                       GdkEventButton *evt);
+static void _gdc_compute_min_size (GncDenseCal *dcal,
+                                   guint *min_width, guint *min_height);
+static void _gdc_set_cal_min_size_req (GncDenseCal *dcal);
+static gint gnc_dense_cal_motion_notify (GtkWidget *widget,
+                                         GdkEventMotion *event);
+static gint gnc_dense_cal_button_press (GtkWidget *widget,
+                                        GdkEventButton *evt);
 
-static void _gdc_view_option_changed(GtkComboBox *widget, gpointer user_data);
+static void _gdc_view_option_changed (GtkComboBox *widget, gpointer user_data);
 
-static inline int day_width_at(GncDenseCal *dcal, guint xScale);
-static inline int day_width(GncDenseCal *dcal);
-static inline int day_height_at(GncDenseCal *dcal, guint yScale);
-static inline int day_height(GncDenseCal *dcal);
-static inline int week_width_at(GncDenseCal *dcal, guint xScale);
-static inline int week_width(GncDenseCal *dcal);
-static inline int week_height_at(GncDenseCal *dcal, guint yScale);
-static inline int week_height(GncDenseCal *dcal);
-static inline int col_width_at(GncDenseCal *dcal, guint xScale);
-static inline int col_width(GncDenseCal *dcal);
+static inline int day_width_at (GncDenseCal *dcal, guint xScale);
+static inline int day_width (GncDenseCal *dcal);
+static inline int day_height_at (GncDenseCal *dcal, guint yScale);
+static inline int day_height (GncDenseCal *dcal);
+static inline int week_width_at (GncDenseCal *dcal, guint xScale);
+static inline int week_width (GncDenseCal *dcal);
+static inline int week_height_at (GncDenseCal *dcal, guint yScale);
+static inline int week_height (GncDenseCal *dcal);
+static inline int col_width_at (GncDenseCal *dcal, guint xScale);
+static inline int col_width (GncDenseCal *dcal);
 
-static inline int col_height(GncDenseCal *dcal);
-static inline int num_cols(GncDenseCal *dcal);
+static inline int col_height (GncDenseCal *dcal);
+static inline int num_cols (GncDenseCal *dcal);
 
-static void _gnc_dense_cal_set_month(GncDenseCal *dcal, GDateMonth mon, gboolean redraw);
-static void _gnc_dense_cal_set_year(GncDenseCal *dcal, guint year, gboolean redraw);
-
+static void _gnc_dense_cal_set_month (GncDenseCal *dcal, GDateMonth mon, gboolean redraw);
+static void _gnc_dense_cal_set_year (GncDenseCal *dcal, guint year, gboolean redraw);
 
 /**
  * Returns the total number of weeks to display in the calendar [irrespective
  * of columns/weeks-per-col].
  **/
-static inline int num_weeks(GncDenseCal *dcal);
+static inline int num_weeks (GncDenseCal *dcal);
 /**
  * Returns the number of weeks per column.  Note that this is the number of
  * weeks needed to display the longest column.
  **/
-static int num_weeks_per_col(GncDenseCal *dcal);
+static int num_weeks_per_col (GncDenseCal *dcal);
 
 /* hotspot calculation */
-static gint wheres_this(GncDenseCal *dcal, int x, int y);
+static gint wheres_this (GncDenseCal *dcal, int x, int y);
 
-static void recompute_x_y_scales(GncDenseCal *dcal);
-static void recompute_mark_storage(GncDenseCal *dcal);
-static void recompute_extents(GncDenseCal *dcal);
-static void populate_hover_window(GncDenseCal *dcal);
+static void recompute_x_y_scales (GncDenseCal *dcal);
+static void recompute_mark_storage (GncDenseCal *dcal);
+static void recompute_extents (GncDenseCal *dcal);
+static void populate_hover_window (GncDenseCal *dcal);
 
-static void month_coords(GncDenseCal *dcal, int monthOfCal, GList **outList);
-static void doc_coords(GncDenseCal *dcal, int dayOfCal,
-                       int *x1, int *y1, int *x2, int *y2);
+static void month_coords (GncDenseCal *dcal, int monthOfCal, GList **outList);
+static void doc_coords (GncDenseCal *dcal, int dayOfCal,
+                        int *x1, int *y1, int *x2, int *y2);
 
-static void gdc_mark_add(GncDenseCal *dcal, guint tag, gchar *name, gchar *info, guint size, GDate **dateArray);
-static void gdc_mark_remove(GncDenseCal *dcal, guint mark_to_remove, gboolean redraw);
+static void gdc_mark_add (GncDenseCal *dcal, guint tag, gchar *name,
+                          gchar *info, guint size, GDate **dateArray);
+static void gdc_mark_remove (GncDenseCal *dcal, guint mark_to_remove, gboolean redraw);
 
-static void gdc_add_tag_markings(GncDenseCal *cal, guint tag);
-static void gdc_add_markings(GncDenseCal *cal);
-static void gdc_remove_markings(GncDenseCal *cal);
+static void gdc_add_tag_markings (GncDenseCal *cal, guint tag);
+static void gdc_add_markings (GncDenseCal *cal);
+static void gdc_remove_markings (GncDenseCal *cal);
 
 typedef struct _gdc_month_coords
 {
@@ -218,7 +220,7 @@ typedef struct _gdc_mark_data
     GList *ourMarks;
 } gdc_mark_data;
 
-G_DEFINE_TYPE (GncDenseCal, gnc_dense_cal, GTK_TYPE_BOX)
+G_DEFINE_TYPE(GncDenseCal, gnc_dense_cal, GTK_TYPE_BOX)
 
 #define MONTH_NAME_BUFSIZE 10
 
@@ -226,20 +228,20 @@ G_DEFINE_TYPE (GncDenseCal, gnc_dense_cal, GTK_TYPE_BOX)
  * 11. Returns the abbreviated month name according to the current
  * locale.*/
 static const gchar*
-month_name(int mon)
+month_name (int mon)
 {
     static gchar buf[MONTH_NAME_BUFSIZE];
     GDate date;
     gint arbitrary_year = 1977;
 
-    memset(buf, 0, MONTH_NAME_BUFSIZE);
-    g_date_clear(&date, 1);
+    memset (buf, 0, MONTH_NAME_BUFSIZE);
+    g_date_clear (&date, 1);
 
-    g_date_set_year(&date, arbitrary_year);
-    g_date_set_day(&date, 1);
+    g_date_set_year (&date, arbitrary_year);
+    g_date_set_day (&date, 1);
     // g_date API is 1..12 (not 0..11)
-    g_date_set_month(&date, mon + 1);
-    g_date_strftime(buf, MONTH_NAME_BUFSIZE, "%b", &date);
+    g_date_set_month (&date, mon + 1);
+    g_date_strftime (buf, MONTH_NAME_BUFSIZE, "%b", &date);
 
     return buf;
 }
@@ -247,25 +249,22 @@ month_name(int mon)
 /* Takes the number of days since Sunday, in the range 0 to 6. Returns
  * the abbreviated weekday name according to the current locale. */
 static void
-day_label(gchar *buf, int buf_len, int dow)
+day_label (gchar *buf, int buf_len, int dow)
 {
-    gnc_dow_abbrev(buf, buf_len, dow);
+    gnc_dow_abbrev (buf, buf_len, dow);
     /* Use only the first two characters */
-    if (g_utf8_strlen(buf, -1) > 2)
+    if (g_utf8_strlen (buf, -1) > 2)
     {
-        gchar *pointer = g_utf8_offset_to_pointer(buf, 2);
+        gchar *pointer = g_utf8_offset_to_pointer (buf, 2);
         *pointer = '\0';
     }
 }
 
 static void
-gnc_dense_cal_class_init(GncDenseCalClass *klass)
+gnc_dense_cal_class_init (GncDenseCalClass *klass)
 {
-    GObjectClass *object_class;
-    GtkWidgetClass *widget_class;
-
-    object_class = G_OBJECT_CLASS (klass);
-    widget_class = GTK_WIDGET_CLASS (klass);
+    GObjectClass *object_class = G_OBJECT_CLASS(klass);
+    GtkWidgetClass *widget_class = GTK_WIDGET_CLASS(klass);
 
     gtk_widget_class_set_css_name (GTK_WIDGET_CLASS(klass), "calendar");
 
@@ -284,24 +283,24 @@ enum _GdcViewOptsColumns
 
 static GtkListStore *_cal_view_options = NULL;
 static GtkListStore*
-_gdc_get_view_options(void)
+_gdc_get_view_options (void)
 {
     if (_cal_view_options == NULL)
     {
-        _cal_view_options = gtk_list_store_new(2, G_TYPE_STRING, G_TYPE_INT);
-        gtk_list_store_insert_with_values(_cal_view_options, NULL, G_MAXINT, 0, _("12 months"), 1, 12, -1);
-        gtk_list_store_insert_with_values(_cal_view_options, NULL, G_MAXINT, 0, _("6 months"), 1, 6, -1);
-        gtk_list_store_insert_with_values(_cal_view_options, NULL, G_MAXINT, 0, _("4 months"), 1, 4, -1);
-        gtk_list_store_insert_with_values(_cal_view_options, NULL, G_MAXINT, 0, _("3 months"), 1, 3, -1);
-        gtk_list_store_insert_with_values(_cal_view_options, NULL, G_MAXINT, 0, _("2 months"), 1, 2, -1);
-        gtk_list_store_insert_with_values(_cal_view_options, NULL, G_MAXINT, 0, _("1 month"), 1, 1, -1);
+        _cal_view_options = gtk_list_store_new (2, G_TYPE_STRING, G_TYPE_INT);
+        gtk_list_store_insert_with_values (_cal_view_options, NULL, G_MAXINT, 0, _("12 months"), 1, 12, -1);
+        gtk_list_store_insert_with_values (_cal_view_options, NULL, G_MAXINT, 0, _("6 months"), 1, 6, -1);
+        gtk_list_store_insert_with_values (_cal_view_options, NULL, G_MAXINT, 0, _("4 months"), 1, 4, -1);
+        gtk_list_store_insert_with_values (_cal_view_options, NULL, G_MAXINT, 0, _("3 months"), 1, 3, -1);
+        gtk_list_store_insert_with_values (_cal_view_options, NULL, G_MAXINT, 0, _("2 months"), 1, 2, -1);
+        gtk_list_store_insert_with_values (_cal_view_options, NULL, G_MAXINT, 0, _("1 month"), 1, 1, -1);
     }
 
     return _cal_view_options;
 }
 
 static void
-gnc_dense_cal_init(GncDenseCal *dcal)
+gnc_dense_cal_init (GncDenseCal *dcal)
 {
     GtkStyleContext *context = gtk_widget_get_style_context (GTK_WIDGET(dcal));
 
@@ -315,42 +314,44 @@ gnc_dense_cal_init(GncDenseCal *dcal)
 
     gtk_style_context_add_class (context, GTK_STYLE_CLASS_CALENDAR);
     {
-        GtkTreeModel *options;
-        GtkCellRenderer *text_rend;
+        GtkTreeModel *options = GTK_TREE_MODEL(_gdc_get_view_options());
+        GtkCellRenderer *text_rend = GTK_CELL_RENDERER(gtk_cell_renderer_text_new ());
 
-        options = GTK_TREE_MODEL(_gdc_get_view_options());
-        dcal->view_options = GTK_COMBO_BOX(gtk_combo_box_new_with_model(options));
-        gtk_combo_box_set_active(GTK_COMBO_BOX(dcal->view_options), 0);
-        text_rend = GTK_CELL_RENDERER(gtk_cell_renderer_text_new());
-        gtk_cell_layout_pack_start(GTK_CELL_LAYOUT(dcal->view_options), text_rend, TRUE);
-        gtk_cell_layout_add_attribute(GTK_CELL_LAYOUT(dcal->view_options),
-                                      text_rend, "text", VIEW_OPTS_COLUMN_LABEL);
-        g_signal_connect(G_OBJECT(dcal->view_options), "changed", G_CALLBACK(_gdc_view_option_changed), (gpointer)dcal);
+        dcal->view_options = GTK_COMBO_BOX(gtk_combo_box_new_with_model (options));
+        gtk_combo_box_set_active (GTK_COMBO_BOX(dcal->view_options), 0);
+        gtk_cell_layout_pack_start (GTK_CELL_LAYOUT(dcal->view_options), text_rend, TRUE);
+        gtk_cell_layout_add_attribute (GTK_CELL_LAYOUT(dcal->view_options),
+                                       text_rend, "text", VIEW_OPTS_COLUMN_LABEL);
+        g_signal_connect (G_OBJECT(dcal->view_options), "changed",
+                          G_CALLBACK(_gdc_view_option_changed), (gpointer)dcal);
     }
 
     {
         GtkWidget *hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
         GtkWidget *label = gtk_label_new (_("View"));
 
-        gtk_box_set_homogeneous (GTK_BOX (hbox), FALSE);
+        gtk_box_set_homogeneous (GTK_BOX(hbox), FALSE);
         gtk_widget_set_halign (label, GTK_ALIGN_END);
         gtk_widget_set_margin_end (label, 5);
-        gtk_box_pack_start(GTK_BOX(hbox), label, TRUE, TRUE, 0);
-        gtk_box_pack_start(GTK_BOX(hbox), GTK_WIDGET(dcal->view_options), FALSE, FALSE, 0);
+        gtk_box_pack_start (GTK_BOX(hbox), label, TRUE, TRUE, 0);
+        gtk_box_pack_start (GTK_BOX(hbox), GTK_WIDGET(dcal->view_options), FALSE, FALSE, 0);
 
-        gtk_box_pack_start(GTK_BOX(dcal), GTK_WIDGET(hbox), FALSE, FALSE, 0);
+        gtk_box_pack_start (GTK_BOX(dcal), GTK_WIDGET(hbox), FALSE, FALSE, 0);
     }
-    dcal->cal_drawing_area = GTK_DRAWING_AREA(gtk_drawing_area_new());
+    dcal->cal_drawing_area = GTK_DRAWING_AREA(gtk_drawing_area_new ());
 
-    gtk_widget_add_events(GTK_WIDGET(dcal->cal_drawing_area), (GDK_EXPOSURE_MASK
-                          | GDK_BUTTON_PRESS_MASK
-                          | GDK_BUTTON_RELEASE_MASK
-                          | GDK_POINTER_MOTION_MASK
-                          | GDK_POINTER_MOTION_HINT_MASK));
-    gtk_box_pack_start(GTK_BOX(dcal), GTK_WIDGET(dcal->cal_drawing_area), TRUE, TRUE, 0);
-    g_signal_connect(G_OBJECT(dcal->cal_drawing_area), "draw", G_CALLBACK(gnc_dense_cal_draw), (gpointer)dcal);
-    g_signal_connect(G_OBJECT(dcal->cal_drawing_area), "realize", G_CALLBACK(gnc_dense_cal_realize), (gpointer)dcal);
-    g_signal_connect(G_OBJECT(dcal->cal_drawing_area), "configure_event", G_CALLBACK(gnc_dense_cal_configure), (gpointer)dcal);
+    gtk_widget_add_events (GTK_WIDGET(dcal->cal_drawing_area), (GDK_EXPOSURE_MASK
+                           | GDK_BUTTON_PRESS_MASK
+                           | GDK_BUTTON_RELEASE_MASK
+                           | GDK_POINTER_MOTION_MASK
+                           | GDK_POINTER_MOTION_HINT_MASK));
+    gtk_box_pack_start (GTK_BOX(dcal), GTK_WIDGET(dcal->cal_drawing_area), TRUE, TRUE, 0);
+    g_signal_connect (G_OBJECT(dcal->cal_drawing_area), "draw",
+                      G_CALLBACK(gnc_dense_cal_draw), (gpointer)dcal);
+    g_signal_connect (G_OBJECT(dcal->cal_drawing_area), "realize",
+                      G_CALLBACK(gnc_dense_cal_realize), (gpointer)dcal);
+    g_signal_connect (G_OBJECT(dcal->cal_drawing_area), "configure_event",
+                      G_CALLBACK(gnc_dense_cal_configure), (gpointer)dcal);
 
     dcal->disposed = FALSE;
     dcal->initialized = FALSE;
@@ -361,7 +362,7 @@ gnc_dense_cal_init(GncDenseCal *dcal)
 
     dcal->showPopup = FALSE;
 
-    dcal->transPopup = GTK_WINDOW(gtk_window_new(GTK_WINDOW_POPUP));
+    dcal->transPopup = GTK_WINDOW(gtk_window_new (GTK_WINDOW_POPUP));
     {
         GtkWidget *vbox, *hbox;
         GtkWidget *l;
@@ -369,41 +370,43 @@ gnc_dense_cal_init(GncDenseCal *dcal)
         GtkTreeView *tree_view;
 
         vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 5);
-        gtk_box_set_homogeneous (GTK_BOX (vbox), FALSE);
+        gtk_box_set_homogeneous (GTK_BOX(vbox), FALSE);
         hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
-        gtk_box_set_homogeneous (GTK_BOX (hbox), FALSE);
+        gtk_box_set_homogeneous (GTK_BOX(hbox), FALSE);
 
         gtk_widget_set_name (GTK_WIDGET(dcal->transPopup), "gnc-id-dense-calendar-popup");
 
-        l = gtk_label_new(_("Date: "));
+        l = gtk_label_new (_("Date: "));
         gtk_widget_set_margin_start (l, 5);
-        gtk_container_add(GTK_CONTAINER(hbox), l);
-        l = gtk_label_new("YY/MM/DD");
-        g_object_set_data(G_OBJECT(dcal->transPopup), "dateLabel", l);
-        gtk_container_add(GTK_CONTAINER(hbox), l);
-        gtk_container_add(GTK_CONTAINER(vbox), hbox);
+        gtk_container_add (GTK_CONTAINER(hbox), l);
+        l = gtk_label_new ("YY/MM/DD");
+        g_object_set_data (G_OBJECT(dcal->transPopup), "dateLabel", l);
+        gtk_container_add (GTK_CONTAINER(hbox), l);
+        gtk_container_add (GTK_CONTAINER(vbox), hbox);
 
-        gtk_container_add(GTK_CONTAINER(vbox), gtk_separator_new (GTK_ORIENTATION_HORIZONTAL));
+        gtk_container_add (GTK_CONTAINER(vbox), gtk_separator_new (GTK_ORIENTATION_HORIZONTAL));
 
-        tree_data = gtk_list_store_new(2, G_TYPE_STRING, G_TYPE_STRING);
-        tree_view = GTK_TREE_VIEW(gtk_tree_view_new_with_model(GTK_TREE_MODEL(tree_data)));
-        gtk_tree_view_insert_column_with_attributes(tree_view, -1, _("Name"), gtk_cell_renderer_text_new(), "text", 0, NULL);
-        gtk_tree_view_insert_column_with_attributes(tree_view, -1, _("Frequency"), gtk_cell_renderer_text_new(), "text", 1, NULL);
+        tree_data = gtk_list_store_new (2, G_TYPE_STRING, G_TYPE_STRING);
+        tree_view = GTK_TREE_VIEW(gtk_tree_view_new_with_model (GTK_TREE_MODEL(tree_data)));
+        gtk_tree_view_insert_column_with_attributes (tree_view, -1, _("Name"),
+                                                     gtk_cell_renderer_text_new (), "text", 0, NULL);
+        gtk_tree_view_insert_column_with_attributes (tree_view, -1, _("Frequency"),
+                                                     gtk_cell_renderer_text_new (), "text", 1, NULL);
         gtk_tree_selection_set_mode (gtk_tree_view_get_selection (GTK_TREE_VIEW(tree_view)), GTK_SELECTION_NONE);
-        g_object_set_data(G_OBJECT(dcal->transPopup), "model", tree_data);
+        g_object_set_data (G_OBJECT(dcal->transPopup), "model", tree_data);
         g_object_unref (tree_data);
-        gtk_container_add(GTK_CONTAINER(vbox), GTK_WIDGET(tree_view));
 
-        gtk_container_add(GTK_CONTAINER(dcal->transPopup), vbox);
+        gtk_container_add (GTK_CONTAINER(vbox), GTK_WIDGET(tree_view));
+        gtk_container_add (GTK_CONTAINER(dcal->transPopup), vbox);
 
-        gtk_window_set_resizable(GTK_WINDOW(dcal->transPopup), FALSE);
+        gtk_window_set_resizable (GTK_WINDOW(dcal->transPopup), FALSE);
 
-        gtk_widget_realize(GTK_WIDGET(dcal->transPopup));
+        gtk_widget_realize (GTK_WIDGET(dcal->transPopup));
     }
 
     /* Deal with the various label sizes. */
     {
-        PangoLayout *layout = gtk_widget_create_pango_layout(GTK_WIDGET(dcal), NULL);
+        PangoLayout *layout = gtk_widget_create_pango_layout (GTK_WIDGET(dcal), NULL);
         GtkStyleContext *stylectxt = gtk_widget_get_style_context (GTK_WIDGET(dcal));
         GtkStateFlags state_flags = gtk_style_context_get_state (stylectxt);
         gint font_size_reduction_units = 1;
@@ -417,17 +420,17 @@ gnc_dense_cal_init(GncDenseCal *dcal)
 
         gtk_style_context_get (stylectxt, state_flags,
                                GTK_STYLE_PROPERTY_FONT, &font_desc, NULL);
-        font_size = pango_font_description_get_size(font_desc);
+        font_size = pango_font_description_get_size (font_desc);
 
-        provider = gtk_css_provider_new();
+        provider = gtk_css_provider_new ();
         dpi = gdk_screen_get_resolution (gdk_screen_get_default ());
         px_size = ((font_size / PANGO_SCALE) - font_size_reduction_units) * (dpi / 72.);
-        px_str = g_strdup_printf("%i", px_size);
+        px_str = g_strdup_printf ("%i", px_size);
         widget_css = g_strconcat ("*{\n  font-size:", px_str, "px;\n}\n", NULL);
 
         gtk_css_provider_load_from_data (provider, widget_css, -1, NULL);
-        gtk_style_context_add_provider (stylectxt, GTK_STYLE_PROVIDER (provider),
-                                   GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+        gtk_style_context_add_provider (stylectxt, GTK_STYLE_PROVIDER(provider),
+                                        GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
         g_object_unref (provider);
         g_free (px_str);
         g_free (widget_css);
@@ -438,17 +441,17 @@ gnc_dense_cal_init(GncDenseCal *dcal)
         for (i = 0; i < 12; i++)
         {
             gint w, h;
-            pango_layout_set_text(layout, month_name(i), -1);
-            pango_layout_get_pixel_size(layout, &w, &h);
+            pango_layout_set_text (layout, month_name(i), -1);
+            pango_layout_get_pixel_size (layout, &w, &h);
             maxWidth = MAX(maxWidth, w);
             maxHeight = MAX(maxHeight, h);
         }
 
         // these two were reversed, before...
-        dcal->label_width    = maxWidth;
-        dcal->label_height   = maxHeight;
+        dcal->label_width = maxWidth;
+        dcal->label_height = maxHeight;
 
-        g_object_unref(layout);
+        g_object_unref (layout);
     }
 
     dcal->month = G_DATE_JANUARY;
@@ -463,12 +466,12 @@ gnc_dense_cal_init(GncDenseCal *dcal)
     GDate now;
     g_date_clear (&now, 1);
         gnc_gdate_set_today (&now);
-        _gnc_dense_cal_set_month(dcal, g_date_get_month(&now), FALSE);
-        _gnc_dense_cal_set_year(dcal, g_date_get_year(&now), FALSE);
+        _gnc_dense_cal_set_month (dcal, g_date_get_month (&now), FALSE);
+        _gnc_dense_cal_set_year (dcal, g_date_get_year (&now), FALSE);
     }
 
-    recompute_extents(dcal);
-    recompute_mark_storage(dcal);
+    recompute_extents (dcal);
+    recompute_mark_storage (dcal);
 
     /* Compute initial scaling factors; will be increased when we're
      * allocated enough space to scale up. */
@@ -477,20 +480,20 @@ gnc_dense_cal_init(GncDenseCal *dcal)
         int width_88, height_88;
         int width_XXX, height_XXX;
 
-        layout = gtk_widget_create_pango_layout(GTK_WIDGET(dcal), NULL);
+        layout = gtk_widget_create_pango_layout (GTK_WIDGET(dcal), NULL);
 
-        pango_layout_set_text(layout, "88", -1);
-        pango_layout_get_pixel_size(layout, &width_88, &height_88);
+        pango_layout_set_text (layout, "88", -1);
+        pango_layout_get_pixel_size (layout, &width_88, &height_88);
 
-        pango_layout_set_text(layout, "XXX", -1);
-        pango_layout_get_pixel_size(layout, &width_XXX, &height_XXX);
+        pango_layout_set_text (layout, "XXX", -1);
+        pango_layout_get_pixel_size (layout, &width_XXX, &height_XXX);
 
         dcal->min_x_scale = dcal->x_scale = width_88 + 2;
-        dcal->min_y_scale = dcal->y_scale = MAX(floor((float)width_XXX / 3.), height_88 + 2);
+        dcal->min_y_scale = dcal->y_scale = MAX(floor ((float)width_XXX / 3.), height_88 + 2);
 
         dcal->dayLabelHeight = height_88;
 
-        g_object_unref(layout);
+        g_object_unref (layout);
     }
 
     dcal->initialized = TRUE;
@@ -507,30 +510,30 @@ gnc_dense_cal_init(GncDenseCal *dcal)
         /* Translators: This string must not show up in gnucash.pot as
            it is looked up in the "gtk20" translation domain
            instead. */
-        week_start_str = dgettext_noextract("gtk20", "calendar:week_start:0");
+        week_start_str = dgettext_noextract ("gtk20", "calendar:week_start:0");
 #undef dgettext_noextract
 
-        parts = g_strsplit(week_start_str, ":", 3);
+        parts = g_strsplit (week_start_str, ":", 3);
         if (parts[0] != NULL
                 && parts[1] != NULL
                 && parts[2] != NULL)
         {
-            if (strcmp("1", parts[2]) == 0)
+            if (strcmp ("1", parts[2]) == 0)
                 dcal->week_starts_monday = 1;
         }
-        g_strfreev(parts);
+        g_strfreev (parts);
     }
 
-    gtk_widget_show_all(GTK_WIDGET(dcal));
+    gtk_widget_show_all (GTK_WIDGET(dcal));
 }
 
 static void
-_gdc_set_cal_min_size_req(GncDenseCal *dcal)
+_gdc_set_cal_min_size_req (GncDenseCal *dcal)
 {
     guint min_width, min_height;
 
-    _gdc_compute_min_size(dcal, &min_width, &min_height);
-    gtk_widget_set_size_request(GTK_WIDGET(dcal->cal_drawing_area), min_width, min_height);
+    _gdc_compute_min_size (dcal, &min_width, &min_height);
+    gtk_widget_set_size_request (GTK_WIDGET(dcal->cal_drawing_area), min_width, min_height);
 }
 
 GtkWidget*
@@ -548,88 +551,88 @@ GtkWidget*
 gnc_dense_cal_new_with_model (GtkWindow *parent, GncDenseCalModel *model)
 {
     GncDenseCal *cal = GNC_DENSE_CAL(gnc_dense_cal_new (parent));
-    gnc_dense_cal_set_model(cal, model);
+    gnc_dense_cal_set_model (cal, model);
     return GTK_WIDGET(cal);
 }
 
 static void
-recompute_first_of_month_offset(GncDenseCal *dcal)
+recompute_first_of_month_offset (GncDenseCal *dcal)
 {
     GDate *tmpDate;
 
-    tmpDate = g_date_new_dmy(1, dcal->month, dcal->year);
-    dcal->firstOfMonthOffset = g_date_get_weekday(tmpDate) % 7;
-    g_date_free(tmpDate);
+    tmpDate = g_date_new_dmy (1, dcal->month, dcal->year);
+    dcal->firstOfMonthOffset = g_date_get_weekday (tmpDate) % 7;
+    g_date_free (tmpDate);
 }
 
 void
-gnc_dense_cal_set_month(GncDenseCal *dcal, GDateMonth mon)
+gnc_dense_cal_set_month (GncDenseCal *dcal, GDateMonth mon)
 {
-    _gnc_dense_cal_set_month(dcal, mon, TRUE);
+    _gnc_dense_cal_set_month (dcal, mon, TRUE);
 }
 
 static void
-_gnc_dense_cal_set_month(GncDenseCal *dcal, GDateMonth mon, gboolean redraw)
+_gnc_dense_cal_set_month (GncDenseCal *dcal, GDateMonth mon, gboolean redraw)
 {
     GTimer *t;
     if (dcal->month == mon)
         return;
-    t = g_timer_new();
+    t = g_timer_new ();
     dcal->month = mon;
-    g_timer_start(t);
-    recompute_first_of_month_offset(dcal);
-    DEBUG("recompute_first_of_month_offset: %f", g_timer_elapsed(t, NULL) * 1000.);
-    g_timer_start(t);
-    recompute_extents(dcal);
-    DEBUG("recompute_extents: %f", g_timer_elapsed(t, NULL) * 1000.);
-    if (redraw && gtk_widget_get_realized(GTK_WIDGET(dcal)))
+    g_timer_start (t);
+    recompute_first_of_month_offset (dcal);
+    DEBUG("recompute_first_of_month_offset: %f", g_timer_elapsed (t, NULL) * 1000.);
+    g_timer_start (t);
+    recompute_extents (dcal);
+    DEBUG("recompute_extents: %f", g_timer_elapsed (t, NULL) * 1000.);
+    if (redraw && gtk_widget_get_realized (GTK_WIDGET(dcal)))
     {
-        g_timer_start(t);
-        recompute_x_y_scales(dcal);
-        DEBUG("recompute_x_y_scales: %f", g_timer_elapsed(t, NULL) * 1000.);
-        g_timer_start(t);
-        gnc_dense_cal_draw_to_buffer(dcal);
-        DEBUG("draw_to_buffer: %f", g_timer_elapsed(t, NULL) * 1000.);
-        g_timer_start(t);
-        gtk_widget_queue_draw(GTK_WIDGET(dcal->cal_drawing_area));
-        DEBUG("queue_draw: %f", g_timer_elapsed(t, NULL) * 1000.);
+        g_timer_start (t);
+        recompute_x_y_scales (dcal);
+        DEBUG("recompute_x_y_scales: %f", g_timer_elapsed (t, NULL) * 1000.);
+        g_timer_start (t);
+        gnc_dense_cal_draw_to_buffer (dcal);
+        DEBUG("draw_to_buffer: %f", g_timer_elapsed (t, NULL) * 1000.);
+        g_timer_start (t);
+        gtk_widget_queue_draw (GTK_WIDGET(dcal->cal_drawing_area));
+        DEBUG("queue_draw: %f", g_timer_elapsed (t, NULL) * 1000.);
     }
-    g_timer_stop(t);
-    g_timer_destroy(t);
+    g_timer_stop (t);
+    g_timer_destroy (t);
 }
 
 void
-gnc_dense_cal_set_year(GncDenseCal *dcal, guint year)
+gnc_dense_cal_set_year (GncDenseCal *dcal, guint year)
 {
-    _gnc_dense_cal_set_year(dcal, year, TRUE);
+    _gnc_dense_cal_set_year (dcal, year, TRUE);
 }
 
 static void
-_gnc_dense_cal_set_year(GncDenseCal *dcal, guint year, gboolean redraw)
+_gnc_dense_cal_set_year (GncDenseCal *dcal, guint year, gboolean redraw)
 {
     if (dcal->year == year)
         return;
     dcal->year = year;
-    recompute_first_of_month_offset(dcal);
-    recompute_extents(dcal);
-    if (redraw && gtk_widget_get_realized(GTK_WIDGET(dcal)))
+    recompute_first_of_month_offset (dcal);
+    recompute_extents (dcal);
+    if (redraw && gtk_widget_get_realized (GTK_WIDGET(dcal)))
     {
-        recompute_x_y_scales(dcal);
-        gnc_dense_cal_draw_to_buffer(dcal);
-        gtk_widget_queue_draw(GTK_WIDGET(dcal->cal_drawing_area));
+        recompute_x_y_scales (dcal);
+        gnc_dense_cal_draw_to_buffer (dcal);
+        gtk_widget_queue_draw (GTK_WIDGET(dcal->cal_drawing_area));
     }
 }
 
 void
-gnc_dense_cal_set_num_months(GncDenseCal *dcal, guint num_months)
+gnc_dense_cal_set_num_months (GncDenseCal *dcal, guint num_months)
 {
     {
-        GtkListStore *options = _gdc_get_view_options();
+        GtkListStore *options = _gdc_get_view_options ();
         GtkTreeIter view_opts_iter, iter_closest_to_req;
         int closest_index_distance = G_MAXINT;
 
         // find closest list value to num_months
-        if (!gtk_tree_model_get_iter_first(GTK_TREE_MODEL(options), &view_opts_iter))
+        if (!gtk_tree_model_get_iter_first (GTK_TREE_MODEL(options), &view_opts_iter))
         {
             g_critical("no view options?");
             return;
@@ -639,8 +642,9 @@ gnc_dense_cal_set_num_months(GncDenseCal *dcal, guint num_months)
         {
             gint months_val, delta_months;
 
-            gtk_tree_model_get(GTK_TREE_MODEL(options), &view_opts_iter, VIEW_OPTS_COLUMN_NUM_MONTHS, &months_val, -1);
-            delta_months = abs(months_val - (int)num_months);
+            gtk_tree_model_get (GTK_TREE_MODEL(options), &view_opts_iter,
+                                VIEW_OPTS_COLUMN_NUM_MONTHS, &months_val, -1);
+            delta_months = abs (months_val - (int)num_months);
             if (delta_months < closest_index_distance)
             {
                 iter_closest_to_req = view_opts_iter;
@@ -648,46 +652,46 @@ gnc_dense_cal_set_num_months(GncDenseCal *dcal, guint num_months)
             }
         }
         while (closest_index_distance != 0
-                && (gtk_tree_model_iter_next(GTK_TREE_MODEL(options), &view_opts_iter)));
+                && (gtk_tree_model_iter_next (GTK_TREE_MODEL(options), &view_opts_iter)));
 
         // set iter on view
-        g_signal_handlers_block_by_func(dcal->view_options, _gdc_view_option_changed, dcal);
-        gtk_combo_box_set_active_iter(GTK_COMBO_BOX(dcal->view_options), &iter_closest_to_req);
-        g_signal_handlers_unblock_by_func(dcal->view_options, _gdc_view_option_changed, dcal);
+        g_signal_handlers_block_by_func (dcal->view_options, _gdc_view_option_changed, dcal);
+        gtk_combo_box_set_active_iter (GTK_COMBO_BOX(dcal->view_options), &iter_closest_to_req);
+        g_signal_handlers_unblock_by_func (dcal->view_options, _gdc_view_option_changed, dcal);
     }
 
     dcal->numMonths = num_months;
-    recompute_extents(dcal);
-    recompute_mark_storage(dcal);
-    if (gtk_widget_get_realized(GTK_WIDGET(dcal)))
+    recompute_extents (dcal);
+    recompute_mark_storage (dcal);
+    if (gtk_widget_get_realized (GTK_WIDGET(dcal)))
     {
-        recompute_x_y_scales(dcal);
-        gnc_dense_cal_draw_to_buffer(dcal);
-        gtk_widget_queue_draw(GTK_WIDGET(dcal->cal_drawing_area));
+        recompute_x_y_scales (dcal);
+        gnc_dense_cal_draw_to_buffer (dcal);
+        gtk_widget_queue_draw (GTK_WIDGET(dcal->cal_drawing_area));
     }
 }
 
 guint
-gnc_dense_cal_get_num_months(GncDenseCal *dcal)
+gnc_dense_cal_get_num_months (GncDenseCal *dcal)
 {
     return dcal->numMonths;
 }
 
 void
-gnc_dense_cal_set_months_per_col(GncDenseCal *dcal, guint monthsPerCol)
+gnc_dense_cal_set_months_per_col (GncDenseCal *dcal, guint monthsPerCol)
 {
     dcal->monthsPerCol = monthsPerCol;
-    recompute_x_y_scales(dcal);
+    recompute_x_y_scales (dcal);
 }
 
 GDateMonth
-gnc_dense_cal_get_month(GncDenseCal *dcal)
+gnc_dense_cal_get_month (GncDenseCal *dcal)
 {
     return dcal->month;
 }
 
 GDateYear
-gnc_dense_cal_get_year(GncDenseCal *dcal)
+gnc_dense_cal_get_year (GncDenseCal *dcal)
 {
     return dcal->year;
 }
@@ -696,8 +700,8 @@ static void
 gnc_dense_cal_dispose (GObject *object)
 {
     GncDenseCal *dcal;
-    g_return_if_fail(object != NULL);
-    g_return_if_fail(GNC_IS_DENSE_CAL(object));
+    g_return_if_fail (object != NULL);
+    g_return_if_fail (GNC_IS_DENSE_CAL(object));
 
     dcal = GNC_DENSE_CAL(object);
 
@@ -705,10 +709,10 @@ gnc_dense_cal_dispose (GObject *object)
         return;
     dcal->disposed = TRUE;
 
-    if (gtk_widget_get_realized(GTK_WIDGET(dcal->transPopup)))
+    if (gtk_widget_get_realized (GTK_WIDGET(dcal->transPopup)))
     {
-        gtk_widget_hide(GTK_WIDGET(dcal->transPopup));
-        gtk_widget_destroy(GTK_WIDGET(dcal->transPopup));
+        gtk_widget_hide (GTK_WIDGET(dcal->transPopup));
+        gtk_widget_destroy (GTK_WIDGET(dcal->transPopup));
         dcal->transPopup = NULL;
     }
 
@@ -720,9 +724,9 @@ gnc_dense_cal_dispose (GObject *object)
 
     /* FIXME: we have a bunch of cleanup to do, here. */
 
-    gdc_free_all_mark_data(dcal);
+    gdc_free_all_mark_data (dcal);
 
-    g_object_unref(G_OBJECT(dcal->model));
+    g_object_unref (G_OBJECT(dcal->model));
 
     G_OBJECT_CLASS(gnc_dense_cal_parent_class)->dispose(object);
 }
@@ -731,22 +735,22 @@ static void
 gnc_dense_cal_finalize (GObject *object)
 {
     g_return_if_fail (object != NULL);
-    g_return_if_fail (GNC_IS_DENSE_CAL (object));
+    g_return_if_fail (GNC_IS_DENSE_CAL(object));
 
     G_OBJECT_CLASS(gnc_dense_cal_parent_class)->finalize(object);
 }
 
 static void
-gnc_dense_cal_configure(GtkWidget *widget,
-                        GdkEventConfigure *event,
-                        gpointer user_data)
+gnc_dense_cal_configure (GtkWidget *widget,
+                         GdkEventConfigure *event,
+                         gpointer user_data)
 {
     GncDenseCal *dcal = GNC_DENSE_CAL(user_data);
-    recompute_x_y_scales(dcal);
-    gdc_reconfig(dcal);
-    gtk_widget_queue_draw_area(widget,
-                               event->x, event->y,
-                               event->width, event->height);
+    recompute_x_y_scales (dcal);
+    gdc_reconfig (dcal);
+    gtk_widget_queue_draw_area (widget,
+                                event->x, event->y,
+                                event->width, event->height);
 }
 
 static void
@@ -754,16 +758,16 @@ gnc_dense_cal_realize (GtkWidget *widget, gpointer user_data)
 {
     GncDenseCal *dcal;
 
-    g_return_if_fail(widget != NULL);
-    g_return_if_fail(GNC_IS_DENSE_CAL (user_data));
+    g_return_if_fail (widget != NULL);
+    g_return_if_fail (GNC_IS_DENSE_CAL(user_data));
     dcal = GNC_DENSE_CAL(user_data);
 
-    recompute_x_y_scales(dcal);
-    gdc_reconfig(dcal);
+    recompute_x_y_scales (dcal);
+    gdc_reconfig (dcal);
 }
 
 static void
-gdc_reconfig(GncDenseCal *dcal)
+gdc_reconfig (GncDenseCal *dcal)
 {
     GtkWidget *widget;
     GtkAllocation alloc;
@@ -776,19 +780,19 @@ gdc_reconfig(GncDenseCal *dcal)
     dcal->surface = cairo_image_surface_create (CAIRO_FORMAT_ARGB32,
                                                 alloc.width,
                                                 alloc.height);
-    gnc_dense_cal_draw_to_buffer(dcal);
+    gnc_dense_cal_draw_to_buffer (dcal);
 }
 
 static void
-_gdc_compute_min_size(GncDenseCal *dcal, guint *min_width, guint *min_height)
+_gdc_compute_min_size (GncDenseCal *dcal, guint *min_width, guint *min_height)
 {
     if (min_width != NULL)
     {
         *min_width =
             (dcal->leftPadding * 2)
-            + (num_cols(dcal) * (col_width_at(dcal, dcal->min_x_scale)
+            + (num_cols (dcal) * (col_width_at (dcal, dcal->min_x_scale)
                                  + dcal->label_width))
-            + ((num_cols(dcal) - 1) * COL_BORDER_SIZE);
+            + ((num_cols (dcal) - 1) * COL_BORDER_SIZE);
     }
 
     if (min_height != NULL)
@@ -797,13 +801,13 @@ _gdc_compute_min_size(GncDenseCal *dcal, guint *min_width, guint *min_height)
             (dcal->topPadding * 2)
             + MINOR_BORDER_SIZE
             + dcal->dayLabelHeight
-            + (num_weeks_per_col(dcal)
-               * week_height_at(dcal, dcal->min_y_scale));
+            + (num_weeks_per_col (dcal)
+               * week_height_at (dcal, dcal->min_y_scale));
     }
 }
 
 static void
-recompute_x_y_scales(GncDenseCal *dcal)
+recompute_x_y_scales (GncDenseCal *dcal)
 {
     int denom;
     int width, height;
@@ -820,32 +824,32 @@ recompute_x_y_scales(GncDenseCal *dcal)
 
     /* FIXME: there's something slightly wrong in the x_scale computation that
      * lets us draw larger than our area. */
-    denom = 7 * num_cols(dcal);
-    g_assert(denom != 0);
+    denom = 7 * num_cols (dcal);
+    g_assert (denom != 0);
     dcal->x_scale = ((gint)(width
                             - (dcal->leftPadding * 2)
-                            - (num_cols(dcal) * ((8 * MINOR_BORDER_SIZE)
+                            - (num_cols (dcal) * ((8 * MINOR_BORDER_SIZE)
                                     + dcal->label_width))
-                            - ((num_cols(dcal) - 1) * COL_BORDER_SIZE))
+                            - ((num_cols (dcal) - 1) * COL_BORDER_SIZE))
                      / denom);
     dcal->x_scale = MAX(dcal->x_scale, dcal->min_x_scale);
 
-    denom = num_weeks_per_col(dcal);
-    g_assert(denom != 0);
+    denom = num_weeks_per_col (dcal);
+    g_assert (denom != 0);
     dcal->y_scale = ((gint)(height
                             - (dcal->topPadding * 2)
                             - MINOR_BORDER_SIZE
                             - dcal->dayLabelHeight
-                            - (num_weeks_per_col(dcal) - 1
+                            - (num_weeks_per_col (dcal) - 1
                                * MINOR_BORDER_SIZE))
                      / denom);
     dcal->y_scale = MAX(dcal->y_scale, dcal->min_y_scale);
 
-    _gdc_set_cal_min_size_req(dcal);
+    _gdc_set_cal_min_size_req (dcal);
 }
 
 static void
-gdc_free_all_mark_data(GncDenseCal *dcal)
+gdc_free_all_mark_data (GncDenseCal *dcal)
 {
     int i;
     GList *l;
@@ -853,9 +857,9 @@ gdc_free_all_mark_data(GncDenseCal *dcal)
     {
         /* Each of these just contains an elt of dcal->markData,
          * which we're about to free, below... */
-        g_list_free(dcal->marks[i]);
+        g_list_free (dcal->marks[i]);
     }
-    g_free(dcal->marks);
+    g_free (dcal->marks);
     dcal->marks = NULL;
     /* Remove the old mark data. */
     for (l = dcal->markData; l; l = l->next)
@@ -866,61 +870,61 @@ gdc_free_all_mark_data(GncDenseCal *dcal)
         g_free (mark->info);
         g_free (mark);
     }
-    g_list_free(dcal->markData);
+    g_list_free (dcal->markData);
     dcal->markData = NULL;
 }
 
 static void
-recompute_mark_storage(GncDenseCal *dcal)
+recompute_mark_storage (GncDenseCal *dcal)
 {
     if (dcal->marks == NULL)
         goto createNew;
-    gdc_free_all_mark_data(dcal);
+    gdc_free_all_mark_data (dcal);
 
 createNew:
-    dcal->numMarks = num_weeks(dcal) * 7;
-    dcal->marks = g_new0(GList*, dcal->numMarks);
+    dcal->numMarks = num_weeks (dcal) * 7;
+    dcal->marks = g_new0 (GList*, dcal->numMarks);
     if (dcal->model)
-        gdc_add_markings(dcal);
+        gdc_add_markings (dcal);
 }
 
 static void
-recompute_extents(GncDenseCal *dcal)
+recompute_extents (GncDenseCal *dcal)
 {
     GDate date;
     gint start_week, end_week;
 
-    g_date_clear(&date, 1);
-    g_date_set_dmy(&date, 1, dcal->month, dcal->year);
+    g_date_clear (&date, 1);
+    g_date_set_dmy (&date, 1, dcal->month, dcal->year);
     start_week = (dcal->week_starts_monday
-                  ? g_date_get_monday_week_of_year(&date)
-                  : g_date_get_sunday_week_of_year(&date));
-    g_date_add_months(&date, dcal->numMonths);
+                  ? g_date_get_monday_week_of_year (&date)
+                  : g_date_get_sunday_week_of_year (&date));
+    g_date_add_months (&date, dcal->numMonths);
     end_week = (dcal->week_starts_monday
-                ? g_date_get_monday_week_of_year(&date)
-                : g_date_get_sunday_week_of_year(&date));
-    if (g_date_get_year(&date) != dcal->year)
+                ? g_date_get_monday_week_of_year (&date)
+                : g_date_get_sunday_week_of_year (&date));
+    if (g_date_get_year (&date) != dcal->year)
     {
         end_week += (dcal->week_starts_monday
-                     ? g_date_get_monday_weeks_in_year(dcal->year)
-                     : g_date_get_sunday_weeks_in_year(dcal->year));
+                     ? g_date_get_monday_weeks_in_year (dcal->year)
+                     : g_date_get_sunday_weeks_in_year (dcal->year));
     }
     dcal->num_weeks = end_week - start_week + 1;
 }
 
 static void
-free_rect(gpointer data, gpointer ud)
+free_rect (gpointer data, gpointer user_data)
 {
-    g_free((GdkRectangle*)data);
+    g_free ((GdkRectangle*)data);
 }
 
 static gboolean
-gnc_dense_cal_draw(GtkWidget *widget, cairo_t *cr, gpointer user_data)
+gnc_dense_cal_draw (GtkWidget *widget, cairo_t *cr, gpointer user_data)
 {
     GncDenseCal *dcal;
 
-    g_return_val_if_fail(widget != NULL, FALSE);
-    g_return_val_if_fail(GNC_IS_DENSE_CAL(user_data), FALSE);
+    g_return_val_if_fail (widget != NULL, FALSE);
+    g_return_val_if_fail (GNC_IS_DENSE_CAL(user_data), FALSE);
 
     dcal = GNC_DENSE_CAL(user_data);
 
@@ -934,7 +938,7 @@ gnc_dense_cal_draw(GtkWidget *widget, cairo_t *cr, gpointer user_data)
 #define LOG_AND_RESET(timer, msg) do { DEBUG("%s: %f", msg, g_timer_elapsed(timer, NULL) * 1000.); g_timer_reset(timer); } while (0);
 
 static void
-gnc_dense_cal_draw_to_buffer(GncDenseCal *dcal)
+gnc_dense_cal_draw_to_buffer (GncDenseCal *dcal)
 {
     GtkWidget *widget;
     GtkStyleContext *stylectxt;
@@ -953,11 +957,11 @@ gnc_dense_cal_draw_to_buffer(GncDenseCal *dcal)
     if (!dcal->surface)
         return;
 
-    timer = g_timer_new();
+    timer = g_timer_new ();
 
-    g_timer_start(timer);
+    g_timer_start (timer);
     cr = cairo_create (dcal->surface);
-    layout = gtk_widget_create_pango_layout(GTK_WIDGET(dcal), NULL);
+    layout = gtk_widget_create_pango_layout (GTK_WIDGET(dcal), NULL);
     LOG_AND_RESET(timer, "create_pango_layout");
 
     gtk_widget_get_allocation (GTK_WIDGET(dcal->cal_drawing_area), &alloc);
@@ -989,8 +993,8 @@ gnc_dense_cal_draw_to_buffer(GncDenseCal *dcal)
     }
 
     /* lets confirm text height size */
-    pango_layout_set_text(layout, "S", -1);
-    pango_layout_get_pixel_size(layout, NULL, &dcal->dayLabelHeight);
+    pango_layout_set_text (layout, "S", -1);
+    pango_layout_get_pixel_size (layout, NULL, &dcal->dayLabelHeight);
 
     /* Fill in alternating month colors. */
     {
@@ -1010,10 +1014,9 @@ gnc_dense_cal_draw_to_buffer(GncDenseCal *dcal)
         for (i = 0; i < dcal->numMonths; i++)
         {
             mcList = NULL;
-            month_coords(dcal, i, &mcList);
-            dcal->monthPositions[i].x
-            = floor(i / dcal->monthsPerCol)
-              * (col_width(dcal) + COL_BORDER_SIZE);
+            month_coords (dcal, i, &mcList);
+            dcal->monthPositions[i].x = floor (i / dcal->monthsPerCol)
+                                            * (col_width (dcal) + COL_BORDER_SIZE);
             dcal->monthPositions[i].y = ((GdkRectangle*)mcList->next->next->next->data)->y;
             for (mcListIter = mcList; mcListIter != NULL; mcListIter = mcListIter->next)
             {
@@ -1028,8 +1031,8 @@ gnc_dense_cal_draw_to_buffer(GncDenseCal *dcal)
                 gtk_render_background (stylectxt, cr, rect->x, rect->y, rect->width, rect->height);
                 gtk_style_context_restore (stylectxt);
             }
-            g_list_foreach(mcList, free_rect, NULL);
-            g_list_free(mcList);
+            g_list_foreach (mcList, free_rect, NULL);
+            g_list_free (mcList);
         }
         gtk_style_context_restore (stylectxt);
     }
@@ -1073,7 +1076,7 @@ gnc_dense_cal_draw_to_buffer(GncDenseCal *dcal)
     }
     LOG_AND_RESET(timer, "marked days");
 
-    for (i = 0; i < num_cols(dcal); i++)
+    for (i = 0; i < num_cols (dcal); i++)
     {
         GdkRGBA color;
         gint x, y, w, h;
@@ -1083,11 +1086,11 @@ gnc_dense_cal_draw_to_buffer(GncDenseCal *dcal)
         gdk_rgba_parse (&color, "black");
 
         x = dcal->leftPadding
-            + (i * (col_width(dcal) + COL_BORDER_SIZE))
+            + (i * (col_width (dcal) + COL_BORDER_SIZE))
             + dcal->label_height + 1;
         y = dcal->topPadding + dcal->dayLabelHeight;
-        w = col_width(dcal) - COL_BORDER_SIZE - dcal->label_width;
-        h = col_height(dcal);
+        w = col_width (dcal) - COL_BORDER_SIZE - dcal->label_width;
+        h = col_height (dcal);
 
         gtk_style_context_save (stylectxt);
 
@@ -1101,9 +1104,9 @@ gnc_dense_cal_draw_to_buffer(GncDenseCal *dcal)
         cairo_set_line_width (cr, 1);
 
         /* draw the week separations */
-        for (j = 0; j < num_weeks_per_col(dcal); j++)
+        for (j = 0; j < num_weeks_per_col (dcal); j++)
         {
-            gint wy = y + (j * week_height(dcal));
+            gint wy = y + (j * week_height (dcal));
             cairo_move_to (cr, x, wy + 0.5);
             cairo_line_to (cr, x + w, wy + 0.5);
             cairo_stroke (cr);
@@ -1112,9 +1115,9 @@ gnc_dense_cal_draw_to_buffer(GncDenseCal *dcal)
         /* draw the day separations */
         for (j = 1; j < 7; j++)
         {
-            gint dx = x + (j * day_width(dcal));
+            gint dx = x + (j * day_width (dcal));
             cairo_move_to (cr, dx + 0.5, y);
-            cairo_line_to (cr, dx + 0.5, y + col_height(dcal));
+            cairo_line_to (cr, dx + 0.5, y + col_height (dcal));
             cairo_stroke (cr);
         }
         cairo_restore (cr);
@@ -1122,31 +1125,34 @@ gnc_dense_cal_draw_to_buffer(GncDenseCal *dcal)
 
 
         /* draw the day of the week labels */
-        pango_layout_set_text(layout, "88", -1);
-        pango_layout_get_pixel_size(layout, &maxWidth, NULL);
+        pango_layout_set_text (layout, "88", -1);
+        pango_layout_get_pixel_size (layout, &maxWidth, NULL);
 
         if (dcal->x_scale > maxWidth)
         {
             gtk_style_context_save (stylectxt);
             gtk_style_context_add_class (stylectxt, GTK_STYLE_CLASS_HEADER);
 
-            gtk_render_background (stylectxt, cr, x, y - dcal->dayLabelHeight, (day_width(dcal) * 7) + 1, dcal->dayLabelHeight);
+            gtk_render_background (stylectxt, cr, x,
+                                                  y - dcal->dayLabelHeight,
+                                                  (day_width(dcal) * 7) + 1,
+                                                  dcal->dayLabelHeight);
 
             for (j = 0; j < 7; j++)
             {
                 int day_label_width;
                 gint label_x_offset, label_y_offset;
                 gint day_label_str_len = 4;
-                gchar day_label_str[day_label_str_len+1];
-                day_label(day_label_str, day_label_str_len, (j + dcal->week_starts_monday) % 7);
-                pango_layout_set_text(layout, day_label_str, -1);
-                pango_layout_get_pixel_size(layout, &day_label_width, NULL);
+                gchar day_label_str[day_label_str_len + 1];
+                day_label (day_label_str, day_label_str_len, (j + dcal->week_starts_monday) % 7);
+                pango_layout_set_text (layout, day_label_str, -1);
+                pango_layout_get_pixel_size (layout, &day_label_width, NULL);
                 label_x_offset = x
-                                 + (j * day_width(dcal))
-                                 + (day_width(dcal) / 2)
+                                 + (j * day_width (dcal))
+                                 + (day_width (dcal) / 2)
                                  - (day_label_width / 2);
                 label_y_offset = y - dcal->dayLabelHeight;
-                pango_layout_set_text(layout, day_label_str, -1);
+                pango_layout_set_text (layout, day_label_str, -1);
                 gtk_render_layout (stylectxt, cr, label_x_offset, label_y_offset, layout);
             }
             gtk_style_context_restore (stylectxt);
@@ -1168,8 +1174,10 @@ gnc_dense_cal_draw_to_buffer(GncDenseCal *dcal)
             if (dcal->monthPositions[i].x == -1)
                 break;
 
-            gtk_render_background (stylectxt, cr, dcal->monthPositions[i].x + x_offset, dcal->topPadding,
-                                   dcal->dayLabelHeight + 1, col_height(dcal) + dcal->dayLabelHeight + 1);
+            gtk_render_background (stylectxt, cr, dcal->monthPositions[i].x + x_offset,
+                                                  dcal->topPadding,
+                                                  dcal->dayLabelHeight + 1,
+                                                  col_height(dcal) + dcal->dayLabelHeight + 1);
         }
 
         for (i = 0; i < 12; i++)
@@ -1179,7 +1187,7 @@ gnc_dense_cal_draw_to_buffer(GncDenseCal *dcal)
             if (dcal->monthPositions[i].x == -1)
                 break;
             idx = (dcal->month - 1 + i) % 12;
-            pango_layout_set_text(layout, month_name(idx), -1);
+            pango_layout_set_text (layout, month_name (idx), -1);
             cairo_save (cr);
             cairo_translate (cr, dcal->monthPositions[i].x + x_offset, dcal->monthPositions[i].y);
             cairo_rotate (cr, -G_PI / 2.);
@@ -1203,16 +1211,16 @@ gnc_dense_cal_draw_to_buffer(GncDenseCal *dcal)
         gtk_style_context_add_class (stylectxt, "day-number");
 
         cairo_save (cr);
-        g_date_set_dmy(&d, 1, dcal->month, dcal->year);
+        g_date_set_dmy (&d, 1, dcal->month, dcal->year);
         eoc = d;
-        g_date_add_months(&eoc, dcal->numMonths);
-        for (doc = 0; g_date_get_julian(&d) < g_date_get_julian(&eoc); g_date_add_days(&d, 1), doc++)
+        g_date_add_months (&eoc, dcal->numMonths);
+        for (doc = 0; g_date_get_julian (&d) < g_date_get_julian (&eoc); g_date_add_days (&d, 1), doc++)
         {
-            doc_coords(dcal, doc, &x1, &y1, &x2, &y2);
-            memset(dayNumBuf, 0, 4);
-            snprintf(dayNumBuf, 4, "%d", g_date_get_day(&d));
-            pango_layout_set_text(layout, dayNumBuf, -1);
-            pango_layout_get_pixel_size(layout, &numW, &numH);
+            doc_coords (dcal, doc, &x1, &y1, &x2, &y2);
+            memset (dayNumBuf, 0, 4);
+            snprintf (dayNumBuf, 4, "%d", g_date_get_day(&d));
+            pango_layout_set_text (layout, dayNumBuf, -1);
+            pango_layout_get_pixel_size (layout, &numW, &numH);
             w = (x2 - x1) + 1;
             h = (y2 - y1) + 1;
             gtk_render_layout (stylectxt, cr, x1 + (w / 2) - (numW / 2), y1 + (h / 2) - (numH / 2), layout);
@@ -1223,11 +1231,11 @@ gnc_dense_cal_draw_to_buffer(GncDenseCal *dcal)
     LOG_AND_RESET(timer, "dates");
 
     gtk_widget_get_allocation (widget, &alloc);
-    gtk_widget_queue_draw_area(GTK_WIDGET(dcal),
-                               alloc.x,
-                               alloc.y,
-                               alloc.width,
-                               alloc.height);
+    gtk_widget_queue_draw_area (GTK_WIDGET(dcal),
+                                alloc.x,
+                                alloc.y,
+                                alloc.width,
+                                alloc.height);
 
     LOG_AND_RESET(timer, "queue draw");
 
@@ -1235,14 +1243,14 @@ gnc_dense_cal_draw_to_buffer(GncDenseCal *dcal)
     g_free (secondary_color_class);
     g_free (marker_color_class);
 
-    g_object_unref(layout);
+    g_object_unref (layout);
     cairo_destroy (cr);
 
-    g_timer_destroy(timer);
+    g_timer_destroy (timer);
 }
 
 static void
-populate_hover_window(GncDenseCal *dcal)
+populate_hover_window (GncDenseCal *dcal)
 {
     GtkWidget *w;
     GDate *date;
@@ -1253,52 +1261,53 @@ populate_hover_window(GncDenseCal *dcal)
         GtkListStore *model;
         GList *l;
 
-        w = GTK_WIDGET(g_object_get_data(G_OBJECT(dcal->transPopup), "dateLabel"));
-        date = g_date_new_dmy(1, dcal->month, dcal->year);
-        g_date_add_days(date, dcal->doc);
+        w = GTK_WIDGET(g_object_get_data (G_OBJECT(dcal->transPopup), "dateLabel"));
+        date = g_date_new_dmy (1, dcal->month, dcal->year);
+        g_date_add_days (date, dcal->doc);
         /* Note: the ISO date format (%F or equivalently
          * %Y-%m-%d) is not a good idea here since many
          * locales will want to use a very different date
          * format. Please leave the specification of the date
          * format up to the preference.  */
-        time64 t64 = gnc_dmy2time64_neutral (g_date_get_day(date),
-                                             g_date_get_month(date),
-                                             g_date_get_year(date));
+        time64 t64 = gnc_dmy2time64_neutral (g_date_get_day (date),
+                                             g_date_get_month (date),
+                                             g_date_get_year (date));
         gchar date_buff [MAX_DATE_LENGTH + 1];
         qof_print_date_buff (date_buff, MAX_DATE_LENGTH, t64);
         gtk_label_set_text (GTK_LABEL(w), date_buff);
 
         o = G_OBJECT(dcal->transPopup);
-        model = GTK_LIST_STORE(g_object_get_data(o, "model"));
-        gtk_list_store_clear(model);
+        model = GTK_LIST_STORE(g_object_get_data (o, "model"));
+        gtk_list_store_clear (model);
         for (l = dcal->marks[dcal->doc]; l; l = l->next)
         {
             GtkTreeIter iter;
             gdc_mark_data *gdcmd;
 
             gdcmd = (gdc_mark_data*)l->data;
-            gtk_list_store_insert(model, &iter, INT_MAX);
-            gtk_list_store_set(model, &iter, 0, (gdcmd->name ? gdcmd->name : _("(unnamed)")), 1, gdcmd->info, -1);
+            gtk_list_store_insert (model, &iter, INT_MAX);
+            gtk_list_store_set (model, &iter, 0, (gdcmd->name ? gdcmd->name : _("(unnamed)")),
+                                                                1, gdcmd->info, -1);
         }
 
         // if there are no rows, add one
         if (gtk_tree_model_iter_n_children (GTK_TREE_MODEL(model), NULL) == 0)
         {
             GtkTreeIter iter;
-            gtk_list_store_insert(model, &iter, -1);
+            gtk_list_store_insert (model, &iter, -1);
         }
 
         // make sure all pending events are processed
-        while(gtk_events_pending())
-            gtk_main_iteration();
+        while(gtk_events_pending ())
+            gtk_main_iteration ();
 
-        g_date_free(date);
+        g_date_free (date);
     }
 }
 
 static gint
-gnc_dense_cal_button_press(GtkWidget *widget,
-                           GdkEventButton *evt)
+gnc_dense_cal_button_press (GtkWidget *widget,
+                            GdkEventButton *evt)
 {
     GdkWindow *win = gdk_screen_get_root_window (gtk_widget_get_screen (widget));
     GdkMonitor *mon = gdk_display_get_monitor_at_window (gtk_widget_get_display (widget), win);
@@ -1313,7 +1322,7 @@ gnc_dense_cal_button_press(GtkWidget *widget,
     dcal->screen_width = work_area_size.width;
     dcal->screen_height = work_area_size.height;
 
-    dcal->doc = wheres_this(dcal, evt->x, evt->y);
+    dcal->doc = wheres_this (dcal, evt->x, evt->y);
     dcal->showPopup = ~(dcal->showPopup);
     if (dcal->showPopup && dcal->doc >= 0)
     {
@@ -1323,13 +1332,13 @@ gnc_dense_cal_button_press(GtkWidget *widget,
         // strategy, but hopefully it'll listen to us.  Certainly the
         // second move after show_all'ing the window should do the
         // trick with a bit of flicker.
-        gtk_window_move(GTK_WINDOW(dcal->transPopup), evt->x_root + 5, evt->y_root + 5);
+        gtk_window_move (GTK_WINDOW(dcal->transPopup), evt->x_root + 5, evt->y_root + 5);
 
-        populate_hover_window(dcal);
-        gtk_widget_queue_resize(GTK_WIDGET(dcal->transPopup));
-        gtk_widget_show_all(GTK_WIDGET(dcal->transPopup));
+        populate_hover_window (dcal);
+        gtk_widget_queue_resize (GTK_WIDGET(dcal->transPopup));
+        gtk_widget_show_all (GTK_WIDGET(dcal->transPopup));
 
-        gtk_widget_get_allocation(GTK_WIDGET(dcal->transPopup), &alloc);
+        gtk_widget_get_allocation (GTK_WIDGET(dcal->transPopup), &alloc);
 
         if (evt->x_root + 5 + alloc.width > dcal->screen_width)
             win_xpos = evt->x_root - 2 - alloc.width;
@@ -1337,19 +1346,19 @@ gnc_dense_cal_button_press(GtkWidget *widget,
         if (evt->y_root + 5 + alloc.height > dcal->screen_height)
             win_ypos = evt->y_root - 2 - alloc.height;
 
-        gtk_window_move(GTK_WINDOW(dcal->transPopup), win_xpos, win_ypos);
+        gtk_window_move (GTK_WINDOW(dcal->transPopup), win_xpos, win_ypos);
     }
     else
     {
         dcal->doc = -1;
-        gtk_widget_hide(GTK_WIDGET(dcal->transPopup));
+        gtk_widget_hide (GTK_WIDGET(dcal->transPopup));
     }
     return TRUE;
 }
 
 static gint
-gnc_dense_cal_motion_notify(GtkWidget *widget,
-                            GdkEventMotion *event)
+gnc_dense_cal_motion_notify (GtkWidget *widget,
+                             GdkEventMotion *event)
 {
     GncDenseCal *dcal;
     GtkAllocation alloc;
@@ -1372,17 +1381,17 @@ gnc_dense_cal_motion_notify(GtkWidget *widget,
         gdk_window_get_device_position (event->window, pointer,  &unused,  &unused, &unused2);
     }
 
-    doc = wheres_this(dcal, event->x, event->y);
+    doc = wheres_this (dcal, event->x, event->y);
     if (doc >= 0)
     {
         if (dcal->doc != doc) // if we are on the same day, no need to reload
         {
             dcal->doc = doc;
-            populate_hover_window(dcal);
-            gtk_widget_queue_resize(GTK_WIDGET(dcal->transPopup));
-            gtk_widget_show_all(GTK_WIDGET(dcal->transPopup));
+            populate_hover_window (dcal);
+            gtk_widget_queue_resize (GTK_WIDGET(dcal->transPopup));
+            gtk_widget_show_all (GTK_WIDGET(dcal->transPopup));
         }
-        gtk_widget_get_allocation(GTK_WIDGET(dcal->transPopup), &alloc);
+        gtk_widget_get_allocation (GTK_WIDGET(dcal->transPopup), &alloc);
 
         if (event->x_root + 5 + alloc.width > dcal->screen_width)
             win_xpos = event->x_root - 2 - alloc.width;
@@ -1390,160 +1399,160 @@ gnc_dense_cal_motion_notify(GtkWidget *widget,
         if (event->y_root + 5 + alloc.height > dcal->screen_height)
             win_ypos = event->y_root - 2 - alloc.height;
 
-        gtk_window_move(GTK_WINDOW(dcal->transPopup), win_xpos, win_ypos);
+        gtk_window_move (GTK_WINDOW(dcal->transPopup), win_xpos, win_ypos);
     }
     else
     {
         dcal->doc = -1;
-        gtk_widget_hide(GTK_WIDGET(dcal->transPopup));
+        gtk_widget_hide (GTK_WIDGET(dcal->transPopup));
     }
     return TRUE;
 }
 
 
 static void
-_gdc_view_option_changed(GtkComboBox *widget, gpointer user_data)
+_gdc_view_option_changed (GtkComboBox *widget, gpointer user_data)
 {
     GtkTreeIter iter;
     GtkTreeModel *model;
     gint months_val;
 
-    model = GTK_TREE_MODEL(gtk_combo_box_get_model(widget));
-    if (!gtk_combo_box_get_active_iter(widget, &iter))
+    model = GTK_TREE_MODEL(gtk_combo_box_get_model (widget));
+    if (!gtk_combo_box_get_active_iter (widget, &iter))
         return;
-    gtk_tree_model_get(model, &iter, VIEW_OPTS_COLUMN_NUM_MONTHS, &months_val, -1);
+    gtk_tree_model_get (model, &iter, VIEW_OPTS_COLUMN_NUM_MONTHS, &months_val, -1);
     DEBUG("changing to %d months", months_val);
-    gnc_dense_cal_set_num_months(GNC_DENSE_CAL(user_data), months_val);
+    gnc_dense_cal_set_num_months (GNC_DENSE_CAL(user_data), months_val);
 }
 
 static inline int
-day_width_at(GncDenseCal *dcal, guint xScale)
+day_width_at (GncDenseCal *dcal, guint xScale)
 {
     return xScale + MINOR_BORDER_SIZE;
 }
 
 static inline int
-day_width(GncDenseCal *dcal)
+day_width (GncDenseCal *dcal)
 {
-    return day_width_at(dcal, dcal->x_scale);
+    return day_width_at (dcal, dcal->x_scale);
 }
 
 static inline int
-day_height_at(GncDenseCal *dcal, guint yScale)
+day_height_at (GncDenseCal *dcal, guint yScale)
 {
     return yScale + MINOR_BORDER_SIZE;
 }
 
 static inline int
-day_height(GncDenseCal *dcal)
+day_height (GncDenseCal *dcal)
 {
-    return day_height_at(dcal, dcal->y_scale);
+    return day_height_at (dcal, dcal->y_scale);
 }
 
 static inline int
-week_width_at(GncDenseCal *dcal, guint xScale)
+week_width_at (GncDenseCal *dcal, guint xScale)
 {
-    return day_width_at(dcal, xScale) * 7;
+    return day_width_at (dcal, xScale) * 7;
 }
 
 static inline int
-week_width(GncDenseCal *dcal)
+week_width (GncDenseCal *dcal)
 {
-    return week_width_at(dcal, dcal->x_scale);
+    return week_width_at (dcal, dcal->x_scale);
 }
 
 static inline int
-week_height_at(GncDenseCal *dcal, guint yScale)
+week_height_at (GncDenseCal *dcal, guint yScale)
 {
-    return day_height_at(dcal, yScale);
+    return day_height_at (dcal, yScale);
 }
 
 static inline int
-week_height(GncDenseCal *dcal)
+week_height (GncDenseCal *dcal)
 {
-    return week_height_at(dcal, dcal->y_scale);
+    return week_height_at (dcal, dcal->y_scale);
 }
 
 static inline int
-col_width_at(GncDenseCal *dcal, guint xScale)
+col_width_at (GncDenseCal *dcal, guint xScale)
 {
-    return (week_width_at(dcal, xScale)
+    return (week_width_at (dcal, xScale)
             + dcal->label_width
             + COL_BORDER_SIZE);
 }
 
 static inline int
-col_width(GncDenseCal *dcal)
+col_width (GncDenseCal *dcal)
 {
-    return col_width_at(dcal, dcal->x_scale);
+    return col_width_at (dcal, dcal->x_scale);
 }
 
 static inline int
-col_height(GncDenseCal *dcal)
+col_height (GncDenseCal *dcal)
 {
-    return week_height(dcal) * num_weeks_per_col(dcal);
+    return week_height (dcal) * num_weeks_per_col (dcal);
 }
 
 static inline int
-num_cols(GncDenseCal *dcal)
+num_cols (GncDenseCal *dcal)
 {
-    return ceil((float)dcal->numMonths / (float)dcal->monthsPerCol);
+    return ceil ((float)dcal->numMonths / (float)dcal->monthsPerCol);
 }
 
 static inline int
-num_weeks(GncDenseCal *dcal)
+num_weeks (GncDenseCal *dcal)
 {
     return dcal->num_weeks;
 }
 
 static
-int num_weeks_per_col(GncDenseCal *dcal)
+int num_weeks_per_col (GncDenseCal *dcal)
 {
     int num_weeks_toRet, numCols, i;
     GDate *start, *end;
     int startWeek, endWeek;
 
-    start = g_date_new();
-    end = g_date_new();
+    start = g_date_new ();
+    end = g_date_new ();
 
     num_weeks_toRet = 0;
-    numCols = num_cols(dcal);
+    numCols = num_cols (dcal);
 
     for (i = 0; i < numCols; i++)
     {
-        g_date_set_dmy(start, 1,
-                       ((dcal->month - 1
-                         + (i * dcal->monthsPerCol)) % 12)
-                       + 1,
-                       dcal->year + floor((dcal->month - 1
-                                           + (i * dcal->monthsPerCol))
-                                          / 12));
+        g_date_set_dmy (start, 1,
+                        ((dcal->month - 1
+                          + (i * dcal->monthsPerCol)) % 12)
+                          + 1,
+                        dcal->year + floor ((dcal->month - 1
+                                             + (i * dcal->monthsPerCol))
+                                             / 12));
         *end = *start;
         /* Add the smaller of (the number of months in the
          * calendar-display, minus the number of months shown in the
          * previous columns) or (the number of months in a column) */
-        g_date_add_months(end, MIN(dcal->numMonths,
-                                   MIN(dcal->monthsPerCol,
-                                       dcal->numMonths
-                                       - ((i - 1)
-                                          * dcal->monthsPerCol))));
-        g_date_subtract_days(end, 1);
+        g_date_add_months (end, MIN(dcal->numMonths,
+                                    MIN(dcal->monthsPerCol,
+                                        dcal->numMonths
+                                        - ((i - 1)
+                                           * dcal->monthsPerCol))));
+        g_date_subtract_days (end, 1);
         startWeek = (dcal->week_starts_monday
-                     ? g_date_get_monday_week_of_year(start)
-                     : g_date_get_sunday_week_of_year(start));
+                     ? g_date_get_monday_week_of_year (start)
+                     : g_date_get_sunday_week_of_year (start));
         endWeek = (dcal->week_starts_monday
-                   ? g_date_get_monday_week_of_year(end)
-                   : g_date_get_sunday_week_of_year(end));
+                   ? g_date_get_monday_week_of_year (end)
+                   : g_date_get_sunday_week_of_year (end));
         if (endWeek < startWeek)
         {
             endWeek += (dcal->week_starts_monday
-                        ? g_date_get_monday_weeks_in_year(g_date_get_year(start))
-                        : g_date_get_sunday_weeks_in_year(g_date_get_year(start)));
+                        ? g_date_get_monday_weeks_in_year (g_date_get_year (start))
+                        : g_date_get_sunday_weeks_in_year (g_date_get_year (start)));
         }
         num_weeks_toRet = MAX(num_weeks_toRet, (endWeek - startWeek) + 1);
     }
-    g_date_free(start);
-    g_date_free(end);
+    g_date_free (start);
+    g_date_free (end);
     return num_weeks_toRet;
 }
 
@@ -1554,7 +1563,7 @@ int num_weeks_per_col(GncDenseCal *dcal)
  * size of the month.
  **/
 static void
-month_coords(GncDenseCal *dcal, int monthOfCal, GList **outList)
+month_coords (GncDenseCal *dcal, int monthOfCal, GList **outList)
 {
     gint weekRow, colNum, previousMonthsInCol, monthOffset;
     gint start;
@@ -1565,69 +1574,69 @@ month_coords(GncDenseCal *dcal, int monthOfCal, GList **outList)
     if (monthOfCal > dcal->numMonths)
         return;
 
-    colNum = floor(monthOfCal / dcal->monthsPerCol);
+    colNum = floor (monthOfCal / dcal->monthsPerCol);
     monthOffset = colNum * dcal->monthsPerCol;
     previousMonthsInCol = MAX(0, (monthOfCal % dcal->monthsPerCol));
 
-    startD = g_date_new();
-    endD = g_date_new();
+    startD = g_date_new ();
+    endD = g_date_new ();
 
     /* Calculate the number of weeks in the column before the month we're
      * interested in. */
     weekRow = 0;
     if (previousMonthsInCol > 0)
     {
-        g_date_set_dmy(startD, 1,
-                       ((dcal->month - 1 + monthOffset) % 12) + 1,
-                       dcal->year + floor((dcal->month - 1 + monthOffset) / 12));
+        g_date_set_dmy (startD, 1,
+                                ((dcal->month - 1 + monthOffset) % 12) + 1,
+                                dcal->year + floor ((dcal->month - 1 + monthOffset) / 12));
         /* get the week of the top of the column */
         startWk = (dcal->week_starts_monday
-                   ? g_date_get_monday_week_of_year(startD)
-                   : g_date_get_sunday_week_of_year(startD));
+                   ? g_date_get_monday_week_of_year (startD)
+                   : g_date_get_sunday_week_of_year (startD));
         /* get the week of the end of the previous months */
         *endD = *startD;
-        g_date_add_months(endD, previousMonthsInCol);
-        g_date_subtract_days(endD, 1);
+        g_date_add_months (endD, previousMonthsInCol);
+        g_date_subtract_days (endD, 1);
         endWk = (dcal->week_starts_monday
-                 ? g_date_get_monday_week_of_year(endD)
-                 : g_date_get_sunday_week_of_year(endD));
+                 ? g_date_get_monday_week_of_year (endD)
+                 : g_date_get_sunday_week_of_year (endD));
         if (endWk < startWk)
         {
             endWk += (dcal->week_starts_monday
-                      ? g_date_get_monday_weeks_in_year(g_date_get_year(startD))
-                      : g_date_get_sunday_weeks_in_year(g_date_get_year(startD)));
+                      ? g_date_get_monday_weeks_in_year (g_date_get_year (startD))
+                      : g_date_get_sunday_weeks_in_year (g_date_get_year (startD)));
         }
         /* determine how many weeks are before the month we're
          * interested in. */
         weekRow = endWk - startWk;
-        if (g_date_get_weekday(endD) == (dcal->week_starts_monday ? G_DATE_SUNDAY : G_DATE_SATURDAY))
+        if (g_date_get_weekday (endD) == (dcal->week_starts_monday ? G_DATE_SUNDAY : G_DATE_SATURDAY))
         {
             weekRow++;
         }
     }
 
-    g_date_set_dmy(startD, 1,
-                   ((dcal->month - 1 + monthOfCal) % 12) + 1,
-                   dcal->year + floor((dcal->month - 1 + monthOfCal) / 12));
+    g_date_set_dmy (startD, 1,
+                            ((dcal->month - 1 + monthOfCal) % 12) + 1,
+                            dcal->year + floor ((dcal->month - 1 + monthOfCal) / 12));
     *endD = *startD;
-    g_date_add_months(endD, 1);
-    g_date_subtract_days(endD, 1);
+    g_date_add_months (endD, 1);
+    g_date_subtract_days (endD, 1);
     /* Get the first week. */
     {
-        start = (g_date_get_weekday(startD) - dcal->week_starts_monday) % 7;
-        rect = g_new0(GdkRectangle, 1);
+        start = (g_date_get_weekday (startD) - dcal->week_starts_monday) % 7;
+        rect = g_new0 (GdkRectangle, 1);
         rect->x = dcal->leftPadding
                   + MINOR_BORDER_SIZE
-                  + (colNum * (col_width(dcal) + COL_BORDER_SIZE))
+                  + (colNum * (col_width (dcal) + COL_BORDER_SIZE))
                   + dcal->label_height
-                  + (start * day_width(dcal));
+                  + (start * day_width (dcal));
         rect->y = dcal->topPadding
                   + dcal->dayLabelHeight
                   + MINOR_BORDER_SIZE
-                  + (weekRow * week_height(dcal));
-        rect->width = (7 - start) * day_width(dcal);
-        rect->height = week_height(dcal);
-        *outList = g_list_append(*outList, (gpointer)rect);
+                  + (weekRow * week_height (dcal));
+        rect->width = (7 - start) * day_width (dcal);
+        rect->height = week_height (dcal);
+        *outList = g_list_append (*outList, (gpointer)rect);
         rect = NULL;
     }
 
@@ -1636,66 +1645,66 @@ month_coords(GncDenseCal *dcal, int monthOfCal, GList **outList)
         gint i, weekStart, weekEnd;
 
         weekStart = (dcal->week_starts_monday
-                     ? g_date_get_monday_week_of_year(startD)
-                     : g_date_get_sunday_week_of_year(startD)) + 1;
+                     ? g_date_get_monday_week_of_year (startD)
+                     : g_date_get_sunday_week_of_year (startD)) + 1;
         weekEnd = (dcal->week_starts_monday
-                   ? g_date_get_monday_week_of_year(endD)
-                   : g_date_get_sunday_week_of_year(endD));
+                   ? g_date_get_monday_week_of_year (endD)
+                   : g_date_get_sunday_week_of_year (endD));
         for (i = weekStart; i < weekEnd; i++)
         {
-            rect = g_new0(GdkRectangle, 1);
+            rect = g_new0 (GdkRectangle, 1);
             rect->x = dcal->leftPadding
                       + MINOR_BORDER_SIZE
                       + dcal->label_height
-                      + (colNum * (col_width(dcal) + COL_BORDER_SIZE));
+                      + (colNum * (col_width (dcal) + COL_BORDER_SIZE));
             rect->y = dcal->topPadding
                       + dcal->dayLabelHeight
                       + MINOR_BORDER_SIZE
-                      + ((weekRow + (i - weekStart) + 1) * week_height(dcal));
-            rect->width  = week_width(dcal);
-            rect->height = week_height(dcal);
+                      + ((weekRow + (i - weekStart) + 1) * week_height (dcal));
+            rect->width  = week_width (dcal);
+            rect->height = week_height (dcal);
 
-            *outList = g_list_append(*outList, (gpointer)rect);
+            *outList = g_list_append (*outList, (gpointer)rect);
             rect = NULL;
         }
     }
 
     /* Get the last week. */
     {
-        gint end_week_of_year = g_date_get_sunday_week_of_year(endD);
-        gint start_week_of_year = g_date_get_sunday_week_of_year(startD);
+        gint end_week_of_year = g_date_get_sunday_week_of_year (endD);
+        gint start_week_of_year = g_date_get_sunday_week_of_year (startD);
         if (dcal->week_starts_monday == 1)
         {
-            end_week_of_year = g_date_get_monday_week_of_year(endD);
-            start_week_of_year = g_date_get_monday_week_of_year(startD);
+            end_week_of_year = g_date_get_monday_week_of_year (endD);
+            start_week_of_year = g_date_get_monday_week_of_year (startD);
         }
 
-        rect = g_new0(GdkRectangle, 1);
+        rect = g_new0 (GdkRectangle, 1);
         rect->x = dcal->leftPadding
                   + MINOR_BORDER_SIZE
                   + dcal->label_height
-                  + (colNum * (col_width(dcal) + COL_BORDER_SIZE));
+                  + (colNum * (col_width (dcal) + COL_BORDER_SIZE));
         rect->y = dcal->topPadding
                   + MINOR_BORDER_SIZE
                   + dcal->dayLabelHeight
                   + ((weekRow
                       + (end_week_of_year - start_week_of_year))
-                     * week_height(dcal));
-        rect->width = (((g_date_get_weekday(endD) - dcal->week_starts_monday) % 7) + 1) * day_width(dcal);
-        rect->height = week_height(dcal);
+                     * week_height (dcal));
+        rect->width = (((g_date_get_weekday (endD) - dcal->week_starts_monday) % 7) + 1) * day_width (dcal);
+        rect->height = week_height (dcal);
 
-        *outList = g_list_append(*outList, (gpointer)rect);
+        *outList = g_list_append (*outList, (gpointer)rect);
         rect = NULL;
     }
 
-    g_date_free(startD);
-    g_date_free(endD);
+    g_date_free (startD);
+    g_date_free (endD);
 }
 
 /* FIXME: make this more like month_coords */
 static void
-doc_coords(GncDenseCal *dcal, int dayOfCal,
-           int *x1, int *y1, int *x2, int *y2)
+doc_coords (GncDenseCal *dcal, int dayOfCal,
+            int *x1, int *y1, int *x2, int *y2)
 {
     GDate d;
     gint docMonth;
@@ -1703,32 +1712,32 @@ doc_coords(GncDenseCal *dcal, int dayOfCal,
     gint colNum, dayCol, weekRow;
 
     /* FIXME: add range checks */
-    g_date_set_dmy(&d, 1, dcal->month, dcal->year);
-    g_date_add_days(&d, dayOfCal);
-    docMonth = g_date_get_month(&d);
-    if (g_date_get_year(&d) != dcal->year)
+    g_date_set_dmy (&d, 1, dcal->month, dcal->year);
+    g_date_add_days (&d, dayOfCal);
+    docMonth = g_date_get_month (&d);
+    if (g_date_get_year (&d) != dcal->year)
     {
         docMonth += 12;
     }
-    colNum  = floor((float)(docMonth - dcal->month) / (float)dcal->monthsPerCol);
-    dayCol  = (g_date_get_weekday(&d) - dcal->week_starts_monday) % 7;
-    d_week_of_cal = g_date_get_sunday_week_of_year(&d);
+    colNum  = floor ((float)(docMonth - dcal->month) / (float)dcal->monthsPerCol);
+    dayCol  = (g_date_get_weekday (&d) - dcal->week_starts_monday) % 7;
+    d_week_of_cal = g_date_get_sunday_week_of_year (&d);
     if (dcal->week_starts_monday == 1)
     {
-        d_week_of_cal = g_date_get_monday_week_of_year(&d);
+        d_week_of_cal = g_date_get_monday_week_of_year (&d);
     }
-    g_date_set_dmy(&d, 1, dcal->month, dcal->year);
-    g_date_add_months(&d, (colNum * dcal->monthsPerCol));
+    g_date_set_dmy (&d, 1, dcal->month, dcal->year);
+    g_date_add_months (&d, (colNum * dcal->monthsPerCol));
     top_of_col_week_of_cal = (dcal->week_starts_monday
-                              ? g_date_get_monday_week_of_year(&d)
-                              : g_date_get_sunday_week_of_year(&d));
+                              ? g_date_get_monday_week_of_year (&d)
+                              : g_date_get_sunday_week_of_year (&d));
     if (d_week_of_cal < top_of_col_week_of_cal)
     {
         gint week_offset;
-        week_offset = g_date_get_sunday_weeks_in_year(dcal->year);
+        week_offset = g_date_get_sunday_weeks_in_year (dcal->year);
         if (dcal->week_starts_monday == 1)
         {
-            week_offset = g_date_get_monday_weeks_in_year(dcal->year);
+            week_offset = g_date_get_monday_weeks_in_year (dcal->year);
         }
         d_week_of_cal += week_offset;
     }
@@ -1740,17 +1749,17 @@ doc_coords(GncDenseCal *dcal, int dayOfCal,
     *x1 = dcal->leftPadding
           + MINOR_BORDER_SIZE
           + dcal->label_height
-          + (colNum * (col_width(dcal) + COL_BORDER_SIZE))
-          + (dayCol * day_width(dcal))
-          + (day_width(dcal) / 4);
+          + (colNum * (col_width (dcal) + COL_BORDER_SIZE))
+          + (dayCol * day_width (dcal))
+          + (day_width (dcal) / 4);
     *y1 = dcal->topPadding
           + MINOR_BORDER_SIZE
           + dcal->dayLabelHeight
-          + (weekRow * week_height(dcal))
-          + (day_height(dcal) / 4);
+          + (weekRow * week_height (dcal))
+          + (day_height (dcal) / 4);
 
-    *x2 = *x1 + (day_width(dcal) / 2);
-    *y2 = *y1 + (day_height(dcal) / 2);
+    *x2 = *x1 + (day_width (dcal) / 2);
+    *y2 = *y1 + (day_height (dcal) / 2);
 }
 
 /**
@@ -1758,7 +1767,7 @@ doc_coords(GncDenseCal *dcal, int dayOfCal,
  * '-1' if invalid.
  **/
 static gint
-wheres_this(GncDenseCal *dcal, int x, int y)
+wheres_this (GncDenseCal *dcal, int x, int y)
 {
     gint colNum, weekRow, dayCol, dayOfCal;
     GDate d, startD;
@@ -1779,25 +1788,25 @@ wheres_this(GncDenseCal *dcal, int x, int y)
     }
 
     /* "outside of displayed table" check */
-    if (x >= (num_cols(dcal) * (col_width(dcal) + COL_BORDER_SIZE)))
+    if (x >= (num_cols(dcal) * (col_width (dcal) + COL_BORDER_SIZE)))
     {
         return -1;
     }
-    if (y >= dcal->dayLabelHeight + col_height(dcal))
+    if (y >= dcal->dayLabelHeight + col_height (dcal))
     {
         return -1;
     }
 
     /* coords -> year-relative-values */
-    colNum = floor(x / (col_width(dcal) + COL_BORDER_SIZE));
+    colNum = floor (x / (col_width (dcal) + COL_BORDER_SIZE));
 
-    x %= (col_width(dcal) + COL_BORDER_SIZE);
+    x %= (col_width (dcal) + COL_BORDER_SIZE);
     x -= dcal->label_width;
     if (x < 0)
     {
         return -1;
     }
-    if (x >= day_width(dcal) * 7)
+    if (x >= day_width (dcal) * 7)
     {
         return -1;
     }
@@ -1808,13 +1817,13 @@ wheres_this(GncDenseCal *dcal, int x, int y)
         return -1;
     }
 
-    dayCol = floor((float)x / (float)day_width(dcal));
-    weekRow = floor((float)y / (float)week_height(dcal));
+    dayCol = floor ((float)x / (float)day_width (dcal));
+    weekRow = floor ((float)y / (float)week_height (dcal));
 
-    g_date_set_dmy(&startD, 1, dcal->month, dcal->year);
+    g_date_set_dmy (&startD, 1, dcal->month, dcal->year);
     d = startD;
-    g_date_add_months(&d, (colNum * dcal->monthsPerCol));
-    dayCol -= ((g_date_get_weekday(&d) - dcal->week_starts_monday) % 7);
+    g_date_add_months (&d, (colNum * dcal->monthsPerCol));
+    dayCol -= ((g_date_get_weekday (&d) - dcal->week_starts_monday) % 7);
     if (weekRow == 0)
     {
         if (dayCol < 0)
@@ -1822,27 +1831,27 @@ wheres_this(GncDenseCal *dcal, int x, int y)
             return -1;
         }
     }
-    g_date_add_days(&d, dayCol + (weekRow * 7));
+    g_date_add_days (&d, dayCol + (weekRow * 7));
 
     /* Check to make sure we're within the column's displayed range. */
     {
         GDate ccd;
-        g_date_set_dmy(&ccd, 1, dcal->month, dcal->year);
-        g_date_add_months(&ccd, (colNum + 1) * dcal->monthsPerCol);
-        if (g_date_get_julian(&d) >= g_date_get_julian(&ccd))
+        g_date_set_dmy (&ccd, 1, dcal->month, dcal->year);
+        g_date_add_months (&ccd, (colNum + 1) * dcal->monthsPerCol);
+        if (g_date_get_julian (&d) >= g_date_get_julian (&ccd))
         {
             return -1;
         }
     }
 
-    dayOfCal = g_date_get_julian(&d) - g_date_get_julian(&startD);
+    dayOfCal = g_date_get_julian (&d) - g_date_get_julian (&startD);
 
     /* one more check before returning... */
-    g_date_subtract_months(&d, dcal->numMonths);
-    if (g_date_get_julian(&d) >= g_date_get_julian(&startD))
+    g_date_subtract_months (&d, dcal->numMonths);
+    if (g_date_get_julian (&d) >= g_date_get_julian (&startD))
     {
         /* we're past the end of the displayed calendar, thus -1 */
-        DEBUG("%d >= %d", g_date_get_julian(&d), g_date_get_julian(&startD));
+        DEBUG("%d >= %d", g_date_get_julian (&d), g_date_get_julian (&startD));
         return -1;
     }
 
@@ -1850,30 +1859,30 @@ wheres_this(GncDenseCal *dcal, int x, int y)
 }
 
 static gint
-gdc_get_doc_offset(GncDenseCal *dcal, GDate *d)
+gdc_get_doc_offset (GncDenseCal *dcal, GDate *d)
 {
     gint toRet;
     /* soc == start-of-calendar */
     GDate soc;
 
-    g_date_clear(&soc, 1);
-    g_date_set_dmy(&soc, 1, dcal->month, dcal->year);
+    g_date_clear (&soc, 1);
+    g_date_set_dmy (&soc, 1, dcal->month, dcal->year);
     /* ensure not before calendar start. */
-    if (g_date_get_julian(d) < g_date_get_julian(&soc))
+    if (g_date_get_julian (d) < g_date_get_julian (&soc))
         return -1;
     /* do computation here, since we're going to change the
      * start-of-calendar date. */
-    toRet = g_date_get_julian(d) - g_date_get_julian(&soc);
+    toRet = g_date_get_julian (d) - g_date_get_julian (&soc);
     /* ensure not after end of visible calendar. */
-    g_date_add_months(&soc, dcal->numMonths);
-    if (g_date_get_julian(d) >= g_date_get_julian(&soc))
+    g_date_add_months (&soc, dcal->numMonths);
+    if (g_date_get_julian (d) >= g_date_get_julian (&soc))
         return -1;
     /* return pre-computed value. */
     return toRet;
 }
 
 static void
-gdc_add_tag_markings(GncDenseCal *cal, guint tag)
+gdc_add_tag_markings (GncDenseCal *cal, guint tag)
 {
     gchar *name, *info;
     gint num_marks, idx;
@@ -1881,91 +1890,91 @@ gdc_add_tag_markings(GncDenseCal *cal, guint tag)
     GDate *calDate;
 
     // copy the values into the old marking function.
-    name = gnc_dense_cal_model_get_name(cal->model, tag);
-    info = gnc_dense_cal_model_get_info(cal->model, tag);
-    num_marks = gnc_dense_cal_model_get_instance_count(cal->model, tag);
+    name = gnc_dense_cal_model_get_name (cal->model, tag);
+    info = gnc_dense_cal_model_get_info (cal->model, tag);
+    num_marks = gnc_dense_cal_model_get_instance_count (cal->model, tag);
 
     if (num_marks == 0)
         goto cleanup;
 
-    dates = g_new0(GDate*, num_marks);
-    calDate = g_date_new_dmy(1, cal->month, cal->year);
+    dates = g_new0 (GDate*, num_marks);
+    calDate = g_date_new_dmy (1, cal->month, cal->year);
 
     for (idx = 0; idx < num_marks; idx++)
     {
-        dates[idx] = g_date_new();
-        gnc_dense_cal_model_get_instance(cal->model, tag, idx, dates[idx]);
+        dates[idx] = g_date_new ();
+        gnc_dense_cal_model_get_instance (cal->model, tag, idx, dates[idx]);
 
     }
-    if (g_date_valid(dates[0]))
+    if (g_date_valid (dates[0]))
     {
-        if (g_date_get_julian(dates[0]) < g_date_get_julian(calDate))
+        if (g_date_get_julian (dates[0]) < g_date_get_julian (calDate))
         {
             /* Oops, first marking is earlier than months displayed.
              * Choose new first month and recalculate all markings for all
              * tags. Their offsets are all wrong with the newly added month(s).
              */
-            _gnc_dense_cal_set_month(cal, g_date_get_month(dates[0]), FALSE);
-            _gnc_dense_cal_set_year(cal, g_date_get_year(dates[0]), FALSE);
+            _gnc_dense_cal_set_month (cal, g_date_get_month (dates[0]), FALSE);
+            _gnc_dense_cal_set_year (cal, g_date_get_year (dates[0]), FALSE);
 
             gdc_remove_markings (cal);
             gdc_add_markings (cal);
         }
         else
-            gdc_mark_add(cal, tag, name, info, num_marks, dates);
+            gdc_mark_add (cal, tag, name, info, num_marks, dates);
     }
     else
     {
-        g_warning("Bad date, skipped.");
+        g_warning ("Bad date, skipped.");
     }
 
     for (idx = 0; idx < num_marks; idx++)
     {
-        g_date_free(dates[idx]);
+        g_date_free (dates[idx]);
     }
-    g_free(dates);
-    g_date_free(calDate);
+    g_free (dates);
+    g_date_free (calDate);
 
 cleanup:
-    g_free(info);
+    g_free (info);
 }
 
 static void
-gdc_add_markings(GncDenseCal *cal)
+gdc_add_markings (GncDenseCal *cal)
 {
-    GList *tags = gnc_dense_cal_model_get_contained(cal->model);
+    GList *tags = gnc_dense_cal_model_get_contained (cal->model);
 
     for (GList *n = tags; n; n = n->next)
-        gdc_add_tag_markings(cal, GPOINTER_TO_UINT(n->data));
+        gdc_add_tag_markings (cal, GPOINTER_TO_UINT(n->data));
 
-    g_list_free(tags);
+    g_list_free (tags);
 }
 
 static void
-gdc_remove_markings(GncDenseCal *cal)
+gdc_remove_markings (GncDenseCal *cal)
 {
-    GList *tags = gnc_dense_cal_model_get_contained(cal->model);
+    GList *tags = gnc_dense_cal_model_get_contained (cal->model);
 
     for (GList *n = tags; n; n = n->next)
-        gdc_mark_remove(cal, GPOINTER_TO_UINT(n->data), FALSE);
+        gdc_mark_remove (cal, GPOINTER_TO_UINT(n->data), FALSE);
 
-    g_list_free(tags);
+    g_list_free (tags);
 }
 
 static void
-gdc_model_added_cb(GncDenseCalModel *model, guint added_tag, gpointer user_data)
+gdc_model_added_cb (GncDenseCalModel *model, guint added_tag, gpointer user_data)
 {
     GncDenseCal *cal = GNC_DENSE_CAL(user_data);
-    DEBUG("gdc_model_added_cb update\n");
-    gdc_add_tag_markings(cal, added_tag);
+    DEBUG("gdc_model_added_cb update");
+    gdc_add_tag_markings (cal, added_tag);
 }
 
 static void
-gdc_model_update_cb(GncDenseCalModel *model, guint update_tag, gpointer user_data)
+gdc_model_update_cb (GncDenseCalModel *model, guint update_tag, gpointer user_data)
 {
-    GncDenseCal *cal = GNC_DENSE_CAL (user_data);
+    GncDenseCal *cal = GNC_DENSE_CAL(user_data);
     gint num_marks = 0;
-    DEBUG ("gdc_model_update_cb update for tag [%d]\n", update_tag);
+    DEBUG("gdc_model_update_cb update for tag [%d]", update_tag);
     num_marks = gnc_dense_cal_model_get_instance_count (cal->model, update_tag);
     // We need to redraw if there are no mark, to ensure they're all erased.
     gdc_mark_remove (cal, update_tag, num_marks==0);
@@ -1974,41 +1983,41 @@ gdc_model_update_cb(GncDenseCalModel *model, guint update_tag, gpointer user_dat
 }
 
 static void
-gdc_model_removing_cb(GncDenseCalModel *model, guint remove_tag, gpointer user_data)
+gdc_model_removing_cb (GncDenseCalModel *model, guint remove_tag, gpointer user_data)
 {
     GncDenseCal *cal = GNC_DENSE_CAL(user_data);
-    DEBUG("gdc_model_removing_cb update [%d]\n", remove_tag);
-    gdc_mark_remove(cal, remove_tag, TRUE);
+    DEBUG("gdc_model_removing_cb update [%d]", remove_tag);
+    gdc_mark_remove (cal, remove_tag, TRUE);
 }
 
 void
-gnc_dense_cal_set_model(GncDenseCal *cal, GncDenseCalModel *model)
+gnc_dense_cal_set_model (GncDenseCal *cal, GncDenseCalModel *model)
 {
     if (cal->model != NULL)
     {
-        gdc_remove_markings(cal);
-        g_object_unref(G_OBJECT(cal->model));
+        gdc_remove_markings (cal);
+        g_object_unref (G_OBJECT(cal->model));
         cal->model = NULL;
     }
     cal->model = model;
-    g_object_ref(G_OBJECT(model));
-    g_signal_connect(G_OBJECT(cal->model), "added", (GCallback)gdc_model_added_cb, cal);
-    g_signal_connect(G_OBJECT(cal->model), "update", (GCallback)gdc_model_update_cb, cal);
-    g_signal_connect(G_OBJECT(cal->model), "removing", (GCallback)gdc_model_removing_cb, cal);
+    g_object_ref (G_OBJECT(model));
+    g_signal_connect (G_OBJECT(cal->model), "added", (GCallback)gdc_model_added_cb, cal);
+    g_signal_connect (G_OBJECT(cal->model), "update", (GCallback)gdc_model_update_cb, cal);
+    g_signal_connect (G_OBJECT(cal->model), "removing", (GCallback)gdc_model_removing_cb, cal);
 
-    gdc_add_markings(cal);
+    gdc_add_markings (cal);
 }
 
 /**
  * Marks the given array of GDate*s on the calendar with the given name.
  **/
 static void
-gdc_mark_add(GncDenseCal *dcal,
-             guint tag,
-             gchar *name,
-             gchar *info,
-             guint size,
-             GDate **dateArray)
+gdc_mark_add (GncDenseCal *dcal,
+              guint tag,
+              gchar *name,
+              gchar *info,
+              guint size,
+              GDate **dateArray)
 {
     guint i;
     gint doc;
@@ -2017,25 +2026,25 @@ gdc_mark_add(GncDenseCal *dcal,
 
     if (size == 0)
     {
-        g_error("0 size not allowed\n");
+        g_error ("0 size not allowed");
         return;
     }
 
-    newMark = g_new0(gdc_mark_data, 1);
+    newMark = g_new0 (gdc_mark_data, 1);
     newMark->name = NULL;
     if (name)
-        newMark->name = g_strdup(name);
+        newMark->name = g_strdup (name);
     newMark->info = NULL;
     if (info)
-        newMark->info = g_strdup(info);
+        newMark->info = g_strdup (info);
     newMark->tag = tag;
     newMark->ourMarks = NULL;
-    DEBUG("saving mark with tag [%d]\n", newMark->tag);
+    DEBUG("saving mark with tag [%d]", newMark->tag);
 
     for (i = 0; i < size; i++)
     {
         d = dateArray[i];
-        doc = gdc_get_doc_offset(dcal, d);
+        doc = gdc_get_doc_offset (dcal, d);
         if (doc < 0)
             continue;
         if (doc >= dcal->numMarks)
@@ -2044,17 +2053,17 @@ gdc_mark_add(GncDenseCal *dcal,
              * stop processing. */
             break;
         }
-        dcal->marks[doc] = g_list_append(dcal->marks[doc], newMark);
-        newMark->ourMarks = g_list_append(newMark->ourMarks,
-                                          GINT_TO_POINTER(doc));
+        dcal->marks[doc] = g_list_append (dcal->marks[doc], newMark);
+        newMark->ourMarks = g_list_append (newMark->ourMarks,
+                                           GINT_TO_POINTER(doc));
     }
-    dcal->markData = g_list_append(dcal->markData, (gpointer)newMark);
-    gnc_dense_cal_draw_to_buffer(dcal);
-    gtk_widget_queue_draw(GTK_WIDGET(dcal->cal_drawing_area));
+    dcal->markData = g_list_append (dcal->markData, (gpointer)newMark);
+    gnc_dense_cal_draw_to_buffer (dcal);
+    gtk_widget_queue_draw (GTK_WIDGET(dcal->cal_drawing_area));
 }
 
 static void
-gdc_mark_remove(GncDenseCal *dcal, guint mark_to_remove, gboolean redraw)
+gdc_mark_remove (GncDenseCal *dcal, guint mark_to_remove, gboolean redraw)
 {
     GList *iter, *calendar_marks;
     gint day_of_cal;
@@ -2088,17 +2097,17 @@ gdc_mark_remove(GncDenseCal *dcal, guint mark_to_remove, gboolean redraw)
     for (calendar_marks = mark_data->ourMarks; calendar_marks != NULL; calendar_marks = calendar_marks->next)
     {
         day_of_cal = GPOINTER_TO_INT(calendar_marks->data);
-        dcal->marks[day_of_cal] = g_list_remove(dcal->marks[day_of_cal], mark_data);
+        dcal->marks[day_of_cal] = g_list_remove (dcal->marks[day_of_cal], mark_data);
     }
-    g_list_free(mark_data->ourMarks);
-    dcal->markData = g_list_remove(dcal->markData, mark_data);
+    g_list_free (mark_data->ourMarks);
+    dcal->markData = g_list_remove (dcal->markData, mark_data);
     g_free (mark_data->name);
     g_free (mark_data->info);
-    g_free(mark_data);
+    g_free (mark_data);
 
     if (redraw)
     {
-        gnc_dense_cal_draw_to_buffer(dcal);
-        gtk_widget_queue_draw(GTK_WIDGET(dcal->cal_drawing_area));
+        gnc_dense_cal_draw_to_buffer (dcal);
+        gtk_widget_queue_draw (GTK_WIDGET(dcal->cal_drawing_area));
     }
 }

--- a/gnucash/gnome-utils/gnc-dense-cal.c
+++ b/gnucash/gnome-utils/gnc-dense-cal.c
@@ -574,31 +574,21 @@ gnc_dense_cal_set_month (GncDenseCal *dcal, GDateMonth mon)
 static void
 _gnc_dense_cal_set_month (GncDenseCal *dcal, GDateMonth mon, gboolean redraw)
 {
-    GTimer *t;
     if (dcal->month == mon)
         return;
-    t = g_timer_new ();
+
     dcal->month = mon;
-    g_timer_start (t);
+
     recompute_first_of_month_offset (dcal);
-    DEBUG("recompute_first_of_month_offset: %f", g_timer_elapsed (t, NULL) * 1000.);
-    g_timer_start (t);
+
     recompute_extents (dcal);
-    DEBUG("recompute_extents: %f", g_timer_elapsed (t, NULL) * 1000.);
+
     if (redraw && gtk_widget_get_realized (GTK_WIDGET(dcal)))
     {
-        g_timer_start (t);
         recompute_x_y_scales (dcal);
-        DEBUG("recompute_x_y_scales: %f", g_timer_elapsed (t, NULL) * 1000.);
-        g_timer_start (t);
         gnc_dense_cal_draw_to_buffer (dcal);
-        DEBUG("draw_to_buffer: %f", g_timer_elapsed (t, NULL) * 1000.);
-        g_timer_start (t);
         gtk_widget_queue_draw (GTK_WIDGET(dcal->cal_drawing_area));
-        DEBUG("queue_draw: %f", g_timer_elapsed (t, NULL) * 1000.);
     }
-    g_timer_stop (t);
-    g_timer_destroy (t);
 }
 
 void
@@ -935,8 +925,6 @@ gnc_dense_cal_draw (GtkWidget *widget, cairo_t *cr, gpointer user_data)
     return TRUE;
 }
 
-#define LOG_AND_RESET(timer, msg) do { DEBUG("%s: %f", msg, g_timer_elapsed(timer, NULL) * 1000.); g_timer_reset(timer); } while (0);
-
 static void
 gnc_dense_cal_draw_to_buffer (GncDenseCal *dcal)
 {
@@ -947,7 +935,6 @@ gnc_dense_cal_draw_to_buffer (GncDenseCal *dcal)
     gint i;
     int maxWidth;
     PangoLayout *layout;
-    GTimer *timer;
     cairo_t *cr;
     gchar *primary_color_class, *secondary_color_class, *marker_color_class;
 
@@ -957,12 +944,8 @@ gnc_dense_cal_draw_to_buffer (GncDenseCal *dcal)
     if (!dcal->surface)
         return;
 
-    timer = g_timer_new ();
-
-    g_timer_start (timer);
     cr = cairo_create (dcal->surface);
     layout = gtk_widget_create_pango_layout (GTK_WIDGET(dcal), NULL);
-    LOG_AND_RESET(timer, "create_pango_layout");
 
     gtk_widget_get_allocation (GTK_WIDGET(dcal->cal_drawing_area), &alloc);
     stylectxt = gtk_widget_get_style_context (GTK_WIDGET(dcal->cal_drawing_area));
@@ -1036,8 +1019,6 @@ gnc_dense_cal_draw_to_buffer (GncDenseCal *dcal)
         }
         gtk_style_context_restore (stylectxt);
     }
-    LOG_AND_RESET(timer, "alternating month colors");
-
 
     /* Highlight the marked days. */
     {
@@ -1074,7 +1055,6 @@ gnc_dense_cal_draw_to_buffer (GncDenseCal *dcal)
         }
         gtk_style_context_restore (stylectxt);
     }
-    LOG_AND_RESET(timer, "marked days");
 
     for (i = 0; i < num_cols (dcal); i++)
     {
@@ -1158,8 +1138,6 @@ gnc_dense_cal_draw_to_buffer (GncDenseCal *dcal)
             gtk_style_context_restore (stylectxt);
         }
     }
-    LOG_AND_RESET(timer, "lines and labels");
-
 
     /* Month labels. */
     {
@@ -1196,8 +1174,6 @@ gnc_dense_cal_draw_to_buffer (GncDenseCal *dcal)
         }
         gtk_style_context_restore (stylectxt);
     }
-    LOG_AND_RESET(timer, "month labels");
-
 
     /* Day number strings [dates] */
     {
@@ -1228,7 +1204,6 @@ gnc_dense_cal_draw_to_buffer (GncDenseCal *dcal)
         cairo_restore (cr);
         gtk_style_context_restore (stylectxt);
     }
-    LOG_AND_RESET(timer, "dates");
 
     gtk_widget_get_allocation (widget, &alloc);
     gtk_widget_queue_draw_area (GTK_WIDGET(dcal),
@@ -1237,16 +1212,12 @@ gnc_dense_cal_draw_to_buffer (GncDenseCal *dcal)
                                 alloc.width,
                                 alloc.height);
 
-    LOG_AND_RESET(timer, "queue draw");
-
     g_free (primary_color_class);
     g_free (secondary_color_class);
     g_free (marker_color_class);
 
     g_object_unref (layout);
     cairo_destroy (cr);
-
-    g_timer_destroy (timer);
 }
 
 static void

--- a/gnucash/gnome-utils/gnc-dense-cal.c
+++ b/gnucash/gnome-utils/gnc-dense-cal.c
@@ -185,7 +185,6 @@ struct _GncDenseCal
 
     gdc_month_coords monthPositions[12];
 
-    guint label_width;
     gint label_height; // dense cal label height
 
     guint month_side_bar_width; // month side bar width
@@ -401,59 +400,6 @@ gnc_dense_cal_init (GncDenseCal *dcal)
         gtk_window_set_resizable (GTK_WINDOW(dcal->transPopup), FALSE);
 
         gtk_widget_realize (GTK_WIDGET(dcal->transPopup));
-    }
-
-    /* Deal with the various label sizes. */
-    {
-        PangoLayout *layout = gtk_widget_create_pango_layout (GTK_WIDGET(dcal), NULL);
-        GtkStyleContext *stylectxt = gtk_widget_get_style_context (GTK_WIDGET(dcal));
-        GtkStateFlags state_flags = gtk_style_context_get_state (stylectxt);
-        gint font_size_reduction_units = 1;
-        PangoFontDescription *font_desc;
-        GtkCssProvider *provider;
-        gint font_size, px_size;
-        gint i;
-        gint maxWidth, maxHeight;
-        gchar *px_str, *widget_css;
-        gdouble dpi;
-
-        gtk_style_context_get (stylectxt, state_flags,
-                               GTK_STYLE_PROPERTY_FONT, &font_desc, NULL);
-        font_size = pango_font_description_get_size (font_desc);
-
-        provider = gtk_css_provider_new ();
-        dpi = gdk_screen_get_resolution (gdk_screen_get_default ());
-        px_size = ((font_size / PANGO_SCALE) - font_size_reduction_units) * (dpi / 72.);
-        px_str = g_strdup_printf ("%i", px_size);
-        widget_css = g_strconcat ("*{\n  font-size:", px_str, "px;\n}\n", NULL);
-
-        gtk_css_provider_load_from_data (provider, widget_css, -1, NULL);
-        gtk_style_context_add_provider (stylectxt, GTK_STYLE_PROVIDER(provider),
-                                        GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
-        g_object_unref (provider);
-        g_free (px_str);
-        g_free (widget_css);
-
-        pango_font_description_free (font_desc);
-
-        maxWidth = maxHeight = 0;
-        for (i = 0; i < 12; i++)
-        {
-            gint w, h;
-            pango_layout_set_text (layout, month_name(i), -1);
-            pango_layout_get_pixel_size (layout, &w, &h);
-            maxWidth = MAX(maxWidth, w);
-            maxHeight = MAX(maxHeight, h);
-        }
-
-        // these two were reversed, before...
-        dcal->label_width = maxWidth;
-        dcal->label_height = maxHeight;
-
-        dcal->month_side_bar_width = dcal->label_height;
-        dcal->day_top_bar_height = dcal->label_height;
-
-        g_object_unref (layout);
     }
 
     dcal->month = G_DATE_JANUARY;

--- a/gnucash/gnome-utils/gnc-dense-cal.h
+++ b/gnucash/gnome-utils/gnc-dense-cal.h
@@ -4,8 +4,8 @@
  *                                                                  *
  * This program is free software; you can redistribute it and/or    *
  * modify it under the terms of the GNU General Public License as   *
- * published by the Free Software Foundation, under version 2 and/or version 3 of    *
- * the License.                                                     *
+ * published by the Free Software Foundation, under version 2 and   *
+ *  / or version 3 of the License.                                  *
  *                                                                  *
  * This program is distributed in the hope that it will be useful,  *
  * but WITHOUT ANY WARRANTY; without even the implied warranty of   *
@@ -31,26 +31,26 @@
 
 G_BEGIN_DECLS
 
-#define GNC_TYPE_DENSE_CAL          (gnc_dense_cal_get_type ())
+#define GNC_TYPE_DENSE_CAL (gnc_dense_cal_get_type ())
 G_DECLARE_FINAL_TYPE (GncDenseCal, gnc_dense_cal, GNC, DENSE_CAL, GtkBox)
 
-GtkWidget*     gnc_dense_cal_new                    (GtkWindow *parent);
-GtkWidget*     gnc_dense_cal_new_with_model         (GtkWindow *parent,
-                                                     GncDenseCalModel *model);
-void gnc_dense_cal_set_model(GncDenseCal *cal, GncDenseCalModel *model);
+GtkWidget* gnc_dense_cal_new (GtkWindow *parent);
+GtkWidget* gnc_dense_cal_new_with_model (GtkWindow *parent,
+                                         GncDenseCalModel *model);
+void gnc_dense_cal_set_model (GncDenseCal *cal, GncDenseCalModel *model);
 
-void gnc_dense_cal_set_month(GncDenseCal *dcal, GDateMonth mon);
-GDateMonth gnc_dense_cal_get_month( GncDenseCal *dcal );
+void gnc_dense_cal_set_month (GncDenseCal *dcal, GDateMonth mon);
+GDateMonth gnc_dense_cal_get_month (GncDenseCal *dcal);
 /**
  * @param year Julian year: 2000 = 2000AD.
  **/
-void gnc_dense_cal_set_year( GncDenseCal *dcal, guint year );
-GDateYear gnc_dense_cal_get_year( GncDenseCal *dcal );
+void gnc_dense_cal_set_year (GncDenseCal *dcal, guint year);
+GDateYear gnc_dense_cal_get_year (GncDenseCal *dcal);
 
-void gnc_dense_cal_set_num_months( GncDenseCal *dcal, guint num_months );
-guint gnc_dense_cal_get_num_months( GncDenseCal *dcal );
+void gnc_dense_cal_set_num_months (GncDenseCal *dcal, guint num_months);
+guint gnc_dense_cal_get_num_months (GncDenseCal *dcal);
 
-void gnc_dense_cal_set_months_per_col( GncDenseCal *dcal, guint monthsPerCol );
+void gnc_dense_cal_set_months_per_col (GncDenseCal *dcal, guint monthsPerCol);
 
 G_END_DECLS
 

--- a/gnucash/gnome/gnc-plugin-page-sx-list.cpp
+++ b/gnucash/gnome/gnc-plugin-page-sx-list.cpp
@@ -82,6 +82,7 @@ G_GNUC_UNUSED static QofLogModule log_module = GNC_MOD_GUI_SX;
 #define PLUGIN_PAGE_SX_LIST_CM_CLASS "plugin-page-sx-list"
 #define STATE_SECTION "SX Transaction List"
 #define GNC_PREF_DIVIDER_POS "divider-position"
+#define GNC_PREF_NUM_OF_MONTHS "number-of-months"
 
 typedef struct GncPluginPageSxListPrivate
 {
@@ -580,8 +581,10 @@ gnc_plugin_page_sx_list_create_widget (GncPluginPage *plugin_page)
         priv->gdcal = GNC_DENSE_CAL(gnc_dense_cal_new_with_model (window, GNC_DENSE_CAL_MODEL(priv->dense_cal_model)));
         g_object_ref_sink (priv->gdcal);
 
-        gnc_dense_cal_set_months_per_col (priv->gdcal, 4);
-        gnc_dense_cal_set_num_months (priv->gdcal, 12);
+        /* Set number of months from preference, default 12 */
+        gchar *num_months = gnc_prefs_get_string (GNC_PREFS_GROUP_SXED, GNC_PREF_NUM_OF_MONTHS);
+        gnc_dense_cal_set_num_months (priv->gdcal, atoi (num_months));
+        g_free (num_months);
 
         gtk_container_add (GTK_CONTAINER(swin), GTK_WIDGET(priv->gdcal));
     }
@@ -760,16 +763,23 @@ gnc_plugin_page_sx_list_cmd_save_layout (GSimpleAction *simple,
 {
     auto plugin_page = GNC_PLUGIN_PAGE_SX_LIST(user_data);
     GncPluginPageSxListPrivate *priv;
+    gchar *num_of_months;
     gint paned_position;
 
     g_return_if_fail (GNC_IS_PLUGIN_PAGE_SX_LIST(plugin_page));
 
     priv = GNC_PLUGIN_PAGE_SX_LIST_GET_PRIVATE(plugin_page);
 
+    num_of_months = g_strdup_printf ("%d", gnc_dense_cal_get_num_months (priv->gdcal));
     paned_position = gtk_paned_get_position (GTK_PANED(priv->widget));
 
     gnc_prefs_set_float (GNC_PREFS_GROUP_SXED, GNC_PREF_DIVIDER_POS,
                          paned_position);
+
+    gnc_prefs_set_string (GNC_PREFS_GROUP_SXED, GNC_PREF_NUM_OF_MONTHS,
+                          num_of_months);
+
+    g_free (num_of_months);
 }
 
 static void

--- a/gnucash/gschemas/org.gnucash.GnuCash.dialogs.sxs.gschema.xml.in
+++ b/gnucash/gschemas/org.gnucash.GnuCash.dialogs.sxs.gschema.xml.in
@@ -54,6 +54,11 @@
       <summary>How many days in advance to notify the user.</summary>
       <description>How many days in advance to notify the user.</description>
     </key>
+    <key name="divider-position" type="d">
+      <default>160</default>
+      <summary>The horizontal position of the editor divider.</summary>
+      <description>The horizontal position of the editor divider.</description>
+    </key>
     <key name="last-geometry" type="(iiii)">
       <default>(-1,-1,-1,-1)</default>
       <summary>Last window position and size</summary>

--- a/gnucash/gschemas/org.gnucash.GnuCash.dialogs.sxs.gschema.xml.in
+++ b/gnucash/gschemas/org.gnucash.GnuCash.dialogs.sxs.gschema.xml.in
@@ -54,6 +54,11 @@
       <summary>How many days in advance to notify the user.</summary>
       <description>How many days in advance to notify the user.</description>
     </key>
+    <key name="number-of-months" type="s">
+      <default>'12'</default>
+      <summary>The number of months to be shown in editor.</summary>
+      <description>The number of months to be shown in editor.</description>
+    </key>
     <key name="divider-position" type="d">
       <default>160</default>
       <summary>The horizontal position of the editor divider.</summary>

--- a/gnucash/ui/gnc-plugin-page-sx-list.ui
+++ b/gnucash/ui/gnc-plugin-page-sx-list.ui
@@ -34,6 +34,12 @@
 
   <menu id="ViewPlaceholder4">
     <item>
+      <attribute name="label" translatable="yes">_Save layout as default</attribute>
+      <attribute name="action">GncPluginPageSxListActions.ViewSaveLayoutAction</attribute>
+      <attribute name="tooltip" translatable="yes">Save current layout as default</attribute>
+      <attribute name="temp" translatable="no">yes</attribute>
+    </item>
+    <item>
       <attribute name="label" translatable="yes">_Refresh</attribute>
       <attribute name="action">GncPluginPageSxListActions.ViewRefreshAction</attribute>
       <attribute name="accel">&lt;Primary&gt;r</attribute>


### PR DESCRIPTION
As promised this was what I was working on last November when I got distracted.

There are couple of bug fixes for saving the scheduled transaction page layout, i.e, the paned position and the number of months along with some tidy up.

The last three commits are the real changes. 

- the first changes the dense calendar code to allow displaying the months to start on any day of the week.
- the second adds some GtkEntry widgets so that month, year and start day can be specified for testing.
- the last connects the dense call to `gnc_get_first_day_of_week` function which is OS specific.

That function is in `gnc-gnome-utils` which maybe in the wrong place but it had other Mac specific code and so was convenient. I am not sure the Mac code is correct but on Windows changing the `start day` under settings is reflected. The Mac and Windows functions do have error detection so that could default to `gnc_start_of_week.`

I have used a website that creates a calendar that allowed you to specify start day and from what I could see the calendars do match but would like other people to test it.
