### PR TITLE
Bug 799701 - SX Editor error When Frequency=Once

### DIFF
--- a/gnucash/gnome/dialog-sx-editor.c
+++ b/gnucash/gnome/dialog-sx-editor.c
@@ -1662,9 +1662,21 @@ gnc_sxed_update_cal (GncSxEditorDialog *sxed)
 
     if (!g_date_valid (&first_date))
     {
+        /* Note: There are no recurrences for PERIOD_NONE and on initial setting
+         * of PERIOD_WEEKLY (no days set), so still need to 'do nothing' */
+        gboolean do_nothing = TRUE;
+        if (recurrences)
+        {
+            Recurrence *r = g_list_nth_data (recurrences, 0);
+            if (r && r->ptype == PERIOD_ONCE)
+                do_nothing = FALSE;
+        }
         /* Nothing to do. */
-        gnc_dense_cal_store_clear (sxed->dense_cal_model);
-        goto cleanup;
+        if (do_nothing)
+        {
+            gnc_dense_cal_store_clear (sxed->dense_cal_model);
+            goto cleanup;
+        }
     }
 
     gnc_dense_cal_store_update_name (sxed->dense_cal_model, xaccSchedXactionGetName (sxed->sx));


### PR DESCRIPTION
When the frequency is once, in the SX edit frequency tab the scheduled date is not marked. This is due to the `first_date` variable not being set and subsequent test for it being valid causing the calendar to be cleared.

This can be seen in the image below...

<img width="1320" height="746" alt="bug799701" src="https://github.com/user-attachments/assets/cb26182c-0fa1-400d-b2b9-dfec84adfbf9" />

Note, I will change bug title to reflect commit before pushing.