### PR TITLE
Fix stale account balances and grand total during transaction import

### DIFF
--- a/gnucash/import-export/import-main-matcher.cpp
+++ b/gnucash/import-export/import-main-matcher.cpp
@@ -590,11 +590,11 @@ on_matcher_ok_clicked (GtkButton *button, GNCImportMainMatcher *info)
 
     gnc_gen_trans_list_delete (info);
 
-    /* Allow GUI refresh again. */
-    gnc_resume_gui_refresh ();
-
     /* DEBUG ("End") */
     g_list_free_full (accounts_modified, (GDestroyNotify)xaccAccountCommitEdit);
+
+    /* Allow GUI refresh again upon commit completion. */
+    gnc_resume_gui_refresh ();
 }
 
 void


### PR DESCRIPTION
The bug:

After importing transactions from an existing account, the grand total net assets is updated to N, and the ending balance of the imported account is X.

Quit and restart gnucash, the net assets changes to N+X.

on_matcher_ok_clicked invokes gnc_resume_gui_refresh before the account is fully commited. xaccAccountRecomputeBalance skips an account if it has pending edits.

The fix:
Invoke gnc_resume_gui_refresh after all accounts have fully commited.

Tests:

make check

reran the above test, the net assets balance is updated to N+X without restarting gnc.