### PR TITLE
Bug 798946 - start/end of current/last quarter have off-by-one error

### DIFF
--- a/libgnucash/engine/gnc-option-date.cpp
+++ b/libgnucash/engine/gnc-option-date.cpp
@@ -524,12 +524,7 @@ gnc_relative_date_to_time64(RelativeDatePeriod period)
                 now.tm_mon += 6;
             break;
         case RelativeDateOffset::QUARTER:
-        {
-            auto delta = (now.tm_mon >= acct_per.tm_mon ?
-                          ( now.tm_mon - acct_per.tm_mon) % 3 :
-                          (3 - acct_per.tm_mon - now.tm_mon) % 3);
-            now.tm_mon = now.tm_mon - delta;
-        }
+            now.tm_mon -= (12 + now.tm_mon - acct_per.tm_mon) % 3;
             [[fallthrough]];
         case RelativeDateOffset::THREE:
             if (reldate_is_prev(period))


### PR DESCRIPTION
Correct determination of current quarter.