### PR TITLE
Added Swiss Fund Data AG to single_quote_sources.

### DIFF
--- a/libgnucash/engine/gnc-commodity.cpp
+++ b/libgnucash/engine/gnc-commodity.cpp
@@ -220,6 +220,7 @@ static QuoteSourceList single_quote_sources =
     { false, SOURCE_SINGLE, NC_("FQ Source", "SIX Swiss Exchange shares, CH"), "six" },
     { false, SOURCE_SINGLE, NC_("FQ Source", "StockData"), "stockdata" },
     { false, SOURCE_SINGLE, NC_("FQ Source", "Stooq, PL"), "stooq" },
+    { false, SOURCE_SINGLE, NC_("FQ Source", "Swiss Fund Data AG, CH"), "swissfunddata" },
     { false, SOURCE_SINGLE, NC_("FQ Source", "Tesouro Direto bonds, BR"), "tesouro_direto" },
     { false, SOURCE_SINGLE, NC_("FQ Source", "Toronto Stock eXchange, CA"), "tsx" },
     { false, SOURCE_SINGLE, NC_("FQ Source", "Tradegate, DE"), "tradegate" },


### PR DESCRIPTION
Added Swiss Fund Data AG to the `single_quote_sources` structure in "libgnucash/engine/gnc-commodity.cpp".
New F::Q source will be available in v1.67.
At this time I am unsure when F::Q v1.67 will be finalized and pushed to CPAN.