### PR TITLE
Expose the percentage-function to the Python-bindings by a typemap

### DIFF
--- a/bindings/python/gnucash_core.i
+++ b/bindings/python/gnucash_core.i
@@ -44,6 +44,29 @@
 %feature("autodoc", "1");
 %module(package="gnucash") gnucash_core_c
 
+%typemap(in) QofPercentageFunc {
+  if ($input == Py_None) {
+    $1 = (QofPercentageFunc)0;
+  } else {
+    $1 = (QofPercentageFunc)PyLong_AsVoidPtr($input);
+  }
+}
+
+%pythoncode
+%{
+import ctypes
+
+qof_percentage_func_type = ctypes.CFUNCTYPE(None, ctypes.c_char_p, ctypes.c_double)
+
+def qof_percentage_func(py_callback):
+    if py_callback == None:
+        f_ptr = None
+    else:
+        f = qof_percentage_func_type(py_callback)
+        f_ptr = ctypes.cast(f, ctypes.c_void_p).value
+    return f_ptr
+%}
+
 %{
 #include <config.h>
 #include <datetime.h>

--- a/bindings/python/gnucash_core.i
+++ b/bindings/python/gnucash_core.i
@@ -56,13 +56,13 @@
 %{
 import ctypes
 
-qof_percentage_func_type = ctypes.CFUNCTYPE(None, ctypes.c_char_p, ctypes.c_double)
+QofPercentageFunc = ctypes.CFUNCTYPE(None, ctypes.c_char_p, ctypes.c_double)
 
 def qof_percentage_func(py_callback):
     if py_callback == None:
         f_ptr = None
     else:
-        f = qof_percentage_func_type(py_callback)
+        f = QofPercentageFunc(py_callback)
         f_ptr = ctypes.cast(f, ctypes.c_void_p).value
     return f_ptr
 %}


### PR DESCRIPTION
The idea is to be able to use the percentage function with a python function callback. Maybe a little bit hacky as SWIG was not designed for these kind of things (i.e. callbacks from the target language back to Python are difficult to achieve with SWIG).

Usage:
```
...
percentageCallback =  gnucash_core_c.qof_percentage_func(lambda a, b: print(a, b) if a else print(b))
...
gnucash_core_c.qof_session_load(inputSession, percentageFunc)
...
```
Complete "save-as" script is here https://github.com/rotdrop/gnucash-python/blob/main/src/save-as.py