### PR TITLE
[trep-engine] show invoice detail in trep

### DIFF
--- a/bindings/guile/test/test-engine-extras.scm
+++ b/bindings/guile/test/test-engine-extras.scm
@@ -524,6 +524,7 @@
 
          ;; inv-1 is generated for a customer
          (inv-1 (let ((inv-1 (gncInvoiceCreate (gnc-get-current-book))))
+                  (gncInvoiceSetID inv-1 "0001")
                   (gncInvoiceSetOwner inv-1 owner-1)
                   (gncInvoiceSetNotes inv-1 "inv-1-notes")
                   (gncInvoiceSetBillingID inv-1 "inv-1-billing-id")
@@ -542,6 +543,7 @@
 
          ;; inv-2 is generated from a customer's job
          (inv-2 (let ((inv-2 (gncInvoiceCreate (gnc-get-current-book))))
+                  (gncInvoiceSetID inv-2 "0002")
                   (gncInvoiceSetOwner inv-2 owner-2)
                   (gncInvoiceSetNotes inv-2 "inv-2-notes")
                   (gncInvoiceSetCurrency inv-2 USD)
@@ -561,6 +563,7 @@
 
          ;; inv-3 is generated from a vendor
          (inv-3 (let ((inv-3 (gncInvoiceCreate (gnc-get-current-book))))
+                  (gncInvoiceSetID inv-3 "0003")
                   (gncInvoiceSetOwner inv-3 owner-3)
                   (gncInvoiceSetNotes inv-3 "inv-3-notes")
                   (gncInvoiceSetCurrency inv-3 USD)
@@ -578,6 +581,7 @@
 
          ;; inv-4 is generated for an employee
          (inv-4 (let ((inv-4 (gncInvoiceCreate (gnc-get-current-book))))
+                  (gncInvoiceSetID inv-4 "0004")
                   (gncInvoiceSetOwner inv-4 owner-4)
                   (gncInvoiceSetNotes inv-4 "inv-4-notes")
                   (gncInvoiceSetCurrency inv-4 USD)
@@ -585,23 +589,27 @@
 
          ;; inv-5 cust-credit-note
          (inv-5 (let ((inv-5 (gncInvoiceCopy inv-1)))
+                  (gncInvoiceSetID inv-5 "0005")
                   (gncInvoiceSetIsCreditNote inv-5 #t)
                   (gncInvoiceSetCurrency inv-5 USD)
                   inv-5))
 
          ;; inv-6 vend-credit-note
          (inv-6 (let ((inv-6 (gncInvoiceCopy inv-3)))
+                  (gncInvoiceSetID inv-6 "0006")
                   (gncInvoiceSetIsCreditNote inv-6 #t)
                   (gncInvoiceSetCurrency inv-6 USD)
                   inv-6))
 
          ;; inv-7 emp-credit-note
          (inv-7 (let ((inv-7 (gncInvoiceCopy inv-4)))
+                  (gncInvoiceSetID inv-7 "0007")
                   (gncInvoiceSetIsCreditNote inv-7 #t)
                   (gncInvoiceSetCurrency inv-7 USD)
                   inv-7))
 
          (inv-8 (let ((inv-8 (gncInvoiceCreate (gnc-get-current-book))))
+                  (gncInvoiceSetID inv-8 "0008")
                   (gncInvoiceSetOwner inv-8 owner-1)
                   (gncInvoiceSetCurrency inv-8 USD)
                   inv-8))

--- a/gnucash/report/reports/standard/test/test-transaction.scm
+++ b/gnucash/report/reports/standard/test/test-transaction.scm
@@ -1002,6 +1002,24 @@
           (get-row-col sxml #f 6))))
     (test-end "subtotal table")
 
+    (test-begin "invoice-column")
+    (let* ((invoices (create-test-invoice-data))
+           (options (default-testing-options)))
+      (set-option! options "General" "Start Date" (cons 'absolute (gnc-dmy2time64 1 9 1980)))
+      (set-option! options "General" "End Date" (cons 'absolute (gnc-dmy2time64 7 9 1980)))
+      (set-option! options "Display" "Invoice" #t)
+      (set-option! options "Accounts" "Accounts"
+                   (list
+                    (gnc-account-lookup-by-full-name bank "Root.Asset.Bank")
+                    (gnc-account-lookup-by-full-name bank "Root.A/Receivable")
+                    (gnc-account-lookup-by-full-name bank "Root.A/Payable")
+                    (gnc-account-lookup-by-full-name bank "Root.Income")))
+      (let ((sxml (options->sxml options "show invoice")))
+        (test-equal "retrieve invoice IDs from trep"
+                    '("0003" "0004" "0006" "0007" "0001" "0002" "0005")
+                    (get-row-col sxml #f 5))))
+    (test-end "invoice-column")
+
     (test-begin "csv-export")
     (let ((options (default-testing-options)))
       (set-option! options "Accounts" "Accounts"

--- a/gnucash/report/trep-engine.scm
+++ b/gnucash/report/trep-engine.scm
@@ -945,6 +945,10 @@ be excluded from periodic reporting.")
         (set! disp-memo? x)
         (apply-selectable-by-name-display-options)))
 
+    (gnc-register-simple-boolean-option
+     options gnc:pagename-display (N_ "Invoice")
+     "d5" (G_ "Display invoice details") #f)
+
     ;; Ditto for Account Name #t -> Use Full Account Name is selectable
     (gnc-register-complex-boolean-option options
       gnc:pagename-display (N_ "Account Name")
@@ -1032,6 +1036,21 @@ be excluded from periodic reporting.")
       (() #f)
       (((? (cut assq <> cell)) . rest) (lp rest))
       ((fld . _) (gnc:error "field " fld " missing in cell " cell) #t))))
+
+(define (split->invoice-anchors split)
+  (define split->invoice (compose gncInvoiceGetInvoiceFromLot xaccSplitGetLot))
+  (define not-apar? (negate (compose xaccAccountIsAPARType xaccAccountGetType xaccSplitGetAccount)))
+  (let lp ((splits (xaccTransGetSplitList (xaccSplitGetParent split))) (invs '()) (rv '()))
+    (match splits
+      (() rv)
+      (((? not-apar?) . rest) (lp rest invs rv))
+      (((= split->invoice inv) . rest)
+       (if (or (null? inv) (member inv invs))
+           (lp rest invs rv)
+           (lp rest
+               (cons inv invs)
+               (cons (gnc:html-markup-anchor (gnc:invoice-anchor-text inv) (gncInvoiceGetID inv))
+                     (if (null? rv) rv (cons (gnc:html-markup-br) rv)))))))))
 
 ;; ;;;;;;;;;;;;;;;;;;;;
 ;; Here comes the big function that builds the whole table.
@@ -1149,6 +1168,15 @@ be excluded from periodic reporting.")
                                      (if (and (string-null? memo) (report-uses? 'notes))
                                          (xaccTransGetNotes trans)
                                          memo)))))
+
+               (add-if (report-uses? 'invoice)
+                       (list (cons 'heading (G_ "Invoice"))
+                             (cons 'renderer-fn
+                                   (lambda (split transaction-row?)
+                                     (and transaction-row?
+                                          (match (split->invoice-anchors split)
+                                            (() #f)
+                                            (inv-anchors (apply gnc:make-html-text inv-anchors))))))))
 
                (add-if (or (report-uses? 'account-name) (report-uses? 'account-code))
                        (list (cons 'heading (G_ "Account"))
@@ -2248,6 +2276,7 @@ be excluded from periodic reporting.")
                 (cons 'account-full-name
                       (opt-val gnc:pagename-display (N_ "Use Full Account Name")))
                 (cons 'memo (opt-val gnc:pagename-display (N_ "Memo")))
+                (cons 'invoice (opt-val gnc:pagename-display (N_ "Invoice")))
                 (cons 'notes (opt-val gnc:pagename-display (N_ "Notes")))
                 (cons 'account-code (opt-val gnc:pagename-display (N_ "Account Code")))
                 (cons 'other-account-code


### PR DESCRIPTION
Premise: "it would be nice" to upgrade the trep to report some business data. As a minimum, link to invoices.

It uses multiple ways to extract link from split to invoice in the trep so that it can link to invoice from any account: income, APAR, invoice payments. If a payment covers multiple invoices, show all of them, separated with `<br/>`.

<img width="640" height="749" alt="Screenshot from 2025-08-22 10-32-21" src="https://github.com/user-attachments/assets/7628dfcd-c43c-4fe4-81cd-732c67254fcc" />
