### PR TITLE
[gnc-commodities.cpp] expose auto_quote_control kvp to test them

### DIFF
--- a/libgnucash/engine/gnc-commodity.cpp
+++ b/libgnucash/engine/gnc-commodity.cpp
@@ -1013,7 +1013,7 @@ gnc_commodity_get_fraction(const gnc_commodity * cm)
  * gnc_commodity_get_auto_quote_control_flag
  ********************************************************************/
 
-static gboolean
+gboolean
 gnc_commodity_get_auto_quote_control_flag(const gnc_commodity *cm)
 {
     GValue v = G_VALUE_INIT;
@@ -1241,7 +1241,7 @@ gnc_commodity_set_fraction(gnc_commodity * cm, int fraction)
  * gnc_commodity_set_auto_quote_control_flag
  ********************************************************************/
 
-static void
+void
 gnc_commodity_set_auto_quote_control_flag(gnc_commodity *cm,
         const gboolean flag)
 {

--- a/libgnucash/engine/gnc-commodity.h
+++ b/libgnucash/engine/gnc-commodity.h
@@ -319,6 +319,8 @@ gnc_commodity * gnc_commodity_clone(const gnc_commodity *src, QofBook *dest_book
 @{
 */
 
+gboolean gnc_commodity_get_auto_quote_control_flag (const gnc_commodity *cm);
+
 /** Retrieve the mnemonic for the specified commodity.  This will be a
  *  pointer to a null terminated string of the form "ACME", "QWER",
  *  etc.
@@ -491,6 +493,8 @@ const char*gnc_commodity_get_nice_symbol(const gnc_commodity *cm);
 /** @name Commodity Accessor Routines - Set
 @{
 */
+
+void gnc_commodity_set_auto_quote_control_flag (gnc_commodity *cm, const gboolean flag);
 
 /** Set the mnemonic for the specified commodity.  This should be a
  *  pointer to a null terminated string of the form "ACME", "QWER",

--- a/libgnucash/engine/test/test-commodities.cpp
+++ b/libgnucash/engine/test/test-commodities.cpp
@@ -27,6 +27,7 @@
 
 #include <config.h>
 #include "gnc-commodity.h"
+#include "qofinstance-p.h"
 #include "qof.h"
 #include "test-engine-stuff.h"
 #include "test-stuff.h"
@@ -233,6 +234,30 @@ test_commodity(void)
 
 }
 
+static void
+test_auto_quote_control_flag ()
+{
+    auto book{qof_book_new ()};
+    auto com{gnc_commodity_new(book, NULL, NULL, NULL, NULL, 0)};
+    auto get_kvp = [com]()
+    { return qof_instance_get_path_kvp<const char*> (QOF_INSTANCE (com), {"auto_quote_control"}); };
+
+    g_assert_true (gnc_commodity_get_auto_quote_control_flag (com));
+    g_assert_false (get_kvp ().has_value());
+
+    gnc_commodity_set_auto_quote_control_flag (com, false);
+    g_assert_false (gnc_commodity_get_auto_quote_control_flag (com));
+    g_assert_true (get_kvp ().has_value());
+    g_assert_cmpstr (*get_kvp (), ==, "false");
+
+    gnc_commodity_set_auto_quote_control_flag (com, true);
+    g_assert_true (gnc_commodity_get_auto_quote_control_flag (com));
+    g_assert_false (get_kvp ().has_value());
+
+    gnc_commodity_destroy(com);
+    qof_book_destroy (book);
+}
+
 int
 main (int argc, char **argv)
 {
@@ -243,6 +268,7 @@ main (int argc, char **argv)
 
     test_commodity();
     test_quote_sources ();
+    test_auto_quote_control_flag ();
 
     print_test_results();
 


### PR DESCRIPTION
this kvp is unusual... default is `true`. expose to test thoroughly.