### PR TITLE
Fix build of test-gnc-date on systems without HAVE_STRUCT_TM_GMTOFF

### DIFF
--- a/libgnucash/engine/test/test-gnc-date.c
+++ b/libgnucash/engine/test/test-gnc-date.c
@@ -1151,7 +1151,7 @@ test_qof_scan_date (void)
     time64 now = gnc_time(NULL);
     gchar buff[MAX_DATE_LENGTH];
     struct tm tm = { 0, 0, 0, 0, 0, 0, 0, 0, 0
-#ifndef G_OS_WIN32
+#ifdef HAVE_STRUCT_TM_GMTOFF
         , 0, 0
 #endif
     };


### PR DESCRIPTION
This is another small fix for systems without `HAVE_STRUCT_TM_GMTOFF`.