### PR TITLE
Improve usability of csv-transaction-import by adding informal text for date-format selection.

### DIFF
--- a/gnucash/gtkbuilder/assistant-csv-trans-import.glade
+++ b/gnucash/gtkbuilder/assistant-csv-trans-import.glade
@@ -591,6 +591,8 @@ To know which lines belong to the same transaction, the importer will compare th
                             <property name="can-focus">False</property>
                             <property name="halign">end</property>
                             <property name="label" translatable="yes">Date Format</property>
+                            <property name="tooltip-text" translatable="yes">Choose the order of day, month and year, to match the formatting in the imported file.
+Choices are displayed with a Hyphen (-) separator, but will also match Dot (.) and Slash (/) as separator.</property>
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
@@ -718,6 +720,8 @@ To know which lines belong to the same transaction, the importer will compare th
                           <object class="GtkBox" id="date_format_container">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
+                            <property name="tooltip-text" translatable="yes">Choose the order of day, month and year, to match the formatting in the imported file.
+Choices are displayed with a Hyphen (-) separator, but will also match Dot (.) and Slash (/) as separator.</property>
                           </object>
                           <packing>
                             <property name="left-attach">1</property>


### PR DESCRIPTION
**The date-format selection box displays all variations with a "-" separator, however this separator also matches "/" and ".".
By adding a short informal text to explain this behavior, it is much clearer to the user.**

_In 2015 I started using Gnucash for accounting in my small Norwegian consulting business.
I've regularly been using the csv-import to import transactions from my bank, which export csv-files with date formatted using dots "." as separators.
It was never clear to me that the dates displayed in the selection box would also match dots ".", so I have been manipulating my csv's to use "-" every year since 2015.
I was going to contribute a PR to add support for dots, when I realized gnucash already supports it._

Hopefully with this change it becomes immediately clear to everyone that the separator also matches dots and slashes.

A screenshot of the updated version:
<img width="600" alt="Screenshot from 2026-01-26 12-15-43" src="https://github.com/user-attachments/assets/1d225010-9886-4a63-9a78-149332b50de8" />
