### PR TITLE
Bug 799661 - Exchange Rate entries displayed in reports in an unstable order

### DIFF
--- a/gnucash/report/html-utilities.scm
+++ b/gnucash/report/html-utilities.scm
@@ -257,7 +257,7 @@
 (define (gnc:html-make-rates-table currency price-fn accounts)
   (define (cell c) (gnc:make-html-table-cell/markup "number-cell" c))
   (define table (gnc:make-html-table))
-  (let lp ((comm-list (gnc:accounts-get-commodities accounts currency)) (entries 0))
+  (let lp ((comm-list (gnc:accounts-get-commodities-sorted accounts currency)) (entries 0))
     (match comm-list
       (()
        (unless (zero? entries)

--- a/gnucash/report/report-utilities.scm
+++ b/gnucash/report/report-utilities.scm
@@ -46,6 +46,7 @@
 (export gnc:decompose-accountlist)
 (export gnc:account-get-type-string-plural)
 (export gnc:accounts-get-commodities)
+(export gnc:accounts-get-commodities-sorted)
 (export gnc:get-current-account-tree-depth)
 (export gnc:accounts-and-all-descendants)
 (export gnc:make-value-collector)
@@ -226,6 +227,17 @@
       (let ((comm (xaccAccountGetCommodity (car accounts)))
             (accum (gnc:accounts-get-commodities (cdr accounts) exclude-commodity)))
         (if (or (equal? exclude-commodity comm) (member comm accum)) accum (cons comm accum)))))
+
+(define (gnc:accounts-get-commodities-sorted accounts exclude-commodity)
+  (stable-sort!
+    (stable-sort!
+      (gnc:accounts-get-commodities accounts exclude-commodity)
+      (lambda (a b)
+        (gnc:string-locale<?
+          (gnc-commodity-get-nice-symbol a) (gnc-commodity-get-nice-symbol b))))
+    (lambda (a b)
+      (gnc:string-locale<?
+        (gnc-commodity-get-namespace a) (gnc-commodity-get-namespace b)))))
 
 ;; Returns the depth of the current account hierarchy, that is, the
 ;; maximum level of subaccounts in the tree

--- a/gnucash/report/reports/standard/test/test-balsheet-pnl.scm
+++ b/gnucash/report/reports/standard/test/test-balsheet-pnl.scm
@@ -332,7 +332,7 @@
         '("#200.00" "$340.00" "30. FUNDS" "$14,424.52" "$106,709.00" "$106,709.00")
         (sxml->table-row-col sxml 1 3 6))
       (test-equal "show-rates enabled"
-        '("1. FUNDS" "$480 + 85/104" "#1.00" "$1.70")
+        '("#1.00" "$1.70" "1. FUNDS" "$480 + 85/104")
         (sxml->table-row-col sxml 2 #f #f)))
 
     ;;make-multilevel


### PR DESCRIPTION
Added gnc:accounts-get-commodities-sorted