### PR TITLE
[gnc-datetime] add boost UK/US/ISO date parsers

### DIFF
--- a/libgnucash/engine/gnc-datetime.hpp
+++ b/libgnucash/engine/gnc-datetime.hpp
@@ -29,6 +29,10 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <functional>
+#include <optional>
+
+#include <boost/date_time/gregorian/gregorian.hpp>
 
 typedef struct
 {
@@ -172,6 +176,8 @@ private:
  * GncDate::c_formats class variable and work with those.
  */
 
+using StringToDate = std::function<boost::gregorian::date(const std::string&)>;
+
 class GncDateFormat
 {
 public:
@@ -182,6 +188,8 @@ public:
      */
     GncDateFormat (const char* fmt, const char* re) :
     m_fmt(fmt), m_re(re) {}
+    GncDateFormat (const char* fmt, StringToDate str_to_date) :
+        m_fmt(fmt), m_str_to_date(str_to_date) {}
     /** A string representing the format. */
     const std::string m_fmt;
 private:
@@ -189,6 +197,7 @@ private:
      * only be used internally by the gnc-datetime code.
      */
     const std::string m_re;
+    std::optional<StringToDate> m_str_to_date;
 
     friend class GncDateImpl;
 };


### PR DESCRIPTION
From https://github.com/Gnucash/gnucash/pull/1710#issuecomment-2336692212

UK: "30 Sep 2024" and "30 September 2024" are accepted. "30 Sept 2024" is rejected.
US: "May 2, 2024" is accepted.
ISO delimited: "2024 Dec 20" and "2024 December 20" are accepted.

Note boost's parser requires 4-digit years.
