### PR TITLE
Add testbuild target which builds tests without running them

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -693,7 +693,8 @@ endif()
 gnc_gtest_configure()
 
 # There are targets that need to build before tests will run
-add_custom_target(check
+add_custom_target(testbuild)
+add_custom_target(check DEPENDS testbuild
   COMMAND ${CMAKE_CTEST_COMMAND}
 )
 

--- a/common/cmake_modules/GncAddTest.cmake
+++ b/common/cmake_modules/GncAddTest.cmake
@@ -102,7 +102,7 @@ function(gnc_add_test _TARGET _SOURCE_FILES TEST_INCLUDE_VAR_NAME TEST_LIBS_VAR_
   target_link_libraries(${_TARGET} PRIVATE ${TEST_LIBS})
   target_include_directories(${_TARGET} PRIVATE ${TEST_INCLUDE_DIRS})
   set_tests_properties(${_TARGET} PROPERTIES ENVIRONMENT "${ENVVARS}$<$<CONFIG:Asan>:;ASAN_OPTIONS=${ASAN_TEST_OPTIONS}>")
-  add_dependencies(check ${_TARGET})
+  add_dependencies(testbuild ${_TARGET})
 endfunction()
 
 function(gnc_add_test_with_guile _TARGET _SOURCE_FILES TEST_INCLUDE_VAR_NAME TEST_LIBS_VAR_NAME)


### PR DESCRIPTION
The openindiana packaging framework includes cmake integration that lets you sensibly compare a test run with prior test results checked into the packaging repo.  It works better if you can just let the system run `ctest` separately so the output isn't cluttered with build messages.

The only way I've found to force a build of all tests is through the `check` target, which also runs the tests once they're all built.  

This change adds a new build target, `testbuild`, which builds tests without running them.
(I'm new to using cmake and just picked a plausible name; I'm open to changing it if anyone's got a better idea).
