### PR TITLE
Bugfix 797045 - Correct error message when connection to database failed

### DIFF
--- a/libgnucash/backend/dbi/gnc-backend-dbi.cpp
+++ b/libgnucash/backend/dbi/gnc-backend-dbi.cpp
@@ -708,7 +708,7 @@ GncDbiBackend<Type>::session_begin (QofSession* session, const char* new_uri,
     else if (m_exists)
     {
         PERR ("Unable to connect to database '%s'\n", uri.dbname());
-        set_error (ERR_BACKEND_SERVER_ERR);
+        set_error (ERR_BACKEND_CANT_CONNECT);
         dbi_conn_close(conn);
         LEAVE("Error");
         return;


### PR DESCRIPTION
This is to fix the defect https://bugs.gnucash.org/show_bug.cgi?id=797045 
Error type chaged to ERR_BACKEND_CANT_CONNECT in gnc-backend-dbi.cpp when connection to database failed