### PR TITLE
Bug 799722 - Inconsistent wording: Bill and Invoice

### DIFF
--- a/gnucash/gnome/dialog-invoice.c
+++ b/gnucash/gnome/dialog-invoice.c
@@ -3899,8 +3899,8 @@ gnc_invoice_show_docs_due (GtkWindow *parent, QofBook *book, double days_in_adva
         message = g_strdup_printf
                   (/* Translators: %d is the number of bills/credit notes due. This is a
                          ngettext(3) message. */
-                      ngettext("The following vendor document is due:",
-                               "The following %d vendor documents are due:",
+                      ngettext("The following vendor business item is due:",
+                               "The following %d vendor business items are due:",
                                len),
                       len);
         title = _("Due Bills Reminder");
@@ -3911,8 +3911,8 @@ gnc_invoice_show_docs_due (GtkWindow *parent, QofBook *book, double days_in_adva
         message = g_strdup_printf
                   (/* Translators: %d is the number of invoices/credit notes due. This is a
                          ngettext(3) message. */
-                      ngettext("The following customer document is due:",
-                               "The following %d customer documents are due:",
+                      ngettext("The following customer business item is due:",
+                               "The following %d customer business items are due:",
                                len),
                       len);
         title = _("Due Invoices Reminder");

--- a/gnucash/gnome/dialog-payment.c
+++ b/gnucash/gnome/dialog-payment.c
@@ -290,7 +290,7 @@ gnc_payment_window_check_payment (PaymentWindow *pw)
     selection = gtk_tree_view_get_selection (GTK_TREE_VIEW(pw->docs_list_tree_view));
     if (gtk_tree_selection_count_selected_rows (selection) == 0)
     {
-        conflict_msg = _("No documents were selected to assign this payment to. This may create an unattached payment.");
+        conflict_msg = _("No business items were selected to assign this payment to. This may create an unattached payment.");
         allow_payment = TRUE;
     }
 

--- a/gnucash/gnome/gnc-plugin-page-invoice.cpp
+++ b/gnucash/gnome/gnc-plugin-page-invoice.cpp
@@ -203,9 +203,9 @@ static action_toolbar_labels invoice_action_labels[] =
 
 static action_toolbar_labels invoice_action_layout_labels[] =
 {
-    {"ViewSaveLayoutAction", N_("_Use as Default Layout for Customer Documents"),
+    {"ViewSaveLayoutAction", N_("_Use as Default Layout for Customer Business items"),
       N_("Use the current layout as default for all customer invoices and credit notes")},
-    {"ViewResetLayoutAction", N_("_Reset Default Layout for Customer Documents"),
+    {"ViewResetLayoutAction", N_("_Reset Default Layout for Customer business items"),
       N_("Reset default layout for all customer invoices and credit notes back to built-in defaults and update the current page accordingly")},
     {NULL, NULL, NULL},
 };
@@ -228,9 +228,9 @@ static action_toolbar_labels bill_action_labels[] =
 
 static action_toolbar_labels bill_action_layout_labels[] =
 {
-    {"ViewSaveLayoutAction", N_("_Use as Default Layout for Vendor Documents"),
+    {"ViewSaveLayoutAction", N_("_Use as Default Layout for Vendor Business items"),
       N_("Use the current layout as default for all vendor bills and credit notes")},
-    {"ViewResetLayoutAction", N_("_Reset Default Layout for Vendor Documents"),
+    {"ViewResetLayoutAction", N_("_Reset Default Layout for Vendor Business items"),
       N_("Reset default layout for all vendor bills and credit notes back to built-in defaults and update the current page accordingly")},
     {NULL, NULL, NULL},
 };
@@ -253,9 +253,9 @@ static action_toolbar_labels voucher_action_labels[] =
 
 static action_toolbar_labels voucher_action_layout_labels[] =
 {
-    {"ViewSaveLayoutAction", N_("_Use as Default Layout for Employee Documents"),
+    {"ViewSaveLayoutAction", N_("_Use as Default Layout for Employee Business items"),
       N_("Use the current layout as default for all employee vouchers and credit notes")},
-    {"ViewResetLayoutAction", N_("_Reset Default Layout for Employee Documents"),
+    {"ViewResetLayoutAction", N_("_Reset Default Layout for Employee Business items"),
       N_("Reset default layout for all employee vouchers and credit notes back to built-in defaults and update the current page accordingly")},
     {NULL, NULL, NULL},
 };

--- a/gnucash/gnome/gnc-plugin-page-register.cpp
+++ b/gnucash/gnome/gnc-plugin-page-register.cpp
@@ -276,7 +276,7 @@ static GncInvoice* invoice_from_split (Split* split);
 #define LINK_TRANSACTION_OPEN_LABEL      N_("_Open Linked Document")
 /* Translators: This is a menu item that will open the bill, invoice, or voucher
    that is posted to the current transaction if there is one. */
-#define JUMP_LINKED_INVOICE_LABEL        N_("Jump to Invoice")
+#define JUMP_LINKED_INVOICE_LABEL        N_("Jump to Business item")
 #define CUT_SPLIT_LABEL                  N_("Cu_t Split")
 #define COPY_SPLIT_LABEL                 N_("_Copy Split")
 #define PASTE_SPLIT_LABEL                N_("_Paste Split")
@@ -289,7 +289,7 @@ static GncInvoice* invoice_from_split (Split* split);
 #define DELETE_TRANSACTION_TIP           N_("Delete the current transaction")
 #define LINK_TRANSACTION_TIP             N_("Add, change, or unlink the document linked with the current transaction")
 #define LINK_TRANSACTION_OPEN_TIP        N_("Open the linked document for the current transaction")
-#define JUMP_LINKED_INVOICE_TIP          N_("Jump to the linked bill, invoice, or voucher")
+#define JUMP_LINKED_INVOICE_TIP          N_("Jump to the linked invoice, bill, expense or credit note")
 #define CUT_SPLIT_TIP                    N_("Cut the selected split into clipboard")
 #define COPY_SPLIT_TIP                   N_("Copy the selected split into clipboard")
 #define PASTE_SPLIT_TIP                  N_("Paste the split from the clipboard")
@@ -4722,8 +4722,8 @@ gnc_plugin_page_register_cmd_jump_linked_invoice (GSimpleAction *simple,
             }
             details = g_list_reverse (details);
             choice = gnc_choose_radio_option_dialog
-                (window, _("Select document"),
-                 _("Several documents are linked with this transaction. \
+                (window, _("Select Business Item"),
+                 _("Several business items are linked with this transaction. \
 Please choose one:"), _("Select"), 0, details);
             if ((choice >= 0) && ((size_t)choice < invoices.size()))
                 invoice = invoices[choice];

--- a/gnucash/gnome/gnc-plugin-page-register.cpp
+++ b/gnucash/gnome/gnc-plugin-page-register.cpp
@@ -401,10 +401,6 @@ static GncToolBarShortNames toolbar_labels[] =
     { "ScheduleTransactionAction",          N_ ("Schedule") },
     { "BlankTransactionAction",             N_ ("Blank") },
     { "ActionsReconcileAction",             N_ ("Reconcile") },
-    { "ActionsAutoClearAction",             N_ ("Auto-clear") },
-    { "LinkTransactionAction",              N_ ("Manage Document Link") },
-    { "LinkedTransactionOpenAction",        N_ ("Open Linked Document") },
-    { "JumpLinkedInvoiceAction",            N_ ("Invoice") },
     { "ActionsStockAssistantAction",        N_ ("Stock Assistant") },
     { NULL, NULL },
 };
@@ -805,9 +801,6 @@ static const char* tran_action_labels[] =
     PASTE_TRANSACTION_LABEL,
     DUPLICATE_TRANSACTION_LABEL,
     DELETE_TRANSACTION_LABEL,
-    LINK_TRANSACTION_LABEL,
-    LINK_TRANSACTION_OPEN_LABEL,
-    JUMP_LINKED_INVOICE_LABEL,
     NULL
 };
 
@@ -819,9 +812,6 @@ static const char* tran_action_tips[] =
     PASTE_TRANSACTION_TIP,
     DUPLICATE_TRANSACTION_TIP,
     DELETE_TRANSACTION_TIP,
-    LINK_TRANSACTION_TIP,
-    LINK_TRANSACTION_OPEN_TIP,
-    JUMP_LINKED_INVOICE_TIP,
     NULL
 };
 

--- a/gnucash/gschemas/org.gnucash.GnuCash.dialogs.business.gschema.xml.in
+++ b/gnucash/gschemas/org.gnucash.GnuCash.dialogs.business.gschema.xml.in
@@ -110,7 +110,7 @@
     <key name="auto-pay" type="b">
       <default>false</default>
       <summary>Auto pay when posting.</summary>
-      <description>At post time, automatically attempt to pay customer documents with outstanding pre-payments and counter documents. The pre-payments and documents obviously have to be against the same customer. Counter documents are documents with opposite sign. For example for an invoice, customer credit notes and negative invoices are considered counter documents.</description>
+      <description>At post time, automatically attempt to pay customer items with outstanding pre-payments and counter items. The pre-payments and items obviously have to be against the same customer. Counter items are items with opposite sign. For example for an invoice, customer credit notes and negative invoices are considered counter items.</description>
     </key>
     <key name="notify-when-due" type="b">
       <default>true</default>
@@ -152,7 +152,7 @@
     <key name="auto-pay" type="b">
       <default>false</default>
       <summary>Auto pay when posting.</summary>
-      <description>At post time, automatically attempt to pay vendor documents with outstanding pre-payments and counter documents. The pre-payments and documents obviously have to be against the same vendor. Counter documents are documents with opposite sign. For example for a bill, vendor credit notes and negative bills are considered counter documents.</description>
+      <description>At post time, automatically attempt to pay vendor items with outstanding pre-payments and counter items. The pre-payments and items obviously have to be against the same vendor. Counter items are items with opposite sign. For example for a bill, vendor credit notes and negative bills are considered counter items.</description>
     </key>
     <key name="notify-when-due" type="b">
       <default>true</default>

--- a/gnucash/gtkbuilder/business-prefs.glade
+++ b/gnucash/gtkbuilder/business-prefs.glade
@@ -166,8 +166,8 @@
             <property name="can-focus">True</property>
             <property name="receives-default">False</property>
             <property name="has-tooltip">True</property>
-            <property name="tooltip-markup">At post time, automatically attempt to pay customer documents with outstanding pre-payments and counter documents. The pre-payments and documents obviously have to be against the same customer. Counter documents are documents with opposite sign. For example for an invoice, customer credit notes and negative invoices are considered counter documents.</property>
-            <property name="tooltip-text" translatable="yes">At post time, automatically attempt to pay customer documents with outstanding pre-payments and counter documents. The pre-payments and documents obviously have to be against the same customer. Counter documents are documents with opposite sign. For example for an invoice, customer credit notes and negative invoices are considered counter documents.</property>
+            <property name="tooltip-markup">At post time, automatically attempt to pay customer items with outstanding pre-payments and counter items. The pre-payments and items obviously have to be against the same customer. Counter items are items with opposite sign. For example for an invoice, customer credit notes and negative invoices are considered counter items.</property>
+            <property name="tooltip-text" translatable="yes">At post time, automatically attempt to pay customer items with outstanding pre-payments and counter items. The pre-payments and items obviously have to be against the same customer. Counter items are items with opposite sign. For example for an invoice, customer credit notes and negative invoices are considered counter items.</property>
             <property name="halign">start</property>
             <property name="use-underline">True</property>
             <property name="draw-indicator">True</property>
@@ -246,8 +246,8 @@
             <property name="can-focus">True</property>
             <property name="receives-default">False</property>
             <property name="has-tooltip">True</property>
-            <property name="tooltip-markup">At post time, automatically attempt to pay vendor documents with outstanding pre-payments and counter documents. The pre-payments and documents obviously have to be against the same vendor. Counter documents are documents with opposite sign. For example for a bill, vendor credit notes and negative bills are considered counter documents.</property>
-            <property name="tooltip-text" translatable="yes">At post time, automatically attempt to pay vendor documents with outstanding pre-payments and counter documents. The pre-payments and documents obviously have to be against the same vendor. Counter documents are documents with opposite sign. For example for a bill, vendor credit notes and negative bills are considered counter documents.</property>
+            <property name="tooltip-markup">At post time, automatically attempt to pay vendor items with outstanding pre-payments and counter items. The pre-payments and items obviously have to be against the same vendor. Counter items are items with opposite sign. For example for a bill, vendor credit notes and negative bills are considered counter items.</property>
+            <property name="tooltip-text" translatable="yes">At post time, automatically attempt to pay vendor items with outstanding pre-payments and counter items. The pre-payments and items obviously have to be against the same vendor. Counter items are items with opposite sign. For example for a bill, vendor credit notes and negative bills are considered counter items.</property>
             <property name="halign">start</property>
             <property name="use-underline">True</property>
             <property name="draw-indicator">True</property>

--- a/gnucash/gtkbuilder/dialog-bi-import-gui.glade
+++ b/gnucash/gtkbuilder/dialog-bi-import-gui.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.22"/>
   <object class="GtkDialog" id="bi_import_dialog">
@@ -371,7 +371,7 @@
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkRadioButton" id="radiobuttonOpenAll">
-                    <property name="label" translatable="yes">Open imported documents in tabs</property>
+                    <property name="label" translatable="yes">Open imported business items in tabs</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -389,7 +389,7 @@
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="radiobuttonOpenNotPosted">
-                    <property name="label" translatable="yes">Open not yet posted documents in tabs</property>
+                    <property name="label" translatable="yes">Open not yet posted business items in tabs</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
@@ -407,7 +407,7 @@
                 </child>
                 <child>
                   <object class="GtkRadioButton" id="radiobuttonOpenNone">
-                    <property name="label" translatable="yes">Don't open imported documents in tabs</property>
+                    <property name="label" translatable="yes">Don't open imported business items in tabs</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>

--- a/gnucash/gtkbuilder/dialog-payment.glade
+++ b/gnucash/gtkbuilder/dialog-payment.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.22"/>
   <object class="GtkAdjustment" id="docs_list_hor_adj">
@@ -332,7 +332,7 @@
                   <object class="GtkLabel" id="label1">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="label" translatable="yes">Documents</property>
+                    <property name="label" translatable="yes">Business items</property>
                     <style>
                       <class name="gnc-class-strong"/>
                     </style>

--- a/gnucash/ui/gnc-plugin-page-register.ui
+++ b/gnucash/ui/gnc-plugin-page-register.ui
@@ -217,9 +217,9 @@
 
   <menu id="TransPlaceholder4">
     <item>
-      <attribute name="label" translatable="yes">Jump to Invoice</attribute>
+      <attribute name="label" translatable="yes">Jump to Business item</attribute>
       <attribute name="action">GncPluginPageRegisterActions.JumpLinkedInvoiceAction</attribute>
-      <attribute name="tooltip" translatable="yes">Jump to the linked bill, invoice, or voucher.</attribute>
+      <attribute name="tooltip" translatable="yes">Jump to the linked invoice, bill, expense or credit note.</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
   </menu>
@@ -402,9 +402,9 @@
     </section>
     <section>
       <item>
-        <attribute name="label" translatable="yes">Jump to Invoice</attribute>
+        <attribute name="label" translatable="yes">Jump to Business item</attribute>
         <attribute name="action">GncPluginPageRegisterActions.JumpLinkedInvoiceAction</attribute>
-        <attribute name="tooltip" translatable="yes">Jump to the linked bill, invoice, or voucher.</attribute>
+        <attribute name="tooltip" translatable="yes">Jump to the linked invoice, bill, expense or credit note.</attribute>
       </item>
     </section>
     <section>
@@ -514,9 +514,9 @@
     </section>
     <section>
       <item>
-        <attribute name="label" translatable="yes">Jump to Invoice</attribute>
+        <attribute name="label" translatable="yes">Jump to Business item</attribute>
         <attribute name="action">GncPluginPageRegisterActions.JumpLinkedInvoiceAction</attribute>
-        <attribute name="tooltip" translatable="yes">Jump to the linked bill, invoice, or voucher.</attribute>
+        <attribute name="tooltip" translatable="yes">Jump to the linked invoice, bill, expense or credit note.</attribute>
       </item>
     </section>
     <section>

--- a/libgnucash/engine/gncOwner.c
+++ b/libgnucash/engine/gncOwner.c
@@ -1009,7 +1009,7 @@ gncOwnerReduceSplitTo (Split *split, gnc_numeric target_amount)
 void
 gncOwnerSetLotLinkMemo (Transaction *ll_txn)
 {
-    gchar *memo_prefix = _("Offset between documents: ");
+    gchar *memo_prefix = _("Offset between business items: ");
     gchar *new_memo;
     SplitList *lts_iter;
     SplitList *splits = NULL, *siter;


### PR DESCRIPTION
I do not know much about the Business side but this is an attempt to fix the inconsistent 'Jump to invoice' menu label.

The first commit is just some entries that I do not think are required, will adjust commit text before pushing.

The second commit is a fix based on static structures which does work but does not seem to be very flexible.

The final commit was a change to using a GSList of menu update structures which again works and I believe is more fixable catering for more than one unrelated menu update.

The last thing I thought of was possibly just changing the `Jump to invoice` to be less specific like `Jump to business document`.

I will adjust commits if this progresses.