### PR TITLE
[gnc-quotes.cpp] fix quote report

### DIFF
--- a/libgnucash/app-utils/gnc-quotes.cpp
+++ b/libgnucash/app-utils/gnc-quotes.cpp
@@ -342,10 +342,11 @@ GncQuotesImpl::report (const char* source, const StrVec& commodities,
     {
         auto quote_str{query_fq (source, commodities)};
         auto ptree{parse_quotes (quote_str)};
+        auto source_pt_ai{ptree.find(source)};
         if (is_currency)
-            show_currency_quotes(ptree, commodities, verbose);
+            show_currency_quotes(source_pt_ai->second, commodities, verbose);
         else
-            show_quotes(ptree, commodities, verbose);
+            show_quotes(source_pt_ai->second, commodities, verbose);
     }
     catch (const GncQuoteException& err)
     {


### PR DESCRIPTION
`gnucash-cli -Q dump ...` stopped working since 5.9, due to due to finance-quote-wrapper output format changes in 6aeca0040e5c6b7e5b4c89bb900b8996dc6a3283.

Update `GncQuotesImpl::report` to work with the new format.