### PR TITLE
Speed up book close

### DIFF
--- a/libgnucash/engine/qofid.cpp
+++ b/libgnucash/engine/qofid.cpp
@@ -318,8 +318,8 @@ foreach_cb (gpointer item, gpointer arg)
 }
 
 void
-qof_collection_foreach (const QofCollection *col, QofInstanceForeachCB cb_func,
-                        gpointer user_data)
+qof_collection_foreach_sorted (const QofCollection *col, QofInstanceForeachCB cb_func,
+                               gpointer user_data, GCompareFunc sort_fn)
 {
     struct _qofid_iterate iter;
     GList *entries;
@@ -333,9 +333,18 @@ qof_collection_foreach (const QofCollection *col, QofInstanceForeachCB cb_func,
     PINFO("Hash Table size of %s before is %d", col->e_type, g_hash_table_size(col->hash_of_entities));
 
     entries = g_hash_table_get_values (col->hash_of_entities);
+    if (sort_fn)
+        entries = g_list_sort (entries, sort_fn);
     g_list_foreach (entries, foreach_cb, &iter);
     g_list_free (entries);
 
     PINFO("Hash Table size of %s after is %d", col->e_type, g_hash_table_size(col->hash_of_entities));
+}
+
+void
+qof_collection_foreach (const QofCollection *col, QofInstanceForeachCB cb_func,
+                        gpointer user_data)
+{
+    qof_collection_foreach_sorted (col, cb_func, user_data, nullptr);
 }
 /* =============================================================== */

--- a/libgnucash/engine/qofid.h
+++ b/libgnucash/engine/qofid.h
@@ -146,6 +146,9 @@ QofInstance * qof_collection_lookup_entity (const QofCollection *, const GncGUID
 typedef void (*QofInstanceForeachCB) (QofInstance *, gpointer user_data);
 
 /** Call the callback for each entity in the collection. */
+void qof_collection_foreach_sorted (const QofCollection *col, QofInstanceForeachCB cb_func,
+                                    gpointer user_data, GCompareFunc sort_fn);
+
 void qof_collection_foreach (const QofCollection *, QofInstanceForeachCB,
                              gpointer user_data);
 


### PR DESCRIPTION
speeds up my book destruction routines from 0.9s to 0.6s

here's benchmarking patch:

```patch
modified   libgnucash/engine/qofsession.cpp
@@ -127,6 +127,8 @@ QofSessionImpl::QofSessionImpl (QofBook* book) noexcept
 
 QofSessionImpl::~QofSessionImpl () noexcept
 {
+    float startTime = (float)clock()/CLOCKS_PER_SEC;
+
     ENTER ("sess=%p uri=%s", this, m_uri.c_str ());
     end ();
     destroy_backend ();
@@ -134,6 +136,11 @@ QofSessionImpl::~QofSessionImpl () noexcept
     qof_book_destroy (m_book);
     m_book = nullptr;
     LEAVE ("sess=%p", this);
+
+    float endTime = (float)clock()/CLOCKS_PER_SEC;
+
+    float timeElapsed = endTime - startTime;
+    PWARN ("quit=%f", timeElapsed);
 }
 
 void
```

and the result -- from UI, repeated reloading of my main datafile; before:
```
* 20:42:15  WARN <qof.session> [QofSessionImpl::~QofSessionImpl()] quit=0.904586
* 20:42:20  WARN <qof.session> [QofSessionImpl::~QofSessionImpl()] quit=0.885174
* 20:42:26  WARN <qof.session> [QofSessionImpl::~QofSessionImpl()] quit=0.895748
* 20:42:35  WARN <qof.session> [QofSessionImpl::~QofSessionImpl()] quit=0.887468
* 20:42:43  WARN <qof.session> [QofSessionImpl::~QofSessionImpl()] quit=0.914600
```

after:
```
* 20:43:34  WARN <qof.session> [QofSessionImpl::~QofSessionImpl()] quit=0.679304
* 20:43:40  WARN <qof.session> [QofSessionImpl::~QofSessionImpl()] quit=0.645597
* 20:43:46  WARN <qof.session> [QofSessionImpl::~QofSessionImpl()] quit=0.652250
* 20:43:51  WARN <qof.session> [QofSessionImpl::~QofSessionImpl()] quit=0.691999
* 20:43:57  WARN <qof.session> [QofSessionImpl::~QofSessionImpl()] quit=0.645178
* 20:44:02  WARN <qof.session> [QofSessionImpl::~QofSessionImpl()] quit=0.664965
```