### PR TITLE
fix plugin page register gui leak

### DIFF
--- a/gnucash/gnome/gnc-plugin-page-register.cpp
+++ b/gnucash/gnome/gnc-plugin-page-register.cpp
@@ -1254,6 +1254,7 @@ gnc_plugin_page_register_create_widget (GncPluginPage* plugin_page)
                              gnc_window_get_gtk_window (gnc_window),
                              numRows, priv->read_only);
     priv->gsr = (GNCSplitReg *)gsr;
+    g_object_ref(gsr);
 
     gtk_widget_show (gsr);
     gtk_box_pack_start (GTK_BOX (priv->widget), gsr, TRUE, TRUE, 0);
@@ -1506,11 +1507,12 @@ gnc_plugin_page_register_destroy_widget (GncPluginPage* plugin_page)
 
     gtk_widget_hide (priv->widget);
 
-    if (GTK_IS_WIDGET(priv->gsr))
-        gtk_widget_destroy(GTK_WIDGET(priv->gsr));
+    g_object_unref(priv->widget);
+    priv->widget = NULL;
 
     gnc_ledger_display_close (priv->ledger);
     priv->ledger = NULL;
+
     LEAVE (" ");
 }
 


### PR DESCRIPTION
Added `g_object_ref()` of `gsr` to `gnc_plugin_page_register_create_widget()` and `g_object_unref()` of `priv->widget` to `gnc_plugin_page_register_destroy_widget()`.  Also, removed the `gtk_widget_destroy()` of `priv->gsr `as `priv->gsr` will be handled by the `g_object_unref ()` of `priv->widget`.