### PR TITLE
Bug 799363 - When selecting "load" two layer ...

### DIFF
--- a/gnucash/html/gnc-html-history.c
+++ b/gnucash/html/gnc-html-history.c
@@ -24,6 +24,7 @@
 
 #include <gtk/gtk.h>
 #include <string.h>
+#include <stdbool.h>
 
 #include "gnc-html-history.h"
 
@@ -32,6 +33,9 @@ struct _gnc_html_history
     GList * nodes;
     GList * current_node;
     GList * last_node;
+
+    /* To know in gnc_html_history_append that the history should not be added if it was pressed */
+    bool pressedBACK, pressedFWD;
 
     /* call this whenever a node is destroyed */
     gnc_html_history_destroy_cb destroy_cb;
@@ -49,6 +53,8 @@ gnc_html_history_new(void)
     hist->nodes         = NULL;
     hist->current_node  = NULL;
     hist->last_node     = NULL;
+    hist->pressedBACK   = FALSE;
+    hist->pressedFWD    = FALSE;
     return hist;
 }
 
@@ -125,6 +131,20 @@ gnc_html_history_append(gnc_html_history * hist,
 {
     GList * n;
     gnc_html_history_node * hn;
+
+    // If Back button has been pressed don't append history.
+    if (hist && hist->pressedBACK) {
+	  hist->pressedBACK = FALSE;
+	  hist->last_node = hist->current_node;
+	  return;
+    }
+
+    // If Forward button has been pressed don't append history.
+    if (hist && hist->pressedFWD) {
+	  hist->pressedFWD = FALSE;
+	  hist->last_node = hist->current_node;
+	  return;
+    }
 
     if (hist->current_node)
     {
@@ -210,6 +230,7 @@ gnc_html_history_forward(gnc_html_history * hist)
     if (hist->current_node->next)
     {
         hist->current_node = hist->current_node->next;
+        hist->pressedFWD = TRUE;
     }
 
     return hist->current_node->data;
@@ -232,6 +253,7 @@ gnc_html_history_back(gnc_html_history * hist)
     if (hist->current_node->prev)
     {
         hist->current_node = hist->current_node->prev;
+        hist->pressedBACK = TRUE;
     }
 
     return hist->current_node->data;

--- a/gnucash/html/gnc-html-history.c
+++ b/gnucash/html/gnc-html-history.c
@@ -134,16 +134,16 @@ gnc_html_history_append(gnc_html_history * hist,
 
     // If Back button has been pressed don't append history.
     if (hist && hist->pressedBACK) {
-	  hist->pressedBACK = FALSE;
-	  hist->last_node = hist->current_node;
-	  return;
+        hist->pressedBACK = FALSE;
+        hist->last_node = hist->current_node;
+        return;
     }
 
     // If Forward button has been pressed don't append history.
     if (hist && hist->pressedFWD) {
-	  hist->pressedFWD = FALSE;
-	  hist->last_node = hist->current_node;
-	  return;
+        hist->pressedFWD = FALSE;
+        hist->last_node = hist->current_node;
+        return;
     }
 
     if (hist->current_node)

--- a/gnucash/html/gnc-html-webkit2.c
+++ b/gnucash/html/gnc-html-webkit2.c
@@ -120,6 +120,11 @@ static void impl_webkit_print (GncHtml* self,const gchar* jobname);
 static void impl_webkit_cancel( GncHtml* self );
 static void impl_webkit_set_parent( GncHtml* self, GtkWindow* parent );
 static void impl_webkit_default_zoom_changed(gpointer prefs, gchar *pref, gpointer user_data);
+static gboolean webkit_context_menu_cb(WebKitWebView         *web_view,
+                                       WebKitContextMenu     *context_menu,
+                                       GdkEvent              *event,
+                                       WebKitHitTestResult   *hit_test_result,
+                                       gpointer               user_data);
 
 static GtkWidget*
 gnc_html_webkit_webview_new (void)
@@ -206,6 +211,10 @@ gnc_html_webkit_init( GncHtmlWebkit* self )
      g_signal_connect (priv->web_view, "resource-load-started",
                        G_CALLBACK (webkit_resource_load_started_cb),
                        self);
+     g_signal_connect(priv->web_view, "context-menu",
+                       G_CALLBACK(webkit_context_menu_cb),
+                       self);
+
      gnc_prefs_register_cb (GNC_PREFS_GROUP_GENERAL_REPORT,
                             GNC_PREF_RPT_DFLT_ZOOM,
                             impl_webkit_default_zoom_changed,
@@ -725,6 +734,56 @@ webkit_resource_load_started_cb (WebKitWebView *web_view,
      g_signal_connect (resource, "finished",
                        G_CALLBACK (webkit_resource_load_finished_cb),
                        data);
+}
+
+/*
+ *
+ * We need to delete the Back and Forward items from the right-click menu because
+ * otherwise the Back and Forward buttons won't work properly.
+ *
+ */
+static gboolean
+webkit_context_menu_cb(WebKitWebView         *web_view,
+                       WebKitContextMenu     *context_menu,
+                       GdkEvent              *event,
+                       WebKitHitTestResult   *hit_test_result,
+                       gpointer               data)
+{
+     // We can only delete one item at a time.
+     GList *menu_items = webkit_context_menu_get_items(context_menu);
+     for (GList *l = menu_items; l != NULL; l = g_list_next(l)) {
+          WebKitContextMenuItem *item = WEBKIT_CONTEXT_MENU_ITEM(l->data);
+          WebKitContextMenuAction action = webkit_context_menu_item_get_stock_action(item);
+          if (action == WEBKIT_CONTEXT_MENU_ACTION_GO_BACK)
+          {
+                webkit_context_menu_remove(context_menu, item);
+                // Because GList has changed we cannot remove another item.
+                break;
+          } else if (action == WEBKIT_CONTEXT_MENU_ACTION_GO_FORWARD) {
+                webkit_context_menu_remove(context_menu, item);
+                // Because GList has changed we cannot remove another item.
+                break;
+          }
+     }
+
+     // We need to get items again.
+     menu_items = webkit_context_menu_get_items(context_menu);
+     for (GList *l = menu_items; l != NULL; l = g_list_next(l)) {
+          WebKitContextMenuItem *item = WEBKIT_CONTEXT_MENU_ITEM(l->data);
+          WebKitContextMenuAction action = webkit_context_menu_item_get_stock_action(item);
+          if (action == WEBKIT_CONTEXT_MENU_ACTION_GO_BACK)
+          {
+                webkit_context_menu_remove(context_menu, item);
+                // Because GList has changed we cannot remove another item.
+                break;
+          } else if (action == WEBKIT_CONTEXT_MENU_ACTION_GO_FORWARD) {
+                webkit_context_menu_remove(context_menu, item);
+                // Because GList has changed we cannot remove another item.
+                break;
+          }
+     }
+
+     return FALSE;
 }
 
 /********************************************************************


### PR DESCRIPTION
The Back and Forward buttons now work correctly.
Added pressedBACK and pressedFWD to _gnc_html_history because gnc_html_history_append needs to know if a button has been pressed.

I had to remove the Back and Forward options from the right-click menu because they interfere with the buttons' functionality.

Clicking and selecting Load clears the existing Forward order. I can't change it because it's JavaScript inside the HTML.