### PR TITLE
Bug 799298 - Shortcut Ctrl-G does not work in the General Journal 

### DIFF
--- a/gnucash/gnome/gnc-split-reg.c
+++ b/gnucash/gnome/gnc-split-reg.c
@@ -1738,8 +1738,12 @@ gnc_split_reg_jump_to_blank (GNCSplitReg *gsr)
     }
 
     if (gnc_split_register_get_split_virt_loc (reg, blank, &vcell_loc))
-        gnucash_register_goto_virt_cell (gsr->reg, vcell_loc);
+    {
+        if ((vcell_loc.virt_row > 1) && (reg->style == REG_STYLE_JOURNAL))
+            vcell_loc.virt_row--; // highlight the date field
 
+        gnucash_register_goto_virt_cell (gsr->reg, vcell_loc);
+    }
     gnc_ledger_display_refresh (gsr->ledger);
     LEAVE(" ");
 }


### PR DESCRIPTION
I think this fixes the bug which is caused by the blank splits of other open registers being included in the General Journal split list and so have to be excluded.

While looking at this I noticed an inconsistency in the jump to blank action. In the General Journal, the highlighted cell is the split `action` field whereas I think it should be the `date` field. I vaguely remember a bug for it that I found, bug798822 but strangely it referenced an already fixed bug.