### PR TITLE
Bug 799521 - Segmentation fault on Autocomplete of Description with ß 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -562,7 +562,7 @@ get_filename_component(PERL_DIR ${PERL_EXECUTABLE} DIRECTORY)
 find_program(POD2MAN_EXECUTABLE pod2man HINTS ${PERL_DIR})
 
 #ICU
-find_package(ICU REQUIRED COMPONENTS uc i18n)
+find_package(ICU 54.0 REQUIRED COMPONENTS uc i18n)
 
 pkg_check_modules (LIBSECRET libsecret-1>=0.18)
 IF (LIBSECRET_FOUND)

--- a/libgnucash/core-utils/CMakeLists.txt
+++ b/libgnucash/core-utils/CMakeLists.txt
@@ -11,6 +11,7 @@ set (core_utils_SOURCES
   gnc-filepath-utils.cpp
   gnc-gkeyfile-utils.c
   gnc-glib-utils.c
+  gnc-unicode.cpp
   gnc-locale-utils.c
   gnc-locale-utils.cpp
   gnc-path.c
@@ -28,6 +29,7 @@ set(core_utils_noinst_HEADERS
   gnc-filepath-utils.h
   gnc-gkeyfile-utils.h
   gnc-glib-utils.h
+  gnc-unicode.h
   gnc-locale-utils.h
   gnc-locale-utils.hpp
   gnc-path.h
@@ -54,6 +56,7 @@ target_link_libraries(gnc-core-utils
         ${Boost_LIBRARIES}
         ${GOBJECT_LDFLAGS}
         ${GTK_MAC_LDFLAGS}
+        ${ICU_LIBRARIES}
         "$<$<BOOL:${MAC_INTEGRATION}>:${OSX_EXTRA_LIBRARIES}>")
 
 target_compile_definitions(gnc-core-utils

--- a/libgnucash/core-utils/gnc-unicode.cpp
+++ b/libgnucash/core-utils/gnc-unicode.cpp
@@ -1,0 +1,220 @@
+/********************************************************************
+ * gnc-icu-locale.cpp -- Localization with ICU.                        *
+ *                                                                  *
+ * Copyright (C) 2025 John Ralls <jralls@ceridwen.us                *
+ *                                                                  *
+ * This program is free software; you can redistribute it and/or    *
+ * modify it under the terms of the GNU General Public License as   *
+ * published by the Free Software Foundation; either version 2 of   *
+ * the License, or (at your option) any later version.              *
+ *                                                                  *
+ * This program is distributed in the hope that it will be useful,  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    *
+ * GNU General Public License for more details.                     *
+ *                                                                  *
+ * You should have received a copy of the GNU General Public License*
+ * along with this program; if not, contact:                        *
+ *                                                                  *
+ * Free Software Foundation           Voice:  +1-617-542-5942       *
+ * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652       *
+ * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
+ ********************************************************************/
+
+#include "gnc-unicode.h"
+
+#include <memory>
+#include <unicode/stsearch.h>
+#include <unicode/tblcoll.h>
+#include <unicode/coll.h>
+#include "gnc-locale-utils.h"
+#include <glib-2.0/glib.h>
+
+constexpr const char *logdomain{"gnc.locale"};
+
+enum class CompareStrength {
+  PRIMARY,
+  SECONDARY,
+  TERTIARY,
+  QUATERNARY,
+  IDENTICAL
+};
+
+static void
+collator_set_strength(icu::Collator* collator, CompareStrength strength)
+{
+    switch (strength)
+    {
+        case CompareStrength::PRIMARY:
+            collator->setStrength(icu::Collator::PRIMARY);
+            break;
+        case CompareStrength::SECONDARY:
+            collator->setStrength(icu::Collator::SECONDARY);
+            break;
+        case CompareStrength::TERTIARY:
+            collator->setStrength(icu::Collator::TERTIARY);
+            break;
+        case CompareStrength::QUATERNARY:
+            collator->setStrength(icu::Collator::QUATERNARY);
+            break;
+        case CompareStrength::IDENTICAL:
+            collator->setStrength(icu::Collator::IDENTICAL);
+            break;
+    }
+}
+
+static bool
+unicode_has_substring_internal(const char* needle, const char* haystack,
+                       int* position, int* length,
+                       CompareStrength strength)
+{
+    UErrorCode status{U_ZERO_ERROR};
+    auto locale{gnc_locale_name()};
+    auto u_needle{icu::UnicodeString::fromUTF8(needle)};
+    auto u_haystack{icu::UnicodeString::fromUTF8(haystack)};
+    icu::StringSearch search(u_needle, u_haystack, locale, nullptr, status);
+    g_free(locale);
+
+    if (U_SUCCESS(status))
+    {
+        auto collator = search.getCollator();
+        collator_set_strength(collator, strength);
+        search.reset();
+    }
+
+    if (U_FAILURE(status))
+    {
+        g_log(logdomain, G_LOG_LEVEL_ERROR,
+              "StringSearch creation failed for %s", haystack);
+        return false;
+    }
+
+    auto pos{search.first(status)};
+    if (U_FAILURE(status))
+    {
+        g_log(logdomain, G_LOG_LEVEL_ERROR,
+              "StringSearch encountered an error finding %s in %s",
+              needle, haystack);
+        return false;
+    }
+    if (pos == USEARCH_DONE)
+    {
+        g_log(logdomain, G_LOG_LEVEL_DEBUG, "%s not found in %s",
+              needle, haystack);
+        return false;
+    }
+
+    if (position && length)
+    {
+        *position = pos;
+        *length = search.getMatchedLength();
+    }
+
+    g_log(logdomain, G_LOG_LEVEL_DEBUG, "%s found in %s at index %d",
+          needle, haystack, pos);
+    return true;
+}
+
+bool
+gnc_unicode_has_substring_base_chars(const char* needle,
+                                     const char* haystack,
+                                     int* position,
+                                     int* length)
+{
+    return unicode_has_substring_internal(needle, haystack, position, length,
+                                          CompareStrength::PRIMARY);
+}
+
+bool
+gnc_unicode_has_substring_accented_chars(const char* needle,
+                                         const char* haystack,
+                                         int* position,
+                                         int* length)
+{
+    return unicode_has_substring_internal(needle, haystack, position, length,
+                                          CompareStrength::SECONDARY);
+}
+
+bool
+gnc_unicode_has_substring_accented_case_sensitive(const char* needle,
+                                                  const char* haystack,
+                                                  int* position,
+                                                  int* length)
+{
+    return unicode_has_substring_internal(needle, haystack, position, length,
+                                          CompareStrength::TERTIARY);
+}
+
+bool
+gnc_unicode_has_substring_identical(const char* needle,
+                                    const char*haystack,
+                                    int* position,
+                                    int* length)
+{
+    auto location = strstr(needle, haystack);
+    if (location && location != haystack)
+    {
+        *position = static_cast<int>(location - haystack);
+        *length = strlen(needle);
+        return true;
+    }
+    return false;
+}
+
+static int
+unicode_compare_internal(const char* one, const char* two,
+                         CompareStrength strength)
+{
+    UErrorCode status{U_ZERO_ERROR};
+    auto locale{gnc_locale_name()};
+    std::unique_ptr<icu::Collator> coll(
+        icu::Collator::createInstance(icu::Locale(locale), status));
+    g_free(locale);
+
+    if (U_SUCCESS(status))
+        collator_set_strength(coll.get(), strength);
+
+    if (U_FAILURE(status))
+    {
+        g_log(logdomain, G_LOG_LEVEL_ERROR,
+              "Failed to create collator for locale %s: %s",
+              locale, u_errorName(status));
+        return -99;
+    }
+
+    auto result = coll->compare(one, two, status);
+
+    if (U_FAILURE(status))
+    {
+        g_log(logdomain, G_LOG_LEVEL_ERROR,
+              "Comparison of %s and %s in locale %s failed: %s",
+              one, two, locale, u_errorName(status));
+        return -99;
+    }
+
+    return result == UCOL_LESS ? -1 : UCOL_EQUAL ? 0 : 1;
+}
+
+int
+gnc_unicode_compare_base_chars(const char* one, const char* two)
+{
+    return unicode_compare_internal(one, two, CompareStrength::PRIMARY);
+}
+
+int
+gnc_unicode_compare_accented_chars(const char* one, const char* two)
+{
+    return unicode_compare_internal(one, two, CompareStrength::SECONDARY);
+}
+
+int
+gnc_unicode_compare_accented_case_sensitive(const char* one, const char* two)
+{
+    return unicode_compare_internal(one, two, CompareStrength::TERTIARY);
+}
+
+int
+gnc_unicode_compare_identical(const char* one, const char* two)
+{
+    return strcmp(one, two);
+}

--- a/libgnucash/core-utils/gnc-unicode.h
+++ b/libgnucash/core-utils/gnc-unicode.h
@@ -1,0 +1,144 @@
+/********************************************************************
+ * gnc-icu-locale.h -- Localization with ICU.                        *
+ *                                                                  *
+ * Copyright (C) 2025 John Ralls <jralls@ceridwen.us                *
+ *                                                                  *
+ * This program is free software; you can redistribute it and/or    *
+ * modify it under the terms of the GNU General Public License as   *
+ * published by the Free Software Foundation; either version 2 of   *
+ * the License, or (at your option) any later version.              *
+ *                                                                  *
+ * This program is distributed in the hope that it will be useful,  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    *
+ * GNU General Public License for more details.                     *
+ *                                                                  *
+ * You should have received a copy of the GNU General Public License*
+ * along with this program; if not, contact:                        *
+ *                                                                  *
+ * Free Software Foundation           Voice:  +1-617-542-5942       *
+ * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652       *
+ * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
+ ********************************************************************/
+
+#pragma once
+#include <stdbool.h>
+
+/** @addtogroup Localization These functions perform string comparison
+    and collation according to the Unicode Common Locale Data
+    Repository rules. The CLDR specifies five levels of
+    comparison.
+
+    - The primary or base level considers all variant codepoints
+    representing a character to be equivalent regardless of case or
+    decorations like accents and vowel or tone marks.
+    - The secondary level differentiates between letters with
+    decorations but still ignores case.
+    - The tertiary level differentiates based on case, decorations,
+    and variants, for example A and Ⓐ.
+    - The Quaternary level differentiates words with punctuation, for
+    example "ab" and "a-b".
+    - Identical differentiates all codepoints with no implicit
+      normalization so a character constructed with combining marks
+      will compare different from the same character represented as a
+      single codepoint.
+*/
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/** Find the first Unicode-equivalent UTF-8-encoded substring in a
+ * UTF-8-encoded string comparing characters at the CLDR primary
+ * level, setting the starting position and length of the matching
+ * part of the string.
+ * @param needle The substring to search for
+ * @param haystack the string to search in
+ * @param output the position of needle in haystack
+ * @param output the length of the match
+ * @return true if needle is found in haystack
+ */
+bool gnc_unicode_has_substring_base_chars(const char* needle, const
+                                          char* haystack, int* position,
+                                          int* length);
+
+/** Find the first Unicode-equivalent UTF-8-encoded substring in a
+ * UTF-8-encoded string comparing characters at the CLDR secondary
+ * level, setting the starting position and length of the matching
+ * part of the string.
+ * @param needle The substring to search for
+ * @param haystack the string to search in
+ * @param output the position of needle in haystack
+ * @param output the length of the match
+ * @return true if needle is found in haystack
+ */
+bool gnc_unicode_has_substring_accented_chars(const char* needle, const
+                                              char* haystack, int* position,
+                                              int* length);
+
+/** Find the first Unicode-equivalent UTF-8-encoded substring in a
+ * UTF-8-encoded string comparing characters at the CLDR tertiary
+ * level, setting the starting position and length of the matching
+ * part of the string.
+ * @param needle The substring to search for
+ * @param haystack the string to search in
+ * @param output the position of needle in haystack
+ * @param output the length of the match
+ * @return true if needle is found in haystack
+ */
+bool gnc_unicode_has_substring_accented_case_sensitive(const char* needle, const
+                                                       char* haystack, int* position,
+                                                       int* length);
+/** Find the first Unicode-equivalent UTF-8-encoded substring in a
+ * UTF-8-encoded string comparing characters at the CLDR identical
+ * level, setting the starting position and length of the matching
+ * part of the string.
+ * @param needle The substring to search for
+ * @param haystack the string to search in
+ * @param output the position of needle in haystack
+ * @param output the length of the match
+ * @return true if needle is found in haystack
+ */
+bool gnc_unicode_has_substring_identical(const char* needle, const
+                                         char* haystack, int* position,
+                                         int* length);
+/** Compare two UTF-8 encoded strings for equivalence at the CLDR
+ * primary level in the current locale. Errors are logged to
+ * gnc.locale.
+ * @param one a string
+ * @param two another string
+ * @return 0 if one and two are equivalent, -1 if one is less that
+ * two, 1 if one is greater than two, -99 on error.
+ */
+int gnc_unicode_compare_base_chars(const char* one, const char* two);
+
+/** Compare two UTF-8 encoded strings for equivalence at the CLDR
+ * secondary level in the current locale. Errors are logged to
+ * gnc.locale.
+ * @param one a string
+ * @param two another string
+ * @return 0 if one and two are equivalent, -1 if one is less that
+ * two, 1 if one is greater than two, -99 on error.
+ */
+int gnc_unicode_compare_accented_chars(const char* one, const char* two);
+
+/** Compare two UTF-8 encoded strings for equivalence at the CLDR
+ * tertiary level in the current locale. Errors are logged to
+ * gnc.locale.
+ * @param one a string
+ * @param two another string
+ * @return 0 if one and two are equivalent, -1 if one is less that
+ * two, 1 if one is greater than two, -99 on error.
+ */
+int gnc_unicode_compare_accented_case_sensitive(const char* one, const char* two);
+/** Compare two UTF-8 encoded strings for equivalence at the CLDR
+ * identical level in the current locale.
+ * @param one a string
+ * @param two another string
+ * @return 0 if one and two are equivalent, -1 if one is less that
+ * two, 1 if one is greater than two, -99 on error.
+ */
+int gnc_unicode_compare_identical(const char* one, const char* two);
+#ifdef __cplusplus
+}
+#endif

--- a/libgnucash/core-utils/test/CMakeLists.txt
+++ b/libgnucash/core-utils/test/CMakeLists.txt
@@ -49,6 +49,22 @@ set(test_gnc_path_util_SOURCES
 gnc_add_test(test-gnc-path-util "${test_gnc_path_util_SOURCES}"
   gtest_core_utils_INCLUDES gtest_core_utils_LIBS "GNC_UNINSTALLED=yes")
 
+set(gtest_icu_locale_INCLUDES
+  ${CMAKE_BINARY_DIR}/common
+  ${MODULEPATH})
+
+set(gtest_icu_locale_LIBS
+  ${Boost_LIBRARIES}
+  ICU::uc
+  ICU::i18n
+  PkgConfig::GLIB2
+  gtest)
+
+gnc_add_test(test-gnc-unicode
+  "${MODULEPATH}/gnc-unicode.cpp;${MODULEPATH}/gnc-locale-utils.c;gtest-gnc-unicode.cpp"
+  gtest_icu_locale_INCLUDES
+  gtest_icu_locale_LIBS)
+
 set_dist_list(test_core_utils_DIST CMakeLists.txt
   test-gnc-glib-utils.c test-resolve-file-path.c test-userdata-dir.c
-  test-userdata-dir-invalid-home.c gtest-path-utilities.cpp)
+  test-userdata-dir-invalid-home.c gtest-gnc-unicode.cpp gtest-path-utilities.cpp)

--- a/libgnucash/core-utils/test/gtest-gnc-unicode.cpp
+++ b/libgnucash/core-utils/test/gtest-gnc-unicode.cpp
@@ -1,0 +1,135 @@
+/********************************************************************\
+ * test-icu-locale.cpp -- Unit tests for GncQuotes            *
+ *                                                                  *
+ * Copyright 2025 John Ralls <jralls@ceridwen.us>                   *
+ *                                                                  *
+ * This program is free software; you can redistribute it and/or    *
+ * modify it under the terms of the GNU General Public License as   *
+ * published by the Free Software Foundation; either version 2 of   *
+ * the License, or (at your option) any later version.              *
+ *                                                                  *
+ * This program is distributed in the hope that it will be useful,  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    *
+ * GNU General Public License for more details.                     *
+ *                                                                  *
+ * You should have received a copy of the GNU General Public License*
+ * along with this program; if not, contact:                        *
+ *                                                                  *
+ * Free Software Foundation           Voice:  +1-617-542-5942       *
+ * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652       *
+ * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
+ *                                                                  *
+\********************************************************************/
+
+#include <gnc-unicode.h>
+#include <stdbool.h>
+#include <gtest/gtest.h>
+
+TEST(GncUnicode, test_ss_base_chars)
+{
+    int pos = 0, len = 0;
+
+    auto result = gnc_unicode_has_substring_base_chars("besi", "Necklace for Bessie",
+                                         &pos, &len);
+    EXPECT_FALSE(result);
+    EXPECT_EQ(0, pos);
+    EXPECT_EQ(0, len);
+
+    result = gnc_unicode_has_substring_base_chars("bessi", "Necklace for Bessie",
+                                         &pos, &len);
+    EXPECT_TRUE(result);
+    EXPECT_EQ(13, pos);
+    EXPECT_EQ(5, len);
+    }
+TEST(GncUnicode, test_ss_accented)
+{
+    int pos = 0, len = 0;
+    auto result = gnc_unicode_has_substring_accented_chars("bessi", "Necklace for Bessie",
+                                         &pos, &len);
+    EXPECT_TRUE(result);
+    EXPECT_EQ(13, pos);
+    EXPECT_EQ(5, len);
+}
+
+TEST(GncUnicode, test_ss_accented_case_sensitive)
+{
+    int pos = 0, len = 0;
+    auto result = gnc_unicode_has_substring_accented_case_sensitive("bessi", "Necklace for Bessie",
+                                         &pos, &len);
+    EXPECT_FALSE(result);
+    EXPECT_EQ(0, pos);
+    EXPECT_EQ(0, len);
+
+    result = gnc_unicode_has_substring_accented_case_sensitive("Bessi", "Necklace for Bessie",
+                                         &pos, &len);
+    EXPECT_TRUE(result);
+    EXPECT_EQ(13, pos);
+    EXPECT_EQ(5, len);
+}
+
+TEST(GncUnicode, test_german_ss_literal)
+{
+    int pos = 0, len = 0;
+    auto result = gnc_unicode_has_substring_base_chars("be\xc3\x9fi", "Necklace for Be\xc3\x9fie",
+                                         &pos, &len);
+    EXPECT_TRUE(result);
+    EXPECT_EQ(13, pos);
+    EXPECT_EQ(4, len);
+
+    pos = 0, len = 0;
+    result = gnc_unicode_has_substring_accented_chars("be\xc3\x9fi", "Necklace for Be\xc3\x9fie",
+                                         &pos, &len);
+    EXPECT_TRUE(result);
+    EXPECT_EQ(13, pos);
+    EXPECT_EQ(4, len);
+
+    pos = 0, len = 0;
+    result = gnc_unicode_has_substring_accented_case_sensitive("be\xc3\x9fi", "Necklace for Be\xc3\x9fie",
+                                         &pos, &len);
+    EXPECT_FALSE(result);
+    EXPECT_EQ(0, pos);
+    EXPECT_EQ(0, len);
+
+    result = gnc_unicode_has_substring_accented_case_sensitive("Be\xc3\x9fi", "Necklace for Be\xc3\x9fie",
+                                         &pos, &len);
+    EXPECT_TRUE(result);
+    EXPECT_EQ(13, pos);
+    EXPECT_EQ(4, len);
+}
+
+TEST(GncUnicode, test_german_ss_decorated_base_chars_nocap)
+{
+    int pos = 0, len = 0;
+    auto result = gnc_unicode_has_substring_base_chars("bessi", "Necklace for Be\xc3\x9fie",
+                                         &pos, &len);
+    EXPECT_TRUE(result);
+    EXPECT_EQ(13, pos);
+    EXPECT_EQ(4, len);
+}
+
+TEST(GncUnicode, test_german_ss_decorated_accented_cap)
+{
+    int pos = 0, len = 0;
+    auto result = gnc_unicode_has_substring_accented_case_sensitive("bessi", "Necklace for Be\xc3\x9fie",
+                                         &pos, &len);
+    EXPECT_FALSE(result);
+    EXPECT_EQ(0, pos);
+    EXPECT_EQ(0, len);
+
+    result = gnc_unicode_has_substring_accented_case_sensitive("Bessi", "Necklace for Be\xc3\x9fie",
+                                         &pos, &len);
+    EXPECT_FALSE(result);
+    EXPECT_EQ(0, pos);
+    EXPECT_EQ(0, len);
+    }
+
+TEST(GncUnicode, test_german_ss_decorated_accented_nocap)
+{
+    int pos = 0, len = 0;
+    auto result = gnc_unicode_has_substring_accented_chars("bessi", "Necklace for Be\xc3\x9fie",
+                                         &pos, &len);
+    EXPECT_FALSE(result);
+    EXPECT_EQ(0, pos);
+    EXPECT_EQ(0, len);
+}

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -620,6 +620,7 @@ libgnucash/core-utils/gnc-locale-utils.c
 libgnucash/core-utils/gnc-locale-utils.cpp
 libgnucash/core-utils/gnc-path.c
 libgnucash/core-utils/gnc-prefs.c
+libgnucash/core-utils/gnc-unicode.cpp
 libgnucash/core-utils/gnc-version.c
 libgnucash/engine/Account.cpp
 libgnucash/engine/cap-gains.cpp


### PR DESCRIPTION
Use [ICU String Search](https://unicode-org.github.io/icu/userguide/collation/string-search.html) to fix both the crash reported in [bug 799521](https://bugs.gnucash.org/show_bug.cgi?id=799521) and the markup-misalignment, both resulting from trying to apply an index and length from a normalized and case-folded string to the original string. When normalizing and case folding change the number of code points in the string the results are unsatisfactory.

This initial version of `gnc_utf8_has_substring` is hard-coded to the broadest matches to support this immediate use case. ISTM it would make sense to enable stricter matching for other uses.