### PR TITLE
Add missing `#include <cstdint>`

### DIFF
--- a/bindings/guile/gnc-kvp-guile.cpp
+++ b/bindings/guile/gnc-kvp-guile.cpp
@@ -2,6 +2,7 @@
 #include <kvp-frame.hpp>
 #include <libguile.h>
 #include <numeric>
+#include <cstdint>
 
 #include <config.h>
 

--- a/gnucash/gnome-utils/gnc-option-gtk-ui.cpp
+++ b/gnucash/gnome-utils/gnc-option-gtk-ui.cpp
@@ -25,6 +25,7 @@
 #include "gnc-option-gtk-ui.hpp"
 #include <config.h>  // for scanf format string
 #include <memory>
+#include <cstdint>
 #include <qof.h>
 #include <gnc-engine.h> // for GNC_MOD_GUI
 #include <gnc-commodity.h> // for GNC_COMMODITY

--- a/gnucash/gnome-utils/test/test-autoclear.cpp
+++ b/gnucash/gnome-utils/test/test-autoclear.cpp
@@ -26,6 +26,7 @@
 // GoogleTest is written in C++, however, the function we test in C.
 #include "../gnc-autoclear.h"
 #include <memory>
+#include <cstdint>
 #include <Account.h>
 #include <Split.h>
 #include <gtest/gtest.h>

--- a/gnucash/import-export/aqb/assistant-ab-initial.c
+++ b/gnucash/import-export/aqb/assistant-ab-initial.c
@@ -51,6 +51,7 @@
 #endif
 #include <fcntl.h>
 #include <unistd.h>
+#include <stdint.h>
 
 #include "dialog-utils.h"
 #include "assistant-ab-initial.h"

--- a/gnucash/import-export/aqb/gnc-gwen-gui.c
+++ b/gnucash/import-export/aqb/gnc-gwen-gui.c
@@ -31,6 +31,7 @@
 #include <config.h>
 
 #include <ctype.h>
+#include <stdint.h>
 #include <glib/gi18n.h>
 #include <gwenhywfar/gui_be.h>
 #include <gwenhywfar/inherit.h>

--- a/gnucash/import-export/csv-imp/assistant-csv-price-import.cpp
+++ b/gnucash/import-export/csv-imp/assistant-csv-price-import.cpp
@@ -34,6 +34,7 @@
 #include <gtk/gtk.h>
 #include <glib/gi18n.h>
 #include <stdlib.h>
+#include <cstdint>
 
 #include "gnc-ui.h"
 #include "gnc-uri-utils.h"

--- a/gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp
+++ b/gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp
@@ -36,6 +36,7 @@
 #include <glib/gi18n.h>
 #include <stdexcept>
 #include <stdlib.h>
+#include <cstdint>
 
 #include "gnc-path.h"
 #include "gnc-ui.h"

--- a/gnucash/import-export/csv-imp/gnc-imp-settings-csv-price.cpp
+++ b/gnucash/import-export/csv-imp/gnc-imp-settings-csv-price.cpp
@@ -33,6 +33,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 #include <config.h>
 

--- a/gnucash/import-export/csv-imp/gnc-imp-settings-csv-tx.cpp
+++ b/gnucash/import-export/csv-imp/gnc-imp-settings-csv-tx.cpp
@@ -33,6 +33,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 #include <config.h>
 

--- a/gnucash/import-export/csv-imp/gnc-imp-settings-csv.hpp
+++ b/gnucash/import-export/csv-imp/gnc-imp-settings-csv.hpp
@@ -35,6 +35,7 @@
 #include <string>
 #include <vector>
 #include <optional>
+#include <cstdint>
 #include <gnc-datetime.hpp>
 #include "gnc-tokenizer.hpp"
 

--- a/gnucash/import-export/csv-imp/gnc-import-price.hpp
+++ b/gnucash/import-export/csv-imp/gnc-import-price.hpp
@@ -38,6 +38,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <cstdint>
 
 #include "gnc-tokenizer.hpp"
 #include "gnc-imp-props-price.hpp"

--- a/gnucash/import-export/csv-imp/gnc-import-tx.hpp
+++ b/gnucash/import-export/csv-imp/gnc-import-tx.hpp
@@ -39,6 +39,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <cstdint>
 
 #include "gnc-tokenizer.hpp"
 #include "gnc-imp-props-tx.hpp"

--- a/gnucash/import-export/csv-imp/gnc-tokenizer-fw.hpp
+++ b/gnucash/import-export/csv-imp/gnc-tokenizer-fw.hpp
@@ -43,6 +43,7 @@
 #include <fstream>      // fstream
 #include <vector>
 #include <string>
+#include <cstdint>
 #include "gnc-tokenizer.hpp"
 
 class GncFwTokenizer : public GncTokenizer

--- a/libgnucash/app-utils/test/test-print-parse-amount.cpp
+++ b/libgnucash/app-utils/test/test-print-parse-amount.cpp
@@ -23,6 +23,7 @@
 
 #include <config.h>
 #include <stdlib.h>
+#include <cstdint>
 
 #include "gnc-ui-util.h"
 #include "gnc-numeric.h"

--- a/libgnucash/backend/dbi/gnc-dbisqlresult.hpp
+++ b/libgnucash/backend/dbi/gnc-dbisqlresult.hpp
@@ -26,6 +26,7 @@
 #define __GNC_DBISQLBACKEND_HPP__
 
 #include <optional>
+#include <cstdint>
 
 #include "gnc-backend-dbi.h"
 #include <gnc-sql-result.hpp>

--- a/libgnucash/backend/sql/gnc-slots-sql.cpp
+++ b/libgnucash/backend/sql/gnc-slots-sql.cpp
@@ -39,6 +39,7 @@
 
 #include <string>
 #include <sstream>
+#include <cstdint>
 
 #include "gnc-sql-connection.hpp"
 #include "gnc-sql-backend.hpp"

--- a/libgnucash/backend/sql/gnc-sql-column-table-entry.cpp
+++ b/libgnucash/backend/sql/gnc-sql-column-table-entry.cpp
@@ -25,6 +25,7 @@
 #include <qof.h>
 #include <sstream>
 #include <iomanip>
+#include <cstdint>
 #include <gnc-datetime.hpp>
 #include "gnc-sql-backend.hpp"
 #include "gnc-sql-object-backend.hpp"

--- a/libgnucash/backend/sql/test/utest-gnc-backend-sql.cpp
+++ b/libgnucash/backend/sql/test/utest-gnc-backend-sql.cpp
@@ -23,6 +23,7 @@
 #include <glib.h>
 
 #include <config.h>
+#include <cstdint>
 #include <string.h>
 #include <unittest-support.h>
 /* Add specific headers for this class */

--- a/libgnucash/backend/xml/io-gncxml-v2.cpp
+++ b/libgnucash/backend/xml/io-gncxml-v2.cpp
@@ -44,6 +44,7 @@
 #endif
 #include <zlib.h>
 #include <errno.h>
+#include <cstdint>
 
 #include "gnc-engine.h"
 #include "gnc-pricedb-p.h"

--- a/libgnucash/backend/xml/sixtp-dom-generators.cpp
+++ b/libgnucash/backend/xml/sixtp-dom-generators.cpp
@@ -27,6 +27,7 @@
 #include <config.h>
 
 #include <gnc-date.h>
+#include <cstdint>
 
 #include "gnc-xml-helper.h"
 #include "sixtp-dom-generators.h"

--- a/libgnucash/engine/gnc-numeric.hpp
+++ b/libgnucash/engine/gnc-numeric.hpp
@@ -27,6 +27,7 @@
 #include <iostream>
 #include <locale>
 #include <typeinfo> // For std::bad_cast exception
+#include <cstdint>
 #include "gnc-rational-rounding.hpp"
 
 class GncRational;

--- a/libgnucash/engine/gnc-option-impl.hpp
+++ b/libgnucash/engine/gnc-option-impl.hpp
@@ -50,6 +50,7 @@
 #include <variant>
 #include <iostream>
 #include <limits>
+#include <cstdint>
 
 #include "gnc-option-uitype.hpp"
 

--- a/libgnucash/engine/gnc-option.hpp
+++ b/libgnucash/engine/gnc-option.hpp
@@ -42,6 +42,7 @@
 #include <variant>
 #include <memory>
 #include <tuple>
+#include <cstdint>
 #include "gnc-option-ui.hpp"
 #include "gnc-option-date.hpp"
 #include "guid.hpp"

--- a/libgnucash/engine/gnc-optiondb.hpp
+++ b/libgnucash/engine/gnc-optiondb.hpp
@@ -38,6 +38,7 @@
 #include <exception>
 #include <optional>
 #include <iostream>
+#include <cstdint>
 
 #include <config.h>
 #include "Account.h"

--- a/libgnucash/engine/gnc-rational.cpp
+++ b/libgnucash/engine/gnc-rational.cpp
@@ -21,6 +21,7 @@
  *******************************************************************/
 
 #include <sstream>
+#include <cstdint>
 #include "gnc-rational.hpp"
 #include "gnc-numeric.hpp"
 

--- a/libgnucash/engine/gncInvoice.c
+++ b/libgnucash/engine/gncInvoice.c
@@ -29,7 +29,6 @@
 
 #include <config.h>
 
-#include <stdint.h>
 #include <inttypes.h>
 #include <glib.h>
 #include <glib/gi18n.h>

--- a/libgnucash/engine/kvp-frame.cpp
+++ b/libgnucash/engine/kvp-frame.cpp
@@ -27,6 +27,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
+#include <cstdint>
 
 #include "kvp-value.hpp"
 #include "kvp-frame.hpp"

--- a/libgnucash/engine/kvp-value.hpp
+++ b/libgnucash/engine/kvp-value.hpp
@@ -27,6 +27,7 @@
 #include <config.h>
 #include "qof.h"
 
+#include <cstdint>
 #include <boost/variant.hpp>
 
 //Must be a struct because it's exposed to C so that it can in turn be

--- a/libgnucash/engine/qofinstance.cpp
+++ b/libgnucash/engine/qofinstance.cpp
@@ -33,6 +33,7 @@
 #include <config.h>
 #include <glib.h>
 
+#include <cstdint>
 #include <utility>
 #include "qof.h"
 #include "qofbook-p.h"

--- a/libgnucash/engine/test-core/test-engine-stuff.cpp
+++ b/libgnucash/engine/test-core/test-engine-stuff.cpp
@@ -47,7 +47,6 @@
 #include <fcntl.h>
 #include <glib.h>
 #include <stdio.h>
-#include <stdint.h>
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>

--- a/libgnucash/engine/test/gtest-gnc-int128.cpp
+++ b/libgnucash/engine/test/gtest-gnc-int128.cpp
@@ -22,6 +22,7 @@
  *******************************************************************/
 
 #include <gtest/gtest.h>
+#include <cstdint>
 #include "../gnc-int128.hpp"
 
 TEST(GncInt128_constructors, test_default_constructor)

--- a/libgnucash/engine/test/gtest-gnc-numeric.cpp
+++ b/libgnucash/engine/test/gtest-gnc-numeric.cpp
@@ -21,6 +21,7 @@
 \********************************************************************/
 
 #include <gtest/gtest.h>
+#include <cstdint>
 #include "../gnc-numeric.hpp"
 #include "../gnc-rational.hpp"
 

--- a/libgnucash/engine/test/gtest-gnc-option.cpp
+++ b/libgnucash/engine/test/gtest-gnc-option.cpp
@@ -33,6 +33,7 @@
 #include "gnc-commodity.h"
 #include "gnc-date.h"
 #include <time.h>
+#include <cstdint>
 #include "gnc-session.h"
 
 TEST(GncOption, test_string_ctor)

--- a/libgnucash/engine/test/gtest-gnc-optiondb.cpp
+++ b/libgnucash/engine/test/gtest-gnc-optiondb.cpp
@@ -27,6 +27,7 @@
 #include "gnc-option-ui.hpp"
 #include "kvp-value.hpp"
 #include <glib-2.0/glib.h>
+#include <cstdint>
 
 #include "gnc-session.h"
 

--- a/libgnucash/engine/test/gtest-gnc-rational.cpp
+++ b/libgnucash/engine/test/gtest-gnc-rational.cpp
@@ -23,6 +23,7 @@
 
 #include <gtest/gtest.h>
 #include <random>
+#include <cstdint>
 #include "../gnc-rational.hpp"
 #include "../gnc-numeric.hpp" //for RoundType
 

--- a/libgnucash/engine/test/gtest-import-map.cpp
+++ b/libgnucash/engine/test/gtest-import-map.cpp
@@ -28,6 +28,7 @@
 #include <kvp-frame.hpp>
 #include <gtest/gtest.h>
 #include <string>
+#include <cstdint>
 
 class ImapTest : public testing::Test
 {

--- a/libgnucash/engine/test/test-kvp-frame.cpp
+++ b/libgnucash/engine/test/test-kvp-frame.cpp
@@ -27,6 +27,7 @@
 #include "../kvp-frame.hpp"
 #include <gtest/gtest.h>
 #include <algorithm>
+#include <cstdint>
 
 class KvpFrameTest : public ::testing::Test
 {

--- a/libgnucash/engine/test/test-kvp-value.cpp
+++ b/libgnucash/engine/test/test-kvp-value.cpp
@@ -28,6 +28,7 @@
 #include "../kvp-frame.hpp"
 #include "../gnc-date.h"
 #include <memory>
+#include <cstdint>
 #include <gtest/gtest.h>
 
 TEST (KvpValueTest, Equality)


### PR DESCRIPTION
* GCC 15 has reduced transitive dependencies between headers.

Bug: https://bugs.gentoo.org/939856