### PR TITLE
[reports] use ICU for Unicode string comparison

### DIFF
--- a/bindings/core-utils.i
+++ b/bindings/core-utils.i
@@ -29,6 +29,7 @@
 #include <gnc-locale-utils.h>
 #include <glib.h>
 #include <glib/gi18n.h>
+#include <gnc-unicode.h>
 #include <gnc-version.h>
 #include <libintl.h>
 
@@ -49,6 +50,7 @@ PyObject* SWIG_init (void);
 
 %include <gnc-environment.h>
 %include <gnc-prefs.h>
+%include <gnc-unicode.h>
 %include <gnc-version.h>
 
 %newobject gnc_path_get_bindir;

--- a/bindings/guile/core-utils.scm
+++ b/bindings/guile/core-utils.scm
@@ -75,8 +75,8 @@
      (issue-deprecation-warning "Using _ to call gettext is disallowed in guile-3 and will be removed in the future. Use G_ instead.")
      (gnc:gettext x))))
 
-(define (gnc:string-locale<? a b) (< (g-utf8-collate a b) 0))
-(define (gnc:string-locale>? a b) (> (g-utf8-collate a b) 0))
+(define (gnc:string-locale<? a b) (< (gnc-unicode-compare-accented-case-sensitive a b) 0))
+(define (gnc:string-locale>? a b) (> (gnc-unicode-compare-accented-case-sensitive a b) 0))
 
 ;; Custom unbound-variable exception printer: instead of generic "In
 ;; procedure module-lookup: Unbound variable: varname", it will first


### PR DESCRIPTION
following #2097 use icu for unicode aware string comparison for use in reports