### PR TITLE
[html-chart] change default mode to 'index and intersect #f

### DIFF
--- a/gnucash/report/html-chart.scm
+++ b/gnucash/report/html-chart.scm
@@ -212,6 +212,8 @@
                                      (cons 'point (list
                                                    (cons 'pointStyle #f)))))
                     (cons 'tooltips (list
+                                     (cons 'mode 'index)
+                                     (cons 'intersect #f)
                                      (cons 'callbacks (list
                                                        (cons 'label #f)))))
 

--- a/gnucash/report/reports/standard/balance-forecast.scm
+++ b/gnucash/report/reports/standard/balance-forecast.scm
@@ -291,10 +291,6 @@ date point, a projected minimum balance including scheduled transactions."))
         (gnc:html-chart-set-currency-symbol!
          chart (gnc-commodity-get-nice-symbol currency))
 
-        ;; Allow tooltip in whole chartarea
-        (gnc:html-chart-set! chart '(options tooltips mode) "index")
-        (gnc:html-chart-set! chart '(options tooltips intersect) #f)
-
         ;; We're done!
         (gnc:html-document-add-object! document chart)
         (gnc:report-finished))))


### PR DESCRIPTION
Will enable tooltips over the chart canvas, instead of requiring the mouse to hover near the data point.

I think the current default is 'point' and this change to 'index' will enable the IMHO nicer tooltip behaviour across all charts.

See demo at https://www.chartjs.org/docs/latest/samples/tooltip/interactions.html 