### PR TITLE
Avoid unused variable warnings on systems without HAVE_STRUCT_TM_GMTOFF

### DIFF
--- a/common/base-typemaps.i
+++ b/common/base-typemaps.i
@@ -95,6 +95,8 @@ typedef char gchar;
     SCM zone = SCM_SIMPLE_VECTOR_REF(tm, 10);
     tzone = SCM_UNBNDP(zone) ? NULL : scm_to_locale_string(zone);
     t.tm_zone = tzone;
+%#else
+    (void)tzone;
 %#endif
     $1 = &t;
  }


### PR DESCRIPTION
When building gnucash 5.11 on a system which did not `HAVE_STRUCT_TM_GMTOFF`, gcc 14 issued a flurry of errors about unused tzoneN variables.  I traced it back to one of the typemaps for `struct tm`; adding an `#else` clause with a no-op reference silenced the warning. 