### PR TITLE
Better account.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ include (MacroAppendForeach)
 include (MacroAddSourceFileCompileFlags)
 include (GncAddSwigCommand)
 include (CheckIncludeFiles)
+include (CheckTypeSize)
 include (GncAddSchemeTargets)
 include (GncAddGSchemaTargets)
 include (GncAddTest)
@@ -258,6 +259,19 @@ if (WITH_GNUCASH)
 endif()
 
 pkg_check_modules (ZLIB REQUIRED zlib)
+
+# Check for size of time_t.
+check_type_size (time_t SIZEOF_TIME_T)
+
+if (NOT DEFINED SIZEOF_TIME_T)
+    message(FATAL_ERROR "Failed to determine size of time_t")
+endif()
+
+message(STATUS "time_t size is ${SIZEOF_TIME_T} bytes")
+
+if (SIZEOF_TIME_T LESS 8)
+    message(FATAL_ERROR "time_t is ${SIZEOF_TIME_T} bytes (32-bit). A 64-bit time_t is required to avoid the 2038 problem.")
+endif()
 
 if (MSVC)
   message (STATUS "Hint: To create the import libraries for the gnome DLLs (e.g. gconf-2.lib), use the dlltool as follows: pexports bin/libgconf-2-4.dll > lib/libgconf-2.def ; dlltool -d lib/libgconf-2.def -D bin/libgconf-2-4.dll -l lib/gconf-2.lib")

--- a/libgnucash/engine/Account.cpp
+++ b/libgnucash/engine/Account.cpp
@@ -1603,7 +1603,9 @@ xaccAccountDestroyAllTransactions(Account *acc)
     std::transform(priv->splits.begin(), priv->splits.end(),
                    back_inserter(transactions),
                    [](auto split) { return split->parent; });
-    std::stable_sort(transactions.begin(), transactions.end());
+    /* the splits are ordered by xaccSplitOrder, therefore, multiple
+       splits within an account from identical transactions will lead
+       to be adjacent transactions */
     transactions.erase(std::unique(transactions.begin(), transactions.end()),
                        transactions.end());
     qof_event_suspend();

--- a/libgnucash/engine/gnc-date.cpp
+++ b/libgnucash/engine/gnc-date.cpp
@@ -1277,10 +1277,6 @@ gnc_dmy2time64_neutral (int day, int month, int year)
 }
 
 
-/* The GDate setter functions all in the end use g_date_set_time_t,
- * which in turn relies on localtime and is therefore subject to the
- * 2038 bug.
- */
 GDate time64_to_gdate (time64 t)
 {
     GDate result;


### PR DESCRIPTION
`std::sort` void* pointers should have Comparator -- apparently comparing void* is UB https://eel.is/c++draft/expr.rel#4.3 (says chatgpt)

`gnc_account_foreach_split` forward loops only because the reverse iteration isn't used at all. having the `reverse` arg is an unnecessary complication.

