### PR TITLE
Fixed Transaction.GetInvoiceFromTxn to convert to the right type of Python object

### DIFF
--- a/bindings/python/gnucash_core.py
+++ b/bindings/python/gnucash_core.py
@@ -822,9 +822,9 @@ class Transaction(GnuCashCoreClass):
         return self.GetSplitList().pop(n)
 
     def GetInvoiceFromTxn(self):
-        from gnucash.gnucash_business import Transaction
+        from gnucash.gnucash_business import Invoice
         return self.do_lookup_create_oo_instance(
-            gncInvoiceGetInvoiceFromTxn, Transaction )
+            gncInvoiceGetInvoiceFromTxn, Invoice )
 
     def __eq__(self, other):
         return self.Equal(other, True, False, False, False)

--- a/bindings/python/tests/test_business.py
+++ b/bindings/python/tests/test_business.py
@@ -74,5 +74,14 @@ class TestBusiness(BusinessSession):
     def test_commodities(self):
         self.assertTrue( self.currency.equal( self.customer.GetCommoditiesList()[0] ) )
 
+    def test_invoice_transaction(self):
+        """
+        Test that you can get the posted transaction from a posted invoice and that you can get the invoice back from the transaction.
+        """
+        posted_transaction = self.invoice.GetPostedTxn()
+        self.assertTrue( posted_transaction != None )
+        invoice_from_transaction = posted_transaction.GetInvoiceFromTxn()
+        self.assertTrue( invoice_from_transaction != None and invoice_from_transaction.GetID() == self.invoice.GetID() )
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
GetInvoiceFromTxn method for Transaction objects in the Python bindings binds to a C function that returns a GncInvoice*, but it was attempting to return a Transaction, which causes errors. Fixed it to return a Python Invoice object.