### PR TITLE
[Bug 799702](https://bugs.gnucash.org/show_bug.cgi?id=799702)

### DIFF
--- a/bindings/guile/test/srfi64-extras.scm
+++ b/bindings/guile/test/srfi64-extras.scm
@@ -34,11 +34,12 @@
         (case (test-result-kind runner)
           ((pass xpass) (set! num-passed (1+ num-passed)))
           ((fail xfail)
-           (if (test-result-ref runner 'expected-value)
+           (if (not (equal? 'no (test-result-ref runner 'expected-value 'no)))
                (format #t "~a\n -> expected: ~s\n -> obtained: ~s\n"
                        (string-join (test-runner-group-path runner) "/")
                        (test-result-ref runner 'expected-value)
-                       (test-result-ref runner 'actual-value)))
+                       (test-result-ref runner 'actual-value))
+               (format #t "~%~a~%" (test-result-alist runner)))
            (set! num-failed (1+ num-failed)))
           (else #t))))
     (test-runner-on-final! runner

--- a/bindings/guile/test/test-core-utils.scm
+++ b/bindings/guile/test/test-core-utils.scm
@@ -42,7 +42,7 @@
     "${symbol} does not exist"
     (gnc:format "${symbol} does not exist" 'existence "none"))
 
-  (test-error "gnc:format syntax error"
+  (test-error "gnc:format syntax error" #t
     (gnc:format "${symbol} does not exist" 'existence)))
 
 (define (run-test)

--- a/bindings/guile/test/test-gnc-optiondb.scm
+++ b/bindings/guile/test/test-gnc-optiondb.scm
@@ -115,7 +115,7 @@
        option-db "waldo" "pepper" "baz"
        "Phony Option" acctlist (list ACCT-TYPE-BANK))
       (let ((acct-list (gnc-option-value option-db "waldo" "pepper")))
-        (test-equal #f (length acct-list))))))
+        (test-error 'wrong-type-arg (length acct-list))))))
 
   (define (test-make-account-sel-limited-option book)
     (test-group "test-make-account-list-option"

--- a/gnucash/report/reports/standard/test/test-transaction.scm
+++ b/gnucash/report/reports/standard/test/test-transaction.scm
@@ -1067,7 +1067,7 @@
      '(("from" "01/01/2010")
        ("to" "31/12/2010")
        ("total" 23500 30000 25/7 sym))))
-  (test-error "gnc:lists->csv improper list"
+  (test-error "gnc:lists->csv improper list" #t
     (gnc:lists->csv
      '(("from" "01/01/2010")
        ("to" "31/12/2010")

--- a/gnucash/report/test/test-commodity-utils.scm
+++ b/gnucash/report/test/test-commodity-utils.scm
@@ -270,8 +270,8 @@
     (let* ((sumlist (list (list USD  (list (list AAPL  aapl-col)))
                           (list GBP (list (list RDSA rdsa-gbp-col)))))
            (return-alist  (gnc:resolve-unknown-comm sumlist USD)))
-      (test-equal "RDSA #f" #f ((caadr (assoc RDSA return-alist)) 'total #f))
-      (test-equal "RDSA #f" #f ((cdadr (assoc RDSA return-alist)) 'total #f)))
+      (test-error "RDSA #f" 'wrong-type-arg (((assoc RDSA return-alist)) 'total #f))
+      (test-error "RDSA #f" 'wrong-type-arg ((cdadr (assoc RDSA return-alist)) 'total #f)))
     (test-end "foreign-no-coll")
     (test-begin "foreign-no-amount")
     ;; There's a collector but it doesn't have a price in it so the returned
@@ -348,8 +348,8 @@
                           (list GBP (list (list DEM gbp-dem-col)
                                           (list RDSA rdsa-gbp-col)))))
            (return-alist  (gnc:resolve-unknown-comm sumlist USD)))
-      (test-equal "Shares fails" #f ((caadr (assoc RDSA return-alist)) 'total #f))
-      (test-equal "Value fails" #f ((cdadr (assoc RDSA return-alist)) 'total #f)))
+      (test-error "Shares fails" 'wrong-type-arg ((caadr (assoc RDSA return-alist)) 'total #f))
+      (test-error "Value fails" 'wrong-type-arg ((cdadr (assoc RDSA return-alist)) 'total #f)))
     (test-end "foreign-3way-gbp->dem->eur->usd")
     (test-begin "foreign-3way-DEM>GBP")
     ;; Three-way conversion, gbp->dem->eur->usd
@@ -359,8 +359,8 @@
                           (list DEM (list (list GBP dem-gbp-col)))
                           (list GBP (list (list RDSA rdsa-gbp-col)))))
            (return-alist  (gnc:resolve-unknown-comm sumlist USD)))
-      (test-equal "Shares fails" #f ((caadr (assoc RDSA return-alist)) 'total #f))
-      (test-equal "Value fails" #f ((cdadr (assoc RDSA return-alist)) 'total #f)))
+      (test-error "Shares fails" 'wrong-type-arg ((caadr (assoc RDSA return-alist)) 'total #f))
+      (test-error "Value fails" 'wrong-type-arg ((cdadr (assoc RDSA return-alist)) 'total #f)))
     (test-end "foreign-3way-DEM>GBP")
     (test-begin "foreign-DEM>EUR")
     ;; Three-way conversion, gbp->dem->eur
@@ -369,8 +369,8 @@
                           (list GBP (list (list DEM gbp-dem-col)
                                           (list RDSA rdsa-gbp-col)))))
            (return-alist  (gnc:resolve-unknown-comm sumlist EUR)))
-      (test-equal "Shares fails" #f ((caadr (assoc RDSA return-alist)) 'total #f))
-      (test-equal "Value fails" #f ((cdadr (assoc RDSA return-alist)) 'total #f)))
+      (test-error "Shares fails" 'wrong-type-arg ((caadr (assoc RDSA return-alist)) 'total #f))
+      (test-error "Value fails" 'wrong-type-arg ((cdadr (assoc RDSA return-alist)) 'total #f)))
     (test-end "foreign-DEM>EUR"))
 
   (teardown)))

--- a/gnucash/report/test/test-commodity-utils.scm
+++ b/gnucash/report/test/test-commodity-utils.scm
@@ -753,9 +753,9 @@
            (exchange-fn
             (gnc:make-gnc-monetary AAPL 1)
             USD
-            (gnc-dmy2time64-neutral 20 02 2012)))))
+            (gnc-dmy2time64-neutral 20 02 2012))))))
 
-      (teardown))))
+      (teardown)))
 
 (define (test-get-match-commodity-splits-sorted)
   (test-group-with-cleanup "test-get-match-commodity-splits-sorted"
@@ -818,6 +818,6 @@
                       "2012-02-20" "2013-08-09" "2014-07-11" "2014-08-08"
                       "2014-08-08" "2014-12-05" "2014-12-05" "2015-04-02"
                       "2015-10-23" "2015-10-23" "2016-03-11" "2016-03-11")
-                    (map split->date all-splits)))
+                    (map split->date all-splits))))
 
-      (teardown))))
+      (teardown)))

--- a/gnucash/report/test/test-html-chart.scm
+++ b/gnucash/report/test/test-html-chart.scm
@@ -60,8 +60,8 @@
       'abc
       (gnc:html-chart-get chart '(options maintainAspectRatio)))
 
-    (test-equal "path doesn't exist"
-      #f
+    (test-error "path doesn't exist"
+      #t
       (gnc:html-chart-get chart '(options scales xAxes (0) time)))
 
     (gnc:html-chart-set! chart '(options scales xAxes (0) time) a-list-of-pairs)
@@ -77,11 +77,11 @@
 
     (test-error
      "1st level option fails - cannot traverse through existing path"
-     'invalid-path
+     'wrong-type-arg
      (gnc:html-chart-set! chart '(options legend position invalid) 'de))
 
-    (test-equal "deep nested new path - inexistent"
-      #f
+    (test-error "deep nested new path - nonexistent"
+      'invalid-path
       (gnc:html-chart-get chart '(create new nested path)))
 
     (gnc:html-chart-set! chart '(create new nested path) 'newpath)

--- a/gnucash/report/test/test-html-chart.scm
+++ b/gnucash/report/test/test-html-chart.scm
@@ -115,6 +115,6 @@
 
     (test-error
      "deep nested new path - cannot set 6th index"
-     'error
+     'index-too-high
      (gnc:html-chart-set! chart '(create list-kth (6) nested path) 'k4th))
     ))

--- a/gnucash/report/test/test-report-utilities.scm
+++ b/gnucash/report/test/test-report-utilities.scm
@@ -483,8 +483,8 @@
           (collector->list
            (gnc:select-assoc-account-balance account-balances bank)))
 
-        (test-equal "gnc:select-assoc-account-balance - miss"
-          #f
+        (test-error "gnc:select-assoc-account-balance - miss"
+          'wrong-type-arg
           (collector->list
            (gnc:select-assoc-account-balance account-balances expense)))
 

--- a/gnucash/report/test/test-report.scm
+++ b/gnucash/report/test/test-report.scm
@@ -195,8 +195,8 @@
     (test-equal "gnc:report-name"
       "basic report"
       (gnc:report-name report))
-    (test-equal "gnc:report-stylesheet"
-      #f
+    (test-error "gnc:report-stylesheet"
+      'wrong-type-arg
       (gnc:report-stylesheet report))
     (test-equal "(gnc:all-report-template-guids)"
       4


### PR DESCRIPTION
Guile 3.0.11 includes a [complete rewrite of SRFI-64](https://codeberg.org/guile/guile/commit/ad90f45a8c4fd00add44c214863850a425f787a0) that is a bit more strict in a few places and that broke the build and a few tests.

A possibly separate issue is that if a test raises an exception the runner no longer sets the expected and actual values on the results. I've extended `gnc:test-runner` to report the exception kind if there is one. It also no longer accepts an empty expected kind nor `'error` to mean any exception. Use `#t` for that, and `#f` if it's not actually supposed to throw.

Finally, and I'm not completely sure about this, it seems that the old implementation would pass `(test-equal "foo" #f (bar baz))` if `(bar baz)` raises an exception; we had a few of the form `(cdr #f)` that throw 'wrong-type-arg. The last commit changes those tests to `test-error`.