### PR TITLE
Bug - When importing csv-transactions, currency_format is not always properly applied.

### DIFF
--- a/gnucash/import-export/csv-imp/gnc-import-tx.cpp
+++ b/gnucash/import-export/csv-imp/gnc-import-tx.cpp
@@ -199,12 +199,9 @@ void GncTxImport::base_account (Account* base_account)
             for (auto line : m_parsed_lines)
                 std::get<PL_PRESPLIT>(line)->set_account (m_settings.m_base_account);
         }
-        else
-        {
-            /* Reparse all of the lines with the new base account's commodity. */
-            tokenize(false);
-        }
 
+    	/* Reparse all of the lines with the new base account's commodity. */
+    	tokenize(false);
     }
 }
 
@@ -219,6 +216,9 @@ void GncTxImport::reset_formatted_column (std::vector<GncTransPropType>& col_typ
         if (col != m_settings.m_column_types.end())
             set_column_type (col - m_settings.m_column_types.begin(), col_type, true);
     }
+
+    /* Reparse all lines */
+    tokenize(false);
 }
 
 void GncTxImport::currency_format (int currency_format)


### PR DESCRIPTION
### The bug:
When importing csv-transactions, currency_format is not always properly applied.
If you start out by setting `currency_format` and `date_format etc, and only choose account as the last action before proceeding, the result of your import will not use the currency_format you chose.

The issue also occurs if you:
- First set account, then currency format.
- Set a random account, then set the correct account, then set currency format.

As seen in screenshots below, gnucash does not properly use the chosen currency format with "comma" as the decimal separator and "dot" as the thousand separator:

<img width="500" alt="1-import-preview" src="https://github.com/user-attachments/assets/7bc9673a-f4bd-4259-9bd5-dd33a1fd2e49" />

<img width="500" alt="2-import-match" src="https://github.com/user-attachments/assets/58cd0e73-1746-43fe-920d-1cc79b769908" />

Here is the sample csv-file I used:
[sample.txt](https://github.com/user-attachments/files/24836641/sample.txt)


### Fix:
Reparse/tokenize all import lines when changing date/currency formats. In addition, make sure this also happens when setting base_account. After this change it works.