### PR TITLE
Autoclear

### DIFF
--- a/gnucash/gnome/reconcile-view.c
+++ b/gnucash/gnome/reconcile-view.c
@@ -533,6 +533,20 @@ gnc_reconcile_view_toggle (GNCReconcileView *view, Split *split)
                    reconcile_view_signals[TOGGLE_RECONCILED], 0, split);
 }
 
+void
+gnc_reconcile_view_unclear_all (GNCReconcileView *view)
+{
+    g_return_if_fail (GNC_IS_RECONCILE_VIEW(view));
+    g_hash_table_remove_all (view->reconciled);
+}
+
+void
+gnc_reconcile_view_set_cleared (GNCReconcileView *view, Split *split)
+{
+    g_return_if_fail (GNC_IS_RECONCILE_VIEW(view));
+    g_hash_table_add (view->reconciled, split);
+}
+
 static gboolean
 follow_select_tree_path (GNCReconcileView *view)
 {

--- a/gnucash/gnome/reconcile-view.h
+++ b/gnucash/gnome/reconcile-view.h
@@ -110,6 +110,10 @@ void gnc_reconcile_view_postpone (GNCReconcileView *view);
 
 void gnc_reconcile_view_unselect_all (GNCReconcileView *view);
 
+void gnc_reconcile_view_unclear_all (GNCReconcileView*);
+
+void gnc_reconcile_view_set_cleared (GNCReconcileView*, Split*);
+
 gboolean gnc_reconcile_view_changed (GNCReconcileView *view);
 
 void gnc_reconcile_view_add_padding (GNCReconcileView *view, gint column, gint xpadding);

--- a/gnucash/gnome/window-reconcile.cpp
+++ b/gnucash/gnome/window-reconcile.cpp
@@ -37,6 +37,8 @@
 #endif
 #include <gdk/gdkkeysyms.h>
 
+#include <algorithm>
+
 #include "Account.hpp"
 #include "Scrub.h"
 #include "Scrub3.h"
@@ -44,6 +46,7 @@
 #include "dialog-transfer.h"
 #include "dialog-utils.h"
 #include "gnc-amount-edit.h"
+#include "gnc-autoclear.h"
 #include "gnc-component-manager.h"
 #include "gnc-date.h"
 #include "gnc-date-edit.h"
@@ -82,9 +85,13 @@ struct _RecnWindow
 
     GtkBuilder *builder;         /* The builder object */
     GSimpleActionGroup *simple_action_group; /* The action group for the window */
+    GtkWidget *autoclear_button;
     GtkAccelGroup *accel_group;
 
     GncPluginPage *page;
+
+    SplitsVec autoclear_splits;
+    SplitsVec initially_cleared_splits;
 
     GtkWidget *starting;         /* The starting balance                 */
     GtkWidget *ending;           /* The ending balance                   */
@@ -137,6 +144,7 @@ static void   recn_destroy_cb (GtkWidget *w, gpointer data);
 static void   recn_cancel (RecnWindow *recnData);
 static gboolean recn_delete_cb (GtkWidget *widget, GdkEvent *event, gpointer data);
 static gboolean recn_key_press_cb (GtkWidget *widget, GdkEventKey *event, gpointer data);
+static void   recnAutoClearCB (GSimpleAction *simple, GVariant *parameter, gpointer user_data);
 static void   recnFinishCB (GSimpleAction *simple, GVariant *parameter, gpointer user_data);
 static void   recnPostponeCB (GSimpleAction *simple, GVariant *parameter, gpointer user_data);
 static void   recnCancelCB (GSimpleAction *simple, GVariant *parameter, gpointer user_data);
@@ -193,6 +201,64 @@ has_account_different_commodities(const Account *account)
     return result != NULL;
 }
 
+static const char*
+get_autoclear_icon (GError* error)
+{
+    static std::unordered_map<gint,const char*> icon_names =
+    {
+        { Autoclear::ABORT_NONE, "media-playback-start" },
+        { Autoclear::ABORT_NOP, "media-playback-stop" },
+        { Autoclear::ABORT_MULTI, "dialog-information" },
+        { Autoclear::ABORT_TIMEOUT, "dialog-error" },
+        { Autoclear::ABORT_UNREACHABLE, "dialog-error" },
+    };
+    auto it = icon_names.find (error ? error->code : Autoclear::ABORT_NONE);
+    return it == icon_names.end() ? "dialog-information" : it->second;
+}
+
+static void
+calculate_autoclear (RecnWindow *recnData)
+{
+    g_return_if_fail (recnData);
+
+    GError* error = nullptr;
+    Account* acct = xaccAccountLookup (&recnData->account, gnc_get_current_book ());
+
+#define MAX_AUTOCLEAR_SECONDS 1
+
+    GList *splits_to_clear = gnc_account_get_autoclear_splits
+        (acct, recnData->new_ending, recnData->statement_date, &error, MAX_AUTOCLEAR_SECONDS);
+
+    gtk_widget_set_sensitive (recnData->autoclear_button, error == nullptr);
+
+    gtk_tool_button_set_icon_name (GTK_TOOL_BUTTON (recnData->autoclear_button),
+                                   get_autoclear_icon (error));
+
+    recnData->autoclear_splits = recnData->initially_cleared_splits;
+    for (auto n = splits_to_clear; n; n = n->next)
+        recnData->autoclear_splits.push_back (GNC_SPLIT (n->data));
+
+    if (error)
+    {
+        gtk_widget_set_tooltip_text (recnData->autoclear_button, _(error->message));
+        g_error_free (error);
+        return;
+    }
+
+    auto num_splits = g_list_length (splits_to_clear);
+    char date_buff[MAX_DATE_LENGTH+1];
+    qof_print_date_buff (date_buff, MAX_DATE_LENGTH, recnData->statement_date);
+    char* tooltip = g_strdup_printf
+        (ngettext("Automatically select %u transaction up to %s that clears to %s",
+                  "Automatically select %u transactions up to %s that clear to %s",
+                  num_splits),
+         num_splits, date_buff,
+         xaccPrintAmount (recnData->new_ending, gnc_account_print_info (acct, true)));
+    gtk_widget_set_tooltip_text (recnData->autoclear_button, tooltip);
+
+    g_free (tooltip);
+    g_list_free (splits_to_clear);
+}
 
 /********************************************************************\
  * recnRefresh                                                      *
@@ -304,6 +370,8 @@ recnRecalculateBalance (RecnWindow *recnData)
     action = g_action_map_lookup_action (G_ACTION_MAP(recnData->simple_action_group),
                                          "TransBalanceAction");
     g_simple_action_set_enabled (G_SIMPLE_ACTION(action), !gnc_numeric_zero_p (diff));
+
+    calculate_autoclear (recnData);
 
     return diff;
 }
@@ -1770,6 +1838,7 @@ static GActionEntry recWindow_actions_entries [] =
     { "RecnFinishAction", recnFinishCB, NULL, NULL, NULL },
     { "RecnPostponeAction", recnPostponeCB, NULL, NULL, NULL },
     { "RecnCancelAction", recnCancelCB, NULL, NULL, NULL },
+    { "RecnAutoClearAction", recnAutoClearCB, NULL, NULL, NULL },
 
     { "AccountOpenAccountAction", gnc_recn_open_cb, NULL, NULL, NULL },
     { "AccountEditAccountAction", gnc_recn_edit_account_cb, NULL, NULL, NULL },
@@ -1845,6 +1914,8 @@ recnWindowWithBalance (GtkWidget *parent, Account *account, gnc_numeric new_endi
     recnData->statement_date = statement_date;
     recnData->window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
     recnData->delete_refresh = FALSE;
+    new (&recnData->autoclear_splits) SplitsVec();
+    new (&recnData->initially_cleared_splits) SplitsVec();
 
     gnc_recn_set_window_name(recnData);
 
@@ -1859,6 +1930,13 @@ recnWindowWithBalance (GtkWidget *parent, Account *account, gnc_numeric new_endi
     gtk_box_set_homogeneous (GTK_BOX (dock), FALSE);
     gtk_widget_show(dock);
     gtk_box_pack_start(GTK_BOX (vbox), dock, FALSE, TRUE, 0);
+
+    auto init_cleared = [&recnData](Split* s)
+    {
+        if (xaccSplitGetReconcile (s) == CREC)
+            recnData->initially_cleared_splits.push_back (s);
+    };
+    gnc_account_foreach_split_until_date (account, statement_date, init_cleared);
 
     {
         GtkToolbar *tool_bar;
@@ -1882,6 +1960,8 @@ recnWindowWithBalance (GtkWidget *parent, Account *account, gnc_numeric new_endi
             g_free (recnData);
             return NULL;
         }
+
+        recnData->autoclear_button = GTK_WIDGET(gtk_builder_get_object(recnData->builder, "autoclear_button"));
 
         menu_model = (GMenuModel *)gtk_builder_get_object (recnData->builder, "recwin-menu");
         menu_bar = gtk_menu_bar_new_from_model (menu_model);
@@ -2200,6 +2280,9 @@ recn_destroy_cb (GtkWidget *w, gpointer data)
     if (recnData->accel_group)
         g_object_unref(recnData->accel_group);
 
+    recnData->autoclear_splits.~SplitsVec();
+    recnData->initially_cleared_splits.~SplitsVec();
+
     //Disable the actions, the handlers try to access recnData
     for (gint i = 0; i < num_actions; i++)
     {
@@ -2423,4 +2506,38 @@ recnCancelCB (GSimpleAction *simple,
 {
     auto recnData = static_cast<RecnWindow*>(user_data);
     recn_cancel(recnData);
+}
+
+/********************************************************************\
+ * recnAutoClearCB                                                  *
+ *   handles the auto-clear button click                            *
+ *                                                                  *
+ * Args:   simple     - the action                                  *
+ *         parameter  - unused                                      *
+ *         user_data  - the reconcile window data                   *
+ * Return: none                                                     *
+\********************************************************************/
+static void
+recnAutoClearCB (GSimpleAction *simple,
+                 GVariant      *parameter,
+                 gpointer       user_data)
+{
+    auto recnData = static_cast<RecnWindow*>(user_data);
+
+    if (recnData->autoclear_splits.empty())
+        return;
+
+    gnc_suspend_gui_refresh ();
+    gnc_reconcile_view_unclear_all (GNC_RECONCILE_VIEW(recnData->debit));
+    gnc_reconcile_view_unclear_all (GNC_RECONCILE_VIEW(recnData->credit));
+    std::for_each (recnData->autoclear_splits.begin(),
+                   recnData->autoclear_splits.end(),
+                   [recnData](Split* split)
+                   {
+                       auto view = gnc_numeric_positive_p (xaccSplitGetAmount (split))
+                           ? recnData->debit : recnData->credit;
+                       gnc_reconcile_view_set_cleared (GNC_RECONCILE_VIEW(view), split);
+                   });
+    recnRefresh (recnData);
+    gnc_resume_gui_refresh ();
 }

--- a/gnucash/gnome/window-reconcile.cpp
+++ b/gnucash/gnome/window-reconcile.cpp
@@ -216,15 +216,25 @@ get_autoclear_icon (GError* error)
     return it == icon_names.end() ? "dialog-information" : it->second;
 }
 
+#define GNC_PREF_ENABLE_AUTOCLEAR "enable-autoclear-in-reconcile"
+
 static void
 calculate_autoclear (RecnWindow *recnData)
 {
     g_return_if_fail (recnData);
 
+    bool enabled = gnc_prefs_get_bool (GNC_PREFS_GROUP_RECONCILE, GNC_PREF_ENABLE_AUTOCLEAR);
+    auto action = g_action_map_lookup_action (G_ACTION_MAP(recnData->simple_action_group),
+                                              "RecnAutoClearAction");
+    g_simple_action_set_enabled (G_SIMPLE_ACTION(action), enabled);
+    gtk_widget_set_visible (recnData->autoclear_button, enabled);
+    if (!enabled)
+        return;
+
     GError* error = nullptr;
     Account* acct = xaccAccountLookup (&recnData->account, gnc_get_current_book ());
 
-#define MAX_AUTOCLEAR_SECONDS 1
+    static const unsigned int MAX_AUTOCLEAR_SECONDS = 1;
 
     GList *splits_to_clear = gnc_account_get_autoclear_splits
         (acct, recnData->new_ending, recnData->statement_date, &error, MAX_AUTOCLEAR_SECONDS);

--- a/gnucash/gschemas/org.gnucash.GnuCash.dialogs.reconcile.gschema.xml.in
+++ b/gnucash/gschemas/org.gnucash.GnuCash.dialogs.reconcile.gschema.xml.in
@@ -20,6 +20,11 @@
       <summary>Always reconcile to today</summary>
       <description>If active, always open the reconcile dialog using today's date for the statement date, regardless of previous reconciliations.</description>
     </key>
+    <key name="enable-autoclear-in-reconcile" type="b">
+      <default>false</default>
+      <summary>Enable autoclear tools in reconciliation</summary>
+      <description>If active, suggests transactions to clear based on amounts summing to the statement balance</description>
+    </key>
     <key name="last-geometry" type="(iiii)">
       <default>(-1,-1,-1,-1)</default>
       <summary>Last window position and size</summary>

--- a/gnucash/gtkbuilder/dialog-preferences.glade
+++ b/gnucash/gtkbuilder/dialog-preferences.glade
@@ -2773,13 +2773,30 @@ many months before the current month</property>
                   </packing>
                 </child>
                 <child>
+                  <object class="GtkCheckButton" id="pref/dialogs.reconcile/enable-autoclear-in-reconcile">
+                    <property name="label" translatable="yes">Enable autoclear tools in reconciliation</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="has-tooltip">True</property>
+                    <property name="tooltip-text" translatable="yes">Provides automatic clearing tools in the reconciliation window. Auto-clear scans unreconciled splits and looks for a unique combination whose cleared balance matches the reconciliation balance entered. The auto-clear tests all combinations of splits, therefore its runtime is potentially high; but limited in reconciliation to 1 second. When a unique match is not available, because the balance cannot be reached, or due to timeout, or multiple combinations are possible, auto-clear is not offered and the icon and its tooltip reflects the outcome.</property>
+                    <property name="halign">start</property>
+                    <property name="use-underline">False</property>
+                    <property name="draw-indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">14</property>
+                  </packing>
+                </child>
+                <child>
                   <object class="GtkLabel">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
-                    <property name="top-attach">14</property>
+                    <property name="top-attach">15</property>
                   </packing>
                 </child>
                 <child>
@@ -2792,7 +2809,7 @@ many months before the current month</property>
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
-                    <property name="top-attach">15</property>
+                    <property name="top-attach">16</property>
                   </packing>
                 </child>
                 <child>
@@ -2810,7 +2827,7 @@ many months before the current month</property>
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
-                    <property name="top-attach">16</property>
+                    <property name="top-attach">17</property>
                   </packing>
                 </child>
                 <child>
@@ -2828,7 +2845,7 @@ many months before the current month</property>
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
-                    <property name="top-attach">17</property>
+                    <property name="top-attach">18</property>
                   </packing>
                 </child>
                 <child>
@@ -2846,7 +2863,7 @@ many months before the current month</property>
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
-                    <property name="top-attach">18</property>
+                    <property name="top-attach">19</property>
                   </packing>
                 </child>
                 <child>
@@ -2864,7 +2881,7 @@ many months before the current month</property>
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
-                    <property name="top-attach">19</property>
+                    <property name="top-attach">20</property>
                   </packing>
                 </child>
                 <child>
@@ -2874,7 +2891,7 @@ many months before the current month</property>
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
-                    <property name="top-attach">20</property>
+                    <property name="top-attach">21</property>
                   </packing>
                 </child>
                 <child>
@@ -2889,7 +2906,7 @@ many months before the current month</property>
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
-                    <property name="top-attach">21</property>
+                    <property name="top-attach">22</property>
                   </packing>
                 </child>
                 <child>
@@ -2907,7 +2924,7 @@ many months before the current month</property>
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
-                    <property name="top-attach">22</property>
+                    <property name="top-attach">23</property>
                   </packing>
                 </child>
               </object>

--- a/gnucash/ui/gnc-reconcile-window.ui
+++ b/gnucash/ui/gnc-reconcile-window.ui
@@ -21,6 +21,11 @@
           <attribute name="accel">&lt;Primary&gt;p</attribute>
         </item>
         <item>
+          <attribute name="label" translatable="yes">_Autoclear</attribute>
+          <attribute name="action">recwin.RecnAutoClearAction</attribute>
+          <attribute name="accel">&lt;Primary&gt;&lt;Shift&gt;c</attribute>
+        </item>
+        <item>
           <attribute name="label" translatable="yes">_Cancel</attribute>
           <attribute name="action">recwin.RecnCancelAction</attribute>
         </item>
@@ -120,6 +125,18 @@
   <object class="GtkToolbar" id="recwin-toolbar">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
+    <child>
+      <object class="GtkToolButton" id="autoclear_button">
+        <property name="visible">True</property>
+        <property name="sensitive">False</property>
+        <property name="can_focus">False</property>
+        <property name="tooltip_text" translatable="no">Automatically clear matching transactions</property>
+        <property name="label" translatable="yes">Auto Clear</property>
+        <property name="use_underline">True</property>
+        <property name="icon_name">media-playback-start</property>
+        <property name="action_name">recwin.RecnAutoClearAction</property>
+      </object>
+    </child>
     <child>
       <object class="GtkToolButton" id="but1">
         <property name="visible">True</property>

--- a/libgnucash/app-utils/gnc-autoclear.cpp
+++ b/libgnucash/app-utils/gnc-autoclear.cpp
@@ -79,7 +79,8 @@ using SplitVec = std::vector<Split*>;
 
 struct Solution
 {
-    std::optional<const char*> abort;
+    const char* abort = nullptr;
+    gint abort_id = Autoclear::ABORT_NONE;
     SplitVec splits;
 };
 
@@ -124,7 +125,11 @@ subset_sum (SplitInfoVec::const_iterator iter,
         DEBUG ("SOLUTION FOUND: %s%s", path_to_str (path),
                solution.splits.empty() ? "" : " ABORT: AMBIGUOUS");
         if (!solution.splits.empty())
+        {
+            solution.abort_id = Autoclear::ABORT_MULTI;
             solution.abort = "Cannot uniquely clear splits. Found multiple possibilities.";
+            return;
+        }
         else
         {
             solution.splits.resize (path.size());
@@ -134,12 +139,13 @@ subset_sum (SplitInfoVec::const_iterator iter,
         }
     }
 
-    if (solution.abort || iter == end)
+    if (solution.abort_id != Autoclear::ABORT_NONE || iter == end)
         return;
 
     if (monitor.should_abort())
     {
         DEBUG ("ABORT: timeout");
+        solution.abort_id = Autoclear::ABORT_TIMEOUT;
         solution.abort = "Auto-clear exceeds allocated time";
         return;
     }
@@ -195,7 +201,7 @@ gnc_account_get_autoclear_splits (Account *account, gnc_numeric toclear_value,
     static GQuark autoclear_quark = g_quark_from_static_string ("autoclear");
     if (target == 0)
     {
-        g_set_error (error, autoclear_quark, 1, "%s",
+        g_set_error (error, autoclear_quark, Autoclear::ABORT_NOP, "%s",
                      "Account is already at Auto-Clear Balance.");
         return nullptr;
     }
@@ -229,13 +235,14 @@ gnc_account_get_autoclear_splits (Account *account, gnc_numeric toclear_value,
 
     if (solution.splits.empty())
     {
-        g_set_error (error, autoclear_quark, 1, "%s",
+        g_set_error (error, autoclear_quark, Autoclear::ABORT_UNREACHABLE, "%s",
                      "The selected amount cannot be cleared.");
         return nullptr;
     }
-    else if (solution.abort)
+    else if (solution.abort_id)
     {
-        g_set_error (error, autoclear_quark, 1, "%s", *solution.abort);
+        g_set_error (error, autoclear_quark,
+                     solution.abort_id, "%s", solution.abort);
         return nullptr;
     }
 

--- a/libgnucash/app-utils/gnc-autoclear.cpp
+++ b/libgnucash/app-utils/gnc-autoclear.cpp
@@ -127,7 +127,7 @@ subset_sum (SplitInfoVec::const_iterator iter,
         if (!solution.splits.empty())
         {
             solution.abort_id = Autoclear::ABORT_MULTI;
-            solution.abort = "Cannot uniquely clear splits. Found multiple possibilities.";
+            solution.abort = N_("Cannot uniquely clear splits. Found multiple possibilities.");
             return;
         }
         else
@@ -146,7 +146,7 @@ subset_sum (SplitInfoVec::const_iterator iter,
     {
         DEBUG ("ABORT: timeout");
         solution.abort_id = Autoclear::ABORT_TIMEOUT;
-        solution.abort = "Auto-clear exceeds allocated time";
+        solution.abort = N_("Auto-clear exceeds allocated time");
         return;
     }
 
@@ -202,7 +202,7 @@ gnc_account_get_autoclear_splits (Account *account, gnc_numeric toclear_value,
     if (target == 0)
     {
         g_set_error (error, autoclear_quark, Autoclear::ABORT_NOP, "%s",
-                     "Account is already at Auto-Clear Balance.");
+                     N_("Account is already at Auto-Clear Balance."));
         return nullptr;
     }
 
@@ -236,7 +236,7 @@ gnc_account_get_autoclear_splits (Account *account, gnc_numeric toclear_value,
     if (solution.splits.empty())
     {
         g_set_error (error, autoclear_quark, Autoclear::ABORT_UNREACHABLE, "%s",
-                     "The selected amount cannot be cleared.");
+                     N_("The selected amount cannot be cleared."));
         return nullptr;
     }
     else if (solution.abort_id)

--- a/libgnucash/app-utils/gnc-autoclear.h
+++ b/libgnucash/app-utils/gnc-autoclear.h
@@ -32,6 +32,15 @@
 extern "C" {
 #endif
 
+typedef enum
+{
+    ABORT_NONE = 0,
+    ABORT_NOP,
+    ABORT_MULTI,
+    ABORT_TIMEOUT,
+    ABORT_UNREACHABLE,
+} Autoclear;
+
 /** Account splits are analysed; attempts to find a unique combination
  *  of uncleared splits which would set cleared balance to
  *  toclear_value. If this is not possible, GError will be error


### PR DESCRIPTION
show the autoclear result in the reconcile toolbar. for the majority of purists, the main benefit is to distinguish between reachable and unreachable. keyboard binding ctrl-shift-c to avoid accidental triggering.

possible:
<img width="637" height="269" alt="Screenshot from 2025-12-22 15-47-23" src="https://github.com/user-attachments/assets/42423206-8ada-4ebc-b301-3a3ddcf9131a" />

unreachable:
<img width="637" height="269" alt="Screenshot from 2025-12-22 15-47-35" src="https://github.com/user-attachments/assets/866eb044-8751-4f1f-a7dd-adc9b85a06eb" />

already at balance:
<img width="637" height="269" alt="Screenshot from 2025-12-22 15-47-43" src="https://github.com/user-attachments/assets/9fbff398-a409-4f1e-a1fb-b1615c60b5ca" />

multi/ambiguous:
<img width="637" height="269" alt="Screenshot from 2025-12-22 15-49-54" src="https://github.com/user-attachments/assets/e568b3d3-93ef-45dc-a046-f5100a4f4460" />
