### PR TITLE
L10N:fi: Restore lost translations

### DIFF
--- a/po/fi.po
+++ b/po/fi.po
@@ -712,7 +712,6 @@ msgstr ""
 "osoitteessa https://wiki.gnucash.org/wiki/Mailing_Lists"
 
 #: doc/tip_of_the_day.list.c:11
-#, fuzzy
 #| msgid ""
 #| "The GnuCash developers are easy to contact. As well as several mailing "
 #| "lists, you can chat to them live on IRC! Join them on #gnucash at irc."
@@ -723,8 +722,8 @@ msgid ""
 "net"
 msgstr ""
 "GnuCashin tekijät on helppo tavoittaa. Useiden sähköpostilistojen lisäksi "
-"voit jutella heidän kanssaan IRC:ssä! Liity #gnucash -kanavalle irc.gnome."
-"org:ssa"
+"voit jutella heidän kanssaan IRC:ssä! Liity #gnucash -kanavalle irc.gimp."
+"net:ssä"
 
 #: doc/tip_of_the_day.list.c:15
 msgid ""
@@ -2747,11 +2746,11 @@ msgstr "CSV-tilikartta"
 
 #: gnucash/gnome/dialog-imap-editor.c:742
 msgid "Online Id"
-msgstr ""
+msgstr "Verkkotunnus"
 
 #: gnucash/gnome/dialog-imap-editor.c:768
 msgid "Online HBCI"
-msgstr ""
+msgstr "Verkkopankki HBCI"
 
 #. Translators: In this context,
 #. 'Billing information' maps to the
@@ -2760,18 +2759,16 @@ msgstr ""
 #. invoiced.
 #: gnucash/gnome/dialog-invoice.c:471 gnucash/gnome/dialog-order.c:180
 msgid "You need to supply Billing Information."
-msgstr ""
+msgstr "Anna laskutustiedot."
 
 #: gnucash/gnome/dialog-invoice.c:727
-#, fuzzy
-#| msgid "Are you sure you want to delete the selected commodity?"
 msgid "Are you sure you want to delete the selected entry?"
-msgstr "Oletko varma että haluat poistaa valitun hyödykkeen?"
+msgstr "Haluatko varmasti poistaa valitun kirjauksen?"
 
 #: gnucash/gnome/dialog-invoice.c:729
 msgid ""
 "This entry is attached to an order and will be deleted from that as well!"
-msgstr ""
+msgstr "Tämä kirjaus on liitetty tilaukseen ja poistetaan myös siitä!"
 
 #: gnucash/gnome/dialog-invoice.c:924
 msgid "Choose a different report template or Printable Invoice will be used"
@@ -2787,207 +2784,177 @@ msgstr ""
 #: gnucash/report/reports/standard/new-owner-report.scm:50
 #: gnucash/report/reports/standard/new-owner-report.scm:937
 #: gnucash/report/reports/support/taxinvoice.eguile.scm:233
-#, fuzzy
-#| msgid "Date"
 msgid "Due Date"
-msgstr "Päiväys"
+msgstr "Eräpäivä"
 
 #: gnucash/gnome/dialog-invoice.c:1039
 #: gnucash/report/reports/standard/new-aging.scm:113
 #: gnucash/report/reports/standard/new-owner-report.scm:938
-#, fuzzy
-#| msgid "Closing Date"
 msgid "Post Date"
-msgstr "Tilinpäätöspäivä"
+msgstr "Vientipäivä"
 
 #: gnucash/gnome/dialog-invoice.c:1040
-#, fuzzy
-#| msgid "Account"
 msgid "Post to Account"
-msgstr "Tili"
+msgstr "Vie tilille"
 
 #: gnucash/gnome/dialog-invoice.c:1041
 msgid "Accumulate Splits?"
-msgstr ""
+msgstr "Kerrytä rivit?"
 
 #: gnucash/gnome/dialog-invoice.c:1133
 msgid "The Invoice must have at least one Entry."
-msgstr ""
+msgstr "Myyntilaskulla täytyy olla ainakin yksi rivi."
 
 #: gnucash/gnome/dialog-invoice.c:1153
 msgid "Do you really want to post the invoice?"
-msgstr ""
+msgstr "Haluatko varmasti viedä tämän myyntilaskun tilikirjaan?"
 
 #: gnucash/gnome/dialog-invoice.c:1171
 msgid ""
 "One or more of the entries are for accounts different from the invoice/bill "
 "currency. You will be asked to enter a conversion rate for each."
 msgstr ""
+"Yksi tai useampi kirjaus on tilille, jotka käyttävät eri valuuttaa kuin "
+"lasku. Sinua pyydetään syöttämään jokaisen vaihtokurssi."
 
 #: gnucash/gnome/dialog-invoice.c:1304
 msgid "The post action was canceled because not all exchange rates were given."
-msgstr ""
+msgstr "Vienti peruttiin, koska kaikkia vaihtokursseja ei syötetty."
 
 #: gnucash/gnome/dialog-invoice.c:1589
 msgid "Total:"
-msgstr ""
+msgstr "Yhteensä:"
 
 #: gnucash/gnome/dialog-invoice.c:1595
 msgid "Subtotal:"
-msgstr ""
+msgstr "Välisumma:"
 
 #: gnucash/gnome/dialog-invoice.c:1596
 msgid "Tax:"
-msgstr ""
+msgstr "Vero:"
 
 #: gnucash/gnome/dialog-invoice.c:1600
 msgid "Total Cash:"
-msgstr ""
+msgstr "Käteinen yhteensä:"
 
 #: gnucash/gnome/dialog-invoice.c:1601
 msgid "Total Charge:"
-msgstr "Kokonaisveloitus:"
+msgstr "Veloitus yhteensä:"
 
 #: gnucash/gnome/dialog-invoice.c:2074 gnucash/gnome/dialog-payment.c:1373
 #: gnucash/gtkbuilder/dialog-invoice.glade:976
 #: gnucash/report/reports/standard/invoice.scm:780
 #: libgnucash/engine/gncInvoice.c:1103
-#, fuzzy
-#| msgid "Credit"
 msgid "Credit Note"
-msgstr "Kredit"
+msgstr "Hyvityslasku"
 
 #: gnucash/gnome/dialog-invoice.c:2270
 msgid "PAID"
-msgstr ""
+msgstr "MAKSETTU"
 
 #: gnucash/gnome/dialog-invoice.c:2272
 #: gnucash/report/reports/standard/new-owner-report.scm:570
 msgid "UNPAID"
-msgstr ""
+msgstr "MAKSAMATTA"
 
 #: gnucash/gnome/dialog-invoice.c:2320 gnucash/gnome/dialog-invoice.c:2339
 #: gnucash/gnome/dialog-invoice.c:2358
 msgid "New Credit Note"
-msgstr ""
+msgstr "Uusi hyvityslasku"
 
 #: gnucash/gnome/dialog-invoice.c:2321
 #: gnucash/gnome/gnc-plugin-page-owner-tree.cpp:226
 #: gnucash/gnome-search/dialog-search.c:1095
 #: gnucash/gtkbuilder/dialog-invoice.glade:760
-#, fuzzy
-#| msgid "Invoice"
 msgid "New Invoice"
-msgstr "Myyntilasku"
+msgstr "Uusi myyntilasku"
 
 #: gnucash/gnome/dialog-invoice.c:2326 gnucash/gnome/dialog-invoice.c:2345
 #: gnucash/gnome/dialog-invoice.c:2364
-#, fuzzy
-#| msgid "Edit Customer"
 msgid "Edit Credit Note"
-msgstr "Muokkaa asiakasta"
+msgstr "Muokkaa hyvityslaskua"
 
 #: gnucash/gnome/dialog-invoice.c:2327
-#, fuzzy
-#| msgid "Invoice"
 msgid "Edit Invoice"
-msgstr "Myyntilasku"
+msgstr "Muokkaa myyntilaskua"
 
 #: gnucash/gnome/dialog-invoice.c:2330 gnucash/gnome/dialog-invoice.c:2349
 #: gnucash/gnome/dialog-invoice.c:2368
 msgid "View Credit Note"
-msgstr ""
+msgstr "Näytä hyvityslasku"
 
 #: gnucash/gnome/dialog-invoice.c:2331
-#, fuzzy
-#| msgid "Invoice"
 msgid "View Invoice"
-msgstr "Myyntilasku"
+msgstr "Näytä myyntilasku"
 
 #: gnucash/gnome/dialog-invoice.c:2340
 #: gnucash/gnome/gnc-plugin-page-owner-tree.cpp:225
 #: gnucash/gnome-search/dialog-search.c:1079
-#, fuzzy
-#| msgid "Bill"
 msgid "New Bill"
-msgstr "Ostolasku"
+msgstr "Uusi ostolasku"
 
 #: gnucash/gnome/dialog-invoice.c:2346
-#, fuzzy
-#| msgid "Bill"
 msgid "Edit Bill"
-msgstr "Ostolasku"
+msgstr "Muokkaa ostolaskua"
 
 #: gnucash/gnome/dialog-invoice.c:2350
-#, fuzzy
-#| msgid "Bill"
 msgid "View Bill"
-msgstr "Ostolasku"
+msgstr "Näytä ostolasku"
 
 #: gnucash/gnome/dialog-invoice.c:2359
 #: gnucash/gnome-search/dialog-search.c:1091
-#, fuzzy
-#| msgid "Expense Vouchers"
 msgid "New Expense Voucher"
-msgstr "Matkalaskut"
+msgstr "Uusi matkalasku"
 
 #: gnucash/gnome/dialog-invoice.c:2365
-#, fuzzy
-#| msgid "Expense Vouchers"
 msgid "Edit Expense Voucher"
-msgstr "Matkalaskut"
+msgstr "Muokkaa matkalaskua"
 
 #: gnucash/gnome/dialog-invoice.c:2369
-#, fuzzy
-#| msgid "Expense Vouchers"
 msgid "View Expense Voucher"
-msgstr "Matkalaskut"
+msgstr "Katso matkalaskua"
 
 #: gnucash/gnome/dialog-invoice.c:2691
 msgid "Open Linked Document:"
-msgstr ""
+msgstr "Avaa yhdistetty asiakirja:"
 
 #: gnucash/gnome/dialog-invoice.c:2805 gnucash/gnome/dialog-invoice.c:3030
 msgid "Bill Information"
-msgstr ""
+msgstr "Ostolaskun tiedot"
 
 #: gnucash/gnome/dialog-invoice.c:2807 gnucash/gnome/dialog-invoice.c:3033
 #: gnucash/gnome/dialog-invoice.c:3614
-#, fuzzy
-#| msgid "Bill"
 msgid "Bill ID"
-msgstr "Ostolasku"
+msgstr "Ostolaskun ID"
 
 #: gnucash/gnome/dialog-invoice.c:2811 gnucash/gnome/dialog-invoice.c:3037
 msgid "Voucher Information"
-msgstr ""
+msgstr "Matkalaskun tiedot"
 
 #: gnucash/gnome/dialog-invoice.c:2813 gnucash/gnome/dialog-invoice.c:3040
 #: gnucash/gnome/dialog-invoice.c:3648
-#, fuzzy
-#| msgid "Voucher"
 msgid "Voucher ID"
-msgstr "Matkalasku"
+msgstr "Matkalaskun tunniste"
 
 #: gnucash/gnome/dialog-invoice.c:3371
 msgid "Date of duplicated entries"
-msgstr ""
+msgstr "Monistettujen kirjausrivien päiväys"
 
 #: gnucash/gnome/dialog-invoice.c:3426
 msgid ""
 "One or more selected invoices have already been posted.\n"
 "Re-check your selection."
 msgstr ""
+"Yksi tai useampi valituista myyntilaskuista on jo viety.\n"
+"Tarkista valintasi."
 
 #: gnucash/gnome/dialog-invoice.c:3430
 msgid "Do you really want to post these invoices?"
-msgstr ""
+msgstr "Haluatko varmasti viedä nämä myyntilaskut kirjanpitoon?"
 
 #: gnucash/gnome/dialog-invoice.c:3518 gnucash/gnome/dialog-invoice.c:3800
-#, fuzzy
-#| msgid "View/Edit Customer"
 msgid "View/Edit Invoice"
-msgstr "Katso/muokkaa asiakasta"
+msgstr "Katso/muokkaa myyntilaskua"
 
 #: gnucash/gnome/dialog-invoice.c:3520 gnucash/gnome/dialog-invoice.c:3529
 #: gnucash/gnome/dialog-invoice.c:3540
@@ -2995,45 +2962,37 @@ msgstr "Katso/muokkaa asiakasta"
 #: gnucash/gnome/gnc-plugin-page-register.cpp:396
 #: gnucash/ui/gnc-embedded-register-window.ui:155
 msgid "Duplicate"
-msgstr ""
+msgstr "Monista"
 
 #: gnucash/gnome/dialog-invoice.c:3521 gnucash/gnome/dialog-invoice.c:3530
 #: gnucash/gnome/dialog-invoice.c:3541
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:289
 msgid "Post"
-msgstr ""
+msgstr "Vie"
 
 #: gnucash/gnome/dialog-invoice.c:3522 gnucash/gnome/dialog-invoice.c:3531
 #: gnucash/gnome/dialog-invoice.c:3542
 msgid "Printable Report"
-msgstr ""
+msgstr "Tulostettava raportti"
 
 #: gnucash/gnome/dialog-invoice.c:3527 gnucash/gnome/dialog-invoice.c:3794
-#, fuzzy
-#| msgid "View/Edit Employee"
 msgid "View/Edit Bill"
-msgstr "Katso/muokkaa työtekijää"
+msgstr "Katso/muokkaa ostolaskua"
 
 #. Translators: The terms 'Voucher' and 'Expense Voucher' are used
 #. interchangeably in gnucash and mean the same thing.
 #: gnucash/gnome/dialog-invoice.c:3538
-#, fuzzy
-#| msgid "View/Edit Customer"
 msgid "View/Edit Voucher"
-msgstr "Katso/muokkaa asiakasta"
+msgstr "Katso/muokkaa matkalaskua"
 
 #: gnucash/gnome/dialog-invoice.c:3552
-#, fuzzy
-#| msgid "Invoice"
 msgid "Invoice Owner"
-msgstr "Myyntilasku"
+msgstr "Myyntilaskun omistaja"
 
 #: gnucash/gnome/dialog-invoice.c:3555
 #: gnucash/report/reports/standard/invoice.scm:502
-#, fuzzy
-#| msgid "Invoice"
 msgid "Invoice Notes"
-msgstr "Myyntilasku"
+msgstr "Myyntilaskun huomautukset"
 
 #: gnucash/gnome/dialog-invoice.c:3558 gnucash/gnome/dialog-invoice.c:3592
 #: gnucash/gnome/dialog-invoice.c:3626 gnucash/gnome/dialog-invoice.c:3655
@@ -3042,22 +3001,18 @@ msgstr "Myyntilasku"
 #: gnucash/gtkbuilder/dialog-invoice.glade:1064
 #: gnucash/gtkbuilder/dialog-job.glade:219
 #: gnucash/report/reports/standard/invoice.scm:494
-#, fuzzy
-#| msgid "Billing Contact"
 msgid "Billing ID"
-msgstr "Laskutusyhteystiedot"
+msgstr "Ostolaskutustunniste"
 
 #: gnucash/gnome/dialog-invoice.c:3561 gnucash/gnome/dialog-invoice.c:3595
 #: gnucash/gnome/dialog-invoice.c:3629
 msgid "Is Paid?"
-msgstr ""
+msgstr "On maksettu?"
 
 #: gnucash/gnome/dialog-invoice.c:3567 gnucash/gnome/dialog-invoice.c:3601
 #: gnucash/gnome/dialog-invoice.c:3635
-#, fuzzy
-#| msgid "Date Posted"
 msgid "Is Posted?"
-msgstr "Vientipäivä"
+msgstr "Viety kirjanpitoon?"
 
 #: gnucash/gnome/dialog-invoice.c:3570 gnucash/gnome/dialog-invoice.c:3604
 #: gnucash/gnome/dialog-invoice.c:3638 gnucash/gnome/dialog-order.c:874
@@ -3066,40 +3021,30 @@ msgstr "Vientipäivä"
 #: gnucash/gtkbuilder/dialog-order.glade:136
 #: gnucash/gtkbuilder/dialog-order.glade:548
 #: gnucash/import-export/bi-import/dialog-bi-import-gui.c:139
-#, fuzzy
-#| msgid "Date Posted"
 msgid "Date Opened"
-msgstr "Vientipäivä"
+msgstr "Luontipäivä"
 
 #: gnucash/gnome/dialog-invoice.c:3580
 #: gnucash/gtkbuilder/dialog-invoice.glade:42
 #: gnucash/gtkbuilder/dialog-invoice.glade:868
-#, fuzzy
-#| msgid "Invoice"
 msgid "Invoice ID"
-msgstr "Myyntilasku"
+msgstr "Laskun tunniste"
 
 #: gnucash/gnome/dialog-invoice.c:3586
 msgid "Bill Owner"
-msgstr ""
+msgstr "Ostolaskun omistaja"
 
 #: gnucash/gnome/dialog-invoice.c:3589
-#, fuzzy
-#| msgid "Notes"
 msgid "Bill Notes"
-msgstr "Huomautukset"
+msgstr "Ostolaskun huomautukset"
 
 #: gnucash/gnome/dialog-invoice.c:3620
-#, fuzzy
-#| msgid "Voucher"
 msgid "Voucher Owner"
-msgstr "Matkalasku"
+msgstr "Matkalaskun omistaja"
 
 #: gnucash/gnome/dialog-invoice.c:3623
-#, fuzzy
-#| msgid "Voucher"
 msgid "Voucher Notes"
-msgstr "Matkalasku"
+msgstr "Matkalaskun huomautukset"
 
 #: gnucash/gnome/dialog-invoice.c:3657 gnucash/gnome/dialog-invoice.c:3817
 #: gnucash/gnome/dialog-lot-viewer.c:908 gnucash/gnome/dialog-tax-info.c:1234
@@ -3121,29 +3066,27 @@ msgstr "Matkalasku"
 #: gnucash/report/reports/standard/new-owner-report.scm:52
 #: gnucash/report/reports/standard/new-owner-report.scm:227
 msgid "Type"
-msgstr ""
+msgstr "Tyyppi"
 
 #: gnucash/gnome/dialog-invoice.c:3659
 #: gnucash/register/ledger-core/split-register-model.c:314
 #: gnucash/report/reports/standard/new-owner-report.scm:808
 msgid "Paid"
-msgstr ""
+msgstr "Maksettu"
 
 #: gnucash/gnome/dialog-invoice.c:3662
-#, fuzzy
-#| msgid "Date Posted"
 msgid "Posted"
-msgstr "Vientipäivä"
+msgstr "Viety"
 
 #: gnucash/gnome/dialog-invoice.c:3667 gnucash/gnome/dialog-invoice.c:3821
 msgid "Due"
-msgstr ""
+msgstr "Eräpäivä"
 
 #: gnucash/gnome/dialog-invoice.c:3669 gnucash/gnome/dialog-lot-viewer.c:914
 #: gnucash/gnome/dialog-order.c:892
 #: gnucash/report/reports/standard/investment-lots.scm:102
 msgid "Opened"
-msgstr ""
+msgstr "Luotu"
 
 #: gnucash/gnome/dialog-invoice.c:3671 gnucash/gnome/dialog-lot-viewer.c:995
 #: gnucash/gnome/dialog-order.c:894 gnucash/gnome/reconcile-view.c:445
@@ -3158,36 +3101,26 @@ msgstr ""
 #: gnucash/report/reports/standard/register.scm:354
 #: gnucash/report/trep-engine.scm:916 gnucash/report/trep-engine.scm:1116
 #: gnucash/report/trep-engine.scm:2236
-#, fuzzy
-#| msgid "Number"
 msgid "Num"
-msgstr "Numero"
+msgstr "Nro"
 
 #: gnucash/gnome/dialog-invoice.c:3752
-#, fuzzy
-#| msgid "Bill"
 msgid "Find Bill"
-msgstr "Ostolasku"
+msgstr "Etsi ostolasku"
 
 #: gnucash/gnome/dialog-invoice.c:3759
-#, fuzzy
-#| msgid "Expense Vouchers"
 msgid "Find Expense Voucher"
-msgstr "Matkalaskut"
+msgstr "Etsi matkalasku"
 
 #: gnucash/gnome/dialog-invoice.c:3760
 #: gnucash/gnome-search/dialog-search.c:1089
 #: gnucash/report/reports/standard/invoice.scm:776
-#, fuzzy
-#| msgid "Expense Vouchers"
 msgid "Expense Voucher"
-msgstr "Matkalaskut"
+msgstr "Matkalasku"
 
 #: gnucash/gnome/dialog-invoice.c:3766
-#, fuzzy
-#| msgid "Invoice"
 msgid "Find Invoice"
-msgstr "Myyntilasku"
+msgstr "Etsi myyntilaskua"
 
 #: gnucash/gnome/dialog-invoice.c:3814 gnucash/gnome/dialog-lot-viewer.c:1015
 #: gnucash/gnome/gnc-split-reg.c:666 gnucash/gnome/reconcile-view.c:437
@@ -3212,10 +3145,8 @@ msgstr "Myyntilasku"
 #: gnucash/report/trep-engine.scm:231 gnucash/report/trep-engine.scm:975
 #: gnucash/report/trep-engine.scm:1333 gnucash/report/trep-engine.scm:1436
 #: gnucash/report/trep-engine.scm:2183 gnucash/report/trep-engine.scm:2203
-#, fuzzy
-#| msgid "Account"
 msgid "Amount"
-msgstr "Tili"
+msgstr "Määrä"
 
 #. Translators: %d is the number of bills/credit notes due. This is a
 #. ngettext(3) message.
@@ -3223,12 +3154,12 @@ msgstr "Tili"
 #, c-format
 msgid "The following vendor document is due:"
 msgid_plural "The following %d vendor documents are due:"
-msgstr[0] "Seuraava toimittajan asiakirja erääntyy:"
-msgstr[1] "Seuraavat %d toimittajan asiakirjat erääntyvät:"
+msgstr[0] "Seuraava osto-/hyvityslasku on erääntymässä:"
+msgstr[1] "Seuraavat %d osto-/hyvityslaskua ovat erääntymässä:"
 
 #: gnucash/gnome/dialog-invoice.c:3906
 msgid "Due Bills Reminder"
-msgstr ""
+msgstr "Muistutus erääntyvistä ostolaskuista"
 
 #. Translators: %d is the number of invoices/credit notes due. This is a
 #. ngettext(3) message.
@@ -3236,104 +3167,90 @@ msgstr ""
 #, c-format
 msgid "The following customer document is due:"
 msgid_plural "The following %d customer documents are due:"
-msgstr[0] "Seuraava asiakkaan asiakirja erääntyy:"
-msgstr[1] "Seuraavat asiakkaan %d asiakirjat erääntyvät:"
+msgstr[0] "Seuraava myynti-/hyvityslasku on erääntymässä:"
+msgstr[1] "Seuraavat %d myynti-/hyvityslaskua ovat erääntymässä:"
 
 #: gnucash/gnome/dialog-invoice.c:3918
 msgid "Due Invoices Reminder"
-msgstr ""
+msgstr "Muistutus erääntyvistä myyntilaskuista"
 
 #: gnucash/gnome/dialog-job.c:136
 msgid "The Job must be given a name."
-msgstr ""
+msgstr "Hankkeelle täytyy antaa nimi."
 
 #: gnucash/gnome/dialog-job.c:146
 msgid "You must choose an owner for this job."
-msgstr ""
+msgstr "Hankkeelle täytyy antaa omistaja."
 
 #: gnucash/gnome/dialog-job.c:154
-#, fuzzy
-#| msgid "Credit must be a positive amount or you must leave it blank."
 msgid "The rate amount must be valid or you must leave it blank."
-msgstr "Luoton tulee olla positiivinen arvo tai tyhjä."
+msgstr "Taksan tulee olla kelvollinen tai se on jätettävä tyhjäksi."
 
 #: gnucash/gnome/dialog-job.c:245
 msgid "Edit Job"
-msgstr ""
+msgstr "Muokkaa hanketta"
 
 #: gnucash/gnome/dialog-job.c:245 gnucash/gnome-search/dialog-search.c:1099
 msgid "New Job"
-msgstr ""
+msgstr "Uusi hanke"
 
 #: gnucash/gnome/dialog-job.c:549
-#, fuzzy
-#| msgid "View/Edit Customer"
 msgid "View/Edit Job"
-msgstr "Katso/muokkaa asiakasta"
+msgstr "Katso/muokkaa hanketta"
 
 #: gnucash/gnome/dialog-job.c:550
-#, fuzzy
-#| msgid "Invoice"
 msgid "View Invoices"
-msgstr "Myyntilasku"
+msgstr "Näytä myyntilaskut"
 
 #: gnucash/gnome/dialog-job.c:560
 msgid "Owner's Name"
-msgstr ""
+msgstr "Omistajan nimi"
 
 #: gnucash/gnome/dialog-job.c:562
 msgid "Only Active?"
-msgstr ""
+msgstr "Vain aktiiviset?"
 
 #: gnucash/gnome/dialog-job.c:566 gnucash/gnome/dialog-job.c:579
 #: gnucash/gtkbuilder/dialog-job.glade:206
 #: gnucash/register/ledger-core/split-register-model.c:374
 msgid "Rate"
-msgstr ""
+msgstr "Taksa"
 
 #: gnucash/gnome/dialog-job.c:568 gnucash/gnome-utils/gnc-tree-view-owner.c:341
 #: gnucash/gtkbuilder/dialog-job.glade:103
-#, fuzzy
-#| msgid "Number"
 msgid "Job Number"
-msgstr "Numero"
+msgstr "Hankkeen numero"
 
 #: gnucash/gnome/dialog-job.c:570 gnucash/gnome/dialog-job.c:583
 #: gnucash/gnome-utils/gnc-tree-view-owner.c:340
 #: gnucash/gtkbuilder/dialog-job.glade:116
-#, fuzzy
-#| msgid "Name"
 msgid "Job Name"
-msgstr "Nimi"
+msgstr "Hankkeen nimi"
 
 #: gnucash/gnome/dialog-job.c:634
-#, fuzzy
-#| msgid "Find Account"
 msgid "Find Job"
-msgstr "Etsi tili"
+msgstr "Etsi hanke"
 
 #: gnucash/gnome/dialog-lot-viewer.c:818
 msgid "Empty"
-msgstr ""
+msgstr "Tyhjä"
 
 #: gnucash/gnome/dialog-lot-viewer.c:830
-#, fuzzy
-#| msgid "Open buy"
 msgctxt "Adjective"
 msgid "Open"
-msgstr "Avoin osto"
+msgstr "Avoin"
 
 #: gnucash/gnome/dialog-lot-viewer.c:924 gnucash/gnome/dialog-order.c:890
 #: gnucash/report/reports/standard/investment-lots.scm:103
 msgid "Closed"
-msgstr ""
+msgstr "Suljettu"
 
 #: gnucash/gnome/dialog-lot-viewer.c:934
 #: gnucash/gtkbuilder/assistant-acct-period.glade:131
 #: gnucash/report/html-fonts.scm:106
 #: gnucash/report/reports/standard/register.scm:341
 msgid "Title"
-msgstr ""
+msgstr "Otsake"
 
 #: gnucash/gnome/dialog-lot-viewer.c:941 gnucash/gnome/dialog-lot-viewer.c:1033
 #: gnucash/gnome-utils/gnc-tree-view-account.c:837
@@ -3346,19 +3263,17 @@ msgstr ""
 #: gnucash/report/reports/standard/new-owner-report.scm:58
 #: gnucash/report/reports/standard/new-owner-report.scm:551
 #: gnucash/report/reports/standard/register.scm:163
-#, fuzzy
-#| msgid "Ne_w Balance"
 msgid "Balance"
-msgstr "_Uusi saldo"
+msgstr "Saldo"
 
 #: gnucash/gnome/dialog-lot-viewer.c:947
 msgid "Gains"
-msgstr ""
+msgstr "Voitto"
 
 #: gnucash/gnome/dialog-lot-viewer.c:1027
 #: gnucash/report/reports/example/average-balance.scm:118
 msgid "Gain/Loss"
-msgstr ""
+msgstr "Voitto/tappio"
 
 #: gnucash/gnome/dialog-lot-viewer.c:1091
 #, c-format
@@ -3371,7 +3286,7 @@ msgstr ""
 
 #: gnucash/gnome/dialog-order.c:277
 msgid "The Order must have at least one Entry."
-msgstr ""
+msgstr "Tilauksella tulee olla vähintään yksi rivi."
 
 #: gnucash/gnome/dialog-order.c:299
 msgid ""
@@ -3380,34 +3295,24 @@ msgid ""
 msgstr ""
 
 #: gnucash/gnome/dialog-order.c:308
-#, fuzzy
-#| msgid "Are you sure you want to delete %s?"
 msgid "Do you really want to close the order?"
-msgstr "Oletko varma että %s voidaan poistaa?"
+msgstr "Haluatko varmasti sulkea tilauksen?"
 
 #: gnucash/gnome/dialog-order.c:309
-#, fuzzy
-#| msgid "Closing Date"
 msgid "Close Date"
-msgstr "Tilinpäätöspäivä"
+msgstr "Sulkemispäivä"
 
 #: gnucash/gnome/dialog-order.c:859
-#, fuzzy
-#| msgid "View/Edit Customer"
 msgid "View/Edit Order"
-msgstr "Katso/muokkaa asiakasta"
+msgstr "Katso/muokkaa tilausta"
 
 #: gnucash/gnome/dialog-order.c:868
-#, fuzzy
-#| msgid "Notes"
 msgid "Order Notes"
-msgstr "Huomautukset"
+msgstr "Tilauksen huomautukset"
 
 #: gnucash/gnome/dialog-order.c:870 gnucash/gtkbuilder/dialog-order.glade:149
-#, fuzzy
-#| msgid "Date Posted"
 msgid "Date Closed"
-msgstr "Vientipäivä"
+msgstr "Sulkemispäivä"
 
 #: gnucash/gnome/dialog-order.c:872
 msgid "Is Closed?"
@@ -3415,38 +3320,32 @@ msgstr ""
 
 #: gnucash/gnome/dialog-order.c:876
 msgid "Owner Name"
-msgstr ""
+msgstr "Omistajan nimi"
 
 #: gnucash/gnome/dialog-order.c:878 gnucash/gtkbuilder/dialog-order.glade:123
 #: gnucash/gtkbuilder/dialog-order.glade:517
 msgid "Order ID"
-msgstr ""
+msgstr "Tilauksen tunnus"
 
 #: gnucash/gnome/dialog-order.c:948
-#, fuzzy
-#| msgid "Find Customer"
 msgid "Find Order"
-msgstr "Etsi asiakas"
+msgstr "Etsi tilaus"
 
 #: gnucash/gnome/dialog-payment.c:238
 msgid "You must enter a valid account name for posting."
 msgstr ""
 
 #: gnucash/gnome/dialog-payment.c:247
-#, fuzzy
-#| msgid "You must select a report configuration to load."
 msgid "You must select a company for payment processing."
-msgstr "Valitse ladattavat raporttiasetukset."
+msgstr "Valitse yritys, jotta maksu voidaan käsitellä."
 
 #: gnucash/gnome/dialog-payment.c:261
 msgid "There is a problem with the Payment or Refund amount."
-msgstr ""
+msgstr "Maksun tai palautuksen määrässä on ongelma."
 
 #: gnucash/gnome/dialog-payment.c:282
-#, fuzzy
-#| msgid "You must select a report configuration to delete."
 msgid "You must select a transfer account from the account tree."
-msgstr "Valitse poistettavat raporttiasetukset."
+msgstr "Valitse tili, jolta maksu tehdään."
 
 #: gnucash/gnome/dialog-payment.c:293
 msgid ""
@@ -3458,16 +3357,14 @@ msgstr ""
 #: gnucash/report/reports/standard/new-aging.scm:177
 #: gnucash/report/reports/standard/new-owner-report.scm:305
 #: gnucash/report/reports/standard/new-owner-report.scm:699
-#, fuzzy
-#| msgid "Payment"
 msgid "Pre-Payment"
-msgstr "Maksu"
+msgstr "Esimaksu"
 
 #: gnucash/gnome/dialog-payment.c:1004
 msgid ""
 "The transfer and post accounts are associated with different currencies. "
 "Please specify the conversion rate."
-msgstr ""
+msgstr "Maksu- ja vientitileillä on eri valuutat. Ilmoita vaihtokurssi."
 
 #: gnucash/gnome/dialog-payment.c:1303 gnucash/gnome/search-owner.c:196
 #: gnucash/gnome-search/dialog-search.c:1081
@@ -3481,10 +3378,8 @@ msgstr ""
 #: gnucash/report/reports/standard/customer-summary.scm:281
 #: gnucash/report/reports/standard/new-owner-report.scm:89
 #: libgnucash/engine/gncOwner.c:216
-#, fuzzy
-#| msgid "Customer ID"
 msgid "Customer"
-msgstr "Asiakastunnus"
+msgstr "Asiakas"
 
 #: gnucash/gnome/dialog-payment.c:1307 gnucash/gnome/search-owner.c:197
 #: gnucash/gnome-search/dialog-search.c:1113
@@ -3495,7 +3390,7 @@ msgstr "Asiakastunnus"
 #: gnucash/report/reports/standard/new-owner-report.scm:104
 #: libgnucash/engine/gncOwner.c:220
 msgid "Vendor"
-msgstr ""
+msgstr "Toimittaja"
 
 #: gnucash/gnome/dialog-payment.c:1311 gnucash/gnome/search-owner.c:198
 #: gnucash/gnome-search/dialog-search.c:1085
@@ -3503,10 +3398,8 @@ msgstr ""
 #: gnucash/gtkbuilder/dialog-payment.glade:48
 #: gnucash/report/reports/standard/new-owner-report.scm:94
 #: libgnucash/engine/gncOwner.c:222
-#, fuzzy
-#| msgid "Employee ID"
 msgid "Employee"
-msgstr "Työntekijätunnus"
+msgstr "Työntekijä"
 
 #: gnucash/gnome/dialog-payment.c:1468
 #, c-format
@@ -3515,6 +3408,8 @@ msgid ""
 "\"%s\" before you continue to process this payment. Perhaps you want to "
 "create an Invoice or Bill first?"
 msgstr ""
+"Sopivaa vientitiliä ei löydy. Luo tili jonka tyyppi on \"%s\" ennen maksun "
+"käsittelyä. Ehkä haluat ensin luoda myös osto- tai myyntilaskun?"
 
 #: gnucash/gnome/dialog-payment.c:1593
 #: gnucash/gnome/gnc-plugin-page-register.cpp:3298
@@ -3522,7 +3417,7 @@ msgstr ""
 #: gnucash/gnome-utils/gnc-tree-view-account.c:858
 #: gnucash/report/trep-engine.scm:158
 msgid "Cleared"
-msgstr ""
+msgstr "Hyväksytty"
 
 #: gnucash/gnome/dialog-payment.c:1595
 #: gnucash/gnome/gnc-plugin-page-register.cpp:3300
@@ -3531,10 +3426,8 @@ msgstr ""
 #: gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp:73
 #: gnucash/import-export/import-match-picker.cpp:357
 #: gnucash/report/trep-engine.scm:159
-#, fuzzy
-#| msgid "Reconcile"
 msgid "Reconciled"
-msgstr "Tarkista"
+msgstr "Täsmätty"
 
 #: gnucash/gnome/dialog-payment.c:1633
 msgid ""
@@ -3552,20 +3445,18 @@ msgstr ""
 
 #: gnucash/gnome/dialog-payment.c:1649
 msgid "Warning"
-msgstr ""
+msgstr "Varoitus"
 
 #: gnucash/gnome/dialog-payment.c:1652
 msgid "Continue"
-msgstr ""
+msgstr "Jatka"
 
 #: gnucash/gnome/dialog-payment.c:1653
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:283
 #: gnucash/gnome/gnc-plugin-page-register.cpp:394
 #: gnucash/ui/gnc-embedded-register-window.ui:210
-#, fuzzy
-#| msgid "_Cancel"
 msgid "Cancel"
-msgstr "_Peruuta"
+msgstr "Peruuta"
 
 #: gnucash/gnome/dialog-payment.c:1777
 #, c-format
@@ -3584,65 +3475,55 @@ msgstr ""
 #, c-format
 msgid "Are you sure you want to delete the selected price?"
 msgid_plural "Are you sure you want to delete the %d selected prices?"
-msgstr[0] "Oletko varma, että haluat poistaa valitun hinnan?"
-msgstr[1] "Oletko varma, että haluat poistaa %d valittua hintaa?"
+msgstr[0] "Oletko varma että haluat poistaa valitun hinnan?"
+msgstr[1] "Oletko varma että haluat poistaa valitut %d hintaa?"
 
 #: gnucash/gnome/dialog-price-edit-db.cpp:209
 msgid "Delete prices?"
-msgstr ""
+msgstr "Poista hinnat?"
 
 #: gnucash/gnome/dialog-price-edit-db.cpp:414
 #: gnucash/gtkbuilder/dialog-invoice.glade:609
 #: gnucash/report/reports/standard/equity-statement.scm:83
 #: gnucash/report/reports/standard/income-statement.scm:110
 #: gnucash/report/reports/standard/trial-balance.scm:85
-#, fuzzy
-#| msgid "Total Entries"
 msgid "Entries"
-msgstr "Yhteensä tietueita"
+msgstr "Kirjaus"
 
 #: gnucash/gnome/dialog-price-edit-db.cpp:444
-#, fuzzy
-#| msgid "Are you sure you want to delete %s?"
 msgid "Are you sure you want to delete these prices?"
-msgstr "Oletko varma että %s voidaan poistaa?"
+msgstr "Oletko varma, että haluat poistaa nämä hinnat?"
 
 #: gnucash/gnome/dialog-price-edit-db.cpp:584
 #: gnucash/gnome-utils/dialog-transfer.cpp:1796
 #, c-format
 msgid "Price retrieval failed: %s"
-msgstr ""
+msgstr "Hintojen haku epäonnistui: %s"
 
 #: gnucash/gnome/dialog-price-editor.c:227
-#, fuzzy
-#| msgid "Are you sure you want to delete %s?"
 msgid "Are you sure you want to replace the existing price?"
-msgstr "Oletko varma että %s voidaan poistaa?"
+msgstr "Oletko varma, että haluat korvata nykyisen hinnan?"
 
 #: gnucash/gnome/dialog-price-editor.c:233
 msgid "Replace price?"
-msgstr ""
+msgstr "Korvaa hinta?"
 
 #: gnucash/gnome/dialog-price-editor.c:239
 msgid "_Replace"
-msgstr ""
+msgstr "_Korvaa"
 
 #: gnucash/gnome/dialog-price-editor.c:270
-#, fuzzy
-#| msgid "You must select a report configuration to load."
 msgid "You must select a Security."
-msgstr "Valitse ladattavat raporttiasetukset."
+msgstr "Valitse arvopaperi."
 
 #: gnucash/gnome/dialog-price-editor.c:275
 msgid "You must select a Currency."
-msgstr ""
+msgstr "Valitse valuutta."
 
 #: gnucash/gnome/dialog-price-editor.c:289
 #: gnucash/gnome-utils/dialog-transfer.cpp:1678
-#, fuzzy
-#| msgid "You must enter a Payment-Address Name."
 msgid "You must enter a valid amount."
-msgstr "Sinun on annettava nimi maksuosoitteelle."
+msgstr "Syötä kelvollinen summa."
 
 #: gnucash/gnome/dialog-print-check.c:862
 msgid "Cannot save check format file."
@@ -3651,7 +3532,7 @@ msgstr ""
 #: gnucash/gnome/dialog-print-check.c:864
 #, c-format
 msgid "Cannot open file %s"
-msgstr ""
+msgstr "Ei voi avata tiedostoa %s"
 
 #: gnucash/gnome/dialog-print-check.c:1552
 msgid "There is a duplicate check format file."
@@ -3675,14 +3556,14 @@ msgstr ""
 #. * gnucash application.
 #: gnucash/gnome/dialog-print-check.c:1603
 msgid "application"
-msgstr ""
+msgstr "sovellus"
 
 #. Translators: This is a directory name. It may be presented to
 #. * the user to indicate that some data file was defined by a
 #. * user herself.
 #: gnucash/gnome/dialog-print-check.c:1611
 msgid "user"
-msgstr ""
+msgstr "käyttäjä"
 
 #: gnucash/gnome/dialog-print-check.c:1635
 #: gnucash/gnome/dialog-print-check.c:2653
@@ -3693,67 +3574,63 @@ msgstr ""
 #: gnucash/gtkbuilder/dialog-print-check.glade:270
 #: gnucash/gtkbuilder/dialog-print-check.glade:290
 #: gnucash/gtkbuilder/gnc-date-format.glade:30
-#, fuzzy
-#| msgid "custom"
 msgid "Custom"
-msgstr "muu"
+msgstr "Mukautettu"
 
 #: gnucash/gnome/dialog-print-check.c:2645
 #: gnucash/gtkbuilder/dialog-preferences.glade:3544
 #: gnucash/gtkbuilder/dialog-print-check.glade:261
 #: gnucash/report/reports/standard/investment-lots.scm:197
 msgid "Top"
-msgstr ""
+msgstr "Ylhäällä"
 
 #: gnucash/gnome/dialog-progress.c:484 gnucash/gnome/dialog-progress.c:533
 msgid "(paused)"
-msgstr ""
+msgstr "(pysäytetty)"
 
 #: gnucash/gnome/dialog-progress.c:768 gnucash/gnome/dialog-progress.c:771
 msgid "Complete"
 msgstr ""
 
 #: gnucash/gnome/dialog-report-column-view.cpp:355
-#, fuzzy
-#| msgid "Contact"
 msgid "Contents"
-msgstr "Yhteyshenkilö"
+msgstr "Sisältö"
 
 #: gnucash/gnome/dialog-report-column-view.cpp:383
 #: gnucash/report/reports/standard/customer-summary.scm:251
 #: gnucash/report/reports/standard/new-owner-report.scm:1031
 msgid "Report"
-msgstr ""
+msgstr "Raportti"
 
 #: gnucash/gnome/dialog-report-column-view.cpp:389
 msgid "Rows"
-msgstr ""
+msgstr "Rivejä"
 
 #: gnucash/gnome/dialog-report-column-view.cpp:395
 msgid "Cols"
-msgstr ""
+msgstr "Sarakkeita"
 
 #: gnucash/gnome/dialog-report-style-sheet.cpp:170
 #, c-format
 msgid "HTML Style Sheet Properties: %s"
-msgstr ""
+msgstr "HTML-tyylitiedoston ominaisuudet: %s"
 
 #: gnucash/gnome/dialog-report-style-sheet.cpp:259
 msgid "You must provide a name for the new style sheet."
-msgstr ""
+msgstr "Anna nimi uudelle tyylitiedostolle."
 
 #: gnucash/gnome/dialog-report-style-sheet.cpp:509
 msgid "Style Sheet Name"
-msgstr ""
+msgstr "Tyylitiedoston nimi"
 
 #: gnucash/gnome/dialog-sx-editor.c:203
 msgid ""
 "This Scheduled Transaction has changed; are you sure you want to cancel?"
-msgstr ""
+msgstr "Tätä tositteen ajastusta on muutettu. Haluatko varmasti peruuttaa?"
 
 #: gnucash/gnome/dialog-sx-editor.c:489
 msgid "Please name the Scheduled Transaction."
-msgstr ""
+msgstr "Anna tositteen ajastukselle nimi."
 
 #: gnucash/gnome/dialog-sx-editor.c:513
 #, c-format
@@ -3781,7 +3658,8 @@ msgstr ""
 msgid ""
 "You have attempted to create a Scheduled Transaction which will never run. "
 "Do you really want to do this?"
-msgstr ""
+msgstr "Yrität tehdä tositteen ajastuksen, joka ei tule koskaan tuottamaan tositetta. "
+"Haluatko todella tehdä tämän?"
 
 #: gnucash/gnome/dialog-sx-editor.c:607
 msgid ""
@@ -3807,7 +3685,7 @@ msgstr ""
 
 #: gnucash/gnome/dialog-sx-editor.c:739
 msgid "Invalid Account in Split"
-msgstr ""
+msgstr "Virheellinen tili rivillä"
 
 #: gnucash/gnome/dialog-sx-editor.c:751
 #, c-format
@@ -3816,7 +3694,7 @@ msgstr ""
 
 #: gnucash/gnome/dialog-sx-editor.c:754 gnucash/gnome/dialog-sx-editor.c:770
 msgid "Unparsable Formula in Split"
-msgstr ""
+msgstr "Tulkintakelvoton kaava rivissä"
 
 #: gnucash/gnome/dialog-sx-editor.c:767
 #, c-format
@@ -3832,7 +3710,7 @@ msgstr ""
 
 #: gnucash/gnome/dialog-sx-editor.c:1408
 msgid "(never)"
-msgstr ""
+msgstr "(ei koskaan)"
 
 #: gnucash/gnome/dialog-sx-editor.c:1571
 msgid ""
@@ -3842,10 +3720,8 @@ msgstr ""
 
 #: gnucash/gnome/dialog-sx-editor.c:1847
 #: gnucash/gnome/gnc-plugin-page-sx-list.cpp:234
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Scheduled Transactions"
-msgstr "Etsi tosite"
+msgstr "Tositteiden ajastukset"
 
 #: gnucash/gnome/dialog-sx-from-trans.cpp:549
 msgid ""
@@ -3864,10 +3740,8 @@ msgid "Ignored"
 msgstr ""
 
 #: gnucash/gnome/dialog-sx-since-last-run.c:370
-#, fuzzy
-#| msgid "Date Posted"
 msgid "Postponed"
-msgstr "Vientipäivä"
+msgstr ""
 
 #: gnucash/gnome/dialog-sx-since-last-run.c:371
 msgid "To-Create"
@@ -3879,27 +3753,23 @@ msgstr ""
 
 #: gnucash/gnome/dialog-sx-since-last-run.c:373
 #: gnucash/gnome/gnc-plugin-budget.c:192
-#, fuzzy
-#| msgid "Tax related"
 msgid "Created"
-msgstr "Veroihin liittyvä"
+msgstr "Luotu"
 
 #: gnucash/gnome/dialog-sx-since-last-run.c:436
 #: gnucash/gtkbuilder/dialog-preferences.glade:1737
 #: gnucash/report/reports/standard/balsheet-pnl.scm:195
 #: gnucash/report/trep-engine.scm:578
 msgid "Never"
-msgstr ""
+msgstr "Ei koskaan"
 
 #: gnucash/gnome/dialog-sx-since-last-run.c:522
 msgid "(Need Value)"
-msgstr ""
+msgstr "(Tarvitsee arvon)"
 
 #: gnucash/gnome/dialog-sx-since-last-run.c:895
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Invalid Transactions"
-msgstr "Etsi tosite"
+msgstr "Virheelliset tositteet"
 
 #: gnucash/gnome/dialog-sx-since-last-run.c:946
 #, c-format
@@ -3922,52 +3792,45 @@ msgstr ""
 
 #: gnucash/gnome/dialog-sx-since-last-run.c:1379
 #: gnucash/gnome-search/dialog-search.c:1105
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Transaction"
-msgstr "Etsi tosite"
+msgstr "Tosite"
 
 #: gnucash/gnome/dialog-sx-since-last-run.c:1402
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:527
 msgid "Status"
-msgstr ""
+msgstr "Tila"
 
 #: gnucash/gnome/dialog-sx-since-last-run.c:1497
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Created Transactions"
-msgstr "Etsi tosite"
+msgstr ""
 
 #: gnucash/gnome/dialog-tax-info.c:287
 msgid "Last Valid Year: "
-msgstr ""
+msgstr "Viimeinen kelvollinen vuosi: "
 
 #: gnucash/gnome/dialog-tax-info.c:288
 msgid "Form Line Data: "
-msgstr ""
+msgstr "Lomakerivin tieto: "
 
 #. Translators: Tax Code
 #: gnucash/gnome/dialog-tax-info.c:290
 msgid "Code"
-msgstr ""
+msgstr "Koodi"
 
 #: gnucash/gnome/dialog-tax-info.c:365
-#, fuzzy
-#| msgid "Unknown"
 msgid "now"
-msgstr "Tuntematon"
+msgstr "nyt"
 
 #: gnucash/gnome/dialog-tax-info.c:871
 #: gnucash/import-export/csv-exp/assistant-csv-export.c:401
-#, fuzzy, c-format
-#| msgid "Accounts Selected:"
+#, c-format
 msgid "Accounts Selected: %d"
-msgstr "Valitut tilit:"
+msgstr "Tilejä valittuna: %d"
 
 #: gnucash/gnome/dialog-tax-info.c:1184
 #: gnucash/gtkbuilder/dialog-tax-info.glade:89
 msgid "Income Tax Identity"
-msgstr ""
+msgstr "Tuloverotunniste"
 
 #: gnucash/gnome/dialog-tax-info.c:1190
 #: gnucash/gtkbuilder/dialog-options.glade:55
@@ -3975,7 +3838,7 @@ msgstr ""
 #: gnucash/gtkbuilder/dialog-reset-warnings.glade:40
 #: gnucash/gtkbuilder/dialog-tax-info.glade:43
 msgid "_Apply"
-msgstr ""
+msgstr "_Toteuta"
 
 #: gnucash/gnome/dialog-tax-info.c:1239
 msgid ""
@@ -3989,42 +3852,36 @@ msgstr ""
 
 #: gnucash/gnome/dialog-vendor.c:276
 msgid "Edit Vendor"
-msgstr ""
+msgstr "Muokkaa toimittajaa"
 
 #: gnucash/gnome/dialog-vendor.c:276 gnucash/gnome-search/dialog-search.c:1115
 #: gnucash/gtkbuilder/dialog-vendor.glade:31
 msgid "New Vendor"
-msgstr ""
+msgstr "Uusi toimittaja"
 
 #: gnucash/gnome/dialog-vendor.c:676
-#, fuzzy
-#| msgid "View/Edit Customer"
 msgid "View/Edit Vendor"
-msgstr "Katso/muokkaa asiakasta"
+msgstr "Katso/muokkaa toimittajaa"
 
 #: gnucash/gnome/dialog-vendor.c:677
-#, fuzzy
-#| msgid "Customer's Jobs"
 msgid "Vendor's Jobs"
-msgstr "Asiakkaan hankkeet"
+msgstr "Toimittajan hankkeet"
 
 #: gnucash/gnome/dialog-vendor.c:679
 msgid "Vendor's Bills"
-msgstr ""
+msgstr "Toimittajan ostolaskut"
 
 #: gnucash/gnome/dialog-vendor.c:680
-#, fuzzy
-#| msgid "Bill"
 msgid "Pay Bill"
-msgstr "Ostolasku"
+msgstr "Maksa ostolasku"
 
 #: gnucash/gnome/dialog-vendor.c:692
 msgid "Vendor ID"
-msgstr ""
+msgstr "Toimittajan tunniste"
 
 #: gnucash/gnome/dialog-vendor.c:727
 msgid "Find Vendor"
-msgstr ""
+msgstr "Etsi toimittaja"
 
 #: gnucash/gnome/gnc-budget-view.c:500
 #: gnucash/import-export/qif-imp/qif-dialog-utils.scm:70
@@ -4041,7 +3898,7 @@ msgstr ""
 #: gnucash/report/report-utilities.scm:205 libgnucash/engine/Account.cpp:178
 #: libgnucash/engine/Account.cpp:4296
 msgid "Income"
-msgstr ""
+msgstr "Tulo"
 
 #: gnucash/gnome/gnc-budget-view.c:503
 #: gnucash/import-export/qif-imp/qif-dialog-utils.scm:117
@@ -4049,10 +3906,8 @@ msgstr ""
 #: gnucash/report/reports/standard/budget-income-statement.scm:492
 #: gnucash/report/reports/standard/income-statement.scm:469
 #: gnucash/report/report-utilities.scm:206
-#, fuzzy
-#| msgid "Other Expense"
 msgid "Expenses"
-msgstr "Muu kulu"
+msgstr "Menot"
 
 #: gnucash/gnome/gnc-budget-view.c:506
 #: gnucash/gnome/gnc-plugin-page-register.cpp:392
@@ -4061,11 +3916,11 @@ msgstr "Muu kulu"
 #: gnucash/register/ledger-core/split-register-model.c:353
 #: gnucash/report/reports/standard/register.scm:143
 msgid "Transfer"
-msgstr ""
+msgstr "Siirto"
 
 #: gnucash/gnome/gnc-budget-view.c:509
 msgid "Remaining to Budget"
-msgstr ""
+msgstr "Jäljellä budjettiin"
 
 #: gnucash/gnome/gnc-budget-view.c:1598 gnucash/gnome/window-reconcile.cpp:1172
 #: gnucash/gnome-utils/gnc-tree-view-account.c:906
@@ -4087,7 +3942,7 @@ msgstr ""
 #: gnucash/report/reports/support/balsheet-eg.eguile.scm:113
 #: gnucash/report/trep-engine.scm:2081
 msgid "Total"
-msgstr ""
+msgstr "Yhteensä"
 
 #: gnucash/gnome/gnc-plugin-basic-commands.c:480
 msgid "There are no Scheduled Transactions to be entered at this time."
@@ -4107,28 +3962,22 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: gnucash/gnome/gnc-plugin-budget.c:320
-#, fuzzy
-#| msgid "Select document"
 msgid "Select a Budget"
-msgstr "Valitse asiakirja"
+msgstr "Valitse budjetti"
 
 #: gnucash/gnome/gnc-plugin-page-account-tree.cpp:294
 #: gnucash/gnome/gnc-plugin-page-budget.cpp:177
 #: gnucash/gnome-utils/gnc-file.c:92 gnucash/gnome-utils/gnc-file.c:329
 #: gnucash/gnome-utils/gnc-file.c:1183
-#, fuzzy
-#| msgid "Open buy"
 msgid "Open"
-msgstr "Avoin osto"
+msgstr "Avaa"
 
 #: gnucash/gnome/gnc-plugin-page-account-tree.cpp:295
 #: gnucash/gnome/gnc-plugin-page-owner-tree.cpp:219
 #: gnucash/gnome/gnc-plugin-page-owner-tree.cpp:220
 #: gnucash/gnome/gnc-plugin-page-owner-tree.cpp:221
-#, fuzzy
-#| msgid "Edit…"
 msgid "Edit"
-msgstr "Muokkaa…"
+msgstr "Muokkaa"
 
 #: gnucash/gnome/gnc-plugin-page-account-tree.cpp:296
 #: gnucash/gnome/gnc-plugin-page-owner-tree.cpp:222
@@ -4136,17 +3985,15 @@ msgstr "Muokkaa…"
 #: gnucash/gnome/gnc-plugin-page-owner-tree.cpp:224
 #: gnucash/gnome-utils/dialog-doclink-utils.c:426
 msgid "New"
-msgstr ""
+msgstr "Uusi"
 
 #: gnucash/gnome/gnc-plugin-page-account-tree.cpp:297
 #: gnucash/gnome/gnc-plugin-page-budget.cpp:178
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:284
 #: gnucash/gnome/gnc-plugin-page-register.cpp:395
 #: gnucash/ui/gnc-embedded-register-window.ui:170
-#, fuzzy
-#| msgid "_Delete"
 msgid "Delete"
-msgstr "_Poista"
+msgstr "Poista"
 
 #: gnucash/gnome/gnc-plugin-page-account-tree.cpp:332
 #: gnucash/gnome/gnc-plugin-page-register.cpp:1823
@@ -4180,10 +4027,8 @@ msgstr ""
 #: gnucash/report/reports/standard/portfolio.scm:62
 #: gnucash/report/reports/standard/trial-balance.scm:70
 #: gnucash/report/trep-engine.scm:70 libgnucash/engine/qofbookslots.h:64
-#, fuzzy
-#| msgid "Account"
 msgid "Accounts"
-msgstr "Tili"
+msgstr "Tilit"
 
 #: gnucash/gnome/gnc-plugin-page-account-tree.cpp:1303
 #, c-format
@@ -4195,22 +4040,22 @@ msgstr ""
 
 #: gnucash/gnome/gnc-plugin-page-account-tree.cpp:1311
 msgid "_Pick another account"
-msgstr ""
+msgstr "_Valitse toinen tili"
 
 #: gnucash/gnome/gnc-plugin-page-account-tree.cpp:1312
 msgid "_Do it anyway"
-msgstr ""
+msgstr "_Tee silti"
 
 #: gnucash/gnome/gnc-plugin-page-account-tree.cpp:1395
 #: gnucash/gnome/gnc-plugin-page-account-tree.cpp:1538
 #: gnucash/gnome/gnc-plugin-page-owner-tree.cpp:1044
 msgid "(no name)"
-msgstr ""
+msgstr "(ei nimeä)"
 
 #: gnucash/gnome/gnc-plugin-page-account-tree.cpp:1407
 #, c-format
 msgid "Deleting account %s"
-msgstr "Poistetaan tiliä %s"
+msgstr "Tilin %s poisto"
 
 #: gnucash/gnome/gnc-plugin-page-account-tree.cpp:1527
 msgid ""
@@ -4232,70 +4077,62 @@ msgstr ""
 #: gnucash/gnome/gnc-plugin-page-account-tree.cpp:1602
 #, c-format
 msgid "The account %s will be deleted."
-msgstr ""
+msgstr "Tili %s poistetaan."
 
 #: gnucash/gnome/gnc-plugin-page-account-tree.cpp:1611
 #, c-format
 msgid "All transactions in this account will be moved to the account %s."
-msgstr ""
+msgstr "Kaikki tämän tilin tositteet siirretään tilille %s."
 
 #: gnucash/gnome/gnc-plugin-page-account-tree.cpp:1618
 msgid "All transactions in this account will be deleted."
-msgstr ""
+msgstr "Kaikki tämän tilin tositteet poistetaan."
 
 #: gnucash/gnome/gnc-plugin-page-account-tree.cpp:1627
 #, c-format
 msgid "Its sub-account will be moved to the account %s."
-msgstr ""
+msgstr "Sen alatili siirretään tilille %s."
 
 #: gnucash/gnome/gnc-plugin-page-account-tree.cpp:1633
 msgid "Its subaccount will be deleted."
-msgstr ""
+msgstr "Sen alatili poistetaan."
 
 #: gnucash/gnome/gnc-plugin-page-account-tree.cpp:1637
 #, c-format
 msgid "All sub-account transactions will be moved to the account %s."
-msgstr ""
+msgstr "Kaikki alatilien tositteet siirretään tilille %s."
 
 #: gnucash/gnome/gnc-plugin-page-account-tree.cpp:1644
 msgid "All sub-account transactions will be deleted."
-msgstr ""
+msgstr "Kaikki alatilien tositteet poistetaan."
 
 #: gnucash/gnome/gnc-plugin-page-account-tree.cpp:1650
-#, fuzzy
-#| msgid "Are you sure you want to delete %s?"
 msgid "Are you sure you want to do this?"
-msgstr "Oletko varma että %s voidaan poistaa?"
+msgstr "Oletko varma että haluat tehdä tämän?"
 
 #: gnucash/gnome/gnc-plugin-page-budget.cpp:179
 #: gnucash/gnome/gnc-plugin-page-report.cpp:236
 #: gnucash/gtkbuilder/assistant-csv-export.glade:99
 #: gnucash/gtkbuilder/dialog-print-check.glade:641
 #: gnucash/gtkbuilder/dialog-sx.glade:932
-#, fuzzy
-#| msgid "Action"
 msgid "Options"
-msgstr "Tapahtuma"
+msgstr "Asetukset"
 
 #: gnucash/gnome/gnc-plugin-page-budget.cpp:180
 msgid "Estimate"
-msgstr ""
+msgstr "Arvio"
 
 #: gnucash/gnome/gnc-plugin-page-budget.cpp:181
-#, fuzzy
-#| msgid "Period"
 msgid "All Periods"
-msgstr "Aikaväli"
+msgstr "Kaikki jaksot"
 
 #: gnucash/gnome/gnc-plugin-page-budget.cpp:182
-#, fuzzy
-#| msgid "Notes"
 msgid "Note"
-msgstr "Huomautukset"
+msgstr "Huomautus"
 
 #: gnucash/gnome/gnc-plugin-page-budget.cpp:183
 msgid "Run Report"
-msgstr ""
+msgstr "Tee raportti"
 
 #: gnucash/gnome/gnc-plugin-page-budget.cpp:263
 #: gnucash/gnome/gnc-plugin-page-budget.cpp:302
@@ -4307,109 +4144,93 @@ msgstr ""
 #: gnucash/report/reports/standard/budget-income-statement.scm:52
 #: gnucash/report/reports/standard/budget.scm:97
 msgid "Budget"
-msgstr ""
+msgstr "Budjetti"
 
 #: gnucash/gnome/gnc-plugin-page-budget.cpp:935
 #: libgnucash/engine/gnc-budget.cpp:110
 msgid "Unnamed Budget"
-msgstr ""
+msgstr "Nimetön budjetti"
 
 #: gnucash/gnome/gnc-plugin-page-budget.cpp:937
 #, c-format
 msgid "Delete %s?"
-msgstr "Poistetaanko %s?"
+msgstr "Poista %s?"
 
 #: gnucash/gnome/gnc-plugin-page-budget.cpp:1037
-#, fuzzy
-#| msgid "You must select a report configuration to delete."
 msgid "You must select at least one account to estimate."
-msgstr "Valitse poistettavat raporttiasetukset."
+msgstr "Valitse arvioitavaksi vähintään yksi tili."
 
 #: gnucash/gnome/gnc-plugin-page-budget.cpp:1168
-#, fuzzy
-#| msgid "You must select a report configuration to delete."
 msgid "You must select at least one account to edit."
-msgstr "Valitse poistettavat raporttiasetukset."
+msgstr "Valitse muokattavaksi vähintään yksi tili."
 
 #: gnucash/gnome/gnc-plugin-page-budget.cpp:1269
-#, fuzzy
-#| msgid "You must select a report configuration to delete."
 msgid "You must select one budget cell to edit."
-msgstr "Valitse poistettavat raporttiasetukset."
+msgstr "Valitse muokattavaksi vähintään yksi budjettisolu."
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:190
 #: gnucash/ui/gnc-plugin-page-invoice.ui:287
-#, fuzzy
-#| msgid "Invoice"
 msgid "_Print Invoice"
-msgstr "Myyntilasku"
+msgstr "_Tulosta myyntilasku"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:190
 #: gnucash/ui/gnc-plugin-page-invoice.ui:289
 msgid "Make a printable invoice"
-msgstr ""
+msgstr "Luo tulostettava myyntilasku"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:191
 #: gnucash/ui/gnc-plugin-page-invoice.ui:367
-#, fuzzy
-#| msgid "Invoice"
 msgid "_Edit Invoice"
-msgstr "Myyntilasku"
+msgstr "_Muokkaa myyntilaskua"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:191
 #: gnucash/ui/gnc-plugin-page-invoice.ui:18
 #: gnucash/ui/gnc-plugin-page-invoice.ui:369
 msgid "Edit this invoice"
-msgstr ""
+msgstr "Muokkaa tätä myyntilaskua"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:192
 #: gnucash/ui/gnc-plugin-page-invoice.ui:382
 msgid "_Duplicate Invoice"
-msgstr ""
+msgstr "_Monista myyntilasku"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:192
 #: gnucash/ui/gnc-plugin-page-invoice.ui:24
 #: gnucash/ui/gnc-plugin-page-invoice.ui:384
 msgid "Create a new invoice as a duplicate of the current one"
-msgstr ""
+msgstr "Luo uusi myyntilasku tämän kopioksi"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:193
 #: gnucash/ui/gnc-plugin-page-invoice.ui:522
-#, fuzzy
-#| msgid "Invoice"
 msgid "_Post Invoice"
-msgstr "Myyntilasku"
+msgstr "_Vie myyntilasku kirjanpitoon"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:193
 #: gnucash/ui/gnc-plugin-page-invoice.ui:30
 #: gnucash/ui/gnc-plugin-page-invoice.ui:524
 msgid "Post this invoice to your Chart of Accounts"
-msgstr ""
+msgstr "Vie tämä myyntilasku tilikirjaan"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:194
 #: gnucash/ui/gnc-plugin-page-invoice.ui:537
-#, fuzzy
-#| msgid "Invoice"
 msgid "_Unpost Invoice"
-msgstr "Myyntilasku"
+msgstr "_Peruuta myyntilaskun vienti kirjanpitoon"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:194
 #: gnucash/ui/gnc-plugin-page-invoice.ui:36
 #: gnucash/ui/gnc-plugin-page-invoice.ui:539
 msgid "Unpost this invoice and make it editable"
-msgstr ""
+msgstr "Peruuta myyntilaskun vienti tilikirjaan ja tee siitä muokattava"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:195
 #: gnucash/ui/gnc-plugin-page-invoice.ui:352
-#, fuzzy
-#| msgid "Invoice"
 msgid "New _Invoice"
-msgstr "Myyntilasku"
+msgstr "Uusi _myyntilasku"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:195
 #: gnucash/ui/gnc-plugin-page-invoice.ui:354
 msgid "Create a new invoice for the same owner as the current one"
-msgstr ""
+msgstr "Luo uusi myyntilasku samalle omistajalle kuin tämä"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:196
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:221
@@ -4419,38 +4240,34 @@ msgstr ""
 #: gnucash/gnome/gnc-plugin-page-register.cpp:402
 #: gnucash/ui/gnc-embedded-register-window.ui:225
 msgid "Blank"
-msgstr ""
+msgstr "Tyhjä"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:196
 msgid "Move to the blank entry at the bottom of the invoice"
-msgstr ""
+msgstr "Siirry pohjalla olevalle tyhjälle laskuriville"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:197
 #: gnucash/ui/gnc-plugin-page-invoice.ui:552
-#, fuzzy
-#| msgid "Invoice"
 msgid "_Pay Invoice"
-msgstr "Myyntilasku"
+msgstr "M_aksa myyntilasku"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:197
 #: gnucash/ui/gnc-plugin-page-invoice.ui:200
 #: gnucash/ui/gnc-plugin-page-invoice.ui:554
 msgid "Enter a payment for the owner of this invoice"
-msgstr ""
+msgstr "Syötä maksu myyntilaskun omistajalle"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:198
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:223
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:248
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:273
 #: gnucash/ui/gnc-plugin-page-invoice.ui:207
-#, fuzzy
-#| msgid "Company Name"
 msgid "_Company Report"
-msgstr "Yrityksen nimi"
+msgstr "_Yritysraportti"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:198
 msgid "Open a customer report window for the owner of this invoice"
-msgstr ""
+msgstr "Avaa myyntilaskun omistajan asiakasraportti-ikkuna"
 
 #. Translators: This is a menu item that opens a dialog for linking an
 #. external file or URL with the bill, invoice, transaction, or voucher or
@@ -4463,10 +4280,8 @@ msgstr ""
 #: gnucash/ui/gnc-plugin-page-register.ui:205
 #: gnucash/ui/gnc-plugin-page-register.ui:393
 #: gnucash/ui/gnc-plugin-page-register.ui:505
-#, fuzzy
-#| msgid "Manage Document Link"
 msgid "_Manage Document Link…"
-msgstr "Vaihda yhdistettyä asiakirjaa"
+msgstr "_Vaihda yhdistetty asiakirja…"
 
 #. Translators: This is a menu item that opens an external file or URI that may
 #. be linked to the current bill, invoice, transaction, or voucher using
@@ -4480,7 +4295,7 @@ msgstr "Vaihda yhdistettyä asiakirjaa"
 #: gnucash/ui/gnc-plugin-page-register.ui:398
 #: gnucash/ui/gnc-plugin-page-register.ui:510
 msgid "_Open Linked Document"
-msgstr ""
+msgstr "_Avaa yhdistetty asiakirja"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:200
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:225
@@ -4488,7 +4303,7 @@ msgstr ""
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:275
 #: gnucash/gnome/gnc-plugin-page-register.cpp:406
 msgid "Open Linked Document"
-msgstr ""
+msgstr "Avaa yhdistetty asiakirja"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:206
 msgid "_Use as Default Layout for Customer Documents"
@@ -4512,74 +4327,68 @@ msgid ""
 msgstr ""
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:215
-#, fuzzy
-#| msgid "Principal"
 msgid "_Print Bill"
-msgstr "Pääoma"
+msgstr "_Tulosta ostolasku"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:215
 msgid "Make a printable bill"
-msgstr ""
+msgstr "Luo tulostettava ostolasku"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:216
 msgid "_Edit Bill"
-msgstr ""
+msgstr "_Muokkaa ostolaskua"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:216
 msgid "Edit this bill"
-msgstr ""
+msgstr "Muokkaa tätä ostolaskua"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:217
 msgid "_Duplicate Bill"
-msgstr ""
+msgstr "M_onista ostolasku"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:217
 msgid "Create a new bill as a duplicate of the current one"
-msgstr ""
+msgstr "Kopio nykyinen ostolasku uudeksi"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:218
 msgid "_Post Bill"
-msgstr ""
+msgstr "_Vie ostolasku kirjanpitoon"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:218
 msgid "Post this bill to your Chart of Accounts"
-msgstr ""
+msgstr "Vie tämä ostolasku tilikirjaan"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:219
 msgid "_Unpost Bill"
-msgstr ""
+msgstr "_Peruuta ostolaskun vienti kirjanpitoon"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:219
 msgid "Unpost this bill and make it editable"
-msgstr ""
+msgstr "Peruuta ostolaskun vienti ja tee siitä muokattava"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:220
-#, fuzzy
-#| msgid "Bill"
 msgid "New _Bill"
-msgstr "Ostolasku"
+msgstr "Uusi _ostolasku"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:220
 msgid "Create a new bill for the same owner as the current one"
-msgstr ""
+msgstr "Luo uusi ostolasku samalle taholle kuin nykyinen"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:221
 msgid "Move to the blank entry at the bottom of the bill"
-msgstr ""
+msgstr "Siirry tyhjälle riville ostolaskun lopussa"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:222
-#, fuzzy
-#| msgid "Bill"
 msgid "_Pay Bill"
-msgstr "Ostolasku"
+msgstr "_Maksa ostolasku"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:222
 msgid "Enter a payment for the owner of this bill"
-msgstr ""
+msgstr "Syötä maksu ostolaskuun"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:223
 msgid "Open a vendor report window for the owner of this bill"
-msgstr ""
+msgstr "Avaa tämän ostolaskun omistajan toimittajaraportti-ikkuna"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:231
 msgid "_Use as Default Layout for Vendor Documents"
@@ -4600,82 +4409,68 @@ msgid ""
 msgstr ""
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:240
-#, fuzzy
-#| msgid "Voucher"
 msgid "_Print Voucher"
-msgstr "Matkalasku"
+msgstr "_Tulosta matkalasku"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:240
 msgid "Make a printable voucher"
-msgstr ""
+msgstr "Luo tulostettava matkalasku"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:241
-#, fuzzy
-#| msgid "Voucher"
 msgid "_Edit Voucher"
-msgstr "Matkalasku"
+msgstr "_Muokkaa matkalaskua"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:241
-#, fuzzy
-#| msgid "End of this year"
 msgid "Edit this voucher"
-msgstr "Tämän vuoden loppu"
+msgstr "Muokkaa tätä matkalaskua"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:242
 msgid "_Duplicate Voucher"
-msgstr ""
+msgstr "_Monista matkalasku"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:242
 msgid "Create a new voucher as a duplicate of the current one"
-msgstr ""
+msgstr "Luo uusi matkalasku tämän kopiona"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:243
-#, fuzzy
-#| msgid "Voucher"
 msgid "_Post Voucher"
-msgstr "Matkalasku"
+msgstr "_Vie matkalasku kirjanpitoon"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:243
 msgid "Post this voucher to your Chart of Accounts"
-msgstr ""
+msgstr "Vie tämä matkalasku tilikirjaan"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:244
-#, fuzzy
-#| msgid "Expense Vouchers"
 msgid "_Unpost Voucher"
-msgstr "Matkalaskut"
+msgstr "_Peruuta matkalaskun vienti kirjanpitoon"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:244
 msgid "Unpost this voucher and make it editable"
-msgstr ""
+msgstr "Peruuta matkalaskun vienti ja tee siitä muokattava"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:245
-#, fuzzy
-#| msgid "Voucher"
 msgid "New _Voucher"
-msgstr "Matkalasku"
+msgstr "Uusi _matkalasku"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:245
 msgid "Create a new voucher for the same owner as the current one"
-msgstr ""
+msgstr "Luo uusi matkalasku samalle taholle kuin nykyinen"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:246
 msgid "Move to the blank entry at the bottom of the voucher"
-msgstr ""
+msgstr "Siirry tyhjälle riville matkalaskun lopussa"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:247
-#, fuzzy
-#| msgid "Voucher"
 msgid "_Pay Voucher"
-msgstr "Matkalasku"
+msgstr "_Maksa matkalasku"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:247
 msgid "Enter a payment for the owner of this voucher"
-msgstr ""
+msgstr "Syötä maksu matkalaskuun"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:248
 msgid "Open a employee report window for the owner of this voucher"
-msgstr ""
+msgstr "Avaa matkalaskun omistajan työntekijäraportti-ikkuna"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:256
 msgid "_Use as Default Layout for Employee Documents"
@@ -4698,149 +4493,131 @@ msgstr ""
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:265
 msgid "_Print Credit Note"
-msgstr ""
+msgstr "_Tulosta hyvityslaskua"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:265
 msgid "Make a printable credit note"
-msgstr ""
+msgstr "Luo tulostettava hyvistyslasku"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:266
-#, fuzzy
-#| msgid "Edit Customer"
 msgid "_Edit Credit Note"
-msgstr "Muokkaa asiakasta"
+msgstr "_Muokkaa hyvityslaskua"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:266
 msgid "Edit this credit note"
-msgstr ""
+msgstr "Muokkaa tätä hyvityslaskua"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:267
 msgid "_Duplicate Credit Note"
-msgstr ""
+msgstr "_Kopioi hyvityslasku"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:267
 msgid "Create a new credit note as a duplicate of the current one"
-msgstr ""
+msgstr "Luo uusi hyvityslasku tämän kopiona"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:268
 msgid "_Post Credit Note"
-msgstr ""
+msgstr "_Vie hyvityslasku kirjanpitoon"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:268
 msgid "Post this credit note to your Chart of Accounts"
-msgstr ""
+msgstr "Vie tämä hyvityslasku tilikirjaan"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:269
 msgid "_Unpost Credit Note"
-msgstr ""
+msgstr "_Peruuta hyvityslaskun vienti kirjanpitoon"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:269
 msgid "Unpost this credit note and make it editable"
-msgstr ""
+msgstr "Peruuta hyvityslaskun vienti ja tee siitä muokattava"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:270
 msgid "New _Credit Note"
-msgstr ""
+msgstr "_Uusi hyvityslasku"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:270
 msgid "Create a new credit note for the same owner as the current one"
-msgstr ""
+msgstr "Luo uusi hyvityslasku samalle taholle kuin nykyinen"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:271
 msgid "Move to the blank entry at the bottom of the credit note"
-msgstr ""
+msgstr "Siirry lopussa olevalle tyhjälle hyvityslaskuriville"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:272
 msgid "_Pay Credit Note"
-msgstr ""
+msgstr "_Maksa hyvityslasku"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:272
 msgid "Enter a payment for the owner of this credit note"
-msgstr ""
+msgstr "Kirjaa hyvityslaskun maksu omistajalle"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:273
 msgid "Open a company report window for the owner of this credit note"
-msgstr ""
+msgstr "Avaa hyvityslaskun omistajan yritysraportti-ikkuna"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:274
-#, fuzzy
-#| msgid "Manage Document Link"
 msgid "Manage Document Link…"
-msgstr "Vaihda yhdistettyä asiakirjaa"
+msgstr "Vaihda yhdistetty asiakirja…"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:282
 #: gnucash/gnome/gnc-plugin-page-register.cpp:393
 #: gnucash/ui/gnc-embedded-register-window.ui:195
-#, fuzzy
-#| msgid "Interest"
 msgid "Enter"
-msgstr "Korko"
+msgstr "Syötä"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:286
 msgid "Up"
-msgstr ""
+msgstr "Ylös"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:287
 msgid "Down"
-msgstr ""
+msgstr "Alas"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:290
 msgid "Unpost"
-msgstr ""
+msgstr "Peruuta vienti"
 
 #: gnucash/gnome/gnc-plugin-page-invoice.cpp:291
-#, fuzzy
-#| msgid "Payment"
 msgid "Pay"
-msgstr "Maksu"
+msgstr "Maksa"
 
 #: gnucash/gnome/gnc-plugin-page-owner-tree.cpp:227
-#, fuzzy
-#| msgid "Voucher"
 msgid "New Voucher"
-msgstr "Matkalasku"
+msgstr "Uusi matkalasku"
 
 #: gnucash/gnome/gnc-plugin-page-owner-tree.cpp:228
 #: gnucash/gnome/gnc-plugin-page-owner-tree.cpp:860
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:125
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:527
-#, fuzzy
-#| msgid "Use Existing"
 msgid "Vendor Listing"
-msgstr "Käytä olemassa olevaa"
+msgstr "Toimittajalista"
 
 #: gnucash/gnome/gnc-plugin-page-owner-tree.cpp:229
 #: gnucash/gnome/gnc-plugin-page-owner-tree.cpp:866
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:110
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:372
-#, fuzzy
-#| msgid "Customer ID"
 msgid "Customer Listing"
-msgstr "Asiakastunnus"
+msgstr "Asiakaslista"
 
 #: gnucash/gnome/gnc-plugin-page-owner-tree.cpp:359
 msgid "Owners"
-msgstr ""
+msgstr "Omistajat"
 
 #: gnucash/gnome/gnc-plugin-page-owner-tree.cpp:556
-#, fuzzy
-#| msgid "Customer ID"
 msgid "Customers"
-msgstr "Asiakastunnus"
+msgstr "Asiakkaat"
 
 #: gnucash/gnome/gnc-plugin-page-owner-tree.cpp:561
 msgid "Jobs"
-msgstr ""
+msgstr "Hankkeet"
 
 #: gnucash/gnome/gnc-plugin-page-owner-tree.cpp:566
 msgid "Vendors"
-msgstr ""
+msgstr "Toimittajat"
 
 #: gnucash/gnome/gnc-plugin-page-owner-tree.cpp:571
-#, fuzzy
-#| msgid "Employee ID"
 msgid "Employees"
-msgstr "Työntekijätunnus"
+msgstr "Työntekijät"
 
 #: gnucash/gnome/gnc-plugin-page-owner-tree.cpp:1052
 #, c-format
@@ -4848,27 +4625,23 @@ msgid ""
 "The owner %s will be deleted.\n"
 "Are you sure you want to do this?"
 msgstr ""
+"Omistaja %s poistetaan.\n"
+"Oletko varma että haluat tehdä tämän?"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:264
 #: gnucash/ui/gnc-plugin-page-register.ui:130
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Cu_t Transaction"
-msgstr "Etsi tosite"
+msgstr "_Leikkaa tosite"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:265
 #: gnucash/ui/gnc-plugin-page-register.ui:136
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "_Copy Transaction"
-msgstr "Etsi tosite"
+msgstr "_Kopioi tosite"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:266
 #: gnucash/ui/gnc-plugin-page-register.ui:142
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "_Paste Transaction"
-msgstr "Etsi tosite"
+msgstr "L_iitä tosite"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:267
 #: gnucash/ui/gnc-embedded-register-window.ui:111
@@ -4876,10 +4649,8 @@ msgstr "Etsi tosite"
 #: gnucash/ui/gnc-plugin-page-register.ui:364
 #: gnucash/ui/gnc-plugin-page-register.ui:574
 #: gnucash/ui/gnc-plugin-page-register.ui:722
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Dup_licate Transaction"
-msgstr "Etsi tosite"
+msgstr "_Monista tosite"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:268
 #: gnucash/gnome/gnc-split-reg.c:1507
@@ -4888,10 +4659,8 @@ msgstr "Etsi tosite"
 #: gnucash/ui/gnc-plugin-page-register.ui:369
 #: gnucash/ui/gnc-plugin-page-register.ui:579
 #: gnucash/ui/gnc-plugin-page-register.ui:737
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "_Delete Transaction"
-msgstr "Etsi tosite"
+msgstr "_Poista tosite"
 
 #. Translators: This is a menu item that will open the bill, invoice, or voucher
 #. that is posted to the current transaction if there is one.
@@ -4899,68 +4668,56 @@ msgstr "Etsi tosite"
 #: gnucash/ui/gnc-plugin-page-register.ui:220
 #: gnucash/ui/gnc-plugin-page-register.ui:405
 #: gnucash/ui/gnc-plugin-page-register.ui:517
-#, fuzzy
-#| msgid "Customer's Invoices"
 msgid "Jump to Invoice"
-msgstr "Asiakkaan myyntilaskut"
+msgstr "Hyppää laskuun"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:280
-#, fuzzy
-#| msgctxt "Action Column"
-#| msgid "Split"
 msgid "Cu_t Split"
-msgstr "Rivi"
+msgstr "_Leikkaa rivi"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:281
-#, fuzzy
-#| msgctxt "Action Column"
-#| msgid "Split"
 msgid "_Copy Split"
-msgstr "Rivi"
+msgstr "_Kopioi rivi"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:282
 msgid "_Paste Split"
-msgstr ""
+msgstr "L_iitä rivi"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:283
 #: gnucash/ui/gnc-plugin-page-register.ui:476
 #: gnucash/ui/gnc-plugin-page-register.ui:613
 msgid "Dup_licate Split"
-msgstr ""
+msgstr "M_onista rivi"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:284
 #: gnucash/gnome/gnc-split-reg.c:1467
 #: gnucash/ui/gnc-plugin-page-register.ui:481
 #: gnucash/ui/gnc-plugin-page-register.ui:618
-#, fuzzy
-#| msgid "_Delete"
 msgid "_Delete Split"
-msgstr "_Poista"
+msgstr "_Poista rivi"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:285
 #: gnucash/ui/gnc-embedded-register-window.ui:35
 msgid "Cut the selected transaction into clipboard"
-msgstr ""
+msgstr "Leikkaa valittu tosite leikepöydälle"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:286
 #: gnucash/ui/gnc-embedded-register-window.ui:40
 msgid "Copy the selected transaction into clipboard"
-msgstr ""
+msgstr "Kopioi valittu tosite leikepöydälle"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:287
 #: gnucash/ui/gnc-embedded-register-window.ui:45
 msgid "Paste the transaction from the clipboard"
-msgstr ""
+msgstr "Liitä tosite leikepöydältä"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:288
 #: gnucash/ui/gnc-embedded-register-window.ui:50
 #: gnucash/ui/gnc-embedded-register-window.ui:113
 #: gnucash/ui/gnc-embedded-register-window.ui:157
 #: gnucash/ui/gnc-plugin-page-register.ui:724
-#, fuzzy
-#| msgid "Last day of the current month."
 msgid "Make a copy of the current transaction"
-msgstr "Tämän kuukauden viimeinen päivä."
+msgstr "Tee kopio valitusta tositteesta"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:289
 #: gnucash/ui/gnc-embedded-register-window.ui:55
@@ -4968,15 +4725,15 @@ msgstr "Tämän kuukauden viimeinen päivä."
 #: gnucash/ui/gnc-embedded-register-window.ui:172
 #: gnucash/ui/gnc-plugin-page-register.ui:739
 msgid "Delete the current transaction"
-msgstr ""
+msgstr "Poista tämä tosite"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:290
 msgid "Add, change, or unlink the document linked with the current transaction"
-msgstr ""
+msgstr "Lisää, muuta tai poista tähän tositteeseen yhdistetty asiakirja"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:291
 msgid "Open the linked document for the current transaction"
-msgstr ""
+msgstr "Avaa tähän tositteeseen yhdistetty asiakirja"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:292
 msgid "Jump to the linked bill, invoice, or voucher"
@@ -4984,69 +4741,63 @@ msgstr ""
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:293
 msgid "Cut the selected split into clipboard"
-msgstr ""
+msgstr "Leikkaa valittu tositerivi leikepöydälle"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:294
 msgid "Copy the selected split into clipboard"
-msgstr ""
+msgstr "Kopioi valittu tositerivi leikepöydälle"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:295
 msgid "Paste the split from the clipboard"
-msgstr ""
+msgstr "Liitä tositerivi leikepöydältä"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:296
-#, fuzzy
-#| msgid "Last day of the current month."
 msgid "Make a copy of the current split"
-msgstr "Tämän kuukauden viimeinen päivä."
+msgstr "Tee kopio tästä tositerivistä"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:297
 msgid "Delete the current split"
-msgstr ""
+msgstr "Poista tämä tositerivi"
 
 #. Translators: This is the label of a toolbar button. So keep it short.
 #: gnucash/gnome/gnc-plugin-page-register.cpp:399
-#, fuzzy
-#| msgid "Stock split"
 msgid "Show Splits"
-msgstr "Osakkeen jako"
+msgstr "Näytä rivit"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:400
 msgid "Jump"
-msgstr ""
+msgstr "Hyppää"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:401
 msgid "Schedule"
-msgstr ""
+msgstr "Ajasta"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:404
 #: gnucash/gnome/window-autoclear.c:88
 msgid "Auto-clear"
-msgstr ""
+msgstr "Automaattinen tyhjennys"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:408
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:146
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:251
 #: gnucash/ui/gnc-plugin-page-register.ui:250
 #: gnucash/ui/gnc-plugin-page-register.ui:904
-#, fuzzy
-#| msgid "Stock split"
 msgid "Stock Assistant"
-msgstr "Osakkeen jako"
+msgstr "Osakeavustin"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:657
 #: gnucash/gnome/gnc-plugin-page-register.cpp:1940
 #: gnucash/gnome/gnc-plugin-page-register.cpp:3393
 #: gnucash/report/reports/standard/general-journal.scm:36
 msgid "General Journal"
-msgstr ""
+msgstr "Päiväkirja"
 
 #. Translators: %s is the name
 #. of the tab page
 #: gnucash/gnome/gnc-plugin-page-register.cpp:1874
 #, c-format
 msgid "Save changes to %s?"
-msgstr ""
+msgstr "Tallenna %s muutokset?"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:1879
 msgid ""
@@ -5054,18 +4805,16 @@ msgid ""
 "the changes to this transaction, discard the transaction, or cancel the "
 "operation?"
 msgstr ""
+"Tilikirjassa on tallentamattomia muutoksia tositteeseen. Haluatko tallentaa "
+"tositteen muutokset, poistaa tositteen vai peruuttaa toiminnon?"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:1882
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "_Discard Transaction"
-msgstr "Etsi tosite"
+msgstr "_Poista tosite"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:1886
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "_Save Transaction"
-msgstr "Etsi tosite"
+msgstr "_Tallenna tosite"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:1919
 #: gnucash/gnome/gnc-plugin-page-register.cpp:1954
@@ -5073,10 +4822,8 @@ msgstr "Etsi tosite"
 #: gnucash/gnome/gnc-plugin-page-register.cpp:2024
 #: gnucash/gnome/gnc-plugin-page-register.cpp:2122
 #: gnucash/gnome/gnc-plugin-page-register.cpp:2245
-#, fuzzy
-#| msgid "Unknown"
 msgid "unknown"
-msgstr "Tuntematon"
+msgstr "tuntematon"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:1942
 #: gnucash/gnome/gnc-plugin-page-register.cpp:3399
@@ -5086,11 +4833,11 @@ msgstr ""
 #: gnucash/gnome/gnc-plugin-page-register.cpp:1944
 #: gnucash/gnome/gnc-plugin-page-register.cpp:3405
 msgid "Search Results"
-msgstr ""
+msgstr "Haun tulokset"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:3271
 msgid "Start Date:"
-msgstr ""
+msgstr "Alkupäivämäärä:"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:3278
 msgid "Show previous number of days:"
@@ -5098,46 +4845,42 @@ msgstr ""
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:3286
 msgid "End Date:"
-msgstr "Päättymispäivä:"
+msgstr "Loppupäivämäärä:"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:3296
 #: gnucash/report/trep-engine.scm:157
-#, fuzzy
-#| msgid "Reconcile"
 msgid "Unreconciled"
-msgstr "Tarkista"
+msgstr "Täsmäyttämättä"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:3302
 #: gnucash/gnome-search/search-reconciled.c:222
 #: gnucash/report/trep-engine.scm:160
 msgid "Frozen"
-msgstr ""
+msgstr "Jäädytetty"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:3304
 #: gnucash/gnome-search/search-reconciled.c:225
 #: gnucash/report/trep-engine.scm:161
 msgid "Voided"
-msgstr ""
+msgstr "Mitätöity"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:3314
 msgid "Show:"
-msgstr ""
+msgstr "Näytä:"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:3322
 msgid "Hide:"
-msgstr ""
+msgstr "Piilota:"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:3333
 msgid "Filter By:"
-msgstr ""
+msgstr "Suodattaja:"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:3395
 #: gnucash/gnome/gnc-plugin-page-register.cpp:3413
 #: gnucash/report/reports/standard/transaction.scm:33
-#, fuzzy
-#| msgid "Transaction Number"
 msgid "Transaction Report"
-msgstr "Tositenumero"
+msgstr "Tositeraportti"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:3401
 msgid "Portfolio Report"
@@ -5145,22 +4888,18 @@ msgstr ""
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:3407
 msgid "Search Results Report"
-msgstr ""
+msgstr "Hakutulosraportti"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:3411
 #: gnucash/gtkbuilder/dialog-preferences.glade:2875
 #: gnucash/report/reports/standard/general-journal.scm:37
 #: gnucash/report/reports/standard/register.scm:64
-#, fuzzy
-#| msgid "Western"
 msgid "Register"
-msgstr "läntinen"
+msgstr "Tilikirja"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:3429
-#, fuzzy
-#| msgid "Find Account"
 msgid "and subaccounts"
-msgstr "Etsi tili"
+msgstr "ja alatilit"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:3606
 msgid "Print checks from multiple accounts?"
@@ -5174,7 +4913,7 @@ msgstr ""
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:3618
 msgid "_Print checks"
-msgstr ""
+msgstr "Tulosta š_ekkejä"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:3637
 msgid ""
@@ -5194,37 +4933,33 @@ msgstr ""
 #: gnucash/gnome/gnc-plugin-page-register.cpp:3961
 #: gnucash/gnome/gnc-split-reg.c:1095
 msgid "A reversing entry has already been created for this transaction."
-msgstr ""
+msgstr "Tälle tositteelle on jo luotu käänteinen tosite."
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:3962
 msgid "Jump to the transaction?"
-msgstr ""
+msgstr "Siirry suoraan tositteelle?"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:3971
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Reverse Transaction"
-msgstr "Etsi tosite"
+msgstr "Käänteinen tosite"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:3971
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:640
-#, fuzzy
-#| msgid "Transaction Document Links"
 msgid "New Transaction Information"
-msgstr "Tositteen asiakirjalinkit"
+msgstr ""
 
 #. Translators: The %s is the name of the plugin page
 #: gnucash/gnome/gnc-plugin-page-register.cpp:4062
 #, c-format
 msgid "Sort %s by…"
-msgstr ""
+msgstr "Lajittele %s…"
 
 #. Translators: The %s is the name of the plugin page
 #: gnucash/gnome/gnc-plugin-page-register.cpp:4152
 #: gnucash/gnome-utils/gnc-tree-view-owner.c:1148
 #, c-format
 msgid "Filter %s by…"
-msgstr ""
+msgstr "Suodata %s…"
 
 #. Translators: %s refer to the following in
 #. order: invoice type, invoice ID, owner name,
@@ -5240,19 +4975,17 @@ msgstr ""
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:4690
 #: gnucash/gnome-search/dialog-search.c:323
-#, fuzzy
-#| msgid "Selected"
 msgid "Select"
-msgstr "Valittu"
+msgstr "Valitse"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:4752
 msgid "Go to Date"
-msgstr ""
+msgstr "Siirry päivään"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:5060
 #: gnucash/gnome/gnc-plugin-page-register.cpp:5089
 msgid "Unable to jump to other account"
-msgstr ""
+msgstr "Ei voi hypätä toiselle tilille"
 
 #: gnucash/gnome/gnc-plugin-page-register.cpp:5063
 msgid ""
@@ -5273,34 +5006,34 @@ msgstr ""
 
 #: gnucash/gnome/gnc-plugin-page-report.cpp:234
 msgid "Print"
-msgstr ""
+msgstr "Tulosta"
 
 #: gnucash/gnome/gnc-plugin-page-report.cpp:235
 #: gnucash/gnome-utils/dialog-file-access.c:339
 #: gnucash/gnome-utils/gnc-file.c:111 gnucash/gnome-utils/gnc-file.c:353
 msgid "Export"
-msgstr ""
+msgstr "Vie"
 
 #. Translators: This string is meant to be a short alternative for "Save Report Configuration"
 #. to be used as toolbar button label.
 #: gnucash/gnome/gnc-plugin-page-report.cpp:239
 msgid "Save Config"
-msgstr ""
+msgstr "Tallenna asetukset"
 
 #. Translators: This string is meant to be a short alternative for "Save Report Configuration As…"
 #. to be used as toolbar button label.
 #: gnucash/gnome/gnc-plugin-page-report.cpp:242
 msgid "Save Config As…"
-msgstr ""
+msgstr "Tallenna asetukset nimellä…"
 
 #: gnucash/gnome/gnc-plugin-page-report.cpp:243
 msgid "Make Pdf"
-msgstr ""
+msgstr "Tee PDF"
 
 #: gnucash/gnome/gnc-plugin-page-report.cpp:377
 #: gnucash/gnome/gnc-plugin-page-report.cpp:378
 msgid "The numeric ID of the report."
-msgstr ""
+msgstr "Raportin ID-numero."
 
 #: gnucash/gnome/gnc-plugin-page-report.cpp:1260
 #, c-format
@@ -5308,6 +5041,8 @@ msgid ""
 "Update the current report's saved configuration. The report configuration "
 "will be saved in the file %s."
 msgstr ""
+"Päivitä raportin tallennetut asetukset. Raportti asetukset tallennetaan "
+"tiedostoon %s."
 
 #: gnucash/gnome/gnc-plugin-page-report.cpp:1263
 #, c-format
@@ -5315,40 +5050,38 @@ msgid ""
 "Add the current report's configuration to the 'Reports->Saved Report "
 "Configurations' menu. The report configuration will be saved in the file %s."
 msgstr ""
+"Lisää nykyisen raportin asetukset Tallennetut raporttiasetukset -valikkoon. "
+"Raportti tallennetaan tiedostoon %s."
 
 #: gnucash/gnome/gnc-plugin-page-report.cpp:1271
 #: gnucash/ui/gnc-plugin-page-report.ui:74
 #: gnucash/ui/gnc-plugin-page-report.ui:255
-#, fuzzy
-#| msgid "Load report configuration"
 msgid "Save _Report Configuration"
-msgstr "Lataa raporttiasetukset"
+msgstr "Tallenna _raportin asetukset"
 
 #: gnucash/gnome/gnc-plugin-page-report.cpp:1272
 #: gnucash/ui/gnc-plugin-page-report.ui:81
 #: gnucash/ui/gnc-plugin-page-report.ui:270
-#, fuzzy
-#| msgid "Load report configuration"
 msgid "Save Report Configuration As…"
-msgstr "Lataa raporttiasetukset"
+msgstr "Tallenna raportin asetukset nimellä…"
 
 #: gnucash/gnome/gnc-plugin-page-report.cpp:1552
 #: gnucash/gnome/gnc-plugin-page-report.cpp:1585
 msgid "HTML"
-msgstr ""
+msgstr "HTML"
 
 #: gnucash/gnome/gnc-plugin-page-report.cpp:1555
 msgid "Choose export format"
-msgstr ""
+msgstr "Valitse vientimuoto"
 
 #: gnucash/gnome/gnc-plugin-page-report.cpp:1556
 msgid "Choose the export format for this report:"
-msgstr ""
+msgstr "Valitse tämän raportin vientimuoto:"
 
 #: gnucash/gnome/gnc-plugin-page-report.cpp:1596
 #, c-format
 msgid "Save %s To File"
-msgstr ""
+msgstr "Tallenna %s tiedostoon"
 
 #: gnucash/gnome/gnc-plugin-page-report.cpp:1625
 #, c-format
@@ -5360,14 +5093,14 @@ msgstr ""
 
 #: gnucash/gnome/gnc-plugin-page-report.cpp:1635
 msgid "You cannot save to that file."
-msgstr ""
+msgstr "Et voi tallentaa tähän tiedostoon."
 
 #: gnucash/gnome/gnc-plugin-page-report.cpp:1644
 #: gnucash/gnome-utils/gnc-file.c:1363 gnucash/gnome-utils/gnc-file.c:1614
 #: gnucash/import-export/csv-exp/assistant-csv-export.c:738
 #, c-format
 msgid "The file %s already exists. Are you sure you want to overwrite it?"
-msgstr ""
+msgstr "Tiedosto %s on jo olemassa. Haluatko varmasti ylikirjoittaa sen?"
 
 #: gnucash/gnome/gnc-plugin-page-report.cpp:1781
 #: gnucash/gnome/gnc-plugin-page-report.cpp:1807
@@ -5384,142 +5117,128 @@ msgstr ""
 
 #: gnucash/gnome/gnc-plugin-page-report.cpp:1863
 msgid "GnuCash-Report"
-msgstr ""
+msgstr "GnuCash-raportti"
 
 #: gnucash/gnome/gnc-plugin-page-report.cpp:1912
 #: gnucash/report/reports/standard/invoice.scm:877
 msgid "Printable Invoice"
-msgstr ""
+msgstr "Tulostettava lasku"
 
 #: gnucash/gnome/gnc-plugin-page-report.cpp:1913
 #: gnucash/report/reports/standard/taxinvoice.scm:301
 #: gnucash/report/reports/standard/taxinvoice.scm:303
 #: gnucash/report/reports/standard/taxinvoice.scm:315
 #: gnucash/report/reports/support/taxinvoice.eguile.scm:423
-#, fuzzy
-#| msgid "Invoice"
 msgid "Tax Invoice"
-msgstr "Myyntilasku"
+msgstr "Verolasku"
 
 #: gnucash/gnome/gnc-plugin-page-report.cpp:1914
 #: gnucash/report/reports/standard/invoice.scm:887
-#, fuzzy
-#| msgid "Invoice"
 msgid "Easy Invoice"
-msgstr "Myyntilasku"
+msgstr "Yksinkertainen lasku"
 
 #: gnucash/gnome/gnc-plugin-page-report.cpp:1915
 #: gnucash/report/reports/standard/invoice.scm:897
-#, fuzzy
-#| msgid "Invoice"
 msgid "Fancy Invoice"
-msgstr "Myyntilasku"
+msgstr "Hieno lasku"
 
 #: gnucash/gnome/gnc-plugin-page-sx-list.cpp:399
 #: gnucash/ui/gnc-plugin-page-sx-list.ui:53
 msgid "_New Schedule"
-msgstr ""
+msgstr "_Uusi ajastus"
 
 #: gnucash/gnome/gnc-plugin-page-sx-list.cpp:405
 #: gnucash/ui/gnc-plugin-page-sx-list.ui:59
 msgid "_Edit Schedule"
-msgstr ""
+msgstr "_Muokkaa ajastusta"
 
 #: gnucash/gnome/gnc-plugin-page-sx-list.cpp:411
 #: gnucash/ui/gnc-plugin-page-sx-list.ui:65
-#, fuzzy
-#| msgid "_Delete"
 msgid "_Delete Schedule"
-msgstr "_Poista"
+msgstr "_Poista ajastus"
 
 #: gnucash/gnome/gnc-plugin-page-sx-list.cpp:493
 #: gnucash/gtkbuilder/dialog-account.glade:553
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Transactions"
-msgstr "Etsi tosite"
+msgstr "Tositteet"
 
 #: gnucash/gnome/gnc-plugin-page-sx-list.cpp:565
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Upcoming Transactions"
-msgstr "Etsi tosite"
+msgstr "Tulevat tositteet"
 
 #: gnucash/gnome/gnc-plugin-page-sx-list.cpp:933
-#, fuzzy
-#| msgid "Are you sure you want to delete the selected commodity?"
 msgid "Do you really want to delete this scheduled transaction?"
 msgid_plural "Do you really want to delete these scheduled transactions?"
-msgstr[0] "Oletko varma että haluat poistaa valitun hyödykkeen?"
-msgstr[1] "Oletko varma että haluat poistaa valitun hyödykkeen?"
+msgstr[0] "Haluatko varmasti poistaa tämän tositteen ajastuksen?"
+msgstr[1] "Haluatko varmasti poistaa nämä tositteiden ajastukset?"
 
 #: gnucash/gnome/gnc-plugin-report-system.c:163
 #: gnucash/report/reports/standard/view-column.scm:95
 msgid "Report error"
-msgstr ""
+msgstr "Raporttivirhe"
 
 #: gnucash/gnome/gnc-plugin-report-system.c:164
 #: gnucash/report/reports/standard/view-column.scm:96
 msgid "An error occurred while running the report."
-msgstr ""
+msgstr "Virhe raportin luonnissa."
 
 #: gnucash/gnome/gnc-plugin-report-system.c:200
 #: gnucash/gnome/gnc-plugin-report-system.c:222
-#, fuzzy, c-format
-#| msgid "Badly formed URL %s"
+#, c-format
 msgid "Badly formed options URL: %s"
-msgstr "Väärin muotoiltu URL %s"
+msgstr "Virheellisesti muotoiltu URL: %s"
 
 #: gnucash/gnome/gnc-plugin-report-system.c:210
-#, fuzzy, c-format
-#| msgid "Badly formed URL %s"
+#, c-format
 msgid "Badly-formed report id: %s"
-msgstr "Väärin muotoiltu URL %s"
+msgstr "Virheellisesti muotoiltu raporttitunnus: %s"
 
 #: gnucash/gnome/gnc-split-reg.c:651
 msgid "Standard Order"
-msgstr ""
+msgstr "Tavanomainen järjestys"
 
 #: gnucash/gnome/gnc-split-reg.c:657
 msgid "Date of Entry"
-msgstr ""
+msgstr "Syöttöpäivämäärä"
 
 #: gnucash/gnome/gnc-split-reg.c:660 gnucash/gnome/window-reconcile.cpp:2048
 msgid "Statement Date"
-msgstr ""
+msgstr "Tiliotteen päiväys"
 
 #: gnucash/gnome/gnc-split-reg.c:683
 #: gnucash/report/reports/standard/customer-summary.scm:118
 #: gnucash/report/reports/standard/new-aging.scm:101
 #: gnucash/report/trep-engine.scm:414
 msgid "Descending"
-msgstr ""
+msgstr "Laskeva"
 
 #: gnucash/gnome/gnc-split-reg.c:685
 #: gnucash/report/reports/standard/customer-summary.scm:117
 #: gnucash/report/reports/standard/new-aging.scm:100
 #: gnucash/report/trep-engine.scm:412
 msgid "Ascending"
-msgstr ""
+msgstr "Nouseva"
 
 #: gnucash/gnome/gnc-split-reg.c:711
 msgid "Filtered"
-msgstr ""
+msgstr "Suodatettu"
 
 #: gnucash/gnome/gnc-split-reg.c:877
 #, c-format
 msgid "Cut the split '%s' from the transaction '%s'?"
-msgstr ""
+msgstr "Poista rivi '%s' tositteelta '%s'?"
 
 #: gnucash/gnome/gnc-split-reg.c:878
 msgid ""
 "You would be removing a reconciled split! This is not a good idea as it will "
 "cause your reconciled balance to be off."
 msgstr ""
+"Olet poistamassa täsmättyä merkintää. Se on huono idea, sillä sen jälkeen "
+"täsmätyt saldot eivät enää pidä paikkaansa."
 
 #: gnucash/gnome/gnc-split-reg.c:881
 msgid "You cannot cut this split."
-msgstr ""
+msgstr "Et voi leikata tätä riviä."
 
 #: gnucash/gnome/gnc-split-reg.c:882
 msgid ""
@@ -5528,43 +5247,41 @@ msgid ""
 "from this window, or you may navigate to a register that shows another side "
 "of this same transaction and remove the split from that register."
 msgstr ""
+"Tämä rivi ankkuroi tämän tositteen tähän kirjaan. Et voi poistaa sitä tämän "
+"kirjan ikkunasta. Voit poistaa koko tositteen tästä ikkunasta, tai voit "
+"siirtyä rivin toisen tilin kirjaan ja poistaa rivin sieltä."
 
 #: gnucash/gnome/gnc-split-reg.c:912 gnucash/gnome/gnc-split-reg.c:1439
 msgid "(no memo)"
-msgstr ""
+msgstr "(ei erittelyä)"
 
 #: gnucash/gnome/gnc-split-reg.c:915 gnucash/gnome/gnc-split-reg.c:1442
-#, fuzzy
-#| msgid "Description"
 msgid "(no description)"
-msgstr "Selite"
+msgstr "(ei selitettä)"
 
 #: gnucash/gnome/gnc-split-reg.c:940
-#, fuzzy
-#| msgctxt "Action Column"
-#| msgid "Split"
 msgid "_Cut Split"
-msgstr "Rivi"
+msgstr "_Leikkaa rivi"
 
 #: gnucash/gnome/gnc-split-reg.c:954
 msgid "Cut the current transaction?"
-msgstr ""
+msgstr "Poista valittu tosite?"
 
 #: gnucash/gnome/gnc-split-reg.c:955
 msgid ""
 "You would be removing a transaction with reconciled splits! This is not a "
 "good idea as it will cause your reconciled balance to be off."
 msgstr ""
+"Olet poistamassa tositteen, jolla on tämäytettyjä rivejä! Sitä ei kannata "
+"tehdä, sillä sen jälkeen täsmäytetyt saldot eivät enää pidä paikkaansa."
 
 #: gnucash/gnome/gnc-split-reg.c:978
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "_Cut Transaction"
-msgstr "Etsi tosite"
+msgstr "_Leikkaa tosite"
 
 #: gnucash/gnome/gnc-split-reg.c:1122
 msgid "Cannot modify or delete this transaction."
-msgstr ""
+msgstr "Tätä tositetta ei voi muokata tai poistaa."
 
 #: gnucash/gnome/gnc-split-reg.c:1136
 msgid ""
@@ -5574,7 +5291,7 @@ msgstr ""
 
 #: gnucash/gnome/gnc-split-reg.c:1172
 msgid "Remove the splits from this transaction?"
-msgstr ""
+msgstr "Poistetaanko rivit tästä tositteesta?"
 
 #: gnucash/gnome/gnc-split-reg.c:1173
 msgid ""
@@ -5584,31 +5301,29 @@ msgstr ""
 
 #. Translators: This is the confirmation button in a warning dialog
 #: gnucash/gnome/gnc-split-reg.c:1202
-#, fuzzy
-#| msgid "Reverse split"
 msgid "_Remove Splits"
-msgstr "Osakkeiden yhdistäminen"
+msgstr "_Poista rivit"
 
 #: gnucash/gnome/gnc-split-reg.c:1263
-#, fuzzy
-#| msgid "Transaction Document Links"
 msgid "Change a Transaction Linked Document"
-msgstr "Tositteen asiakirjalinkit"
+msgstr "Muuta tositteeseen yhdistettyä asiakirjaa"
 
 #: gnucash/gnome/gnc-split-reg.c:1403
 #, c-format
 msgid "Delete the split '%s' from the transaction '%s'?"
-msgstr ""
+msgstr "Poista rivi '%s' tositteelta '%s'?"
 
 #: gnucash/gnome/gnc-split-reg.c:1404
 msgid ""
 "You would be deleting a reconciled split! This is not a good idea as it will "
 "cause your reconciled balance to be off."
 msgstr ""
+"Olet poistamassa täsmättyä riviä! Se on huono idea, sillä sen jälkeen "
+"täsmätyt saldot eivät enää pidä paikkaansa."
 
 #: gnucash/gnome/gnc-split-reg.c:1407
 msgid "You cannot delete this split."
-msgstr ""
+msgstr "Et voi poistaa tää riviä."
 
 #: gnucash/gnome/gnc-split-reg.c:1408
 msgid ""
@@ -5617,16 +5332,21 @@ msgid ""
 "from this window, or you may navigate to a register that shows another side "
 "of this same transaction and delete the split from that register."
 msgstr ""
+"Tämä rivi ankkuroi tämän tositteen tähän kirjaan. Et voi poistaa sitä tästä "
+"tilikirjaikkunasta. Voit poistaa koko tositteen tästä ikkunasta, tai voit "
+"siirtyä rivin toisen tilin kirjaan ja poistaa rivin sieltä."
 
 #: gnucash/gnome/gnc-split-reg.c:1483
 msgid "Delete the current transaction?"
-msgstr ""
+msgstr "Poista tämä tosite?"
 
 #: gnucash/gnome/gnc-split-reg.c:1484
 msgid ""
 "You would be deleting a transaction with reconciled splits! This is not a "
 "good idea as it will cause your reconciled balance to be off."
 msgstr ""
+"Poistaisit tositteen, jolla on tämättyjä jakoja! Se ei ole hyvä idea, sillä "
+"sen jälkeen täsmätyt saldot eivät enää pidä paikkaansa."
 
 #: gnucash/gnome/gnc-split-reg.c:1679
 #, c-format
@@ -5645,44 +5365,44 @@ msgstr ""
 
 #: gnucash/gnome/gnc-split-reg.c:2309
 msgid "Present:"
-msgstr ""
+msgstr "Nykyinen:"
 
 #: gnucash/gnome/gnc-split-reg.c:2310
 msgid "Future:"
-msgstr ""
+msgstr "Tuleva:"
 
 #: gnucash/gnome/gnc-split-reg.c:2311
 msgid "Cleared:"
-msgstr ""
+msgstr "Hyväksytty:"
 
 #: gnucash/gnome/gnc-split-reg.c:2312
 msgid "Reconciled:"
-msgstr "Täsmennetty:"
+msgstr "Täsmäytetty:"
 
 #: gnucash/gnome/gnc-split-reg.c:2313
 msgid "Projected Minimum:"
-msgstr ""
+msgstr "Ennustettu vähin:"
 
 #: gnucash/gnome/gnc-split-reg.c:2317
 msgid "Shares:"
-msgstr "Osuudet:"
+msgstr "Osuuksia:"
 
 #: gnucash/gnome/gnc-split-reg.c:2318
 msgid "Current Value:"
-msgstr ""
+msgstr "Nykyinen arvo:"
 
 #: gnucash/gnome/gnc-split-reg.c:2324
 msgid "Sort By:"
-msgstr ""
+msgstr "Lajitteluperuste:"
 
 #: gnucash/gnome/gnc-split-reg.c:2400
 msgid "This account register is read-only."
-msgstr ""
+msgstr "Tämä tilikirja on kirjoitussuojattu."
 
 #: gnucash/gnome/gnc-split-reg.c:2401
 #, c-format
 msgid "The '%s' account register is read-only."
-msgstr ""
+msgstr "Tilin '%s' tilikirja on kirjoitussuojattu."
 
 #: gnucash/gnome/gnc-split-reg.c:2460
 msgid ""
@@ -5697,6 +5417,9 @@ msgid ""
 "If you want to edit transactions in this register, please open the account "
 "options and turn off the placeholder checkbox."
 msgstr ""
+"Tämän tilin tositteita ei voi muokata.\n"
+"Jos haluat muokata tämän tilin tositteita, avaa tilin asetukset ja poista "
+"koontitili-valinta."
 
 #: gnucash/gnome/gnc-split-reg.c:2482
 msgid ""
@@ -5705,24 +5428,25 @@ msgid ""
 "account options and turn off the placeholder checkbox.\n"
 "You may also open an individual account instead of a set of accounts."
 msgstr ""
+"Yhtä valituista alatileistä ei voi muokata.\n"
+"Jos haluat muokata tilikirjan tositteita, avaa alatilin asetukset ja poista "
+"koontitilin valinta.\n"
+"Voit myös avata yksittaisen tilin ryhmän sijaan."
 
 #: gnucash/gnome/gnucash.appdata.xml.in.in:5
 #: gnucash/gnome/gnucash.desktop.in.in:5
-#, fuzzy
-#| msgctxt "Stock Assistant: Page name"
-#| msgid "Cash"
 msgid "GnuCash"
-msgstr "Käteinen"
+msgstr "GnuCash"
 
 #: gnucash/gnome/gnucash.appdata.xml.in.in:6
 #: gnucash/gnome/gnucash.desktop.in.in:7
 msgid "Manage your finances, accounts, and investments"
-msgstr ""
+msgstr "Hallitse rahavirtojasi, tilejäsi ja sijoituksiasi"
 
 #: gnucash/gnome/gnucash.appdata.xml.in.in:8
 msgid ""
 "GnuCash is a program for personal and small-business financial-accounting."
-msgstr ""
+msgstr "GnuCash on ohjelma henkilökohtaiseen ja pienyritysten kirjanpitoon."
 
 #: gnucash/gnome/gnucash.appdata.xml.in.in:11
 msgid ""
@@ -5732,88 +5456,94 @@ msgid ""
 "principles like double-entry accounting to ensure balanced books and "
 "accurate reports."
 msgstr ""
+"Helppokäyttöiseksi, mutta silti tehokkaaksi ja joustavaksi suunnitellun "
+"GnuCashin avulla voit seurata pankkitilejä, osakkeita, tuloja ja menoja. "
+"Käyttö on helppoa ja intuitiivista kuten ruutuvihkon käyttö. Silti GnuCash "
+"sisältää ammattimaisten omaksumia periaatteita kuten kahdenkertaisen "
+"kirjanpidon varmistaakseen tasapainossa olevat merkkaukset ja tarkat "
+"raportit."
 
 #: gnucash/gnome/gnucash.appdata.xml.in.in:15
 msgid "With GnuCash you can (but are not limited to):"
-msgstr ""
+msgstr "GnuCashin avulla voit (mutta et ole rajoittunut):"
 
 #: gnucash/gnome/gnucash.appdata.xml.in.in:17
 msgid "Keep track of your day to day personal income and expenses"
-msgstr ""
+msgstr "Pitää kirjaa päivittäisistä tuloista ja menoista"
 
 #: gnucash/gnome/gnucash.appdata.xml.in.in:18
 msgid "Manage your stock, bond and mutual fund accounts with ease"
-msgstr ""
+msgstr "Hallita osake-, bondi- ja rahastotilejä helposti"
 
 #: gnucash/gnome/gnucash.appdata.xml.in.in:19
 msgid "Keep your small business' accounting up to date"
-msgstr ""
+msgstr "Pitää pienyrityksesi kirjanpidon ajan tasalla"
 
 #: gnucash/gnome/gnucash.appdata.xml.in.in:20
 msgid "Create accurate reports and graphs from your financial data"
-msgstr ""
+msgstr "Luoda tarkkoja raportteja ja kuvaajia taloustietoihisi pohjaten"
 
 #: gnucash/gnome/gnucash.appdata.xml.in.in:21
 msgid "Set up scheduled transactions to avoid repeated data entry"
 msgstr ""
+"Aseta tositteiden ajastuksia välttääksesi toistuvien tietojen "
+"kirjaamisen"
 
 #: gnucash/gnome/gnucash.appdata.xml.in.in:22
 msgid ""
 "Exchange by CSV/FinTS(former HBCI) or import SWIFT-MT9xx/QIF/OFX data "
 "including Transaction Matching"
 msgstr ""
+"Vaihtaa tietoja CSV-/FinTS (entinen HBCI) -muodoissa tai tuoda SWIFT-MT9xx-/"
+"QIF-/OFX-tietoa sisältäen tapahtumien täsmäämisen"
 
 #: gnucash/gnome/gnucash.appdata.xml.in.in:23
 msgid "Perform financial calculations, such as a loan repayment"
 msgstr ""
+"Suorittaa talouteen liittyviä laskutoimituksia, kuten lainan "
+"takaisinmaksusuunnitelman"
 
 #: gnucash/gnome/gnucash.appdata.xml.in.in:33
 msgid "GnuCash Project"
-msgstr ""
+msgstr "GnuCash-projekti"
 
 #: gnucash/gnome/gnucash.desktop.in.in:6
-#, fuzzy
-#| msgid "Insurance Payment"
 msgid "Finance Management"
-msgstr "Vakuutusmaksu"
+msgstr "Taloudenhallinta"
 
 #: gnucash/gnome/reconcile-view.c:431
 #: gnucash/register/ledger-core/split-register-layout.c:697
 #: gnucash/register/ledger-core/split-register-model.c:317
 msgctxt "Column header for 'Reconciled'"
 msgid "R"
-msgstr ""
+msgstr "V"
 
 #: gnucash/gnome/report-menus.scm:57
 #, scheme-format
 msgid "Display the ~a report"
-msgstr ""
+msgstr "Näytä ~a -raportti"
 
 #: gnucash/gnome/report-menus.scm:90
 #: gnucash/gtkbuilder/dialog-custom-report.glade:8
-#, fuzzy
-#| msgid "Load report configuration"
 msgid "Saved Report Configurations"
-msgstr "Lataa raporttiasetukset"
+msgstr "Tallennetut raporttiasetukset"
 
 #: gnucash/gnome/report-menus.scm:92
-#, fuzzy
-#| msgid "Load report configuration"
 msgid "Manage and run saved report configurations"
-msgstr "Lataa raporttiasetukset"
+msgstr "Hallitse tallennettuja raporttiasetuksia"
 
 #: gnucash/gnome/report-menus.scm:116
 #: gnucash/report/reports/standard/dashboard.scm:51
 msgid "Dashboard"
-msgstr ""
+msgstr "Kojelauta"
 
 #: gnucash/gnome/report-menus.scm:118
 msgid "A basic dashboard for your accounting data"
-msgstr ""
+msgstr "Kojelauta tilitiedoillesi"
 
 #: gnucash/gnome/search-owner.c:130
 msgid "You have not selected an owner"
-msgstr ""
+msgstr "Et ole valinnut omistajaa"
 
 #: gnucash/gnome/search-owner.c:199 gnucash/gnome-search/dialog-search.c:1097
 #: gnucash/gtkbuilder/dialog-invoice.glade:278
@@ -5823,17 +5553,17 @@ msgstr ""
 #: gnucash/report/reports/standard/new-owner-report.scm:99
 #: libgnucash/engine/gncOwner.c:218
 msgid "Job"
-msgstr ""
+msgstr "Hanke"
 
 #: gnucash/gnome/search-owner.c:216
 #: gnucash/gnome-search/search-reconciled.c:175
 msgid "is"
-msgstr ""
+msgstr "on"
 
 #: gnucash/gnome/search-owner.c:217
 #: gnucash/gnome-search/search-reconciled.c:176
 msgid "is not"
-msgstr ""
+msgstr "ei ole"
 
 #: gnucash/gnome/top-level.c:103
 #, c-format
@@ -5843,24 +5573,21 @@ msgstr "Entiteettiä ei löytynyt: %s"
 #: gnucash/gnome/top-level.c:164
 #, c-format
 msgid "Transaction with no Accounts: %s"
-msgstr "Tapahtuma ilman tilejä: %s"
+msgstr "Vienti ilman tilejä: %s"
 
 #: gnucash/gnome/top-level.c:207
 #, c-format
 msgid "Unsupported entity type: %s"
-msgstr ""
+msgstr "Entiteetin tyyppi ei ole tuettu: %s"
 
 #: gnucash/gnome/top-level.c:248
-#, fuzzy, c-format
-#| msgid "No such entity: %s"
+#, c-format
 msgid "No such price: %s"
-msgstr "Vastaavaa entiteettiä ei löytynyt: %s"
+msgstr "Hintaa ei löytynyt: %s"
 
 #: gnucash/gnome/window-autoclear.c:115
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Cleared Transactions"
-msgstr "Etsi tosite"
+msgstr "Hyväksytyt viennit"
 
 #. Translators: %d is the number of days in the future
 #: gnucash/gnome/window-reconcile.cpp:383
@@ -5885,59 +5612,47 @@ msgid ""
 msgstr ""
 
 #: gnucash/gnome/window-reconcile.cpp:484
-#, fuzzy
-#| msgid "Insurance Payment"
 msgid "Interest Payment"
-msgstr "Vakuutusmaksu"
+msgstr "Korkomaksu"
 
 #: gnucash/gnome/window-reconcile.cpp:487
-#, fuzzy
-#| msgid "Interest"
 msgid "Interest Charge"
-msgstr "Korko"
+msgstr "Korkoveloitus"
 
 #: gnucash/gnome/window-reconcile.cpp:495
 #: gnucash/gtkbuilder/dialog-vendor.glade:630
 #: gnucash/gtkbuilder/dialog-vendor.glade:652
 msgid "Payment Information"
-msgstr ""
+msgstr "Maksun tiedot"
 
 #: gnucash/gnome/window-reconcile.cpp:505
 #: gnucash/gtkbuilder/assistant-loan.glade:571
 #: gnucash/gtkbuilder/assistant-loan.glade:772
-#, fuzzy
-#| msgid "Payment"
 msgid "Payment From"
-msgstr "Maksu"
+msgstr "Maksu tililtä"
 
 #: gnucash/gnome/window-reconcile.cpp:511
 #: gnucash/gnome/window-reconcile.cpp:521
-#, fuzzy
-#| msgid "Reconcile"
 msgid "Reconcile Account"
-msgstr "Tarkista"
+msgstr "Tarkistustili"
 
 #: gnucash/gnome/window-reconcile.cpp:526
 #: gnucash/gtkbuilder/assistant-loan.glade:824
-#, fuzzy
-#| msgid "Payment"
 msgid "Payment To"
-msgstr "Maksu"
+msgstr "Maksu vastaanottajalle"
 
 #: gnucash/gnome/window-reconcile.cpp:787
 #: gnucash/gtkbuilder/window-reconcile.glade:215
 msgid "Enter _Interest Payment…"
-msgstr ""
+msgstr "Syötä _korko…"
 
 #: gnucash/gnome/window-reconcile.cpp:789
 msgid "Enter _Interest Charge…"
-msgstr ""
+msgstr "Syötä _korkoveloitus…"
 
 #: gnucash/gnome/window-reconcile.cpp:1395
-#, fuzzy
-#| msgid "Are you sure you want to delete the selected commodity?"
 msgid "Are you sure you want to delete the selected transaction?"
-msgstr "Oletko varma että haluat poistaa valitun hyödykkeen?"
+msgstr "Oletko varma että haluat poistaa valitun viennin?"
 
 #: gnucash/gnome/window-reconcile.cpp:1946
 msgid ""
@@ -5955,27 +5670,21 @@ msgstr ""
 
 #: gnucash/gnome/window-reconcile.cpp:2058
 #: gnucash/gtkbuilder/window-reconcile.glade:106
-#, fuzzy
-#| msgid "Opening Balance"
 msgid "Starting Balance"
-msgstr "Avaussaldo"
+msgstr "Alkusaldo"
 
 #: gnucash/gnome/window-reconcile.cpp:2068
-#, fuzzy
-#| msgid "Opening Balance"
 msgid "Ending Balance"
-msgstr "Avaussaldo"
+msgstr "Loppusaldo"
 
 #: gnucash/gnome/window-reconcile.cpp:2078
-#, fuzzy
-#| msgid "Reconciled Date"
 msgid "Reconciled Balance"
-msgstr "Tarkistuspäivämäärä"
+msgstr "Täsmätty saldo"
 
 #: gnucash/gnome/window-reconcile.cpp:2088
 #: gnucash/report/reports/standard/cash-flow.scm:305
 msgid "Difference"
-msgstr ""
+msgstr "Erotus"
 
 #: gnucash/gnome/window-reconcile.cpp:2201
 msgid ""
@@ -5997,202 +5706,178 @@ msgstr ""
 
 #: gnucash/gnome/window-report.cpp:214
 msgid "There are no options for this report."
-msgstr ""
+msgstr "Tälle raportille ei ole asetuksia."
 
 #: gnucash/gnome-search/dialog-search.c:229
-#, fuzzy
-#| msgid "You must select a report configuration to delete."
 msgid "You must select an item from the list"
-msgstr "Valitse poistettavat raporttiasetukset."
+msgstr ""
 
 #: gnucash/gnome-search/dialog-search.c:706
 #: gnucash/gtkbuilder/dialog-commodities.glade:138
 #: gnucash/gtkbuilder/dialog-doclink.glade:215
 #: gnucash/gtkbuilder/dialog-price.glade:865
 msgid "_Remove"
-msgstr ""
+msgstr "_Poista"
 
 #: gnucash/gnome-search/dialog-search.c:1101
 msgid "Order"
-msgstr ""
+msgstr "Tilaus"
 
 #: gnucash/gnome-search/dialog-search.c:1103
 #: gnucash/gtkbuilder/dialog-order.glade:421
 msgid "New Order"
-msgstr ""
+msgstr "Uusi tilaus"
 
 #: gnucash/gnome-search/dialog-search.c:1107
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "New Transaction"
-msgstr "Etsi tosite"
+msgstr "Uusi tosite"
 
 #: gnucash/gnome-search/dialog-search.c:1109
-#, fuzzy
-#| msgctxt "Action Column"
-#| msgid "Split"
 msgid "Split"
-msgstr "Rivi"
+msgstr "Rivit"
 
 #: gnucash/gnome-search/dialog-search.c:1111
-#, fuzzy
-#| msgctxt "Action Column"
-#| msgid "Split"
 msgid "New Split"
-msgstr "Rivi"
+msgstr "Uusi rivi"
 
 #: gnucash/gnome-search/dialog-search.c:1120
-#, fuzzy
-#| msgid "New Customer"
 msgctxt ""
 "Item represents an unknown object type (in the sense of bill, customer, "
 "invoice, transaction, split,…)!"
 msgid "New item"
-msgstr "Uusi asiakas"
+msgstr "Uusi kohde"
 
 #: gnucash/gnome-search/dialog-search.c:1163
 #: gnucash/gtkbuilder/dialog-commodities.glade:121
 #: gnucash/gtkbuilder/dialog-price.glade:848
 msgid "_Add"
-msgstr ""
+msgstr "_Lisää"
 
 #: gnucash/gnome-search/dialog-search.c:1173
 msgid "all criteria are met"
-msgstr ""
+msgstr "kaikki kriteerit täyttyvät"
 
 #: gnucash/gnome-search/dialog-search.c:1174
 msgid "any criteria are met"
-msgstr ""
+msgstr "jokin kriteereistä täyttyy"
 
 #: gnucash/gnome-search/search-account.c:153
 msgid "You have not selected any accounts"
-msgstr ""
+msgstr "Et ole valinnut yhtään tiliä"
 
 #: gnucash/gnome-search/search-account.c:174
-#, fuzzy
-#| msgid "All Accounts"
 msgid "matches all accounts"
-msgstr "Kaikki tilit"
+msgstr "sopii kaikkiin tileihin"
 
 #: gnucash/gnome-search/search-account.c:179
-#, fuzzy
-#| msgid "existing account"
 msgid "matches any account"
-msgstr "olemassa oleva tili"
+msgstr "sopii johonkin tiliin"
 
 #: gnucash/gnome-search/search-account.c:180
-#, fuzzy
-#| msgid "existing account"
 msgid "matches no accounts"
-msgstr "olemassa oleva tili"
+msgstr "ei sovi yhteenkään tiliin"
 
 #: gnucash/gnome-search/search-account.c:197
 #: gnucash/report/reports/standard/cash-flow.scm:249
-#, fuzzy
-#| msgid "All Accounts"
 msgid "Selected Accounts"
-msgstr "Kaikki tilit"
+msgstr "Valitut tilit"
 
 #: gnucash/gnome-search/search-account.c:198
-#, fuzzy
-#| msgid "All Accounts"
 msgid "Choose Accounts"
-msgstr "Kaikki tilit"
+msgstr "Valitse tilit"
 
 #: gnucash/gnome-search/search-account.c:232
-#, fuzzy
-#| msgid "CSV Account Map"
 msgid "Select Accounts to Match"
-msgstr "CSV-tilikartta"
+msgstr "Valitse vertailtavat tilit"
 
 #: gnucash/gnome-search/search-account.c:236
 msgid "Select the Accounts to Compare"
-msgstr ""
+msgstr "Valitse vertailtavat tilit"
 
 #: gnucash/gnome-search/search-date.c:187
 msgid "is before"
-msgstr ""
+msgstr "on ennen"
 
 #: gnucash/gnome-search/search-date.c:188
 msgid "is before or on"
-msgstr ""
+msgstr "on ennen tai sama"
 
 #: gnucash/gnome-search/search-date.c:189
 msgid "is on"
-msgstr ""
+msgstr "on sama"
 
 #: gnucash/gnome-search/search-date.c:190
 msgid "is not on"
-msgstr ""
+msgstr "ei ole"
 
 #: gnucash/gnome-search/search-date.c:191
 msgid "is after"
-msgstr ""
+msgstr "on jälkeen"
 
 #: gnucash/gnome-search/search-date.c:192
 msgid "is on or after"
-msgstr ""
+msgstr "on sama tai jälkeen"
 
 #: gnucash/gnome-search/search-double.c:175
 #: gnucash/gnome-search/search-int64.c:176
 #: gnucash/gnome-search/search-numeric.c:203
 msgid "is less than"
-msgstr ""
+msgstr "on vähemmän kuin"
 
 #: gnucash/gnome-search/search-double.c:176
 #: gnucash/gnome-search/search-int64.c:177
 #: gnucash/gnome-search/search-numeric.c:207
 msgid "is less than or equal to"
-msgstr ""
+msgstr "on vähemmän tai yhtäsuuri kuin"
 
 #: gnucash/gnome-search/search-double.c:177
 #: gnucash/gnome-search/search-int64.c:178
 #: gnucash/gnome-search/search-numeric.c:210
 #: gnucash/gnome-search/search-string.c:236
 msgid "equals"
-msgstr ""
+msgstr "on yhtäsuuri kuin"
 
 #: gnucash/gnome-search/search-double.c:178
 #: gnucash/gnome-search/search-int64.c:179
 #: gnucash/gnome-search/search-numeric.c:213
 msgid "does not equal"
-msgstr ""
+msgstr "on erisuuri"
 
 #: gnucash/gnome-search/search-double.c:179
 #: gnucash/gnome-search/search-int64.c:180
 #: gnucash/gnome-search/search-numeric.c:216
 msgid "is greater than"
-msgstr ""
+msgstr "on suurempi kuin"
 
 #: gnucash/gnome-search/search-double.c:180
 #: gnucash/gnome-search/search-int64.c:181
 #: gnucash/gnome-search/search-numeric.c:220
 msgid "is greater than or equal to"
-msgstr ""
+msgstr "on suurempi tai yhtäsuuri kuin"
 
 #: gnucash/gnome-search/search-numeric.c:203
 msgid "less than"
-msgstr ""
+msgstr "on vähemmän kuin"
 
 #: gnucash/gnome-search/search-numeric.c:206
 msgid "less than or equal to"
-msgstr ""
+msgstr "on vähemmän tai yhtäsuuri kuin"
 
 #: gnucash/gnome-search/search-numeric.c:210
 msgid "equal to"
-msgstr ""
+msgstr "yhtäsuuri kuin"
 
 #: gnucash/gnome-search/search-numeric.c:213
 msgid "not equal to"
-msgstr ""
+msgstr "erisuuri kuin"
 
 #: gnucash/gnome-search/search-numeric.c:216
 msgid "greater than"
-msgstr ""
+msgstr "suurempi kuin"
 
 #: gnucash/gnome-search/search-numeric.c:219
 msgid "greater than or equal to"
-msgstr ""
+msgstr "suurempi tai yhtäsuuri kuin"
 
 #: gnucash/gnome-search/search-numeric.c:236
 msgid "has credits or debits"
@@ -6207,14 +5892,12 @@ msgid "has credits"
 msgstr ""
 
 #: gnucash/gnome-search/search-reconciled.c:213
-#, fuzzy
-#| msgid "Not Used"
 msgid "Not Cleared"
-msgstr "Ei käytetty"
+msgstr ""
 
 #: gnucash/gnome-search/search-string.c:162
 msgid "You need to enter some search text."
-msgstr ""
+msgstr "Syötä hakuteksti."
 
 #: gnucash/gnome-search/search-string.c:191
 #: gnucash/import-export/bi-import/dialog-bi-import.c:136
@@ -6225,22 +5908,24 @@ msgid ""
 "Error in regular expression '%s':\n"
 "%s"
 msgstr ""
+"Virhe säännöllisessä lausekkeessa '%s':\n"
+"%s"
 
 #: gnucash/gnome-search/search-string.c:235
 msgid "contains"
-msgstr ""
+msgstr "sisältää"
 
 #: gnucash/gnome-search/search-string.c:237
 msgid "matches regex"
-msgstr ""
+msgstr "täsmää säännölliseen lausekkeeseen"
 
 #: gnucash/gnome-search/search-string.c:239
 msgid "does not match regex"
-msgstr ""
+msgstr "ei täsmää säännölliseen lausekkeeseen"
 
 #: gnucash/gnome-search/search-string.c:307
 msgid "Match case"
-msgstr ""
+msgstr "Huomioi kirjainkoko"
 
 #: gnucash/gnome-utils/assistant-xml-encoding.c:178
 msgid ""
@@ -6267,7 +5952,7 @@ msgstr ""
 
 #: gnucash/gnome-utils/assistant-xml-encoding.c:198
 msgid "Ambiguous character encoding"
-msgstr ""
+msgstr "Epämääräinen merkistökoodaus"
 
 #: gnucash/gnome-utils/assistant-xml-encoding.c:201
 msgid ""
@@ -6279,10 +5964,8 @@ msgid ""
 msgstr ""
 
 #: gnucash/gnome-utils/assistant-xml-encoding.c:226
-#, fuzzy
-#| msgid "Central European"
 msgid "European"
-msgstr "keskieurooppalainen"
+msgstr "Eurooppalainen"
 
 #: gnucash/gnome-utils/assistant-xml-encoding.c:227
 msgid "ISO-8859-1 (West European)"
@@ -6309,10 +5992,8 @@ msgid "ISO-8859-6 (Arabic)"
 msgstr ""
 
 #: gnucash/gnome-utils/assistant-xml-encoding.c:233
-#, fuzzy
-#| msgid "Greek (ISO-8859-7)"
 msgid "ISO-8859-7 (Greek)"
-msgstr "Kreikkalainen (ISO-8859-7)"
+msgstr ""
 
 #: gnucash/gnome-utils/assistant-xml-encoding.c:234
 msgid "ISO-8859-8 (Hebrew)"
@@ -6323,26 +6004,20 @@ msgid "ISO-8859-9 (Turkish)"
 msgstr ""
 
 #: gnucash/gnome-utils/assistant-xml-encoding.c:236
-#, fuzzy
-#| msgid "Nordic (ISO-8859-10)"
 msgid "ISO-8859-10 (Nordic)"
-msgstr "Pohjoismainen (ISO-8859-10)"
+msgstr ""
 
 #: gnucash/gnome-utils/assistant-xml-encoding.c:237
 msgid "ISO-8859-11 (Thai)"
 msgstr ""
 
 #: gnucash/gnome-utils/assistant-xml-encoding.c:238
-#, fuzzy
-#| msgid "Baltic (ISO-8859-13)"
 msgid "ISO-8859-13 (Baltic)"
-msgstr "Balttialainen (ISO-8859-13)"
+msgstr ""
 
 #: gnucash/gnome-utils/assistant-xml-encoding.c:239
-#, fuzzy
-#| msgid "Celtic (ISO-8859-14)"
 msgid "ISO-8859-14 (Celtic)"
-msgstr "Kelttiläinen (ISO-8859-14)"
+msgstr ""
 
 #: gnucash/gnome-utils/assistant-xml-encoding.c:240
 msgid "ISO-8859-15 (West European, Euro sign)"
@@ -6357,10 +6032,8 @@ msgid "KOI8-R (Russian)"
 msgstr ""
 
 #: gnucash/gnome-utils/assistant-xml-encoding.c:244
-#, fuzzy
-#| msgid "Ukrainian (MacUkrainian)"
 msgid "KOI8-U (Ukrainian)"
-msgstr "Ukrainalainen (MacUkrainian)"
+msgstr ""
 
 #: gnucash/gnome-utils/assistant-xml-encoding.c:680
 #, c-format
@@ -6387,26 +6060,26 @@ msgstr ""
 #: gnucash/gnome-utils/assistant-xml-encoding.c:1089
 #: gnucash/gnome-utils/assistant-xml-encoding.c:1109
 msgid "The file could not be reopened."
-msgstr ""
+msgstr "Tiedostoa ei voitu avata uudelleen."
 
 #: gnucash/gnome-utils/assistant-xml-encoding.c:1094
 msgid "Reading file…"
-msgstr ""
+msgstr "Luetaan tiedostoa…"
 
 #: gnucash/gnome-utils/assistant-xml-encoding.c:1117
 msgid "Parsing file…"
-msgstr ""
+msgstr "Tulkitaan tiedostoa…"
 
 #: gnucash/gnome-utils/assistant-xml-encoding.c:1124
 #: gnucash/import-export/csv-imp/gnc-import-tx.cpp:423
 #: gnucash/import-export/csv-imp/gnc-tokenizer-csv.cpp:131
 msgid "There was an error parsing the file."
-msgstr ""
+msgstr "Tiedoston tulkinnassa tapahtui virhe."
 
 #: gnucash/gnome-utils/assistant-xml-encoding.c:1149
 #: gnucash/gnome-utils/gnc-file.c:1452 gnucash/gnome-utils/gnc-file.c:1695
 msgid "Writing file…"
-msgstr ""
+msgstr "Kirjoitetaan tiedostoa…"
 
 #: gnucash/gnome-utils/assistant-xml-encoding.c:1307
 msgid "This encoding has been added to the list already."
@@ -6418,7 +6091,7 @@ msgstr ""
 
 #: gnucash/gnome-utils/dialog-account.c:659
 msgid "Could not create opening balance."
-msgstr ""
+msgstr "Ei voitu luoda avaussaldoa."
 
 #: gnucash/gnome-utils/dialog-account.c:860
 msgid "Give the children the same type?"
@@ -6433,27 +6106,23 @@ msgstr ""
 
 #: gnucash/gnome-utils/dialog-account.c:882
 msgid "_Show children accounts"
-msgstr ""
+msgstr "Näytä _alatilit"
 
 #: gnucash/gnome-utils/dialog-account.c:954
-#, fuzzy
-#| msgid "Stock amount must be positive."
 msgid "The account must be given a name."
-msgstr "Osakkeen määrän on oltava positiivinen."
+msgstr "Tilille tulee antaa nimi."
 
 #: gnucash/gnome-utils/dialog-account.c:980
 msgid "There is already an account with that name."
-msgstr ""
+msgstr "Tällä nimellä on jo tili."
 
 #: gnucash/gnome-utils/dialog-account.c:989
 msgid "You must choose a valid parent account."
 msgstr ""
 
 #: gnucash/gnome-utils/dialog-account.c:998
-#, fuzzy
-#| msgid "You must select a report configuration to delete."
 msgid "You must select an account type."
-msgstr "Valitse poistettavat raporttiasetukset."
+msgstr "Tilin tyyppi tulee valita."
 
 #: gnucash/gnome-utils/dialog-account.c:1007
 msgid ""
@@ -6463,7 +6132,7 @@ msgstr ""
 
 #: gnucash/gnome-utils/dialog-account.c:1019
 msgid "You must choose a commodity."
-msgstr ""
+msgstr "Valitse hyödyke."
 
 #: gnucash/gnome-utils/dialog-account.c:1039
 msgid "Balance limits must be different unless they are both zero."
@@ -6490,42 +6159,40 @@ msgstr ""
 
 #: gnucash/gnome-utils/dialog-account.c:1482
 msgid "Cannot change currency"
-msgstr ""
+msgstr "Rahayksikköä ei voi vaihtaa"
 
 #: gnucash/gnome-utils/dialog-account.c:1571
 msgid ""
 "This Account contains Transactions.\n"
 "Changing this option is not possible."
 msgstr ""
+"Tällä tilillä on tositteita.\n"
+"Asetuksen muuttaminen ei ole mahdollista."
 
 #: gnucash/gnome-utils/dialog-account.c:1745
 #: gnucash/gnome-utils/dialog-utils.c:836
 msgid "<No name>"
-msgstr ""
+msgstr "<Ei nimeä>"
 
 #: gnucash/gnome-utils/dialog-account.c:1775
-#, fuzzy
-#| msgid "Find Account"
 msgid "Edit Account"
-msgstr "Etsi tili"
+msgstr "Muokkaa tiliä"
 
 #: gnucash/gnome-utils/dialog-account.c:1778
 #, c-format
 msgid "(%d) New Accounts"
-msgstr "(%d) Uudet tilit"
+msgstr "(%d) uutta tiliä"
 
 #: gnucash/gnome-utils/dialog-account.c:1786
 #: gnucash/gtkbuilder/dialog-account.glade:1104
 #: gnucash/gtkbuilder/dialog-account-picker.glade:176
-#, fuzzy
-#| msgid "Account"
 msgid "New Account"
-msgstr "Tili"
+msgstr "Uusi tili"
 
 #: gnucash/gnome-utils/dialog-account.c:2355
 #, c-format
 msgid "Renumber the immediate sub-accounts of '%s'?"
-msgstr ""
+msgstr "Uudelleennumeroi '%s':n välittömät alatilit?"
 
 #: gnucash/gnome-utils/dialog-account.c:2461
 #, c-format
@@ -6559,12 +6226,16 @@ msgid ""
 "\n"
 "Please select a commodity to match"
 msgstr ""
+"\n"
+"Valitse vertailtava hyödyke"
 
 #: gnucash/gnome-utils/dialog-commodity.cpp:169
 msgid ""
 "\n"
 "Commodity: "
 msgstr ""
+"\n"
+"Hyödyke: "
 
 #. Translators: Replace here and later CUSIP by the name of your local
 #. National Securities Identifying Number
@@ -6586,34 +6257,30 @@ msgstr ""
 #: gnucash/gnome-utils/dialog-commodity.cpp:277
 #: gnucash/gtkbuilder/dialog-commodity.glade:634
 msgid "Select security/currency"
-msgstr ""
+msgstr "Valitse arvopaperi/rahayksikkö"
 
 #: gnucash/gnome-utils/dialog-commodity.cpp:278
 #: gnucash/gtkbuilder/dialog-account.glade:1260
 msgid "_Security/currency"
-msgstr ""
+msgstr "_Arvopaperi/valuutta"
 
 #: gnucash/gnome-utils/dialog-commodity.cpp:282
-#, fuzzy
-#| msgid "Select document"
 msgid "Select security"
-msgstr "Valitse asiakirja"
+msgstr "Valitse arvopaperi"
 
 #: gnucash/gnome-utils/dialog-commodity.cpp:283
 #: gnucash/gtkbuilder/dialog-price.glade:153
 msgid "_Security"
-msgstr ""
+msgstr "_Arvopaperi"
 
 #: gnucash/gnome-utils/dialog-commodity.cpp:287
-#, fuzzy
-#| msgid "Select document"
 msgid "Select currency"
-msgstr "Valitse asiakirja"
+msgstr "Valitse valuutta"
 
 #: gnucash/gnome-utils/dialog-commodity.cpp:288
 #: gnucash/gtkbuilder/dialog-price.glade:168
 msgid "Cu_rrency"
-msgstr ""
+msgstr "_Valuutta"
 
 #: gnucash/gnome-utils/dialog-commodity.cpp:765
 #: gnucash/gnome-utils/gnc-tree-view-owner.c:394
@@ -6625,40 +6292,36 @@ msgstr ""
 #: gnucash/gtkbuilder/dialog-vendor.glade:502
 #: gnucash/report/trep-engine.scm:110 libgnucash/engine/Account.cpp:4295
 msgid "Currency"
-msgstr ""
+msgstr "Rahayksikkö"
 
 #: gnucash/gnome-utils/dialog-commodity.cpp:860
-#, fuzzy
-#| msgid "Use Global"
 msgid "Use local time"
-msgstr "Käytä oletusasetusta"
+msgstr "Käytä paikallista aikaa"
 
 #: gnucash/gnome-utils/dialog-commodity.cpp:990
 msgid "Edit currency"
-msgstr ""
+msgstr "Muokkaa valuuttaa"
 
 #: gnucash/gnome-utils/dialog-commodity.cpp:991
 msgid "Currency Information"
-msgstr ""
+msgstr "Valuutan tiedot"
 
 #: gnucash/gnome-utils/dialog-commodity.cpp:996
-#, fuzzy
-#| msgid "Edit Customer"
 msgid "Edit security"
-msgstr "Muokkaa asiakasta"
+msgstr "Muuta arvopaperia"
 
 #: gnucash/gnome-utils/dialog-commodity.cpp:996
 msgid "New security"
-msgstr ""
+msgstr "Uusi arvopaperi"
 
 #: gnucash/gnome-utils/dialog-commodity.cpp:997
 #: gnucash/gtkbuilder/dialog-commodity.glade:229
 msgid "Security Information"
-msgstr ""
+msgstr "Arvopaperin tiedot"
 
 #: gnucash/gnome-utils/dialog-commodity.cpp:1274
 msgid "You may not create a new national currency."
-msgstr ""
+msgstr "Et voi luoda uutta valtion valuuttaa."
 
 #: gnucash/gnome-utils/dialog-commodity.cpp:1284
 #, c-format
@@ -6667,7 +6330,7 @@ msgstr ""
 
 #: gnucash/gnome-utils/dialog-commodity.cpp:1299
 msgid "That commodity already exists."
-msgstr ""
+msgstr "Hyödyke on jo olemassa."
 
 #: gnucash/gnome-utils/dialog-commodity.cpp:1350
 msgid ""
@@ -6687,26 +6350,24 @@ msgstr ""
 #, c-format
 msgid "Path head not set, using '%s' for relative paths"
 msgstr ""
+"Polun alkuosaa ei ole asetettu, käytetään suhteellisten polkujen alkuosana "
+"'%s'"
 
 #: gnucash/gnome-utils/dialog-doclink-utils.c:425
-#, fuzzy
-#| msgid "Use Existing"
 msgid "Existing"
-msgstr "Käytä olemassa olevaa"
+msgstr "Olemassaoleva"
 
 #: gnucash/gnome-utils/dialog-dup-trans.c:149
 msgid "You can type '+' or '-' to increment or decrement the number."
 msgstr ""
 
 #: gnucash/gnome-utils/dialog-dup-trans.c:298
-#, fuzzy
-#| msgid "Transaction Number"
 msgid "Action/Number"
-msgstr "Tositenumero"
+msgstr "Tapahtuma/Numero"
 
 #: gnucash/gnome-utils/dialog-file-access.c:323
 msgid "Open…"
-msgstr ""
+msgstr "Avaa…"
 
 #: gnucash/gnome-utils/dialog-file-access.c:324
 #: gnucash/gnome-utils/gnc-file.c:90
@@ -6714,25 +6375,23 @@ msgstr ""
 #: gnucash/gtkbuilder/dialog-customer-import-gui.glade:106
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:784
 #: gnucash/ui/gnc-reconcile-window.ui:220
-#, fuzzy
-#| msgid "Open buy"
 msgid "_Open"
-msgstr "Avoin osto"
+msgstr "_Avaa"
 
 #: gnucash/gnome-utils/dialog-file-access.c:330
 msgid "Save As…"
-msgstr ""
+msgstr "Tallenna nimellä…"
 
 #: gnucash/gnome-utils/dialog-file-access.c:331
 #: gnucash/gnome-utils/dialog-file-access.c:340
 #: gnucash/gtkbuilder/dialog-file-access.glade:40
 msgid "_Save As"
-msgstr ""
+msgstr "_Tallenna nimellä"
 
 #: gnucash/gnome-utils/dialog-file-access.c:359
 #: gnucash/gnome-utils/gnc-file.c:149
 msgid "All files"
-msgstr ""
+msgstr "Kaikki tiedostot"
 
 #. Translators: *.gnucash and *.xac are file patterns and must not
 #. be translated
@@ -6779,19 +6438,19 @@ msgstr ""
 #: gnucash/ui/gnc-plugin-page-report.ui:120
 #: gnucash/ui/gnc-plugin-page-sx-list.ui:103
 msgid "_Close"
-msgstr ""
+msgstr "_Sulje"
 
 #: gnucash/gnome-utils/dialog-options.cpp:307
 msgid "Reset defaults"
-msgstr ""
+msgstr "Palauta oletukset"
 
 #: gnucash/gnome-utils/dialog-options.cpp:309
 msgid "Reset all values to their defaults."
-msgstr ""
+msgstr "Palauta kaikki asetukset oletusarvoihinsa."
 
 #: gnucash/gnome-utils/dialog-options.cpp:561
 msgid "Page"
-msgstr ""
+msgstr "Sivu"
 
 #. Translators: Both %s will be the account separator character; the
 #. resulting string is a demonstration how the account separator
@@ -6802,7 +6461,7 @@ msgstr ""
 #: gnucash/gnome-utils/dialog-preferences.c:171
 #, c-format
 msgid "Income%sSalary%sTaxable"
-msgstr ""
+msgstr "Tulot%sPalkka%sVerollinen"
 
 #: gnucash/gnome-utils/dialog-preferences.c:908
 msgid "Path does not exist, "
@@ -6810,10 +6469,8 @@ msgstr ""
 
 #: gnucash/gnome-utils/dialog-preferences.c:964
 #: gnucash/gnome-utils/dialog-preferences.c:1461
-#, fuzzy
-#| msgid "Selected"
 msgid "Select a folder"
-msgstr "Valittu"
+msgstr "Valitse kansio"
 
 #: gnucash/gnome-utils/dialog-preferences.c:1464
 #: gnucash/gnome-utils/gnc-option-gtk-ui.cpp:1534
@@ -6823,11 +6480,11 @@ msgstr "Valittu"
 #: gnucash/gtkbuilder/dialog-fincalc.glade:315
 #: gnucash/gtkbuilder/dialog-fincalc.glade:330
 msgid "Clear"
-msgstr ""
+msgstr "Tyhjennä"
 
 #: gnucash/gnome-utils/dialog-tax-table.c:159
 msgid "You must provide a name for this Tax Table."
-msgstr ""
+msgstr "Anna nimi verokannalle."
 
 #: gnucash/gnome-utils/dialog-tax-table.c:166
 #, c-format
@@ -6835,63 +6492,59 @@ msgid ""
 "You must provide a unique name for this Tax Table. Your choice \"%s\" is "
 "already in use."
 msgstr ""
+"Anna yksilöllinen nimi tälle verokannalle. Valitsemasi \"%s\" on jo käytössä."
 
 #: gnucash/gnome-utils/dialog-tax-table.c:190
 msgid "Percentage amount must be between -100 and 100."
-msgstr ""
+msgstr "Prosenttimäärän täytyy olla väliltä -100 ja 100."
 
 #: gnucash/gnome-utils/dialog-tax-table.c:199
 msgid "You must choose a Tax Account."
-msgstr ""
+msgstr "Valitse verotili."
 
 #: gnucash/gnome-utils/dialog-tax-table.c:697
-#, fuzzy
-#| msgid "Username"
 msgid "Rename"
-msgstr "Käyttäjätunnus"
+msgstr "Nimeä uudelleen"
 
 #: gnucash/gnome-utils/dialog-tax-table.c:698
 msgid "Please enter new name"
-msgstr ""
+msgstr "Syötä uusi nimi"
 
 #: gnucash/gnome-utils/dialog-tax-table.c:699
 #: gnucash/gtkbuilder/dialog-tax-table.glade:73
-#, fuzzy
-#| msgid "Username"
 msgid "_Rename"
-msgstr "Käyttäjätunnus"
+msgstr "_Nimeä uudelleen"
 
 #: gnucash/gnome-utils/dialog-tax-table.c:705
 #, c-format
 msgid "Tax table name \"%s\" already exists."
-msgstr ""
+msgstr "Verokanta nimeltä \"%s\" on jo olemassa."
 
 #: gnucash/gnome-utils/dialog-tax-table.c:729
-#, fuzzy, c-format
-#| msgid "Term \"%s\" is in use. You cannot delete it."
+#, c-format
 msgid "Tax table \"%s\" is in use. You cannot delete it."
-msgstr "Ehto \"%s\" on käytössä. Et voi poistaa sitä."
+msgstr "Verokanta \"%s\" on käytössä. Et voi poistaa sitä."
 
 #: gnucash/gnome-utils/dialog-tax-table.c:777
 msgid ""
 "You cannot remove the last entry from the tax table. Try deleting the tax "
 "table if you want to do that."
 msgstr ""
+"Et voi poistaa verokannan viimeistä merkintää. Koeta poistaa verotaulu jos "
+"haluat varmasti tehdä niin."
 
 #: gnucash/gnome-utils/dialog-tax-table.c:784
-#, fuzzy
-#| msgid "Are you sure you want to delete %s?"
 msgid "Are you sure you want to delete this entry?"
-msgstr "Oletko varma että %s voidaan poistaa?"
+msgstr "Haluatko varmasti poistaa kirjauksen?"
 
 #: gnucash/gnome-utils/dialog-transfer.cpp:571
 msgid "Show the income and expense accounts"
-msgstr ""
+msgstr "Näytä tulo- ja menotilit"
 
 #: gnucash/gnome-utils/dialog-transfer.cpp:673
 #: gnucash/report/trep-engine.scm:2432 gnucash/report/trep-engine.scm:2438
 msgid "Error"
-msgstr ""
+msgstr "Virhe"
 
 #: gnucash/gnome-utils/dialog-transfer.cpp:1291
 msgid ""
@@ -6918,7 +6571,7 @@ msgstr ""
 #: gnucash/register/ledger-core/split-register.c:1998
 #, c-format
 msgid "The account %s does not allow transactions."
-msgstr ""
+msgstr "Tili %s ei salli tositteita."
 
 #: gnucash/gnome-utils/dialog-transfer.cpp:1434
 msgid ""
@@ -6927,56 +6580,44 @@ msgid ""
 msgstr ""
 
 #: gnucash/gnome-utils/dialog-transfer.cpp:1452
-#, fuzzy
-#| msgid "You must enter a Payment-Address Name."
 msgid "You must enter a valid price."
-msgstr "Sinun on annettava nimi maksuosoitteelle."
+msgstr "Syötä kelvollinen summa."
 
 #: gnucash/gnome-utils/dialog-transfer.cpp:1464
-#, fuzzy
-#| msgid "You must enter a Payment-Address Name."
 msgid "You must enter a valid 'to' amount."
-msgstr "Sinun on annettava nimi maksuosoitteelle."
+msgstr ""
 
 #: gnucash/gnome-utils/dialog-transfer.cpp:1687
-#, fuzzy
-#| msgid "You must enter a Payment-Address Name."
 msgid "You must enter an amount to transfer."
-msgstr "Sinun on annettava nimi maksuosoitteelle."
+msgstr "Syötä siirrettävä summa."
 
 #: gnucash/gnome-utils/dialog-transfer.cpp:1913
 #: gnucash/gtkbuilder/dialog-employee.glade:629
-#, fuzzy
-#| msgid "Find Account"
 msgid "Credit Account"
-msgstr "Etsi tili"
+msgstr "Kredit-tili"
 
 #: gnucash/gnome-utils/dialog-transfer.cpp:1917
-#, fuzzy
-#| msgid "Find Account"
 msgid "Debit Account"
-msgstr "Etsi tili"
+msgstr "Debet-tili"
 
 #: gnucash/gnome-utils/dialog-transfer.cpp:1935
 #: gnucash/gtkbuilder/dialog-transfer.glade:273
 msgid "Transfer From"
-msgstr ""
+msgstr "Tililtä"
 
 #: gnucash/gnome-utils/dialog-transfer.cpp:1939
 #: gnucash/gtkbuilder/dialog-transfer.glade:334
 msgid "Transfer To"
-msgstr ""
+msgstr "Tilille"
 
 #: gnucash/gnome-utils/dialog-transfer.cpp:1996
 msgid "Debit Amount"
-msgstr ""
+msgstr "Debitin määrä"
 
 #: gnucash/gnome-utils/dialog-transfer.cpp:2001
 #: gnucash/gtkbuilder/dialog-transfer.glade:560
-#, fuzzy
-#| msgid "Account"
 msgid "To Amount"
-msgstr "Tili"
+msgstr "Summaan"
 
 #. Translators: Use your locale date format here!
 #: gnucash/gnome-utils/dialog-utils.c:435
@@ -6987,33 +6628,31 @@ msgstr ""
 
 #: gnucash/gnome-utils/dialog-utils.c:437
 msgid "Date out of range"
-msgstr ""
+msgstr "Päiväys ei ole jaksolla"
 
 #: gnucash/gnome-utils/dialog-utils.c:760
 msgid "Remember and don't _ask me again."
-msgstr ""
+msgstr "Muista valinta, älä _kysy uudelleen."
 
 #: gnucash/gnome-utils/dialog-utils.c:761
 msgid "Don't _tell me again."
-msgstr ""
+msgstr "_Älä kerro uudelleen."
 
 #: gnucash/gnome-utils/dialog-utils.c:764
 msgid "Remember and don't ask me again this _session."
-msgstr ""
+msgstr "Muista valinta, älä kysy uudellen _tämän istunnon aikana."
 
 #: gnucash/gnome-utils/dialog-utils.c:765
 msgid "Don't tell me again this _session."
-msgstr ""
+msgstr "Älä _kerro uudelleen tämän istunnon aikana."
 
 #: gnucash/gnome-utils/gnc-account-sel.c:521
 msgid "Hide _Placeholder Accounts"
-msgstr ""
+msgstr "Piilota _koontitilit"
 
 #: gnucash/gnome-utils/gnc-account-sel.c:523
-#, fuzzy
-#| msgid "Find Account"
 msgid "Hide _Hidden Accounts"
-msgstr "Etsi tili"
+msgstr "Piilota _piilotetut tilit"
 
 #: gnucash/gnome-utils/gnc-account-sel.c:700
 msgid "Set the visibility of placeholder and hidden accounts."
@@ -7025,19 +6664,19 @@ msgstr ""
 #.
 #: gnucash/gnome-utils/gnc-account-sel.c:982
 msgid "New…"
-msgstr ""
+msgstr "Uusi…"
 
 #: gnucash/gnome-utils/gnc-amount-edit.c:453
 #: gnucash/register/register-core/formulacell.c:121
 #: gnucash/register/register-core/pricecell.c:161
 #, c-format
 msgid "An error occurred while processing '%s' at position %d"
-msgstr ""
+msgstr "Tapahtui virhe käsiteltäessä '%s' kohdassa %d"
 
 #: gnucash/gnome-utils/gnc-amount-edit.c:459
 #, c-format
 msgid "An error occurred while processing '%s'"
-msgstr ""
+msgstr "Tapahtui virhe käsiteltäessä '%s'"
 
 #: gnucash/gnome-utils/gnc-autoclear.c:151
 #, c-format
@@ -7047,7 +6686,7 @@ msgstr ""
 #: gnucash/gnome-utils/gnc-autoclear.c:157
 #, c-format
 msgid "No uncleared splits found."
-msgstr ""
+msgstr "Hyväksymättömiä rivejä ei löytynyt."
 
 #: gnucash/gnome-utils/gnc-autoclear.c:173
 #, c-format
@@ -7060,14 +6699,13 @@ msgid "Cannot uniquely clear splits. Found multiple possibilities."
 msgstr ""
 
 #: gnucash/gnome-utils/gnc-autoclear.c:190
-#, fuzzy, c-format
-#| msgid "The interest rate cannot be zero."
+#, c-format
 msgid "The selected amount cannot be cleared."
-msgstr "Korkoprosentti ei voi olla nolla."
+msgstr ""
 
 #: gnucash/gnome-utils/gnc-autosave.c:101
 msgid "Save file automatically?"
-msgstr ""
+msgstr "Tallenna tiedosto automaattisesti?"
 
 #: gnucash/gnome-utils/gnc-autosave.c:108
 #, c-format
@@ -7090,66 +6728,82 @@ msgid_plural ""
 "\n"
 "Should your file be saved automatically?"
 msgstr[0] ""
+"Tiedostosi täytyy tallentaa kiintolevyllesi jotta muutoksesi tallentuvat. "
+"GnuCash voi tallentaa tiedoston automaattisesti joka minuutti, aivan kuin "
+"olisit painanut Tallenna-painiketta joka kerta.\n"
+"\n"
+"Voit muuttaa aikaväliä tai laittaa ominaisuuden pois päältä Muokkaa-"
+">Asetukset->Yleistä->Automaattitallennuksen aikaväli.\n"
+"\n"
+"Tulisiko tiedostosi tallentaa automaattisesti?"
 msgstr[1] ""
+"Tiedostosi täytyy tallentaa kiintolevyllesi jotta muutoksesi tallentuvat. "
+"GnuCash voi tallentaa tiedoston automaattisesti joka %d. minuutti, aivan "
+"kuin olisit painanut Tallenna-painiketta joka kerta.\n"
+"\n"
+"Voit muuttaa aikaväliä tai laittaa ominaisuuden pois päältä Muokkaa-"
+">Asetukset->Yleistä->Automaattitallennuksen aikaväli.\n"
+"\n"
+"Tulisiko tiedostosi tallentaa automaattisesti?"
 
 #: gnucash/gnome-utils/gnc-autosave.c:123
 msgid "_Yes, this time"
-msgstr ""
+msgstr "_Kyllä, tämän kerran"
 
 #: gnucash/gnome-utils/gnc-autosave.c:124
 msgid "Yes, _always"
-msgstr ""
+msgstr "Kyllä, _aina"
 
 #: gnucash/gnome-utils/gnc-autosave.c:125
 msgid "No, n_ever"
-msgstr ""
+msgstr "Ei, k_oskaan"
 
 #: gnucash/gnome-utils/gnc-autosave.c:126
 msgid "_No, not this time"
-msgstr ""
+msgstr "_Ei, tällä kertaa"
 
 #: gnucash/gnome-utils/gnc-cell-view.c:74
 msgid "Use Shift combined with Return or Keypad Enter to finish editing"
 msgstr ""
+"Käytä Shift -näppäintä yhdessä rivinvaihdon tai numeronäppäimistön syötön "
+"kanssa viimeistelläksesi muokkauksen"
 
 #: gnucash/gnome-utils/gnc-date-edit.c:842
 msgid "Calendar"
-msgstr ""
+msgstr "Kalenteri"
 
 #: gnucash/gnome-utils/gnc-dense-cal.c:291
 msgid "12 months"
-msgstr ""
+msgstr "12 kuukautta"
 
 #: gnucash/gnome-utils/gnc-dense-cal.c:292
 msgid "6 months"
-msgstr ""
+msgstr "6 kuukautta"
 
 #: gnucash/gnome-utils/gnc-dense-cal.c:293
 msgid "4 months"
-msgstr ""
+msgstr "4 kuukautta"
 
 #: gnucash/gnome-utils/gnc-dense-cal.c:294
 msgid "3 months"
-msgstr ""
+msgstr "3 kuukautta"
 
 #: gnucash/gnome-utils/gnc-dense-cal.c:295
 msgid "2 months"
-msgstr ""
+msgstr "2 kuukautta"
 
 #: gnucash/gnome-utils/gnc-dense-cal.c:296
 msgid "1 month"
-msgstr ""
+msgstr "1 kuukausi"
 
 #: gnucash/gnome-utils/gnc-dense-cal.c:331
 msgid "View"
-msgstr ""
+msgstr "Näytä"
 
 #: gnucash/gnome-utils/gnc-dense-cal.c:379
 #: gnucash/report/stylesheets/footer.scm:344
-#, fuzzy
-#| msgid "Date"
 msgid "Date: "
-msgstr "Päiväys"
+msgstr "Päiväys: "
 
 #: gnucash/gnome-utils/gnc-dense-cal.c:393
 #: gnucash/gnome-utils/gnc-tree-view-sx-list.c:129
@@ -7159,21 +6813,21 @@ msgstr "Päiväys"
 #: gnucash/gtkbuilder/dialog-sx.glade:1420
 #: gnucash/gtkbuilder/gnc-frequency.glade:593
 msgid "Frequency"
-msgstr ""
+msgstr "Kausi"
 
 #: gnucash/gnome-utils/gnc-dense-cal.c:1330
 msgid "(unnamed)"
-msgstr ""
+msgstr "(nimeämätön)"
 
 #: gnucash/gnome-utils/gnc-file.c:96 gnucash/ui/gnc-main-window.ui:17
 msgid "_Import"
-msgstr ""
+msgstr "T_uo"
 
 #: gnucash/gnome-utils/gnc-file.c:98 gnucash/gnome-utils/gnc-file.c:337
 #: gnucash/gtkbuilder/dialog-preferences.glade:2371
 #: gnucash/import-export/qif-imp/gnc-plugin-qif-import.c:137
 msgid "Import"
-msgstr ""
+msgstr "Tuo"
 
 #: gnucash/gnome-utils/gnc-file.c:102 gnucash/gnome-utils/gnc-file.c:668
 #: gnucash/gnome-utils/gnc-main-window.cpp:1271
@@ -7189,16 +6843,16 @@ msgstr ""
 #: gnucash/ui/gnc-plugin-page-report.ui:105
 #: gnucash/ui/gnc-plugin-page-sx-list.ui:88
 msgid "_Save"
-msgstr ""
+msgstr "_Tallenna"
 
 #: gnucash/gnome-utils/gnc-file.c:104 gnucash/gnome-utils/gnc-file.c:345
 #: gnucash/gnome-utils/gnc-file.c:1237 gnucash/gnome-utils/gnc-file.c:1509
 msgid "Save"
-msgstr ""
+msgstr "Tallenna"
 
 #: gnucash/gnome-utils/gnc-file.c:108 gnucash/ui/gnc-main-window.ui:51
 msgid "_Export"
-msgstr ""
+msgstr "_Vie"
 
 #: gnucash/gnome-utils/gnc-file.c:263
 msgid "(null)"
@@ -7212,33 +6866,38 @@ msgstr ""
 #: gnucash/gnome-utils/gnc-file.c:287
 #, c-format
 msgid "The URL %s is not supported by this version of GnuCash."
-msgstr ""
+msgstr "Tämä GnuCash-versio ei tue URL-osoitetta %s."
 
 #: gnucash/gnome-utils/gnc-file.c:292
 #, c-format
 msgid "Can't parse the URL %s."
-msgstr ""
+msgstr "Virheellisesti muotoiltu URL-osoite %s."
 
 #: gnucash/gnome-utils/gnc-file.c:297
 #, c-format
 msgid "Can't connect to %s. The host, username or password were incorrect."
 msgstr ""
+"Yhdistäminen kohteeseen %s epäonnistui. Osoite, käyttäjätunnus tai salasana "
+"oli virheellinen."
 
 #: gnucash/gnome-utils/gnc-file.c:303
 #, c-format
 msgid "Can't connect to %s. Connection was lost, unable to send data."
 msgstr ""
+"Ei voi yhdistää kohteeseen %s. Yhteys menetettiin, dataa ei voi lähettää."
 
 #: gnucash/gnome-utils/gnc-file.c:309
 msgid ""
 "This file/URL appears to be from a newer version of GnuCash. You must "
 "upgrade your version of GnuCash to work with this data."
 msgstr ""
+"Tämä tiedosto/URL-osoite vaikuttaa olevan GnuCashin uudemmasta versiosta. "
+"Päivitä käyttämäsi GnuCashin versio käyttääksesi tätä dataa."
 
 #: gnucash/gnome-utils/gnc-file.c:316
 #, c-format
 msgid "The database %s doesn't seem to exist. Do you want to create it?"
-msgstr ""
+msgstr "Tietokantaa %s ei vaikuta olevan olemassa. Haluatko luoda sen?"
 
 #: gnucash/gnome-utils/gnc-file.c:330
 #, c-format
@@ -7284,12 +6943,16 @@ msgstr ""
 #, c-format
 msgid "The file/URL %s does not contain GnuCash data or the data is corrupt."
 msgstr ""
+"Tiedosto/URL-osoite %s ei vaikuta sisältävän GnuCashin dataa tai data on "
+"rikkoutunut."
 
 #: gnucash/gnome-utils/gnc-file.c:393
 #, c-format
 msgid ""
 "The server at URL %s experienced an error or encountered bad or corrupt data."
 msgstr ""
+"Osoitteessa %s olevalla palvelimella tapahtui virhe tai tieto oli "
+"virheellistä."
 
 #: gnucash/gnome-utils/gnc-file.c:399
 #, c-format
@@ -7303,17 +6966,17 @@ msgstr ""
 
 #: gnucash/gnome-utils/gnc-file.c:409
 msgid "There was an error reading the file. Do you want to continue?"
-msgstr ""
+msgstr "Tiedostoa luettaessa tapahtui virhe. Haluatko jatkaa?"
 
 #: gnucash/gnome-utils/gnc-file.c:418
 #, c-format
 msgid "There was an error parsing the file %s."
-msgstr ""
+msgstr "Tiedostoa %s jäsentäessä tapahtui virhe."
 
 #: gnucash/gnome-utils/gnc-file.c:423
 #, c-format
 msgid "The file %s is empty."
-msgstr ""
+msgstr "Tiedosto %s on tyhjä."
 
 #: gnucash/gnome-utils/gnc-file.c:436
 #, c-format
@@ -7326,21 +6989,21 @@ msgstr ""
 #: gnucash/gnome-utils/gnc-file.c:442
 #, c-format
 msgid "The file/URI %s could not be found."
-msgstr ""
+msgstr "Tiedostoa/URI:a %s ei löydy."
 
 #: gnucash/gnome-utils/gnc-file.c:449
 msgid "This file is from an older version of GnuCash. Do you want to continue?"
-msgstr ""
+msgstr "Tämä tiedosto GnuCashin vanhemmasta versiosta. Haluatko jatkaa?"
 
 #: gnucash/gnome-utils/gnc-file.c:458
 #, c-format
 msgid "The file type of file %s is unknown."
-msgstr ""
+msgstr "Tiedoston %s tiedostotyyppi on tuntematon."
 
 #: gnucash/gnome-utils/gnc-file.c:463
 #, c-format
 msgid "Could not make a backup of the file %s"
-msgstr ""
+msgstr "Tiedostosta %s ei voitu tehdä varmuuskopiota"
 
 #: gnucash/gnome-utils/gnc-file.c:468
 #, c-format
@@ -7352,7 +7015,7 @@ msgstr ""
 #: gnucash/gnome-utils/gnc-file.c:475
 #, c-format
 msgid "No read permission to read from file %s."
-msgstr ""
+msgstr "Ei oikeutta lukea tiedostoa %s."
 
 #. Translators: the first %s is a path in the filesystem,
 #. the second %s is PACKAGE_NAME, which by default is "GnuCash"
@@ -7372,6 +7035,9 @@ msgid ""
 "This database is from an older version of GnuCash. Select OK to upgrade it "
 "to the current version, Cancel to mark it read-only."
 msgstr ""
+"Tämä tietokanta on GnuCashin vanhemmasta versiosta. Valitse OK "
+"päivittääksesi sen nykyiseen versioon, Peruuta merkitäksesi sen \"vain "
+"luku\"-tilaan."
 
 #: gnucash/gnome-utils/gnc-file.c:498
 msgid ""
@@ -7415,11 +7081,11 @@ msgstr ""
 #: gnucash/gnome-utils/gnc-file.c:550
 #, c-format
 msgid "An unknown I/O error (%d) occurred."
-msgstr ""
+msgstr "Tapahtui tuntematon I/O-virhe (%d)."
 
 #: gnucash/gnome-utils/gnc-file.c:645
 msgid "Save changes to the file?"
-msgstr ""
+msgstr "Tallenna muutokset tiedostoon?"
 
 #: gnucash/gnome-utils/gnc-file.c:658
 #: gnucash/gnome-utils/gnc-main-window.cpp:1264
@@ -7427,12 +7093,12 @@ msgstr ""
 msgid "If you don't save, changes from the past %d minute will be discarded."
 msgid_plural ""
 "If you don't save, changes from the past %d minutes will be discarded."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Jos et tallenna, muutokset edellisen minuutin ajalta hukataan."
+msgstr[1] "Jos et tallenna, muutokset edellisten %d minuutin ajalta hukataan."
 
 #: gnucash/gnome-utils/gnc-file.c:662
 msgid "Continue _Without Saving"
-msgstr ""
+msgstr "J_atka tallentamatta"
 
 #: gnucash/gnome-utils/gnc-file.c:726
 msgid ""
@@ -7442,15 +7108,13 @@ msgid ""
 msgstr ""
 
 #: gnucash/gnome-utils/gnc-file.c:754
-#, fuzzy
-#| msgid "The following warnings exist:"
 msgid "The following are noted in this file:"
-msgstr "Seuraavat varoitukset ovat olemassa:"
+msgstr "Huomiot tästä tiedostosta:"
 
 #: gnucash/gnome-utils/gnc-file.c:880
 #, c-format
 msgid "GnuCash could not obtain the lock for %s."
-msgstr ""
+msgstr "GnuCash ei voinut lukita tietokantaa %s."
 
 #: gnucash/gnome-utils/gnc-file.c:882
 msgid ""
@@ -7469,39 +7133,35 @@ msgstr ""
 #: gnucash/gnome-utils/gnc-file.c:908
 #: gnucash/gtkbuilder/dialog-file-access.glade:98
 msgid "Open _Read-Only"
-msgstr ""
+msgstr "Avaa _kirjoitussuojattuna"
 
 #: gnucash/gnome-utils/gnc-file.c:911
 msgid "Create _New File"
-msgstr ""
+msgstr "Luo _uusi tiedosto"
 
 #: gnucash/gnome-utils/gnc-file.c:914
-#, fuzzy
-#| msgid "Open buy"
 msgid "Open _Anyway"
-msgstr "Avoin osto"
+msgstr "_Avaa siitä huolimatta"
 
 #: gnucash/gnome-utils/gnc-file.c:917
-#, fuzzy
-#| msgid "Open short"
 msgid "Open _Folder"
-msgstr "Avoin lyhyeksimyynti"
+msgstr "_Avaa hakemisto"
 
 #: gnucash/gnome-utils/gnc-file.c:923 gnucash/ui/gnc-main-window.ui:83
 msgid "_Quit"
-msgstr ""
+msgstr "_Lopeta"
 
 #: gnucash/gnome-utils/gnc-file.c:1009 gnucash/gnome-utils/gnc-file.c:1029
 msgid "Loading user data…"
-msgstr ""
+msgstr "Ladataan käyttäjätietoja…"
 
 #: gnucash/gnome-utils/gnc-file.c:1045
 msgid "Re-saving user data…"
-msgstr ""
+msgstr "Tallennetaan käyttäjätietoja…"
 
 #: gnucash/gnome-utils/gnc-file.c:1392
 msgid "Exporting file…"
-msgstr ""
+msgstr "Viedään tiedostoa…"
 
 #: gnucash/gnome-utils/gnc-file.c:1405
 #, c-format
@@ -7510,12 +7170,17 @@ msgid ""
 "\n"
 "%s"
 msgstr ""
+"Virhe tiedostoa tallentaessa.\n"
+"\n"
+"%s"
 
 #: gnucash/gnome-utils/gnc-file.c:1440
 msgid ""
 "The database was opened read-only. Do you want to save it to a different "
 "place?"
 msgstr ""
+"Tietokanta avattiin \"vain luku\"-tilassa. Haluatko tallentaa sen eri "
+"sijaintiin?"
 
 #: gnucash/gnome-utils/gnc-file.c:1739
 #, c-format
@@ -7526,55 +7191,55 @@ msgstr ""
 
 #: gnucash/gnome-utils/gnc-file.c:1747
 #: gnucash/gnome-utils/gnc-main-window.cpp:1232
-#, fuzzy
-#| msgid "Unknown"
 msgid "<unknown>"
-msgstr "Tuntematon"
+msgstr "<tuntematon>"
 
 #: gnucash/gnome-utils/gnc-general-select.c:183
 msgid "View…"
-msgstr ""
+msgstr "Näytä…"
 
 #: gnucash/gnome-utils/gnc-gnome-utils.c:69
 msgid "GnuCash could not find the files of the help documentation."
-msgstr ""
+msgstr "GnuCash ei löytänyt ohjetiedostoja."
 
 #: gnucash/gnome-utils/gnc-gnome-utils.c:71
 msgid ""
 "This is likely because the \"gnucash-docs\" package is not properly "
 "installed."
 msgstr ""
+"Tämä johtuu todennäköisesti siitä, ettei gnucash-docs-pakettia ole asennettu "
+"oikein."
 
 #. Translators: URI of missing help files
 #: gnucash/gnome-utils/gnc-gnome-utils.c:73
 msgid "Expected location"
-msgstr ""
+msgstr "Odotettu sijainti"
 
 #: gnucash/gnome-utils/gnc-gnome-utils.c:387
 #: gnucash/gnome-utils/gnc-gnome-utils.c:427
 msgid "GnuCash could not find the linked document."
-msgstr ""
+msgstr "GnuCash ei löytänyt yhdistettyä asiakirjaa."
 
 #: gnucash/gnome-utils/gnc-gnome-utils.c:457
 msgid "GnuCash could not open the linked document:"
-msgstr ""
+msgstr "GnuCash ei voinut avata yhdistettyä asiakirjaa:"
 
 #. Translators: %s is a path to a database or any other url,
 #. like mysql://user@server.somewhere/somedb, https://www.somequotes.com/thequotes
 #: gnucash/gnome-utils/gnc-keyring.c:358
 #, c-format
 msgid "Enter a user name and password to connect to: %s"
-msgstr ""
+msgstr "Syötä käyttäjätunnus ja salasana yhdistääksesi kohteeseen %s"
 
 #: gnucash/gnome-utils/gnc-main-window.cpp:150
 #, c-format
 msgid "Changes will be saved automatically in %u seconds"
-msgstr ""
+msgstr "Muutokset tallennetaan automaattisesti %u sekunnissa"
 
 #: gnucash/gnome-utils/gnc-main-window.cpp:1215
 #, c-format
 msgid "Save changes to file %s before closing?"
-msgstr ""
+msgstr "Tallennetaanko muutokset tiedostoon %s ennen sulkemista?"
 
 #: gnucash/gnome-utils/gnc-main-window.cpp:1218
 #, c-format
@@ -7582,6 +7247,8 @@ msgid ""
 "If you don't save, changes from the past %d hours and %d minutes will be "
 "discarded."
 msgstr ""
+"Jos et tallenna, muutokset edellisen %d tunnin ja %d minuutin ajalta "
+"hukataan."
 
 #: gnucash/gnome-utils/gnc-main-window.cpp:1220
 #, c-format
@@ -7589,38 +7256,39 @@ msgid ""
 "If you don't save, changes from the past %d days and %d hours will be "
 "discarded."
 msgstr ""
+"Jos et tallenna, muutoksen edellisen %d päivän ja %d tunnin ajalta hukataan."
 
 #: gnucash/gnome-utils/gnc-main-window.cpp:1269
 msgid "Close _Without Saving"
-msgstr ""
+msgstr "Sulje t_allentamatta"
 
 #: gnucash/gnome-utils/gnc-main-window.cpp:1416
 msgid "This window is closing and will not be restored."
-msgstr ""
+msgstr "Ikkuna suljetaan eikä sitä palauteta."
 
 #: gnucash/gnome-utils/gnc-main-window.cpp:1422
 msgid "Close Window?"
-msgstr ""
+msgstr "Suljetaanko ikkuna?"
 
 #. Translators: This string is shown in the window title if this
 #. document is, well, read-only.
 #: gnucash/gnome-utils/gnc-main-window.cpp:1552
 msgid "(read-only)"
-msgstr ""
+msgstr "(vain luku)"
 
 #: gnucash/gnome-utils/gnc-main-window.cpp:1560
 msgid "Unsaved Book"
-msgstr ""
+msgstr "Tallentamaton kirjanpito"
 
 #: gnucash/gnome-utils/gnc-main-window.cpp:1753
 msgid "Last modified on %a, %b %d, %Y at %I:%M %p"
-msgstr ""
+msgstr "Muokattu edellisen kerran %x %X"
 
 #. Translators: This message appears in the status bar after opening the file.
 #: gnucash/gnome-utils/gnc-main-window.cpp:1756
 #, c-format
 msgid "File %s opened. %s"
-msgstr ""
+msgstr "Tiedosto %s avattu. %s"
 
 #: gnucash/gnome-utils/gnc-main-window.cpp:3000
 msgctxt "lower case key for short cut to 'Accounts'"
@@ -7629,24 +7297,23 @@ msgstr ""
 
 #: gnucash/gnome-utils/gnc-main-window.cpp:3087
 msgid "Unable to save to database."
-msgstr ""
+msgstr "Tietokannan tallennus epäonnistui."
 
 #: gnucash/gnome-utils/gnc-main-window.cpp:3089
 msgid "Unable to save to database: Book is marked read-only."
-msgstr ""
+msgstr "Tietokantaa ei voi tallentaa: kirja on merkitty vain luku -muotoon."
 
 #: gnucash/gnome-utils/gnc-main-window.cpp:4749
 #: gnucash/gtkbuilder/assistant-qif-import.glade:943
-#, fuzzy
-#| msgid "New Book Options"
 msgid "Book Options"
-msgstr "Uuden kirjanpidon asetukset"
+msgstr "Kirjanpidon asetukset"
 
 #: gnucash/gnome-utils/gnc-main-window.cpp:5073
 msgid ""
 "The maximum number of window menu entries reached, no more entries will be "
 "added."
 msgstr ""
+"Valintojen enimmäismäärä valikossa on saavutettu, lisää merkintöjä ei lisätä."
 
 #: gnucash/gnome-utils/gnc-main-window.cpp:5311
 #: gnucash/gnucash-core-app.cpp:241
@@ -7657,21 +7324,21 @@ msgstr ""
 #: gnucash/gnome-utils/gnc-main-window.cpp:5336
 #, c-format
 msgid "Copyright © 1997-%s The GnuCash contributors."
-msgstr ""
+msgstr "Tekijänoikeus © 1997-%s GnuCashin tekijät."
 
 #: gnucash/gnome-utils/gnc-main-window.cpp:5348
 #: gnucash/gnome-utils/gnc-splash.c:99
 msgid "Version"
-msgstr ""
+msgstr "Versio"
 
 #: gnucash/gnome-utils/gnc-main-window.cpp:5349
 #: gnucash/gnome-utils/gnc-splash.c:100 gnucash/gnucash-core-app.cpp:257
 msgid "Build ID"
-msgstr ""
+msgstr "Koontitunniste"
 
 #: gnucash/gnome-utils/gnc-main-window.cpp:5357
 msgid "Accounting for personal and small business finance."
-msgstr ""
+msgstr "Kirjanpito henkilökohtaiseen tai pienen yrityksen talouteen."
 
 #. Translators: the following string will be shown in Help->About->Credits
 #. Enter your name or that of your team and an email contact for feedback.
@@ -7680,72 +7347,63 @@ msgstr ""
 #: gnucash/gnome-utils/gnc-main-window.cpp:5366
 msgid "translator-credits"
 msgstr ""
-"Jiri Grönroos: 2021; Jyri-Petteri Paloposki: 2021Marko Kohtala: 2020, 2023; "
-"Sampo Harjula: 2022; Tuomo Hartikainen: 2017Tuomo Kohvakka: 2008"
+"Jiri Grönroos, 2021\n"
+"Jyri-Petteri ”ZeiP” Paloposki, 2020\n"
+"Marko Kohtala, 2020\n"
+"Tuomo Hartikainen, 2017\n"
+"Tuomo Kohvakka, 2008"
 
 #: gnucash/gnome-utils/gnc-main-window.cpp:5369
 msgid "Visit the GnuCash website."
-msgstr ""
+msgstr "Vieraile GnuCashin verkkosivustolla."
 
 #: gnucash/gnome-utils/gnc-option-gtk-ui.cpp:993
 #: gnucash/gnome-utils/gnc-option-gtk-ui.cpp:1237
-#, fuzzy
-#| msgid "Selected"
 msgid "Select All"
-msgstr "Valittu"
+msgstr "Valitse kaikki"
 
 #: gnucash/gnome-utils/gnc-option-gtk-ui.cpp:995
-#, fuzzy
-#| msgid "Select document"
 msgid "Select all accounts."
-msgstr "Valitse asiakirja"
+msgstr "Valitse kaikki tilit."
 
 #: gnucash/gnome-utils/gnc-option-gtk-ui.cpp:1000
 #: gnucash/gnome-utils/gnc-option-gtk-ui.cpp:1244
 msgid "Clear All"
-msgstr ""
+msgstr "Tyhjennä valinnat"
 
 #: gnucash/gnome-utils/gnc-option-gtk-ui.cpp:1002
 msgid "Clear the selection and unselect all accounts."
 msgstr ""
 
 #: gnucash/gnome-utils/gnc-option-gtk-ui.cpp:1007
-#, fuzzy
-#| msgid "Select document"
 msgid "Select Children"
-msgstr "Valitse asiakirja"
+msgstr "Valitse lapset"
 
 #: gnucash/gnome-utils/gnc-option-gtk-ui.cpp:1009
 msgid "Select all descendents of selected account."
-msgstr ""
+msgstr "Valitse kaikki valitun tilin alatilit."
 
 #: gnucash/gnome-utils/gnc-option-gtk-ui.cpp:1015
 #: gnucash/gnome-utils/gnc-option-gtk-ui.cpp:1251
-#, fuzzy
-#| msgid "Selected"
 msgid "Select Default"
-msgstr "Valittu"
+msgstr "Valitse oletukset"
 
 #: gnucash/gnome-utils/gnc-option-gtk-ui.cpp:1017
 msgid "Select the default account selection."
-msgstr ""
+msgstr "Valitse oletustilivalinta."
 
 #: gnucash/gnome-utils/gnc-option-gtk-ui.cpp:1034
-#, fuzzy
-#| msgid "Find Account"
 msgid "Show Hidden Accounts"
-msgstr "Etsi tili"
+msgstr "Näytä piilotetut tilit"
 
 #: gnucash/gnome-utils/gnc-option-gtk-ui.cpp:1036
 #: gnucash/gtkbuilder/dialog-account.glade:972
 msgid "Show accounts that have been marked hidden."
-msgstr ""
+msgstr "Näytä tilit, jotka on merkitty piilotetuiksi."
 
 #: gnucash/gnome-utils/gnc-option-gtk-ui.cpp:1239
-#, fuzzy
-#| msgid "Total Entries"
 msgid "Select all entries."
-msgstr "Yhteensä tietueita"
+msgstr "Valitse kaikki merkinnät."
 
 #: gnucash/gnome-utils/gnc-option-gtk-ui.cpp:1246
 msgid "Clear the selection and unselect all entries."
@@ -7753,21 +7411,19 @@ msgstr ""
 
 #: gnucash/gnome-utils/gnc-option-gtk-ui.cpp:1253
 msgid "Select the default selection."
-msgstr ""
+msgstr "Valitse oletusvalinta."
 
 #: gnucash/gnome-utils/gnc-option-gtk-ui.cpp:1535
 msgid "Clear any selected image file."
-msgstr ""
+msgstr "Tyhjennä kuvan valinta."
 
 #: gnucash/gnome-utils/gnc-option-gtk-ui.cpp:1536
-#, fuzzy
-#| msgid "Selected"
 msgid "Select image"
-msgstr "Valittu"
+msgstr "Valitse kuva"
 
 #: gnucash/gnome-utils/gnc-option-gtk-ui.cpp:1538
 msgid "Select an image file."
-msgstr ""
+msgstr "Valitse kuvatiedosto."
 
 #: gnucash/gnome-utils/gnc-option-gtk-ui.cpp:1751
 msgid "Pixels"
@@ -7775,61 +7431,46 @@ msgstr ""
 
 #: gnucash/gnome-utils/gnc-option-gtk-ui.cpp:1752
 msgid "Percent"
-msgstr ""
+msgstr "Prosentti"
 
 #: gnucash/gnome-utils/gnc-period-select.c:68
-#, fuzzy
-#| msgid "Start of previous quarter"
 msgid "Start of this quarter"
-msgstr "Edellisen vuosineljänneksen alku"
+msgstr "Tämän vuosineljänneksen alku"
 
 #: gnucash/gnome-utils/gnc-period-select.c:74
-#, fuzzy
-#| msgid "Start of accounting period"
 msgid "Start of this accounting period"
-msgstr "Tilikauden alku"
+msgstr "Tämän tilikauden alku"
 
 #: gnucash/gnome-utils/gnc-period-select.c:75
-#, fuzzy
-#| msgid "Start of accounting period"
 msgid "Start of previous accounting period"
-msgstr "Tilikauden alku"
+msgstr "Edellisen tilikauden alku"
 
 #: gnucash/gnome-utils/gnc-period-select.c:84
-#, fuzzy
-#| msgid "End of previous quarter"
 msgid "End of this quarter"
-msgstr "Viime vuosineljänneksen loppu"
+msgstr "Tämän vuosineljänneksen loppu"
 
 #: gnucash/gnome-utils/gnc-period-select.c:90
-#, fuzzy
-#| msgid "End of accounting period"
 msgid "End of this accounting period"
-msgstr "Tilikauden loppu"
+msgstr "Tämän tilikauden loppu"
 
 #: gnucash/gnome-utils/gnc-period-select.c:91
-#, fuzzy
-#| msgid "End of accounting period"
 msgid "End of previous accounting period"
-msgstr "Tilikauden loppu"
+msgstr "Viime tilikauden loppu"
 
 #: gnucash/gnome-utils/gnc-plugin-menu-additions.c:424
 #: gnucash/report/report-core.scm:161
-#, fuzzy
-#| msgid "custom"
 msgid "_Custom"
-msgstr "muu"
+msgstr "_Mukautettu"
 
 #: gnucash/gnome-utils/gnc-report-combo.c:247
 msgid "Selected Report is Missing"
-msgstr ""
+msgstr "Valittu raportti puuttuu"
 
 #. Translators: %s is the report name.
 #: gnucash/gnome-utils/gnc-report-combo.c:300
-#, fuzzy, c-format
-#| msgid "Amount for %s is missing."
+#, c-format
 msgid "'%s' is missing"
-msgstr "%s määrä puuttuu."
+msgstr ""
 
 #. Translators: %s is the internal report guid.
 #: gnucash/gnome-utils/gnc-report-combo.c:304
@@ -7839,15 +7480,15 @@ msgstr ""
 
 #: gnucash/gnome-utils/gnc-splash.c:114
 msgid "Loading…"
-msgstr ""
+msgstr "Ladataan…"
 
 #: gnucash/gnome-utils/gnc-sx-list-tree-model-adapter.c:482
 msgid "never"
-msgstr ""
+msgstr "ei koskaan"
 
 #: gnucash/gnome-utils/gnc-tree-model-account.c:721
 msgid "New top level account"
-msgstr ""
+msgstr "Uusi ylimmän tason tili"
 
 #: gnucash/gnome-utils/gnc-tree-view-account.c:788
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:983
@@ -7860,17 +7501,13 @@ msgstr ""
 #: gnucash/report/reports/standard/trial-balance.scm:561
 #: gnucash/report/trep-engine.scm:179 gnucash/report/trep-engine.scm:950
 #: gnucash/report/trep-engine.scm:2238
-#, fuzzy
-#| msgid "Account"
 msgid "Account Name"
-msgstr "Tili"
+msgstr "Tilin nimi"
 
 #: gnucash/gnome-utils/gnc-tree-view-account.c:799
 #: gnucash/gtkbuilder/dialog-price.glade:580
-#, fuzzy
-#| msgid "Delete commodity?"
 msgid "Commodity"
-msgstr "Poista hyödyke?"
+msgstr "Hyödyke"
 
 #: gnucash/gnome-utils/gnc-tree-view-account.c:805
 #: gnucash/import-export/csv-exp/csv-tree-export.cpp:61
@@ -7880,82 +7517,68 @@ msgstr "Poista hyödyke?"
 #: gnucash/report/reports/standard/general-ledger.scm:94
 #: gnucash/report/trep-engine.scm:185 gnucash/report/trep-engine.scm:921
 #: gnucash/report/trep-engine.scm:2252
-#, fuzzy
-#| msgid "Account"
 msgid "Account Code"
-msgstr "Tili"
+msgstr "Tilinumero"
 
 #: gnucash/gnome-utils/gnc-tree-view-account.c:817
 msgid "Last Num"
-msgstr ""
+msgstr "Viimeisin numero"
 
 #: gnucash/gnome-utils/gnc-tree-view-account.c:823
 msgid "Present"
-msgstr ""
+msgstr "Nykyinen"
 
 #: gnucash/gnome-utils/gnc-tree-view-account.c:830
 msgid "Present (Report)"
-msgstr ""
+msgstr "Nykyinen (raportti)"
 
 #: gnucash/gnome-utils/gnc-tree-view-account.c:844
-#, fuzzy
-#| msgid "Balance Zero"
 msgid "Balance (Report)"
-msgstr "Saldo nolla"
+msgstr "Tase (raportti)"
 
 #: gnucash/gnome-utils/gnc-tree-view-account.c:851
-#, fuzzy
-#| msgid "Balance Zero"
 msgid "Balance (Period)"
-msgstr "Saldo nolla"
+msgstr "Tase (aikaväli)"
 
 #: gnucash/gnome-utils/gnc-tree-view-account.c:865
 msgid "Cleared (Report)"
-msgstr ""
+msgstr "Hyväksytty (raportti)"
 
 #: gnucash/gnome-utils/gnc-tree-view-account.c:879
-#, fuzzy
-#| msgid "Reconciled Date"
 msgid "Reconciled (Report)"
-msgstr "Tarkistuspäivämäärä"
+msgstr "Täsmäytetty (raportti)"
 
 #: gnucash/gnome-utils/gnc-tree-view-account.c:886
-#, fuzzy
-#| msgid "Reconciled Date"
 msgid "Last Reconcile Date"
-msgstr "Tarkistuspäivämäärä"
+msgstr "Viimeisin täsmäytyspäivä"
 
 #: gnucash/gnome-utils/gnc-tree-view-account.c:892
 msgid "Future Minimum"
-msgstr ""
+msgstr "Ennustettu alhaisin"
 
 #: gnucash/gnome-utils/gnc-tree-view-account.c:899
 msgid "Future Minimum (Report)"
-msgstr ""
+msgstr "Ennustettu alhaisin (raportti)"
 
 #: gnucash/gnome-utils/gnc-tree-view-account.c:913
 msgid "Total (Report)"
-msgstr ""
+msgstr "Yhteensä (Raportti)"
 
 #: gnucash/gnome-utils/gnc-tree-view-account.c:920
-#, fuzzy
-#| msgid "Period"
 msgid "Total (Period)"
-msgstr "Aikaväli"
+msgstr "Yhteensä (Jakso)"
 
 #: gnucash/gnome-utils/gnc-tree-view-account.c:929
 msgctxt "Column header for 'Color'"
 msgid "C"
-msgstr ""
+msgstr "V"
 
 #: gnucash/gnome-utils/gnc-tree-view-account.c:937
 #: gnucash/gnome-utils/gnc-tree-view-account.c:940
 #: gnucash/gtkbuilder/dialog-preferences.glade:816
 #: gnucash/import-export/csv-exp/csv-tree-export.cpp:61
-#, fuzzy
-#| msgid "Account"
 msgid "Account Color"
-msgstr "Tili"
+msgstr "Tilin väri"
 
 #: gnucash/gnome-utils/gnc-tree-view-account.c:944
 msgctxt "Column header for 'Balance Limit'"
@@ -7965,25 +7588,23 @@ msgstr ""
 #: gnucash/gnome-utils/gnc-tree-view-account.c:953
 #: gnucash/gnome-utils/gnc-tree-view-account.c:956
 #: gnucash/gtkbuilder/dialog-account.glade:1705
-#, fuzzy
-#| msgid "Balance Zero"
 msgid "Balance Limit"
-msgstr "Saldo nolla"
+msgstr "Saldoraja"
 
 #: gnucash/gnome-utils/gnc-tree-view-account.c:966
 #: gnucash/import-export/csv-exp/csv-tree-export.cpp:63
 msgid "Tax Info"
-msgstr ""
+msgstr "Verotieto"
 
 #: gnucash/gnome-utils/gnc-tree-view-account.c:980
 msgctxt "Column header for 'Hidden'"
 msgid "H"
-msgstr ""
+msgstr "P"
 
 #: gnucash/gnome-utils/gnc-tree-view-account.c:988
 msgctxt "Column header for 'Placeholder'"
 msgid "P"
-msgstr ""
+msgstr "K"
 
 #: gnucash/gnome-utils/gnc-tree-view-account.c:996
 msgctxt "Column header for 'Opening Balance'"
@@ -7994,32 +7615,32 @@ msgstr ""
 #: gnucash/gnome-utils/gnc-tree-view-account.c:1788
 #, c-format
 msgid "Present (%s)"
-msgstr ""
+msgstr "Nykyinen (%s)"
 
 #. Translators: %s is a currency mnemonic.
 #: gnucash/gnome-utils/gnc-tree-view-account.c:1791
 #: gnucash/gnome-utils/gnc-tree-view-owner.c:897
 #, c-format
 msgid "Balance (%s)"
-msgstr "Saldo (%s)"
+msgstr "Tase (%s)"
 
 #. Translators: %s is a currency mnemonic.
 #: gnucash/gnome-utils/gnc-tree-view-account.c:1794
 #, c-format
 msgid "Cleared (%s)"
-msgstr ""
+msgstr "Hyväksytty (%s)"
 
 #. Translators: %s is a currency mnemonic.
 #: gnucash/gnome-utils/gnc-tree-view-account.c:1797
 #, c-format
 msgid "Reconciled (%s)"
-msgstr "Täsmennetty (%s)"
+msgstr "Täsmäytetty (%s)"
 
 #. Translators: %s is a currency mnemonic.
 #: gnucash/gnome-utils/gnc-tree-view-account.c:1800
 #, c-format
 msgid "Future Minimum (%s)"
-msgstr ""
+msgstr "Ennustettu alhaisin (%s)"
 
 #. Translators: %s is a currency mnemonic.
 #: gnucash/gnome-utils/gnc-tree-view-account.c:1803
@@ -8031,26 +7652,24 @@ msgstr "Yhteensä (%s)"
 #: gnucash/gnome-utils/gnc-tree-view-account.c:2298
 #, c-format
 msgid "Filter %s by..."
-msgstr ""
+msgstr "Suodata %s..."
 
 #: gnucash/gnome-utils/gnc-tree-view-commodity.c:346
 #: gnucash/import-export/csv-exp/csv-tree-export.cpp:62
-#, fuzzy
-#| msgid "Name"
 msgid "Namespace"
-msgstr "Nimi"
+msgstr "Nimiavaruus"
 
 #: gnucash/gnome-utils/gnc-tree-view-commodity.c:363
 msgid "Print Name"
-msgstr ""
+msgstr "Tulostettava nimi"
 
 #: gnucash/gnome-utils/gnc-tree-view-commodity.c:369
 msgid "Display symbol"
-msgstr ""
+msgstr "Näytettävä symboli"
 
 #: gnucash/gnome-utils/gnc-tree-view-commodity.c:375
 msgid "Unique Name"
-msgstr ""
+msgstr "Yksilöllinen nimi"
 
 #. Translators: Again replace CUSIP by the name of your
 #. National Securities Identifying Number.
@@ -8059,14 +7678,12 @@ msgid "ISIN/CUSIP"
 msgstr ""
 
 #: gnucash/gnome-utils/gnc-tree-view-commodity.c:388
-#, fuzzy
-#| msgid "Action"
 msgid "Fraction"
-msgstr "Tapahtuma"
+msgstr "Murto-osa"
 
 #: gnucash/gnome-utils/gnc-tree-view-commodity.c:395
 msgid "Get Quotes"
-msgstr ""
+msgstr "Päivitä kurssit"
 
 #: gnucash/gnome-utils/gnc-tree-view-commodity.c:396
 msgctxt "Column letter for 'Get Quotes'"
@@ -8077,71 +7694,55 @@ msgstr ""
 #: gnucash/gnome-utils/gnc-tree-view-price.c:404
 #: gnucash/gtkbuilder/dialog-price.glade:652
 msgid "Source"
-msgstr ""
+msgstr "Lähde"
 
 #: gnucash/gnome-utils/gnc-tree-view-commodity.c:407
 msgid "Timezone"
-msgstr ""
+msgstr "Aikavyöhyke"
 
 #: gnucash/gnome-utils/gnc-tree-view-owner.c:337
 #: gnucash/gtkbuilder/dialog-customer.glade:133
-#, fuzzy
-#| msgid "Customer ID"
 msgid "Customer Number"
-msgstr "Asiakastunnus"
+msgstr "Asiakasnumero"
 
 #: gnucash/gnome-utils/gnc-tree-view-owner.c:345
 #: gnucash/gtkbuilder/dialog-vendor.glade:134
-#, fuzzy
-#| msgid "Number"
 msgid "Vendor Number"
-msgstr "Numero"
+msgstr "Myyjän numeoro"
 
 #: gnucash/gnome-utils/gnc-tree-view-owner.c:349
 #: gnucash/gtkbuilder/dialog-employee.glade:109
-#, fuzzy
-#| msgid "Employee Name"
 msgid "Employee Number"
-msgstr "Työntekijän nimi"
+msgstr "Työntekijän numero"
 
 #: gnucash/gnome-utils/gnc-tree-view-owner.c:399
 #: gnucash/report/reports/standard/new-aging.scm:49
-#, fuzzy
-#| msgid "Address Found"
 msgid "Address Name"
-msgstr "Osoite löytyi"
+msgstr "Osoitteen nimi"
 
 #: gnucash/gnome-utils/gnc-tree-view-owner.c:404
 #: gnucash/import-export/customer-import/dialog-customer-import-gui.c:126
 #: gnucash/report/reports/standard/new-aging.scm:52
-#, fuzzy
-#| msgid "Address Found"
 msgid "Address 1"
-msgstr "Osoite löytyi"
+msgstr "Osoite 1"
 
 #: gnucash/gnome-utils/gnc-tree-view-owner.c:409
 #: gnucash/import-export/customer-import/dialog-customer-import-gui.c:127
 #: gnucash/report/reports/standard/new-aging.scm:53
-#, fuzzy
-#| msgid "Address Found"
 msgid "Address 2"
-msgstr "Osoite löytyi"
+msgstr "Osoite 2"
 
 #: gnucash/gnome-utils/gnc-tree-view-owner.c:414
 #: gnucash/import-export/customer-import/dialog-customer-import-gui.c:128
 #: gnucash/report/reports/standard/new-aging.scm:54
-#, fuzzy
-#| msgid "Address Found"
 msgid "Address 3"
-msgstr "Osoite löytyi"
+msgstr "Osoite 3"
 
 #: gnucash/gnome-utils/gnc-tree-view-owner.c:419
 #: gnucash/import-export/customer-import/dialog-customer-import-gui.c:129
 #: gnucash/report/reports/standard/new-aging.scm:55
-#, fuzzy
-#| msgid "Address Found"
 msgid "Address 4"
-msgstr "Osoite löytyi"
+msgstr "Osoite 4"
 
 #: gnucash/gnome-utils/gnc-tree-view-owner.c:424
 #: gnucash/gtkbuilder/dialog-customer.glade:263
@@ -8152,7 +7753,7 @@ msgstr "Osoite löytyi"
 #: gnucash/register/ledger-core/split-register.c:2573
 #: gnucash/report/reports/support/taxinvoice.eguile.scm:175
 msgid "Phone"
-msgstr ""
+msgstr "Puhelin"
 
 #: gnucash/gnome-utils/gnc-tree-view-owner.c:429
 #: gnucash/gtkbuilder/dialog-customer.glade:276
@@ -8161,14 +7762,12 @@ msgstr ""
 #: gnucash/gtkbuilder/dialog-vendor.glade:278
 #: gnucash/import-export/customer-import/dialog-customer-import-gui.c:131
 #: gnucash/report/reports/support/taxinvoice.eguile.scm:181
-#, fuzzy
-#| msgid "Tax"
 msgid "Fax"
-msgstr "Vero"
+msgstr "Faxi"
 
 #: gnucash/gnome-utils/gnc-tree-view-owner.c:434
 msgid "E-mail"
-msgstr ""
+msgstr "Sähköposti"
 
 #: gnucash/gnome-utils/gnc-tree-view-owner.c:460
 #: gnucash/gtkbuilder/dialog-customer.glade:156
@@ -8178,10 +7777,8 @@ msgstr ""
 #: gnucash/gtkbuilder/dialog-order.glade:217
 #: gnucash/gtkbuilder/dialog-vendor.glade:185
 #: gnucash/report/reports/standard/new-aging.scm:59
-#, fuzzy
-#| msgid "Action"
 msgid "Active"
-msgstr "Tapahtuma"
+msgstr "Aktiivinen"
 
 #: gnucash/gnome-utils/gnc-tree-view-owner.c:461
 msgctxt "Column letter for 'Active'"
@@ -8190,7 +7787,7 @@ msgstr ""
 
 #: gnucash/gnome-utils/gnc-tree-view-price.c:386
 msgid "Security"
-msgstr ""
+msgstr "Arvopaperi"
 
 #: gnucash/gnome-utils/gnc-tree-view-price.c:416
 #: gnucash/gtkbuilder/assistant-stock-transaction.glade:390
@@ -8211,34 +7808,32 @@ msgstr ""
 #: gnucash/report/reports/standard/register.scm:378
 #: gnucash/report/trep-engine.scm:928 gnucash/report/trep-engine.scm:1202
 #: gnucash/report/trep-engine.scm:2243
-#, fuzzy
-#| msgid "Share Price"
 msgid "Price"
-msgstr "Osuuden arvo"
+msgstr "Hinta"
 
 #: gnucash/gnome-utils/gnc-tree-view-sx-list.c:122
 #: gnucash/gtkbuilder/dialog-sx.glade:1088
 #: gnucash/report/html-utilities.scm:309
 msgid "Enabled"
-msgstr ""
+msgstr "Käytössä"
 
 #: gnucash/gnome-utils/gnc-tree-view-sx-list.c:123
 msgctxt "Single-character short column-title form of 'Enabled'"
 msgid "E"
-msgstr ""
+msgstr "K"
 
 #: gnucash/gnome-utils/gnc-tree-view-sx-list.c:134
 msgid "Last Occur"
-msgstr ""
+msgstr "Edellinen esiintymä"
 
 #: gnucash/gnome-utils/gnc-tree-view-sx-list.c:139
 msgid "Next Occur"
-msgstr ""
+msgstr "Seuraava esiintymä"
 
 #: gnucash/gnome-utils/window-main-summarybar.c:309
 #, c-format
 msgid "%s, Total:"
-msgstr ""
+msgstr "%s, yhteensä:"
 
 #: gnucash/gnome-utils/window-main-summarybar.c:312
 #, c-format
@@ -8248,20 +7843,20 @@ msgstr ""
 #: gnucash/gnome-utils/window-main-summarybar.c:315
 #, c-format
 msgid "%s, Grand Total:"
-msgstr ""
+msgstr "%s, loppusumma:"
 
 #: gnucash/gnome-utils/window-main-summarybar.c:319
 #, c-format
 msgid "%s:"
-msgstr ""
+msgstr "%s:"
 
 #: gnucash/gnome-utils/window-main-summarybar.c:421
 msgid "Net Assets:"
-msgstr ""
+msgstr "Netto-omaisuus:"
 
 #: gnucash/gnome-utils/window-main-summarybar.c:424
 msgid "Profits:"
-msgstr ""
+msgstr "Voittoa:"
 
 #: gnucash/gnucash-cli.cpp:94
 msgid "Price Quotes Retrieval Options"
@@ -8296,7 +7891,7 @@ msgstr ""
 
 #: gnucash/gnucash-cli.cpp:110
 msgid "Report Generation Options"
-msgstr ""
+msgstr "Raportin luontiasetukset"
 
 #: gnucash/gnucash-cli.cpp:113
 msgid ""
@@ -8310,15 +7905,15 @@ msgstr ""
 
 #: gnucash/gnucash-cli.cpp:119
 msgid "Name of the report to run\n"
-msgstr ""
+msgstr "Ajettavan raportin nimi\n"
 
 #: gnucash/gnucash-cli.cpp:121
 msgid "Specify export type\n"
-msgstr ""
+msgstr "Määritä viennin tyyppi\n"
 
 #: gnucash/gnucash-cli.cpp:123
 msgid "Output file for report\n"
-msgstr ""
+msgstr "Tulostustiedosto raportille\n"
 
 #: gnucash/gnucash-cli.cpp:147 gnucash/gnucash-cli.cpp:182
 msgid "Missing data file parameter"
@@ -8326,19 +7921,17 @@ msgstr ""
 
 #: gnucash/gnucash-cli.cpp:160
 msgid "Not enough information for quotes dump"
-msgstr ""
+msgstr "Tieto ei ole riittävä kurssikyselyihin"
 
 #: gnucash/gnucash-cli.cpp:170
-#, c++-format
 msgid "Unknown quotes command '{1}'"
 msgstr ""
 
 #: gnucash/gnucash-cli.cpp:206
 msgid "Missing --name parameter"
-msgstr ""
+msgstr "--name-parametri puuttuu"
 
 #: gnucash/gnucash-cli.cpp:214
-#, c++-format
 msgid "Unknown report command '{1}'"
 msgstr ""
 
@@ -8348,7 +7941,6 @@ msgstr ""
 
 #: gnucash/gnucash-commands.cpp:317 gnucash/gnucash-commands.cpp:363
 #: gnucash/gnucash.cpp:179
-#, c++-format
 msgid "Found Finance::Quote version {1}."
 msgstr ""
 
@@ -8362,21 +7954,21 @@ msgstr ""
 
 #: gnucash/gnucash-core-app.cpp:77
 msgid "This is a development version. It may or may not work."
-msgstr ""
+msgstr "Tämä on kehitysversio. Se saattaa toimia tai olla toimimatta."
 
 #: gnucash/gnucash-core-app.cpp:78
 msgid "Report bugs and other problems to gnucash-devel@gnucash.org"
 msgstr ""
+"Raportoi bugit ja muut ongelmat sähköpostiosoitteeseen gnucash-devel@gnucash."
+"org"
 
 #. Translators: {1} will be replaced with an URL
 #: gnucash/gnucash-core-app.cpp:80
-#, c++-format
 msgid "You can also lookup and file bug reports at {1}"
-msgstr ""
+msgstr "Voit myös etsiä ja lähettää virheraportteja osoitteessa {1}"
 
 #. Translators: {1} will be replaced with an URL
 #: gnucash/gnucash-core-app.cpp:82
-#, c++-format
 msgid "To find the last stable version, please refer to {1}"
 msgstr ""
 
@@ -8391,40 +7983,35 @@ msgstr ""
 
 #: gnucash/gnucash-core-app.cpp:206
 msgid "- GnuCash, accounting for personal and small business finance"
-msgstr ""
+msgstr "- GnuCash, kirjanpito henkilökohtaiseen tai pienen yrityksen talouteen"
 
 #: gnucash/gnucash-core-app.cpp:208
-#, c++-format
 msgid "{1} [options] [datafile]"
-msgstr ""
+msgstr "{1} [valinnat] [tiedosto]"
 
 #: gnucash/gnucash-core-app.cpp:236
 msgid "GnuCash Paths"
-msgstr ""
+msgstr "GnuCash polut"
 
 #: gnucash/gnucash-core-app.cpp:249
-#, c++-format
 msgid "GnuCash {1}"
-msgstr ""
+msgstr "GnuCash {1}"
 
 #: gnucash/gnucash-core-app.cpp:250
-#, c++-format
 msgid "GnuCash {1} development version"
-msgstr ""
+msgstr "GnuCash {1} kehitysversio"
 
 #: gnucash/gnucash-core-app.cpp:275
-#, fuzzy
-#| msgid "New Book Options"
 msgid "Common Options"
-msgstr "Uuden kirjanpidon asetukset"
+msgstr "Yleiset asetukset"
 
 #: gnucash/gnucash-core-app.cpp:278
 msgid "Show this help message"
-msgstr ""
+msgstr "Näytä tämä ohjeviesti"
 
 #: gnucash/gnucash-core-app.cpp:280
 msgid "Show GnuCash version"
-msgstr ""
+msgstr "Näytä GnuCashin versio"
 
 #: gnucash/gnucash-core-app.cpp:282
 msgid ""
@@ -8446,7 +8033,7 @@ msgstr ""
 
 #: gnucash/gnucash-core-app.cpp:288
 msgid "Show paths"
-msgstr ""
+msgstr "Näytä polut"
 
 #: gnucash/gnucash-core-app.cpp:290
 msgid ""
@@ -8455,10 +8042,8 @@ msgid ""
 msgstr ""
 
 #: gnucash/gnucash-core-app.cpp:292
-#, fuzzy
-#| msgid "New Book Options"
 msgid "Hidden Options"
-msgstr "Uuden kirjanpidon asetukset"
+msgstr "Piilotetut asetukset"
 
 #: gnucash/gnucash-core-app.cpp:295
 msgid "[datafile]"
@@ -8466,23 +8051,23 @@ msgstr ""
 
 #: gnucash/gnucash.cpp:176
 msgid "Checking Finance::Quote…"
-msgstr ""
+msgstr "Tarkistetaan Finance::Quote…"
 
 #: gnucash/gnucash.cpp:186
 msgid "Unable to load Finance::Quote."
-msgstr ""
+msgstr "Ei voi ladata Finance::Quote."
 
 #: gnucash/gnucash.cpp:197
 msgid "Loading data…"
-msgstr ""
+msgstr "Ladataan tietoja…"
 
 #: gnucash/gnucash.cpp:257
 msgid "Application Options"
-msgstr ""
+msgstr "Sovellusasetukset"
 
 #: gnucash/gnucash.cpp:260
 msgid "Do not load the last file opened"
-msgstr ""
+msgstr "Älä lataa viimeksi avattua tiedostoa"
 
 #. Translators: Do not translate $DISPLAY! It is an environment variable for X11
 #: gnucash/gnucash.cpp:298
@@ -8640,10 +8225,15 @@ msgid ""
 "are documents with opposite sign. For example for an invoice, customer "
 "credit notes and negative invoices are considered counter documents."
 msgstr ""
+"Yritä automaattisesti maksaa asiakkaan tosite aiemmilla etumaksuilla ja "
+"vastatositteilla laskun kirjauksen yhteydessä. Esimaksujen ja tositteiden "
+"täytyy luonnollisesti kohdistua samaan asiakkaaseen. Vastatositteet ovat "
+"tositteita, joissa on vastakkainen etumerkki. Esimerkiksi myyntilaskulle "
+"vastatosite on asiakkaan luotto tai hyvityslasku."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.business.gschema.xml.in:117
 msgid "Show invoices due reminder at startup"
-msgstr ""
+msgstr "Muistuta erääntyvistä myyntilaskuista ohjelmaa avattaessa"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.business.gschema.xml.in:118
 msgid ""
@@ -8674,11 +8264,13 @@ msgid ""
 "If active, extra toolbar buttons for common business functions are shown as "
 "well. Otherwise they are not shown."
 msgstr ""
+"Jos valittu, painikepalkissa näytetään useille yrityksille olennaisille "
+"toiminnoille omat painikkeet."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.business.gschema.xml.in:132
 #: libgnucash/engine/gnc-optiondb.cpp:1332
 msgid "The invoice report to be used for printing."
-msgstr ""
+msgstr "Rapotti jota käytetään laskun tulostukseen."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.business.gschema.xml.in:133
 msgid "The name of the report to be used for invoice printing."
@@ -8686,7 +8278,7 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.business.gschema.xml.in:137
 msgid "Open new invoice in new window"
-msgstr ""
+msgstr "Avaa lasku uudessa ikkunassa"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.business.gschema.xml.in:138
 msgid ""
@@ -8714,6 +8306,11 @@ msgid ""
 "opposite sign. For example for a bill, vendor credit notes and negative "
 "bills are considered counter documents."
 msgstr ""
+"Yritä automaattisesti maksaa myyjän tosite aiemmilla etumaksuilla ja "
+"vastatositteilla laskun kirjauksen yhteydessä. Esimaksujen ja tositteiden "
+"täytyy luonnollisesti kohdistua samaan asiakkaaseen. Vastatositteet ovat "
+"tositteitä, joissa on vastakkainen etumerkki. Esimerkiksi ostolaskulle "
+"vastatosite on myyjän luotto tai hyvityslasku."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.business.gschema.xml.in:159
 msgid "Show bills due reminder at startup"
@@ -8766,7 +8363,7 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.checkprinting.gschema.xml.in:20
 msgid "Date format to use"
-msgstr ""
+msgstr "Käytettävä päivämäärämuoto"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.checkprinting.gschema.xml.in:21
 msgid "This is the numerical identifier of the predefined date format to use."
@@ -8774,7 +8371,7 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.checkprinting.gschema.xml.in:25
 msgid "Custom date format"
-msgstr ""
+msgstr "Mukautettu päivämäärämuoto"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.checkprinting.gschema.xml.in:26
 msgid ""
@@ -8794,7 +8391,7 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.checkprinting.gschema.xml.in:35
 msgid "Position of payee name"
-msgstr ""
+msgstr "Maksunsaajan nimen sijainti"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.checkprinting.gschema.xml.in:36
 msgid ""
@@ -8804,7 +8401,7 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.checkprinting.gschema.xml.in:40
 msgid "Position of date line"
-msgstr ""
+msgstr "Päiväysrivin sijainti"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.checkprinting.gschema.xml.in:41
 msgid ""
@@ -8837,7 +8434,7 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.checkprinting.gschema.xml.in:55
 msgid "Position of payee address"
-msgstr ""
+msgstr "Maksunsaajan osoitteen sijainti"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.checkprinting.gschema.xml.in:56
 msgid ""
@@ -8848,7 +8445,7 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.checkprinting.gschema.xml.in:60
 msgid "Position of notes line"
-msgstr ""
+msgstr "Huomautusrivin sijainti"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.checkprinting.gschema.xml.in:61
 msgid ""
@@ -8859,7 +8456,7 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.checkprinting.gschema.xml.in:65
 msgid "Position of memo line"
-msgstr ""
+msgstr "Muistiinpanorivin sijainti"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.checkprinting.gschema.xml.in:66
 msgid ""
@@ -8884,7 +8481,7 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.checkprinting.gschema.xml.in:76
 msgid "Number of degrees to rotate the check."
-msgstr ""
+msgstr "Montako astetta šekkiä käännetään."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.checkprinting.gschema.xml.in:80
 msgid "Position of split's amount in numbers"
@@ -8942,12 +8539,12 @@ msgstr ""
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.checkprinting.gschema.xml.in:105
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.checkprinting.gschema.xml.in:106
 msgid "Print '***' before and after text."
-msgstr ""
+msgstr "Tulosta '***' ennen ja jälkeen tekstin."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.commodities.gschema.xml.in:5
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.commodities.gschema.xml.in:6
 msgid "Show currencies in this dialog"
-msgstr ""
+msgstr "Näytä rahayksiköt tässä ikkunassa"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.export.csv.gschema.xml.in:12
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.gschema.xml.in:177
@@ -8959,7 +8556,7 @@ msgstr ""
 #: gnucash/import-export/aqb/gschemas/org.gnucash.GnuCash.dialogs.import.hbci.gschema.xml.in:55
 #: gnucash/import-export/ofx/gschemas/org.gnucash.GnuCash.dialogs.import.ofx.gschema.xml.in:5
 msgid "Last pathname used"
-msgstr ""
+msgstr "Viimeisin käytetty polku"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.export.csv.gschema.xml.in:13
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.gschema.xml.in:178
@@ -8977,7 +8574,7 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.export.csv.gschema.xml.in:17
 msgid "Window geometry"
-msgstr ""
+msgstr "Ikkunageometria"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.export.csv.gschema.xml.in:18
 msgid "The position of paned window when it was last closed."
@@ -9003,7 +8600,7 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.gschema.xml.in:249
 msgid "Show the new user window"
-msgstr ""
+msgstr "Näytä uusi käyttäjäikkuna"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.gschema.xml.in:250
 msgid ""
@@ -9012,7 +8609,7 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.gschema.xml.in:264
 msgid "New hierarchy window on \"New File\""
-msgstr ""
+msgstr "Uusi hierarkiaikkuna Uusi tiedosto -valinnalla"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.gschema.xml.in:265
 msgid ""
@@ -9073,7 +8670,7 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.import.generic.gschema.xml.in:25
 msgid "Likely matching transaction within these days"
-msgstr ""
+msgstr "Todennäköisesti vastaava tosite näiden päivien sisällä"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.import.generic.gschema.xml.in:26
 msgid ""
@@ -9083,7 +8680,7 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.import.generic.gschema.xml.in:30
 msgid "UnLikely matching a transaction outside of these days"
-msgstr ""
+msgstr "Todennäköisesti ei ole vastaava tosite näiden päivien ulkopuolella"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.import.generic.gschema.xml.in:31
 msgid ""
@@ -9136,7 +8733,7 @@ msgstr ""
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.import.generic.gschema.xml.in:50
 #: gnucash/gtkbuilder/dialog-preferences.glade:2275
 msgid "Automatically create new commodities"
-msgstr ""
+msgstr "Luo uudet hyödykkeet automaattisesti"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.import.generic.gschema.xml.in:51
 #: gnucash/gtkbuilder/dialog-preferences.glade:2281
@@ -9145,10 +8742,13 @@ msgid ""
 "is encountered during import. Otherwise the user will be asked what to do "
 "with each unknown commodity."
 msgstr ""
+"Jos tuontiin kuuluu ennestään tuntemattomia hyödykkeitä, luo ne "
+"automaattisesti. Muussa tapauksessa käyttäjältä kysytään mitä kullekkin "
+"hyödykkeelle tulisi tehdä."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.import.generic.gschema.xml.in:68
 msgid "Display or hide reconciled matches"
-msgstr ""
+msgstr "Näytä tai piilota täsmäysten osumat"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.import.generic.gschema.xml.in:69
 msgid ""
@@ -9159,7 +8759,7 @@ msgstr ""
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.import.qif.gschema.xml.in:5
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.import.qif.gschema.xml.in:10
 msgid "Default QIF transaction status"
-msgstr ""
+msgstr "Oletus QIF tositteen tila"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.import.qif.gschema.xml.in:6
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.import.qif.gschema.xml.in:11
@@ -9173,17 +8773,17 @@ msgid ""
 "When the status is not specified in a QIF file, the transactions are marked "
 "as reconciled."
 msgstr ""
+"Kun QIF-tiedostossa ei ole määritelty tositteen tilaa, merkitse se "
+"täsmäytetyksi."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.import.qif.gschema.xml.in:32
-#, fuzzy
-#| msgid "Select document"
 msgid "Show documentation"
-msgstr "Valitse asiakirja"
+msgstr "Näytä ohjeet"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.import.qif.gschema.xml.in:33
 #: gnucash/gtkbuilder/dialog-account-picker.glade:40
 msgid "Show some documentation-only pages in QIF Import assistant."
-msgstr ""
+msgstr "Näytä myös pelkkiä ohjeita sisältävät sivut QIF-tuonnin avustajassa."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.reconcile.gschema.xml.in:5
 msgid "Pre-select cleared transactions"
@@ -9208,10 +8808,12 @@ msgid ""
 "only enabled for Bank, Credit, Mutual, Asset, Receivable, Payable, and "
 "Liability accounts."
 msgstr ""
+"Ennen korkoa maksavan tilin täsmäytystä, pyydä käyttäjää syöttämään "
+"maksettavan tai saatavan koron määrä."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.reconcile.gschema.xml.in:15
 msgid "Prompt for credit card payment"
-msgstr ""
+msgstr "Kysy luottokorttimaksua"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.reconcile.gschema.xml.in:16
 msgid ""
@@ -9221,7 +8823,7 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.reconcile.gschema.xml.in:20
 msgid "Always reconcile to today"
-msgstr ""
+msgstr "Täsmäytä aina tähän päivään"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.reconcile.gschema.xml.in:21
 msgid ""
@@ -9269,6 +8871,8 @@ msgstr ""
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.sxs.gschema.xml.in:32
 msgid "Set the sort column in the \"since last run\" dialog."
 msgstr ""
+"Aseta järjestyksen määräävä sarake \"edellisen ajon jälkeen\" "
+"-valintaikkunaa varten."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.sxs.gschema.xml.in:33
 msgid "This settings sets the sort column in the \"since last run\" dialog."
@@ -9306,10 +8910,8 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.sxs.gschema.xml.in:59
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.sxs.gschema.xml.in:60
-#, fuzzy
-#| msgid "The number of payments cannot be zero."
 msgid "The number of months to be shown in editor."
-msgstr "Maksujen määrä ei voi olla nolla."
+msgstr "Editorissa näytettävien kuukausien määrä."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.sxs.gschema.xml.in:64
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.sxs.gschema.xml.in:65
@@ -9336,11 +8938,11 @@ msgstr ""
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.totd.gschema.xml.in:5
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.totd.gschema.xml.in:6
 msgid "The next tip to show."
-msgstr ""
+msgstr "Seuraava näytettävä vinkki."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.totd.gschema.xml.in:17
 msgid "Show \"Tip Of The Day\" at GnuCash start"
-msgstr ""
+msgstr "Näytä päivän vinkki GnuCashia käynnistettäessä"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.dialogs.totd.gschema.xml.in:18
 msgid ""
@@ -9351,7 +8953,7 @@ msgstr ""
 #: gnucash/gschemas/org.gnucash.GnuCash.general.finance-quote.gschema.xml.in:5
 #: gnucash/gtkbuilder/dialog-preferences.glade:3747
 msgid "Alpha Vantage API key"
-msgstr ""
+msgstr "Alpha Vantagen rajapinta-avain"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.general.finance-quote.gschema.xml.in:6
 #: gnucash/gtkbuilder/dialog-preferences.glade:3746
@@ -9378,7 +8980,7 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:10
 msgid "The version of these settings"
-msgstr ""
+msgstr "Näiden asetusten versio"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:11
 msgid ""
@@ -9408,6 +9010,10 @@ msgid ""
 "character, or any of the following strings: \"colon\", \"slash\", "
 "\"backslash\", \"dash\" and \"period\"."
 msgstr ""
+"Merkki jota käytetään erottamaan tilin nimen osat. Merkki voi olla mikä "
+"tahansa muu kuin aakkosmerkki tai numero. Myös seuraavat termit hyväksytään: "
+"\"colon\" (:), \"slash\" (/), \"backslash\" (\\), \"dash\" (-) ja "
+"\"period\" (.)."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:25
 msgid "Transaction Linked Files head path"
@@ -9420,7 +9026,7 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:30
 msgid "Compress the data file"
-msgstr ""
+msgstr "Pakkaa tiedosto"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:31
 msgid "Enables file compression when writing the data file."
@@ -9438,7 +9044,7 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:40
 msgid "Auto-save time interval"
-msgstr ""
+msgstr "Automaattitallennuksen aikaväli"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:41
 #: gnucash/gtkbuilder/dialog-preferences.glade:1674
@@ -9446,11 +9052,13 @@ msgid ""
 "The number of minutes until saving of the data file to harddisk will be "
 "started automatically. If zero, no saving will be started automatically."
 msgstr ""
+"Kuinka monen minuutin jäljeen tiedot tallennetaan levylle automaattisesti. "
+"Jos arvo on nolla, automaattitallennus ei ole käytössä."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:45
 #: gnucash/gtkbuilder/dialog-preferences.glade:1791
 msgid "Enable timeout on \"Save changes on closing\" question"
-msgstr ""
+msgstr "Käytä aikakatkaisua automaattitallennuksen vahvistukselle"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:46
 #: gnucash/gtkbuilder/dialog-preferences.glade:1795
@@ -9460,6 +9068,9 @@ msgid ""
 "that time, the changes will be saved automatically and the question window "
 "closed."
 msgstr ""
+"Jos valittu, automaattitallennuksen vahvistus on näkyvissä vain määrätyn "
+"ajan. Jos vahvistuspyyntöön ei reagoida, tiedosto tallennetaan ja "
+"vahvistusikkuna suljetaan."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:50
 msgid "Time to wait for answer"
@@ -9471,11 +9082,13 @@ msgid ""
 "The number of seconds to wait before the question window will be closed and "
 "the changes saved automatically."
 msgstr ""
+"Kuinka monta sekuntia vastausta odotetaan ennen kuin vahvistusikkuna "
+"suljetaan ja muutoksen tallennetaan automaattisesti."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:55
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:56
 msgid "Display negative amounts in red"
-msgstr ""
+msgstr "Näytä negatiiviset summat punaisina"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:60
 msgid "Automatically insert a decimal point"
@@ -9513,7 +9126,7 @@ msgstr ""
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:75
 #: gnucash/gtkbuilder/dialog-preferences.glade:1743
 msgid "Do not create log/backup files."
-msgstr ""
+msgstr "Älä käytä loki-/varmaaskopiotiedostoja."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:76
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:81
@@ -9530,11 +9143,13 @@ msgstr ""
 #: gnucash/gtkbuilder/dialog-preferences.glade:1761
 msgid "Delete old log/backup files after this many days (0 = never)."
 msgstr ""
+"Poista vanhat loki-/varmuuskopiotiedostot tämän ajan jälkeen (0 = ei "
+"koskaan)."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:85
 #: gnucash/gtkbuilder/dialog-preferences.glade:1779
 msgid "Do not delete log/backup files."
-msgstr ""
+msgstr "Älä poista loki-/varmuuskopiotiedostoja."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:90
 msgid "Delete old log/backup files after this many days (0 = never)"
@@ -9549,7 +9164,7 @@ msgstr ""
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:95
 #: gnucash/gtkbuilder/dialog-preferences.glade:656
 msgid "Don't sign reverse any accounts."
-msgstr ""
+msgstr "Älä käytä käänteistä etumerkkiä millekkään tilille."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:96
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:101
@@ -9569,15 +9184,17 @@ msgid ""
 "Sign reverse balances on the following: Credit Card, Payable, Liability, "
 "Equity, and Income."
 msgstr ""
+"Käänteinen etumerkki luottokortille, ostolaskuille, veloille, omalle "
+"pääomalle ja tuloille."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:105
 #: gnucash/gtkbuilder/dialog-preferences.glade:694
 msgid "Sign reverse balances on income and expense accounts."
-msgstr ""
+msgstr "Käänteinen etumerkki tulo- ja menotileillä."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:110
 msgid "Use account colors in the account hierarchy"
-msgstr ""
+msgstr "Käytä tilien värejä tilihierarkiassa"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:111
 msgid ""
@@ -9643,10 +9260,8 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:140
 #: gnucash/gtkbuilder/dialog-preferences.glade:942
-#, fuzzy
-#| msgid "Please choose the currency to use for new accounts."
 msgid "Use the system locale currency for all newly created accounts."
-msgstr "Valitse luotaville tileille käytettävä valuutta."
+msgstr "Käytä järjestelmän valuuttaa kaikille uusille tileille."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:141
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:146
@@ -9660,16 +9275,12 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:145
 #: gnucash/gtkbuilder/dialog-preferences.glade:922
-#, fuzzy
-#| msgid "Please choose the currency to use for new accounts."
 msgid "Use the specified currency for all newly created accounts."
-msgstr "Valitse luotaville tileille käytettävä valuutta."
+msgstr "Käytä valittua valuuttaa kaikille uusille tileille."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:150
-#, fuzzy
-#| msgid "Please choose the currency to use for new accounts."
 msgid "Default currency for new accounts"
-msgstr "Valitse luotaville tileille käytettävä valuutta."
+msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:151
 msgid ""
@@ -9680,7 +9291,7 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:155
 msgid "Use 24 hour time format"
-msgstr ""
+msgstr "Käytä 24 tunnin aikamuotoa"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:156
 msgid ""
@@ -9689,7 +9300,7 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:160
 msgid "Date format choice"
-msgstr ""
+msgstr "Päivämäärämuodon valinta"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:161
 msgid ""
@@ -9701,10 +9312,8 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:165
 #: gnucash/gtkbuilder/dialog-preferences.glade:1125
-#, fuzzy
-#| msgid "Last day of the current calendar year."
 msgid "In the current calendar year"
-msgstr "Tämän kalenterivuoden viimeinen päivä."
+msgstr "Nykyiseksi kalenterivuodeksi"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:166
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:171
@@ -9730,10 +9339,13 @@ msgid ""
 "Dates will be completed so that they are close to the current date. Enter "
 "the maximum number of months to go backwards in time when completing dates."
 msgstr ""
+"Päivämäät täydennetään niin, että vuosi on lähellä nykyistä päivämäärää. "
+"Syötä enimmäismäärä kuukausia, jonka verran tulisi mennä ajassa taaksepäin "
+"päivämäärää täydennettäessä."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:180
 msgid "Show Horizontal Grid Lines"
-msgstr ""
+msgstr "Näytä vaakasuuntaiset rajat solujen välissä"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:181
 msgid ""
@@ -9743,7 +9355,7 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:185
 msgid "Show Vertical Grid Lines"
-msgstr ""
+msgstr "Näytä pystysuorat viivat solujen välissä"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:186
 msgid ""
@@ -9753,7 +9365,7 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:190
 msgid "Show splash screen"
-msgstr ""
+msgstr "Näytä latausruutu"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:191
 msgid ""
@@ -9764,7 +9376,7 @@ msgstr ""
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:195
 #: gnucash/gtkbuilder/dialog-preferences.glade:3461
 msgid "Display the notebook tabs at the top of the window."
-msgstr ""
+msgstr "Näytä välilehdet ikkunan yläreunassa."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:196
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:201
@@ -9779,22 +9391,22 @@ msgstr ""
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:200
 #: gnucash/gtkbuilder/dialog-preferences.glade:3480
 msgid "Display the notebook tabs at the bottom of the window."
-msgstr ""
+msgstr "Näytä välilehdet ikkunan alareunassa."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:205
 #: gnucash/gtkbuilder/dialog-preferences.glade:3499
 msgid "Display the notebook tabs at the left of the window."
-msgstr ""
+msgstr "Näytä välilehdet ikkunan vasemmassa reunassa."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:210
 #: gnucash/gtkbuilder/dialog-preferences.glade:3518
 msgid "Display the notebook tabs at the right of the window."
-msgstr ""
+msgstr "Näytä välilehdet ikkunan oikeassa reunassa."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:215
 #: gnucash/gtkbuilder/dialog-preferences.glade:3550
 msgid "Display the summary bar at the top of the page."
-msgstr ""
+msgstr "Näytä yhteenvetopalkki ikkunan yläreunassa."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:216
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:221
@@ -9807,12 +9419,13 @@ msgstr ""
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:220
 #: gnucash/gtkbuilder/dialog-preferences.glade:3569
 msgid "Display the summary bar at the bottom of the page."
-msgstr ""
+msgstr "Näytä yhteenvetopalkki ikkunan alareunassa."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:225
 #: gnucash/gtkbuilder/dialog-preferences.glade:3419
 msgid "Closing a tab moves to the most recently visited tab."
 msgstr ""
+"Siirry välilehden sulkemisen jälkeen viimeisimmäksi käytetylle välilehdelle."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:226
 msgid ""
@@ -9826,6 +9439,8 @@ msgid ""
 "Set book option on new files to use split \"action\" field for \"Num\" field "
 "on registers/reports"
 msgstr ""
+"Aseta tilikirja-asetus uusille tiedostoille käyttää rivin \"toiminto\"-"
+"kenttää \"Nro\"-kenttänä tileissä ja raporteissa"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:231
 #: gnucash/gtkbuilder/dialog-preferences.glade:1445
@@ -9837,6 +9452,11 @@ msgid ""
 "is set so that the 'Num' cell on registers shows/updates the transaction "
 "'num' field."
 msgstr ""
+"Jos valittu, oletuksena uusissa tilikirjatiedostoissa tilien ja raporttien "
+"'Nro'-solu näyttää/päivittää rivin 'toiminto'-kentän ja tositteen "
+"numerokenttä näytetään toisella rivillä kahden rivin näkymässä (eikä sitä "
+"näytetä lainkaan yhden rivin näkymässä). Muussa tapauksessa oletuksena "
+"uusissa tilikirjatiedostoissa 'Nro'-kenttä näyttää tositteen numeron."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:247
 msgid "Color the register using a gnucash specific color theme"
@@ -9932,7 +9552,7 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:292
 msgid "Show future transactions after the blank transaction in a register"
-msgstr ""
+msgstr "Näytä tulevat tositteet kirjan tyhjän tositteen jälkeen"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:293
 msgid ""
@@ -9945,7 +9565,7 @@ msgstr ""
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:297
 #: gnucash/gtkbuilder/dialog-preferences.glade:2934
 msgid "Hide splits in all transactions."
-msgstr ""
+msgstr "Piilota kaikkien tositteiden rivit."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:298
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:303
@@ -9967,17 +9587,22 @@ msgid ""
 "transactions are shown on one or two lines depending on whether Double line "
 "view is set."
 msgstr ""
+"Näytä automaattisesti valitun tositteen kaikki rivit. Kaikki muut tositteet "
+"näytetään yhdellä tai kahdella rivillä riippuen onko kahden rivin näkymä "
+"käytössä."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:307
 #: gnucash/gtkbuilder/dialog-preferences.glade:2972
 msgid "All transactions are expanded to show all splits."
-msgstr ""
+msgstr "Kaikki tositteet avataan näyttämään kaikki rivit."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:312
 msgid ""
 "Show a second line with \"Action\", \"Notes\", and \"Linked Documents\" for "
 "each transaction."
 msgstr ""
+"Näytä toinen rivi, jossa näytetään toimenpide, muistiinpano ja yhdistetty "
+"asiakirja, joka tositteelle."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:313
 msgid ""
@@ -10001,7 +9626,7 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:322
 msgid "Show the entered and reconcile dates"
-msgstr ""
+msgstr "Näytä kirjautut ja täsmäyksen päiväykset"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:323
 msgid ""
@@ -10019,7 +9644,7 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:332
 msgid "Show the calendar buttons"
-msgstr ""
+msgstr "Näytä kalenteripainikkeet"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:333
 msgid "Show the calendar buttons Cancel, Today and Select."
@@ -10037,14 +9662,14 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:342
 msgid "Number of transactions to show in a register."
-msgstr ""
+msgstr "Tilikirjassa näytettävä tositteiden lukumäärä."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:343
 #: gnucash/gtkbuilder/dialog-preferences.glade:3003
 msgid ""
 "Show this many transactions in a register. A value of zero means show all "
 "transactions."
-msgstr ""
+msgstr "Näytä kirjan näin monta tositetta. 0 näyttää kaikki tositteet."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:347
 msgid "Number of characters for auto complete."
@@ -10069,7 +9694,7 @@ msgstr ""
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:360
 #: gnucash/gtkbuilder/dialog-preferences.glade:3287
 msgid "Use the system locale currency for all newly created reports."
-msgstr ""
+msgstr "Käytä järjestelmän valuuttaa kaikille vasta luoduille raporteille."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:361
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:371
@@ -10083,11 +9708,11 @@ msgstr ""
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:365
 #: gnucash/gtkbuilder/dialog-preferences.glade:3267
 msgid "Use the specified currency for all newly created reports."
-msgstr ""
+msgstr "Käytä määritettyä valittua valuuttaa kaikille uusille raporteille."
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:370
 msgid "Default currency for new reports"
-msgstr ""
+msgstr "Uusien raporttien oletusvaluutta"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in:375
 msgid "Zoom factor to use by default for reports."
@@ -10143,7 +9768,7 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.history.gschema.xml.in:5
 msgid "Number of files in history"
-msgstr ""
+msgstr "Tiedostojen määrä historiassa"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.history.gschema.xml.in:6
 msgid ""
@@ -10154,7 +9779,7 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.history.gschema.xml.in:10
 msgid "Most recently opened file"
-msgstr ""
+msgstr "Viimeksi avattu tiedosto"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.history.gschema.xml.in:11
 msgid "This field contains the full path of the most recently opened file."
@@ -10200,7 +9825,7 @@ msgstr ""
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:14
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:147
 msgid "Confirm Window Close"
-msgstr ""
+msgstr "Vahvista ikkunan sulkeminen"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:15
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:148
@@ -10210,7 +9835,7 @@ msgstr ""
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:19
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:152
 msgid "Commit changes to a invoice entry"
-msgstr ""
+msgstr "Tallenna muutokset laskutietueeseen"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:20
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:153
@@ -10222,7 +9847,7 @@ msgstr ""
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:24
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:157
 msgid "Duplicating a changed invoice entry"
-msgstr ""
+msgstr "Monista muokattu myyntilasku"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:25
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:158
@@ -10233,10 +9858,8 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:29
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:162
-#, fuzzy
-#| msgid "Delete commodity?"
 msgid "Delete a commodity"
-msgstr "Poista hyödyke?"
+msgstr "Poista hyödyke"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:30
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:163
@@ -10245,10 +9868,8 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:34
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:167
-#, fuzzy
-#| msgid "Delete commodity?"
 msgid "Delete a commodity with price quotes"
-msgstr "Poista hyödyke?"
+msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:35
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:168
@@ -10272,7 +9893,7 @@ msgstr ""
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:44
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:177
 msgid "Replace existing price"
-msgstr ""
+msgstr "Korvaa nykyinen hinta"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:45
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:178
@@ -10296,7 +9917,7 @@ msgstr ""
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:54
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:187
 msgid "Read only register"
-msgstr ""
+msgstr "Vain luku -tilikirja"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:55
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:188
@@ -10332,7 +9953,7 @@ msgstr ""
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:69
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:202
 msgid "Cut a split from a transaction"
-msgstr ""
+msgstr "Leikkaa rivi tositteelta"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:70
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:203
@@ -10344,7 +9965,7 @@ msgstr ""
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:74
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:207
 msgid "Cut a reconciled split from a transaction"
-msgstr ""
+msgstr "Leikkaa täsmätty rivi tositteelta"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:75
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:208
@@ -10357,7 +9978,7 @@ msgstr ""
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:79
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:212
 msgid "Remove a split from a transaction"
-msgstr ""
+msgstr "Poista jako tositteesta"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:80
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:213
@@ -10384,7 +10005,7 @@ msgstr ""
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:222
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:227
 msgid "Remove all the splits from a transaction"
-msgstr ""
+msgstr "Poista kaikki tositteen viennit"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:90
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:223
@@ -10404,10 +10025,8 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:99
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:232
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Cut a transaction"
-msgstr "Etsi tosite"
+msgstr "Leikkaa tosite"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:100
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:233
@@ -10417,7 +10036,7 @@ msgstr ""
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:104
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:237
 msgid "Cut a transaction with reconciled splits"
-msgstr ""
+msgstr "Leikkaa tosite, jossa täsmäytetyt rivit"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:105
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:238
@@ -10429,10 +10048,8 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:109
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:242
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Delete a transaction"
-msgstr "Etsi tosite"
+msgstr "Poista tosite"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:110
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:243
@@ -10442,7 +10059,7 @@ msgstr ""
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:114
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:247
 msgid "Delete a transaction with reconciled splits"
-msgstr ""
+msgstr "Poistaa tositteen täsmäytettyine vienteineen"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:115
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:248
@@ -10455,7 +10072,7 @@ msgstr ""
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:119
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:252
 msgid "Duplicating a changed transaction"
-msgstr ""
+msgstr "Kopioidaan muutettu tosite"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:120
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:253
@@ -10467,7 +10084,7 @@ msgstr ""
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:124
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:257
 msgid "Commit changes to a transaction"
-msgstr ""
+msgstr "Tallennetaan muutokset tositteeseen"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:125
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:258
@@ -10479,7 +10096,7 @@ msgstr ""
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:129
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:262
 msgid "Jump when there are multiple other accounts"
-msgstr ""
+msgstr "Hyppää kun on useita muita tilejä"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:130
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:263
@@ -10492,7 +10109,7 @@ msgstr ""
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:134
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:267
 msgid "Jump when there are no other accounts"
-msgstr ""
+msgstr "Hyppää kun ei ole muita tilejä"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:135
 #: gnucash/gschemas/org.gnucash.GnuCash.warnings.gschema.xml.in:268
@@ -10597,7 +10214,7 @@ msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.window.pages.gschema.xml.in:5
 msgid "Display this column"
-msgstr ""
+msgstr "Näytä tämä sarake"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.window.pages.gschema.xml.in:6
 msgid ""
@@ -10606,10 +10223,8 @@ msgid ""
 msgstr ""
 
 #: gnucash/gschemas/org.gnucash.GnuCash.window.pages.gschema.xml.in:10
-#, fuzzy
-#| msgid "End of this month"
 msgid "Width of this column"
-msgstr "Tämän kuun loppu"
+msgstr "Tämän sarakkeen leveys"
 
 #: gnucash/gschemas/org.gnucash.GnuCash.window.pages.gschema.xml.in:11
 msgid "This setting stores the width of the given column in pixels."
@@ -10625,10 +10240,8 @@ msgid ""
 msgstr ""
 
 #: gnucash/gtkbuilder/assistant-acct-period.glade:24
-#, fuzzy
-#| msgid "Start of accounting period"
 msgid "Setup Account Period"
-msgstr "Tilikauden alku"
+msgstr "Aseta tilikausi"
 
 #: gnucash/gtkbuilder/assistant-acct-period.glade:38
 msgid ""
@@ -10639,31 +10252,29 @@ msgid ""
 msgstr ""
 
 #: gnucash/gtkbuilder/assistant-acct-period.glade:81
-#, fuzzy
-#| msgid "Closing Date"
 msgid "Book Closing Dates"
-msgstr "Tilinpäätöspäivä"
+msgstr ""
 
 #: gnucash/gtkbuilder/assistant-acct-period.glade:196
 #: gnucash/gtkbuilder/dialog-book-close.glade:7
 msgid "Close Book"
-msgstr ""
+msgstr "Tee tilinpäätös"
 
 #: gnucash/gtkbuilder/assistant-acct-period.glade:210
 msgid "Account Period Finish"
-msgstr ""
+msgstr "Tilikauden päätös"
 
 #: gnucash/gtkbuilder/assistant-acct-period.glade:237
 msgid "Press 'Close' to Exit."
-msgstr ""
+msgstr "Paina ”Sulje” poistuaksesi."
 
 #: gnucash/gtkbuilder/assistant-acct-period.glade:248
 msgid "Summary Page"
-msgstr ""
+msgstr "Yhteenvetosivu"
 
 #: gnucash/gtkbuilder/assistant-csv-account-import.glade:13
 msgid "CSV Import Assistant"
-msgstr ""
+msgstr "CSV-tuontiavustin"
 
 #. Run the assistant in your language to see GTK's translation of the button labels.
 #: gnucash/gtkbuilder/assistant-csv-account-import.glade:30
@@ -10685,55 +10296,55 @@ msgstr ""
 
 #: gnucash/gtkbuilder/assistant-csv-account-import.glade:51
 msgid "Import Account Assistant"
-msgstr ""
+msgstr "Tilien tuonnin avustin"
 
 #: gnucash/gtkbuilder/assistant-csv-account-import.glade:66
 msgid "Enter file name and location for the Import…"
-msgstr ""
+msgstr "Syötä tuotavan tiedoston nimi ja sijainti…"
 
 #: gnucash/gtkbuilder/assistant-csv-account-import.glade:77
 msgid "Choose File to Import"
-msgstr ""
+msgstr "Valitse tuotava tiedosto"
 
 #: gnucash/gtkbuilder/assistant-csv-account-import.glade:97
 msgid "Number of rows for the Header"
-msgstr ""
+msgstr "Otsakkeen rivien määrä"
 
 #: gnucash/gtkbuilder/assistant-csv-account-import.glade:143
 #: gnucash/gtkbuilder/assistant-csv-export.glade:128
 #: gnucash/gtkbuilder/assistant-csv-price-import.glade:316
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:305
 msgid "Comma (,)"
-msgstr ""
+msgstr "Pilkku (,)"
 
 #: gnucash/gtkbuilder/assistant-csv-account-import.glade:159
 #: gnucash/gtkbuilder/assistant-csv-export.glade:161
 #: gnucash/gtkbuilder/assistant-csv-price-import.glade:349
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:338
 msgid "Semicolon (;)"
-msgstr ""
+msgstr "Puolipiste (;)"
 
 #: gnucash/gtkbuilder/assistant-csv-account-import.glade:175
 #: gnucash/gtkbuilder/dialog-bi-import-gui.glade:288
 #: gnucash/gtkbuilder/dialog-customer-import-gui.glade:288
 msgid "Custom regular expression"
-msgstr ""
+msgstr "Mukautettu säännöllinen lauseke"
 
 #: gnucash/gtkbuilder/assistant-csv-account-import.glade:191
 #: gnucash/gtkbuilder/assistant-csv-export.glade:144
 #: gnucash/gtkbuilder/assistant-csv-price-import.glade:333
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:322
 msgid "Colon (:)"
-msgstr ""
+msgstr "Kaksoispiste (:)"
 
 #: gnucash/gtkbuilder/assistant-csv-account-import.glade:217
 #: gnucash/gtkbuilder/assistant-csv-export.glade:214
 msgid "Select Separator Character"
-msgstr ""
+msgstr "Valitse erotinmerkki"
 
 #: gnucash/gtkbuilder/assistant-csv-account-import.glade:255
 msgid "Preview"
-msgstr ""
+msgstr "Esikatselu"
 
 #: gnucash/gtkbuilder/assistant-csv-account-import.glade:268
 msgid "Import Account Preview, first 10 rows only"
@@ -10747,20 +10358,18 @@ msgid ""
 msgstr ""
 
 #: gnucash/gtkbuilder/assistant-csv-account-import.glade:283
-#, fuzzy
-#| msgid "Map Account NOT found"
 msgid "Import Accounts Now"
-msgstr "Karttatiliä EI löytynyt"
+msgstr "Tuo tilit nyt"
 
 #: gnucash/gtkbuilder/assistant-csv-account-import.glade:333
 #: gnucash/gtkbuilder/assistant-csv-price-import.glade:1057
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:1139
 msgid "Import Summary"
-msgstr ""
+msgstr "Yhteenveto tuonnista"
 
 #: gnucash/gtkbuilder/assistant-csv-export.glade:8
 msgid "CSV Export Assistant"
-msgstr ""
+msgstr "CSV-vientiavustin"
 
 #: gnucash/gtkbuilder/assistant-csv-export.glade:25
 msgid ""
@@ -10770,7 +10379,7 @@ msgstr ""
 
 #: gnucash/gtkbuilder/assistant-csv-export.glade:65
 msgid "Use Quotes"
-msgstr ""
+msgstr "Lainausmerkit"
 
 #: gnucash/gtkbuilder/assistant-csv-export.glade:80
 msgid "Simple Layout"
@@ -10778,76 +10387,64 @@ msgstr ""
 
 #: gnucash/gtkbuilder/assistant-csv-export.glade:230
 msgid "Choose Export Settings"
-msgstr ""
+msgstr "Valitse viennin asetukset"
 
 #: gnucash/gtkbuilder/assistant-csv-export.glade:245
 msgid "Select the accounts to be exported and date range if required."
-msgstr ""
+msgstr "Valitse vietävät tilit ja aikaväli."
 
 #: gnucash/gtkbuilder/assistant-csv-export.glade:353
 #: gnucash/gtkbuilder/dialog-tax-info.glade:408
-#, fuzzy
-#| msgid "Select document"
 msgid "_Select Subaccounts"
-msgstr "Valitse asiakirja"
+msgstr "_Valitse alatilit"
 
 #: gnucash/gtkbuilder/assistant-csv-export.glade:368
-#, fuzzy
-#| msgid "Selected"
 msgid "Select _All"
-msgstr "Valittu"
+msgstr "Valitse k_aikki"
 
 #: gnucash/gtkbuilder/assistant-csv-export.glade:412
 #: gnucash/gtkbuilder/assistant-loan.glade:1205
 #: gnucash/report/reports/standard/new-owner-report.scm:1131
 msgid "Date Range"
-msgstr ""
+msgstr "Jakso"
 
 #: gnucash/gtkbuilder/assistant-csv-export.glade:425
 #: gnucash/gtkbuilder/assistant-hierarchy.glade:256
 #: gnucash/gtkbuilder/dialog-account.glade:890
 #: gnucash/gtkbuilder/dialog-reset-warnings.glade:104
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:470
-#, fuzzy
-#| msgid "Selected"
 msgid "_Select All"
-msgstr "Valittu"
+msgstr "_Valitse kaikki"
 
 #: gnucash/gtkbuilder/assistant-csv-export.glade:442
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:141
-#, fuzzy
-#| msgid "Selected"
 msgid "Select _Range"
-msgstr "Valittu"
+msgstr "Valitse aika_väli"
 
 #. Filter By Dialog, Date Tab, Start section
 #: gnucash/gtkbuilder/assistant-csv-export.glade:470
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:170
 msgid "Start"
-msgstr ""
+msgstr "Alku"
 
 #: gnucash/gtkbuilder/assistant-csv-export.glade:479
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:179
 msgid "_Earliest"
-msgstr ""
+msgstr "_Varhaisin"
 
 #: gnucash/gtkbuilder/assistant-csv-export.glade:496
-#, fuzzy
-#| msgid "Closing Date"
 msgid "Cho_ose Date"
-msgstr "Tilinpäätöspäivä"
+msgstr "_Valitse päivämäärä"
 
 #: gnucash/gtkbuilder/assistant-csv-export.glade:513
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:211
-#, fuzzy
-#| msgid "Today"
 msgid "Toda_y"
-msgstr "Tämä päivä"
+msgstr "_Tänään"
 
 #: gnucash/gtkbuilder/assistant-csv-export.glade:530
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:228
 msgid "_Latest"
-msgstr ""
+msgstr "_Viimeisin"
 
 #. Filter By Dialog, Date Tab, End section
 #: gnucash/gtkbuilder/assistant-csv-export.glade:552
@@ -10855,51 +10452,45 @@ msgstr ""
 #: gnucash/gtkbuilder/dialog-sx.glade:422
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:258
 msgid "End"
-msgstr ""
+msgstr "Lopussa"
 
 #: gnucash/gtkbuilder/assistant-csv-export.glade:561
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:267
-#, fuzzy
-#| msgid "Closing Date"
 msgid "C_hoose Date"
-msgstr "Tilinpäätöspäivä"
+msgstr "_Valitse päivämäärä"
 
 #: gnucash/gtkbuilder/assistant-csv-export.glade:578
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:284
-#, fuzzy
-#| msgid "Today"
 msgid "_Today"
-msgstr "Tämä päivä"
+msgstr "_Tänään"
 
 #: gnucash/gtkbuilder/assistant-csv-export.glade:659
-#, fuzzy
-#| msgid "Accounts in '%s'"
 msgid "Account Selection"
-msgstr "Tilit kategoriassa '%s'"
+msgstr "Tilien valinta"
 
 #: gnucash/gtkbuilder/assistant-csv-export.glade:673
 msgid "Enter file name and location for the Export…"
-msgstr ""
+msgstr "Syötä vientitiedoston nimi ja sijainti…"
 
 #: gnucash/gtkbuilder/assistant-csv-export.glade:684
 msgid "Choose File Name for Export"
-msgstr ""
+msgstr "Valitse kohdetiedoston nimi"
 
 #: gnucash/gtkbuilder/assistant-csv-export.glade:698
 msgid "Export Now…"
-msgstr ""
+msgstr "Toteuta vienti…"
 
 #: gnucash/gtkbuilder/assistant-csv-export.glade:706
 msgid "Summary"
-msgstr ""
+msgstr "Yhteenveto"
 
 #: gnucash/gtkbuilder/assistant-csv-export.glade:711
 msgid "Export Summary"
-msgstr ""
+msgstr "Viennin yhteenveto"
 
 #: gnucash/gtkbuilder/assistant-csv-price-import.glade:38
 msgid "CSV Price Import"
-msgstr ""
+msgstr "CSV hintojen tuonti"
 
 #. You should localize the (british) examples to your region.
 #: gnucash/gtkbuilder/assistant-csv-price-import.glade:53
@@ -10936,7 +10527,7 @@ msgstr ""
 
 #: gnucash/gtkbuilder/assistant-csv-price-import.glade:72
 msgid "Price Import Assistant"
-msgstr ""
+msgstr "Hintojen tuontiavustin"
 
 #: gnucash/gtkbuilder/assistant-csv-price-import.glade:87
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:77
@@ -10948,7 +10539,7 @@ msgstr ""
 #: gnucash/gtkbuilder/assistant-csv-price-import.glade:100
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:90
 msgid "Select File for Import"
-msgstr ""
+msgstr "Valitse tuotava tiedosto"
 
 #: gnucash/gtkbuilder/assistant-csv-price-import.glade:139
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:127
@@ -10980,29 +10571,27 @@ msgstr ""
 #: gnucash/gtkbuilder/assistant-csv-price-import.glade:225
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:214
 msgid "Character-separated"
-msgstr ""
+msgstr "Merkillä erotettu"
 
 #: gnucash/gtkbuilder/assistant-csv-price-import.glade:242
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:231
 msgid "Fixed-Width"
-msgstr ""
+msgstr "Kiinteäleveyksinen"
 
 #: gnucash/gtkbuilder/assistant-csv-price-import.glade:284
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:273
 msgid "Space"
-msgstr ""
+msgstr "Tyhjä"
 
 #: gnucash/gtkbuilder/assistant-csv-price-import.glade:300
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:289
-#, fuzzy
-#| msgid "Tax"
 msgid "Tab"
-msgstr "Vero"
+msgstr "Sarkain"
 
 #: gnucash/gtkbuilder/assistant-csv-price-import.glade:365
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:354
 msgid "Hyphen (-)"
-msgstr ""
+msgstr "Viiva (-)"
 
 #: gnucash/gtkbuilder/assistant-csv-price-import.glade:461
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:451
@@ -11027,23 +10616,19 @@ msgstr ""
 #: gnucash/gtkbuilder/assistant-csv-price-import.glade:559
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:551
 msgid "<b>File Format</b>"
-msgstr ""
+msgstr "<b>Tiedostomuoto</b>"
 
 #: gnucash/gtkbuilder/assistant-csv-price-import.glade:589
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:587
 #: gnucash/gtkbuilder/dialog-preferences.glade:1046
 #: gnucash/gtkbuilder/gnc-date-format.glade:39
-#, fuzzy
-#| msgid "Fancy Date Format"
 msgid "Date Format"
-msgstr "Hieno päivämäärämuoto"
+msgstr "Päivämäärämuoto"
 
 #: gnucash/gtkbuilder/assistant-csv-price-import.glade:601
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:599
-#, fuzzy
-#| msgid "Fancy Date Format"
 msgid "Currency Format"
-msgstr "Hieno päivämäärämuoto"
+msgstr "Valuuttamuoto"
 
 #: gnucash/gtkbuilder/assistant-csv-price-import.glade:613
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:611
@@ -11079,14 +10664,12 @@ msgstr ""
 
 #: gnucash/gtkbuilder/assistant-csv-price-import.glade:781
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:784
-#, fuzzy
-#| msgid "Miscellaneous Payment"
 msgid "<b>Miscellaneous</b>"
-msgstr "Muu maksu"
+msgstr "<b>Sekalaista</b>"
 
 #: gnucash/gtkbuilder/assistant-csv-price-import.glade:841
 msgid "<b>Commodity From</b>"
-msgstr ""
+msgstr "<b>Hyödykkeen lähde</b>"
 
 #: gnucash/gtkbuilder/assistant-csv-price-import.glade:886
 #: gnucash/import-export/csv-imp/gnc-imp-props-price.cpp:56
@@ -11096,17 +10679,17 @@ msgstr ""
 #: gnucash/gtkbuilder/assistant-csv-price-import.glade:953
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:882
 msgid "Select the type of each column to import."
-msgstr ""
+msgstr "Valitse tuotavien sarakkeiden tyypit."
 
 #: gnucash/gtkbuilder/assistant-csv-price-import.glade:975
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:904
 msgid "Skip Errors"
-msgstr ""
+msgstr "Ohita virheet"
 
 #: gnucash/gtkbuilder/assistant-csv-price-import.glade:998
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:927
 msgid "Import Preview"
-msgstr ""
+msgstr "Tuonnin esikatselu"
 
 #: gnucash/gtkbuilder/assistant-csv-price-import.glade:1014
 msgid ""
@@ -11116,13 +10699,11 @@ msgstr ""
 
 #: gnucash/gtkbuilder/assistant-csv-price-import.glade:1029
 msgid "Import Prices Now"
-msgstr ""
+msgstr "Tuo hinnat nyt"
 
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:28
-#, fuzzy
-#| msgid "Transaction Number"
 msgid "CSV Transaction Import"
-msgstr "Tositenumero"
+msgstr "CSV-tositteiden tuonti"
 
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:44
 msgid ""
@@ -11157,14 +10738,12 @@ msgid ""
 msgstr ""
 
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:62
-#, fuzzy
-#| msgid "Transaction Document Links"
 msgid "Transaction Import Assistant"
-msgstr "Tositteen asiakirjalinkit"
+msgstr "Tositteiden tuonnin avustaja"
 
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:520
 msgid "Multi-split"
-msgstr ""
+msgstr "Monirivinen"
 
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:524
 msgid ""
@@ -11195,10 +10774,8 @@ msgid ""
 msgstr ""
 
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:815
-#, fuzzy
-#| msgid "Account"
 msgid "<b>Account</b>"
-msgstr "Tili"
+msgstr "<b>Tili</b>"
 
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:942
 msgid "Select a row to change the mappings"
@@ -11212,21 +10789,19 @@ msgstr ""
 
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:971
 #: gnucash/import-export/import-account-matcher.cpp:166
-#, fuzzy
-#| msgid "Account"
 msgid "Account ID"
-msgstr "Tili"
+msgstr "Tilin tunniste"
 
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:1010
 msgid "Error text."
-msgstr ""
+msgstr "Virheteksti."
 
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:1021
 #: gnucash/gtkbuilder/assistant-qif-import.glade:603
 #: gnucash/gtkbuilder/assistant-qif-import.glade:734
 #: gnucash/gtkbuilder/assistant-qif-import.glade:863
 msgid "Change GnuCash _Account…"
-msgstr ""
+msgstr "Muuta GnuCashin _tiliä…"
 
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:1044
 msgid "Match Import and GnuCash accounts"
@@ -11257,16 +10832,12 @@ msgid ""
 msgstr ""
 
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:1085
-#, fuzzy
-#| msgid "Transaction Document Links"
 msgid "Transaction Information"
-msgstr "Tositteen asiakirjalinkit"
+msgstr "Tositetiedot"
 
 #: gnucash/gtkbuilder/assistant-csv-trans-import.glade:1112
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Match Transactions"
-msgstr "Etsi tosite"
+msgstr "Yhdistä tositteet"
 
 #: gnucash/gtkbuilder/assistant-hierarchy.glade:21
 msgid ""
@@ -11282,14 +10853,24 @@ msgid ""
 "\n"
 "Click 'Cancel' if you do not wish to create any new accounts now."
 msgstr ""
+"Tämän avustajan avulla voit luoda tilikirjaan valmiin joukon tilejä "
+"vastaaville (kuten käyttö- ja säästötileille sekä sijoituksille), "
+"vastattaville (kuten velat) sekä erilaisille tulo- ja menotileille.\n"
+"\n"
+"Voit valita joukon tilejä jotka näyttävät olevan lähellä tarpeitasi. "
+"Myöhemmin voit lisätä, uudelleennimetä, muokata ja poistaa tilejä milloin "
+"vain. Voit myös siirtää tilejä (alatileineen) yhden tilin alta toisen tilin "
+"alle.\n"
+"\n"
+"Valitse 'Peruuta' jos et halua luoda uusia tilejä nyt."
 
 #: gnucash/gtkbuilder/assistant-hierarchy.glade:30
 msgid "New Account Hierarchy Setup"
-msgstr ""
+msgstr "Uuden tilihierarkian luonti"
 
 #: gnucash/gtkbuilder/assistant-hierarchy.glade:101
 msgid "Choose Currency"
-msgstr ""
+msgstr "Valitse valuutta"
 
 #: gnucash/gtkbuilder/assistant-hierarchy.glade:116
 msgid ""
@@ -11300,22 +10881,20 @@ msgstr ""
 
 #: gnucash/gtkbuilder/assistant-hierarchy.glade:162
 msgid "<b>Categories</b>"
-msgstr ""
+msgstr "<b>Kategoriat</b>"
 
 #: gnucash/gtkbuilder/assistant-hierarchy.glade:272
 msgid "C_lear All"
-msgstr ""
+msgstr "_Tyhjennä valinnat"
 
 #: gnucash/gtkbuilder/assistant-hierarchy.glade:310
 msgid "<b>Category Description</b>"
-msgstr ""
+msgstr "<b>Kategorian kuvaus</b>"
 
 #. %s is an account template
 #: gnucash/gtkbuilder/assistant-hierarchy.glade:376
-#, fuzzy
-#| msgid "Accounts in '%s'"
 msgid "Accounts in %s"
-msgstr "Tilit kategoriassa '%s'"
+msgstr "Tilit mallissa '%s'"
 
 #: gnucash/gtkbuilder/assistant-hierarchy.glade:470
 msgid ""
@@ -11329,6 +10908,8 @@ msgid ""
 "account hierarchy. Accounts can be added, renamed, moved, or deleted by hand "
 "later at any time."
 msgstr ""
+"Tässä tekemäsi valinta on vain pohja omalle tilihierarkiallesi. Tilejä voi "
+"luoda, uudelleennimetä, siirtää tai poistaa myöhemmin."
 
 #: gnucash/gtkbuilder/assistant-hierarchy.glade:500
 msgid "GnuCash Account Template Wiki"
@@ -11336,7 +10917,7 @@ msgstr ""
 
 #: gnucash/gtkbuilder/assistant-hierarchy.glade:515
 msgid "Choose accounts to create"
-msgstr ""
+msgstr "Valitse luotavat tilit"
 
 #: gnucash/gtkbuilder/assistant-hierarchy.glade:530
 msgid ""
@@ -11355,10 +10936,23 @@ msgid ""
 "<b>Note:</b> all accounts except Equity and placeholder accounts may have an "
 "opening balance."
 msgstr ""
+"Jos haluat muuttaa tilin nimeä, valitse kyseinen rivi, klikkaa tilin nimeä "
+"ja muuta se.\n"
+"\n"
+"Jotkin tileistä on merkitty \"koontitileiksi\". Koontitilejä käytetään "
+"luomaan kirjaan tarvittava tilihierarkia, mutta niillä ei itsellään ole "
+"yleensä tapahtumia tai avaussaldoa. Jos haluat määrittää jonkin tilin "
+"koontitiliksi, valitse valintalaatikko tilin riviltä.\n"
+"\n"
+"Jos haluat määrittää tilille avaususaldon, valitse ensin kyseinen rivi, "
+"klikkaa Avaussaldo-kenttää ja syötä saldo.\n"
+"\n"
+"<b>Huomaa:</b> Kaikilla paitsi koonti- ja oma pääoma -tileillä voi olla "
+"avaussaldo."
 
 #: gnucash/gtkbuilder/assistant-hierarchy.glade:563
 msgid "Setup selected accounts"
-msgstr ""
+msgstr "Määritä valitut tilit"
 
 #: gnucash/gtkbuilder/assistant-hierarchy.glade:573
 msgid ""
@@ -11369,83 +10963,85 @@ msgid ""
 "\n"
 "Press 'Cancel' to close this dialog without creating any new accounts."
 msgstr ""
+"Klikkaa Toteuta luodaksesi uudet tilit. Luonnin jälkeen voit tallentaa ne "
+"tiedostoon tai tietokantaan\n"
+"\n"
+"Klikkaa Takaisin muuttaaksesi valintojasi.\n"
+"\n"
+"Klikkaa Peruuta sulkeaksesi tämän ikkunan luomatta tilejä."
 
 #: gnucash/gtkbuilder/assistant-hierarchy.glade:582
-#, fuzzy
-#| msgid "Find Account"
 msgid "Finish Account Setup"
-msgstr "Etsi tili"
+msgstr "Vahvista tilien luonti"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:12
 #: gnucash/gtkbuilder/gnc-date-format.glade:170
 #: gnucash/report/reports/standard/price-scatter.scm:115
 msgid "Months"
-msgstr ""
+msgstr "Kuukautta"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:15
 #: gnucash/gtkbuilder/gnc-date-format.glade:182
 #: gnucash/report/reports/standard/price-scatter.scm:118
 msgid "Years"
-msgstr ""
+msgstr "Vuotta"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:26
 msgid "Current Year"
-msgstr ""
+msgstr "Kuluva vuosi"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:29
 msgid "Now + 1 Year"
-msgstr ""
+msgstr "Nyt + 1 vuosi"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:32
 msgid "Whole Loan"
-msgstr ""
+msgstr "Koko laina"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:46
 #: gnucash/gtkbuilder/assistant-loan.glade:152
-#, fuzzy
-#| msgid "Interest"
 msgid "Interest Rate"
-msgstr "Korko"
+msgstr "Korkoprosentti"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:49
 msgid "APR (Compounded Daily)"
-msgstr ""
+msgstr "Todellinen vuosikorko (kerrytetään päivittäin)"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:52
 msgid "APR (Compounded Weekly)"
-msgstr ""
+msgstr "Todellinen vuosikorko (kerrytetään viikottain)"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:55
 msgid "APR (Compounded Monthly)"
-msgstr ""
+msgstr "Todellinen vuosikorko (kerrytetään kuukausittain)"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:58
 msgid "APR (Compounded Quarterly)"
-msgstr ""
+msgstr "Todellinen vuosikorko (kerrytetään vuosineljänneksittäin)"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:61
 msgid "APR (Compounded Annually)"
-msgstr ""
+msgstr "Todellinen vuosikorko (kerrytetään vuosittain)"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:72
 msgid "Fixed Rate"
-msgstr ""
+msgstr "Kiinteäkorkoinen"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:75
 msgid "3/1 Year ARM"
-msgstr ""
+msgstr "3 vuoden jakso"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:78
 msgid "5/1 Year ARM"
-msgstr ""
+msgstr "5 vuoden jakso"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:81
 msgid "7/1 Year ARM"
-msgstr ""
+msgstr "7 vuoden jakso"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:84
 msgid "10/1 Year ARM"
-msgstr ""
+msgstr "10 vuoden jakso"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:104
 msgid ""
@@ -11457,15 +11053,21 @@ msgid ""
 "If you make a mistake or want to make changes later, you can edit the "
 "created Scheduled Transactions directly."
 msgstr ""
+"Tämä on vaiheittainen avustaja, jolla voit luoda GnuCashiin lainan "
+"takaisinmaksun suunnitelman. Avustaja kysyy lainan ja sen takaisinmaksun "
+"tiedot, ja luo sen perusteella tarvittavat tositteiden ajastukset.\n"
+"\n"
+"Jos teet virheen tai haluat tehdä muutoksia myöhemmin, voit muokata luotuja "
+"tositteiden ajastuksia suoraan."
 
 #: gnucash/gtkbuilder/assistant-loan.glade:111
 msgid "Loan / Mortgage Repayment Setup"
-msgstr ""
+msgstr "Lainan takaisunmaksun luonti"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:127
 msgid ""
 "Enter the Loan Details, as a minimum enter a valid Loan Account and Amount.\n"
-msgstr ""
+msgstr "Syötä lainan tiedot. Anna vähintään lainan tili ja summa.\n"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:165
 #: gnucash/gtkbuilder/assistant-loan.glade:1173
@@ -11491,147 +11093,134 @@ msgstr ""
 #: gnucash/report/reports/standard/txn-columns.scm:34
 #: gnucash/report/trep-engine.scm:103
 msgid "Start Date"
-msgstr ""
+msgstr "Alkupäivämäärä"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:178
 msgid "Length"
-msgstr ""
+msgstr "Pituus"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:204
-#, fuzzy
-#| msgid "Find Account"
 msgid "Loan Account"
-msgstr "Etsi tili"
+msgstr "Lainan tili"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:219
 msgid ""
 "Enter the number of months still to be paid off. This determines both the "
 "remaining principle and the duration of the scheduled transaction."
 msgstr ""
+"Syötä jäljellä olevien kuukausien määrä. Tämän mukaan lasketaan sekä "
+"jäljellä oleva lainapääoma sekä tositteiden ajastuksen kesto."
 
 #: gnucash/gtkbuilder/assistant-loan.glade:288
 msgid "Months Remaining"
-msgstr ""
+msgstr "Kuukausia jäljellä"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:340
 msgid ""
 "Enter the annual interest rate in percent. Accepts values from 0.001 - 100. "
 "The Mortgage Assistant does not support zero-interest loans."
 msgstr ""
+"Kirjoita vuotuinen korko prosentteina. Hyväksytään arvot 0,001-100. Laina-"
+"apuri ei tue nollakorkoisia lainoja."
 
 #: gnucash/gtkbuilder/assistant-loan.glade:359
 #: gnucash/register/ledger-core/gncEntryLedgerLoad.c:55
 #: gnucash/report/reports/standard/invoice.scm:107
 msgid "%"
-msgstr ""
+msgstr "%"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:390
 msgid "Interest Rate Change Frequency"
-msgstr ""
+msgstr "Koron muutostiheys"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:436
 msgid "Loan Details"
-msgstr ""
+msgstr "Lainan tiedot"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:451
 msgid "Do you utilize an escrow account, if so an account must be specified…"
-msgstr ""
+msgstr "Jos käytät sulkutiliä, tili täytyy määritellä…"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:470
 msgid "… utilize an escrow account for payments?"
-msgstr ""
+msgstr "… käytä sulkutiliä maksuille?"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:495
-#, fuzzy
-#| msgid "via Escrow account?"
 msgid "Escrow Account"
-msgstr "sulkutilin kautta?"
+msgstr "Sulkutili"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:531
-#, fuzzy
-#| msgid "Loan Repayment Option: \"%s\""
 msgid "Loan Repayment Options"
-msgstr "Lainanlyhennyksen valinta: \"%s\""
+msgstr "Lainan takaisinmaksun asetukst"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:544
 msgid "All accounts must have valid entries to continue."
-msgstr ""
+msgstr "Kaikilla tileillä on oltava kirjaukset, jotta voit jatkaa."
 
 #: gnucash/gtkbuilder/assistant-loan.glade:584
-#, fuzzy
-#| msgid "Principal"
 msgid "Principal To"
-msgstr "Pääoma"
+msgstr "Pääoma tilille"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:623
-#, fuzzy
-#| msgid "Interest"
 msgid "Interest To"
-msgstr "Korko"
+msgstr "Korko tilille"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:679
 msgid "Repayment Frequency"
-msgstr ""
+msgstr "Takaisinmaksun aikataulu"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:714
-#, fuzzy
-#| msgid "Loan Repayment Option: \"%s\""
 msgid "Loan Repayment"
-msgstr "Lainanlyhennyksen valinta: \"%s\""
+msgstr "Lainan takaisinmaksu"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:727
 msgid "All enabled option pages must contain valid entries to continue."
 msgstr ""
+"Kaikilla valituilla valintasivuilla on oltava kelvolliset merkinnät, jotta "
+"voit jatkaa."
 
 #: gnucash/gtkbuilder/assistant-loan.glade:798
 msgid "Payment To (Escrow)"
-msgstr ""
+msgstr "Maksa tilille (sulku)"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:811
 msgid "Payment From (Escrow)"
-msgstr ""
+msgstr "Maksu tililtä (sulku)"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:834
 msgid "Specify Source Account"
-msgstr ""
+msgstr "Määritä lähdetili"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:849
-#, fuzzy
-#| msgid "via Escrow account?"
 msgid "Use Escrow Account"
-msgstr "sulkutilin kautta?"
+msgstr "Käytä sulkutiliä"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:940
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Part of Payment Transaction"
-msgstr "Etsi tosite"
+msgstr "Osa maksutositetta"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:1006
 msgid "Payment Frequency"
-msgstr ""
+msgstr "Maksuväli"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:1032
 msgid "Previous Option"
-msgstr ""
+msgstr "Edellinen vaihtoehto"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:1046
-#, fuzzy
-#| msgid "New Book Options"
 msgid "Next Option"
-msgstr "Uuden kirjanpidon asetukset"
+msgstr "Seuraava vaihtoehto"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:1068
-#, fuzzy
-#| msgid "Tax Payment"
 msgid "Loan Payment"
-msgstr "Veronmaksu"
+msgstr "Lainanmaksu"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:1081
 msgid ""
 "Review the details below and if correct press \"Apply\"\" to create the "
 "schedule."
 msgstr ""
+"Tarkista allaolevat tiedot ja valitse \"Toteuta\" luodaksesi ajastuksen."
 
 #: gnucash/gtkbuilder/assistant-loan.glade:1108
 msgid "Range"
@@ -11657,28 +11246,24 @@ msgstr ""
 #: gnucash/report/reports/standard/price-scatter.scm:37
 #: gnucash/report/reports/standard/txn-columns.scm:35
 #: gnucash/report/trep-engine.scm:104
-#, fuzzy
-#| msgid "Date"
 msgid "End Date"
-msgstr "Päiväys"
+msgstr "Loppupäivämäärä"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:1244
 msgid "Loan Review"
-msgstr ""
+msgstr "Lainan yhteenveto"
 
 #: gnucash/gtkbuilder/assistant-loan.glade:1252
-#, fuzzy
-#| msgid "The book was closed successfully."
 msgid "Schedule added successfully."
-msgstr "Tilinpäätös tehtiin onnistuneesti."
+msgstr "Aikataulu lisätty onnistuneesti."
 
 #: gnucash/gtkbuilder/assistant-loan.glade:1258
 msgid "Loan Summary"
-msgstr ""
+msgstr "Lainan yhteenveto"
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:14
 msgid "QIF Import Assistant"
-msgstr ""
+msgstr "QIF-tuontiavustin"
 
 #. Run the assistant in your language to see GTK's translation of the button labels.
 #: gnucash/gtkbuilder/assistant-qif-import.glade:26
@@ -11696,7 +11281,7 @@ msgstr ""
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:35
 msgid "Import QIF files"
-msgstr ""
+msgstr "Tuo QIF-tiedostoja"
 
 #. Run the assistant in your language to see GTK's translation of the button labels.
 #: gnucash/gtkbuilder/assistant-qif-import.glade:50
@@ -11710,22 +11295,20 @@ msgid ""
 msgstr ""
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:86
-#, fuzzy
-#| msgid "Select…"
 msgid "_Select…"
-msgstr "Valitse…"
+msgstr "_Valitse…"
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:109
 msgid "Select a QIF file to load"
-msgstr ""
+msgstr "Valitse tuotava QIF-tiedosto"
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:185
 msgid "_Start"
-msgstr ""
+msgstr "_Aloita"
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:255
 msgid "Load QIF files"
-msgstr ""
+msgstr "Lataa QIF-tiedostot"
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:269
 msgid ""
@@ -11760,10 +11343,8 @@ msgid ""
 msgstr ""
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:352
-#, fuzzy
-#| msgid "Account"
 msgid "Account name"
-msgstr "Tili"
+msgstr "Tilin nimi"
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:401
 msgid "Set the default QIF account name"
@@ -11785,11 +11366,11 @@ msgstr ""
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:473
 msgid "_Load another file"
-msgstr ""
+msgstr "_Lataa toinen tiedosto"
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:495
 msgid "QIF files you have loaded"
-msgstr ""
+msgstr "Lataamasi QIF-tiedostot"
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:510
 msgid ""
@@ -11811,7 +11392,7 @@ msgstr ""
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:524
 msgid "Accounts and stock holdings"
-msgstr ""
+msgstr "Tilit ja osakeomistukset"
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:538
 #: gnucash/gtkbuilder/assistant-qif-import.glade:669
@@ -11846,7 +11427,7 @@ msgstr ""
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:655
 msgid "Income and Expense categories"
-msgstr ""
+msgstr "Tulo- ja menoluokat"
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:757
 msgid "Match QIF categories with GnuCash accounts"
@@ -11880,7 +11461,7 @@ msgstr ""
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:915
 msgid "_Select the currency to use for all imported transactions:"
-msgstr "_Valitse kaikissa tuoduissa tapahtumissa käytettävä valuutta:"
+msgstr ""
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:958
 msgid ""
@@ -11916,11 +11497,11 @@ msgstr ""
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:1008
 msgid "Enter Information about…"
-msgstr ""
+msgstr "Syötä tietoa…"
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:1034
 msgid "All fields must be complete to continue…"
-msgstr ""
+msgstr "Täytä kaikki kentät jatkaaksesi…"
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:1051
 msgid "Tradable commodities"
@@ -11928,18 +11509,18 @@ msgstr ""
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:1127
 msgid "_Start Import"
-msgstr ""
+msgstr "_Aloita tuonti"
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:1142
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:1859
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:3113
 msgid "P_ause"
-msgstr ""
+msgstr "_Keskeytä"
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:1197
 #: gnucash/gtkbuilder/dialog-account-picker.glade:22
 msgid "QIF Import"
-msgstr ""
+msgstr "QIF-tuonti"
 
 #. Run the assistant in your language to see GTK's translation of the button labels.
 #: gnucash/gtkbuilder/assistant-qif-import.glade:1211
@@ -11958,10 +11539,8 @@ msgid ""
 msgstr ""
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:1226
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Match existing transactions"
-msgstr "Etsi tosite"
+msgstr ""
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:1268
 msgid "_Imported transactions needing review"
@@ -11973,7 +11552,7 @@ msgstr ""
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:1327
 msgid "Select possible duplicates"
-msgstr ""
+msgstr "Valitse mahdolliset kaksoiskappaleet"
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:1335
 msgid ""
@@ -11995,18 +11574,16 @@ msgstr ""
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:1352
 msgid "Summary Text"
-msgstr ""
+msgstr "Yhteenvetoteksti"
 
 #: gnucash/gtkbuilder/assistant-qif-import.glade:1357
 msgid "Qif Import Summary"
-msgstr ""
+msgstr "QIF-tuonnin yhteenveto"
 
 #: gnucash/gtkbuilder/assistant-stock-split.glade:9
 #: gnucash/gtkbuilder/assistant-stock-split.glade:28
-#, fuzzy
-#| msgid "Stock split"
 msgid "Stock Split Assistant"
-msgstr "Osakkeen jako"
+msgstr "Osakejakoavustin"
 
 #: gnucash/gtkbuilder/assistant-stock-split.glade:22
 msgid "This assistant will help you record a stock split or stock merger.\n"
@@ -12018,10 +11595,8 @@ msgid ""
 msgstr ""
 
 #: gnucash/gtkbuilder/assistant-stock-split.glade:77
-#, fuzzy
-#| msgid "Stock split"
 msgid "Stock Split Account"
-msgstr "Osakkeen jako"
+msgstr "Osakkeenjakotili"
 
 #: gnucash/gtkbuilder/assistant-stock-split.glade:92
 msgid ""
@@ -12038,20 +11613,14 @@ msgstr ""
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:666
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:877
 #: gnucash/ui/gnc-plugin-page-invoice.ui:90
-#, fuzzy
-#| msgid "Date"
 msgid "_Date"
-msgstr "Päiväys"
+msgstr "_Päivämäärä"
 
 #: gnucash/gtkbuilder/assistant-stock-split.glade:143
-#, fuzzy
-#| msgid "Description"
 msgid "Desc_ription"
-msgstr "Selite"
+msgstr "_Selite"
 
 #: gnucash/gtkbuilder/assistant-stock-split.glade:158
-#, fuzzy
-#| msgid "Stock split"
 msgid "Stock Split"
 msgstr "Osakkeen jako"
 
@@ -12062,20 +11631,16 @@ msgid ""
 msgstr ""
 
 #: gnucash/gtkbuilder/assistant-stock-split.glade:197
-#, fuzzy
-#| msgid "Share Price"
 msgid "New _Price"
-msgstr "Osuuden arvo"
+msgstr "Uusi _Hinta"
 
 #: gnucash/gtkbuilder/assistant-stock-split.glade:211
 msgid "Currenc_y"
-msgstr ""
+msgstr "_Valuutta"
 
 #: gnucash/gtkbuilder/assistant-stock-split.glade:241
-#, fuzzy
-#| msgid "Stock split"
 msgid "Stock Split Details"
-msgstr "Osakkeen jako"
+msgstr "Osakejaon yksityiskohdat"
 
 #: gnucash/gtkbuilder/assistant-stock-split.glade:257
 msgid ""
@@ -12089,10 +11654,8 @@ msgstr ""
 #: gnucash/gtkbuilder/assistant-stock-transaction.glade:703
 #: gnucash/gtkbuilder/assistant-stock-transaction.glade:816
 #: gnucash/import-export/aqb/dialog-ab.glade:1201
-#, fuzzy
-#| msgid "Account"
 msgid "_Amount"
-msgstr "Tili"
+msgstr "_Määrä"
 
 #: gnucash/gtkbuilder/assistant-stock-split.glade:293
 #: gnucash/gtkbuilder/assistant-stock-transaction.glade:365
@@ -12103,28 +11666,26 @@ msgstr "Tili"
 #: gnucash/gtkbuilder/dialog-import.glade:958
 #: gnucash/gtkbuilder/dialog-print-check.glade:1129
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:972
-#, fuzzy
-#| msgid "Memo"
 msgid "_Memo"
-msgstr "Erittely"
+msgstr "_Erittely"
 
 #. Default memo text for the remains of a stock split
 #: gnucash/gtkbuilder/assistant-stock-split.glade:309
 msgid "Cash in lieu"
-msgstr ""
+msgstr "Käteisjäännös"
 
 #: gnucash/gtkbuilder/assistant-stock-split.glade:346
 msgid "<b>_Income Account</b>"
-msgstr ""
+msgstr "<b>_Tulotili</b>"
 
 #: gnucash/gtkbuilder/assistant-stock-split.glade:359
 msgid "<b>A_sset Account</b>"
-msgstr ""
+msgstr "<b>_Omaisuustili</b>"
 
 #. Dialog title for the remains of a stock split
 #: gnucash/gtkbuilder/assistant-stock-split.glade:403
 msgid "Cash In Lieu"
-msgstr ""
+msgstr "Käteisjäännös"
 
 #: gnucash/gtkbuilder/assistant-stock-split.glade:413
 msgid ""
@@ -12134,15 +11695,13 @@ msgid ""
 msgstr ""
 
 #: gnucash/gtkbuilder/assistant-stock-split.glade:418
-#, fuzzy
-#| msgid "Stock split"
 msgid "Stock Split Finish"
-msgstr "Osakkeen jako"
+msgstr "Osakejaon päättäminen"
 
 #: gnucash/gtkbuilder/assistant-stock-transaction.glade:9
 #: gnucash/gtkbuilder/assistant-stock-transaction.glade:27
 msgid "Stock Transaction Assistant"
-msgstr ""
+msgstr "Osaketapahtumien avustaja"
 
 #: gnucash/gtkbuilder/assistant-stock-transaction.glade:22
 msgid ""
@@ -12157,14 +11716,12 @@ msgstr ""
 
 #: gnucash/gtkbuilder/assistant-stock-transaction.glade:45
 msgid "Select the date and description for your records."
-msgstr ""
+msgstr "Valitse päiväys ja kuvaus tositteillesi."
 
 #: gnucash/gtkbuilder/assistant-stock-transaction.glade:109
 #: gnucash/gtkbuilder/dialog-payment.glade:662
-#, fuzzy
-#| msgid "Transaction Document Links"
 msgid "Transaction Details"
-msgstr "Tositteen asiakirjalinkit"
+msgstr "Maksun tiedot"
 
 #: gnucash/gtkbuilder/assistant-stock-transaction.glade:127
 msgid ""
@@ -12175,38 +11732,28 @@ msgid ""
 msgstr ""
 
 #: gnucash/gtkbuilder/assistant-stock-transaction.glade:195
-#, fuzzy
-#| msgid "Transaction Number"
 msgid "Transaction Type"
-msgstr "Tositenumero"
+msgstr "Tositetyyppi"
 
 #: gnucash/gtkbuilder/assistant-stock-transaction.glade:248
-#, fuzzy
-#| msgid "Opening Balance"
 msgid "Previous Balance"
-msgstr "Avaussaldo"
+msgstr "Edellinen saldo"
 
 #: gnucash/gtkbuilder/assistant-stock-transaction.glade:312
-#, fuzzy
-#| msgid "Stock split"
 msgid "Stock Amount"
-msgstr "Osakkeen jako"
+msgstr "Osakemäärä"
 
 #: gnucash/gtkbuilder/assistant-stock-transaction.glade:329
 msgid "Enter the value of the shares."
-msgstr ""
+msgstr "Syötä osakkeiden arvo."
 
 #: gnucash/gtkbuilder/assistant-stock-transaction.glade:404
-#, fuzzy
-#| msgid "Stock split"
 msgid "_Stock Value"
-msgstr "Osakkeen jako"
+msgstr "_Osakearvo"
 
 #: gnucash/gtkbuilder/assistant-stock-transaction.glade:425
-#, fuzzy
-#| msgid "Stock split"
 msgid "Stock Value"
-msgstr "Osakkeen jako"
+msgstr "Osakearvo"
 
 #: gnucash/gtkbuilder/assistant-stock-transaction.glade:442
 msgid ""
@@ -12221,17 +11768,12 @@ msgstr ""
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:530
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:1090
 #: gnucash/report/report-utilities.scm:198 libgnucash/engine/Account.cpp:4289
-#, fuzzy
-#| msgctxt "Stock Assistant: Page name"
-#| msgid "Cash"
 msgid "Cash"
 msgstr "Käteinen"
 
 #: gnucash/gtkbuilder/assistant-stock-transaction.glade:516
-#, fuzzy
-#| msgid "Account"
 msgid "Cash Account"
-msgstr "Tili"
+msgstr "Käteistili"
 
 #: gnucash/gtkbuilder/assistant-stock-transaction.glade:555
 msgid ""
@@ -12244,11 +11786,8 @@ msgstr ""
 
 #: gnucash/gtkbuilder/assistant-stock-transaction.glade:606
 #: gnucash/gtkbuilder/assistant-stock-transaction.glade:665
-#, fuzzy
-#| msgctxt "Stock Assistant: Page name"
-#| msgid "Fees"
 msgid "Fees"
-msgstr "Palkkiot"
+msgstr ""
 
 #: gnucash/gtkbuilder/assistant-stock-transaction.glade:629
 #: gnucash/report/reports/standard/advanced-portfolio.scm:1065
@@ -12264,10 +11803,8 @@ msgid "In this page, input any dividend income received in this transaction."
 msgstr ""
 
 #: gnucash/gtkbuilder/assistant-stock-transaction.glade:756
-#, fuzzy
-#| msgid "Find Account"
 msgid "Dividend Account"
-msgstr "Etsi tili"
+msgstr "Osinkotili"
 
 #: gnucash/gtkbuilder/assistant-stock-transaction.glade:795
 msgid ""
@@ -12276,23 +11813,14 @@ msgid ""
 msgstr ""
 
 #: gnucash/gtkbuilder/assistant-stock-transaction.glade:846
-#, fuzzy
-#| msgctxt "Stock Assistant: Page name"
-#| msgid "Capital Gains"
 msgid "Capital Gain"
-msgstr "Pääomatulot"
+msgstr "Pääomatulo"
 
 #: gnucash/gtkbuilder/assistant-stock-transaction.glade:869
-#, fuzzy
-#| msgctxt "Stock Assistant: Page name"
-#| msgid "Capital Gains"
 msgid "Capital Gains Account"
-msgstr "Pääomatulot"
+msgstr "Pääomatulotili"
 
 #: gnucash/gtkbuilder/assistant-stock-transaction.glade:891
-#, fuzzy
-#| msgctxt "Stock Assistant: Page name"
-#| msgid "Capital Gains"
 msgid "Capital Gains"
 msgstr "Pääomatulot"
 
@@ -12305,35 +11833,31 @@ msgstr ""
 
 #: gnucash/gtkbuilder/assistant-stock-transaction.glade:956
 msgid "Finish"
-msgstr ""
+msgstr "Vahvista"
 
 #: gnucash/gtkbuilder/assistant-xml-encoding.glade:16
 msgid "Introduction placeholder"
 msgstr ""
 
 #: gnucash/gtkbuilder/assistant-xml-encoding.glade:21
-#, fuzzy
-#| msgid "Placeholder"
 msgid "Title placeholder"
-msgstr "Koontitili"
+msgstr "Otsikon paikanpitäjä"
 
 #: gnucash/gtkbuilder/assistant-xml-encoding.glade:46
 msgid "_Edit list of encodings"
-msgstr ""
+msgstr "_Muokkaa koodauslistaa"
 
 #: gnucash/gtkbuilder/assistant-xml-encoding.glade:69
 msgid "Default encoding"
-msgstr ""
+msgstr "Oletus_fontti"
 
 #: gnucash/gtkbuilder/assistant-xml-encoding.glade:136
 msgid "Convert the file"
-msgstr ""
+msgstr "Muunna tiedosto"
 
 #: gnucash/gtkbuilder/assistant-xml-encoding.glade:145
-#, fuzzy
-#| msgid "Placeholder"
 msgid "finish placeholder"
-msgstr "Koontitili"
+msgstr ""
 
 #: gnucash/gtkbuilder/assistant-xml-encoding.glade:150
 msgid "Finish GnuCash Datafile Import"
@@ -12341,7 +11865,7 @@ msgstr ""
 
 #: gnucash/gtkbuilder/assistant-xml-encoding.glade:163
 msgid "Edit the list of encodings"
-msgstr ""
+msgstr "Muokkaa koodauslistaa"
 
 #: gnucash/gtkbuilder/assistant-xml-encoding.glade:239
 msgid "<b>S_ystem input encodings</b>"
@@ -12349,11 +11873,11 @@ msgstr ""
 
 #: gnucash/gtkbuilder/assistant-xml-encoding.glade:325
 msgid "<b>_Custom encoding</b>"
-msgstr ""
+msgstr "<b>_Mukautettu koodaus</b>"
 
 #: gnucash/gtkbuilder/assistant-xml-encoding.glade:408
 msgid "<b>_Selected encodings</b>"
-msgstr ""
+msgstr "<b>_Valitut koodaukset</b>"
 
 #: gnucash/gtkbuilder/business-prefs.glade:22
 #: gnucash/gtkbuilder/dialog-account-picker.glade:8
@@ -12397,25 +11921,27 @@ msgstr ""
 #: gnucash/report/stylesheets/plain.scm:45
 #: gnucash/report/stylesheets/plain.scm:49
 msgid "General"
-msgstr ""
+msgstr "Yleistä"
 
 #: gnucash/gtkbuilder/business-prefs.glade:48
 msgid "Enable extra _buttons"
-msgstr ""
+msgstr "Näytä palkissa lisää _painikkeita"
 
 #: gnucash/gtkbuilder/business-prefs.glade:66
 msgid "_Open in new window"
-msgstr ""
+msgstr "_Avaa uudessa ikkunassa"
 
 #: gnucash/gtkbuilder/business-prefs.glade:72
 msgid ""
 "If checked, each invoice will be opened in its own top level window. If "
 "clear, the invoice will be opened in the current window."
 msgstr ""
+"Jos valittu, kukin lasku avautuu omaan päätason ikkunaansa. Muussa "
+"tapauksessa lasku avautuu samaan ikkunnan."
 
 #: gnucash/gtkbuilder/business-prefs.glade:84
 msgid "_Accumulate splits on post"
-msgstr ""
+msgstr "K_errytä rivit yhteen"
 
 #: gnucash/gtkbuilder/business-prefs.glade:90
 msgid ""
@@ -12423,79 +11949,80 @@ msgid ""
 "should be accumulated into a single split by default. This setting can be "
 "changed in the Post dialog."
 msgstr ""
+"Kerrytetäänkö useat yhdessä myyntilaskussa olevat samalle tilille vietävät "
+"rivit yhdeksi riviksi. Tätä asetusta voi muuttaa laskun kirjausikkunassa."
 
 #: gnucash/gtkbuilder/business-prefs.glade:115
-#, fuzzy
-#| msgid "Invoice"
 msgid "<b>Invoices</b>"
-msgstr "Myyntilasku"
+msgstr "<b>Myyntilaskut</b>"
 
 #: gnucash/gtkbuilder/business-prefs.glade:125
 msgid "Not_ify when due"
-msgstr ""
+msgstr "_Ilmoita erääntymisestä"
 
 #: gnucash/gtkbuilder/business-prefs.glade:131
 #: gnucash/gtkbuilder/business-prefs.glade:208
 msgid "Whether to display the list of Bills Due at startup."
 msgstr ""
+"Näytetäänkö ohjelmaa käynnistettäessä muistutus erääntyvistä ostolaskuista."
 
 #: gnucash/gtkbuilder/business-prefs.glade:143
 msgid "_Tax included"
-msgstr ""
+msgstr "_Verot sisällytetty"
 
 #: gnucash/gtkbuilder/business-prefs.glade:149
 msgid ""
 "Whether tax is included by default in entries on Bills. This setting is "
 "inherited by new customers and vendors."
 msgstr ""
+"Sisältyykö ostolaskujen riveihin verot. Tämä asetus periytyy asiakkaille ja "
+"myyjille."
 
 #. See the tooltip "At post time…" for details.
 #: gnucash/gtkbuilder/business-prefs.glade:161
-#, fuzzy
-#| msgid "Process Payment"
 msgid "_Process payments on posting"
-msgstr "Käsittele maksu"
+msgstr "_Käsittele maksut laskun kirjauksen yhteydessä"
 
 #: gnucash/gtkbuilder/business-prefs.glade:192
 msgid "<b>Bills</b>"
-msgstr ""
+msgstr "<b>Ostolaskut</b>"
 
 #: gnucash/gtkbuilder/business-prefs.glade:202
 msgid "_Notify when due"
-msgstr ""
+msgstr "_Ilmoita erääntymisestä"
 
 #: gnucash/gtkbuilder/business-prefs.glade:220
 msgid "Ta_x included"
-msgstr ""
+msgstr "_Verot sisällytetty"
 
 #: gnucash/gtkbuilder/business-prefs.glade:226
 msgid ""
 "Whether tax is included by default in entries on Invoices. This setting is "
 "inherited by new customers and vendors."
 msgstr ""
+"Onko verot oletuksena sisällytetty myyntilaskujen tuotteisiin. Tämä asetus "
+"periytyy uusille asiakkaille ja myyjille."
 
 #. See the tooltip "At post time…" for details.
 #: gnucash/gtkbuilder/business-prefs.glade:238
-#, fuzzy
-#| msgid "Process Payment"
 msgid "Pro_cess payments on posting"
-msgstr "Käsittele maksu"
+msgstr "Käsi_ttele maksut laskun kirjauksen yhteydessä"
 
 #: gnucash/gtkbuilder/business-prefs.glade:258
 msgid "Days in ad_vance"
-msgstr ""
+msgstr "_Päivää etukäteen"
 
 #: gnucash/gtkbuilder/business-prefs.glade:273
 msgid "How many days in the future to warn about Bills coming due."
-msgstr ""
+msgstr "Kuinka monta päivää etukäteen ostolaskujen erääntymisestä varoitetaan."
 
 #: gnucash/gtkbuilder/business-prefs.glade:288
 msgid "How many days in the future to warn about Invoices coming due."
-msgstr ""
+msgstr "Kuinka monta päivää etukäteen ostolaskujen erääntymisestä varoitetaan."
 
 #: gnucash/gtkbuilder/business-prefs.glade:300
 msgid "_Days in advance"
-msgstr ""
+msgstr "_Päivää etukäteen"
 
 #: gnucash/gtkbuilder/dialog-account.glade:7
 msgid "Cascade Account Values"
@@ -12522,7 +12049,7 @@ msgstr ""
 #: gnucash/report/html-style-sheet.scm:259 gnucash/report/report-core.scm:317
 #: gnucash/report/stylesheets/plain.scm:218
 msgid "Default"
-msgstr ""
+msgstr "Oletus"
 
 #: gnucash/gtkbuilder/dialog-account.glade:222
 msgid ""
@@ -12531,118 +12058,113 @@ msgid ""
 msgstr ""
 
 #: gnucash/gtkbuilder/dialog-account.glade:233
-#, fuzzy
-#| msgid "existing account"
 msgid "Replace any existing account colors"
-msgstr "olemassa oleva tili"
+msgstr "Korvaa olemassa olevat tilivärit"
 
 #: gnucash/gtkbuilder/dialog-account.glade:362
-#, fuzzy
-#| msgid "All Accounts"
 msgid "Delete Account"
-msgstr "Kaikki tilit"
+msgstr "Poista tili"
 
 #: gnucash/gtkbuilder/dialog-account.glade:447
-#, fuzzy
-#| msgid "Su_b-accounts of '%s'"
 msgid "<b>Sub-accounts</b>"
-msgstr "Tilin \"%s\" _alitilit"
+msgstr "<b>Alatilit</b>"
 
 #: gnucash/gtkbuilder/dialog-account.glade:469
 msgid "This account has a sub-account. What would you like to do with it?"
-msgstr ""
+msgstr "Tällä tilillä on alatilejä. Mitä haluaisit tehdä niille?"
 
 #: gnucash/gtkbuilder/dialog-account.glade:480
 msgid "_Move to"
-msgstr ""
+msgstr "_Siirrä tilille"
 
 #: gnucash/gtkbuilder/dialog-account.glade:498
 msgid "Delete the _subaccount"
-msgstr ""
+msgstr "Poista _alatili"
 
 #: gnucash/gtkbuilder/dialog-account.glade:574
 #: gnucash/gtkbuilder/dialog-account.glade:693
 msgid "M_ove to"
-msgstr ""
+msgstr "_Siirrä tilille"
 
 #: gnucash/gtkbuilder/dialog-account.glade:590
 #: gnucash/gtkbuilder/dialog-account.glade:709
 msgid "Delete all _transactions"
-msgstr ""
+msgstr "Poista kaikki _tositteet"
 
 #: gnucash/gtkbuilder/dialog-account.glade:611
 msgid ""
 "This account contains transactions. What would you like to do with these "
 "transactions?"
-msgstr ""
+msgstr "Tällä tilillä on kirjauksia. Mitä haluat tehdä niille?"
 
 #: gnucash/gtkbuilder/dialog-account.glade:625
 msgid "This account contains read-only transactions which may not be deleted."
-msgstr ""
+msgstr "Tällä tilillä on kirjoitussuojattuja kirjauksia joita ei voi poistaa."
 
 #: gnucash/gtkbuilder/dialog-account.glade:674
 msgid "<b>Sub-account Transactions</b>"
-msgstr ""
+msgstr "<b>Alatilin tositteet</b>"
 
 #: gnucash/gtkbuilder/dialog-account.glade:730
 msgid ""
 "You've said to delete the subaccount and it contains transactions. What "
 "would you like to do with these transactions?"
 msgstr ""
+"Pyysit poistamaan alatilin, mutta se sisältää tositteita. Mitä niille "
+"tehdään?"
 
 #: gnucash/gtkbuilder/dialog-account.glade:744
 msgid ""
 "One or more sub-accounts contain read-only transactions which may not be "
 "deleted."
 msgstr ""
+"Yksi tai useampi alatili sisältää kirjoitussuojattuja tapahtumia joita ei "
+"voi poistaa."
 
 #: gnucash/gtkbuilder/dialog-account.glade:801
 #: gnucash/gtkbuilder/gnc-tree-view-owner.glade:8
 #: gnucash/report/trep-engine.scm:71
 msgid "Filter By…"
-msgstr ""
+msgstr "Suodata…"
 
 #: gnucash/gtkbuilder/dialog-account.glade:906
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:498
 #, fuzzy
-#| msgid "Selected"
 msgid "Clear _All"
-msgstr "Valittu"
+msgstr "_Tyhjennä valinnat"
 
 #: gnucash/gtkbuilder/dialog-account.glade:922
 msgid "_Default"
-msgstr ""
+msgstr "_Oletus"
 
 #: gnucash/gtkbuilder/dialog-account.glade:954
 #: gnucash/report/reports/standard/account-summary.scm:116
-#, fuzzy
-#| msgid "Account Types"
 msgid "Account Type"
-msgstr "Tilityypit"
+msgstr "Tilin tyyppi"
 
 #: gnucash/gtkbuilder/dialog-account.glade:968
 msgid "Show _hidden accounts"
-msgstr ""
+msgstr "Näytä _piilotetut tilit"
 
 #: gnucash/gtkbuilder/dialog-account.glade:986
 msgid "Show _unused accounts"
-msgstr ""
+msgstr "Näytä _käyttämättömät tilit"
 
 #: gnucash/gtkbuilder/dialog-account.glade:990
 msgid "Show accounts which do not have any transactions."
-msgstr ""
+msgstr "Näytä tilit joilla ei ole tositteita."
 
 #: gnucash/gtkbuilder/dialog-account.glade:1004
 msgid "Show _zero total accounts"
-msgstr ""
+msgstr "Näytä _nollasaldotilit"
 
 #: gnucash/gtkbuilder/dialog-account.glade:1008
 msgid "Show accounts which have a zero total value."
-msgstr ""
+msgstr "Näytä tilit joiden loppuarvo on nolla."
 
 #: gnucash/gtkbuilder/dialog-account.glade:1067
 msgid "Use Commodity Value"
-msgstr ""
+msgstr "Käytä hyödykkeen arvoa"
 
 #: gnucash/gtkbuilder/dialog-account.glade:1121
 #: gnucash/gtkbuilder/dialog-bi-import-gui.glade:23
@@ -12671,70 +12193,56 @@ msgstr ""
 #: gnucash/ui/gnc-main-window.ui:492 gnucash/ui/gnc-reconcile-window.ui:85
 #: gnucash/ui/gnc-reconcile-window.ui:88
 msgid "_Help"
-msgstr ""
+msgstr "O_hje"
 
 #: gnucash/gtkbuilder/dialog-account.glade:1194
 #: gnucash/gtkbuilder/dialog-customer.glade:206
 #: gnucash/gtkbuilder/dialog-employee.glade:190
 #: gnucash/gtkbuilder/dialog-vendor.glade:208
 msgid "Identification"
-msgstr ""
+msgstr "Tunniste"
 
 #: gnucash/gtkbuilder/dialog-account.glade:1217
-#, fuzzy
-#| msgid "Account"
 msgid "Account _name"
-msgstr "Tili"
+msgstr "Tilin _nimi"
 
 #: gnucash/gtkbuilder/dialog-account.glade:1232
-#, fuzzy
-#| msgid "Account"
 msgid "_Account code"
-msgstr "Tili"
+msgstr "Tilin_umero"
 
 #: gnucash/gtkbuilder/dialog-account.glade:1246
 #: gnucash/gtkbuilder/dialog-import.glade:930
-#, fuzzy
-#| msgid "Description"
 msgid "_Description"
-msgstr "Selite"
+msgstr "_Kuvaus"
 
 #: gnucash/gtkbuilder/dialog-account.glade:1286
 msgid "Smallest _fraction"
-msgstr ""
+msgstr "Pienin _osuus"
 
 #: gnucash/gtkbuilder/dialog-account.glade:1300
-#, fuzzy
-#| msgid "Account"
 msgid "Account _Color"
-msgstr "Tili"
+msgstr "Tilin _väri"
 
 #: gnucash/gtkbuilder/dialog-account.glade:1353
 msgid "No_tes"
-msgstr ""
+msgstr "_Huomautuksia"
 
 #: gnucash/gtkbuilder/dialog-account.glade:1425
 msgid "Smallest fraction of this commodity that can be referenced."
-msgstr ""
+msgstr "Hyödykkeen pienin mahdollinen käsiteltävissä oleva osuus."
 
 #: gnucash/gtkbuilder/dialog-account.glade:1451
 #: gnucash/gtkbuilder/dialog-tax-info.glade:632
-#, fuzzy
-#| msgid "Find Account"
 msgid "_Parent Account"
-msgstr "Etsi tili"
+msgstr "_Ylätili"
 
 #: gnucash/gtkbuilder/dialog-account.glade:1464
-#, fuzzy
-#| msgid "Account Types"
 msgid "Acco_unt Type"
-msgstr "Tilityypit"
+msgstr "Tilin _tyyppi"
 
 #: gnucash/gtkbuilder/dialog-account.glade:1514
-#, fuzzy
-#| msgid "Placeholder"
 msgid "Placeholde_r"
-msgstr "Koontitili"
+msgstr "_Paikanpitäjä"
 
 #: gnucash/gtkbuilder/dialog-account.glade:1518
 msgid ""
@@ -12742,16 +12250,16 @@ msgid ""
 "Transactions may not be posted to this account, only to sub-accounts of this "
 "account."
 msgstr ""
+"Tämä tili toimii ainoastaan paikanpitäjänä tilihierarkiassa. Tiliin ei voi "
+"merkitä tapahtumia, ainoastaan sen alatileihin."
 
 #: gnucash/gtkbuilder/dialog-account.glade:1530
 msgid "Auto _interest transfer"
 msgstr ""
 
 #: gnucash/gtkbuilder/dialog-account.glade:1546
-#, fuzzy
-#| msgid "Hidden"
 msgid "H_idden"
-msgstr "Piilotettu"
+msgstr "P_iilotettu"
 
 #: gnucash/gtkbuilder/dialog-account.glade:1550
 msgid ""
@@ -12761,10 +12269,12 @@ msgid ""
 "account tree and check the \"show hidden accounts\" option. Doing so will "
 "allow you to select the account and reopen this dialog."
 msgstr ""
+"Tämä tili ja sen alatilit piilotetaan tililistasta, eikä se esiinny tilien "
+"valinnan pudotusvalikoissa. Aiemmin piilotettujen tilien kohdalla pääset "
+"tähän valintaan käsiksi \"Suodata…\"-toiminnon kautta valitsemalla\"näytä "
+"piilotetut tilit\" valinnan."
 
 #: gnucash/gtkbuilder/dialog-account.glade:1562
-#, fuzzy
-#| msgid "Opening Balance"
 msgid "Opening balance"
 msgstr "Avaussaldo"
 
@@ -12775,10 +12285,8 @@ msgid ""
 msgstr ""
 
 #: gnucash/gtkbuilder/dialog-account.glade:1577
-#, fuzzy
-#| msgid "Tax related"
 msgid "Ta_x related"
-msgstr "Veroihin liittyvä"
+msgstr "_Veroihin liittyvä"
 
 #. Translators: use the same words here as in 'Ta_x Report Options'.
 #: gnucash/gtkbuilder/dialog-account.glade:1582
@@ -12789,7 +12297,7 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-account.glade:1636
 msgid "_Higher Balance Limit"
-msgstr ""
+msgstr "_Korkeampi saldoraja"
 
 #: gnucash/gtkbuilder/dialog-account.glade:1649
 msgid ""
@@ -12816,51 +12324,46 @@ msgid ""
 msgstr ""
 
 #: gnucash/gtkbuilder/dialog-account.glade:1692
-#, fuzzy
-#| msgid "Ne_w Balance"
 msgid "_Lower Balance Limit"
-msgstr "_Uusi saldo"
+msgstr "_Alempi saldoraja"
 
 #: gnucash/gtkbuilder/dialog-account.glade:1718
 msgid "_Include sub accounts"
-msgstr ""
+msgstr "_Sisällytä alatilit"
 
 #: gnucash/gtkbuilder/dialog-account.glade:1755
 msgid "More Properties"
-msgstr ""
+msgstr "Lisää ominaisuuksia"
 
 #: gnucash/gtkbuilder/dialog-account.glade:1781
 msgid "<b>Balance Information</b>"
-msgstr ""
+msgstr "<b>Saldotiedot</b>"
 
 #: gnucash/gtkbuilder/dialog-account.glade:1795
 msgid "<b>Initial Balance Transfer</b>"
-msgstr ""
+msgstr "<b>Avaussaldon siirto</b>"
 
 #: gnucash/gtkbuilder/dialog-account.glade:1837
 #, fuzzy
-#| msgid "Ne_w Balance"
 msgctxt "field label"
 msgid "_Balance"
-msgstr "_Uusi saldo"
+msgstr "_Tase"
 
 #: gnucash/gtkbuilder/dialog-account.glade:1862
 msgid "_Use equity 'Opening Balances' account"
-msgstr ""
+msgstr "_Käytä oman pääoman \"Avaussaldot\"-tiliä"
 
 #: gnucash/gtkbuilder/dialog-account.glade:1879
 msgid "_Select transfer account"
-msgstr ""
+msgstr "_Valitse tositteen tili"
 
 #: gnucash/gtkbuilder/dialog-account.glade:1987
 msgid "Renumber sub-accounts"
-msgstr ""
+msgstr "_Uudelleennumeroi alatilit"
 
 #: gnucash/gtkbuilder/dialog-account.glade:2020
-#, fuzzy
-#| msgid "Number"
 msgid "_Renumber"
-msgstr "Numero"
+msgstr "_Uudelleennumeroi"
 
 #: gnucash/gtkbuilder/dialog-account.glade:2053
 msgid "Prefix"
@@ -12868,18 +12371,16 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-account.glade:2093
 msgid "Examples"
-msgstr ""
+msgstr "Esimerkki"
 
 #: gnucash/gtkbuilder/dialog-account.glade:2105
 #: gnucash/report/reports/standard/balance-forecast.scm:43
-#, fuzzy
-#| msgid "Interest"
 msgid "Interval"
-msgstr "Korko"
+msgstr ""
 
 #: gnucash/gtkbuilder/dialog-account.glade:2190
 msgid "Number of Digits"
-msgstr ""
+msgstr "Numeroiden määrä"
 
 #: gnucash/gtkbuilder/dialog-account.glade:2204
 msgid ""
@@ -12889,103 +12390,98 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-account-picker.glade:34
 msgid "_Show documentation"
-msgstr ""
+msgstr "_Näytä ohjeet"
 
 #: gnucash/gtkbuilder/dialog-account-picker.glade:53
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:406
-#, fuzzy
-#| msgid "Reconcile"
 msgid "_Reconciled"
-msgstr "Tarkista"
+msgstr "_Täsmätty"
 
 #: gnucash/gtkbuilder/dialog-account-picker.glade:72
 msgid "_Cleared"
-msgstr ""
+msgstr "_Hyväksytty"
 
 #: gnucash/gtkbuilder/dialog-account-picker.glade:78
 msgid ""
 "When the status is not specified in a QIF file, the transactions are marked "
 "as cleared."
-msgstr ""
+msgstr "Kun QIF-tiedostossa ei ole määritelty muuta, aseta se hyväksytyksi."
 
 #: gnucash/gtkbuilder/dialog-account-picker.glade:91
-#, fuzzy
-#| msgid "Not Used"
 msgid "_Not cleared"
-msgstr "Ei käytetty"
+msgstr "_Ei hyväksytty"
 
 #: gnucash/gtkbuilder/dialog-account-picker.glade:97
 msgid ""
 "When the status is not specified in a QIF file, the transactions are marked "
 "as not cleared."
-msgstr ""
+msgstr "Kun QIF-tiedestossa ei ole määritelty muuta, aseta se ei-hyväksytyksi."
 
 #: gnucash/gtkbuilder/dialog-account-picker.glade:113
 msgid ""
 "Default transaction status (overridden by the status given by the QIF file)"
 msgstr ""
+"Tositteen oletustila (ylikirjoitetaan QIF-tiedostosta saatavalla tilalla)"
 
 #: gnucash/gtkbuilder/dialog-account-picker.glade:159
 #: gnucash/gtkbuilder/dialog-import.glade:12
-#, fuzzy
-#| msgid "Select document"
 msgid "Select Account"
-msgstr "Valitse asiakirja"
+msgstr "Valitse tili"
 
 #: gnucash/gtkbuilder/dialog-account-picker.glade:237
 msgid "_Select or add a GnuCash account:"
-msgstr ""
+msgstr "_Valitse tai lisää GnuCash-tili:"
 
 #: gnucash/gtkbuilder/dialog-bi-import-gui.glade:7
 msgid "Import transactions from text file"
-msgstr ""
+msgstr "Tuo tositteet tekstitiedostosta"
 
 #: gnucash/gtkbuilder/dialog-bi-import-gui.glade:123
 #: gnucash/gtkbuilder/dialog-customer-import-gui.glade:126
 msgid "1. Choose the file to import"
-msgstr ""
+msgstr "1. Valitse tuotava tiedosto"
 
 #: gnucash/gtkbuilder/dialog-bi-import-gui.glade:153
 msgid "Import bill CSV data"
-msgstr ""
+msgstr "Tuo ostolaskujen CSV-tiedot"
 
 #: gnucash/gtkbuilder/dialog-bi-import-gui.glade:173
 msgid "Import invoice CSV data"
-msgstr ""
+msgstr "Tuo myyntilaskujen CSV-tiedot"
 
 #: gnucash/gtkbuilder/dialog-bi-import-gui.glade:191
 msgid "2. Select import type"
-msgstr ""
+msgstr "2. Valitse tuonnin tyyppi"
 
 #: gnucash/gtkbuilder/dialog-bi-import-gui.glade:216
 #: gnucash/gtkbuilder/dialog-customer-import-gui.glade:217
 msgid "Semicolon separated"
-msgstr ""
+msgstr "Puolipisteellä erottu"
 
 #: gnucash/gtkbuilder/dialog-bi-import-gui.glade:234
 #: gnucash/gtkbuilder/dialog-customer-import-gui.glade:234
 msgid "Comma separated"
-msgstr ""
+msgstr "Pilkulla erotettu"
 
 #: gnucash/gtkbuilder/dialog-bi-import-gui.glade:252
 #: gnucash/gtkbuilder/dialog-customer-import-gui.glade:252
 msgid "Semicolon separated with quotes"
-msgstr ""
+msgstr "Lainatut tekstit puolipisteellä erotettuna"
 
 #: gnucash/gtkbuilder/dialog-bi-import-gui.glade:270
 #: gnucash/gtkbuilder/dialog-customer-import-gui.glade:270
 msgid "Comma separated with quotes"
-msgstr ""
+msgstr "Lainatut tekstit pilkulla erotettuna"
 
 #: gnucash/gtkbuilder/dialog-bi-import-gui.glade:310
 #: gnucash/gtkbuilder/dialog-customer-import-gui.glade:310
 msgid "3. Select import options"
-msgstr ""
+msgstr "3. Valitse tuonnin asetukset"
 
 #: gnucash/gtkbuilder/dialog-bi-import-gui.glade:349
 #: gnucash/gtkbuilder/dialog-customer-import-gui.glade:353
 msgid "4. Preview"
-msgstr ""
+msgstr "4. Esikatsele"
 
 #: gnucash/gtkbuilder/dialog-bi-import-gui.glade:374
 msgid "Open imported documents in tabs"
@@ -12993,7 +12489,7 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-bi-import-gui.glade:392
 msgid "Open not yet posted documents in tabs"
-msgstr ""
+msgstr "Avaa viemättä olevat asiakirjat tabeille"
 
 #: gnucash/gtkbuilder/dialog-bi-import-gui.glade:410
 msgid "Don't open imported documents in tabs"
@@ -13001,7 +12497,7 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-bi-import-gui.glade:432
 msgid "5. Afterwards"
-msgstr ""
+msgstr "5. Jälkikäteen"
 
 #: gnucash/gtkbuilder/dialog-billterms.glade:48
 #: gnucash/import-export/aqb/dialog-ab-pref.glade:8
@@ -13009,47 +12505,45 @@ msgid "window1"
 msgstr ""
 
 #: gnucash/gtkbuilder/dialog-billterms.glade:73
-#, fuzzy
-#| msgid "Days"
 msgid "Due Days"
-msgstr "Paivää"
+msgstr "Maksupäiviä"
 
 #: gnucash/gtkbuilder/dialog-billterms.glade:86
-#, fuzzy
-#| msgid "Account Types"
 msgid "Discount Days"
-msgstr "Tilityypit"
+msgstr "Alennuspäiviä"
 
 #: gnucash/gtkbuilder/dialog-billterms.glade:99
 #: gnucash/gtkbuilder/dialog-billterms.glade:238
 msgid "Discount %"
-msgstr ""
+msgstr "Alennus %"
 
 #: gnucash/gtkbuilder/dialog-billterms.glade:113
 msgid "The percentage discount applied for early payment."
-msgstr ""
+msgstr "Aikaisen maksun alennusprosentti."
 
 #: gnucash/gtkbuilder/dialog-billterms.glade:134
 msgid ""
 "The number of days after the post date during which a discount will be "
 "applied for early payment."
 msgstr ""
+"Kuinka monta päivää laskun luonnin jälkeen sille myönnetään alennusta "
+"aikaisesta maksusta."
 
 #: gnucash/gtkbuilder/dialog-billterms.glade:155
 msgid "The number of days to pay the bill after the post date."
-msgstr ""
+msgstr "Kuinka monta päivää laskulla on maksuaikaa."
 
 #: gnucash/gtkbuilder/dialog-billterms.glade:212
 msgid "Due Day"
-msgstr ""
+msgstr "Erääntymispäivämäärä"
 
 #: gnucash/gtkbuilder/dialog-billterms.glade:225
 msgid "Discount Day"
-msgstr ""
+msgstr "Alennuspäivämäärä"
 
 #: gnucash/gtkbuilder/dialog-billterms.glade:251
 msgid "Cutoff Day"
-msgstr ""
+msgstr "Rajapäivä"
 
 #: gnucash/gtkbuilder/dialog-billterms.glade:265
 msgid ""
@@ -13057,22 +12551,25 @@ msgid ""
 "are applied to the following month. Negative values count backwards from the "
 "end of the month."
 msgstr ""
+"Rajapäivä, jonka mukaan erääntymiiskuukausi määräytyy. Päivän jälkeen luodut "
+"laskut siirtyvät seuraavalle kuukaudelle. Negatiiviset arvot lasketaan "
+"kuukauden lopusta lähtien."
 
 #: gnucash/gtkbuilder/dialog-billterms.glade:287
 msgid "The discount percentage applied if paid early."
-msgstr ""
+msgstr "Aikaisen maksun alennusprosentti."
 
 #: gnucash/gtkbuilder/dialog-billterms.glade:309
 msgid "The last day of the month for the early payment discount."
-msgstr ""
+msgstr "Viimeinen päivä, jolloin myönnetään alennus aikaisesta maksusta."
 
 #: gnucash/gtkbuilder/dialog-billterms.glade:331
 msgid "The day of the month bills are due"
-msgstr ""
+msgstr "Päivä kuukaudesta, jolloin laskut erääntyvät"
 
 #: gnucash/gtkbuilder/dialog-billterms.glade:395
 msgid "Table"
-msgstr ""
+msgstr "Taulu"
 
 #: gnucash/gtkbuilder/dialog-billterms.glade:408
 #: gnucash/gtkbuilder/dialog-billterms.glade:433
@@ -13081,11 +12578,11 @@ msgstr ""
 #: gnucash/gtkbuilder/dialog-invoice.glade:1077
 #: gnucash/gtkbuilder/dialog-vendor.glade:515
 msgid "Terms"
-msgstr ""
+msgstr "Maksuehto"
 
 #: gnucash/gtkbuilder/dialog-billterms.glade:482
 msgid "Delete the current Billing Term"
-msgstr ""
+msgstr "Poista tämä laskutusehto"
 
 #: gnucash/gtkbuilder/dialog-billterms.glade:494
 #: gnucash/gtkbuilder/dialog-commodity.glade:650
@@ -13095,25 +12592,23 @@ msgstr ""
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:768
 #: gnucash/ui/gnc-plugin-page-sx-list.ui:153
 msgid "_New"
-msgstr ""
+msgstr "_Uusi"
 
 #: gnucash/gtkbuilder/dialog-billterms.glade:500
 msgid "Create a new Billing Term"
-msgstr ""
+msgstr "Luo uusi laskutusehto"
 
 #: gnucash/gtkbuilder/dialog-billterms.glade:546
 #: gnucash/gtkbuilder/dialog-billterms.glade:844
 #: gnucash/gtkbuilder/dialog-billterms.glade:1087
 msgid "<b>Term Definition</b>"
-msgstr ""
+msgstr "<b>Maksuehdon tiedot</b>"
 
 #: gnucash/gtkbuilder/dialog-billterms.glade:574
 #: gnucash/gtkbuilder/dialog-billterms.glade:909
 #: gnucash/gtkbuilder/dialog-billterms.glade:1135
-#, fuzzy
-#| msgid "Description"
 msgid "De_scription"
-msgstr "Selite"
+msgstr "_Kuvaus"
 
 #: gnucash/gtkbuilder/dialog-billterms.glade:589
 #: gnucash/gtkbuilder/dialog-billterms.glade:924
@@ -13121,13 +12616,13 @@ msgstr "Selite"
 #: gnucash/gtkbuilder/dialog-price.glade:210
 #: gnucash/gtkbuilder/dialog-tax-table.glade:476
 msgid "_Type"
-msgstr ""
+msgstr "_Tyyppi"
 
 #: gnucash/gtkbuilder/dialog-billterms.glade:604
 #: gnucash/gtkbuilder/dialog-billterms.glade:859
 #: gnucash/gtkbuilder/dialog-billterms.glade:1041
 msgid "The description of the Billing Term, printed on invoices"
-msgstr ""
+msgstr "Maksuehdon kuvaus, joka tulostetaan myös laskuihin"
 
 #: gnucash/gtkbuilder/dialog-billterms.glade:679
 #: gnucash/gtkbuilder/dialog-commodities.glade:156
@@ -13139,84 +12634,74 @@ msgstr ""
 #: gnucash/ui/gnc-main-window.ui:93 gnucash/ui/gnc-plugin-page-sx-list.ui:168
 #: gnucash/ui/gnc-reconcile-window.ui:63 gnucash/ui/gnc-reconcile-window.ui:102
 #: gnucash/ui/gnc-reconcile-window.ui:145
-#, fuzzy
-#| msgid "Edit…"
 msgid "_Edit"
-msgstr "Muokkaa…"
+msgstr "_Muokkaa"
 
 #: gnucash/gtkbuilder/dialog-billterms.glade:685
 msgid "Edit the current Billing Term"
-msgstr ""
+msgstr "Muokkaa tätä laskutusehtoa"
 
 #: gnucash/gtkbuilder/dialog-billterms.glade:738
 msgid "Close this window"
-msgstr ""
+msgstr "Sulje tämä ikkuna"
 
 #: gnucash/gtkbuilder/dialog-billterms.glade:797
 #: gnucash/gtkbuilder/dialog-billterms.glade:975
 msgid "Cancel your changes"
-msgstr ""
+msgstr "Peruuta muutoksesi"
 
 #: gnucash/gtkbuilder/dialog-billterms.glade:815
 #: gnucash/gtkbuilder/dialog-billterms.glade:993
 msgid "Commit this Billing Term"
-msgstr ""
+msgstr "Tallenna laskutusehdot"
 
 #: gnucash/gtkbuilder/dialog-billterms.glade:1023
 msgid "The internal name of the Billing Term."
-msgstr ""
+msgstr "Maksuehdon sisäinen nimi."
 
 #: gnucash/gtkbuilder/dialog-billterms.glade:1072
 msgid "<b>New Billing Term</b>"
-msgstr ""
+msgstr "<b>Uusi laskun maksuehto</b>"
 
 #: gnucash/gtkbuilder/dialog-billterms.glade:1120
 #: gnucash/gtkbuilder/dialog-report.glade:780
 #: gnucash/gtkbuilder/dialog-tax-table.glade:461
-#, fuzzy
-#| msgid "Name"
 msgid "_Name"
-msgstr "Nimi"
+msgstr "_Nimi"
 
 #: gnucash/gtkbuilder/dialog-book-close.glade:98
 msgid "Income Total"
-msgstr ""
+msgstr "Tulot yhteensä"
 
 #: gnucash/gtkbuilder/dialog-book-close.glade:110
-#, fuzzy
-#| msgid "Expense Vouchers"
 msgid "Expense Total"
-msgstr "Matkalaskut"
+msgstr "Kulut yhteensä"
 
 #: gnucash/gtkbuilder/dialog-choose-owner.glade:7
 msgid "Choose Owner Dialog"
-msgstr ""
+msgstr "Valitse omistaja -ikkuna"
 
 #: gnucash/gtkbuilder/dialog-commodities.glade:8
 #: gnucash/gtkbuilder/dialog-commodities.glade:27
 #: gnucash/report/reports/standard/account-piecharts.scm:62
 msgid "Securities"
-msgstr ""
+msgstr "Arvopaperit"
 
 #: gnucash/gtkbuilder/dialog-commodities.glade:77
 msgid "Show National Currencies"
-msgstr ""
+msgstr "Näytä valtioiden valuutat"
 
 #: gnucash/gtkbuilder/dialog-commodities.glade:126
 msgid "Add a new commodity."
-msgstr ""
+msgstr "Lisää uusi hyödyke."
 
 #: gnucash/gtkbuilder/dialog-commodities.glade:144
-#, fuzzy
-#| msgid "Last day of the current month."
 msgid "Remove the current commodity."
-msgstr "Tämän kuukauden viimeinen päivä."
+msgstr "Poista tämä hyödyke."
 
 #: gnucash/gtkbuilder/dialog-commodities.glade:162
-#, fuzzy
-#| msgid "First day of the current month."
 msgid "Edit the current commodity."
-msgstr "Tämän kuukauden ensimmäinen päivä."
+msgstr "Muokkaa tätä hyödykettä."
 
 #: gnucash/gtkbuilder/dialog-commodity.glade:120
 msgid ""
@@ -13230,6 +12715,10 @@ msgid ""
 "retrieving quotes online, this field must exactly match the ticker symbol "
 "used by the quote source (including case)."
 msgstr ""
+"Syötä arvopaperin kaupankäyntitunnus (esim. NOKIA tai TYRES). Jos haet "
+"kurssit verkosta, tämän kentän täytyy olla täsmälleen sama kuin "
+"tiedonlähteesi käyttämä kaupankäyntitunnus (mukaanlukien isot ja pienet "
+"kirjaimet)."
 
 #: gnucash/gtkbuilder/dialog-commodity.glade:156
 msgid ""
@@ -13242,10 +12731,12 @@ msgid ""
 "Enter the smallest fraction of the commodity which can be traded. For stocks "
 "which can only be traded in whole numbers, enter 1."
 msgstr ""
+"Syötä pienin osuus joka voidaan kerralla kaupata. Osakkeille, joita voidaan "
+"myydä vain yksittäin, syötä 1."
 
 #: gnucash/gtkbuilder/dialog-commodity.glade:215
 msgid "<b>Quote Source Information</b>"
-msgstr ""
+msgstr "<b>Kurssitietojen lähde</b>"
 
 #: gnucash/gtkbuilder/dialog-commodity.glade:296
 msgid ""
@@ -13262,21 +12753,19 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-commodity.glade:335
 msgid "Type of quote source"
-msgstr ""
+msgstr "Kurssien lähteen tyyppi"
 
 #: gnucash/gtkbuilder/dialog-commodity.glade:348
 msgid "_Display symbol"
-msgstr ""
+msgstr "_Näytettävä symboli"
 
 #: gnucash/gtkbuilder/dialog-commodity.glade:363
 msgid "Time_zone"
-msgstr ""
+msgstr "_Aikavyöhyke"
 
 #: gnucash/gtkbuilder/dialog-commodity.glade:374
-#, fuzzy
-#| msgid "Unknown"
 msgid "_Unknown"
-msgstr "Tuntematon"
+msgstr "_Ei tiedossa"
 
 #: gnucash/gtkbuilder/dialog-commodity.glade:380
 msgid ""
@@ -13284,10 +12773,12 @@ msgid ""
 "know if these sources retrieve information from a single site or from "
 "multiple sites on the internet."
 msgstr ""
+"Kurssien lähteet jotka on lisätty F::Q -moduuliin äskettäin. GnuCash ei "
+"tiedä noutaako lähteet tiedot yhdeltä vai useammalta sivulta internetistä."
 
 #: gnucash/gtkbuilder/dialog-commodity.glade:395
 msgid "_Multiple"
-msgstr ""
+msgstr "_Usea"
 
 #: gnucash/gtkbuilder/dialog-commodity.glade:401
 msgid ""
@@ -13295,10 +12786,13 @@ msgid ""
 "on the internet. If one of the sites is unavailable, F::Q will attempt to "
 "retrieve the information from another site."
 msgstr ""
+"Nämä ovat F::Q kurssien lähteitä, joiden perusteella kurssit noudetaan "
+"useammalta sivulta internetistä. Jos jotain näistä sivuista ei ole "
+"saatavilla, F::Q yrittää hakea tiedot toiselta sivulta."
 
 #: gnucash/gtkbuilder/dialog-commodity.glade:416
 msgid "Si_ngle"
-msgstr ""
+msgstr "_Yksittäinen"
 
 #: gnucash/gtkbuilder/dialog-commodity.glade:422
 msgid ""
@@ -13306,56 +12800,57 @@ msgid ""
 "the internet. If that site is unavailable, you will not be able to retrieve "
 "quotes."
 msgstr ""
+"Nämä ovat F::Q kurssien lähteitä, joiden perusteella kurssit noudetaan "
+"yksittäiseltä sivulta internetistä. Jos sivu ei ole saatavilla, uusia "
+"kursseja ei voi noutaa."
 
 #: gnucash/gtkbuilder/dialog-commodity.glade:437
 msgid "_Get Online Quotes"
-msgstr ""
+msgstr "_Hae kurssit verkosta"
 
 #: gnucash/gtkbuilder/dialog-commodity.glade:456
 msgid "F_raction traded"
-msgstr ""
+msgstr "Kaupattava _osuus"
 
 #. Again replace CUSIP by your National Securities Identifying Number.
 #: gnucash/gtkbuilder/dialog-commodity.glade:470
 msgid "ISIN, CUSI_P or other code"
-msgstr ""
+msgstr "ISIN, CUSI_P tai muu koodi"
 
 #: gnucash/gtkbuilder/dialog-commodity.glade:485
 #: gnucash/gtkbuilder/dialog-commodity.glade:767
 #: gnucash/gtkbuilder/dialog-price.glade:138
 msgid "Nam_espace"
-msgstr ""
+msgstr "Nimi_avaruus"
 
 #: gnucash/gtkbuilder/dialog-commodity.glade:500
 msgid "_Symbol/abbreviation"
-msgstr ""
+msgstr "_Symboli/lyhenne"
 
 #: gnucash/gtkbuilder/dialog-commodity.glade:515
 msgid "_Full name"
-msgstr ""
+msgstr "_Koko nimi"
 
 #: gnucash/gtkbuilder/dialog-commodity.glade:553
 msgid "Warning: Finance::Quote not installed properly."
-msgstr ""
+msgstr "Varoitus: Finance::Quote -moduuli ei ole asennettu oikein."
 
 #: gnucash/gtkbuilder/dialog-commodity.glade:713
 msgid "Select user information here…"
-msgstr ""
+msgstr "Valitse käyttäjätiedot täältä…"
 
 #: gnucash/gtkbuilder/dialog-customer.glade:187
 msgid ""
 "The customer ID number. If left blank a reasonable number will be chosen for "
 "you"
-msgstr ""
+msgstr "Asiakasnumero. Jos jätetään tyhjäksi, numero valitaan puolestasi"
 
 #: gnucash/gtkbuilder/dialog-customer.glade:250
 #: gnucash/gtkbuilder/dialog-customer.glade:757
 #: gnucash/gtkbuilder/dialog-employee.glade:234
 #: gnucash/gtkbuilder/dialog-vendor.glade:252
-#, fuzzy
-#| msgid "Address Found"
 msgid "Address"
-msgstr "Osoite löytyi"
+msgstr "Osoite"
 
 #: gnucash/gtkbuilder/dialog-customer.glade:289
 #: gnucash/gtkbuilder/dialog-customer.glade:796
@@ -13364,50 +12859,40 @@ msgstr "Osoite löytyi"
 #: gnucash/import-export/customer-import/dialog-customer-import-gui.c:132
 #: gnucash/report/reports/support/taxinvoice.eguile.scm:187
 msgid "Email"
-msgstr ""
+msgstr "Sähköposti"
 
 #: gnucash/gtkbuilder/dialog-customer.glade:414
-#, fuzzy
-#| msgid "Company Address"
 msgid "Billing Address"
-msgstr "Yrityksen osoite"
+msgstr "Laskutusosoite"
 
 #: gnucash/gtkbuilder/dialog-customer.glade:532
 #: gnucash/import-export/bi-import/dialog-bi-import-gui.c:152
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:72
 #: gnucash/report/reports/standard/invoice.scm:97
 #: gnucash/report/reports/standard/invoice.scm:430
-#, fuzzy
-#| msgid "Account"
 msgid "Discount"
-msgstr "Tili"
+msgstr "Alennus"
 
 #: gnucash/gtkbuilder/dialog-customer.glade:545
-#, fuzzy
-#| msgid "Credit"
 msgid "Credit Limit"
-msgstr "Kredit"
+msgstr "Luottoraja"
 
 #: gnucash/gtkbuilder/dialog-customer.glade:558
 #: gnucash/gtkbuilder/dialog-vendor.glade:528
-#, fuzzy
-#| msgid "Tax related"
 msgid "Tax Included"
-msgstr "Veroihin liittyvä"
+msgstr "Verot sisältyy"
 
 #: gnucash/gtkbuilder/dialog-customer.glade:648
 #: gnucash/gtkbuilder/dialog-tax-table.glade:399
 #: gnucash/gtkbuilder/dialog-vendor.glade:590
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:97
-#, fuzzy
-#| msgid "Tax Number"
 msgid "Tax Table"
-msgstr "Veronumero"
+msgstr "Verokanta"
 
 #: gnucash/gtkbuilder/dialog-customer.glade:652
 #: gnucash/gtkbuilder/dialog-vendor.glade:594
 msgid "Override the global Tax Table?"
-msgstr ""
+msgstr "Ylikirjoita globaali verokanta?"
 
 #: gnucash/gtkbuilder/dialog-customer.glade:688
 #: gnucash/gtkbuilder/dialog-customer.glade:710
@@ -13417,31 +12902,25 @@ msgstr ""
 #: gnucash/gtkbuilder/dialog-invoice.glade:1151
 #: gnucash/gtkbuilder/dialog-order.glade:312
 #: gnucash/gtkbuilder/dialog-order.glade:659
-#, fuzzy
-#| msgid "Billing Contact"
 msgid "Billing Information"
-msgstr "Laskutusyhteystiedot"
+msgstr "Laskutustiedot"
 
 #: gnucash/gtkbuilder/dialog-customer.glade:921
-#, fuzzy
-#| msgid "Shipping Contact"
 msgid "Shipping Information"
-msgstr "Toimitusyhteystiedot"
+msgstr "Lähetystiedot"
 
 #: gnucash/gtkbuilder/dialog-customer.glade:940
-#, fuzzy
-#| msgid "Company Address"
 msgid "Shipping Address"
-msgstr "Yrityksen osoite"
+msgstr "Lähetysosoite"
 
 #. Title of dialog
 #: gnucash/gtkbuilder/dialog-customer-import-gui.glade:9
 msgid "Import customers or vendors from text file"
-msgstr ""
+msgstr "Tuo asiakkaat tai toimittajat tekstitiedostosta"
 
 #: gnucash/gtkbuilder/dialog-customer-import-gui.glade:157
 msgid "For importing customer lists."
-msgstr ""
+msgstr "Asiakaslistausten tuontiin."
 
 #: gnucash/gtkbuilder/dialog-customer-import-gui.glade:174
 msgid "For importing vendor lists."
@@ -13449,17 +12928,15 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-customer-import-gui.glade:192
 msgid "<b>2. Select Import Type</b>"
-msgstr ""
+msgstr "<b>2. Valitse tuonnin tyyppi</b>"
 
 #: gnucash/gtkbuilder/dialog-custom-report.glade:52
-#, fuzzy
-#| msgid "Edit report configuration name"
 msgid "Exit the saved report configurations dialog"
-msgstr "Muokkaa raporttiasetusten nimeä"
+msgstr "Poisto tallennettujen raporttiasetusten valikosta"
 
 #: gnucash/gtkbuilder/dialog-custom-report.glade:100
 msgid "Currently you have no saved reports."
-msgstr ""
+msgstr "Sinulla ei ole tallennettuja raportteja."
 
 #: gnucash/gtkbuilder/dialog-custom-report.glade:112
 msgid ""
@@ -13472,14 +12949,12 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-date-close.glade:7
 #: gnucash/gtkbuilder/dialog-date-close.glade:260
-#, fuzzy
-#| msgid "Description"
 msgid "Question"
-msgstr "Selite"
+msgstr "Kysymys"
 
 #: gnucash/gtkbuilder/dialog-doclink.glade:49
 msgid "Change Linked Document path head"
-msgstr ""
+msgstr "Muuta yhdistettyjen asiakirjojen polun alkuosaa"
 
 #: gnucash/gtkbuilder/dialog-doclink.glade:85
 msgid ""
@@ -13499,60 +12974,56 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-doclink.glade:276
 msgid "Linked _File"
-msgstr ""
+msgstr "_Tiedosto"
 
 #: gnucash/gtkbuilder/dialog-doclink.glade:292
 msgid "Linked _Location"
-msgstr ""
+msgstr "_Sijainti"
 
 #: gnucash/gtkbuilder/dialog-doclink.glade:346
 #: gnucash/gtkbuilder/dialog-import.glade:729
 msgid "(none)"
-msgstr ""
+msgstr "(ei mikään)"
 
 #: gnucash/gtkbuilder/dialog-doclink.glade:409
 msgid "Enter an URL like \"https://www.gnucash.org\""
-msgstr ""
+msgstr "Syötä URL-osoite, esimerkiksi \"https://www.gnucash.org\""
 
 #: gnucash/gtkbuilder/dialog-doclink.glade:454
 msgid "Location does not start with a valid scheme"
-msgstr ""
+msgstr "Sijainti ei ala kelvollisella protokollalla"
 
 #: gnucash/gtkbuilder/dialog-doclink.glade:530
 msgid "Reload and Locate Linked Documents"
-msgstr ""
+msgstr "Lataa uudelleen ja paikanna yhdistetyt asiakirjat"
 
 #: gnucash/gtkbuilder/dialog-doclink.glade:544
 msgid "_Reload"
-msgstr ""
+msgstr "_Päivitä"
 
 #: gnucash/gtkbuilder/dialog-doclink.glade:558
 msgid "_Locate Linked Documents"
-msgstr ""
+msgstr "_Paikanna yhdistetyt asiakirjat"
 
 #: gnucash/gtkbuilder/dialog-doclink.glade:598
-#, fuzzy
-#| msgid "Business Document Links"
 msgid "All Linked Documents"
-msgstr "Yrityksen asiakirjalinkit"
+msgstr "Kaikki yhdistetyt asiakirjat"
 
 #: gnucash/gtkbuilder/dialog-doclink.glade:652
 msgid "Id"
-msgstr ""
+msgstr "Tunniste"
 
 #: gnucash/gtkbuilder/dialog-doclink.glade:680
-#, fuzzy
-#| msgid "Business Document Links"
 msgid "Linked Document"
-msgstr "Yrityksen asiakirjalinkit"
+msgstr "Yhdistetty asiakirja"
 
 #: gnucash/gtkbuilder/dialog-doclink.glade:697
 msgid "Available"
-msgstr ""
+msgstr "Saatavilla"
 
 #: gnucash/gtkbuilder/dialog-doclink.glade:712
 msgid "Relative"
-msgstr ""
+msgstr "Suhteellinen"
 
 #: gnucash/gtkbuilder/dialog-doclink.glade:756
 msgid ""
@@ -13571,86 +13042,82 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-employee.glade:416
 #: gnucash/gtkbuilder/dialog-vendor.glade:410
-#, fuzzy
-#| msgid "Company Address"
 msgid "Payment Address"
-msgstr "Yrityksen osoite"
+msgstr "Laskutusosoite"
 
 #: gnucash/gtkbuilder/dialog-employee.glade:450
 msgid "Language"
-msgstr ""
+msgstr "Kieli"
 
 #: gnucash/gtkbuilder/dialog-employee.glade:488
-#, fuzzy
-#| msgid "Interest"
 msgid "Interface"
-msgstr "Korko"
+msgstr "Käyttöliittymä"
 
 #: gnucash/gtkbuilder/dialog-employee.glade:579
 msgid "Default Hours per Day"
-msgstr ""
+msgstr "Oletustunnit per päivä"
 
 #: gnucash/gtkbuilder/dialog-employee.glade:592
 msgid "Default Rate"
-msgstr ""
+msgstr "Oletuskurssi"
 
 #: gnucash/gtkbuilder/dialog-employee.glade:700
 msgid "Access Control List"
-msgstr ""
+msgstr "Pääsynhallintalista"
 
 #: gnucash/gtkbuilder/dialog-employee.glade:719
 msgid "Access Control"
-msgstr ""
+msgstr "Pääsynhallinta"
 
 #: gnucash/gtkbuilder/dialog-file-access.glade:72
 msgid "<b>Data Format</b>"
-msgstr ""
+msgstr "<b>Tietomuoto</b>"
 
 #: gnucash/gtkbuilder/dialog-file-access.glade:140
 msgid "<b>File</b>"
-msgstr ""
+msgstr "<b>Tiedosto</b>"
 
 #: gnucash/gtkbuilder/dialog-file-access.glade:171
 msgid "Host"
-msgstr ""
+msgstr "Isäntä"
 
 #: gnucash/gtkbuilder/dialog-file-access.glade:184
 msgid "Database"
-msgstr ""
+msgstr "Tietokanta"
 
 #: gnucash/gtkbuilder/dialog-file-access.glade:210
 msgid "Password"
-msgstr ""
+msgstr "Salasana"
 
 #: gnucash/gtkbuilder/dialog-file-access.glade:281
 msgid "<b>Database Connection</b>"
-msgstr ""
+msgstr "<b>Tietokantayhteys</b>"
 
 #: gnucash/gtkbuilder/dialog-fincalc.glade:12
 #: gnucash/gtkbuilder/dialog-fincalc.glade:53
 msgid "Annual"
-msgstr ""
+msgstr "Vuosittain"
 
 #: gnucash/gtkbuilder/dialog-fincalc.glade:15
 #: gnucash/gtkbuilder/dialog-fincalc.glade:56
 msgid "Semi-annual"
-msgstr ""
+msgstr "Kahdesti vuodessa"
 
 #: gnucash/gtkbuilder/dialog-fincalc.glade:18
 #: gnucash/gtkbuilder/dialog-fincalc.glade:59
 msgid "Tri-annual"
-msgstr ""
+msgstr "Kolmesti vuodessa"
 
 #: gnucash/gtkbuilder/dialog-fincalc.glade:21
 #: gnucash/gtkbuilder/dialog-fincalc.glade:62
 #: gnucash/gtkbuilder/dialog-sx.glade:135 gnucash/report/trep-engine.scm:334
 msgid "Quarterly"
-msgstr ""
+msgstr "Neljännesvuosittain"
 
 #: gnucash/gtkbuilder/dialog-fincalc.glade:24
 #: gnucash/gtkbuilder/dialog-fincalc.glade:65
 msgid "Bi-monthly"
-msgstr ""
+msgstr "Joka toinen kuukausi"
 
 #: gnucash/gtkbuilder/dialog-fincalc.glade:27
 #: gnucash/gtkbuilder/dialog-fincalc.glade:68
@@ -13662,18 +13129,18 @@ msgstr ""
 #: gnucash/report/trep-engine.scm:326 libgnucash/engine/Recurrence.cpp:761
 #: libgnucash/engine/Recurrence.cpp:775
 msgid "Monthly"
-msgstr ""
+msgstr "Kuukausittain"
 
 #: gnucash/gtkbuilder/dialog-fincalc.glade:30
 #: gnucash/gtkbuilder/dialog-fincalc.glade:71
 #: libgnucash/engine/Recurrence.cpp:712
 msgid "Semi-monthly"
-msgstr ""
+msgstr "Kahdesti kuussa"
 
 #: gnucash/gtkbuilder/dialog-fincalc.glade:33
 #: gnucash/gtkbuilder/dialog-fincalc.glade:74
 msgid "Bi-weekly"
-msgstr ""
+msgstr "Joka toinen viikko"
 
 #: gnucash/gtkbuilder/dialog-fincalc.glade:36
 #: gnucash/gtkbuilder/dialog-fincalc.glade:77
@@ -13684,23 +13151,21 @@ msgstr ""
 #: gnucash/report/reports/standard/category-barchart.scm:121
 #: gnucash/report/trep-engine.scm:318 libgnucash/engine/Recurrence.cpp:622
 msgid "Weekly"
-msgstr ""
+msgstr "Viikoittain"
 
 #: gnucash/gtkbuilder/dialog-fincalc.glade:39
 #: gnucash/gtkbuilder/dialog-fincalc.glade:80
 msgid "Daily (360)"
-msgstr ""
+msgstr "Päivittäin (360)"
 
 #: gnucash/gtkbuilder/dialog-fincalc.glade:42
 #: gnucash/gtkbuilder/dialog-fincalc.glade:83
 msgid "Daily (365)"
-msgstr ""
+msgstr "Päivittäin (365)"
 
 #: gnucash/gtkbuilder/dialog-fincalc.glade:90
-#, fuzzy
-#| msgid "Loan Repayment Option: \"%s\""
 msgid "Loan Repayment Calculator"
-msgstr "Lainanlyhennyksen valinta: \"%s\""
+msgstr "Lainan takaisinmaksun laskin"
 
 #: gnucash/gtkbuilder/dialog-fincalc.glade:151
 msgid "_Schedule"
@@ -13708,33 +13173,27 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-fincalc.glade:186
 msgid "<b>Calculations</b>"
-msgstr ""
+msgstr "<b>Laskelma</b>"
 
 #: gnucash/gtkbuilder/dialog-fincalc.glade:207
-#, fuzzy
-#| msgid "Payment"
 msgid "Payment periods"
-msgstr "Maksu"
+msgstr "Lyhennysten määrä"
 
 #: gnucash/gtkbuilder/dialog-fincalc.glade:221
-#, fuzzy
-#| msgid "Interest"
 msgid "Interest rate"
-msgstr "Korko"
+msgstr "Korkoprosentti"
 
 #: gnucash/gtkbuilder/dialog-fincalc.glade:234
 msgid "Present value"
-msgstr ""
+msgstr "Nykyinen summa"
 
 #: gnucash/gtkbuilder/dialog-fincalc.glade:247
-#, fuzzy
-#| msgid "Process Payment"
 msgid "Periodic payment"
-msgstr "Käsittele maksu"
+msgstr "Lyhennys"
 
 #: gnucash/gtkbuilder/dialog-fincalc.glade:260
 msgid "Future value"
-msgstr ""
+msgstr "Tuleva summa"
 
 #: gnucash/gtkbuilder/dialog-fincalc.glade:274
 #: gnucash/gtkbuilder/dialog-fincalc.glade:289
@@ -13742,41 +13201,39 @@ msgstr ""
 #: gnucash/gtkbuilder/dialog-fincalc.glade:319
 #: gnucash/gtkbuilder/dialog-fincalc.glade:334
 msgid "Clear the entry."
-msgstr ""
+msgstr "Tyhjennä tietue."
 
 #: gnucash/gtkbuilder/dialog-fincalc.glade:348
 msgid "Precision"
-msgstr ""
+msgstr "Tarkkuus"
 
 #: gnucash/gtkbuilder/dialog-fincalc.glade:379
 msgid "Calculate"
-msgstr ""
+msgstr "Laske"
 
 #: gnucash/gtkbuilder/dialog-fincalc.glade:385
 msgid "Recalculate the (single) blank entry in the above fields."
-msgstr ""
+msgstr "Laske yllä olevaan (yksittäisen) tyhjän kentän arvo."
 
 #: gnucash/gtkbuilder/dialog-fincalc.glade:514
 msgid "<b>Payment Options</b>"
-msgstr ""
+msgstr "<b>Maksun tiedot</b>"
 
 #: gnucash/gtkbuilder/dialog-fincalc.glade:535
-#, fuzzy
-#| msgid "Payment"
 msgid "Payment Total"
-msgstr "Maksu"
+msgstr "Takaisinmaksettava yhteensä"
 
 #: gnucash/gtkbuilder/dialog-fincalc.glade:565
 msgid "Discrete"
-msgstr ""
+msgstr "Diskreetti"
 
 #: gnucash/gtkbuilder/dialog-fincalc.glade:582
 msgid "Continuous"
-msgstr ""
+msgstr "Jatkuva"
 
 #: gnucash/gtkbuilder/dialog-fincalc.glade:598
 msgid "Beginning"
-msgstr ""
+msgstr "Alussa"
 
 #: gnucash/gtkbuilder/dialog-fincalc.glade:634
 msgid "<b>Compounding</b>"
@@ -13784,36 +13241,32 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-fincalc.glade:780
 msgid "When paid"
-msgstr ""
+msgstr "Maksetaan"
 
 #: gnucash/gtkbuilder/dialog-find-account.glade:25
 #: gnucash/gtkbuilder/dialog-find-account.glade:96
 msgid "Search the Account List"
-msgstr ""
+msgstr "Hae tililistasta"
 
 #: gnucash/gtkbuilder/dialog-find-account.glade:38
 msgid "Close _on Jump"
-msgstr ""
+msgstr "Sulje _siirryttäessä"
 
 #: gnucash/gtkbuilder/dialog-find-account.glade:55
 msgid "_Jump To"
-msgstr ""
+msgstr "_Siirry tilille"
 
 #: gnucash/gtkbuilder/dialog-find-account.glade:127
-#, fuzzy
-#| msgid "All Accounts"
 msgid "All _accounts"
-msgstr "Kaikki tilit"
+msgstr "_Kaikki tilit"
 
 #: gnucash/gtkbuilder/dialog-find-account.glade:165
 msgid "Search scope"
-msgstr ""
+msgstr "Haun laajuus"
 
 #: gnucash/gtkbuilder/dialog-find-account.glade:191
-#, fuzzy
-#| msgid "Account Types"
 msgid "Account Full Name"
-msgstr "Tilityypit"
+msgstr "Tilin koko nimi"
 
 #: gnucash/gtkbuilder/dialog-find-account.glade:215
 msgid "Case insensitive searching is available on 'Account Full Name'."
@@ -13821,7 +13274,7 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-find-account.glade:258
 msgid "Sea_rch"
-msgstr ""
+msgstr "_Hae"
 
 #: gnucash/gtkbuilder/dialog-find-account.glade:294
 msgid ""
@@ -13832,19 +13285,19 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-imap-editor.glade:35
 msgid "Import Map Editor"
-msgstr ""
+msgstr "Kartantuontimuokkain"
 
 #: gnucash/gtkbuilder/dialog-imap-editor.glade:52
 msgid "_Remove Invalid Mappings"
-msgstr ""
+msgstr "_Poista virheelliset liitännät"
 
 #: gnucash/gtkbuilder/dialog-imap-editor.glade:106
 msgid "<b>What type of information to display?</b>"
-msgstr ""
+msgstr "<b>Minkä tyyppistä tietoa näytetään?</b>"
 
 #: gnucash/gtkbuilder/dialog-imap-editor.glade:139
 msgid "Non-Bayesian"
-msgstr ""
+msgstr "Ei-Bayesialainen"
 
 #: gnucash/gtkbuilder/dialog-imap-editor.glade:156
 #: gnucash/register/ledger-core/split-register.c:2574
@@ -13853,10 +13306,8 @@ msgid "Online"
 msgstr ""
 
 #: gnucash/gtkbuilder/dialog-imap-editor.glade:193
-#, fuzzy
-#| msgid "CSV Account Map"
 msgid "Source Account Name"
-msgstr "CSV-tilikartta"
+msgstr "Lähdetilin nimi"
 
 #: gnucash/gtkbuilder/dialog-imap-editor.glade:205
 msgid "Based On"
@@ -13867,10 +13318,8 @@ msgid "Match String"
 msgstr ""
 
 #: gnucash/gtkbuilder/dialog-imap-editor.glade:233
-#, fuzzy
-#| msgid "Map Account NOT found"
 msgid "Mapped to Account Name"
-msgstr "Karttatiliä EI löytynyt"
+msgstr "Liitetty tiliin"
 
 #: gnucash/gtkbuilder/dialog-imap-editor.glade:247
 msgid "Count of Match String Usage"
@@ -13884,15 +13333,15 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-imap-editor.glade:335
 msgid "_Filter"
-msgstr ""
+msgstr "_Suodata"
 
 #: gnucash/gtkbuilder/dialog-imap-editor.glade:349
 msgid "_Expand All"
-msgstr ""
+msgstr "_Laajenna kaikki"
 
 #: gnucash/gtkbuilder/dialog-imap-editor.glade:363
 msgid "Collapse _All"
-msgstr ""
+msgstr "_Supista kaikki"
 
 #: gnucash/gtkbuilder/dialog-imap-editor.glade:399
 msgid ""
@@ -13903,10 +13352,8 @@ msgstr ""
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:110
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:266
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:412
-#, fuzzy
-#| msgid "Account"
 msgid "New _Account…"
-msgstr "Tili"
+msgstr "_Uusi tili…"
 
 #: gnucash/gtkbuilder/dialog-import.glade:86
 msgid "Please select or create an appropriate GnuCash account for:"
@@ -13914,7 +13361,7 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-import.glade:99
 msgid "Online account ID here…"
-msgstr ""
+msgstr "Verkkopankin tilin nimi…"
 
 #: gnucash/gtkbuilder/dialog-import.glade:170
 #: gnucash/gtkbuilder/dialog-import.glade:278
@@ -13933,15 +13380,13 @@ msgstr ""
 
 #. Dialog Select matching transactions
 #: gnucash/gtkbuilder/dialog-import.glade:313
-#, fuzzy
-#| msgid "Reconcile"
 msgid "Show Reconciled"
-msgstr "Tarkista"
+msgstr "Näytä täsmätyt"
 
 #. Dialog Select matching transactions
 #: gnucash/gtkbuilder/dialog-import.glade:374
 msgid "Imported transaction's first split"
-msgstr ""
+msgstr "Tositteen ensimmäinen rivi"
 
 #. Dialog Select matching transactions
 #: gnucash/gtkbuilder/dialog-import.glade:408
@@ -13979,10 +13424,8 @@ msgid ""
 msgstr ""
 
 #: gnucash/gtkbuilder/dialog-import.glade:470
-#, fuzzy
-#| msgid "Transaction Number"
 msgid "Transaction List Help"
-msgstr "Tositenumero"
+msgstr "Tositelistan ohje"
 
 #: gnucash/gtkbuilder/dialog-import.glade:521
 #: gnucash/report/stylesheets/footer.scm:103
@@ -14003,14 +13446,12 @@ msgstr "Tositenumero"
 #: gnucash/report/stylesheets/head-or-tail.scm:180
 #: gnucash/report/stylesheets/plain.scm:53
 msgid "Colors"
-msgstr ""
+msgstr "Värit"
 
 #: gnucash/gtkbuilder/dialog-import.glade:636
 #: gnucash/gtkbuilder/dialog-preferences.glade:2504
-#, fuzzy
-#| msgid "Action"
 msgid "<b>Actions</b>"
-msgstr "Tapahtuma"
+msgstr "<b>Toiminnot</b>"
 
 #: gnucash/gtkbuilder/dialog-import.glade:648
 msgid "\"A\""
@@ -14018,15 +13459,15 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-import.glade:659
 msgid "\"U+C\""
-msgstr ""
+msgstr "\"P+H\""
 
 #: gnucash/gtkbuilder/dialog-import.glade:670
 msgid "\"C\""
-msgstr ""
+msgstr "\"H\""
 
 #: gnucash/gtkbuilder/dialog-import.glade:682
 msgid "Select \"A\" to add the transaction as new."
-msgstr ""
+msgstr "Valitse A lisätäksesi tositteen uutena."
 
 #: gnucash/gtkbuilder/dialog-import.glade:694
 msgid ""
@@ -14043,30 +13484,26 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-import.glade:776
 msgid "Red"
-msgstr ""
+msgstr "Punainen"
 
 #: gnucash/gtkbuilder/dialog-import.glade:793
 msgid "Yellow"
-msgstr ""
+msgstr "Keltainen"
 
 #: gnucash/gtkbuilder/dialog-import.glade:810
-#, fuzzy
-#| msgid "Greek"
 msgid "Green"
-msgstr "kreikkalainen"
+msgstr "Vihreä"
 
 #: gnucash/gtkbuilder/dialog-import.glade:871
 msgid "Edit imported transaction details"
-msgstr ""
+msgstr "Muokkaa tuodun tositteen yksityiskohtia"
 
 #: gnucash/gtkbuilder/dialog-import.glade:944
 #: gnucash/gtkbuilder/dialog-lot-viewer.glade:151
 #: gnucash/gtkbuilder/dialog-print-check.glade:745
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:1029
-#, fuzzy
-#| msgid "Notes"
 msgid "_Notes"
-msgstr "Huomautukset"
+msgstr "_Huomautukset"
 
 #: gnucash/gtkbuilder/dialog-import.glade:1058
 msgid ""
@@ -14075,19 +13512,19 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-import.glade:1100
 msgid "Show _Account column"
-msgstr ""
+msgstr "Näytä _tilisarake"
 
 #: gnucash/gtkbuilder/dialog-import.glade:1116
 msgid "Show _Memo column"
-msgstr ""
+msgstr "Näytä _muistiinpanosarake"
 
 #: gnucash/gtkbuilder/dialog-import.glade:1132
 msgid "Show matched _information"
-msgstr ""
+msgstr "Näytä _sopivat tiedot"
 
 #: gnucash/gtkbuilder/dialog-import.glade:1147
 msgid "A_ppend"
-msgstr ""
+msgstr "_Liitä vanhoihin"
 
 #: gnucash/gtkbuilder/dialog-import.glade:1151
 msgid ""
@@ -14097,107 +13534,101 @@ msgid ""
 msgstr ""
 
 #: gnucash/gtkbuilder/dialog-import.glade:1163
-#, fuzzy
-#| msgid "Reconciled Date"
 msgid "_Reconcile after match"
-msgstr "Tarkistuspäivämäärä"
+msgstr "_Täsmäytä sopivan löytymisen jälkeen"
 
 #: gnucash/gtkbuilder/dialog-import.glade:1186
 msgid "Generic import transaction matcher"
 msgstr ""
 
 #: gnucash/gtkbuilder/dialog-invoice.glade:120
-#, fuzzy
-#| msgid "Find Account"
 msgid "Posted Account"
-msgstr "Etsi tili"
+msgstr "Vientitili"
 
 #: gnucash/gtkbuilder/dialog-invoice.glade:224
 #: gnucash/gtkbuilder/dialog-invoice.glade:1009
 msgid "Invoice Information"
-msgstr ""
+msgstr "Myyntilaskun tiedot"
 
 #: gnucash/gtkbuilder/dialog-invoice.glade:252
 msgid "(owner)"
-msgstr ""
+msgstr "(omistaja)"
 
 #: gnucash/gtkbuilder/dialog-invoice.glade:412
-#, fuzzy
-#| msgid "Manage Document Link"
 msgid "Open Document Link"
-msgstr "Vaihda yhdistettyä asiakirjaa"
+msgstr "Avaa asiakirjalinkki"
 
 #: gnucash/gtkbuilder/dialog-invoice.glade:529
 #: gnucash/gtkbuilder/dialog-invoice.glade:1234
 msgid "Default Chargeback Project"
-msgstr ""
+msgstr "Oletusprojekti hyvitystä varten"
 
 #: gnucash/gtkbuilder/dialog-invoice.glade:556
 msgid "Additional to Card"
 msgstr ""
 
 #: gnucash/gtkbuilder/dialog-invoice.glade:585
-#, fuzzy
-#| msgid "Tax Payment"
 msgid "Extra Payments"
-msgstr "Veronmaksu"
+msgstr "Ylimääräiset maksut"
 
 #: gnucash/gtkbuilder/dialog-invoice.glade:625
 msgid "Report template"
-msgstr ""
+msgstr "Raportin malli"
 
 #: gnucash/gtkbuilder/dialog-invoice.glade:687
 msgid "Use template report"
-msgstr ""
+msgstr "Käytä malliraporttia"
 
 #: gnucash/gtkbuilder/dialog-invoice.glade:715
 msgid "Choose a different report template before timeout"
-msgstr ""
+msgstr "Valitse toinen raporttimalli ennen kuin aikaraja ylittyy"
 
 #: gnucash/gtkbuilder/dialog-invoice.glade:907
 msgid ""
 "The invoice ID number. If left blank a reasonable number will be chosen for "
 "you."
-msgstr ""
+msgstr "Laskun ID. Jos jätetään tyhjäksi sopiva arvo valitaan puolestasi."
 
 #: gnucash/gtkbuilder/dialog-invoice.glade:1381
 msgid ""
 "Unposting this Invoice will delete the posted transaction.\n"
 "Are you sure you want to unpost it?"
 msgstr ""
+"Laskun viennin peruminen poistaa vastaavan tositteen.\n"
+"Oletko varma että haluat perua viennin?"
 
 #: gnucash/gtkbuilder/dialog-invoice.glade:1410
 msgid "Yes, reset the Tax Tables"
-msgstr ""
+msgstr "Kyllä, palauta verokannat"
 
 #: gnucash/gtkbuilder/dialog-invoice.glade:1427
 msgid "No, keep them as they are"
-msgstr ""
+msgstr "Ei, pidä ne ennallaan"
 
 #: gnucash/gtkbuilder/dialog-invoice.glade:1450
 msgid "Reset Tax Tables to present Values?"
-msgstr ""
+msgstr "Palauta verokannat nykyisiin arvoihin?"
 
 #: gnucash/gtkbuilder/dialog-job.glade:7
 msgid "Job Dialog"
-msgstr ""
+msgstr "Hankeikkuna"
 
 #: gnucash/gtkbuilder/dialog-job.glade:130
 msgid ""
 "The job ID number. If left blank a reasonable number will be chosen for you"
-msgstr ""
+msgstr "Hankkeen ID-numero. Jos jätetään tyhjäksi, numero valitaan puolestasi"
 
 #: gnucash/gtkbuilder/dialog-job.glade:164
 msgid "Job Information"
-msgstr ""
+msgstr "Hankkeen tiedot"
 
 #: gnucash/gtkbuilder/dialog-job.glade:273
 msgid "Owner Information"
-msgstr ""
+msgstr "Omistajan tiedot"
 
 #: gnucash/gtkbuilder/dialog-job.glade:291
 msgid "Job Active"
-msgstr ""
+msgstr "Hanke on aktiivinen"
 
 #: gnucash/gtkbuilder/dialog-lot-viewer.glade:7
 #: gnucash/report/reports/standard/lot-viewer.scm:34
@@ -14206,13 +13637,11 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-lot-viewer.glade:25
 msgid "_New Lot"
-msgstr ""
+msgstr "_Uusi erä"
 
 #: gnucash/gtkbuilder/dialog-lot-viewer.glade:40
-#, fuzzy
-#| msgid "Account"
 msgid "Scrub _Account"
-msgstr "Tili"
+msgstr ""
 
 #: gnucash/gtkbuilder/dialog-lot-viewer.glade:55
 msgid "_Scrub"
@@ -14224,11 +13653,11 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-lot-viewer.glade:78
 msgid "Delete the highlighted lot"
-msgstr ""
+msgstr "Poista merkitty erä"
 
 #: gnucash/gtkbuilder/dialog-lot-viewer.glade:136
 msgid "Enter a name for the highlighted lot."
-msgstr ""
+msgstr "Syötä merkitylle erälle nimi."
 
 #: gnucash/gtkbuilder/dialog-lot-viewer.glade:174
 msgid "Enter any notes you want to make about this lot."
@@ -14236,15 +13665,15 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-lot-viewer.glade:193
 msgid "<b>_Title</b>"
-msgstr ""
+msgstr "<b>_Otsikko</b>"
 
 #: gnucash/gtkbuilder/dialog-lot-viewer.glade:223
 msgid "<b>_Lots in This Account</b>"
-msgstr ""
+msgstr "<b>_Erät tilillä</b>"
 
 #: gnucash/gtkbuilder/dialog-lot-viewer.glade:260
 msgid "Show only open lots"
-msgstr ""
+msgstr "Näytä vain avoimet erät"
 
 #: gnucash/gtkbuilder/dialog-lot-viewer.glade:304
 msgid "<b>Splits _free</b>"
@@ -14255,19 +13684,19 @@ msgid "<b>Splits _in lot</b>"
 msgstr ""
 
 #: gnucash/gtkbuilder/dialog-new-user.glade:25
-#, fuzzy
-#| msgid "No"
 msgid "_No"
-msgstr "Ei"
+msgstr "_Ei"
 
 #: gnucash/gtkbuilder/dialog-new-user.glade:40
 msgid "_Yes"
-msgstr ""
+msgstr "_Kyllä"
 
 #: gnucash/gtkbuilder/dialog-new-user.glade:87
 msgid ""
 "<span weight=\"bold\" size=\"larger\">Display Welcome Dialog Again?</span>"
 msgstr ""
+"<span weight=\"bold\" size=\"larger\">Näytetäänkö tervetuloikkuna uudelleen?"
+"</span>"
 
 #: gnucash/gtkbuilder/dialog-new-user.glade:101
 msgid ""
@@ -14279,6 +13708,7 @@ msgstr ""
 #: gnucash/gtkbuilder/dialog-new-user.glade:210
 msgid "<span size=\"larger\" weight=\"bold\">Welcome to GnuCash!</span>"
 msgstr ""
+"<span size=\"larger\" weight=\"bold\">Tervetuloa, tämä on GnuCash!</span>"
 
 #: gnucash/gtkbuilder/dialog-new-user.glade:230
 msgid ""
@@ -14287,18 +13717,22 @@ msgid ""
 "the <i>OK</i> button or press the <i>Cancel</i> button if you don't want to "
 "perform any of them."
 msgstr ""
+"Tarjolla on esimääriteltyjä toimintoja, jotka soveltuvat useimmille uusille "
+"GnuCash-käyttäjille. Valitse haluamasi toiminto alapuolelta ja napsauta "
+"<i>OK</i>, tai napsauta <i>Peru</i> jos et halua käyttää mitään näistä "
+"toiminnoista."
 
 #: gnucash/gtkbuilder/dialog-new-user.glade:244
 msgid "C_reate a new set of accounts"
-msgstr ""
+msgstr "_Luo uusi joukko tilejä"
 
 #: gnucash/gtkbuilder/dialog-new-user.glade:261
 msgid "_Import my QIF files"
-msgstr ""
+msgstr "_Tuo QIF-tiedostoja"
 
 #: gnucash/gtkbuilder/dialog-new-user.glade:278
 msgid "_Open the new user tutorial"
-msgstr ""
+msgstr "_Avaa uuden käyttäjän opas"
 
 #: gnucash/gtkbuilder/dialog-object-references.glade:8
 msgid "Object references"
@@ -14325,19 +13759,17 @@ msgid "Order Entry"
 msgstr ""
 
 #: gnucash/gtkbuilder/dialog-order.glade:58
-#, fuzzy
-#| msgid "Invoice"
 msgid "_Invoices"
-msgstr "Myyntilasku"
+msgstr "Myynti_laskut"
 
 #: gnucash/gtkbuilder/dialog-order.glade:74
 msgid "Close _Order"
-msgstr ""
+msgstr "Sulje _tilaus"
 
 #: gnucash/gtkbuilder/dialog-order.glade:230
 #: gnucash/gtkbuilder/dialog-order.glade:575
 msgid "Order Information"
-msgstr ""
+msgstr "Tilauksen tiedot"
 
 #: gnucash/gtkbuilder/dialog-order.glade:272
 #: gnucash/gtkbuilder/dialog-order.glade:630
@@ -14347,10 +13779,8 @@ msgid "Reference"
 msgstr ""
 
 #: gnucash/gtkbuilder/dialog-order.glade:391
-#, fuzzy
-#| msgid "Total Entries"
 msgid "Order Entries"
-msgstr "Yhteensä tietueita"
+msgstr "Tilauksen tietueet"
 
 #: gnucash/gtkbuilder/dialog-order.glade:531
 msgid ""
@@ -14360,7 +13790,7 @@ msgstr ""
 #: gnucash/gtkbuilder/dialog-payment.glade:136
 #: gnucash/gtkbuilder/dialog-payment.glade:168
 msgid "The company associated with this payment."
-msgstr ""
+msgstr "Yritys jolle maksu on osoitettu."
 
 #: gnucash/gtkbuilder/dialog-payment.glade:169
 msgid "Partner"
@@ -14368,11 +13798,11 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-payment.glade:207
 msgid "Post To"
-msgstr ""
+msgstr "Vie tilille"
 
 #: gnucash/gtkbuilder/dialog-payment.glade:335
 msgid "Documents"
-msgstr ""
+msgstr "Tositteet"
 
 #: gnucash/gtkbuilder/dialog-payment.glade:412
 #: gnucash/gtkbuilder/dialog-payment.glade:439
@@ -14392,16 +13822,25 @@ msgid ""
 "automatically assign the remaining amount to the first unpaid invoice for "
 "this company."
 msgstr ""
+"Laskun maksettava summa.\n"
+"\n"
+"Jos olet valinnut laskun, GnuCash ehdottaa sen jäljellä olevaa summaa. Voit "
+"muuttaa summaa maksaaksesi laskun osittain tai maksaaksesi sen liian "
+"suurella summalla.\n"
+"\n"
+"Jos maksat laskun liian suurella summalla tai jos laskua ei ollut valittuna, "
+"GnuCash siirtää kohdistamattoman summan seuraavalle samalle yritykselle "
+"maksettavalle laskulle."
 
 #: gnucash/gtkbuilder/dialog-payment.glade:469
 #: gnucash/report/reports/standard/new-owner-report.scm:282
 msgid "Refund"
-msgstr ""
+msgstr "Hyvitys"
 
 #: gnucash/gtkbuilder/dialog-payment.glade:623
 #: gnucash/gtkbuilder/dialog-print-check.glade:296
 msgid "Print Check"
-msgstr ""
+msgstr "Tulosta šekki"
 
 #: gnucash/gtkbuilder/dialog-payment.glade:640
 msgid "(USD)"
@@ -14409,10 +13848,8 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-payment.glade:698
 #: gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp:76
-#, fuzzy
-#| msgid "Find Account"
 msgid "Transfer Account"
-msgstr "Etsi tili"
+msgstr "Maksa tililtä"
 
 #. Date format label for 07/31/2013
 #: gnucash/gtkbuilder/dialog-preferences.glade:50
@@ -14440,19 +13877,17 @@ msgstr ""
 #: gnucash/import-export/csv-imp/gnc-import-price.cpp:57
 #: gnucash/import-export/csv-imp/gnc-import-tx.cpp:57
 #: libgnucash/engine/gnc-datetime.cpp:159
-#, fuzzy
-#| msgid "Locale: "
 msgid "Locale"
-msgstr "Maa-asetusto: "
+msgstr ""
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:140
 msgid "_Reset"
-msgstr ""
+msgstr "_Palauta"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:185
 #: gnucash/gtkbuilder/dialog-preferences.glade:599
 msgid "<b>Separator Character</b>"
-msgstr ""
+msgstr "<b>Erotusmerkki</b>"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:211
 msgid ""
@@ -14463,139 +13898,140 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:254
 msgid "GnuCash Preferences"
-msgstr ""
+msgstr "GnuCashin asetukset"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:329
 msgid "<b>Summarybar Content</b>"
-msgstr ""
+msgstr "<b>Yhteenvetopalkin sisältö</b>"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:339
 msgid "Include _grand total"
-msgstr ""
+msgstr "Sisällytä _loppusumma"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:345
 msgid ""
 "Show a grand total of all accounts converted to the default report currency."
-msgstr ""
+msgstr "Näytä kaikkien tilien loppusumma muutettuna oltusvaluuttaksi."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:357
 msgid "Include _non-currency totals"
-msgstr ""
+msgstr "Sisällytä myös _muut kuin valuuttatilit"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:363
 msgid ""
 "If checked, non-currency commodities will be shown in the summary bar. If "
 "clear, only currencies will be shown."
 msgstr ""
+"Jos valittuna, muiden kuin valuuttatilien arvo sisällytetään "
+"yhteenvetopalkissa näkyvään summaan. Ilman valintaa summaan sisällytetään "
+"ainoastaan valuuttamuotoiset tilit."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:405
 msgid "_Relative"
-msgstr ""
+msgstr "_Suhteellinen"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:411
 msgid "Use the specified relative starting date for profit/loss calculations."
 msgstr ""
+"Käytä määritettyä suhteellista aloituspäivää voitto-/tappiolaskelmille."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:424
 msgid "_Absolute"
-msgstr ""
+msgstr "_Määritetty"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:430
 msgid "Use the specified absolute starting date for profit/loss calculations."
-msgstr ""
+msgstr "Käytä määritettyä aloituspäivää voitto-/tappiolaskelmille."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:443
 msgid "Re_lative"
-msgstr ""
+msgstr "S_uhteellinen"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:449
 msgid ""
 "Use the specified relative ending date for profit/loss calculations. Also "
 "use this date for net assets calculations."
 msgstr ""
+"Käytä määritettyä suhteellista päättymispäivää voitto-/tappiolaskelmille."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:462
 msgid "Ab_solute"
-msgstr ""
+msgstr "Mää_ritetty"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:468
 msgid ""
 "Use the specified absolute ending date for profit/loss calculations. Also "
 "use this date for net assets calculations."
-msgstr ""
+msgstr "Käytä määritettyä päättymispäivää voitto-/tappiolaskelmille."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:579
-#, fuzzy
-#| msgid "End of accounting period"
 msgid "Accounting Period"
-msgstr "Tilikauden loppu"
+msgstr "Tilikausi"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:609
 msgid "Use _formal accounting labels"
-msgstr ""
+msgstr "Käytä _virallisia kirjanpitotermejä"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:615
 msgid "Use only 'debit' and 'credit' instead of informal synonyms."
 msgstr ""
+"Käytä ainoastaan \"debet\" ja \"kredit\" -ilmauksia epävirallisten nimien "
+"sijaan."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:630
 msgid "<b>Labels</b>"
-msgstr ""
+msgstr "<b>Nimikkeet</b>"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:650
 #: gnucash/gtkbuilder/dialog-price.glade:453
-#, fuzzy
-#| msgid "None"
 msgid "_None"
-msgstr "Ei mitään"
+msgstr "_Ei mitään"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:669
-#, fuzzy
-#| msgid "existing account"
 msgid "C_redit accounts"
-msgstr "olemassa oleva tili"
+msgstr "Vas_tattavat tilit"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:688
 msgid "_Income & expense"
-msgstr ""
+msgstr "_Tulo ja meno"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:710
 msgid "<b>Reverse Balanced Accounts</b>"
-msgstr ""
+msgstr "<b>Tilien käänteiset etumerkit</b>"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:743
 msgid "<b>Default Currency</b>"
-msgstr ""
+msgstr "<b>Oletusvaluutta</b>"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:756
 #: gnucash/gtkbuilder/dialog-preferences.glade:3160
 msgid "US Dollars (USD)"
-msgstr ""
+msgstr "Yhdysvaltain dollarit (USD)"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:779
 msgid "Character"
-msgstr ""
+msgstr "Merkki"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:791
 #: gnucash/gtkbuilder/gnc-date-format.glade:207
 msgid "Sample"
-msgstr ""
+msgstr "Esimerkki"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:828
 msgid "Show the Account Color as background"
-msgstr ""
+msgstr "Näytä tilin väri taustalla"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:834
 msgid "Show the Account Color as Account Name Background."
-msgstr ""
+msgstr "Näytä tilin väri tilin nimen taustana."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:856
 msgid "Show the Account Color on tabs"
-msgstr ""
+msgstr "Näytä tilin väri välilehdessä"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:862
 msgid "Show the Account Color as tab background."
-msgstr ""
+msgstr "Näytä tilin väri välilehden taustana."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:896
 msgid ""
@@ -14604,63 +14040,66 @@ msgid ""
 "the following strings: \"colon\" \"slash\", \"backslash\", \"dash\" and "
 "\"period\"."
 msgstr ""
+"Merkki jota käytetään erottamaan tilin nimen osat. Merkki voi olla mikä "
+"tahansa muu kuin aakkonen tai numero. Myös seuraavat termit hyväksytään: "
+"\"colon\" (:), \"slash\" (/), \"backslash\" (\\), \"dash\" (-) ja "
+"\"period\" (.)."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:916
 #: gnucash/gtkbuilder/dialog-preferences.glade:3261
 msgid "Ch_oose"
-msgstr ""
+msgstr "_Valitse"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:936
 #: gnucash/gtkbuilder/dialog-preferences.glade:3281
 msgid "Loc_ale"
-msgstr ""
+msgstr "_Maa-asetusto"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1061
 msgid "<b>Time Format</b>"
-msgstr ""
+msgstr "<b>Ajan muoto</b>"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1081
 msgid "U_se 24-hour clock"
-msgstr ""
+msgstr "_Käytä 24 tunnin kelloa"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1087
 msgid "Use a 24 hour (instead of a 12 hour) time format."
-msgstr ""
+msgstr "Käytä 24 tunnin kelloa 12 tunnin sijaan."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1102
 msgid "<b>Date Completion</b>"
-msgstr ""
+msgstr "<b>Päivämäärän täydennys</b>"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1115
 msgid "When a date is entered without year, it should be taken"
-msgstr ""
+msgstr "Kun päivämäärä syötetään ilman vuotta, vuosi tulisi tulkita"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1131
-#, fuzzy
-#| msgid "Last day of the current calendar year."
 msgid ""
 "Dates will be completed so that they are within the current calendar year."
-msgstr "Tämän kalenterivuoden viimeinen päivä."
+msgstr ""
+"Päivämäärät täydennetään niin, että ne ovat nykyisen kalenterivuoden sisällä."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1144
 msgid ""
 "In a sliding 12-month window starting this\n"
 "many months before the current month"
 msgstr ""
+"Liukuvan 12 kuukauden jakson perusteella, joka\n"
+"alkaa näin monta kuukautta ennen tätä kuukautta"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1168
 msgid "Enter number of months."
-msgstr ""
+msgstr "Syötä kuukausien määrä."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1189
 msgid "Use the date format specified by the system locale."
-msgstr ""
+msgstr "Käytä järjestelmän asetusta päivämäärän muotoilulle."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1215
-#, fuzzy
-#| msgid "Number"
 msgid "<b>Numbers</b>"
-msgstr "Numero"
+msgstr "<b>Numerot</b>"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1225
 msgid "Force P_rices to display as decimals"
@@ -14668,53 +14107,55 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1243
 msgid "Display ne_gative amounts in red"
-msgstr ""
+msgstr "Näytä ne_gatiiviset luvut punaisena"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1249
 msgid "Display negative amounts in red."
-msgstr ""
+msgstr "Näytä negatiiviset luvut punaisena."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1261
 msgid "_Automatic decimal point"
-msgstr ""
+msgstr "_Automaattinen desimaalipilkun lisäys"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1267
 msgid ""
 "Automatically insert a decimal point into values that are entered without "
 "one."
 msgstr ""
+"Lisää desimaalipilkku automaattisesti luvuille, jotka lisätään ilman sitä."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1282
 msgid "_Decimal places"
-msgstr ""
+msgstr "_Desimaalipaikkoja"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1297
 msgid "How many automatic decimal places will be filled in."
-msgstr ""
+msgstr "Kuinka monta desimaalia luvuille täydennetään automaattisesti."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1389
 msgid "Numbers, Date, Time"
-msgstr ""
+msgstr "Numerot, päivämäärä, aika"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1421
 msgid "Perform account list _setup on new file"
-msgstr ""
+msgstr "Suorita tilien _lisäys uuteen tiedostoon"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1427
 msgid "Present the new account list dialog when you choose File->New File."
 msgstr ""
+"Esitä tilien lisäysikkuna uutta kirjaa luotaessa (Tiedosto->Uusi tiedosto)."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1458
 msgid "Display \"_tip of the day\" dialog"
-msgstr ""
+msgstr "Näytä \"päivän _vinkki\""
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1464
 msgid "Display hints for using GnuCash at startup."
-msgstr ""
+msgstr "Näytä vinkkejä GnuCashin käyttöön ohjelmaa avattaessa."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1485
 msgid "How many days to keep old log/backup files."
-msgstr ""
+msgstr "Kuinka monta päivää vanhat loki-/varmuuskopiotiedostot säilytetään."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1504
 #: gnucash/gtkbuilder/dialog-sx.glade:615
@@ -14722,79 +14163,83 @@ msgstr ""
 #: gnucash/gtkbuilder/dialog-sx.glade:1011
 #: gnucash/gtkbuilder/dialog-sx.glade:1071
 msgid "days"
-msgstr ""
+msgstr "päivää"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1523
 msgid "<b>_Retain log/backup files</b>"
-msgstr ""
+msgstr "<b>_Säilytä loki-/varmuuskopiotiedostot</b>"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1535
 msgid "Com_press files"
-msgstr ""
+msgstr "_Pakkaa tiedostot"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1541
 msgid "Compress the data file with gzip when saving it to disk."
-msgstr ""
+msgstr "Gzip-pakkaa tiedostot ennen niiden tallentamista levylle."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1556
 msgid "<b>Files</b>"
-msgstr ""
+msgstr "<b>Tiedostot</b>"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1589
 msgid "<b>Search Dialog</b>"
-msgstr ""
+msgstr "<b>Hakuikkuna</b>"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1602
 msgid "New search _limit"
-msgstr ""
+msgstr "Uuden _haun raja"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1617
 msgid "Default to 'new search' if fewer than this number of items is returned."
 msgstr ""
+"Ehdota oletuksena uutta hakua, jos haku palauttaa vähemmän kuin valitun "
+"määrän tuloksia."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1633
 msgid "Show splash scree_n"
-msgstr ""
+msgstr "Näytä _latausruutu"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1639
 msgid "Show splash screen at startup."
-msgstr ""
+msgstr "Näytä latausruutu ohjelmaa avattaessa."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1654
 msgid "Auto-save time _interval"
-msgstr ""
+msgstr "Automaattitallennuksen aika_väli"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1693
 msgid "minutes"
-msgstr ""
+msgstr "minuuttia"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1709
 msgid "Show auto-save confirmation _question"
-msgstr ""
+msgstr "_Kysy automaattitallennuksen vahvistus"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1715
 msgid ""
 "If active, GnuCash shows a confirmation question each time the auto-save "
 "feature is started. Otherwise no extra explanation is shown."
 msgstr ""
+"Jos valittu, GnuCash näyttää kysyy aina ennen automaattitallennus "
+"vahvistuksen käyttäjältä. Muussa tapauksess erillistä vahvistusta ei pyydetä."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1755
 msgctxt "keep"
 msgid "For"
-msgstr ""
+msgstr "Kunnes"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1773
 #: gnucash/gtkbuilder/dialog-sx.glade:1227
 msgid "Forever"
-msgstr ""
+msgstr "Ikuisesti"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1812
 msgid "Time to _wait for answer"
-msgstr ""
+msgstr "Aika joka _odotetaan vastausta"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1849
 msgid "seconds"
-msgstr ""
+msgstr "sekuntia"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1877
 #: gnucash/gtkbuilder/dialog-preferences.glade:1895
@@ -14803,7 +14248,7 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1924
 msgid "Enable horizontal grid lines on table displays"
-msgstr ""
+msgstr "Näytä vaakasuuntaiset rajat solujen välissä"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1928
 msgid ""
@@ -14823,7 +14268,7 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:1961
 msgid "<b>Linked Files</b>"
-msgstr ""
+msgstr "<b>Liittyvät tiedostot</b>"
 
 #. Preferences->Online Banking:Generic
 #: gnucash/gtkbuilder/dialog-preferences.glade:2057
@@ -14877,7 +14322,7 @@ msgstr ""
 #. Preferences->Online Banking:Generic
 #: gnucash/gtkbuilder/dialog-preferences.glade:2203
 msgid "Commercial ATM _fees threshold"
-msgstr ""
+msgstr "Kaupallisten pankkiautomaattien _kustannusten raja"
 
 #. Preferences->Online Banking:Generic
 #: gnucash/gtkbuilder/dialog-preferences.glade:2217
@@ -14887,12 +14332,12 @@ msgstr ""
 #. Preferences->Online Banking:Generic
 #: gnucash/gtkbuilder/dialog-preferences.glade:2231
 msgid "Auto-_add threshold"
-msgstr ""
+msgstr "Lisää _raja automaattisesti"
 
 #. Preferences->Online Banking:Generic
 #: gnucash/gtkbuilder/dialog-preferences.glade:2245
 msgid "Match _display threshold"
-msgstr ""
+msgstr "Täsmää _näytön rajaan"
 
 #. Preferences->Online Banking:Generic
 #: gnucash/gtkbuilder/dialog-preferences.glade:2256
@@ -14907,12 +14352,12 @@ msgstr ""
 #. Preferences->Online Banking:Generic
 #: gnucash/gtkbuilder/dialog-preferences.glade:2296
 msgid "Likely match _day threshold"
-msgstr ""
+msgstr "Todennäköisesti täsmäävän _päiväyksen raja"
 
 #. Preferences->Online Banking:Generic
 #: gnucash/gtkbuilder/dialog-preferences.glade:2309
 msgid "_Unlikely match day threshold"
-msgstr ""
+msgstr "Todennäköisesti _ei täsmäävän päiväyksen raja"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2323
 msgid ""
@@ -14928,41 +14373,40 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2391
 msgid "<b>Checks</b>"
-msgstr ""
+msgstr "<b>Sekit</b>"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2406
 msgid "The default check printing font."
-msgstr ""
+msgstr "Oletusfontti šhekin tulostukseen."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2416
-#, fuzzy
-#| msgid "Fancy Date Format"
 msgid "Print _date format"
-msgstr "Hieno päivämäärämuoto"
+msgstr "Tulosta _päiväyksen muoto"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2422
 msgid "Below the actual date, print the format of that date in 8 point type."
 msgstr ""
+"Tulosta käytetty päiväyksen muoto itse päiväyksen alle 8 pisteen fontilla."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2434
 msgid "Print _blocking chars"
-msgstr ""
+msgstr "Tulosta _korostukset"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2440
 msgid "Print '***' before and after each text field on the check."
-msgstr ""
+msgstr "Tulosta '***'' šekkiin ennen jokaista tekstikenttää ja niiden jälkeen."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2455
 msgid "Default _font"
-msgstr ""
+msgstr "Oletus_fontti"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2484
 msgid "Printing"
-msgstr ""
+msgstr "Tulostus"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2514
 msgid "'_Enter' moves to blank transaction"
-msgstr ""
+msgstr "'_Enter' siirtää tyhjään tositteeseen"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2520
 msgid ""
@@ -14970,22 +14414,26 @@ msgid ""
 "transaction in the register. If clear, pressing the 'Enter' key will move "
 "down one row."
 msgstr ""
+"Jos valittu, painamalla rivinvaihto-näppäintä valinta siirtyy kirjan "
+"viimeiselle, tyhjälle riville. Jos ei valittu, rivinvaihdon painaminen "
+"siirtää valinnan yhden rivin alaspäin."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2532
 msgid "_Auto-raise lists"
-msgstr ""
+msgstr "_Näytä listat automaattisesti"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2538
 msgid "Automatically raise the list of accounts or actions during input."
 msgstr ""
+"Näytä lista tileistä tai toiminnoista automaattisesti tietojen syötön aikana."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2550
 msgid "Tab order in_cludes Transfer on Memorised Transactions"
-msgstr ""
+msgstr "_Säilytä sarkaimen järjestys täydennettäessä tosite"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2556
 msgid "Move to Transfer field when memorised transaction auto filled."
-msgstr ""
+msgstr "Siirry \"siirto\"-kenttään kun tosite täydennetään automaattisesti."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2581
 msgid "<b>Jump action for multiple splits</b>"
@@ -15001,7 +14449,7 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2599
 msgid "Do nothing."
-msgstr ""
+msgstr "Älä tee mitään."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2612
 msgid "Go to the first split with the _largest value"
@@ -15014,7 +14462,7 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2632
 msgid "Go to the first split with the _smallest value"
-msgstr ""
+msgstr "Siirry ensimmäiselle riville, jolla on _pienin arvo"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2638
 msgid ""
@@ -15023,75 +14471,82 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2665
 msgid "<b>Reconciling</b>"
-msgstr ""
+msgstr "<b>Täsmäyttää</b>"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2675
 msgid "Check cleared _transactions"
-msgstr ""
+msgstr "Valitse hyväksytyt _tositteet"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2681
 msgid "Pre-check cleared transactions when creating a reconcile dialog."
-msgstr ""
+msgstr "Esivalitse hyväksytyt tositteet täsmäytysikkunaa avattaessa."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2693
 msgid "Automatic credit card _payment"
-msgstr ""
+msgstr "Automaattinen luottokortin _maksu"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2699
 msgid ""
 "After reconciling a credit card statement, prompt the user to enter a credit "
 "card payment."
 msgstr ""
+"Luottokortin tapahtumien täsmäytyksen jälkeen pyydä käyttäjää syöttämään "
+"maksu."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2711
 msgid "Always reconcile to t_oday"
-msgstr ""
+msgstr "Täsmäytä aina _nykyiselle päivälle"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2717
 msgid ""
 "Always open the reconcile dialog using today's date for the statement date, "
 "regardless of previous reconciliations."
 msgstr ""
+"Avaa täsmäytysikkuna käyttäen kuluvaa päivää täsmäytyspäivämääränä "
+"riippumatta edellisen täsmäytyksen ajankohdasta."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2742
 msgid "<b>Graphics</b>"
-msgstr ""
+msgstr "<b>Grafiikka</b>"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2752
 msgid "_Use GnuCash built-in color theme"
-msgstr ""
+msgstr "Käytä GnuCashin _omaa väriteemaa"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2758
 msgid ""
 "GnuCash uses a yellow/green theme by default for register windows. Uncheck "
 "this if you want to use the system color theme instead."
 msgstr ""
+"GnuCash käyttää oletuksena kelta-vihreää teemaa tilikirjaikkunassa. Poista "
+"valinta, jos haluat käyttää järjestelmän väriteemaa oletuksen sijaan."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2770
 msgid "Double _mode colors alternate with transactions"
-msgstr ""
+msgstr "_Vuorottele värejä tositteiden mukaan"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2776
 msgid ""
 "Alternate the primary and secondary colors by transaction instead of by "
 "alternating by row."
 msgstr ""
+"Vuorottele ensi- ja toissijaista väriä tositteiden, eikä rivien, mukaan."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2788
 msgid "Draw hori_zontal lines between rows"
-msgstr ""
+msgstr "Piirrä _vaakasuorat viivat rivien väliin"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2794
 msgid "Show horizontal borders on the cells."
-msgstr ""
+msgstr "Näytä vaakasuuntaiset rajat solujen välissä."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2806
 msgid "Draw _vertical lines between columns"
-msgstr ""
+msgstr "Piirrä _pystysuorat viivat sarakkeiden väliin"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2812
 msgid "Show vertical borders on the cells."
-msgstr ""
+msgstr "Näytä pystysuorat viivat solujen välissä."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2837
 #: gnucash/report/reports/standard/invoice.scm:401
@@ -15103,11 +14558,11 @@ msgstr ""
 #: gnucash/report/reports/standard/invoice.scm:543
 #: gnucash/report/reports/standard/invoice.scm:549
 msgid "Layout"
-msgstr ""
+msgstr "Asettelu"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2849
 msgid "_Placement of future transactions"
-msgstr ""
+msgstr "_Tulevien tositteiden sijainti"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2855
 msgid ""
@@ -15120,37 +14575,33 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2895
 msgid "<b>Default Style</b>"
-msgstr ""
+msgstr "<b>Oletustyyli</b>"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2918
 msgid "<b>Other Defaults</b>"
-msgstr ""
+msgstr "<b>Muut oletusasetukset</b>"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2928
 msgid "_Basic ledger"
-msgstr ""
+msgstr "_Yksinkertainen tilikirja"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2947
 msgid "_Auto-split ledger"
-msgstr ""
+msgstr "_Automaattisesti jaettu tilikirja"
 
 #. Translators: This is a menu item in the View menu
 #: gnucash/gtkbuilder/dialog-preferences.glade:2966
 #: gnucash/ui/gnc-plugin-page-register.ui:87
-#, fuzzy
-#| msgid "Transaction Number"
 msgid "Transaction _Journal"
-msgstr "Tositenumero"
+msgstr "_Pääkirja"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:2988
-#, fuzzy
-#| msgid "Number/Action"
 msgid "Number of _transactions"
-msgstr "Numero/Tapahtuma"
+msgstr "_Tositteiden lukumäärä"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3021
 msgid "_Double line view"
-msgstr ""
+msgstr "_Kahden rivin näkymä"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3027
 #: gnucash/ui/gnc-embedded-register-window.ui:83
@@ -15159,20 +14610,24 @@ msgid ""
 "Show a second line with Action, Notes, and Linked Document fields for each "
 "transaction."
 msgstr ""
+"Näytä toinen rivi, jossa näytetään toimenpide, muistiinpano ja yhdistetty "
+"asiakirja joka tositteelle."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3039
 msgid "Register opens in a new _window"
-msgstr ""
+msgstr "Tilikirja avautuu uuteen _ikkunaan"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3045
 msgid ""
 "If checked, each register will be opened in its own top level window. If "
 "clear, the register will be opened in the current window."
 msgstr ""
+"Jos valittu, kukin tilikirja avautuu omaan päätason ikkunaansa. Jos ei "
+"valittu, tilikirja avautuu nykyiseen ikkunaan."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3057
 msgid "_Only display leaf account names"
-msgstr ""
+msgstr "Näytä ainoastaan a_limman tason tilin nimi"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3063
 msgid ""
@@ -15181,115 +14636,125 @@ msgid ""
 "display the full name, including the path in the account tree. Checking this "
 "option implies that you use unique leaf names."
 msgstr ""
+"Jos valittu, näytä ainoastaan alimman tason tilin nimi tilikirjassa ja tilin "
+"valinnan pudotusvalikoissa. Oletuksena näytetään tilin koko nimi, mukaan "
+"lukien polku kyseiseen tiliin päätasolta lähtien. Valinta olettaa, että "
+"käytät yksilöllisiä tilien nimiä."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3140
 msgid "Register Defaults"
-msgstr ""
+msgstr "Tilikirjan oletusasetukset"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3172
 msgid "<b>Default Report Currency</b>"
-msgstr ""
+msgstr "<b>Raporttien oletusvaluutta</b>"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3195
 msgid "<b>Location</b>"
-msgstr ""
+msgstr "<b>Sijainti</b>"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3205
 msgid "Report opens in a new _window"
-msgstr ""
+msgstr "Raportti avautuu uuteen _ikkunaan"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3211
 msgid ""
 "If checked, each report will be opened in its own top level window. If "
 "clear, the report will be opened in the current window."
 msgstr ""
+"Jos valittuna, kukin raportti avautuu omaan päätason ikkunaansa. Jos ei "
+"valittuna, raportit avataan nykyiseen ikkunaan."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3239
 #: gnucash/gtkbuilder/dialog-preferences.glade:3319
 msgid "Default zoom level"
-msgstr ""
+msgstr "Oletus-zoom-taso"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3354
 msgid "Reports"
-msgstr ""
+msgstr "Raportit"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3374
 msgid "<b>Window Geometry</b>"
-msgstr ""
+msgstr "<b>Ikkunan geometria</b>"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3394
 msgid "_Save window size and position"
-msgstr ""
+msgstr "Tallenna _ikkunan koko ja sijainti"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3400
 msgid "Save window size and location when it is closed."
-msgstr ""
+msgstr "Tallenna ikkunan koko ja sijainti suljettaessa."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3413
 msgid "Bring the most _recent tab to the front"
-msgstr ""
+msgstr "Tuo _viimeisin välilehti etualalle"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3445
 msgid "<b>Tab Position</b>"
-msgstr ""
+msgstr "<b>Välilehtien kielekkeiden sijainti</b>"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3455
 #: gnucash/ui/gnc-main-window.ui:195
 msgid "To_p"
-msgstr ""
+msgstr "_Ylhäällä"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3474
 #: gnucash/ui/gnc-main-window.ui:201
 msgid "B_ottom"
-msgstr ""
+msgstr "_Alhaalla"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3493
 #: gnucash/ui/gnc-main-window.ui:207
 msgid "_Left"
-msgstr ""
+msgstr "_Vasemmalla"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3512
 #: gnucash/ui/gnc-main-window.ui:213
 msgid "_Right"
-msgstr ""
+msgstr "_Oikealla"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3534
 msgid "<b>Summary Bar Position</b>"
-msgstr ""
+msgstr "<b>Yhteenvetopalkin sijainti</b>"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3563
 #: gnucash/gtkbuilder/dialog-print-check.glade:267
 #: gnucash/report/reports/standard/investment-lots.scm:198
 msgid "Bottom"
-msgstr ""
+msgstr "Alhaalla"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3595
 msgid "<b>Tabs</b>"
-msgstr ""
+msgstr "<b>Välilehdet</b>"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3605
 msgid "Show close button on _notebook tabs"
-msgstr ""
+msgstr "Näytä sulkemispainike _välilehdellä"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3611
 msgid ""
 "Show a close button on each notebook tab. These function identically to the "
 "'Close' menu item."
 msgstr ""
+"Näytä sulkemispainike välilehdillä. Painike toimii samalla lailla kuin "
+"valikon 'Sulje'-painike."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3632
 msgid ""
 "If the text in the tab is longer than this value (the test is approximate) "
 "then the tab label will have the middle cut and replaced with an ellipsis."
 msgstr ""
+"Jos välilehden teksti on tätä arvoa pidempi (testi ei ole tarkka), otsikon "
+"keskikohta leikataan pois."
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3652
 msgid "characters"
-msgstr ""
+msgstr "merkkiä"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3671
 msgid "_Width"
-msgstr ""
+msgstr "_Leveys"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3682
 msgid "Open new tabs _adjacent to current tab"
@@ -15301,47 +14766,47 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3727
 msgid "Windows"
-msgstr ""
+msgstr "Ikkuna"
 
 #: gnucash/gtkbuilder/dialog-preferences.glade:3795
 #: gnucash/gtkbuilder/dialog-preferences.glade:3818
 msgid "Online Quotes"
-msgstr ""
+msgstr "Hae kurssi verkosta"
 
 #: gnucash/gtkbuilder/dialog-price.glade:12
 msgid "Bid"
-msgstr ""
+msgstr "Osto"
 
 #: gnucash/gtkbuilder/dialog-price.glade:15
 msgid "Ask"
-msgstr ""
+msgstr "Myynti"
 
 #: gnucash/gtkbuilder/dialog-price.glade:18
 msgid "Last"
-msgstr ""
+msgstr "Viimeisin"
 
 #: gnucash/gtkbuilder/dialog-price.glade:21
 msgid "Net Asset Value"
-msgstr ""
+msgstr "Omaisuuserän nettoarvo"
 
 #: gnucash/gtkbuilder/dialog-price.glade:43
 msgid "Price Editor"
-msgstr ""
+msgstr "Hintamuokkain"
 
 #: gnucash/gtkbuilder/dialog-price.glade:195
 msgid "S_ource"
-msgstr ""
+msgstr "_Lähde"
 
 #: gnucash/gtkbuilder/dialog-price.glade:225
 #: gnucash/register/ledger-core/split-register.c:2117
 #: gnucash/register/ledger-core/split-register.c:2120
 #: gnucash/ui/gnc-plugin-page-invoice.ui:108
 msgid "_Price"
-msgstr ""
+msgstr "_Hinta"
 
 #: gnucash/gtkbuilder/dialog-price.glade:374
 msgid "Remove Old Prices"
-msgstr ""
+msgstr "Poista vanhat hinnat"
 
 #: gnucash/gtkbuilder/dialog-price.glade:437
 msgid "Delete prices that meet the following criteria:"
@@ -15349,31 +14814,27 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-price.glade:457
 msgid "Remove all prices before date."
-msgstr ""
+msgstr "Poista annettua päiväystä vanhemmat hinnat."
 
 #: gnucash/gtkbuilder/dialog-price.glade:471
 msgid "Last of _Week"
-msgstr ""
+msgstr "_Viikon viimeinen"
 
 #: gnucash/gtkbuilder/dialog-price.glade:475
 msgid "Keep the last price of each week if present before date."
 msgstr ""
 
 #: gnucash/gtkbuilder/dialog-price.glade:488
-#, fuzzy
-#| msgid "Start of this month"
 msgid "Last of _Month"
-msgstr "Tämän kuun alku"
+msgstr "_Kuun viimeinen"
 
 #: gnucash/gtkbuilder/dialog-price.glade:492
 msgid "Keep the last price of each month if present before date."
 msgstr ""
 
 #: gnucash/gtkbuilder/dialog-price.glade:505
-#, fuzzy
-#| msgid "Start of current quarter"
 msgid "Last of _Quarter"
-msgstr "Tämän vuosineljänneksen alku"
+msgstr "Vuosi_neljänneksen viimeinen"
 
 #: gnucash/gtkbuilder/dialog-price.glade:509
 msgid ""
@@ -15383,7 +14844,7 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-price.glade:522
 msgid "Last of _Period"
-msgstr ""
+msgstr "_Jakson viimeinen"
 
 #: gnucash/gtkbuilder/dialog-price.glade:526
 msgid ""
@@ -15404,11 +14865,11 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-price.glade:591
 msgid "First Date"
-msgstr ""
+msgstr "Ensimmäinen päivämäärä"
 
 #: gnucash/gtkbuilder/dialog-price.glade:622
 msgid "From these Commodities"
-msgstr ""
+msgstr "Näistä hyödykkeistä"
 
 #: gnucash/gtkbuilder/dialog-price.glade:636
 msgid "Keeping the last available price for option"
@@ -15432,7 +14893,7 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-price.glade:708
 msgid "_Added by the application"
-msgstr ""
+msgstr "_Lisätty sovelluksen toimesta"
 
 #: gnucash/gtkbuilder/dialog-price.glade:712
 msgid ""
@@ -15446,44 +14907,40 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-price.glade:758
 msgid "Before _Date"
-msgstr ""
+msgstr "Ennen _päiväystä"
 
 #: gnucash/gtkbuilder/dialog-price.glade:798
 #: gnucash/report/reports/standard/price-scatter.scm:76
 msgid "Price Database"
-msgstr ""
+msgstr "Hintatietokanta"
 
 #: gnucash/gtkbuilder/dialog-price.glade:853
 msgid "Add a new price."
-msgstr ""
+msgstr "Lisää uusi hinta."
 
 #: gnucash/gtkbuilder/dialog-price.glade:871
-#, fuzzy
-#| msgid "The current date."
 msgid "Remove the current price."
-msgstr "Tämä päiväys."
+msgstr "Poista nykyinen hinta."
 
 #: gnucash/gtkbuilder/dialog-price.glade:889
-#, fuzzy
-#| msgid "The current date."
 msgid "Edit the current price."
-msgstr "Tämä päiväys."
+msgstr "Muokkaa nykyistä hintaa."
 
 #: gnucash/gtkbuilder/dialog-price.glade:901
 msgid "Remove _Old"
-msgstr ""
+msgstr "Poista _vanha"
 
 #: gnucash/gtkbuilder/dialog-price.glade:906
 msgid "Remove prices older than a user-entered date."
-msgstr ""
+msgstr "Poista annettua päiväystä vanhemmat hinnat."
 
 #: gnucash/gtkbuilder/dialog-price.glade:918
 msgid "_Get Quotes"
-msgstr ""
+msgstr "_Päivitä kurssit"
 
 #: gnucash/gtkbuilder/dialog-price.glade:923
 msgid "Get new online quotes for stock accounts."
-msgstr ""
+msgstr "Nouda osakkeiden kurssit verkosta."
 
 #: gnucash/gtkbuilder/dialog-print-check.glade:129
 msgid "Save Custom Check Format"
@@ -15498,23 +14955,23 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-print-check.glade:241
 msgid "Inches"
-msgstr ""
+msgstr "Tuumaa"
 
 #: gnucash/gtkbuilder/dialog-print-check.glade:244
 msgid "Centimeters"
-msgstr ""
+msgstr "Senttimetriä"
 
 #: gnucash/gtkbuilder/dialog-print-check.glade:247
 msgid "Millimeters"
-msgstr ""
+msgstr "Millimetriä"
 
 #: gnucash/gtkbuilder/dialog-print-check.glade:250
 msgid "Points"
-msgstr ""
+msgstr "Pistettä"
 
 #: gnucash/gtkbuilder/dialog-print-check.glade:264
 msgid "Middle"
-msgstr ""
+msgstr "Keskellä"
 
 #: gnucash/gtkbuilder/dialog-print-check.glade:281
 msgid "Quicken/QuickBooks (tm) US-Letter"
@@ -15536,21 +14993,19 @@ msgstr ""
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:6
 #: gnucash/ui/gnc-plugin-page-sx-list.ui:6
 msgid "_Print"
-msgstr ""
+msgstr "_Tulosta"
 
 #: gnucash/gtkbuilder/dialog-print-check.glade:384
 msgid "Check _format"
-msgstr ""
+msgstr "Šhekin _muoto"
 
 #: gnucash/gtkbuilder/dialog-print-check.glade:399
 msgid "Check po_sition"
-msgstr ""
+msgstr "Šhekin _sijainti"
 
 #: gnucash/gtkbuilder/dialog-print-check.glade:415
-#, fuzzy
-#| msgid "Fancy Date Format"
 msgid "_Date format"
-msgstr "Hieno päivämäärämuoto"
+msgstr "_Päiväyksen muoto"
 
 #: gnucash/gtkbuilder/dialog-print-check.glade:529
 msgid ""
@@ -15561,22 +15016,20 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-print-check.glade:533
 #: gnucash/gtkbuilder/dialog-print-check.glade:1084
-#, fuzzy
-#| msgid "Address Found"
 msgid "_Address"
-msgstr "Osoite löytyi"
+msgstr "_Osoite"
 
 #: gnucash/gtkbuilder/dialog-print-check.glade:560
 msgid "Checks on first _page"
-msgstr ""
+msgstr "Shekkejä ensimmäisellä _sivulla"
 
 #: gnucash/gtkbuilder/dialog-print-check.glade:660
 msgid "x"
-msgstr ""
+msgstr "x"
 
 #: gnucash/gtkbuilder/dialog-print-check.glade:672
 msgid "y"
-msgstr ""
+msgstr "y"
 
 #: gnucash/gtkbuilder/dialog-print-check.glade:685
 msgid "Pa_yee"
@@ -15584,21 +15037,19 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-print-check.glade:715
 msgid "Amount (_words)"
-msgstr ""
+msgstr "Määrä (_sanoja)"
 
 #: gnucash/gtkbuilder/dialog-print-check.glade:730
 msgid "Amount (_numbers)"
-msgstr ""
+msgstr "Määrä (_numeroita)"
 
 #: gnucash/gtkbuilder/dialog-print-check.glade:938
 msgid "_Units"
-msgstr ""
+msgstr "_Yksiköt"
 
 #: gnucash/gtkbuilder/dialog-print-check.glade:969
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "_Translation"
-msgstr "Etsi tosite"
+msgstr "_Käännös"
 
 #: gnucash/gtkbuilder/dialog-print-check.glade:984
 msgid "_Rotation"
@@ -15614,82 +15065,75 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-print-check.glade:1057
 msgid "Degrees"
-msgstr ""
+msgstr "Astetta"
 
 #: gnucash/gtkbuilder/dialog-print-check.glade:1066
-#, fuzzy
-#| msgid "Fancy Date Format"
 msgid "_Save Format"
-msgstr "Hieno päivämäärämuoto"
+msgstr "_Tallennusmuoto"
 
 #: gnucash/gtkbuilder/dialog-print-check.glade:1176
-#, fuzzy
-#| msgctxt "Action Column"
-#| msgid "Split"
 msgid "Splits Memo"
-msgstr "Rivi"
+msgstr "Rivin erittely"
 
 #: gnucash/gtkbuilder/dialog-print-check.glade:1191
 msgid "Splits Amount"
-msgstr ""
+msgstr "Rivin määrä"
 
 #: gnucash/gtkbuilder/dialog-print-check.glade:1206
-#, fuzzy
-#| msgid "Find Account"
 msgid "Splits Account"
-msgstr "Etsi tili"
+msgstr "Rivin tili"
 
 #: gnucash/gtkbuilder/dialog-print-check.glade:1359
 msgid "Custom format"
-msgstr ""
+msgstr "Mukautettu muoto"
 
 #: gnucash/gtkbuilder/dialog-progress.glade:12
 msgid "Working…"
-msgstr ""
+msgstr "Käsitellään…"
 
 #: gnucash/gtkbuilder/dialog-report.glade:55
 msgid "<b>A_vailable reports</b>"
-msgstr ""
+msgstr "<b>_Käytettävissä olevat raportit</b>"
 
 #: gnucash/gtkbuilder/dialog-report.glade:71
 msgid "<b>_Selected Reports</b>"
-msgstr ""
+msgstr "<b>_Valitut raportit</b>"
 
 #: gnucash/gtkbuilder/dialog-report.glade:101
 msgid "A_dd >>"
-msgstr ""
+msgstr "_Lisää >>"
 
 #: gnucash/gtkbuilder/dialog-report.glade:117
 msgid "<< _Remove"
-msgstr ""
+msgstr "<< _Poista"
 
 #: gnucash/gtkbuilder/dialog-report.glade:145
 msgid "Move _up"
-msgstr ""
+msgstr "Siirrä _ylös"
 
 #: gnucash/gtkbuilder/dialog-report.glade:161
 msgid "Move dow_n"
-msgstr ""
+msgstr "Siirrä _alas"
 
 #: gnucash/gtkbuilder/dialog-report.glade:189
 msgid "Si_ze…"
-msgstr ""
+msgstr "_Koko…"
 
 #: gnucash/gtkbuilder/dialog-report.glade:253
 msgid "HTML Style Sheets"
-msgstr ""
+msgstr "HTML-tyylitiedostot"
 
 #: gnucash/gtkbuilder/dialog-report.glade:302
 msgid "<b>Available style sheets</b>"
-msgstr ""
+msgstr "<b>Saatavilla olevat tyylitiedostot</b>"
 
 #: gnucash/gtkbuilder/dialog-report.glade:382
 msgid "<b>Style sheet options</b>"
-msgstr ""
+msgstr "<b>Tyylitiedoston valinnat</b>"
 
 #: gnucash/gtkbuilder/dialog-report.glade:433
 msgid "Report Size"
-msgstr ""
+msgstr "Raportin koko"
 
 #: gnucash/gtkbuilder/dialog-report.glade:499
 msgid "Enter report row/column span"
@@ -15705,25 +15149,23 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-report.glade:585
 msgid "Select HTML Style Sheet"
-msgstr ""
+msgstr "Valitse HTML-tyylitiedosto"
 
 #: gnucash/gtkbuilder/dialog-report.glade:703
 msgid "New Style Sheet"
-msgstr ""
+msgstr "Uusi tyylitiedosto"
 
 #: gnucash/gtkbuilder/dialog-report.glade:759
 msgid "<b>New style sheet info</b>"
-msgstr ""
+msgstr "<b>Uuden tyylitiedoston tiedot</b>"
 
 #: gnucash/gtkbuilder/dialog-report.glade:795
-#, fuzzy
-#| msgid "Tax related"
 msgid "_Template"
-msgstr "Veroihin liittyvä"
+msgstr "_Mallipohja"
 
 #: gnucash/gtkbuilder/dialog-reset-warnings.glade:8
 msgid "Reset Warnings"
-msgstr ""
+msgstr "Nollaa varoitukset"
 
 #: gnucash/gtkbuilder/dialog-reset-warnings.glade:86
 msgid ""
@@ -15734,7 +15176,7 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-reset-warnings.glade:120
 msgid "_Unselect All"
-msgstr ""
+msgstr "_Poista kaikkien valinta"
 
 #: gnucash/gtkbuilder/dialog-reset-warnings.glade:146
 msgid "No warnings to reset."
@@ -15742,72 +15184,69 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-reset-warnings.glade:164
 msgid "Permanent Warnings"
-msgstr ""
+msgstr "Pysyvät varoitukset"
 
 #: gnucash/gtkbuilder/dialog-reset-warnings.glade:205
 msgid "Temporary Warnings"
-msgstr ""
+msgstr "Väliaikaiset varoitukset"
 
 #: gnucash/gtkbuilder/dialog-search.glade:37
 msgid "_New item…"
-msgstr ""
+msgstr "_Uusi merkintä…"
 
 #: gnucash/gtkbuilder/dialog-search.glade:82
 msgid "_Find"
-msgstr ""
+msgstr "_Etsi"
 
 #: gnucash/gtkbuilder/dialog-search.glade:134
 msgid " Search "
-msgstr ""
+msgstr " Haku "
 
 #: gnucash/gtkbuilder/dialog-search.glade:207
 msgid "Search for items where"
-msgstr ""
+msgstr "Etsi tuloksia joille"
 
 #: gnucash/gtkbuilder/dialog-search.glade:228
 msgid "<b>Match all entries</b>"
-msgstr ""
+msgstr "<b>Täsmää kaikkiin</b>"
 
 #: gnucash/gtkbuilder/dialog-search.glade:281
 msgid "Search Criteria"
-msgstr ""
+msgstr "Hakuasetukset"
 
 #: gnucash/gtkbuilder/dialog-search.glade:314
-#, fuzzy
-#| msgid "New Customer"
 msgid "New search"
-msgstr "Uusi asiakas"
+msgstr "Uusi haku"
 
 #: gnucash/gtkbuilder/dialog-search.glade:331
 msgid "Refine current search"
-msgstr ""
+msgstr "Muokkaa nykyistä hakua"
 
 #: gnucash/gtkbuilder/dialog-search.glade:348
 msgid "Add results to current search"
-msgstr ""
+msgstr "Lisää tulokset nykyiseen hakuun"
 
 #: gnucash/gtkbuilder/dialog-search.glade:365
 msgid "Delete results from current search"
-msgstr ""
+msgstr "Poista tulokset nykyisestä hausta"
 
 #: gnucash/gtkbuilder/dialog-search.glade:393
 msgid "Search only active data"
-msgstr ""
+msgstr "Etsi ainoastaan aktiivista tietoa"
 
 #: gnucash/gtkbuilder/dialog-search.glade:399
 msgid ""
 "Choose whether to search all your data or only that marked as \"active\"."
 msgstr ""
+"Valitse haetaanko kaikkea vai ainoastaan \"aktiiviseksi\" merkittyä tietoa."
 
 #: gnucash/gtkbuilder/dialog-search.glade:417
 msgid "Type of search"
-msgstr ""
+msgstr "Haun tyyppi"
 
 #: gnucash/gtkbuilder/dialog-sx.glade:8
-#, fuzzy
-#| msgid "Accounts in '%s'"
 msgid "Account Deletion"
-msgstr "Tilit kategoriassa '%s'"
+msgstr "Tilin poistaminen"
 
 #: gnucash/gtkbuilder/dialog-sx.glade:55
 msgid ""
@@ -15821,222 +15260,210 @@ msgstr ""
 #: gnucash/report/reports/standard/category-barchart.scm:122
 #: gnucash/report/trep-engine.scm:312 libgnucash/engine/Recurrence.cpp:744
 msgid "Daily"
-msgstr ""
+msgstr "Päivittäin"
 
 #: gnucash/gtkbuilder/dialog-sx.glade:129
 msgid "Bi-Weekly"
-msgstr ""
+msgstr "Joka toinen viikko"
 
 #: gnucash/gtkbuilder/dialog-sx.glade:138
 #: gnucash/report/reports/standard/account-piecharts.scm:111
 #: gnucash/report/trep-engine.scm:342 libgnucash/engine/Recurrence.cpp:787
 msgid "Yearly"
-msgstr ""
+msgstr "Vuosittain"
 
 #: gnucash/gtkbuilder/dialog-sx.glade:144
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Make Scheduled Transaction"
-msgstr "Etsi tosite"
+msgstr "Luo tositteen ajastus"
 
 #: gnucash/gtkbuilder/dialog-sx.glade:159
 msgid "Advanced…"
-msgstr ""
+msgstr "Lisäasetukset…"
 
 #: gnucash/gtkbuilder/dialog-sx.glade:310
 msgid "Never End"
-msgstr ""
+msgstr "Päättymätön"
 
 #: gnucash/gtkbuilder/dialog-sx.glade:362
 msgid "Number of Occurrences"
-msgstr ""
+msgstr "Esiintymämäärä"
 
 #: gnucash/gtkbuilder/dialog-sx.glade:508
 msgid "<b>Since Last Run</b>"
-msgstr ""
+msgstr "<b>Edellisen ajon jälkeen</b>"
 
 #: gnucash/gtkbuilder/dialog-sx.glade:531
 msgid "<b>Transaction Editor Defaults</b>"
-msgstr ""
+msgstr "<b>Tositemuokkaimen oletusasetukset</b>"
 
 #: gnucash/gtkbuilder/dialog-sx.glade:541
 msgid "_Run when data file opened"
-msgstr ""
+msgstr "_Aja kun tiedosto avataan"
 
 #: gnucash/gtkbuilder/dialog-sx.glade:545
 msgid "Run the \"since last run\" process when a file is opened."
-msgstr ""
+msgstr "Aja \"edellisen ajon jälkeen\"-rutiini kun tiedosto avataan."
 
 #: gnucash/gtkbuilder/dialog-sx.glade:558
 msgid "_Show notification window"
-msgstr ""
+msgstr "_Näytä ilmoitusikkuna"
 
 #: gnucash/gtkbuilder/dialog-sx.glade:562
 msgid ""
 "Show the notification window for the \"since last run\" process when a file "
 "is opened."
 msgstr ""
+"Näytä ilmoitusikkuna \"edellisen ajon jälkeen\"-rutiinille kun tiedosto "
+"avataan."
 
 #: gnucash/gtkbuilder/dialog-sx.glade:575
 msgid "_Auto-create new transactions"
-msgstr ""
+msgstr "_Luo uudet tositteet automaattisesti"
 
 #: gnucash/gtkbuilder/dialog-sx.glade:579
 msgid "Set the 'auto-create' flag on newly created scheduled transactions."
-msgstr ""
+msgstr "Aseta uudet tositteiden ajastukset automaattisiksi."
 
 #: gnucash/gtkbuilder/dialog-sx.glade:599
 msgid "Begin notifications this many days before the transaction is created."
-msgstr ""
+msgstr "Ilmoita luotavista tapahtumista näin monta päivää etukäteen."
 
 #: gnucash/gtkbuilder/dialog-sx.glade:638
 msgid "Create the transaction this many days before its effective date."
-msgstr ""
+msgstr "Luo ajoitettu tosite näin monta päivää ennen varsinaista päivää."
 
 #: gnucash/gtkbuilder/dialog-sx.glade:670
 msgid "_Notify before transactions are created"
-msgstr ""
+msgstr "Ilm_oita ennen tositteen luontia"
 
 #: gnucash/gtkbuilder/dialog-sx.glade:675
 msgid "Set the 'notify' flag on newly created scheduled transactions."
-msgstr ""
+msgstr "Aseta uudet tositteiden ajastukset ilmoittamaan luonnista."
 
 #: gnucash/gtkbuilder/dialog-sx.glade:694
 msgid "Crea_te in advance"
-msgstr ""
+msgstr "Luo _etukäteen"
 
 #: gnucash/gtkbuilder/dialog-sx.glade:709
-#, fuzzy
-#| msgid "Opening Balance"
 msgid "R_emind in advance"
-msgstr "Avaussaldo"
+msgstr "_Ilmoita etukäteen"
 
 #: gnucash/gtkbuilder/dialog-sx.glade:720
 msgid "Re_view created transactions"
-msgstr ""
+msgstr "_Tarkista luodut tositteet"
 
 #: gnucash/gtkbuilder/dialog-sx.glade:724
 msgid ""
 "Set 'Review created transactions' as the default in the \"since last run\" "
 "dialog."
 msgstr ""
+"Aseta 'Tarkista luodut tositteet' oletusasetukseksi \"edellisen ajon "
+"jälkeen\" -valintaikkunassa."
 
 #: gnucash/gtkbuilder/dialog-sx.glade:788
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Edit Scheduled Transaction"
-msgstr "Etsi tosite"
+msgstr "Muokkaa tositteen ajastusta"
 
 #: gnucash/gtkbuilder/dialog-sx.glade:954
 msgid "Create in advance"
-msgstr ""
+msgstr "Luo etukäteen"
 
 #: gnucash/gtkbuilder/dialog-sx.glade:969
-#, fuzzy
-#| msgid "Opening Balance"
 msgid "Remind in advance"
-msgstr "Avaussaldo"
+msgstr "Muistuta etukäteen"
 
 #: gnucash/gtkbuilder/dialog-sx.glade:1028
 msgid "Create automatically"
-msgstr ""
+msgstr "Luo automaattisesti"
 
 #: gnucash/gtkbuilder/dialog-sx.glade:1032
 msgid "Conditional on splits not having variables"
-msgstr ""
+msgstr "Ehtona on, että jako ei sisällä muuttujia"
 
 #: gnucash/gtkbuilder/dialog-sx.glade:1103
 msgid "Notify me when created"
-msgstr ""
+msgstr "Ilmoita luotaessa"
 
 #: gnucash/gtkbuilder/dialog-sx.glade:1151
 msgid "<b>Occurrences</b>"
-msgstr ""
+msgstr "<b>Esiintymät</b>"
 
 #: gnucash/gtkbuilder/dialog-sx.glade:1174
 msgid "Last Occurred: "
-msgstr ""
+msgstr "Edellinen esiintymä: "
 
 #: gnucash/gtkbuilder/dialog-sx.glade:1208
 msgid "Repeats:"
-msgstr ""
+msgstr "Toistuu:"
 
 #: gnucash/gtkbuilder/dialog-sx.glade:1243
 msgid "Until"
-msgstr ""
+msgstr "Asti"
 
 #: gnucash/gtkbuilder/dialog-sx.glade:1259
 msgctxt "repeat"
 msgid "For"
-msgstr ""
+msgstr "Toistuu"
 
 #: gnucash/gtkbuilder/dialog-sx.glade:1278
 msgid "occurrences"
-msgstr ""
+msgstr "esiintymää"
 
 #: gnucash/gtkbuilder/dialog-sx.glade:1290
 msgid "remaining"
-msgstr ""
+msgstr "jäljellä"
 
 #: gnucash/gtkbuilder/dialog-sx.glade:1372
 msgid "Overview"
-msgstr ""
+msgstr "Yleistä"
 
 #: gnucash/gtkbuilder/dialog-sx.glade:1445
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Template Transaction"
-msgstr "Etsi tosite"
+msgstr "Tositemalline"
 
 #: gnucash/gtkbuilder/dialog-sx.glade:1476
 msgid "Since Last Run…"
-msgstr ""
+msgstr "Viime ajon jälkeen…"
 
 #: gnucash/gtkbuilder/dialog-sx.glade:1593
 msgid "_Review created transactions"
-msgstr ""
+msgstr "_Tarkista luodut tositteet"
 
 #: gnucash/gtkbuilder/dialog-tax-info.glade:13
 msgid "Income Tax Information"
-msgstr ""
+msgstr "Tuloverotiedot"
 
 #: gnucash/gtkbuilder/dialog-tax-info.glade:145
 msgid "Click to change Tax Name and/or Tax Type."
 msgstr ""
 
 #: gnucash/gtkbuilder/dialog-tax-info.glade:246
-#, fuzzy
-#| msgid "Account"
 msgid "<b>_Accounts</b>"
-msgstr "Tili"
+msgstr "<b>_Tilit</b>"
 
 #: gnucash/gtkbuilder/dialog-tax-info.glade:270
 msgid "_Income"
-msgstr ""
+msgstr "_Tulo"
 
 #: gnucash/gtkbuilder/dialog-tax-info.glade:286
-#, fuzzy
-#| msgid "Other Expense"
 msgid "_Expense"
-msgstr "Muu kulu"
+msgstr "_Kulu"
 
 #: gnucash/gtkbuilder/dialog-tax-info.glade:302
 msgid "_Asset"
-msgstr ""
+msgstr "_Vastaavaa"
 
 #: gnucash/gtkbuilder/dialog-tax-info.glade:318
 msgid "_Liability/Equity"
-msgstr ""
+msgstr "_Oma ja vieras pääoma"
 
 #: gnucash/gtkbuilder/dialog-tax-info.glade:458
 msgid "<b>Account Tax Information</b>"
-msgstr ""
+msgstr "<b>Tilin verotiedot</b>"
 
 #: gnucash/gtkbuilder/dialog-tax-info.glade:469
-#, fuzzy
-#| msgid "Tax related"
 msgid "Tax _Related"
-msgstr "Veroihin liittyvä"
+msgstr ""
 
 #: gnucash/gtkbuilder/dialog-tax-info.glade:501
 msgid "<b>_TXF Categories</b>"
@@ -16044,140 +15471,124 @@ msgstr ""
 
 #: gnucash/gtkbuilder/dialog-tax-info.glade:604
 msgid "<b>Payer Name Source</b>"
-msgstr ""
+msgstr "<b>Maksajan nimen lähde</b>"
 
 #: gnucash/gtkbuilder/dialog-tax-info.glade:615
-#, fuzzy
-#| msgid "Find Account"
 msgid "C_urrent Account"
-msgstr "Etsi tili"
+msgstr "_Nykyinen tili"
 
 #: gnucash/gtkbuilder/dialog-tax-info.glade:665
-#, fuzzy
-#| msgid "Company Fax Number"
 msgid "<b>Copy Number</b>"
-msgstr "Yrityksen faxinumero"
+msgstr "<b>Kopioi numero</b>"
 
 #: gnucash/gtkbuilder/dialog-tax-table.glade:7
 #: gnucash/gtkbuilder/dialog-tax-table.glade:31
-#, fuzzy
-#| msgid "Tax Number"
 msgid "Tax Tables"
-msgstr "Veronumero"
+msgstr "Verokannat"
 
 #: gnucash/gtkbuilder/dialog-tax-table.glade:142
 msgid "<b>Tax Table Entries</b>"
-msgstr ""
+msgstr "<b>Verokannan sisältö</b>"
 
 #: gnucash/gtkbuilder/dialog-tax-table.glade:197
-#, fuzzy
-#| msgid "_Delete"
 msgid "De_lete"
 msgstr "_Poista"
 
 #: gnucash/gtkbuilder/dialog-tax-table.glade:212
 msgid "Ne_w"
-msgstr ""
+msgstr "_Uusi"
 
 #: gnucash/gtkbuilder/dialog-tax-table.glade:286
-#, fuzzy
-#| msgid "Value"
 msgid "Value $"
-msgstr "Arvo"
+msgstr "Arvo €"
 
 #: gnucash/gtkbuilder/dialog-tax-table.glade:289
 msgid "Percent %"
-msgstr ""
+msgstr "Prosentti %"
 
 #: gnucash/gtkbuilder/dialog-tax-table.glade:385
 msgid "<b>Tax Table Entry</b>"
-msgstr ""
+msgstr "<b>Verokannan syöttö</b>"
 
 #: gnucash/gtkbuilder/dialog-tax-table.glade:491
 #: gnucash/register/ledger-core/split-register.c:2124
 #: gnucash/register/ledger-core/split-register.c:2127
-#, fuzzy
-#| msgid "Value"
 msgid "_Value"
-msgstr "Arvo"
+msgstr "_Arvo"
 
 #: gnucash/gtkbuilder/dialog-tax-table.glade:506
 #: gnucash/ui/gnc-reconcile-window.ui:30
-#, fuzzy
-#| msgid "Account"
 msgid "_Account"
-msgstr "Tili"
+msgstr "_Tili"
 
 #: gnucash/gtkbuilder/dialog-totd.glade:8
 msgid "GnuCash Tip Of The Day"
-msgstr ""
+msgstr "GnuCashin päivän vinkki"
 
 #: gnucash/gtkbuilder/dialog-totd.glade:26
 msgid "_Previous"
-msgstr ""
+msgstr "_Edellinen"
 
 #: gnucash/gtkbuilder/dialog-totd.glade:41
 msgid "_Next"
-msgstr ""
+msgstr "_Seuraava"
 
 #: gnucash/gtkbuilder/dialog-totd.glade:95
 msgid "<b>Tip of the Day</b>"
-msgstr ""
+msgstr "<b>Päivän vinkki</b>"
 
 #: gnucash/gtkbuilder/dialog-totd.glade:145
 msgid "_Show tips at startup"
-msgstr ""
+msgstr "_Näytä vinkkejä käynnistettäessä"
 
 #: gnucash/gtkbuilder/dialog-transfer.glade:8
 msgid "Transfer Funds"
-msgstr ""
+msgstr "Siirrä varoja"
 
 #: gnucash/gtkbuilder/dialog-transfer.glade:80
 msgid "<b>Basic Information</b>"
-msgstr ""
+msgstr "<b>Perustiedot</b>"
 
 #: gnucash/gtkbuilder/dialog-transfer.glade:441
 #: gnucash/gtkbuilder/dialog-transfer.glade:457
 #: gnucash/report/reports/standard/net-charts.scm:47
 msgid "Show Income/Expense"
-msgstr ""
+msgstr "Näytä tulo/meno"
 
 #: gnucash/gtkbuilder/dialog-transfer.glade:491
 msgid "<b>Currency Transfer</b>"
-msgstr ""
+msgstr "<b>Valuutan siirto</b>"
 
 #: gnucash/gtkbuilder/dialog-transfer.glade:520
 msgid "Exchange Rate"
-msgstr ""
+msgstr "Valuuttakurssi"
 
 #: gnucash/gtkbuilder/dialog-transfer.glade:601
 msgid "_Fetch Rate"
-msgstr ""
+msgstr "_Nouda kurssi"
 
 #: gnucash/gtkbuilder/dialog-userpass.glade:7
 msgid "Username and Password"
-msgstr ""
+msgstr "Käyttäjätunnus ja salasana"
 
 #: gnucash/gtkbuilder/dialog-userpass.glade:63
 msgid "Enter your username and password"
-msgstr ""
+msgstr "Syötä käyttäjätunnus ja salasana"
 
 #: gnucash/gtkbuilder/dialog-userpass.glade:85
-#, fuzzy
-#| msgid "Username"
 msgid "_Username"
-msgstr "Käyttäjätunnus"
+msgstr "_Käyttäjätunnus"
 
 #: gnucash/gtkbuilder/dialog-userpass.glade:100
 #: gnucash/import-export/aqb/dialog-ab.glade:781
 msgid "_Password"
-msgstr ""
+msgstr "_Salasana"
 
 #: gnucash/gtkbuilder/dialog-vendor.glade:159
 msgid ""
 "The vendor ID number. If left blank a reasonable number will be chosen for "
 "you"
-msgstr ""
+msgstr "Myyjän ID-numero. Jos jätetään tyhjäksi, arvo valitaan puolestasi"
 
 #: gnucash/gtkbuilder/gnc-date-format.glade:12
 msgid "US (12/31/2001)"
@@ -16189,499 +15600,487 @@ msgstr ""
 
 #: gnucash/gtkbuilder/gnc-date-format.glade:18
 msgid "Europe (31.12.2001)"
-msgstr ""
+msgstr "Eurooppalainen (31.12.2001)"
 
 #: gnucash/gtkbuilder/gnc-date-format.glade:21
 msgid "ISO (2001-12-31)"
-msgstr ""
+msgstr "ISO (2001-12-31)"
 
 #: gnucash/gtkbuilder/gnc-date-format.glade:27
 msgid "UTC - Coordinated Universal Time"
 msgstr ""
 
 #: gnucash/gtkbuilder/gnc-date-format.glade:33
-#, fuzzy
-#| msgid "Fancy Date Format"
 msgid "No Fancy Date Format"
-msgstr "Hieno päivämäärämuoto"
+msgstr ""
 
 #: gnucash/gtkbuilder/gnc-date-format.glade:66
 msgid "%Y-%m-%d"
-msgstr ""
+msgstr "%Y-%m-%d"
 
 #: gnucash/gtkbuilder/gnc-date-format.glade:78
 msgid "Include Century"
-msgstr ""
+msgstr "Sisällytä vuosisata"
 
 #: gnucash/gtkbuilder/gnc-date-format.glade:116
 msgid "Abbreviation"
 msgstr ""
 
 #: gnucash/gtkbuilder/gnc-date-format.glade:226
-#, fuzzy
-#| msgid "Fancy Date Format"
 msgid "Date format"
-msgstr "Hieno päivämäärämuoto"
+msgstr "Päiväyksen muoto"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:40
 #: gnucash/gtkbuilder/gnc-frequency.glade:208
 #: gnucash/gtkbuilder/gnc-frequency.glade:434
 #: libgnucash/engine/Recurrence.cpp:666
 msgid "1st"
-msgstr ""
+msgstr "1."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:43
 #: gnucash/gtkbuilder/gnc-frequency.glade:211
 #: gnucash/gtkbuilder/gnc-frequency.glade:437
 #: libgnucash/engine/Recurrence.cpp:666
 msgid "2nd"
-msgstr ""
+msgstr "2."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:46
 #: gnucash/gtkbuilder/gnc-frequency.glade:214
 #: gnucash/gtkbuilder/gnc-frequency.glade:440
 #: libgnucash/engine/Recurrence.cpp:666
 msgid "3rd"
-msgstr ""
+msgstr "3."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:49
 #: gnucash/gtkbuilder/gnc-frequency.glade:217
 #: gnucash/gtkbuilder/gnc-frequency.glade:443
 #: libgnucash/engine/Recurrence.cpp:666
 msgid "4th"
-msgstr ""
+msgstr "4."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:52
 #: gnucash/gtkbuilder/gnc-frequency.glade:220
 #: gnucash/gtkbuilder/gnc-frequency.glade:446
 msgid "5th"
-msgstr ""
+msgstr "5."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:55
 #: gnucash/gtkbuilder/gnc-frequency.glade:223
 #: gnucash/gtkbuilder/gnc-frequency.glade:449
 msgid "6th"
-msgstr ""
+msgstr "6."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:58
 #: gnucash/gtkbuilder/gnc-frequency.glade:226
 #: gnucash/gtkbuilder/gnc-frequency.glade:452
 msgid "7th"
-msgstr ""
+msgstr "7."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:61
 #: gnucash/gtkbuilder/gnc-frequency.glade:229
 #: gnucash/gtkbuilder/gnc-frequency.glade:455
 msgid "8th"
-msgstr ""
+msgstr "8."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:64
 #: gnucash/gtkbuilder/gnc-frequency.glade:232
 #: gnucash/gtkbuilder/gnc-frequency.glade:458
 msgid "9th"
-msgstr ""
+msgstr "9."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:67
 #: gnucash/gtkbuilder/gnc-frequency.glade:235
 #: gnucash/gtkbuilder/gnc-frequency.glade:461
 msgid "10th"
-msgstr ""
+msgstr "10."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:70
 #: gnucash/gtkbuilder/gnc-frequency.glade:238
 #: gnucash/gtkbuilder/gnc-frequency.glade:464
 msgid "11th"
-msgstr ""
+msgstr "11."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:73
 #: gnucash/gtkbuilder/gnc-frequency.glade:241
 #: gnucash/gtkbuilder/gnc-frequency.glade:467
 msgid "12th"
-msgstr ""
+msgstr "12."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:76
 #: gnucash/gtkbuilder/gnc-frequency.glade:244
 #: gnucash/gtkbuilder/gnc-frequency.glade:470
 msgid "13th"
-msgstr ""
+msgstr "13."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:79
 #: gnucash/gtkbuilder/gnc-frequency.glade:247
 #: gnucash/gtkbuilder/gnc-frequency.glade:473
 msgid "14th"
-msgstr ""
+msgstr "14."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:82
 #: gnucash/gtkbuilder/gnc-frequency.glade:250
 #: gnucash/gtkbuilder/gnc-frequency.glade:476
 msgid "15th"
-msgstr ""
+msgstr "15."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:85
 #: gnucash/gtkbuilder/gnc-frequency.glade:253
 #: gnucash/gtkbuilder/gnc-frequency.glade:479
 msgid "16th"
-msgstr ""
+msgstr "16."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:88
 #: gnucash/gtkbuilder/gnc-frequency.glade:256
 #: gnucash/gtkbuilder/gnc-frequency.glade:482
 msgid "17th"
-msgstr ""
+msgstr "17."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:91
 #: gnucash/gtkbuilder/gnc-frequency.glade:259
 #: gnucash/gtkbuilder/gnc-frequency.glade:485
 msgid "18th"
-msgstr ""
+msgstr "18."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:94
 #: gnucash/gtkbuilder/gnc-frequency.glade:262
 #: gnucash/gtkbuilder/gnc-frequency.glade:488
 msgid "19th"
-msgstr ""
+msgstr "19."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:97
 #: gnucash/gtkbuilder/gnc-frequency.glade:265
 #: gnucash/gtkbuilder/gnc-frequency.glade:491
 msgid "20th"
-msgstr ""
+msgstr "20."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:100
 #: gnucash/gtkbuilder/gnc-frequency.glade:268
 #: gnucash/gtkbuilder/gnc-frequency.glade:494
 msgid "21st"
-msgstr ""
+msgstr "21."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:103
 #: gnucash/gtkbuilder/gnc-frequency.glade:271
 #: gnucash/gtkbuilder/gnc-frequency.glade:497
 msgid "22nd"
-msgstr ""
+msgstr "22."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:106
 #: gnucash/gtkbuilder/gnc-frequency.glade:274
 #: gnucash/gtkbuilder/gnc-frequency.glade:500
 msgid "23rd"
-msgstr ""
+msgstr "23."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:109
 #: gnucash/gtkbuilder/gnc-frequency.glade:277
 #: gnucash/gtkbuilder/gnc-frequency.glade:503
 msgid "24th"
-msgstr ""
+msgstr "24."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:112
 #: gnucash/gtkbuilder/gnc-frequency.glade:280
 #: gnucash/gtkbuilder/gnc-frequency.glade:506
 msgid "25th"
-msgstr ""
+msgstr "25."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:115
 #: gnucash/gtkbuilder/gnc-frequency.glade:283
 #: gnucash/gtkbuilder/gnc-frequency.glade:509
 msgid "26th"
-msgstr ""
+msgstr "26."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:118
 #: gnucash/gtkbuilder/gnc-frequency.glade:286
 #: gnucash/gtkbuilder/gnc-frequency.glade:512
 msgid "27th"
-msgstr ""
+msgstr "27."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:121
 #: gnucash/gtkbuilder/gnc-frequency.glade:289
 #: gnucash/gtkbuilder/gnc-frequency.glade:515
 msgid "28th"
-msgstr ""
+msgstr "28."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:124
 #: gnucash/gtkbuilder/gnc-frequency.glade:292
 #: gnucash/gtkbuilder/gnc-frequency.glade:518
 msgid "29th"
-msgstr ""
+msgstr "29."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:127
 #: gnucash/gtkbuilder/gnc-frequency.glade:295
 #: gnucash/gtkbuilder/gnc-frequency.glade:521
 msgid "30th"
-msgstr ""
+msgstr "30."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:130
 #: gnucash/gtkbuilder/gnc-frequency.glade:298
 #: gnucash/gtkbuilder/gnc-frequency.glade:524
 msgid "31st"
-msgstr ""
+msgstr "31."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:133
 #: gnucash/gtkbuilder/gnc-frequency.glade:301
 #: gnucash/gtkbuilder/gnc-frequency.glade:527
-#, fuzzy
-#| msgid "Last day of previous month."
 msgid "Last day of month"
-msgstr "Edellisen kuukauden viimeinen päivä."
+msgstr "Viimeinen päivä"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:136
 #: gnucash/gtkbuilder/gnc-frequency.glade:304
 #: gnucash/gtkbuilder/gnc-frequency.glade:530
 msgid "Last Monday"
-msgstr ""
+msgstr "Viimeinen maanantai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:139
 #: gnucash/gtkbuilder/gnc-frequency.glade:307
 #: gnucash/gtkbuilder/gnc-frequency.glade:533
 msgid "Last Tuesday"
-msgstr ""
+msgstr "Viimeinen tiistai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:142
 #: gnucash/gtkbuilder/gnc-frequency.glade:310
 #: gnucash/gtkbuilder/gnc-frequency.glade:536
 msgid "Last Wednesday"
-msgstr ""
+msgstr "Viimeinen keskiviikko"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:145
 #: gnucash/gtkbuilder/gnc-frequency.glade:313
 #: gnucash/gtkbuilder/gnc-frequency.glade:539
 msgid "Last Thursday"
-msgstr ""
+msgstr "Viimeinen torstai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:148
 #: gnucash/gtkbuilder/gnc-frequency.glade:316
 #: gnucash/gtkbuilder/gnc-frequency.glade:542
 msgid "Last Friday"
-msgstr ""
+msgstr "Viimeinen perjantai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:151
 #: gnucash/gtkbuilder/gnc-frequency.glade:319
 #: gnucash/gtkbuilder/gnc-frequency.glade:545
 msgid "Last Saturday"
-msgstr ""
+msgstr "Viimeinen lauantai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:154
 #: gnucash/gtkbuilder/gnc-frequency.glade:322
 #: gnucash/gtkbuilder/gnc-frequency.glade:548
 msgid "Last Sunday"
-msgstr ""
+msgstr "Viimeinen sunnuntai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:168
 #: gnucash/gtkbuilder/gnc-frequency.glade:692
 #: libgnucash/engine/Recurrence.cpp:739
 msgid "Once"
-msgstr ""
+msgstr "Kerran"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:177
 #: gnucash/gtkbuilder/gnc-frequency.glade:1239
 msgid "Semi-Monthly"
-msgstr ""
+msgstr "Kahdesti kuussa"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:191
 #: gnucash/gtkbuilder/gnc-frequency.glade:417
 #: gnucash/gtkbuilder/gnc-frequency.glade:559
 msgid "No change"
-msgstr ""
+msgstr "Ei muutosta"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:194
 #: gnucash/gtkbuilder/gnc-frequency.glade:420
 #: gnucash/gtkbuilder/gnc-frequency.glade:562
-#, fuzzy
-#| msgid "End of previous year"
 msgid "Use previous weekday"
-msgstr "Viime vuoden loppu"
+msgstr "Käytä edellistä arkipäivää"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:197
 #: gnucash/gtkbuilder/gnc-frequency.glade:423
 #: gnucash/gtkbuilder/gnc-frequency.glade:565
 msgid "Use next weekday"
-msgstr ""
+msgstr "Käytä seuraavaa arkipäivää"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:325
 msgid "1st Mon"
-msgstr ""
+msgstr "1. maanantai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:328
 msgid "1st Tue"
-msgstr ""
+msgstr "1. tiistai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:331
 msgid "1st Wed"
-msgstr ""
+msgstr "1. keskiviikko"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:334
 msgid "1st Thu"
-msgstr ""
+msgstr "1. torstai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:337
 msgid "1st Fri"
-msgstr ""
+msgstr "1. perjantai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:340
 msgid "1st Sat"
-msgstr ""
+msgstr "1. lauantai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:343
 msgid "1st Sun"
-msgstr ""
+msgstr "1. sunnuntai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:346
 msgid "2nd Mon"
-msgstr ""
+msgstr "2. maanantai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:349
 msgid "2nd Tue"
-msgstr ""
+msgstr "2. tiistai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:352
 msgid "2nd Wed"
-msgstr ""
+msgstr "2. keskiviikko"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:355
 msgid "2nd Thu"
-msgstr ""
+msgstr "2. torstai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:358
 msgid "2nd Fri"
-msgstr ""
+msgstr "2. perjantai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:361
 msgid "2nd Sat"
-msgstr ""
+msgstr "2. lauantai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:364
 msgid "2nd Sun"
-msgstr ""
+msgstr "2. sunnuntai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:367
 msgid "3rd Mon"
-msgstr ""
+msgstr "3. maanantai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:370
 msgid "3rd Tue"
-msgstr ""
+msgstr "3. tiistai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:373
 msgid "3rd Wed"
-msgstr ""
+msgstr "3. keskiviikko"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:376
 msgid "3rd Thu"
-msgstr ""
+msgstr "3. torstai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:379
 msgid "3rd Fri"
-msgstr ""
+msgstr "3. perjantai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:382
 msgid "3rd Sat"
-msgstr ""
+msgstr "3. lauantai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:385
 msgid "3rd Sun"
-msgstr ""
+msgstr "3. sunnuntai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:388
 msgid "4th Mon"
-msgstr ""
+msgstr "4. maanantai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:391
 msgid "4th Tue"
-msgstr ""
+msgstr "4. tiistai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:394
 msgid "4th Wed"
-msgstr ""
+msgstr "4. keskiviikko"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:397
 msgid "4th Thu"
-msgstr ""
+msgstr "4. torstai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:400
 msgid "4th Fri"
-msgstr ""
+msgstr "4. perjantai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:403
 msgid "4th Sat"
-msgstr ""
+msgstr "4. lauantai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:406
 msgid "4th Sun"
-msgstr ""
+msgstr "4. sunnuntai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:649
-#, fuzzy
-#| msgid "Not Used"
 msgid "Not scheduled"
-msgstr "Ei käytetty"
+msgstr "Ei ajastettu"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:673
-#, fuzzy
-#| msgid "The current date."
 msgid "Select occurrence date above."
-msgstr "Tämä päiväys."
+msgstr ""
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:710
 msgctxt "Daily"
 msgid "Every"
-msgstr ""
+msgstr "Päivittäin"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:741
 msgctxt "Daily"
 msgid "days."
-msgstr ""
+msgstr "päivää."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:787
 msgctxt "Weekly"
 msgid "Every"
-msgstr ""
+msgstr "Viikoittain"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:818
 msgctxt "Weekly"
 msgid "weeks."
-msgstr ""
+msgstr "viikkoa."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:853
 #: gnucash/report/reports/example/daily-reports.scm:163
 msgid "Saturday"
-msgstr ""
+msgstr "Lauantai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:868
 #: gnucash/report/reports/example/daily-reports.scm:163
 msgid "Friday"
-msgstr ""
+msgstr "Perjantai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:883
 #: gnucash/report/reports/example/daily-reports.scm:162
 msgid "Wednesday"
-msgstr ""
+msgstr "Keskiviikko"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:898
 #: gnucash/report/reports/example/daily-reports.scm:163
 msgid "Thursday"
-msgstr ""
+msgstr "Torstai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:913
 #: gnucash/report/reports/example/daily-reports.scm:161
 msgid "Sunday"
-msgstr ""
+msgstr "Sunnuntai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:928
 #: gnucash/report/reports/example/daily-reports.scm:161
 msgid "Monday"
-msgstr ""
+msgstr "Maanantai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:943
 #: gnucash/report/reports/example/daily-reports.scm:162
 msgid "Tuesday"
-msgstr ""
+msgstr "Tiistai"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:1023
 msgctxt "Semimonthly"
 msgid "Every"
-msgstr ""
+msgstr "Puolikuukausittain"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:1053
 msgctxt "Semimonthly"
 msgid "months."
-msgstr ""
+msgstr "kuukautta."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:1078
 msgid "First on the"
@@ -16691,7 +16090,7 @@ msgstr ""
 #: gnucash/gtkbuilder/gnc-frequency.glade:1188
 #: gnucash/gtkbuilder/gnc-frequency.glade:1358
 msgid "except on weekends"
-msgstr ""
+msgstr "paitsi viikonloppuisin"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:1155
 msgid "then on the"
@@ -16700,16 +16099,16 @@ msgstr ""
 #: gnucash/gtkbuilder/gnc-frequency.glade:1267
 msgctxt "Monthly"
 msgid "Every"
-msgstr ""
+msgstr "Kuukausittain"
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:1299
 msgctxt "Monthly"
 msgid "months."
-msgstr ""
+msgstr "kuukautta."
 
 #: gnucash/gtkbuilder/gnc-frequency.glade:1325
 msgid "On the"
-msgstr ""
+msgstr "Kuun"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:15
 msgid "Edit budget for all periods"
@@ -16717,7 +16116,7 @@ msgstr ""
 
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:117
 msgid "Replace"
-msgstr ""
+msgstr "Korvaa"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:121
 msgid ""
@@ -16727,7 +16126,7 @@ msgstr ""
 
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:134
 msgid "Add"
-msgstr ""
+msgstr "Lisää"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:138
 msgid "Add 'value' to current budget for each period"
@@ -16735,7 +16134,7 @@ msgstr ""
 
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:152
 msgid "Multiply"
-msgstr ""
+msgstr "Moninkertaista"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:156
 msgid "Multiply current budget for each period by 'value'"
@@ -16744,12 +16143,12 @@ msgstr ""
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:178
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:316
 msgid "The number of leading digits to keep when rounding"
-msgstr ""
+msgstr "Merkitsevien numeroiden määrä pyöristettäessä lukuja"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:197
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:334
 msgid "Significant Digits"
-msgstr ""
+msgstr "Merkitseviä numeroita"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:209
 msgid "Use a fixed value or apply transformation for all periods."
@@ -16757,11 +16156,11 @@ msgstr ""
 
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:238
 msgid "Estimate Budget Values"
-msgstr ""
+msgstr "Arvioi budjettiluvut"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:299
 msgid "Use Average"
-msgstr ""
+msgstr "Käytä keskiarvoa"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:303
 msgid "Use the average value over all actual periods for all projected periods"
@@ -16772,41 +16171,35 @@ msgid ""
 "GnuCash will estimate budget values for the selected accounts from past "
 "transactions."
 msgstr ""
+"GnuCash arvioi valituille tileille budjetin arvot aiempien tapahtumien "
+"perusteella."
 
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:410
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:658
-#, fuzzy
-#| msgid "New Book Options"
 msgid "Budget Options"
-msgstr "Uuden kirjanpidon asetukset"
+msgstr "Budjetin asetukset"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:477
 msgid "Budget Name"
-msgstr ""
+msgstr "Budjetin nimi"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:541
 msgid "Number of Periods"
-msgstr ""
+msgstr "Jaksojen määrä"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:571
-#, fuzzy
-#| msgid "Period"
 msgid "Budget Period"
-msgstr "Aikaväli"
+msgstr "Budjettijakso"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:620
 #: gnucash/report/reports/standard/general-ledger.scm:126
 #: gnucash/report/trep-engine.scm:91 gnucash/report/trep-engine.scm:2281
-#, fuzzy
-#| msgid "CSV Account Map"
 msgid "Show Account Code"
-msgstr "CSV-tilikartta"
+msgstr "Näytä tilinumero"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:634
-#, fuzzy
-#| msgid "Description"
 msgid "Show Description"
-msgstr "Selite"
+msgstr "Näytä kuvaus"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:675
 msgid "Note: Use View->'Filter By…' to control visible accounts."
@@ -16814,45 +16207,45 @@ msgstr ""
 
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:693
 msgid "Budget List"
-msgstr ""
+msgstr "Budjettilista"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:713
 msgid "Close the Budget List"
-msgstr ""
+msgstr "Sulje budjettilista"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:773
 msgid "Create a New Budget"
-msgstr ""
+msgstr "Luo uusi budjetti"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:789
 msgid "Open the Selected Budget"
-msgstr ""
+msgstr "Avaa valittu budjetti"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:805
 msgid "Delete the Selected Budget"
-msgstr ""
+msgstr "Poista valittu budjetti"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:837
 msgid "Budget Notes"
-msgstr ""
+msgstr "Budjettimuistiinpanot"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-budget.glade:892
 msgid "Enter Note"
-msgstr ""
+msgstr "Syötä muistiinpano"
 
 #. Filter register by… Dialog
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:13
 msgid "Filter register by…"
-msgstr ""
+msgstr "_Lajittele tilikirja…"
 
 #. Filter By Dialog, Date Tab
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:80
 msgid "Show _All"
-msgstr ""
+msgstr "Näytä _kaikki"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:100
 msgid "Show _number of days"
-msgstr ""
+msgstr "Näytä päivien _määrä"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:120
 msgid ""
@@ -16861,17 +16254,13 @@ msgid ""
 msgstr ""
 
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:195
-#, fuzzy
-#| msgid "Closing Date"
 msgid "Choo_se Date"
-msgstr "Tilinpäätöspäivä"
+msgstr "_Valitse päivämäärä"
 
 #. Filter By Dialog, State Tab
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:390
-#, fuzzy
-#| msgid "Reconcile"
 msgid "_Unreconciled"
-msgstr "Tarkista"
+msgstr ""
 
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:422
 msgid "C_leared"
@@ -16879,7 +16268,7 @@ msgstr ""
 
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:438
 msgid "_Voided"
-msgstr ""
+msgstr "_Mitätöity"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:454
 msgid "_Frozen"
@@ -16892,35 +16281,29 @@ msgstr ""
 
 #. Duplicate Transaction Dialog
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:581
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Duplicate Transaction"
-msgstr "Etsi tosite"
+msgstr "Monista tosite"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:680
-#, fuzzy
-#| msgid "Number"
 msgid "_Number"
-msgstr "Numero"
+msgstr "_Numero"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:708
-#, fuzzy
-#| msgid "Transaction Number"
 msgid "_Transaction Number"
-msgstr "Tositenumero"
+msgstr "_Tositteen numero"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:738
 msgid "Keep Linked Document Entry"
-msgstr ""
+msgstr "Säilytä yhdistetyn asiakirjan tietue"
 
 #. Sort register by Dialog
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:785
 msgid "Sort register by…"
-msgstr ""
+msgstr "_Lajittele tilikirja…"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:848
 msgid "_Standard Order"
-msgstr ""
+msgstr "_Tavanomainen järjestys"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:852
 msgid "Keep normal account order."
@@ -16928,16 +16311,16 @@ msgstr ""
 
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:881
 msgid "Sort by date."
-msgstr ""
+msgstr "Järjestä päivän mukaan."
 
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:896
 #: gnucash/ui/gnc-plugin-page-invoice.ui:96
 msgid "Date of _Entry"
-msgstr ""
+msgstr "_Syöttöpäivämäärä"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:900
 msgid "Sort by the date of entry."
-msgstr ""
+msgstr "Lajittele syöttöpäivän mukaan."
 
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:915
 msgid "S_tatement Date"
@@ -16950,51 +16333,45 @@ msgstr ""
 
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:934
 msgid "Num_ber"
-msgstr ""
+msgstr "_Numero"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:938
 msgid "Sort by number."
-msgstr ""
+msgstr "Järjestä numeron mukaan."
 
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:953
 msgid "Amo_unt"
-msgstr ""
+msgstr "_Määrä"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:957
 msgid "Sort by amount."
-msgstr ""
+msgstr "Järjestä määrän mukaan."
 
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:976
 msgid "Sort by memo."
-msgstr ""
+msgstr "Järjestä erittelyn mukaan."
 
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:991
 #: gnucash/ui/gnc-plugin-page-invoice.ui:114
-#, fuzzy
-#| msgid "Description"
 msgid "Descri_ption"
-msgstr "Selite"
+msgstr "_Kuvaus"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:995
-#, fuzzy
-#| msgid "Description"
 msgid "Sort by description."
-msgstr "Selite"
+msgstr "Järjestä selitteen mukaan."
 
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:1010
 #: gnucash/ui/gnc-embedded-register-window.ui:88
-#, fuzzy
-#| msgid "Action"
 msgid "_Action"
-msgstr "Tapahtuma"
+msgstr "_Toiminto"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:1014
 msgid "Sort by action field."
-msgstr ""
+msgstr "Järjestä toimintokentän mukaan."
 
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:1033
 msgid "Sort by notes field."
-msgstr ""
+msgstr "Järjestä huomautusten mukaan."
 
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:1064
 msgid "Sa_ve Sort Order"
@@ -17006,37 +16383,35 @@ msgstr ""
 
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:1084
 msgid "_Reverse Order"
-msgstr ""
+msgstr "_Käänteinen järjestys"
 
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:1088
 msgid "Sort in descending order."
-msgstr ""
+msgstr "Järjestä alenevasti."
 
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:1124
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Void Transaction"
-msgstr "Etsi tosite"
+msgstr ""
 
 #: gnucash/gtkbuilder/gnc-plugin-page-register.glade:1188
 msgid "Reason for voiding transaction"
-msgstr ""
+msgstr "Tositteen mitätöinnin syy"
 
 #: gnucash/gtkbuilder/gnc-recurrence.glade:12
 msgid "day(s)"
-msgstr ""
+msgstr "päivää"
 
 #: gnucash/gtkbuilder/gnc-recurrence.glade:15
 msgid "week(s)"
-msgstr ""
+msgstr "viikkoa"
 
 #: gnucash/gtkbuilder/gnc-recurrence.glade:18
 msgid "month(s)"
-msgstr ""
+msgstr "kuukautta"
 
 #: gnucash/gtkbuilder/gnc-recurrence.glade:21
 msgid "year(s)"
-msgstr ""
+msgstr "vuotta"
 
 #: gnucash/gtkbuilder/gnc-recurrence.glade:50
 msgid "Every "
@@ -17050,13 +16425,11 @@ msgstr ""
 
 #: gnucash/gtkbuilder/gnc-recurrence.glade:109
 msgid "beginning on"
-msgstr ""
+msgstr "alkaen"
 
 #: gnucash/gtkbuilder/gnc-recurrence.glade:144
-#, fuzzy
-#| msgid "Start of this month"
 msgid "last of month"
-msgstr "Tämän kuun alku"
+msgstr "kuukauden viimeinen"
 
 #: gnucash/gtkbuilder/gnc-recurrence.glade:148
 msgid "Always use the last day (or day of week) in the month?"
@@ -17064,13 +16437,15 @@ msgstr ""
 
 #: gnucash/gtkbuilder/gnc-recurrence.glade:160
 msgid "same week & day"
-msgstr ""
+msgstr "sama viikko ja päivä"
 
 #: gnucash/gtkbuilder/gnc-recurrence.glade:164
 msgid ""
 "Match the \"day of week\" and \"week of month\"? (for example, the \"second "
 "Tuesday\" of every month)"
 msgstr ""
+"Säilytetäänkö viikonpäivä ja kuukauden viikko samoina? (esimerkiksi "
+"\"jokaisen kuukauden toinen tiistai\")"
 
 #: gnucash/gtkbuilder/gnc-tree-view-owner.glade:62
 msgid "Only show _active owners"
@@ -17078,7 +16453,7 @@ msgstr ""
 
 #: gnucash/gtkbuilder/gnc-tree-view-owner.glade:79
 msgid "Show _zero balance owners"
-msgstr ""
+msgstr "Näytä _nollasaldolliset omistajat"
 
 #: gnucash/gtkbuilder/window-autoclear.glade:71
 msgid "About Auto-Clear"
@@ -17093,7 +16468,7 @@ msgstr ""
 
 #: gnucash/gtkbuilder/window-autoclear.glade:101
 msgid "Caution!"
-msgstr ""
+msgstr "Varoitus!"
 
 #: gnucash/gtkbuilder/window-autoclear.glade:116
 msgid ""
@@ -17104,16 +16479,12 @@ msgstr ""
 
 #: gnucash/gtkbuilder/window-autoclear.glade:139
 #: gnucash/gtkbuilder/window-reconcile.glade:118
-#, fuzzy
-#| msgid "Opening Balance"
 msgid "_Ending Balance"
-msgstr "Avaussaldo"
+msgstr "_Loppusaldo"
 
 #: gnucash/gtkbuilder/window-autoclear.glade:181
-#, fuzzy
-#| msgid "Reverse split"
 msgid "_Review cleared splits"
-msgstr "Osakkeiden yhdistäminen"
+msgstr ""
 
 #: gnucash/gtkbuilder/window-autoclear.glade:185
 msgid "Select this option to open a register tab with newly cleared splits."
@@ -17121,35 +16492,35 @@ msgstr ""
 
 #: gnucash/gtkbuilder/window-reconcile.glade:71
 msgid "<b>Reconcile Information</b>"
-msgstr ""
+msgstr "<b>Täsmäytyksen tiedot</b>"
 
 #: gnucash/gtkbuilder/window-reconcile.glade:93
 msgid "Statement _Date"
-msgstr ""
+msgstr "Raportin _päiväys"
 
 #: gnucash/gtkbuilder/window-reconcile.glade:128
 msgid "Include _subaccounts"
-msgstr ""
+msgstr "_Sisällytä alatilit"
 
 #: gnucash/gtkbuilder/window-reconcile.glade:132
 msgid ""
 "Include all descendant accounts in the reconcile. All of them must use the "
 "same commodity as this one."
 msgstr ""
+"Sisällytä alatilit täsmäytykseen. Niiden kaikkien täytyy käyttää samaa "
+"hyödykettä kuin tämä tili."
 
 #: gnucash/gtkbuilder/window-reconcile.glade:258
 msgid "Statement Date is after today"
 msgstr ""
 
 #: gnucash/html/gnc-html-webkit1.c:78 gnucash/html/gnc-html-webkit2.c:87
-#, fuzzy
-#| msgid "File Not Found"
 msgid "Not found"
-msgstr "Tiedostoa ei löytynyt"
+msgstr "Ei löytynyt"
 
 #: gnucash/html/gnc-html-webkit1.c:79 gnucash/html/gnc-html-webkit2.c:88
 msgid "The specified URL could not be loaded."
-msgstr ""
+msgstr "Määritettyä URL-osoitetta ei voitu ladata."
 
 #: gnucash/html/gnc-html-webkit1.c:560 gnucash/html/gnc-html-webkit1.c:979
 #: gnucash/html/gnc-html-webkit2.c:563 gnucash/html/gnc-html-webkit2.c:930
@@ -17172,30 +16543,28 @@ msgstr ""
 
 #: gnucash/html/gnc-html-webkit1.c:1211
 msgid "Export to PDF File"
-msgstr ""
+msgstr "Vie PDF-tiedostoon"
 
 #. Translators: Strings are 1. Bank code, 2. Bank name,
 #. 3. Account Number, 4. Subaccount ID
 #: gnucash/import-export/aqb/assistant-ab-initial.c:481
 #, c-format
 msgid "Bank code %s (%s), Account %s (%s)"
-msgstr ""
+msgstr "Pankkikoodi %s (%s), Tili %s (%s)"
 
 #: gnucash/import-export/aqb/assistant-ab-initial.c:773
 msgid "Online Banking Account Name"
-msgstr ""
+msgstr "Verkkopankin tilin nimi"
 
 #: gnucash/import-export/aqb/assistant-ab-initial.c:778
-#, fuzzy
-#| msgid "CSV Account Map"
 msgid "GnuCash Account Name"
-msgstr "CSV-tilikartta"
+msgstr "GnuCash-tilin nimi"
 
 #: gnucash/import-export/aqb/assistant-ab-initial.c:784
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:591
 #: gnucash/import-export/qif-imp/dialog-account-picker.c:452
 msgid "New?"
-msgstr ""
+msgstr "Uusi?"
 
 #: gnucash/import-export/aqb/assistant-ab-initial.glade:8
 msgid "AqBanking Initial Assistant"
@@ -17206,6 +16575,8 @@ msgid ""
 "This assistant helps you setting up your Online Banking connection with your "
 "bank."
 msgstr ""
+"Tämä ohjattu avustustoiminto auttaa sinua määrittämään verkkopankkiyhteyden "
+"pankkisi kanssa."
 
 #: gnucash/import-export/aqb/assistant-ab-initial.glade:39
 msgid ""
@@ -17244,7 +16615,7 @@ msgstr ""
 
 #: gnucash/import-export/aqb/assistant-ab-initial.glade:89
 msgid "Initial Online Banking Setup"
-msgstr ""
+msgstr "Verkkopankin määrityksen aloitus"
 
 #: gnucash/import-export/aqb/assistant-ab-initial.glade:111
 msgid ""
@@ -17274,11 +16645,11 @@ msgstr ""
 
 #: gnucash/import-export/aqb/assistant-ab-initial.glade:170
 msgid "_Start AqBanking Setup"
-msgstr ""
+msgstr "_Aloita AqBanking määritys"
 
 #: gnucash/import-export/aqb/assistant-ab-initial.glade:186
 msgid "Start Online Banking Setup"
-msgstr ""
+msgstr "Aloita verkkopankin määritys"
 
 #: gnucash/import-export/aqb/assistant-ab-initial.glade:204
 msgid ""
@@ -17293,7 +16664,7 @@ msgstr ""
 
 #: gnucash/import-export/aqb/assistant-ab-initial.glade:265
 msgid "Match Online accounts with GnuCash accounts"
-msgstr ""
+msgstr "Täsmää verkkopankkitilit GnuCash-tilien kanssa"
 
 #: gnucash/import-export/aqb/assistant-ab-initial.glade:280
 msgid ""
@@ -17308,42 +16679,40 @@ msgstr ""
 
 #: gnucash/import-export/aqb/assistant-ab-initial.glade:296
 msgid "Online Banking Setup Finished"
-msgstr ""
+msgstr "Verkkopankin määritys valmistui"
 
 #: gnucash/import-export/aqb/dialog-ab.glade:8
 msgid "Online Banking Connection Window"
-msgstr ""
+msgstr "Verkkopankin yhteysikkuna"
 
 #: gnucash/import-export/aqb/dialog-ab.glade:26
 msgid "_Abort"
-msgstr ""
+msgstr "_Keskeytä"
 
 #: gnucash/import-export/aqb/dialog-ab.glade:82
 #: gnucash/import-export/aqb/dialog-ab.glade:148
 msgid "Progress"
-msgstr ""
+msgstr "Eteneminen"
 
 #: gnucash/import-export/aqb/dialog-ab.glade:106
 msgid "Current _Job"
-msgstr ""
+msgstr "Nykyinen _työ"
 
 #: gnucash/import-export/aqb/dialog-ab.glade:162
 msgid "Current _Action"
-msgstr ""
+msgstr "Nykyinen _toiminto"
 
 #: gnucash/import-export/aqb/dialog-ab.glade:211
 msgid "<b>_Log Messages</b>"
-msgstr ""
+msgstr "<b>_Lokiviestit</b>"
 
 #: gnucash/import-export/aqb/dialog-ab.glade:254
 msgid "Close when _finished"
-msgstr ""
+msgstr "_Sulje kun valmis"
 
 #: gnucash/import-export/aqb/dialog-ab.glade:287
-#, fuzzy
-#| msgid "Transaction Number"
 msgid "Get Transactions Online"
-msgstr "Tositenumero"
+msgstr ""
 
 #: gnucash/import-export/aqb/dialog-ab.glade:349
 msgid "Date range of transactions to retrieve:"
@@ -17355,19 +16724,19 @@ msgstr ""
 #: gnucash/report/reports/standard/customer-summary.scm:40
 #: gnucash/report/reports/standard/new-owner-report.scm:44
 msgid "From"
-msgstr ""
+msgstr "Alkaen"
 
 #: gnucash/import-export/aqb/dialog-ab.glade:390
 msgid "_Earliest possible date"
-msgstr ""
+msgstr "_Varhaisin mahdollinen päivämäärä"
 
 #: gnucash/import-export/aqb/dialog-ab.glade:407
 msgid "_Last retrieval date"
-msgstr ""
+msgstr "_Viimeisin noutopäivämäärä"
 
 #: gnucash/import-export/aqb/dialog-ab.glade:424
 msgid "E_nter date:"
-msgstr ""
+msgstr "_Syötä päivämäärä:"
 
 #: gnucash/import-export/aqb/dialog-ab.glade:474
 #: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:145
@@ -17376,23 +16745,23 @@ msgstr ""
 #: gnucash/report/reports/standard/new-aging.scm:39
 #: gnucash/report/reports/standard/new-owner-report.scm:45
 msgid "To"
-msgstr ""
+msgstr "Päättyen"
 
 #: gnucash/import-export/aqb/dialog-ab.glade:495
 msgid "Ente_r date:"
-msgstr ""
+msgstr "_Syötä päivämäärä:"
 
 #: gnucash/import-export/aqb/dialog-ab.glade:512
 msgid "No_w"
-msgstr ""
+msgstr "_Nyt"
 
 #: gnucash/import-export/aqb/dialog-ab.glade:569
 msgid "Enter Password"
-msgstr ""
+msgstr "Syötä salasana"
 
 #: gnucash/import-export/aqb/dialog-ab.glade:630
 msgid "Enter your password"
-msgstr ""
+msgstr "Syötä salasanasi"
 
 #: gnucash/import-export/aqb/dialog-ab.glade:649
 msgid "Bar_width"
@@ -17404,10 +16773,8 @@ msgid "Setting the bar width, adapting to the size of the TAN generator."
 msgstr ""
 
 #: gnucash/import-export/aqb/dialog-ab.glade:681
-#, fuzzy
-#| msgid "_Delete"
 msgid "_Delay"
-msgstr "_Poista"
+msgstr "_Viive"
 
 #. TAN generator with flicker interface common in DE only
 #: gnucash/import-export/aqb/dialog-ab.glade:695
@@ -17425,11 +16792,11 @@ msgstr ""
 
 #: gnucash/import-export/aqb/dialog-ab.glade:796
 msgid "Con_firm Password"
-msgstr ""
+msgstr "_Vahvista salasana"
 
 #: gnucash/import-export/aqb/dialog-ab.glade:836
 msgid "_Remember the PIN in memory"
-msgstr ""
+msgstr "Tallenna _PIN muistiin"
 
 #: gnucash/import-export/aqb/dialog-ab.glade:842
 msgid ""
@@ -17440,21 +16807,19 @@ msgstr ""
 
 #: gnucash/import-export/aqb/dialog-ab.glade:877
 msgid "Name for new template"
-msgstr ""
+msgstr "Uuden mallineen nimi"
 
 #: gnucash/import-export/aqb/dialog-ab.glade:939
 msgid "_Name of the new template"
-msgstr ""
+msgstr "_Uuden mallineen nimi"
 
 #: gnucash/import-export/aqb/dialog-ab.glade:953
 msgid "Enter a unique name for the new template."
 msgstr ""
 
 #: gnucash/import-export/aqb/dialog-ab.glade:983
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Online Transaction"
-msgstr "Etsi tosite"
+msgstr ""
 
 #: gnucash/import-export/aqb/dialog-ab.glade:998
 msgid "Execute _later (unimpl.)"
@@ -17462,29 +16827,27 @@ msgstr ""
 
 #: gnucash/import-export/aqb/dialog-ab.glade:1027
 msgid "Execute _Now"
-msgstr ""
+msgstr "Suorita _nyt"
 
 #: gnucash/import-export/aqb/dialog-ab.glade:1035
 msgid "Execute this online transaction now"
 msgstr ""
 
 #: gnucash/import-export/aqb/dialog-ab.glade:1062
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Enter an Online Transaction"
-msgstr "Etsi tosite"
+msgstr ""
 
 #: gnucash/import-export/aqb/dialog-ab.glade:1099
 msgid "Recipient Account _Number"
-msgstr ""
+msgstr "Vastaanottajan tilin _numero"
 
 #: gnucash/import-export/aqb/dialog-ab.glade:1128
 msgid "Recipient _Bank Code"
-msgstr ""
+msgstr "Vastaanottajan _pankkikoodi"
 
 #: gnucash/import-export/aqb/dialog-ab.glade:1158
 msgid "_Recipient Name"
-msgstr ""
+msgstr "_Vastaanottajan nimi"
 
 #: gnucash/import-export/aqb/dialog-ab.glade:1174
 #: gnucash/import-export/aqb/dialog-ab.glade:1274
@@ -17493,7 +16856,7 @@ msgstr ""
 
 #: gnucash/import-export/aqb/dialog-ab.glade:1187
 msgid "(filled in automatically)"
-msgstr ""
+msgstr "(täytetään automaattisesti)"
 
 #: gnucash/import-export/aqb/dialog-ab.glade:1216
 msgid "Payment _Purpose (only for recipient)"
@@ -17508,14 +16871,12 @@ msgid "_Originator Name"
 msgstr ""
 
 #: gnucash/import-export/aqb/dialog-ab.glade:1298
-#, fuzzy
-#| msgid "Transaction Number"
 msgid "Originator Account Number"
-msgstr "Tositenumero"
+msgstr ""
 
 #: gnucash/import-export/aqb/dialog-ab.glade:1322
 msgid "Bank Code"
-msgstr ""
+msgstr "Pankkikoodi"
 
 #: gnucash/import-export/aqb/dialog-ab.glade:1483
 msgid "_Add current"
@@ -17527,7 +16888,7 @@ msgstr ""
 
 #: gnucash/import-export/aqb/dialog-ab.glade:1501
 msgid "_Up"
-msgstr ""
+msgstr "_Ylös"
 
 #: gnucash/import-export/aqb/dialog-ab.glade:1507
 msgid "Move the selected transaction template one row up"
@@ -17535,7 +16896,7 @@ msgstr ""
 
 #: gnucash/import-export/aqb/dialog-ab.glade:1519
 msgid "_Down"
-msgstr ""
+msgstr "_Alas"
 
 #: gnucash/import-export/aqb/dialog-ab.glade:1525
 msgid "Move the selected transaction template one row down"
@@ -17543,15 +16904,13 @@ msgstr ""
 
 #: gnucash/import-export/aqb/dialog-ab.glade:1537
 msgid "_Sort"
-msgstr ""
+msgstr "_Järjestä"
 
 #: gnucash/import-export/aqb/dialog-ab.glade:1543
 msgid "Sort the list of transaction templates alphabetically"
 msgstr ""
 
 #: gnucash/import-export/aqb/dialog-ab.glade:1555
-#, fuzzy
-#| msgid "_Delete"
 msgid "D_elete"
 msgstr "_Poista"
 
@@ -17565,7 +16924,7 @@ msgstr ""
 
 #: gnucash/import-export/aqb/dialog-ab.glade:1661
 msgid "Select File Import Format and Template"
-msgstr ""
+msgstr "Valitse tuotavan tiedoston muoto ja malli"
 
 #: gnucash/import-export/aqb/dialog-ab.glade:1730
 msgid ""
@@ -17575,10 +16934,8 @@ msgid ""
 msgstr ""
 
 #: gnucash/import-export/aqb/dialog-ab.glade:1733
-#, fuzzy
-#| msgid "File Found"
 msgid "File Format"
-msgstr "Tiedosto löytyi"
+msgstr "Tiedostomuoto"
 
 #: gnucash/import-export/aqb/dialog-ab.glade:1779
 msgid ""
@@ -17588,16 +16945,16 @@ msgstr ""
 
 #: gnucash/import-export/aqb/dialog-ab.glade:1787
 msgid "Profiles"
-msgstr ""
+msgstr "Profiilit"
 
 #: gnucash/import-export/aqb/dialog-ab-pref.glade:22
 #: gnucash/import-export/aqb/gncmod-aqbanking.c:70
 msgid "Online Banking"
-msgstr ""
+msgstr "Verkkopankki"
 
 #: gnucash/import-export/aqb/dialog-ab-pref.glade:34
 msgid "_Close log window when finished"
-msgstr ""
+msgstr "_Sulje loki-ikkuna kun valmis"
 
 #: gnucash/import-export/aqb/dialog-ab-pref.glade:40
 #: gnucash/import-export/aqb/gschemas/org.gnucash.GnuCash.dialogs.import.hbci.gschema.xml.in:16
@@ -17641,10 +16998,8 @@ msgid ""
 msgstr ""
 
 #: gnucash/import-export/aqb/dialog-ab-trans.c:281
-#, fuzzy
-#| msgid "Unknown"
 msgid "(unknown)"
-msgstr "Tuntematon"
+msgstr "(tuntematon)"
 
 #. Translators: Strings from this file are
 #. needed only in countries that have one of
@@ -17685,20 +17040,16 @@ msgid "Enter a SEPA Internal Transfer"
 msgstr ""
 
 #: gnucash/import-export/aqb/dialog-ab-trans.c:398
-#, fuzzy
-#| msgid "All Accounts"
 msgid "Target Accounts"
-msgstr "Kaikki tilit"
+msgstr "Kohdetilit"
 
 #: gnucash/import-export/aqb/dialog-ab-trans.c:409
 msgid "Enter a SEPA Online Direct Debit Note"
 msgstr ""
 
 #: gnucash/import-export/aqb/dialog-ab-trans.c:412
-#, fuzzy
-#| msgid "Find Account"
 msgid "Debited Account Owner"
-msgstr "Etsi tili"
+msgstr ""
 
 #: gnucash/import-export/aqb/dialog-ab-trans.c:414
 msgid "Debited IBAN (International Account Number)"
@@ -17769,20 +17120,14 @@ msgid ""
 msgstr ""
 
 #: gnucash/import-export/aqb/dialog-ab-trans.c:1028
-#, fuzzy
-#| msgid ""
-#| "A saved report configuration with this name already exists, please choose "
-#| "another name."
 msgid ""
 "A template with the given name already exists. Please enter another name."
 msgstr ""
-"Tallennettu raporttiasetustiedosto tällä nimellä on jo olemassa. Valitse "
-"toinen nimi."
 
 #: gnucash/import-export/aqb/dialog-ab-trans.c:1164
 #, c-format
 msgid "Do you really want to delete the template with the name \"%s\"?"
-msgstr "Haluatko todella poistaa mallin nimellä \"%s\"?"
+msgstr ""
 
 #: gnucash/import-export/aqb/gnc-ab-getbalance.c:73
 #: gnucash/import-export/aqb/gnc-ab-gettrans.c:124
@@ -17828,7 +17173,7 @@ msgstr ""
 
 #: gnucash/import-export/aqb/gnc-ab-transfer.c:116
 msgid "No reference accounts found."
-msgstr ""
+msgstr "Kohdetilejä ei löytynyt."
 
 #: gnucash/import-export/aqb/gnc-ab-transfer.c:181
 msgid ""
@@ -17863,10 +17208,8 @@ msgid "Online Banking European (SEPA) Debit Note"
 msgstr ""
 
 #: gnucash/import-export/aqb/gnc-ab-transfer.c:230
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Online Banking Transaction"
-msgstr "Etsi tosite"
+msgstr ""
 
 #: gnucash/import-export/aqb/gnc-ab-transfer.c:291
 msgid ""
@@ -17884,7 +17227,7 @@ msgstr ""
 #: gnucash/import-export/aqb/gnc-ab-utils.c:478
 #: gnucash/report/report-utilities.scm:197 libgnucash/engine/Account.cpp:4288
 msgid "Bank"
-msgstr ""
+msgstr "Pankki"
 
 #: gnucash/import-export/aqb/gnc-ab-utils.c:725
 msgid ""
@@ -17953,10 +17296,8 @@ msgid ""
 msgstr ""
 
 #: gnucash/import-export/aqb/gnc-ab-utils.c:1051
-#, fuzzy
-#| msgid "Reconciled Date"
 msgid "Reconcile account now?"
-msgstr "Tarkistuspäivämäärä"
+msgstr ""
 
 #: gnucash/import-export/aqb/gnc-ab-utils.c:1127
 msgid "The bank has sent a message in its response."
@@ -17964,11 +17305,11 @@ msgstr ""
 
 #: gnucash/import-export/aqb/gnc-ab-utils.c:1128
 msgid "Subject:"
-msgstr ""
+msgstr "Aihe:"
 
 #: gnucash/import-export/aqb/gnc-file-aqb-import.c:78
 msgid "Select a file to import"
-msgstr ""
+msgstr "Valitse tuotava tiedosto"
 
 #: gnucash/import-export/aqb/gnc-gwen-gui.c:1093
 #, c-format
@@ -17992,24 +17333,20 @@ msgstr ""
 
 #: gnucash/import-export/aqb/gnc-plugin-aqbanking.ui:14
 msgid "_Online Actions"
-msgstr ""
+msgstr "_Verkkotoiminnot"
 
 #: gnucash/import-export/aqb/gnc-plugin-aqbanking.ui:18
-#, fuzzy
-#| msgid "Next Balance"
 msgid "Get _Balance"
-msgstr "Uusi saldo"
+msgstr "Hae _saldo"
 
 #: gnucash/import-export/aqb/gnc-plugin-aqbanking.ui:20
 #: gnucash/ui/gnc-plugin-basic-commands.ui:86
 msgid "The list of Scheduled Transactions"
-msgstr ""
+msgstr "Lista tositeiden ajastuksista"
 
 #: gnucash/import-export/aqb/gnc-plugin-aqbanking.ui:23
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Get _Transactions…"
-msgstr "Etsi tosite"
+msgstr "Hae _tositteet…"
 
 #: gnucash/import-export/aqb/gnc-plugin-aqbanking.ui:25
 msgid "Get the transactions online through Online Banking"
@@ -18018,7 +17355,7 @@ msgstr ""
 #. Translators: https://en.wikipedia.org/wiki/Single_Euro_Payments_Area
 #: gnucash/import-export/aqb/gnc-plugin-aqbanking.ui:31
 msgid "Issue _SEPA Transaction…"
-msgstr ""
+msgstr "Luo _SEPA-maksu…"
 
 #: gnucash/import-export/aqb/gnc-plugin-aqbanking.ui:33
 msgid ""
@@ -18028,7 +17365,7 @@ msgstr ""
 
 #: gnucash/import-export/aqb/gnc-plugin-aqbanking.ui:36
 msgid "Issue SEPA I_nternal Transaction…"
-msgstr ""
+msgstr "Luo _SEPA-maksu…"
 
 #: gnucash/import-export/aqb/gnc-plugin-aqbanking.ui:38
 msgid ""
@@ -18037,10 +17374,8 @@ msgid ""
 msgstr ""
 
 #: gnucash/import-export/aqb/gnc-plugin-aqbanking.ui:41
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "_Internal Transaction…"
-msgstr "Etsi tosite"
+msgstr "S_isäinen tosite…"
 
 #: gnucash/import-export/aqb/gnc-plugin-aqbanking.ui:43
 msgid "Issue a new bank-internal transaction online through Online Banking"
@@ -18048,7 +17383,7 @@ msgstr ""
 
 #: gnucash/import-export/aqb/gnc-plugin-aqbanking.ui:46
 msgid "Issue SEPA Direct _Debit…"
-msgstr ""
+msgstr "Luo SEPA-suo_raveloitus…"
 
 #: gnucash/import-export/aqb/gnc-plugin-aqbanking.ui:48
 msgid ""
@@ -18058,15 +17393,15 @@ msgstr ""
 
 #: gnucash/import-export/aqb/gnc-plugin-aqbanking.ui:53
 msgid "Show _log window"
-msgstr ""
+msgstr "Näytä _loki-ikkuna"
 
 #: gnucash/import-export/aqb/gnc-plugin-aqbanking.ui:55
 msgid "Show the online banking log window"
-msgstr ""
+msgstr "Näytä verkkopankin loki-ikkuna"
 
 #: gnucash/import-export/aqb/gnc-plugin-aqbanking.ui:63
 msgid "_Online Banking Setup…"
-msgstr ""
+msgstr "_Verkkopankin määritys…"
 
 #: gnucash/import-export/aqb/gnc-plugin-aqbanking.ui:65
 msgid ""
@@ -18076,11 +17411,11 @@ msgstr ""
 
 #: gnucash/import-export/aqb/gschemas/org.gnucash.GnuCash.dialogs.import.hbci.gschema.xml.in:15
 msgid "Close window when finished"
-msgstr ""
+msgstr "Sulje ikkuna, kun valmistunut"
 
 #: gnucash/import-export/aqb/gschemas/org.gnucash.GnuCash.dialogs.import.hbci.gschema.xml.in:20
 msgid "Remember the PIN in memory"
-msgstr ""
+msgstr "Tallenna PIN muistiin"
 
 #: gnucash/import-export/aqb/gschemas/org.gnucash.GnuCash.dialogs.import.hbci.gschema.xml.in:25
 msgid "Put the transaction text in front of the purpose of a transaction."
@@ -18137,7 +17472,7 @@ msgstr ""
 #: gnucash/import-export/bi-import/dialog-bi-import.c:297
 #, c-format
 msgid "Validation…\n"
-msgstr ""
+msgstr "Tarkistus…\n"
 
 #: gnucash/import-export/bi-import/dialog-bi-import.c:327
 #, c-format
@@ -18202,12 +17537,12 @@ msgstr ""
 
 #: gnucash/import-export/bi-import/dialog-bi-import.c:645
 msgid "Processing…"
-msgstr ""
+msgstr "Käsitellään…"
 
 #: gnucash/import-export/bi-import/dialog-bi-import.c:714
 #, c-format
 msgid "Invoice %s created.\n"
-msgstr ""
+msgstr "Lasku %s luotu.\n"
 
 #: gnucash/import-export/bi-import/dialog-bi-import.c:729
 msgid "Do you want to update existing bills/invoices?"
@@ -18216,7 +17551,7 @@ msgstr ""
 #: gnucash/import-export/bi-import/dialog-bi-import.c:737
 #, c-format
 msgid "Invoice %s not updated because it already exists.\n"
-msgstr ""
+msgstr "Laskua %s ei päivitetty, koska se on jo olemassa.\n"
 
 #: gnucash/import-export/bi-import/dialog-bi-import.c:752
 #, c-format
@@ -18226,12 +17561,12 @@ msgstr ""
 #: gnucash/import-export/bi-import/dialog-bi-import.c:765
 #, c-format
 msgid "Invoice %s updated.\n"
-msgstr ""
+msgstr "Lasku %s päivitetty.\n"
 
 #: gnucash/import-export/bi-import/dialog-bi-import.c:881
 #, c-format
 msgid "Invoice %s posted.\n"
-msgstr ""
+msgstr "Lasku %s lähetetty.\n"
 
 #: gnucash/import-export/bi-import/dialog-bi-import.c:886
 #, c-format
@@ -18246,57 +17581,53 @@ msgstr ""
 #: gnucash/import-export/bi-import/dialog-bi-import.c:916
 #, c-format
 msgid "Nothing to process.\n"
-msgstr ""
+msgstr "Ei käsiteltävää.\n"
 
 #: gnucash/import-export/bi-import/dialog-bi-import-gui.c:138
 #: gnucash/import-export/customer-import/dialog-customer-import-gui.c:123
-#, fuzzy
-#| msgid "ID #"
 msgid "ID"
-msgstr "ID nro"
+msgstr "Tunnus"
 
 #: gnucash/import-export/bi-import/dialog-bi-import-gui.c:140
 msgid "Owner-ID"
-msgstr ""
+msgstr "Omistajan tunnus"
 
 #: gnucash/import-export/bi-import/dialog-bi-import-gui.c:141
 msgid "Billing-ID"
-msgstr ""
+msgstr "Laskutustunnus"
 
 #: gnucash/import-export/bi-import/dialog-bi-import-gui.c:148
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:92
 #: gnucash/report/reports/standard/invoice.scm:93
 #: gnucash/report/reports/standard/invoice.scm:422
 msgid "Quantity"
-msgstr ""
+msgstr "Määrä"
 
 #: gnucash/import-export/bi-import/dialog-bi-import-gui.c:150
 msgid "Disc-type"
-msgstr ""
+msgstr "Alennustyyppi"
 
 #: gnucash/import-export/bi-import/dialog-bi-import-gui.c:151
 msgid "Disc-how"
-msgstr ""
+msgstr "Alennustapa"
 
 #: gnucash/import-export/bi-import/dialog-bi-import-gui.c:153
 #: gnucash/report/reports/standard/invoice.scm:99
 #: gnucash/report/reports/standard/invoice.scm:434
 msgid "Taxable"
-msgstr ""
+msgstr "Verollinen"
 
 #: gnucash/import-export/bi-import/dialog-bi-import-gui.c:154
 msgid "Taxincluded"
-msgstr ""
+msgstr "Verot sisältyy"
 
 #: gnucash/import-export/bi-import/dialog-bi-import-gui.c:155
 msgid "Tax-table"
-msgstr ""
+msgstr "Verokanta"
 
 #: gnucash/import-export/bi-import/dialog-bi-import-gui.c:159
-#, fuzzy
-#| msgid "Account Types"
 msgid "Account-posted"
-msgstr "Tilityypit"
+msgstr ""
 
 #: gnucash/import-export/bi-import/dialog-bi-import-gui.c:160
 msgid "Memo-posted"
@@ -18308,7 +17639,7 @@ msgstr ""
 
 #: gnucash/import-export/bi-import/dialog-bi-import-gui.c:194
 msgid "Import Bills or Invoices from csv"
-msgstr ""
+msgstr "Tuo osto- ja myyntilaskut CSV:stä"
 
 #: gnucash/import-export/bi-import/dialog-bi-import-gui.c:222
 #, c-format
@@ -18332,10 +17663,8 @@ msgstr ""
 #: gnucash/import-export/bi-import/dialog-bi-import-gui.c:232
 #: gnucash/import-export/csv-imp/assistant-csv-account-import.c:392
 #: gnucash/import-export/customer-import/dialog-customer-import-gui.c:208
-#, fuzzy
-#| msgid "The interest rate cannot be zero."
 msgid "The input file can not be opened."
-msgstr "Korkoprosentti ei voi olla nolla."
+msgstr "Syöttötiedoston avaaminen epäonnistui."
 
 #: gnucash/import-export/bi-import/dialog-bi-import-gui.c:353
 #: gnucash/import-export/csv-imp/assistant-csv-account-import.c:302
@@ -18359,6 +17688,11 @@ msgid ""
 "Select the settings you require for the file and then click \"Next\" to "
 "proceed or \"Cancel\" to abort the export.\n"
 msgstr ""
+"Tämän avustajan kautta voit viedä tilihierarkian tiedostoon käyttäen alla "
+"määriteltyä erotinta.\n"
+"\n"
+"Valitse haluamasi asetukset ja klikkaa Eteenpäin jatkaaksesi tai Peruuta "
+"keskeyttääksesi viennin.\n"
 
 #. Translators: %s is one of the following paragraphs about rows/transaction.
 #: gnucash/import-export/csv-exp/assistant-csv-export.c:87
@@ -18402,6 +17736,10 @@ msgid ""
 "You can also verify your selections by clicking on \"Back\" or \"Cancel\" to "
 "abort the export.\n"
 msgstr ""
+"Vie tilihierarkia tiedostoon \"%s\" klikkaamalla \"Toteuta\".\n"
+"\n"
+"Voit vielä muuttaa valintojasi valitsemalla \"Takaisin\" tai peruuttaa "
+"viennin klikkaamalla \"Peruuta\"\n"
 
 #. Translators: %s is the file name and %u the number of accounts.
 #: gnucash/import-export/csv-exp/assistant-csv-export.c:114
@@ -18413,6 +17751,11 @@ msgid ""
 "You can also verify your selections by clicking on \"Back\" or \"Cancel\" to "
 "abort the export.\n"
 msgstr ""
+"Kun klikkaat \"Toteuta\", tositteet viedään tiedostoon '%s'. Vietäviä tilejä "
+"on %u kappaletta.\n"
+"\n"
+"Voit vielä muuttaa valintojasi valitsemalla \"Takaisin\" tai peruuttaa "
+"viennin klikkaamalla \"Peruuta\"\n"
 
 #. Translators: %s is the file name.
 #: gnucash/import-export/csv-exp/assistant-csv-export.c:120
@@ -18424,6 +17767,10 @@ msgid ""
 "You can also verify your selections by clicking on \"Back\" or \"Cancel\" to "
 "abort the export.\n"
 msgstr ""
+"Kun klikkaat \"Toteuta\", tositteet viedään tiedostoon '%s'.\n"
+"\n"
+"Voit vielä muuttaa valintojasi valitsemalla \"Takaisin\" tai peruuttaa "
+"viennin klikkaamalla \"Peruuta\"\n"
 
 #: gnucash/import-export/csv-exp/assistant-csv-export.c:759
 msgid ""
@@ -18435,16 +17782,14 @@ msgstr ""
 
 #: gnucash/import-export/csv-exp/assistant-csv-export.c:763
 msgid "File exported successfully!\n"
-msgstr ""
+msgstr "Tiedoston vienti onnistui!\n"
 
 #: gnucash/import-export/csv-exp/csv-transactions-export.cpp:135
 #: gnucash/import-export/import-main-matcher.cpp:1893
 #: gnucash/report/reports/standard/register.scm:217
 #: libgnucash/engine/Split.cpp:1612 libgnucash/engine/Split.cpp:1629
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "-- Split Transaction --"
-msgstr "Etsi tosite"
+msgstr "-- Monirivinen --"
 
 #: gnucash/import-export/csv-exp/csv-transactions-export.cpp:368
 msgid "Full Category Path"
@@ -18453,61 +17798,51 @@ msgstr ""
 #: gnucash/import-export/csv-exp/csv-transactions-export.cpp:370
 #: gnucash/import-export/csv-exp/csv-transactions-export.cpp:390
 msgid "Amount With Sym"
-msgstr ""
+msgstr "Määrä symbolilla"
 
 #: gnucash/import-export/csv-exp/csv-transactions-export.cpp:371
 #: gnucash/import-export/csv-exp/csv-transactions-export.cpp:391
 msgid "Amount Num."
-msgstr ""
+msgstr "Määrä numerona"
 
 #: gnucash/import-export/csv-exp/csv-transactions-export.cpp:372
 #: gnucash/import-export/csv-exp/csv-transactions-export.cpp:392
 msgid "Value With Sym"
-msgstr ""
+msgstr "Arvo symbolilla"
 
 #: gnucash/import-export/csv-exp/csv-transactions-export.cpp:373
 #: gnucash/import-export/csv-exp/csv-transactions-export.cpp:393
-#, fuzzy
-#| msgid "Value"
 msgid "Value Num."
-msgstr "Arvo"
+msgstr "Numeerinen arvo."
 
 #: gnucash/import-export/csv-exp/csv-transactions-export.cpp:374
 #: gnucash/import-export/csv-exp/csv-transactions-export.cpp:396
-#, fuzzy
-#| msgid "Share Price"
 msgid "Rate/Price"
-msgstr "Osuuden arvo"
+msgstr "Kurssi/Hinta"
 
 #: gnucash/import-export/csv-exp/csv-transactions-export.cpp:380
 #: gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp:58
-#, fuzzy
-#| msgid "Transaction Number"
 msgid "Transaction ID"
-msgstr "Tositenumero"
+msgstr "Tositteen numero"
 
 #: gnucash/import-export/csv-exp/csv-transactions-export.cpp:384
 msgid "Commodity/Currency"
-msgstr ""
+msgstr "Hyödyke/valuutta"
 
 #: gnucash/import-export/csv-exp/csv-transactions-export.cpp:385
 #: gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp:64
 msgid "Void Reason"
-msgstr ""
+msgstr "Mitätöintisyy"
 
 #: gnucash/import-export/csv-exp/csv-transactions-export.cpp:388
 #: gnucash/import-export/csv-exp/csv-tree-export.cpp:60
-#, fuzzy
-#| msgid "All Accounts"
 msgid "Full Account Name"
-msgstr "Kaikki tilit"
+msgstr "Tilin koko nimi"
 
 #: gnucash/import-export/csv-exp/csv-transactions-export.cpp:395
 #: gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp:74
-#, fuzzy
-#| msgid "Reconciled Date"
 msgid "Reconcile Date"
-msgstr "Tarkistuspäivämäärä"
+msgstr "Täsmäytyspäivämäärä"
 
 #: gnucash/import-export/csv-imp/assistant-csv-account-import.c:69
 #, c-format
@@ -18517,6 +17852,10 @@ msgid ""
 "You can verify your selections by clicking on 'Back' or 'Cancel' to Abort "
 "Import.\n"
 msgstr ""
+"Tilihierarkia tuodaan tiedostosta '%s' kun klikkaat 'Toteuta'.\n"
+"\n"
+"Voit tarkistaa valintasi valitsemalla 'Takaisin' tai 'Peruuta' "
+"keskeyttääksesi tuonnin.\n"
 
 #: gnucash/import-export/csv-imp/assistant-csv-account-import.c:73
 #, c-format
@@ -18561,7 +17900,7 @@ msgstr ""
 #: gnucash/import-export/csv-imp/assistant-csv-price-import.cpp:904
 #: gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp:882
 msgid "Delete the Import Settings."
-msgstr ""
+msgstr "Poista tuonnin asetukset."
 
 #: gnucash/import-export/csv-imp/assistant-csv-price-import.cpp:938
 #: gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp:916
@@ -18571,17 +17910,17 @@ msgstr ""
 #: gnucash/import-export/csv-imp/assistant-csv-price-import.cpp:952
 #: gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp:930
 msgid "The settings have been saved."
-msgstr ""
+msgstr "Asetukset on tallennettu."
 
 #: gnucash/import-export/csv-imp/assistant-csv-price-import.cpp:977
 #: gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp:955
 msgid "There was a problem saving the settings, please try again."
-msgstr ""
+msgstr "Asetuksia tallentaessa ilmeni ongelma, yritä myöhemmin uudelleen."
 
 #: gnucash/import-export/csv-imp/assistant-csv-price-import.cpp:1148
 #: gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp:1129
 msgid "Invalid encoding selected"
-msgstr ""
+msgstr "Virheellinen koodaus valittu"
 
 #: gnucash/import-export/csv-imp/assistant-csv-price-import.cpp:1309
 #: gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp:1239
@@ -18613,24 +17952,24 @@ msgstr ""
 #, c-format
 msgid "%d added price"
 msgid_plural "%d added prices"
-msgstr[0] "%d lisätty hinta"
-msgstr[1] "%d lisättyä hintaa"
+msgstr[0] "%d hinta lisätty"
+msgstr[1] "%d hintaa lisätty"
 
 #. Translators: This is a ngettext(3) message, %d is the number of duplicate prices
 #: gnucash/import-export/csv-imp/assistant-csv-price-import.cpp:1929
 #, c-format
 msgid "%d duplicate price"
 msgid_plural "%d duplicate prices"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d hinta moneen kertaan"
+msgstr[1] "%d hintaa moneen kertaan"
 
 #. Translators: This is a ngettext(3) message, %d is the number of replaced prices
 #: gnucash/import-export/csv-imp/assistant-csv-price-import.cpp:1934
 #, c-format
 msgid "%d replaced price"
 msgid_plural "%d replaced prices"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%d muutettu hinta"
+msgstr[1] "%d muutettua hintaa"
 
 #: gnucash/import-export/csv-imp/assistant-csv-price-import.cpp:1939
 #, c-format
@@ -18642,6 +17981,12 @@ msgid ""
 "- %s\n"
 "- %s"
 msgstr ""
+"Hinnat tuotiin tiedostosta '%s'.\n"
+"\n"
+"Tuonnin yhteenveto:\n"
+"- %s\n"
+"- %s\n"
+"- %s"
 
 #: gnucash/import-export/csv-imp/assistant-csv-price-import.cpp:1984
 #, c-format
@@ -18654,16 +17999,12 @@ msgid ""
 msgstr ""
 
 #: gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp:1433
-#, fuzzy
-#| msgid "The following warnings exist:"
 msgid "This line has the following parse issues:"
-msgstr "Seuraavat varoitukset ovat olemassa:"
+msgstr ""
 
 #: gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp:1784
-#, fuzzy
-#| msgid "Find Account"
 msgid "No Linked Account"
-msgstr "Etsi tili"
+msgstr "Ei yhdistettyä tiliä"
 
 #: gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp:2137
 #, c-format
@@ -18681,9 +18022,8 @@ msgstr ""
 
 #. Translators: {1} will be replaced with a filename
 #: gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp:2216
-#, c++-format
 msgid "The transactions were imported from file '{1}'."
-msgstr ""
+msgstr "Tositteet tuotiin tiedostosta '{1}'."
 
 #: gnucash/import-export/csv-imp/csv-account-import.c:253
 #, c-format
@@ -18795,7 +18135,7 @@ msgstr ""
 
 #: gnucash/import-export/csv-imp/gnc-import-tx.cpp:507
 msgid "Please select a (negated) amount column."
-msgstr ""
+msgstr "Valitse (kumottu) summasarake."
 
 #: gnucash/import-export/csv-imp/gnc-import-tx.cpp:524
 msgid ""
@@ -18824,26 +18164,24 @@ msgstr ""
 
 #: gnucash/import-export/csv-imp/gnc-import-tx.cpp:685
 msgid "Parse Error"
-msgstr ""
+msgstr "Tulkintavirhe"
 
 #: gnucash/import-export/csv-imp/gnc-import-tx.cpp:701
 msgid "Problem creating preliminary transaction"
-msgstr ""
+msgstr "Ongelma alustavan tapahtuman luomisessa"
 
 #: gnucash/import-export/csv-imp/gnc-imp-props-price.cpp:54
-#, fuzzy
-#| msgid "Symbol"
 msgid "From Symbol"
-msgstr "Symboli"
+msgstr "Symbolista"
 
 #: gnucash/import-export/csv-imp/gnc-imp-props-price.cpp:55
 msgid "From Namespace"
-msgstr ""
+msgstr "Nimiavaruudesta"
 
 #: gnucash/import-export/csv-imp/gnc-imp-props-price.cpp:69
 #: gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp:139
 msgid "Value doesn't appear to contain a valid number."
-msgstr ""
+msgstr "Arvo ei vaikuta sisältävän kelvollista numeroa."
 
 #: gnucash/import-export/csv-imp/gnc-imp-props-price.cpp:82
 #: gnucash/import-export/csv-imp/gnc-imp-props-price.cpp:87
@@ -18888,13 +18226,12 @@ msgstr ""
 #: gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp:291
 #: gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp:550
 #: gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp:630
-#, c++-format
 msgid "{1}: {2}"
 msgstr ""
 
 #: gnucash/import-export/csv-imp/gnc-imp-props-price.cpp:279
 msgid "No date column."
-msgstr ""
+msgstr "Ei päiväyssaraketta."
 
 #: gnucash/import-export/csv-imp/gnc-imp-props-price.cpp:281
 msgid "No amount column."
@@ -18913,48 +18250,40 @@ msgid "Failed to create price from selected columns."
 msgstr ""
 
 #: gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp:63
-#, fuzzy
-#| msgid "Transaction Number"
 msgid "Transaction Commodity"
-msgstr "Tositenumero"
+msgstr ""
 
 #: gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp:68
 msgid "Amount (Negated)"
-msgstr ""
+msgstr "Määrä (kumottu)"
 
 #: gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp:70
 msgid "Value (Negated)"
 msgstr ""
 
 #: gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp:75
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Transfer Action"
-msgstr "Etsi tosite"
+msgstr ""
 
 #: gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp:77
 msgid "Transfer Amount"
-msgstr ""
+msgstr "Siirron määrä"
 
 #: gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp:78
 msgid "Transfer Amount (Negated)"
-msgstr ""
+msgstr "Siirron määrä (kumottu)"
 
 #: gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp:79
 msgid "Transfer Memo"
-msgstr ""
+msgstr "Siirton erittely"
 
 #: gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp:80
-#, fuzzy
-#| msgid "Reconcile"
 msgid "Transfer Reconciled"
-msgstr "Tarkista"
+msgstr "Siirto täsmäytetty"
 
 #: gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp:81
-#, fuzzy
-#| msgid "Reconciled Date"
 msgid "Transfer Reconcile Date"
-msgstr "Tarkistuspäivämäärä"
+msgstr "Siirron täsmäytyspäiväys"
 
 #: gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp:182
 msgid "Value can't be parsed into a valid reconcile state."
@@ -18970,13 +18299,11 @@ msgstr ""
 
 #: gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp:312
 msgid "No valid date."
-msgstr ""
+msgstr "Virheellinen päiväys."
 
 #: gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp:315
-#, fuzzy
-#| msgid "No description provided."
 msgid "No valid description."
-msgstr "Ei annettu selitettä."
+msgstr "Ei kelvollista kuvausta."
 
 #: gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp:448
 msgid "Account value can't be empty."
@@ -19022,79 +18349,59 @@ msgstr ""
 
 #: gnucash/import-export/csv-imp/gnc-imp-settings-csv.cpp:46
 msgid "No Settings"
-msgstr ""
+msgstr "Ei asetuksia"
 
 #: gnucash/import-export/csv-imp/gnc-imp-settings-csv.cpp:47
 msgid "GnuCash Export Format"
-msgstr ""
+msgstr "GnuCashin vientimuoto"
 
 #: gnucash/import-export/csv-imp/gnc-imp-settings-csv.cpp:48
 msgid "GnuCash Export Format (4.x and older)"
-msgstr ""
+msgstr "GnuCashin vientimuoto (4.x tai vanhempi)"
 
 #: gnucash/import-export/customer-import/dialog-customer-import-gui.c:134
-#, fuzzy
-#| msgid "Shipping Contact"
 msgid "Shipping Name"
-msgstr "Toimitusyhteystiedot"
+msgstr "Toimitusnimi"
 
 #: gnucash/import-export/customer-import/dialog-customer-import-gui.c:135
-#, fuzzy
-#| msgid "Company Address"
 msgid "Shipping Address 1"
-msgstr "Yrityksen osoite"
+msgstr "Toimitusosoite 1"
 
 #: gnucash/import-export/customer-import/dialog-customer-import-gui.c:136
-#, fuzzy
-#| msgid "Company Address"
 msgid "Shipping Address 2"
-msgstr "Yrityksen osoite"
+msgstr "Toimitusosoite 2"
 
 #: gnucash/import-export/customer-import/dialog-customer-import-gui.c:137
-#, fuzzy
-#| msgid "Company Address"
 msgid "Shipping Address 3"
-msgstr "Yrityksen osoite"
+msgstr "Toimitusosoite 3"
 
 #: gnucash/import-export/customer-import/dialog-customer-import-gui.c:138
-#, fuzzy
-#| msgid "Company Address"
 msgid "Shipping Address 4"
-msgstr "Yrityksen osoite"
+msgstr "Toimitusosoite 4"
 
 #: gnucash/import-export/customer-import/dialog-customer-import-gui.c:139
-#, fuzzy
-#| msgid "Shipping Contact"
 msgid "Shipping Phone"
-msgstr "Toimitusyhteystiedot"
+msgstr "Toimituspuhelin"
 
 #: gnucash/import-export/customer-import/dialog-customer-import-gui.c:140
-#, fuzzy
-#| msgid "Shipping Contact"
 msgid "Shipping Fax"
-msgstr "Toimitusyhteystiedot"
+msgstr "Toimitusfaksi"
 
 #: gnucash/import-export/customer-import/dialog-customer-import-gui.c:141
-#, fuzzy
-#| msgid "Shipping Contact"
 msgid "Shipping Email"
-msgstr "Toimitusyhteystiedot"
+msgstr "Toimitussähköposti"
 
 #: gnucash/import-export/customer-import/dialog-customer-import-gui.c:172
-#, fuzzy
-#| msgid "Customer's Jobs"
 msgid "Import Customers from csv"
-msgstr "Asiakkaan hankkeet"
+msgstr "Tuo asiakkaat CSV-tiedostosta"
 
 #: gnucash/import-export/customer-import/dialog-customer-import-gui.c:188
-#, fuzzy
-#| msgid "custom"
 msgid "customers"
-msgstr "muu"
+msgstr "asiakkaat"
 
 #: gnucash/import-export/customer-import/dialog-customer-import-gui.c:189
 msgid "vendors"
-msgstr ""
+msgstr "toimittajat"
 
 #: gnucash/import-export/customer-import/dialog-customer-import-gui.c:197
 #, c-format
@@ -19117,10 +18424,8 @@ msgid ""
 msgstr ""
 
 #: gnucash/import-export/import-account-matcher.cpp:419
-#, fuzzy
-#| msgid "All Accounts"
 msgid "(Full account ID: "
-msgstr "Kaikki tilit"
+msgstr ""
 
 #: gnucash/import-export/import-commodity-matcher.cpp:92
 msgid ""
@@ -19131,23 +18436,23 @@ msgstr ""
 
 #: gnucash/import-export/import-format-dialog.cpp:78
 msgid "m/d/y"
-msgstr ""
+msgstr "m/d/y"
 
 #: gnucash/import-export/import-format-dialog.cpp:86
 msgid "d/m/y"
-msgstr ""
+msgstr "d/m/y"
 
 #: gnucash/import-export/import-format-dialog.cpp:94
 msgid "y/m/d"
-msgstr ""
+msgstr "y/m/d"
 
 #: gnucash/import-export/import-format-dialog.cpp:102
 msgid "y/d/m"
-msgstr ""
+msgstr "y/d/m"
 
 #: gnucash/import-export/import-main-matcher.cpp:503
 msgid "No new transactions were found in this import."
-msgstr ""
+msgstr "Tässä tuonnissa ei löytynyt uusia tositteita."
 
 #: gnucash/import-export/import-main-matcher.cpp:775
 msgid "Destination account for the auto-balance split."
@@ -19160,24 +18465,22 @@ msgstr ""
 #. Translators: Menu entry, no full stop
 #: gnucash/import-export/import-main-matcher.cpp:1419
 msgid "_Assign transfer account"
-msgstr ""
+msgstr "Määritä tositteen _tili"
 
 #. Translators: Menu entry, no full stop
 #: gnucash/import-export/import-main-matcher.cpp:1424
 msgid "Assign e_xchange rate"
-msgstr ""
+msgstr "Määritä _muuntokurssi"
 
 #. Translators: Menu entry, no full stop
 #: gnucash/import-export/import-main-matcher.cpp:1429
-#, fuzzy
-#| msgid "Description, Notes, or Memo"
 msgid "_Edit description, notes, or memo"
-msgstr "Selite, huomautus tai erittely"
+msgstr "_Muokkaa kuvausta, huomautuksia tai erittelyä"
 
 #. Translators: Menu entry, no full stop
 #: gnucash/import-export/import-main-matcher.cpp:1434
 msgid "_Reset all edits"
-msgstr ""
+msgstr "_Poista kaikki muokkaukset"
 
 #: gnucash/import-export/import-main-matcher.cpp:1597
 msgctxt "Column header for 'Adding transaction'"
@@ -19187,12 +18490,12 @@ msgstr ""
 #: gnucash/import-export/import-main-matcher.cpp:1601
 msgctxt "Column header for 'Updating plus Clearing transaction'"
 msgid "U+C"
-msgstr ""
+msgstr "P+H"
 
 #: gnucash/import-export/import-main-matcher.cpp:1605
 msgctxt "Column header for 'Clearing transaction'"
 msgid "C"
-msgstr ""
+msgstr "H"
 
 #: gnucash/import-export/import-main-matcher.cpp:1612
 msgid "Info"
@@ -19204,51 +18507,49 @@ msgid "Additional Comments"
 msgstr ""
 
 #: gnucash/import-export/import-main-matcher.cpp:2004
-#, fuzzy
-#| msgid "Ne_w Balance"
 msgid "New, already balanced"
-msgstr "_Uusi saldo"
+msgstr "Uusi, jo tasapainotettu"
 
 #. Translators: %1$s is the amount to be transferred,
 #. %2$s the destination account.
 #: gnucash/import-export/import-main-matcher.cpp:2026
 #, c-format
 msgid "New, transfer %s to (manual) \"%s\""
-msgstr ""
+msgstr "Uusi, siirrä %s (käsin) tilille \"%s\""
 
 #. Translators: %1$s is the amount to be transferred,
 #. %2$s the destination account.
 #: gnucash/import-export/import-main-matcher.cpp:2034
 #, c-format
 msgid "New, transfer %s to (auto) \"%s\""
-msgstr ""
+msgstr "Uusi, siirrä %s (automaattisesti) tilille \"%s\""
 
 #. Translators: %s is the amount to be transferred.
 #: gnucash/import-export/import-main-matcher.cpp:2047
 #, c-format
 msgid "New, UNBALANCED (need price to transfer %s to acct %s)!"
-msgstr ""
+msgstr "Uusi, EPÄTASAN (tarvitsee siirrettävän hinnan %s tilille %s)!"
 
 #. Translators: %s is the amount to be transferred.
 #: gnucash/import-export/import-main-matcher.cpp:2063
 #, c-format
 msgid "New, UNBALANCED (need acct to transfer %s)!"
-msgstr ""
+msgstr "Uusi, EPÄTASAN (tarvitsee tilin, jolle siirtää %s)!"
 
 #: gnucash/import-export/import-main-matcher.cpp:2081
 #, c-format
 msgid "Reconcile (manual) match to %s"
-msgstr ""
+msgstr "Täsmäytä (käsin) tiliin %s"
 
 #: gnucash/import-export/import-main-matcher.cpp:2086
 #, c-format
 msgid "Reconcile (auto) match to %s"
-msgstr ""
+msgstr "Täsmäytä (automaattisesti) tiliin %s"
 
 #: gnucash/import-export/import-main-matcher.cpp:2095
 #: gnucash/import-export/import-main-matcher.cpp:2124
 msgid "Match missing!"
-msgstr "Täsmäävä puuttuu!"
+msgstr ""
 
 #: gnucash/import-export/import-main-matcher.cpp:2110
 #, c-format
@@ -19269,19 +18570,17 @@ msgid "Confidence"
 msgstr ""
 
 #: gnucash/import-export/import-match-picker.cpp:358
-#, fuzzy
-#| msgid "Action"
 msgid "Pending Action"
-msgstr "Tapahtuma"
+msgstr ""
 
 #: gnucash/import-export/import-pending-matches.cpp:191
 #: libgnucash/engine/policy.cpp:62
 msgid "Manual"
-msgstr ""
+msgstr "Manuaalinen"
 
 #: gnucash/import-export/import-pending-matches.cpp:193
 msgid "Auto"
-msgstr ""
+msgstr "Automaattinen"
 
 #: gnucash/import-export/log-replay/gnc-log-replay.cpp:573
 msgid "Select a .log file to replay"
@@ -19319,7 +18618,7 @@ msgstr ""
 
 #: gnucash/import-export/ofx/gnc-ofx-import.cpp:1045
 msgid "Unknown OFX account"
-msgstr ""
+msgstr "Tuntematon OFX-tili"
 
 #: gnucash/import-export/ofx/gnc-ofx-import.cpp:1068
 msgid "Unknown OFX checking account"
@@ -19351,7 +18650,7 @@ msgstr ""
 
 #: gnucash/import-export/ofx/gnc-ofx-import.cpp:1308
 msgid "Removing duplicate transactions…"
-msgstr ""
+msgstr "Poistetaan monistettuja tositteita…"
 
 #: gnucash/import-export/ofx/gnc-ofx-import.cpp:1362
 #, c-format
@@ -19370,7 +18669,7 @@ msgstr ""
 
 #: gnucash/import-export/ofx/gnc-plugin-ofx.ui:6
 msgid "Import _OFX/QFX…"
-msgstr ""
+msgstr "Tuo _OFX/QFX…"
 
 #: gnucash/import-export/ofx/gnc-plugin-ofx.ui:8
 msgid "Process an OFX/QFX response file"
@@ -19378,7 +18677,7 @@ msgstr ""
 
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:575
 msgid "GnuCash account name"
-msgstr ""
+msgstr "GnuCash-tilin nimi"
 
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:880
 msgid "Enter a name or short description, such as \"Red Hat Stock\"."
@@ -19398,10 +18697,8 @@ msgid ""
 msgstr ""
 
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:925
-#, fuzzy
-#| msgid "Description"
 msgid "Name or _description"
-msgstr "Selite"
+msgstr "_Nimi tai kuvaus"
 
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:949
 msgid "_Ticker symbol or other abbreviation"
@@ -19413,21 +18710,16 @@ msgstr ""
 
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:1199
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:3433
-#, fuzzy
-#| msgctxt "Action Column"
-#| msgid "Split"
 msgid "(split)"
-msgstr "Rivi"
+msgstr "(rivi)"
 
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:1392
-#, fuzzy
-#| msgid "Are you sure you want to delete %s?"
 msgid "Are you sure you want to cancel?"
-msgstr "Oletko varma että %s voidaan poistaa?"
+msgstr "Oletko varma että haluat peruuttaa?"
 
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:1710
 msgid "Please select a file to load."
-msgstr ""
+msgstr "Valitse ladattava tiedosto."
 
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:1713
 msgid "File not found or read permission denied. Please select another file."
@@ -19435,13 +18727,11 @@ msgstr ""
 
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:1724
 msgid "That QIF file is already loaded. Please select another file."
-msgstr ""
+msgstr "Kyseinen QIF-tiedosto on jo ladattu. Valitse toinen tiedosto."
 
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:1788
-#, fuzzy
-#| msgid "Selected"
 msgid "Select QIF File"
-msgstr "Valittu"
+msgstr "Valitse QIF-tiedosto"
 
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:1851
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:1854
@@ -19453,10 +18743,8 @@ msgstr ""
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:1937
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:2014
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:3190
-#, fuzzy
-#| msgid "_Cancel"
 msgid "Canceled"
-msgstr "_Peruuta"
+msgstr ""
 
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:1951
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:1955
@@ -19471,7 +18759,7 @@ msgstr ""
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:3231
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:3279
 msgid "Failed"
-msgstr ""
+msgstr "Epäonnistui"
 
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:2010
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:2027
@@ -19489,7 +18777,7 @@ msgstr ""
 
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:2107
 msgid "Loading completed"
-msgstr ""
+msgstr "Lataaminen valmis"
 
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:2140
 msgid ""
@@ -19512,10 +18800,8 @@ msgid "A bug was detected while converting the QIF data."
 msgstr ""
 
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:3264
-#, fuzzy
-#| msgid "_Cancel"
 msgid "Canceling"
-msgstr "_Peruuta"
+msgstr ""
 
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:3278
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:3282
@@ -19523,10 +18809,8 @@ msgid "A bug was detected while detecting duplicates."
 msgstr ""
 
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:3301
-#, fuzzy
-#| msgid "Conversion Direction"
 msgid "Conversion completed"
-msgstr "Muunnossuunta"
+msgstr ""
 
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:3329
 msgid ""
@@ -19541,23 +18825,23 @@ msgstr ""
 
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:3568
 msgid "There was a problem with the import."
-msgstr ""
+msgstr "Tuonnissa tapahtui virhe."
 
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:3569
 msgid "QIF Import Completed."
-msgstr ""
+msgstr "QIF-tuonti valmis."
 
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:3790
 msgid "QIF account name"
-msgstr ""
+msgstr "QIF-tilin nimi"
 
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:3796
 msgid "QIF category name"
-msgstr ""
+msgstr "QIF-luokan nimi"
 
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:3802
 msgid "QIF payee/memo"
-msgstr ""
+msgstr "QIF-maksunsaaja/muistiinpano"
 
 #: gnucash/import-export/qif-imp/assistant-qif-import.c:3905
 msgid "Match?"
@@ -19569,7 +18853,7 @@ msgstr ""
 
 #: gnucash/import-export/qif-imp/dialog-account-picker.c:235
 msgid "Enter a name for the account"
-msgstr ""
+msgstr "Syötä tilin nimi"
 
 #: gnucash/import-export/qif-imp/dialog-account-picker.c:299
 #, c-format
@@ -19579,16 +18863,12 @@ msgid ""
 msgstr ""
 
 #: gnucash/import-export/qif-imp/dialog-account-picker.c:443
-#, fuzzy
-#| msgid "Placeholder"
 msgid "Placeholder?"
-msgstr "Koontitili"
+msgstr "Koontitili?"
 
 #: gnucash/import-export/qif-imp/qif-dialog-utils.scm:71
-#, fuzzy
-#| msgid "Dividend"
 msgid "Dividends"
-msgstr "Osinko"
+msgstr ""
 
 #: gnucash/import-export/qif-imp/qif-dialog-utils.scm:86
 msgid "Cap Return"
@@ -19614,7 +18894,7 @@ msgstr ""
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:685
 #: libgnucash/app-utils/gnc-ui-util.cpp:637 libgnucash/engine/Account.cpp:4298
 msgid "Equity"
-msgstr ""
+msgstr "Oma pääoma"
 
 #: gnucash/import-export/qif-imp/qif-dialog-utils.scm:110
 #: gnucash/import-export/qif-imp/qif-dialog-utils.scm:114
@@ -19624,24 +18904,20 @@ msgstr ""
 #: gnucash/report/reports/support/balsheet-eg.eguile.scm:189
 #: libgnucash/app-utils/gnc-ui-util.cpp:554
 msgid "Retained Earnings"
-msgstr ""
+msgstr "Kertyneet voittovarat"
 
 #: gnucash/import-export/qif-imp/qif-dialog-utils.scm:118
-#, fuzzy
-#| msgid "missing"
 msgid "Commissions"
-msgstr "puuttuu"
+msgstr ""
 
 #: gnucash/import-export/qif-imp/qif-dialog-utils.scm:123
-#, fuzzy
-#| msgid "Interest"
 msgid "Margin Interest"
-msgstr "Korko"
+msgstr ""
 
 #: gnucash/import-export/qif-imp/qif-file.scm:105
 #: gnucash/import-export/qif-imp/qif-file.scm:113
 msgid "Line"
-msgstr ""
+msgstr "Viiva"
 
 #: gnucash/import-export/qif-imp/qif-file.scm:116
 msgid "Read aborted."
@@ -19666,15 +18942,15 @@ msgstr ""
 
 #: gnucash/import-export/qif-imp/qif-file.scm:248
 msgid "Ignoring unknown option"
-msgstr ""
+msgstr "Jätetään huomiotta tuntematon asetus"
 
 #: gnucash/import-export/qif-imp/qif-file.scm:386
 msgid "Date required."
-msgstr ""
+msgstr "Päivämäärä on pakollinen."
 
 #: gnucash/import-export/qif-imp/qif-file.scm:387
 msgid "Discarding this transaction."
-msgstr ""
+msgstr "Ohitetaan tosite."
 
 #: gnucash/import-export/qif-imp/qif-file.scm:419
 msgid "Ignoring class line"
@@ -19690,61 +18966,47 @@ msgstr ""
 
 #: gnucash/import-export/qif-imp/qif-file.scm:532
 msgid "Could not parse price line"
-msgstr ""
+msgstr "Hintariviä ei ymmärretty"
 
 #: gnucash/import-export/qif-imp/qif-file.scm:540
 msgid "File does not appear to be in QIF format"
-msgstr ""
+msgstr "Tiedosto ei vaikuta olevan QIF-muotoa"
 
 #: gnucash/import-export/qif-imp/qif-file.scm:716
-#, fuzzy
-#| msgid "Transaction Number"
 msgid "Transaction date"
-msgstr "Tositenumero"
+msgstr "Tositteen päivämäärä"
 
 #: gnucash/import-export/qif-imp/qif-file.scm:717
-#, fuzzy
-#| msgid "Transaction Document Links"
 msgid "Transaction amount"
-msgstr "Tositteen asiakirjalinkit"
+msgstr "Tositteen summa"
 
 #: gnucash/import-export/qif-imp/qif-file.scm:718
-#, fuzzy
-#| msgid "Share Price"
 msgid "Share price"
-msgstr "Osuuden arvo"
+msgstr "Osuuden hinta"
 
 #: gnucash/import-export/qif-imp/qif-file.scm:719
 msgid "Share quantity"
-msgstr ""
+msgstr "Osuuden määrä"
 
 #: gnucash/import-export/qif-imp/qif-file.scm:720
 msgid "Investment action"
 msgstr ""
 
 #: gnucash/import-export/qif-imp/qif-file.scm:721
-#, fuzzy
-#| msgid "Reconciled Date"
 msgid "Reconciliation status"
-msgstr "Tarkistuspäivämäärä"
+msgstr ""
 
 #: gnucash/import-export/qif-imp/qif-file.scm:722
-#, fuzzy
-#| msgid "missing"
 msgid "Commission"
-msgstr "puuttuu"
+msgstr ""
 
 #: gnucash/import-export/qif-imp/qif-file.scm:723
-#, fuzzy
-#| msgid "Account Types"
 msgid "Account type"
-msgstr "Tilityypit"
+msgstr "Tilin tyyppi"
 
 #: gnucash/import-export/qif-imp/qif-file.scm:724
-#, fuzzy
-#| msgid "Tax related"
 msgid "Tax class"
-msgstr "Veroihin liittyvä"
+msgstr "Veroluokka"
 
 #: gnucash/import-export/qif-imp/qif-file.scm:725
 msgid "Category budget amount"
@@ -19755,34 +19017,24 @@ msgid "Account budget amount"
 msgstr ""
 
 #: gnucash/import-export/qif-imp/qif-file.scm:727
-#, fuzzy
-#| msgid "Credit"
 msgid "Credit limit"
-msgstr "Kredit"
+msgstr "Luottoraja"
 
 #: gnucash/import-export/qif-imp/qif-file.scm:740
-#, fuzzy
-#| msgid "Closing Entries"
 msgid "Parsing categories"
-msgstr "Tilinpäätöstositteet"
+msgstr ""
 
 #: gnucash/import-export/qif-imp/qif-file.scm:775
-#, fuzzy
-#| msgid "existing account"
 msgid "Parsing accounts"
-msgstr "olemassa oleva tili"
+msgstr "Tulkitaan tilejä"
 
 #: gnucash/import-export/qif-imp/qif-file.scm:816
-#, fuzzy
-#| msgid "Closing Entries"
 msgid "Parsing prices"
-msgstr "Tilinpäätöstositteet"
+msgstr "Tulkitaan hintoja"
 
 #: gnucash/import-export/qif-imp/qif-file.scm:849
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Parsing transactions"
-msgstr "Etsi tosite"
+msgstr ""
 
 #: gnucash/import-export/qif-imp/qif-file.scm:1025
 msgid "Unrecognized or inconsistent format."
@@ -19790,7 +19042,7 @@ msgstr ""
 
 #: gnucash/import-export/qif-imp/qif-file.scm:1067
 msgid "Parsing failed."
-msgstr ""
+msgstr "Jäsentäminen epäonnistui."
 
 #: gnucash/import-export/qif-imp/qif-file.scm:1108
 msgid "Parse ambiguity between formats"
@@ -19802,10 +19054,8 @@ msgid "Value '~a' could be ~a or ~a."
 msgstr ""
 
 #: gnucash/import-export/qif-imp/qif-merge-groups.scm:110
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Finding duplicate transactions"
-msgstr "Etsi tosite"
+msgstr "Etsitään kaksinkertaisia tositteita"
 
 #. Translators: Mapping the QIF account type to a GnuCash account type.
 #. see https://en.wikipedia.org/wiki/Quicken_Interchange_Format#Detail_items
@@ -19835,36 +19085,28 @@ msgid "Preparing to convert your QIF data"
 msgstr ""
 
 #: gnucash/import-export/qif-imp/qif-to-gnc.scm:359
-#, fuzzy
-#| msgid "existing account"
 msgid "Creating accounts"
-msgstr "olemassa oleva tili"
+msgstr "Luodaan tilejä"
 
 #: gnucash/import-export/qif-imp/qif-to-gnc.scm:408
 msgid "Matching transfers between accounts"
-msgstr ""
+msgstr "Kohdistaa siirtoja tileille"
 
 #: gnucash/import-export/qif-imp/qif-to-gnc.scm:426
-#, fuzzy
-#| msgid "Conversion Direction"
 msgid "Converting"
-msgstr "Muunnossuunta"
+msgstr ""
 
 #: gnucash/import-export/qif-imp/qif-to-gnc.scm:491
 msgid "Discarding duplicate prices"
-msgstr ""
+msgstr "Hylkää toistuvat hinnat"
 
 #: gnucash/import-export/qif-imp/qif-to-gnc.scm:521
-#, fuzzy
-#| msgid "Error adding price."
 msgid "Adding prices"
-msgstr "Virhe lisättäessä hintaa."
+msgstr "Lisätään hintoja"
 
 #: gnucash/import-export/qif-imp/qif-to-gnc.scm:594
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Missing transaction date."
-msgstr "Etsi tosite"
+msgstr "Tositepäivämäärä puuttuu."
 
 #: gnucash/import-export/qif-imp/qif-to-gnc.scm:746
 #, scheme-format
@@ -19872,55 +19114,53 @@ msgid "Missing QIF investment action for transaction dated ~a."
 msgstr ""
 
 #: gnucash/import-export/qif-imp/qif-to-gnc.scm:1431
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Invalid transaction date."
-msgstr "Etsi tosite"
+msgstr "Virheellinen tositteen päiväys."
 
 #: gnucash/python/init.py:18
 msgid "Welcome to GnuCash"
-msgstr ""
+msgstr "Tervetuloa GnuCashiin"
 
 #: gnucash/python/init.py:103
 #: gnucash/report/reports/example/sample-report.scm:427
 msgid "Have a nice day!"
-msgstr ""
+msgstr "Mukavaa päivää!"
 
 #: gnucash/python/init.py:118
 #, python-format
 msgid "Welcome to GnuCash %s Shell"
-msgstr ""
+msgstr "Tervetuloa GnuCash %s pääteyhteyteen"
 
 #: gnucash/register/ledger-core/gncEntryLedger.c:86
 #: gnucash/register/ledger-core/split-register.c:1999
 #, c-format
 msgid "The account %s does not exist. Would you like to create it?"
-msgstr ""
+msgstr "Tiliä %s ei ole olemassa. Haluatko luoda sen?"
 
 #: gnucash/register/ledger-core/gncEntryLedger.c:251
 msgid "Hours"
-msgstr ""
+msgstr "Tunnit"
 
 #: gnucash/register/ledger-core/gncEntryLedger.c:252
 msgid "Project"
-msgstr ""
+msgstr "Projekti"
 
 #: gnucash/register/ledger-core/gncEntryLedger.c:253
 msgid "Material"
-msgstr ""
+msgstr "Materiaali"
 
 #: gnucash/register/ledger-core/gncEntryLedger.c:905
 #: gnucash/register/ledger-core/gncEntryLedgerControl.c:875
-#, fuzzy
-#| msgid "Last day of the current month."
 msgid "Save the current entry?"
-msgstr "Tämän kuukauden viimeinen päivä."
+msgstr "Tallenna tämä merkintä?"
 
 #: gnucash/register/ledger-core/gncEntryLedger.c:907
 msgid ""
 "The current transaction has been changed. Would you like to record the "
 "changes before duplicating this entry, or cancel the duplication?"
 msgstr ""
+"Tätä tositetta on muutettu. Haluatko tallentaa muutokset ennen kirjauksen "
+"monistamista, vai peruuttaa monistamisen?"
 
 #: gnucash/register/ledger-core/gncEntryLedger.c:922
 #: gnucash/register/ledger-core/gncEntryLedgerControl.c:897
@@ -19973,15 +19213,11 @@ msgid "12/12/2000"
 msgstr ""
 
 #: gnucash/register/ledger-core/gncEntryLedgerLayout.c:86
-#, fuzzy
-#| msgid "Description"
 msgctxt "sample for 'Description'"
 msgid "Description of an Entry"
-msgstr "Selite"
+msgstr "Syötteen kuvaus"
 
 #: gnucash/register/ledger-core/gncEntryLedgerLayout.c:92
-#, fuzzy
-#| msgid "Action"
 msgctxt "sample"
 msgid "Action"
 msgstr "Tapahtuma"
@@ -20019,13 +19255,13 @@ msgstr ""
 #: gnucash/register/ledger-core/split-register-layout.c:737
 msgctxt "sample"
 msgid "Expenses:Automobile:Gasoline"
-msgstr ""
+msgstr "Kulut:Auto:Huolto:Huoltotarvikkeet"
 
 #. Translators: Abbreviation sample for Taxable?
 #: gnucash/register/ledger-core/gncEntryLedgerLayout.c:132
 msgctxt "sample for 'Taxable'"
 msgid "T?"
-msgstr ""
+msgstr "V?"
 
 #. Translators: Abbreviation sample for Tax Included
 #: gnucash/register/ledger-core/gncEntryLedgerLayout.c:137
@@ -20036,7 +19272,7 @@ msgstr ""
 #: gnucash/register/ledger-core/gncEntryLedgerLayout.c:141
 msgctxt "sample for 'Tax Table'"
 msgid "Tax Table 1"
-msgstr ""
+msgstr "Verotaulu 1"
 
 #: gnucash/register/ledger-core/gncEntryLedgerLayout.c:149
 msgctxt "sample"
@@ -20050,27 +19286,25 @@ msgid "BI"
 msgstr ""
 
 #: gnucash/register/ledger-core/gncEntryLedgerLayout.c:158
-#, fuzzy
-#| msgid "Payment"
 msgctxt "sample"
 msgid "Payment"
 msgstr "Maksu"
 
 #: gnucash/register/ledger-core/gncEntryLedgerLoad.c:53
 msgid "$"
-msgstr ""
+msgstr "$"
 
 #: gnucash/register/ledger-core/gncEntryLedgerLoad.c:67
 msgid "<"
-msgstr ""
+msgstr "<"
 
 #: gnucash/register/ledger-core/gncEntryLedgerLoad.c:69
 msgid "="
-msgstr ""
+msgstr "="
 
 #: gnucash/register/ledger-core/gncEntryLedgerLoad.c:71
 msgid ">"
-msgstr ""
+msgstr ">"
 
 #: gnucash/register/ledger-core/gncEntryLedgerLoad.c:133
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:532
@@ -20078,29 +19312,23 @@ msgstr ""
 #: gnucash/register/ledger-core/split-register.c:2566
 #: libgnucash/engine/Account.cpp:158 libgnucash/engine/Account.cpp:172
 msgid "Charge"
-msgstr ""
+msgstr "Veloitus"
 
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:47
-#, fuzzy
-#| msgid "Find Account"
 msgid "Income Account"
-msgstr "Etsi tili"
+msgstr "Tulotili"
 
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:52
-#, fuzzy
-#| msgid "Find Account"
 msgid "Expense Account"
-msgstr "Etsi tili"
+msgstr "Kulutili"
 
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:77
-#, fuzzy
-#| msgid "Account Types"
 msgid "Discount Type"
-msgstr "Tilityypit"
+msgstr "Alennuslaji"
 
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:82
 msgid "Discount How"
-msgstr ""
+msgstr "Alennustapa"
 
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:87
 #: gnucash/report/reports/standard/invoice.scm:95
@@ -20109,32 +19337,28 @@ msgstr ""
 #: gnucash/report/reports/standard/taxinvoice.scm:102
 #: gnucash/report/reports/standard/taxinvoice.scm:183
 msgid "Unit Price"
-msgstr ""
+msgstr "Yksikköhinta"
 
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:102
 msgid "Taxable?"
-msgstr ""
+msgstr "Verotettava?"
 
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:107
 msgid "Tax Included?"
-msgstr ""
+msgstr "Sis. verot?"
 
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:112
-#, fuzzy
-#| msgid "Invoice"
 msgid "Invoiced?"
-msgstr "Myyntilasku"
+msgstr "Laskutettu?"
 
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:117
 #: gnucash/report/reports/standard/invoice.scm:450
 msgid "Subtotal"
-msgstr ""
+msgstr "Välisumma"
 
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:127
-#, fuzzy
-#| msgid "Bill"
 msgid "Billable?"
-msgstr "Ostolasku"
+msgstr "Laskutettavissa?"
 
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:548
 msgid ""
@@ -20143,42 +19367,42 @@ msgstr ""
 
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:561
 msgid "Enter the type of Entry"
-msgstr ""
+msgstr "Syötä tietueen tyyppi"
 
 #. Translators: This is a date format, see i.e.
 #. https://www.gnu.org/software/libc/manual/html_node/Formatting-Calendar-Time.html
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:577
 #: gnucash/register/ledger-core/split-register-model.c:1002
 msgid "%A %d %B %Y"
-msgstr ""
+msgstr "%A %d %B %Y"
 
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:587
 msgid "Enter the Entry Description"
-msgstr ""
+msgstr "Syötä tietueen kuvaus"
 
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:603
 msgid "Enter the Discount Amount"
-msgstr ""
+msgstr "Syötä alennusmäärä"
 
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:606
 msgid "Enter the Discount Percent"
-msgstr ""
+msgstr "Syötä alennusprosentti"
 
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:609
 msgid "Enter the Discount … unknown type"
-msgstr ""
+msgstr "Syötä alennusmäärä … tuntematon tyyppi"
 
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:627
 msgid "Discount Type: Monetary Value"
-msgstr ""
+msgstr "Alennuksen tyyppi: Raha-arvo"
 
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:630
 msgid "Discount Type: Percent"
-msgstr ""
+msgstr "Alennuksen tyyppi: Prosentti"
 
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:633
 msgid "Select the Discount Type"
-msgstr ""
+msgstr "Valitse alennustyyppi"
 
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:650
 msgid "Tax computed after discount is applied"
@@ -20198,7 +19422,7 @@ msgstr ""
 
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:672
 msgid "Enter the unit-Price for this Entry"
-msgstr ""
+msgstr "Syötä tietueen yksikköhinta"
 
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:684
 msgid "Enter the Quantity of units for this Entry"
@@ -20210,15 +19434,15 @@ msgstr ""
 
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:705
 msgid "Is this entry taxable?"
-msgstr ""
+msgstr "Onko kirjaus verotettava?"
 
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:714
 msgid "Is the tax already included in the price of this entry?"
-msgstr ""
+msgstr "Sisältyykö vero jo kirjauksen hintaan?"
 
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:732
 msgid "Is this entry invoiced?"
-msgstr ""
+msgstr "Onko tietue laskutettu?"
 
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:738
 msgid "Is this entry credited?"
@@ -20241,10 +19465,8 @@ msgid "The subtotal value of this entry"
 msgstr ""
 
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:774
-#, fuzzy
-#| msgid "Start of this year"
 msgid "The total tax of this entry "
-msgstr "Tämän vuoden alku"
+msgstr ""
 
 #: gnucash/register/ledger-core/gncEntryLedgerModel.c:783
 msgid "Is this entry billable to a customer or job?"
@@ -20262,22 +19484,24 @@ msgstr ""
 
 #: gnucash/register/ledger-core/split-register.c:479
 msgid "Save transaction before duplicating?"
-msgstr ""
+msgstr "Tallenna kirjaus ennen monistamista?"
 
 #: gnucash/register/ledger-core/split-register.c:481
 msgid ""
 "The current transaction has been changed. Would you like to record the "
 "changes before duplicating the transaction, or cancel the duplication?"
 msgstr ""
+"Tätä tositetta on muutettu. Haluatko tallentaa muutokset ennen sen "
+"monistamista, vai peruuttaa monistamisen?"
 
 #: gnucash/register/ledger-core/split-register.c:535
 msgid "New Split Information"
-msgstr ""
+msgstr "Uuden rivin tiedot"
 
 #: gnucash/register/ledger-core/split-register.c:644
 #: gnucash/register/register-gnome/datecell-gnome.c:108
 msgid "Cannot store a transaction at this date"
-msgstr ""
+msgstr "Tälle päivämäärälle ei voi luoda tositetta"
 
 #: gnucash/register/ledger-core/split-register.c:646
 msgid ""
@@ -20285,6 +19509,9 @@ msgid ""
 "Threshold\" set for this book. This setting can be changed in File-"
 ">Properties->Accounts."
 msgstr ""
+"Monistettavan tositteen päiväys on vanhempi kuin tälle kirjalle määritetty "
+"kirjoitussuojatun aikarajan asetus. Voit halutessasi muuttaa asetusta "
+"Tiedosto->Ominaisuudet->Tilit."
 
 #: gnucash/register/ledger-core/split-register.c:963
 msgid ""
@@ -20298,6 +19525,9 @@ msgid ""
 "overwrite it from this register window. You may overwrite it if you navigate "
 "to a register that shows another side of this same transaction."
 msgstr ""
+"Tämä rivi ankkuroi kyseisen tositteen tiliin. Et voi ylitsekirjoittaa sitä "
+"tästä tilikirjaikkunasta. Voit kirjoittaa sen yli jos siirryt tilikirjaan "
+"joka näyttää tositteen toisen puolen."
 
 #: gnucash/register/ledger-core/split-register.c:1023
 msgid ""
@@ -20306,35 +19536,35 @@ msgid ""
 msgstr ""
 
 #: gnucash/register/ledger-core/split-register.c:2103
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Recalculate Transaction"
-msgstr "Etsi tosite"
+msgstr "Laske vienti uudelleen"
 
 #: gnucash/register/ledger-core/split-register.c:2104
 msgid ""
 "The values entered for this transaction are inconsistent. Which value would "
 "you like to have recalculated?"
 msgstr ""
+"Tälle kirjaukselle syötetyt arvot ovat ristiriitaisia. Minkä arvon haluaisit "
+"laskettavan uudelleen?"
 
 #: gnucash/register/ledger-core/split-register.c:2111
 #: gnucash/register/ledger-core/split-register.c:2118
 #: gnucash/register/ledger-core/split-register.c:2125
 msgid "Changed"
-msgstr ""
+msgstr "Muuttunut"
 
 #: gnucash/register/ledger-core/split-register.c:2136
 msgid "_Recalculate"
-msgstr ""
+msgstr "_Laske"
 
 #: gnucash/register/ledger-core/split-register.c:2559
 msgctxt "Action Column"
 msgid "Deposit"
-msgstr ""
+msgstr "Talletus"
 
 #: gnucash/register/ledger-core/split-register.c:2560
 msgid "Withdraw"
-msgstr ""
+msgstr "Nosto"
 
 #: gnucash/register/ledger-core/split-register.c:2561
 msgid "Check"
@@ -20343,12 +19573,12 @@ msgstr ""
 #: gnucash/register/ledger-core/split-register.c:2563
 #: gnucash/register/ledger-core/split-register.c:2594
 msgid "ATM Deposit"
-msgstr ""
+msgstr "Pankkiautomaattitalletus"
 
 #: gnucash/register/ledger-core/split-register.c:2564
 #: gnucash/register/ledger-core/split-register.c:2595
 msgid "ATM Draw"
-msgstr ""
+msgstr "Pankkiautomaattinosto"
 
 #: gnucash/register/ledger-core/split-register.c:2565
 msgid "Teller"
@@ -20360,7 +19590,7 @@ msgstr ""
 #: gnucash/report/reports/support/receipt.eguile.scm:276
 #: gnucash/report/reports/support/receipt.eguile.scm:283
 msgid "Receipt"
-msgstr ""
+msgstr "Kuitti"
 
 #: gnucash/register/ledger-core/split-register.c:2569
 #: gnucash/register/ledger-core/split-register.c:2583
@@ -20370,7 +19600,7 @@ msgstr ""
 #: libgnucash/engine/Account.cpp:153 libgnucash/engine/Account.cpp:174
 #: libgnucash/engine/Account.cpp:182 libgnucash/engine/Account.cpp:183
 msgid "Increase"
-msgstr ""
+msgstr "Lisäys"
 
 #: gnucash/register/ledger-core/split-register.c:2570
 #: gnucash/register/ledger-core/split-register.c:2584
@@ -20380,7 +19610,7 @@ msgstr ""
 #: libgnucash/engine/Account.cpp:154 libgnucash/engine/Account.cpp:162
 #: libgnucash/engine/Account.cpp:163 libgnucash/engine/Account.cpp:173
 msgid "Decrease"
-msgstr ""
+msgstr "Vähennys"
 
 #: gnucash/register/ledger-core/split-register.c:2572
 msgid "POS"
@@ -20396,16 +19626,13 @@ msgstr ""
 
 #: gnucash/register/ledger-core/split-register.c:2579
 msgid "Direct Debit"
-msgstr ""
+msgstr "Tilisiirto"
 
 #: gnucash/register/ledger-core/split-register.c:2591
 #: gnucash/register/ledger-core/split-register.c:2598
 #: gnucash/register/ledger-core/split-register.c:2647
-#, fuzzy
-#| msgctxt "Stock Assistant: Page name"
-#| msgid "Fees"
 msgid "Fee"
-msgstr "Palkkiot"
+msgstr ""
 
 #: gnucash/register/ledger-core/split-register.c:2625
 #: libgnucash/engine/Account.cpp:179
@@ -20435,18 +19662,16 @@ msgid ""
 msgstr ""
 
 #: gnucash/register/ledger-core/split-register-control.cpp:93
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Rebalance Transaction"
-msgstr "Etsi tosite"
+msgstr "Tasaa vienti"
 
 #: gnucash/register/ledger-core/split-register-control.cpp:94
 msgid "The current transaction is not balanced."
-msgstr ""
+msgstr "Tämä vienti ei ole tasan."
 
 #: gnucash/register/ledger-core/split-register-control.cpp:176
 msgid "Balance it _manually"
-msgstr ""
+msgstr "Tasaa _manuaalisesti"
 
 #: gnucash/register/ledger-core/split-register-control.cpp:178
 msgid "Let GnuCash _add an adjusting split"
@@ -20461,15 +19686,13 @@ msgid "Adjust _other account split total"
 msgstr ""
 
 #: gnucash/register/ledger-core/split-register-control.cpp:199
-#, fuzzy
-#| msgid "Ne_w Balance"
 msgid "_Rebalance"
-msgstr "_Uusi saldo"
+msgstr ""
 
 #: gnucash/register/ledger-core/split-register-control.cpp:1347
 #: gnucash/register/ledger-core/split-register-control.cpp:1360
 msgid "This register does not support editing exchange rates."
-msgstr ""
+msgstr "Tämä kirja ei tue vaihtokurssien muokkausta."
 
 #: gnucash/register/ledger-core/split-register-control.cpp:1386
 msgid "You need to select a split in order to modify its exchange rate."
@@ -20482,10 +19705,8 @@ msgid ""
 msgstr ""
 
 #: gnucash/register/ledger-core/split-register-control.cpp:1413
-#, fuzzy
-#| msgid "The interest rate cannot be zero."
 msgid "The entered account could not be found."
-msgstr "Korkoprosentti ei voi olla nolla."
+msgstr ""
 
 #: gnucash/register/ledger-core/split-register-control.cpp:1448
 #: gnucash/register/ledger-core/split-register-control.cpp:1461
@@ -20498,7 +19719,7 @@ msgstr ""
 
 #: gnucash/register/ledger-core/split-register-control.cpp:1562
 msgid "Save the changed transaction?"
-msgstr ""
+msgstr "Tallennetaanko muutettu vienti?"
 
 #: gnucash/register/ledger-core/split-register-control.cpp:1564
 msgid ""
@@ -20509,15 +19730,15 @@ msgstr ""
 
 #: gnucash/register/ledger-core/split-register-control.cpp:1577
 msgid "_Discard Changes"
-msgstr ""
+msgstr "_Hylkää muutokset"
 
 #: gnucash/register/ledger-core/split-register-control.cpp:1579
 msgid "_Record Changes"
-msgstr ""
+msgstr "_Tallenna muutokset"
 
 #: gnucash/register/ledger-core/split-register-control.cpp:1867
 msgid "Mark split as unreconciled?"
-msgstr ""
+msgstr "Haluatko merkitä rivin täsmäyttämättömäksi?"
 
 #: gnucash/register/ledger-core/split-register-control.cpp:1869
 msgid ""
@@ -20526,10 +19747,8 @@ msgid ""
 msgstr ""
 
 #: gnucash/register/ledger-core/split-register-control.cpp:1886
-#, fuzzy
-#| msgid "Reconcile"
 msgid "_Unreconcile"
-msgstr "Tarkista"
+msgstr ""
 
 #. Translators: The 'sample:' items are
 #. strings which are not displayed, but only
@@ -20552,7 +19771,7 @@ msgstr ""
 #: gnucash/register/ledger-core/split-register-layout.c:681
 msgctxt "sample"
 msgid "Description of a transaction"
-msgstr ""
+msgstr "Tositteen kuvaus"
 
 #. Translators: 'L' is short for Linked Document
 #: gnucash/register/ledger-core/split-register-layout.c:705
@@ -20587,7 +19806,7 @@ msgstr ""
 #: gnucash/register/ledger-core/split-register-layout.c:819
 msgctxt "Column header for 'Type'"
 msgid "T"
-msgstr ""
+msgstr "T"
 
 #: gnucash/register/ledger-core/split-register-layout.c:827
 msgctxt "sample"
@@ -20617,7 +19836,7 @@ msgstr ""
 #.
 #: gnucash/register/ledger-core/split-register-model.c:258
 msgid "Ref"
-msgstr ""
+msgstr "Viite"
 
 #: gnucash/register/ledger-core/split-register-model.c:274
 msgid "T-Ref"
@@ -20640,128 +19859,128 @@ msgstr ""
 #: gnucash/register/ledger-core/split-register-model.c:467
 #, c-format
 msgid "Tot %s"
-msgstr ""
+msgstr "Yht. %s"
 
 #: gnucash/register/ledger-core/split-register-model.c:449
-#, fuzzy
-#| msgid "Credit"
 msgid "Tot Credit"
-msgstr "Kredit"
+msgstr "Yht. kredit"
 
 #: gnucash/register/ledger-core/split-register-model.c:473
-#, fuzzy
-#| msgid "Debit"
 msgid "Tot Debit"
-msgstr "Debet"
+msgstr "Yht. debet"
 
 #: gnucash/register/ledger-core/split-register-model.c:482
-#, fuzzy
-#| msgid "Shares"
 msgid "Tot Shares"
-msgstr "Osuuksia"
+msgstr "Yht. osakkeet"
 
 #: gnucash/register/ledger-core/split-register-model.c:503
 msgid "Debit Formula"
-msgstr ""
+msgstr "Debet-kaava"
 
 #: gnucash/register/ledger-core/split-register-model.c:510
-#, fuzzy
-#| msgid "Credit"
 msgid "Credit Formula"
-msgstr "Kredit"
+msgstr "Kredit-kaava"
 
 #: gnucash/register/ledger-core/split-register-model.c:532
 #, c-format
 msgid "Reconciled on %s"
-msgstr "Täsmäytys %s"
+msgstr "Täsmäytetty: %s"
 
 #: gnucash/register/ledger-core/split-register-model.c:1013
 msgid "Scheduled"
-msgstr ""
+msgstr "Ajastettu"
 
 #: gnucash/register/ledger-core/split-register-model.c:1062
 msgid ""
 "Enter a reference, such as an invoice or check number, common to all entry "
 "lines (splits)"
 msgstr ""
+"Syötä viite, esimerkiksi laskun tai šekin numero, joka on yhteinen tositteen "
+"kaikille vienneille"
 
 #: gnucash/register/ledger-core/split-register-model.c:1064
 msgid ""
 "Enter a reference, such as an invoice or check number, unique to each entry "
 "line (split)"
 msgstr ""
+"Syötä viite, esimerkiksi laskun tai šekin numero, joka on yksilöllinen "
+"tositteen jokaiselle viennille"
 
 #: gnucash/register/ledger-core/split-register-model.c:1069
 msgid ""
 "Enter a reference, such as a check number, common to all entry lines (splits)"
 msgstr ""
+"Syötä viite, esimerkiksi šekin numero, joka on yhteinen tositteen kaikille "
+"vienneille"
 
 #: gnucash/register/ledger-core/split-register-model.c:1071
 msgid ""
 "Enter a reference, such as a check number, unique to each entry line (split)"
 msgstr ""
+"Syötä viite, esimerkiksi šekin numero, joka on yksilöllinen tositteen "
+"jokaiselle viennille"
 
 #: gnucash/register/ledger-core/split-register-model.c:1092
 msgid ""
 "Enter a transaction reference, such as an invoice or check number, common to "
 "all entry lines (splits)"
 msgstr ""
+"Syötä tositeviite, esimerkiksi laskun tai šekin numero, joka on yhteinen "
+"kaikille vienneille"
 
 #: gnucash/register/ledger-core/split-register-model.c:1096
 msgid ""
 "Enter a transaction reference that will be common to all entry lines (splits)"
-msgstr ""
+msgstr "Syötä tositteelle viittaus, joka on sama kaikille riveille"
 
 #: gnucash/register/ledger-core/split-register-model.c:1132
 msgid "Enter the name of the Customer"
-msgstr ""
+msgstr "Syötä asiakkaan nimi"
 
 #: gnucash/register/ledger-core/split-register-model.c:1135
 msgid "Enter the name of the Vendor"
-msgstr ""
+msgstr "Syötä toimittajan nimi"
 
 #: gnucash/register/ledger-core/split-register-model.c:1138
 msgid "Enter a description of the transaction"
-msgstr ""
+msgstr "Syötä tositteen selite"
 
 #: gnucash/register/ledger-core/split-register-model.c:1169
-#, fuzzy
-#| msgid "Enter the number of shares you gained or lost in the transaction."
 msgid "Enter notes for the transaction"
-msgstr "Syötä saamiesi tai menettämiesi osakkeiden määrä tositteelle."
+msgstr "Syötä huomautukset tositteelle"
 
 #: gnucash/register/ledger-core/split-register-model.c:1202
 msgid "Reason the transaction was voided"
-msgstr ""
+msgstr "Tositteen mitätöinnin syy"
 
 #: gnucash/register/ledger-core/split-register-model.c:1301
 msgid "Enter an action type, or choose one from the list"
-msgstr ""
+msgstr "Syötä tapahtumatyyppi tai valitse listalta"
 
 #: gnucash/register/ledger-core/split-register-model.c:1302
 msgid ""
 "Enter a reference number, such as the next check number, or choose an action "
 "type from the list"
 msgstr ""
+"Syötä viitenumero, esimerkiksi seuraavan šekin numero, tai valitse "
+"tapahtumatyyppi listalta"
 
 #: gnucash/register/ledger-core/split-register-model.c:1330
 msgid "Enter a description of the split"
-msgstr ""
+msgstr "Syötä rivin kuvaus"
 
 #: gnucash/register/ledger-core/split-register-model.c:1404
 msgid "Enter the effective share price"
 msgstr ""
 
 #: gnucash/register/ledger-core/split-register-model.c:1440
-#, fuzzy
-#| msgid "Enter the number of shares you gained or lost in the transaction."
 msgid "Enter the number of shares bought or sold"
-msgstr "Syötä saamiesi tai menettämiesi osakkeiden määrä tositteelle."
+msgstr ""
 
 #: gnucash/register/ledger-core/split-register-model.c:1492
 #: gnucash/register/ledger-core/split-register-model.c:1559
 msgid "Enter the account to transfer from, or choose one from the list"
-msgstr ""
+msgstr "Syötä tili, jolta siirretään tai valitse se listalta"
 
 #: gnucash/register/ledger-core/split-register-model.c:1569
 msgid ""
@@ -20784,7 +20003,7 @@ msgstr ""
 
 #: gnucash/register/ledger-core/split-register-model.c:2203
 msgid "Change transaction containing a reconciled split?"
-msgstr ""
+msgstr "Muuta tositetta, jossa on täsmätty rivi?"
 
 #: gnucash/register/ledger-core/split-register-model.c:2205
 #, c-format
@@ -20798,7 +20017,7 @@ msgstr ""
 
 #: gnucash/register/ledger-core/split-register-model.c:2215
 msgid "Change reconciled split?"
-msgstr ""
+msgstr "Muutetaanko täsmäytettyä jakoa?"
 
 #: gnucash/register/ledger-core/split-register-model.c:2217
 msgid ""
@@ -20809,13 +20028,11 @@ msgstr ""
 
 #: gnucash/register/ledger-core/split-register-model.c:2239
 msgid "Chan_ge Split"
-msgstr ""
+msgstr "Muuta _jako"
 
 #: gnucash/register/ledger-core/split-register-model.c:2242
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Chan_ge Transaction"
-msgstr "Etsi tosite"
+msgstr "_Muuta tositetta"
 
 #: gnucash/register/ledger-core/split-register-model.c:2343
 msgid "Enter debit formula for real transaction"
@@ -20827,7 +20044,7 @@ msgstr ""
 
 #: gnucash/register/register-gnome/completioncell-gnome.c:75
 msgid "Don't autocomplete"
-msgstr ""
+msgstr "Älä täydennä automaattisesti"
 
 #: gnucash/register/register-gnome/datecell-gnome.c:104
 msgid ""
@@ -20835,11 +20052,14 @@ msgid ""
 "Threshold\" set for this book. This setting can be changed in File-"
 ">Properties->Accounts, resetting to the threshold."
 msgstr ""
+"Tositteen päiväys on vanhempi kuin tälle kirjalle määritetty "
+"kirjoitussuojatun aikarajan asetus. Tätä asetusta voi muuttaa valikossa "
+"Tiedosto->Ominaisuudet->Tilit."
 
 #: gnucash/register/register-gnome/gnucash-item-list.c:539
 #: gnucash/report/reports/standard/investment-lots.scm:384
 msgid "List"
-msgstr ""
+msgstr "Lista"
 
 #: gnucash/report/eguile.scm:150
 #, scheme-format
@@ -20848,7 +20068,7 @@ msgstr ""
 
 #: gnucash/report/html-chart.scm:476
 msgid "Load"
-msgstr ""
+msgstr "Lataa"
 
 #: gnucash/report/html-fonts.scm:105 gnucash/report/html-fonts.scm:109
 #: gnucash/report/html-fonts.scm:113 gnucash/report/html-fonts.scm:117
@@ -20856,93 +20076,85 @@ msgstr ""
 #: gnucash/report/html-fonts.scm:129 gnucash/report/html-fonts.scm:134
 #: gnucash/report/html-fonts.scm:139
 msgid "Fonts"
-msgstr ""
+msgstr "Fontit"
 
 #: gnucash/report/html-fonts.scm:106
 msgid "Font info for the report title."
-msgstr ""
+msgstr "Raportin otsikon fontti."
 
 #: gnucash/report/html-fonts.scm:110
-#, fuzzy
-#| msgid "Account"
 msgid "Account link"
-msgstr "Tili"
+msgstr "Tililinkki"
 
 #: gnucash/report/html-fonts.scm:110
 msgid "Font info for account name."
-msgstr ""
+msgstr "Tilin nimen fontti."
 
 #: gnucash/report/html-fonts.scm:114
-#, fuzzy
-#| msgid "Number"
 msgid "Number cell"
-msgstr "Numero"
+msgstr "Numerosolu"
 
 #: gnucash/report/html-fonts.scm:114
 msgid "Font info for regular number cells."
-msgstr ""
+msgstr "Numerosolujen fontti."
 
 #: gnucash/report/html-fonts.scm:118
 msgid "Negative Values in Red"
-msgstr ""
+msgstr "Näytä negatiiviset arvot punaisina"
 
 #: gnucash/report/html-fonts.scm:118
 msgid "Display negative values in red."
-msgstr ""
+msgstr "Näytä negatiiviset arvot punaisina."
 
 #: gnucash/report/html-fonts.scm:122
-#, fuzzy
-#| msgid "Number"
 msgid "Number header"
-msgstr "Numero"
+msgstr "Numeron otsikko"
 
 #: gnucash/report/html-fonts.scm:122
 msgid "Font info for number headers."
-msgstr ""
+msgstr "Numeroiden otsikoiden fontti."
 
 #: gnucash/report/html-fonts.scm:126
 msgid "Text cell"
-msgstr ""
+msgstr "Tekstisolu"
 
 #: gnucash/report/html-fonts.scm:126
 msgid "Font info for regular text cells."
-msgstr ""
+msgstr "Normaalien tekstisolujen fontti."
 
 #: gnucash/report/html-fonts.scm:130
-#, fuzzy
-#| msgid "Total Entries"
 msgid "Total number cell"
-msgstr "Yhteensä tietueita"
+msgstr "Loppusumman solu"
 
 #: gnucash/report/html-fonts.scm:131
 msgid "Font info for number cells containing a total."
-msgstr ""
+msgstr "Loppusumman solujen fontti."
 
 #: gnucash/report/html-fonts.scm:135
 msgid "Total label cell"
-msgstr ""
+msgstr "Loppusumman otsikon solu"
 
 #: gnucash/report/html-fonts.scm:136
 msgid "Font info for cells containing total labels."
-msgstr ""
+msgstr "Loppusummien otsikkosolujen fontti."
 
 #: gnucash/report/html-fonts.scm:140
 msgid "Centered label cell"
-msgstr ""
+msgstr "Keskitetty otsikkosolu"
 
 #: gnucash/report/html-fonts.scm:140
 msgid "Font info for centered label cells."
-msgstr ""
+msgstr "Keskitettyjen otsikkosolujen fontti."
 
 #: gnucash/report/html-style-sheet.scm:150
 msgid "Can't save style sheet"
-msgstr ""
+msgstr "Tyylitiedosto ei voida tallentaa"
 
 #: gnucash/report/html-utilities.scm:263
 msgid "Exchange rate"
 msgid_plural "Exchange rates"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Muuntokurssi"
+msgstr[1] "Muuntokurssit"
 
 #: gnucash/report/html-utilities.scm:276
 msgid "No budgets exist. You must create at least one budget."
@@ -20950,26 +20162,22 @@ msgstr ""
 
 #: gnucash/report/html-utilities.scm:293
 #: gnucash/ui/gnc-plugin-page-report.ui:242
-#, fuzzy
-#| msgid "Edit report configuration name"
 msgid "Edit report options"
-msgstr "Muokkaa raporttiasetusten nimeä"
+msgstr "Muokkaa raportin valintoja"
 
 #: gnucash/report/html-utilities.scm:309
 #: gnucash/report/reports/standard/balsheet-pnl.scm:143
 #: gnucash/report/reports/standard/new-owner-report.scm:925
 msgid "Disabled"
-msgstr ""
+msgstr "Estetty"
 
 #: gnucash/report/html-utilities.scm:361
 msgid "This report requires you to specify certain report options."
 msgstr ""
 
 #: gnucash/report/html-utilities.scm:368
-#, fuzzy
-#| msgid "No Account selected. Please try again."
 msgid "No accounts selected"
-msgstr "Tiliä ei valittu. Yritä uudestaan."
+msgstr "Ei valittuja tilejä"
 
 #: gnucash/report/html-utilities.scm:369
 msgid "This report requires accounts to be selected in the report options."
@@ -20978,7 +20186,7 @@ msgstr ""
 #: gnucash/report/html-utilities.scm:376
 #: gnucash/report/reports/standard/price-scatter.scm:250
 msgid "No data"
-msgstr ""
+msgstr "Ei tietoja"
 
 #: gnucash/report/html-utilities.scm:377
 msgid ""
@@ -20988,19 +20196,15 @@ msgstr ""
 
 #: gnucash/report/options-utilities.scm:51
 msgid "Select a date to report on."
-msgstr ""
+msgstr "Valitse päivämäärä raportille."
 
 #: gnucash/report/options-utilities.scm:57
-#, fuzzy
-#| msgid "Start of accounting period"
 msgid "Start of reporting period."
-msgstr "Tilikauden alku"
+msgstr "Raportointikauden alku."
 
 #: gnucash/report/options-utilities.scm:58
-#, fuzzy
-#| msgid "End of accounting period"
 msgid "End of reporting period."
-msgstr "Tilikauden loppu"
+msgstr "Raportointikauden loppu."
 
 #: gnucash/report/options-utilities.scm:66
 msgid "The amount of time between data points."
@@ -21008,41 +20212,41 @@ msgstr ""
 
 #: gnucash/report/options-utilities.scm:68
 msgid "One Day"
-msgstr ""
+msgstr "Yksi päivä"
 
 #: gnucash/report/options-utilities.scm:69
 #: gnucash/report/reports/standard/balsheet-pnl.scm:149
 msgid "One Week"
-msgstr ""
+msgstr "Yksi viikko"
 
 #: gnucash/report/options-utilities.scm:70
 #: gnucash/report/reports/standard/balsheet-pnl.scm:148
 msgid "Two Weeks"
-msgstr ""
+msgstr "Kaksi viikkoa"
 
 #: gnucash/report/options-utilities.scm:71
 #: gnucash/report/reports/standard/balsheet-pnl.scm:147
 msgid "One Month"
-msgstr ""
+msgstr "Yksi kuukausi"
 
 #: gnucash/report/options-utilities.scm:72
 #: gnucash/report/reports/standard/balsheet-pnl.scm:146
 msgid "Quarter Year"
-msgstr ""
+msgstr "Neljännesvuosi"
 
 #: gnucash/report/options-utilities.scm:73
 #: gnucash/report/reports/standard/balsheet-pnl.scm:145
 msgid "Half Year"
-msgstr ""
+msgstr "Puoli vuotta"
 
 #: gnucash/report/options-utilities.scm:74
 #: gnucash/report/reports/standard/balsheet-pnl.scm:144
 msgid "One Year"
-msgstr ""
+msgstr "Yksi vuosi"
 
 #: gnucash/report/options-utilities.scm:87
 msgid "All"
-msgstr ""
+msgstr "Kaikki"
 
 #: gnucash/report/options-utilities.scm:103
 msgid "Show accounts to this depth, overriding any other option."
@@ -21072,7 +20276,7 @@ msgstr ""
 #: gnucash/report/reports/standard/investment-lots.scm:337
 #: gnucash/report/reports/standard/price-scatter.scm:72
 msgid "The source of price information."
-msgstr ""
+msgstr "Hintatiedon lähde."
 
 #: gnucash/report/options-utilities.scm:140
 msgid "Average cost of purchases weighted by volume"
@@ -21090,7 +20294,7 @@ msgstr ""
 #: gnucash/report/options-utilities.scm:143
 #: gnucash/report/reports/standard/investment-lots.scm:339
 msgid "Closest to report date"
-msgstr ""
+msgstr "Lähinnä raportin päiväystä"
 
 #: gnucash/report/options-utilities.scm:144
 #: gnucash/report/reports/standard/advanced-portfolio.scm:76
@@ -21132,7 +20336,7 @@ msgstr ""
 
 #: gnucash/report/options-utilities.scm:181
 msgid "Dash"
-msgstr ""
+msgstr "Katkoviiva"
 
 #: gnucash/report/options-utilities.scm:182
 msgid "Filled diamond"
@@ -21147,14 +20351,12 @@ msgid "Filled square"
 msgstr ""
 
 #: gnucash/report/options-utilities.scm:191
-#, fuzzy
-#| msgid "Please choose the currency to use for new accounts."
 msgid "Choose the method for sorting accounts."
-msgstr "Valitse luotaville tileille käytettävä valuutta."
+msgstr ""
 
 #: gnucash/report/options-utilities.scm:194
 msgid "Alphabetical by account code"
-msgstr ""
+msgstr "Aakkostettu tilinumeron mukaan"
 
 #: gnucash/report/options-utilities.scm:195
 msgid "Alphabetical by account name"
@@ -21166,7 +20368,7 @@ msgstr ""
 
 #: gnucash/report/options-utilities.scm:212
 msgid "How to show the balances of parent accounts."
-msgstr ""
+msgstr "Valitsee miten näytetään ylätilien saldot."
 
 #: gnucash/report/options-utilities.scm:213
 msgid "Account Balance in the parent account, excluding any subaccounts."
@@ -21174,29 +20376,27 @@ msgstr ""
 
 #: gnucash/report/options-utilities.scm:214
 msgid "Do not show any balances of parent accounts."
-msgstr ""
+msgstr "Älä näytä mitään saldoja ylätileille."
 
 #: gnucash/report/options-utilities.scm:217
 #: gnucash/report/reports/standard/account-summary.scm:112
 #: gnucash/report/trep-engine.scm:931 gnucash/report/trep-engine.scm:1368
 #: gnucash/report/trep-engine.scm:1473
-#, fuzzy
-#| msgid "Next Balance"
 msgid "Account Balance"
-msgstr "Uusi saldo"
+msgstr "Tilin saldo"
 
 #: gnucash/report/options-utilities.scm:218
 msgid "Calculate Subtotal"
-msgstr ""
+msgstr "Laske välisummat"
 
 #: gnucash/report/options-utilities.scm:219
 #: gnucash/report/options-utilities.scm:234
 msgid "Do not show"
-msgstr ""
+msgstr "Älä näytä"
 
 #: gnucash/report/options-utilities.scm:228
 msgid "How to show account subtotals for parent accounts."
-msgstr ""
+msgstr "Miten välisummat ylätileille näytetään."
 
 #: gnucash/report/options-utilities.scm:229
 msgid "Show subtotals for selected parent accounts which have subaccounts."
@@ -21204,43 +20404,39 @@ msgstr ""
 
 #: gnucash/report/options-utilities.scm:230
 msgid "Do not show any subtotals for parent accounts."
-msgstr ""
+msgstr "Älä näytä mitään välisummia ylätileille."
 
 #: gnucash/report/options-utilities.scm:233
 msgid "Show subtotals"
-msgstr ""
+msgstr "Näytä välisummat"
 
 #: gnucash/report/report-core.scm:154
 msgid "_Assets & Liabilities"
-msgstr ""
+msgstr "_Vastaavat ja vastattavat"
 
 #: gnucash/report/report-core.scm:155
-#, fuzzy
-#| msgid "Other Expense"
 msgid "_Income & Expense"
-msgstr "Muu kulu"
+msgstr "_Tulot ja menot"
 
 #: gnucash/report/report-core.scm:156 gnucash/ui/gnc-plugin-budget.ui:6
 msgid "B_udget"
-msgstr ""
+msgstr "B_udjetti"
 
 #: gnucash/report/report-core.scm:157
-#, fuzzy
-#| msgid "Taxes"
 msgid "_Taxes"
-msgstr "Verot"
+msgstr "_Verot"
 
 #: gnucash/report/report-core.scm:158
 msgid "E_xamples"
-msgstr ""
+msgstr "E_simerkkejä"
 
 #: gnucash/report/report-core.scm:159
 msgid "_Experimental"
-msgstr ""
+msgstr "_Kokeellinen"
 
 #: gnucash/report/report-core.scm:160
 msgid "_Multicolumn"
-msgstr ""
+msgstr "_Monisarakkeinen"
 
 #: gnucash/report/report-core.scm:164
 #: gnucash/report/reports/standard/invoice.scm:446
@@ -21275,30 +20471,24 @@ msgstr ""
 #: gnucash/report/reports/standard/register.scm:398
 #: gnucash/report/reports/standard/taxinvoice.scm:70
 msgid "Display"
-msgstr ""
+msgstr "Näytä"
 
 #: gnucash/report/report-core.scm:165
-#, fuzzy
-#| msgid "Username"
 msgid "Report name"
-msgstr "Käyttäjätunnus"
+msgstr "Raportin nimi"
 
 #: gnucash/report/report-core.scm:166
 msgid "Stylesheet"
-msgstr ""
+msgstr "Tyylitiedosto"
 
 #: gnucash/report/report-core.scm:167 gnucash/ui/gnc-main-window.ui:357
 #: gnucash/ui/gnc-plugin-business.ui:159
-#, fuzzy
-#| msgid "Business"
 msgid "_Business"
-msgstr "Liiketoiminta"
+msgstr "_Liiketoiminta"
 
 #: gnucash/report/report-core.scm:168
-#, fuzzy
-#| msgid "Invoice"
 msgid "Invoice Number"
-msgstr "Myyntilasku"
+msgstr "Laskunumero"
 
 #: gnucash/report/report-core.scm:216
 msgid ""
@@ -21306,30 +20496,29 @@ msgid ""
 "report system, especially your saved reports, for a report with this report-"
 "guid: "
 msgstr ""
+"Yhdellä raporteistasi on report-guid joka on sama toisen kanssa. Tarkista "
+"raporttijärjestelmä, erityisesti tallennetut raporttisi, sellaisen raportin "
+"varalta jonka report-guid on: "
 
 #: gnucash/report/report-core.scm:217
-#, fuzzy
-#| msgid "Load report configuration"
 msgid "Wrong report definition: "
-msgstr "Lataa raporttiasetukset"
+msgstr "Väärä raportin määrittely: "
 
 #: gnucash/report/report-core.scm:218
 msgid " Report is missing a GUID."
-msgstr ""
+msgstr " Raportista puuttuu GUID-tunniste."
 
 #: gnucash/report/report-core.scm:309
 msgid "Enter a descriptive name for this report."
-msgstr ""
+msgstr "Syötä kuvaava nimi raportille."
 
 #: gnucash/report/report-core.scm:316
 msgid "Select a stylesheet for the report."
-msgstr ""
+msgstr "Valitse tyylitiedosto raportille."
 
 #: gnucash/report/reports/example/average-balance.scm:38
-#, fuzzy
-#| msgid "Opening Balance"
 msgid "Average Balance"
-msgstr "Avaussaldo"
+msgstr ""
 
 #: gnucash/report/reports/example/average-balance.scm:42
 #: gnucash/report/reports/standard/cashflow-barchart.scm:57
@@ -21363,7 +20552,7 @@ msgstr ""
 #: gnucash/report/reports/standard/trial-balance.scm:123
 #: gnucash/report/trep-engine.scm:114
 msgid "Report's currency"
-msgstr ""
+msgstr "Raportin valuutta"
 
 #: gnucash/report/reports/example/average-balance.scm:44
 #: gnucash/report/reports/example/daily-reports.scm:55
@@ -21388,18 +20577,16 @@ msgstr ""
 #: gnucash/report/reports/standard/trial-balance.scm:124
 #: gnucash/report/trep-engine.scm:111
 msgid "Price Source"
-msgstr ""
+msgstr "Hintalähde"
 
 #: gnucash/report/reports/example/average-balance.scm:45
 #: gnucash/report/reports/example/daily-reports.scm:59
-#, fuzzy
-#| msgid "All Accounts"
 msgid "Include Sub-Accounts"
-msgstr "Kaikki tilit"
+msgstr "Sisällytä alatilit"
 
 #: gnucash/report/reports/example/average-balance.scm:46
 msgid "Exclude transactions between selected accounts"
-msgstr ""
+msgstr "Rajaa siirrot valittujen tilien välillä pois"
 
 #: gnucash/report/reports/example/average-balance.scm:47
 #: gnucash/report/reports/example/daily-reports.scm:62
@@ -21427,10 +20614,8 @@ msgstr ""
 
 #: gnucash/report/reports/example/average-balance.scm:75
 #: gnucash/report/reports/example/daily-reports.scm:84
-#, fuzzy
-#| msgid "The %s amount has no associated account."
 msgid "Include sub-accounts of all selected accounts."
-msgstr "Määrää %s ei ole liitetty tilille."
+msgstr "Sisällytä kaikkien valittujen tilian alatilit."
 
 #: gnucash/report/reports/example/average-balance.scm:80
 msgid ""
@@ -21440,7 +20625,7 @@ msgstr ""
 
 #: gnucash/report/reports/example/average-balance.scm:86
 msgid "Do transaction report on this account."
-msgstr ""
+msgstr "Tee tositeraportti tällä tilillä."
 
 #: gnucash/report/reports/example/average-balance.scm:105
 #: gnucash/report/reports/example/average-balance.scm:289
@@ -21449,7 +20634,7 @@ msgstr ""
 #: gnucash/report/reports/standard/net-charts.scm:118
 #: gnucash/report/reports/standard/net-charts.scm:204
 msgid "Show table"
-msgstr ""
+msgstr "Näytä taulu"
 
 #: gnucash/report/reports/example/average-balance.scm:106
 #: gnucash/report/reports/standard/cashflow-barchart.scm:109
@@ -21461,7 +20646,7 @@ msgstr ""
 #: gnucash/report/reports/example/average-balance.scm:109
 #: gnucash/report/reports/example/average-balance.scm:288
 msgid "Show plot"
-msgstr ""
+msgstr "Näytä kuvaaja"
 
 #: gnucash/report/reports/example/average-balance.scm:110
 msgid "Display a graph of the selected data."
@@ -21469,14 +20654,12 @@ msgstr ""
 
 #: gnucash/report/reports/example/average-balance.scm:113
 #: gnucash/report/reports/example/average-balance.scm:287
-#, fuzzy
-#| msgid "Account Types"
 msgid "Plot Type"
-msgstr "Tilityypit"
+msgstr "Kuvaajatyyppi"
 
 #: gnucash/report/reports/example/average-balance.scm:114
 msgid "The type of graph to generate."
-msgstr ""
+msgstr "Luotavan kuvaajan tyyppi."
 
 #: gnucash/report/reports/example/average-balance.scm:116
 #: gnucash/report/reports/example/average-balance.scm:136
@@ -21492,33 +20675,29 @@ msgid "Profit"
 msgstr ""
 
 #: gnucash/report/reports/example/average-balance.scm:136
-#, fuzzy
-#| msgid "Period"
 msgid "Period start"
-msgstr "Aikaväli"
+msgstr "Aikavälin alku"
 
 #: gnucash/report/reports/example/average-balance.scm:136
-#, fuzzy
-#| msgid "Period"
 msgid "Period end"
-msgstr "Aikaväli"
+msgstr "Aikavälin loppu"
 
 #: gnucash/report/reports/example/average-balance.scm:137
 msgid "Maximum"
-msgstr ""
+msgstr "Enintään"
 
 #: gnucash/report/reports/example/average-balance.scm:137
 #: gnucash/report/reports/standard/balance-forecast.scm:235
 msgid "Minimum"
-msgstr ""
+msgstr "Vähintään"
 
 #: gnucash/report/reports/example/average-balance.scm:137
 msgid "Gain"
-msgstr ""
+msgstr "Tulo"
 
 #: gnucash/report/reports/example/average-balance.scm:138
 msgid "Loss"
-msgstr ""
+msgstr "Meno"
 
 #: gnucash/report/reports/example/daily-reports.scm:37
 #: gnucash/report/reports/example/daily-reports.scm:49
@@ -21551,12 +20730,12 @@ msgstr ""
 #: gnucash/report/reports/standard/income-statement.scm:58
 #: gnucash/report/reports/standard/trial-balance.scm:73
 msgid "Levels of Subaccounts"
-msgstr ""
+msgstr "Näytä alatilien tasoja"
 
 #: gnucash/report/reports/example/daily-reports.scm:61
 #: gnucash/report/reports/standard/account-piecharts.scm:74
 msgid "Show Totals"
-msgstr ""
+msgstr "Näytä summat"
 
 #: gnucash/report/reports/example/daily-reports.scm:89
 #: gnucash/report/reports/standard/account-piecharts.scm:118
@@ -21572,7 +20751,7 @@ msgstr ""
 
 #: gnucash/report/reports/example/sample-graphs.scm:42
 msgid "Sample Graphs"
-msgstr ""
+msgstr "Mallikuvaajat"
 
 #: gnucash/report/reports/example/sample-graphs.scm:135
 msgid "Pie:"
@@ -21602,7 +20781,7 @@ msgstr ""
 #: gnucash/report/reports/standard/taxinvoice.scm:93
 #: gnucash/report/reports/standard/trial-balance.scm:62
 msgid "Report Title"
-msgstr ""
+msgstr "Raportin otsikko"
 
 #: gnucash/report/reports/example/sample-report.scm:42
 #: gnucash/report/reports/standard/account-summary.scm:70
@@ -21614,7 +20793,7 @@ msgstr ""
 #: gnucash/report/reports/standard/income-statement.scm:50
 #: gnucash/report/reports/standard/trial-balance.scm:63
 msgid "Title for this report."
-msgstr ""
+msgstr "Näytä raportin otsikko."
 
 #: gnucash/report/reports/example/sample-report.scm:61
 #: gnucash/report/reports/example/sample-report.scm:72
@@ -21628,10 +20807,8 @@ msgid "Tab B"
 msgstr ""
 
 #: gnucash/report/reports/example/sample-report.scm:61
-#, fuzzy
-#| msgid "New Book Options"
 msgid "Boolean Option"
-msgstr "Uuden kirjanpidon asetukset"
+msgstr ""
 
 #: gnucash/report/reports/example/sample-report.scm:62
 msgid "This is a boolean option."
@@ -21650,20 +20827,16 @@ msgid "First Option"
 msgstr ""
 
 #: gnucash/report/reports/example/sample-report.scm:75
-#, fuzzy
-#| msgid "New Book Options"
 msgid "Second Option"
-msgstr "Uuden kirjanpidon asetukset"
+msgstr ""
 
 #: gnucash/report/reports/example/sample-report.scm:76
 msgid "Third Option"
 msgstr ""
 
 #: gnucash/report/reports/example/sample-report.scm:77
-#, fuzzy
-#| msgid "New Book Options"
 msgid "Fourth Options"
-msgstr "Uuden kirjanpidon asetukset"
+msgstr "Neljännet asetukset"
 
 #: gnucash/report/reports/example/sample-report.scm:85
 msgid "String Option"
@@ -21679,48 +20852,46 @@ msgstr ""
 
 #: gnucash/report/reports/example/sample-report.scm:99
 msgid "Just a Date Option"
-msgstr ""
+msgstr "Vain päiväys -asetus"
 
 #: gnucash/report/reports/example/sample-report.scm:100
 msgid "This is a date option."
-msgstr ""
+msgstr "Tämä on päiväysasetus."
 
 #: gnucash/report/reports/example/sample-report.scm:104
 msgid "Combo Date Option"
-msgstr ""
+msgstr "Yhdistetty päiväasetus"
 
 #: gnucash/report/reports/example/sample-report.scm:105
 msgid "This is a combination date option."
-msgstr ""
+msgstr "Tämä on yhdistetty päiväasetus."
 
 #: gnucash/report/reports/example/sample-report.scm:109
 msgid "Relative Date Option"
-msgstr ""
+msgstr "Suhteellinen päiväasetus"
 
 #: gnucash/report/reports/example/sample-report.scm:110
 msgid "This is a relative date option."
-msgstr ""
+msgstr "Tämä on suhteellinen päiväasetus."
 
 #: gnucash/report/reports/example/sample-report.scm:119
-#, fuzzy
-#| msgid "Number/Action"
 msgid "Number Option"
-msgstr "Numero/Tapahtuma"
+msgstr "Numeroasetus"
 
 #: gnucash/report/reports/example/sample-report.scm:120
 msgid "This is a number option."
-msgstr ""
+msgstr "Tämä on numeroasetus."
 
 #: gnucash/report/reports/example/sample-report.scm:131
 #: gnucash/report/stylesheets/footer.scm:104
 #: gnucash/report/stylesheets/head-or-tail.scm:143
 #: gnucash/report/stylesheets/plain.scm:42
 msgid "Background Color"
-msgstr ""
+msgstr "Taustan väri"
 
 #: gnucash/report/reports/example/sample-report.scm:132
 msgid "This is a color option."
-msgstr ""
+msgstr "Tämä on väriasetus."
 
 #: gnucash/report/reports/example/sample-report.scm:147
 #: gnucash/report/reports/example/sample-report.scm:158
@@ -21728,22 +20899,20 @@ msgid "Tab A"
 msgstr ""
 
 #: gnucash/report/reports/example/sample-report.scm:147
-#, fuzzy
-#| msgid "End of accounting period"
 msgid "An account list option"
-msgstr "Tilikauden loppu"
+msgstr "Tilivalinta-asetus"
 
 #: gnucash/report/reports/example/sample-report.scm:148
 msgid "This is an account list option."
-msgstr ""
+msgstr "Tämä on tilin valinta luettelosta."
 
 #: gnucash/report/reports/example/sample-report.scm:158
 msgid "A list option"
-msgstr ""
+msgstr "Lista-asetus"
 
 #: gnucash/report/reports/example/sample-report.scm:159
 msgid "This is a list option."
-msgstr ""
+msgstr "Tämä on lista-asetus."
 
 #: gnucash/report/reports/example/sample-report.scm:161
 msgid "The Good"
@@ -21758,14 +20927,12 @@ msgid "The Ugly"
 msgstr ""
 
 #: gnucash/report/reports/example/sample-report.scm:168
-#, fuzzy
-#| msgid "Use Existing"
 msgid "Testing"
-msgstr "Käytä olemassa olevaa"
+msgstr ""
 
 #: gnucash/report/reports/example/sample-report.scm:169
 msgid "Report Title Default"
-msgstr ""
+msgstr "Raportin oletusotsikko"
 
 #: gnucash/report/reports/example/sample-report.scm:285
 #, scheme-format
@@ -21795,24 +20962,22 @@ msgid ""
 msgstr ""
 
 #: gnucash/report/reports/example/sample-report.scm:302
-#, fuzzy, scheme-format
-#| msgid "The current date."
+#, scheme-format
 msgid "The current time is ~a."
-msgstr "Tämä päiväys."
+msgstr "Kello on nyt ~a."
 
 #: gnucash/report/reports/example/sample-report.scm:307
-#, fuzzy, scheme-format
-#| msgid "The menu of options"
+#, scheme-format
 msgid "The boolean option is ~a."
-msgstr "Vaihtoehtojen valikko"
+msgstr "Kyllä/ei arvo on ~a."
 
 #: gnucash/report/reports/example/sample-report.scm:308
 msgid "true"
-msgstr ""
+msgstr "kyllä"
 
 #: gnucash/report/reports/example/sample-report.scm:308
 msgid "false"
-msgstr ""
+msgstr "ei"
 
 #: gnucash/report/reports/example/sample-report.scm:312
 #, scheme-format
@@ -21820,22 +20985,19 @@ msgid "The radio button option is ~a."
 msgstr ""
 
 #: gnucash/report/reports/example/sample-report.scm:317
-#, fuzzy, scheme-format
-#| msgid "The menu of options"
+#, scheme-format
 msgid "The multi-choice option is ~a."
-msgstr "Vaihtoehtojen valikko"
+msgstr "Monivalinta on ~a."
 
 #: gnucash/report/reports/example/sample-report.scm:322
-#, fuzzy, scheme-format
-#| msgid "The menu of options"
+#, scheme-format
 msgid "The string option is ~a."
-msgstr "Vaihtoehtojen valikko"
+msgstr "Merkkijonovalinta on ~a."
 
 #: gnucash/report/reports/example/sample-report.scm:327
-#, fuzzy, scheme-format
-#| msgid "The menu of options"
+#, scheme-format
 msgid "The date option is ~a."
-msgstr "Vaihtoehtojen valikko"
+msgstr "Päivämäärävalinta on ~a."
 
 #: gnucash/report/reports/example/sample-report.scm:332
 #, scheme-format
@@ -21848,10 +21010,9 @@ msgid "The combination date option is ~a."
 msgstr ""
 
 #: gnucash/report/reports/example/sample-report.scm:342
-#, fuzzy, scheme-format
-#| msgid "The menu of options"
+#, scheme-format
 msgid "The number option is ~a."
-msgstr "Vaihtoehtojen valikko"
+msgstr ""
 
 #: gnucash/report/reports/example/sample-report.scm:353
 #, scheme-format
@@ -21876,20 +21037,20 @@ msgstr ""
 
 #: gnucash/report/reports/example/sample-report.scm:422
 msgid "Display help"
-msgstr ""
+msgstr "Näytä ohje"
 
 #: gnucash/report/reports/example/sample-report.scm:442
 #: gnucash/report/reports/example/sample-report.scm:453
 msgid "Sample Report"
-msgstr ""
+msgstr "Malliraportti"
 
 #: gnucash/report/reports/example/sample-report.scm:457
 msgid "An options example report."
-msgstr ""
+msgstr "Vaihtoehtojen esimerkkiraportti."
 
 #: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:79
 msgid "Tax Report / TXF Export"
-msgstr ""
+msgstr "Veroraportti / TXF-vienti"
 
 #: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:148
 #: gnucash/report/reports/locale-specific/us/taxtxf.scm:178
@@ -21932,7 +21093,7 @@ msgstr ""
 #: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:156
 #: gnucash/report/reports/locale-specific/us/taxtxf.scm:189
 msgid "Last Year"
-msgstr ""
+msgstr "Viime vuosi"
 
 #: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:157
 #: gnucash/report/reports/locale-specific/us/taxtxf.scm:190
@@ -21960,19 +21121,17 @@ msgstr ""
 #: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:163
 #: gnucash/report/reports/locale-specific/us/taxtxf.scm:199
 msgid "Select Accounts (none = all)"
-msgstr ""
+msgstr "Valitse tilit (ilman valintaa = kaikki)"
 
 #: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:164
 #: gnucash/report/reports/locale-specific/us/taxtxf.scm:200
-#, fuzzy
-#| msgid "Select document"
 msgid "Select accounts."
-msgstr "Valitse asiakirja"
+msgstr "Valitse tilit."
 
 #: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:168
 #: gnucash/report/reports/locale-specific/us/taxtxf.scm:203
 msgid "Suppress $0.00 values"
-msgstr ""
+msgstr "Estä $0,00-arvot"
 
 #: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:169
 msgid "$0.00 valued Accounts won't be printed."
@@ -21984,7 +21143,7 @@ msgstr ""
 
 #: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:173
 msgid "Print all Parent account names."
-msgstr ""
+msgstr "Tulosta kaikki ylätilien nimet."
 
 #: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:251
 msgid ""
@@ -21995,11 +21154,11 @@ msgstr ""
 #: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:800
 #, scheme-format
 msgid "Period from ~a to ~a"
-msgstr ""
+msgstr "Aikavälillä alkaen ~a ja päättyen ~a"
 
 #: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:837
 msgid "Tax Report & XML Export"
-msgstr ""
+msgstr "Veroraportti & XML-vienti"
 
 #: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:839
 msgid "Taxable Income / Deductible Expenses / Export to .XML file"
@@ -22016,7 +21175,7 @@ msgstr ""
 
 #: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:848
 msgid "XML"
-msgstr ""
+msgstr "XML"
 
 #: gnucash/report/reports/locale-specific/de_DE/taxtxf.scm:852
 msgid "This page shows your Taxable Income and Deductible Expenses."
@@ -22024,7 +21183,7 @@ msgstr ""
 
 #: gnucash/report/reports/locale-specific/us/taxtxf.scm:119
 msgid "Tax Schedule Report/TXF Export"
-msgstr ""
+msgstr "Veroaikatauluraportti / TXF-vienti"
 
 #: gnucash/report/reports/locale-specific/us/taxtxf.scm:204
 msgid "$0.00 valued Tax codes won't be printed."
@@ -22056,11 +21215,11 @@ msgstr ""
 
 #: gnucash/report/reports/locale-specific/us/taxtxf.scm:220
 msgid "Do not print T-Num:Memo data"
-msgstr ""
+msgstr "Älä näytä tositenumero:kuvaus tietoa"
 
 #: gnucash/report/reports/locale-specific/us/taxtxf.scm:221
 msgid "Do not print T-Num:Memo data for transactions."
-msgstr ""
+msgstr "Älä näytä tositteiden tositenumero:erittely tietoa."
 
 #: gnucash/report/reports/locale-specific/us/taxtxf.scm:223
 msgid "Do not print Action:Memo data"
@@ -22068,11 +21227,11 @@ msgstr ""
 
 #: gnucash/report/reports/locale-specific/us/taxtxf.scm:224
 msgid "Do not print Action:Memo data for transactions."
-msgstr ""
+msgstr "Älä näytä tositteiden tapahtuma:erittely tietoa."
 
 #: gnucash/report/reports/locale-specific/us/taxtxf.scm:227
 msgid "Do not print transaction detail"
-msgstr ""
+msgstr "Älä näytä tositteen yksityiskohtia"
 
 #: gnucash/report/reports/locale-specific/us/taxtxf.scm:228
 msgid "Do not print transaction detail for accounts."
@@ -22084,11 +21243,11 @@ msgstr ""
 
 #: gnucash/report/reports/locale-specific/us/taxtxf.scm:232
 msgid "Do not print transactions out of specified dates."
-msgstr ""
+msgstr "Älä näytä tositteita määritettyjen päivien ulkopuolelta."
 
 #: gnucash/report/reports/locale-specific/us/taxtxf.scm:235
 msgid "Currency conversion date"
-msgstr ""
+msgstr "Rahayksikön muunnospäivämäärä"
 
 #: gnucash/report/reports/locale-specific/us/taxtxf.scm:236
 msgid "Select date to use for PriceDB lookups."
@@ -22096,16 +21255,16 @@ msgstr ""
 
 #: gnucash/report/reports/locale-specific/us/taxtxf.scm:239
 msgid "Nearest to transaction date"
-msgstr ""
+msgstr "Lähimpänä tositteen päiväystä"
 
 #: gnucash/report/reports/locale-specific/us/taxtxf.scm:241
 #: gnucash/report/reports/standard/advanced-portfolio.scm:77
 msgid "Nearest to report date"
-msgstr ""
+msgstr "Lähimpänä raportin päiväystä"
 
 #: gnucash/report/reports/locale-specific/us/taxtxf.scm:3310
 msgid "Tax Schedule Report & TXF Export"
-msgstr ""
+msgstr "Veroaikatauluraportti & TXF-vienti"
 
 #: gnucash/report/reports/locale-specific/us/taxtxf.scm:3312
 msgid ""
@@ -22127,20 +21286,19 @@ msgstr ""
 #: gnucash/report/reports/locale-specific/us/taxtxf.scm:3325
 msgid "This page shows transaction detail for relevant Income Tax accounts."
 msgstr ""
+"Tämä sivu näyttää liittyvien tuloverotilien tositteiden yksityiskohdat."
 
 #: gnucash/report/reports/standard/account-piecharts.scm:36
 msgid "Income Piechart"
-msgstr ""
+msgstr "Tulokuvaaja"
 
 #: gnucash/report/reports/standard/account-piecharts.scm:37
-#, fuzzy
-#| msgid "Expense Vouchers"
 msgid "Expense Piechart"
-msgstr "Matkalaskut"
+msgstr "Kulukuvaaja"
 
 #: gnucash/report/reports/standard/account-piecharts.scm:38
 msgid "Asset Piechart"
-msgstr ""
+msgstr "Vastaavaa-kuvaaja"
 
 #: gnucash/report/reports/standard/account-piecharts.scm:39
 msgid "Security Piechart"
@@ -22148,7 +21306,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/account-piecharts.scm:40
 msgid "Liability Piechart"
-msgstr ""
+msgstr "Vastattavaa-kuvaaja"
 
 #: gnucash/report/reports/standard/account-piecharts.scm:45
 msgid "Shows a piechart with the Income per given time interval"
@@ -22173,18 +21331,14 @@ msgstr ""
 #: gnucash/report/reports/standard/account-piecharts.scm:59
 #: gnucash/report/reports/standard/customer-summary.scm:48
 #: gnucash/report/reports/standard/customer-summary.scm:49
-#, fuzzy
-#| msgid "All Accounts"
 msgid "Income Accounts"
-msgstr "Kaikki tilit"
+msgstr "Tulotilit"
 
 #: gnucash/report/reports/standard/account-piecharts.scm:60
 #: gnucash/report/reports/standard/customer-summary.scm:56
 #: gnucash/report/reports/standard/customer-summary.scm:57
-#, fuzzy
-#| msgid "Expense Vouchers"
 msgid "Expense Accounts"
-msgstr "Matkalaskut"
+msgstr "Kulutilit"
 
 #: gnucash/report/reports/standard/account-piecharts.scm:61
 #: gnucash/report/reports/standard/balance-sheet.scm:451
@@ -22193,7 +21347,7 @@ msgstr "Matkalaskut"
 #: gnucash/report/reports/standard/net-charts.scm:402
 #: gnucash/report/report-utilities.scm:200
 msgid "Assets"
-msgstr ""
+msgstr "Vastaavaa"
 
 #: gnucash/report/reports/standard/account-piecharts.scm:63
 #: gnucash/report/reports/standard/balance-sheet.scm:352
@@ -22202,15 +21356,15 @@ msgstr ""
 #: gnucash/report/reports/standard/net-charts.scm:402
 #: gnucash/report/report-utilities.scm:201
 msgid "Liabilities"
-msgstr ""
+msgstr "Vieras pääoma"
 
 #: gnucash/report/reports/standard/account-piecharts.scm:73
 msgid "Show long names"
-msgstr ""
+msgstr "Näytä pitkät nimet"
 
 #: gnucash/report/reports/standard/account-piecharts.scm:75
 msgid "Show Percents"
-msgstr ""
+msgstr "Näytä prosentit"
 
 #: gnucash/report/reports/standard/account-piecharts.scm:76
 msgid "Maximum Slices"
@@ -22219,12 +21373,12 @@ msgstr ""
 #: gnucash/report/reports/standard/account-piecharts.scm:79
 #: gnucash/report/reports/standard/category-barchart.scm:91
 msgid "Sort Method"
-msgstr ""
+msgstr "Lajittelutapa"
 
 #: gnucash/report/reports/standard/account-piecharts.scm:81
 #: gnucash/report/reports/standard/category-barchart.scm:93
 msgid "Show Average"
-msgstr ""
+msgstr "Näytä keskiarvo"
 
 #: gnucash/report/reports/standard/account-piecharts.scm:82
 #: gnucash/report/reports/standard/category-barchart.scm:94
@@ -22263,7 +21417,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/account-piecharts.scm:145
 msgid "Show the percentage in legend?"
-msgstr ""
+msgstr "Näytä prosentit selitteessä?"
 
 #: gnucash/report/reports/standard/account-piecharts.scm:150
 msgid "Maximum number of slices in pie."
@@ -22271,55 +21425,54 @@ msgstr ""
 
 #: gnucash/report/reports/standard/account-piecharts.scm:383
 msgid "Yearly Average"
-msgstr ""
+msgstr "Vuosittainen keskiarvo"
 
 #: gnucash/report/reports/standard/account-piecharts.scm:384
 #: gnucash/report/reports/standard/category-barchart.scm:312
 msgid "Monthly Average"
-msgstr ""
+msgstr "Kuukausittainen keskiarvo"
 
 #: gnucash/report/reports/standard/account-piecharts.scm:385
 #: gnucash/report/reports/standard/category-barchart.scm:313
 msgid "Weekly Average"
-msgstr ""
+msgstr "Viikottainen keskiarvo"
 
 #: gnucash/report/reports/standard/account-piecharts.scm:518
-#, fuzzy, scheme-format
-#| msgid "Balance Zero"
+#, scheme-format
 msgid "Balance at ~a"
-msgstr "Saldo nolla"
+msgstr "~a saldo"
 
 #: gnucash/report/reports/standard/account-summary.scm:66
-#, fuzzy
-#| msgid "Account Types"
 msgid "Account Summary"
-msgstr "Tilityypit"
+msgstr "Yhteenveto tileistä"
 
 #: gnucash/report/reports/standard/account-summary.scm:67
 msgid "Future Scheduled Transactions Summary"
-msgstr ""
+msgstr "Yhteenveto tulevista ajastetuista tositteista"
 
 #: gnucash/report/reports/standard/account-summary.scm:85
 msgid "Depth limit behavior"
-msgstr ""
+msgstr "Syvyysrajoitteen toiminta"
 
 #: gnucash/report/reports/standard/account-summary.scm:89
 msgid "How to treat accounts which exceed the specified depth limit (if any)."
-msgstr ""
+msgstr "Mahdollisen syvyysrajoitteen ylittävien tilien käsittely."
 
 #: gnucash/report/reports/standard/account-summary.scm:90
 msgid ""
 "Show the total balance, including balances in subaccounts, of any account at "
 "the depth limit."
 msgstr ""
+"Näytä kokonaissaldot, mukaanlukien alatilien saldot, mille tahansa tilille "
+"syvyysrajalla."
 
 #: gnucash/report/reports/standard/account-summary.scm:91
 msgid "Raise accounts deeper than the depth limit to the depth limit."
-msgstr ""
+msgstr "Nosta syvyysrajaa syvemmät tilit syvyysrajaan."
 
 #: gnucash/report/reports/standard/account-summary.scm:92
 msgid "Omit any accounts deeper than the depth limit."
-msgstr ""
+msgstr "Syvyysrajaa syvemmät tilit jätetään pois."
 
 #: gnucash/report/reports/standard/account-summary.scm:94
 #: gnucash/report/reports/standard/balance-sheet.scm:90
@@ -22327,7 +21480,7 @@ msgstr ""
 #: gnucash/report/reports/standard/budget-income-statement.scm:78
 #: gnucash/report/reports/standard/income-statement.scm:65
 msgid "Parent account balances"
-msgstr ""
+msgstr "Ylätilien saldot"
 
 #: gnucash/report/reports/standard/account-summary.scm:95
 #: gnucash/report/reports/standard/balance-sheet.scm:91
@@ -22335,7 +21488,7 @@ msgstr ""
 #: gnucash/report/reports/standard/budget-income-statement.scm:79
 #: gnucash/report/reports/standard/income-statement.scm:66
 msgid "Parent account subtotals"
-msgstr ""
+msgstr "Ylätilien välisaldot"
 
 #: gnucash/report/reports/standard/account-summary.scm:97
 #: gnucash/report/reports/standard/balance-sheet.scm:93
@@ -22345,7 +21498,7 @@ msgstr ""
 #: gnucash/report/reports/standard/income-statement.scm:68
 #: gnucash/report/reports/standard/trial-balance.scm:115
 msgid "Include accounts with zero total balances"
-msgstr ""
+msgstr "Sisällytä tilit joiden saldo on nolla"
 
 #: gnucash/report/reports/standard/account-summary.scm:99
 #: gnucash/report/reports/standard/balance-sheet.scm:95
@@ -22355,7 +21508,7 @@ msgstr ""
 #: gnucash/report/reports/standard/income-statement.scm:70
 #: gnucash/report/reports/standard/trial-balance.scm:117
 msgid "Include accounts with zero total (recursive) balances in this report."
-msgstr ""
+msgstr "Sisällytä tilit joiden alatilien yhdistetty saldo on nolla."
 
 #: gnucash/report/reports/standard/account-summary.scm:100
 #: gnucash/report/reports/standard/balance-sheet.scm:96
@@ -22364,7 +21517,7 @@ msgstr ""
 #: gnucash/report/reports/standard/budget-income-statement.scm:84
 #: gnucash/report/reports/standard/income-statement.scm:71
 msgid "Omit zero balance figures"
-msgstr ""
+msgstr "Jätä nollasaldo merkitsemättä"
 
 #: gnucash/report/reports/standard/account-summary.scm:102
 #: gnucash/report/reports/standard/balance-sheet.scm:98
@@ -22382,7 +21535,7 @@ msgstr ""
 #: gnucash/report/reports/standard/equity-statement.scm:70
 #: gnucash/report/reports/standard/income-statement.scm:75
 msgid "Show accounting-style rules"
-msgstr ""
+msgstr "Näytä kirjanpitotyyliset viivat"
 
 #: gnucash/report/reports/standard/account-summary.scm:106
 #: gnucash/report/reports/standard/balance-sheet.scm:102
@@ -22402,7 +21555,7 @@ msgstr ""
 #: gnucash/report/reports/standard/income-statement.scm:79
 #: gnucash/report/reports/standard/trial-balance.scm:119
 msgid "Display accounts as hyperlinks"
-msgstr ""
+msgstr "Näytä tilit hyperlinkkeinä"
 
 #: gnucash/report/reports/standard/account-summary.scm:110
 #: gnucash/report/reports/standard/balance-sheet.scm:105
@@ -22417,35 +21570,31 @@ msgstr ""
 
 #: gnucash/report/reports/standard/account-summary.scm:113
 msgid "Show an account's balance."
-msgstr ""
+msgstr "Näytä tilin saldo."
 
 #: gnucash/report/reports/standard/account-summary.scm:115
 msgid "Show an account's account code."
-msgstr ""
+msgstr "Näytä tilin tilinumero."
 
 #: gnucash/report/reports/standard/account-summary.scm:117
 msgid "Show an account's account type."
-msgstr ""
+msgstr "Näytä tilin tyyppi."
 
 #: gnucash/report/reports/standard/account-summary.scm:118
-#, fuzzy
-#| msgid "Description"
 msgid "Account Description"
-msgstr "Selite"
+msgstr "Tilin kuvaus"
 
 #: gnucash/report/reports/standard/account-summary.scm:119
 msgid "Show an account's description."
-msgstr ""
+msgstr "Näytä tilin kuvaus."
 
 #: gnucash/report/reports/standard/account-summary.scm:120
-#, fuzzy
-#| msgid "Account Types"
 msgid "Account Notes"
-msgstr "Tilityypit"
+msgstr "Tilin huomautukset"
 
 #: gnucash/report/reports/standard/account-summary.scm:121
 msgid "Show an account's notes."
-msgstr ""
+msgstr "Näytä tilin huomautukset."
 
 #: gnucash/report/reports/standard/account-summary.scm:123
 #: gnucash/report/reports/standard/balance-sheet.scm:129
@@ -22457,7 +21606,7 @@ msgstr ""
 #: gnucash/report/reports/standard/income-statement.scm:101
 #: gnucash/report/reports/standard/trial-balance.scm:122
 msgid "Commodities"
-msgstr ""
+msgstr "Hyödykkeet"
 
 #: gnucash/report/reports/standard/account-summary.scm:126
 #: gnucash/report/reports/standard/balance-sheet.scm:132
@@ -22468,7 +21617,7 @@ msgstr ""
 #: gnucash/report/reports/standard/income-statement.scm:104
 #: gnucash/report/reports/standard/trial-balance.scm:125
 msgid "Show Foreign Currencies"
-msgstr ""
+msgstr "Näytä vieraat rahayksiköt"
 
 #: gnucash/report/reports/standard/account-summary.scm:128
 #: gnucash/report/reports/standard/balance-sheet.scm:134
@@ -22491,7 +21640,7 @@ msgstr ""
 #: gnucash/report/reports/standard/income-statement.scm:107
 #: gnucash/report/reports/standard/trial-balance.scm:128
 msgid "Show Exchange Rates"
-msgstr ""
+msgstr "Näytä valuuttakurssit"
 
 #: gnucash/report/reports/standard/account-summary.scm:130
 #: gnucash/report/reports/standard/balance-sheet.scm:136
@@ -22503,25 +21652,19 @@ msgstr ""
 #: gnucash/report/reports/standard/income-statement.scm:108
 #: gnucash/report/reports/standard/trial-balance.scm:129
 msgid "Show the exchange rates used."
-msgstr ""
+msgstr "Näytä käytetyt valuuttakurssit."
 
 #: gnucash/report/reports/standard/account-summary.scm:174
-#, fuzzy
-#| msgid "Opening Balance"
 msgid "Recursive Balance"
-msgstr "Avaussaldo"
+msgstr "Rekursiivinen tase"
 
 #: gnucash/report/reports/standard/account-summary.scm:175
-#, fuzzy
-#| msgid "All Accounts"
 msgid "Raise Accounts"
-msgstr "Kaikki tilit"
+msgstr "Korota tilit"
 
 #: gnucash/report/reports/standard/account-summary.scm:176
-#, fuzzy
-#| msgid "All Accounts"
 msgid "Omit Accounts"
-msgstr "Kaikki tilit"
+msgstr "Ohita tilit"
 
 #: gnucash/report/reports/standard/account-summary.scm:291
 #: gnucash/report/reports/standard/equity-statement.scm:279
@@ -22531,10 +21674,8 @@ msgid "${company-name} ${report-title} For Period Covering ${start} to ${end}"
 msgstr ""
 
 #: gnucash/report/reports/standard/account-summary.scm:381
-#, fuzzy
-#| msgid "Account"
 msgid "Account title"
-msgstr "Tili"
+msgstr "Tilin nimi"
 
 #: gnucash/report/reports/standard/advanced-portfolio.scm:38
 msgid "Advanced Portfolio"
@@ -22549,25 +21690,23 @@ msgstr ""
 #: gnucash/report/reports/standard/investment-lots.scm:46
 #: gnucash/report/reports/standard/portfolio.scm:37
 msgid "Include accounts with no shares"
-msgstr ""
+msgstr "Sisällytä tilit joissa ei ole osakkeita"
 
 #: gnucash/report/reports/standard/advanced-portfolio.scm:43
 msgid "Show ticker symbols"
-msgstr ""
+msgstr "Näytä kaupankäyntitunnukset"
 
 #: gnucash/report/reports/standard/advanced-portfolio.scm:44
 msgid "Show listings"
 msgstr ""
 
 #: gnucash/report/reports/standard/advanced-portfolio.scm:45
-#, fuzzy
-#| msgid "Share Price"
 msgid "Show prices"
-msgstr "Osuuden arvo"
+msgstr "Näytä hinnat"
 
 #: gnucash/report/reports/standard/advanced-portfolio.scm:46
 msgid "Show number of shares"
-msgstr ""
+msgstr "Näytä osakkeiden määrä"
 
 #: gnucash/report/reports/standard/advanced-portfolio.scm:47
 msgid "Basis calculation method"
@@ -22591,11 +21730,11 @@ msgstr ""
 
 #: gnucash/report/reports/standard/advanced-portfolio.scm:83
 msgid "First-in first-out"
-msgstr ""
+msgstr "Ensimmäiset ensin ulos"
 
 #: gnucash/report/reports/standard/advanced-portfolio.scm:84
 msgid "Last-in first-out"
-msgstr ""
+msgstr "Viimeiset ensin ulos"
 
 #: gnucash/report/reports/standard/advanced-portfolio.scm:88
 msgid "Prefer use of price editor pricing over transactions, where applicable."
@@ -22611,23 +21750,23 @@ msgstr ""
 
 #: gnucash/report/reports/standard/advanced-portfolio.scm:96
 msgid "Include in gain/loss"
-msgstr ""
+msgstr "Sisällytä voitto/tappioon"
 
 #: gnucash/report/reports/standard/advanced-portfolio.scm:97
 msgid "Omit from report"
-msgstr ""
+msgstr "Jätä pois raportilta"
 
 #: gnucash/report/reports/standard/advanced-portfolio.scm:101
 msgid "Display the ticker symbols."
-msgstr ""
+msgstr "Näytä kaupankäyntitunnukset."
 
 #: gnucash/report/reports/standard/advanced-portfolio.scm:106
 msgid "Display exchange listings."
-msgstr ""
+msgstr "Näytä pörssilistaukset."
 
 #: gnucash/report/reports/standard/advanced-portfolio.scm:111
 msgid "Display numbers of shares in accounts."
-msgstr ""
+msgstr "Näytä osakkeiden määrät tileillä."
 
 #: gnucash/report/reports/standard/advanced-portfolio.scm:116
 #: gnucash/report/reports/standard/portfolio.scm:57
@@ -22636,28 +21775,24 @@ msgstr ""
 
 #: gnucash/report/reports/standard/advanced-portfolio.scm:121
 msgid "Display share prices."
-msgstr ""
+msgstr "Näytä osakkeiden hinnat."
 
 #: gnucash/report/reports/standard/advanced-portfolio.scm:128
 #: gnucash/report/reports/standard/investment-lots.scm:145
 #: gnucash/report/reports/standard/portfolio.scm:64
-#, fuzzy
-#| msgid "Stock amount must be positive."
 msgid "Stock Accounts to report on."
-msgstr "Osakkeen määrän on oltava positiivinen."
+msgstr "Raportoitavat osaketilit."
 
 #: gnucash/report/reports/standard/advanced-portfolio.scm:136
 #: gnucash/report/reports/standard/investment-lots.scm:156
 #: gnucash/report/reports/standard/portfolio.scm:72
 msgid "Include accounts that have a zero share balances."
-msgstr ""
+msgstr "Näytä tilit, joilla on nollatase."
 
 #: gnucash/report/reports/standard/advanced-portfolio.scm:1042
 #: gnucash/report/reports/standard/portfolio.scm:246
-#, fuzzy
-#| msgid "Use Existing"
 msgid "Listing"
-msgstr "Käytä olemassa olevaa"
+msgstr ""
 
 #: gnucash/report/reports/standard/advanced-portfolio.scm:1054
 msgid "Basis"
@@ -22675,7 +21810,7 @@ msgstr ""
 #: gnucash/report/reports/standard/cashflow-barchart.scm:321
 #: gnucash/report/reports/standard/cash-flow.scm:293
 msgid "Money Out"
-msgstr ""
+msgstr "Rahaa ulos"
 
 #: gnucash/report/reports/standard/advanced-portfolio.scm:1058
 #: gnucash/report/reports/standard/investment-lots.scm:122
@@ -22688,25 +21823,20 @@ msgid "Unrealized Gain"
 msgstr ""
 
 #: gnucash/report/reports/standard/advanced-portfolio.scm:1060
-#, fuzzy
-#| msgctxt "Stock Assistant: Page name"
-#| msgid "Capital Gains"
 msgid "Total Gain"
-msgstr "Pääomatulot"
+msgstr ""
 
 #: gnucash/report/reports/standard/advanced-portfolio.scm:1061
 msgid "Rate of Gain"
-msgstr ""
+msgstr "Voiton tahti"
 
 #: gnucash/report/reports/standard/advanced-portfolio.scm:1067
-#, fuzzy
-#| msgid "Total Entries"
 msgid "Total Return"
-msgstr "Yhteensä tietueita"
+msgstr ""
 
 #: gnucash/report/reports/standard/advanced-portfolio.scm:1068
 msgid "Rate of Return"
-msgstr ""
+msgstr "Tuottotahti"
 
 #: gnucash/report/reports/standard/advanced-portfolio.scm:1165
 msgid ""
@@ -22724,10 +21854,8 @@ msgid "** this commodity has no price and a price of 1 has been used."
 msgstr ""
 
 #: gnucash/report/reports/standard/balance-forecast.scm:36
-#, fuzzy
-#| msgid "Balance Zero"
 msgid "Balance Forecast"
-msgstr "Saldo nolla"
+msgstr "Saldoennuste"
 
 #: gnucash/report/reports/standard/balance-forecast.scm:39
 #: gnucash/report/reports/standard/budget-barchart.scm:116
@@ -22738,7 +21866,7 @@ msgstr "Saldo nolla"
 #: gnucash/report/reports/standard/trial-balance.scm:72
 #: gnucash/report/trep-engine.scm:656
 msgid "Report on these accounts."
-msgstr ""
+msgstr "Tee raportti näistä tileistä."
 
 #: gnucash/report/reports/standard/balance-forecast.scm:50
 #: gnucash/report/reports/standard/net-charts.scm:59
@@ -22753,11 +21881,11 @@ msgstr ""
 #: gnucash/report/reports/standard/balance-forecast.scm:53
 #: gnucash/report/reports/standard/balance-forecast.scm:54
 msgid "Show reserve line"
-msgstr ""
+msgstr "Näytä reserviviiva"
 
 #: gnucash/report/reports/standard/balance-forecast.scm:56
 msgid "Reserve amount"
-msgstr ""
+msgstr "Reservin määrä"
 
 #: gnucash/report/reports/standard/balance-forecast.scm:57
 msgid "The reserve amount is set to a minimum balance desired"
@@ -22766,7 +21894,7 @@ msgstr ""
 #: gnucash/report/reports/standard/balance-forecast.scm:60
 #: gnucash/report/reports/standard/balance-forecast.scm:61
 msgid "Show target line"
-msgstr ""
+msgstr "Näytä kohdeviiva"
 
 #: gnucash/report/reports/standard/balance-forecast.scm:63
 msgid "Target amount above reserve"
@@ -22780,7 +21908,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/balance-forecast.scm:68
 msgid "Show future minimum"
-msgstr ""
+msgstr "Näytä ennustettu alhaisin"
 
 #: gnucash/report/reports/standard/balance-forecast.scm:69
 msgid ""
@@ -22798,22 +21926,18 @@ msgstr ""
 
 #: gnucash/report/reports/standard/balance-sheet.scm:68
 #: gnucash/report/reports/standard/trial-balance.scm:536
-#, fuzzy
-#| msgid "Balance Zero"
 msgid "Balance Sheet"
-msgstr "Saldo nolla"
+msgstr "Tase"
 
 #: gnucash/report/reports/standard/balance-sheet.scm:75
 #: gnucash/report/reports/standard/balsheet-eg.scm:143
-#, fuzzy
-#| msgid "Balance Zero"
 msgid "Balance Sheet Date"
-msgstr "Saldo nolla"
+msgstr ""
 
 #: gnucash/report/reports/standard/balance-sheet.scm:76
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:45
 msgid "Single column Balance Sheet"
-msgstr ""
+msgstr "Yksisarakkeinen taselaskelma"
 
 #: gnucash/report/reports/standard/balance-sheet.scm:78
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:47
@@ -22829,7 +21953,7 @@ msgstr ""
 #: gnucash/report/reports/standard/budget.scm:93
 #: gnucash/report/reports/standard/income-statement.scm:61
 msgid "Flatten list to depth limit"
-msgstr ""
+msgstr "Litistä lista näytettävien tasojen rajaan"
 
 #: gnucash/report/reports/standard/balance-sheet.scm:88
 #: gnucash/report/reports/standard/balsheet-eg.scm:152
@@ -22838,12 +21962,12 @@ msgstr ""
 #: gnucash/report/reports/standard/budget.scm:95
 #: gnucash/report/reports/standard/income-statement.scm:63
 msgid "Displays accounts which exceed the depth limit at the depth limit."
-msgstr ""
+msgstr "Näyttää asetettua tasoa alempana olevat tilit asetetulla tasolla."
 
 #: gnucash/report/reports/standard/balance-sheet.scm:107
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:76
 msgid "Label the assets section"
-msgstr ""
+msgstr "Otsikoi vastaavat"
 
 #: gnucash/report/reports/standard/balance-sheet.scm:109
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:78
@@ -22853,7 +21977,7 @@ msgstr ""
 #: gnucash/report/reports/standard/balance-sheet.scm:110
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:79
 msgid "Include assets total"
-msgstr ""
+msgstr "Sisällytä vastaavien summa"
 
 #: gnucash/report/reports/standard/balance-sheet.scm:112
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:81
@@ -22873,17 +21997,17 @@ msgstr ""
 #: gnucash/report/reports/standard/balance-sheet.scm:116
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:82
 msgid "Label the liabilities section"
-msgstr ""
+msgstr "Otsikoi vieras pääoma"
 
 #: gnucash/report/reports/standard/balance-sheet.scm:118
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:84
 msgid "Whether or not to include a label for the liabilities section."
-msgstr ""
+msgstr "Otsikoida vai ei vieraan pääoman kappale."
 
 #: gnucash/report/reports/standard/balance-sheet.scm:119
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:85
 msgid "Include liabilities total"
-msgstr ""
+msgstr "Sisällytä vieraan pääoman summa"
 
 #: gnucash/report/reports/standard/balance-sheet.scm:121
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:87
@@ -22893,7 +22017,7 @@ msgstr ""
 #: gnucash/report/reports/standard/balance-sheet.scm:122
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:88
 msgid "Label the equity section"
-msgstr ""
+msgstr "Otsikoi oma pääoma"
 
 #: gnucash/report/reports/standard/balance-sheet.scm:124
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:90
@@ -22903,7 +22027,7 @@ msgstr ""
 #: gnucash/report/reports/standard/balance-sheet.scm:125
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:91
 msgid "Include equity total"
-msgstr ""
+msgstr "Sisällytä oman pääoman summa"
 
 #: gnucash/report/reports/standard/balance-sheet.scm:127
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:93
@@ -22912,33 +22036,26 @@ msgstr ""
 
 #: gnucash/report/reports/standard/balance-sheet.scm:356
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:678
-#, fuzzy
-#| msgid "Total Entries"
 msgid "Total Liabilities"
-msgstr "Yhteensä tietueita"
+msgstr "Yhteensä vieras pääoma"
 
 #: gnucash/report/reports/standard/balance-sheet.scm:454
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:645
-#, fuzzy
-#| msgid "Total Entries"
 msgid "Total Assets"
-msgstr "Yhteensä tietueita"
+msgstr "Yhteensä vastaavaa"
 
 #: gnucash/report/reports/standard/balance-sheet.scm:476
 #: gnucash/report/reports/support/balsheet-eg.eguile.scm:188
 msgid "Retained Losses"
-msgstr ""
+msgstr "Jakamaton tappio"
 
 #: gnucash/report/reports/standard/balance-sheet.scm:480
-#, fuzzy
-#| msgctxt "Stock Assistant: Page name"
-#| msgid "Capital Gains"
 msgid "Trading Gains"
-msgstr "Pääomatulot"
+msgstr "Muunnosvoitot"
 
 #: gnucash/report/reports/standard/balance-sheet.scm:481
 msgid "Trading Losses"
-msgstr ""
+msgstr "Muunnostappiot"
 
 #: gnucash/report/reports/standard/balance-sheet.scm:485
 #: gnucash/report/reports/standard/balsheet-pnl.scm:1055
@@ -22946,33 +22063,31 @@ msgstr ""
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:725
 #: gnucash/report/reports/standard/trial-balance.scm:697
 msgid "Unrealized Gains"
-msgstr ""
+msgstr "Toteutumattomat tulot"
 
 #: gnucash/report/reports/standard/balance-sheet.scm:486
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:726
 #: gnucash/report/reports/standard/trial-balance.scm:698
 msgid "Unrealized Losses"
-msgstr ""
+msgstr "Toteutumattomat tappiot"
 
 #: gnucash/report/reports/standard/balance-sheet.scm:490
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:741
-#, fuzzy
-#| msgid "Total Entries"
 msgid "Total Equity"
-msgstr "Yhteensä tietueita"
+msgstr "Oma pääoma yhteensä"
 
 #: gnucash/report/reports/standard/balance-sheet.scm:500
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:747
 msgid "Total Liabilities & Equity"
-msgstr ""
+msgstr "Vieras ja oma pääoma yhteensä"
 
 #: gnucash/report/reports/standard/balsheet-eg.scm:136
 msgid "Balance Sheet (eguile)"
-msgstr ""
+msgstr "Taselaskelma (eguile)"
 
 #: gnucash/report/reports/standard/balsheet-eg.scm:144
 msgid "Report format"
-msgstr ""
+msgstr "Raportin muoto"
 
 #: gnucash/report/reports/standard/balsheet-eg.scm:146
 msgid "The balance sheet can be displayed with either 1 or 2 columns."
@@ -22980,17 +22095,17 @@ msgstr ""
 
 #: gnucash/report/reports/standard/balsheet-eg.scm:154
 msgid "Exclude accounts with zero total balances"
-msgstr ""
+msgstr "Jätä pois tilit joiden saldo on nolla"
 
 #: gnucash/report/reports/standard/balsheet-eg.scm:156
 msgid ""
 "Exclude non-top-level accounts with zero balance and no non-zero sub-"
 "accounts."
-msgstr ""
+msgstr "Jätä pois nollasaldoiset alatilit, joiden alla on vain nollasaldoja."
 
 #: gnucash/report/reports/standard/balsheet-eg.scm:161
 msgid "Negative amount format"
-msgstr ""
+msgstr "Negatiivisten arvojen muoto"
 
 #: gnucash/report/reports/standard/balsheet-eg.scm:163
 msgid ""
@@ -23000,7 +22115,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/balsheet-eg.scm:165
 msgid "Font family"
-msgstr ""
+msgstr "Fonttiperhe"
 
 #: gnucash/report/reports/standard/balsheet-eg.scm:166
 msgid "Font definition in CSS font-family format."
@@ -23008,7 +22123,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/balsheet-eg.scm:167
 msgid "Font size"
-msgstr ""
+msgstr "Fontin koko"
 
 #: gnucash/report/reports/standard/balsheet-eg.scm:168
 msgid "Font size in CSS font-size format (e.g. \"medium\" or \"10pt\")."
@@ -23018,7 +22133,7 @@ msgstr ""
 #: gnucash/report/reports/standard/receipt.scm:44
 #: gnucash/report/reports/standard/taxinvoice.scm:94
 msgid "Template file"
-msgstr ""
+msgstr "Mallinetiedosto"
 
 #: gnucash/report/reports/standard/balsheet-eg.scm:171
 msgid ""
@@ -23031,7 +22146,7 @@ msgstr ""
 #: gnucash/report/reports/standard/receipt.scm:45
 #: gnucash/report/reports/standard/taxinvoice.scm:95
 msgid "CSS stylesheet file"
-msgstr ""
+msgstr "CSS-tyylitiedosto"
 
 #: gnucash/report/reports/standard/balsheet-eg.scm:174
 msgid ""
@@ -23044,10 +22159,8 @@ msgstr ""
 #: gnucash/report/reports/standard/invoice.scm:514
 #: gnucash/report/reports/standard/receipt.scm:64
 #: gnucash/report/reports/standard/taxinvoice.scm:112
-#, fuzzy
-#| msgid "Notes"
 msgid "Extra Notes"
-msgstr "Huomautukset"
+msgstr "Lisämerkinnät"
 
 #: gnucash/report/reports/standard/balsheet-eg.scm:176
 #: gnucash/report/reports/standard/taxinvoice.scm:221
@@ -23072,7 +22185,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/balsheet-eg.scm:226
 msgid "Brackets: ($10.00)"
-msgstr ""
+msgstr "Suluissa: (10,00 €)"
 
 #: gnucash/report/reports/standard/balsheet-eg.scm:251
 msgid ""
@@ -23084,16 +22197,16 @@ msgstr ""
 #: gnucash/report/reports/standard/balsheet-eg.scm:376
 #: libgnucash/engine/Scrub.cpp:464
 msgid "Imbalance"
-msgstr ""
+msgstr "Epätasapaino"
 
 #: gnucash/report/reports/standard/balsheet-eg.scm:379
 #: libgnucash/engine/Scrub.cpp:125
 msgid "Orphan"
-msgstr ""
+msgstr "Orpo"
 
 #: gnucash/report/reports/standard/balsheet-eg.scm:554
 msgid "Balance Sheet using eguile-gnc"
-msgstr ""
+msgstr "Taselaskelma eguile-gnc:llä"
 
 #: gnucash/report/reports/standard/balsheet-eg.scm:555
 msgid "Display a balance sheet (using eguile template)"
@@ -23101,7 +22214,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/balsheet-pnl.scm:55
 msgid "Period duration"
-msgstr ""
+msgstr "Jakson kesto"
 
 #: gnucash/report/reports/standard/balsheet-pnl.scm:56
 msgid "Duration between time periods"
@@ -23114,7 +22227,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/balsheet-pnl.scm:61
 msgid "Enable dual columns"
-msgstr ""
+msgstr "Käytä kahta saraketta"
 
 #: gnucash/report/reports/standard/balsheet-pnl.scm:62
 msgid "Selecting this option will enable double-column reporting."
@@ -23137,10 +22250,8 @@ msgstr ""
 
 #: gnucash/report/reports/standard/balsheet-pnl.scm:69
 #: gnucash/report/trep-engine.scm:571
-#, fuzzy
-#| msgid "The menu of options"
 msgid "Add summary of options."
-msgstr "Vaihtoehtojen valikko"
+msgstr ""
 
 #: gnucash/report/reports/standard/balsheet-pnl.scm:71
 msgid "Account full name instead of indenting"
@@ -23154,7 +22265,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/balsheet-pnl.scm:80
 msgid "Parent account amounts include children"
-msgstr ""
+msgstr "Ylätilin määrät sisältävät alatilit"
 
 #: gnucash/report/reports/standard/balsheet-pnl.scm:81
 msgid ""
@@ -23166,7 +22277,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/balsheet-pnl.scm:95
 msgid "Display amounts as hyperlinks"
-msgstr ""
+msgstr "Näytä määrät hyperlinkkeinä"
 
 #: gnucash/report/reports/standard/balsheet-pnl.scm:96
 msgid "Shows each amounts in the table as a hyperlink to a register or report."
@@ -23174,41 +22285,41 @@ msgstr ""
 
 #: gnucash/report/reports/standard/balsheet-pnl.scm:99
 msgid "Label sections"
-msgstr ""
+msgstr "Otsikoi kappaleet"
 
 #: gnucash/report/reports/standard/balsheet-pnl.scm:100
 msgid "Whether or not to include a label for sections."
-msgstr ""
+msgstr "Otsikoida vai ei kappaleet."
 
 #: gnucash/report/reports/standard/balsheet-pnl.scm:101
 msgid "Include totals"
-msgstr ""
+msgstr "Sisällytä loppusummat"
 
 #: gnucash/report/reports/standard/balsheet-pnl.scm:102
 msgid "Whether or not to include a line indicating total amounts."
-msgstr ""
+msgstr "Sisällyttää vai ei rivit loppusummille."
 
 #: gnucash/report/reports/standard/balsheet-pnl.scm:106
 msgid "Enable chart"
-msgstr ""
+msgstr "Käytä kaaviota"
 
 #: gnucash/report/reports/standard/balsheet-pnl.scm:107
 msgid "Enable link to chart"
-msgstr ""
+msgstr "Käytä linkkiä kaavioon"
 
 #: gnucash/report/reports/standard/balsheet-pnl.scm:109
 #: gnucash/report/trep-engine.scm:112
 msgid "Common Currency"
-msgstr ""
+msgstr "Yhteinen valuutta"
 
 #: gnucash/report/reports/standard/balsheet-pnl.scm:110
 msgid "Convert all amounts to a single currency."
-msgstr ""
+msgstr "Muunna kaikki kirjaukset yhteiseen valuuttaan."
 
 #: gnucash/report/reports/standard/balsheet-pnl.scm:116
 #: gnucash/report/trep-engine.scm:113
 msgid "Show original currency amount"
-msgstr ""
+msgstr "Näytä määrä alkuperäisessä valuutassa"
 
 #: gnucash/report/reports/standard/balsheet-pnl.scm:117
 #: gnucash/report/trep-engine.scm:556
@@ -23228,26 +22339,24 @@ msgstr ""
 #: gnucash/report/reports/standard/balsheet-pnl.scm:194
 #: gnucash/report/trep-engine.scm:577
 msgid "Always"
-msgstr ""
+msgstr "Aina"
 
 #: gnucash/report/reports/standard/balsheet-pnl.scm:437
 #: gnucash/report/reports/standard/balsheet-pnl.scm:595
 #: gnucash/report/reports/standard/txn-columns.scm:185
 #: gnucash/report/trep-engine.scm:1737
-#, fuzzy
-#| msgid "Total Entries"
 msgid "Total For "
-msgstr "Yhteensä tietueita"
+msgstr "Yhteensä: "
 
 #: gnucash/report/reports/standard/balsheet-pnl.scm:1044
 #: libgnucash/engine/Account.cpp:4290
 msgid "Asset"
-msgstr ""
+msgstr "Vastaavaa"
 
 #: gnucash/report/reports/standard/balsheet-pnl.scm:1047
 #: libgnucash/engine/Account.cpp:4292
 msgid "Liability"
-msgstr ""
+msgstr "Vieras pääoma"
 
 #: gnucash/report/reports/standard/balsheet-pnl.scm:1065
 msgid "Liability and Equity"
@@ -23256,7 +22365,7 @@ msgstr ""
 #: gnucash/report/reports/standard/balsheet-pnl.scm:1083
 #: gnucash/report/reports/standard/balsheet-pnl.scm:1226
 msgid "Exchange Rates"
-msgstr ""
+msgstr "Valuuttakurssit"
 
 #: gnucash/report/reports/standard/balsheet-pnl.scm:1093
 msgid "Barchart"
@@ -23264,7 +22373,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/balsheet-pnl.scm:1156
 msgid " to "
-msgstr " tähän "
+msgstr ""
 
 #: gnucash/report/reports/standard/balsheet-pnl.scm:1215
 #: gnucash/report/reports/standard/customer-summary.scm:110
@@ -23273,33 +22382,29 @@ msgstr " tähän "
 #: gnucash/report/reports/standard/net-charts.scm:401
 #: libgnucash/engine/Account.cpp:159 libgnucash/engine/Account.cpp:4297
 #: libgnucash/engine/gncInvoice.c:1099
-#, fuzzy
-#| msgid "Other Expense"
 msgid "Expense"
-msgstr "Muu kulu"
+msgstr "Kulu"
 
 #: gnucash/report/reports/standard/balsheet-pnl.scm:1219
 #: gnucash/report/reports/standard/trial-balance.scm:823
 msgid "Net Income"
-msgstr ""
+msgstr "Nettotulot"
 
 #: gnucash/report/reports/standard/balsheet-pnl.scm:1252
 msgid "Balance Sheet (Multicolumn)"
-msgstr ""
+msgstr "Taselaskelma (monisarakkeinen)"
 
 #: gnucash/report/reports/standard/balsheet-pnl.scm:1253
 msgid "Income Statement (Multicolumn)"
-msgstr ""
+msgstr "Tuloslaskelma (monisarakkeinen)"
 
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:38
-#, fuzzy
-#| msgid "Next Balance"
 msgid "Budget Balance Sheet"
-msgstr "Uusi saldo"
+msgstr "Budjetoitu taselaskelma"
 
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:94
 msgid "Include new/existing totals"
-msgstr ""
+msgstr "Sisällytä uudet/vanhat loppusummat"
 
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:96
 msgid ""
@@ -23313,80 +22418,72 @@ msgstr ""
 #: gnucash/report/reports/standard/budget-income-statement.scm:53
 #: gnucash/report/reports/standard/budget.scm:123
 msgid "Budget to use."
-msgstr ""
+msgstr "Käytettävä budjetti."
 
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:636
-#, fuzzy
-#| msgid "Existing Document Link is"
 msgid "Existing Assets"
-msgstr "Nykyinen asiakirjalinkki on"
+msgstr "Olemassaolevat ominaisuudet"
 
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:638
 msgid "Allocated Assets"
-msgstr ""
+msgstr "Sijoitetut varat"
 
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:642
 msgid "Unallocated Assets"
-msgstr ""
+msgstr "Sijoittamattomat varat"
 
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:672
 msgid "Existing Liabilities"
-msgstr ""
+msgstr "Olemassa olevat velat"
 
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:675
 msgid "New Liabilities"
-msgstr ""
+msgstr "Uudet velat"
 
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:706
-#, fuzzy
-#| msgid "Existing Document Link is"
 msgid "Existing Retained Earnings"
-msgstr "Nykyinen asiakirjalinkki on"
+msgstr "Olemassa olevat kertyneet voittovarat"
 
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:707
-#, fuzzy
-#| msgid "Existing Document Link is"
 msgid "Existing Retained Losses"
-msgstr "Nykyinen asiakirjalinkki on"
+msgstr "Olemassa olevat kertyneet tappiot"
 
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:712
 msgid "New Retained Earnings"
-msgstr ""
+msgstr "Uudet kertyneet voittovarat"
 
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:713
 msgid "New Retained Losses"
-msgstr ""
+msgstr "Uudet kertyneet tappiot"
 
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:718
 msgid "Total Retained Earnings"
-msgstr ""
+msgstr "Kokonaiskertyneet voittovarat"
 
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:719
 msgid "Total Retained Losses"
-msgstr ""
+msgstr "Kokonaiskertyneet tappiot"
 
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:735
-#, fuzzy
-#| msgid "existing account"
 msgid "Existing Equity"
-msgstr "olemassa oleva tili"
+msgstr "Olemassa oleva oma pääoma"
 
 #: gnucash/report/reports/standard/budget-balance-sheet.scm:738
 msgid "New Equity"
-msgstr ""
+msgstr "Uusi oma pääoma"
 
 #: gnucash/report/reports/standard/budget-barchart.scm:36
 msgid "Budget Chart"
-msgstr ""
+msgstr "Budjettikaavio"
 
 #: gnucash/report/reports/standard/budget-barchart.scm:41
 msgid "Running Sum"
-msgstr ""
+msgstr "Juokseva summa"
 
 #: gnucash/report/reports/standard/budget-barchart.scm:42
 #: gnucash/report/reports/standard/category-barchart.scm:84
 msgid "Chart Type"
-msgstr ""
+msgstr "Kaavion tyyppi"
 
 #: gnucash/report/reports/standard/budget-barchart.scm:50
 #: gnucash/report/reports/standard/budget-income-statement.scm:60
@@ -23422,10 +22519,8 @@ msgstr ""
 
 #: gnucash/report/reports/standard/budget-barchart.scm:60
 #: gnucash/report/reports/standard/budget.scm:84
-#, fuzzy
-#| msgid "End of accounting period"
 msgid "Exact end period"
-msgstr "Tilikauden loppu"
+msgstr "Täsmällinen loppujakso"
 
 #: gnucash/report/reports/standard/budget-barchart.scm:62
 #: gnucash/report/reports/standard/budget.scm:86
@@ -23435,36 +22530,36 @@ msgstr ""
 #: gnucash/report/reports/standard/budget-barchart.scm:65
 #: gnucash/report/reports/standard/budget.scm:111
 msgid "First budget period"
-msgstr ""
+msgstr "Ensimmäinen budjettijakso"
 
 #: gnucash/report/reports/standard/budget-barchart.scm:66
 #: gnucash/report/reports/standard/budget.scm:112
 msgid "Previous budget period"
-msgstr ""
+msgstr "Edellinen budjettijakso"
 
 #: gnucash/report/reports/standard/budget-barchart.scm:67
 #: gnucash/report/reports/standard/budget.scm:113
 msgid "Current budget period"
-msgstr ""
+msgstr "Nykyinen budjettijakso"
 
 #: gnucash/report/reports/standard/budget-barchart.scm:68
 #: gnucash/report/reports/standard/budget.scm:114
 msgid "Next budget period"
-msgstr ""
+msgstr "Seuraava budjettijakso"
 
 #: gnucash/report/reports/standard/budget-barchart.scm:69
 #: gnucash/report/reports/standard/budget.scm:115
 msgid "Last budget period"
-msgstr ""
+msgstr "Viimeinen budjettijakso"
 
 #: gnucash/report/reports/standard/budget-barchart.scm:70
 #: gnucash/report/reports/standard/budget.scm:116
 msgid "Manual period selection"
-msgstr ""
+msgstr "Manuaalinen ajanjakson valinta"
 
 #: gnucash/report/reports/standard/budget-barchart.scm:127
 msgid "Calculate as running sum?"
-msgstr ""
+msgstr "Laske juoksevana summana?"
 
 #: gnucash/report/reports/standard/budget-barchart.scm:132
 msgid "Select which chart type to use."
@@ -23490,17 +22585,15 @@ msgstr ""
 
 #: gnucash/report/reports/standard/budget-barchart.scm:196
 msgid "Actual"
-msgstr ""
+msgstr "Toteutunut"
 
 #: gnucash/report/reports/standard/budget-flow.scm:36
 msgid "Budget Flow"
 msgstr ""
 
 #: gnucash/report/reports/standard/budget-flow.scm:67
-#, fuzzy
-#| msgid "Period"
 msgid "Period number."
-msgstr "Aikaväli"
+msgstr "Jakson numero."
 
 #: gnucash/report/reports/standard/budget-flow.scm:296
 #, scheme-format
@@ -23528,7 +22621,7 @@ msgstr ""
 #: gnucash/report/reports/standard/budget-income-statement.scm:95
 #: gnucash/report/reports/standard/income-statement.scm:82
 msgid "Label the revenue section"
-msgstr ""
+msgstr "Otsikoi tulot"
 
 #: gnucash/report/reports/standard/budget-income-statement.scm:97
 #: gnucash/report/reports/standard/income-statement.scm:84
@@ -23538,7 +22631,7 @@ msgstr ""
 #: gnucash/report/reports/standard/budget-income-statement.scm:98
 #: gnucash/report/reports/standard/income-statement.scm:85
 msgid "Include revenue total"
-msgstr ""
+msgstr "Sisällytä tulojen summa"
 
 #: gnucash/report/reports/standard/budget-income-statement.scm:100
 #: gnucash/report/reports/standard/income-statement.scm:87
@@ -23548,7 +22641,7 @@ msgstr ""
 #: gnucash/report/reports/standard/budget-income-statement.scm:101
 #: gnucash/report/reports/standard/income-statement.scm:94
 msgid "Label the expense section"
-msgstr ""
+msgstr "Otsikoi kulut"
 
 #: gnucash/report/reports/standard/budget-income-statement.scm:103
 #: gnucash/report/reports/standard/income-statement.scm:96
@@ -23558,7 +22651,7 @@ msgstr ""
 #: gnucash/report/reports/standard/budget-income-statement.scm:104
 #: gnucash/report/reports/standard/income-statement.scm:97
 msgid "Include expense total"
-msgstr ""
+msgstr "Sisällytä kulujen summa"
 
 #: gnucash/report/reports/standard/budget-income-statement.scm:106
 #: gnucash/report/reports/standard/income-statement.scm:99
@@ -23568,7 +22661,7 @@ msgstr ""
 #: gnucash/report/reports/standard/budget-income-statement.scm:118
 #: gnucash/report/reports/standard/income-statement.scm:123
 msgid "Display as a two column report"
-msgstr ""
+msgstr "Näytä kaksisarakkeisena raporttina"
 
 #: gnucash/report/reports/standard/budget-income-statement.scm:120
 #: gnucash/report/reports/standard/income-statement.scm:125
@@ -23578,7 +22671,7 @@ msgstr ""
 #: gnucash/report/reports/standard/budget-income-statement.scm:122
 #: gnucash/report/reports/standard/income-statement.scm:127
 msgid "Display in standard, income first, order"
-msgstr ""
+msgstr "Näytä standardissa tulot-ensin -järjestyksessä"
 
 #: gnucash/report/reports/standard/budget-income-statement.scm:124
 #: gnucash/report/reports/standard/income-statement.scm:129
@@ -23598,36 +22691,32 @@ msgstr ""
 #: gnucash/report/reports/standard/budget-income-statement.scm:482
 #: gnucash/report/reports/standard/income-statement.scm:461
 msgid "Revenues"
-msgstr ""
+msgstr "Tulot"
 
 #: gnucash/report/reports/standard/budget-income-statement.scm:485
 #: gnucash/report/reports/standard/income-statement.scm:464
-#, fuzzy
-#| msgid "Total Entries"
 msgid "Total Revenue"
-msgstr "Yhteensä tietueita"
+msgstr "Tulot yhteensä"
 
 #: gnucash/report/reports/standard/budget-income-statement.scm:495
 #: gnucash/report/reports/standard/income-statement.scm:472
-#, fuzzy
-#| msgid "Total Entries"
 msgid "Total Expenses"
-msgstr "Yhteensä tietueita"
+msgstr "Menot yhteensä"
 
 #: gnucash/report/reports/standard/budget-income-statement.scm:503
 #, scheme-format
 msgid "for Budget ~a"
-msgstr ""
+msgstr "budjetille ~a"
 
 #: gnucash/report/reports/standard/budget-income-statement.scm:505
 #, scheme-format
 msgid "for Budget ~a Period ~d"
-msgstr ""
+msgstr "budjetille ~a jakso ~d"
 
 #: gnucash/report/reports/standard/budget-income-statement.scm:508
 #, scheme-format
 msgid "for Budget ~a Periods ~d - ~d"
-msgstr ""
+msgstr "budjetille ~a jaksot ~d - ~d"
 
 #: gnucash/report/reports/standard/budget-income-statement.scm:536
 #: gnucash/report/reports/standard/equity-statement.scm:434
@@ -23635,7 +22724,7 @@ msgstr ""
 #: gnucash/report/reports/standard/income-statement.scm:515
 #: gnucash/report/reports/standard/income-statement.scm:529
 msgid "Net income"
-msgstr ""
+msgstr "Nettotulot"
 
 #: gnucash/report/reports/standard/budget-income-statement.scm:537
 #: gnucash/report/reports/standard/equity-statement.scm:435
@@ -23643,21 +22732,21 @@ msgstr ""
 #: gnucash/report/reports/standard/income-statement.scm:516
 #: gnucash/report/reports/standard/income-statement.scm:530
 msgid "Net loss"
-msgstr ""
+msgstr "Nettotappiot"
 
 #: gnucash/report/reports/standard/budget-income-statement.scm:577
 msgid "Budget Income Statement"
-msgstr ""
+msgstr "Budjetoitu tuloslaskelma"
 
 #: gnucash/report/reports/standard/budget-income-statement.scm:578
 msgid "Budget Profit & Loss"
-msgstr ""
+msgstr "Budjetoitu tuloslaskelma"
 
 #: gnucash/report/reports/standard/budget.scm:41
 #: gnucash/ui/gnc-plugin-page-budget.ui:40
 #: gnucash/ui/gnc-plugin-page-budget.ui:285
 msgid "Budget Report"
-msgstr ""
+msgstr "Budjettiraportti"
 
 #: gnucash/report/reports/standard/budget.scm:47
 #: gnucash/report/reports/standard/cash-flow.scm:45
@@ -23666,48 +22755,44 @@ msgstr ""
 
 #: gnucash/report/reports/standard/budget.scm:48
 #: gnucash/report/reports/standard/cash-flow.scm:46
-#, fuzzy
-#| msgid "via Escrow account?"
 msgid "Always show sub-accounts"
-msgstr "sulkutilin kautta?"
+msgstr "Näytä aina alitilit"
 
 #: gnucash/report/reports/standard/budget.scm:51
 msgid "Show Budget"
-msgstr ""
+msgstr "Näytä budjetti"
 
 #: gnucash/report/reports/standard/budget.scm:52
 msgid "Display a column for the budget values."
-msgstr ""
+msgstr "Näytä sarake budjettiarvoille."
 
 #: gnucash/report/reports/standard/budget.scm:53
 msgid "Show Budget Notes"
-msgstr ""
+msgstr "Näytä budjettimuistiinpanot"
 
 #: gnucash/report/reports/standard/budget.scm:54
 msgid "Display a column for the budget notes."
-msgstr ""
+msgstr "Näytä sarake budjettimuistiinpanoille."
 
 #: gnucash/report/reports/standard/budget.scm:55
 msgid "Show Actual"
-msgstr ""
+msgstr "Näytä toteutuma"
 
 #: gnucash/report/reports/standard/budget.scm:56
 msgid "Display a column for the actual values."
-msgstr ""
+msgstr "Näytä sarake toteutuneille arvoille."
 
 #: gnucash/report/reports/standard/budget.scm:57
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Link to actual transactions"
-msgstr "Etsi tosite"
+msgstr "Linkki todellisiin tositteisiin"
 
 #: gnucash/report/reports/standard/budget.scm:58
 msgid "Show the actual transactions for the budget period"
-msgstr ""
+msgstr "Näytä budjettikauden todelliset tapahtumat"
 
 #: gnucash/report/reports/standard/budget.scm:59
 msgid "Show Difference"
-msgstr ""
+msgstr "Näytä ero"
 
 #: gnucash/report/reports/standard/budget.scm:60
 msgid "Display the difference as budget - actual."
@@ -23723,21 +22808,23 @@ msgstr ""
 
 #: gnucash/report/reports/standard/budget.scm:63
 msgid "Show Column with Totals"
-msgstr ""
+msgstr "Näytä sarake loppusummille"
 
 #: gnucash/report/reports/standard/budget.scm:64
 msgid "Display a column with the row totals."
-msgstr ""
+msgstr "Näytä sarake rivien loppusummille."
 
 #: gnucash/report/reports/standard/budget.scm:65
 msgid "Include accounts with zero total balances and budget values"
-msgstr ""
+msgstr "Sisällytä tilit joiden saldo ja budjetti on nolla"
 
 #: gnucash/report/reports/standard/budget.scm:66
 msgid ""
 "Include accounts with zero total (recursive) balances and budget values in "
 "this report."
 msgstr ""
+"Sisällytä tähän raporttiin tilit joiden saldo ja budjetti alatileineen on "
+"nolla."
 
 #: gnucash/report/reports/standard/budget.scm:88
 msgid "Include collapsed periods before selected."
@@ -23762,14 +22849,12 @@ msgstr ""
 #. Translators: Abbreviation for "Budget" amount
 #: gnucash/report/reports/standard/budget.scm:492
 msgid "Bgt"
-msgstr ""
+msgstr "Bud"
 
 #. Translators: Abbreviation for "Actual" amount
 #: gnucash/report/reports/standard/budget.scm:497
-#, fuzzy
-#| msgid "Action"
 msgid "Act"
-msgstr "Tapahtuma"
+msgstr "Tot"
 
 #. Translators: Abbreviation for "Difference" amount
 #: gnucash/report/reports/standard/budget.scm:502
@@ -23786,28 +22871,28 @@ msgstr ""
 
 #: gnucash/report/reports/standard/cashflow-barchart.scm:40
 msgid "Cash Flow Barchart"
-msgstr ""
+msgstr "Kassavirta -pylväskaavio"
 
 #: gnucash/report/reports/standard/cashflow-barchart.scm:46
 #: gnucash/report/reports/standard/cash-flow.scm:53
 msgid "Include Trading Accounts in report"
-msgstr ""
+msgstr "Sisällytä muunnostilit raportille"
 
 #: gnucash/report/reports/standard/cashflow-barchart.scm:48
 msgid "Show Money In"
-msgstr ""
+msgstr "Näytä sisääntulevat rahaerät"
 
 #: gnucash/report/reports/standard/cashflow-barchart.scm:49
 msgid "Show Money Out"
-msgstr ""
+msgstr "Näytä lähtevät rahaerät"
 
 #: gnucash/report/reports/standard/cashflow-barchart.scm:50
 msgid "Show Net Flow"
-msgstr ""
+msgstr "Näytä nettovirta"
 
 #: gnucash/report/reports/standard/cashflow-barchart.scm:51
 msgid "Show Table"
-msgstr ""
+msgstr "Näytä taulukko"
 
 #: gnucash/report/reports/standard/cashflow-barchart.scm:92
 #: gnucash/report/reports/standard/cash-flow.scm:96
@@ -23816,11 +22901,11 @@ msgstr ""
 
 #: gnucash/report/reports/standard/cashflow-barchart.scm:97
 msgid "Show money in?"
-msgstr ""
+msgstr "Näytä raha sisään?"
 
 #: gnucash/report/reports/standard/cashflow-barchart.scm:101
 msgid "Show money out?"
-msgstr ""
+msgstr "Näytä raha ulos?"
 
 #: gnucash/report/reports/standard/cashflow-barchart.scm:105
 msgid "Show net money flow?"
@@ -23829,43 +22914,37 @@ msgstr ""
 #: gnucash/report/reports/standard/cashflow-barchart.scm:286
 #: gnucash/report/reports/standard/cashflow-barchart.scm:322
 msgid "Net Flow"
-msgstr ""
+msgstr "Nettovirta"
 
 #: gnucash/report/reports/standard/cashflow-barchart.scm:325
 msgid "Overview:"
-msgstr ""
+msgstr "Yleiskatsaus:"
 
 #: gnucash/report/reports/standard/cashflow-barchart.scm:351
 msgid "Shows a barchart with cash flow over time"
 msgstr ""
 
 #: gnucash/report/reports/standard/cash-flow.scm:38
-#, fuzzy
-#| msgctxt "Stock Assistant: Page name"
-#| msgid "Cash"
 msgid "Cash Flow"
-msgstr "Käteinen"
+msgstr "Kassavirta"
 
 #: gnucash/report/reports/standard/cash-flow.scm:52
-#, fuzzy
-#| msgid "All Accounts"
 msgid "Show Full Account Names"
-msgstr "Kaikki tilit"
+msgstr "Näytä täydet tilinimet"
 
 #: gnucash/report/reports/standard/cash-flow.scm:79
 msgid "Show full account names (including parent accounts)."
-msgstr ""
+msgstr "Näytä täydet tilien nimet (sisältäen ylätilit)."
 
 #: gnucash/report/reports/standard/cash-flow.scm:198
-#, fuzzy, scheme-format
-#| msgid "Find Account"
+#, scheme-format
 msgid "~a and subaccounts"
-msgstr "Etsi tili"
+msgstr "~a ja alatilit"
 
 #: gnucash/report/reports/standard/cash-flow.scm:199
 #, scheme-format
 msgid "~a and selected subaccounts"
-msgstr ""
+msgstr "~a ja valitut alatilit"
 
 #: gnucash/report/reports/standard/cash-flow.scm:263
 msgid "Money into selected accounts comes from"
@@ -23878,24 +22957,22 @@ msgstr ""
 #: gnucash/report/reports/standard/category-barchart.scm:45
 #: gnucash/report/reports/standard/net-charts.scm:348
 msgid "Income Chart"
-msgstr ""
+msgstr "Tulokuvaaja"
 
 #: gnucash/report/reports/standard/category-barchart.scm:46
 #: gnucash/report/reports/standard/net-charts.scm:369
-#, fuzzy
-#| msgid "Expense Vouchers"
 msgid "Expense Chart"
-msgstr "Matkalaskut"
+msgstr "Kulukuvaaja"
 
 #: gnucash/report/reports/standard/category-barchart.scm:47
 #: gnucash/report/reports/standard/net-charts.scm:349
 msgid "Asset Chart"
-msgstr ""
+msgstr "Vastaavaa-kuvaaja"
 
 #: gnucash/report/reports/standard/category-barchart.scm:48
 #: gnucash/report/reports/standard/net-charts.scm:370
 msgid "Liability Chart"
-msgstr ""
+msgstr "Vastattavaa-kuvaaja"
 
 #: gnucash/report/reports/standard/category-barchart.scm:53
 msgid "Shows a chart with the Income per interval developing over time"
@@ -23915,26 +22992,24 @@ msgstr ""
 
 #: gnucash/report/reports/standard/category-barchart.scm:67
 msgid "Income Over Time"
-msgstr ""
+msgstr "Tulo ajan yli"
 
 #: gnucash/report/reports/standard/category-barchart.scm:68
-#, fuzzy
-#| msgid "Expense Vouchers"
 msgid "Expense Over Time"
-msgstr "Matkalaskut"
+msgstr "Kulut ajan yli"
 
 #: gnucash/report/reports/standard/category-barchart.scm:69
 msgid "Assets Over Time"
-msgstr ""
+msgstr "Vastaavat ajan yli"
 
 #: gnucash/report/reports/standard/category-barchart.scm:70
 msgid "Liabilities Over Time"
-msgstr ""
+msgstr "Vastattavat ajan yli"
 
 #: gnucash/report/reports/standard/category-barchart.scm:82
 #: gnucash/report/reports/standard/investment-lots.scm:71
 msgid "Show long account names"
-msgstr ""
+msgstr "Näytä pitkät tilinimet"
 
 #: gnucash/report/reports/standard/category-barchart.scm:86
 msgid "Use Stacked Charts"
@@ -23955,7 +23030,7 @@ msgstr ""
 #: gnucash/report/reports/standard/category-barchart.scm:173
 #: gnucash/report/reports/standard/category-barchart.scm:245
 msgid "Percentage chart"
-msgstr ""
+msgstr "Prosenttikaavio"
 
 #: gnucash/report/reports/standard/category-barchart.scm:174
 msgid ""
@@ -23965,7 +23040,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/category-barchart.scm:275
 msgid "Invalid dates"
-msgstr ""
+msgstr "Virheelliset päiväykset"
 
 #: gnucash/report/reports/standard/category-barchart.scm:276
 msgid "Start date must be earlier than End date"
@@ -23973,13 +23048,12 @@ msgstr ""
 
 #: gnucash/report/reports/standard/category-barchart.scm:314
 msgid "Daily Average"
-msgstr ""
+msgstr "Päivittäinen keskiarvo"
 
 #: gnucash/report/reports/standard/category-barchart.scm:524
-#, fuzzy, scheme-format
-#| msgid "~a to ~a"
+#, scheme-format
 msgid "Balances ~a to ~a"
-msgstr "~a → ~a"
+msgstr "Saldot ~a - ~a"
 
 #: gnucash/report/reports/standard/category-barchart.scm:654
 #: gnucash/report/reports/standard/category-barchart.scm:674
@@ -23987,12 +23061,12 @@ msgstr "~a → ~a"
 #: gnucash/report/trep-engine.scm:77 gnucash/report/trep-engine.scm:1799
 #: gnucash/report/trep-engine.scm:2067
 msgid "Grand Total"
-msgstr ""
+msgstr "Loppusumma"
 
 #: gnucash/report/reports/standard/category-barchart.scm:688
 #: gnucash/report/reports/standard/net-charts.scm:453
 msgid "No exportable data"
-msgstr ""
+msgstr "Ei vietävää tietoa"
 
 #: gnucash/report/reports/standard/customer-summary.scm:51
 msgid "The income accounts where the sales and income was recorded."
@@ -24006,17 +23080,15 @@ msgstr ""
 
 #: gnucash/report/reports/standard/customer-summary.scm:63
 msgid "Show Expense Column"
-msgstr ""
+msgstr "Näytä kulusarake"
 
 #: gnucash/report/reports/standard/customer-summary.scm:64
 msgid "Show the column with the expenses per customer."
 msgstr ""
 
 #: gnucash/report/reports/standard/customer-summary.scm:65
-#, fuzzy
-#| msgid "Company Address"
 msgid "Show Company Address"
-msgstr "Yrityksen osoite"
+msgstr "Näytä yrityksen osoite"
 
 #: gnucash/report/reports/standard/customer-summary.scm:66
 msgid "Show your own company's address and the date of printing."
@@ -24034,7 +23106,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/customer-summary.scm:72
 msgid "Show Inactive Customers"
-msgstr ""
+msgstr "Näytä passiiviset asiakkaat"
 
 #: gnucash/report/reports/standard/customer-summary.scm:73
 msgid "Include customers that have been marked inactive."
@@ -24042,7 +23114,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/customer-summary.scm:75
 msgid "Sort Column"
-msgstr ""
+msgstr "Järjestä sarake"
 
 #: gnucash/report/reports/standard/customer-summary.scm:76
 msgid "Choose the column by which the result table is sorted."
@@ -24050,20 +23122,16 @@ msgstr ""
 
 #: gnucash/report/reports/standard/customer-summary.scm:77
 #: gnucash/report/reports/standard/new-aging.scm:41
-#, fuzzy
-#| msgid "Short sell"
 msgid "Sort Order"
-msgstr "Lyhyeksimyynti"
+msgstr "Järjestyssuunta"
 
 #: gnucash/report/reports/standard/customer-summary.scm:78
 msgid "Choose the ordering of the column sort."
-msgstr ""
+msgstr "Valitse sarakelajittelun järjestys."
 
 #: gnucash/report/reports/standard/customer-summary.scm:106
-#, fuzzy
-#| msgid "Customer ID"
 msgid "Customer Name"
-msgstr "Asiakastunnus"
+msgstr "Asiakkaan nimi"
 
 #: gnucash/report/reports/standard/customer-summary.scm:108
 msgid "Markup (which is profit amount divided by sales)"
@@ -24073,7 +23141,7 @@ msgstr ""
 #: gnucash/report/reports/standard/customer-summary.scm:284
 #: gnucash/report/reports/standard/income-gst-statement.scm:130
 msgid "Sales"
-msgstr ""
+msgstr "Myynti"
 
 #: gnucash/report/reports/standard/customer-summary.scm:254
 #, scheme-format
@@ -24082,23 +23150,19 @@ msgstr ""
 
 #: gnucash/report/reports/standard/customer-summary.scm:274
 msgid "No valid customer found."
-msgstr ""
+msgstr "Sopivaa asiakasta ei löydy."
 
 #: gnucash/report/reports/standard/customer-summary.scm:283
 msgid "Markup"
 msgstr ""
 
 #: gnucash/report/reports/standard/customer-summary.scm:362
-#, fuzzy
-#| msgid "New Customer"
 msgid "No Customer"
-msgstr "Uusi asiakas"
+msgstr "Ei asiakasta"
 
 #: gnucash/report/reports/standard/customer-summary.scm:476
-#, fuzzy
-#| msgid "Customer ID"
 msgid "Customer Summary"
-msgstr "Asiakastunnus"
+msgstr "Yhteenveto asiakkaista"
 
 #. Translators: This statement is about a range of time
 #: gnucash/report/reports/standard/equity-statement.scm:56
@@ -24112,229 +23176,208 @@ msgstr ""
 #: gnucash/report/reports/standard/equity-statement.scm:84
 #: gnucash/report/reports/standard/income-statement.scm:111
 #: gnucash/report/reports/standard/trial-balance.scm:98
-#, fuzzy
-#| msgid "Closing Entries"
 msgid "Closing Entries pattern"
-msgstr "Tilinpäätöstositteet"
+msgstr "Tilinpäätöstositteen malli"
 
 #: gnucash/report/reports/standard/equity-statement.scm:86
 #: gnucash/report/reports/standard/income-statement.scm:113
 #: gnucash/report/reports/standard/trial-balance.scm:100
 msgid "Any text in the Description column which identifies closing entries."
 msgstr ""
+"Mikä vain teksti kuvaussarakkeessa, josta tilinpäätöstosite tunnistetaan."
 
 #: gnucash/report/reports/standard/equity-statement.scm:88
 #: gnucash/report/reports/standard/income-statement.scm:115
 #: gnucash/report/reports/standard/trial-balance.scm:102
 msgid "Closing Entries pattern is case-sensitive"
-msgstr ""
+msgstr "Tilinpäätöstositteen malli ottaa huomioon isot ja pienet kirjaimet"
 
 #: gnucash/report/reports/standard/equity-statement.scm:90
 #: gnucash/report/reports/standard/income-statement.scm:117
 #: gnucash/report/reports/standard/trial-balance.scm:104
 msgid "Causes the Closing Entries Pattern match to be case-sensitive."
 msgstr ""
+"Saa tilinpäätöstositteen mallin ottamaan huomioon isot ja pienet kirjaimet."
 
 #: gnucash/report/reports/standard/equity-statement.scm:92
 #: gnucash/report/reports/standard/income-statement.scm:119
 #: gnucash/report/reports/standard/trial-balance.scm:106
 msgid "Closing Entries Pattern is regular expression"
-msgstr ""
+msgstr "Tilinpäätöstositteen malli on säännöllinen lauseke"
 
 #: gnucash/report/reports/standard/equity-statement.scm:94
 #: gnucash/report/reports/standard/income-statement.scm:121
 #: gnucash/report/reports/standard/trial-balance.scm:108
 msgid ""
 "Causes the Closing Entries Pattern to be treated as a regular expression."
-msgstr ""
+msgstr "Saa tilinpäätösmallin toimimaan säännöllisenä lausekkeena."
 
 #: gnucash/report/reports/standard/equity-statement.scm:402
 #: gnucash/report/reports/standard/income-statement.scm:442
 #: gnucash/report/reports/standard/trial-balance.scm:365
-#, fuzzy
-#| msgid "Period"
 msgid "for Period"
-msgstr "Aikaväli"
+msgstr "aikavälillä"
 
 #: gnucash/report/reports/standard/equity-statement.scm:429
 #: gnucash/report/reports/standard/equity-statement.scm:465
-#, fuzzy
-#| msgctxt "Stock Assistant: Page name"
-#| msgid "Capital Gains"
 msgid "Capital"
-msgstr "Pääomatulot"
+msgstr "Pääoma"
 
 #: gnucash/report/reports/standard/equity-statement.scm:440
 msgid "Investments"
-msgstr ""
+msgstr "Investoinnit"
 
 #: gnucash/report/reports/standard/equity-statement.scm:445
 msgid "Withdrawals"
-msgstr ""
+msgstr "Nostot"
 
 #: gnucash/report/reports/standard/equity-statement.scm:451
 msgid "Unrealized Gains for Period"
-msgstr ""
+msgstr "Realisoitumattomat voitot kaudelta"
 
 #: gnucash/report/reports/standard/equity-statement.scm:452
 msgid "Unrealized Losses for Period"
-msgstr ""
+msgstr "Realisoitumattomat tappiot kaudella"
 
 #: gnucash/report/reports/standard/equity-statement.scm:458
 msgid "Increase in capital"
-msgstr ""
+msgstr "Pääoman kasvu"
 
 #: gnucash/report/reports/standard/equity-statement.scm:459
-#, fuzzy
-#| msgid "Return of capital"
 msgid "Decrease in capital"
-msgstr "Pääoman takaisinmaksu"
+msgstr "Pääoman vähennys"
 
 #: gnucash/report/reports/standard/general-journal.scm:94
 #: gnucash/report/reports/standard/general-ledger.scm:68
 #: gnucash/report/reports/standard/register.scm:134
 #: gnucash/report/reports/standard/register.scm:351
 #: gnucash/report/trep-engine.scm:915 gnucash/report/trep-engine.scm:2235
-#, fuzzy
-#| msgid "Number/Action"
 msgid "Num/Action"
-msgstr "Numero/Tapahtuma"
+msgstr "Num./Tapahtuma"
 
 #: gnucash/report/reports/standard/general-journal.scm:102
 #: gnucash/report/reports/standard/general-ledger.scm:82
 #: gnucash/report/reports/standard/general-ledger.scm:102
 #: gnucash/report/reports/standard/register.scm:394
 #: gnucash/report/trep-engine.scm:1361 gnucash/report/trep-engine.scm:1466
-#, fuzzy
-#| msgid "Opening Balance"
 msgid "Running Balance"
-msgstr "Avaussaldo"
+msgstr "Juokseva saldo"
 
 #: gnucash/report/reports/standard/general-journal.scm:103
 #: gnucash/report/reports/standard/general-ledger.scm:83
 #: gnucash/report/reports/standard/general-ledger.scm:103
 #: gnucash/report/reports/standard/register.scm:398
-#, fuzzy
-#| msgid "Total Entries"
 msgid "Totals"
-msgstr "Yhteensä tietueita"
+msgstr "Summat"
 
 #: gnucash/report/reports/standard/general-ledger.scm:39
 msgid "General Ledger"
-msgstr ""
+msgstr "Pääkirja"
 
 #: gnucash/report/reports/standard/general-ledger.scm:50
 #: gnucash/report/reports/standard/income-gst-statement.scm:44
 #: gnucash/report/trep-engine.scm:85
 msgid "Sorting"
-msgstr ""
+msgstr "Järjestys"
 
 #: gnucash/report/reports/standard/general-ledger.scm:69
 #: gnucash/report/trep-engine.scm:936 gnucash/report/trep-engine.scm:2260
-#, fuzzy
-#| msgid "Tax Number"
 msgid "Trans Number"
-msgstr "Veronumero"
+msgstr "Tositenumero"
 
 #: gnucash/report/reports/standard/general-ledger.scm:73
 #: gnucash/report/reports/standard/general-ledger.scm:93
 #: gnucash/report/trep-engine.scm:873 gnucash/report/trep-engine.scm:920
 #: gnucash/report/trep-engine.scm:2249
-#, fuzzy
-#| msgid "All Accounts"
 msgid "Use Full Account Name"
-msgstr "Kaikki tilit"
+msgstr "Käytä tilin koko nimeä"
 
 #: gnucash/report/reports/standard/general-ledger.scm:75
 #: gnucash/report/reports/standard/general-ledger.scm:95
 #: gnucash/report/trep-engine.scm:219 gnucash/report/trep-engine.scm:877
 #: gnucash/report/trep-engine.scm:958 gnucash/report/trep-engine.scm:2241
-#, fuzzy
-#| msgid "CSV Account Map"
 msgid "Other Account Name"
-msgstr "CSV-tilikartta"
+msgstr "Toisen tilin nimi"
 
 #: gnucash/report/reports/standard/general-ledger.scm:76
 #: gnucash/report/reports/standard/general-ledger.scm:96
 #: gnucash/report/trep-engine.scm:893 gnucash/report/trep-engine.scm:923
 #: gnucash/report/trep-engine.scm:2258
 msgid "Use Full Other Account Name"
-msgstr ""
+msgstr "Käytä toisen tilin koko nimeä"
 
 #: gnucash/report/reports/standard/general-ledger.scm:77
 #: gnucash/report/reports/standard/general-ledger.scm:97
 #: gnucash/report/trep-engine.scm:225 gnucash/report/trep-engine.scm:897
 #: gnucash/report/trep-engine.scm:924 gnucash/report/trep-engine.scm:2255
 msgid "Other Account Code"
-msgstr ""
+msgstr "Toisen tilin numero"
 
 #: gnucash/report/reports/standard/general-ledger.scm:84
 #: gnucash/report/reports/standard/general-ledger.scm:104
 #: gnucash/report/trep-engine.scm:881 gnucash/report/trep-engine.scm:991
 #: gnucash/report/trep-engine.scm:2184
-#, fuzzy
-#| msgid "Reverse split"
 msgid "Sign Reverses"
-msgstr "Osakkeiden yhdistäminen"
+msgstr "Etumerkkien kääntö"
 
 #: gnucash/report/reports/standard/general-ledger.scm:111
 #: gnucash/report/trep-engine.scm:75
 msgid "Detail Level"
-msgstr ""
+msgstr "Yksityiskohtaisuus"
 
 #: gnucash/report/reports/standard/general-ledger.scm:124
 #: gnucash/report/trep-engine.scm:86
 msgid "Primary Key"
-msgstr ""
+msgstr "Ensisijainen järjestysperuste"
 
 #: gnucash/report/reports/standard/general-ledger.scm:125
 #: gnucash/report/trep-engine.scm:90 gnucash/report/trep-engine.scm:2283
 msgid "Show Full Account Name"
-msgstr ""
+msgstr "Näytä tilin koko nimi"
 
 #: gnucash/report/reports/standard/general-ledger.scm:127
 #: gnucash/report/trep-engine.scm:87
 msgid "Primary Subtotal"
-msgstr ""
+msgstr "Välisummat ensisijaiselle perusteelle"
 
 #: gnucash/report/reports/standard/general-ledger.scm:128
 #: gnucash/report/trep-engine.scm:89
 msgid "Primary Subtotal for Date Key"
-msgstr ""
+msgstr "Välisumma jos järjestetty päivämäärän mukaan"
 
 #: gnucash/report/reports/standard/general-ledger.scm:129
 #: gnucash/report/trep-engine.scm:88
 msgid "Primary Sort Order"
-msgstr ""
+msgstr "Ensisijaisen järjestyksen suunta"
 
 #: gnucash/report/reports/standard/general-ledger.scm:130
 #: gnucash/report/trep-engine.scm:97
 msgid "Secondary Key"
-msgstr ""
+msgstr "Toissijainen järjestysperuste"
 
 #: gnucash/report/reports/standard/general-ledger.scm:131
 #: gnucash/report/trep-engine.scm:98
 msgid "Secondary Subtotal"
-msgstr ""
+msgstr "Välisummat toissijaiselle perusteelle"
 
 #: gnucash/report/reports/standard/general-ledger.scm:132
 #: gnucash/report/trep-engine.scm:100
 msgid "Secondary Subtotal for Date Key"
-msgstr ""
+msgstr "Välisumma jos järjestetty päivän mukaan"
 
 #: gnucash/report/reports/standard/general-ledger.scm:133
 #: gnucash/report/trep-engine.scm:99
 msgid "Secondary Sort Order"
-msgstr ""
+msgstr "Toissijaisen järjestyksen suunta"
 
 #: gnucash/report/reports/standard/income-gst-statement.scm:43
 msgid "Income and GST Statement"
-msgstr ""
+msgstr "Tulo- ja LVV-laskelma"
 
 #: gnucash/report/reports/standard/income-gst-statement.scm:45
 #: gnucash/report/trep-engine.scm:117
 msgid "Filter"
-msgstr ""
+msgstr "Suodatin"
 
 #: gnucash/report/reports/standard/income-gst-statement.scm:52
 msgid ""
@@ -24399,10 +23442,8 @@ msgstr ""
 
 #: gnucash/report/reports/standard/income-gst-statement.scm:116
 #: gnucash/report/reports/standard/income-gst-statement.scm:345
-#, fuzzy
-#| msgid "Ne_w Balance"
 msgid "Gross Balance"
-msgstr "_Uusi saldo"
+msgstr ""
 
 #: gnucash/report/reports/standard/income-gst-statement.scm:117
 msgid "Display the gross balance (gross sales - gross purchases)"
@@ -24410,10 +23451,8 @@ msgstr ""
 
 #: gnucash/report/reports/standard/income-gst-statement.scm:118
 #: gnucash/report/reports/standard/income-gst-statement.scm:353
-#, fuzzy
-#| msgid "Next Balance"
 msgid "Net Balance"
-msgstr "Uusi saldo"
+msgstr ""
 
 #: gnucash/report/reports/standard/income-gst-statement.scm:119
 msgid "Display the net balance (sales without tax - purchases without tax)"
@@ -24421,10 +23460,8 @@ msgstr ""
 
 #: gnucash/report/reports/standard/income-gst-statement.scm:121
 #: gnucash/report/reports/standard/income-gst-statement.scm:360
-#, fuzzy
-#| msgid "Tax Payment"
 msgid "Tax payable"
-msgstr "Veronmaksu"
+msgstr "Maksettava vero"
 
 #: gnucash/report/reports/standard/income-gst-statement.scm:122
 msgid "Display the tax payable (tax on sales - tax on purchases)"
@@ -24435,10 +23472,8 @@ msgid "Purchases"
 msgstr ""
 
 #: gnucash/report/reports/standard/income-gst-statement.scm:142
-#, fuzzy
-#| msgid "All Accounts"
 msgid "Tax Accounts"
-msgstr "Kaikki tilit"
+msgstr "Verotilit"
 
 #: gnucash/report/reports/standard/income-gst-statement.scm:143
 msgid ""
@@ -24452,14 +23487,12 @@ msgstr ""
 #: gnucash/report/reports/standard/income-gst-statement.scm:151
 #: gnucash/report/reports/standard/income-gst-statement.scm:155
 msgid "Report Format"
-msgstr ""
+msgstr "Raportin muoto"
 
 #: gnucash/report/reports/standard/income-gst-statement.scm:156
 #: gnucash/report/reports/standard/income-gst-statement.scm:165
-#, fuzzy
-#| msgid "Fancy Date Format"
 msgid "Default Format"
-msgstr "Hieno päivämäärämuoto"
+msgstr "Oletusmuoto"
 
 #: gnucash/report/reports/standard/income-gst-statement.scm:157
 msgid ""
@@ -24489,11 +23522,11 @@ msgstr ""
 
 #: gnucash/report/reports/standard/income-gst-statement.scm:312
 msgid "Net Sales"
-msgstr ""
+msgstr "Nettomyynnit"
 
 #: gnucash/report/reports/standard/income-gst-statement.scm:319
 msgid "Tax on Sales"
-msgstr ""
+msgstr "Myynnin vero"
 
 #. Translators: "Gross Purchases" refer to Net Purchase +
 #. GST/VAT on Purchase
@@ -24503,23 +23536,23 @@ msgstr ""
 
 #: gnucash/report/reports/standard/income-gst-statement.scm:331
 msgid "Net Purchases"
-msgstr ""
+msgstr "Netto-ostot"
 
 #: gnucash/report/reports/standard/income-gst-statement.scm:339
 msgid "Tax on Purchases"
-msgstr ""
+msgstr "Ostojen vero"
 
 #: gnucash/report/reports/standard/income-statement.scm:88
 msgid "Label the trading accounts section"
-msgstr ""
+msgstr "Otsikoi muunnostilien kappale"
 
 #: gnucash/report/reports/standard/income-statement.scm:90
 msgid "Whether or not to include a label for the trading accounts section."
-msgstr ""
+msgstr "Otsikoidaanko muunnostilien kappale."
 
 #: gnucash/report/reports/standard/income-statement.scm:91
 msgid "Include trading accounts total"
-msgstr ""
+msgstr "Sisällytä muunnostilien loppusumma"
 
 #: gnucash/report/reports/standard/income-statement.scm:93
 msgid ""
@@ -24532,86 +23565,82 @@ msgid "Trading"
 msgstr ""
 
 #: gnucash/report/reports/standard/income-statement.scm:480
-#, fuzzy
-#| msgid "Total Entries"
 msgid "Total Trading"
-msgstr "Yhteensä tietueita"
+msgstr "Muunnokset yhteensä"
 
 #: gnucash/report/reports/standard/income-statement.scm:552
 #: gnucash/report/reports/standard/trial-balance.scm:535
-#, fuzzy
-#| msgid "Insurance Payment"
 msgid "Income Statement"
-msgstr "Vakuutusmaksu"
+msgstr "Tuloslaskelma"
 
 #: gnucash/report/reports/standard/income-statement.scm:553
 msgid "Profit & Loss"
-msgstr ""
+msgstr "Tuloslaskelma"
 
 #: gnucash/report/reports/standard/investment-lots.scm:40
 msgid "Chart"
-msgstr ""
+msgstr "Kaavio"
 
 #: gnucash/report/reports/standard/investment-lots.scm:41
 msgid "Columns"
-msgstr ""
+msgstr "Sarakkeet"
 
 #: gnucash/report/reports/standard/investment-lots.scm:42
 msgid "Validation"
-msgstr ""
+msgstr "Tarkistus"
 
 #: gnucash/report/reports/standard/investment-lots.scm:47
 #: gnucash/report/reports/standard/investment-lots.scm:163
 msgid "Include accounts with no lots"
-msgstr ""
+msgstr "Sisällytä tilit ilman eriä"
 
 #: gnucash/report/reports/standard/investment-lots.scm:50
 msgid "Show Chart"
-msgstr ""
+msgstr "Näytä kaavio"
 
 #: gnucash/report/reports/standard/investment-lots.scm:51
 msgid "Chart type"
-msgstr ""
+msgstr "Kaavion tyyppi"
 
 #: gnucash/report/reports/standard/investment-lots.scm:52
 msgid "Chart location"
-msgstr ""
+msgstr "Kaavion sijainti"
 
 #: gnucash/report/reports/standard/investment-lots.scm:53
 msgid "Plot width"
-msgstr ""
+msgstr "Kuvaajan leveys"
 
 #: gnucash/report/reports/standard/investment-lots.scm:54
 msgid "Plot height"
-msgstr ""
+msgstr "Kuvaajan korkeus"
 
 #: gnucash/report/reports/standard/investment-lots.scm:57
 msgid "Show lot GUID column"
-msgstr ""
+msgstr "Näytä erän GUID -sarake"
 
 #: gnucash/report/reports/standard/investment-lots.scm:58
 msgid "Show date columns"
-msgstr ""
+msgstr "Näytä päiväyssarakkeet"
 
 #: gnucash/report/reports/standard/investment-lots.scm:59
 msgid "Show bought columns"
-msgstr ""
+msgstr "Näytä ostosarakkeet"
 
 #: gnucash/report/reports/standard/investment-lots.scm:60
 msgid "Show sold columns"
-msgstr ""
+msgstr "Näytä myyntisarakkeet"
 
 #: gnucash/report/reports/standard/investment-lots.scm:61
 msgid "Show end columns"
-msgstr ""
+msgstr "Näytä loppusarakkeet"
 
 #: gnucash/report/reports/standard/investment-lots.scm:63
 msgid "Show realized gain column(s)"
-msgstr ""
+msgstr "Näytä realisoituneen voiton sarakkeet"
 
 #: gnucash/report/reports/standard/investment-lots.scm:65
 msgid "Show unrealized gain column(s)"
-msgstr ""
+msgstr "Näytä realisoitumattoman voiton sarakkeet"
 
 #: gnucash/report/reports/standard/investment-lots.scm:67
 msgid "Group gains by age (short term and long term)"
@@ -24623,39 +23652,39 @@ msgstr ""
 
 #: gnucash/report/reports/standard/investment-lots.scm:72
 msgid "Show mnemonic in amounts"
-msgstr ""
+msgstr "Näytä osakekoodi määrissä"
 
 #: gnucash/report/reports/standard/investment-lots.scm:73
 msgid "Include closed lots"
-msgstr ""
+msgstr "Sisällytä suljetut erät"
 
 #: gnucash/report/reports/standard/investment-lots.scm:75
 msgid "Show blanks instead of zeros in table cells"
-msgstr ""
+msgstr "Näytä tyhjää nollien paikalla taulukon soluissa"
 
 #: gnucash/report/reports/standard/investment-lots.scm:76
 msgid "Show lot split rows"
-msgstr ""
+msgstr "Näytä erän jaetut rivit"
 
 #: gnucash/report/reports/standard/investment-lots.scm:79
 msgid "Investment Lots"
-msgstr ""
+msgstr "Investointierät"
 
 #: gnucash/report/reports/standard/investment-lots.scm:80
 msgid "Start date"
-msgstr ""
+msgstr "Alkupäivämäärä"
 
 #: gnucash/report/reports/standard/investment-lots.scm:81
 msgid "End date"
-msgstr ""
+msgstr "Loppupäivämäärä"
 
 #: gnucash/report/reports/standard/investment-lots.scm:83
 msgid "Price source"
-msgstr ""
+msgstr "Hintalähde"
 
 #: gnucash/report/reports/standard/investment-lots.scm:87
 msgid "Include only accounts with warnings"
-msgstr ""
+msgstr "Sisällytä vain tilit, joilla on varoituksia"
 
 #: gnucash/report/reports/standard/investment-lots.scm:89
 msgid "Warn if a lot has more than one bought split"
@@ -24686,7 +23715,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/investment-lots.scm:101
 msgid "Lot Title"
-msgstr ""
+msgstr "Erän otsikko"
 
 #: gnucash/report/reports/standard/investment-lots.scm:104
 msgid "GUID"
@@ -24694,7 +23723,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/investment-lots.scm:105
 msgid "Bought Amount"
-msgstr ""
+msgstr "Ostettu määrä"
 
 #: gnucash/report/reports/standard/investment-lots.scm:106
 msgid "Bought Value (Basis)"
@@ -24705,30 +23734,24 @@ msgid "Bought Average Price"
 msgstr ""
 
 #: gnucash/report/reports/standard/investment-lots.scm:108
-#, fuzzy
-#| msgid "Stock split"
 msgid "Sold Splits"
-msgstr "Osakkeen jako"
+msgstr "Myydyt erät"
 
 #: gnucash/report/reports/standard/investment-lots.scm:109
-#, fuzzy
-#| msgid "Find Account"
 msgid "Sold Amount"
-msgstr "Etsi tili"
+msgstr "Myyty määrä"
 
 #: gnucash/report/reports/standard/investment-lots.scm:110
 msgid "Sold Basis"
 msgstr ""
 
 #: gnucash/report/reports/standard/investment-lots.scm:111
-#, fuzzy
-#| msgid "Value"
 msgid "Sold Value"
-msgstr "Arvo"
+msgstr "Myyty arvo"
 
 #: gnucash/report/reports/standard/investment-lots.scm:112
 msgid "ST Sold Amount"
-msgstr ""
+msgstr "LA myyty määrä"
 
 #: gnucash/report/reports/standard/investment-lots.scm:113
 msgid "ST Sold Basis"
@@ -24740,7 +23763,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/investment-lots.scm:115
 msgid "LT Sold Amount"
-msgstr ""
+msgstr "PA myyty määrä"
 
 #: gnucash/report/reports/standard/investment-lots.scm:116
 msgid "LT Sold Basis"
@@ -24751,54 +23774,48 @@ msgid "LT Sold Value"
 msgstr ""
 
 #: gnucash/report/reports/standard/investment-lots.scm:118
-#, fuzzy
-#| msgid "Share Price"
 msgid "Sold Average Price"
-msgstr "Osuuden arvo"
+msgstr "Myyty keskihinta"
 
 #: gnucash/report/reports/standard/investment-lots.scm:119
-#, fuzzy
-#| msgid "Find Account"
 msgid "End Amount"
-msgstr "Etsi tili"
+msgstr "Loppumäärä"
 
 #: gnucash/report/reports/standard/investment-lots.scm:120
 msgid "End Basis"
 msgstr ""
 
 #: gnucash/report/reports/standard/investment-lots.scm:121
-#, fuzzy
-#| msgid "Value"
 msgid "End Value"
-msgstr "Arvo"
+msgstr "Loppuarvo"
 
 #: gnucash/report/reports/standard/investment-lots.scm:123
 msgid "ST Realized Gain"
-msgstr ""
+msgstr "LA toteutuneet voitot"
 
 #: gnucash/report/reports/standard/investment-lots.scm:124
 msgid "LT Realized Gain"
-msgstr ""
+msgstr "PA toteutuneet voitot"
 
 #: gnucash/report/reports/standard/investment-lots.scm:125
 msgid "Realized ROI"
-msgstr ""
+msgstr "Sijoitetun pääoman tuotto (ROI)"
 
 #: gnucash/report/reports/standard/investment-lots.scm:127
 msgid "ST Unrealized Gain"
-msgstr ""
+msgstr "LA toteutumattomat voitot"
 
 #: gnucash/report/reports/standard/investment-lots.scm:128
 msgid "LT Unrealized Gain"
-msgstr ""
+msgstr "PA toteutumattomat voitot"
 
 #: gnucash/report/reports/standard/investment-lots.scm:129
 msgid "Unrealized ROI"
-msgstr ""
+msgstr "Toteutumattomat pääomatulot (ROI)"
 
 #: gnucash/report/reports/standard/investment-lots.scm:131
 msgid "Account Lots Total"
-msgstr ""
+msgstr "Tilin erät yhteensä"
 
 #: gnucash/report/reports/standard/investment-lots.scm:171
 msgid "Include a chart that shows lot gains, grouped by account and gain type"
@@ -24814,7 +23831,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/investment-lots.scm:195
 msgid "Where to place the chart"
-msgstr ""
+msgstr "Mihin kaavio sijoitetaan"
 
 #: gnucash/report/reports/standard/investment-lots.scm:214
 msgid "Show the lot GUID table column"
@@ -24822,7 +23839,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/investment-lots.scm:221
 msgid "Show the lot open and close table columns"
-msgstr ""
+msgstr "Näytä erän avaus ja sulku -taulukkosarakkeet"
 
 #: gnucash/report/reports/standard/investment-lots.scm:228
 msgid "Show purchase-related table columns"
@@ -24830,7 +23847,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/investment-lots.scm:235
 msgid "Show sale-related table columns"
-msgstr ""
+msgstr "Näytä myyntiin liittyvät taulukon sarakkeet"
 
 #: gnucash/report/reports/standard/investment-lots.scm:242
 msgid "Show end date amount and value table columns"
@@ -24850,11 +23867,11 @@ msgstr ""
 
 #: gnucash/report/reports/standard/investment-lots.scm:266
 msgid "Gains Only"
-msgstr ""
+msgstr "Vain voitot"
 
 #: gnucash/report/reports/standard/investment-lots.scm:267
 msgid "Gains and Sales"
-msgstr ""
+msgstr "Voitot ja myynti"
 
 #: gnucash/report/reports/standard/investment-lots.scm:281
 msgid "Commodities held longer than this many years count as long-term (LT)."
@@ -24862,7 +23879,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/investment-lots.scm:293
 msgid "Show long (instead of short) account names"
-msgstr ""
+msgstr "Näytä pitkät (eikä lyhyet) tilinimet"
 
 #: gnucash/report/reports/standard/investment-lots.scm:300
 msgid "Show mnemonics with commodity amounts"
@@ -24915,10 +23932,8 @@ msgid "Detect splits that have not been assigned to a lot."
 msgstr ""
 
 #: gnucash/report/reports/standard/investment-lots.scm:383
-#, fuzzy
-#| msgid "Account"
 msgid "Count"
-msgstr "Tili"
+msgstr "Lukumäärä"
 
 #: gnucash/report/reports/standard/investment-lots.scm:390
 msgid ""
@@ -24932,14 +23947,11 @@ msgstr ""
 
 #: gnucash/report/reports/standard/investment-lots.scm:813
 msgid "No price found"
-msgstr ""
+msgstr "Ei löytynyt hintaa"
 
 #: gnucash/report/reports/standard/investment-lots.scm:1230
-#, fuzzy
-#| msgctxt "Action Column"
-#| msgid "Split"
 msgid "split"
-msgstr "Rivi"
+msgstr "rivi"
 
 #: gnucash/report/reports/standard/investment-lots.scm:1351
 #, scheme-format
@@ -24982,7 +23994,7 @@ msgstr ""
 #: gnucash/report/reports/standard/investment-lots.scm:1425
 #, scheme-format
 msgid ": amount ~a, value ~a"
-msgstr ""
+msgstr ": määrä ~a, arvo ~a"
 
 #: gnucash/report/reports/standard/investment-lots.scm:1445
 #, scheme-format
@@ -24992,16 +24004,13 @@ msgid ""
 msgstr ""
 
 #: gnucash/report/reports/standard/investment-lots.scm:1963
-#, fuzzy, scheme-format
-#| msgid "~a to ~a"
+#, scheme-format
 msgid "~a, ~a to ~a"
-msgstr "~a → ~a"
+msgstr "~a, ~a → ~a"
 
 #: gnucash/report/reports/standard/investment-lots.scm:1989
-#, fuzzy
-#| msgid "Accounts in '%s'"
 msgid "Account Lot Gains"
-msgstr "Tilit kategoriassa '%s'"
+msgstr "Tilin erien voitot"
 
 #: gnucash/report/reports/standard/invoice.scm:101
 #: gnucash/report/reports/standard/invoice.scm:438
@@ -25009,10 +24018,8 @@ msgstr "Tilit kategoriassa '%s'"
 #: gnucash/report/reports/standard/receipt.scm:128
 #: gnucash/report/reports/standard/taxinvoice.scm:107
 #: gnucash/report/reports/standard/taxinvoice.scm:193
-#, fuzzy
-#| msgid "Tax Payment"
 msgid "Tax Amount"
-msgstr "Veronmaksu"
+msgstr "Veron määrä"
 
 #: gnucash/report/reports/standard/invoice.scm:157
 msgid "REF"
@@ -25021,35 +24028,33 @@ msgstr ""
 #: gnucash/report/reports/standard/invoice.scm:258
 #: gnucash/report/reports/support/taxinvoice.eguile.scm:225
 msgid "Invoice in progress…"
-msgstr ""
+msgstr "Lasku vaiheessa…"
 
 #: gnucash/report/reports/standard/invoice.scm:266
 msgid "Reference:"
-msgstr ""
+msgstr "Viite:"
 
 #: gnucash/report/reports/standard/invoice.scm:278
 msgid "Terms:"
-msgstr ""
+msgstr "Ehdot:"
 
 #: gnucash/report/reports/standard/invoice.scm:288
 #: gnucash/report/reports/standard/taxinvoice.scm:214
 msgid "Job number:"
-msgstr ""
+msgstr "Hankenumero:"
 
 #: gnucash/report/reports/standard/invoice.scm:293
 #: gnucash/report/reports/standard/taxinvoice.scm:217
 msgid "Job name:"
-msgstr ""
+msgstr "Hankkeen nimi:"
 
 #: gnucash/report/reports/standard/invoice.scm:317
 msgid "Client or vendor name, address and ID"
 msgstr ""
 
 #: gnucash/report/reports/standard/invoice.scm:321
-#, fuzzy
-#| msgid "Company Email Address"
 msgid "Company name, address and tax-ID"
-msgstr "Yrityksen sähköpostiosoite"
+msgstr "Yrityksen nimi, osoite ja alv-numero"
 
 #: gnucash/report/reports/standard/invoice.scm:325
 msgid "Invoice date, due date, billing ID, terms, job details"
@@ -25057,21 +24062,19 @@ msgstr ""
 
 #: gnucash/report/reports/standard/invoice.scm:329
 msgid "Today's date"
-msgstr ""
+msgstr "Tämä päiväys"
 
 #: gnucash/report/reports/standard/invoice.scm:333
 msgid "Picture"
-msgstr ""
+msgstr "Kuva"
 
 #: gnucash/report/reports/standard/invoice.scm:338
 msgid "Empty space"
-msgstr ""
+msgstr "Tyhjä tila"
 
 #: gnucash/report/reports/standard/invoice.scm:396
-#, fuzzy
-#| msgid "Customer ID"
 msgid "Custom Title"
-msgstr "Asiakastunnus"
+msgstr "Mukautettu otsikko"
 
 #: gnucash/report/reports/standard/invoice.scm:397
 msgid "A custom string to replace Invoice, Bill or Expense Voucher."
@@ -25081,7 +24084,7 @@ msgstr ""
 #: gnucash/report/stylesheets/css.scm:118
 #: gnucash/report/stylesheets/css.scm:224
 msgid "CSS"
-msgstr ""
+msgstr "CSS"
 
 #: gnucash/report/reports/standard/invoice.scm:401
 msgid ""
@@ -25091,7 +24094,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/invoice.scm:406
 msgid "Picture Location"
-msgstr ""
+msgstr "Kuvan sijainti"
 
 #: gnucash/report/reports/standard/invoice.scm:406
 msgid "Location for Picture"
@@ -25119,30 +24122,28 @@ msgstr ""
 #: gnucash/report/reports/standard/new-owner-report.scm:915
 #: gnucash/report/reports/standard/new-owner-report.scm:930
 msgid "Display Columns"
-msgstr ""
+msgstr "Näytä sarakkeet"
 
 #: gnucash/report/reports/standard/invoice.scm:411
 #: gnucash/report/reports/standard/register.scm:347
 #: gnucash/report/reports/standard/taxinvoice.scm:124
 #: gnucash/report/trep-engine.scm:911
 msgid "Display the date?"
-msgstr ""
+msgstr "Näytä päivämäärä?"
 
 #: gnucash/report/reports/standard/invoice.scm:415
 #: gnucash/report/reports/standard/register.scm:359
 #: gnucash/report/trep-engine.scm:917
-#, fuzzy
-#| msgid "Description"
 msgid "Display the description?"
-msgstr "Selite"
+msgstr "Näytä kuvaus?"
 
 #: gnucash/report/reports/standard/invoice.scm:419
 msgid "Display the action?"
-msgstr ""
+msgstr "Näytä toimenpide?"
 
 #: gnucash/report/reports/standard/invoice.scm:423
 msgid "Display the quantity of items?"
-msgstr ""
+msgstr "Näytä tietueiden määrä?"
 
 #: gnucash/report/reports/standard/invoice.scm:427
 msgid "Display the price per item?"
@@ -25150,11 +24151,11 @@ msgstr ""
 
 #: gnucash/report/reports/standard/invoice.scm:431
 msgid "Display the entry's discount?"
-msgstr ""
+msgstr "Näytä rivin alennus?"
 
 #: gnucash/report/reports/standard/invoice.scm:435
 msgid "Display the entry's taxable status?"
-msgstr ""
+msgstr "Näytä rivin verotettavuus?"
 
 #: gnucash/report/reports/standard/invoice.scm:439
 msgid "Display each entry's total total tax?"
@@ -25162,15 +24163,15 @@ msgstr ""
 
 #: gnucash/report/reports/standard/invoice.scm:443
 msgid "Display the entry's value?"
-msgstr ""
+msgstr "Näytä rivin arvo?"
 
 #: gnucash/report/reports/standard/invoice.scm:447
 msgid "Display due date?"
-msgstr ""
+msgstr "Näytä eräpäivä?"
 
 #: gnucash/report/reports/standard/invoice.scm:451
 msgid "Display the subtotals?"
-msgstr ""
+msgstr "Näytä välisummat?"
 
 #: gnucash/report/reports/standard/invoice.scm:454
 msgid "Payable to"
@@ -25178,7 +24179,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/invoice.scm:455
 msgid "Display the Payable to: information."
-msgstr ""
+msgstr "Näytä tieto kenelle maksetaan."
 
 #: gnucash/report/reports/standard/invoice.scm:461
 msgid "Payable to string"
@@ -25193,20 +24194,16 @@ msgid "Please make all checks payable to"
 msgstr ""
 
 #: gnucash/report/reports/standard/invoice.scm:466
-#, fuzzy
-#| msgid "Company Contact Person"
 msgid "Company contact"
 msgstr "Yrityksen yhteyshenkilö"
 
 #: gnucash/report/reports/standard/invoice.scm:467
 msgid "Display the Company contact information."
-msgstr ""
+msgstr "Näytä yrityksen yhteystiedot."
 
 #: gnucash/report/reports/standard/invoice.scm:472
-#, fuzzy
-#| msgid "Company Contact Person"
 msgid "Company contact string"
-msgstr "Yrityksen yhteyshenkilö"
+msgstr "Yrityksen yhteyshenkilö merkkijonona"
 
 #: gnucash/report/reports/standard/invoice.scm:473
 msgid "The phrase used to introduce the company contact."
@@ -25222,7 +24219,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/invoice.scm:478
 msgid "The minimum number of invoice entries to display."
-msgstr ""
+msgstr "Vähimmäismäärä näytettäviä myyntilaskurivejä."
 
 #: gnucash/report/reports/standard/invoice.scm:482
 msgid "Use Detailed Tax Summary"
@@ -25244,7 +24241,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/invoice.scm:490
 msgid "Billing Terms"
-msgstr ""
+msgstr "Laskutusehdot"
 
 #: gnucash/report/reports/standard/invoice.scm:491
 msgid "Display the invoice billing terms?"
@@ -25252,27 +24249,23 @@ msgstr ""
 
 #: gnucash/report/reports/standard/invoice.scm:495
 msgid "Display the billing id?"
-msgstr ""
+msgstr "Näytä laskutustunniste?"
 
 #: gnucash/report/reports/standard/invoice.scm:498
-#, fuzzy
-#| msgid "Invoice"
 msgid "Invoice owner ID"
-msgstr "Myyntilasku"
+msgstr "Myyntilaskun omistajan tunnus"
 
 #: gnucash/report/reports/standard/invoice.scm:499
 msgid "Display the customer/vendor id?"
-msgstr ""
+msgstr "Näytä asiakkaan/toimittajan tunnus?"
 
 #: gnucash/report/reports/standard/invoice.scm:503
 msgid "Display the invoice notes?"
-msgstr ""
+msgstr "Näytä laskuhuomautukset?"
 
 #: gnucash/report/reports/standard/invoice.scm:506
-#, fuzzy
-#| msgid "Payment"
 msgid "Payments"
-msgstr "Maksu"
+msgstr "Maksut"
 
 #: gnucash/report/reports/standard/invoice.scm:507
 msgid "Display the payments applied to this invoice?"
@@ -25280,83 +24273,77 @@ msgstr ""
 
 #: gnucash/report/reports/standard/invoice.scm:510
 msgid "Job Details"
-msgstr ""
+msgstr "Hankkeen yksityiskohdat"
 
 #: gnucash/report/reports/standard/invoice.scm:511
 msgid "Display the job name for this invoice?"
-msgstr ""
+msgstr "Näytä hankkeen nimi tälle myyntilaskulle?"
 
 #: gnucash/report/reports/standard/invoice.scm:515
 msgid "Extra notes to put on the invoice."
-msgstr ""
+msgstr "Laskulle lisättävät ylimääräiset huomautukset."
 
 #: gnucash/report/reports/standard/invoice.scm:516
 #: gnucash/report/reports/standard/taxinvoice.scm:222
 msgid "Thank you for your patronage!"
-msgstr ""
+msgstr "Kiitos asiakkuudestanne!"
 
 #: gnucash/report/reports/standard/invoice.scm:519
 msgid "Row 1 Left"
-msgstr ""
+msgstr "Rivi 1 vasemmalla"
 
 #: gnucash/report/reports/standard/invoice.scm:525
 msgid "Row 1 Right"
-msgstr ""
+msgstr "Rivi 1 oikella"
 
 #: gnucash/report/reports/standard/invoice.scm:531
 msgid "Row 2 Left"
-msgstr ""
+msgstr "Rivi 2 vasemmalla"
 
 #: gnucash/report/reports/standard/invoice.scm:537
 msgid "Row 2 Right"
-msgstr ""
+msgstr "Rivi 2 oikella"
 
 #: gnucash/report/reports/standard/invoice.scm:543
 msgid "Row 3 Left"
-msgstr ""
+msgstr "Rivi 3 vasemmalla"
 
 #: gnucash/report/reports/standard/invoice.scm:549
 msgid "Row 3 Right"
-msgstr ""
+msgstr "Rivi 3 oikella"
 
 #: gnucash/report/reports/standard/invoice.scm:599
 msgid "Payment, thank you!"
-msgstr ""
+msgstr "Maksu, kiitos!"
 
 #. Translators: This "T" is displayed in the taxable column, if this entry contains tax
 #: gnucash/report/reports/standard/invoice.scm:656
 msgid "T"
-msgstr ""
+msgstr "V"
 
 #: gnucash/report/reports/standard/invoice.scm:703
 #: gnucash/report/reports/standard/receipt.scm:57
 #: gnucash/report/reports/standard/receipt.scm:124
 #: gnucash/report/reports/standard/taxinvoice.scm:105
 #: gnucash/report/reports/standard/taxinvoice.scm:189
-#, fuzzy
-#| msgid "Share Price"
 msgid "Net Price"
-msgstr "Osuuden arvo"
+msgstr "Nettohinta"
 
 #: gnucash/report/reports/standard/invoice.scm:719
 #: gnucash/report/reports/standard/receipt.scm:60
 #: gnucash/report/reports/standard/receipt.scm:130
 #: gnucash/report/reports/standard/taxinvoice.scm:108
 #: gnucash/report/reports/standard/taxinvoice.scm:195
-#, fuzzy
-#| msgid "Total Entries"
 msgid "Total Price"
-msgstr "Yhteensä tietueita"
+msgstr "Kokonaishinta"
 
 #: gnucash/report/reports/standard/invoice.scm:739
 #: gnucash/report/reports/standard/receipt.scm:62
 #: gnucash/report/reports/standard/receipt.scm:134
 #: gnucash/report/reports/standard/taxinvoice.scm:110
 #: gnucash/report/reports/standard/taxinvoice.scm:199
-#, fuzzy
-#| msgid "Account Types"
 msgid "Amount Due"
-msgstr "Tilityypit"
+msgstr "Maksettava"
 
 #: gnucash/report/reports/standard/invoice.scm:766
 msgid ""
@@ -25376,19 +24363,19 @@ msgstr ""
 
 #: gnucash/report/reports/standard/lot-viewer.scm:56
 msgid "The account to search for lots."
-msgstr ""
+msgstr "Tili jolta erät haetaan."
 
 #: gnucash/report/reports/standard/net-charts.scm:48
 msgid "Show Net Profit"
-msgstr ""
+msgstr "Näytä nettovoitto"
 
 #: gnucash/report/reports/standard/net-charts.scm:50
 msgid "Show Asset & Liability"
-msgstr ""
+msgstr "Näytä Vastaavat ja vastattavat"
 
 #: gnucash/report/reports/standard/net-charts.scm:51
 msgid "Show Net Worth"
-msgstr ""
+msgstr "Näytä nettoarvo"
 
 #: gnucash/report/reports/standard/net-charts.scm:56
 msgid "Line Width"
@@ -25400,11 +24387,11 @@ msgstr ""
 
 #: gnucash/report/reports/standard/net-charts.scm:62
 msgid "Grid"
-msgstr ""
+msgstr "Ruudukko"
 
 #: gnucash/report/reports/standard/net-charts.scm:103
 msgid "Show Income and Expenses?"
-msgstr ""
+msgstr "Näytä tulo ja kulut?"
 
 #: gnucash/report/reports/standard/net-charts.scm:104
 msgid "Show the Asset and the Liability bars?"
@@ -25412,7 +24399,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/net-charts.scm:112
 msgid "Show the net profit?"
-msgstr ""
+msgstr "Näytä nettovoitto?"
 
 #: gnucash/report/reports/standard/net-charts.scm:113
 msgid "Show a Net Worth bar?"
@@ -25420,57 +24407,55 @@ msgstr ""
 
 #: gnucash/report/reports/standard/net-charts.scm:136
 msgid "Add grid lines."
-msgstr ""
+msgstr "Lisää ruutuviivat."
 
 #: gnucash/report/reports/standard/net-charts.scm:375
 #: gnucash/report/reports/standard/net-charts.scm:406
 msgid "Net Profit"
-msgstr ""
+msgstr "Nettovoitto"
 
 #: gnucash/report/reports/standard/net-charts.scm:375
 #: gnucash/report/reports/standard/net-charts.scm:407
 msgid "Net Worth"
-msgstr ""
+msgstr "Nettoarvo"
 
 #: gnucash/report/reports/standard/net-charts.scm:471
 msgid "Net Worth Barchart"
-msgstr ""
+msgstr "Nettoarvo pylväskuvaajana"
 
 #: gnucash/report/reports/standard/net-charts.scm:482
 msgid "Income/Expense Chart"
-msgstr ""
+msgstr "Tulo-/menokuvaaja"
 
 #: gnucash/report/reports/standard/net-charts.scm:484
 msgid "Income & Expense Barchart"
-msgstr ""
+msgstr "Tulot ja menot -pylväskaavio"
 
 #: gnucash/report/reports/standard/net-charts.scm:494
 msgid "Net Worth Linechart"
-msgstr ""
+msgstr "Nettoarvon viivakuvaaja"
 
 #: gnucash/report/reports/standard/net-charts.scm:507
 #: gnucash/report/reports/standard/net-charts.scm:509
 msgid "Income & Expense Linechart"
-msgstr ""
+msgstr "Tulot ja menot -viivakaavio"
 
 #: gnucash/report/reports/standard/new-aging.scm:40
 msgid "Sort By"
-msgstr ""
+msgstr "Järjestä"
 
 #: gnucash/report/reports/standard/new-aging.scm:42
 msgid "Show zero balance items"
-msgstr ""
+msgstr "Näytä nollasaldolliset"
 
 #: gnucash/report/reports/standard/new-aging.scm:43
 #: gnucash/report/reports/standard/new-owner-report.scm:46
 msgid "Due or Post Date"
-msgstr ""
+msgstr "Erä- tai lähetyspäivä"
 
 #: gnucash/report/reports/standard/new-aging.scm:46
-#, fuzzy
-#| msgid "Address Found"
 msgid "Address Source"
-msgstr "Osoite löytyi"
+msgstr "Osoitelähde"
 
 #: gnucash/report/reports/standard/new-aging.scm:50
 msgid ""
@@ -25479,62 +24464,48 @@ msgid ""
 msgstr ""
 
 #: gnucash/report/reports/standard/new-aging.scm:52
-#, fuzzy
-#| msgid "Company Address"
 msgid "Display Address 1."
-msgstr "Yrityksen osoite"
+msgstr "Näytä osoite 1."
 
 #: gnucash/report/reports/standard/new-aging.scm:53
-#, fuzzy
-#| msgid "Company Address"
 msgid "Display Address 2."
-msgstr "Yrityksen osoite"
+msgstr "Näytä osoite 2."
 
 #: gnucash/report/reports/standard/new-aging.scm:54
-#, fuzzy
-#| msgid "Company Address"
 msgid "Display Address 3."
-msgstr "Yrityksen osoite"
+msgstr "Näytä osoite 3."
 
 #: gnucash/report/reports/standard/new-aging.scm:55
-#, fuzzy
-#| msgid "Company Address"
 msgid "Display Address 4."
-msgstr "Yrityksen osoite"
+msgstr "Näytä osoite 4."
 
 #: gnucash/report/reports/standard/new-aging.scm:56
-#, fuzzy
-#| msgid "Address Found"
 msgid "Address Phone"
-msgstr "Osoite löytyi"
+msgstr "Osoitteen puhelinnumero"
 
 #: gnucash/report/reports/standard/new-aging.scm:56
 msgid "Display Phone."
-msgstr ""
+msgstr "Näytä puhelin."
 
 #: gnucash/report/reports/standard/new-aging.scm:57
-#, fuzzy
-#| msgid "Address Found"
 msgid "Address Fax"
-msgstr "Osoite löytyi"
+msgstr "Osoitteen faksinumero"
 
 #: gnucash/report/reports/standard/new-aging.scm:57
 msgid "Display Fax."
-msgstr ""
+msgstr "Näytä faksi."
 
 #: gnucash/report/reports/standard/new-aging.scm:58
-#, fuzzy
-#| msgid "Address Found"
 msgid "Address Email"
-msgstr "Osoite löytyi"
+msgstr "Osoitteen sähköpostiosoite"
 
 #: gnucash/report/reports/standard/new-aging.scm:58
 msgid "Display Email."
-msgstr ""
+msgstr "Näytä sähköposti."
 
 #: gnucash/report/reports/standard/new-aging.scm:59
 msgid "Display Active status."
-msgstr ""
+msgstr "Näytä onko aktiivinen."
 
 #: gnucash/report/reports/standard/new-aging.scm:61
 msgid ""
@@ -25549,11 +24520,11 @@ msgstr ""
 
 #: gnucash/report/reports/standard/new-aging.scm:89
 msgid "Sort companies by."
-msgstr ""
+msgstr "Yritysten lajitteluperuste."
 
 #: gnucash/report/reports/standard/new-aging.scm:92
 msgid "Name of the company"
-msgstr ""
+msgstr "Yrityksen nimi"
 
 #: gnucash/report/reports/standard/new-aging.scm:93
 msgid "Total amount owed to/from Company"
@@ -25565,7 +24536,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/new-aging.scm:97
 msgid "Sort order."
-msgstr ""
+msgstr "Järjestyksen suunta."
 
 #: gnucash/report/reports/standard/new-aging.scm:105
 msgid "Show all vendors/customers even if they have a zero balance."
@@ -25574,76 +24545,68 @@ msgstr ""
 #: gnucash/report/reports/standard/new-aging.scm:109
 #: gnucash/report/reports/standard/new-owner-report.scm:935
 msgid "Leading date."
-msgstr ""
+msgstr "Määrittelevä päiväys."
 
 #: gnucash/report/reports/standard/new-aging.scm:145
 msgctxt "One-letter indication for 'yes'"
 msgid "Y"
-msgstr ""
+msgstr "K"
 
 #: gnucash/report/reports/standard/new-aging.scm:145
-#, fuzzy
-#| msgid "No"
 msgctxt "One-letter indication for 'no'"
 msgid "N"
-msgstr "Ei"
+msgstr "E"
 
 #: gnucash/report/reports/standard/new-aging.scm:178
 #: gnucash/report/reports/standard/new-owner-report.scm:306
 msgid "Current"
-msgstr ""
+msgstr "Nyt"
 
 #: gnucash/report/reports/standard/new-aging.scm:179
 #: gnucash/report/reports/standard/new-owner-report.scm:307
 msgid "0-30 days"
-msgstr ""
+msgstr "0–30 päivää"
 
 #: gnucash/report/reports/standard/new-aging.scm:180
 #: gnucash/report/reports/standard/new-owner-report.scm:308
 msgid "31-60 days"
-msgstr ""
+msgstr "31–60 päivää"
 
 #: gnucash/report/reports/standard/new-aging.scm:181
 #: gnucash/report/reports/standard/new-owner-report.scm:309
 msgid "61-90 days"
-msgstr ""
+msgstr "61–90 päivää"
 
 #: gnucash/report/reports/standard/new-aging.scm:182
 #: gnucash/report/reports/standard/new-owner-report.scm:310
 msgid "91+ days"
-msgstr ""
+msgstr "91+ päivää"
 
 #: gnucash/report/reports/standard/new-aging.scm:321
 #: gnucash/report/reports/standard/new-owner-report.scm:533
 msgid "Please note some transactions were not processed"
-msgstr ""
+msgstr "Huomaa, ettei joitain tositteita käsitelty"
 
 #: gnucash/report/reports/standard/new-aging.scm:354
 #, scheme-format
 msgid "Invalid Txn Type ~a"
-msgstr ""
+msgstr "Virheellinen verotustyyppi ~a"
 
 #: gnucash/report/reports/standard/new-aging.scm:364
 msgid "Payment has no owner"
-msgstr ""
+msgstr "Maksulla ei ole omistajaa"
 
 #: gnucash/report/reports/standard/new-aging.scm:392
-#, fuzzy
-#| msgid "Address Found"
 msgid "Address source."
-msgstr "Osoite löytyi"
+msgstr "Osoitelähde."
 
 #: gnucash/report/reports/standard/new-aging.scm:395
-#, fuzzy
-#| msgid "Billing Contact"
 msgid "Billing address"
-msgstr "Laskutusyhteystiedot"
+msgstr "Laskutusosoite"
 
 #: gnucash/report/reports/standard/new-aging.scm:396
-#, fuzzy
-#| msgid "Shipping Contact"
 msgid "Shipping address"
-msgstr "Toimitusyhteystiedot"
+msgstr "Toimitusosoite"
 
 #: gnucash/report/reports/standard/new-aging.scm:410
 msgid "Payable Aging"
@@ -25655,36 +24618,28 @@ msgstr ""
 
 #: gnucash/report/reports/standard/new-owner-report.scm:54
 msgid "Sale"
-msgstr ""
+msgstr "Myynti"
 
 #: gnucash/report/reports/standard/new-owner-report.scm:56
 #: gnucash/report/report-utilities.scm:199
-#, fuzzy
-#| msgid "Credit"
 msgid "Credits"
-msgstr "Kredit"
+msgstr ""
 
 #: gnucash/report/reports/standard/new-owner-report.scm:57
-#, fuzzy
-#| msgid "Debit"
 msgid "Debits"
-msgstr "Debet"
+msgstr ""
 
 #: gnucash/report/reports/standard/new-owner-report.scm:59
-#, fuzzy
-#| msgid "Manage Document Link"
 msgid "Document Links"
-msgstr "Vaihda yhdistettyä asiakirjaa"
+msgstr "Liittyvät asiakirjat"
 
 #: gnucash/report/reports/standard/new-owner-report.scm:60
-#, fuzzy
-#| msgid "Transaction Document Links"
 msgid "Transaction Links"
-msgstr "Tositteen asiakirjalinkit"
+msgstr "Liittyvät tositteet"
 
 #: gnucash/report/reports/standard/new-owner-report.scm:90
 msgid "No valid customer selected."
-msgstr ""
+msgstr "Kelvollista asiakasta ei ole valittu."
 
 #: gnucash/report/reports/standard/new-owner-report.scm:91
 msgid "This report requires a customer to be selected."
@@ -25692,7 +24647,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/new-owner-report.scm:95
 msgid "No valid employee selected."
-msgstr ""
+msgstr "Kelvollista työntekijää ei ole valittu."
 
 #: gnucash/report/reports/standard/new-owner-report.scm:96
 msgid "This report requires a employee to be selected."
@@ -25700,7 +24655,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/new-owner-report.scm:100
 msgid "No valid job selected."
-msgstr ""
+msgstr "Kelvollista työtä ei ole valittu."
 
 #: gnucash/report/reports/standard/new-owner-report.scm:101
 msgid "This report requires a job to be selected."
@@ -25708,7 +24663,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/new-owner-report.scm:105
 msgid "No valid vendor selected."
-msgstr ""
+msgstr "Kelvollista toimittajaa ei ole valittu."
 
 #: gnucash/report/reports/standard/new-owner-report.scm:106
 msgid "This report requires a vendor to be selected."
@@ -25716,7 +24671,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/new-owner-report.scm:230
 msgid "Partial Amount"
-msgstr ""
+msgstr "Osittainen määrä"
 
 #: gnucash/report/reports/standard/new-owner-report.scm:283
 #: gnucash/report/trep-engine.scm:927 gnucash/report/trep-engine.scm:2244
@@ -25732,13 +24687,11 @@ msgstr ""
 
 #: gnucash/report/reports/standard/new-owner-report.scm:335
 msgid "Linked Details"
-msgstr ""
+msgstr "Liitetyt tiedot"
 
 #: gnucash/report/reports/standard/new-owner-report.scm:492
-#, fuzzy
-#| msgid "Period"
 msgid "Period Totals"
-msgstr "Aikaväli"
+msgstr "Jaksojen loppusummat"
 
 #: gnucash/report/reports/standard/new-owner-report.scm:505
 msgid ""
@@ -25746,68 +24699,62 @@ msgid ""
 msgstr ""
 
 #: gnucash/report/reports/standard/new-owner-report.scm:517
-#, fuzzy
-#| msgid "Credit"
 msgid "Total Credit"
-msgstr "Kredit"
+msgstr "Yhteensä kredit"
 
 #: gnucash/report/reports/standard/new-owner-report.scm:518
-#, fuzzy
-#| msgid "Total Entries"
 msgid "Total Due"
-msgstr "Yhteensä tietueita"
+msgstr "Yhteensä erääntyy"
 
 #: gnucash/report/reports/standard/new-owner-report.scm:863
 msgid "The company for this report."
-msgstr ""
+msgstr "Tämän raportin yritys."
 
 #: gnucash/report/reports/standard/new-owner-report.scm:876
 #: gnucash/report/reports/standard/new-owner-report.scm:880
 msgid "Display the transaction date?"
-msgstr ""
+msgstr "Näytä tositteen päiväys?"
 
 #: gnucash/report/reports/standard/new-owner-report.scm:884
 msgid "Display the transaction reference?"
-msgstr ""
+msgstr "Näytä tositeviite?"
 
 #: gnucash/report/reports/standard/new-owner-report.scm:888
 msgid "Display the transaction type?"
-msgstr ""
+msgstr "Näytä tositetyyppi?"
 
 #: gnucash/report/reports/standard/new-owner-report.scm:892
 msgid "Display the transaction description?"
-msgstr ""
+msgstr "Näytä tositekuvaus?"
 
 #: gnucash/report/reports/standard/new-owner-report.scm:896
 msgid "Display the sale amount column?"
-msgstr ""
+msgstr "Näytä myyntimäärä?"
 
 #: gnucash/report/reports/standard/new-owner-report.scm:900
 msgid "Display the tax column?"
-msgstr ""
+msgstr "Näytä verosarake?"
 
 #: gnucash/report/reports/standard/new-owner-report.scm:904
 msgid "Display the period debits column?"
-msgstr ""
+msgstr "Näytä jakson veloitukset -sarake?"
 
 #: gnucash/report/reports/standard/new-owner-report.scm:908
 msgid "Display the period credits column?"
-msgstr ""
+msgstr "Näytä jakson talletukset -sarake?"
 
 #: gnucash/report/reports/standard/new-owner-report.scm:912
 #: gnucash/report/reports/standard/register.scm:395
 msgid "Display a running balance?"
-msgstr ""
+msgstr "Näytä juokseva saldo?"
 
 #: gnucash/report/reports/standard/new-owner-report.scm:919
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Show linked transactions"
-msgstr "Etsi tosite"
+msgstr "Näytä liitetyt tositteet"
 
 #: gnucash/report/reports/standard/new-owner-report.scm:920
 msgid "Linked transactions are hidden."
-msgstr ""
+msgstr "Liitetyt tositteen ovat piilossa."
 
 #: gnucash/report/reports/standard/new-owner-report.scm:921
 msgid "Invoices show if paid, payments show invoice numbers."
@@ -25820,64 +24767,54 @@ msgstr ""
 
 #: gnucash/report/reports/standard/new-owner-report.scm:926
 msgid "Simple"
-msgstr ""
+msgstr "Yksinkertainen"
 
 #: gnucash/report/reports/standard/new-owner-report.scm:927
 msgid "Detailed"
-msgstr ""
+msgstr "Yksityiskohtainen"
 
 #: gnucash/report/reports/standard/new-owner-report.scm:931
-#, fuzzy
-#| msgid "Business Document Links"
 msgid "Display document link?"
-msgstr "Yrityksen asiakirjalinkit"
+msgstr "Näytä yhdistetty asiakirja?"
 
 #: gnucash/report/reports/standard/new-owner-report.scm:1046
-#, fuzzy
-#| msgid "Map Account NOT found"
 msgid "No valid account found"
-msgstr "Karttatiliä EI löytynyt"
+msgstr "Sopivaa tilia ei löydy"
 
 #: gnucash/report/reports/standard/new-owner-report.scm:1047
 msgid "This report requires a valid AP/AR account to be available."
 msgstr ""
 
 #: gnucash/report/reports/standard/new-owner-report.scm:1070
-#, fuzzy
-#| msgid "Transaction Number"
 msgid "No transactions found."
-msgstr "Tositenumero"
+msgstr "Tositteita ei löydy."
 
 #: gnucash/report/reports/standard/new-owner-report.scm:1071
 #: gnucash/report/trep-engine.scm:141
 msgid "No matching transactions found"
-msgstr ""
+msgstr "Osuvia tositteita ei löytynyt"
 
 #: gnucash/report/reports/standard/new-owner-report.scm:1166
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:104
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:164
-#, fuzzy
-#| msgid "Customer ID"
 msgid "Customer Report"
-msgstr "Asiakastunnus"
+msgstr "Asiakasraportti"
 
 #: gnucash/report/reports/standard/new-owner-report.scm:1175
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:119
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:198
 msgid "Vendor Report"
-msgstr ""
+msgstr "Toimittajaraportti"
 
 #: gnucash/report/reports/standard/new-owner-report.scm:1184
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:134
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:232
-#, fuzzy
-#| msgid "Employee Name"
 msgid "Employee Report"
-msgstr "Työntekijän nimi"
+msgstr "Työntekijäraportti"
 
 #: gnucash/report/reports/standard/new-owner-report.scm:1193
 msgid "Job Report"
-msgstr ""
+msgstr "Hankeraportti"
 
 #: gnucash/report/reports/standard/portfolio.scm:33
 msgid "Investment Portfolio"
@@ -25885,7 +24822,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/price-scatter.scm:42
 msgid "Price of Commodity"
-msgstr ""
+msgstr "Hyödykkeen hinta"
 
 #: gnucash/report/reports/standard/price-scatter.scm:44
 msgid "Invert prices"
@@ -25901,17 +24838,15 @@ msgstr ""
 
 #: gnucash/report/reports/standard/price-scatter.scm:67
 msgid "Calculate the price of this commodity."
-msgstr ""
+msgstr "Laske tämän hyödykkeen hinta."
 
 #: gnucash/report/reports/standard/price-scatter.scm:74
 msgid "Weighted Average"
 msgstr ""
 
 #: gnucash/report/reports/standard/price-scatter.scm:75
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Actual Transactions"
-msgstr "Etsi tosite"
+msgstr ""
 
 #: gnucash/report/reports/standard/price-scatter.scm:81
 msgid "Plot commodity per currency rather than currency per commodity."
@@ -25923,7 +24858,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/price-scatter.scm:113
 msgid "Weeks"
-msgstr ""
+msgstr "Viikkoa"
 
 #: gnucash/report/reports/standard/price-scatter.scm:114
 msgid "Double-Weeks"
@@ -25931,11 +24866,11 @@ msgstr ""
 
 #: gnucash/report/reports/standard/price-scatter.scm:116
 msgid "Quarters"
-msgstr ""
+msgstr "Neljänneksittäin"
 
 #: gnucash/report/reports/standard/price-scatter.scm:117
 msgid "Half Years"
-msgstr ""
+msgstr "Puolivuosittain"
 
 #: gnucash/report/reports/standard/price-scatter.scm:212
 msgid "Identical commodities"
@@ -25955,7 +24890,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/price-scatter.scm:256
 msgid "Only one price"
-msgstr ""
+msgstr "Vain yksi hinta"
 
 #: gnucash/report/reports/standard/price-scatter.scm:257
 msgid ""
@@ -25965,7 +24900,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/price-scatter.scm:263
 msgid "All Prices equal"
-msgstr ""
+msgstr "Kaikki hinnat samoja"
 
 #: gnucash/report/reports/standard/price-scatter.scm:264
 msgid ""
@@ -25985,43 +24920,43 @@ msgstr ""
 
 #: gnucash/report/reports/standard/price-scatter.scm:303
 msgid "Price Scatterplot"
-msgstr ""
+msgstr "Hintojen hajontakuvaaja"
 
 #: gnucash/report/reports/standard/receipt.scm:36
 #: gnucash/report/reports/standard/taxinvoice.scm:67
 msgid "Headings 1"
-msgstr ""
+msgstr "Otsikko 1"
 
 #: gnucash/report/reports/standard/receipt.scm:37
 #: gnucash/report/reports/standard/taxinvoice.scm:68
 msgid "Headings 2"
-msgstr ""
+msgstr "Otsikko 2"
 
 #: gnucash/report/reports/standard/receipt.scm:46
 #: gnucash/report/reports/standard/taxinvoice.scm:96
 msgid "Heading font"
-msgstr ""
+msgstr "Otsikon fontti"
 
 #: gnucash/report/reports/standard/receipt.scm:47
 #: gnucash/report/reports/standard/taxinvoice.scm:97
 msgid "Text font"
-msgstr ""
+msgstr "Tekstin fontti"
 
 #: gnucash/report/reports/standard/receipt.scm:48
 msgid "Header logo filename"
-msgstr ""
+msgstr "Ylätunnisteen logon tiedostonimi"
 
 #: gnucash/report/reports/standard/receipt.scm:49
 msgid "Header logo width"
-msgstr ""
+msgstr "Ylätunnisteen logon leveys"
 
 #: gnucash/report/reports/standard/receipt.scm:50
 msgid "Footer logo filename"
-msgstr ""
+msgstr "Alatunnisteen logon tiedostonimi"
 
 #: gnucash/report/reports/standard/receipt.scm:51
 msgid "Footer logo width"
-msgstr ""
+msgstr "Alatunnisteen logon leveys"
 
 #: gnucash/report/reports/standard/receipt.scm:53
 #: gnucash/report/reports/standard/receipt.scm:116
@@ -26035,41 +24970,37 @@ msgstr ""
 #: gnucash/report/reports/standard/taxinvoice.scm:103
 #: gnucash/report/reports/standard/taxinvoice.scm:185
 msgid "Discount Rate"
-msgstr ""
+msgstr "Alennusprosentti"
 
 #: gnucash/report/reports/standard/receipt.scm:56
 #: gnucash/report/reports/standard/receipt.scm:122
 #: gnucash/report/reports/standard/taxinvoice.scm:104
 #: gnucash/report/reports/standard/taxinvoice.scm:187
 msgid "Discount Amount"
-msgstr ""
+msgstr "Alennusmäärä"
 
 #: gnucash/report/reports/standard/receipt.scm:58
 #: gnucash/report/reports/standard/receipt.scm:126
 #: gnucash/report/reports/standard/taxinvoice.scm:106
 #: gnucash/report/reports/standard/taxinvoice.scm:191
-#, fuzzy
-#| msgid "Tax related"
 msgid "Tax Rate"
-msgstr "Veroihin liittyvä"
+msgstr "Veroprosentti"
 
 #: gnucash/report/reports/standard/receipt.scm:61
 #: gnucash/report/reports/standard/receipt.scm:132
 #: gnucash/report/reports/standard/taxinvoice.scm:109
 #: gnucash/report/reports/standard/taxinvoice.scm:197
 msgid "Sub-total"
-msgstr ""
+msgstr "Välisumma"
 
 #: gnucash/report/reports/standard/receipt.scm:63
 #: gnucash/report/reports/standard/taxinvoice.scm:111
 msgid "Payment received text"
-msgstr ""
+msgstr "Maksu vastaanotettu -teksti"
 
 #: gnucash/report/reports/standard/receipt.scm:65
-#, fuzzy
-#| msgid "Fancy Date Format"
 msgid "Today date format"
-msgstr "Hieno päivämäärämuoto"
+msgstr "Päiväyksen muoto"
 
 #: gnucash/report/reports/standard/receipt.scm:77
 #: gnucash/report/reports/standard/taxinvoice.scm:149
@@ -26132,7 +25063,7 @@ msgstr ""
 #: gnucash/report/reports/standard/receipt.scm:137
 #: gnucash/report/reports/standard/taxinvoice.scm:202
 msgid "Payment received, thank you!"
-msgstr ""
+msgstr "Maksu vastaanotettu, kiitos!"
 
 #: gnucash/report/reports/standard/receipt.scm:141
 msgid "Notes added at end of invoice -- may contain HTML markup"
@@ -26152,69 +25083,61 @@ msgstr ""
 #: gnucash/report/reports/standard/reconcile-report.scm:85
 #: libgnucash/engine/Account.cpp:149
 msgid "Funds In"
-msgstr ""
+msgstr "Varoja sisään"
 
 #: gnucash/report/reports/standard/reconcile-report.scm:92
 #: libgnucash/engine/Account.cpp:169
 msgid "Funds Out"
-msgstr ""
+msgstr "Varoja ulos"
 
 #: gnucash/report/reports/standard/reconcile-report.scm:108
-#, fuzzy
-#| msgid "Reconciled Date"
 msgid "Reconciliation Report"
-msgstr "Tarkistuspäivämäärä"
+msgstr "Täsmäysraportti"
 
 #: gnucash/report/reports/standard/register.scm:147
 #: gnucash/report/reports/standard/register.scm:374
 #: libgnucash/engine/gnc-lot.cpp:791
 msgid "Lot"
-msgstr ""
+msgstr "Erä"
 
 #: gnucash/report/reports/standard/register.scm:159
-#, fuzzy
-#| msgid "Debit"
 msgid "Debit Value"
-msgstr "Debet"
+msgstr "Debit-arvo"
 
 #: gnucash/report/reports/standard/register.scm:161
-#, fuzzy
-#| msgid "Credit"
 msgid "Credit Value"
-msgstr "Kredit"
+msgstr "Kredit-arvo"
 
 #: gnucash/report/reports/standard/register.scm:342
 msgid "The title of the report."
-msgstr ""
+msgstr "Raportin otsikko."
 
 #: gnucash/report/reports/standard/register.scm:343
 msgid "Register Report"
-msgstr ""
+msgstr "Tilikirjaraportti"
 
 #: gnucash/report/reports/standard/register.scm:352
 msgid "Display the check number/action?"
-msgstr ""
+msgstr "Näytä šekkinumero/tapahtuma?"
 
 #: gnucash/report/reports/standard/register.scm:355
 #: gnucash/report/trep-engine.scm:915 gnucash/report/trep-engine.scm:916
 msgid "Display the check number?"
-msgstr ""
+msgstr "Näytä šekkinumero?"
 
 #: gnucash/report/reports/standard/register.scm:363
 #: gnucash/report/trep-engine.scm:943
 msgid "Display the memo?"
-msgstr ""
+msgstr "Näytä muistiinpano?"
 
 #: gnucash/report/reports/standard/register.scm:367
-#, fuzzy
-#| msgid "via Escrow account?"
 msgid "Display the account?"
-msgstr "sulkutilin kautta?"
+msgstr "Näytä tili?"
 
 #: gnucash/report/reports/standard/register.scm:371
 #: gnucash/report/trep-engine.scm:926
 msgid "Display the number of shares?"
-msgstr ""
+msgstr "Näytä osakkeiden määrä?"
 
 #: gnucash/report/reports/standard/register.scm:375
 msgid "Display the name of lot the shares are in?"
@@ -26223,54 +25146,50 @@ msgstr ""
 #: gnucash/report/reports/standard/register.scm:379
 #: gnucash/report/trep-engine.scm:928
 msgid "Display the shares price?"
-msgstr ""
+msgstr "Näytä osakkeiden hinta?"
 
 #: gnucash/report/reports/standard/register.scm:383
 #: gnucash/report/trep-engine.scm:976
 msgid "Display the amount?"
-msgstr ""
+msgstr "Näytä summa?"
 
 #: gnucash/report/reports/standard/register.scm:386
 #: gnucash/report/trep-engine.scm:980
 msgid "Single Column"
-msgstr ""
+msgstr "Yksisarakkeinen"
 
 #: gnucash/report/reports/standard/register.scm:387
 #: gnucash/report/trep-engine.scm:981
 msgid "Two Columns"
-msgstr ""
+msgstr "Kaksisarakkeinen"
 
 #: gnucash/report/reports/standard/register.scm:391
 msgid "Display the value in transaction currency?"
-msgstr ""
+msgstr "Näytä arvo tositteen valuutassa?"
 
 #: gnucash/report/reports/standard/register.scm:399
 msgid "Display the totals?"
-msgstr ""
+msgstr "Näytä summat?"
 
 #: gnucash/report/reports/standard/register.scm:538
-#, fuzzy
-#| msgid "Total Entries"
 msgid "Total Debits"
-msgstr "Yhteensä tietueita"
+msgstr "Yhteensä debet"
 
 #: gnucash/report/reports/standard/register.scm:540
-#, fuzzy
-#| msgid "Total Entries"
 msgid "Total Credits"
-msgstr "Yhteensä tietueita"
+msgstr "Yhteensä kredit"
 
 #: gnucash/report/reports/standard/register.scm:542
 msgid "Total Value Debits"
-msgstr ""
+msgstr "Debit-arvo yhteensä"
 
 #: gnucash/report/reports/standard/register.scm:544
 msgid "Total Value Credits"
-msgstr ""
+msgstr "Kredit-arvo yhteensä"
 
 #: gnucash/report/reports/standard/register.scm:547
 msgid "Net Change"
-msgstr ""
+msgstr "Nettomuutos"
 
 #: gnucash/report/reports/standard/register.scm:549
 msgid "Value Change"
@@ -26282,45 +25201,39 @@ msgstr ""
 
 #: gnucash/report/reports/standard/taxinvoice.scm:71
 msgid "Elements"
-msgstr ""
+msgstr "Elementit"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:73
 msgid "column: Date"
-msgstr ""
+msgstr "sarake: Päiväys"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:74
 msgid "column: Tax Rate"
-msgstr ""
+msgstr "sarake: Veroprosentti"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:75
 msgid "column: Units"
-msgstr ""
+msgstr "sarake: Yksiköt"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:76
-#, fuzzy
-#| msgid "Company Address"
 msgid "row: Address"
-msgstr "Yrityksen osoite"
+msgstr "rivi: Osoite"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:77
-#, fuzzy
-#| msgid "Contact"
 msgid "row: Contact"
-msgstr "Yhteyshenkilö"
+msgstr "rivi: Yhteystieto"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:78
 msgid "row: Invoice Number"
-msgstr ""
+msgstr "rivi: Laskun numero"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:79
-#, fuzzy
-#| msgid "Company Name"
 msgid "row: Company Name"
-msgstr "Yrityksen nimi"
+msgstr "rivi: Yrityksen nimi"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:80
 msgid "Invoice number text"
-msgstr ""
+msgstr "Laskun numero teksti"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:81
 msgid "To text"
@@ -26332,33 +25245,31 @@ msgstr ""
 
 #: gnucash/report/reports/standard/taxinvoice.scm:83
 msgid "Job Name text"
-msgstr ""
+msgstr "Työn nimiteksti"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:84
 msgid "Job Number text"
-msgstr ""
+msgstr "Hankenumeroteksti"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:85
 msgid "Show Job name"
-msgstr ""
+msgstr "Näytä hankkeen nimi"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:86
 msgid "Show Job number"
-msgstr ""
+msgstr "Näytä hankkeen numero"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:87
-#, fuzzy
-#| msgid "Share Price"
 msgid "Show net price"
-msgstr "Osuuden arvo"
+msgstr "Näytä nettohinta"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:88
 msgid "Invoice number next to title"
-msgstr ""
+msgstr "Laskun numero otsikon viereen"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:89
 msgid "table-border-collapse"
-msgstr ""
+msgstr "table-border-collapse"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:90
 msgid "table-header-border-color"
@@ -26370,59 +25281,55 @@ msgstr ""
 
 #: gnucash/report/reports/standard/taxinvoice.scm:92
 msgid "Embedded CSS"
-msgstr ""
+msgstr "Upotettu CSS"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:98
 msgid "Logo filename"
-msgstr ""
+msgstr "Logon tiedostonimi"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:99
 msgid "Logo width"
-msgstr ""
+msgstr "Logon leveys"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:126
 msgid "Display the Tax Rate?"
-msgstr ""
+msgstr "Näytä veroprosentti?"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:128
 msgid "Display the Units?"
-msgstr ""
+msgstr "Näytä yksiköt?"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:130
 msgid "Display the contact?"
-msgstr ""
+msgstr "Näytä yhteystieto?"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:132
 msgid "Display the address?"
-msgstr ""
+msgstr "Näytä osoite?"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:134
 msgid "Display the Invoice Number?"
-msgstr ""
+msgstr "Näytä laskun numero?"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:136
-#, fuzzy
-#| msgid "Company Name"
 msgid "Display the Company Name?"
-msgstr "Yrityksen nimi"
+msgstr "Näytä yrityksen nimi?"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:138
 msgid "Invoice Number next to title?"
-msgstr ""
+msgstr "Laskun numero otsikon viereen?"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:140
 msgid "Display Job name?"
-msgstr ""
+msgstr "Näytä hankkeen nimi?"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:142
 msgid "Invoice Job number?"
-msgstr ""
+msgstr "Myyntilaskun hankkeen numero?"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:144
-#, fuzzy
-#| msgid "Share Price"
 msgid "Show net price?"
-msgstr "Osuuden arvo"
+msgstr "Näytä nettohinta?"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:163
 msgid "Name of a file containing a logo to be used on the report."
@@ -26446,15 +25353,15 @@ msgstr ""
 
 #: gnucash/report/reports/standard/taxinvoice.scm:205
 msgid "Invoice number:"
-msgstr "Laskunumero:"
+msgstr "Myyntilaskun numero:"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:208
 msgid "To:"
-msgstr ""
+msgstr "Päättyen:"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:211
 msgid "Your ref:"
-msgstr ""
+msgstr "Viitteenne:"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:226
 msgid "Embedded CSS."
@@ -26466,38 +25373,36 @@ msgstr ""
 
 #: gnucash/report/reports/standard/taxinvoice.scm:316
 msgid "Unit"
-msgstr ""
+msgstr "Yksikkö"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:317
 msgid "GST Rate"
-msgstr ""
+msgstr "LVV prosentti"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:318
 msgid "GST Amount"
-msgstr ""
+msgstr "LVV määrä"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:319
 msgid "Amount Due (inc GST)"
-msgstr ""
+msgstr "Maksettava (sis. GST eli kulutusvero)"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:320
-#, fuzzy
-#| msgid "Invoice"
 msgid "Invoice #: "
-msgstr "Myyntilasku"
+msgstr "Lasku #: "
 
 #: gnucash/report/reports/standard/taxinvoice.scm:321
 msgid "Reference: "
-msgstr ""
+msgstr "Viite: "
 
 #: gnucash/report/reports/standard/taxinvoice.scm:322
 msgid "Engagement: "
-msgstr ""
+msgstr "Toimeksianto: "
 
 #: gnucash/report/reports/standard/taxinvoice.scm:328
 #: gnucash/report/reports/standard/taxinvoice.scm:330
 msgid "Australian Tax Invoice"
-msgstr ""
+msgstr "Australialainen verolasku"
 
 #: gnucash/report/reports/standard/taxinvoice.scm:331
 msgid ""
@@ -26507,10 +25412,8 @@ msgstr ""
 
 #: gnucash/report/reports/standard/trial-balance.scm:58
 #: gnucash/report/reports/standard/trial-balance.scm:532
-#, fuzzy
-#| msgid "Opening Balance"
 msgid "Trial Balance"
-msgstr "Avaussaldo"
+msgstr "Koetase"
 
 #: gnucash/report/reports/standard/trial-balance.scm:65
 msgid "Start of Adjusting/Closing"
@@ -26518,11 +25421,11 @@ msgstr ""
 
 #: gnucash/report/reports/standard/trial-balance.scm:66
 msgid "Date of Report"
-msgstr ""
+msgstr "Raportin päivämäärä"
 
 #: gnucash/report/reports/standard/trial-balance.scm:67
 msgid "Report variation"
-msgstr ""
+msgstr "Raportin variaatio"
 
 #: gnucash/report/reports/standard/trial-balance.scm:68
 msgid "Kind of trial balance to generate."
@@ -26554,10 +25457,8 @@ msgid ""
 msgstr ""
 
 #: gnucash/report/reports/standard/trial-balance.scm:86
-#, fuzzy
-#| msgid "Closing Entries"
 msgid "Adjusting Entries pattern"
-msgstr "Tilinpäätöstositteet"
+msgstr ""
 
 #: gnucash/report/reports/standard/trial-balance.scm:88
 msgid "Any text in the Description column which identifies adjusting entries."
@@ -26582,23 +25483,19 @@ msgstr ""
 
 #: gnucash/report/reports/standard/trial-balance.scm:188
 msgid "General journal exact balances"
-msgstr ""
+msgstr "Päiväkirjan tarkat saldot"
 
 #: gnucash/report/reports/standard/trial-balance.scm:189
-#, fuzzy
-#| msgid "Closing Entries"
 msgid "No adjusting/closing entries"
-msgstr "Tilinpäätöstositteet"
+msgstr "Ei oikaisu- tai tilinpäätöskirjauksia"
 
 #: gnucash/report/reports/standard/trial-balance.scm:190
 msgid "Full end-of-period work sheet"
 msgstr ""
 
 #: gnucash/report/reports/standard/trial-balance.scm:247
-#, fuzzy
-#| msgid "Closing Entries"
 msgid "Adjusting Entries"
-msgstr "Tilinpäätöstositteet"
+msgstr ""
 
 #: gnucash/report/reports/standard/trial-balance.scm:370
 msgid "${company-name} ${report-title} ${date}"
@@ -26614,17 +25511,16 @@ msgstr ""
 
 #: gnucash/report/reports/standard/trial-balance.scm:823
 msgid "Net Loss"
-msgstr ""
+msgstr "Kulut"
 
 #: gnucash/report/reports/standard/txn-columns.scm:33
 #, fuzzy
-#| msgid "Transaction Number"
 msgid "Transaction Breakdown Report"
-msgstr "Tositenumero"
+msgstr "Tositeraportti"
 
 #: gnucash/report/reports/standard/txn-columns.scm:37
 msgid "Limit for number of columns"
-msgstr ""
+msgstr "Raja sarakkeiden määrälle"
 
 #: gnucash/report/reports/standard/txn-columns.scm:38
 msgid "Set the upper limit for number of columns"
@@ -26632,7 +25528,7 @@ msgstr ""
 
 #: gnucash/report/reports/standard/txn-columns.scm:154
 msgid "Too many accounts"
-msgstr ""
+msgstr "Liian monta tiliä"
 
 #: gnucash/report/reports/standard/txn-columns.scm:155
 msgid ""
@@ -26643,10 +25539,8 @@ msgstr ""
 
 #: gnucash/report/reports/standard/view-column.scm:45
 #: gnucash/report/reports/standard/view-column.scm:56
-#, fuzzy
-#| msgid "Number/Action"
 msgid "Number of columns"
-msgstr "Numero/Tapahtuma"
+msgstr "Sarakkeiden määrä"
 
 #: gnucash/report/reports/standard/view-column.scm:46
 msgid "Number of columns before wrapping to a new row."
@@ -26654,44 +25548,36 @@ msgstr ""
 
 #: gnucash/report/reports/standard/view-column.scm:123
 msgid "Edit Options"
-msgstr ""
+msgstr "Muokkaa asetuksia"
 
 #: gnucash/report/reports/standard/view-column.scm:130
 msgid "Single Report"
-msgstr ""
+msgstr "Yksittäinen raportti"
 
 #: gnucash/report/reports/standard/view-column.scm:182
 msgid "Multicolumn View"
-msgstr ""
+msgstr "Monisarakenäkymä"
 
 #: gnucash/report/reports/standard/view-column.scm:184
 msgid "Custom Multicolumn Report"
-msgstr ""
+msgstr "Mukautettu monisarakeraportti"
 
 #: gnucash/report/reports/support/balsheet-eg.eguile.scm:167
-#, fuzzy
-#| msgid "All Accounts"
 msgid "Assets Accounts"
-msgstr "Kaikki tilit"
+msgstr "Vastaavaa tilit"
 
 #: gnucash/report/reports/support/balsheet-eg.eguile.scm:173
-#, fuzzy
-#| msgid "All Accounts"
 msgid "Liability Accounts"
-msgstr "Kaikki tilit"
+msgstr "Vastattavaa tilit"
 
 #: gnucash/report/reports/support/balsheet-eg.eguile.scm:179
-#, fuzzy
-#| msgid "All Accounts"
 msgid "Equity Accounts"
-msgstr "Kaikki tilit"
+msgstr "Oman pääoman tilit"
 
 #: gnucash/report/reports/support/balsheet-eg.eguile.scm:182
 #: gnucash/report/report-utilities.scm:214
-#, fuzzy
-#| msgid "Find Account"
 msgid "Trading Accounts"
-msgstr "Etsi tili"
+msgstr "Muunnostilit"
 
 #: gnucash/report/reports/support/balsheet-eg.eguile.scm:241
 msgid "Total Equity, Trading, and Liabilities"
@@ -26699,17 +25585,15 @@ msgstr ""
 
 #: gnucash/report/reports/support/balsheet-eg.eguile.scm:250
 msgid "Imbalance Amount"
-msgstr ""
+msgstr "Epätasapainoinen summa"
 
 #: gnucash/report/reports/support/balsheet-eg.eguile.scm:267
 msgid "<strong>Exchange Rates</strong> used for this report"
 msgstr ""
 
 #: gnucash/report/reports/support/receipt.eguile.scm:124
-#, fuzzy
-#| msgid "Invoice"
 msgid "Invoice No."
-msgstr "Myyntilasku"
+msgstr "Laskun numero"
 
 #: gnucash/report/reports/support/receipt.eguile.scm:144
 msgid "Descr."
@@ -26729,28 +25613,23 @@ msgstr ""
 
 #: gnucash/report/reports/support/taxinvoice.eguile.scm:193
 msgid "Website"
-msgstr ""
+msgstr "Web-sivusto"
 
 #: gnucash/report/reports/support/taxinvoice.eguile.scm:229
-#, fuzzy
-#| msgid "Invoice"
 msgid "Invoice Date"
-msgstr "Myyntilasku"
+msgstr "Laskun päiväys"
 
 #: gnucash/report/report-utilities.scm:202
-#, fuzzy
-#| msgctxt "Stock Assistant: Page name"
-#| msgid "Stock"
 msgid "Stocks"
-msgstr "Osake"
+msgstr "Osakkeet"
 
 #: gnucash/report/report-utilities.scm:203
 msgid "Mutual Funds"
-msgstr ""
+msgstr "Sijoitusrahastot"
 
 #: gnucash/report/report-utilities.scm:204
 msgid "Currencies"
-msgstr ""
+msgstr "Valuutat"
 
 #: gnucash/report/report-utilities.scm:207
 msgid "Equities"
@@ -26762,43 +25641,37 @@ msgstr ""
 
 #: gnucash/report/report-utilities.scm:209
 msgid "Savings"
-msgstr ""
+msgstr "Säästö"
 
 #: gnucash/report/report-utilities.scm:210
 msgid "Money Market"
 msgstr ""
 
 #: gnucash/report/report-utilities.scm:211
-#, fuzzy
-#| msgid "Accounts in Category"
 msgid "Accounts Receivable"
-msgstr "Kategorian tilit"
+msgstr "Myyntisaamiset"
 
 #: gnucash/report/report-utilities.scm:212
-#, fuzzy
-#| msgid "Account Types"
 msgid "Accounts Payable"
-msgstr "Tilityypit"
+msgstr "Ostovelat"
 
 #: gnucash/report/report-utilities.scm:213
-#, fuzzy
-#| msgid "Credit"
 msgid "Credit Lines"
-msgstr "Kredit"
+msgstr ""
 
 #: gnucash/report/report-utilities.scm:639
 #, scheme-format
 msgid "Building '~a' report …"
-msgstr ""
+msgstr "Rakennetaan raporttia '~a' …"
 
 #: gnucash/report/report-utilities.scm:645
 #, scheme-format
 msgid "Rendering '~a' report …"
-msgstr ""
+msgstr "Luodaan raportin '~a' näkymää …"
 
 #: gnucash/report/report-utilities.scm:647
 msgid "Untitled"
-msgstr ""
+msgstr "Nimetön"
 
 #: gnucash/report/stylesheets/css.scm:119
 msgid "CSS code. This field specifies the CSS code for styling reports."
@@ -26810,59 +25683,59 @@ msgstr ""
 
 #: gnucash/report/stylesheets/css.scm:228
 msgid "CSS-based stylesheet (experimental)"
-msgstr ""
+msgstr "CSS-pohjainen tyylitiedosto (kokeellinen)"
 
 #: gnucash/report/stylesheets/footer.scm:50
 #: gnucash/report/stylesheets/head-or-tail.scm:50
 msgid "Preparer"
-msgstr ""
+msgstr "Tekijä"
 
 #: gnucash/report/stylesheets/footer.scm:51
 #: gnucash/report/stylesheets/head-or-tail.scm:51
 msgid "Name of person preparing the report."
-msgstr ""
+msgstr "Raportin tekevä henkilö."
 
 #: gnucash/report/stylesheets/footer.scm:56
 #: gnucash/report/stylesheets/head-or-tail.scm:55
 msgid "Prepared for"
-msgstr ""
+msgstr "Raportin omistaja"
 
 #: gnucash/report/stylesheets/footer.scm:57
 #: gnucash/report/stylesheets/head-or-tail.scm:56
 msgid "Name of organization or company prepared for."
-msgstr ""
+msgstr "Yrityksen tai organisaation nimi, jolle raportti on tehty."
 
 #: gnucash/report/stylesheets/footer.scm:62
 #: gnucash/report/stylesheets/head-or-tail.scm:60
 msgid "Show preparer info"
-msgstr ""
+msgstr "Näytä tekijän tiedot"
 
 #: gnucash/report/stylesheets/footer.scm:63
 #: gnucash/report/stylesheets/head-or-tail.scm:61
 msgid "Name of organization or company."
-msgstr ""
+msgstr "Organisaation tai yrityksen nimi."
 
 #: gnucash/report/stylesheets/footer.scm:68
 #: gnucash/report/stylesheets/head-or-tail.scm:85
 #: gnucash/report/stylesheets/plain.scm:50 gnucash/report/trep-engine.scm:987
 msgid "Enable Links"
-msgstr ""
+msgstr "Käytä linkkejä"
 
 #: gnucash/report/stylesheets/footer.scm:69
 #: gnucash/report/stylesheets/head-or-tail.scm:86
 #: gnucash/report/stylesheets/plain.scm:50
 msgid "Enable hyperlinks in reports."
-msgstr ""
+msgstr "Käytä linkkejä raporteissa."
 
 #: gnucash/report/stylesheets/footer.scm:74
 #: gnucash/report/stylesheets/footer.scm:392
 #: gnucash/report/stylesheets/footer.scm:398
 msgid "Footer"
-msgstr ""
+msgstr "Alaviite"
 
 #: gnucash/report/stylesheets/footer.scm:75
 msgid "String to be placed as a footer."
-msgstr ""
+msgstr "Teksti jota käytetään raportin alaviitteenä."
 
 #: gnucash/report/stylesheets/footer.scm:79
 #: gnucash/report/stylesheets/footer.scm:84
@@ -26873,141 +25746,137 @@ msgstr ""
 #: gnucash/report/stylesheets/head-or-tail.scm:130
 #: gnucash/report/stylesheets/head-or-tail.scm:137
 msgid "Images"
-msgstr ""
+msgstr "Kuvat"
 
 #: gnucash/report/stylesheets/footer.scm:80
 #: gnucash/report/stylesheets/head-or-tail.scm:122
 msgid "Background Tile"
-msgstr ""
+msgstr "Taustan kuvio"
 
 #: gnucash/report/stylesheets/footer.scm:80
 #: gnucash/report/stylesheets/head-or-tail.scm:122
 #: gnucash/report/stylesheets/plain.scm:46
 msgid "Background tile for reports."
-msgstr ""
+msgstr "Raportin taustan kuvio."
 
 #. Translators: Banner is an image like Logo.
 #: gnucash/report/stylesheets/footer.scm:86
 #: gnucash/report/stylesheets/head-or-tail.scm:127
-#, fuzzy
-#| msgid "Opening Balance"
 msgid "Heading Banner"
-msgstr "Avaussaldo"
+msgstr "Otsikon banneri"
 
 #: gnucash/report/stylesheets/footer.scm:86
 #: gnucash/report/stylesheets/footer.scm:91
 #: gnucash/report/stylesheets/head-or-tail.scm:127
 #: gnucash/report/stylesheets/head-or-tail.scm:131
 msgid "Banner for top of report."
-msgstr ""
+msgstr "Raportin yläosan banneri."
 
 #: gnucash/report/stylesheets/footer.scm:91
 #: gnucash/report/stylesheets/head-or-tail.scm:131
 msgid "Heading Alignment"
-msgstr ""
+msgstr "Otsikon sijainti"
 
 #: gnucash/report/stylesheets/footer.scm:93
 #: gnucash/report/stylesheets/head-or-tail.scm:133
 msgid "Left"
-msgstr ""
+msgstr "Vasemmalla"
 
 #: gnucash/report/stylesheets/footer.scm:94
 #: gnucash/report/stylesheets/head-or-tail.scm:134
 msgid "Center"
-msgstr ""
+msgstr "Keskellä"
 
 #: gnucash/report/stylesheets/footer.scm:95
 #: gnucash/report/stylesheets/head-or-tail.scm:135
 msgid "Right"
-msgstr ""
+msgstr "Oikella"
 
 #: gnucash/report/stylesheets/footer.scm:99
 #: gnucash/report/stylesheets/head-or-tail.scm:138
 msgid "Logo"
-msgstr ""
+msgstr "Logo"
 
 #: gnucash/report/stylesheets/footer.scm:99
 #: gnucash/report/stylesheets/head-or-tail.scm:138
-#, fuzzy
-#| msgid "Company Name"
 msgid "Company logo image."
-msgstr "Yrityksen nimi"
+msgstr "Yrityksen logo kuvana."
 
 #: gnucash/report/stylesheets/footer.scm:104
 #: gnucash/report/stylesheets/head-or-tail.scm:143
 msgid "General background color for report."
-msgstr ""
+msgstr "Raportin yleinen taustaväri."
 
 #: gnucash/report/stylesheets/footer.scm:109
 #: gnucash/report/stylesheets/head-or-tail.scm:148
 msgid "Text Color"
-msgstr ""
+msgstr "Tekstin väri"
 
 #: gnucash/report/stylesheets/footer.scm:109
 #: gnucash/report/stylesheets/head-or-tail.scm:148
 msgid "Normal body text color."
-msgstr ""
+msgstr "Leipätekstin väri."
 
 #: gnucash/report/stylesheets/footer.scm:114
 #: gnucash/report/stylesheets/head-or-tail.scm:153
 msgid "Link Color"
-msgstr ""
+msgstr "Linkkien väri"
 
 #: gnucash/report/stylesheets/footer.scm:114
 #: gnucash/report/stylesheets/head-or-tail.scm:153
 msgid "Link text color."
-msgstr ""
+msgstr "Linkkitekstien väri."
 
 #: gnucash/report/stylesheets/footer.scm:119
 #: gnucash/report/stylesheets/head-or-tail.scm:158
 msgid "Table Cell Color"
-msgstr ""
+msgstr "Taulukon solun väri"
 
 #: gnucash/report/stylesheets/footer.scm:119
 #: gnucash/report/stylesheets/head-or-tail.scm:158
 msgid "Default background for table cells."
-msgstr ""
+msgstr "Oletus solun taustavärille."
 
 #: gnucash/report/stylesheets/footer.scm:124
 #: gnucash/report/stylesheets/head-or-tail.scm:163
 #: gnucash/report/stylesheets/plain.scm:54
 msgid "Alternate Table Cell Color"
-msgstr ""
+msgstr "Vaihtoehtoinen taulukon solun väri"
 
 #: gnucash/report/stylesheets/footer.scm:125
 #: gnucash/report/stylesheets/head-or-tail.scm:164
 msgid "Default alternate background for table cells."
-msgstr ""
+msgstr "Oletus vaihtoehtoiselle taulukon taustavärille."
 
 #: gnucash/report/stylesheets/footer.scm:130
 #: gnucash/report/stylesheets/head-or-tail.scm:169
 msgid "Subheading/Subtotal Cell Color"
-msgstr ""
+msgstr "Alaotsikon/välisumman solun väri"
 
 #: gnucash/report/stylesheets/footer.scm:131
 #: gnucash/report/stylesheets/head-or-tail.scm:170
 msgid "Default color for subtotal rows."
-msgstr ""
+msgstr "Oletusväri välisumman riveille."
 
 #: gnucash/report/stylesheets/footer.scm:136
 #: gnucash/report/stylesheets/head-or-tail.scm:175
 msgid "Sub-subheading/total Cell Color"
-msgstr ""
+msgstr "Ala-alaotsikon/summan solun väri"
 
 #: gnucash/report/stylesheets/footer.scm:137
 #: gnucash/report/stylesheets/head-or-tail.scm:176
 msgid "Color for subsubtotals."
-msgstr ""
+msgstr "Väri ala-alasummille."
 
 #: gnucash/report/stylesheets/footer.scm:142
 #: gnucash/report/stylesheets/head-or-tail.scm:181
 msgid "Grand Total Cell Color"
-msgstr ""
+msgstr "Loppusumman solun väri"
 
 #: gnucash/report/stylesheets/footer.scm:143
 #: gnucash/report/stylesheets/head-or-tail.scm:182
 msgid "Color for grand totals."
-msgstr ""
+msgstr "Loppusumman solun väri."
 
 #: gnucash/report/stylesheets/footer.scm:147
 #: gnucash/report/stylesheets/footer.scm:152
@@ -27019,84 +25888,84 @@ msgstr ""
 #: gnucash/report/stylesheets/plain.scm:61
 #: gnucash/report/stylesheets/plain.scm:65
 msgid "Tables"
-msgstr ""
+msgstr "Taulukot"
 
 #: gnucash/report/stylesheets/footer.scm:148
 #: gnucash/report/stylesheets/head-or-tail.scm:187
 #: gnucash/report/stylesheets/plain.scm:58
 msgid "Table cell spacing"
-msgstr ""
+msgstr "Taulukon solujen väli"
 
 #: gnucash/report/stylesheets/footer.scm:148
 #: gnucash/report/stylesheets/head-or-tail.scm:187
 #: gnucash/report/stylesheets/plain.scm:58
 msgid "Space between table cells."
-msgstr ""
+msgstr "Tila taulukon solujen välissä."
 
 #: gnucash/report/stylesheets/footer.scm:153
 #: gnucash/report/stylesheets/head-or-tail.scm:192
 #: gnucash/report/stylesheets/plain.scm:62
 msgid "Table cell padding"
-msgstr ""
+msgstr "Taulukon solujen marginaali"
 
 #: gnucash/report/stylesheets/footer.scm:153
 #: gnucash/report/stylesheets/head-or-tail.scm:192
 #: gnucash/report/stylesheets/plain.scm:62
 msgid "Space between table cell edge and content."
-msgstr ""
+msgstr "Tila taulukon solun reunan ja sisällön välissä."
 
 #: gnucash/report/stylesheets/footer.scm:158
 #: gnucash/report/stylesheets/head-or-tail.scm:197
 #: gnucash/report/stylesheets/plain.scm:66
 msgid "Table border width"
-msgstr ""
+msgstr "Taulukon reunuksen leveys"
 
 #: gnucash/report/stylesheets/footer.scm:158
 #: gnucash/report/stylesheets/head-or-tail.scm:197
 #: gnucash/report/stylesheets/plain.scm:66
 msgid "Bevel depth on tables."
-msgstr ""
+msgstr "Taulukon syvyysliukuma."
 
 #: gnucash/report/stylesheets/footer.scm:338
 #: gnucash/report/stylesheets/head-or-tail.scm:385
 #: gnucash/report/stylesheets/head-or-tail.scm:479
 msgid "Prepared by: "
-msgstr ""
+msgstr "Valmistellut: "
 
 #: gnucash/report/stylesheets/footer.scm:341
 #: gnucash/report/stylesheets/head-or-tail.scm:393
 #: gnucash/report/stylesheets/head-or-tail.scm:487
 msgid "Prepared for: "
-msgstr ""
+msgstr "Valmisteltu: "
 
 #: gnucash/report/stylesheets/footer.scm:380
 #: gnucash/report/stylesheets/footer.scm:396
 msgid "Easy"
-msgstr ""
+msgstr "Helppo"
 
 #: gnucash/report/stylesheets/footer.scm:386
 msgid "Fancy"
-msgstr ""
+msgstr "Hieno"
 
 #: gnucash/report/stylesheets/footer.scm:397
 msgid "Technicolor"
-msgstr ""
+msgstr "Technicolor"
 
 #: gnucash/report/stylesheets/head-or-tail.scm:65
 msgid "Show receiver info"
-msgstr ""
+msgstr "Näytä vastaanottajan tiedot"
 
 #: gnucash/report/stylesheets/head-or-tail.scm:66
 msgid "Name of organization or company the report is prepared for."
-msgstr ""
+msgstr "Yrityksen tai organisaation nimi, jolle raportti on tehty."
 
 #: gnucash/report/stylesheets/head-or-tail.scm:70
 msgid "Show date"
-msgstr ""
+msgstr "Näytä päiväys"
 
 #: gnucash/report/stylesheets/head-or-tail.scm:71
 msgid "The creation date for this report."
-msgstr ""
+msgstr "Näytä raportin luontipäiväys."
 
 #: gnucash/report/stylesheets/head-or-tail.scm:75
 msgid "Show time in addition to date"
@@ -27109,11 +25978,11 @@ msgstr ""
 
 #: gnucash/report/stylesheets/head-or-tail.scm:80
 msgid "Show GnuCash Version"
-msgstr ""
+msgstr "Näytä GnuCashin versio"
 
 #: gnucash/report/stylesheets/head-or-tail.scm:81
 msgid "Show the currently used GnuCash version."
-msgstr ""
+msgstr "Näytä käytössä oleva GnuCashin versio."
 
 #: gnucash/report/stylesheets/head-or-tail.scm:92
 msgid "String for additional report information."
@@ -27121,7 +25990,7 @@ msgstr ""
 
 #: gnucash/report/stylesheets/head-or-tail.scm:96
 msgid "Show preparer info at bottom"
-msgstr ""
+msgstr "Näytä tekijän tiedot lopussa"
 
 #: gnucash/report/stylesheets/head-or-tail.scm:97
 msgid "Per default the preparer info will be shown before the report data."
@@ -27129,7 +25998,7 @@ msgstr ""
 
 #: gnucash/report/stylesheets/head-or-tail.scm:101
 msgid "Show receiver info at bottom"
-msgstr ""
+msgstr "Näytä vastaanottajan tiedot lopussa"
 
 #: gnucash/report/stylesheets/head-or-tail.scm:102
 msgid "Per default the receiver info will be shown before the report data."
@@ -27145,7 +26014,7 @@ msgstr ""
 
 #: gnucash/report/stylesheets/head-or-tail.scm:111
 msgid "Show comments at bottom"
-msgstr ""
+msgstr "Näytä kommentit lopussa"
 
 #: gnucash/report/stylesheets/head-or-tail.scm:112
 msgid ""
@@ -27155,7 +26024,7 @@ msgstr ""
 
 #: gnucash/report/stylesheets/head-or-tail.scm:116
 msgid "Show GnuCash version at bottom"
-msgstr ""
+msgstr "Näytä GnuCashin versio alalaidassa"
 
 #: gnucash/report/stylesheets/head-or-tail.scm:117
 msgid "Per default the GnuCash version will be shown before the report data."
@@ -27166,14 +26035,11 @@ msgstr ""
 #: gnucash/report/stylesheets/head-or-tail.scm:496
 #: gnucash/report/stylesheets/head-or-tail.scm:503
 msgid "Report Creation Date: "
-msgstr ""
+msgstr "Raportin luontipäiväys: "
 
 #: gnucash/report/stylesheets/head-or-tail.scm:511
-#, fuzzy
-#| msgctxt "Stock Assistant: Page name"
-#| msgid "Cash"
 msgid "GnuCash "
-msgstr "Käteinen"
+msgstr "GnuCash "
 
 #: gnucash/report/stylesheets/head-or-tail.scm:526
 #: gnucash/report/stylesheets/head-or-tail.scm:530
@@ -27182,27 +26048,27 @@ msgstr ""
 
 #: gnucash/report/stylesheets/plain.scm:42
 msgid "Background color for reports."
-msgstr ""
+msgstr "Raportin taustan väri."
 
 #: gnucash/report/stylesheets/plain.scm:46
 msgid "Background Pixmap"
-msgstr ""
+msgstr "Taustan kuvio"
 
 #: gnucash/report/stylesheets/plain.scm:54
 msgid "Background color for alternate lines."
-msgstr ""
+msgstr "Taustan väri vaihteleville riveille."
 
 #: gnucash/report/stylesheets/plain.scm:213
 msgid "Plain"
-msgstr ""
+msgstr "Perus"
 
 #: gnucash/report/trep-engine.scm:72
 msgid "Filter Type"
-msgstr ""
+msgstr "Suodattimen toiminta"
 
 #: gnucash/report/trep-engine.scm:76
 msgid "Subtotal Table"
-msgstr ""
+msgstr "Välisummataulu"
 
 #. Translators: a running total is a total that is continually adjusted on every line.
 #. To be consistent, also consider how the term "Running Balance" is translated.
@@ -27210,13 +26076,11 @@ msgstr ""
 #. To be consistent, also consider how the singular form "Running Total" is translated.
 #: gnucash/report/trep-engine.scm:82
 msgid "Running Totals"
-msgstr ""
+msgstr "Juoksevat saldot"
 
 #: gnucash/report/trep-engine.scm:92 gnucash/report/trep-engine.scm:2285
-#, fuzzy
-#| msgid "Description"
 msgid "Show Account Description"
-msgstr "Selite"
+msgstr "Näytä tilin kuvaus"
 
 #: gnucash/report/trep-engine.scm:93
 msgid "Show Informal Debit/Credit Headers"
@@ -27224,27 +26088,23 @@ msgstr ""
 
 #: gnucash/report/trep-engine.scm:95
 msgid "Show subtotals only (hide transactional data)"
-msgstr ""
+msgstr "Näytä vain välisummat (piilota tositetiedot)"
 
 #: gnucash/report/trep-engine.scm:96
 msgid "Add indenting columns"
 msgstr ""
 
 #: gnucash/report/trep-engine.scm:105
-#, fuzzy
-#| msgid "Date Posted"
 msgid "Date Filter"
-msgstr "Vientipäivä"
+msgstr "Päiväyssuodin"
 
 #: gnucash/report/trep-engine.scm:106
 msgid "Table for Exporting"
 msgstr ""
 
 #: gnucash/report/trep-engine.scm:118
-#, fuzzy
-#| msgid "Accounts in Category"
 msgid "Account Name Filter"
-msgstr "Kategorian tilit"
+msgstr "Tilin nimisuodin"
 
 #: gnucash/report/trep-engine.scm:120
 msgid "Use regular expressions for account name filter"
@@ -27252,17 +26112,15 @@ msgstr ""
 
 #: gnucash/report/trep-engine.scm:122
 msgid "Account Name Filter excludes matched strings"
-msgstr ""
+msgstr "Tilin nimi -suodatin sulkee pois sopivat merkkijonot"
 
 #: gnucash/report/trep-engine.scm:123
-#, fuzzy
-#| msgid "Transaction Number"
 msgid "Transaction Filter"
-msgstr "Tositenumero"
+msgstr "Tositesuodin"
 
 #: gnucash/report/trep-engine.scm:125
 msgid "Use regular expressions for transaction filter"
-msgstr ""
+msgstr "Käytä säännöllistä lauseketta tositesuotimena"
 
 #: gnucash/report/trep-engine.scm:127
 msgid "Transaction Filter excludes matched strings"
@@ -27273,22 +26131,16 @@ msgid "Transaction Filter is case insensitive"
 msgstr ""
 
 #: gnucash/report/trep-engine.scm:130 gnucash/report/trep-engine.scm:205
-#, fuzzy
-#| msgid "Reconciled Date"
 msgid "Reconciled Status"
-msgstr "Tarkistuspäivämäärä"
+msgstr "Täsmäystilanne"
 
 #: gnucash/report/trep-engine.scm:131
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Void Transactions"
-msgstr "Etsi tosite"
+msgstr "Mitätöidyt tositteet"
 
 #: gnucash/report/trep-engine.scm:132
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Closing transactions"
-msgstr "Etsi tosite"
+msgstr "Päättävät tositteet"
 
 #: gnucash/report/trep-engine.scm:142
 msgid ""
@@ -27298,69 +26150,61 @@ msgstr ""
 
 #: gnucash/report/trep-engine.scm:213
 msgid "Register Order"
-msgstr ""
+msgstr "Tilikirjan järjestys"
 
 #: gnucash/report/trep-engine.scm:350
 msgid "Do not do any filtering"
-msgstr ""
+msgstr "Älä suodata"
 
 #: gnucash/report/trep-engine.scm:353
 msgid "Include Transactions to/from Filter Accounts"
-msgstr ""
+msgstr "Sisällytä tositteet suodatetuilta tileiltä"
 
 #: gnucash/report/trep-engine.scm:356
 msgid "Exclude Transactions to/from Filter Accounts"
-msgstr ""
+msgstr "Rajaa suodatettujen tilien tositteet pois"
 
 #: gnucash/report/trep-engine.scm:362
 msgid "Non-void only"
-msgstr ""
+msgstr "Vain mitätöimättömät"
 
 #: gnucash/report/trep-engine.scm:366
 msgid "Void only"
-msgstr ""
+msgstr "Vain mitätöidyt"
 
 #: gnucash/report/trep-engine.scm:370
 msgid "Both (and include void transactions in totals)"
-msgstr ""
+msgstr "Molemmat (ja sisällytä mitätöidyt tositteet summiin)"
 
 #: gnucash/report/trep-engine.scm:375
 msgid "Exclude closing transactions"
-msgstr ""
+msgstr "Rajaa päättävät tositteet pois"
 
 #: gnucash/report/trep-engine.scm:379
 msgid "Show both closing and regular transactions"
-msgstr ""
+msgstr "Näytä sekä päättävät että tavalliset tositteet"
 
 #: gnucash/report/trep-engine.scm:383
 msgid "Show closing transactions only"
-msgstr ""
+msgstr "Näytä vain päättävät tositteet"
 
 #: gnucash/report/trep-engine.scm:393
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Show All Transactions"
-msgstr "Etsi tosite"
+msgstr "Näytä kaikki tositteet"
 
 #: gnucash/report/trep-engine.scm:397
-#, fuzzy
-#| msgid "Reconciled Date"
 msgid "Unreconciled only"
-msgstr "Tarkistuspäivämäärä"
+msgstr "Vain täsmäyttämättömät"
 
 #: gnucash/report/trep-engine.scm:401
 msgid "Cleared only"
-msgstr ""
+msgstr "Vain hyväksytyt"
 
 #: gnucash/report/trep-engine.scm:405
-#, fuzzy
-#| msgid "Reconcile"
 msgid "Reconciled only"
-msgstr "Tarkista"
+msgstr "Vain täsmätyt"
 
 #: gnucash/report/trep-engine.scm:419
-#, fuzzy
-#| msgid "Use Global"
 msgid "Use Global Preference"
 msgstr "Käytä oletusasetusta"
 
@@ -27370,13 +26214,11 @@ msgstr ""
 
 #: gnucash/report/trep-engine.scm:425
 msgid "Income and Expense"
-msgstr ""
+msgstr "Tulot ja menot"
 
 #: gnucash/report/trep-engine.scm:428
-#, fuzzy
-#| msgid "All Accounts"
 msgid "Credit Accounts"
-msgstr "Kaikki tilit"
+msgstr ""
 
 #: gnucash/report/trep-engine.scm:537
 msgid "Specify date to filter by…"
@@ -27384,14 +26226,12 @@ msgstr ""
 
 #: gnucash/report/trep-engine.scm:541 gnucash/report/trep-engine.scm:913
 #: gnucash/report/trep-engine.scm:1093 gnucash/report/trep-engine.scm:2233
-#, fuzzy
-#| msgid "Date Posted"
 msgid "Date Entered"
-msgstr "Vientipäivä"
+msgstr "Syöttöpäivämäärä"
 
 #: gnucash/report/trep-engine.scm:545
 msgid "Convert all transactions into a common currency."
-msgstr ""
+msgstr "Muunna kaikki kirjaukset yhteiseen valuuttaan."
 
 #: gnucash/report/trep-engine.scm:566
 msgid "Formats the table suitable for cut & paste exporting with extra cells."
@@ -27399,7 +26239,7 @@ msgstr ""
 
 #: gnucash/report/trep-engine.scm:576
 msgid "If no transactions matched"
-msgstr ""
+msgstr "Jos yksikään tosite ei sopinut"
 
 #: gnucash/report/trep-engine.scm:584
 msgid ""
@@ -27447,11 +26287,11 @@ msgstr ""
 
 #: gnucash/report/trep-engine.scm:632
 msgid "Filter by reconcile status."
-msgstr ""
+msgstr "Suodata täsmäytystilanteen mukaan."
 
 #: gnucash/report/trep-engine.scm:638
 msgid "How to handle void transactions."
-msgstr ""
+msgstr "Miten mitätöidyt tositteet käsitellään."
 
 #: gnucash/report/trep-engine.scm:644
 msgid ""
@@ -27463,17 +26303,15 @@ msgstr ""
 
 #: gnucash/report/trep-engine.scm:666
 msgid "Filter on these accounts."
-msgstr ""
+msgstr "Suodata näillä tileillä."
 
 #: gnucash/report/trep-engine.scm:671
-#, fuzzy
-#| msgid "Find Account"
 msgid "Filter account."
-msgstr "Etsi tili"
+msgstr "Suodata tili."
 
 #: gnucash/report/trep-engine.scm:762
 msgid "Sort by this criterion first."
-msgstr ""
+msgstr "Järjestä ensin tämän mukaan."
 
 #: gnucash/report/trep-engine.scm:772
 msgid "Show the full account name for subtotals and subheadings?"
@@ -27481,15 +26319,15 @@ msgstr ""
 
 #: gnucash/report/trep-engine.scm:778
 msgid "Show the account code for subtotals and subheadings?"
-msgstr ""
+msgstr "Näytä tilinumero alisummille ja alaotsakkeille?"
 
 #: gnucash/report/trep-engine.scm:784
 msgid "Show the account description for subheadings?"
-msgstr ""
+msgstr "Näytä tilin kuvaus alaotsakkeille?"
 
 #: gnucash/report/trep-engine.scm:790
 msgid "Show the informal headers for debit/credit accounts?"
-msgstr ""
+msgstr "Näytä epämuodolliset otsakkeet tulo- ja menotileille?"
 
 #: gnucash/report/trep-engine.scm:796
 msgid "Add indenting columns with grouping and subtotals?"
@@ -27497,41 +26335,39 @@ msgstr ""
 
 #: gnucash/report/trep-engine.scm:802
 msgid "Show subtotals only, hiding transactional detail?"
-msgstr ""
+msgstr "Näytä vain välisummat piilottaen tositteiden yksityiskohdat?"
 
 #: gnucash/report/trep-engine.scm:808
 msgid "Subtotal according to the primary key?"
-msgstr ""
+msgstr "Välisumma ensisijaisen avaimen mukaan?"
 
 #: gnucash/report/trep-engine.scm:815 gnucash/report/trep-engine.scm:849
 msgid "Do a date subtotal."
-msgstr ""
+msgstr "Näytä päivittäiset välisummat."
 
 #: gnucash/report/trep-engine.scm:824
 msgid "Order of primary sorting."
-msgstr ""
+msgstr "Ensisijaisen järjestyksen suunta."
 
 #: gnucash/report/trep-engine.scm:832
 msgid "Sort by this criterion second."
-msgstr ""
+msgstr "Järjestä toissijaisesti tämän mukaan."
 
 #: gnucash/report/trep-engine.scm:842
 msgid "Subtotal according to the secondary key?"
-msgstr ""
+msgstr "Välisumma toissijaisen avaimen mukaan?"
 
 #: gnucash/report/trep-engine.scm:858
 msgid "Order of Secondary sorting."
-msgstr ""
+msgstr "Toissijaisen järjestyksen suunta."
 
 #: gnucash/report/trep-engine.scm:912
-#, fuzzy
-#| msgid "Reconciled Date"
 msgid "Display the reconciled date?"
-msgstr "Tarkistuspäivämäärä"
+msgstr "Näytä täsmäytyspäivä?"
 
 #: gnucash/report/trep-engine.scm:913
 msgid "Display the entered date?"
-msgstr ""
+msgstr "Näytä kirjauspäivä?"
 
 #: gnucash/report/trep-engine.scm:918
 msgid "Display the notes if the memo is unavailable?"
@@ -27539,19 +26375,19 @@ msgstr ""
 
 #: gnucash/report/trep-engine.scm:920 gnucash/report/trep-engine.scm:923
 msgid "Display the full account name?"
-msgstr ""
+msgstr "Näytä koko tilin nimi?"
 
 #: gnucash/report/trep-engine.scm:921
 msgid "Display the account code?"
-msgstr ""
+msgstr "Näytä tilinumero?"
 
 #: gnucash/report/trep-engine.scm:924
 msgid "Display the other account code?"
-msgstr ""
+msgstr "Näytä toinen tilinumero?"
 
 #: gnucash/report/trep-engine.scm:927
 msgid "Display the transaction linked document"
-msgstr ""
+msgstr "Näytä tositteeseen yhdistetty asiakirja"
 
 #: gnucash/report/trep-engine.scm:930
 msgid "Display a subtotal summary table."
@@ -27559,19 +26395,19 @@ msgstr ""
 
 #: gnucash/report/trep-engine.scm:931
 msgid "Display the balance of the underlying account on each line?"
-msgstr ""
+msgstr "Näytetäänkö perustana olevan tilin saldo kullakin rivillä?"
 
 #: gnucash/report/trep-engine.scm:932
 msgid "Display a grand total section at the bottom?"
-msgstr ""
+msgstr "Näytä loppusumma-osio alareunassa?"
 
 #: gnucash/report/trep-engine.scm:937
 msgid "Display the trans number?"
-msgstr ""
+msgstr "Näytä tositenumero?"
 
 #: gnucash/report/trep-engine.scm:951
 msgid "Display the account name?"
-msgstr ""
+msgstr "Näytä tilin nimi?"
 
 #: gnucash/report/trep-engine.scm:959
 msgid ""
@@ -27581,25 +26417,23 @@ msgstr ""
 
 #: gnucash/report/trep-engine.scm:966
 msgid "Amount of detail to display per transaction."
-msgstr ""
+msgstr "Miten paljon yksityiskohtia näytetään tositetta kohden."
 
 #: gnucash/report/trep-engine.scm:968
 msgid "One split per line"
 msgstr ""
 
 #: gnucash/report/trep-engine.scm:969
-#, fuzzy
-#| msgid "Transaction Number"
 msgid "One transaction per line"
-msgstr "Tositenumero"
+msgstr "Yksi tosite riviä kohti"
 
 #: gnucash/report/trep-engine.scm:979
 msgid "Hide"
-msgstr ""
+msgstr "Piilota"
 
 #: gnucash/report/trep-engine.scm:988
 msgid "Enable hyperlinks in amounts."
-msgstr ""
+msgstr "Käytä linkkejä määrissä."
 
 #: gnucash/report/trep-engine.scm:992
 msgid "Reverse amount display for certain account types."
@@ -27611,15 +26445,15 @@ msgstr ""
 
 #: gnucash/report/trep-engine.scm:1001
 msgid "Grand Total and Subtotals"
-msgstr ""
+msgstr "Loppusumma ja välisummat"
 
 #: gnucash/report/trep-engine.scm:1002
 msgid "Grand Total Only"
-msgstr ""
+msgstr "Vain loppusumma"
 
 #: gnucash/report/trep-engine.scm:1003
 msgid "Subtotals Only"
-msgstr ""
+msgstr "Vain välisummat"
 
 #: gnucash/report/trep-engine.scm:1115
 msgid "Num/T-Num"
@@ -27627,7 +26461,7 @@ msgstr ""
 
 #: gnucash/report/trep-engine.scm:1165
 msgid "Transfer from/to"
-msgstr ""
+msgstr "Siirrä tililtä/tilille"
 
 #. Translators: this is the running total for the secondary subtotal.
 #. For translation to be consistent, make sure it follows the same
@@ -27635,7 +26469,7 @@ msgstr ""
 #. "Secondary Subtotal” and "Running Primary Subtotal"
 #: gnucash/report/trep-engine.scm:1383 gnucash/report/trep-engine.scm:1484
 msgid "Running Secondary Subtotal"
-msgstr ""
+msgstr "Juokseva toissijainen välisumma"
 
 #. Translators: this is the running total for the primary subtotal.
 #. For translation to be consistent, make sure it follows the same
@@ -27643,14 +26477,14 @@ msgstr ""
 #. “Primary Subtotal”
 #: gnucash/report/trep-engine.scm:1399 gnucash/report/trep-engine.scm:1497
 msgid "Running Primary Subtotal"
-msgstr ""
+msgstr "Juokseva ensisijainen välisumma"
 
 #. Translators: "Running Subtotal" is a shorter version of
 #. "Running Primary Subtotal" used when a running primary subtotal
 #. is displayed without a secondary subtotal.
 #: gnucash/report/trep-engine.scm:1403 gnucash/report/trep-engine.scm:1498
 msgid "Running Subtotal"
-msgstr ""
+msgstr "Juokseva välisumma"
 
 #. Translators: this is the running total for the grand total.
 #. For translation to be consistent, make sure it follows the same
@@ -27658,7 +26492,7 @@ msgstr ""
 #. "Grand Total”
 #: gnucash/report/trep-engine.scm:1420 gnucash/report/trep-engine.scm:1512
 msgid "Running Grand Total"
-msgstr ""
+msgstr "Juokseva loppusumma"
 
 #. Translators: "Running Total" is a shorter version of
 #. "Running Grand Total" used when the running grand total is
@@ -27666,21 +26500,17 @@ msgstr ""
 #. how the plural form "Running Totals" is translated.
 #: gnucash/report/trep-engine.scm:1425 gnucash/report/trep-engine.scm:1513
 msgid "Running Total"
-msgstr ""
+msgstr "Juokseva saldo"
 
 #. Translators: Balance b/f stands for "Balance
 #. brought forward".
 #: gnucash/report/trep-engine.scm:1571
-#, fuzzy
-#| msgid "Balance Zero"
 msgid "Balance b/f"
-msgstr "Saldo nolla"
+msgstr "Siirtyvä saldo"
 
 #: gnucash/report/trep-engine.scm:1748
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Split Transaction"
-msgstr "Etsi tosite"
+msgstr "Monirivinen tosite"
 
 #: gnucash/report/trep-engine.scm:2001
 msgid "CSV disabled for double column amounts"
@@ -27688,47 +26518,44 @@ msgstr ""
 
 #. Translators: Both ~a's are dates
 #: gnucash/report/trep-engine.scm:2547
-#, fuzzy, scheme-format
-#| msgid "~a to ~a"
+#, scheme-format
 msgid "From ~a to ~a"
-msgstr "~a → ~a"
+msgstr "~a - ~a"
 
 #: gnucash/ui/gnc-embedded-register-window.ui:9
 #: gnucash/ui/gnc-main-window.ui:102
 msgid "Cu_t"
-msgstr ""
+msgstr "_Leikkaa"
 
 #: gnucash/ui/gnc-embedded-register-window.ui:12
 #: gnucash/ui/gnc-main-window.ui:105
 msgid "Cut the current selection and copy it to clipboard"
-msgstr ""
+msgstr "Leikkaa nykyinen valinta ja kopioi se leikepöydälle"
 
 #: gnucash/ui/gnc-embedded-register-window.ui:15
 #: gnucash/ui/gnc-main-window.ui:108
 msgid "_Copy"
-msgstr ""
+msgstr "_Kopioi"
 
 #: gnucash/ui/gnc-embedded-register-window.ui:18
 #: gnucash/ui/gnc-main-window.ui:111
 msgid "Copy the current selection to clipboard"
-msgstr ""
+msgstr "Kopioi nykyinen valinta leikepöydälle"
 
 #: gnucash/ui/gnc-embedded-register-window.ui:21
 #: gnucash/ui/gnc-main-window.ui:114
 msgid "_Paste"
-msgstr ""
+msgstr "L_iitä"
 
 #: gnucash/ui/gnc-embedded-register-window.ui:24
 #: gnucash/ui/gnc-main-window.ui:117
 msgid "Paste the clipboard content at the cursor position"
-msgstr ""
+msgstr "Liitä leikepöydän sisältö kursorin osoittamaan kohtaan"
 
 #: gnucash/ui/gnc-embedded-register-window.ui:29
 #: gnucash/ui/gnc-reconcile-window.ui:55
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "_Transaction"
-msgstr "Etsi tosite"
+msgstr "_Tosite"
 
 #: gnucash/ui/gnc-embedded-register-window.ui:58
 #: gnucash/ui/gnc-embedded-register-window.ui:121
@@ -27737,15 +26564,13 @@ msgstr "Etsi tosite"
 #: gnucash/ui/gnc-plugin-page-register.ui:486
 #: gnucash/ui/gnc-plugin-page-register.ui:584
 #: gnucash/ui/gnc-plugin-page-register.ui:623
-#, fuzzy
-#| msgid "Reverse split"
 msgid "Remo_ve Other Splits"
-msgstr "Osakkeiden yhdistäminen"
+msgstr "P_oista muut rivit"
 
 #: gnucash/ui/gnc-embedded-register-window.ui:60
 #: gnucash/ui/gnc-embedded-register-window.ui:123
 msgid "Remove all splits in the current transaction"
-msgstr ""
+msgstr "Poista tositteen kaikki rivit"
 
 #: gnucash/ui/gnc-embedded-register-window.ui:65
 #: gnucash/ui/gnc-embedded-register-window.ui:128
@@ -27755,17 +26580,15 @@ msgstr ""
 #: gnucash/ui/gnc-plugin-page-register.ui:591
 #: gnucash/ui/gnc-plugin-page-register.ui:630
 #: gnucash/ui/gnc-plugin-page-register.ui:762
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "_Enter Transaction"
-msgstr "Etsi tosite"
+msgstr "_Kirjaa tosite"
 
 #: gnucash/ui/gnc-embedded-register-window.ui:67
 #: gnucash/ui/gnc-embedded-register-window.ui:130
 #: gnucash/ui/gnc-embedded-register-window.ui:197
 #: gnucash/ui/gnc-plugin-page-register.ui:764
 msgid "Record the current transaction"
-msgstr ""
+msgstr "Tallenna tämä tosite"
 
 #: gnucash/ui/gnc-embedded-register-window.ui:70
 #: gnucash/ui/gnc-embedded-register-window.ui:133
@@ -27775,27 +26598,25 @@ msgstr ""
 #: gnucash/ui/gnc-plugin-page-register.ui:596
 #: gnucash/ui/gnc-plugin-page-register.ui:635
 #: gnucash/ui/gnc-plugin-page-register.ui:777
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Ca_ncel Transaction"
-msgstr "Etsi tosite"
+msgstr "_Peruuta tosite"
 
 #: gnucash/ui/gnc-embedded-register-window.ui:72
 #: gnucash/ui/gnc-embedded-register-window.ui:135
 #: gnucash/ui/gnc-embedded-register-window.ui:212
 #: gnucash/ui/gnc-plugin-page-register.ui:779
 msgid "Cancel the current transaction"
-msgstr ""
+msgstr "Peruuta tämä tosite"
 
 #: gnucash/ui/gnc-embedded-register-window.ui:77
 #: gnucash/ui/gnc-main-window.ui:169
 msgid "_View"
-msgstr ""
+msgstr "_Näytä"
 
 #: gnucash/ui/gnc-embedded-register-window.ui:81
 #: gnucash/ui/gnc-plugin-page-register.ui:97
 msgid "_Double Line"
-msgstr ""
+msgstr "_Kaksi riviä"
 
 #: gnucash/ui/gnc-embedded-register-window.ui:92
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:125
@@ -27804,14 +26625,14 @@ msgstr ""
 #: gnucash/ui/gnc-plugin-page-register.ui:872
 #: gnucash/ui/gnc-reconcile-window.ui:43
 msgid "_Transfer…"
-msgstr ""
+msgstr "_Siirto…"
 
 #: gnucash/ui/gnc-embedded-register-window.ui:95
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:128
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:246
 #: gnucash/ui/gnc-plugin-page-register.ui:874
 msgid "Transfer funds from one account to another"
-msgstr ""
+msgstr "Siirrä varoja tililtä toiselle"
 
 #: gnucash/ui/gnc-embedded-register-window.ui:98
 #: gnucash/ui/gnc-embedded-register-window.ui:140
@@ -27821,36 +26642,34 @@ msgstr ""
 #: gnucash/ui/gnc-plugin-page-register.ui:603
 #: gnucash/ui/gnc-plugin-page-register.ui:642
 #: gnucash/ui/gnc-plugin-page-register.ui:802
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "_Blank Transaction"
-msgstr "Etsi tosite"
+msgstr "_Tyhjennä tosite"
 
 #: gnucash/ui/gnc-embedded-register-window.ui:101
 #: gnucash/ui/gnc-embedded-register-window.ui:142
 #: gnucash/ui/gnc-embedded-register-window.ui:227
 msgid "Move to the blank transaction at the bottom of the register"
-msgstr ""
+msgstr "Siirry tilikirjan lopussa olevaan tyhjään tositteeseen"
 
 #: gnucash/ui/gnc-main-window.ui:8
 msgid "_File"
-msgstr ""
+msgstr "_Tiedosto"
 
 #: gnucash/ui/gnc-main-window.ui:40
 msgid "Pa_ge Setup"
-msgstr ""
+msgstr "S_ivun asetukset"
 
 #: gnucash/ui/gnc-main-window.ui:43
 msgid "Specify the page size and orientation for printing"
-msgstr ""
+msgstr "Määrittele sivun koko ja asettelu tulostusta varten"
 
 #: gnucash/ui/gnc-main-window.ui:62
 msgid "Proper_ties"
-msgstr ""
+msgstr "_Ominaisuudet"
 
 #: gnucash/ui/gnc-main-window.ui:65 gnucash/ui/gnc-plugin-file-history.ui:8
 msgid "Edit the properties of the current file"
-msgstr ""
+msgstr "Muokkaa nykyisen tiedoston ominaisuuksia"
 
 #: gnucash/ui/gnc-main-window.ui:80 gnucash/ui/gnc-main-window.ui:560
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:324
@@ -27863,83 +26682,79 @@ msgstr ""
 #: gnucash/ui/gnc-plugin-page-report.ui:122
 #: gnucash/ui/gnc-plugin-page-sx-list.ui:105
 msgid "Close the currently active page"
-msgstr ""
+msgstr "Sulje avoin sivu"
 
 #: gnucash/ui/gnc-main-window.ui:86
 msgid "Quit this application"
-msgstr ""
+msgstr "Lopeta sovellus"
 
 #: gnucash/ui/gnc-main-window.ui:143
 msgid "Pr_eferences"
-msgstr ""
+msgstr "_Asetukset"
 
 #: gnucash/ui/gnc-main-window.ui:145
 msgid "Edit the global preferences of GnuCash"
-msgstr ""
+msgstr "Muokkaa ohjelman asetuksia"
 
 #: gnucash/ui/gnc-main-window.ui:178
 msgid "_Toolbar"
-msgstr ""
+msgstr "_Työkalupalkki"
 
 #: gnucash/ui/gnc-main-window.ui:180
 msgid "Show/hide the toolbar on this window"
-msgstr ""
+msgstr "Näytä/piilota ikkunan työkalupalkki"
 
 #: gnucash/ui/gnc-main-window.ui:183
 msgid "Su_mmary Bar"
-msgstr ""
+msgstr "Y_hteenvetopalkki"
 
 #: gnucash/ui/gnc-main-window.ui:185
 msgid "Show/hide the summary bar on this window"
-msgstr ""
+msgstr "Näytä/piilota ikkunan yhteenvetopalkki"
 
 #: gnucash/ui/gnc-main-window.ui:188
 msgid "Stat_us Bar"
-msgstr ""
+msgstr "T_ilapalkki"
 
 #: gnucash/ui/gnc-main-window.ui:190
 msgid "Show/hide the status bar on this window"
-msgstr ""
+msgstr "Näytä/piilota ikkunan tilapalkki"
 
 #: gnucash/ui/gnc-main-window.ui:193
 msgid "Tab P_osition"
-msgstr ""
+msgstr "Välilehden kielekkeen _sijainti"
 
 #: gnucash/ui/gnc-main-window.ui:198
 msgid "Display the notebook tabs at the top of the window"
-msgstr ""
+msgstr "Näytä välilehdet ikkunan yläreunassa"
 
 #: gnucash/ui/gnc-main-window.ui:204
 msgid "Display the notebook tabs at the bottom of the window"
-msgstr ""
+msgstr "Näytä välilehdet ikkunan alareunassa"
 
 #: gnucash/ui/gnc-main-window.ui:210
 msgid "Display the notebook tabs at the left of the window"
-msgstr ""
+msgstr "Näytä välilehdet ikkunan vasemmassa reunassa"
 
 #: gnucash/ui/gnc-main-window.ui:216
 msgid "Display the notebook tabs at the right of the window"
-msgstr ""
+msgstr "Näytä välilehdet ikkunan oikeassa reunassa"
 
 #: gnucash/ui/gnc-main-window.ui:256
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Tra_nsaction"
-msgstr "Etsi tosite"
+msgstr "To_site"
 
 #: gnucash/ui/gnc-main-window.ui:297
-#, fuzzy
-#| msgid "Action"
 msgid "_Actions"
-msgstr "Tapahtuma"
+msgstr "T_oiminnot"
 
 #: gnucash/ui/gnc-main-window.ui:344
 msgid "Reset _Warnings…"
-msgstr ""
+msgstr "_Nollaa varoitukset…"
 
 #: gnucash/ui/gnc-main-window.ui:346
 msgid "Reset the state of all warning messages so they will be shown again"
-msgstr ""
+msgstr "Nollaa varoitusilmoitusten tila, jotta ne näytettäisiin uudelleen"
 
 #: gnucash/ui/gnc-main-window.ui:349
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:200
@@ -27950,7 +26765,7 @@ msgstr ""
 #: gnucash/ui/gnc-plugin-page-register.ui:357
 #: gnucash/ui/gnc-plugin-page-register.ui:469
 msgid "Re_name Page"
-msgstr ""
+msgstr "Muuta sivun _nimeä"
 
 #: gnucash/ui/gnc-main-window.ui:351
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:202
@@ -27959,69 +26774,67 @@ msgstr ""
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:181
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:215
 msgid "Rename this page"
-msgstr ""
+msgstr "Muuta avoimen sivun nimeä"
 
 #: gnucash/ui/gnc-main-window.ui:390
 msgid "_Scheduled"
-msgstr ""
+msgstr "_Ajastetut"
 
 #: gnucash/ui/gnc-main-window.ui:403
 msgid "_Reports"
-msgstr ""
+msgstr "_Raportit"
 
 #: gnucash/ui/gnc-main-window.ui:422
 msgid "_Tools"
-msgstr ""
+msgstr "T_yökalut"
 
 #: gnucash/ui/gnc-main-window.ui:444
 msgid "E_xtensions"
-msgstr ""
+msgstr "_Laajennukset"
 
 #: gnucash/ui/gnc-main-window.ui:457
 msgid "_Windows"
-msgstr ""
+msgstr "_Ikkunat"
 
 #: gnucash/ui/gnc-main-window.ui:466
 msgid "_New Window"
-msgstr ""
+msgstr "_Uusi ikkuna"
 
 #: gnucash/ui/gnc-main-window.ui:468
 msgid "Open a new top-level GnuCash window"
-msgstr ""
+msgstr "Avaa uusi päätason GnuCash-ikkuna"
 
 #: gnucash/ui/gnc-main-window.ui:471
 msgid "New Window with _Page"
-msgstr ""
+msgstr "Uusi ikkuna _sivun kanssa"
 
 #: gnucash/ui/gnc-main-window.ui:473
 msgid "Move the current page to a new top-level GnuCash window"
-msgstr ""
+msgstr "Siirrä nykyinen sivu uuteen päätason GnuCash ikkunaan"
 
 #: gnucash/ui/gnc-main-window.ui:501
 msgid "Tutorial and Concepts _Guide"
-msgstr ""
+msgstr "Aloitus_opas ja käsitteet"
 
 #: gnucash/ui/gnc-main-window.ui:504
 msgid "Open the GnuCash Tutorial"
-msgstr ""
+msgstr "Avaa GnuCashin aloitusopas"
 
 #: gnucash/ui/gnc-main-window.ui:512
-#, fuzzy
-#| msgid "Contact"
 msgid "_Contents"
-msgstr "Yhteyshenkilö"
+msgstr "_Sisältö"
 
 #: gnucash/ui/gnc-main-window.ui:515
 msgid "Open the GnuCash Help"
-msgstr ""
+msgstr "Avaa GnuCashin ohjeet"
 
 #: gnucash/ui/gnc-main-window.ui:518
 msgid "_About"
-msgstr ""
+msgstr "_Tietoja"
 
 #: gnucash/ui/gnc-main-window.ui:520
 msgid "About GnuCash"
-msgstr ""
+msgstr "Tietoja GnuCashistä"
 
 #: gnucash/ui/gnc-main-window.ui:545 gnucash/ui/gnc-plugin-basic-commands.ui:24
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:309
@@ -28033,10 +26846,8 @@ msgstr ""
 #: gnucash/ui/gnc-plugin-page-register.ui:659
 #: gnucash/ui/gnc-plugin-page-report.ui:107
 #: gnucash/ui/gnc-plugin-page-sx-list.ui:90
-#, fuzzy
-#| msgid "The current date."
 msgid "Save the current file"
-msgstr "Tämä päiväys."
+msgstr "Tallenna tämä tiedosto"
 
 #: gnucash/ui/gnc-main-window.ui:585 gnucash/ui/gnc-plugin-business.ui:26
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:349
@@ -28049,7 +26860,7 @@ msgstr "Tämä päiväys."
 #: gnucash/ui/gnc-plugin-page-report.ui:147
 #: gnucash/ui/gnc-plugin-page-sx-list.ui:130
 msgid "Open the New Invoice dialog"
-msgstr ""
+msgstr "Avaa uuden myyntilaskun luonti-ikkuna"
 
 #: gnucash/ui/gnc-main-window.ui:588 gnucash/ui/gnc-plugin-business.ui:24
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:347
@@ -28063,52 +26874,48 @@ msgstr ""
 #: gnucash/ui/gnc-plugin-page-register.ui:697
 #: gnucash/ui/gnc-plugin-page-report.ui:145
 #: gnucash/ui/gnc-plugin-page-sx-list.ui:128
-#, fuzzy
-#| msgid "Invoice"
 msgid "New _Invoice…"
-msgstr "Myyntilasku"
+msgstr "Uusi _myyntilasku…"
 
 #: gnucash/ui/gnc-plugin-account-tree.ui:6
-#, fuzzy
-#| msgid "CSV Account Map"
 msgid "New Accounts _Page"
-msgstr "CSV-tilikartta"
+msgstr "Uu_si tilivalikko"
 
 #: gnucash/ui/gnc-plugin-account-tree.ui:8
 msgid "Open a new Account Tree page"
-msgstr ""
+msgstr "Avaa uusi tilivalikko"
 
 #: gnucash/ui/gnc-plugin-basic-commands.ui:6
 msgid "New _File"
-msgstr ""
+msgstr "Uusi _tiedosto"
 
 #: gnucash/ui/gnc-plugin-basic-commands.ui:9
 msgid "Create a new file"
-msgstr ""
+msgstr "Luo uusi tiedosto"
 
 #: gnucash/ui/gnc-plugin-basic-commands.ui:12
 msgid "_Open…"
-msgstr ""
+msgstr "_Avaa…"
 
 #: gnucash/ui/gnc-plugin-basic-commands.ui:15
 msgid "Open an existing GnuCash file"
-msgstr ""
+msgstr "Avaa olemassa oleva GnuCash-tiedosto"
 
 #: gnucash/ui/gnc-plugin-basic-commands.ui:27
 msgid "Save _As…"
-msgstr ""
+msgstr "Tallenna _nimellä…"
 
 #: gnucash/ui/gnc-plugin-basic-commands.ui:30
 msgid "Save this file with a different name"
-msgstr ""
+msgstr "Tallenna nykyinen tiedosto uudella nimellä"
 
 #: gnucash/ui/gnc-plugin-basic-commands.ui:33
 msgid "Re_vert"
-msgstr ""
+msgstr "Pa_lauta"
 
 #: gnucash/ui/gnc-plugin-basic-commands.ui:35
 msgid "Reload the current database, reverting all unsaved changes"
-msgstr ""
+msgstr "Lataa tietokanta uudelleen peruen kaikki tallentamattomat muutokset"
 
 #: gnucash/ui/gnc-plugin-basic-commands.ui:44
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:9
@@ -28117,17 +26924,15 @@ msgstr ""
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:9
 #: gnucash/ui/gnc-plugin-page-sx-list.ui:9
 msgid "Print the currently active page"
-msgstr ""
+msgstr "Tulosta avoin sivu"
 
 #: gnucash/ui/gnc-plugin-basic-commands.ui:51
-#, fuzzy
-#| msgid "All Accounts"
 msgid "Export _Accounts"
-msgstr "Kaikki tilit"
+msgstr "Vie _tilit"
 
 #: gnucash/ui/gnc-plugin-basic-commands.ui:53
 msgid "Export the account hierarchy to a new GnuCash datafile"
-msgstr ""
+msgstr "Vie tilihierarkia uuteen GnuCash-tiedostoon"
 
 #: gnucash/ui/gnc-plugin-basic-commands.ui:59
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:67
@@ -28138,7 +26943,7 @@ msgstr ""
 #: gnucash/ui/gnc-plugin-page-report.ui:16
 #: gnucash/ui/gnc-plugin-page-sx-list.ui:16
 msgid "_Find…"
-msgstr ""
+msgstr "_Etsi…"
 
 #: gnucash/ui/gnc-plugin-basic-commands.ui:62
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:70
@@ -28147,10 +26952,8 @@ msgstr ""
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:68
 #: gnucash/ui/gnc-plugin-page-report.ui:19
 #: gnucash/ui/gnc-plugin-page-sx-list.ui:19
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Find transactions with a search"
-msgstr "Etsi tosite"
+msgstr "Etsi tapahtumia"
 
 #. Translators: remember to reuse this translation in dialog-account.glade
 #: gnucash/ui/gnc-plugin-basic-commands.ui:70
@@ -28161,10 +26964,8 @@ msgstr "Etsi tosite"
 #: gnucash/ui/gnc-plugin-page-register.ui:60
 #: gnucash/ui/gnc-plugin-page-report.ui:36
 #: gnucash/ui/gnc-plugin-page-sx-list.ui:27
-#, fuzzy
-#| msgid "Loan Repayment Option: \"%s\""
 msgid "Ta_x Report Options"
-msgstr "Lainanlyhennyksen valinta: \"%s\""
+msgstr "_Veroraportin asetukset"
 
 #. Translators: currently implemented are, US: income tax and DE: VAT, So adjust this string
 #: gnucash/ui/gnc-plugin-basic-commands.ui:73
@@ -28175,117 +26976,107 @@ msgstr "Lainanlyhennyksen valinta: \"%s\""
 #: gnucash/ui/gnc-plugin-page-report.ui:39
 #: gnucash/ui/gnc-plugin-page-sx-list.ui:30
 msgid "Setup relevant accounts for tax reports, e.g. US income tax"
-msgstr ""
+msgstr "Määritä tilit veroraporttia varten"
 
 #: gnucash/ui/gnc-plugin-basic-commands.ui:80
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "_Scheduled Transactions"
-msgstr "Etsi tosite"
+msgstr "_Tositteiden ajastukset"
 
 #: gnucash/ui/gnc-plugin-basic-commands.ui:84
 msgid "_Scheduled Transaction Editor"
-msgstr ""
+msgstr "_Tositteiden ajastusten muokkaus"
 
 #: gnucash/ui/gnc-plugin-basic-commands.ui:89
 msgid "Since _Last Run…"
-msgstr ""
+msgstr "_Edellisen ajon jälkeen…"
 
 #: gnucash/ui/gnc-plugin-basic-commands.ui:91
 msgid "Create Scheduled Transactions since the last time run"
-msgstr ""
+msgstr "Luo edellisen ajon jälkeen ajastetut tositteet"
 
 #: gnucash/ui/gnc-plugin-basic-commands.ui:94
 msgid "_Mortgage & Loan Repayment…"
-msgstr ""
+msgstr "_Lainan takaisinmaksu…"
 
 #: gnucash/ui/gnc-plugin-basic-commands.ui:96
 msgid "Setup scheduled transactions for repayment of a loan"
-msgstr ""
+msgstr "Luo tositteen ajastus lainan takaisinmaksulle"
 
 #: gnucash/ui/gnc-plugin-basic-commands.ui:104
 msgid "_Price Database"
-msgstr ""
+msgstr "_Hintakanta"
 
 #: gnucash/ui/gnc-plugin-basic-commands.ui:106
 msgid "View and edit the prices for stocks and mutual funds"
-msgstr ""
+msgstr "Katso ja muokkaa osakkeiden ja rahastojen hintoja"
 
 #: gnucash/ui/gnc-plugin-basic-commands.ui:109
 msgid "_Security Editor"
-msgstr ""
+msgstr "_Arvopaperimuokkain"
 
 #: gnucash/ui/gnc-plugin-basic-commands.ui:111
 msgid "View and edit the commodities for stocks and mutual funds"
-msgstr ""
+msgstr "Katso ja muokkaa osakkeiden ja rahastojen hyödykkeitä"
 
 #: gnucash/ui/gnc-plugin-basic-commands.ui:114
-#, fuzzy
-#| msgid "Loan Repayment Option: \"%s\""
 msgid "_Loan Repayment Calculator"
-msgstr "Lainanlyhennyksen valinta: \"%s\""
+msgstr "_Lainalaskin"
 
 #: gnucash/ui/gnc-plugin-basic-commands.ui:116
 msgid "Use the loan/mortgage repayment calculator"
-msgstr ""
+msgstr "Lainan takaisinmaksulaskin"
 
 #: gnucash/ui/gnc-plugin-basic-commands.ui:119
 msgid "_Close Book…"
-msgstr ""
+msgstr "_Tee tilinpäätös…"
 
 #: gnucash/ui/gnc-plugin-basic-commands.ui:121
 msgid "Close the Book at the end of the Period"
-msgstr ""
+msgstr "Tee tilinpäätös jakson päättyessä"
 
 #: gnucash/ui/gnc-plugin-basic-commands.ui:124
 msgid "_Import Map Editor"
-msgstr ""
+msgstr "_Tuontikartan muokkain"
 
 #: gnucash/ui/gnc-plugin-basic-commands.ui:126
 msgid "View and Delete Bayesian and non-Bayesian information"
 msgstr ""
 
 #: gnucash/ui/gnc-plugin-basic-commands.ui:129
-#, fuzzy
-#| msgid "Transaction Document Links"
 msgid "_Transaction Linked Documents"
-msgstr "Tositteen asiakirjalinkit"
+msgstr "_Tositteeseen yhdistetyt asiakirjat"
 
 #: gnucash/ui/gnc-plugin-basic-commands.ui:131
-#, fuzzy
-#| msgid "Transaction Document Links"
 msgid "View all Transaction Linked Documents"
-msgstr "Tositteen asiakirjalinkit"
+msgstr ""
 
 #: gnucash/ui/gnc-plugin-basic-commands.ui:137
 msgid "_Tips Of The Day"
-msgstr ""
+msgstr "_Päivän vinkit"
 
 #: gnucash/ui/gnc-plugin-basic-commands.ui:139
 msgid "View the Tips of the Day"
-msgstr ""
+msgstr "Näytä päivän vinkit"
 
 #: gnucash/ui/gnc-plugin-bi-import.ui:6
 msgid "Import Bills & _Invoices…"
-msgstr ""
+msgstr "Tuo osto- ja myynti_laskut…"
 
 #: gnucash/ui/gnc-plugin-bi-import.ui:8
 msgid "Import bills and invoices from a CSV text file"
-msgstr ""
+msgstr "Tuo osto- ja myyntilaskut CSV-tekstitiedostosta"
 
 #: gnucash/ui/gnc-plugin-budget.ui:10
 msgid "_New Budget"
-msgstr ""
+msgstr "_Uusi budjetti"
 
 #: gnucash/ui/gnc-plugin-budget.ui:12
 msgid "Create a new Budget"
-msgstr ""
+msgstr "Luo uusi budjetti"
 
 #: gnucash/ui/gnc-plugin-budget.ui:15
-#, fuzzy
-#| msgid "Open buy"
 msgid "_Open Budget"
-msgstr "Avoin osto"
+msgstr "_Avaa budjetti"
 
 #: gnucash/ui/gnc-plugin-budget.ui:17
 msgid ""
@@ -28295,257 +27086,217 @@ msgstr ""
 
 #: gnucash/ui/gnc-plugin-budget.ui:20
 msgid "_Copy Budget"
-msgstr ""
+msgstr "_Kopioi budjetti"
 
 #: gnucash/ui/gnc-plugin-budget.ui:22
 msgid "Copy an existing Budget"
-msgstr ""
+msgstr "Kopioi olemassa oleva budjetti"
 
 #: gnucash/ui/gnc-plugin-budget.ui:25
-#, fuzzy
-#| msgid "_Delete"
 msgid "_Delete Budget"
-msgstr "_Poista"
+msgstr "_Poista budjetti"
 
 #: gnucash/ui/gnc-plugin-budget.ui:27
 msgid "Delete an existing Budget"
-msgstr ""
+msgstr "Poista olemassa oleva budjetti"
 
 #: gnucash/ui/gnc-plugin-business.ui:6
-#, fuzzy
-#| msgid "Customer ID"
 msgid "_Customer"
-msgstr "Asiakastunnus"
+msgstr "_Asiakas"
 
 #: gnucash/ui/gnc-plugin-business.ui:9
-#, fuzzy
-#| msgid "Customer's Invoices"
 msgid "Customers Overview"
-msgstr "Asiakkaan myyntilaskut"
+msgstr "Asiakaslista"
 
 #: gnucash/ui/gnc-plugin-business.ui:11
 msgid "Open a Customer overview page"
-msgstr ""
+msgstr "Avaa lista asiakkaista"
 
 #: gnucash/ui/gnc-plugin-business.ui:14
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:23
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:317
-#, fuzzy
-#| msgid "New Customer"
 msgid "_New Customer…"
-msgstr "Uusi asiakas"
+msgstr "_Uusi asiakas…"
 
 #: gnucash/ui/gnc-plugin-business.ui:16
-#, fuzzy
-#| msgid "New Customer"
 msgid "Open the New Customer dialog"
-msgstr "Uusi asiakas"
+msgstr "Avaa ikkuna uuden asiakkaan luomiseksi"
 
 #: gnucash/ui/gnc-plugin-business.ui:19
-#, fuzzy
-#| msgid "Find Customer"
 msgid "_Find Customer…"
-msgstr "Etsi asiakas"
+msgstr "_Etsi asiakas…"
 
 #: gnucash/ui/gnc-plugin-business.ui:21
-#, fuzzy
-#| msgid "Find Customer"
 msgid "Open the Find Customer dialog"
-msgstr "Etsi asiakas"
+msgstr "Avaa asiakkaiden hakuikkuna"
 
 #: gnucash/ui/gnc-plugin-business.ui:29
-#, fuzzy
-#| msgid "Invoice"
 msgid "Find In_voice…"
-msgstr "Myyntilasku"
+msgstr "Etsi myynti_lasku…"
 
 #: gnucash/ui/gnc-plugin-business.ui:31
 msgid "Open the Find Invoice dialog"
-msgstr ""
+msgstr "Avaa myyntilaskun hakuikkuna"
 
 #: gnucash/ui/gnc-plugin-business.ui:34 gnucash/ui/gnc-plugin-business.ui:83
 msgid "New _Job…"
-msgstr ""
+msgstr "Uusi _hanke…"
 
 #: gnucash/ui/gnc-plugin-business.ui:36 gnucash/ui/gnc-plugin-business.ui:85
 msgid "Open the New Job dialog"
-msgstr ""
+msgstr "Avaa uuden hankkeen luonti-ikkuna"
 
 #: gnucash/ui/gnc-plugin-business.ui:39 gnucash/ui/gnc-plugin-business.ui:88
 msgid "Find Jo_b…"
-msgstr ""
+msgstr "Etsi h_anke…"
 
 #: gnucash/ui/gnc-plugin-business.ui:41 gnucash/ui/gnc-plugin-business.ui:90
 msgid "Open the Find Job dialog"
-msgstr ""
+msgstr "Avaa hankkeen hakuikkuna"
 
 #: gnucash/ui/gnc-plugin-business.ui:44 gnucash/ui/gnc-plugin-business.ui:93
 #: gnucash/ui/gnc-plugin-business.ui:132
-#, fuzzy
-#| msgid "Process Payment"
 msgid "_Process Payment…"
-msgstr "Käsittele maksu"
+msgstr "_Käsittele maksu…"
 
 #: gnucash/ui/gnc-plugin-business.ui:46 gnucash/ui/gnc-plugin-business.ui:95
 #: gnucash/ui/gnc-plugin-business.ui:134
-#, fuzzy
-#| msgid "Process Payment"
 msgid "Open the Process Payment dialog"
-msgstr "Käsittele maksu"
+msgstr "Avaa maksun käsittelyikkuna"
 
 #: gnucash/ui/gnc-plugin-business.ui:49
 msgid "Invoices _Due Reminder"
-msgstr ""
+msgstr "Muistuta _erääntyvistä myyntilaskuista"
 
 #: gnucash/ui/gnc-plugin-business.ui:51
 msgid "Open the Invoices Due Reminder dialog"
-msgstr ""
+msgstr "Avaa erääntyvien myyntilaskujen muistutusikkuna"
 
 #: gnucash/ui/gnc-plugin-business.ui:55
 msgid "_Vendor"
-msgstr ""
+msgstr "T_oimittaja"
 
 #: gnucash/ui/gnc-plugin-business.ui:58
 msgid "Vendors Overview"
-msgstr ""
+msgstr "Toimittajalista"
 
 #: gnucash/ui/gnc-plugin-business.ui:60
 msgid "Open a Vendor overview page"
-msgstr ""
+msgstr "Näytä lista toimittajista"
 
 #: gnucash/ui/gnc-plugin-business.ui:63
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:39
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:472
 msgid "_New Vendor…"
-msgstr ""
+msgstr "Uusi t_oimittaja…"
 
 #: gnucash/ui/gnc-plugin-business.ui:65
 msgid "Open the New Vendor dialog"
-msgstr ""
+msgstr "Avaa uuden toimittajan luonti-ikkuna"
 
 #: gnucash/ui/gnc-plugin-business.ui:68
 msgid "_Find Vendor…"
-msgstr ""
+msgstr "Etsi to_imittaja…"
 
 #: gnucash/ui/gnc-plugin-business.ui:70
 msgid "Open the Find Vendor dialog"
-msgstr ""
+msgstr "Avaa toimittajien hakuikkuna"
 
 #: gnucash/ui/gnc-plugin-business.ui:73
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:193
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:512
 msgid "New _Bill…"
-msgstr ""
+msgstr "Uusi _ostolasku…"
 
 #: gnucash/ui/gnc-plugin-business.ui:75
 msgid "Open the New Bill dialog"
-msgstr ""
+msgstr "Avaa uuden ostolaskun luonti-ikkuna"
 
 #: gnucash/ui/gnc-plugin-business.ui:78
 msgid "Find Bi_ll…"
-msgstr ""
+msgstr "Etsi o_stolasku…"
 
 #: gnucash/ui/gnc-plugin-business.ui:80
 msgid "Open the Find Bill dialog"
-msgstr ""
+msgstr "Avaa uuden ostolaskun luonti-ikkuna"
 
 #: gnucash/ui/gnc-plugin-business.ui:98
 msgid "Bills _Due Reminder"
-msgstr ""
+msgstr "Muistuta _erääntyvistä ostolaskuista"
 
 #: gnucash/ui/gnc-plugin-business.ui:100
 msgid "Open the Bills Due Reminder dialog"
-msgstr ""
+msgstr "Avaa erääntyvien ostolaskujen muistutusikkuna"
 
 #: gnucash/ui/gnc-plugin-business.ui:104
-#, fuzzy
-#| msgid "Employee ID"
 msgid "_Employee"
-msgstr "Työntekijätunnus"
+msgstr "T_yöntekijä"
 
 #: gnucash/ui/gnc-plugin-business.ui:107
-#, fuzzy
-#| msgid "Employee Username"
 msgid "Employees Overview"
-msgstr "Työntekijän käyttäjätunnus"
+msgstr "Työntekijälista"
 
 #: gnucash/ui/gnc-plugin-business.ui:109
 msgid "Open a Employee overview page"
-msgstr ""
+msgstr "Avaa lista työntekijöistä"
 
 #: gnucash/ui/gnc-plugin-business.ui:112
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:55
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:627
-#, fuzzy
-#| msgid "New Employee"
 msgid "_New Employee…"
-msgstr "Uusi työntekijä"
+msgstr "_Uusi työntekijä…"
 
 #: gnucash/ui/gnc-plugin-business.ui:114
-#, fuzzy
-#| msgid "New Employee"
 msgid "Open the New Employee dialog"
-msgstr "Uusi työntekijä"
+msgstr "Avaa uuden työntekijän luonti-ikkuna"
 
 #: gnucash/ui/gnc-plugin-business.ui:117
-#, fuzzy
-#| msgid "Find Employee"
 msgid "_Find Employee…"
-msgstr "Etsi työntekijä"
+msgstr "_Etsi työntekijä…"
 
 #: gnucash/ui/gnc-plugin-business.ui:119
-#, fuzzy
-#| msgid "Find Employee"
 msgid "Open the Find Employee dialog"
-msgstr "Etsi työntekijä"
+msgstr "Avaa työntekijän hakuikkuna"
 
 #: gnucash/ui/gnc-plugin-business.ui:122
-#, fuzzy
-#| msgid "Expense Vouchers"
 msgid "New _Expense Voucher…"
-msgstr "Matkalaskut"
+msgstr "Uusi _matkalasku…"
 
 #: gnucash/ui/gnc-plugin-business.ui:124
 msgid "Open the New Voucher dialog"
-msgstr ""
+msgstr "Avaa uuden matkalaskun luonti-ikkuna"
 
 #: gnucash/ui/gnc-plugin-business.ui:127
-#, fuzzy
-#| msgid "Expense Vouchers"
 msgid "Find Expense _Voucher…"
-msgstr "Matkalaskut"
+msgstr "Etsi m_atkalasku…"
 
 #: gnucash/ui/gnc-plugin-business.ui:129
 msgid "Open the Find Expense Voucher dialog"
-msgstr ""
+msgstr "Avaa matkalaskun hakuikkuna"
 
 #: gnucash/ui/gnc-plugin-business.ui:138
-#, fuzzy
-#| msgid "Business Document Links"
 msgid "Business Linked Documents"
-msgstr "Yrityksen asiakirjalinkit"
+msgstr "Yrityksen yhdistetyt asiakirjat"
 
 #: gnucash/ui/gnc-plugin-business.ui:140
-#, fuzzy
-#| msgid "Business Document Links"
 msgid "View all Linked Business Documents"
-msgstr "Yrityksen asiakirjalinkit"
+msgstr "Näytä kaikki linkitetyt yrityksen asiakirjat"
 
 #: gnucash/ui/gnc-plugin-business.ui:146
 msgid "Sales _Tax Table"
-msgstr ""
+msgstr "Myynnin _verokannat"
 
 #: gnucash/ui/gnc-plugin-business.ui:148
 msgid "View and edit the list of Sales Tax Tables (GST/VAT)"
-msgstr ""
+msgstr "Näytä ja muokkaa listaa verokannoista (ALV)"
 
 #: gnucash/ui/gnc-plugin-business.ui:151
 msgid "_Billing Terms Editor"
-msgstr ""
+msgstr "Muokkaa _maksuehtoja"
 
 #: gnucash/ui/gnc-plugin-business.ui:153
 msgid "View and edit the list of Billing Terms"
-msgstr ""
+msgstr "Näytä ja muokkaa listaa maksuehdoista"
 
 #: gnucash/ui/gnc-plugin-business.ui:163 gnucash/ui/gnc-plugin-business.ui:165
 msgid "Test Search Dialog"
@@ -28553,79 +27304,79 @@ msgstr ""
 
 #: gnucash/ui/gnc-plugin-business.ui:168 gnucash/ui/gnc-plugin-business.ui:170
 msgid "Initialize Test Data"
-msgstr ""
+msgstr "Alusta testitiedot"
 
 #: gnucash/ui/gnc-plugin-csv-export.ui:6
 msgid "Export Account T_ree to CSV…"
-msgstr ""
+msgstr "Vie _tilihierarkia CSV-tiedostoon…"
 
 #: gnucash/ui/gnc-plugin-csv-export.ui:8
 msgid "Export the Account Tree to a CSV file"
-msgstr ""
+msgstr "Vie tilihierarkia CSV-tiedostoon"
 
 #: gnucash/ui/gnc-plugin-csv-export.ui:11
 msgid "Export _Transactions to CSV…"
-msgstr ""
+msgstr "Vie _tositteet CSV-tiedostoon…"
 
 #: gnucash/ui/gnc-plugin-csv-export.ui:13
 msgid "Export the Transactions to a CSV file"
-msgstr ""
+msgstr "Vie tositteet CSV-tiedostoon"
 
 #: gnucash/ui/gnc-plugin-csv-export.ui:16
 msgid "Export A_ctive Register to CSV…"
-msgstr ""
+msgstr "Vie t_ilikirja CSV-tiedostoon…"
 
 #: gnucash/ui/gnc-plugin-csv-export.ui:18
 msgid "Export the Active Register to a CSV file"
-msgstr ""
+msgstr "Vie aktiivinen tilikirja CSV-tiedostoon"
 
 #: gnucash/ui/gnc-plugin-csv-import.ui:6
 msgid "Import _Accounts from CSV…"
-msgstr ""
+msgstr "Tuo _tilit CSV-tiedostosta…"
 
 #: gnucash/ui/gnc-plugin-csv-import.ui:8
 msgid "Import Accounts from a CSV file"
-msgstr ""
+msgstr "Tuo tilit CSV-tiedostosta"
 
 #: gnucash/ui/gnc-plugin-csv-import.ui:11
 msgid "Import _Transactions from CSV…"
-msgstr ""
+msgstr "Tuo t_ositteet CSV-tiedostosta…"
 
 #: gnucash/ui/gnc-plugin-csv-import.ui:13
 msgid "Import Transactions from a CSV file"
-msgstr ""
+msgstr "Tuo tositteet CSV-tiedostosta"
 
 #: gnucash/ui/gnc-plugin-csv-import.ui:16
 msgid "Import _Prices from a CSV file…"
-msgstr ""
+msgstr "Tuo _hinnat CSV-tiedostosta…"
 
 #: gnucash/ui/gnc-plugin-csv-import.ui:18
 msgid "Import Prices from a CSV file"
-msgstr ""
+msgstr "Tuo hinnat CSV-tiedostosta"
 
 #: gnucash/ui/gnc-plugin-customer-import.ui:6
 msgid "Import _Customers & Vendors…"
-msgstr ""
+msgstr "Tuo _asiakkaat ja toimittajat…"
 
 #: gnucash/ui/gnc-plugin-customer-import.ui:8
 msgid "Import Customers and Vendors from a CSV text file"
-msgstr ""
+msgstr "Tuo asiakkaat ja toimittajat CSV-tiedostosta"
 
 #: gnucash/ui/gnc-plugin-log-replay.ui:6
 msgid "_Replay GnuCash .log file…"
-msgstr ""
+msgstr "Tuo tapahtumat GnuCashin ._log-tiedostosta…"
 
 #: gnucash/ui/gnc-plugin-log-replay.ui:8
 msgid "Replay a GnuCash log file after a crash. This cannot be undone"
 msgstr ""
+"Tuo ohjelman kaatumisen jälkeen tapahtumat uudelleen GnuCashin lokista. Tätä "
+"ei voi perua"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:16
 #: gnucash/ui/gnc-plugin-page-register.ui:32
 #: gnucash/ui/gnc-reconcile-window.ui:37
-#, fuzzy
-#| msgid "Find Account"
 msgid "_Edit Account"
-msgstr "Etsi tili"
+msgstr "_Muokkaa tiliä"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:19
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:26
@@ -28633,33 +27384,27 @@ msgstr "Etsi tili"
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:389
 #: gnucash/ui/gnc-plugin-page-budget.ui:18
 msgid "Edit the selected account"
-msgstr ""
+msgstr "Muokkaa valittua tiliä"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:23
-#, fuzzy
-#| msgid "All Accounts"
 msgid "_Delete Account"
-msgstr "Kaikki tilit"
+msgstr "_Poista tili"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:30
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:227
 #: gnucash/ui/gnc-plugin-page-register.ui:39
-#, fuzzy
-#| msgid "Find Account"
 msgid "F_ind Account"
-msgstr "Etsi tili"
+msgstr "_Etsi tili"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:33
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:229
-#, fuzzy
-#| msgid "Find Account"
 msgid "Find an account"
 msgstr "Etsi tili"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:37
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:222
 msgid "_Cascade Account Properties…"
-msgstr ""
+msgstr "_Limitä tilin ominaisuudet…"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:39
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:224
@@ -28668,39 +27413,35 @@ msgstr ""
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:43
 msgid "_Renumber Subaccounts…"
-msgstr ""
+msgstr "_Uudelleennumeroi alatilit…"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:45
 msgid "Renumber the children of the selected account"
-msgstr ""
+msgstr "Uudelleennumeroi valitun tilin alla olevat tilit"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:52
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:207
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:372
 #: gnucash/ui/gnc-plugin-page-budget.ui:175
-#, fuzzy
-#| msgid "Find Account"
 msgid "Open _Account"
-msgstr "Etsi tili"
+msgstr "_Avaa tili"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:54
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:209
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:374
 #: gnucash/ui/gnc-plugin-page-budget.ui:177
 msgid "Open the selected account"
-msgstr ""
+msgstr "Avaa valittu tili"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:58
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:212
-#, fuzzy
-#| msgid "All Accounts"
 msgid "Open _SubAccounts"
-msgstr "Kaikki tilit"
+msgstr "Avaa a_latilit"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:60
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:214
 msgid "Open the selected account and all its subaccounts"
-msgstr ""
+msgstr "Avaa valittu tili ja kaikki sen alatilit"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:90
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:195
@@ -28710,7 +27451,7 @@ msgstr ""
 #: gnucash/ui/gnc-plugin-page-register.ui:353
 #: gnucash/ui/gnc-plugin-page-register.ui:465
 msgid "_Filter By…"
-msgstr ""
+msgstr "_Suodata…"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:98
 #: gnucash/ui/gnc-plugin-page-budget.ui:87
@@ -28720,7 +27461,7 @@ msgstr ""
 #: gnucash/ui/gnc-plugin-page-report.ui:46
 #: gnucash/ui/gnc-plugin-page-sx-list.ui:43
 msgid "_Refresh"
-msgstr ""
+msgstr "_Päivitä"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:101
 #: gnucash/ui/gnc-plugin-page-budget.ui:90
@@ -28729,42 +27470,40 @@ msgstr ""
 #: gnucash/ui/gnc-plugin-page-report.ui:49
 #: gnucash/ui/gnc-plugin-page-sx-list.ui:46
 msgid "Refresh this window"
-msgstr ""
+msgstr "Päivitä tämä ikkuna"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:112
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:268
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:414
 msgid "Create a new Account"
-msgstr ""
+msgstr "Luo uusi tili"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:116
 msgid "New Account _Hierarchy…"
-msgstr ""
+msgstr "Uusi tili_hierarkia…"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:118
 msgid "Extend the current book by merging with new account type categories"
-msgstr ""
+msgstr "Laajenna kirjanpitoa liittämällä uusia tilityyppikategorioita"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:132
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:234
 #: gnucash/ui/gnc-plugin-page-register.ui:236
 #: gnucash/ui/gnc-plugin-page-register.ui:887
-#, fuzzy
-#| msgid "Reconcile"
 msgid "_Reconcile…"
-msgstr "Tarkista"
+msgstr "_Täsmää…"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:134
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:236
 #: gnucash/ui/gnc-plugin-page-register.ui:889
 msgid "Reconcile the selected account"
-msgstr ""
+msgstr "Täsmäytä valittu tili"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:138
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:239
 #: gnucash/ui/gnc-plugin-page-register.ui:242
 msgid "_Auto-clear…"
-msgstr ""
+msgstr "_Automaattinen tyhjennys…"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:140
 msgid ""
@@ -28776,34 +27515,30 @@ msgstr ""
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:249
 #: gnucash/ui/gnc-plugin-page-register.ui:248
 #: gnucash/ui/gnc-plugin-page-register.ui:902
-#, fuzzy
-#| msgid "Stock split"
 msgid "Stock Ass_istant…"
-msgstr "Osakkeen jako"
+msgstr "Osakeavust_in…"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:150
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:254
 #: gnucash/ui/gnc-plugin-page-register.ui:254
-#, fuzzy
-#| msgid "Stock split"
 msgid "Stoc_k Split…"
-msgstr "Osakkeen jako"
+msgstr "Osakkeen _jako…"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:152
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:256
 msgid "Record a stock split or a stock merger"
-msgstr ""
+msgstr "Merkitse osakejako tai osakkeiden yhdistäminen"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:156
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:259
 #: gnucash/ui/gnc-plugin-page-register.ui:260
 msgid "View _Lots…"
-msgstr ""
+msgstr "Näytä _erät…"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:158
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:261
 msgid "Bring up the lot viewer/editor window"
-msgstr ""
+msgstr "Avaa erien katselu- ja muokkausikkuna"
 
 #. Translators: The following 2 are Scrub actions in register view
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:165
@@ -28811,24 +27546,24 @@ msgstr ""
 #: gnucash/ui/gnc-plugin-page-register.ui:314
 #: gnucash/ui/gnc-reconcile-window.ui:49
 msgid "_Check & Repair"
-msgstr ""
+msgstr "_Tarkista ja korjaa"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:169
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:281
 msgid "Check & Repair A_ccount"
-msgstr ""
+msgstr "Tarkista ja korjaa _tili"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:171
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:283
 msgid ""
 "Check for and repair unbalanced transactions and orphan splits in this "
 "account"
-msgstr ""
+msgstr "Tarkista ja korjaa täsmäämättömät tositteet ja tämän tilin orporivit"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:175
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:286
 msgid "Check & Repair Su_baccounts"
-msgstr ""
+msgstr "Tarkista ja korjaa _alatilit"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:177
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:288
@@ -28836,11 +27571,13 @@ msgid ""
 "Check for and repair unbalanced transactions and orphan splits in this "
 "account and its subaccounts"
 msgstr ""
+"Tarkista ja korjaa täsmäämättömät tositteet ja orporivit tällä sekä sen "
+"alatileillä"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:181
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:291
 msgid "Check & Repair A_ll"
-msgstr ""
+msgstr "Tarkista ja korjaa _kaikki"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:183
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:293
@@ -28848,56 +27585,53 @@ msgid ""
 "Check for and repair unbalanced transactions and orphan splits in all "
 "accounts"
 msgstr ""
+"Tarkista ja korjaa täsmäämättömät tositteet ja orporivit kaikilla tileillä"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:197
-#, fuzzy
-#| msgid "All Accounts"
 msgid "Filter accounts"
-msgstr "Kaikki tilit"
+msgstr "Suodata tilit"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:217
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:387
-#, fuzzy
-#| msgid "Find Account"
 msgid "Edit _Account"
-msgstr "Etsi tili"
+msgstr "_Muokkaa tiliä"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:241
 msgid "Automatically clear individual transactions, given a cleared amount"
 msgstr ""
+"Hyväksy yksittäiset tositteet automaattisesti, jos niissä on hyväksytty määrä"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:271
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:427
-#, fuzzy
-#| msgid "All Accounts"
 msgid "_Delete Account…"
-msgstr "Kaikki tilit"
+msgstr "_Poista tili…"
 
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:273
 #: gnucash/ui/gnc-plugin-page-account-tree.ui:429
 msgid "Delete selected account"
-msgstr ""
+msgstr "Poista valittu tili"
 
 #: gnucash/ui/gnc-plugin-page-budget.ui:16
 #: gnucash/ui/gnc-plugin-page-budget.ui:225
 msgid "Esti_mate Budget…"
-msgstr ""
+msgstr "_Arvioi budjetti…"
 
 #: gnucash/ui/gnc-plugin-page-budget.ui:22
 #: gnucash/ui/gnc-plugin-page-budget.ui:240
 msgid "_All Periods…"
-msgstr ""
+msgstr "_Kaikki jaksot…"
 
 #: gnucash/ui/gnc-plugin-page-budget.ui:24
 #: gnucash/ui/gnc-plugin-page-budget.ui:227
 msgid ""
 "Estimate a budget value for the selected accounts from past transactions"
 msgstr ""
+"Arvioi valituille tileille budjettiluvut aiempien tositteiden perusteella"
 
 #: gnucash/ui/gnc-plugin-page-budget.ui:28
 #: gnucash/ui/gnc-plugin-page-budget.ui:255
 msgid "_Delete Budget…"
-msgstr ""
+msgstr "_Poista budjetti…"
 
 #: gnucash/ui/gnc-plugin-page-budget.ui:30
 #: gnucash/ui/gnc-plugin-page-budget.ui:257
@@ -28906,361 +27640,331 @@ msgstr ""
 
 #: gnucash/ui/gnc-plugin-page-budget.ui:34
 #: gnucash/ui/gnc-plugin-page-budget.ui:270
-#, fuzzy
-#| msgid "Edit Customer"
 msgid "Edit Note"
-msgstr "Muokkaa asiakasta"
+msgstr "Muokkaa huomautusta"
 
 #: gnucash/ui/gnc-plugin-page-budget.ui:36
 #: gnucash/ui/gnc-plugin-page-budget.ui:272
-#, fuzzy
-#| msgid "End of accounting period"
 msgid "Edit note for the selected account and period"
-msgstr "Tilikauden loppu"
+msgstr "Muokkaa muistiinpanoa valitulta tililtä ja aikaväliltä"
 
 #: gnucash/ui/gnc-plugin-page-budget.ui:42
 #: gnucash/ui/gnc-plugin-page-budget.ui:287
 msgid "Run the budget report"
-msgstr ""
+msgstr "Aja budjettiraportti"
 
 #: gnucash/ui/gnc-plugin-page-budget.ui:70
 #: gnucash/ui/gnc-plugin-page-budget.ui:200
 msgid "Budget _Options…"
-msgstr ""
+msgstr "Budjetin _asetukset…"
 
 #: gnucash/ui/gnc-plugin-page-budget.ui:72
 #: gnucash/ui/gnc-plugin-page-budget.ui:202
 msgid "Edit this budget's options"
-msgstr ""
+msgstr "Muokkaa budjetin asetuksia"
 
 #: gnucash/ui/gnc-plugin-page-budget.ui:242
 msgid "Edit budget for all periods for the selected accounts"
-msgstr ""
+msgstr "Muokkaa kaikkien aikavälien budjettia valituilta tileiltä"
 
 #: gnucash/ui/gnc-plugin-page-invoice.ui:79
 msgid "Sort _Order"
-msgstr ""
+msgstr "_Järjestys"
 
 #: gnucash/ui/gnc-plugin-page-invoice.ui:84
 msgid "_Standard"
-msgstr ""
+msgstr "_Tavanomainen"
 
 #: gnucash/ui/gnc-plugin-page-invoice.ui:102
 msgid "_Quantity"
-msgstr ""
+msgstr "_Määrä"
 
 #: gnucash/ui/gnc-plugin-page-invoice.ui:135
 #: gnucash/ui/gnc-plugin-page-invoice.ui:225
 #: gnucash/ui/gnc-plugin-page-invoice.ui:407
 msgid "_Enter"
-msgstr ""
+msgstr "_Syötä"
 
 #: gnucash/ui/gnc-plugin-page-invoice.ui:137
 #: gnucash/ui/gnc-plugin-page-invoice.ui:227
 #: gnucash/ui/gnc-plugin-page-invoice.ui:409
-#, fuzzy
-#| msgid "First day of the current month."
 msgid "Record the current entry"
-msgstr "Tämän kuukauden ensimmäinen päivä."
+msgstr "Syötä nykyinen rivi"
 
 #: gnucash/ui/gnc-plugin-page-invoice.ui:143
 #: gnucash/ui/gnc-plugin-page-invoice.ui:232
 #: gnucash/ui/gnc-plugin-page-invoice.ui:424
 msgid "Cancel the current entry"
-msgstr ""
+msgstr "Peruuta rivin lisäys"
 
 #: gnucash/ui/gnc-plugin-page-invoice.ui:149
 #: gnucash/ui/gnc-plugin-page-invoice.ui:237
 #: gnucash/ui/gnc-plugin-page-invoice.ui:439
 msgid "Delete the current entry"
-msgstr ""
+msgstr "Poista nykyinen rivi"
 
 #: gnucash/ui/gnc-plugin-page-invoice.ui:153
 #: gnucash/ui/gnc-plugin-page-invoice.ui:257
 #: gnucash/ui/gnc-plugin-page-invoice.ui:497
 msgid "_Blank"
-msgstr ""
+msgstr "_Tyhjä"
 
 #: gnucash/ui/gnc-plugin-page-invoice.ui:155
 msgid "Move to the blank entry at the bottom"
-msgstr ""
+msgstr "Siirry tyhjälle riville lopussa"
 
 #: gnucash/ui/gnc-plugin-page-invoice.ui:162
 #: gnucash/ui/gnc-plugin-page-invoice.ui:242
 #: gnucash/ui/gnc-plugin-page-invoice.ui:452
 msgid "Dup_licate Entry"
-msgstr ""
+msgstr "_Monista rivi"
 
 #: gnucash/ui/gnc-plugin-page-invoice.ui:164
 #: gnucash/ui/gnc-plugin-page-invoice.ui:244
 #: gnucash/ui/gnc-plugin-page-invoice.ui:454
-#, fuzzy
-#| msgid "Last day of the current month."
 msgid "Make a copy of the current entry"
-msgstr "Tämän kuukauden viimeinen päivä."
+msgstr "Tee kopio nykyisestä rivistä"
 
 #: gnucash/ui/gnc-plugin-page-invoice.ui:168
 #: gnucash/ui/gnc-plugin-page-invoice.ui:247
 #: gnucash/ui/gnc-plugin-page-invoice.ui:467
 msgid "Move Entry _Up"
-msgstr ""
+msgstr "Siirrä riviä _ylös"
 
 #: gnucash/ui/gnc-plugin-page-invoice.ui:170
 #: gnucash/ui/gnc-plugin-page-invoice.ui:249
 #: gnucash/ui/gnc-plugin-page-invoice.ui:469
 msgid "Move the current entry one row upwards"
-msgstr ""
+msgstr "Siirrä riviä yksi rivi ylöspäin"
 
 #: gnucash/ui/gnc-plugin-page-invoice.ui:174
 #: gnucash/ui/gnc-plugin-page-invoice.ui:252
 #: gnucash/ui/gnc-plugin-page-invoice.ui:482
 msgid "Move Entry Do_wn"
-msgstr ""
+msgstr "Siirrä riviä _alas"
 
 #: gnucash/ui/gnc-plugin-page-invoice.ui:176
 #: gnucash/ui/gnc-plugin-page-invoice.ui:254
 #: gnucash/ui/gnc-plugin-page-invoice.ui:484
 msgid "Move the current entry one row downwards"
-msgstr ""
+msgstr "Siirrä riviä yksi rivi alaspäin"
 
 #: gnucash/ui/gnc-plugin-page-invoice.ui:185
 msgid "Manage link of an external document to this item"
 msgstr ""
 
 #: gnucash/ui/gnc-plugin-page-invoice.ui:191
-#, fuzzy
-#| msgid "Select document"
 msgid "Open the linked document"
-msgstr "Valitse asiakirja"
+msgstr "Avaa yhdistetty asiakirja"
 
 #: gnucash/ui/gnc-plugin-page-invoice.ui:209
 msgid "Open a company report window for the owner of this invoice"
-msgstr ""
+msgstr "Avaa myyntilaskun omistajan yritysraportti-ikkuna"
 
 #: gnucash/ui/gnc-plugin-page-invoice.ui:259
 #: gnucash/ui/gnc-plugin-page-invoice.ui:499
 msgid "Move to the blank entry at the bottom of the Invoice"
-msgstr ""
+msgstr "Siirry pohjalla olevalle tyhjälle laskuriville"
 
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:16
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:152
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:332
-#, fuzzy
-#| msgid "Edit Customer"
 msgid "E_dit Customer"
-msgstr "Muokkaa asiakasta"
+msgstr "_Muokkaa asiakasta"
 
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:19
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:154
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:222
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:334
-#, fuzzy
-#| msgid "Edit Customer"
 msgid "Edit the selected customer"
-msgstr "Muokkaa asiakasta"
+msgstr "Muokkaa valittua asiakasta"
 
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:25
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:319
-#, fuzzy
-#| msgid "New Customer"
 msgid "Create a new customer"
-msgstr "Uusi asiakas"
+msgstr "Luo uusi asiakas"
 
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:32
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:186
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:487
 msgid "E_dit Vendor"
-msgstr ""
+msgstr "_Muokkaa toimittajaa"
 
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:35
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:188
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:489
 msgid "Edit the selected vendor"
-msgstr ""
+msgstr "Muokkaa valittua toimittajaa"
 
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:41
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:474
 msgid "Create a new vendor"
-msgstr ""
+msgstr "Luo uusi toimittaja"
 
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:48
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:220
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:642
-#, fuzzy
-#| msgid "Edit Employee"
 msgid "E_dit Employee"
-msgstr "Muokkaa työntekijää"
+msgstr "_Muokkaa työntekijää"
 
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:51
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:644
-#, fuzzy
-#| msgid "Edit Employee"
 msgid "Edit the selected employee"
-msgstr "Muokkaa työntekijää"
+msgstr "Muokkaa valittua työntekijää"
 
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:57
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:629
-#, fuzzy
-#| msgid "New Employee"
 msgid "Create a new employee"
-msgstr "Uusi työntekijä"
+msgstr "Luo uusi työntekijä"
 
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:106
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:166
 msgid "Show customer report"
-msgstr ""
+msgstr "Näytä asiakasraportti"
 
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:112
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:374
 msgid "Show customer aging overview for all customers"
-msgstr ""
+msgstr "Näytä asiakkaiden vanhentumisnäkymä"
 
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:121
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:200
 msgid "Show vendor report"
-msgstr ""
+msgstr "Näytä toimittajaraportti"
 
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:127
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:529
 msgid "Show vendor aging overview for all vendors"
-msgstr ""
+msgstr "Näytä kaikkien toimittajien vanhentumisnäkymä"
 
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:136
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:234
 msgid "Show employee report"
-msgstr ""
+msgstr "Näytä työntekijäraportti"
 
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:161
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:359
 msgid "Create a new invoice"
-msgstr ""
+msgstr "Luo uusi myyntilasku"
 
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:195
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:514
 msgid "Create a new bill"
-msgstr ""
+msgstr "Luo uusi ostolasku"
 
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:227
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:667
-#, fuzzy
-#| msgid "Voucher"
 msgid "New _Voucher…"
-msgstr "Matkalasku"
+msgstr "Uusi _matkalasku…"
 
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:229
 #: gnucash/ui/gnc-plugin-page-owner-tree.ui:669
 msgid "Create a new voucher"
-msgstr ""
+msgstr "Luo uusi matkalasku"
 
 #: gnucash/ui/gnc-plugin-page-register.ui:6
 msgid "_Print Checks…"
-msgstr ""
+msgstr "_Tulosta šekkejä…"
 
 #: gnucash/ui/gnc-plugin-page-register.ui:15
 #: gnucash/ui/gnc-plugin-page-register.ui:444
 #: gnucash/ui/gnc-plugin-page-register.ui:556
 msgid "Assign as payment…"
-msgstr ""
+msgstr "Määritä maksuksi…"
 
 #: gnucash/ui/gnc-plugin-page-register.ui:17
 #: gnucash/ui/gnc-plugin-page-register.ui:446
 #: gnucash/ui/gnc-plugin-page-register.ui:558
 msgid "Assign the selected transaction as payment."
-msgstr ""
+msgstr "Määritä valittu tosite maksuksi."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:22
 #: gnucash/ui/gnc-plugin-page-register.ui:450
 #: gnucash/ui/gnc-plugin-page-register.ui:562
-#, fuzzy
-#| msgid "Edit…"
 msgid "Edit payment…"
-msgstr "Muokkaa…"
+msgstr "Muokkaa maksua…"
 
 #: gnucash/ui/gnc-plugin-page-register.ui:24
 #: gnucash/ui/gnc-plugin-page-register.ui:452
 #: gnucash/ui/gnc-plugin-page-register.ui:564
 msgid "Edit the payment this transaction is a part of."
-msgstr ""
+msgstr "Muokkaa maksua, jonka osa tämä tosite on."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:35
 msgid "Edit the selected account."
-msgstr ""
+msgstr "Muokkaa valittua tiliä."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:42
-#, fuzzy
-#| msgid "Find Account"
 msgid "Find an account."
-msgstr "Etsi tili"
+msgstr "Etsi tili."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:52
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Find transactions with a search."
-msgstr "Etsi tosite"
+msgstr "Etsi tapahtumia haulla."
 
 #. Translators: currently implemented are, US: income tax and DE: VAT, So adjust this string
 #: gnucash/ui/gnc-plugin-page-register.ui:63
 msgid "Setup relevant accounts for tax reports, e.g. US income tax."
-msgstr ""
+msgstr "Määritä tilit veroraporttia varten."
 
 #. Translators: This is a menu item in the View menu
 #: gnucash/ui/gnc-plugin-page-register.ui:71
 msgid "_Basic Ledger"
-msgstr ""
+msgstr "_Yksinkertainen näkymä"
 
 #: gnucash/ui/gnc-plugin-page-register.ui:74
 msgid "Show transactions on one or two lines."
-msgstr ""
+msgstr "Näytä tositteet yhdellä tai kahdella rivillä."
 
 #. Translators: This is a menu item in the View menu
 #: gnucash/ui/gnc-plugin-page-register.ui:79
 msgid "_Auto-Split Ledger"
-msgstr ""
+msgstr "_Tilikirjan automaattinen jako"
 
 #: gnucash/ui/gnc-plugin-page-register.ui:82
 msgid ""
 "Show transactions on one or two lines and expand the current transaction."
 msgstr ""
+"Näytä tositteet joko yhdellä tai kahdella rivillä, ja näytä valittu tosite "
+"kokonaan."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:90
 msgid "Show expanded transactions with all splits."
-msgstr ""
+msgstr "Näytä laajennetut tositteet kaikkine riveineen."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:107
 #: gnucash/ui/gnc-plugin-page-register.ui:349
 #: gnucash/ui/gnc-plugin-page-register.ui:461
 msgid "_Sort By…"
-msgstr ""
+msgstr "_Järjestä…"
 
 #: gnucash/ui/gnc-plugin-page-register.ui:123
 msgid "Refresh this window."
-msgstr ""
+msgstr "Päivitä tämä ikkuna."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:132
 msgid "Cut the selected transaction into clipboard."
-msgstr ""
+msgstr "Leikkaa valittu tosite leikepöydälle."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:138
 msgid "Copy the selected transaction into clipboard."
-msgstr ""
+msgstr "Kopioi valittu tosite leikepöydälle."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:144
 msgid "Paste the transaction from the clipboard."
-msgstr ""
+msgstr "Liitä tosite leikepöydältä."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:150
 #: gnucash/ui/gnc-plugin-page-register.ui:366
 #: gnucash/ui/gnc-plugin-page-register.ui:576
-#, fuzzy
-#| msgid "Last day of the current month."
 msgid "Make a copy of the current transaction."
-msgstr "Tämän kuukauden viimeinen päivä."
+msgstr "Tee kopio valitusta tositteesta."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:156
 #: gnucash/ui/gnc-plugin-page-register.ui:371
 #: gnucash/ui/gnc-plugin-page-register.ui:581
 msgid "Delete the current transaction."
-msgstr ""
+msgstr "Poista tämä tosite."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:162
 #: gnucash/ui/gnc-plugin-page-register.ui:376
@@ -29268,7 +27972,7 @@ msgstr ""
 #: gnucash/ui/gnc-plugin-page-register.ui:586
 #: gnucash/ui/gnc-plugin-page-register.ui:625
 msgid "Remove all splits in the current transaction."
-msgstr ""
+msgstr "Poista tositteen kaikki rivit."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:171
 #: gnucash/ui/gnc-plugin-page-register.ui:383
@@ -29276,7 +27980,7 @@ msgstr ""
 #: gnucash/ui/gnc-plugin-page-register.ui:593
 #: gnucash/ui/gnc-plugin-page-register.ui:632
 msgid "Record the current transaction."
-msgstr ""
+msgstr "Kirjaa tämä tosite."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:177
 #: gnucash/ui/gnc-plugin-page-register.ui:388
@@ -29284,52 +27988,44 @@ msgstr ""
 #: gnucash/ui/gnc-plugin-page-register.ui:598
 #: gnucash/ui/gnc-plugin-page-register.ui:637
 msgid "Cancel the current transaction."
-msgstr ""
+msgstr "Peruuta tämä tosite."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:184
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "_Void Transaction"
-msgstr "Etsi tosite"
+msgstr "_Mitätöi tosite"
 
 #: gnucash/ui/gnc-plugin-page-register.ui:186
-#, fuzzy
-#| msgid "The current date."
 msgid "Void the current transaction."
-msgstr "Tämä päiväys."
+msgstr "Mitätöi tämä tosite."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:190
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "_Unvoid Transaction"
-msgstr "Etsi tosite"
+msgstr "K_umoa mitätöinti"
 
 #: gnucash/ui/gnc-plugin-page-register.ui:192
 msgid "Unvoid the current transaction."
-msgstr ""
+msgstr "Kumoa tämän tositteen mitätöinti."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:196
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Add _Reversing Transaction"
-msgstr "Etsi tosite"
+msgstr "Lisää k_äänteinen tosite"
 
 #: gnucash/ui/gnc-plugin-page-register.ui:198
 msgid "Add a reversing transaction."
-msgstr ""
+msgstr "Lisää käänteinen tosite."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:207
 #: gnucash/ui/gnc-plugin-page-register.ui:395
 #: gnucash/ui/gnc-plugin-page-register.ui:507
 msgid ""
 "Add, change, or unlink the document linked with the current transaction."
-msgstr ""
+msgstr "Lisää, muuta tai poista tähän tositteeseen yhdistetty asiakirja."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:213
 #: gnucash/ui/gnc-plugin-page-register.ui:400
 #: gnucash/ui/gnc-plugin-page-register.ui:512
 msgid "Open the linked document for the current transaction."
-msgstr ""
+msgstr "Avaa tähän tositteeseen yhdistetty asiakirja."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:222
 #: gnucash/ui/gnc-plugin-page-register.ui:407
@@ -29339,25 +28035,26 @@ msgstr ""
 
 #: gnucash/ui/gnc-plugin-page-register.ui:232
 msgid "Transfer funds from one account to another."
-msgstr ""
+msgstr "Siirrä varoja tililtä toiselle."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:238
 msgid "Reconcile the selected account."
-msgstr ""
+msgstr "Täsmäytä valittu tili."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:244
 msgid ""
 "Automatically clear individual transactions, so as to reach a certain "
 "cleared amount."
 msgstr ""
+"Hyväksy yksittäiset tositteet automaattisesti, jos niissä on hyväksytty määrä."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:256
 msgid "Record a stock split or a stock merger."
-msgstr ""
+msgstr "Merkitse osakejako tai osakkeiden yhdistäminen."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:262
 msgid "Bring up the lot viewer/editor window."
-msgstr ""
+msgstr "Avaa erien katselu- ja muokkausikkuna."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:272
 #: gnucash/ui/gnc-plugin-page-register.ui:414
@@ -29365,55 +28062,52 @@ msgstr ""
 #: gnucash/ui/gnc-plugin-page-register.ui:605
 #: gnucash/ui/gnc-plugin-page-register.ui:644
 msgid "Move to the blank transaction in the register."
-msgstr ""
+msgstr "Siirry tilikirjan tyhjään tositteeseen."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:276
 #: gnucash/ui/gnc-plugin-page-register.ui:417
 #: gnucash/ui/gnc-plugin-page-register.ui:529
 msgid "_Go to Date"
-msgstr ""
+msgstr "_Siirry päivään"
 
 #: gnucash/ui/gnc-plugin-page-register.ui:279
 #: gnucash/ui/gnc-plugin-page-register.ui:419
 #: gnucash/ui/gnc-plugin-page-register.ui:531
+#, fuzzy
 msgid "Move to the split at the specified date."
-msgstr ""
+msgstr "Siirry annetun päivän riville."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:283
 #: gnucash/ui/gnc-plugin-page-register.ui:422
 #: gnucash/ui/gnc-plugin-page-register.ui:534
 #: gnucash/ui/gnc-plugin-page-register.ui:817
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "S_plit Transaction"
-msgstr "Etsi tosite"
+msgstr "_Jaa tosite"
 
 #: gnucash/ui/gnc-plugin-page-register.ui:285
 #: gnucash/ui/gnc-plugin-page-register.ui:424
 #: gnucash/ui/gnc-plugin-page-register.ui:536
 msgid "Show all splits in the current transaction."
-msgstr ""
+msgstr "Näytä valitun tositteen kaikki rivit."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:289
 #: gnucash/ui/gnc-plugin-page-register.ui:427
 #: gnucash/ui/gnc-plugin-page-register.ui:539
 msgid "Edit E_xchange Rate"
-msgstr ""
+msgstr "Muuta valuutta_kurssia"
 
 #: gnucash/ui/gnc-plugin-page-register.ui:291
 #: gnucash/ui/gnc-plugin-page-register.ui:429
 #: gnucash/ui/gnc-plugin-page-register.ui:541
-#, fuzzy
-#| msgid "Enter the number of shares you gained or lost in the transaction."
 msgid "Edit the exchange rate for the current transaction."
-msgstr "Syötä saamiesi tai menettämiesi osakkeiden määrä tositteelle."
+msgstr "Muuta valuuttakurssia tälle tositteelle."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:295
 #: gnucash/ui/gnc-plugin-page-register.ui:432
 #: gnucash/ui/gnc-plugin-page-register.ui:544
 #: gnucash/ui/gnc-plugin-page-register.ui:847
 msgid "Sche_dule…"
-msgstr ""
+msgstr "Ajas_ta…"
 
 #: gnucash/ui/gnc-plugin-page-register.ui:297
 #: gnucash/ui/gnc-plugin-page-register.ui:434
@@ -29423,6 +28117,8 @@ msgid ""
 "Create a Scheduled Transaction with the current transaction as a template or "
 "edit the Scheduled Transaction that current transaction was created by."
 msgstr ""
+"Luo uusi tositteen ajastus tämän tositteen pohjalta "
+"tai muokkaa ajastusta, joka oli tehnyt tämän tositteen."
 
 #. Translators: This is a menu item that will open a register tab for the
 #. account of the first other account in the current transaction's split list
@@ -29432,126 +28128,110 @@ msgstr ""
 #: gnucash/ui/gnc-plugin-page-register.ui:549
 #: gnucash/ui/gnc-plugin-page-register.ui:832
 msgid "_Jump to the other account"
-msgstr ""
+msgstr "_Hyppää toiseen tiliin"
 
 #: gnucash/ui/gnc-plugin-page-register.ui:306
 #: gnucash/ui/gnc-plugin-page-register.ui:439
 #: gnucash/ui/gnc-plugin-page-register.ui:551
 msgid ""
 "Open a new register tab for the other account with focus on this transaction."
-msgstr ""
+msgstr "Avaa tämä tosite uudella välilehdellä tositteen toiselle tilille."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:318
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "All Transactions"
-msgstr "Etsi tosite"
+msgstr "Kaikki tositteet"
 
 #: gnucash/ui/gnc-plugin-page-register.ui:323
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "This transaction"
-msgstr "Etsi tosite"
+msgstr "Valittu tosite"
 
 #: gnucash/ui/gnc-plugin-page-register.ui:332
-#, fuzzy
-#| msgid "Account Types"
 msgid "Account Report"
-msgstr "Tilityypit"
+msgstr "Tiliraportti"
 
 #: gnucash/ui/gnc-plugin-page-register.ui:334
 msgid "Open a register report for this Account."
-msgstr ""
+msgstr "Avaa tilikirjaraportti tästä tilistä."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:338
 msgid "Account Report - Single Transaction"
-msgstr ""
+msgstr "Tiliraportti - yksi tosite"
 
 #: gnucash/ui/gnc-plugin-page-register.ui:340
 msgid "Open a register report for the selected Transaction."
-msgstr ""
+msgstr "Avaa tilikirjaraportti valitulle tositteelle."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:359
 #: gnucash/ui/gnc-plugin-page-register.ui:471
 msgid "Rename this page."
-msgstr ""
+msgstr "Muuta avoimen sivun nimeä."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:478
 #: gnucash/ui/gnc-plugin-page-register.ui:615
-#, fuzzy
-#| msgid "Last day of the current month."
 msgid "Make a copy of the current split."
-msgstr "Tämän kuukauden viimeinen päivä."
+msgstr "Tee kopio tästä tositerivistä."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:483
 #: gnucash/ui/gnc-plugin-page-register.ui:620
-#, fuzzy
-#| msgid "The current date."
 msgid "Delete the current split."
-msgstr "Tämä päiväys."
+msgstr "Poista tämä tositerivi."
 
 #: gnucash/ui/gnc-plugin-page-register.ui:804
 msgid "Move to the blank transaction in the register"
-msgstr ""
+msgstr "Siirry tilikirjan tyhjään tositteeseen"
 
 #: gnucash/ui/gnc-plugin-page-register.ui:819
 msgid "Show all splits in the current transaction"
-msgstr ""
+msgstr "Näytä valitun tositteen kaikki rivit"
 
 #: gnucash/ui/gnc-plugin-page-register.ui:834
 msgid ""
 "Open a new register tab for the other account with focus on this transaction"
-msgstr ""
+msgstr "Avaa tämä tosite uudella välilehdellä tositteen toiselle tilille"
 
 #: gnucash/ui/gnc-plugin-page-report.ui:6
 #: gnucash/ui/gnc-plugin-page-report.ui:300
 msgid "_Print Report…"
-msgstr ""
+msgstr "_Tulosta raportti…"
 
 #: gnucash/ui/gnc-plugin-page-report.ui:9
 #: gnucash/ui/gnc-plugin-page-report.ui:302
-#, fuzzy
-#| msgid "Start of current quarter"
 msgid "Print the current report"
-msgstr "Tämän vuosineljänneksen alku"
+msgstr "Tulosta tämä raportti"
 
 #: gnucash/ui/gnc-plugin-page-report.ui:26
 #: gnucash/ui/gnc-plugin-page-report.ui:240
-#, fuzzy
-#| msgid "New Book Options"
 msgid "_Report Options"
-msgstr "Uuden kirjanpidon asetukset"
+msgstr "_Raportin asetukset"
 
 #: gnucash/ui/gnc-plugin-page-report.ui:28
 #: gnucash/ui/gnc-plugin-report-system.ui:8
 msgid "Edit report style sheets"
-msgstr ""
+msgstr "Muokkaa raportin tyyliä"
 
 #: gnucash/ui/gnc-plugin-page-report.ui:56
 #: gnucash/ui/gnc-plugin-page-report.ui:315
 msgid "Export as P_DF…"
-msgstr ""
+msgstr "Vie P_DF:ksi…"
 
 #: gnucash/ui/gnc-plugin-page-report.ui:58
 #: gnucash/ui/gnc-plugin-page-report.ui:317
 msgid "Export the current report as a PDF document"
-msgstr ""
+msgstr "Vie tämä raportti PDF-tiedostoon"
 
 #: gnucash/ui/gnc-plugin-page-report.ui:65
 msgid "Export _Report…"
-msgstr ""
+msgstr "Vie _raportti…"
 
 #: gnucash/ui/gnc-plugin-page-report.ui:67
 #: gnucash/ui/gnc-plugin-page-report.ui:287
 msgid "Export HTML-formatted report to file"
-msgstr ""
+msgstr "Vie HTML-muotoiltu raportti tiedostoon"
 
 #: gnucash/ui/gnc-plugin-page-report.ui:77
 #: gnucash/ui/gnc-plugin-page-report.ui:257
-#, fuzzy
-#| msgid "Delete report configuration"
 msgid "Update the current report's saved configuration"
-msgstr "Poista raportin asetuksia"
+msgstr "Päivitä nykyisen raportin tallennetut asetukset"
 
 #: gnucash/ui/gnc-plugin-page-report.ui:84
 #: gnucash/ui/gnc-plugin-page-report.ui:272
@@ -29559,44 +28239,43 @@ msgid ""
 "Add the current report's configuration to the 'Reports->Saved Report "
 "Configurations' menu"
 msgstr ""
+"Lisää nykyisen raportin asetukset 'Tallennetut raporttiasetukset' -valikkoon"
 
 #: gnucash/ui/gnc-plugin-page-report.ui:170
 msgid "Back"
-msgstr ""
+msgstr "Taaksepäin"
 
 #: gnucash/ui/gnc-plugin-page-report.ui:172
 msgid "Move back one step in the history"
-msgstr ""
+msgstr "Siirry yksi sivu taaksepäin historiassa"
 
 #: gnucash/ui/gnc-plugin-page-report.ui:185
 msgid "Forward"
-msgstr ""
+msgstr "Eteenpäin"
 
 #: gnucash/ui/gnc-plugin-page-report.ui:187
 msgid "Move forward one step in the history"
-msgstr ""
+msgstr "Siirry yksi sivu eteenpäin historiassa"
 
 #: gnucash/ui/gnc-plugin-page-report.ui:200
 msgid "Reload"
-msgstr ""
+msgstr "Päivitä"
 
 #: gnucash/ui/gnc-plugin-page-report.ui:202
-#, fuzzy
-#| msgid "The current date."
 msgid "Reload the current page"
-msgstr "Tämä päiväys."
+msgstr "Päivitä sivu"
 
 #: gnucash/ui/gnc-plugin-page-report.ui:215
 msgid "Stop"
-msgstr ""
+msgstr "Pysäytä"
 
 #: gnucash/ui/gnc-plugin-page-report.ui:217
 msgid "Cancel outstanding HTML requests"
-msgstr ""
+msgstr "Peruuta keskeneräinen HTML-pyyntö"
 
 #: gnucash/ui/gnc-plugin-page-report.ui:285
 msgid "Export _Report"
-msgstr ""
+msgstr "Vie _raportti"
 
 #: gnucash/ui/gnc-plugin-page-sx-list.ui:37
 msgid "_Save layout as default"
@@ -29609,81 +28288,72 @@ msgstr ""
 #: gnucash/ui/gnc-plugin-page-sx-list.ui:55
 #: gnucash/ui/gnc-plugin-page-sx-list.ui:155
 msgid "Create a new scheduled transaction"
-msgstr ""
+msgstr "Luo uusi tositteen ajastus"
 
 #: gnucash/ui/gnc-plugin-page-sx-list.ui:61
 #: gnucash/ui/gnc-plugin-page-sx-list.ui:170
 msgid "Edit the selected scheduled transaction"
-msgstr ""
+msgstr "Muokkaa valittua tositteen ajastusta"
 
 #: gnucash/ui/gnc-plugin-page-sx-list.ui:67
 #: gnucash/ui/gnc-plugin-page-sx-list.ui:195
 msgid "Delete the selected scheduled transaction"
-msgstr ""
+msgstr "Poista valittu tositteen ajastus"
 
 #: gnucash/ui/gnc-plugin-qif-import.ui:6
 msgid "Import _QIF…"
-msgstr ""
+msgstr "Tuo _QIF-tiedosto…"
 
 #: gnucash/ui/gnc-plugin-qif-import.ui:8
 msgid "Import a Quicken QIF file"
-msgstr ""
+msgstr "Tuo Quicken QIF-tiedosto"
 
 #: gnucash/ui/gnc-plugin-register.ui:6
 msgid "_General Journal"
-msgstr ""
+msgstr "_Päiväkirja"
 
 #: gnucash/ui/gnc-plugin-register.ui:8
 msgid "Open general journal window"
-msgstr ""
+msgstr "Avaa päiväkirjaikkuna"
 
 #: gnucash/ui/gnc-plugin-report-system.ui:6
 msgid "St_yle Sheets"
-msgstr ""
+msgstr "_Tyylit"
 
 #: gnucash/ui/gnc-reconcile-window.ui:5
-#, fuzzy
-#| msgid "Reconcile"
 msgid "_Reconcile"
-msgstr "Tarkista"
+msgstr ""
 
 #: gnucash/ui/gnc-reconcile-window.ui:8
-#, fuzzy
-#| msgid "Reconciled Date"
 msgid "_Reconcile Information…"
-msgstr "Tarkistuspäivämäärä"
+msgstr "_Täsmäytyksen tiedot…"
 
 #: gnucash/ui/gnc-reconcile-window.ui:14 gnucash/ui/gnc-reconcile-window.ui:247
 msgid "_Finish"
-msgstr ""
+msgstr "_Valmis"
 
 #: gnucash/ui/gnc-reconcile-window.ui:19 gnucash/ui/gnc-reconcile-window.ui:263
 msgid "_Postpone"
-msgstr ""
+msgstr "_Lykkää"
 
 #: gnucash/ui/gnc-reconcile-window.ui:33
-#, fuzzy
-#| msgid "Find Account"
 msgid "_Open Account"
-msgstr "Etsi tili"
+msgstr "_Avaa tili"
 
 #: gnucash/ui/gnc-reconcile-window.ui:58 gnucash/ui/gnc-reconcile-window.ui:98
 #: gnucash/ui/gnc-reconcile-window.ui:129
 #, fuzzy
-#| msgid "Ne_w Balance"
 msgctxt "reconcile menu"
 msgid "_Balance"
-msgstr "_Uusi saldo"
+msgstr "_Tase"
 
 #: gnucash/ui/gnc-reconcile-window.ui:68 gnucash/ui/gnc-reconcile-window.ui:106
-#, fuzzy
-#| msgid "Reconciled Date"
 msgid "_Reconcile Selection"
-msgstr "Tarkistuspäivämäärä"
+msgstr "_Täsmäytä valinta"
 
 #: gnucash/ui/gnc-reconcile-window.ui:73 gnucash/ui/gnc-reconcile-window.ui:110
 msgid "_Unreconcile Selection"
-msgstr ""
+msgstr "_Peruuta valitun täsmäytys"
 
 #: gnucash/ui/gnc-reconcile-window.ui:127
 msgid "Add a new balancing entry to the account"
@@ -29691,47 +28361,43 @@ msgstr ""
 
 #: gnucash/ui/gnc-reconcile-window.ui:144
 msgid "Edit the current transaction"
-msgstr ""
+msgstr "Muokkaa tätä vientiä"
 
 #: gnucash/ui/gnc-reconcile-window.ui:159
 msgid "Reconcile the selected transactions"
-msgstr ""
+msgstr "Täsmäytä valitut tositteet"
 
 #: gnucash/ui/gnc-reconcile-window.ui:161
-#, fuzzy
-#| msgid "Reconciled Date"
 msgid "Reconcile Selection"
-msgstr "Tarkistuspäivämäärä"
+msgstr "Täsmäytä valinta"
 
 #: gnucash/ui/gnc-reconcile-window.ui:175
 msgid "Unreconcile the selected transactions"
-msgstr ""
+msgstr "Peruuta valittujen tositteiden täsmäytys"
 
 #: gnucash/ui/gnc-reconcile-window.ui:177
 msgid "Unreconcile Selection"
-msgstr ""
+msgstr "Peruuta valinan täsmäytys"
 
 #: gnucash/ui/gnc-reconcile-window.ui:191
 msgid "Delete the selected transaction"
-msgstr ""
+msgstr "Poista valittu vienti"
 
 #: gnucash/ui/gnc-reconcile-window.ui:218
-#, fuzzy
-#| msgid "existing account"
 msgid "Open the account"
-msgstr "olemassa oleva tili"
+msgstr "Avaa tili"
 
 #: gnucash/ui/gnc-reconcile-window.ui:245
 msgid "Finish the reconciliation of this account"
-msgstr ""
+msgstr "Merkitse tämän tilin täsmäytys valmiiksi"
 
 #: gnucash/ui/gnc-reconcile-window.ui:261
 msgid "Postpone the reconciliation of this account"
-msgstr ""
+msgstr "Lykkää tämän tilin täsmäytystä"
 
 #: gnucash/ui/gnc-reconcile-window.ui:277
 msgid "Cancel the reconciliation of this account"
-msgstr ""
+msgstr "Peruuta tämän tilin täsmäytys"
 
 #: libgnucash/app-utils/gnc-exp-parser.c:615
 msgid "Illegal variable in expression."
@@ -29743,33 +28409,31 @@ msgstr ""
 
 #: libgnucash/app-utils/gnc-exp-parser.c:628
 msgid "Stack overflow"
-msgstr ""
+msgstr "Pinon ylivuoto"
 
 #: libgnucash/app-utils/gnc-exp-parser.c:630
 msgid "Stack underflow"
-msgstr ""
+msgstr "Pinon alivuoto"
 
 #: libgnucash/app-utils/gnc-exp-parser.c:632
-#, fuzzy
-#| msgid "Undefined"
 msgid "Undefined character"
-msgstr "Määrittelemätön"
+msgstr "Määrittelemätön merkki"
 
 #: libgnucash/app-utils/gnc-exp-parser.c:634
 msgid "Not a variable"
-msgstr ""
+msgstr "Ei ole muuttuja"
 
 #: libgnucash/app-utils/gnc-exp-parser.c:636
 msgid "Not a defined function"
-msgstr ""
+msgstr "Ei ole määritetty funktio"
 
 #: libgnucash/app-utils/gnc-exp-parser.c:638
 msgid "Out of memory"
-msgstr ""
+msgstr "Muisti loppu"
 
 #: libgnucash/app-utils/gnc-exp-parser.c:640
 msgid "Numeric error"
-msgstr ""
+msgstr "Numeerinen virhe"
 
 #: libgnucash/app-utils/gnc-quotes.cpp:165
 msgid "Failed to initialize Finance::Quote: "
@@ -29797,7 +28461,7 @@ msgstr ""
 
 #: libgnucash/app-utils/gnc-quotes.cpp:338
 msgid "There were no commodities for which to retrieve quotes."
-msgstr ""
+msgstr "Ei ollut hyödykkeitä, joille hakea tarjouksia."
 
 #: libgnucash/app-utils/gnc-quotes.cpp:353
 msgid "Finance::Quote retrieval failed with error "
@@ -29841,7 +28505,7 @@ msgstr ""
 
 #: libgnucash/app-utils/gnc-quotes.cpp:395
 msgid "The quote has no error set."
-msgstr ""
+msgstr "Tarjouksessa ei ole virhettä."
 
 #: libgnucash/app-utils/gnc-quotes.cpp:404
 msgid "Quotes for the following commodities were unavailable or unusable:\n"
@@ -29871,29 +28535,25 @@ msgstr ""
 #: libgnucash/app-utils/gnc-quotes.cpp:816
 msgctxt "Finance::Quote"
 msgid "required"
-msgstr ""
+msgstr "vaadittu"
 
 #. Translators: Means that the quote will work best if the preceding element is provided
 #: libgnucash/app-utils/gnc-quotes.cpp:818
 msgctxt "Finance::Quote"
 msgid "recommended"
-msgstr ""
+msgstr "suositeltu"
 
 #. Translators: Means that one of the indicated elements is required
 #: libgnucash/app-utils/gnc-quotes.cpp:820
-#, fuzzy
-#| msgid "End of this year"
 msgctxt "Finance::Quote"
 msgid "one of these"
-msgstr "Tämän vuoden loppu"
+msgstr "jokin näistä"
 
 #. Translators: Means that a required element wasn't reported. The *s are for emphasis.
 #: libgnucash/app-utils/gnc-quotes.cpp:822
-#, fuzzy
-#| msgid "missing"
 msgctxt "Finance::Quote"
 msgid "**missing**"
-msgstr "puuttuu"
+msgstr ""
 
 #: libgnucash/app-utils/gnc-quotes.cpp:829
 msgid "Finance::Quote fields GnuCash uses:"
@@ -29901,29 +28561,27 @@ msgstr ""
 
 #. Translators: The stock or Mutual Fund symbol, ISIN, CUSIP, etc.
 #: libgnucash/app-utils/gnc-quotes.cpp:831
-#, fuzzy
-#| msgid "Symbol"
 msgctxt "Finance::Quote"
 msgid "symbol: "
-msgstr "Symboli"
+msgstr "symboli: "
 
 #. Translators: The date of the quote.
 #: libgnucash/app-utils/gnc-quotes.cpp:833
 msgctxt "Finance::Quote"
 msgid "date: "
-msgstr ""
+msgstr "päiväys: "
 
 #. Translators: The quote currency
 #: libgnucash/app-utils/gnc-quotes.cpp:835
 msgctxt "Finance::Quote"
 msgid "currency: "
-msgstr ""
+msgstr "rahayksikkö: "
 
 #. Translators: The quote is for the most recent trade on the exchange
 #: libgnucash/app-utils/gnc-quotes.cpp:841
 msgctxt "Finance::Quote"
 msgid "last: "
-msgstr ""
+msgstr "viimeisin: "
 
 #. Translators: The quote is for an open-ended mutual fund and represents the net asset value of one unit of the fund at the previous close of trading.
 #: libgnucash/app-utils/gnc-quotes.cpp:843
@@ -29935,7 +28593,7 @@ msgstr ""
 #: libgnucash/app-utils/gnc-quotes.cpp:845
 msgctxt "Finance::Quote"
 msgid "price: "
-msgstr ""
+msgstr "hinta: "
 
 #: libgnucash/app-utils/gnc-quotes.cpp:865
 msgid "Finance::Quote reported a failure for symbol "
@@ -30001,27 +28659,27 @@ msgstr ""
 #: libgnucash/app-utils/gnc-ui-util.cpp:472
 msgctxt "Reconciled flag 'not cleared'"
 msgid "n"
-msgstr ""
+msgstr "e"
 
 #: libgnucash/app-utils/gnc-ui-util.cpp:474
 msgctxt "Reconciled flag 'cleared'"
 msgid "c"
-msgstr ""
+msgstr "h"
 
 #: libgnucash/app-utils/gnc-ui-util.cpp:476
 msgctxt "Reconciled flag 'reconciled'"
 msgid "y"
-msgstr ""
+msgstr "t"
 
 #: libgnucash/app-utils/gnc-ui-util.cpp:478
 msgctxt "Reconciled flag 'frozen'"
 msgid "f"
-msgstr ""
+msgstr "j"
 
 #: libgnucash/app-utils/gnc-ui-util.cpp:480
 msgctxt "Reconciled flag 'void'"
 msgid "v"
-msgstr ""
+msgstr "m"
 
 #: libgnucash/app-utils/gnc-ui-util.cpp:520
 msgctxt "Document Link flag for 'web'"
@@ -30031,18 +28689,16 @@ msgstr ""
 #: libgnucash/app-utils/gnc-ui-util.cpp:522
 msgctxt "Document Link flag for 'file'"
 msgid "f"
-msgstr ""
+msgstr "t"
 
 #: libgnucash/app-utils/gnc-ui-util.cpp:551
-#, fuzzy
-#| msgid "Opening Balance"
 msgid "Opening Balances"
-msgstr "Avaussaldo"
+msgstr "Avaussaldot"
 
 #. Translators: this string refers to a file name that gets renamed
 #: libgnucash/core-utils/gnc-filepath-utils.cpp:648
 msgid "Renamed to:"
-msgstr ""
+msgstr "Nimetty uudelleen nimelle:"
 
 #: libgnucash/core-utils/gnc-filepath-utils.cpp:673
 msgid "Notice"
@@ -30055,16 +28711,15 @@ msgstr ""
 #. Translators: this refers to a directory name.
 #: libgnucash/core-utils/gnc-filepath-utils.cpp:680
 msgid "Old location:"
-msgstr ""
+msgstr "Vanha kansio:"
 
 #. Translators: this refers to a directory name.
 #: libgnucash/core-utils/gnc-filepath-utils.cpp:682
 msgid "New location:"
-msgstr "Uusi sijainti:"
+msgstr "Uusi kansio:"
 
 #. Translators {1} will be replaced with the package name (typically Gnucash) at runtime
 #: libgnucash/core-utils/gnc-filepath-utils.cpp:684
-#, c++-format
 msgid ""
 "If you no longer intend to run {1} 2.6.x or older on this system you can "
 "safely remove the old directory."
@@ -30075,17 +28730,14 @@ msgid "In addition:"
 msgstr ""
 
 #: libgnucash/core-utils/gnc-filepath-utils.cpp:697
-#, c++-format
 msgid "The following file has been copied to {1} instead:"
 msgid_plural "The following files have been copied to {1} instead:"
 msgstr[0] ""
 msgstr[1] ""
 
 #: libgnucash/core-utils/gnc-filepath-utils.cpp:701
-#, fuzzy, c++-format
-#| msgid "The following errors must be fixed:"
 msgid "The following file in {1} has been renamed:"
-msgstr "Seuraavat virheet on korjattava:"
+msgstr ""
 
 #: libgnucash/core-utils/gnc-filepath-utils.cpp:711
 msgid "The following file has become obsolete and will be ignored:"
@@ -30094,16 +28746,14 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: libgnucash/core-utils/gnc-filepath-utils.cpp:721
-#, fuzzy, c++-format
-#| msgid "The following errors must be fixed:"
 msgid "The following file could not be moved to {1}:"
 msgid_plural "The following files could not be moved to {1}:"
-msgstr[0] "Seuraavat virheet on korjattava:"
-msgstr[1] "Seuraavat virheet on korjattava:"
+msgstr[0] ""
+msgstr[1] ""
 
 #: libgnucash/engine/Account.cpp:150
 msgid "Deposit"
-msgstr ""
+msgstr "Talletus"
 
 #: libgnucash/engine/Account.cpp:151
 msgid "Receive"
@@ -30111,11 +28761,11 @@ msgstr ""
 
 #: libgnucash/engine/Account.cpp:170
 msgid "Withdrawal"
-msgstr ""
+msgstr "Nosto"
 
 #: libgnucash/engine/Account.cpp:171
 msgid "Spend"
-msgstr ""
+msgstr "Kulutus"
 
 #: libgnucash/engine/Account.cpp:249
 #, c-format
@@ -30130,21 +28780,16 @@ msgid ""
 msgstr ""
 
 #: libgnucash/engine/Account.cpp:4291
-#, fuzzy
-#| msgid "Credit"
 msgid "Credit Card"
-msgstr "Kredit"
+msgstr "Luottokortti"
 
 #: libgnucash/engine/Account.cpp:4293
-#, fuzzy
-#| msgctxt "Stock Assistant: Page name"
-#| msgid "Stock"
 msgid "Stock"
 msgstr "Osake"
 
 #: libgnucash/engine/Account.cpp:4294
 msgid "Mutual Fund"
-msgstr ""
+msgstr "Rahasto"
 
 #: libgnucash/engine/Account.cpp:4299
 msgid "A/Receivable"
@@ -30160,12 +28805,12 @@ msgstr ""
 
 #: libgnucash/engine/Account.cpp:4741
 msgid "Orphaned Gains"
-msgstr ""
+msgstr "Hylätyt tulot"
 
 #: libgnucash/engine/Account.cpp:4755 libgnucash/engine/cap-gains.cpp:804
 #: libgnucash/engine/cap-gains.cpp:809 libgnucash/engine/cap-gains.cpp:810
 msgid "Realized Gain/Loss"
-msgstr ""
+msgstr "Toteutuneet tulot/menot"
 
 #: libgnucash/engine/Account.cpp:4757
 msgid ""
@@ -30504,33 +29149,33 @@ msgstr ""
 #: libgnucash/engine/gnc-commodity.h:110
 msgctxt "Commodity Type"
 msgid "All non-currency"
-msgstr ""
+msgstr "Kaikki ei-valuutta"
 
 #: libgnucash/engine/gnc-commodity.h:111
 msgctxt "Commodity Type"
 msgid "Currencies"
-msgstr ""
+msgstr "Valuutat"
 
 #: libgnucash/engine/gnc-date.cpp:76
 msgid "%B %#d, %Y"
-msgstr ""
+msgstr "%#d.%#m.%Y"
 
 #. Translators: call "man strftime" for possible values.
 #: libgnucash/engine/gnc-date.cpp:80
 msgid "%B %e, %Y"
-msgstr ""
+msgstr "%d.%m.%Y"
 
 #: libgnucash/engine/gnc-datetime.cpp:95
 msgid "y-m-d"
-msgstr ""
+msgstr "y-m-d"
 
 #: libgnucash/engine/gnc-datetime.cpp:108
 msgid "d-m-y"
-msgstr ""
+msgstr "d-m-y"
 
 #: libgnucash/engine/gnc-datetime.cpp:121
 msgid "m-d-y"
-msgstr ""
+msgstr "m-d-y"
 
 #: libgnucash/engine/gnc-datetime.cpp:136
 msgid "d-m"
@@ -30542,7 +29187,7 @@ msgstr ""
 
 #: libgnucash/engine/gnc-datetime.cpp:688
 msgid "Unknown date format specifier passed as argument."
-msgstr ""
+msgstr "Tuntematon määrittely päiväyksen muotoilulle annettu argumenttina."
 
 #: libgnucash/engine/gnc-datetime.cpp:706
 msgid "Value can't be parsed into a date using the selected date format."
@@ -30573,161 +29218,135 @@ msgstr " (lähetetty)"
 
 #: libgnucash/engine/gnc-option-date.cpp:88
 msgid "One Week Ago"
-msgstr ""
+msgstr "Viikko sitten"
 
 #: libgnucash/engine/gnc-option-date.cpp:89
 msgid "One Week Ago."
-msgstr ""
+msgstr "Viikko sitten."
 
 #: libgnucash/engine/gnc-option-date.cpp:96
 msgid "One Week Ahead"
-msgstr ""
+msgstr "Viikko eteenpäin"
 
 #: libgnucash/engine/gnc-option-date.cpp:97
 msgid "One Week Ahead."
-msgstr ""
+msgstr "Viikko eteenpäin."
 
 #: libgnucash/engine/gnc-option-date.cpp:104
 msgid "One Month Ago"
-msgstr ""
+msgstr "Kuukausi sitten"
 
 #: libgnucash/engine/gnc-option-date.cpp:105
 msgid "One Month Ago."
-msgstr ""
+msgstr "Kuukausi sitten."
 
 #: libgnucash/engine/gnc-option-date.cpp:112
 msgid "One Month Ahead"
-msgstr ""
+msgstr "Kuukausi eteenpäin"
 
 #: libgnucash/engine/gnc-option-date.cpp:113
 msgid "One Month Ahead."
-msgstr ""
+msgstr "Kuukausi eteenpäin."
 
 #: libgnucash/engine/gnc-option-date.cpp:120
 msgid "Three Months Ago"
-msgstr ""
+msgstr "Kolme kuukautta sitten"
 
 #: libgnucash/engine/gnc-option-date.cpp:121
 msgid "Three Months Ago."
-msgstr ""
+msgstr "Kolme kuukautta sitten."
 
 #: libgnucash/engine/gnc-option-date.cpp:128
 msgid "Three Months Ahead"
-msgstr ""
+msgstr "Kolme kuukautta eteenpäin"
 
 #: libgnucash/engine/gnc-option-date.cpp:129
 msgid "Three Months Ahead."
-msgstr ""
+msgstr "Kolme kuukautta eteenpäin."
 
 #: libgnucash/engine/gnc-option-date.cpp:136
 msgid "Six Months Ago"
-msgstr ""
+msgstr "Kuusi kuukautta sitten"
 
 #: libgnucash/engine/gnc-option-date.cpp:137
 msgid "Six Months Ago."
-msgstr ""
+msgstr "Kuusi kuukautta sitten."
 
 #: libgnucash/engine/gnc-option-date.cpp:144
 msgid "Six Months Ahead"
-msgstr ""
+msgstr "Kuusi kuukautta eteenpäin"
 
 #: libgnucash/engine/gnc-option-date.cpp:145
 msgid "Six Months Ahead."
-msgstr ""
+msgstr "Kuusi kuukautta eteenpäin."
 
 #: libgnucash/engine/gnc-option-date.cpp:152
 msgid "One Year Ago"
-msgstr ""
+msgstr "Vuosi sitten"
 
 #: libgnucash/engine/gnc-option-date.cpp:153
 msgid "One Year Ago."
-msgstr ""
+msgstr "Vuosi sitten."
 
 #: libgnucash/engine/gnc-option-date.cpp:160
 msgid "One Year Ahead"
-msgstr ""
+msgstr "Vuosi eteenpäin"
 
 #: libgnucash/engine/gnc-option-date.cpp:161
 msgid "One Year Ahead."
-msgstr ""
+msgstr "Vuosi eteenpäin."
 
 #: libgnucash/engine/gnc-option-date.cpp:200
-#, fuzzy
-#| msgid "Start of this month"
 msgid "Start of next month"
-msgstr "Tämän kuun alku"
+msgstr "Seuraavan kuukauden alku"
 
 #: libgnucash/engine/gnc-option-date.cpp:201
-#, fuzzy
-#| msgid "First day of the current month."
 msgid "First day of the next month."
-msgstr "Tämän kuukauden ensimmäinen päivä."
+msgstr "Seuraavan kuukauden ensimmäinen päivä."
 
 #: libgnucash/engine/gnc-option-date.cpp:208
-#, fuzzy
-#| msgid "End of this month"
 msgid "End of next month"
-msgstr "Tämän kuun loppu"
+msgstr "Seuraavan kuukauden loppu"
 
 #: libgnucash/engine/gnc-option-date.cpp:209
-#, fuzzy
-#| msgid "Last day of previous month."
 msgid "Last day of next month."
-msgstr "Edellisen kuukauden viimeinen päivä."
+msgstr "Seuraavan kuukauden viimeinen päivä."
 
 #: libgnucash/engine/gnc-option-date.cpp:248
-#, fuzzy
-#| msgid "Start of current quarter"
 msgid "Start of next quarter"
-msgstr "Tämän vuosineljänneksen alku"
+msgstr "Seuraavan vuosineljänneksen alku"
 
 #: libgnucash/engine/gnc-option-date.cpp:249
-#, fuzzy
-#| msgid "First day of the current quarterly accounting period."
 msgid "First day of the next quarterly accounting period."
-msgstr "Tämän vuosineljänneksen aloituspäivä."
+msgstr "Seuraavan vuosineljänneksen ensimmäinen päivä."
 
 #: libgnucash/engine/gnc-option-date.cpp:256
-#, fuzzy
-#| msgid "End of current quarter"
 msgid "End of next quarter"
-msgstr "Tämän vuosineljänneksen loppu"
+msgstr "Seuraavan vuosineljänneksen loppu"
 
 #: libgnucash/engine/gnc-option-date.cpp:257
-#, fuzzy
-#| msgid "Last day of previous quarterly accounting period."
 msgid "Last day of next quarterly accounting period."
-msgstr "Edellisen vuosineljänneksen viimeinen päivä."
+msgstr "Seuraavan vuosineljänneksen viimeinen päivä."
 
 #: libgnucash/engine/gnc-option-date.cpp:296
-#, fuzzy
-#| msgid "Start of this year"
 msgid "Start of next year"
-msgstr "Tämän vuoden alku"
+msgstr "Seuraavan vuoden alku"
 
 #: libgnucash/engine/gnc-option-date.cpp:297
-#, fuzzy
-#| msgid "First day of the current calendar year."
 msgid "First day of the next calendar year."
-msgstr "Tämän kalenterivuoden ensimmäinen päivä."
+msgstr "Seuraavan kalenterivuoden ensimmäinen päivä."
 
 #: libgnucash/engine/gnc-option-date.cpp:304
-#, fuzzy
-#| msgid "End of this year"
 msgid "End of next year"
-msgstr "Tämän vuoden loppu"
+msgstr "Seuraavan vuoden loppu"
 
 #: libgnucash/engine/gnc-option-date.cpp:305
-#, fuzzy
-#| msgid "Last day of the current calendar year."
 msgid "Last day of the next calendar year."
-msgstr "Tämän kalenterivuoden viimeinen päivä."
+msgstr "Seuraavan kalenterivuoden viimeinen päivä."
 
 #: libgnucash/engine/gnc-optiondb.cpp:1202
-#, fuzzy
-#| msgid "Interest"
 msgid "Counters"
-msgstr "Korko"
+msgstr "Laskurit"
 
 #: libgnucash/engine/gnc-optiondb.cpp:1209
 msgid ""
@@ -30756,209 +29375,224 @@ msgid "Budget to be used when none has been otherwise specified."
 msgstr ""
 
 #: libgnucash/engine/gnc-optiondb.cpp:1231
-#, fuzzy
-#| msgid "Customer ID"
 msgid "Customer number"
-msgstr "Asiakastunnus"
+msgstr "Asiakkaan numero"
 
 #: libgnucash/engine/gnc-optiondb.cpp:1232
 msgid ""
 "The previous customer number generated. This number will be incremented to "
 "generate the next customer number."
 msgstr ""
+"Edellisen luodun asiakkaan numero. Tätä numeroa kasvatetaan seuraavan "
+"asiakkaan numeroa muodostaessa."
 
 #: libgnucash/engine/gnc-optiondb.cpp:1235
 msgid "Customer number format"
-msgstr ""
+msgstr "Asiakkaan numeron muotoilu"
 
 #: libgnucash/engine/gnc-optiondb.cpp:1237
 msgid ""
 "The format string to use for generating customer numbers. This is a printf-"
 "style format string."
 msgstr ""
+"Muotoilulause asiakkaiden numeroiden luontiin. Käytä printf-tyylistä "
+"muotoilua."
 
 #: libgnucash/engine/gnc-optiondb.cpp:1240
-#, fuzzy
-#| msgid "Employee Name"
 msgid "Employee number"
-msgstr "Työntekijän nimi"
+msgstr "Työntekijän numero"
 
 #: libgnucash/engine/gnc-optiondb.cpp:1241
 msgid ""
 "The previous employee number generated. This number will be incremented to "
 "generate the next employee number."
 msgstr ""
+"Edellisen luodun työntekijän numero. Tätä numeroa kasvatetaan seuraavan "
+"työntekijän numeroa muodostettaessa."
 
 #: libgnucash/engine/gnc-optiondb.cpp:1244
-#, fuzzy
-#| msgid "Employee Name"
 msgid "Employee number format"
-msgstr "Työntekijän nimi"
+msgstr "Työntekijän numeron muotoilu"
 
 #: libgnucash/engine/gnc-optiondb.cpp:1246
 msgid ""
 "The format string to use for generating employee numbers. This is a printf-"
 "style format string."
 msgstr ""
+"Muotoilulasue työntekijöiden numeroiden luontiin. Käytä printf-tyylistä "
+"muotoilua."
 
 #: libgnucash/engine/gnc-optiondb.cpp:1249
-#, fuzzy
-#| msgid "Invoice"
 msgid "Invoice number"
-msgstr "Myyntilasku"
+msgstr "Laskun numero"
 
 #: libgnucash/engine/gnc-optiondb.cpp:1250
 msgid ""
 "The previous invoice number generated. This number will be incremented to "
 "generate the next invoice number."
 msgstr ""
+"Edellisen luodun myyntilaskun numero. Tätä numeroa kasvatetaan seuraavan "
+"laskun numeroa muodostettaessa."
 
 #: libgnucash/engine/gnc-optiondb.cpp:1253
 msgid "Invoice number format"
-msgstr ""
+msgstr "Myyntilaskun numeron muotoilu"
 
 #: libgnucash/engine/gnc-optiondb.cpp:1255
 msgid ""
 "The format string to use for generating invoice numbers. This is a printf-"
 "style format string."
 msgstr ""
+"Muotoilulause myyntilaskujen numeroiden luontiin. Käytä printf-tyylistä "
+"muotoilua."
 
 #: libgnucash/engine/gnc-optiondb.cpp:1258
 msgid "Bill number"
-msgstr ""
+msgstr "Ostolaskun numero"
 
 #: libgnucash/engine/gnc-optiondb.cpp:1259
 msgid ""
 "The previous bill number generated. This number will be incremented to "
 "generate the next bill number."
 msgstr ""
+"Edellisen luodun ostolaskun numero. Tätä numeroa kasvatetaan seuraavan "
+"laskun numeroa muodostaessa."
 
 #: libgnucash/engine/gnc-optiondb.cpp:1262
 msgid "Bill number format"
-msgstr ""
+msgstr "Ostolaskun numeron muotoilu"
 
 #: libgnucash/engine/gnc-optiondb.cpp:1263
 msgid ""
 "The format string to use for generating bill numbers. This is a printf-style "
 "format string."
 msgstr ""
+"Muotoilulause ostolaskujen numeroiden luontiin. Käytä printf-tyylistä "
+"muotoilua."
 
 #: libgnucash/engine/gnc-optiondb.cpp:1266
-#, fuzzy
-#| msgid "Expense Vouchers"
 msgid "Expense voucher number"
-msgstr "Matkalaskut"
+msgstr "Kulutositteen numero"
 
 #: libgnucash/engine/gnc-optiondb.cpp:1267
 msgid ""
 "The previous expense voucher number generated. This number will be "
 "incremented to generate the next voucher number."
 msgstr ""
+"Edellisen luodun kulutositteen numero. Tätä numeroa kasvatetaan uutta "
+"kulutositteen numeroa muodostettaessa."
 
 #: libgnucash/engine/gnc-optiondb.cpp:1270
-#, fuzzy
-#| msgid "Expense Vouchers"
 msgid "Expense voucher number format"
-msgstr "Matkalaskut"
+msgstr "Kulutositteen numeron muotoilu"
 
 #: libgnucash/engine/gnc-optiondb.cpp:1272
 msgid ""
 "The format string to use for generating expense voucher numbers. This is a "
 "printf-style format string."
 msgstr ""
+"Muotoilulause kulutositteiden numeroiden luontiin. Käytä printf-tyylistä "
+"muotoilua."
 
 #: libgnucash/engine/gnc-optiondb.cpp:1275
-#, fuzzy
-#| msgid "Number"
 msgid "Job number"
-msgstr "Numero"
+msgstr "Työn numero"
 
 #: libgnucash/engine/gnc-optiondb.cpp:1276
 msgid ""
 "The previous job number generated. This number will be incremented to "
 "generate the next job number."
 msgstr ""
+"Edellisen luodun hankkeen numero. Tätä numeroa kasvatetaan seuraavaa "
+"hanketta luotaessa."
 
 #: libgnucash/engine/gnc-optiondb.cpp:1279
 msgid "Job number format"
-msgstr ""
+msgstr "Hankkeen numeron muotoilu"
 
 #: libgnucash/engine/gnc-optiondb.cpp:1280
 msgid ""
 "The format string to use for generating job numbers. This is a printf-style "
 "format string."
 msgstr ""
+"Muotoilulause hankkeiden numeroiden luontiin. Käytä printf-tyylistä "
+"muotoilua."
 
 #: libgnucash/engine/gnc-optiondb.cpp:1283
 msgid "Order number"
-msgstr ""
+msgstr "Tilauksen numero"
 
 #: libgnucash/engine/gnc-optiondb.cpp:1284
 msgid ""
 "The previous order number generated. This number will be incremented to "
 "generate the next order number."
 msgstr ""
+"Edellisen luodun tilauksen numero. Tätä numeroa kasvatetaan seuraavaa "
+"tilauksen numeroa muodostettaessa."
 
 #: libgnucash/engine/gnc-optiondb.cpp:1287
 msgid "Order number format"
-msgstr ""
+msgstr "Tilauksen numeron muotoilu"
 
 #: libgnucash/engine/gnc-optiondb.cpp:1288
 msgid ""
 "The format string to use for generating order numbers. This is a printf-"
 "style format string."
 msgstr ""
+"Muotoilulause tilausten numeroiden luomiseen. Käytä printf-tyylistä "
+"muotoilua."
 
 #: libgnucash/engine/gnc-optiondb.cpp:1291
 msgid "Vendor number"
-msgstr ""
+msgstr "Myyjän numero"
 
 #: libgnucash/engine/gnc-optiondb.cpp:1292
 msgid ""
 "The previous vendor number generated. This number will be incremented to "
 "generate the next vendor number."
 msgstr ""
+"Edellinen luotu myyjän numero. Tätä numeroa kasvatetaan seuraavaa numeroa "
+"muodostettaessa."
 
 #: libgnucash/engine/gnc-optiondb.cpp:1295
 msgid "Vendor number format"
-msgstr ""
+msgstr "Myyjän numeron muotoilu"
 
 #: libgnucash/engine/gnc-optiondb.cpp:1296
 msgid ""
 "The format string to use for generating vendor numbers. This is a printf-"
 "style format string."
 msgstr ""
+"Muotoilulause myyjän numeron luomiseen. Käytä printf-tyylistä muotoilua."
 
 #: libgnucash/engine/gnc-optiondb.cpp:1302
-#, fuzzy
-#| msgid "The menu of options"
 msgid "The name of your business."
-msgstr "Vaihtoehtojen valikko"
+msgstr "Yrityksesi nimi."
 
 #: libgnucash/engine/gnc-optiondb.cpp:1305
 msgid "The address of your business."
-msgstr ""
+msgstr "Yrityksesi osoite."
 
 #: libgnucash/engine/gnc-optiondb.cpp:1309
 #: libgnucash/engine/gnc-optiondb.cpp:1313
 msgid "The contact person to print on invoices."
-msgstr ""
+msgstr "Laskuihin tulostettavan yhteyshenkilön nimi."
 
 #: libgnucash/engine/gnc-optiondb.cpp:1317
 msgid "The fax number of your business."
-msgstr ""
+msgstr "Yrityksesi faxinumero."
 
 #: libgnucash/engine/gnc-optiondb.cpp:1321
 msgid "The email address of your business."
-msgstr ""
+msgstr "Yrityksesi sähköpostiosoite."
 
 #: libgnucash/engine/gnc-optiondb.cpp:1325
 msgid "The URL address of your website."
-msgstr ""
+msgstr "Yrityksesi kotisivun osoite."
 
 #: libgnucash/engine/gnc-optiondb.cpp:1328
 msgid "The ID for your company (eg 'Tax-ID: 00-000000)."
-msgstr ""
+msgstr "Yrityksesi Y-tunnus (esim. Y: 1234567-8)."
 
 #: libgnucash/engine/gnc-optiondb.cpp:1336
 msgid ""
@@ -31004,7 +29638,7 @@ msgstr ""
 
 #: libgnucash/engine/policy.cpp:53
 msgid "First In, First Out"
-msgstr ""
+msgstr "FIFO (ensin sisään, ensin ulos)"
 
 #: libgnucash/engine/policy.cpp:54
 msgid "Use oldest lots first."
@@ -31012,7 +29646,7 @@ msgstr ""
 
 #: libgnucash/engine/policy.cpp:56
 msgid "Last In, First Out"
-msgstr ""
+msgstr "LIFO (viimeksi sisään, ensin ulos)"
 
 #: libgnucash/engine/policy.cpp:57
 msgid "Use newest lots first."
@@ -31024,13 +29658,11 @@ msgstr ""
 
 #: libgnucash/engine/policy.cpp:63
 msgid "Manually select lots."
-msgstr ""
+msgstr "Käsin valitut erät."
 
 #: libgnucash/engine/qofbookslots.h:65
-#, fuzzy
-#| msgid "Find Account"
 msgid "Use Trading Accounts"
-msgstr "Etsi tili"
+msgstr "Käytä muunnostilejä"
 
 #: libgnucash/engine/qofbookslots.h:66
 msgid "Day Threshold for Read-Only Transactions (red line)"
@@ -31042,15 +29674,15 @@ msgstr ""
 
 #: libgnucash/engine/qofbookslots.h:69
 msgid "Budgeting"
-msgstr ""
+msgstr "Budjetointi"
 
 #: libgnucash/engine/qofbookslots.h:70
 msgid "Default Budget"
-msgstr ""
+msgstr "Oletusbudjetti"
 
 #: libgnucash/engine/qofbookslots.h:74
 msgid "Default Invoice Report"
-msgstr ""
+msgstr "Oletus myyntilaskuraportti"
 
 #: libgnucash/engine/qofbookslots.h:75
 msgid "Default Invoice Report Timeout"
@@ -31076,14 +29708,14 @@ msgstr ""
 #: libgnucash/engine/Recurrence.cpp:660
 #, c-format
 msgid "last %s"
-msgstr ""
+msgstr "viimeisin %s"
 
 #. Translators: %s is the string 1st, 2nd, 3rd and so on, and
 #. %s is an already-localized form of the day of the week.
 #: libgnucash/engine/Recurrence.cpp:674
 #, c-format
 msgid "%s %s"
-msgstr ""
+msgstr "%s %s"
 
 #. Translators: %d is the number of Recurrences in the list.
 #: libgnucash/engine/Recurrence.cpp:727
@@ -31124,25 +29756,18 @@ msgid "Looking for imbalances in transaction date %s: %u of %zu"
 msgstr ""
 
 #: libgnucash/engine/Split.cpp:1645
-#, fuzzy
-#| msgctxt "Action Column"
-#| msgid "Split"
 msgctxt ""
 "Displayed account code of the other account in a multi-split transaction"
 msgid "Split"
-msgstr "Rivi"
+msgstr "Monta"
 
 #: libgnucash/engine/Transaction.cpp:2661
-#, fuzzy
-#| msgid "Find Transaction"
 msgid "Voided transaction"
-msgstr "Etsi tosite"
+msgstr "Mitätöity tosite"
 
 #: libgnucash/engine/Transaction.cpp:2674
-#, fuzzy
-#| msgid "Transaction Number"
 msgid "Transaction Voided"
-msgstr "Tositenumero"
+msgstr "Tosite mitätöity"
 
 #. Translators: This and the following strings appear on
 #. the account tab if the Tax Info column is displayed,
@@ -31213,4 +29838,4 @@ msgstr ""
 
 #: libgnucash/tax/us/txf.scm:122
 msgid "No help available."
-msgstr ""
+msgstr "Apua ei ole tarjolla."


### PR DESCRIPTION
Commit 63714e5e93b2091b35bbd0d28f69bce03a397d3e removed large number of translations and replaced many with invalid fuzzy translations.

This merges back translations from the parent commit tree. It also updates some translations.