### PR TITLE
Bug799430 Split auto complete bug

### DIFF
--- a/gnucash/register/ledger-core/split-register-control.cpp
+++ b/gnucash/register/ledger-core/split-register-control.cpp
@@ -696,7 +696,7 @@ gnc_find_split_in_trans_by_memo (Transaction *trans, const char *memo,
         if (unit_price)
         {
             gnc_numeric price = xaccSplitGetSharePrice (split);
-            if (!gnc_numeric_equal (price, gnc_numeric_create (1, 1)))
+            if (!gnc_numeric_zero_p (price))
                 continue;
         }
 


### PR DESCRIPTION
I think the first commit fixes the issue that if you try to auto complete a split using the memo text from a split that has no values it fails to fill in the transfer account. This has stemmed from a change in the return value of [xaccSplitSetSharePrice](https://github.com/Gnucash/gnucash/commit/87b0a41e9b0b4db6556523ce5e3009fa03dd7734#diff-154ee983af0cf96a53b09614667e634d03e6a3b4321c6913046d04bbbfc8494cR1196) in version 4.10

Just looking for confirmation of change before I push this.

The second commit is just realigning the source file after the change to cpp.