### PR TITLE
Fix segfault in gnc_gsettings_get_settings_obj when GSettings schemas are not installed

### DIFF
--- a/libgnucash/app-utils/gnc-gsettings.cpp
+++ b/libgnucash/app-utils/gnc-gsettings.cpp
@@ -105,20 +105,10 @@ static GSettings * gnc_gsettings_get_settings_obj (const gchar *schema_str)
     auto full_name_str = normalize_schema_name (schema_str);
     auto full_name = full_name_str.c_str();
     auto schema_source {g_settings_schema_source_get_default()};
-    if (!schema_source)
-    {
-        PWARN ("No GSettings schema source available; cannot access schema %s", full_name);
-        LEAVE("");
-        return nullptr;
-    }
+    g_return_val_if_fail(schema_source, nullptr);
 
     auto schema {g_settings_schema_source_lookup(schema_source, full_name, true)};
-    if (!schema)
-    {
-        PWARN ("GSettings schema %s not found", full_name);
-        LEAVE("");
-        return nullptr;
-    }
+    g_return_val_if_fail(schema, nullptr);
 
     auto gset = g_settings_new_full (schema, nullptr, nullptr);
     DEBUG ("Created gsettings object %p for schema %s", gset, full_name);
@@ -559,11 +549,7 @@ gnc_settings_dump_schema_paths (void)
     gchar **non_relocatable;
 
     auto schema_source {g_settings_schema_source_get_default()};
-    if (!schema_source)
-    {
-        PWARN ("No GSettings schema source available; cannot dump schema paths");
-        return;
-    }
+    g_return_if_fail(schema_source);
 
     g_settings_schema_source_list_schemas (schema_source, true,
                                            &non_relocatable, nullptr);

--- a/libgnucash/app-utils/gnc-gsettings.cpp
+++ b/libgnucash/app-utils/gnc-gsettings.cpp
@@ -105,7 +105,21 @@ static GSettings * gnc_gsettings_get_settings_obj (const gchar *schema_str)
     auto full_name_str = normalize_schema_name (schema_str);
     auto full_name = full_name_str.c_str();
     auto schema_source {g_settings_schema_source_get_default()};
+    if (!schema_source)
+    {
+        PWARN ("No GSettings schema source available; cannot access schema %s", full_name);
+        LEAVE("");
+        return nullptr;
+    }
+
     auto schema {g_settings_schema_source_lookup(schema_source, full_name, true)};
+    if (!schema)
+    {
+        PWARN ("GSettings schema %s not found", full_name);
+        LEAVE("");
+        return nullptr;
+    }
+
     auto gset = g_settings_new_full (schema, nullptr, nullptr);
     DEBUG ("Created gsettings object %p for schema %s", gset, full_name);
 
@@ -545,6 +559,12 @@ gnc_settings_dump_schema_paths (void)
     gchar **non_relocatable;
 
     auto schema_source {g_settings_schema_source_get_default()};
+    if (!schema_source)
+    {
+        PWARN ("No GSettings schema source available; cannot dump schema paths");
+        return;
+    }
+
     g_settings_schema_source_list_schemas (schema_source, true,
                                            &non_relocatable, nullptr);
 


### PR DESCRIPTION
## Summary

Fixes segfault in `gnc_gsettings_get_settings_obj()` when GSettings schemas are missing (e.g., library-only builds with `-DWITH_GNUCASH=OFF`).

## Problem

When `g_settings_schema_source_get_default()` returns NULL (no compiled schemas), the code was passing NULL directly to `g_settings_schema_source_lookup()`, causing a segmentation fault. The existing `G_IS_SETTINGS()` check came too late—after three potential NULL dereferences.

**Crash sequence:**
```
import gnucash (Python)
→ gnc_prefs_init()
→ gnc_gsettings_version_upgrade()
→ gnc_gsettings_get_settings_obj("general")
→ SEGFAULT at line 108
```

## Solution

Added NULL guards before dereferencing GLib function return values:
- Check `schema_source` before passing to `g_settings_schema_source_lookup()`
- Check `schema` before passing to `g_settings_new_full()`
- Added same guard in `gnc_settings_dump_schema_paths()` for consistency

All callers already handle NULL returns via `G_IS_SETTINGS()` checks.

## Testing Status

⚠️ **NEEDS TESTING** - Requires specific build configuration:
- Build with `-DWITH_GNUCASH=OFF` (library-only, due to bug, currently installs no schemas)
- Test Python import: `python3 -c "import gnucash"`
- Should complete without segfault (will log warnings but not crash)

Without this fix, the import immediately segfaults. With the fix, it should gracefully degrade.

## Related

- Bug report: https://bugs.gnucash.org/show_bug.cgi?id=799740
- Companion bug: https://bugs.gnucash.org/show_bug.cgi?id=799739