### PR TITLE
Bug 799344 - Add "Postpone All" button to Scheduled Transactions dialog

### DIFF
--- a/gnucash/gnome/dialog-sx-since-last-run.c
+++ b/gnucash/gnome/dialog-sx-since-last-run.c
@@ -72,6 +72,7 @@ struct _GncSxSinceLastRunDialog
     GncSxSlrTreeModelAdapter *editing_model;
     GtkTreeView *instance_view;
     GtkToggleButton *review_created_txns_toggle;
+    GtkButton *postpone_all_button;
     GList *created_txns;
 
     GtkCellEditable *temp_ce; // used when editing values
@@ -139,6 +140,7 @@ static void _show_created_transactions (GncSxSinceLastRunDialog *app_dialog, GLi
 static void close_handler (gpointer user_data);
 static void dialog_destroy_cb (GtkWidget *object, GncSxSinceLastRunDialog *app_dialog);
 static void dialog_response_cb (GtkDialog *dialog, gint response_id, GncSxSinceLastRunDialog *app_dialog);
+static void postpone_all_button_clicked_cb (GtkButton *button, GncSxSinceLastRunDialog *app_dialog);
 
 #define debug_path(fn, text, path) {\
     gchar *path_string = gtk_tree_path_to_string (path);\
@@ -1340,6 +1342,7 @@ gnc_ui_sx_since_last_run_dialog (GtkWindow *parent, GncSxInstanceModel *sx_insta
 
     dialog->editing_model = gnc_sx_slr_tree_model_adapter_new (sx_instances);
     dialog->review_created_txns_toggle = GTK_TOGGLE_BUTTON(gtk_builder_get_object (builder, "review_txn_toggle"));
+    dialog->postpone_all_button = GTK_BUTTON(gtk_builder_get_object (builder, "postpone_all_button"));
 
     gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON(dialog->review_created_txns_toggle),
                                   gnc_prefs_get_bool (GNC_PREFS_GROUP_STARTUP, GNC_PREF_SET_REVIEW));
@@ -1350,6 +1353,9 @@ gnc_ui_sx_since_last_run_dialog (GtkWindow *parent, GncSxInstanceModel *sx_insta
 
     g_signal_connect (G_OBJECT(ok_button), "button-press-event",
                       G_CALLBACK(finish_editing_before_ok_cb), dialog);
+
+    g_signal_connect (G_OBJECT(dialog->postpone_all_button), "clicked",
+                      G_CALLBACK(postpone_all_button_clicked_cb), dialog);
 
     {
         GtkCellRenderer *renderer;
@@ -1526,6 +1532,39 @@ close_handler (gpointer user_data)
     gnc_save_window_size (GNC_PREFS_GROUP_STARTUP, GTK_WINDOW(app_dialog->dialog));
     gtk_widget_destroy (app_dialog->dialog);
     g_free (app_dialog);
+}
+
+static void
+postpone_all_button_clicked_cb (GtkButton *button, GncSxSinceLastRunDialog *app_dialog)
+{
+    GncSxInstanceModel *instance_model;
+    GList *sx_instances_list;
+    GList *sx_iter;
+
+    g_return_if_fail (app_dialog != NULL);
+    g_return_if_fail (app_dialog->editing_model != NULL);
+
+    instance_model = gnc_sx_slr_tree_model_adapter_get_instance_model (app_dialog->editing_model);
+    sx_instances_list = gnc_sx_instance_model_get_sx_instances_list (instance_model);
+
+    // Iterate through all scheduled transaction instances
+    for (sx_iter = sx_instances_list; sx_iter != NULL; sx_iter = sx_iter->next)
+    {
+        GncSxInstances *sx_instances = (GncSxInstances*)sx_iter->data;
+        GList *instance_iter;
+
+        // Iterate through each instance within this scheduled transaction
+        for (instance_iter = sx_instances->instance_list; instance_iter != NULL; instance_iter = instance_iter->next)
+        {
+            GncSxInstance *instance = (GncSxInstance*)instance_iter->data;
+            
+            // Only change instances that are not already created
+            if (instance->state != SX_INSTANCE_STATE_CREATED)
+            {
+                gnc_sx_instance_model_change_instance_state (instance_model, instance, SX_INSTANCE_STATE_POSTPONED);
+            }
+        }
+    }
 }
 
 static void

--- a/gnucash/gtkbuilder/dialog-sx.glade
+++ b/gnucash/gtkbuilder/dialog-sx.glade
@@ -1506,6 +1506,21 @@
               </packing>
             </child>
             <child>
+              <object class="GtkButton" id="postpone_all_button">
+                <property name="label" translatable="yes">_Postpone all</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="use-underline">True</property>
+                <property name="tooltip-text" translatable="yes">Postpone all scheduled transactions for manual review</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkButton" id="cancelbutton2">
                 <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
@@ -1518,7 +1533,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
-                <property name="position">1</property>
+                <property name="position">2</property>
               </packing>
             </child>
             <child>
@@ -1533,7 +1548,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
-                <property name="position">2</property>
+                <property name="position">3</property>
               </packing>
             </child>
           </object>
@@ -1577,17 +1592,6 @@
               <object class="GtkBox" id="hbox179">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <child>
-                  <object class="GtkFixed" id="fixed1">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
                 <child>
                   <object class="GtkCheckButton" id="review_txn_toggle">
                     <property name="label" translatable="yes">_Review created transactions</property>


### PR DESCRIPTION
Adds a "Postpone All" button to the "Since Last Run" Dialog.

Useful for cases where a user has a large number of "To Create" scheduled transactions and and wants to avoid accidentally dismissing scheduled transactions.

Especially helpful if it's been a while since opening a database and the user wants to manually validate that "auto pay" transactions have properly cleared.

<img width="730" height="241" alt="image" src="https://github.com/user-attachments/assets/618ccb42-072a-4c6e-8017-1782eb7dcc6f" />


Relates to:
* https://bugs.gnucash.org/show_bug.cgi?id=799344
* https://bugs.gnucash.org/show_bug.cgi?id=792121
* https://bugs.gnucash.org/show_bug.cgi?id=797005