### PR TITLE
Budget Report Features: Rollover (Envelope) Budgeting and Unselected Account Exclusion

### DIFF
--- a/gnucash/report/reports/standard/budget.scm
+++ b/gnucash/report/reports/standard/budget.scm
@@ -532,6 +532,10 @@
     ;;   colnum - starting column number
     ;;   budget - budget to use
     ;;   acct - account being displayed
+    ;;   column-list - list of columns to display, each element corresponds to a single column:
+    ;;       - a number indicates a (zero-indexed) period
+    ;;       - a list of numbers indicates a range of periods to sum
+    ;;       - 'total' indicates the total column
     ;;   exchange-fn - exchange function (not used)
     (define (gnc:html-table-add-budget-line!
              html-table rownum colnum budget acct
@@ -619,7 +623,6 @@
               ((period-list
                  (cond
                   ;; if this column is a range of periods, use that list
-                  ;; TODO: is it a bug or intended behavior to not include previous periods here when accumulate is true?
                   ((list? (car column-list)) (car column-list))
                   ;; if we're accumulating or rolling over budget, use all periods up
                   ;; until the indicated one
@@ -634,9 +637,15 @@
                        (list? (car column-list))) (iota (car (car column-list))))
                     (rollover? (iota (car column-list)))
                     (else '())))
-                (note (and (= 1 (length period-list))
+                ;; value of the period to fetch the note for: i.e. current period unless it's a range
+                (note-period
+                  (cond
+                    ((list? (car column-list)) #f)
+                    (else (car column-list))))
+                ;; note value of the current period
+                (note (and note-period
                            (gnc-budget-get-account-period-note
-                            budget acct (car period-list))))
+                            budget acct note-period)))
                 ;; total budget for all periods in period-list
                 (bgt-val-all (gnc:get-account-periodlist-budget-value
                                budget acct period-list))

--- a/gnucash/report/reports/standard/test/test-budget.scm
+++ b/gnucash/report/reports/standard/test/test-budget.scm
@@ -158,6 +158,43 @@
         '("Bank" "$60.00" "$15.00" "$45.00" "$60.00" "$82.00" "-$22.00"
           "$120.00" "$159.00" "-$39.00" "$120.00" "$159.00" "-$39.00")
         (sxml->table-row-col sxml 1 5 #f)))
+
+    ; Tests for Roll Over Difference feature
+    (set-option options "General" "Range start" 'first)
+    (set-option options "General" "Range end" 'last)
+    (set-option options "General" "Use accumulated amounts" #f)
+    (set-option options "General" "Roll over difference" #t)
+    (set-option options "Display" "Show Column with Totals" #t)
+
+    (set-option options "Display" "Show Budget" #t)
+    (set-option options "Display" "Show Actual" #t)
+    (set-option options "Display" "Show Difference" #t)
+    (set-option options "Display" "Show Budget Notes" #t)
+    (let ((sxml (options->sxml options budget-uuid "Roll over difference")))
+       (test-equal "expense"
+         '("Expenses"
+            "." "$20.00" "-$20.00"
+            "$10.00 " "2" "$20.00" "-$10.00"
+            "$10.00" "$0.00" "$10.00"
+            "$50.00" "$0.00" "$50.00"
+            "$50.00" "$0.00" "$50.00"
+            "$50.00" "$0.00" "$50.00"
+            "$90.00" "$40.00" "$50.00"  ; <- total column doesn't change
+            )
+         (sxml->table-row-col sxml 1 11 #f)))
+
+     (set-option options "Display" "Show Budget Notes" #f)
+     (set-option options "Display" "Show Column with Totals" #f)
+     (let ((sxml (options->sxml options budget-uuid "Roll over difference no notes or total")))
+       (test-equal "expense"
+         '("Expenses"
+            "." "$20.00" "-$20.00"
+            "$10.00" "$20.00" "-$10.00"
+            "$10.00" "$0.00" "$10.00"
+            "$50.00" "$0.00" "$50.00"
+            "$50.00" "$0.00" "$50.00"
+            "$50.00" "$0.00" "$50.00")
+         (sxml->table-row-col sxml 1 11 #f)))
     ))
 
 (define (test-budget-income-statement)

--- a/gnucash/report/reports/standard/test/test-budget.scm
+++ b/gnucash/report/reports/standard/test/test-budget.scm
@@ -195,6 +195,38 @@
             "$50.00" "$0.00" "$50.00"
             "$50.00" "$0.00" "$50.00")
          (sxml->table-row-col sxml 1 11 #f)))
+
+    ; Tests for Exclude Unselected Amounts feature
+    (set-option options "General" "Roll over difference" #f)
+    (set-option options "Display" "Show Column with Totals" #t)
+    (set-option options "Accounts" "Exclude unselected amounts" #t)
+    (let ((sxml (options->sxml options budget-uuid "Unselected amounts skip empty Assets")))
+      (test-equal "root"
+        '("Root"
+           "-$35.00" "$0.00" "-$35.00"
+           "$70.00" "$0.00" "$70.00"
+           "-$45.00" "$0.00" "-$45.00"
+           "$25.00" "$0.00" "$25.00"
+           "." "$0.00" "."
+           "." "$0.00" "."
+           "$15.00" "$0.00" "$15.00")
+        (sxml->table-row-col sxml 1 3 #f)))
+
+    (let* ((all-accounts (gnc-optiondb-lookup-value options "Accounts" "Account"))
+            (accounts-no-bank (append (take all-accounts 2) (drop all-accounts 3))))
+      (set-option options "Accounts" "Account" accounts-no-bank))
+    (let ((sxml (options->sxml options budget-uuid "Unselected amounts skip Bank")))
+      (test-equal "root"
+        '("Root"
+           "-$55.00" "-$35.00" "-$20.00"
+           "$30.00" "$20.00" "$10.00"
+           "-$45.00" "-$67.00" "$22.00"
+           "-$35.00" "-$77.00" "$42.00"
+           "." "$0.00" "."
+           "." "$0.00" "."
+           "-$105.00" "-$159.00" "$54.00")
+        (sxml->table-row-col sxml 1 3 #f)))
+
     ))
 
 (define (test-budget-income-statement)


### PR DESCRIPTION
Hi Gnucash team! I'm a longtime user and have opened a PR with two features I added to my custom Budget Report, in case they're useful to others in the community. The features are:

1. **Budget Rollover:** the option to roll over budget surplus or deficit to the following period
2. **Unselected Account Exclusion:** the option to exclude balances of deselected accounts from their ancestor totals.
    - e.g. if your "Groceries" account is not selected to display in the budget report the value of transactions in that account will not be included in "Expenses"

I implemented these because they're valuable to me, and I thought others in the community might find them useful as well. If maintainers agree that either or both make sense to have in the main program, I'll add unit tests and implement any suggested changes. If they're best left to a Custom Report, I'll keep using them myself that way!

Thanks,
Reese

## Details

### Budget Rollover

The implementation of budget rollover is similar to the Accumulated Amounts feature: when the option is selected, previous periods are added up along with the current period. The difference as that with Budget Rollver, the Budget totals from previous periods are added to the current period Budget but Actual totals from previous periods are subtracted from the current period budget, rather than being added to the current period Actuals. Only one of the Use Accumulated Amounts and Rollover Budget Difference options can be selected.

I found quite a few mailing list messages requesting this feature, so I believe this one in particular may be valuable. A sampling:
- [How can I do something like the "Envelope System" (2009)](https://lists.gnucash.org/pipermail/gnucash-user/2009-January/027884.html)
- [Envelope budgeting with credit cards (2010)](https://lists.gnucash.org/pipermail/gnucash-user/2010-February/033469.html)
- [How to Budget Investment Accounts? (2014)](https://lists.gnucash.org/pipermail/gnucash-user/2014-August/055807.html)
- [Budgets - how does the community want to use them (2015)](https://lists.gnucash.org/pipermail/gnucash-user/2015-December/063202.html)


### Unselected Account Exclusion

In general, Unselected Acount Exclusion works by subtracting the balance of unselected accounts from selected parent/ancestor accounts. The nuance is that sometimes balances need to be added as well. For example, if a grandparent account is selected, parent account is unselected, and child account is selected, the parent account balance will be subtracted from the grandparent balance and child account added to the grandparent balance. This is explained in greater detail in [this code comment](https://github.com/rmehyde/gnucash/blob/5a820356155afc53bc55829ddf7d51183116d039/gnucash/report/reports/standard/budget.scm#L427-L464).

An ideal solution would probably just be a C++ function to get an account balance with these offsets. But unfortunately my C(++) skills are almost nonexistent, so learning Scheme and implementing it this way worked best for me.

I didn't find any mailing list messages for this one so there may not be much other interest but I was also less sure what to search for here.
