### PR TITLE
Faster unicode string compare

### DIFF
--- a/libgnucash/core-utils/gnc-unicode.cpp
+++ b/libgnucash/core-utils/gnc-unicode.cpp
@@ -24,6 +24,7 @@
 #include "gnc-unicode.h"
 
 #include <memory>
+#include <vector>
 #include <unicode/stsearch.h>
 #include <unicode/tblcoll.h>
 #include <unicode/coll.h>
@@ -161,10 +162,15 @@ gnc_unicode_has_substring_identical(const char* needle,
     return false;
 }
 
-static int
-unicode_compare_internal(const char* one, const char* two,
-                         CompareStrength strength)
+static icu::Collator*
+get_collator(CompareStrength strength)
 {
+    thread_local std::vector<std::pair<CompareStrength, std::unique_ptr<icu::Collator>>> cache;
+
+    for (const auto& kvp : cache)
+        if (kvp.first == strength)
+            return kvp.second.get();
+
     UErrorCode status{U_ZERO_ERROR};
     auto locale{gnc_locale_name()};
     std::unique_ptr<icu::Collator> coll(
@@ -179,21 +185,37 @@ unicode_compare_internal(const char* one, const char* two,
               "Failed to create collator for locale %s: %s",
               locale, u_errorName(status));
         g_free(locale);
-        return -99;
+        cache.push_back ({strength, nullptr});
+        return nullptr;
     }
 
+    auto* ptr = coll.get();
+    cache.push_back ({strength, std::move(coll)});
+
+    g_free(locale);
+    return ptr;
+}
+
+
+static int
+unicode_compare_internal(const char* one, const char* two,
+                         CompareStrength strength)
+{
+    auto coll = get_collator (strength);
+    if (!coll)
+        return -99;
+
+    UErrorCode status{U_ZERO_ERROR};
     auto result = coll->compare(one, two, status);
 
     if (U_FAILURE(status))
     {
         g_log(logdomain, G_LOG_LEVEL_ERROR,
-              "Comparison of %s and %s in locale %s failed: %s",
-              one, two, locale, u_errorName(status));
-        g_free(locale);
+              "Comparison of %s and %s failed: %s",
+              one, two, u_errorName(status));
         return -99;
     }
 
-    g_free(locale);
     return result == UCOL_LESS ? -1 : result == UCOL_EQUAL ? 0 : 1;
 }
 

--- a/libgnucash/core-utils/test/gtest-gnc-unicode.cpp
+++ b/libgnucash/core-utils/test/gtest-gnc-unicode.cpp
@@ -136,7 +136,10 @@ TEST(GncUnicode, test_german_ss_decorated_accented_nocap)
 
 TEST (GncUnicode, test_simple_identical)
 {
-    EXPECT_EQ (gnc_unicode_compare_identical ("alice", "alice"), 0);
-    EXPECT_EQ (gnc_unicode_compare_identical ("alice", "bob"), -1);
-    EXPECT_EQ (gnc_unicode_compare_identical ("bob", "alice"), 1);
+    for (int i = 0; i < 5000000; ++i)
+    {
+        EXPECT_EQ (gnc_unicode_compare_identical ("alice", "alice"), 0);
+        EXPECT_EQ (gnc_unicode_compare_identical ("alice", "bob"), -1);
+        EXPECT_EQ (gnc_unicode_compare_identical ("bob", "alice"), 1);
+    }
 }


### PR DESCRIPTION
I still think that unicode collator needs to be [cached](https://github.com/Gnucash/gnucash/pull/2097#issuecomment-2933184220); it's heavily used by ui and report code everywhere... Here's benchmark comparing 5M strings. Without caching:

```
24: Test command: /home/chris/sources/gnucash/build-stable/bin/test-gnc-unicode
24: Working Directory: /home/chris/sources/gnucash/build-stable/libgnucash/core-utils/test
24: Environment variables: 
24:  GNC_UNINSTALLED=YES
24:  GNC_BUILDDIR=/home/chris/sources/gnucash/build-stable
24: Test timeout computed to be: 10000000
24: Running main() from /tmp/guix-build-googletest-1.17.0.drv-0/source/googletest/src/gtest_main.cc
24: [==========] Running 8 tests from 1 test suite.
24: [----------] Global test environment set-up.
24: [----------] 8 tests from GncUnicode
24: [ RUN      ] GncUnicode.test_ss_base_chars
24: [       OK ] GncUnicode.test_ss_base_chars (3 ms)
24: [ RUN      ] GncUnicode.test_ss_accented
24: [       OK ] GncUnicode.test_ss_accented (0 ms)
24: [ RUN      ] GncUnicode.test_ss_accented_case_sensitive
24: [       OK ] GncUnicode.test_ss_accented_case_sensitive (0 ms)
24: [ RUN      ] GncUnicode.test_german_ss_literal
24: [       OK ] GncUnicode.test_german_ss_literal (0 ms)
24: [ RUN      ] GncUnicode.test_german_ss_decorated_base_chars_nocap
24: [       OK ] GncUnicode.test_german_ss_decorated_base_chars_nocap (0 ms)
24: [ RUN      ] GncUnicode.test_german_ss_decorated_accented_cap
24: [       OK ] GncUnicode.test_german_ss_decorated_accented_cap (0 ms)
24: [ RUN      ] GncUnicode.test_german_ss_decorated_accented_nocap
24: [       OK ] GncUnicode.test_german_ss_decorated_accented_nocap (0 ms)
24: [ RUN      ] GncUnicode.test_simple_identical
24: [       OK ] GncUnicode.test_simple_identical (24931 ms)
24: [----------] 8 tests from GncUnicode (24935 ms total)
24: 
24: [----------] Global test environment tear-down
24: [==========] 8 tests from 1 test suite ran. (24935 ms total)
24: [  PASSED  ] 8 tests.
1/1 Test #24: test-gnc-unicode .................   Passed   24.94 sec
```

With caching:
```
24: Test command: /home/chris/sources/gnucash/build-stable/bin/test-gnc-unicode
24: Working Directory: /home/chris/sources/gnucash/build-stable/libgnucash/core-utils/test
24: Environment variables: 
24:  GNC_UNINSTALLED=YES
24:  GNC_BUILDDIR=/home/chris/sources/gnucash/build-stable
24: Test timeout computed to be: 10000000
24: Running main() from /tmp/guix-build-googletest-1.17.0.drv-0/source/googletest/src/gtest_main.cc
24: [==========] Running 8 tests from 1 test suite.
24: [----------] Global test environment set-up.
24: [----------] 8 tests from GncUnicode
24: [ RUN      ] GncUnicode.test_ss_base_chars
24: [       OK ] GncUnicode.test_ss_base_chars (2 ms)
24: [ RUN      ] GncUnicode.test_ss_accented
24: [       OK ] GncUnicode.test_ss_accented (0 ms)
24: [ RUN      ] GncUnicode.test_ss_accented_case_sensitive
24: [       OK ] GncUnicode.test_ss_accented_case_sensitive (0 ms)
24: [ RUN      ] GncUnicode.test_german_ss_literal
24: [       OK ] GncUnicode.test_german_ss_literal (0 ms)
24: [ RUN      ] GncUnicode.test_german_ss_decorated_base_chars_nocap
24: [       OK ] GncUnicode.test_german_ss_decorated_base_chars_nocap (0 ms)
24: [ RUN      ] GncUnicode.test_german_ss_decorated_accented_cap
24: [       OK ] GncUnicode.test_german_ss_decorated_accented_cap (0 ms)
24: [ RUN      ] GncUnicode.test_german_ss_decorated_accented_nocap
24: [       OK ] GncUnicode.test_german_ss_decorated_accented_nocap (0 ms)
24: [ RUN      ] GncUnicode.test_simple_identical
24: [       OK ] GncUnicode.test_simple_identical (1428 ms)
24: [----------] 8 tests from GncUnicode (1431 ms total)
24: 
24: [----------] Global test environment tear-down
24: [==========] 8 tests from 1 test suite ran. (1431 ms total)
24: [  PASSED  ] 8 tests.
1/1 Test #24: test-gnc-unicode .................   Passed    1.44 sec
```

Also instead of returning `-99` how about logging an ICU failure and returning `g_strcmp0 (one,two)`?