### PR TITLE
[gnc-autoclear.cpp] implement pruning if remaining amts are small

### DIFF
--- a/libgnucash/app-utils/gnc-autoclear.cpp
+++ b/libgnucash/app-utils/gnc-autoclear.cpp
@@ -69,6 +69,8 @@ struct RuntimeMonitor
 struct SplitInfo
 {
     int64_t m_amount;
+    int64_t m_rem_pos;
+    int64_t m_rem_neg;
     Split* m_split;
 };
 
@@ -111,8 +113,11 @@ subset_sum (SplitInfoVec::const_iterator iter,
             SplitInfoVec& path, Solution& solution,
             int64_t target, RuntimeMonitor& monitor)
 {
-    DEBUG ("this=%" PRId64" target=%" PRId64 " path=%s",
-           iter == end ? 0 : iter->m_amount, target, path_to_str (path));
+    DEBUG ("this=%" PRId64" target=%" PRId64 " rem_pos=%" PRId64
+           " rem_neg=%" PRId64 " path=%s",
+           iter == end ? 0 : iter->m_amount, target,
+           iter == end ? 0 : iter->m_rem_pos,
+           iter == end ? 0 : iter->m_rem_neg, path_to_str (path));
 
     if (target == 0)
     {
@@ -136,6 +141,13 @@ subset_sum (SplitInfoVec::const_iterator iter,
     {
         DEBUG ("ABORT: timeout");
         solution.abort = true;
+        return;
+    }
+
+    if (target < iter->m_rem_neg || target > iter->m_rem_pos)
+    {
+        DEBUG ("PRUNE target=%" PRId64 " rem_pos=%" PRId64" rem_neg=%" PRId64,
+               target, iter->m_rem_pos, iter->m_rem_neg);
         return;
     }
 
@@ -177,7 +189,7 @@ gnc_account_get_autoclear_splits (Account *account, gnc_numeric toclear_value,
         else if (amt == 0)
             DEBUG ("skipping zero-amount split %p", split);
         else
-            splits.push_back ({amt, split});
+            splits.push_back ({amt, 0, 0, split});
     }
 
     static GQuark autoclear_quark = g_quark_from_static_string ("autoclear");
@@ -187,6 +199,24 @@ gnc_account_get_autoclear_splits (Account *account, gnc_numeric toclear_value,
                      "Account is already at Auto-Clear Balance.");
         return nullptr;
     }
+
+    // sort splits in descending absolute amount
+    std::sort (splits.begin(), splits.end(),
+               [](const SplitInfo& a, const SplitInfo& b)
+               {
+                   int64_t aa = std::llabs(a.m_amount);
+                   int64_t bb = std::llabs(b.m_amount);
+                   return (aa == bb) ? a.m_amount > b.m_amount : aa > bb;
+               });
+
+    // for each split, precompute sums of remaining pos or neg amounts
+    int64_t rem_pos{0}, rem_neg{0};
+    std::for_each (splits.rbegin(), splits.rend(),
+                   [&rem_pos, &rem_neg](SplitInfo& s)
+                   {
+                       s.m_rem_pos = rem_pos += std::max<int64_t>(s.m_amount, 0);
+                       s.m_rem_neg = rem_neg += std::min<int64_t>(s.m_amount, 0);
+                   });
 
     RuntimeMonitor monitor{max_seconds};
     Solution solution;


### PR DESCRIPTION
after #2147, this optimisation will reduce the search size. for any search branch, if remaining absolute amounts are too small, then any combination of splits will not reach target. bail early.

add a slow test in test-autoclear. previously completed in 600ms now complete in 20ms.

e.g. split amounts 100 3 200 4 300 5
initially sort descending: 300 200 100 5 4 3
precompute sums of remaining positive amounts: 612 312 112 12 7 3
also precompute sums of remaining negative amounts 0 0 0 0 0 0

pruning will abort when `target` > `rem_pos` or `target` < `rem_neg`. allegedly it'll increase the number of splits processed per unit time from 20 to 30-40 for typical financial amounts. Runtime reduction from O(2^n) to O(1.3^n)

testing target 515.

with pruning:
```
* 10:31:23 DEBUG <gnc.autoclear> [gnc_account_get_autoclear_splits] idx=5 split=3 rem_pos=3 rem_neg=0
* 10:31:23 DEBUG <gnc.autoclear> [gnc_account_get_autoclear_splits] idx=4 split=4 rem_pos=7 rem_neg=0
* 10:31:23 DEBUG <gnc.autoclear> [gnc_account_get_autoclear_splits] idx=3 split=5 rem_pos=12 rem_neg=0
* 10:31:23 DEBUG <gnc.autoclear> [gnc_account_get_autoclear_splits] idx=2 split=100 rem_pos=112 rem_neg=0
* 10:31:23 DEBUG <gnc.autoclear> [gnc_account_get_autoclear_splits] idx=1 split=200 rem_pos=312 rem_neg=0
* 10:31:23 DEBUG <gnc.autoclear> [gnc_account_get_autoclear_splits] idx=0 split=300 rem_pos=612 rem_neg=0
* 10:31:23 DEBUG <gnc.autoclear> [subset_sum] idx=0 this=300 target=515 rem_pos=612 rem_neg=0 path=<empty>
* 10:31:23 DEBUG <gnc.autoclear> [subset_sum] idx=1 this=200 target=215 rem_pos=312 rem_neg=0 path=300
* 10:31:23 DEBUG <gnc.autoclear> [subset_sum] idx=2 this=100 target=15 rem_pos=112 rem_neg=0 path=300|200
* 10:31:23 DEBUG <gnc.autoclear> [subset_sum] idx=3 this=5 target=-85 rem_pos=12 rem_neg=0 path=300|200|100
* 10:31:23 DEBUG <gnc.autoclear> [subset_sum] PRUNE idx=3 target=-85 rem_pos=12 rem_neg=0
* 10:31:23 DEBUG <gnc.autoclear> [subset_sum] idx=3 this=5 target=15 rem_pos=12 rem_neg=0 path=300|200
* 10:31:23 DEBUG <gnc.autoclear> [subset_sum] PRUNE idx=3 target=15 rem_pos=12 rem_neg=0
* 10:31:23 DEBUG <gnc.autoclear> [subset_sum] idx=2 this=100 target=215 rem_pos=112 rem_neg=0 path=300
* 10:31:23 DEBUG <gnc.autoclear> [subset_sum] PRUNE idx=2 target=215 rem_pos=112 rem_neg=0
* 10:31:23 DEBUG <gnc.autoclear> [subset_sum] idx=1 this=200 target=515 rem_pos=312 rem_neg=0 path=<empty>
* 10:31:23 DEBUG <gnc.autoclear> [subset_sum] PRUNE idx=1 target=515 rem_pos=312 rem_neg=0
* 10:31:23 DEBUG <gnc.autoclear> [gnc_account_get_autoclear_splits] finished subset_sum in 0.000903 seconds
* 10:31:23  WARN <gnc.gui> [offer_autoclear()] cannot autoclear: The selected amount cannot be cleared.
```

without pruning:
```
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=100 target=515 path=<empty>
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=3 target=415 path=100
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=200 target=412 path=100|3
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=4 target=212 path=100|3|200
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=300 target=208 path=100|3|200|4
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=5 target=-92 path=100|3|200|4|300
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=-97 path=100|3|200|4|300|5
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=-92 path=100|3|200|4|300
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=5 target=208 path=100|3|200|4
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=203 path=100|3|200|4|5
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=208 path=100|3|200|4
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=300 target=212 path=100|3|200
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=5 target=-88 path=100|3|200|300
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=-93 path=100|3|200|300|5
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=-88 path=100|3|200|300
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=5 target=212 path=100|3|200
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=207 path=100|3|200|5
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=212 path=100|3|200
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=4 target=412 path=100|3
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=300 target=408 path=100|3|4
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=5 target=108 path=100|3|4|300
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=103 path=100|3|4|300|5
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=108 path=100|3|4|300
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=5 target=408 path=100|3|4
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=403 path=100|3|4|5
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=408 path=100|3|4
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=300 target=412 path=100|3
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=5 target=112 path=100|3|300
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=107 path=100|3|300|5
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=112 path=100|3|300
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=5 target=412 path=100|3
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=407 path=100|3|5
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=412 path=100|3
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=200 target=415 path=100
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=4 target=215 path=100|200
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=300 target=211 path=100|200|4
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=5 target=-89 path=100|200|4|300
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=-94 path=100|200|4|300|5
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=-89 path=100|200|4|300
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=5 target=211 path=100|200|4
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=206 path=100|200|4|5
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=211 path=100|200|4
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=300 target=215 path=100|200
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=5 target=-85 path=100|200|300
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=-90 path=100|200|300|5
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=-85 path=100|200|300
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=5 target=215 path=100|200
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=210 path=100|200|5
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=215 path=100|200
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=4 target=415 path=100
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=300 target=411 path=100|4
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=5 target=111 path=100|4|300
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=106 path=100|4|300|5
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=111 path=100|4|300
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=5 target=411 path=100|4
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=406 path=100|4|5
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=411 path=100|4
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=300 target=415 path=100
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=5 target=115 path=100|300
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=110 path=100|300|5
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=115 path=100|300
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=5 target=415 path=100
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=410 path=100|5
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=415 path=100
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=3 target=515 path=<empty>
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=200 target=512 path=3
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=4 target=312 path=3|200
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=300 target=308 path=3|200|4
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=5 target=8 path=3|200|4|300
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=3 path=3|200|4|300|5
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=8 path=3|200|4|300
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=5 target=308 path=3|200|4
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=303 path=3|200|4|5
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=308 path=3|200|4
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=300 target=312 path=3|200
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=5 target=12 path=3|200|300
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=7 path=3|200|300|5
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=12 path=3|200|300
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=5 target=312 path=3|200
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=307 path=3|200|5
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=312 path=3|200
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=4 target=512 path=3
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=300 target=508 path=3|4
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=5 target=208 path=3|4|300
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=203 path=3|4|300|5
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=208 path=3|4|300
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=5 target=508 path=3|4
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=503 path=3|4|5
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=508 path=3|4
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=300 target=512 path=3
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=5 target=212 path=3|300
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=207 path=3|300|5
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=212 path=3|300
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=5 target=512 path=3
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=507 path=3|5
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=512 path=3
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=200 target=515 path=<empty>
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=4 target=315 path=200
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=300 target=311 path=200|4
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=5 target=11 path=200|4|300
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=6 path=200|4|300|5
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=11 path=200|4|300
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=5 target=311 path=200|4
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=306 path=200|4|5
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=311 path=200|4
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=300 target=315 path=200
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=5 target=15 path=200|300
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=10 path=200|300|5
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=15 path=200|300
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=5 target=315 path=200
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=310 path=200|5
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=315 path=200
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=4 target=515 path=<empty>
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=300 target=511 path=4
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=5 target=211 path=4|300
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=206 path=4|300|5
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=211 path=4|300
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=5 target=511 path=4
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=506 path=4|5
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=511 path=4
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=300 target=515 path=<empty>
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=5 target=215 path=300
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=210 path=300|5
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=215 path=300
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=5 target=515 path=<empty>
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=510 path=5
* 10:29:34 DEBUG <gnc.autoclear> [subset_sum] this=0 target=515 path=<empty>
* 10:29:34 DEBUG <gnc.autoclear> [gnc_account_get_autoclear_splits] finished subset_sum in 0.002750 seconds
* 10:29:34  WARN <gnc.gui> [offer_autoclear()] cannot autoclear: The selected amount cannot be cleared.
```