### PR TITLE
Reset gui component session

### DIFF
--- a/gnucash/gnome-utils/gnc-component-manager.c
+++ b/gnucash/gnome-utils/gnc-component-manager.c
@@ -820,6 +820,20 @@ gnc_gui_component_set_session (gint component_id, gpointer session)
 }
 
 void
+gnc_gui_component_reset_session (gpointer old_session, gpointer new_session)
+{
+    GList *node;
+
+    for (node = components; node; node = node->next)
+    {
+        ComponentInfo *ci = node->data;
+
+        if (ci->session == old_session)
+            ci->session = new_session;
+    }
+}
+
+void
 gnc_close_gui_component_by_session (gpointer session)
 {
     GList *list;

--- a/gnucash/gnome-utils/gnc-component-manager.h
+++ b/gnucash/gnome-utils/gnc-component-manager.h
@@ -163,6 +163,14 @@ gint gnc_register_gui_component (const char *component_class,
  */
 void gnc_gui_component_set_session (gint component_id, gpointer session);
 
+/* gnc_gui_component_reset_session
+ *   Reset the associated session of all components with the original session
+ *
+ * old_session:      the original session 
+ * new_session:      the new session
+ */
+void gnc_gui_component_reset_session (gpointer old_session, gpointer new_session);
+
 /* gnc_gui_component_watch_entity
  *   Add an entity to the list of those being watched by the component.
  *   Only entities with refresh handlers should add watches.

--- a/gnucash/gnome-utils/gnc-file.c
+++ b/gnucash/gnome-utils/gnc-file.c
@@ -1714,6 +1714,7 @@ gnc_file_do_save_as (GtkWindow *parent, const char* filename)
     {
         /* Yay! Save was successful, we can dump the old session */
         qof_event_suspend();
+        gnc_gui_component_reset_session (session, new_session);
         gnc_clear_current_session();
         gnc_set_current_session( new_session );
         qof_event_resume();


### PR DESCRIPTION
When saving a new file, reset the managed gui components to the new session prior to clearing the old session.

This is the follow-on patch noted in: https://lists.gnucash.org/pipermail/gnucash-user/2025-October/117787.html