### PR TITLE
Remove diacritics when comparing case insensitive strings.

### DIFF
--- a/libgnucash/engine/qofquerycore.cpp
+++ b/libgnucash/engine/qofquerycore.cpp
@@ -150,16 +150,20 @@ string_match_predicate (gpointer object,
     {
         if (pdata->options == QOF_STRING_MATCH_CASEINSENSITIVE)
         {
+            char* s_clean = qof_utf8_replace_diacritics(s);
+            char* m_clean = qof_utf8_replace_diacritics(pdata->matchstring);
             if (pd->how == QOF_COMPARE_CONTAINS || pd->how == QOF_COMPARE_NCONTAINS)
             {
-                if (qof_utf8_substr_nocase (s, pdata->matchstring)) //uses strstr
+                if (qof_utf8_substr_nocase (s_clean, m_clean)) //uses strstr
                     ret = 1;
             }
             else
             {
-                 if (safe_strcasecmp (s, pdata->matchstring) == 0) //uses collate
+                if (safe_strcasecmp (s_clean, m_clean) == 0) //uses collate
                     ret = 1;
             }
+            g_free(s_clean);
+            g_free(m_clean);
         }
         else
         {

--- a/libgnucash/engine/qofutil.cpp
+++ b/libgnucash/engine/qofutil.cpp
@@ -75,6 +75,36 @@ qof_utf8_substr_nocase (const gchar *haystack, const gchar *needle)
     return p != NULL;
 }
 
+std::unordered_map<gunichar, gunichar> qof_diacritics = {
+    {L'À', 'A'}, {L'à', 'a'},
+    {L'Á', 'A'}, {L'á', 'a'},
+    {L'Ç', 'C'}, {L'ç', 'c'},
+    {L'È', 'E'}, {L'è', 'e'},
+    {L'É', 'E'}, {L'é', 'e'},
+    {L'Ì', 'I'}, {L'ì', 'i'},
+    {L'Í', 'I'}, {L'í', 'i'},
+    {L'Ñ', 'N'}, {L'ñ', 'n'},
+    {L'Ò', 'O'}, {L'ò', 'o'},
+    {L'Ó', 'O'}, {L'ó', 'o'},
+    {L'Ù', 'O'}, {L'ù', 'u'},
+    {L'Ú', 'O'}, {L'ú', 'u'},
+};
+
+gchar *
+qof_utf8_replace_diacritics (const gchar *str)
+{
+    gunichar* s = g_utf8_to_ucs4(str, -1, NULL, NULL, NULL);
+    for (int i = 0; s[i] != 0; i++) {
+        auto diacritic = qof_diacritics.find(s[i]);
+        if (diacritic != qof_diacritics.end()) {
+            s[i] = diacritic->second;
+        }
+    }
+    gchar* utf8out = g_ucs4_to_utf8(s, -1, NULL, NULL, NULL);
+    g_free(s);
+    return utf8out;
+}
+
 /** Use g_utf8_casefold and g_utf8_collate to compare two utf8 strings,
  * ignore case. Return < 0 if da compares before db, 0 if they compare
  * equal, > 0 if da compares after db. */

--- a/libgnucash/engine/qofutil.h
+++ b/libgnucash/engine/qofutil.h
@@ -166,6 +166,11 @@ void g_hash_table_foreach_sorted(GHashTable *hash_table, GHFunc func, gpointer u
  * otherwise. */
 gboolean qof_utf8_substr_nocase (const gchar *haystack, const gchar *needle);
 
+/**
+ * Replace diacritics from a string with simple letters.
+ */
+gchar *qof_utf8_replace_diacritics (const gchar *str);
+
 /** case sensitive comparison of strings da and db - either
 may be NULL. A non-NULL string is greater than a NULL string.
 


### PR DESCRIPTION
Bank statements usually have inconsistent diacritics. I propose removing them when performing a case-insensitive search.

I've only added the diacritics that I'm interested in but I can add more.