### PR TITLE
use chromium-embedded-framework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,6 +242,44 @@ if (WITH_GNUCASH)
   pkg_check_modules (GTK3 REQUIRED IMPORTED_TARGET gtk+-3.0>=${GTK_MIN_VERSION})
 endif()
 
+find_path(CEF_FIND cef_app.h)
+set(CEF_INCLUDE_DIR "${CEF_FIND}/..")
+set(CEF_LIB_DIR "${CEF_INCLUDE_DIR}/lib")
+find_path(CEF_RESOURCES_DIR icudtl.dat
+          PATHS "${CEF_INCLUDE_DIR}/share/cef"
+                "${CEF_LIB_DIR}")
+find_library(CEF_LIB cef)
+find_library(CEF_DLL_WRAPPER cef_dll_wrapper
+             PATHS "${CEF_INCLUDE_DIR}/libcef_dll_wrapper"
+                   "${CEF_LIB_DIR}")
+
+message (STATUS "Path CEF_FIND ${CEF_FIND}")
+message (STATUS "Path CEF_INCLUDE_DIR ${CEF_INCLUDE_DIR}")
+message (STATUS "Path CEF_LIB_DIR ${CEF_LIB_DIR}")
+message (STATUS "Path CEF_RESOURCES_DIR ${CEF_RESOURCES_DIR}")
+message (STATUS "Path CEF_LIB ${CEF_LIB}")
+message (STATUS "Path CEF_DLL_WRAPPER ${CEF_DLL_WRAPPER}")
+
+include_directories(${CEF_FIND})
+link_directories(${CEF_DLL_WRAPPER})
+
+# If you want to use target-based linkage, you can define an imported library:
+add_library(cef SHARED IMPORTED)
+set_target_properties(cef PROPERTIES
+    IMPORTED_LOCATION "${CEF_LIB_DIR}/libcef.so"
+    INTERFACE_INCLUDE_DIRECTORIES "${CEF_INCLUDE_DIR}"
+)
+
+# Example: install resource files (adjust destination as needed)
+install(FILES
+    "${CEF_RESOURCES_DIR}/icudtl.dat"
+    "${CEF_RESOURCES_DIR}/chrome_100_percent.pak"
+    "${CEF_RESOURCES_DIR}/chrome_200_percent.pak"
+    "${CEF_RESOURCES_DIR}/resources.pak"
+    DESTINATION share/cef
+)
+add_definitions(-DCEF_RESOURCES_DIR="${CEF_RESOURCES_DIR}")
+
 pkg_check_modules (ZLIB REQUIRED zlib)
 
 if (MSVC)

--- a/gnucash/gnucash.cpp
+++ b/gnucash/gnucash.cpp
@@ -57,6 +57,7 @@
 #include <gnucash-register.h>
 #include <search-core-type.h>
 #include <top-level.h>
+#include "gnc-html-cef.h"
 
 #include <boost/locale.hpp>
 #include <boost/optional.hpp>
@@ -264,13 +265,17 @@ Gnucash::Gnucash::configure_program_options (void)
 }
 
 int
-Gnucash::Gnucash::start ([[maybe_unused]] int argc, [[maybe_unused]] char **argv)
+Gnucash::Gnucash::start (int argc, char **argv)
 {
     Gnucash::CoreApp::start();
 
     /* Now the module files are looked up, which might cause some library
      initialization to be run, hence gtk must be initialized beforehand. */
     gnc_module_system_init();
+
+    printf ("init...\n");
+    cef_wrapper_init (argc, argv);
+    printf ("complete...\n");
 
     gnc_gui_init();
 

--- a/gnucash/html/CMakeLists.txt
+++ b/gnucash/html/CMakeLists.txt
@@ -26,9 +26,9 @@ if (WEBKIT1)
   list(APPEND html_SOURCES gnc-html-webkit1.c)
   set(html_EXTRA_DIST gnc-html-webkit2.h gnc-html-webkit2.c)
 else ()
-  list(APPEND html_HEADERS gnc-html-webkit2.h)
-  list(APPEND html_SOURCES gnc-html-webkit2.c)
-  set(html_EXTRA_DIST gnc-html-webkit1.h gnc-html-webkit1.c)
+  list(APPEND html_HEADERS gnc-html-cef.h gnc-html-webkit2.h)
+  list(APPEND html_SOURCES gnc-html-cef.cpp gnc-html-webkit2.c)
+  set(html_EXTRA_DIST gnc-html-cef.c gnc-html-cef.h gnc-html-webkit1.h gnc-html-webkit1.c)
 endif()
 
 
@@ -58,12 +58,16 @@ target_link_libraries(gnc-html
         gnc-gnome-utils
         PkgConfig::GTK3
         PkgConfig::WEBKIT
+        ${CEF_DLL_WRAPPER}
+        cef
         ${GUILE_LDFLAGS})
 
 target_compile_definitions(gnc-html PRIVATE -DG_LOG_DOMAIN=\"gnc.html\")
 
 
 target_include_directories (gnc-html
+PRIVATE
+    cef
 PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
@@ -73,6 +77,10 @@ if (APPLE)
 endif()
 
 add_dependencies(gnc-html swig-gnc-html-c)
+
+set_target_properties(gnc-html PROPERTIES
+    LINK_FLAGS "-Wl,-rpath,${CEF_LIB_DIR}"
+)
 
 if (COVERAGE)
   add_coverage_target(gnc-html)

--- a/gnucash/html/gnc-html-cef.cpp
+++ b/gnucash/html/gnc-html-cef.cpp
@@ -1,0 +1,95 @@
+#include "gnc-html-cef.h"
+#include <gtk/gtk.h>
+#include <gdk/gdkx.h>
+#include "include/cef_app.h"
+#include "include/cef_client.h"
+#include "include/cef_browser.h"
+#include <unistd.h>
+#include <limits.h>
+
+class SimpleHandler : public CefClient, public CefLifeSpanHandler
+{
+public:
+    SimpleHandler() {}
+    CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() override { return this; }
+    void OnAfterCreated(CefRefPtr<CefBrowser> browser) override { m_browser = browser; }
+    bool DoClose(CefRefPtr<CefBrowser>) override { return false; }
+    void OnBeforeClose(CefRefPtr<CefBrowser>) override { m_browser = nullptr; }
+    void LoadFile(const std::string& path) { if (m_browser) m_browser->GetMainFrame()->LoadURL(path); }
+
+private:
+    CefRefPtr<CefBrowser> m_browser;
+    IMPLEMENT_REFCOUNTING(SimpleHandler);
+};
+
+class SimpleCefApp : public CefApp, public CefBrowserProcessHandler
+{
+public:
+    SimpleCefApp() {}
+    CefRefPtr<CefBrowserProcessHandler> GetBrowserProcessHandler() override { return this; }
+    void OnContextInitialized() override {}
+    IMPLEMENT_REFCOUNTING(SimpleCefApp);
+};
+
+static CefRefPtr<SimpleHandler> g_handler;
+static CefRefPtr<SimpleCefApp> g_app;
+
+void cef_wrapper_init(int argc, char* argv[])
+{
+    CefMainArgs main_args(argc, argv);
+    if (auto exit_code = CefExecuteProcess(main_args, nullptr, nullptr); exit_code >= 0)
+        return;
+
+    CefSettings settings;
+    settings.no_sandbox = true;
+    settings.multi_threaded_message_loop = true;
+
+    g_app = new SimpleCefApp;
+    printf ("cefapp=%p\n", g_app.get());
+    if (!CefInitialize(main_args, settings, g_app, nullptr))
+    {
+        printf ("CEF initialization failed\n");
+        return;
+    }
+    printf ("CEF initialization success\n");
+}
+
+static GtkWidget* get_cef_window ()
+{
+    static GtkWidget* cef_window = nullptr;
+    if (!cef_window)
+    {
+        cef_window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+        gtk_window_set_default_size(GTK_WINDOW(cef_window), 1024, 768);
+        g_signal_connect(cef_window, "destroy", G_CALLBACK(gtk_main_quit), NULL);
+        gtk_widget_show_all(cef_window);
+    }
+    return cef_window;
+}
+
+void cef_wrapper_create_browser (const char* html_file)
+{
+    GtkWidget *window = get_cef_window ();
+    Window xid = gdk_x11_window_get_xid(gtk_widget_get_window(window));
+
+    CefWindowInfo window_info;
+    GtkAllocation alloc;
+    gtk_widget_get_allocation(window, &alloc);
+    window_info.SetAsChild (xid, CefRect(0, 0, alloc.width, alloc.height));
+
+    CefBrowserSettings browser_settings;
+    g_handler = new SimpleHandler();
+
+    CefBrowserHost::CreateBrowserSync(window_info, g_handler.get(), html_file,
+                                      browser_settings, nullptr, nullptr);
+}
+
+void cef_wrapper_load_file(const char* html_file)
+{
+    if (g_handler) g_handler->LoadFile(html_file);
+}
+
+void cef_wrapper_shutdown()
+{
+    CefShutdown();
+}

--- a/gnucash/html/gnc-html-cef.h
+++ b/gnucash/html/gnc-html-cef.h
@@ -1,0 +1,21 @@
+
+#ifndef GNC_HTML_CEF_H
+#define GNC_HTML_CEF_H
+
+#include <glib-object.h>
+#include <gtk/gtk.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void cef_wrapper_init (int argc, char* argv[]);
+void cef_wrapper_create_browser (const char* html_file);
+void cef_wrapper_load_file(const char* html_file);
+void cef_wrapper_shutdown();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/gnucash/html/gnc-html-webkit2.c
+++ b/gnucash/html/gnc-html-webkit2.c
@@ -56,6 +56,7 @@
 #include "gnc-html-webkit.h"
 #include "gnc-html-history.h"
 #include "print-session.h"
+#include "gnc-html-cef.h"
 
 
 G_DEFINE_TYPE(GncHtmlWebkit, gnc_html_webkit, GNC_TYPE_HTML )
@@ -181,6 +182,7 @@ gnc_html_webkit_init( GncHtmlWebkit* self )
                  GNC_PREF_RPT_DFLT_ZOOM);
      webkit_web_view_set_zoom_level (priv->web_view, zoom);
 
+     cef_wrapper_create_browser ("about:blank");
 
      gtk_container_add( GTK_CONTAINER(priv->base.container),
                         GTK_WIDGET(priv->web_view) );
@@ -270,6 +272,7 @@ gnc_html_webkit_finalize( GObject* obj )
 //              g_free( self->priv );
      self->priv = NULL;
 //      }
+     cef_wrapper_shutdown();
 
      G_OBJECT_CLASS(gnc_html_webkit_parent_class)->finalize( obj );
 }
@@ -775,6 +778,7 @@ impl_webkit_show_data( GncHtml* self, const gchar* data, int datalen )
      g_free(filename);
      DEBUG("Loading uri '%s'", uri);
      webkit_web_view_load_uri( priv->web_view, uri );
+     cef_wrapper_load_file(uri);
      g_free( uri );
 
      LEAVE("");

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -292,6 +292,7 @@ gnucash/gtkbuilder/gnc-tree-view-owner.glade
 gnucash/gtkbuilder/window-autoclear.glade
 gnucash/gtkbuilder/window-reconcile.glade
 gnucash/html/gnc-html.c
+gnucash/html/gnc-html-cef.cpp
 gnucash/html/gnc-html-factory.c
 gnucash/html/gnc-html-history.c
 gnucash/html/gnc-html-webkit1.c


### PR DESCRIPTION
very early draft. it does compile, but freezes during init. chatgpt heavily used.

if `chromium-embedded-framework` is available, CMake hopefully will find it and set appropriate paths. this currently piggybacks onto webkit2 to try update a simultaneous chromium window. unfortunately, for unfathomable reasons, it freezes during `CefInitialize` in `gnc-html-cef.cpp` and therewith the gdb backtrace:

```
#0  0x00007c65f87b97a9 in __pthread_once_slow.isra.0 () from /gnu/store/mprrfhb2cq6dwsxf6pgj1zmjincd4x5h-glibc-2.41/lib/libc.so.6
#1  0x00007c65f87b9889 in pthread_once@GLIBC_2.2.5 () from /gnu/store/mprrfhb2cq6dwsxf6pgj1zmjincd4x5h-glibc-2.41/lib/libc.so.6
#2  0x00007c65f3881189 in localtime_r () from /gnu/store/s66a716vbk4zba4zap7nza6qz1nyqx8a-profile/include/../lib/libcef.so
#3  0x00007c65f1da1892 in logging::LogMessage::Init(char const*, int) () from /gnu/store/s66a716vbk4zba4zap7nza6qz1nyqx8a-profile/include/../lib/libcef.so
#4  0x00007c65f38816d1 in sandbox::InitLibcLocaltimeFunctionsImpl() () from /gnu/store/s66a716vbk4zba4zap7nza6qz1nyqx8a-profile/include/../lib/libcef.so
#5  0x00007c65f87b9817 in __pthread_once_slow.isra.0 () from /gnu/store/mprrfhb2cq6dwsxf6pgj1zmjincd4x5h-glibc-2.41/lib/libc.so.6
#6  0x00007c65f87b9889 in pthread_once@GLIBC_2.2.5 () from /gnu/store/mprrfhb2cq6dwsxf6pgj1zmjincd4x5h-glibc-2.41/lib/libc.so.6
#7  0x00007c65f3881189 in localtime_r () from /gnu/store/s66a716vbk4zba4zap7nza6qz1nyqx8a-profile/include/../lib/libcef.so
#8  0x00007c65f1da1892 in logging::LogMessage::Init(char const*, int) () from /gnu/store/s66a716vbk4zba4zap7nza6qz1nyqx8a-profile/include/../lib/libcef.so
#9  0x00007c65f24a6c70 in base::i18n::(anonymous namespace)::InitializeICUWithFileDescriptorInternal(int, base::MemoryMappedFile::Region const&) ()
   from /gnu/store/s66a716vbk4zba4zap7nza6qz1nyqx8a-profile/include/../lib/libcef.so
#10 0x00007c65f24a6f36 in base::i18n::InitializeICU() () from /gnu/store/s66a716vbk4zba4zap7nza6qz1nyqx8a-profile/include/../lib/libcef.so
#11 0x00007c65f17ed1df in content::ContentMainRunnerImpl::Initialize(content::ContentMainParams) () from /gnu/store/s66a716vbk4zba4zap7nza6qz1nyqx8a-profile/include/../lib/libcef.so
#12 0x00007c65f17eb99b in content::ContentMainInitialize(content::ContentMainParams, content::ContentMainRunner*) () from /gnu/store/s66a716vbk4zba4zap7nza6qz1nyqx8a-profile/include/../lib/libcef.so
#13 0x00007c65ee44c168 in CefMainRunner::ContentMainInitialize(CefMainArgs const&, void*, int*) () from /gnu/store/s66a716vbk4zba4zap7nza6qz1nyqx8a-profile/include/../lib/libcef.so
#14 0x00007c65ee44bfae in CefMainRunner::Initialize(CefStructBase<CefSettingsTraits>*, scoped_refptr<CefApp>, CefMainArgs const&, void*, bool*, base::OnceCallback<void ()>) ()
   from /gnu/store/s66a716vbk4zba4zap7nza6qz1nyqx8a-profile/include/../lib/libcef.so
#15 0x00007c65ee4209ee in CefContext::Initialize(CefMainArgs const&, CefStructBase<CefSettingsTraits> const&, scoped_refptr<CefApp>, void*) ()
   from /gnu/store/s66a716vbk4zba4zap7nza6qz1nyqx8a-profile/include/../lib/libcef.so
#16 0x00007c65ee4206fb in CefInitialize(CefMainArgs const&, CefStructBase<CefSettingsTraits> const&, scoped_refptr<CefApp>, void*) ()
   from /gnu/store/s66a716vbk4zba4zap7nza6qz1nyqx8a-profile/include/../lib/libcef.so
#17 0x00007c65ee393362 in cef_initialize () from /gnu/store/s66a716vbk4zba4zap7nza6qz1nyqx8a-profile/include/../lib/libcef.so
#18 0x00007c65f78d5418 in vtable for CefStructBase<CefSettingsTraits> () from /gnu/store/s66a716vbk4zba4zap7nza6qz1nyqx8a-profile/include/../lib/libcef.so
#19 0x00000000000001a0 in ?? ()
```