### PR TITLE
Fix plugin page register gui leak

### DIFF
--- a/gnucash/gnome/gnc-plugin-page-register.cpp
+++ b/gnucash/gnome/gnc-plugin-page-register.cpp
@@ -1506,11 +1506,12 @@ gnc_plugin_page_register_destroy_widget (GncPluginPage* plugin_page)
 
     gtk_widget_hide (priv->widget);
 
-    if (GTK_IS_WIDGET(priv->gsr))
-        gtk_widget_destroy(GTK_WIDGET(priv->gsr));
-
     gnc_ledger_display_close (priv->ledger);
     priv->ledger = NULL;
+
+    g_object_unref(priv->widget);
+    priv->widget = NULL;
+
     LEAVE (" ");
 }
 


### PR DESCRIPTION
Added `g_object_unref()` of `priv->widget` to `gnc_plugin_page_register_destroy_widget()`.  Removed the `gtk_widget_destroy()` of `priv->psr` as `priv->psr` will be handled by the `g_object_unref()` of `priv->widget`.