### PR TITLE
Bug 799451 - Cannot translate different meanings of string  "_Balance" to Chinese.

### DIFF
--- a/gnucash/gnome-utils/gnc-tree-view-account.c
+++ b/gnucash/gnome-utils/gnc-tree-view-account.c
@@ -834,7 +834,7 @@ gnc_tree_view_account_new_with_root (Account *root, gboolean show_root)
                                            GNC_TREE_VIEW_COLUMN_VISIBLE_ALWAYS,
                                            sort_by_present_value);
 
-    gnc_tree_view_add_numeric_column(GNC_TREE_VIEW(view), C_("column header", "Balance"), "balance",
+    gnc_tree_view_add_numeric_column(GNC_TREE_VIEW(view), _("Balance"), "balance",
                                      SAMPLE_ACCOUNT_VALUE,
                                      GNC_TREE_MODEL_ACCOUNT_COL_BALANCE,
                                      GNC_TREE_MODEL_ACCOUNT_COL_COLOR_BALANCE,
@@ -1787,7 +1787,7 @@ gtva_update_column_names (GncTreeViewAccount *view)
                             /* Translators: %s is a currency mnemonic.*/
                             _("Present (%s)"), mnemonic);
     gtva_update_column_name(view->balance_report_column,
-                            /* Translators: %s is a currency mnemonic and this is a column header.*/
+                            /* Translators: %s is a currency mnemonic.*/
                             _("Balance (%s)"), mnemonic);
     gtva_update_column_name(view->cleared_report_column,
                             /* Translators: %s is a currency mnemonic.*/

--- a/gnucash/gnome-utils/gnc-tree-view-owner.c
+++ b/gnucash/gnome-utils/gnc-tree-view-owner.c
@@ -436,22 +436,20 @@ gnc_tree_view_owner_new (GncOwnerType owner_type)
                                   GNC_TREE_MODEL_OWNER_COL_EMAIL,
                                   GNC_TREE_VIEW_COLUMN_VISIBLE_ALWAYS,
                                   sort_by_string);
-    gnc_tree_view_add_numeric_column(GNC_TREE_VIEW(view), C_("column header", "Balance"),
-                                     GNC_OWNER_TREE_BALANCE_COL,
+    gnc_tree_view_add_numeric_column(GNC_TREE_VIEW(view), _("Balance"), GNC_OWNER_TREE_BALANCE_COL,
                                      SAMPLE_OWNER_VALUE,
                                      GNC_TREE_MODEL_OWNER_COL_BALANCE,
                                      GNC_TREE_MODEL_OWNER_COL_COLOR_BALANCE,
                                      GNC_TREE_VIEW_COLUMN_VISIBLE_ALWAYS,
                                      sort_by_balance_value);
 
-    view->balance_report_column =
-      gnc_tree_view_add_numeric_column(GNC_TREE_VIEW(view), C_("column header", "Balance"),
-                                       GNC_OWNER_TREE_BALANCE_REPORT_COL,
-                                       SAMPLE_OWNER_VALUE,
-                                       GNC_TREE_MODEL_OWNER_COL_BALANCE_REPORT,
-                                       GNC_TREE_MODEL_OWNER_COL_COLOR_BALANCE,
-                                       GNC_TREE_VIEW_COLUMN_VISIBLE_ALWAYS,
-                                       sort_by_balance_value);
+    view->balance_report_column
+        = gnc_tree_view_add_numeric_column(GNC_TREE_VIEW(view), _("Balance"), GNC_OWNER_TREE_BALANCE_REPORT_COL,
+                                           SAMPLE_OWNER_VALUE,
+                                           GNC_TREE_MODEL_OWNER_COL_BALANCE_REPORT,
+                                           GNC_TREE_MODEL_OWNER_COL_COLOR_BALANCE,
+                                           GNC_TREE_VIEW_COLUMN_VISIBLE_ALWAYS,
+                                           sort_by_balance_value);
 
     view->notes_column
         = gnc_tree_view_add_text_column(GNC_TREE_VIEW(view), _("Notes"), GNC_OWNER_TREE_NOTES_COL, NULL,
@@ -895,7 +893,7 @@ gtvo_update_column_names (GncTreeViewOwner *view)
     const gchar *mnemonic = gnc_commodity_get_mnemonic(gnc_default_report_currency());
 
     gtvo_update_column_name(view->balance_report_column,
-                            /* Translators: %s is a currency mnemonic and this is a column header.*/
+                            /* Translators: %s is a currency mnemonic.*/
                             _("Balance (%s)"), mnemonic);
     gnc_tree_view_set_show_column_menu(GNC_TREE_VIEW(view), FALSE);
     gnc_tree_view_set_show_column_menu(GNC_TREE_VIEW(view), TRUE);

--- a/gnucash/gnome/dialog-lot-viewer.c
+++ b/gnucash/gnome/dialog-lot-viewer.c
@@ -938,7 +938,7 @@ lv_init_lot_view (GNCLotViewer *lv)
     gtk_tree_view_append_column(view, column);
 
     renderer = gtk_cell_renderer_text_new();
-    column = gtk_tree_view_column_new_with_attributes(C_("column heading", "Balance"), renderer,
+    column = gtk_tree_view_column_new_with_attributes(_("Balance"), renderer,
              "text", LOT_COL_BALN, NULL);
     configure_number_columns (column, renderer, LOT_COL_BALN_DOUBLE);
     gtk_tree_view_append_column(view, column);
@@ -1030,7 +1030,7 @@ lv_init_split_view (GNCLotViewer *lv, GtkTreeView *view)
     gtk_tree_view_append_column(view, column);
 
     renderer = gtk_cell_renderer_text_new();
-    column = gtk_tree_view_column_new_with_attributes(C_("column header", "Balance"), renderer,
+    column = gtk_tree_view_column_new_with_attributes(_("Balance"), renderer,
              "text", SPLIT_COL_BALANCE, NULL);
     configure_number_columns (column, renderer, SPLIT_COL_BALANCE_DOUBLE);
     gtk_tree_view_append_column(view, column);

--- a/gnucash/gtkbuilder/dialog-account.glade
+++ b/gnucash/gtkbuilder/dialog-account.glade
@@ -1834,7 +1834,7 @@ Clear the entry to have no warning.</property>
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="halign">end</property>
-                        <property name="label" translatable="yes">_Balance</property>
+                        <property name="label" translatable="yes" context="field label">_Balance</property>
                         <property name="use-underline">True</property>
                         <property name="justify">right</property>
                       </object>

--- a/gnucash/ui/gnc-reconcile-window.ui
+++ b/gnucash/ui/gnc-reconcile-window.ui
@@ -95,7 +95,7 @@
 
   <menu id="recwin-popup">
     <item>
-      <attribute name="label" translatable="yes">_Balance</attribute>
+      <attribute name="label" translatable="yes" context="reconcile menu">_Balance</attribute>
       <attribute name="action">recwin.TransBalanceAction</attribute>
     </item>
     <item>
@@ -126,7 +126,7 @@
         <property name="can-focus">False</property>
         <property name="tooltip-text" translatable="yes">Add a new balancing entry to the account</property>
         <property name="action-name">recwin.TransBalanceAction</property>
-        <property name="label" translatable="yes">_Balance</property>
+        <property name="label" translatable="yes" context="reconcile menu">_Balance</property>
         <property name="use-underline">True</property>
         <property name="icon-name">document-new</property>
       </object>


### PR DESCRIPTION
The previous fix (https://github.com/Gnucash/gnucash/commit/2e52086451549fc58355ac656e702f952bc352f4) for this ticket added context for some uses of string "Balance" but that's not part of the original ticket and doesn't have ambiguity (it's always used as a noun). The real problem "_Balance" (the underscore indicates it is a label of an action) however is not fully covered. This ticket adds context all uses of "_Balance" and removed the unnecesary contexts for "Balance".