### PR TITLE
Bug 799602 - Unit Price on Invoice will NOT display as decimals

### DIFF
--- a/gnucash/report/reports/support/taxinvoice.eguile.scm
+++ b/gnucash/report/reports/support/taxinvoice.eguile.scm
@@ -331,7 +331,7 @@
         <td align="right"><?scm:d (fmtnumeric qty) ?></td>
       <?scm )) ?>
       <?scm (if (or units? qty? discount?) (begin ?>
-        <td align="right"><?scm:d (fmtmoney currency each) ?></td>
+        <td align="right"><?scm:d (nbsp (gnc:default-price-renderer currency each)) ?></td>
       <?scm )) ?>
       <?scm (if discount? (begin ?>
         <?scm (if (equal? disctype GNC-AMT-TYPE-VALUE) (begin ?>


### PR DESCRIPTION
Add a new form gnc:price->string to complement gnc:monetary->string that uses the gnc-price-print-info and so observes the price-force-decimal preference. Add an eguile form fmtprice that wraps it and replace fmtmoney with fmtprice when printing the unit price in the tas invoice report.