### PR TITLE
Bug799047 - AutoComplete Only Considers Visible Transaction

### DIFF
--- a/gnucash/gnome/dialog-sx-editor.c
+++ b/gnucash/gnome/dialog-sx-editor.c
@@ -1509,7 +1509,7 @@ schedXact_editor_populate (GncSxEditorDialog *sxed)
         if (splitList)
         {
             splitReg = gnc_ledger_display_get_split_register (sxed->ledger);
-            gnc_split_register_load (splitReg, splitList, NULL);
+            gnc_split_register_load (splitReg, splitList, NULL, NULL);
         } /* otherwise, use the existing stuff. */
         g_list_free (splitList);
     }

--- a/gnucash/register/ledger-core/gnc-ledger-display.c
+++ b/gnucash/register/ledger-core/gnc-ledger-display.c
@@ -445,7 +445,6 @@ gnc_ledger_display_gl (void)
 {
     Query* query;
     time64 start;
-    struct tm tm;
     GNCLedgerDisplay* ld;
     GHashTable *exclude_template_accounts_hash;
 
@@ -464,11 +463,12 @@ gnc_ledger_display_gl (void)
      * See Gnome Bug 86302.
      *         -- jsled */
     // Exclude any template accounts for search register and gl
-     exclude_template_accounts (query, exclude_template_accounts_hash);
+    exclude_template_accounts (query, exclude_template_accounts_hash);
 
-    gnc_tm_get_today_start (&tm);
-    tm.tm_mon--; /* Default the register to the last month's worth of transactions. */
-    start = gnc_mktime (&tm);
+    // the default is to show last 30 days
+    static const time64 secs_per_thirty_days = 2592000;
+    start = gnc_time64_get_today_start () - secs_per_thirty_days;
+
     xaccQueryAddDateMatchTT (query,
                              TRUE, start,
                              FALSE, 0,

--- a/gnucash/register/ledger-core/split-register.h
+++ b/gnucash/register/ledger-core/split-register.h
@@ -530,10 +530,12 @@ void gnc_split_register_cancel_cursor_trans_changes (SplitRegister* reg);
  *
  *  @param slist a list of splits
  *
+ *  @param pre_filter_slist the list of splits before applying filter
+ *
  *  @param default_account an account to provide defaults for the blank split
  */
 void gnc_split_register_load (SplitRegister* reg, GList* slist,
-                              Account* default_account);
+                              GList* pre_filter_slist, Account* default_account);
 
 /** Copy the contents of the current cursor to a split. The split and
  *    transaction that are updated are the ones associated with the

--- a/libgnucash/engine/Query.h
+++ b/libgnucash/engine/Query.h
@@ -180,6 +180,8 @@ typedef enum
 } cleared_match_t;
 
 void xaccQueryAddClearedMatch(QofQuery * q, cleared_match_t how, QofQueryOp op);
+cleared_match_t xaccQueryGetClearedMatch(QofQuery * q);
+
 void xaccQueryAddGUIDMatch(QofQuery * q, const GncGUID *guid,
                            QofIdType id_type, QofQueryOp op);
 

--- a/libgnucash/engine/qofquerycore.cpp
+++ b/libgnucash/engine/qofquerycore.cpp
@@ -1205,6 +1205,18 @@ qof_query_char_predicate (QofCharMatch options, const char *chars)
     return ((QofQueryPredData*)pdata);
 }
 
+gboolean
+qof_query_char_predicate_get_char (const QofQueryPredData *pd, char **chars)
+{
+    const query_char_t pdata = (const query_char_t)pd;
+
+    if (pdata->pd.type_name != query_char_type)
+        return FALSE;
+
+    *chars = g_strdup (pdata->char_list);
+    return TRUE;
+}
+
 static char *
 char_to_string (gpointer object, QofParam *getter)
 {

--- a/libgnucash/engine/qofquerycore.h
+++ b/libgnucash/engine/qofquerycore.h
@@ -184,6 +184,8 @@ void qof_query_core_predicate_free (QofQueryPredData *pdata);
 
 /** Retrieve a predicate. */
 gboolean qof_query_date_predicate_get_date (const QofQueryPredData *pd, time64 *date);
+gboolean qof_query_char_predicate_get_char (const QofQueryPredData *pd, char **chars);
+
 /** Return a printable string for a core data object.  Caller needs
  *  to g_free() the returned string.
  */


### PR DESCRIPTION
In the past, all transactions were used on the first load of the register and this is when the autocomplete would be populated, on
subsequent loads it would be a filtered list. With the change to delay loading the register, the first load split list is empty and the autocomplete is now being populated by the filtered list.

To fix this, make a copy of the original query and compare this query to the query used for refresh. When different, pass a second full list of splits to the register to populate the autocomplete lists.
