### PR TITLE
test-userdata-dir-invalid-home: Unset XDG_DATA_HOME

### DIFF
--- a/libgnucash/core-utils/test/test-userdata-dir-invalid-home.c
+++ b/libgnucash/core-utils/test/test-userdata-dir-invalid-home.c
@@ -85,6 +85,7 @@ main(G_GNUC_UNUSED int argc, G_GNUC_UNUSED char **argv)
      * directory in that case. */
     g_setenv("HOME", homedir, TRUE);
     g_setenv("GNC_DATA_HOME", testdatahome, TRUE);
+    g_setenv("XDG_DATA_HOME", "", TRUE);
     g_free (homedir);
     g_free (testdatahome);
 


### PR DESCRIPTION
The test was failing on the openSUSE Build Service for openSUSE Tumbleweed because XDG_DATA_HOME is set to $HOME/.local/share