### PR TITLE
Bug 799656 - Invoice and bills still display prices as fractional amounts with "Force Prices to display as decimals"

### DIFF
--- a/gnucash/register/ledger-core/gncEntryLedger.c
+++ b/gnucash/register/ledger-core/gncEntryLedger.c
@@ -713,9 +713,14 @@ gnc_entry_ledger_compute_value (GncEntryLedger *ledger,
     GList *taxes = NULL;
     int denom = 100;
     gnc_numeric value_unrounded, taxes_unrounded;
+	GncEntry *entry;
 
     gnc_entry_ledger_get_numeric (ledger, ENTRY_QTY_CELL, &qty);
-    gnc_entry_ledger_get_numeric (ledger, ENTRY_PRIC_CELL, &price);
+    entry = gnc_entry_ledger_get_current_entry (ledger);
+	if (ledger->is_cust_doc)
+		price = gncEntryGetInvPrice (entry);
+    else
+        price = gncEntryGetBillPrice (entry);
     gnc_entry_ledger_get_numeric (ledger, ENTRY_DISC_CELL, &discount);
 
     disc_type = gnc_entry_ledger_get_type (ledger, ENTRY_DISTYPE_CELL);

--- a/gnucash/register/ledger-core/gncEntryLedgerModel.c
+++ b/gnucash/register/ledger-core/gncEntryLedgerModel.c
@@ -281,6 +281,8 @@ static const char * get_pric_entry (VirtualLocation virt_loc,
     GncEntryLedger *ledger = user_data;
     GncEntry *entry;
     gnc_numeric price;
+    gnc_commodity *curr;
+    GNCPrintAmountInfo print_info;
 
     entry = gnc_entry_ledger_get_entry (ledger, virt_loc.vcell_loc);
     if (ledger->is_cust_doc)
@@ -291,7 +293,10 @@ static const char * get_pric_entry (VirtualLocation virt_loc,
     if (gnc_numeric_zero_p (price))
         return NULL;
 
-    return xaccPrintAmount (price, gnc_default_print_info (FALSE));
+    curr = gncInvoiceGetCurrency (ledger->invoice);
+    print_info = gnc_default_price_print_info (curr);
+
+    return xaccPrintAmount (price, print_info);
 }
 
 static const char * get_qty_entry (VirtualLocation virt_loc,


### PR DESCRIPTION
gncEntryLedgerModel.c:get_pric_entry() is changed to coerce the forced-decimal amount in to the price's display cell.

gncEntryLedger.c:gnc_entry_ledger_compute_value() is changed to pull the price from the ledger (instead of the cell). 