### PR TITLE
Export qof_book_mark_session_dirty to the Python bindings.

### DIFF
--- a/libgnucash/engine/qofbook.h
+++ b/libgnucash/engine/qofbook.h
@@ -326,9 +326,6 @@ gboolean qof_book_shutting_down (const QofBook *book);
  */
 gboolean qof_book_session_not_saved (const QofBook *book);
 
-/* The following functions are not useful in scripting languages */
-#ifndef SWIG
-
 /** The qof_book_mark_saved() routine marks the book as having been
  *    saved (to a file, to a database). Used by backends to mark the
  *    notsaved flag as FALSE just after loading.  Can also be used
@@ -344,6 +341,9 @@ void qof_book_mark_session_dirty(QofBook *book);
 
 /** Retrieve the earliest modification time on the book. */
 time64 qof_book_get_session_dirty_time(const QofBook *book);
+
+/* The following functions are not useful in scripting languages */
+#ifndef SWIG
 
 /** Set the function to call when a book transitions from clean to
  *    dirty, or vice versa.


### PR DESCRIPTION
Use case: implement a command line "save-as" script. This works by using the gnucash_core_c bindings like follows but for the problem that qof_book_mark_session_dirty() is not exported, and without "dirty" the function `qof_session_save(outputSession)` does nothing.

```
...
inputSession = gnucash_core_c.qof_session_new(gnucash_core_c.qof_book_new())
gnucash_core_c.qof_session_begin(inputSession, inputURI, SessionOpenMode.SESSION_READ_ONLY)
gnucash_core_c.qof_session_load(inputSession, None)

outputSession = gnucash_core_c.qof_session_new(gnucash_core_c.qof_book_new())
gnucash_core_c.qof_session_begin(outputSession, outputURI, SessionOpenMode.SESSION_NEW_OVERWRITE)

gnucash_core_c.qof_session_swap_data(inputSession, outputSession)
gnucash_core_c.qof_book_mark_session_dirty(gnucash_core_c.qof_session_get_book(outputSession))

gnucash_core_c.qof_session_save(outputSession, None)
gnucash_core_c.qof_session_end(outputSession)
```

Complete script is here https://github.com/rotdrop/gnucash-python/blob/main/src/save-as.py