### PR TITLE
[engine.i] convert gnc_account_accumulate_at_dates to c++

### DIFF
--- a/bindings/guile/gnc-engine-guile.cpp
+++ b/bindings/guile/gnc-engine-guile.cpp
@@ -1781,6 +1781,13 @@ gnc_book_to_scm (const QofBook *book)
     return gnc_generic_to_scm (book, stype);
 }
 
+SCM
+gnc_split_to_scm (const Split *split)
+{
+    static auto stype = get_swig_type ("_p_Split");
+    return gnc_generic_to_scm (split, stype);
+}
+
 GncAccountValue * gnc_scm_to_account_value_ptr (SCM valuearg)
 {
     GncAccountValue *res;

--- a/bindings/guile/gnc-engine-guile.h
+++ b/bindings/guile/gnc-engine-guile.h
@@ -66,6 +66,8 @@ SCM gnc_commodity_to_scm(const gnc_commodity* commodity);
 
 SCM gnc_book_to_scm(const QofBook* book);
 
+SCM gnc_split_to_scm (const Split *split);
+
 /* Conversion routines used with tax tables */
 GncAccountValue* gnc_scm_to_account_value_ptr(SCM valuearg);
 


### PR DESCRIPTION
to speed up traversal of account->splits through std::vector instead of scm_list.

ample testing in test-report-utilities.scm and test-balsheet-pnl.scm