### PR TITLE
Expand widget to full width in GncOption

### DIFF
--- a/gnucash/gnome-utils/gnc-option-gtk-ui.hpp
+++ b/gnucash/gnome-utils/gnc-option-gtk-ui.hpp
@@ -150,7 +150,7 @@ wrap_widget (const GncOption& option, GtkWidget* widget, GtkGrid* page_box, int 
 {
     auto enclosing{gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5)};
     gtk_box_set_homogeneous (GTK_BOX (enclosing), FALSE);
-    gtk_box_pack_start(GTK_BOX(enclosing), widget, FALSE, FALSE, 0);
+    gtk_box_pack_start(GTK_BOX(enclosing), widget, false, true, 0);
     set_name_label(option, page_box, row, false);
     set_tool_tip(option, enclosing);
     gtk_widget_show_all(enclosing);


### PR DESCRIPTION
The `GncAccountSel` should be expanded.

Before:
![image](https://github.com/Gnucash/gnucash/assets/1975870/11566c11-c81a-4397-8d91-21b5724e76f7)

After:
![image](https://github.com/Gnucash/gnucash/assets/1975870/38b0a0b6-ad9b-40e7-93cf-07fe130140f8)

