### PR TITLE
Bug 799514 - Pie chart hovering shows wrong information in pop-up

### DIFF
--- a/gnucash/report/html-chart.scm
+++ b/gnucash/report/html-chart.scm
@@ -271,7 +271,8 @@
   (gnc:html-chart-get chart '(type)))
 
 (define (gnc:html-chart-set-type! chart type)
-  (gnc:html-chart-set! chart '(type) type))
+  (gnc:html-chart-set! chart '(type) type)
+  (gnc:html-chart-set! chart '(options tooltips intersect) (equal? type 'pie)))
 
 (define (gnc:html-chart-title chart)
   (gnc:html-chart-get chart '(options title text)))


### PR DESCRIPTION
Set intersect to true for pie charts.