### PR TITLE
Bug 799487 - Unable to save gnucash DB file as XML file

### DIFF
--- a/gnucash/gnome-utils/gnc-file.c
+++ b/gnucash/gnome-utils/gnc-file.c
@@ -1593,8 +1593,12 @@ gnc_file_do_save_as (GtkWindow *parent, const char* filename)
     }
 
     /* Make sure all of the data from the old file is loaded */
+    qof_event_suspend ();
+    gnc_suspend_gui_refresh ();
     qof_session_ensure_all_data_loaded(session);
-
+    gnc_resume_gui_refresh ();
+    qof_event_resume ();
+    
     /* -- this session code is NOT identical in FileOpen and FileSaveAs -- */
 
     save_in_progress++;

--- a/libgnucash/backend/sql/gnc-sql-backend.cpp
+++ b/libgnucash/backend/sql/gnc-sql-backend.cpp
@@ -30,6 +30,7 @@
 #include <gncTaxTable.h>
 #include <gncInvoice.h>
 #include <gnc-pricedb.h>
+#include <TransLog.h>
 
 #include <algorithm>
 #include <cassert>
@@ -347,8 +348,10 @@ GncSqlBackend::load (QofBook* book, QofBackendLoadType loadType)
      * m_loading true prevents changes from being written back to the
      * database. Do that now.
      */
+    xaccLogDisable();
     auto transactions = qof_book_get_collection (book, GNC_ID_TRANS);
     qof_collection_foreach(transactions, scrub_txn_callback, nullptr);
+    xaccLogEnable();
 
     /* Mark the session as clean -- though it should never be marked
      * dirty with this backend


### PR DESCRIPTION
Not quite true, it just takes a really long time for a large database.

The underlying problem is gnc_file_do_save_as reloads the data to make sure that the save-as saves everything. On the SQL backend that triggers a scrub. The scrub itseld doesn't take long, but every transaction commit was logged in the transaction log and did a refresh of the registers. So:
* Suspend logging while doing the scrub.
* Suspend UI refreshes while reloading the data.
* Make the register page event handler obey the refresh being suspended.

@Bob-IT I'm a bit concerned about that last bullet: Is there a reason that `gnc_plugin_page_register_event_handler` doesn't respect the suspend? Or is it that none of the handlers check whether the GUI is suspended because suspension is supposed to be handled somewhere else?