### PR TITLE
[gnc-optiondb] allow any report option to have a "changed" callback

### DIFF
--- a/bindings/guile/gnc-engine-guile.cpp
+++ b/bindings/guile/gnc-engine-guile.cpp
@@ -1788,6 +1788,13 @@ gnc_split_to_scm (const Split *split)
     return gnc_generic_to_scm (split, stype);
 }
 
+SCM
+gnc_account_to_scm (const Account *account)
+{
+    static auto stype = get_swig_type ("_p_Account");
+    return gnc_generic_to_scm (account, stype);
+}
+
 GncAccountValue * gnc_scm_to_account_value_ptr (SCM valuearg)
 {
     GncAccountValue *res;
@@ -1816,7 +1823,6 @@ GncAccountValue * gnc_scm_to_account_value_ptr (SCM valuearg)
 
 SCM gnc_account_value_ptr_to_scm (GncAccountValue *av)
 {
-    static auto account_type = get_swig_type ("_p_Account");
     gnc_commodity * com;
     gnc_numeric val;
 
@@ -1826,7 +1832,7 @@ SCM gnc_account_value_ptr_to_scm (GncAccountValue *av)
     val = gnc_numeric_convert (av->value, gnc_commodity_get_fraction (com),
                                GNC_HOW_RND_ROUND_HALF_UP);
 
-    return scm_cons (SWIG_NewPointerObj(av->account, account_type, 0),
+    return scm_cons (gnc_account_to_scm (av->account),
                      gnc_numeric_to_scm (val));
 }
 

--- a/bindings/guile/gnc-engine-guile.h
+++ b/bindings/guile/gnc-engine-guile.h
@@ -68,6 +68,8 @@ SCM gnc_book_to_scm(const QofBook* book);
 
 SCM gnc_split_to_scm (const Split *split);
 
+SCM gnc_account_to_scm (const Account *account);
+
 /* Conversion routines used with tax tables */
 GncAccountValue* gnc_scm_to_account_value_ptr(SCM valuearg);
 

--- a/bindings/guile/gnc-optiondb.i
+++ b/bindings/guile/gnc-optiondb.i
@@ -978,6 +978,8 @@ wrap_unique_ptr(GncOptionDBPtr, GncOptionDB);
                                                   GncMultichoiceOptionChoices&&,
                                                   SCM);
 
+    void gnc_option_set_changed_callback (GncOptionDBPtr& db, const char* section,
+                                          const char* name, SCM widget_changed_cb);
 
 %} //%header
 
@@ -1672,6 +1674,25 @@ void gnc_register_complex_boolean_option(GncOptionDBPtr& db,
     db->register_option(section, std::move(option));
 }
 
+ /**
+ * Make an option sensitive to change
+ *
+ * @param db A GncOptionDB* for calling from C. Caller retains ownership.
+ * @param section The database section for the option.
+ * @param name The option name.
+ * @param widget_changed_cb A Scheme callback to run from the UIItem's "changed" signal.
+ */
+ void gnc_option_set_changed_callback (GncOptionDBPtr& db, const char* section,
+                                       const char* name, SCM widget_changed_cb)
+{
+    auto option{db->find_option(section, name)};
+    if (!option)
+    {
+        PWARN ("option not found: %s/%s", section, name);
+        return;
+    }
+    option->set_widget_changed(std::make_any<SCMCallbackWrapper>(widget_changed_cb));
+}
 /**
  * Create a new multichoice option and register it in the options database.
  *

--- a/gnucash/gnome-utils/gnc-option-gtk-ui.cpp
+++ b/gnucash/gnome-utils/gnc-option-gtk-ui.cpp
@@ -31,6 +31,7 @@
 #include <gnc-commodity.h> // for GNC_COMMODITY
 #include "gnc-account-sel.h" // for GNC_ACCOUNT_SEL
 #include "gnc-currency-edit.h" //for GNC_CURRENCY_EDIT
+#include "gnc-engine-guile.h" // for gnc_account_to_scm
 #include "gnc-commodity-edit.h" //for gnc_commodity_get_string
 #include "gnc-date-edit.h" // for gnc_date_edit
 #include "gnc-date-format.h" //for GNC_DATE_FORMAT
@@ -1085,6 +1086,11 @@ public:
         auto widget{GNC_ACCOUNT_SEL(get_widget())};
 // Must cast it to const Account* to get the template specialization to recognize it.
         option.set_value(static_cast<const Account*>(gnc_account_sel_get_account(widget)));
+    }
+    SCM get_widget_scm_value(const GncOption& option) const override
+    {
+        auto widget{GNC_ACCOUNT_SEL(get_widget())};
+        return gnc_account_to_scm (gnc_account_sel_get_account (widget));
     }
 };
 

--- a/gnucash/report/reports/standard/ifrs-cost-basis.scm
+++ b/gnucash/report/reports/standard/ifrs-cost-basis.scm
@@ -89,6 +89,21 @@ the split action field to detect capitalized fees on stock activity")
       gnc:pagename-general optname-stock-acct "b" "Stock Account"
       '() (list ACCT-TYPE-STOCK ACCT-TYPE-MUTUAL))
 
+    (gnc-option-set-changed-callback
+     options gnc:pagename-general optname-stock-acct
+     (lambda (new-acct)
+       (define db (gnc:optiondb options))
+       (define (set-acct name tag)
+         (let ((assoc-acct (xaccAccountGetAssociatedAccount new-acct tag)))
+           (unless (null? assoc-acct)
+             (gnc:pk 'set-acct name tag assoc-acct)
+             (gnc-set-option db gnc:pagename-general name assoc-acct))))
+       (gnc:pk 'new-account-selected new-acct)
+       (set-acct "Proceeds Account" "stock-cash-proceeds")
+       (set-acct "Dividend Account" "stock-dividends")
+       (set-acct "Cap Gains Account" "stock-capgains")
+       (set-acct "Fees Account" "stock-broker-fees")))
+
     (gnc-register-account-sel-limited-option options
       gnc:pagename-general optname-proceeds-acct "c" "Proceeds Account"
       '() (list ACCT-TYPE-ASSET ACCT-TYPE-BANK))


### PR DESCRIPTION
Thus options other than `boolean` and `multichoice` can have callbacks. e.g. we can attach a callback to the `account-sel` option to set other options.

Adding another option type callback is as easy as:

```diff
modified   gnucash/gnome-utils/gnc-option-gtk-ui.cpp
@@ -215,6 +215,11 @@ public:
         auto widget{GTK_ENTRY(get_widget())};
         option.set_value(std::string{gtk_entry_get_text(widget)});
     }
+    SCM get_widget_scm_value(const GncOption& option) const override
+    {
+        auto widget{GTK_ENTRY(get_widget())};
+        return scm_from_utf8_string (gtk_entry_get_text (widget));
+    }
 };
 
 template<> void
modified   gnucash/report/trep-engine.scm
@@ -595,6 +595,11 @@ Expenses:Car and Expenses:Flights. Use a period (.) to match a single character
 '20../.' will match 'Travel 2017/1 London'. ")
     #f)
 
+  (gnc-option-set-changed-callback
+   options pagename-filter optname-account-matcher
+   (lambda (txt) (gnc:pk "new account matcher: " txt)))
+
   (gnc-register-simple-boolean-option options
     pagename-filter optname-account-matcher-exclude "a7"
     (G_ "If this option is selected, accounts matching filter are excluded.")
```

TODO: after updating other options, need to find a way to refresh ui.