### PR TITLE
Bug 343711 - Splits to Imbalance-USD do not disappear when zero-valued.

### DIFF
--- a/libgnucash/engine/Scrub.cpp
+++ b/libgnucash/engine/Scrub.cpp
@@ -594,9 +594,6 @@ add_balance_split (Transaction *trans, gnc_numeric imbalance,
         LEAVE("");
         return;
     }
-    account = xaccSplitGetAccount(balance_split);
-
-    xaccTransBeginEdit (trans);
 
     old_value = xaccSplitGetValue (balance_split);
 
@@ -607,8 +604,25 @@ add_balance_split (Transaction *trans, gnc_numeric imbalance,
                                  gnc_commodity_get_fraction(currency),
                                  GNC_HOW_RND_ROUND_HALF_UP);
 
-    xaccSplitSetValue (balance_split, new_value);
+    if (gnc_numeric_zero_p (new_value))
+    {
+        const char *p;
+        p = xaccSplitGetMemo (balance_split);
+        if (!p || !*p)
+        {
+            p = xaccSplitGetAction (balance_split);
+            if (!p || !*p)
+            {
+                xaccSplitDestroy (balance_split);
+                return;
+            }
+        }
+    }
 
+    xaccTransBeginEdit (trans);
+    xaccSplitSetValue (balance_split, new_value);
+        
+    account = xaccSplitGetAccount(balance_split);
     commodity = xaccAccountGetCommodity (account);
     if (gnc_commodity_equiv (currency, commodity))
     {

--- a/libgnucash/engine/test/utest-Split.cpp
+++ b/libgnucash/engine/test/utest-Split.cpp
@@ -667,7 +667,7 @@ test_xaccSplitRollbackEdit (Fixture *fixture, gconstpointer pData)
     fixture->split->orig_parent = NULL;
 
     xaccSplitRollbackEdit (fixture->split);
-    test_signal_assert_hits (sig1, 1);
+    test_signal_assert_hits (sig1, 2);
     test_signal_assert_hits (sig2, 0);
     test_signal_assert_hits (sig3, 0);
     g_assert_true (fixture->split->acc == NULL);
@@ -684,9 +684,9 @@ test_xaccSplitRollbackEdit (Fixture *fixture, gconstpointer pData)
     g_assert_true (fixture->split->acc == acc);
     g_assert_true (fixture->split->parent == txn1);
     g_assert_true (fixture->split->orig_parent == txn1);
-    test_signal_assert_hits (sig1, 1);
+    test_signal_assert_hits (sig1, 2);
     test_signal_assert_hits (sig2, 1);
-    test_signal_assert_hits (sig3, 1);
+    test_signal_assert_hits (sig3, 2);
     g_assert_true (fixture->split->parent == fixture->split->orig_parent);
     g_assert_true (fixture->split->parent == txn1);
 


### PR DESCRIPTION
To mitigate potential impact, the Imbalance split is only removed when the split transitions to zero value during the commit of the transaction and the split's memo and action have no value.