### PR TITLE
Delay report generation

### DIFF
--- a/gnucash/gnome/gnc-plugin-page-report.cpp
+++ b/gnucash/gnome/gnc-plugin-page-report.cpp
@@ -674,7 +674,12 @@ gnc_plugin_page_report_load_cb (GncHtml * html, URLType type,
             && (strlen(location) > 3)
             && !strncmp("id=", location, 3))
     {
-        report_id = atoi(location + 3);
+        report_id = gnc_report_id_string_to_report_id (location + 3);
+        if (report_id < 0)
+        {
+            LEAVE ("id_string error %s", location);
+            return;
+        }
         DEBUG( "parsed id=%d", report_id );
     }
     else if (!g_strcmp0( type, URL_TYPE_OPTIONS)

--- a/gnucash/report/gnc-report.h
+++ b/gnucash/report/gnc-report.h
@@ -41,6 +41,7 @@ extern "C"
  */
 void gnc_report_init(void);
 
+gint gnc_report_id_string_to_report_id (const char *id_string);
 
 gboolean gnc_run_report_with_error_handling(gint report_id,
                                             gchar** data,

--- a/gnucash/report/report-core.scm
+++ b/gnucash/report/report-core.scm
@@ -760,6 +760,7 @@ not found.")))
         (and template
              (let* ((renderer (gnc:report-template-renderer template))
                     (stylesheet (gnc:report-stylesheet report))
+                    (_ (report-set-anchors! report (ht:make-hash-table)))
                     (doc (renderer report))
                     (html (cond
                            ((string? doc) doc)


### PR DESCRIPTION
better than #2092 

This will change behaviour of all html anchors from report to another report.

Previously the resulting report would be generated `(gnc:make-report)` and the options also generated, which is slow. This change will simply store the required data to generate the report into a hash table within the `report` SCM object. Thus a 5-year monthly multicolumn income statment renders in 1.3s instead of 4-5s.

~Unfortunately the report page isn't updated yet. With this change try:~

~1. load "Income Statemnt (Multicolumn)" report.~
~2. click on any amount cell, which _should_ switch to the transaction report. However the report tab is not yet updated.~
~3. quit and relaunch gnucash; the tab now shows the transaction report.~

~Something is missing between 2 and 3 to update the tab.~

Note this change uses srfi-69 which has a O(1) `hash-table-size`