### PR TITLE
Fix math methods not found on MINGW32 build

### DIFF
--- a/gnucash/gnucash-core-app.hpp
+++ b/gnucash/gnucash-core-app.hpp
@@ -25,8 +25,13 @@
 #define GNUCASH_CORE_APP_HPP
 
 #ifdef __MINGW32__
-#undef _GLIBCXX_USE_C99_MATH_TR1 // Avoid cmath missing function decl.
+// Avoid cmath missing function decl.
+#undef _GLIBCXX_USE_C99_MATH_TR1
+#if (__GNUC__ > 14) || (__GNUC__ == 14 && __GNUC_MINOR__ >= 1)
+#undef _GLIBCXX_USE_C99_MATH_FUNCS
 #endif
+#endif
+
 #include <boost/optional.hpp>
 #include <boost/program_options.hpp>
 #include <string>


### PR DESCRIPTION
_GLIBCXX_USE_C99_MATH_FUNCS replaced  _GLIBCXX_USE_C99_MATH_TR1 in gcc 14.1.0, see https://github.com/gcc-mirror/gcc/commit/1f378f6dd33ad5067a437d1c456979f8662020d6

Build throws error on gcc 14.2.0, 

```
gnucash.dir/gnucash-core-app.cpp.obj -c C:/gcdev64/gnucash/stable/src/gnucash-git/gnucash/gnucash-core-app.cpp
In file included from C:/gcdev64/msys2/mingw32/include/boost/core/cmath.hpp:19,
                 from C:/gcdev64/msys2/mingw32/include/boost/lexical_cast/detail/converter_numeric.hpp:26,
                 from C:/gcdev64/msys2/mingw32/include/boost/lexical_cast/try_lexical_convert.hpp:31,
                 from C:/gcdev64/msys2/mingw32/include/boost/lexical_cast.hpp:33,
                 from C:/gcdev64/msys2/mingw32/include/boost/program_options/value_semantic.hpp:14,
                 from C:/gcdev64/msys2/mingw32/include/boost/program_options/options_description.hpp:13,
                 from C:/gcdev64/msys2/mingw32/include/boost/program_options.hpp:15,
                 from C:/gcdev64/gnucash/stable/src/gnucash-git/gnucash/gnucash-core-app.hpp:31,
                 from C:/gcdev64/gnucash/stable/src/gnucash-git/gnucash/gnucash-core-app.cpp:32:
C:/gcdev64/msys2/mingw32/include/c++/14.2.0/cmath:2106:11: error: 'copysign' has not been declared in '::'
 2106 |   using ::copysign;
      |           ^~~~~~~~
[124/131] Building CXX object gnucash/CMakeFiles/gnucash.dir/gnucash.cpp.obj
FAILED: gnucash/CMakeFiles/gnucash.dir/gnucash.cpp.obj 
```

Details in -

https://bugs.gnucash.org/show_bug.cgi?id=799405
https://lists.gnucash.org/pipermail/gnucash-user/2024-August/112726.html
