### PR TITLE
Csv import: GncDateFormat ->date_locale

### DIFF
--- a/gnucash/import-export/csv-imp/assistant-csv-price-import.cpp
+++ b/gnucash/import-export/csv-imp/assistant-csv-price-import.cpp
@@ -35,6 +35,7 @@
 #include <glib/gi18n.h>
 #include <stdlib.h>
 
+#include "gnc-locale-utils.hpp"
 #include "gnc-ui.h"
 #include "gnc-uri-utils.h"
 #include "gnc-ui-util.h"
@@ -659,8 +660,8 @@ CsvImpPriceAssist::CsvImpPriceAssist ()
 
         /* Add in the date format combo box and hook it up to an event handler. */
         date_format_combo = GTK_COMBO_BOX_TEXT(gtk_combo_box_text_new());
-        for (auto& date_fmt : GncDate::c_formats)
-            gtk_combo_box_text_append_text (date_format_combo, _(date_fmt.m_fmt.c_str()));
+        for (auto locale : gnc_get_available_locales())
+            gtk_combo_box_text_append_text (date_format_combo, _(locale.c_str()));
         gtk_combo_box_set_active (GTK_COMBO_BOX(date_format_combo), 0);
         g_signal_connect (G_OBJECT(date_format_combo), "changed",
                          G_CALLBACK(csv_price_imp_preview_date_fmt_sel_cb), this);
@@ -1159,7 +1160,11 @@ CsvImpPriceAssist::preview_update_encoding (const char* encoding)
 void
 CsvImpPriceAssist::preview_update_date_format ()
 {
-    price_imp->date_format (gtk_combo_box_get_active (GTK_COMBO_BOX(date_format_combo)));
+    if (char *text = gtk_combo_box_text_get_active_text(date_format_combo))
+    {
+        price_imp->date_locale (text);
+        g_free (text);
+    }
     preview_refresh_table ();
 }
 
@@ -1764,8 +1769,12 @@ CsvImpPriceAssist::preview_refresh ()
             (price_imp->file_format() != GncImpFileFormat::CSV));
 
     // This section deals with the combo's and character encoding
-    gtk_combo_box_set_active (GTK_COMBO_BOX(date_format_combo),
-            price_imp->date_format());
+    auto locales = gnc_get_available_locales();
+    auto locale_it = std::find (locales.begin(), locales.end(), price_imp->date_locale());
+    if (locale_it != locales.end())
+        gtk_combo_box_set_active (GTK_COMBO_BOX(date_format_combo),
+                                  std::distance (locales.begin(), locale_it));
+
     gtk_combo_box_set_active (GTK_COMBO_BOX(currency_format_combo),
             price_imp->currency_format());
     go_charmap_sel_set_encoding (encselector, price_imp->encoding().c_str());

--- a/gnucash/import-export/csv-imp/gnc-imp-props-price.cpp
+++ b/gnucash/import-export/csv-imp/gnc-imp-props-price.cpp
@@ -162,7 +162,7 @@ void GncImportPrice::set (GncPricePropType prop_type, const std::string& value, 
         {
             case GncPricePropType::DATE:
                 m_date.reset();
-                m_date = GncDate(value, GncDate::c_formats[m_date_format].m_fmt); // Throws if parsing fails
+                m_date = GncDate(value, m_date_locale); // Throws if parsing fails
                 break;
 
             case GncPricePropType::AMOUNT:

--- a/gnucash/import-export/csv-imp/gnc-imp-props-price.hpp
+++ b/gnucash/import-export/csv-imp/gnc-imp-props-price.hpp
@@ -83,11 +83,11 @@ GncNumeric parse_amount_price (const std::string &str, int currency_format);
 struct GncImportPrice
 {
 public:
-    GncImportPrice (int date_format, int currency_format) : m_date_format{date_format},
+    GncImportPrice (std::string date_locale, int currency_format) : m_date_locale{date_locale},
         m_currency_format{currency_format}{};
 
     void set (GncPricePropType prop_type, const std::string& value, bool enable_test_empty);
-    void set_date_format (int date_format) { m_date_format = date_format ;}
+    void set_date_locale (std::string date_locale) { m_date_locale = date_locale ;}
     void set_currency_format (int currency_format) { m_currency_format = currency_format ;}
     void reset (GncPricePropType prop_type);
     std::string verify_essentials (void);
@@ -102,7 +102,7 @@ public:
     std::string errors();
 
 private:
-    int m_date_format;
+    std::string m_date_locale;
     int m_currency_format;
     std::optional<GncDate> m_date;
     std::optional<GncNumeric> m_amount;

--- a/gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp
+++ b/gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp
@@ -239,7 +239,7 @@ void GncPreTrans::set (GncTransPropType prop_type, const std::string& value)
             case GncTransPropType::DATE:
                 m_date.reset();
                 if (!value.empty())
-                    m_date = GncDate(value, GncDate::c_formats[m_date_format].m_fmt); // Throws if parsing fails
+                    m_date = GncDate(value, m_date_locale);
                 else if (!m_multi_split)
                     throw std::invalid_argument (
                         (bl::format (std::string{_("Date field can not be empty if 'Multi-split' option is unset.\n")}) %
@@ -527,15 +527,13 @@ void GncPreSplit::set (GncTransPropType prop_type, const std::string& value)
             case GncTransPropType::REC_DATE:
                 m_rec_date.reset();
                 if (!value.empty())
-                    m_rec_date = GncDate (value,
-                                          GncDate::c_formats[m_date_format].m_fmt); // Throws if parsing fails
+                    m_rec_date = GncDate (value, m_date_locale); // Throws if parsing fails
                 break;
 
             case GncTransPropType::TREC_DATE:
                 m_trec_date.reset();
                 if (!value.empty())
-                    m_trec_date = GncDate (value,
-                                           GncDate::c_formats[m_date_format].m_fmt); // Throws if parsing fails
+                    m_trec_date = GncDate (value, m_date_locale); // Throws if parsing fails
                 break;
 
             default:

--- a/gnucash/import-export/csv-imp/gnc-imp-props-tx.hpp
+++ b/gnucash/import-export/csv-imp/gnc-imp-props-tx.hpp
@@ -154,11 +154,11 @@ struct DraftTransaction
 class GncPreTrans
 {
 public:
-    GncPreTrans(int date_format, bool multi_split)
-        : m_date_format{date_format}, m_multi_split{multi_split}, m_currency{nullptr} {};
+    GncPreTrans(const std::string date_locale, bool multi_split)
+        : m_date_locale{date_locale}, m_multi_split{multi_split}, m_currency{nullptr} {};
 
     void set (GncTransPropType prop_type, const std::string& value);
-    void set_date_format (int date_format) { m_date_format = date_format ;}
+    void set_date_locale (const std::string date_locale) { m_date_locale = date_locale ;}
     void set_multi_split (bool multi_split) { m_multi_split = multi_split ;}
     void reset (GncTransPropType prop_type);
     StrVec verify_essentials (void);
@@ -190,7 +190,7 @@ public:
 
 
 private:
-    int m_date_format;
+    std::string m_date_locale;
     bool m_multi_split;
     std::optional<std::string> m_differ;
     std::optional<GncDate> m_date;
@@ -221,12 +221,12 @@ private:
 class GncPreSplit
 {
 public:
-    GncPreSplit (int date_format, int currency_format) : m_date_format{date_format},
+    GncPreSplit (const std::string date_locale, int currency_format) : m_date_locale{date_locale},
         m_currency_format{currency_format} {};
     void set (GncTransPropType prop_type, const std::string& value);
     void reset (GncTransPropType prop_type);
     void add (GncTransPropType prop_type, const std::string& value);
-    void set_date_format (int date_format) { m_date_format = date_format ;}
+    void set_date_locale (const std::string date_locale) { m_date_locale = date_locale ;}
     void set_currency_format (int currency_format) { m_currency_format = currency_format; }
     void set_pre_trans (std::shared_ptr<GncPreTrans> pre_trans) { m_pre_trans = pre_trans; }
     std::shared_ptr<GncPreTrans> get_pre_trans (void) { return m_pre_trans; }
@@ -241,7 +241,7 @@ private:
     void UpdateCrossSplitCounters ();
 
     std::shared_ptr<GncPreTrans> m_pre_trans;
-    int m_date_format;
+    std::string m_date_locale;
     int m_currency_format;
     std::optional<std::string> m_action;
     std::optional<Account*> m_account;

--- a/gnucash/import-export/csv-imp/gnc-imp-settings-csv.hpp
+++ b/gnucash/import-export/csv-imp/gnc-imp-settings-csv.hpp
@@ -50,7 +50,7 @@ enum SETTINGS_COL {SET_GROUP, SET_NAME};
 struct CsvImportSettings
 {
     CsvImportSettings() : m_file_format (GncImpFileFormat::CSV), m_encoding {"UTF-8"},
-            m_date_format {0}, m_currency_format {0},
+            m_date_locale {"en_AU"}, m_currency_format {0},
             m_skip_start_lines{0}, m_skip_end_lines{0}, m_skip_alt_lines (false),
             m_separators {","}, m_load_error {false} { }
     virtual ~CsvImportSettings() = default;
@@ -75,7 +75,7 @@ void remove (void);
 std::string   m_name;                         // Name given to this preset by the user
 GncImpFileFormat m_file_format;               // CSV import Format
 std::string   m_encoding;                     // File encoding
-int           m_date_format;                  // Date Active id
+std::string   m_date_locale;                  // Date Active id
 int           m_currency_format;              // Currency Active id
 uint32_t      m_skip_start_lines;             // Number of header rows to skip
 uint32_t      m_skip_end_lines;               // Number of footer rows to skip

--- a/gnucash/import-export/csv-imp/gnc-import-price.cpp
+++ b/gnucash/import-export/csv-imp/gnc-import-price.cpp
@@ -213,15 +213,15 @@ void GncPriceImport::currency_format (int currency_format)
 }
 int GncPriceImport::currency_format () { return m_settings.m_currency_format; }
 
-void GncPriceImport::date_format (int date_format)
+void GncPriceImport::date_locale (std::string date_locale)
 {
-    m_settings.m_date_format = date_format;
+    m_settings.m_date_locale = date_locale;
 
     /* Reparse all date related columns */
     std::vector<GncPricePropType> dates = { GncPricePropType::DATE };
     reset_formatted_column (dates);
 }
-int GncPriceImport::date_format () { return m_settings.m_date_format; }
+std::string GncPriceImport::date_locale () { return m_settings.m_date_locale; }
 
 /** Converts raw file data using a new encoding. This function must be
  * called after load_file only if load_file guessed
@@ -385,7 +385,7 @@ void GncPriceImport::tokenize (bool guessColTypes)
         auto length = tokenized_line.size();
         if (length > 0)
             m_parsed_lines.push_back (std::make_tuple (tokenized_line, std::string(),
-                    std::make_shared<GncImportPrice>(date_format(), currency_format()),
+                    std::make_shared<GncImportPrice>(date_locale(), currency_format()),
                     false));
         if (length > max_cols)
             max_cols = length;
@@ -750,7 +750,7 @@ GncPriceImport::set_column_type_price (uint32_t position, GncPricePropType type,
         /* Reset date and currency formats for each price props object
          * to ensure column updates use the most recent one
          */
-        std::get<PL_PREPRICE>(*parsed_lines_it)->set_date_format (m_settings.m_date_format);
+        std::get<PL_PREPRICE>(*parsed_lines_it)->set_date_locale (m_settings.m_date_locale);
         std::get<PL_PREPRICE>(*parsed_lines_it)->set_currency_format (m_settings.m_currency_format);
 
         uint32_t row = parsed_lines_it - m_parsed_lines.begin();

--- a/gnucash/import-export/csv-imp/gnc-import-price.hpp
+++ b/gnucash/import-export/csv-imp/gnc-import-price.hpp
@@ -100,8 +100,8 @@ public:
     void currency_format (int currency_format);
     int currency_format ();
 
-    void date_format (int date_format);
-    int date_format ();
+    void date_locale (std::string date_locale);
+    std::string date_locale ();
 
     void encoding (const std::string& encoding);
     std::string encoding ();

--- a/gnucash/import-export/csv-imp/gnc-import-tx.cpp
+++ b/gnucash/import-export/csv-imp/gnc-import-tx.cpp
@@ -228,9 +228,9 @@ void GncTxImport::currency_format (int currency_format)
 }
 int GncTxImport::currency_format () { return m_settings.m_currency_format; }
 
-void GncTxImport::date_format (int date_format)
+void GncTxImport::date_locale (std::string date_locale)
 {
-    m_settings.m_date_format = date_format;
+    m_settings.m_date_locale = date_locale;
 
     /* Reparse all date related columns */
     std::vector<GncTransPropType> dates = { GncTransPropType::DATE,
@@ -238,7 +238,7 @@ void GncTxImport::date_format (int date_format)
             GncTransPropType::TREC_DATE};
     reset_formatted_column (dates);
 }
-int GncTxImport::date_format () { return m_settings.m_date_format; }
+std::string GncTxImport::date_locale () { return m_settings.m_date_locale; }
 
 /** Converts raw file data using a new encoding. This function must be
  * called after load_file only if load_file guessed
@@ -407,8 +407,8 @@ void GncTxImport::tokenize (bool guessColTypes)
         auto length = tokenized_line.size();
         if (length > 0)
         {
-            auto pretrans = std::make_shared<GncPreTrans>(date_format(), m_settings.m_multi_split);
-            auto presplit = std::make_shared<GncPreSplit>(date_format(), currency_format());
+            auto pretrans = std::make_shared<GncPreTrans>(date_locale(), m_settings.m_multi_split);
+            auto presplit = std::make_shared<GncPreSplit>(date_locale(), currency_format());
             presplit->set_pre_trans (std::move (pretrans));
             m_parsed_lines.push_back (std::make_tuple (tokenized_line, ErrMap(),
                                       presplit->get_pre_trans(), std::move (presplit), false));
@@ -781,7 +781,7 @@ void GncTxImport::update_pre_trans_props (parse_line_t& parsed_line, uint32_t co
 
     /* Reset date format for each trans props object
      * to ensure column updates use the most recent one */
-    trans_props->set_date_format (m_settings.m_date_format);
+    trans_props->set_date_locale (m_settings.m_date_locale);
     trans_props->set_multi_split (m_settings.m_multi_split);
 
     if ((old_type > GncTransPropType::NONE) && (old_type <= GncTransPropType::TRANS_PROPS))
@@ -820,7 +820,7 @@ void GncTxImport::update_pre_split_props (parse_line_t& parsed_line, uint32_t co
     auto trans_props = std::get<PL_PRETRANS> (parsed_line);
     /* Reset date format for each split props object
      * to ensure column updates use the most recent one */
-    split_props->set_date_format (m_settings.m_date_format);
+    split_props->set_date_locale (m_settings.m_date_locale);
     if (m_settings.m_multi_split && trans_props->is_part_of( m_parent))
         split_props->set_pre_trans (m_parent);
     else

--- a/gnucash/import-export/csv-imp/gnc-import-tx.hpp
+++ b/gnucash/import-export/csv-imp/gnc-import-tx.hpp
@@ -119,8 +119,8 @@ public:
     void currency_format (int currency_format);
     int currency_format ();
 
-    void date_format (int date_format);
-    int date_format ();
+    void date_locale (std::string date_locale);
+    std::string date_locale ();
 
     void encoding (const std::string& encoding);
     std::string encoding ();

--- a/gnucash/import-export/csv-imp/gnc-tokenizer-csv.hpp
+++ b/gnucash/import-export/csv-imp/gnc-tokenizer-csv.hpp
@@ -59,4 +59,6 @@ private:
     std::string m_sep_str = ",";
 };
 
+void gnc_filter_locales (StrVec& candidate_locales, const StrVec dates);
+
 #endif

--- a/gnucash/import-export/csv-imp/gnc-tokenizer.cpp
+++ b/gnucash/import-export/csv-imp/gnc-tokenizer.cpp
@@ -125,3 +125,25 @@ GncTokenizer::get_tokens()
 {
     return m_tokenized_contents;
 }
+
+
+
+using StrVec = std::vector<std::string>;
+#include "gnc-datetime.hpp"
+
+void
+gnc_filter_locales (StrVec& candidate_locales, const StrVec dates)
+{
+    StrVec new_candidate_locales;
+    new_candidate_locales.reserve (candidate_locales.size());
+
+    for (const auto& date : dates)
+    {
+        new_candidate_locales.clear ();
+        for (const auto& locale : candidate_locales)
+            try { GncDate (date, locale); new_candidate_locales.push_back (locale); }
+            catch (const std::exception&) {};
+
+        std::swap (candidate_locales, new_candidate_locales);
+    }
+}

--- a/gnucash/import-export/csv-imp/test/test-tokenizer.cpp
+++ b/gnucash/import-export/csv-imp/test/test-tokenizer.cpp
@@ -245,7 +245,35 @@ static tokenize_fw_test_data fixed_width [] = {
                 { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL } },
 };
 
+#include <ctime> // time_t
+#include "gnc-locale-utils.hpp"
+
+static void test_filter_locales ()
+{
+    std::vector<std::string> dates;
+
+    for (auto i = 0; i < 500; ++i)
+        dates.push_back ("09/22/2021");
+
+    auto locales = gnc_get_available_locales ();
+    std::cout << locales.size() << " locales available. Testing "
+              << dates.size() << " dates.\n";
+
+    auto start = clock();
+    gnc_filter_locales (locales, dates);
+    auto end = clock();
+
+    double duration_sec = double(end-start)/CLOCKS_PER_SEC;
+
+    std::cout << locales.size() << " locales left, checked in "
+              << duration_sec << " seconds:\n";
+    for (auto locale : locales)
+        std::cout << ' ' << locale;
+    std::cout << '\n';
+}
+
 TEST_F (GncTokenizerTest, tokenize_fw)
 {
     test_gnc_tokenize_helper (fixed_width);
+    test_filter_locales ();
 }

--- a/libgnucash/core-utils/CMakeLists.txt
+++ b/libgnucash/core-utils/CMakeLists.txt
@@ -52,6 +52,7 @@ target_link_libraries(gnc-core-utils
 	PkgConfig::GLIB2
     PRIVATE
         ${Boost_LIBRARIES}
+        ${ICU4C_I18N_LDFLAGS}
         ${GOBJECT_LDFLAGS}
         ${GTK_MAC_LDFLAGS}
         "$<$<BOOL:${MAC_INTEGRATION}>:${OSX_EXTRA_LIBRARIES}>")

--- a/libgnucash/core-utils/gnc-locale-utils.cpp
+++ b/libgnucash/core-utils/gnc-locale-utils.cpp
@@ -22,6 +22,7 @@
 #include <glib.h>
 #include <clocale>
 #include <boost/locale.hpp>
+#include <unicode/uloc.h>
 #include "gnc-locale-utils.hpp"
 #include <config.h>
 
@@ -115,3 +116,14 @@ gnc_get_boost_locale()
 }
 
 
+std::vector<std::string>
+gnc_get_available_locales ()
+{
+    std::vector<std::string> rv;
+    auto num_locales{uloc_countAvailable()};
+    rv.reserve (num_locales);
+    for (int32_t i = 0; i < num_locales; ++i)
+        if (auto localeID = uloc_getAvailable (i))
+            rv.push_back (localeID);
+    return rv;
+}

--- a/libgnucash/core-utils/gnc-locale-utils.hpp
+++ b/libgnucash/core-utils/gnc-locale-utils.hpp
@@ -23,6 +23,7 @@
 #define GNC_LOCALE_UTILS_HPP
 
 #include <locale>
+#include <vector>
 #include <string>
 
 /** Get the default application locale.
@@ -62,5 +63,7 @@ void gnc_init_boost_locale(const std::string& messages_path);
  *  setlocale() in main(), but generated from boost::locale.
  */
 const std::locale& gnc_get_boost_locale();
+
+std::vector<std::string> gnc_get_available_locales ();
 
 #endif /* GNC_LOCALE_UTILS_HPP */

--- a/libgnucash/core-utils/test/CMakeLists.txt
+++ b/libgnucash/core-utils/test/CMakeLists.txt
@@ -36,6 +36,7 @@ set(gtest_core_utils_INCLUDES
 set(gtest_core_utils_LIBS
   PkgConfig::GLIB2
   ${Boost_LIBRARIES}
+  ${ICU4C_I18N_LDFLAGS}
   ${GTHREAD_LDFLAGS}
   gtest)
 

--- a/libgnucash/engine/gnc-datetime.cpp
+++ b/libgnucash/engine/gnc-datetime.cpp
@@ -552,10 +552,11 @@ locale_to_formatter_and_calendar (const std::string locale_str)
     if (!tuple)
     {
         auto locale = icu::Locale::createCanonical (locale_str.c_str());
-        std::shared_ptr<icu::DateFormat> formatter(icu::DateFormat::createDateInstance(icu::DateFormat::kDefault, locale));
+        std::shared_ptr<icu::DateFormat> formatter(icu::DateFormat::createDateInstance(icu::DateFormat::kShort, locale));
         if (formatter == nullptr)
             throw std::invalid_argument ("Cannot parse string");
 
+        formatter->setLenient (false);
         UErrorCode status = U_ZERO_ERROR;
         std::shared_ptr<icu::Calendar> calendar(icu::Calendar::createInstance(locale, status));
         if (U_FAILURE(status))
@@ -573,7 +574,7 @@ GncDateImpl::GncDateImpl(const std::string str, const std::string locale_str) :
     /* Temporarily initialized to today, will be used and adjusted in the code below */
     m_greg(boost::gregorian::day_clock::local_day())
 {
-    std::cout << locale_str << '|' << str << ": ";
+    // std::cout << locale_str << '|' << str << ": ";
 
     auto [formatter, calendar] = locale_to_formatter_and_calendar (locale_str);
     icu::UnicodeString input = icu::UnicodeString::fromUTF8(str);
@@ -582,7 +583,7 @@ GncDateImpl::GncDateImpl(const std::string str, const std::string locale_str) :
     UDate date = formatter->parse(input, parsePos);
     if (parsePos.getErrorIndex() != -1)
     {
-        std::cout << "cannot parse " << std::endl;
+        // std::cout << "cannot parse " << std::endl;
         throw std::invalid_argument ("Cannot parse string");
     }
 
@@ -598,7 +599,7 @@ GncDateImpl::GncDateImpl(const std::string str, const std::string locale_str) :
     if (U_FAILURE(status))
         throw std::invalid_argument ("Cannot parse string");
 
-    std::cout << day << '/' << month << '/' << year << std::endl;
+    // std::cout << day << '/' << month << '/' << year << std::endl;
     m_greg = Date(year, month, day);
 }
 

--- a/libgnucash/engine/gnc-datetime.cpp
+++ b/libgnucash/engine/gnc-datetime.cpp
@@ -549,6 +549,8 @@ GncDateImpl::GncDateImpl(const std::string str, const std::string locale_str) :
 {
     UErrorCode status = U_ZERO_ERROR;
 
+    std::cout << locale_str << '|' << str << ": ";
+
     icu::Locale locale = icu::Locale::createCanonical (locale_str.c_str());
     std::unique_ptr<icu::DateFormat> formatter(icu::DateFormat::createDateInstance(icu::DateFormat::kDefault, locale));
     if (formatter == nullptr)
@@ -559,23 +561,36 @@ GncDateImpl::GncDateImpl(const std::string str, const std::string locale_str) :
 
     UDate date = formatter->parse(input, parsePos);
     if (parsePos.getErrorIndex() != -1)
+    {
+        std::cout << "1\n";
         throw std::invalid_argument ("Cannot parse string");
+    }
 
     std::unique_ptr<icu::Calendar> calendar(icu::Calendar::createInstance(locale, status));
     if (U_FAILURE(status))
+    {
+        std::cout << "2\n";
         throw std::invalid_argument ("Cannot parse string");
+    }
 
     calendar->setTime(date, status);
     if (U_FAILURE(status))
+    {
+        std::cout << "3\n";
         throw std::invalid_argument ("Cannot parse string");
+    }
 
     int32_t day = calendar->get(UCAL_DATE, status);
     int32_t month = calendar->get(UCAL_MONTH, status) + 1;
     int32_t year = calendar->get(UCAL_YEAR, status);
 
     if (U_FAILURE(status))
+    {
+        std::cout << "4\n";
         throw std::invalid_argument ("Cannot parse string");
+    }
 
+    std::cout << day << '/' << month << '/' << year << std::endl;
     m_greg = Date(year, month, day);
 }
 

--- a/libgnucash/engine/gnc-datetime.hpp
+++ b/libgnucash/engine/gnc-datetime.hpp
@@ -162,37 +162,6 @@ private:
     std::unique_ptr<GncDateTimeImpl> m_impl;
 };
 
-/** GnuCash DateFormat class
- *
- * A helper class to represent a date format understood
- * by the GncDate string/format constructor. Consumers
- * of this header file are not supposed to create
- * objects of this class themselves. Instead they
- * can get a list of the understood formats from the
- * GncDate::c_formats class variable and work with those.
- */
-
-class GncDateFormat
-{
-public:
-    /** Construct a GncDateFormat with a given format and corresponding
-     * regular expression. This should only be used internally by the
-     * GncDate implementation. Consumers should never construct a GncDateFormat
-     * themselves!
-     */
-    GncDateFormat (const char* fmt, const char* re) :
-    m_fmt(fmt), m_re(re) {}
-    /** A string representing the format. */
-    const std::string m_fmt;
-private:
-    /** Regular expression associated with the format string. This is to and
-     * only be used internally by the gnc-datetime code.
-     */
-    const std::string m_re;
-
-    friend class GncDateImpl;
-};
-
 /** GnuCash Date class
  *
  * The represented date is limited to the period
@@ -202,23 +171,6 @@ private:
 class GncDate
 {
     public:
-        /** A vector with all the date formats supported by the string constructor.
-         * The currently supported formats are:
-         * "y-m-d" (including yyyymmdd)
-         * "d-m-y" (including ddmmyyyy)
-         * "m-d-y" (including mmddyyyy)
-         * "d-m"   (including ddmm)
-         * "m-d"   (including mmdd)
-         *
-         * Notes:
-         * - while the format names are using a "-" as separator, the
-         * regexes will accept any of "-/.' " and will also work for dates
-         * without separators.
-         * - the format strings are marked for translation so it is possible
-         * to use a localized version of a format string using gettext. Example:
-         * gettext(GncDate::c_formats[0])
-         */
-        static const std::vector<GncDateFormat> c_formats;
         /** Construct a GncDate representing the current day.
          */
         GncDate();
@@ -252,7 +204,7 @@ class GncDate
          *   (like month being 13, or day being 31 in February)
          * - fmt doesn't specify a year, yet a year was found in the string
          */
-        GncDate(const std::string str, const std::string fmt);
+        GncDate(const std::string str, const std::string locale_str);
         /** Construct a GncDate from a GncDateImpl.
          */
         GncDate(std::unique_ptr<GncDateImpl> impl);

--- a/libgnucash/engine/test/gtest-gnc-datetime.cpp
+++ b/libgnucash/engine/test/gtest-gnc-datetime.cpp
@@ -71,95 +71,83 @@ typedef struct
 TEST(gnc_date_constructors, test_str_format_constructor)
 {
     auto today = GncDate();
-    auto today_ymd = today.year_month_day();
-    auto curr_year = today_ymd.year;
+    // auto today_ymd = today.year_month_day();
+    // auto curr_year = today_ymd.year;
 
     parse_date_data test_dates[] =
     {
         // supported combinations  -/.'
-        { "y-m-d", "2013-08-01", 2013,  8,  1},
-        { "y-m-d",  "2013-8-01", 2013,  8,  1},
-        { "y-m-d",  "2013-08-1", 2013,  8,  1},
-        { "y-m-d",   "2013-8-1", 2013,  8,  1},
-        { "y-m-d",   "13-08-01", 2013,  8,  1},
-        { "y-m-d",    "13-8-01", 2013,  8,  1},
-        { "y-m-d",    "13-08-1", 2013,  8,  1},
-        { "y-m-d",     "13-8-1", 2013,  8,  1},
-        { "y-m-d", "2009/11/04", 2009, 11,  4},
-        { "y-m-d",  "1985.3.12", 1985,  3, 12},
-        { "y-m-d",      "3'6'8", 2003,  6,  8},
-        { "y-m-d",   "20130801", 2013,  8,  1},
-        { "d-m-y", "01-08-2013", 2013,  8,  1},
-        { "d-m-y",  "01-8-2013", 2013,  8,  1},
-        { "d-m-y",  "1-08-2013", 2013,  8,  1},
-        { "d-m-y",   "1-8-2013", 2013,  8,  1},
-        { "d-m-y",   "01-08-13", 2013,  8,  1},
-        { "d-m-y",    "01-8-13", 2013,  8,  1},
-        { "d-m-y",    "1-08-13", 2013,  8,  1},
-        { "d-m-y",     "1-8-13", 2013,  8,  1},
-        { "d-m-y", "04/11/2009", 2009, 11,  4},
-        { "d-m-y",  "12.3.1985", 1985,  3, 12},
-        { "d-m-y",      "8'6'3", 2003,  6,  8},
-        { "d-m-y",   "01082013", 2013,  8,  1},
-        { "m-d-y", "08-01-2013", 2013,  8,  1},
-        { "m-d-y",  "8-01-2013", 2013,  8,  1},
-        { "m-d-y",  "08-1-2013", 2013,  8,  1},
-        { "m-d-y",   "8-1-2013", 2013,  8,  1},
-        { "m-d-y",   "08-01-13", 2013,  8,  1},
-        { "m-d-y",    "8-01-13", 2013,  8,  1},
-        { "m-d-y",    "08-1-13", 2013,  8,  1},
-        { "m-d-y",     "8-1-13", 2013,  8,  1},
-        { "m-d-y", "11/04/2009", 2009, 11,  4},
-        { "m-d-y",  "3.12.1985", 1985,  3, 12},
-        { "m-d-y",      "6'8'3", 2003,  6,  8},
-        { "m-d-y",   "08012013", 2013,  8,  1},
-        {   "d-m",      "01-08",   curr_year,  8,  1},
-        {   "d-m",       "01-8",   curr_year,  8,  1},
-        {   "d-m",       "1-08",   curr_year,  8,  1},
-        {   "d-m",        "1-8",   curr_year,  8,  1},
-        {   "d-m",      "04/11",   curr_year, 11,  4},
-        {   "d-m",       "12.3",   curr_year,  3, 12},
-        {   "d-m",        "8'6",   curr_year,  6,  8},
-        {   "d-m",       "0108",   curr_year,  8,  1},
-        {   "m-d",      "08-01",   curr_year,  8,  1},
-        {   "m-d",       "8-01",   curr_year,  8,  1},
-        {   "m-d",       "08-1",   curr_year,  8,  1},
-        {   "m-d",        "8-1",   curr_year,  8,  1},
-        {   "m-d",      "11/04",   curr_year, 11,  4},
-        {   "m-d",       "3.12",   curr_year,  3, 12},
-        {   "m-d",        "6'8",   curr_year,  6,  8},
-        {   "m-d",       "0801",   curr_year,  8,  1},
+        { "en_GB", "01-08-2013", 2013,  8,  1},
+        { "en_GB",  "01-8-2013", 2013,  8,  1},
+        { "en_GB",  "1-08-2013", 2013,  8,  1},
+        { "en_GB",   "1-8-2013", 2013,  8,  1},
+        { "en_GB",   "01-08-13", 2013,  8,  1},
+        { "en_GB",    "01-8-13", 2013,  8,  1},
+        { "en_GB",    "1-08-13", 2013,  8,  1},
+        { "en_GB",     "1-8-13", 2013,  8,  1},
+        { "en_GB", "04/11/2009", 2009, 11,  4},
+        { "en_GB",  "12.3.1985", 1985,  3, 12},
+        // { "en_GB",      "8'6'3", 2003,  6,  8},
+        // { "en_GB",   "01082013", 2013,  8,  1},
+        { "en_US", "08-01-2013", 2013,  8,  1},
+        { "en_US",  "8-01-2013", 2013,  8,  1},
+        { "en_US",  "08-1-2013", 2013,  8,  1},
+        { "en_US",   "8-1-2013", 2013,  8,  1},
+        { "en_US",   "08-01-13", 2013,  8,  1},
+        { "en_US",    "8-01-13", 2013,  8,  1},
+        { "en_US",    "08-1-13", 2013,  8,  1},
+        { "en_US",     "8-1-13", 2013,  8,  1},
+        { "en_US", "11/04/2009", 2009, 11,  4},
+        { "en_US",  "3.12.1985", 1985,  3, 12},
+        // { "en_US",      "6'8'3", 2003,  6,  8},
+        // { "en_US",   "08012013", 2013,  8,  1},
+        // {   "d-m",      "01-08",   curr_year,  8,  1},
+        // {   "d-m",       "01-8",   curr_year,  8,  1},
+        // {   "d-m",       "1-08",   curr_year,  8,  1},
+        // {   "d-m",        "1-8",   curr_year,  8,  1},
+        // {   "d-m",      "04/11",   curr_year, 11,  4},
+        // {   "d-m",       "12.3",   curr_year,  3, 12},
+        // {   "d-m",        "8'6",   curr_year,  6,  8},
+        // {   "d-m",       "0108",   curr_year,  8,  1},
+        // {   "m-d",      "08-01",   curr_year,  8,  1},
+        // {   "m-d",       "8-01",   curr_year,  8,  1},
+        // {   "m-d",       "08-1",   curr_year,  8,  1},
+        // {   "m-d",        "8-1",   curr_year,  8,  1},
+        // {   "m-d",      "11/04",   curr_year, 11,  4},
+        // {   "m-d",       "3.12",   curr_year,  3, 12},
+        // {   "m-d",        "6'8",   curr_year,  6,  8},
+        // {   "m-d",       "0801",   curr_year,  8,  1},
 
         // ambiguous date formats
         // current parser doesn't know how to disambiguate
         // and hence refuses to parse
         // can possibly improved with a smarter parser
-        { "y-m-d",     "130801",          -1,     -1, -1},
-        { "d-m-y",     "010813",          -1,     -1, -1},
-        { "m-d-y",     "080113",          -1,     -1, -1},
+        // { "y-m-d",     "130801",          -1,     -1, -1},
+        { "en_GB",     "010813",          -1,     -1, -1},
+        { "en_US",     "080113",          -1,     -1, -1},
 
         // Combinations that don't make sense
         // but can still be entered by a user
         // Should ideally all result in refusal to parse...
-        { "y-m-d",      "08-01",          -1,     -1, -1},
-        { "y-m-d",       "0801",          -1,     -1, -1},
-        { "d-m-y",      "01-08",          -1,     -1, -1},
-        { "d-m-y",       "0108",          -1,     -1, -1},
-        { "m-d-y",      "08-01",          -1,     -1, -1},
-        { "m-d-y",       "0801",          -1,     -1, -1},
-        {   "d-m", "01-08-2013",          -1,     -1, -1},
-        {   "d-m",   "01-08-13",          -1,     -1, -1},
-        {   "d-m",   "08-08-08",          -1,     -1, -1},
-        {   "d-m",   "01082013",          -1,     -1, -1},
-        {   "d-m",     "010813",          -1,     -1, -1},
-        {   "d-m",   "20130108",          -1,     -1, -1},
-        {   "m-d", "08-01-2013",          -1,     -1, -1},
-        {   "m-d",   "08-01-13",          -1,     -1, -1},
-        {   "m-d", "2013-08-01",          -1,     -1, -1},
-        {   "m-d",   "09-08-01",          -1,     -1, -1},
-        {   "m-d",   "08012013",          -1,     -1, -1},
-        {   "m-d",     "080113",          -1,     -1, -1},
-        {   "m-d",   "20130801",          -1,     -1, -1},
+        // { "y-m-d",      "08-01",          -1,     -1, -1},
+        // { "y-m-d",       "0801",          -1,     -1, -1},
+        { "en_GB",      "01-08",          -1,     -1, -1},
+        { "en_GB",       "0108",          -1,     -1, -1},
+        { "en_US",      "08-01",          -1,     -1, -1},
+        { "en_US",       "0801",          -1,     -1, -1},
+        // {   "d-m", "01-08-2013",          -1,     -1, -1},
+        // {   "d-m",   "01-08-13",          -1,     -1, -1},
+        // {   "d-m",   "08-08-08",          -1,     -1, -1},
+        // {   "d-m",   "01082013",          -1,     -1, -1},
+        // {   "d-m",     "010813",          -1,     -1, -1},
+        // {   "d-m",   "20130108",          -1,     -1, -1},
+        // {   "m-d", "08-01-2013",          -1,     -1, -1},
+        // {   "m-d",   "08-01-13",          -1,     -1, -1},
+        // {   "m-d", "2013-08-01",          -1,     -1, -1},
+        // {   "m-d",   "09-08-01",          -1,     -1, -1},
+        // {   "m-d",   "08012013",          -1,     -1, -1},
+        // {   "m-d",     "080113",          -1,     -1, -1},
+        // {   "m-d",   "20130801",          -1,     -1, -1},
 
         // Unknown date format specifier should also trigger an exception
         {   "y-d-m H:M:S",   "20130801",          -1,     -1, -1},
@@ -445,11 +433,11 @@ TEST(gnc_datetime_constructors, test_create_in_transition)
      * savings time it ended at 23:59:59 and the next second was
      * 01:00:00 so that's when the day starts.
      */
-    GncDate date0{"2018-11-03", "y-m-d"};
+    GncDate date0{"03-11-2018", "en_GB"};
     GncDateTime gncdt0{date0, DayPart::end};
     EXPECT_EQ(gncdt0.format_zulu("%Y-%m-%d %H:%M:%S %Z"), "2018-11-04 02:59:59 UTC");
     EXPECT_EQ(gncdt0.format("%Y-%m-%d %H:%M:%S %Z"), "2018-11-03 23:59:59 -03");
-    GncDate date1{"2018-11-04", "y-m-d"};
+    GncDate date1{"04-11-2018", "en_GB"};
     GncDateTime gncdt1{date1, DayPart::start};
     EXPECT_EQ(gncdt1.format_zulu("%Y-%m-%d %H:%M:%S %Z"), "2018-11-04 03:00:00 UTC");
     EXPECT_EQ(gncdt1.format("%Y-%m-%d %H:%M:%S %Z"), "2018-11-04 01:00:00 -02");
@@ -457,7 +445,7 @@ TEST(gnc_datetime_constructors, test_create_in_transition)
      * std time, i.e. -03. Unfortunately sometimes boost::date_time
      * decides that it's still DST and returns the first one.
      */
-    GncDate date2{"2018-02-17", "y-m-d"};
+    GncDate date2{"17-02-2018", "en_GB"};
     GncDateTime gncdt2{date2, DayPart::end};
     if (gncdt2.offset() == -7200)
     {
@@ -473,7 +461,7 @@ TEST(gnc_datetime_constructors, test_create_in_transition)
      * Savings. This test checks to ensure that GncTimeZone doesn't
      * try to project 2018's rule forward.
      */
-    GncDate date3{"2019-11-01", "y-m-d"};
+    GncDate date3{"01-11-2019", "en_GB"};
     GncDateTime gncdt3{date3, DayPart::start};
     EXPECT_EQ(gncdt3.format_zulu("%Y-%m-%d %H:%M:%S %Z"), "2019-11-01 03:00:00 UTC");
     EXPECT_EQ(gncdt3.format("%Y-%m-%d %H:%M:%S %Z"), "2019-11-01 00:00:00 -03");


### PR DESCRIPTION
offshoot #1710 -- here's attempt.

all GncDateFormat changed to use locales. The locale combobox is currently 799 items long!

but it doesn't seem to parse all dates. see example with debugging code. looks like ICU type issue which cannot understand "Sep" yet can understand "Apr".

![image](https://github.com/user-attachments/assets/e8e161c2-0e67-42ef-9dbf-484a6dac0465)
