### PR TITLE
prevent hidden or placeholder accounts in CSV transaction import

### DIFF
--- a/gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp
+++ b/gnucash/import-export/csv-imp/assistant-csv-trans-import.cpp
@@ -83,6 +83,12 @@ namespace bl = boost::locale;
 /* This static indicates the debugging module that this .o belongs to.  */
 static QofLogModule log_module = GNC_MOD_ASSISTANT;
 
+static bool
+csv_tximp_account_is_eligible (Account *account)
+{
+    return account && !xaccAccountGetPlaceholder (account) && !xaccAccountIsHidden (account);
+}
+
 enum GncImportColumn {
     MAPPING_STRING,
     MAPPING_FULLPATH,
@@ -1804,9 +1810,11 @@ csv_tximp_acct_match_load_mappings (GtkTreeModel *mappings_store)
         // It may already be set in the tree model. If not we try to match the map_string with
         // - an entry in our saved account maps
         // - a full name of any of our existing accounts
-        if (account ||
-            (account = gnc_account_imap_find_any (gnc_get_current_book(), IMAP_CAT_CSV, map_string)) ||
-            (account = gnc_account_lookup_by_full_name (gnc_get_current_root_account(), map_string)))
+        if ((account && csv_tximp_account_is_eligible (account)) ||
+            ((account = gnc_account_imap_find_any (gnc_get_current_book(), IMAP_CAT_CSV, map_string)) &&
+             csv_tximp_account_is_eligible (account)) ||
+            ((account = gnc_account_lookup_by_full_name (gnc_get_current_root_account(), map_string)) &&
+             csv_tximp_account_is_eligible (account)))
         {
             auto fullpath = gnc_account_get_full_name (account);
             gtk_list_store_set (GTK_LIST_STORE(mappings_store), &iter, MAPPING_FULLPATH, fullpath, -1);

--- a/gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp
+++ b/gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp
@@ -52,6 +52,12 @@ namespace bl = boost::locale;
 
 G_GNUC_UNUSED static QofLogModule log_module = GNC_MOD_IMPORT;
 
+static bool
+gnc_csv_account_is_eligible (Account *account)
+{
+    return account && !xaccAccountGetPlaceholder (account) && !xaccAccountIsHidden (account);
+}
+
 /* This map contains a set of strings representing the different column types. */
 std::map<GncTransPropType, const char*> gnc_csv_col_type_strs = {
         { GncTransPropType::NONE, N_("None") },
@@ -446,8 +452,10 @@ void GncPreSplit::set (GncTransPropType prop_type, const std::string& value)
                 m_account.reset();
                 if (value.empty())
                     throw std::invalid_argument (_("Account value can't be empty."));
-                if ((acct = gnc_account_imap_find_any (gnc_get_current_book(), IMAP_CAT_CSV, value.c_str())) ||
-                    (acct = gnc_account_lookup_by_full_name (gnc_get_current_root_account(), value.c_str())))
+                if (((acct = gnc_account_imap_find_any (gnc_get_current_book(), IMAP_CAT_CSV, value.c_str())) &&
+                     gnc_csv_account_is_eligible (acct)) ||
+                    ((acct = gnc_account_lookup_by_full_name (gnc_get_current_root_account(), value.c_str())) &&
+                     gnc_csv_account_is_eligible (acct)))
                     m_account = acct;
                 else
                     throw std::invalid_argument (_("Account value can't be mapped back to an account."));
@@ -458,8 +466,10 @@ void GncPreSplit::set (GncTransPropType prop_type, const std::string& value)
                 if (value.empty())
                     throw std::invalid_argument (_("Transfer account value can't be empty."));
 
-                if ((acct = gnc_account_imap_find_any (gnc_get_current_book(), IMAP_CAT_CSV,value.c_str())) ||
-                    (acct = gnc_account_lookup_by_full_name (gnc_get_current_root_account(), value.c_str())))
+                if (((acct = gnc_account_imap_find_any (gnc_get_current_book(), IMAP_CAT_CSV,value.c_str())) &&
+                     gnc_csv_account_is_eligible (acct)) ||
+                    ((acct = gnc_account_lookup_by_full_name (gnc_get_current_root_account(), value.c_str())) &&
+                     gnc_csv_account_is_eligible (acct)))
                     m_taccount = acct;
                 else
                     throw std::invalid_argument (_("Transfer account value can't be mapped back to an account."));


### PR DESCRIPTION
prevent hidden or placeholder accounts to be suggested in automatic mapping in CSV transaction import