### PR TITLE
Bug 799682 - Unable to "Save As" (or open) a non-xml data file

### DIFF
--- a/libgnucash/backend/dbi/gnc-backend-dbi.cpp
+++ b/libgnucash/backend/dbi/gnc-backend-dbi.cpp
@@ -1096,7 +1096,10 @@ gnc_module_init_backend_dbi (void)
     {
 #if HAVE_LIBDBI_R
         if (dbi_instance)
-            return;
+        {
+            dbi_shutdown_r (dbi_instance);
+            dbi_instance = nullptr;
+        }
 #endif
         gchar *libdir = gnc_path_get_libdir ();
         gchar *dir = g_build_filename (libdir, "dbd", nullptr);


### PR DESCRIPTION
Fixes a generic bug in gnc_module_init_backend_dbi() when HAVE_LIBDBI_R is defined.  Specifically, when the initial dbi_initialize_r() returns no drivers, the dbi_instance variable is still set.