### PR TITLE
Avoid ub in fast_iso8601_utc_parse

### DIFF
--- a/libgnucash/engine/gnc-date.cpp
+++ b/libgnucash/engine/gnc-date.cpp
@@ -241,7 +241,7 @@ gnc_timegm (struct tm* time)
         *time = static_cast<struct tm>(gncdt);
         time->tm_sec -= gncdt.offset();
         normalize_struct_tm(time);
-#ifdef HAVE_STRUcT_TM_GMTOFF
+#ifdef HAVE_STRUCT_TM_GMTOFF
         time->tm_gmtoff = 0;
 #endif
         return static_cast<time64>(gncdt) - gncdt.offset();
@@ -409,7 +409,7 @@ time64CanonicalDayTime (time64 t)
     return gnc_mktime (&tm);
 }
 
-/* NB: month is 1-12, year is 0001 - 9999. */
+/* NB: month is 0-11, year is 0001 - 9999. */
 int gnc_date_get_last_mday (int month, int year)
 {
     static int last_day_of_month[12] =

--- a/libgnucash/engine/gnc-datetime.cpp
+++ b/libgnucash/engine/gnc-datetime.cpp
@@ -381,13 +381,12 @@ static std::optional<PTime>
 fast_iso8601_utc_parse (const char* str)
 {
     int32_t year, month, mday, hour, min, sec;
-
-    // parse the first 4 bytes into year
-    if (!str || !parse_chars_into_num (str, str + 4, year))
-        return {};
+    const size_t len = str ? strnlen (str, 26) : 0;
 
     // parse iso-8601 utc format "YYYY-MM-DD HH:MM:SS +0000"
-    if (str[4] == '-' &&
+    constexpr size_t expanded_iso_string_len = 25;
+    if (len == expanded_iso_string_len &&
+        parse_chars_into_num (str,      str +  4, year)  && str[ 4] == '-' &&
         parse_chars_into_num (str +  5, str +  7, month) && str[ 7] == '-' &&
         parse_chars_into_num (str +  8, str + 10, mday)  && str[10] == ' ' &&
         parse_chars_into_num (str + 11, str + 13, hour)  && str[13] == ':' &&
@@ -400,12 +399,14 @@ fast_iso8601_utc_parse (const char* str)
     }
 
     // parse compressed iso-8601 format "YYYYMMDDHHMMSS"
-    if (parse_chars_into_num (str +  4, str +  6, month) &&
+    constexpr size_t compact_iso_string_len = 14;
+    if (len == compact_iso_string_len &&
+        parse_chars_into_num (str,      str +  4, year)  &&
+        parse_chars_into_num (str +  4, str +  6, month) &&
         parse_chars_into_num (str +  6, str +  8, mday)  &&
         parse_chars_into_num (str +  8, str + 10, hour)  &&
         parse_chars_into_num (str + 10, str + 12, min)   &&
-        parse_chars_into_num (str + 12, str + 14, sec)   &&
-        str[14] == '\0')
+        parse_chars_into_num (str + 12, str + 14, sec))
     {
         return PTime (boost::gregorian::date (year, month, mday),
                       boost::posix_time::time_duration (hour, min, sec));


### PR DESCRIPTION
if `const char*` argument was 3 bytes or less.
also some comment and typo fixes.