### PR TITLE
Optiondb set changed cb

### DIFF
--- a/bindings/guile/gnc-optiondb.i
+++ b/bindings/guile/gnc-optiondb.i
@@ -981,6 +981,8 @@ wrap_unique_ptr(GncOptionDBPtr, GncOptionDB);
                                                   GncMultichoiceOptionChoices&&,
                                                   SCM);
 
+    void gnc_option_set_changed_callback (GncOptionDBPtr& db, const char* section,
+                                          const char* name, SCM widget_changed_cb);
 
 %} //%header
 
@@ -1676,6 +1678,25 @@ void gnc_register_complex_boolean_option(GncOptionDBPtr& db,
     db->register_option(section, std::move(option));
 }
 
+ /**
+ * Make an option sensitive to change
+ *
+ * @param db A GncOptionDB* for calling from C. Caller retains ownership.
+ * @param section The database section for the option.
+ * @param name The option name.
+ * @param widget_changed_cb A Scheme callback to run from the UIItem's "changed" signal.
+ */
+ void gnc_option_set_changed_callback (GncOptionDBPtr& db, const char* section,
+                                       const char* name, SCM widget_changed_cb)
+{
+    auto option{db->find_option(section, name)};
+    if (!option)
+    {
+        PWARN ("option not found: %s/%s", section, name);
+        return;
+    }
+    option->set_widget_changed(std::make_any<SCMCallbackWrapper>(widget_changed_cb));
+}
 /**
  * Create a new multichoice option and register it in the options database.
  *

--- a/gnucash/gnome-utils/gnc-option-gtk-ui.cpp
+++ b/gnucash/gnome-utils/gnc-option-gtk-ui.cpp
@@ -1085,6 +1085,11 @@ public:
 // Must cast it to const Account* to get the template specialization to recognize it.
         option.set_value(static_cast<const Account*>(gnc_account_sel_get_account(widget)));
     }
+    SCM get_widget_scm_value(const GncOption& option) const override
+    {
+        auto widget{GNC_ACCOUNT_SEL(get_widget())};
+        return scm_from_value (gnc_account_sel_get_account(widget));
+    }
 };
 
 template<> void

--- a/gnucash/report/reports/standard/ifrs-cost-basis.scm
+++ b/gnucash/report/reports/standard/ifrs-cost-basis.scm
@@ -89,6 +89,19 @@ the split action field to detect capitalized fees on stock activity")
       gnc:pagename-general optname-stock-acct "b" "Stock Account"
       '() (list ACCT-TYPE-STOCK ACCT-TYPE-MUTUAL))
 
+    (gnc-option-set-changed-callback
+     options gnc:pagename-general optname-stock-acct
+     (lambda (new-acct)
+       (define (set-acct name tag)
+         (let ((assoc-acct (xaccAccountGetAssociatedAccount new-acct tag)))
+           (unless (null? assoc-acct)
+             (gnc-option-set-value options gnc:pagename-general name assoc-acct))))
+       (gnc:pk 'new-account-selected new-acct)
+       (set-acct "Proceeds Account" "stock-cash-proceeds")
+       (set-acct "Dividend Account" "stock-dividends")
+       (set-acct "Cap Gains Account" "stock-capgains")
+       (set-acct "Fees Account" "stock-broker-fees")))
+
     (gnc-register-account-sel-limited-option options
       gnc:pagename-general optname-proceeds-acct "c" "Proceeds Account"
       '() (list ACCT-TYPE-ASSET ACCT-TYPE-BANK))


### PR DESCRIPTION
Adds a generic `gnc-option-set-changed-callback` instead of adding a specialised `gnc-register-complex-account-sel-limited-option`.

Unfortunately `scm_from_value` isn't defined in `gnome-utils/gnc-option-gtk-ui.cpp`.