### PR TITLE
Fix incorrect deallocation type

### DIFF
--- a/libgnucash/backend/xml/gnc-account-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-account-xml-v2.cpp
@@ -375,7 +375,7 @@ account_parent_handler (xmlNodePtr node, gpointer act_pdata)
     parent = xaccAccountLookup (gid, pdata->book);
     if (!parent)
     {
-        g_free (gid);
+        guid_free (gid);
         g_return_val_if_fail (parent, FALSE);
     }
 


### PR DESCRIPTION
Objects created with ```dom_tree_to_guid``` must be destroyed with ```guid_free```.