### PR TITLE
Better UX - instead of Yes/No or OK/Cancel, offer Action/Cancel choices

### DIFF
--- a/gnucash/gnome-utils/dialog-tax-table.c
+++ b/gnucash/gnome-utils/dialog-tax-table.c
@@ -733,7 +733,7 @@ tax_table_delete_table_cb (GtkButton *button, TaxTableWindow *ttw)
         return;
     }
 
-    if (gnc_verify_dialog (GTK_WINDOW(ttw->dialog), FALSE,
+    if (gnc_action_dialog (GTK_WINDOW(ttw->dialog), _("_Delete"), FALSE,
                            _("Are you sure you want to delete \"%s\"?"),
                            gncTaxTableGetName (ttw->current_table)))
     {
@@ -780,7 +780,7 @@ tax_table_delete_entry_cb (GtkButton *button, TaxTableWindow *ttw)
         return;
     }
 
-    if (gnc_verify_dialog (GTK_WINDOW(ttw->dialog), FALSE, "%s",
+    if (gnc_action_dialog (GTK_WINDOW(ttw->dialog), _("_Delete"), FALSE, "%s",
                            _("Are you sure you want to delete this entry?")))
     {
         /* Ok, let's remove it */

--- a/gnucash/gnome-utils/gnc-file.c
+++ b/gnucash/gnome-utils/gnc-file.c
@@ -315,7 +315,7 @@ show_session_error (GtkWindow *parent,
     case ERR_BACKEND_NO_SUCH_DB:
         fmt = _("The database %s doesn't seem to exist. "
                 "Do you want to create it?");
-        if (gnc_verify_dialog (parent, TRUE, fmt, displayname))
+        if (gnc_action_dialog (parent, _("_Create"), TRUE, fmt, displayname))
         {
             uh_oh = FALSE;
         }
@@ -408,7 +408,7 @@ show_session_error (GtkWindow *parent,
     case ERR_FILEIO_FILE_BAD_READ:
         fmt = _("There was an error reading the file. "
                 "Do you want to continue?");
-        if (gnc_verify_dialog (parent, TRUE, "%s", fmt))
+        if (gnc_action_dialog (parent, _("_Continue"),TRUE, "%s", fmt))
         {
             uh_oh = FALSE;
         }
@@ -434,7 +434,7 @@ show_session_error (GtkWindow *parent,
             if (gnc_history_test_for_file (displayname))
             {
                 fmt = _("The file/URI %s could not be found.\n\nThe file is in the history list, do you want to remove it?");
-                if (gnc_verify_dialog (parent, FALSE, fmt, displayname))
+                if (gnc_action_dialog (parent, _("_Remove"), FALSE, fmt, displayname))
                     gnc_history_remove_file (displayname);
             }
             else
@@ -448,7 +448,7 @@ show_session_error (GtkWindow *parent,
     case ERR_FILEIO_FILE_TOO_OLD:
         fmt = _("This file is from an older version of GnuCash. "
                 "Do you want to continue?");
-        if (gnc_verify_dialog (parent, TRUE, "%s", fmt))
+        if (gnc_action_dialog (parent, C_("Load file", "_Load"), TRUE, "%s", fmt))
         {
             uh_oh = FALSE;
         }
@@ -1369,7 +1369,7 @@ gnc_file_do_export(GtkWindow *parent, const char * filename)
         else
             name = gnc_uri_normalize_uri ( newfile, FALSE );
         /* if user says cancel, we should break out */
-        if (!gnc_verify_dialog (parent, FALSE, format, name))
+        if (!gnc_action_dialog (parent, C_("Overwrite file", "_Overwrite"), FALSE, format, name))
         {
             return;
         }
@@ -1621,7 +1621,7 @@ gnc_file_do_save_as (GtkWindow *parent, const char* filename)
             name = gnc_uri_normalize_uri ( newfile, FALSE );
 
         /* if user says cancel, we should break out */
-        if (!gnc_verify_dialog (parent, FALSE, format, name ))
+        if (!gnc_action_dialog (parent, C_("Overwrite file", "_Overwrite"), FALSE, format, name ))
         {
             xaccLogDisable();
             qof_session_destroy (new_session);
@@ -1750,7 +1750,7 @@ gnc_file_revert (GtkWindow *parent)
     else
         filename = fileurl;
 
-    if (!gnc_verify_dialog (parent, FALSE, title, filename))
+    if (!gnc_action_dialog (parent, _("_Revert changes"), FALSE, title, filename))
         return;
 
     qof_book_mark_session_saved (qof_session_get_book (session));

--- a/gnucash/gnome/dialog-billterms.c
+++ b/gnucash/gnome/dialog-billterms.c
@@ -675,7 +675,7 @@ billterms_delete_term_cb (GtkButton *button, BillTermsWindow *btw)
         return;
     }
 
-    if (gnc_verify_dialog (GTK_WINDOW(btw->window), FALSE,
+    if (gnc_action_dialog (GTK_WINDOW(btw->window), _("_Delete"), FALSE,
                            _("Are you sure you want to delete \"%s\"?"),
                            gncBillTermGetName (btw->current_term)))
     {

--- a/gnucash/gnome/dialog-custom-report.c
+++ b/gnucash/gnome/dialog-custom-report.c
@@ -327,7 +327,8 @@ custom_report_delete (SCM guid, CustomReportDialog *crd)
     report_name = gnc_scm_to_utf8_string(scm_call_2(template_menu_name, guid, SCM_BOOL_F));
 
     /* we must confirm the user wants to delete their precious custom report! */
-    if (gnc_verify_dialog( GTK_WINDOW (crd->dialog), FALSE, _("Are you sure you want to delete %s?"), report_name))
+    if (gnc_action_dialog (GTK_WINDOW (crd->dialog), _("_Delete"),
+                           FALSE, _("Are you sure you want to delete %s?"), report_name))
     {
         SCM del_report = scm_c_eval_string("gnc:delete-report");
         scm_call_1(del_report, guid);

--- a/gnucash/gnome/dialog-imap-editor.c
+++ b/gnucash/gnome/dialog-imap-editor.c
@@ -369,7 +369,7 @@ gnc_imap_invalid_maps_dialog (ImapDialog *imap_dialog)
 
         gchar *text = g_strdup_printf ("%s\n\n%s\n\n%s", message, message2, _("(Note, if there is a large number, it may take a while)"));
 
-        if (gnc_verify_dialog (GTK_WINDOW (imap_dialog->dialog), FALSE, "%s", text))
+        if (gnc_action_dialog (GTK_WINDOW (imap_dialog->dialog), _("_Remove"), FALSE, "%s", text))
         {
             gnc_imap_remove_invalid_maps (imap_dialog);
             gtk_widget_hide (imap_dialog->remove_button);

--- a/gnucash/gnome/dialog-invoice.c
+++ b/gnucash/gnome/dialog-invoice.c
@@ -736,7 +736,8 @@ gnc_invoice_window_deleteCB (GtkWidget *widget, gpointer data)
         else
             msg = g_strdup (message);
 
-        result = gnc_verify_dialog (GTK_WINDOW (iw_get_window(iw)), FALSE, "%s", msg);
+        result = gnc_action_dialog (GTK_WINDOW (iw_get_window(iw)), _("_Delete"),
+                                    FALSE, "%s", msg);
         g_free (msg);
 
         if (!result)

--- a/gnucash/gnome/dialog-order.c
+++ b/gnucash/gnome/dialog-order.c
@@ -300,7 +300,8 @@ gnc_order_window_close_order_cb (GtkWidget *widget, gpointer data)
                     "Are you sure you want to close it out before "
                     "you invoice all the entries?");
 
-        if (gnc_verify_dialog (GTK_WINDOW (ow->dialog), FALSE, "%s", message) == FALSE)
+        if (gnc_action_dialog (GTK_WINDOW (ow->dialog), C_("Close order", "_Close"),
+                               FALSE, "%s", message) == FALSE)
             return;
     }
 

--- a/gnucash/gnome/dialog-price-edit-db.cpp
+++ b/gnucash/gnome/dialog-price-edit-db.cpp
@@ -445,7 +445,9 @@ gnc_prices_dialog_remove_old_clicked (GtkWidget *widget, gpointer data)
         auto comm_list = gnc_prices_dialog_get_commodities (pdb_dialog->remove_view);
 
         // Are you sure you want to delete the entries and we have commodities
-        if ((g_list_length (comm_list) != 0) && (gnc_verify_dialog (GTK_WINDOW (pdb_dialog->remove_dialog), FALSE, fmt, NULL)))
+        if (comm_list != nullptr &&
+            gnc_action_dialog (GTK_WINDOW (pdb_dialog->remove_dialog),
+                               _("_Delete"), FALSE, fmt, NULL))
         {
             time64 last;
             GDate fiscal_end_date = get_fiscal_end_date ();

--- a/gnucash/gnome/dialog-sx-editor.c
+++ b/gnucash/gnome/dialog-sx-editor.c
@@ -512,7 +512,7 @@ gnc_sxed_check_names (GncSxEditorDialog *sxed)
         const char *sx_has_existing_name_msg =
             _("A Scheduled Transaction with the name \"%s\" already exists. "
               "Are you sure you want to name this one the same?");
-        if (!gnc_verify_dialog (GTK_WINDOW (sxed->dialog), FALSE,
+        if (!gnc_action_dialog (GTK_WINDOW (sxed->dialog), _("_Overwrite"), FALSE,
                                 sx_has_existing_name_msg, name))
             return FALSE;
     }
@@ -584,7 +584,7 @@ gnc_sxed_check_endpoint (GncSxEditorDialog *sxed)
         const char *invalid_sx_check_msg =
             _("You have attempted to create a Scheduled Transaction which "
               "will never run. Do you really want to do this?");
-        if (!gnc_verify_dialog (GTK_WINDOW (sxed->dialog), FALSE,
+        if (!gnc_action_dialog (GTK_WINDOW (sxed->dialog), _("_Create"), FALSE,
                                "%s", invalid_sx_check_msg))
             return FALSE;
     }
@@ -873,7 +873,7 @@ gnc_sxed_check_consistent (GncSxEditorDialog *sxed)
         const char *msg =
             _("The Scheduled Transaction Editor cannot automatically "
               "balance this transaction. Should it still be entered?");
-        if (!gnc_verify_dialog (GTK_WINDOW (sxed->dialog), FALSE, "%s", msg))
+        if (!gnc_action_dialog (GTK_WINDOW (sxed->dialog), _("_Enter"), FALSE, "%s", msg))
             return FALSE;
     }
 
@@ -1579,7 +1579,7 @@ gnc_sxed_reg_check_close (GncSxEditorDialog *sxed)
         return;
     }
 
-    if (gnc_verify_dialog (GTK_WINDOW (sxed->dialog), TRUE, "%s", message))
+    if (gnc_action_dialog (GTK_WINDOW (sxed->dialog), _("_Save"), TRUE, "%s", message))
     {
         if (!gnc_split_register_save (reg, TRUE))
             return;

--- a/gnucash/gnome/dialog-sx-from-trans.cpp
+++ b/gnucash/gnome/dialog-sx-from-trans.cpp
@@ -256,7 +256,8 @@ sxftd_add_template_trans(SXFromTransInfo *sxfti)
     }
 
     if ( ! gnc_numeric_zero_p( runningBalance )
-            && !gnc_verify_dialog (GTK_WINDOW (sxfti->dialog),
+            && !gnc_action_dialog (GTK_WINDOW (sxfti->dialog),
+                                   C_("Enter imbalanced scheduled transaction", "_Enter"),
                                    FALSE, "%s",
                                    _("The Scheduled Transaction Editor "
                                      "cannot automatically balance "

--- a/gnucash/gnome/gnc-plugin-page-budget.cpp
+++ b/gnucash/gnome/gnc-plugin-page-budget.cpp
@@ -934,7 +934,7 @@ gnc_budget_gui_delete_budget (GncBudget *budget)
     if (!name)
         name = _("Unnamed Budget");
 
-    if (gnc_verify_dialog (NULL, FALSE, _("Delete %s?"), name))
+    if (gnc_action_dialog (NULL, _("_Delete"), FALSE, _("Delete %s?"), name))
     {
         QofBook* book = gnc_get_current_book ();
 

--- a/gnucash/gnome/gnc-plugin-page-register.cpp
+++ b/gnucash/gnome/gnc-plugin-page-register.cpp
@@ -3960,7 +3960,8 @@ gnc_plugin_page_register_cmd_reverse_transaction (GSimpleAction *simple,
     {
         const char *rev = _("A reversing entry has already been created for this transaction.");
         const char *jump = _("Jump to the transaction?");
-        if (!gnc_verify_dialog (GTK_WINDOW (window), TRUE, "%s\n\n%s", rev, jump))
+        if (!gnc_action_dialog (GTK_WINDOW (window), C_("Jump to reversing transaction", "_Jump"),
+                                TRUE, "%s\n\n%s", rev, jump))
         {
             LEAVE ("reverse cancelled");
             return;

--- a/gnucash/gnome/gnc-plugin-page-report.cpp
+++ b/gnucash/gnome/gnc-plugin-page-report.cpp
@@ -1649,7 +1649,7 @@ gnc_get_export_filename (SCM choice, GtkWindow *parent)
         const char *format = _("The file %s already exists. "
                                "Are you sure you want to overwrite it?");
 
-        if (!gnc_verify_dialog (parent, FALSE, format, filepath))
+        if (!gnc_action_dialog (parent, C_("Overwrite file", "_Overwrite"), FALSE, format, filepath))
         {
             g_free(filepath);
             return nullptr;

--- a/gnucash/gnome/gnc-plugin-page-sx-list.cpp
+++ b/gnucash/gnome/gnc-plugin-page-sx-list.cpp
@@ -938,7 +938,7 @@ gnc_plugin_page_sx_list_cmd_delete (GSimpleAction *simple,
     g_free (text_list_of_scheduled_transaction_names);
     g_list_free (to_delete_names);
 
-    if (gnc_verify_dialog (window, false, "%s", message))
+    if (gnc_action_dialog (window, _("_Delete"), false, "%s", message))
     {
         gppsl_update_selected_list (plugin_page, true, nullptr);
 

--- a/gnucash/gnome/window-reconcile.cpp
+++ b/gnucash/gnome/window-reconcile.cpp
@@ -1414,7 +1414,8 @@ gnc_ui_reconcile_window_delete_cb (GSimpleAction *simple,
                                 "transaction?");
         gboolean result;
 
-        result = gnc_verify_dialog (GTK_WINDOW (recnData->window), FALSE, "%s", message);
+        result = gnc_action_dialog (GTK_WINDOW (recnData->window),
+                                    _("_Delete"), FALSE, "%s", message);
 
         if (!result)
             return;
@@ -2328,7 +2329,7 @@ recnFinishCB (GSimpleAction *simple,
     {
         const char *message = _("The account is not balanced. "
                                 "Are you sure you want to finish?");
-        if (!gnc_verify_dialog (GTK_WINDOW (recnData->window), FALSE, "%s", message))
+        if (!gnc_action_dialog (GTK_WINDOW (recnData->window), _("_Finish"), FALSE, "%s", message))
             return;
     }
 
@@ -2388,7 +2389,8 @@ recnPostponeCB (GSimpleAction *simple,
     {
         const char *message = _("Do you want to postpone this reconciliation "
                                 "and finish it later?");
-        if (!gnc_verify_dialog (GTK_WINDOW (recnData->window), FALSE, "%s", message))
+        if (!gnc_action_dialog (GTK_WINDOW (recnData->window),
+                                C_("Postpone Reconciliation", "_Postpone"), FALSE, "%s", message))
             return;
     }
 

--- a/gnucash/import-export/aqb/dialog-ab-trans.c
+++ b/gnucash/import-export/aqb/dialog-ab-trans.c
@@ -1159,8 +1159,8 @@ gnc_ab_trans_dialog_del_templ_cb(GtkButton *button, gpointer user_data)
     }
 
     gtk_tree_model_get(model, &iter, TEMPLATE_NAME, &name, -1);
-    if (gnc_verify_dialog (
-                GTK_WINDOW (td->parent), FALSE,
+    if (gnc_action_dialog (
+                GTK_WINDOW (td->parent), _("_Delete"), FALSE,
                 _("Do you really want to delete the template with the name \"%s\"?"),
                 name))
     {

--- a/gnucash/import-export/aqb/gnc-ab-transfer.c
+++ b/gnucash/import-export/aqb/gnc-ab-transfer.c
@@ -55,8 +55,8 @@ save_templates(GtkWidget *parent, Account *gnc_acc, GList *templates,
                gboolean dont_ask)
 {
     g_return_if_fail(gnc_acc);
-    if (dont_ask || gnc_verify_dialog (
-                GTK_WINDOW (parent), FALSE, "%s",
+    if (dont_ask || gnc_action_dialog (
+                GTK_WINDOW (parent), _("_Save"), FALSE, "%s",
                 _("You have changed the list of online transfer templates, "
                   "but you cancelled the transfer dialog. "
                   "Do you nevertheless want to store the changes?")))
@@ -176,8 +176,8 @@ gnc_ab_maketrans(GtkWidget *parent, Account *gnc_acc,
         job = gnc_ab_trans_dialog_get_job(td);
         if (!job || AB_AccountSpec_GetTransactionLimitsForCommand(ab_acc, AB_Transaction_GetCommand(job))==NULL)
         {
-            if (!gnc_verify_dialog (
-                        GTK_WINDOW (parent), FALSE, "%s",
+            if (!gnc_action_dialog (
+                        GTK_WINDOW (parent), _("_Retry"), FALSE, "%s",
                         _("The backend found an error during the preparation "
                           "of the job. It is not possible to execute this job.\n"
                           "\n"
@@ -286,8 +286,8 @@ gnc_ab_maketrans(GtkWidget *parent, Account *gnc_acc,
                 && job_status != AB_Transaction_StatusPending)
             {
                 successful = FALSE;
-                if (!gnc_verify_dialog (
-                            GTK_WINDOW (parent), FALSE, "%s",
+                if (!gnc_action_dialog (
+                            GTK_WINDOW (parent), _("_Retry"), FALSE, "%s",
                             _("An error occurred while executing the job. Please check "
                               "the log window for the exact error message.\n"
                               "\n"

--- a/gnucash/import-export/aqb/gnc-ab-utils.c
+++ b/gnucash/import-export/aqb/gnc-ab-utils.c
@@ -720,8 +720,8 @@ txn_transaction_cb (const AB_TRANSACTION *element, gpointer user_data)
         if (!job || AB_AccountSpec_GetTransactionLimitsForCommand (data->ab_acc, AB_Transaction_GetCommand (job)) == NULL)
         {
             /* Oops, no job, probably not supported by bank */
-            if (gnc_verify_dialog (
-                        GTK_WINDOW(data->parent), FALSE, "%s",
+            if (gnc_action_dialog (
+                        GTK_WINDOW(data->parent), _("_Retry"), FALSE, "%s",
                         _("The backend found an error during the preparation "
                           "of the job. It is not possible to execute this job.\n"
                           "\n"
@@ -815,7 +815,7 @@ txn_accountinfo_cb (AB_IMEXPORTER_ACCOUNTINFO *element, gpointer user_data)
 
     if (!(data->awaiting & AWAIT_TRANSACTIONS))
     {
-        if (gnc_verify_dialog (GTK_WINDOW(data->parent), TRUE, "%s",
+        if (gnc_action_dialog (GTK_WINDOW(data->parent), _("_Import"), TRUE, "%s",
                               _("The bank has sent transaction information "
                                 "in its response."
                                 "\n"
@@ -917,7 +917,7 @@ bal_accountinfo_cb (AB_IMEXPORTER_ACCOUNTINFO *element, gpointer user_data)
             return NULL;
 
         /* Ask the user whether to import unawaited non-zero balance */
-        if (gnc_verify_dialog (parent, TRUE, "%s", balance_msg))
+        if (gnc_action_dialog (parent, _("_Import"), TRUE, "%s", balance_msg))
         {
             data->awaiting |= AWAIT_BALANCES;
         }
@@ -1050,7 +1050,8 @@ bal_accountinfo_cb (AB_IMEXPORTER_ACCOUNTINFO *element, gpointer user_data)
         {
             const char *message3 = _("Reconcile account now?");
 
-            show_recn_window = gnc_verify_dialog (GTK_WINDOW(data->parent), TRUE, "%s\n%s\n%s",
+            show_recn_window = gnc_action_dialog (GTK_WINDOW(data->parent), _("_Reconcile"),
+                                                  TRUE, "%s\n%s\n%s",
                                                   message1, message2, message3);
         }
         g_free (booked_str);

--- a/gnucash/import-export/aqb/gnc-gwen-gui.c
+++ b/gnucash/import-export/aqb/gnc-gwen-gui.c
@@ -1092,7 +1092,7 @@ get_input(GncGWENGui *gui, guint32 flags, const gchar *title,
             gchar *msg = g_strdup_printf(
                              _("The PIN needs to be at least %d characters\n"
                                "long. Do you want to try again?"), min_len);
-            retval = gnc_verify_dialog (GTK_WINDOW (gui->parent), TRUE, "%s", msg);
+            retval = gnc_action_dialog (GTK_WINDOW (gui->parent), _("_Retry"), TRUE, "%s", msg);
             g_free(msg);
             if (!retval)
                 break;

--- a/gnucash/import-export/csv-exp/assistant-csv-export.c
+++ b/gnucash/import-export/csv-exp/assistant-csv-export.c
@@ -739,7 +739,8 @@ csv_export_assistant_finish_page_prepare (GtkAssistant *assistant,
                                "Are you sure you want to overwrite it?");
 
         /* if user says cancel, we should go back a page */
-        if (!gnc_verify_dialog (GTK_WINDOW (assistant), FALSE, format, info->file_name))
+        if (!gnc_action_dialog (GTK_WINDOW (assistant), C_("Overwrite file", "_Overwrite"),
+                                FALSE, format, info->file_name))
             gtk_assistant_previous_page (assistant);
     }
     /* Enable the Assistant Buttons */

--- a/gnucash/import-export/ofx/gnc-ofx-import.cpp
+++ b/gnucash/import-export/ofx/gnc-ofx-import.cpp
@@ -634,8 +634,8 @@ continue_account_selection(GtkWidget* parent, Account* account,
                            gnc_commodity* commodity)
 {
     gboolean keep_going =
-        gnc_verify_dialog(
-            GTK_WINDOW (parent), TRUE,
+        gnc_action_dialog(
+            GTK_WINDOW (parent), _("_Choose account"), TRUE,
             "The chosen account \"%s\" does not have the correct "
             "currency/security \"%s\" (it has \"%s\" instead). "
             "This account cannot be used. "

--- a/gnucash/register/ledger-core/gncEntryLedger.c
+++ b/gnucash/register/ledger-core/gncEntryLedger.c
@@ -98,7 +98,7 @@ gnc_entry_ledger_get_account_by_name (GncEntryLedger *ledger, BasicCell * bcell,
     if (!account)
     {
         /* Ask if they want to create a new one. */
-        if (!gnc_verify_dialog (GTK_WINDOW (ledger->parent), TRUE, missing, name))
+        if (!gnc_action_dialog (GTK_WINDOW (ledger->parent), _("_Create"), TRUE, missing, name))
             return NULL;
 
         /* No changes, as yet. */

--- a/gnucash/register/ledger-core/gncEntryLedgerControl.c
+++ b/gnucash/register/ledger-core/gncEntryLedgerControl.c
@@ -759,7 +759,7 @@ static gboolean gnc_entry_ledger_traverse (VirtualLocation *p_new_virt_loc,
         {
             const char *format = _("The tax table %s does not exist. "
                                    "Would you like to create it?");
-            if (!gnc_verify_dialog (GTK_WINDOW (ledger->parent), TRUE, format, name))
+            if (!gnc_action_dialog (GTK_WINDOW (ledger->parent), _("_Create"), TRUE, format, name))
                 break;
         }
 
@@ -992,7 +992,8 @@ gnc_entry_ledger_check_close_internal (GtkWidget *parent,
     if (!gnc_entry_ledger_verify_can_save (ledger))
         return FALSE;
 
-    if (dontask || gnc_verify_dialog (GTK_WINDOW (parent), TRUE, "%s", message))
+    if (dontask || gnc_action_dialog (GTK_WINDOW (parent), C_("Save entry", "_Save"), TRUE,
+                                      "%s", message))
         gnc_entry_ledger_save (ledger, TRUE);
     else
         gnc_entry_ledger_cancel_cursor_changes (ledger);

--- a/gnucash/register/ledger-core/split-register.c
+++ b/gnucash/register/ledger-core/split-register.c
@@ -986,7 +986,8 @@ gnc_split_register_paste_current (SplitRegister* reg)
                 LEAVE ("anchore split");
                 return;
             }
-            else if (!gnc_verify_dialog (GTK_WINDOW (gnc_split_register_get_parent (reg)),
+            else if (!gnc_action_dialog (GTK_WINDOW (gnc_split_register_get_parent (reg)),
+                                         C_("Overwrite transaction", "_Overwrite"),
                                          FALSE, "%s", message))
             {
                 LEAVE ("user cancelled");
@@ -1044,8 +1045,8 @@ gnc_split_register_paste_current (SplitRegister* reg)
 
         /* Ask before overwriting an existing transaction. */
         if (split != blank_split &&
-            !gnc_verify_dialog (GTK_WINDOW (gnc_split_register_get_parent (reg)),
-                                FALSE, "%s", message))
+            !gnc_action_dialog (GTK_WINDOW (gnc_split_register_get_parent (reg)),
+                                C_("Overwrite transaction", "_Overwrite"), FALSE, "%s", message))
         {
             LEAVE ("user cancelled");
             return;
@@ -2022,7 +2023,7 @@ gnc_split_register_get_account_by_name (SplitRegister* reg, BasicCell* bcell,
     if (!account && !creating_account)
     {
         /* Ask if they want to create a new one. */
-        if (!gnc_verify_dialog (parent, TRUE, missing, name))
+        if (!gnc_action_dialog (parent, C_("Create account", "_Create"), TRUE, missing, name))
             return NULL;
         creating_account = TRUE;
         /* User said yes, they want to create a new account. */


### PR DESCRIPTION
I'd postulate that most `gnc_verify_dialog` could use `gnc_action_dialog` to have better UX. Example: "Do you want to revert?" changed from Yes/No to Cancel/Revert.

Downisde: users with muscle memory may object.