### PR TITLE
Support "Show long account names" option in Advanced Portfolio report

### DIFF
--- a/gnucash/report/html-utilities.scm
+++ b/gnucash/report/html-utilities.scm
@@ -46,6 +46,7 @@
 (export gnc:report-anchor-text)
 (export gnc:make-report-anchor)
 (export gnc:html-account-anchor)
+(export gnc:html-long-account-anchor)
 (export gnc:html-split-anchor)
 (export gnc:html-transaction-anchor)
 (export gnc:html-transaction-doclink-anchor)
@@ -187,6 +188,14 @@
                           (gnc:html-markup-anchor
                            (gnc:account-anchor-text acct)
                            (xaccAccountGetName acct))
+                          "")))
+
+;; returns the long account name as html-text and anchor to the register.
+(define (gnc:html-long-account-anchor acct)
+  (gnc:make-html-text (if (and acct (not (null? acct)))
+                          (gnc:html-markup-anchor
+                           (gnc:account-anchor-text acct)
+                           (gnc-account-get-full-name acct))
                           "")))
 
 (define (gnc:html-split-anchor split text)

--- a/gnucash/report/reports/standard/advanced-portfolio.scm
+++ b/gnucash/report/reports/standard/advanced-portfolio.scm
@@ -100,7 +100,7 @@ by preventing negative stock balances.<br/>")
     (gnc-register-simple-boolean-option options
         gnc:pagename-display optname-show-long-account-names "a"
         (N_ "Show long (instead of short) account names.")
-        #t)
+        #f)
 
     (gnc-register-simple-boolean-option options
         gnc:pagename-display optname-show-symbol "b"

--- a/gnucash/report/reports/standard/advanced-portfolio.scm
+++ b/gnucash/report/reports/standard/advanced-portfolio.scm
@@ -39,6 +39,7 @@
 
 (define optname-price-source (N_ "Price Source"))
 (define optname-shares-digits (N_ "Share decimal places"))
+(define optname-show-long-account-names (N_ "Show long account names"))
 (define optname-zero-shares (N_ "Include accounts with no shares"))
 (define optname-show-symbol (N_ "Show ticker symbols"))
 (define optname-show-listing (N_ "Show listings"))
@@ -97,27 +98,32 @@ by preventing negative stock balances.<br/>")
             (vector 'ignore-brokerage (N_ "Omit from report"))))
 
     (gnc-register-simple-boolean-option options
-        gnc:pagename-display optname-show-symbol "a"
+        gnc:pagename-display optname-show-long-account-names "a"
+        (N_ "Show long (instead of short) account names.")
+        #t)
+
+    (gnc-register-simple-boolean-option options
+        gnc:pagename-display optname-show-symbol "b"
         (N_ "Display the ticker symbols.")
         #t)
 
     (gnc-register-simple-boolean-option options
-        gnc:pagename-display optname-show-listing "b"
+        gnc:pagename-display optname-show-listing "c"
         (N_ "Display exchange listings.")
         #t)
 
     (gnc-register-simple-boolean-option options
-        gnc:pagename-display optname-show-shares "c"
+        gnc:pagename-display optname-show-shares "d"
         (N_ "Display numbers of shares in accounts.")
         #t)
 
     (gnc-register-number-range-option options
       gnc:pagename-display optname-shares-digits
-      "d" (N_ "The number of decimal places to use for share numbers.") 2
+      "e" (N_ "The number of decimal places to use for share numbers.") 2
       0 9 1)
 
     (gnc-register-simple-boolean-option options
-        gnc:pagename-display optname-show-price "e"
+        gnc:pagename-display optname-show-price "f"
         (N_ "Display share prices.")
         #t)
 
@@ -381,6 +387,7 @@ by preventing negative stock balances.<br/>")
                  (unit-collector (gnc:account-get-comm-balance-at-date
                                   current to-date #f))
                  (units (cadr (unit-collector 'getpair commodity #f)))
+                 (show-long-account-names (get-option gnc:pagename-display optname-show-long-account-names))
 
                  ;; Counter to keep track of stuff
                  (brokeragecoll (gnc:make-commodity-collector))
@@ -408,6 +415,12 @@ by preventing negative stock balances.<br/>")
                  (drp-holding-amount (gnc-numeric-zero))
                  )
 
+            ;; Gets the account name.
+            (define (account->name account)
+              (if show-long-account-names
+                (gnc-account-get-full-name account)
+                (xaccAccountGetName account)))
+
             (define (my-exchange-fn fromunits tocurrency)
               (if (and (gnc-commodity-equiv currency tocurrency)
                        (gnc-commodity-equiv (gnc:gnc-monetary-commodity fromunits) commodity))
@@ -429,7 +442,7 @@ by preventing negative stock balances.<br/>")
                       tocurrency)
                     (exchange-fn fromunits tocurrency)))
 
-            (gnc:debug "Starting account " (xaccAccountGetName current) ", initial price: "
+            (gnc:debug "Starting account " (account->name current) ", initial price: "
                        (and price
                             (gnc:monetary->string
                              (gnc:make-gnc-monetary
@@ -799,8 +812,7 @@ by preventing negative stock balances.<br/>")
             ;; the report even though it doesn't have a split in the account
             ;; being reported on.
 
-            (let ((parent-account (gnc-account-get-parent current))
-                  (account-name (xaccAccountGetName current)))
+            (let ((parent-account (gnc-account-get-parent current)))
               (if (and (not (null? parent-account))
                        (member (xaccAccountGetType parent-account) (list ACCT-TYPE-ASSET ACCT-TYPE-BANK))
                        (gnc-commodity-is-currency (xaccAccountGetCommodity parent-account)))
@@ -813,7 +825,7 @@ by preventing negative stock balances.<br/>")
                            (txn-date (xaccTransGetDate parent)))
                       (if (and (not (null? other-acct))
                                (<= txn-date to-date)
-                               (string=? (xaccAccountGetName other-acct) account-name)
+                               (string=? (account->name other-acct) (account->name current))
                                (gnc-commodity-is-currency (xaccAccountGetCommodity other-acct)))
                         ;; This is a two split transaction where the other split is to an
                         ;; account with the same name as the current account.  If it's an
@@ -867,7 +879,7 @@ by preventing negative stock balances.<br/>")
                                                                                     (gnc:gnc-monetary-amount income)
                                                                                 currency-frac GNC-RND-ROUND)))
 
-                  (activecols (list (gnc:html-account-anchor current)))
+                  (activecols (list (if show-long-account-names (gnc:html-long-account-anchor current) (gnc:html-account-anchor current))))
                   )
 
               ;; If we're using the txn, warn the user

--- a/gnucash/report/reports/standard/advanced-portfolio.scm
+++ b/gnucash/report/reports/standard/advanced-portfolio.scm
@@ -387,7 +387,8 @@ by preventing negative stock balances.<br/>")
                  (unit-collector (gnc:account-get-comm-balance-at-date
                                   current to-date #f))
                  (units (cadr (unit-collector 'getpair commodity #f)))
-                 (show-long-account-names (get-option gnc:pagename-display optname-show-long-account-names))
+                 (show-long-account-names (get-option gnc:pagename-display
+                                            optname-show-long-account-names))
 
                  ;; Counter to keep track of stuff
                  (brokeragecoll (gnc:make-commodity-collector))
@@ -879,7 +880,9 @@ by preventing negative stock balances.<br/>")
                                                                                     (gnc:gnc-monetary-amount income)
                                                                                 currency-frac GNC-RND-ROUND)))
 
-                  (activecols (list (if show-long-account-names (gnc:html-long-account-anchor current) (gnc:html-account-anchor current))))
+                  (activecols (list (if show-long-account-names
+                                      (gnc:html-long-account-anchor current)
+                                      (gnc:html-account-anchor current))))
                   )
 
               ;; If we're using the txn, warn the user


### PR DESCRIPTION
My portfolio consists of roughly the same securities in multiple different accounts. As such, this results in there being duplicate account names in the advanced portfolio report which makes it pretty confusing to know which account each line actually represents. This PR adds an opt-in feature to let it use the long account names like you can in the investment lots report.

This is my first contribution, so happy to make any required changes! Will open as a draft to start.