### PR TITLE
Transaction Cut and Paste problems

### DIFF
--- a/gnucash/register/ledger-core/split-register.c
+++ b/gnucash/register/ledger-core/split-register.c
@@ -73,6 +73,7 @@ typedef struct
     };
     CursorClass cursor_class;
     GncGUID leader_guid;
+    gint anchor_split_index;
 } ft_fs_store;
 
 static ft_fs_store copied_item = { 0, { NULL } };
@@ -101,6 +102,7 @@ clear_copied_item()
     copied_item.ft = NULL;
     copied_item.cursor_class = CURSOR_CLASS_NONE;
     copied_item.leader_guid = *guid_null();
+    copied_item.anchor_split_index = 0;
 }
 
 static void
@@ -828,6 +830,7 @@ gnc_split_register_copy_current_internal (SplitRegister* reg,
             }
 
             copied_item.leader_guid = info->default_account;
+            copied_item.anchor_split_index = xaccTransGetSplitIndex (trans, split);
         }
     }
 
@@ -1082,7 +1085,11 @@ gnc_split_register_paste_current (SplitRegister* reg)
         if (trans == blank_trans)
         {
             /* In pasting, the blank split is deleted. Pick a new one. */
-            blank_split = xaccTransGetSplit (trans, 0);
+            gint anchor_split_index = copied_item.anchor_split_index;
+            if (anchor_split_index > num_splits)
+                anchor_split_index = 0;
+
+            blank_split = xaccTransGetSplit (trans, anchor_split_index);
             info->blank_split_guid = *xaccSplitGetGUID (blank_split);
             info->blank_split_edited = TRUE;
             info->auto_complete = FALSE;

--- a/gnucash/register/ledger-core/split-register.c
+++ b/gnucash/register/ledger-core/split-register.c
@@ -98,6 +98,7 @@ clear_copied_item()
         gnc_float_txn_free (copied_item.ft);
     copied_item.ftype = 0;
     copied_item.fs = NULL;
+    copied_item.ft = NULL;
     copied_class = CURSOR_CLASS_NONE;
     copied_leader_guid = *guid_null();
 }
@@ -785,6 +786,9 @@ gnc_split_register_copy_current_internal (SplitRegister* reg,
         return;
     }
 
+    /* unprotect the old object, if any */
+    clear_copied_item();
+
     /* Ok, we are now ready to make the copy. */
 
     if (cursor_class == CURSOR_CLASS_SPLIT)
@@ -833,9 +837,6 @@ gnc_split_register_copy_current_internal (SplitRegister* reg,
         LEAVE ("copy failed");
         return;
     }
-
-    /* unprotect the old object, if any */
-    clear_copied_item();
 
     if (new_fs)
     {


### PR DESCRIPTION
A couple of bug fixes...
The first commit I think is correct but am unsure on second one, it works but may be I am missing something.

Below is an image illustrating problem...
![cutpaste](https://github.com/user-attachments/assets/fdcfba4b-9c4c-4f1f-960a-ac538805b8cc)

The last transaction was copied and pasted to the blank transaction and as you can see the transfer account is that of the current register. The transaction is still correct but could be confusing and hence the bug report.

To fix this, when the register loads an existing check is made to ensure the transaction and splits being edited are in the split list we are loading and as part of that I am recording the anchor split of the pending transaction. If the pending transaction is the blank transaction I use that to set the leading virtual cell in the register.

There is one situation when this would fail, if the copied transaction has two splits for the same account as it would always pick the same anchor split. I do not think this is a common occurrence so for most users not a problem. I did think of another way to fix this which involved passing the copied current cursor split to `gnc_txn_to_float_txn` and making sure it was the first in the floating split list but decided to do it register load.  


