### PR TITLE
SX editor - use integer-type schema parameters rather than string and…

### DIFF
--- a/gnucash/gnome/gnc-plugin-page-sx-list.cpp
+++ b/gnucash/gnome/gnc-plugin-page-sx-list.cpp
@@ -508,7 +508,7 @@ gnc_plugin_page_sx_list_create_widget (GncPluginPage *plugin_page)
 
     /* Set the paned position from the preferences, default 160 */
     gtk_paned_set_position (GTK_PANED(priv->widget),
-                            gnc_prefs_get_float (GNC_PREFS_GROUP_SXED,
+                            gnc_prefs_get_int (GNC_PREFS_GROUP_SXED,
                                                  GNC_PREF_DIVIDER_POS));
 
     {
@@ -585,9 +585,8 @@ gnc_plugin_page_sx_list_create_widget (GncPluginPage *plugin_page)
         g_object_ref_sink (priv->gdcal);
 
         /* Set number of months from preference, default 12 */
-        gchar *num_months = gnc_prefs_get_string (GNC_PREFS_GROUP_SXED, GNC_PREF_NUM_OF_MONTHS);
-        gnc_dense_cal_set_num_months (priv->gdcal, atoi (num_months));
-        g_free (num_months);
+        auto num_months = gnc_prefs_get_int (GNC_PREFS_GROUP_SXED, GNC_PREF_NUM_OF_MONTHS);
+        gnc_dense_cal_set_num_months (priv->gdcal, num_months);
 
         gtk_container_add (GTK_CONTAINER(swin), GTK_WIDGET(priv->gdcal));
     }
@@ -766,23 +765,19 @@ gnc_plugin_page_sx_list_cmd_save_layout (GSimpleAction *simple,
 {
     auto plugin_page = GNC_PLUGIN_PAGE_SX_LIST(user_data);
     GncPluginPageSxListPrivate *priv;
-    gchar *num_of_months;
     gint paned_position;
 
     g_return_if_fail (GNC_IS_PLUGIN_PAGE_SX_LIST(plugin_page));
 
     priv = GNC_PLUGIN_PAGE_SX_LIST_GET_PRIVATE(plugin_page);
 
-    num_of_months = g_strdup_printf ("%d", gnc_dense_cal_get_num_months (priv->gdcal));
     paned_position = gtk_paned_get_position (GTK_PANED(priv->widget));
 
-    gnc_prefs_set_float (GNC_PREFS_GROUP_SXED, GNC_PREF_DIVIDER_POS,
+    gnc_prefs_set_int (GNC_PREFS_GROUP_SXED, GNC_PREF_DIVIDER_POS,
                          paned_position);
 
-    gnc_prefs_set_string (GNC_PREFS_GROUP_SXED, GNC_PREF_NUM_OF_MONTHS,
-                          num_of_months);
-
-    g_free (num_of_months);
+    gnc_prefs_set_int (GNC_PREFS_GROUP_SXED, GNC_PREF_NUM_OF_MONTHS,
+                          gnc_dense_cal_get_num_months (priv->gdcal));
 }
 
 static void

--- a/gnucash/gnome/gnc-plugin-page-sx-list.cpp
+++ b/gnucash/gnome/gnc-plugin-page-sx-list.cpp
@@ -586,6 +586,11 @@ gnc_plugin_page_sx_list_create_widget (GncPluginPage *plugin_page)
 
         /* Set number of months from preference, default 12 */
         auto num_months = gnc_prefs_get_int (GNC_PREFS_GROUP_SXED, GNC_PREF_NUM_OF_MONTHS);
+        if (num_months == 0)
+        {
+            PWARN ("Got invalid value '0' for number of months to display. This suggests a gsettings configuration issue. Continuing with a default value of 12 instead.");
+            num_months = 12;
+        }
         gnc_dense_cal_set_num_months (priv->gdcal, num_months);
 
         gtk_container_add (GTK_CONTAINER(swin), GTK_WIDGET(priv->gdcal));

--- a/gnucash/gschemas/org.gnucash.GnuCash.dialogs.sxs.gschema.xml.in
+++ b/gnucash/gschemas/org.gnucash.GnuCash.dialogs.sxs.gschema.xml.in
@@ -54,12 +54,12 @@
       <summary>How many days in advance to notify the user.</summary>
       <description>How many days in advance to notify the user.</description>
     </key>
-    <key name="number-of-months" type="s">
-      <default>'12'</default>
+    <key name="number-of-months" type="i">
+      <default>12</default>
       <summary>The number of months to be shown in editor.</summary>
       <description>The number of months to be shown in editor.</description>
     </key>
-    <key name="divider-position" type="d">
+    <key name="divider-position" type="i">
       <default>160</default>
       <summary>The horizontal position of the editor divider.</summary>
       <description>The horizontal position of the editor divider.</description>


### PR DESCRIPTION
… double

GnuCash expects these values to be integers anyway, so this avoids needless type conversions