### PR TITLE
Converted the gnc-html target to C++

### DIFF
--- a/gnucash/gnome/gnc-plugin-page-report.cpp
+++ b/gnucash/gnome/gnc-plugin-page-report.cpp
@@ -57,7 +57,7 @@
 #include "gnc-guile-utils.h"
 #include "gnc-html-history.h"
 #include "gnc-html.h"
-#include "gnc-html-factory.h"
+#include "gnc-html-factory.hpp"
 #include "gnc-file.h"
 #include "gnc-filepath-utils.h"
 #include "gnc-gtk-utils.h"

--- a/gnucash/html/CMakeLists.txt
+++ b/gnucash/html/CMakeLists.txt
@@ -3,32 +3,34 @@ set (html_HEADERS
   gnc-html-history.h
   gnc-html.h
   gnc-html-p.h
-  gnc-html-factory.h
+  gnc-html-factory.hpp
   gnc-html-extras.h
-  gnc-html-webkit-p.h
-  gnc-html-webkit.h
+  gnc-html-webkit-p.hpp
+  gnc-html-webkit.hpp
 )
 
-# Command to generate the swig-gnc-html.c wrapper file
-gnc_add_swig_guile_command (swig-gnc-html-c
-    SWIG_GNC_HTML_C swig-gnc-html.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/gnc-html.i "" "${html_HEADERS}"
+# Command to generate the swig-gnc-html.cpp wrapper file
+set(SWIG_ARGS "-c++" "-procdoc" "sw-gnc-option-doc" "-procdocformat" "plain")
+gnc_add_swig_guile_command (swig-gnc-html-cpp
+    SWIG_GNC_HTML_CPP swig-gnc-html.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gnc-html.i ${html_HEADERS}
 )
+unset(SWIG_ARGS)
 
 set (html_SOURCES
-  gnc-html.c
-  gnc-html-history.c
-  gnc-html-factory.c
+  gnc-html.cpp
+  gnc-html-history.cpp
+  gnc-html-factory.cpp
 )
 
 if (WEBKIT1)
-  list(APPEND html_HEADERS gnc-html-webkit1.h)
-  list(APPEND html_SOURCES gnc-html-webkit1.c)
-  set(html_EXTRA_DIST gnc-html-webkit2.h gnc-html-webkit2.c)
+  list(APPEND html_HEADERS gnc-html-webkit1.hpp)
+  list(APPEND html_SOURCES gnc-html-webkit1.cpp)
+  set(html_EXTRA_DIST gnc-html-webkit2.hpp gnc-html-webkit2.cpp)
 else ()
-  list(APPEND html_HEADERS gnc-html-webkit2.h)
-  list(APPEND html_SOURCES gnc-html-webkit2.c)
-  set(html_EXTRA_DIST gnc-html-webkit1.h gnc-html-webkit1.c)
+  list(APPEND html_HEADERS gnc-html-webkit2.hpp)
+  list(APPEND html_SOURCES gnc-html-webkit2.cpp)
+  set(html_EXTRA_DIST gnc-html-webkit1.hpp gnc-html-webkit1.cpp)
 endif()
 
 
@@ -48,7 +50,7 @@ set_dist_list(html_DIST CMakeLists.txt ${html_HEADERS} ${html_SOURCES} gnc-html.
 
 add_library (gnc-html
   ${html_SOURCES}
-  ${SWIG_GNC_HTML_C}
+  ${SWIG_GNC_HTML_CPP}
   ${html_HEADERS}
 )
 
@@ -72,7 +74,7 @@ if (APPLE)
   set_target_properties (gnc-html PROPERTIES INSTALL_NAME_DIR "${CMAKE_INSTALL_FULL_LIBDIR}/gnucash")
 endif()
 
-add_dependencies(gnc-html swig-gnc-html-c)
+add_dependencies(gnc-html swig-gnc-html-cpp)
 
 if (COVERAGE)
   add_coverage_target(gnc-html)

--- a/gnucash/html/gnc-html-extras.h
+++ b/gnucash/html/gnc-html-extras.h
@@ -27,8 +27,6 @@
 // gnc-html.i file.  The full gnc-html.h file can't be parsed because of the new
 // use of GObject
 
-typedef const char* URLType;
-
 #define URL_TYPE_FILE       "file"
 #define URL_TYPE_JUMP       "jump"
 #define URL_TYPE_HTTP       "http"
@@ -45,8 +43,21 @@ typedef const char* URLType;
 #define URL_TYPE_OTHER      "other"
 #define URL_TYPE_BUDGET     "budget"
 
-gchar* gnc_build_url( URLType type, const gchar* location, const gchar* label );
+typedef const char* URLType;
 
-gboolean gnc_html_engine_supports_css( void );
-
+#ifdef __cplusplus
+#define NOEXCEPT noexcept
+extern "C"
+{
+#else
+#define NOEXCEPT
 #endif
+
+gchar* gnc_build_url( URLType type, const gchar* location, const gchar* label ) NOEXCEPT;
+gboolean gnc_html_engine_supports_css( void ) NOEXCEPT;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // GNC_HTML_EXTRAS_H

--- a/gnucash/html/gnc-html-factory.cpp
+++ b/gnucash/html/gnc-html-factory.cpp
@@ -1,5 +1,6 @@
 /********************************************************************
- * gnc-html-webkit.h -- display html with gnc special tags          *
+ * gnc-html_factory.c -- Factory to create HTML component           *
+ *                                                                  *
  * Copyright (C) 2009 Phil Longstaff <plongstaff@rogers.com>        *
  *                                                                  *
  * This program is free software; you can redistribute it and/or    *
@@ -18,44 +19,30 @@
  * Free Software Foundation           Voice:  +1-617-542-5942       *
  * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652       *
  * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
-\********************************************************************/
+ ********************************************************************/
 
-#ifndef GNC_HTML_WEBKIT_H
-#define GNC_HTML_WEBKIT_H
+#include <config.h>
 
-#include <glib-object.h>
+#include <gtk/gtk.h>
+
 #include "gnc-html.h"
+#include "gnc-html-webkit.hpp"
+#include "qoflog.h"
+#include "gnc-engine.h"
 
-G_BEGIN_DECLS
+#include "gnc-html-factory.hpp"
 
-#define GNC_TYPE_HTML_WEBKIT       (gnc_html_webkit_get_type())
-#define GNC_HTML_WEBKIT(o)         (G_TYPE_CHECK_INSTANCE_CAST ((o), GNC_TYPE_HTML_WEBKIT, GncHtmlWebkit))
-#define GNC_HTML_WEBKIT_CLASS(k)   (G_TYPE_CHECK_CLASS_CAST((k), GNC_TYPE_HTML_WEBKIT, GncHtmlWebkitClass))
-#define GNC_IS_HTML_WEBKIT(o)      (G_TYPE_CHECK_INSTANCE_TYPE((o), GNC_TYPE_HTML_WEBKIT))
-#define GNC_IS_HTML_WEBKIT_CLASS(k)   (G_TYPE_CHECK_CLASS_TYPE((k), GNC_TYPE_HTML_WEBKIT))
-#define GNC_HTML_WEBKIT_GET_CLASS(o)  (G_TYPE_INSTANCE_GET_CLASS((o), GNC_TYPE_HTML_WEBKIT, GncHtmlWebkitClass))
+/* indicates the debugging module that this .o belongs to.  */
+G_GNUC_UNUSED static QofLogModule log_module = GNC_MOD_HTML;
 
-typedef struct _GncHtmlWebkit GncHtmlWebkit;
-typedef struct _GncHtmlWebkitClass GncHtmlWebkitClass;
-typedef struct _GncHtmlWebkitPrivate GncHtmlWebkitPrivate;
-
-struct _GncHtmlWebkit
+GncHtml*
+gnc_html_factory_create_html( void ) noexcept
 {
-    GncHtml parent_instance;
+    return gnc_html_webkit_new();
+}
 
-    /*< private >*/
-    GncHtmlWebkitPrivate* priv;
-};
-
-struct _GncHtmlWebkitClass
+gboolean
+gnc_html_engine_supports_css( void ) noexcept
 {
-    GncHtmlClass parent_class;
-};
-
-GType gnc_html_webkit_get_type( void );
-
-GncHtml* gnc_html_webkit_new( void );
-
-G_END_DECLS
-
-#endif
+    return TRUE;
+}

--- a/gnucash/html/gnc-html-factory.hpp
+++ b/gnucash/html/gnc-html-factory.hpp
@@ -1,5 +1,5 @@
 /********************************************************************
- * gnc-html-webkit.h -- display html with gnc special tags          *
+ * gnc-html-factory.hpp -- display html with gnc special tags         *
  * Copyright (C) 2009 Phil Longstaff <plongstaff@rogers.com>        *
  *                                                                  *
  * This program is free software; you can redistribute it and/or    *
@@ -20,45 +20,11 @@
  * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
 \********************************************************************/
 
-#ifndef GNC_HTML_WEBKIT_H
-#define GNC_HTML_WEBKIT_H
+#ifndef GNC_HTML_FACTORY_H
+#define GNC_HTML_FACTORY_H
 
-#include <glib-object.h>
 #include "gnc-html.h"
 
-G_BEGIN_DECLS
-
-#define GNC_TYPE_HTML_WEBKIT       (gnc_html_webkit_get_type())
-#define GNC_HTML_WEBKIT(o)         (G_TYPE_CHECK_INSTANCE_CAST ((o), GNC_TYPE_HTML_WEBKIT, GncHtmlWebkit))
-#define GNC_HTML_WEBKIT_CLASS(k)   (G_TYPE_CHECK_CLASS_CAST((k), GNC_TYPE_HTML_WEBKIT, GncHtmlWebkitClass))
-#define GNC_IS_HTML_WEBKIT(o)      (G_TYPE_CHECK_INSTANCE_TYPE((o), GNC_TYPE_HTML_WEBKIT))
-#define GNC_IS_HTML_WEBKIT_CLASS(k)   (G_TYPE_CHECK_CLASS_TYPE((k), GNC_TYPE_HTML_WEBKIT))
-#define GNC_HTML_WEBKIT_GET_CLASS(o)  (G_TYPE_INSTANCE_GET_CLASS((o), GNC_TYPE_HTML_WEBKIT, GncHtmlWebkitClass))
-
-typedef struct _GncHtmlWebkit GncHtmlWebkit;
-typedef struct _GncHtmlWebkitClass GncHtmlWebkitClass;
-typedef struct _GncHtmlWebkitPrivate GncHtmlWebkitPrivate;
-
-/** Key for saving the PDF-export directory in the print settings */
-#define GNC_GTK_PRINT_SETTINGS_EXPORT_DIR "gnc-pdf-export-directory"
-
-struct _GncHtmlWebkit
-{
-    GncHtml parent_instance;
-
-    /*< private >*/
-    GncHtmlWebkitPrivate* priv;
-};
-
-struct _GncHtmlWebkitClass
-{
-    GncHtmlClass parent_class;
-};
-
-GType gnc_html_webkit_get_type( void );
-
-GncHtml* gnc_html_webkit_new( void );
-
-G_END_DECLS
+extern "C" GncHtml* gnc_html_factory_create_html( void ) NOEXCEPT;
 
 #endif

--- a/gnucash/html/gnc-html-history.cpp
+++ b/gnucash/html/gnc-html-history.cpp
@@ -23,7 +23,7 @@
 #include <config.h>
 
 #include <gtk/gtk.h>
-#include <string.h>
+#include <string>
 
 #include "gnc-html-history.h"
 
@@ -43,12 +43,12 @@ struct _gnc_html_history
  ********************************************************************/
 
 gnc_html_history *
-gnc_html_history_new(void)
+gnc_html_history_new(void) noexcept
 {
     gnc_html_history * hist = g_new0(gnc_html_history, 1);
-    hist->nodes         = NULL;
-    hist->current_node  = NULL;
-    hist->last_node     = NULL;
+    hist->nodes         = nullptr;
+    hist->current_node  = nullptr;
+    hist->last_node     = nullptr;
     return hist;
 }
 
@@ -59,11 +59,9 @@ gnc_html_history_new(void)
  ********************************************************************/
 
 void
-gnc_html_history_destroy(gnc_html_history * hist)
+gnc_html_history_destroy(gnc_html_history * hist) noexcept
 {
-    GList * n;
-
-    for (n = hist->nodes; n ; n = n->next)
+    for (GList *n = hist->nodes; n ; n = n->next)
     {
         if (hist->destroy_cb)
         {
@@ -74,9 +72,9 @@ gnc_html_history_destroy(gnc_html_history * hist)
     }
     g_list_free(hist->nodes);
 
-    hist->nodes         = NULL;
-    hist->current_node  = NULL;
-    hist->last_node     = NULL;
+    hist->nodes         = nullptr;
+    hist->current_node  = nullptr;
+    hist->last_node     = nullptr;
     g_free(hist);
 }
 
@@ -87,7 +85,7 @@ gnc_html_history_destroy(gnc_html_history * hist)
 void
 gnc_html_history_set_node_destroy_cb(gnc_html_history * hist,
                                      gnc_html_history_destroy_cb cb,
-                                     gpointer cb_data)
+                                     gpointer cb_data) noexcept
 {
     hist->destroy_cb = cb;
     hist->destroy_cb_data = cb_data;
@@ -121,14 +119,11 @@ g_strcmp(char * a, char * b)
  ********************************************************************/
 void
 gnc_html_history_append(gnc_html_history * hist,
-                        gnc_html_history_node * node)
+                        gnc_html_history_node * node) noexcept
 {
-    GList * n;
-    gnc_html_history_node * hn;
-
     if (hist->current_node)
     {
-        hn = hist->current_node->data;
+        auto hn = static_cast<gnc_html_history_node *>(hist->current_node->data);
         if ((hn->type == node->type) &&
                 !g_strcmp(hn->location, node->location) &&
                 !g_strcmp(hn->label, node->label))
@@ -142,7 +137,7 @@ gnc_html_history_append(gnc_html_history * hist,
         }
 
         /* blow away the history after this point, if there is one */
-        for (n = hist->current_node->next; n; n = n->next)
+        for (GList *n = hist->current_node->next; n; n = n->next)
         {
             if (hist->destroy_cb)
             {
@@ -152,14 +147,14 @@ gnc_html_history_append(gnc_html_history * hist,
             gnc_html_history_node_destroy((gnc_html_history_node *)n->data);
         }
         g_list_free(hist->current_node->next);
-        hist->current_node->next = NULL;
+        hist->current_node->next = nullptr;
         hist->last_node = hist->current_node;
     }
 
-    n = g_list_alloc();
+    GList *n = g_list_alloc();
     n->data = (gpointer) node;
-    n->next = NULL;
-    n->prev = NULL;
+    n->next = nullptr;
+    n->prev = nullptr;
 
     if (hist->nodes && hist->last_node)
     {
@@ -187,11 +182,11 @@ gnc_html_history_append(gnc_html_history * hist,
  ********************************************************************/
 
 gnc_html_history_node *
-gnc_html_history_get_current(gnc_html_history * hist)
+gnc_html_history_get_current(gnc_html_history * hist) noexcept
 {
-    if (!hist || !(hist->current_node)) return NULL;
+    if (!hist || !(hist->current_node)) return nullptr;
 
-    return hist->current_node->data;
+    return static_cast<gnc_html_history_node *>(hist->current_node->data);
 }
 
 
@@ -200,11 +195,11 @@ gnc_html_history_get_current(gnc_html_history * hist)
  ********************************************************************/
 
 gnc_html_history_node *
-gnc_html_history_forward(gnc_html_history * hist)
+gnc_html_history_forward(gnc_html_history * hist) noexcept
 {
     if (!hist || !(hist->current_node))
     {
-        return NULL;
+        return nullptr;
     }
 
     if (hist->current_node->next)
@@ -212,7 +207,7 @@ gnc_html_history_forward(gnc_html_history * hist)
         hist->current_node = hist->current_node->next;
     }
 
-    return hist->current_node->data;
+    return static_cast<gnc_html_history_node *>(hist->current_node->data);
 }
 
 
@@ -221,12 +216,12 @@ gnc_html_history_forward(gnc_html_history * hist)
  ********************************************************************/
 
 gnc_html_history_node *
-gnc_html_history_back(gnc_html_history * hist)
+gnc_html_history_back(gnc_html_history * hist) noexcept
 {
 
     if (!hist || !(hist->current_node))
     {
-        return NULL;
+        return nullptr;
     }
 
     if (hist->current_node->prev)
@@ -234,7 +229,7 @@ gnc_html_history_back(gnc_html_history * hist)
         hist->current_node = hist->current_node->prev;
     }
 
-    return hist->current_node->data;
+    return static_cast<gnc_html_history_node *>(hist->current_node->data);
 }
 
 
@@ -244,7 +239,7 @@ gnc_html_history_back(gnc_html_history * hist)
  ********************************************************************/
 
 int
-gnc_html_history_back_p(gnc_html_history * hist)
+gnc_html_history_back_p(gnc_html_history * hist) noexcept
 {
     if (hist && hist->current_node && hist->current_node->prev)
     {
@@ -263,7 +258,7 @@ gnc_html_history_back_p(gnc_html_history * hist)
  ********************************************************************/
 
 int
-gnc_html_history_forward_p(gnc_html_history * hist)
+gnc_html_history_forward_p(gnc_html_history * hist) noexcept
 {
     if (hist && hist->current_node && hist->current_node->next)
     {
@@ -282,7 +277,7 @@ gnc_html_history_forward_p(gnc_html_history * hist)
 
 gnc_html_history_node *
 gnc_html_history_node_new(URLType type, const gchar * location,
-                          const gchar * label)
+                          const gchar * label) noexcept
 {
     gnc_html_history_node * rv = g_new0(gnc_html_history_node, 1);
 
@@ -298,7 +293,7 @@ gnc_html_history_node_new(URLType type, const gchar * location,
  ********************************************************************/
 
 void
-gnc_html_history_node_destroy(gnc_html_history_node * node)
+gnc_html_history_node_destroy(gnc_html_history_node * node) noexcept
 {
 
     /* free the url resources and cached text */
@@ -306,8 +301,8 @@ gnc_html_history_node_destroy(gnc_html_history_node * node)
     g_free(node->location);
     g_free(node->label);
 
-    node->location = NULL;
-    node->label    = NULL;
+    node->location = nullptr;
+    node->label    = nullptr;
 
     g_free(node);
 }

--- a/gnucash/html/gnc-html-history.h
+++ b/gnucash/html/gnc-html-history.h
@@ -28,8 +28,12 @@ typedef struct _gnc_html_history gnc_html_history;
 
 #include "gnc-html.h"
 
+typedef void (* gnc_html_history_destroy_cb)(gnc_html_history_node * n,
+        gpointer user_data);
+
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 struct _gnc_html_history_node
@@ -39,35 +43,28 @@ struct _gnc_html_history_node
     gchar   * label;
 };
 
-typedef void (* gnc_html_history_destroy_cb)(gnc_html_history_node * n,
-        gpointer user_data);
-
-gnc_html_history      * gnc_html_history_new(void);
-void                    gnc_html_history_destroy(gnc_html_history * hist);
+gnc_html_history      * gnc_html_history_new(void) NOEXCEPT;
+void                    gnc_html_history_destroy(gnc_html_history * hist) NOEXCEPT;
 
 void                    gnc_html_history_append(gnc_html_history * h,
-        gnc_html_history_node * n);
-gnc_html_history_node * gnc_html_history_get_current(gnc_html_history * h);
-gnc_html_history_node * gnc_html_history_forward(gnc_html_history * h);
-gnc_html_history_node * gnc_html_history_back(gnc_html_history * h);
-int                     gnc_html_history_forward_p(gnc_html_history * h);
-int                     gnc_html_history_back_p(gnc_html_history * h);
+        gnc_html_history_node * n) NOEXCEPT;
+gnc_html_history_node * gnc_html_history_get_current(gnc_html_history * h) NOEXCEPT;
+gnc_html_history_node * gnc_html_history_forward(gnc_html_history * h) NOEXCEPT;
+gnc_html_history_node * gnc_html_history_back(gnc_html_history * h) NOEXCEPT;
+int                     gnc_html_history_forward_p(gnc_html_history * h) NOEXCEPT;
+int                     gnc_html_history_back_p(gnc_html_history * h) NOEXCEPT;
 void  gnc_html_history_set_node_destroy_cb(gnc_html_history * h,
         gnc_html_history_destroy_cb cb,
-        gpointer cb_data);
+        gpointer cb_data) NOEXCEPT;
 
 gnc_html_history_node * gnc_html_history_node_new(URLType type,
         const gchar * location,
-        const gchar * label);
+        const gchar *label) NOEXCEPT;
 
-void                    gnc_html_history_node_destroy(gnc_html_history_node *
-        node);
+void gnc_html_history_node_destroy(gnc_html_history_node *node) NOEXCEPT;
 
 #ifdef __cplusplus
 }
 #endif
 
-
-#endif
-
-
+#endif // GNC_HTML_HISTORY_H

--- a/gnucash/html/gnc-html-webkit-p.hpp
+++ b/gnucash/html/gnc-html-webkit-p.hpp
@@ -1,5 +1,5 @@
 /********************************************************************
- * gnc-html-webkit-p.h -- display html with gnc special tags        *
+ * gnc-html-webkit-p.hpp -- display html with gnc special tags        *
  * Copyright (C) 2009 Phil Longstaff <plongstaff@rogers.com>        *
  *                                                                  *
  * This program is free software; you can redistribute it and/or    *
@@ -25,9 +25,9 @@
 
 #include "gnc-html-p.h"
 
-struct _GncHtmlWebkitPrivate
+struct GncHtmlWebkitPrivate
 {
-    struct _GncHtmlPrivate base;
+    GncHtmlPrivate base;
 
     WebKitWebView* web_view;				/* webkit widget itself */
     gchar* html_string;						/* html string being displayed */

--- a/gnucash/html/gnc-html-webkit.hpp
+++ b/gnucash/html/gnc-html-webkit.hpp
@@ -1,5 +1,5 @@
 /********************************************************************
- * gnc-html-webkit.h -- display html with gnc special tags          *
+ * gnc-html-webkit.hpp -- display html with gnc special tags          *
  * Copyright (C) 2017 John Ralls <jralls@ceridwen.us>               *
  *                                                                  *
  * This program is free software; you can redistribute it and/or    *
@@ -22,7 +22,7 @@
 
 #include <config.h>
 #ifdef WEBKIT1
-#include "gnc-html-webkit1.h"
+#include "gnc-html-webkit1.hpp"
 #else
-#include "gnc-html-webkit2.h"
+#include "gnc-html-webkit2.hpp"
 #endif

--- a/gnucash/html/gnc-html-webkit1.cpp
+++ b/gnucash/html/gnc-html-webkit1.cpp
@@ -31,9 +31,9 @@
 #include <glib/gstdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <stdlib.h>
-#include <string.h>
-#include <errno.h>
+#include <cstdlib>
+#include <string>
+#include <cerrno>
 #include <fcntl.h>
 #include <unistd.h>
 #include <regex.h>
@@ -45,7 +45,7 @@
 #include "gnc-gui-query.h"
 #include "gnc-engine.h"
 #include "gnc-html.h"
-#include "gnc-html-webkit.h"
+#include "gnc-html-webkit.hpp"
 #include "gnc-html-history.h"
 #include "print-session.h"
 
@@ -56,14 +56,10 @@ static void gnc_html_webkit_finalize( GObject* obj );
 
 #define GNC_HTML_WEBKIT_GET_PRIVATE(o) (GNC_HTML_WEBKIT(o)->priv)
 
-#include "gnc-html-webkit-p.h"
+#include "gnc-html-webkit-p.hpp"
 
 /* indicates the debugging module that this .o belongs to.  */
 static QofLogModule log_module = GNC_MOD_HTML;
-
-/* hashes for URLType -> protocol and protocol -> URLType */
-//extern GHashTable* gnc_html_type_to_proto_hash;
-//extern GHashTable* gnc_html_proto_to_type_hash;
 
 /* hashes an HTML <object classid="ID"> classid to a handler function */
 extern GHashTable* gnc_html_object_handlers;
@@ -121,33 +117,29 @@ static void impl_webkit_default_zoom_changed(gpointer prefs, gchar *pref, gpoint
 static void
 gnc_html_webkit_init( GncHtmlWebkit* self )
 {
-    GncHtmlWebkitPrivate* priv;
-    GncHtmlWebkitPrivate* new_priv;
-    GtkStyleContext *stylecontext;
-    WebKitWebSettings* webkit_settings = NULL;
-    const char* default_font_family = NULL;
-    PangoFontDescription *font_desc;
-    gdouble zoom = 1.0;
+    PangoFontDescription *font_desc = nullptr;
 
-    new_priv = g_realloc( GNC_HTML(self)->priv, sizeof(GncHtmlWebkitPrivate) );
-    priv = self->priv = new_priv;
-    GNC_HTML(self)->priv = (GncHtmlPrivate*)priv;
+    auto new_priv = static_cast<GncHtmlWebkitPrivate*>(
+        g_realloc( GNC_HTML(self)->priv, sizeof(GncHtmlWebkitPrivate) )
+    );
+    auto priv = self->priv = new_priv;
+    GNC_HTML(self)->priv = reinterpret_cast<GncHtmlPrivate*>(priv);
 
-    priv->html_string = NULL;
+    priv->html_string = nullptr;
     priv->web_view = WEBKIT_WEB_VIEW(webkit_web_view_new());
 
     /* Get the default font family from GtkStyleContext of a GtkWidget(priv->web_view). */
-    stylecontext = gtk_widget_get_style_context (GTK_WIDGET(priv->web_view));
+    auto stylecontext = gtk_widget_get_style_context (GTK_WIDGET(priv->web_view));
     gtk_style_context_get (stylecontext, gtk_widget_get_state_flags (GTK_WIDGET(priv->web_view)),
-                           "font", &font_desc, NULL);
+                           "font", &font_desc, nullptr);
 
-    default_font_family = pango_font_description_get_family (font_desc);
+    const char *default_font_family = pango_font_description_get_family (font_desc);
     pango_font_description_free (font_desc);
 
     /* Set default webkit settings */
-    webkit_settings = webkit_web_view_get_settings (priv->web_view);
-    g_object_set (G_OBJECT(webkit_settings), "default-encoding", "utf-8", NULL);
-    if (default_font_family == NULL)
+    auto webkit_settings = webkit_web_view_get_settings (priv->web_view);
+    g_object_set (G_OBJECT(webkit_settings), "default-encoding", "utf-8", nullptr);
+    if (default_font_family == nullptr)
     {
         PWARN("webkit_settings: Cannot get default font family.");
     }
@@ -155,11 +147,11 @@ gnc_html_webkit_init( GncHtmlWebkit* self )
     {
         g_object_set (G_OBJECT(webkit_settings),
                       "default-font-family", default_font_family,
-                      NULL);
+                      nullptr);
         PINFO("webkit_settings: Set default font to [%s]", default_font_family);
     }
     /* Scale everything up */
-    zoom = gnc_prefs_get_float (GNC_PREFS_GROUP_GENERAL_REPORT, GNC_PREF_RPT_DFLT_ZOOM);
+    gdouble zoom = gnc_prefs_get_float (GNC_PREFS_GROUP_GENERAL_REPORT, GNC_PREF_RPT_DFLT_ZOOM);
     webkit_web_view_set_full_content_zoom (priv->web_view, TRUE);
     webkit_web_view_set_zoom_level (priv->web_view, zoom);
 
@@ -209,8 +201,8 @@ gnc_html_webkit_init( GncHtmlWebkit* self )
 
     gnc_prefs_register_cb (GNC_PREFS_GROUP_GENERAL_REPORT,
             GNC_PREF_RPT_DFLT_ZOOM,
-            impl_webkit_default_zoom_changed,
-                           self);
+            reinterpret_cast<gpointer>(impl_webkit_default_zoom_changed),
+            self);
 
     LEAVE("retval %p", self);
 }
@@ -240,23 +232,25 @@ gnc_html_webkit_dispose( GObject* obj )
     GncHtmlWebkit* self = GNC_HTML_WEBKIT(obj);
     GncHtmlWebkitPrivate* priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
 
-    if ( priv->web_view != NULL )
+    if ( priv->web_view != nullptr )
     {
         gtk_container_remove( GTK_CONTAINER(priv->base.container),
                               GTK_WIDGET(priv->web_view) );
-        priv->web_view = NULL;
+        priv->web_view = nullptr;
     }
 
-    if ( priv->html_string != NULL )
+    if ( priv->html_string != nullptr )
     {
         g_free( priv->html_string );
-        priv->html_string = NULL;
+        priv->html_string = nullptr;
     }
 
     gnc_prefs_remove_cb_by_func (GNC_PREFS_GROUP_GENERAL_REPORT,
             GNC_PREF_RPT_DFLT_ZOOM,
-            impl_webkit_default_zoom_changed,
-                                 obj);
+            reinterpret_cast<gpointer>(
+                impl_webkit_default_zoom_changed
+            ),
+            obj);
 
     G_OBJECT_CLASS(gnc_html_webkit_parent_class)->dispose( obj );
 }
@@ -266,10 +260,7 @@ gnc_html_webkit_finalize( GObject* obj )
 {
     GncHtmlWebkit* self = GNC_HTML_WEBKIT(obj);
 
-//	if( self->priv != NULL ) {
-//		g_free( self->priv );
-    self->priv = NULL;
-//	}
+    self->priv = nullptr;
 
     G_OBJECT_CLASS(gnc_html_webkit_parent_class)->finalize( obj );
 }
@@ -279,15 +270,16 @@ gnc_html_webkit_finalize( GObject* obj )
 static char*
 extract_base_name(URLType type, const gchar* path)
 {
-    gchar       machine_rexp[] = "^(//[^/]*)/*(/.*)?$";
-    gchar       path_rexp[] = "^/*(.*)/+([^/]*)$";
+    constexpr gchar       machine_rexp[] = "^(//[^/]*)/*(/.*)?$";
+    constexpr gchar       path_rexp[] = "^/*(.*)/+([^/]*)$";
     regex_t    compiled_m, compiled_p;
-    regmatch_t match[4];
-    gchar       * machine = NULL, * location = NULL, * base = NULL;
-    gchar       * basename = NULL;
+    constexpr size_t MATCH_LEN = 4;
+    regmatch_t match[MATCH_LEN];
+    gchar       * machine = nullptr, * location = nullptr, * base = nullptr;
+    gchar       * basename = nullptr;
 
     DEBUG(" ");
-    if (!path) return NULL;
+    if (!path) return nullptr;
 
     regcomp(&compiled_m, machine_rexp, REG_EXTENDED);
     regcomp(&compiled_p, path_rexp, REG_EXTENDED);
@@ -299,7 +291,7 @@ extract_base_name(URLType type, const gchar* path)
 
         /* step 1: split the machine name away from the path
          * components */
-        if (!regexec(&compiled_m, path, 4, match, 0))
+        if (!regexec(&compiled_m, path, MATCH_LEN, match, 0))
         {
             /* $1 is the machine name */
             if (match[1].rm_so != -1)
@@ -332,7 +324,7 @@ extract_base_name(URLType type, const gchar* path)
             }
             else
             {
-                base = NULL;
+                base = nullptr;
             }
         }
     }
@@ -344,11 +336,11 @@ extract_base_name(URLType type, const gchar* path)
     {
         if (base && (strlen(base) > 0))
         {
-            basename = g_strconcat(machine, "/", base, "/", NULL);
+            basename = g_strconcat(machine, "/", base, "/", nullptr);
         }
         else
         {
-            basename = g_strconcat(machine, "/", NULL);
+            basename = g_strconcat(machine, "/", nullptr);
         }
     }
     else
@@ -359,7 +351,7 @@ extract_base_name(URLType type, const gchar* path)
         }
         else
         {
-            basename = NULL;
+            basename = nullptr;
         }
     }
 
@@ -391,9 +383,9 @@ handle_embedded_object( GncHtmlWebkit* self, gchar* html_str )
     gchar* object_tag;
     gchar* end_object_tag;
     gchar* object_contents;
-    gchar* html_str_start = NULL;
+    gchar* html_str_start = nullptr;
     gchar* html_str_middle;
-    gchar* html_str_result = NULL;
+    gchar* html_str_result = nullptr;
     gchar* classid_start;
     gchar* classid_end;
     gchar* classid_str;
@@ -409,7 +401,7 @@ handle_embedded_object( GncHtmlWebkit* self, gchar* html_str )
         classid_str = g_strndup( classid_start, (classid_end - classid_start) );
 
         end_object_tag = g_strstr_len( object_tag, -1, "</object>" );
-        if ( end_object_tag == NULL )
+        if ( end_object_tag == nullptr )
         {
             /*  Hmmm... no object end tag
                 Return the original html string because we can't properly parse it */
@@ -420,8 +412,9 @@ handle_embedded_object( GncHtmlWebkit* self, gchar* html_str )
         end_object_tag += strlen( "</object>" );
         object_contents = g_strndup( object_tag, (end_object_tag - object_tag) );
 
-        h = g_hash_table_lookup( gnc_html_object_handlers, classid_str );
-        if ( h != NULL )
+        const gpointer p = g_hash_table_lookup( gnc_html_object_handlers, classid_str );
+        h = reinterpret_cast<GncHTMLObjectCB>(p);
+        if ( h != nullptr )
         {
             (void)h( GNC_HTML(self), object_contents, &html_str_middle );
         }
@@ -433,9 +426,9 @@ handle_embedded_object( GncHtmlWebkit* self, gchar* html_str )
         html_str_start = html_str_result;
         new_chunk = g_strndup (remainder_str, (object_tag - remainder_str));
         if (!html_str_start)
-            html_str_result = g_strconcat (new_chunk, html_str_middle, NULL);
+            html_str_result = g_strconcat (new_chunk, html_str_middle, nullptr);
         else
-            html_str_result = g_strconcat (html_str_start, new_chunk, html_str_middle, NULL);
+            html_str_result = g_strconcat (html_str_start, new_chunk, html_str_middle, nullptr);
 
         g_free( html_str_start );
         g_free( new_chunk );
@@ -448,7 +441,7 @@ handle_embedded_object( GncHtmlWebkit* self, gchar* html_str )
     if (html_str_result)
     {
         html_str_start =  html_str_result;
-        html_str_result = g_strconcat (html_str_start, remainder_str, NULL);
+        html_str_result = g_strconcat (html_str_start, remainder_str, nullptr);
         g_free (html_str_start);
     }
     else
@@ -467,61 +460,60 @@ static gboolean
 load_to_stream( GncHtmlWebkit* self, URLType type,
                 const gchar* location, const gchar* label )
 {
-    gchar* fdata = NULL;
+    gchar* fdata = nullptr;
     int fdata_len = 0;
     GncHtmlWebkitPrivate* priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
 
     DEBUG( "type %s, location %s, label %s", type ? type : "(null)",
            location ? location : "(null)", label ? label : "(null)");
 
-    g_return_val_if_fail( self != NULL, FALSE );
+    g_return_val_if_fail( self != nullptr, FALSE );
 
-    if ( gnc_html_stream_handlers != NULL )
+    if ( gnc_html_stream_handlers != nullptr )
     {
-        GncHTMLStreamCB stream_handler;
-
-        stream_handler = g_hash_table_lookup( gnc_html_stream_handlers, type );
+        const gpointer p = g_hash_table_lookup( gnc_html_stream_handlers, type );
+        GncHTMLStreamCB stream_handler = reinterpret_cast<GncHTMLStreamCB>(p);
         if ( stream_handler )
         {
             GncHtml *weak_html = GNC_HTML(self);
-            gboolean ok;
 
             g_object_add_weak_pointer(G_OBJECT(self), (gpointer *)(&weak_html));
 
-            ok = stream_handler(location, &fdata, &fdata_len);
+            bool ok = stream_handler(location, &fdata, &fdata_len);
 
-              if (!weak_html) // will be NULL if self has been destroyed
-              {
-                  g_free (fdata);
-                  return FALSE;
-              }
-              else
-              {
-                  g_object_remove_weak_pointer(G_OBJECT(self),
-                                               (gpointer*)(&weak_html));
-              }
+            if (!weak_html) // will be nullptr if self has been destroyed
+            {
+                g_free (fdata);
+                return FALSE;
+            }
+            else
+            {
+                g_object_remove_weak_pointer(G_OBJECT(self),
+                                            (gpointer*)(&weak_html));
+            }
 
-            if (ok) {
+            if (ok)
+            {
                 fdata = fdata ? fdata : g_strdup("");
 
-            // Until webkitgtk supports download requests, look for "<object
-            // classid=" indicating the beginning of an embedded graph.  If
-            // found, handle it
-            if (g_strstr_len(fdata, -1, "<object classid=") != NULL) {
-              gchar *new_fdata;
-              new_fdata = handle_embedded_object(self, fdata);
-              g_free(fdata);
-              fdata = new_fdata;
-            }
+                // Until webkitgtk supports download requests, look for "<object
+                // classid=" indicating the beginning of an embedded graph.  If
+                // found, handle it
+                if (g_strstr_len(fdata, -1, "<object classid=") != nullptr)
+                {
+                    gchar *new_fdata;
+                    new_fdata = handle_embedded_object(self, fdata);
+                    g_free(fdata);
+                    fdata = new_fdata;
+                }
 
-            // Save a copy for export purposes
-            if (priv->html_string != NULL) {
-              g_free(priv->html_string);
-            }
-            priv->html_string = g_strdup(fdata);
-            impl_webkit_show_data(GNC_HTML(self), fdata, strlen(fdata));
-            //                webkit_web_view_load_html_string( priv->web_view,
-            //                fdata, BASE_URI_NAME );
+                // Save a copy for export purposes
+                if (priv->html_string != nullptr)
+                {
+                    g_free(priv->html_string);
+                }
+                priv->html_string = g_strdup(fdata);
+                impl_webkit_show_data(GNC_HTML(self), fdata, strlen(fdata));
             }
             else
             {
@@ -590,7 +582,7 @@ load_to_stream( GncHtmlWebkit* self, URLType type,
         }
 
     }
-    while ( FALSE );
+    while ( false );
     return TRUE;
 }
 
@@ -604,8 +596,8 @@ static void
 gnc_html_link_clicked_cb( GtkHTML* html, const gchar* url, gpointer data )
 {
     URLType type;
-    gchar* location = NULL;
-    gchar* label = NULL;
+    gchar* location = nullptr;
+    gchar* label = nullptr;
     GncHtmlWebkit* self = GNC_HTML_WEBKIT(data);
 
     DEBUG("Clicked %s", url);
@@ -626,9 +618,8 @@ webkit_navigation_requested_cb( WebKitWebView* web_view, WebKitWebFrame* frame,
                                 WebKitNetworkRequest* request,
                                 gpointer data )
 {
-    URLType type;
-    gchar* location = NULL;
-    gchar* label = NULL;
+    gchar* location = nullptr;
+    gchar* label = nullptr;
     GncHtmlWebkit* self = GNC_HTML_WEBKIT(data);
     const gchar* url = webkit_network_request_get_uri( request );
 
@@ -639,7 +630,7 @@ webkit_navigation_requested_cb( WebKitWebView* web_view, WebKitWebFrame* frame,
         return WEBKIT_NAVIGATION_RESPONSE_ACCEPT;
     }
 
-    type = gnc_html_parse_url( GNC_HTML(self), url, &location, &label );
+    URLType type = gnc_html_parse_url( GNC_HTML(self), url, &location, &label );
     if ( strcmp( type, "file" ) == 0 )
     {
         LEAVE("URI type is 'file'");
@@ -684,12 +675,11 @@ gnc_html_object_requested_cb( GtkHTML* html, GtkHTMLEmbedded* eb,
                               gpointer data )
 {
     GncHtmlWebkit* self = GNC_HTML_WEBKIT(data);
-    GncHTMLObjectCB h;
 
     DEBUG( " " );
     if ( !eb || !(eb->classid) || !gnc_html_object_handlers ) return FALSE;
 
-    h = g_hash_table_lookup( gnc_html_object_handlers, eb->classid );
+    auto h = g_hash_table_lookup( gnc_html_object_handlers, eb->classid );
     if ( h )
     {
         return h( GNC_HTML(self), eb, data );
@@ -731,12 +721,11 @@ gnc_html_set_base_cb( GtkHTML* gtkhtml, const gchar* base,
 {
     GncHtmlWebkit* self = GNC_HTML_WEBKIT(data);
     GncHtmlWebkitPrivate* priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
-    URLType type;
-    gchar* location = NULL;
-    gchar* label = NULL;
+    gchar* location = nullptr;
+    gchar* label = nullptr;
 
     DEBUG( "Setting base location to %s", base );
-    type = gnc_html_parse_url( GNC_HTML(self), base, &location, &label );
+    URLType type = gnc_html_parse_url( GNC_HTML(self), base, &location, &label );
 
     g_free( priv->base.base_location );
     g_free( label );
@@ -760,7 +749,7 @@ gnc_html_button_press_cb( GtkWidget* widg, GdkEventButton* event,
     GncHtmlWebkitPrivate* priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
 
     DEBUG( "Button Press" );
-    if ( priv->base.button_cb != NULL )
+    if ( priv->base.button_cb != nullptr )
     {
         (priv->base.button_cb)( GNC_HTML(self), event, priv->base.button_cb_data );
         return TRUE;
@@ -794,32 +783,27 @@ gnc_html_open_scm( GncHtmlWebkit* self, const gchar * location,
 static void
 impl_webkit_show_data( GncHtml* self, const gchar* data, int datalen )
 {
-    GncHtmlWebkitPrivate* priv;
 #define TEMPLATE_REPORT_FILE_NAME "gnc-report-XXXXXX.html"
-    int fd;
-    gchar* uri;
-    gchar *filename;
-
-    g_return_if_fail( self != NULL );
+    g_return_if_fail( self != nullptr );
     g_return_if_fail( GNC_IS_HTML_WEBKIT(self) );
 
     ENTER( "datalen %d, data %20.20s", datalen, data );
 
-    priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
+    auto priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
 
     /* Export the HTML to a file and load the file URI.   On Linux, this seems to get around some
        security problems (otherwise, it can complain that embedded images aren't permitted to be
        viewed because they are local resources).  On Windows, this allows the embedded images to
        be viewed (maybe for the same reason as on Linux, but I haven't found where it puts those
        messages. */
-    filename = g_build_filename(g_get_tmp_dir(), TEMPLATE_REPORT_FILE_NAME, (gchar *)NULL);
-    fd = g_mkstemp( filename );
+    gchar *filename = g_build_filename(g_get_tmp_dir(), TEMPLATE_REPORT_FILE_NAME, (gchar *)nullptr);
+    int fd = g_mkstemp( filename );
     impl_webkit_export_to_file( self, filename );
     close( fd );
 #ifdef G_OS_WIN32
-    uri = g_strdup_printf( "file:///%s", filename );
+    gchar *uri = g_strdup_printf( "file:///%s", filename );
 #else
-    uri = g_strdup_printf( "file://%s", filename );
+    gchar *uri = g_strdup_printf( "file://%s", filename );
 #endif
     g_free(filename);
     DEBUG("Loading uri '%s'", uri);
@@ -842,16 +826,15 @@ impl_webkit_show_url( GncHtml* self, URLType type,
                       const gchar* location, const gchar* label,
                       gboolean new_window_hint )
 {
-    GncHTMLUrlCB url_handler;
-    gboolean new_window;
-    GncHtmlWebkitPrivate* priv;
-    gboolean stream_loaded = FALSE;
+    GncHTMLUrlCB url_handler = nullptr;
+    bool new_window = false;
+    bool stream_loaded = false;
 
-    g_return_if_fail( self != NULL );
+    g_return_if_fail( self != nullptr );
     g_return_if_fail( GNC_IS_HTML_WEBKIT(self) );
-    g_return_if_fail( location != NULL );
+    g_return_if_fail( location != nullptr );
 
-    priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
+    auto priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
 
     /* make sure it's OK to show this URL type in this window */
     if ( new_window_hint == 0 )
@@ -860,14 +843,10 @@ impl_webkit_show_url( GncHtml* self, URLType type,
         {
             new_window = !((priv->base.urltype_cb)( type ));
         }
-        else
-        {
-            new_window = FALSE;
-        }
     }
     else
     {
-        new_window = TRUE;
+        new_window = true;
     }
 
     if ( !new_window )
@@ -877,28 +856,25 @@ impl_webkit_show_url( GncHtml* self, URLType type,
 
     if ( gnc_html_url_handlers )
     {
-        url_handler = g_hash_table_lookup( gnc_html_url_handlers, type );
-    }
-    else
-    {
-        url_handler = NULL;
+        url_handler = reinterpret_cast<GncHTMLUrlCB>(
+            g_hash_table_lookup( gnc_html_url_handlers, type )
+        );
     }
 
     if ( url_handler )
     {
         GNCURLResult result;
-        gboolean ok;
 
         result.load_to_stream = FALSE;
         result.url_type = type;
-        result.location = NULL;
-        result.label = NULL;
+        result.location = nullptr;
+        result.label = nullptr;
         result.base_type = URL_TYPE_FILE;
-        result.base_location = NULL;
-        result.error_message = NULL;
+        result.base_location = nullptr;
+        result.error_message = nullptr;
         result.parent = GTK_WINDOW (priv->base.parent);
 
-        ok = url_handler( location, label, new_window, &result );
+        bool ok = url_handler( location, label, new_window, &result );
         if ( !ok )
         {
             if ( result.error_message )
@@ -940,7 +916,7 @@ impl_webkit_show_url( GncHtml* self, URLType type,
                                             result.url_type,
                                             new_location, new_label );
 
-            if ( stream_loaded && priv->base.load_cb != NULL )
+            if ( stream_loaded && priv->base.load_cb != nullptr )
             {
                 priv->base.load_cb( GNC_HTML(self), result.url_type,
                                     new_location, new_label, priv->base.load_cb_data );
@@ -997,7 +973,7 @@ impl_webkit_show_url( GncHtml* self, URLType type,
 
             priv->base.base_type = type;
 
-            if ( priv->base.base_location != NULL ) g_free( priv->base.base_location );
+            if ( priv->base.base_location != nullptr ) g_free( priv->base.base_location );
             priv->base.base_location = extract_base_name( type, location );
 
             /* FIXME : handle new_window = 1 */
@@ -1015,7 +991,7 @@ impl_webkit_show_url( GncHtml* self, URLType type,
         PERR( "URLType %s not supported.", type );
     }
 
-    if ( stream_loaded && priv->base.load_cb != NULL )
+    if ( stream_loaded && priv->base.load_cb != nullptr )
     {
         (priv->base.load_cb)( GNC_HTML(self), type, location, label, priv->base.load_cb_data );
     }
@@ -1034,7 +1010,7 @@ impl_webkit_reload( GncHtml* self, gboolean force_rebuild )
 {
     GncHtmlWebkitPrivate* priv;
 
-    g_return_if_fail( self != NULL );
+    g_return_if_fail( self != nullptr );
     g_return_if_fail( GNC_IS_HTML_WEBKIT(self) );
 
     priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
@@ -1042,7 +1018,7 @@ impl_webkit_reload( GncHtml* self, gboolean force_rebuild )
     if ( force_rebuild )
     {
         gnc_html_history_node *n = gnc_html_history_get_current( priv->base.history );
-        if ( n != NULL )
+        if ( n != nullptr )
             gnc_html_show_url( self, n->type, n->location, n->label, 0 );
     }
     else
@@ -1058,7 +1034,9 @@ impl_webkit_reload( GncHtml* self, gboolean force_rebuild )
 GncHtml*
 gnc_html_webkit_new( void )
 {
-    GncHtmlWebkit* self = g_object_new( GNC_TYPE_HTML_WEBKIT, NULL );
+    GncHtmlWebkit* self = static_cast<GncHtmlWebkit *>(
+        g_object_new( GNC_TYPE_HTML_WEBKIT, nullptr )
+    );
     return GNC_HTML(self);
 }
 
@@ -1080,15 +1058,12 @@ impl_webkit_cancel( GncHtml* self )
 {
     GncHtmlWebkitPrivate* priv;
 
-    g_return_if_fail( self != NULL );
+    g_return_if_fail( self != nullptr );
     g_return_if_fail( GNC_IS_HTML_WEBKIT(self) );
 
     priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
 
-    /* remove our own references to requests */
-    //gnc_http_cancel_requests( priv->http );
-
-    g_hash_table_foreach_remove( priv->base.request_info, webkit_cancel_helper, NULL );
+    g_hash_table_foreach_remove( priv->base.request_info, webkit_cancel_helper, nullptr );
 }
 
 static void
@@ -1096,7 +1071,7 @@ impl_webkit_copy_to_clipboard( GncHtml* self )
 {
     GncHtmlWebkitPrivate* priv;
 
-    g_return_if_fail( self != NULL );
+    g_return_if_fail( self != nullptr );
     g_return_if_fail( GNC_IS_HTML_WEBKIT(self) );
 
     priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
@@ -1119,17 +1094,17 @@ impl_webkit_export_to_file( GncHtml* self, const char *filepath )
     FILE *fh;
     GncHtmlWebkitPrivate* priv;
 
-    g_return_val_if_fail( self != NULL, FALSE );
+    g_return_val_if_fail( self != nullptr, FALSE );
     g_return_val_if_fail( GNC_IS_HTML_WEBKIT(self), FALSE );
-    g_return_val_if_fail( filepath != NULL, FALSE );
+    g_return_val_if_fail( filepath != nullptr, FALSE );
 
     priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
-    if ( priv->html_string == NULL )
+    if ( priv->html_string == nullptr )
     {
         return FALSE;
     }
     fh = g_fopen( filepath, "w" );
-    if ( fh != NULL )
+    if ( fh != nullptr )
     {
         gint written;
         gint len = strlen( priv->html_string );
@@ -1165,11 +1140,11 @@ impl_webkit_export_to_file( GncHtml* self, const char *filepath )
 static void
 impl_webkit_print( GncHtml* self, const gchar* jobname, gboolean export_pdf )
 {
-    gchar *export_filename = NULL;
+    gchar *export_filename = nullptr;
     GncHtmlWebkitPrivate* priv;
     WebKitWebFrame* frame;
     GtkPrintOperation* op = gtk_print_operation_new();
-    GError* error = NULL;
+    GError* error = nullptr;
     GtkPrintSettings *print_settings;
 
     priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
@@ -1193,7 +1168,7 @@ impl_webkit_print( GncHtml* self, const gchar* jobname, gboolean export_pdf )
     }
     else
     {
-        export_filename = g_strconcat(jobname, ".pdf", NULL);
+        export_filename = g_strconcat(jobname, ".pdf", nullptr);
     }
 
     // Two different modes of operation. Either export to PDF, or run the
@@ -1202,18 +1177,18 @@ impl_webkit_print( GncHtml* self, const gchar* jobname, gboolean export_pdf )
     {
         GtkWidget *dialog;
         gint result;
-        gchar *export_dirname = NULL;
+        gchar *export_dirname = nullptr;
         gchar* basename;
 
         // Before we save the PDF file, we always ask the user for the export
         // file name. We will store the chosen directory in the gtk print settings
         // as well.
         dialog = gtk_file_chooser_dialog_new (_("Export to PDF File"),
-                                              NULL,
+                                              nullptr,
                                               GTK_FILE_CHOOSER_ACTION_SAVE,
                                               _("_Cancel"), GTK_RESPONSE_CANCEL,
                                               _("_Save"), GTK_RESPONSE_ACCEPT,
-                                              NULL);
+                                              nullptr);
         gtk_file_chooser_set_do_overwrite_confirmation (GTK_FILE_CHOOSER (dialog), TRUE);
 
         // Does the jobname look like a valid full file path?
@@ -1223,12 +1198,15 @@ impl_webkit_print( GncHtml* self, const gchar* jobname, gboolean export_pdf )
             gchar *tmp_basename;
             gchar *tmp_dirname = g_path_get_dirname(jobname);
 
-            if (g_file_test(tmp_dirname, G_FILE_TEST_EXISTS | G_FILE_TEST_IS_DIR))
+            if (g_file_test(tmp_dirname,
+                static_cast<GFileTest>(
+                    G_FILE_TEST_EXISTS | G_FILE_TEST_IS_DIR
+                )))
             {
                 // Yes, the jobname starts with a directory name that actually
                 // exists. Hence we use this as output directory.
                 export_dirname = tmp_dirname;
-                tmp_dirname = NULL;
+                tmp_dirname = nullptr;
 
                 // As the prefix part of the "jobname" is the directory path, we
                 // need to extract the suffix part for the filename.
@@ -1249,7 +1227,10 @@ impl_webkit_print( GncHtml* self, const gchar* jobname, gboolean export_pdf )
             const char* tmp_dirname = gtk_print_settings_get(print_settings,
                                       GNC_GTK_PRINT_SETTINGS_EXPORT_DIR);
             // Only use the directory subsequently if it exists.
-            if (g_file_test(tmp_dirname, G_FILE_TEST_EXISTS | G_FILE_TEST_IS_DIR))
+            if (g_file_test(tmp_dirname,
+                static_cast<GFileTest>(
+                    G_FILE_TEST_EXISTS | G_FILE_TEST_IS_DIR
+                )))
             {
                 export_dirname = g_strdup(tmp_dirname);
             }
@@ -1278,7 +1259,10 @@ impl_webkit_print( GncHtml* self, const gchar* jobname, gboolean export_pdf )
 
             // Store the directory part of the file for later
             dirname = g_path_get_dirname(export_filename);
-            if (g_file_test(dirname, G_FILE_TEST_EXISTS | G_FILE_TEST_IS_DIR))
+            if (g_file_test(dirname,
+                static_cast<GFileTest>(
+                    G_FILE_TEST_EXISTS | G_FILE_TEST_IS_DIR
+                )))
             {
                 gtk_print_settings_set(print_settings, GNC_GTK_PRINT_SETTINGS_EXPORT_DIR, dirname);
             }
@@ -1312,7 +1296,7 @@ impl_webkit_print( GncHtml* self, const gchar* jobname, gboolean export_pdf )
             gchar *dirname = g_path_get_dirname(olduri);
             gchar *newuri = (g_strcmp0(dirname, ".") == 0)
                             ? g_strdup(export_filename)
-                            : g_build_filename(dirname, export_filename, NULL);
+                            : g_build_filename(dirname, export_filename, nullptr);
             //g_warning("olduri=%s newuri=%s", olduri, newuri);
 
             // This function expects the full filename including protocol, path, and name
@@ -1331,17 +1315,17 @@ impl_webkit_print( GncHtml* self, const gchar* jobname, gboolean export_pdf )
         webkit_web_frame_print_full( frame, op, GTK_PRINT_OPERATION_ACTION_PRINT_DIALOG, &error );
     }
 
-    if ( error != NULL )
+    if ( error != nullptr )
     {
         GtkWidget* window = gtk_widget_get_toplevel( GTK_WIDGET(priv->web_view) );
-        GtkWidget* dialog = gtk_message_dialog_new( gtk_widget_is_toplevel(window) ? GTK_WINDOW(window) : NULL,
+        GtkWidget* dialog = gtk_message_dialog_new( gtk_widget_is_toplevel(window) ? GTK_WINDOW(window) : nullptr,
                             GTK_DIALOG_DESTROY_WITH_PARENT,
                             GTK_MESSAGE_ERROR,
                             GTK_BUTTONS_CLOSE,
                             "%s", error->message );
         g_error_free( error );
 
-        g_signal_connect( dialog, "response", G_CALLBACK(gtk_widget_destroy), NULL);
+        g_signal_connect( dialog, "response", G_CALLBACK(gtk_widget_destroy), nullptr);
         gtk_widget_show( dialog );
     }
 
@@ -1356,7 +1340,7 @@ impl_webkit_set_parent( GncHtml* self, GtkWindow* parent )
 {
     GncHtmlWebkitPrivate* priv;
 
-    g_return_if_fail( self != NULL );
+    g_return_if_fail( self != nullptr );
     g_return_if_fail( GNC_IS_HTML_WEBKIT(self) );
 
     priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
@@ -1370,7 +1354,7 @@ impl_webkit_default_zoom_changed(gpointer prefs, gchar *pref, gpointer user_data
     GncHtmlWebkit* self = GNC_HTML_WEBKIT(user_data);
     GncHtmlWebkitPrivate* priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
 
-    g_return_if_fail(user_data != NULL);
+    g_return_if_fail(user_data != nullptr);
 
     zoom = gnc_prefs_get_float (GNC_PREFS_GROUP_GENERAL_REPORT, GNC_PREF_RPT_DFLT_ZOOM);
     webkit_web_view_set_zoom_level (priv->web_view, zoom);

--- a/gnucash/html/gnc-html-webkit1.hpp
+++ b/gnucash/html/gnc-html-webkit1.hpp
@@ -1,6 +1,5 @@
 /********************************************************************
- * gnc-html_factory.c -- Factory to create HTML component           *
- *                                                                  *
+ * gnc-html-webkit.hpp -- display html with gnc special tags          *
  * Copyright (C) 2009 Phil Longstaff <plongstaff@rogers.com>        *
  *                                                                  *
  * This program is free software; you can redistribute it and/or    *
@@ -19,29 +18,41 @@
  * Free Software Foundation           Voice:  +1-617-542-5942       *
  * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652       *
  * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
- ********************************************************************/
+\********************************************************************/
 
-#include <config.h>
+#ifndef GNC_HTML_WEBKIT_H
+#define GNC_HTML_WEBKIT_H
 
-#include <gtk/gtk.h>
-
+#include <glib-object.h>
 #include "gnc-html.h"
-#include "gnc-html-webkit.h"
-#include "qoflog.h"
-#include "gnc-engine.h"
 
-#include "gnc-html-factory.h"
+G_BEGIN_DECLS
 
-/* indicates the debugging module that this .o belongs to.  */
-G_GNUC_UNUSED static QofLogModule log_module = GNC_MOD_HTML;
+#define GNC_TYPE_HTML_WEBKIT       (gnc_html_webkit_get_type())
+#define GNC_HTML_WEBKIT(o)         (G_TYPE_CHECK_INSTANCE_CAST ((o), GNC_TYPE_HTML_WEBKIT, GncHtmlWebkit))
+#define GNC_HTML_WEBKIT_CLASS(k)   (G_TYPE_CHECK_CLASS_CAST((k), GNC_TYPE_HTML_WEBKIT, GncHtmlWebkitClass))
+#define GNC_IS_HTML_WEBKIT(o)      (G_TYPE_CHECK_INSTANCE_TYPE((o), GNC_TYPE_HTML_WEBKIT))
+#define GNC_IS_HTML_WEBKIT_CLASS(k)   (G_TYPE_CHECK_CLASS_TYPE((k), GNC_TYPE_HTML_WEBKIT))
+#define GNC_HTML_WEBKIT_GET_CLASS(o)  (G_TYPE_INSTANCE_GET_CLASS((o), GNC_TYPE_HTML_WEBKIT, GncHtmlWebkitClass))
 
-GncHtml* gnc_html_factory_create_html( void )
+struct GncHtmlWebkitPrivate;
+
+struct GncHtmlWebkit
 {
-    return gnc_html_webkit_new();
-}
+    GncHtml parent_instance;
 
-gboolean
-gnc_html_engine_supports_css( void )
+    /*< private >*/
+    GncHtmlWebkitPrivate* priv;
+};
+
+struct GncHtmlWebkitClass
 {
-    return TRUE;
-}
+    GncHtmlClass parent_class;
+};
+
+extern "C" GType gnc_html_webkit_get_type( void );
+extern "C" GncHtml* gnc_html_webkit_new( void );
+
+G_END_DECLS
+
+#endif // GNC_HTML_WEBKIT_H

--- a/gnucash/html/gnc-html-webkit2.cpp
+++ b/gnucash/html/gnc-html-webkit2.cpp
@@ -39,9 +39,9 @@
 #include <glib/gstdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <stdlib.h>
+#include <cstdlib>
 #include <string.h>
-#include <errno.h>
+#include <cerrno>
 #include <fcntl.h>
 #include <unistd.h>
 #include <regex.h>
@@ -53,7 +53,7 @@
 #include "gnc-gui-query.h"
 #include "gnc-engine.h"
 #include "gnc-html.h"
-#include "gnc-html-webkit.h"
+#include "gnc-html-webkit.hpp"
 #include "gnc-html-history.h"
 #include "print-session.h"
 
@@ -65,14 +65,10 @@ static void gnc_html_webkit_finalize( GObject* obj );
 
 #define GNC_HTML_WEBKIT_GET_PRIVATE(o) (GNC_HTML_WEBKIT(o)->priv)
 
-#include "gnc-html-webkit-p.h"
+#include "gnc-html-webkit-p.hpp"
 
 /* indicates the debugging module that this .o belongs to.  */
 static QofLogModule log_module = GNC_MOD_HTML;
-
-/* hashes for URLType -> protocol and protocol -> URLType */
-//extern GHashTable* gnc_html_type_to_proto_hash;
-//extern GHashTable* gnc_html_proto_to_type_hash;
 
 /* hashes an HTML <object classid="ID"> classid to a handler function */
 extern GHashTable* gnc_html_object_handlers;
@@ -125,8 +121,8 @@ static GtkWidget*
 gnc_html_webkit_webview_new (void)
 {
      GtkWidget *view = webkit_web_view_new ();
-     WebKitSettings *webkit_settings = NULL;
-     const char *default_font_family = NULL;
+     WebKitSettings *webkit_settings = nullptr;
+     const char *default_font_family = nullptr;
      GtkStyleContext *style = gtk_widget_get_style_context (view);
      GValue val = G_VALUE_INIT;
      GtkStateFlags state = gtk_style_context_get_state (style);
@@ -151,11 +147,11 @@ gnc_html_webkit_webview_new (void)
                    "enable-site-specific-quirks", FALSE,
                    "enable-xss-auditor", FALSE,
                    "enable-developer-extras", TRUE,
-                   NULL);
-     if (default_font_family != NULL)
+                   nullptr);
+     if (default_font_family != nullptr)
      {
           g_object_set (G_OBJECT (webkit_settings),
-              "default-font-family", default_font_family, NULL);
+              "default-font-family", default_font_family, nullptr);
      }
      g_value_unset (&val);
      return view;
@@ -164,20 +160,17 @@ gnc_html_webkit_webview_new (void)
 static void
 gnc_html_webkit_init( GncHtmlWebkit* self )
 {
-     GncHtmlWebkitPrivate* priv;
-     GncHtmlWebkitPrivate* new_priv;
-     gdouble zoom = 1.0;
-
-     new_priv = g_realloc (GNC_HTML(self)->priv, sizeof(GncHtmlWebkitPrivate));
-     priv = self->priv = new_priv;
+     const gpointer p = g_realloc (GNC_HTML(self)->priv, sizeof(GncHtmlWebkitPrivate));
+     auto new_priv = reinterpret_cast<GncHtmlWebkitPrivate *>(p);
+     auto priv = self->priv = new_priv;
      GNC_HTML(self)->priv = (GncHtmlPrivate*)priv;
 
-     priv->html_string = NULL;
+     priv->html_string = nullptr;
      priv->web_view = WEBKIT_WEB_VIEW (gnc_html_webkit_webview_new ());
 
 
      /* Scale everything up */
-     zoom = gnc_prefs_get_float (GNC_PREFS_GROUP_GENERAL_REPORT,
+     gdouble zoom = gnc_prefs_get_float (GNC_PREFS_GROUP_GENERAL_REPORT,
                  GNC_PREF_RPT_DFLT_ZOOM);
      webkit_web_view_set_zoom_level (priv->web_view, zoom);
 
@@ -208,7 +201,7 @@ gnc_html_webkit_init( GncHtmlWebkit* self )
                        self);
      gnc_prefs_register_cb (GNC_PREFS_GROUP_GENERAL_REPORT,
                             GNC_PREF_RPT_DFLT_ZOOM,
-                            impl_webkit_default_zoom_changed,
+                            reinterpret_cast<gpointer>(impl_webkit_default_zoom_changed),
                             self);
 
      LEAVE("retval %p", self);
@@ -239,23 +232,23 @@ gnc_html_webkit_dispose( GObject* obj )
      GncHtmlWebkit* self = GNC_HTML_WEBKIT(obj);
      GncHtmlWebkitPrivate* priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
 
-     if ( priv->web_view != NULL )
+     if ( priv->web_view != nullptr )
      {
           gtk_container_remove (GTK_CONTAINER(priv->base.container),
                                 GTK_WIDGET(priv->web_view));
 
-          priv->web_view = NULL;
+          priv->web_view = nullptr;
      }
 
-     if ( priv->html_string != NULL )
+     if ( priv->html_string != nullptr )
      {
           g_free( priv->html_string );
-          priv->html_string = NULL;
+          priv->html_string = nullptr;
      }
 
      gnc_prefs_remove_cb_by_func (GNC_PREFS_GROUP_GENERAL_REPORT,
                                   GNC_PREF_RPT_DFLT_ZOOM,
-                                  impl_webkit_default_zoom_changed,
+                                  reinterpret_cast<gpointer>(impl_webkit_default_zoom_changed),
                                   obj);
 
      G_OBJECT_CLASS(gnc_html_webkit_parent_class)->dispose( obj );
@@ -266,10 +259,7 @@ gnc_html_webkit_finalize( GObject* obj )
 {
      GncHtmlWebkit* self = GNC_HTML_WEBKIT(obj);
 
-//      if( self->priv != NULL ) {
-//              g_free( self->priv );
-     self->priv = NULL;
-//      }
+     self->priv = nullptr;
 
      G_OBJECT_CLASS(gnc_html_webkit_parent_class)->finalize( obj );
 }
@@ -279,15 +269,16 @@ gnc_html_webkit_finalize( GObject* obj )
 static char*
 extract_base_name(URLType type, const gchar* path)
 {
-     gchar       machine_rexp[] = "^(//[^/]*)/*(/.*)?$";
-     gchar       path_rexp[] = "^/*(.*)/+([^/]*)$";
+     constexpr gchar       machine_rexp[] = "^(//[^/]*)/*(/.*)?$";
+     constexpr gchar       path_rexp[] = "^/*(.*)/+([^/]*)$";
      regex_t     compiled_m, compiled_p;
-     regmatch_t  match[4];
-     gchar       * machine = NULL, * location = NULL, * base = NULL;
-     gchar       * basename = NULL;
+     constexpr size_t MATCH_LEN = 4;
+     regmatch_t  match[MATCH_LEN];
+     gchar       * machine = nullptr, * location = nullptr, * base = nullptr;
+     gchar       * basename = nullptr;
 
      DEBUG(" ");
-     if (!path) return NULL;
+     if (!path) return nullptr;
 
      regcomp(&compiled_m, machine_rexp, REG_EXTENDED);
      regcomp(&compiled_p, path_rexp, REG_EXTENDED);
@@ -299,7 +290,7 @@ extract_base_name(URLType type, const gchar* path)
 
           /* step 1: split the machine name away from the path
            * components */
-          if (!regexec(&compiled_m, path, 4, match, 0))
+          if (!regexec(&compiled_m, path, MATCH_LEN, match, 0))
           {
                /* $1 is the machine name */
                if (match[1].rm_so != -1)
@@ -329,10 +320,6 @@ extract_base_name(URLType type, const gchar* path)
                     base = g_strndup(location + match[1].rm_so,
                                      match[1].rm_eo - match[1].rm_so);
                }
-               else
-               {
-                    base = NULL;
-               }
           }
      }
 
@@ -343,11 +330,11 @@ extract_base_name(URLType type, const gchar* path)
      {
           if (base && (strlen(base) > 0))
           {
-               basename = g_strconcat(machine, "/", base, "/", NULL);
+               basename = g_strconcat(machine, "/", base, "/", nullptr);
           }
           else
           {
-               basename = g_strconcat(machine, "/", NULL);
+               basename = g_strconcat(machine, "/", nullptr);
           }
      }
      else
@@ -355,10 +342,6 @@ extract_base_name(URLType type, const gchar* path)
           if (base && (strlen(base) > 0))
           {
                basename = g_strdup(base);
-          }
-          else
-          {
-               basename = NULL;
           }
      }
 
@@ -390,9 +373,9 @@ handle_embedded_object( GncHtmlWebkit* self, gchar* html_str )
      gchar* object_tag;
      gchar* end_object_tag;
      gchar* object_contents;
-     gchar* html_str_start = NULL;
+     gchar* html_str_start = nullptr;
      gchar* html_str_middle;
-     gchar* html_str_result = NULL;
+     gchar* html_str_result = nullptr;
      gchar* classid_start;
      gchar* classid_end;
      gchar* classid_str;
@@ -408,7 +391,7 @@ handle_embedded_object( GncHtmlWebkit* self, gchar* html_str )
           classid_str = g_strndup( classid_start, (classid_end - classid_start) );
 
           end_object_tag = g_strstr_len( object_tag, -1, "</object>" );
-          if ( end_object_tag == NULL )
+          if ( end_object_tag == nullptr )
           {
                /*  Hmmm... no object end tag
                    Return the original html string because we can't properly parse it */
@@ -419,8 +402,9 @@ handle_embedded_object( GncHtmlWebkit* self, gchar* html_str )
           end_object_tag += strlen( "</object>" );
           object_contents = g_strndup( object_tag, (end_object_tag - object_tag) );
 
-          h = g_hash_table_lookup( gnc_html_object_handlers, classid_str );
-          if ( h != NULL )
+          const gpointer p = g_hash_table_lookup( gnc_html_object_handlers, classid_str );
+          h = reinterpret_cast<GncHTMLObjectCB>(p);
+          if ( h != nullptr )
           {
                (void)h( GNC_HTML(self), object_contents, &html_str_middle );
           }
@@ -432,9 +416,9 @@ handle_embedded_object( GncHtmlWebkit* self, gchar* html_str )
           html_str_start = html_str_result;
           new_chunk = g_strndup (remainder_str, (object_tag - remainder_str));
           if (!html_str_start)
-               html_str_result = g_strconcat (new_chunk, html_str_middle, NULL);
+               html_str_result = g_strconcat (new_chunk, html_str_middle, nullptr);
           else
-               html_str_result = g_strconcat (html_str_start, new_chunk, html_str_middle, NULL);
+               html_str_result = g_strconcat (html_str_start, new_chunk, html_str_middle, nullptr);
 
           g_free( html_str_start );
           g_free( new_chunk );
@@ -447,7 +431,7 @@ handle_embedded_object( GncHtmlWebkit* self, gchar* html_str )
      if (html_str_result)
      {
           html_str_start =  html_str_result;
-          html_str_result = g_strconcat (html_str_start, remainder_str, NULL);
+          html_str_result = g_strconcat (html_str_start, remainder_str, nullptr);
           g_free (html_str_start);
      }
      else
@@ -466,30 +450,28 @@ static gboolean
 load_to_stream( GncHtmlWebkit* self, URLType type,
                 const gchar* location, const gchar* label )
 {
-     gchar* fdata = NULL;
+     gchar* fdata = nullptr;
      int fdata_len = 0;
      GncHtmlWebkitPrivate* priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
 
      DEBUG( "type %s, location %s, label %s", type ? type : "(null)",
             location ? location : "(null)", label ? label : "(null)");
 
-     g_return_val_if_fail( self != NULL, FALSE );
+     g_return_val_if_fail( self != nullptr, FALSE );
 
-     if ( gnc_html_stream_handlers != NULL )
+     if ( gnc_html_stream_handlers != nullptr )
      {
-          GncHTMLStreamCB stream_handler;
-
-          stream_handler = g_hash_table_lookup( gnc_html_stream_handlers, type );
+          const gpointer p = g_hash_table_lookup( gnc_html_stream_handlers, type );
+          GncHTMLStreamCB stream_handler = reinterpret_cast<GncHTMLStreamCB>(p);
           if ( stream_handler )
           {
               GncHtml *weak_html = GNC_HTML(self);
-              gboolean ok;
 
               g_object_add_weak_pointer(G_OBJECT(self),
                                         (gpointer*)(&weak_html));
-              ok = stream_handler( location, &fdata, &fdata_len );
+              bool ok = stream_handler( location, &fdata, &fdata_len );
 
-              if (!weak_html) // will be NULL if self has been destroyed
+              if (!weak_html) // will be nullptr if self has been destroyed
               {
                   g_free (fdata);
                   return FALSE;
@@ -508,23 +490,20 @@ load_to_stream( GncHtmlWebkit* self, URLType type,
                     // look for "<object classid=" indicating the
                     // beginning of an embedded graph.  If found,
                     // handle it
-                    if ( g_strstr_len( fdata, -1, "<object classid=" ) != NULL )
+                    if ( g_strstr_len( fdata, -1, "<object classid=" ) != nullptr )
                     {
-                         gchar* new_fdata;
-                         new_fdata = handle_embedded_object( self, fdata );
+                         gchar *new_fdata = handle_embedded_object( self, fdata );
                          g_free( fdata );
                          fdata = new_fdata;
                     }
 
                     // Save a copy for export purposes
-                    if ( priv->html_string != NULL )
+                    if ( priv->html_string != nullptr )
                     {
                          g_free( priv->html_string );
                     }
                     priv->html_string = g_strdup( fdata );
                     impl_webkit_show_data( GNC_HTML(self), fdata, strlen(fdata) );
-//                webkit_web_view_load_html (priv->web_view, fdata,
-//                                           BASE_URI_NAME);
                }
                else
                {
@@ -591,7 +570,7 @@ load_to_stream( GncHtmlWebkit* self, URLType type,
                g_free( fdata );
           }
      }
-     while ( FALSE );
+     while ( false );
      return TRUE;
 }
 
@@ -600,10 +579,8 @@ perform_navigation_policy (WebKitWebView *web_view,
                WebKitNavigationPolicyDecision *decision,
                GncHtml *self)
 {
-     WebKitURIRequest *req = NULL;
-     const gchar* uri, *scheme; // Can't init it here.
-     gchar *location = NULL, *label = NULL;
-     gboolean ignore = FALSE;
+     gchar *location = nullptr, *label = nullptr;
+     bool ignore = false;
      WebKitNavigationAction *action =
       webkit_navigation_policy_decision_get_navigation_action (decision);
      if (webkit_navigation_action_get_navigation_type (action) !=
@@ -612,13 +589,13 @@ perform_navigation_policy (WebKitWebView *web_view,
           webkit_policy_decision_use ((WebKitPolicyDecision*)decision);
           return TRUE;
      }
-     req = webkit_navigation_action_get_request (action);
-     uri = webkit_uri_request_get_uri (req);
-     scheme =  gnc_html_parse_url (self, uri, &location, &label);
+     auto req = webkit_navigation_action_get_request (action);
+     const gchar *uri = webkit_uri_request_get_uri (req);
+     const gchar *scheme =  gnc_html_parse_url (self, uri, &location, &label);
      if (strcmp (scheme, URL_TYPE_FILE) != 0)
      {
           impl_webkit_show_url (self, scheme, location, label, FALSE);
-          ignore = TRUE;
+          ignore = true;
      }
      g_free (location);
      g_free (label);
@@ -650,15 +627,12 @@ static void
 webkit_mouse_target_cb (WebKitWebView *web_view, WebKitHitTestResult *hit,
             guint modifiers, gpointer user_data)
 {
-     GncHtmlWebkitPrivate* priv;
-     GncHtmlWebkit *self = (GncHtmlWebkit*)user_data;
-     gchar *uri;
-
      if (!webkit_hit_test_result_context_is_link (hit))
          return;
 
-     priv = GNC_HTML_WEBKIT_GET_PRIVATE (self);
-     uri = g_strdup (webkit_hit_test_result_get_link_uri (hit));
+     auto self = static_cast<GncHtmlWebkit*>(user_data);
+     auto priv = GNC_HTML_WEBKIT_GET_PRIVATE (self);
+     gchar *uri = g_strdup (webkit_hit_test_result_get_link_uri (hit));
      g_free (priv->base.current_link);
      priv->base.current_link = uri;
      if (priv->base.flyover_cb)
@@ -667,18 +641,17 @@ webkit_mouse_target_cb (WebKitWebView *web_view, WebKitHitTestResult *hit,
                    priv->base.flyover_cb_data);
      }
 }
+
 static gboolean
 webkit_notification_cb (WebKitWebView* web_view, WebKitNotification *note,
             gpointer user_data)
 {
-     GtkWindow *top = NULL;
-     GtkWidget *dialog = NULL;
      GncHtmlWebkit *self = (GncHtmlWebkit*)user_data;
-     g_return_val_if_fail (self != NULL, FALSE);
-     g_return_val_if_fail (note != NULL, FALSE);
+     g_return_val_if_fail (self != nullptr, FALSE);
+     g_return_val_if_fail (note != nullptr, FALSE);
 
-     top = GTK_WINDOW (gtk_widget_get_toplevel (GTK_WIDGET (web_view)));
-     dialog = gtk_message_dialog_new (top, GTK_DIALOG_MODAL,
+     auto top = GTK_WINDOW (gtk_widget_get_toplevel (GTK_WIDGET (web_view)));
+     auto dialog = gtk_message_dialog_new (top, GTK_DIALOG_MODAL,
                                       GTK_MESSAGE_WARNING, GTK_BUTTONS_CLOSE,
                                       "%s\n%s",
                                       webkit_notification_get_title (note),
@@ -695,6 +668,7 @@ webkit_load_failed_cb (WebKitWebView *web_view, WebKitLoadEvent event,
      PERR ("WebKit load of %s failed due to %s\n", uri, error->message);
      return FALSE;
 }
+
 static void
 webkit_resource_load_failed_cb (WebKitWebResource *resource,
                                 GError *error,
@@ -749,29 +723,24 @@ gnc_html_open_scm( GncHtmlWebkit* self, const gchar * location,
 static void
 impl_webkit_show_data( GncHtml* self, const gchar* data, int datalen )
 {
-     GncHtmlWebkitPrivate* priv;
-#define TEMPLATE_REPORT_FILE_NAME "gnc-report-XXXXXX.html"
-     int fd;
-     gchar* uri;
-     gchar *filename;
-
-     g_return_if_fail( self != NULL );
+     constexpr char TEMPLATE_REPORT_FILE_NAME[] = "gnc-report-XXXXXX.html";
+     g_return_if_fail( self != nullptr );
      g_return_if_fail( GNC_IS_HTML_WEBKIT(self) );
 
      ENTER( "datalen %d, data %20.20s", datalen, data );
 
-     priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
+     auto priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
 
      /* Export the HTML to a file and load the file URI.   On Linux, this seems to get around some
         security problems (otherwise, it can complain that embedded images aren't permitted to be
         viewed because they are local resources).  On Windows, this allows the embedded images to
         be viewed (maybe for the same reason as on Linux, but I haven't found where it puts those
         messages. */
-     filename = g_build_filename(g_get_tmp_dir(), TEMPLATE_REPORT_FILE_NAME, (gchar *)NULL);
-     fd = g_mkstemp( filename );
+     gchar *filename = g_build_filename(g_get_tmp_dir(), TEMPLATE_REPORT_FILE_NAME, (gchar *)nullptr);
+     int fd = g_mkstemp( filename );
      impl_webkit_export_to_file( self, filename );
      close( fd );
-     uri = g_strdup_printf( "file://%s", filename );
+     gchar *uri = g_strdup_printf( "file://%s", filename );
      g_free(filename);
      DEBUG("Loading uri '%s'", uri);
      webkit_web_view_load_uri( priv->web_view, uri );
@@ -793,16 +762,15 @@ impl_webkit_show_url( GncHtml* self, URLType type,
                       const gchar* location, const gchar* label,
                       gboolean new_window_hint )
 {
-     GncHTMLUrlCB url_handler;
-     gboolean new_window;
-     GncHtmlWebkitPrivate* priv;
-     gboolean stream_loaded = FALSE;
+     GncHTMLUrlCB url_handler = nullptr;
+     bool new_window = false;
+     bool stream_loaded = false;
 
-     g_return_if_fail( self != NULL );
+     g_return_if_fail( self != nullptr );
      g_return_if_fail( GNC_IS_HTML_WEBKIT(self) );
-     g_return_if_fail( location != NULL );
+     g_return_if_fail( location != nullptr );
 
-     priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
+     auto priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
 
      /* make sure it's OK to show this URL type in this window */
      if ( new_window_hint == 0 )
@@ -811,14 +779,10 @@ impl_webkit_show_url( GncHtml* self, URLType type,
           {
                new_window = !((priv->base.urltype_cb)( type ));
           }
-          else
-          {
-               new_window = FALSE;
-          }
      }
      else
      {
-          new_window = TRUE;
+          new_window = true;
      }
 
      if ( !new_window )
@@ -828,28 +792,24 @@ impl_webkit_show_url( GncHtml* self, URLType type,
 
      if ( gnc_html_url_handlers )
      {
-          url_handler = g_hash_table_lookup( gnc_html_url_handlers, type );
-     }
-     else
-     {
-          url_handler = NULL;
+          const gpointer p = g_hash_table_lookup( gnc_html_url_handlers, type );
+          url_handler = reinterpret_cast<GncHTMLUrlCB>(p);
      }
 
      if ( url_handler )
      {
           GNCURLResult result;
-          gboolean ok;
 
           result.load_to_stream = FALSE;
           result.url_type = type;
-          result.location = NULL;
-          result.label = NULL;
+          result.location = nullptr;
+          result.label = nullptr;
           result.base_type = URL_TYPE_FILE;
-          result.base_location = NULL;
-          result.error_message = NULL;
+          result.base_location = nullptr;
+          result.error_message = nullptr;
           result.parent = GTK_WINDOW (priv->base.parent);
 
-          ok = url_handler( location, label, new_window, &result );
+          bool ok = url_handler( location, label, new_window, &result );
           if ( !ok )
           {
                if ( result.error_message )
@@ -870,13 +830,9 @@ impl_webkit_show_url( GncHtml* self, URLType type,
           }
           else if ( result.load_to_stream )
           {
-               gnc_html_history_node *hnode;
-               const char *new_location;
-               const char *new_label;
-
-               new_location = result.location ? result.location : location;
-               new_label = result.label ? result.label : label;
-               hnode = gnc_html_history_node_new( result.url_type, new_location, new_label );
+               const char *new_location = result.location ? result.location : location;
+               const char *new_label = result.label ? result.label : label;
+               auto hnode = gnc_html_history_node_new( result.url_type, new_location, new_label );
 
                gnc_html_history_append( priv->base.history, hnode );
 
@@ -891,7 +847,7 @@ impl_webkit_show_url( GncHtml* self, URLType type,
                                                result.url_type,
                                                new_location, new_label );
 
-               if ( stream_loaded && priv->base.load_cb != NULL )
+               if ( stream_loaded && priv->base.load_cb != nullptr )
                {
                     priv->base.load_cb( GNC_HTML(self), result.url_type,
                                         new_location, new_label, priv->base.load_cb_data );
@@ -948,7 +904,7 @@ impl_webkit_show_url( GncHtml* self, URLType type,
 
                priv->base.base_type = type;
 
-               if ( priv->base.base_location != NULL ) g_free( priv->base.base_location );
+               if ( priv->base.base_location != nullptr ) g_free( priv->base.base_location );
                priv->base.base_location = extract_base_name( type, location );
 
                /* FIXME : handle new_window = 1 */
@@ -958,14 +914,14 @@ impl_webkit_show_url( GncHtml* self, URLType type,
                                                type, location, label );
 
           }
-          while ( FALSE );
+          while ( false );
      }
      else
      {
           PERR( "URLType %s not supported.", type );
      }
 
-     if ( stream_loaded && priv->base.load_cb != NULL )
+     if ( stream_loaded && priv->base.load_cb != nullptr )
      {
           (priv->base.load_cb)( GNC_HTML(self), type, location, label, priv->base.load_cb_data );
      }
@@ -982,17 +938,15 @@ impl_webkit_show_url( GncHtml* self, URLType type,
 static void
 impl_webkit_reload( GncHtml* self, gboolean force_rebuild )
 {
-     GncHtmlWebkitPrivate* priv;
-
-     g_return_if_fail( self != NULL );
+     g_return_if_fail( self != nullptr );
      g_return_if_fail( GNC_IS_HTML_WEBKIT(self) );
 
-     priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
+     auto priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
 
      if ( force_rebuild )
      {
           gnc_html_history_node *n = gnc_html_history_get_current( priv->base.history );
-          if ( n != NULL )
+          if ( n != nullptr )
                gnc_html_show_url( self, n->type, n->location, n->label, 0 );
      }
      else
@@ -1006,9 +960,9 @@ impl_webkit_reload( GncHtml* self, gboolean force_rebuild )
  ********************************************************************/
 
 GncHtml*
-gnc_html_webkit_new( void )
+gnc_html_webkit_new( void ) noexcept
 {
-     GncHtmlWebkit* self = g_object_new( GNC_TYPE_HTML_WEBKIT, NULL );
+     auto self = static_cast<GncHtmlWebkit*>(g_object_new( GNC_TYPE_HTML_WEBKIT, nullptr ));
      return GNC_HTML(self);
 }
 
@@ -1028,28 +982,21 @@ webkit_cancel_helper(gpointer key, gpointer value, gpointer user_data)
 static void
 impl_webkit_cancel( GncHtml* self )
 {
-     GncHtmlWebkitPrivate* priv;
-
-     g_return_if_fail( self != NULL );
+     g_return_if_fail( self != nullptr );
      g_return_if_fail( GNC_IS_HTML_WEBKIT(self) );
 
-     priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
+     auto priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
 
-     /* remove our own references to requests */
-     //gnc_http_cancel_requests( priv->http );
-
-     g_hash_table_foreach_remove( priv->base.request_info, webkit_cancel_helper, NULL );
+     g_hash_table_foreach_remove( priv->base.request_info, webkit_cancel_helper, nullptr );
 }
 
 static void
 impl_webkit_copy_to_clipboard( GncHtml* self )
 {
-     GncHtmlWebkitPrivate* priv;
-
-     g_return_if_fail( self != NULL );
+     g_return_if_fail( self != nullptr );
      g_return_if_fail( GNC_IS_HTML_WEBKIT(self) );
 
-     priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
+     auto priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
      webkit_web_view_execute_editing_command (priv->web_view,
                           WEBKIT_EDITING_COMMAND_COPY);
 }
@@ -1064,25 +1011,20 @@ impl_webkit_copy_to_clipboard( GncHtml* self )
 static gboolean
 impl_webkit_export_to_file( GncHtml* self, const char *filepath )
 {
-     FILE *fh;
-     GncHtmlWebkitPrivate* priv;
-
-     g_return_val_if_fail( self != NULL, FALSE );
+     g_return_val_if_fail( self != nullptr, FALSE );
      g_return_val_if_fail( GNC_IS_HTML_WEBKIT(self), FALSE );
-     g_return_val_if_fail( filepath != NULL, FALSE );
+     g_return_val_if_fail( filepath != nullptr, FALSE );
 
-     priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
-     if ( priv->html_string == NULL )
+     auto priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
+     if ( priv->html_string == nullptr )
      {
           return FALSE;
      }
-     fh = g_fopen( filepath, "w" );
-     if ( fh != NULL )
+     FILE *fh = g_fopen( filepath, "w" );
+     if ( fh != nullptr )
      {
-          gint written;
           gint len = strlen( priv->html_string );
-
-          written = fwrite( priv->html_string, 1, len, fh );
+          gint written = fwrite( priv->html_string, 1, len, fh );
           fclose (fh);
 
           if ( written != len )
@@ -1115,38 +1057,29 @@ impl_webkit_export_to_file( GncHtml* self, const char *filepath )
 static void
 impl_webkit_print (GncHtml* self,const gchar* jobname)
 {
-     WebKitPrintOperation *op = NULL;
-     GtkWindow *top = NULL;
-     GncHtmlWebkitPrivate *priv;
-     GtkPrintSettings *print_settings = NULL;
-     WebKitPrintOperationResponse print_response;
-     gchar *export_dirname = NULL;
-     gchar *export_filename = NULL;
-     gchar* basename = NULL;
-
-     g_return_if_fail (self != NULL);
+     g_return_if_fail (self != nullptr);
      g_return_if_fail (GNC_IS_HTML_WEBKIT (self));
-     priv = GNC_HTML_WEBKIT_GET_PRIVATE (self);
-     op = webkit_print_operation_new (priv->web_view);
-     basename = g_path_get_basename(jobname);
-     print_settings = gtk_print_settings_new();
+
+     auto priv = GNC_HTML_WEBKIT_GET_PRIVATE (self);
+     auto op = webkit_print_operation_new (priv->web_view);
+     gchar *basename = g_path_get_basename(jobname);
+     auto print_settings = gtk_print_settings_new();
      webkit_print_operation_set_print_settings(op, print_settings);
-     export_filename = g_strdup(jobname);
+     gchar *export_filename = g_strdup(jobname);
      g_free(basename);
      gtk_print_settings_set(print_settings,
                     GTK_PRINT_SETTINGS_OUTPUT_BASENAME,
                     export_filename);
      webkit_print_operation_set_print_settings(op, print_settings);
      // Open a print dialog
-     top = GTK_WINDOW (gtk_widget_get_toplevel (GTK_WIDGET (priv->web_view)));
-     print_response = webkit_print_operation_run_dialog (op, top);
+     auto top = GTK_WINDOW (gtk_widget_get_toplevel (GTK_WIDGET (priv->web_view)));
+     auto print_response = webkit_print_operation_run_dialog (op, top);
      if (print_response == WEBKIT_PRINT_OPERATION_RESPONSE_PRINT)
      {
           // Get the newly updated print settings
           g_object_unref(print_settings);
           print_settings = g_object_ref(webkit_print_operation_get_print_settings(op));
      }
-     g_free(export_dirname);
      g_free(export_filename);
      g_object_unref (op);
      g_object_unref (print_settings);
@@ -1155,25 +1088,20 @@ impl_webkit_print (GncHtml* self,const gchar* jobname)
 static void
 impl_webkit_set_parent( GncHtml* self, GtkWindow* parent )
 {
-     GncHtmlWebkitPrivate* priv;
-
-     g_return_if_fail( self != NULL );
+     g_return_if_fail( self != nullptr );
      g_return_if_fail( GNC_IS_HTML_WEBKIT(self) );
 
-     priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
+     auto priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
      priv->base.parent = GTK_WIDGET(parent);
 }
 
 static void
 impl_webkit_default_zoom_changed(gpointer prefs, gchar *pref, gpointer user_data)
 {
-     gdouble zoom = 1.0;
+     g_return_if_fail(user_data != nullptr);
+
      GncHtmlWebkit* self = GNC_HTML_WEBKIT(user_data);
      GncHtmlWebkitPrivate* priv = GNC_HTML_WEBKIT_GET_PRIVATE(self);
-
-     g_return_if_fail(user_data != NULL);
-
-     zoom = gnc_prefs_get_float (GNC_PREFS_GROUP_GENERAL_REPORT, GNC_PREF_RPT_DFLT_ZOOM);
+     gdouble zoom = gnc_prefs_get_float (GNC_PREFS_GROUP_GENERAL_REPORT, GNC_PREF_RPT_DFLT_ZOOM);
      webkit_web_view_set_zoom_level (priv->web_view, zoom);
-
 }

--- a/gnucash/html/gnc-html-webkit2.hpp
+++ b/gnucash/html/gnc-html-webkit2.hpp
@@ -1,5 +1,5 @@
 /********************************************************************
- * gnc-html-factory.h -- display html with gnc special tags         *
+ * gnc-html-webkit.hpp -- display html with gnc special tags          *
  * Copyright (C) 2009 Phil Longstaff <plongstaff@rogers.com>        *
  *                                                                  *
  * This program is free software; you can redistribute it and/or    *
@@ -20,19 +20,42 @@
  * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
 \********************************************************************/
 
-#ifndef GNC_HTML_FACTORY_H
-#define GNC_HTML_FACTORY_H
+#ifndef GNC_HTML_WEBKIT_H
+#define GNC_HTML_WEBKIT_H
 
+#include <glib-object.h>
 #include "gnc-html.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+G_BEGIN_DECLS
 
-GncHtml* gnc_html_factory_create_html( void );
+#define GNC_TYPE_HTML_WEBKIT       (gnc_html_webkit_get_type())
+#define GNC_HTML_WEBKIT(o)         (G_TYPE_CHECK_INSTANCE_CAST ((o), GNC_TYPE_HTML_WEBKIT, GncHtmlWebkit))
+#define GNC_HTML_WEBKIT_CLASS(k)   (G_TYPE_CHECK_CLASS_CAST((k), GNC_TYPE_HTML_WEBKIT, GncHtmlWebkitClass))
+#define GNC_IS_HTML_WEBKIT(o)      (G_TYPE_CHECK_INSTANCE_TYPE((o), GNC_TYPE_HTML_WEBKIT))
+#define GNC_IS_HTML_WEBKIT_CLASS(k)   (G_TYPE_CHECK_CLASS_TYPE((k), GNC_TYPE_HTML_WEBKIT))
+#define GNC_HTML_WEBKIT_GET_CLASS(o)  (G_TYPE_INSTANCE_GET_CLASS((o), GNC_TYPE_HTML_WEBKIT, GncHtmlWebkitClass))
 
-#ifdef __cplusplus
-}
-#endif
+struct GncHtmlWebkitPrivate;
 
-#endif
+/** Key for saving the PDF-export directory in the print settings */
+#define GNC_GTK_PRINT_SETTINGS_EXPORT_DIR "gnc-pdf-export-directory"
+
+struct GncHtmlWebkit
+{
+    GncHtml parent_instance;
+
+    /*< private >*/
+    GncHtmlWebkitPrivate* priv;
+};
+
+struct GncHtmlWebkitClass
+{
+    GncHtmlClass parent_class;
+};
+
+extern "C" GType gnc_html_webkit_get_type( void );
+extern "C" GncHtml* gnc_html_webkit_new( void ) NOEXCEPT;
+
+G_END_DECLS
+
+#endif // GNC_HTML_WEBKIT_H

--- a/gnucash/html/gnc-html.cpp
+++ b/gnucash/html/gnc-html.cpp
@@ -723,7 +723,7 @@ gnc_html_encode_string(const char * str_in) noexcept
     if (!str_in) return nullptr;
 
     constexpr gchar safe[] = "$-._!*(),"; /* RFC 1738 */
-    GString *encoded  = g_string_new ("");
+    std::string encoded;
     constexpr size_t BUF_SIZE = 5;
     gchar buffer[BUF_SIZE];
     guchar c;
@@ -737,24 +737,24 @@ gnc_html_encode_string(const char * str_in) noexcept
                 (( c >= '0') && ( c <= '9')) ||
                 (std::strchr(safe, c)))
         {
-            encoded = g_string_append_c (encoded, c);
+            encoded.push_back(c);
         }
         else if ( c == ' ' )
         {
-            encoded = g_string_append_c (encoded, '+');
+            encoded.push_back(' ');
         }
         else if ( c == '\n' )
         {
-            encoded = g_string_append (encoded, "%0D%0A");
+            encoded.append("%0D%0A");
         }
         else if ( c != '\r' )
         {
             std::snprintf( buffer, BUF_SIZE, "%%%02X", static_cast<int>(c) );
-            encoded = g_string_append (encoded, buffer);
+            encoded.append(buffer, BUF_SIZE);
         }
     }
 
-    return g_string_free (encoded, FALSE);
+    return strdup(encoded.c_str());
 }
 
 
@@ -764,7 +764,7 @@ gnc_html_decode_string(const char * str) noexcept
     if (!str) return nullptr;
 
     constexpr gchar safe[] = "$-._!*(),"; /* RFC 1738 */
-    GString * decoded  = g_string_new ("");
+    std::string decoded;
     guchar  c;
     guint   hexval;
     std::string_view sv = str;
@@ -777,29 +777,29 @@ gnc_html_decode_string(const char * str) noexcept
                 (( c >= '0') && ( c <= '9')) ||
                 (std::strchr(safe, c)))
         {
-            decoded = g_string_append_c (decoded, c);
+            decoded.push_back(c);
         }
         else if ( c == '+' )
         {
-            decoded = g_string_append_c (decoded, ' ');
+            decoded.push_back(' ');
         }
         else if (sv.substr(i,5).compare("%0D0A") == 0)
         {
-            decoded = g_string_append (decoded, "\n");
+            decoded.push_back('\n');
             i += 4;
         }
         else if (c == '%')
         {
             // this logic preassumes that the number after '%' is a single character ?
             if (1 == std::sscanf(sv.substr(i+1).data(), "%02X", &hexval))
-                decoded = g_string_append_c(decoded, static_cast<char>(hexval));
+                decoded.push_back(static_cast<char>(hexval));
             else
-                decoded = g_string_append_c(decoded, ' ');
+                decoded.push_back(' ');
             i += 2;
         }
     }
 
-    return g_string_free (decoded, FALSE);
+    return strdup(decoded.c_str());
 }
 
 /********************************************************************
@@ -810,46 +810,43 @@ gnc_html_decode_string(const char * str) noexcept
 char *
 gnc_html_unescape_newlines(const gchar * in) noexcept
 {
-    GString * rv = g_string_new("");
+    std::string rv;
     std::string_view sv = in;
 
     for (size_t i = 0; i < sv.size(); i++)
     {
         if (sv.substr(i,2).compare("\\n") == 0)
         {
-            g_string_append(rv, "\n");
+            rv.push_back('\n');
             i++;
         }
         else
         {
-            g_string_append_c(rv, sv[i]);
+            rv.push_back(sv[i]);
         }
     }
 
-    g_string_append_c(rv, 0);
-    return g_string_free (rv, FALSE);
+    return strdup(rv.c_str());
 }
 
 char *
 gnc_html_escape_newlines(const gchar * in) noexcept
 {
-    GString * escaped = g_string_new("");
-
+    std::string escaped;
     std::string_view sv = in;
 
     for (const char c : sv)
     {
         if (c == '\012')
         {
-            g_string_append(escaped, "\\n");
+            escaped.append("\\n");
         }
         else
         {
-            g_string_append_c(escaped, c);
+            escaped.push_back(c);
         }
     }
-    g_string_append_c(escaped, 0);
-    return g_string_free (escaped, FALSE);
+    return strdup(escaped.c_str());
 }
 
 void

--- a/gnucash/html/gnc-html.cpp
+++ b/gnucash/html/gnc-html.cpp
@@ -34,9 +34,11 @@
 #include <glib/gstdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <stdlib.h>
-#include <string.h>
-#include <errno.h>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <string_view>
+#include <cerrno>
 #include <fcntl.h>
 #include <unistd.h>
 #include <regex.h>
@@ -51,17 +53,17 @@
 static QofLogModule log_module = GNC_MOD_HTML;
 
 /* hashes for URLType -> protocol and protocol -> URLType */
-static GHashTable * gnc_html_type_to_proto_hash = NULL;
-GHashTable * gnc_html_proto_to_type_hash = NULL;
+static GHashTable * gnc_html_type_to_proto_hash = nullptr;
+GHashTable * gnc_html_proto_to_type_hash = nullptr;
 
 /* hashes an HTML <object classid="ID"> classid to a handler function */
-GHashTable* gnc_html_object_handlers = NULL;
+GHashTable* gnc_html_object_handlers = nullptr;
 
 /* hashes handlers for loading different URLType data */
-GHashTable* gnc_html_stream_handlers = NULL;
+GHashTable* gnc_html_stream_handlers = nullptr;
 
 /* hashes handlers for handling different URLType data */
-GHashTable* gnc_html_url_handlers = NULL;
+GHashTable* gnc_html_url_handlers = nullptr;
 
 /* hashes an HTML <object classid="ID"> classid to a handler function */
 extern GHashTable* gnc_html_object_handlers;
@@ -86,24 +88,23 @@ gnc_html_class_init( GncHtmlClass* klass )
     gobject_class->dispose = gnc_html_dispose;
     gobject_class->finalize = gnc_html_finalize;
 
-    klass->show_url = NULL;
-    klass->show_data = NULL;
-    klass->reload = NULL;
-    klass->copy_to_clipboard = NULL;
-    klass->export_to_file = NULL;
-    klass->print = NULL;
-    klass->cancel = NULL;
-    klass->parse_url = NULL;
-    klass->set_parent = NULL;
+    klass->show_url = nullptr;
+    klass->show_data = nullptr;
+    klass->reload = nullptr;
+    klass->copy_to_clipboard = nullptr;
+    klass->export_to_file = nullptr;
+    klass->print = nullptr;
+    klass->cancel = nullptr;
+    klass->parse_url = nullptr;
+    klass->set_parent = nullptr;
 }
 
 static void
 gnc_html_init( GncHtml* self )
 {
-    GncHtmlPrivate* priv;
-    priv = self->priv = g_new0( GncHtmlPrivate, 1 );
+    GncHtmlPrivate *priv = self->priv = g_new0( GncHtmlPrivate, 1 );
 
-    priv->container = gtk_scrolled_window_new( NULL, NULL );
+    priv->container = gtk_scrolled_window_new( nullptr, nullptr );
     gtk_scrolled_window_set_policy( GTK_SCROLLED_WINDOW(priv->container),
                                     GTK_POLICY_AUTOMATIC,
                                     GTK_POLICY_AUTOMATIC );
@@ -118,21 +119,21 @@ gnc_html_dispose( GObject* obj )
     GncHtml* self = GNC_HTML(obj);
     GncHtmlPrivate* priv = GNC_HTML_GET_PRIVATE(self);
 
-    if ( priv->container != NULL )
+    if ( priv->container != nullptr )
     {
         gtk_widget_destroy( GTK_WIDGET(priv->container) );
         g_object_unref( G_OBJECT(priv->container) );
-        priv->container = NULL;
+        priv->container = nullptr;
     }
-    if ( priv->request_info != NULL )
+    if ( priv->request_info != nullptr )
     {
         g_hash_table_destroy( priv->request_info );
-        priv->request_info = NULL;
+        priv->request_info = nullptr;
     }
-    if ( priv->history != NULL )
+    if ( priv->history != nullptr )
     {
         gnc_html_history_destroy( priv->history );
-        priv->history = NULL;
+        priv->history = nullptr;
     }
 
     G_OBJECT_CLASS(gnc_html_parent_class)->dispose( obj );
@@ -143,10 +144,10 @@ gnc_html_finalize( GObject* obj )
 {
     GncHtml* self = GNC_HTML(obj);
 
-    if ( self->priv != NULL )
+    if ( self->priv != nullptr )
     {
         g_free( self->priv );
-        self->priv = NULL;
+        self->priv = nullptr;
     }
 
     G_OBJECT_CLASS(gnc_html_parent_class)->finalize( obj );
@@ -157,18 +158,19 @@ gnc_html_finalize( GObject* obj )
 static char*
 extract_machine_name( const gchar* path )
 {
-    gchar machine_rexp[] = "^(//[^/]*)/*(.*)?$";
+    constexpr gchar machine_rexp[] = "^(//[^/]*)/*(.*)?$";
     regex_t compiled_m;
-    regmatch_t match[4];
-    gchar* machine = NULL;
+    constexpr size_t MATCH_LEN = 4;
+    regmatch_t match[MATCH_LEN];
+    gchar* machine = nullptr;
 
-    if ( path == NULL ) return NULL;
+    if ( path == nullptr ) return nullptr;
 
     regcomp( &compiled_m, machine_rexp, REG_EXTENDED );
 
     /* step 1: split the machine name away from the path
      * components */
-    if ( !regexec( &compiled_m, path, 4, match, 0 ) )
+    if ( !regexec( &compiled_m, path, MATCH_LEN, match, 0 ) )
     {
         /* $1 is the machine name */
         if ( match[1].rm_so != -1 )
@@ -188,22 +190,23 @@ extract_machine_name( const gchar* path )
 
 URLType
 gnc_html_parse_url( GncHtml* self, const gchar* url,
-                    gchar** url_location, gchar** url_label )
+                    gchar** url_location, gchar** url_label ) noexcept
 {
-    gchar uri_rexp[] = "^(([^:][^:]+):)?([^#]+)?(#(.*))?$";
+    constexpr gchar uri_rexp[] = "^(([^:][^:]+):)?([^#]+)?(#(.*))?$";
     regex_t compiled;
-    regmatch_t match[6];
-    gchar* protocol = NULL;
-    gchar* path = NULL;
-    gchar* label = NULL;
-    gboolean found_protocol = FALSE;
-    gboolean found_path = FALSE;
-    gboolean found_label = FALSE;
+    constexpr size_t MATCH_LEN = 6;
+    regmatch_t match[MATCH_LEN];
+    gchar* protocol = nullptr;
+    gchar* path = nullptr;
+    gchar* label = nullptr;
+    bool found_protocol = false;
+    bool found_path = false;
+    bool found_label = false;
     URLType retval;
     GncHtmlPrivate* priv = GNC_HTML_GET_PRIVATE(self);
 
-    g_return_val_if_fail( self != NULL, NULL );
-    g_return_val_if_fail( GNC_IS_HTML(self), NULL );
+    g_return_val_if_fail( self != nullptr, nullptr );
+    g_return_val_if_fail( GNC_IS_HTML(self), nullptr );
 
     DEBUG( "parsing %s, base_location %s",
            url ? url : "(null)",
@@ -213,28 +216,28 @@ gnc_html_parse_url( GncHtml* self, const gchar* url,
 
     regcomp( &compiled, uri_rexp, REG_EXTENDED );
 
-    if ( !regexec( &compiled, url, 6, match, 0 ) )
+    if ( !regexec( &compiled, url, MATCH_LEN, match, 0 ) )
     {
         if ( match[2].rm_so != -1 )
         {
             protocol = g_new0( gchar, match[2].rm_eo - match[2].rm_so + 1 );
             strncpy( protocol, url + match[2].rm_so, match[2].rm_eo - match[2].rm_so );
             protocol[match[2].rm_eo - match[2].rm_so] = 0;
-            found_protocol = TRUE;
+            found_protocol = true;
         }
         if ( match[3].rm_so != -1 )
         {
             path = g_new0( gchar, match[3].rm_eo - match[3].rm_so + 1 );
             strncpy( path, url + match[3].rm_so, match[3].rm_eo - match[3].rm_so );
             path[match[3].rm_eo - match[3].rm_so] = 0;
-            found_path = TRUE;
+            found_path = true;
         }
         if ( match[5].rm_so != -1 )
         {
             label = g_new0( gchar, match[5].rm_eo - match[5].rm_so + 1 );
             strncpy( label, url + match[5].rm_so, match[5].rm_eo - match[5].rm_so );
             label[match[5].rm_eo - match[5].rm_so] = 0;
-            found_label = TRUE;
+            found_label = true;
         }
     }
 
@@ -242,8 +245,9 @@ gnc_html_parse_url( GncHtml* self, const gchar* url,
 
     if ( found_protocol )
     {
-        retval = g_hash_table_lookup( gnc_html_proto_to_type_hash, protocol );
-        if ( retval == NULL )
+        const gpointer p = g_hash_table_lookup( gnc_html_proto_to_type_hash, protocol );
+        retval = static_cast<const char *>(p);
+        if ( retval == nullptr )
         {
             PWARN( "unhandled URL type for '%s'", url ? url : "(null)" );
             retval = URL_TYPE_OTHER;
@@ -277,7 +281,7 @@ gnc_html_parse_url( GncHtml* self, const gchar* url,
             }
             else
             {
-                *url_location = g_build_filename( priv->base_location, path, (gchar*)NULL );
+                *url_location = g_build_filename( priv->base_location, path, nullptr );
             }
             g_free( path );
         }
@@ -290,7 +294,7 @@ gnc_html_parse_url( GncHtml* self, const gchar* url,
     }
     else if ( !g_strcmp0( retval, URL_TYPE_JUMP ) )
     {
-        *url_location = NULL;
+        *url_location = nullptr;
         g_free( path );
 
     }
@@ -303,11 +307,11 @@ gnc_html_parse_url( GncHtml* self, const gchar* url,
             if ( g_path_is_absolute( path ) )
             {
                 *url_location = g_build_filename( extract_machine_name( priv->base_location ),
-                                                  path, (gchar*)NULL );
+                                                  path, nullptr );
             }
             else
             {
-                *url_location = g_build_filename( priv->base_location, path, (gchar*)NULL );
+                *url_location = g_build_filename( priv->base_location, path, nullptr );
             }
             g_free( path );
         }
@@ -329,12 +333,12 @@ gnc_html_parse_url( GncHtml* self, const gchar* url,
  ********************************************************************/
 
 void
-gnc_html_show_data( GncHtml* self, const gchar* data, int datalen )
+gnc_html_show_data( GncHtml* self, const gchar* data, int datalen ) noexcept
 {
-    g_return_if_fail( self != NULL );
+    g_return_if_fail( self != nullptr );
     g_return_if_fail( GNC_IS_HTML(self) );
 
-    if ( GNC_HTML_GET_CLASS(self)->show_data != NULL )
+    if ( GNC_HTML_GET_CLASS(self)->show_data != nullptr )
     {
         GNC_HTML_GET_CLASS(self)->show_data( self, data, datalen );
     }
@@ -356,15 +360,14 @@ gnc_html_show_data( GncHtml* self, const gchar* data, int datalen )
 void
 gnc_html_show_url( GncHtml* self, URLType type,
                    const gchar* location, const gchar* label,
-                   gboolean new_window_hint )
+                   gboolean new_window_hint ) noexcept
 {
-    char* lc_type = NULL;
-
-    g_return_if_fail( self != NULL );
+    g_return_if_fail( self != nullptr );
     g_return_if_fail( GNC_IS_HTML(self) );
 
-    lc_type = g_ascii_strdown (type, -1);
-    if ( GNC_HTML_GET_CLASS(self)->show_url != NULL )
+    char* lc_type = g_ascii_strdown (type, -1);
+
+    if ( GNC_HTML_GET_CLASS(self)->show_url != nullptr )
     {
         GNC_HTML_GET_CLASS(self)->show_url( self, lc_type, location, label, new_window_hint );
     }
@@ -385,12 +388,12 @@ gnc_html_show_url( GncHtml* self, URLType type,
  ********************************************************************/
 
 void
-gnc_html_reload( GncHtml* self, gboolean force_rebuild )
+gnc_html_reload( GncHtml* self, gboolean force_rebuild ) noexcept
 {
-    g_return_if_fail( self != NULL );
+    g_return_if_fail( self != nullptr );
     g_return_if_fail( GNC_IS_HTML(self) );
 
-    if ( GNC_HTML_GET_CLASS(self)->reload != NULL )
+    if ( GNC_HTML_GET_CLASS(self)->reload != nullptr )
     {
         GNC_HTML_GET_CLASS(self)->reload( self, force_rebuild );
     }
@@ -406,12 +409,12 @@ gnc_html_reload( GncHtml* self, gboolean force_rebuild )
  ********************************************************************/
 
 void
-gnc_html_cancel( GncHtml* self )
+gnc_html_cancel( GncHtml* self ) noexcept
 {
-    g_return_if_fail( self != NULL );
+    g_return_if_fail( self != nullptr );
     g_return_if_fail( GNC_IS_HTML(self) );
 
-    if ( GNC_HTML_GET_CLASS(self)->cancel != NULL )
+    if ( GNC_HTML_GET_CLASS(self)->cancel != nullptr )
     {
         GNC_HTML_GET_CLASS(self)->cancel( self );
     }
@@ -428,9 +431,9 @@ gnc_html_cancel( GncHtml* self )
  ********************************************************************/
 
 void
-gnc_html_destroy( GncHtml* self )
+gnc_html_destroy( GncHtml* self ) noexcept
 {
-    g_return_if_fail( self != NULL );
+    g_return_if_fail( self != nullptr );
     g_return_if_fail( GNC_IS_HTML(self) );
 
     if ( g_object_is_floating( G_OBJECT(self) ) )
@@ -442,63 +445,55 @@ gnc_html_destroy( GncHtml* self )
 }
 
 void
-gnc_html_set_urltype_cb( GncHtml* self, GncHTMLUrltypeCB urltype_cb )
+gnc_html_set_urltype_cb( GncHtml* self, GncHTMLUrltypeCB urltype_cb ) noexcept
 {
-    GncHtmlPrivate* priv;
-
-    g_return_if_fail( self != NULL );
+    g_return_if_fail( self != nullptr );
     g_return_if_fail( GNC_IS_HTML(self) );
 
-    priv = GNC_HTML_GET_PRIVATE(self);
+    auto priv = GNC_HTML_GET_PRIVATE(self);
     priv->urltype_cb = urltype_cb;
 }
 
 void
-gnc_html_set_load_cb( GncHtml* self, GncHTMLLoadCB load_cb, gpointer data )
+gnc_html_set_load_cb( GncHtml* self, GncHTMLLoadCB load_cb, gpointer data ) noexcept
 {
-    GncHtmlPrivate* priv;
-
-    g_return_if_fail( self != NULL );
+    g_return_if_fail( self != nullptr );
     g_return_if_fail( GNC_IS_HTML(self) );
 
-    priv = GNC_HTML_GET_PRIVATE(self);
+    auto priv = GNC_HTML_GET_PRIVATE(self);
     priv->load_cb = load_cb;
     priv->load_cb_data = data;
 }
 
 void
-gnc_html_set_flyover_cb( GncHtml* self, GncHTMLFlyoverCB flyover_cb, gpointer data )
+gnc_html_set_flyover_cb( GncHtml* self, GncHTMLFlyoverCB flyover_cb, gpointer data ) noexcept
 {
-    GncHtmlPrivate* priv;
-
-    g_return_if_fail( self != NULL );
+    g_return_if_fail( self != nullptr );
     g_return_if_fail( GNC_IS_HTML(self) );
 
-    priv = GNC_HTML_GET_PRIVATE(self);
+    auto priv = GNC_HTML_GET_PRIVATE(self);
     priv->flyover_cb = flyover_cb;
     priv->flyover_cb_data = data;
 }
 
 void
-gnc_html_set_button_cb( GncHtml* self, GncHTMLButtonCB button_cb, gpointer data )
+gnc_html_set_button_cb( GncHtml* self, GncHTMLButtonCB button_cb, gpointer data ) noexcept
 {
-    GncHtmlPrivate* priv;
-
-    g_return_if_fail( self != NULL );
+    g_return_if_fail( self != nullptr );
     g_return_if_fail( GNC_IS_HTML(self) );
 
-    priv = GNC_HTML_GET_PRIVATE(self);
+    auto priv = GNC_HTML_GET_PRIVATE(self);
     priv->button_cb = button_cb;
     priv->button_cb_data = data;
 }
 
 void
-gnc_html_copy_to_clipboard( GncHtml* self )
+gnc_html_copy_to_clipboard( GncHtml* self ) noexcept
 {
-    g_return_if_fail( self != NULL );
+    g_return_if_fail( self != nullptr );
     g_return_if_fail( GNC_IS_HTML(self) );
 
-    if ( GNC_HTML_GET_CLASS(self)->copy_to_clipboard != NULL )
+    if ( GNC_HTML_GET_CLASS(self)->copy_to_clipboard != nullptr )
     {
         GNC_HTML_GET_CLASS(self)->copy_to_clipboard( self );
     }
@@ -513,12 +508,12 @@ gnc_html_copy_to_clipboard( GncHtml* self )
  **************************************************************/
 
 gboolean
-gnc_html_export_to_file( GncHtml* self, const gchar* filepath )
+gnc_html_export_to_file( GncHtml* self, const gchar* filepath ) noexcept
 {
-    g_return_val_if_fail( self != NULL, FALSE );
+    g_return_val_if_fail( self != nullptr, FALSE );
     g_return_val_if_fail( GNC_IS_HTML(self), FALSE );
 
-    if ( GNC_HTML_GET_CLASS(self)->export_to_file != NULL )
+    if ( GNC_HTML_GET_CLASS(self)->export_to_file != nullptr )
     {
         return GNC_HTML_GET_CLASS(self)->export_to_file( self, filepath );
     }
@@ -530,20 +525,20 @@ gnc_html_export_to_file( GncHtml* self, const gchar* filepath )
 }
 #ifdef WEBKIT1
 void
-gnc_html_print (GncHtml* self, const char *jobname, gboolean export_pdf)
+gnc_html_print (GncHtml* self, const char *jobname, gboolean export_pdf) noexcept
 #else
 void
-gnc_html_print (GncHtml* self, const char *jobname)
+gnc_html_print (GncHtml* self, const char *jobname) noexcept
 #endif
 {
-    g_return_if_fail( self != NULL );
-     g_return_if_fail( jobname != NULL );
+    g_return_if_fail( self != nullptr );
+    g_return_if_fail( jobname != nullptr );
     g_return_if_fail( GNC_IS_HTML(self) );
 
-    if ( GNC_HTML_GET_CLASS(self)->print != NULL )
+    if ( GNC_HTML_GET_CLASS(self)->print != nullptr )
     {
 #ifdef WEBKIT1
-      GNC_HTML_GET_CLASS(self)->print (self, jobname, export_pdf);
+        GNC_HTML_GET_CLASS(self)->print (self, jobname, export_pdf);
 #else
         GNC_HTML_GET_CLASS(self)->print (self, jobname);
 #endif
@@ -555,48 +550,45 @@ gnc_html_print (GncHtml* self, const char *jobname)
 }
 
 gnc_html_history *
-gnc_html_get_history( GncHtml* self )
+gnc_html_get_history( GncHtml* self ) noexcept
 {
-    g_return_val_if_fail( self != NULL, NULL );
-    g_return_val_if_fail( GNC_IS_HTML(self), NULL );
+    g_return_val_if_fail( self != nullptr, nullptr );
+    g_return_val_if_fail( GNC_IS_HTML(self), nullptr );
 
     return GNC_HTML_GET_PRIVATE(self)->history;
 }
 
 
 GtkWidget *
-gnc_html_get_widget( GncHtml* self )
+gnc_html_get_widget( GncHtml* self ) noexcept
 {
-    g_return_val_if_fail( self != NULL, NULL );
-    g_return_val_if_fail( GNC_IS_HTML(self), NULL );
+    g_return_val_if_fail( self != nullptr, nullptr );
+    g_return_val_if_fail( GNC_IS_HTML(self), nullptr );
 
     return GNC_HTML_GET_PRIVATE(self)->container;
 }
 
 
 GtkWidget *
-gnc_html_get_webview( GncHtml* self )
+gnc_html_get_webview( GncHtml* self ) noexcept
 {
-    GncHtmlPrivate* priv;
-    GList *sw_list = NULL;
-    GtkWidget *webview = NULL;
+    g_return_val_if_fail (self != nullptr, nullptr);
+    g_return_val_if_fail (GNC_IS_HTML(self), nullptr);
 
-    g_return_val_if_fail (self != NULL, NULL);
-    g_return_val_if_fail (GNC_IS_HTML(self), NULL);
-
-    priv = GNC_HTML_GET_PRIVATE(self);
-    sw_list = gtk_container_get_children (GTK_CONTAINER(priv->container));
+    auto priv = GNC_HTML_GET_PRIVATE(self);
+    GList *sw_list = gtk_container_get_children (GTK_CONTAINER(priv->container));
+    GtkWidget *webview = nullptr;
 
     if (sw_list) // the scroll window has only one child
     {
 #ifdef WEBKIT1
-        webview = sw_list->data;
+        webview = static_cast<GtkWidget *>(sw_list->data);
 #else
         GList *vp_list = gtk_container_get_children (GTK_CONTAINER(sw_list->data));
- 
+
         if (vp_list) // the viewport has only one child
         {
-            webview = vp_list->data;
+            webview = static_cast<GtkWidget *>(vp_list->data);
             g_list_free (vp_list);
         }
 #endif
@@ -607,12 +599,12 @@ gnc_html_get_webview( GncHtml* self )
 
 
 void
-gnc_html_set_parent( GncHtml* self, GtkWindow* parent )
+gnc_html_set_parent( GncHtml* self, GtkWindow* parent ) noexcept
 {
-    g_return_if_fail( self != NULL );
+    g_return_if_fail( self != nullptr );
     g_return_if_fail( GNC_IS_HTML(self) );
 
-    if ( GNC_HTML_GET_CLASS(self)->set_parent != NULL )
+    if ( GNC_HTML_GET_CLASS(self)->set_parent != nullptr )
     {
         GNC_HTML_GET_CLASS(self)->set_parent( self, parent );
     }
@@ -626,41 +618,38 @@ gnc_html_set_parent( GncHtml* self, GtkWindow* parent )
  * Returns TRUE if successful, FALSE if the type already exists.
  */
 gboolean
-gnc_html_register_urltype( URLType type, const char *protocol )
+gnc_html_register_urltype( URLType type, const char *protocol ) noexcept
 {
-    char*  lc_type  = NULL;
-    char    *lc_proto = NULL;
+    if (!protocol) return FALSE;
 
     if (!gnc_html_type_to_proto_hash)
     {
         gnc_html_type_to_proto_hash = g_hash_table_new (g_str_hash, g_str_equal);
         gnc_html_proto_to_type_hash = g_hash_table_new (g_str_hash, g_str_equal);
     }
-    if (!protocol) return FALSE;
 
-    lc_type = g_ascii_strdown (type, -1);
+    char *lc_type  = g_ascii_strdown (type, -1);
     if (g_hash_table_lookup (gnc_html_type_to_proto_hash, lc_type))
     {
         g_free (lc_type);
         return FALSE;
     }
 
-    lc_proto = g_ascii_strdown (protocol, -1);
-    g_hash_table_insert (gnc_html_type_to_proto_hash, lc_type, (gpointer)lc_proto);
+    char *lc_proto = g_ascii_strdown (protocol, -1);
+    g_hash_table_insert (gnc_html_type_to_proto_hash, lc_type, static_cast<gpointer>(lc_proto));
     if (*lc_proto)
-        g_hash_table_insert (gnc_html_proto_to_type_hash, (gpointer)lc_proto, lc_type);
+        g_hash_table_insert (gnc_html_proto_to_type_hash, static_cast<gpointer>(lc_proto), lc_type);
 
     return TRUE;
 }
 
 void
-gnc_html_initialize( void )
+gnc_html_initialize( void ) noexcept
 {
-    int i;
     static struct
     {
         URLType	type;
-        char *	protocol;
+        const char *protocol;
     } types[] =
     {
         { URL_TYPE_FILE, "file" },
@@ -677,12 +666,13 @@ gnc_html_initialize( void )
         { URL_TYPE_XMLDATA, "gnc-xml" },
         { URL_TYPE_PRICE, "gnc-price" },
         { URL_TYPE_BUDGET, "gnc-budget" },
-        { URL_TYPE_OTHER, "" },
-        { NULL, NULL }
+        { URL_TYPE_OTHER, "" }
     };
 
-    for (i = 0; types[i].type; i++)
-        gnc_html_register_urltype (types[i].type, types[i].protocol);
+    for (const auto& elem : types)
+    {
+        (void) gnc_html_register_urltype (elem.type, elem.protocol);
+    }
 }
 
 /**
@@ -694,15 +684,13 @@ gnc_html_initialize( void )
  * @return Newly created URL.  This string must be freed by the caller.
  */
 gchar*
-gnc_build_url( URLType type, const gchar* location, const gchar* label )
+gnc_build_url( URLType type, const gchar* location, const gchar* label ) noexcept
 {
-    char*  lc_type  = NULL;
-    char * type_name;
-
     DEBUG(" ");
-    lc_type = g_ascii_strdown (type, -1);
-    type_name = g_hash_table_lookup (gnc_html_type_to_proto_hash, lc_type);
-    g_free (lc_type);
+    char *lc_type = g_ascii_strdown (type, -1);
+    const gpointer p = g_hash_table_lookup (gnc_html_type_to_proto_hash, lc_type);
+    const char *type_name = static_cast<const char *>(p);
+    g_free (static_cast<gpointer>(lc_type));
     if (!type_name)
         type_name = "";
 
@@ -730,25 +718,24 @@ gnc_build_url( URLType type, const gchar* location, const gchar* label )
  ********************************************************************/
 
 char *
-gnc_html_encode_string(const char * str)
+gnc_html_encode_string(const char * str_in) noexcept
 {
-    static gchar *safe = "$-._!*(),"; /* RFC 1738 */
-    unsigned pos      = 0;
+    if (!str_in) return nullptr;
+
+    constexpr gchar safe[] = "$-._!*(),"; /* RFC 1738 */
     GString *encoded  = g_string_new ("");
-    static const size_t buf_size = 5;
-    gchar buffer[buf_size], *ptr;
+    constexpr size_t BUF_SIZE = 5;
+    gchar buffer[BUF_SIZE];
     guchar c;
+    std::string str = str_in;
 
-    if (!str) return NULL;
-
-    while (pos < strlen(str))
+    for (const char ch : str)
     {
-        c = (unsigned char) str[pos];
-
+        c = static_cast<guchar>(ch);
         if ((( c >= 'A') && ( c <= 'Z')) ||
                 (( c >= 'a') && ( c <= 'z')) ||
                 (( c >= '0') && ( c <= '9')) ||
-                (strchr(safe, c)))
+                (std::strchr(safe, c)))
         {
             encoded = g_string_append_c (encoded, c);
         }
@@ -762,37 +749,33 @@ gnc_html_encode_string(const char * str)
         }
         else if ( c != '\r' )
         {
-            snprintf( buffer, buf_size, "%%%02X", (int)c );
+            std::snprintf( buffer, BUF_SIZE, "%%%02X", static_cast<int>(c) );
             encoded = g_string_append (encoded, buffer);
         }
-        pos++;
     }
 
-    ptr = g_string_free (encoded, FALSE);
-
-    return (char *)ptr;
+    return g_string_free (encoded, FALSE);
 }
 
 
 char *
-gnc_html_decode_string(const char * str)
+gnc_html_decode_string(const char * str) noexcept
 {
-    static gchar * safe = "$-._!*(),"; /* RFC 1738 */
+    if (!str) return nullptr;
+
+    constexpr gchar safe[] = "$-._!*(),"; /* RFC 1738 */
     GString * decoded  = g_string_new ("");
-    const gchar   * ptr;
     guchar  c;
     guint   hexval;
-    ptr = str;
+    std::string_view sv = str;
 
-    if (!str) return NULL;
-
-    while (*ptr)
+    for (size_t i = 0; i < sv.size(); i++)
     {
-        c = (unsigned char) * ptr;
+        c = static_cast<guchar>(sv[i]);
         if ((( c >= 'A') && ( c <= 'Z')) ||
                 (( c >= 'a') && ( c <= 'z')) ||
                 (( c >= '0') && ( c <= '9')) ||
-                (strchr(safe, c)))
+                (std::strchr(safe, c)))
         {
             decoded = g_string_append_c (decoded, c);
         }
@@ -800,25 +783,23 @@ gnc_html_decode_string(const char * str)
         {
             decoded = g_string_append_c (decoded, ' ');
         }
-        else if (!strncmp(ptr, "%0D0A", 5))
+        else if (sv.substr(i,5).compare("%0D0A") == 0)
         {
             decoded = g_string_append (decoded, "\n");
-            ptr += 4;
+            i += 4;
         }
         else if (c == '%')
         {
-            ptr++;
-            if (1 == sscanf(ptr, "%02X", &hexval))
-                decoded = g_string_append_c(decoded, (char)hexval);
+            // this logic preassumes that the number after '%' is a single character ?
+            if (1 == std::sscanf(sv.substr(i+1).data(), "%02X", &hexval))
+                decoded = g_string_append_c(decoded, static_cast<char>(hexval));
             else
                 decoded = g_string_append_c(decoded, ' ');
-            ptr++;
+            i += 2;
         }
-        ptr++;
     }
-    ptr = g_string_free (decoded, FALSE);
 
-    return (char *)ptr;
+    return g_string_free (decoded, FALSE);
 }
 
 /********************************************************************
@@ -827,85 +808,81 @@ gnc_html_decode_string(const char * str)
  ********************************************************************/
 
 char *
-gnc_html_unescape_newlines(const gchar * in)
+gnc_html_unescape_newlines(const gchar * in) noexcept
 {
-    const char * ip = in;
-    char    * cstr = NULL;
     GString * rv = g_string_new("");
+    std::string_view sv = in;
 
-    for (ip = in; *ip; ip++)
+    for (size_t i = 0; i < sv.size(); i++)
     {
-        if ((*ip == '\\') && (*(ip + 1) == 'n'))
+        if (sv.substr(i,2).compare("\\n") == 0)
         {
             g_string_append(rv, "\n");
-            ip++;
+            i++;
         }
         else
         {
-            g_string_append_c(rv, *ip);
+            g_string_append_c(rv, sv[i]);
         }
     }
 
     g_string_append_c(rv, 0);
-    cstr = g_string_free (rv, FALSE);
-    return cstr;
+    return g_string_free (rv, FALSE);
 }
 
 char *
-gnc_html_escape_newlines(const gchar * in)
+gnc_html_escape_newlines(const gchar * in) noexcept
 {
-    char *out;
-    const char * ip   = in;
     GString * escaped = g_string_new("");
 
-    for (ip = in; *ip; ip++)
+    std::string_view sv = in;
+
+    for (const char c : sv)
     {
-        if (*ip == '\012')
+        if (c == '\012')
         {
             g_string_append(escaped, "\\n");
         }
         else
         {
-            g_string_append_c(escaped, *ip);
+            g_string_append_c(escaped, c);
         }
     }
     g_string_append_c(escaped, 0);
-    out = g_string_free (escaped, FALSE);
-    return out;
+    return g_string_free (escaped, FALSE);
 }
 
 void
 gnc_html_register_object_handler( const char * classid,
-                                  GncHTMLObjectCB hand )
+                                  GncHTMLObjectCB hand ) noexcept
 {
-    g_return_if_fail( classid != NULL );
+    g_return_if_fail( classid != nullptr );
 
-    if ( gnc_html_object_handlers == NULL )
+    if ( gnc_html_object_handlers == nullptr )
     {
         gnc_html_object_handlers = g_hash_table_new( g_str_hash, g_str_equal );
     }
 
     gnc_html_unregister_object_handler( classid );
-    if ( hand != NULL )
+    if ( hand != nullptr )
     {
         gchar *lc_id  = g_ascii_strdown (classid, -1);
-        g_hash_table_insert( gnc_html_object_handlers, lc_id, hand );
+        g_hash_table_insert( gnc_html_object_handlers, lc_id,
+            reinterpret_cast<gpointer>(hand) );
     }
 }
 
 void
-gnc_html_unregister_object_handler( const gchar* classid )
+gnc_html_unregister_object_handler( const gchar* classid ) noexcept
 {
-    gchar* keyptr = NULL;
-    gchar* valptr = NULL;
-    gchar** p_keyptr = &keyptr;
-    gchar** p_valptr = &valptr;
+    gchar* keyptr = nullptr;
+    gchar* valptr = nullptr;
     gchar* lc_id = g_ascii_strdown (classid, -1);
 
     if ( g_hash_table_lookup_extended( gnc_html_object_handlers,
                                        lc_id,
-                                       (gpointer *)p_keyptr,
-                                       (gpointer *)p_valptr) )
+                                       reinterpret_cast<gpointer *>(&keyptr),
+                                       reinterpret_cast<gpointer *>(&valptr) ) )
     {
         g_hash_table_remove( gnc_html_object_handlers, lc_id );
         g_free( keyptr );
@@ -914,25 +891,26 @@ gnc_html_unregister_object_handler( const gchar* classid )
 }
 
 void
-gnc_html_register_stream_handler( URLType url_type, GncHTMLStreamCB hand )
+gnc_html_register_stream_handler( URLType url_type, GncHTMLStreamCB hand ) noexcept
 {
-    g_return_if_fail( url_type != NULL && *url_type != '\0' );
+    g_return_if_fail( url_type != nullptr && *url_type != '\0' );
 
-    if ( gnc_html_stream_handlers == NULL )
+    if ( gnc_html_stream_handlers == nullptr )
     {
         gnc_html_stream_handlers = g_hash_table_new( g_str_hash, g_str_equal );
     }
 
     gnc_html_unregister_stream_handler( url_type );
-    if ( hand != NULL )
+    if ( hand != nullptr )
     {
         char*  lc_type  = g_ascii_strdown (url_type, -1);
-        g_hash_table_insert( gnc_html_stream_handlers, lc_type, hand );
+        g_hash_table_insert( gnc_html_stream_handlers, lc_type,
+            reinterpret_cast<gpointer>(hand) );
     }
 }
 
 void
-gnc_html_unregister_stream_handler( URLType url_type )
+gnc_html_unregister_stream_handler( URLType url_type ) noexcept
 {
     char*  lc_type = g_ascii_strdown (url_type, -1);
     g_hash_table_remove( gnc_html_stream_handlers, lc_type );
@@ -940,25 +918,26 @@ gnc_html_unregister_stream_handler( URLType url_type )
 }
 
 void
-gnc_html_register_url_handler( URLType url_type, GncHTMLUrlCB hand )
+gnc_html_register_url_handler( URLType url_type, GncHTMLUrlCB hand ) noexcept
 {
-    g_return_if_fail( url_type != NULL && *url_type != '\0' );
+    g_return_if_fail( url_type != nullptr && *url_type != '\0' );
 
-    if ( gnc_html_url_handlers == NULL )
+    if ( gnc_html_url_handlers == nullptr )
     {
         gnc_html_url_handlers = g_hash_table_new( g_str_hash, g_str_equal );
     }
 
     gnc_html_unregister_url_handler( url_type );
-    if ( hand != NULL )
+    if ( hand != nullptr )
     {
         char* lc_type = g_ascii_strdown (url_type, -1);
-        g_hash_table_insert( gnc_html_url_handlers, lc_type, hand );
+        g_hash_table_insert( gnc_html_url_handlers, lc_type,
+            reinterpret_cast<gpointer>(hand) );
     }
 }
 
 void
-gnc_html_unregister_url_handler( URLType url_type )
+gnc_html_unregister_url_handler( URLType url_type ) noexcept
 {
     char* lc_type = g_ascii_strdown (url_type, -1);
     g_hash_table_remove( gnc_html_url_handlers, lc_type );

--- a/gnucash/html/gnc-html.h
+++ b/gnucash/html/gnc-html.h
@@ -40,11 +40,21 @@ G_BEGIN_DECLS
 #define GNC_IS_HTML_CLASS(k)  (G_TYPE_CHECK_CLASS_TYPE((o), GNC_TYPE_HTML))
 #define GNC_HTML_GET_CLASS(o) (G_TYPE_INSTANCE_GET_CLASS((o), GNC_TYPE_HTML, GncHtmlClass))
 
-GType gnc_html_get_type(void);
-
 typedef struct _GncHtml GncHtml;
 typedef struct _GncHtmlClass GncHtmlClass;
 typedef struct _GncHtmlPrivate GncHtmlPrivate;
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+GType gnc_html_get_type(void);
+
+#ifdef __cplusplus
+}
+#endif
+
 
 #include "gnc-html-extras.h"
 
@@ -61,8 +71,8 @@ typedef struct
                             * perform all needed actions itself. */
 
     URLType url_type;        /* Defaults to original */
-    gchar* location;         /* If NULL, use original (NULL is default) */
-    gchar* label;            /* If NULL, use original (NULL is default) */
+    gchar* location;         /* If nullptr, use original (nullptr is default) */
+    gchar* label;            /* If nullptr, use original (nullptr is default) */
 
     URLType base_type;
     gchar* base_location;
@@ -80,49 +90,52 @@ typedef gboolean (* GncHTMLStreamCB)(const gchar* location, gchar** data, int* d
 typedef gboolean (* GncHTMLUrlCB)(const gchar* location, const gchar* label,
                                   gboolean new_window, GNCURLResult* result);
 
+#ifdef __cplusplus
+#define NOEXCEPT noexcept
+extern "C"
+{
+#else
+#define NOEXCEPT
+#endif
+
 /**
  * Registers a new URLType.
  * returns TRUE if successful, FALSE if type already exists.
  *
  * @param type New URL type
  * @param prococol Protocol - should be an empty string if there is no corresponding protocol.
- * @return TRUE if successful, FALSE if type already exists or protocol is NULL.
+ * @return TRUE if successful, FALSE if type already exists or protocol is nullptr.
  */
-gboolean gnc_html_register_urltype( URLType type, const gchar* protocol );
+gboolean gnc_html_register_urltype( URLType type, const gchar* protocol ) NOEXCEPT;
 
 /**
  * Initializes the html subsystem
  */
-void gnc_html_initialize( void );
+void gnc_html_initialize( void ) NOEXCEPT;
 
-gchar* gnc_html_encode_string( const gchar* in );
-gchar* gnc_html_decode_string( const gchar* in );
-gchar* gnc_html_escape_newlines( const gchar* in );
-gchar* gnc_html_unescape_newlines( const gchar* in );
+gchar* gnc_html_encode_string( const gchar* in ) NOEXCEPT;
+gchar* gnc_html_decode_string( const gchar* in ) NOEXCEPT;
+gchar* gnc_html_escape_newlines( const gchar* in ) NOEXCEPT;
+gchar* gnc_html_unescape_newlines( const gchar* in ) NOEXCEPT;
 
 /* object handlers deal with <object classid="foo"> objects in HTML.
  * the handlers are looked up at object load time. */
-void gnc_html_register_object_handler( const gchar* classid, GncHTMLObjectCB hand );
-void gnc_html_unregister_object_handler( const gchar* classid );
+void gnc_html_register_object_handler( const gchar* classid, GncHTMLObjectCB hand ) NOEXCEPT;
+void gnc_html_unregister_object_handler( const gchar* classid ) NOEXCEPT;
 
 /* stream handlers load data for particular URLTypes. */
-void gnc_html_register_stream_handler( URLType url_type, GncHTMLStreamCB hand );
-void gnc_html_unregister_stream_handler( URLType url_type );
+void gnc_html_register_stream_handler( URLType url_type, GncHTMLStreamCB hand ) NOEXCEPT;
+void gnc_html_unregister_stream_handler( URLType url_type ) NOEXCEPT;
 
 /* handlers for particular URLTypes. */
-void gnc_html_register_url_handler( URLType url_type, GncHTMLUrlCB hand );
-void gnc_html_unregister_url_handler( URLType url_type );
+void gnc_html_register_url_handler( URLType url_type, GncHTMLUrlCB hand ) NOEXCEPT;
+void gnc_html_unregister_url_handler( URLType url_type ) NOEXCEPT;
+
+#ifdef __cplusplus
+}
+#endif
 
 #include "gnc-html-history.h"
-
-typedef int  (* GncHTMLUrltypeCB)(URLType ut);
-typedef void (* GncHTMLFlyoverCB)(GncHtml* html, const gchar* url,
-                                  gpointer data);
-typedef void (* GncHTMLLoadCB)(GncHtml* html, URLType type,
-                               const gchar* location, const gchar* label,
-                               gpointer data);
-typedef int  (* GncHTMLButtonCB)(GncHtml* html, GdkEventButton* event,
-                                 gpointer data);
 
 struct _GncHtmlClass
 {
@@ -157,12 +170,26 @@ struct _GncHtml
     GncHtmlPrivate* priv;
 };
 
+typedef int  (* GncHTMLUrltypeCB)(URLType ut);
+typedef void (* GncHTMLFlyoverCB)(GncHtml* html, const gchar* url,
+                                  gpointer data);
+typedef void (* GncHTMLLoadCB)(GncHtml* html, URLType type,
+                               const gchar* location, const gchar* label,
+                               gpointer data);
+typedef int  (* GncHTMLButtonCB)(GncHtml* html, GdkEventButton* event,
+                                 gpointer data);
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 /**
  * Destroys a GncHtml object.
  *
  * @param html GncHtml object to destroy
  */
-void gnc_html_destroy( GncHtml* html );
+void gnc_html_destroy( GncHtml* html ) NOEXCEPT;
 
 /**
  * Displays a URL in a GncHtml object.
@@ -170,14 +197,14 @@ void gnc_html_destroy( GncHtml* html );
  * @param html GncHtml object
  */
 void gnc_html_show_url( GncHtml* html, URLType type, const gchar* location,
-                        const gchar* label, gboolean new_window_hint );
+                        const gchar* label, gboolean new_window_hint ) NOEXCEPT;
 
 /**
  * Displays an HTML string in a GncHtml object.
  *
  * @param html GncHtml object
  */
-void gnc_html_show_data( GncHtml* html, const gchar* data, int datalen );
+void gnc_html_show_data( GncHtml* html, const gchar* data, int datalen ) NOEXCEPT;
 
 /**
  * Reloads the current GncHtml object.
@@ -185,14 +212,14 @@ void gnc_html_show_data( GncHtml* html, const gchar* data, int datalen );
  * @param html GncHtml object
  * @param view if TRUE, view is reloaded, if FALSE, report is recreated
  */
-void gnc_html_reload( GncHtml* html, gboolean view );
+void gnc_html_reload( GncHtml* html, gboolean view ) NOEXCEPT;
 
 /**
  * Copies the html to the clipboard
  *
  * @param html GncHtml object
  */
-void gnc_html_copy_to_clipboard( GncHtml* html );
+void gnc_html_copy_to_clipboard( GncHtml* html ) NOEXCEPT;
 
 /**
  * Exports the html to an external file.
@@ -201,7 +228,7 @@ void gnc_html_copy_to_clipboard( GncHtml* html );
  * @param filename External file name
  * @param TRUE if successful, FALSE if unsuccessful
  */
-gboolean gnc_html_export_to_file( GncHtml* html, const gchar* filename );
+gboolean gnc_html_export_to_file( GncHtml* html, const gchar* filename ) NOEXCEPT;
 
 #ifdef WEBKIT1
 /**
@@ -213,21 +240,21 @@ gboolean gnc_html_export_to_file( GncHtml* html, const gchar* filename );
  * @param export_pdf If TRUE write a PDF file using the jobname for a
  *                   filename; otherwise put up a print dialog.
  */
-void gnc_html_print (GncHtml* html, const char* jobname, gboolean export_pdf);
+void gnc_html_print (GncHtml* html, const char* jobname, gboolean export_pdf) NOEXCEPT;
 #else
 /**
  * Prints the report.
  *
  * @param html GncHtml object
  */
-void gnc_html_print (GncHtml* html, const char* jobname);
+void gnc_html_print (GncHtml* html, const char* jobname) NOEXCEPT;
 #endif
 /**
  * Cancels the current operation
  *
  * @param html GncHtml object
  */
-void gnc_html_cancel( GncHtml* html );
+void gnc_html_cancel( GncHtml* html ) NOEXCEPT;
 
 /**
  * Parses a URL into URI and label
@@ -238,7 +265,7 @@ void gnc_html_cancel( GncHtml* html );
  * @param url_label Pointer where to store address of string containing label
  */
 URLType gnc_html_parse_url( GncHtml* html, const gchar* url,
-                            gchar** url_location, gchar** url_label );
+                            gchar** url_location, gchar** url_label ) NOEXCEPT;
 
 /**
  * Returns the history for this html engine
@@ -246,7 +273,7 @@ URLType gnc_html_parse_url( GncHtml* html, const gchar* url,
  * @param html GncHtml object
  * @return History
  */
-gnc_html_history* gnc_html_get_history( GncHtml* html );
+gnc_html_history* gnc_html_get_history( GncHtml* html ) NOEXCEPT;
 
 /**
  * Returns the main widget for this html engine
@@ -254,7 +281,7 @@ gnc_html_history* gnc_html_get_history( GncHtml* html );
  * @param html GncHtml object
  * @return Main widget
  */
-GtkWidget* gnc_html_get_widget( GncHtml* html );
+GtkWidget* gnc_html_get_widget( GncHtml* html ) NOEXCEPT;
 
 /**
  * Returns the webview widget for this html engine
@@ -262,7 +289,7 @@ GtkWidget* gnc_html_get_widget( GncHtml* html );
  * @param html GncHtml object
  * @return webview widget
  */
-GtkWidget* gnc_html_get_webview( GncHtml* html );
+GtkWidget* gnc_html_get_webview( GncHtml* html ) NOEXCEPT;
 
 
 /**
@@ -271,28 +298,32 @@ GtkWidget* gnc_html_get_webview( GncHtml* html );
  * @param html GncHtml object
  * @param parent Parent window
  */
-void gnc_html_set_parent( GncHtml* html, GtkWindow* parent );
+void gnc_html_set_parent( GncHtml* html, GtkWindow* parent ) NOEXCEPT;
 
 /* setting callbacks */
-void gnc_html_set_urltype_cb( GncHtml* html, GncHTMLUrltypeCB urltype_cb );
-void gnc_html_set_load_cb( GncHtml* html, GncHTMLLoadCB load_cb, gpointer data );
-void gnc_html_set_flyover_cb( GncHtml* html, GncHTMLFlyoverCB newwin_cb, gpointer data );
-void gnc_html_set_button_cb( GncHtml* html, GncHTMLButtonCB button_cb, gpointer data );
+void gnc_html_set_urltype_cb( GncHtml* html, GncHTMLUrltypeCB urltype_cb ) NOEXCEPT;
+void gnc_html_set_load_cb( GncHtml* html, GncHTMLLoadCB load_cb, gpointer data ) NOEXCEPT;
+void gnc_html_set_flyover_cb( GncHtml* html, GncHTMLFlyoverCB newwin_cb, gpointer data ) NOEXCEPT;
+void gnc_html_set_button_cb( GncHtml* html, GncHTMLButtonCB button_cb, gpointer data ) NOEXCEPT;
 
 /* object handlers deal with <object classid="foo"> objects in HTML.
  * the handlers are looked up at object load time. */
-void gnc_html_register_object_handler( const gchar* classid, GncHTMLObjectCB hand );
-void gnc_html_unregister_object_handler( const gchar* classid );
+void gnc_html_register_object_handler( const gchar* classid, GncHTMLObjectCB hand ) NOEXCEPT;
+void gnc_html_unregister_object_handler( const gchar* classid ) NOEXCEPT;
 
 /* stream handlers load data for particular URLTypes. */
-void gnc_html_register_stream_handler( URLType url_type, GncHTMLStreamCB hand );
-void gnc_html_unregister_stream_handler( URLType url_type );
+void gnc_html_register_stream_handler( URLType url_type, GncHTMLStreamCB hand ) NOEXCEPT;
+void gnc_html_unregister_stream_handler( URLType url_type ) NOEXCEPT;
 
 /* handlers for particular URLTypes. */
-void gnc_html_register_url_handler( URLType url_type, GncHTMLUrlCB hand );
-void gnc_html_unregister_url_handler( URLType url_type );
+void gnc_html_register_url_handler( URLType url_type, GncHTMLUrlCB hand ) NOEXCEPT;
+void gnc_html_unregister_url_handler( URLType url_type ) NOEXCEPT;
 
-const gchar* gnc_html_get_embedded_param( gpointer eb, const gchar* param_name );
+const gchar* gnc_html_get_embedded_param( gpointer eb, const gchar* param_name ) NOEXCEPT;
+
+#ifdef __cplusplus
+}
+#endif
 
 G_END_DECLS
 #endif

--- a/gnucash/html/gnc-html.i
+++ b/gnucash/html/gnc-html.i
@@ -39,7 +39,7 @@
 %{
 #include "guile-mappings.h"
 
-SCM scm_init_sw_gnc_html_module(void);
+extern "C" SCM scm_init_sw_gnc_html_module(void);
 %}
 #endif
 
@@ -50,13 +50,13 @@ SCM scm_init_sw_gnc_html_module(void);
 
 %include "gnc-html-extras.h"
 
-void gnc_html_initialize(void);
+void gnc_html_initialize(void) noexcept;
 
 %init {
   {
     char tmp[100];
 
-#define SET_ENUM(e) snprintf(tmp, 100, "(set! %s (%s))", (e), (e));  \
+#define SET_ENUM(e) std::snprintf(tmp, 100, "(set! %s (%s))", (e), (e));  \
     scm_c_eval_string(tmp);
 
     SET_ENUM("URL-TYPE-FILE");

--- a/gnucash/python/gncmod-python.c
+++ b/gnucash/python/gncmod-python.c
@@ -73,7 +73,7 @@ libgncmod_python_gnc_module_init(int refcount)
     PyStatus status;
     PyConfig config;
     PyConfig_InitPythonConfig(&config);
-    status = PyConfig_SetBytesArgv(&config, 0, &argv);
+    status = PyConfig_SetBytesArgv(&config, 0, (char * const *)&argv);
     if (PyStatus_Exception(status))
     {
         PyConfig_Clear(&config);

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -290,11 +290,11 @@ gnucash/gtkbuilder/gnc-recurrence.glade
 gnucash/gtkbuilder/gnc-tree-view-owner.glade
 gnucash/gtkbuilder/window-autoclear.glade
 gnucash/gtkbuilder/window-reconcile.glade
-gnucash/html/gnc-html.c
-gnucash/html/gnc-html-factory.c
-gnucash/html/gnc-html-history.c
-gnucash/html/gnc-html-webkit1.c
-gnucash/html/gnc-html-webkit2.c
+gnucash/html/gnc-html.cpp
+gnucash/html/gnc-html-factory.cpp
+gnucash/html/gnc-html-history.cpp
+gnucash/html/gnc-html-webkit1.cpp
+gnucash/html/gnc-html-webkit2.cpp
 gnucash/html/html.scm
 gnucash/import-export/aqb/assistant-ab-initial.c
 gnucash/import-export/aqb/assistant-ab-initial.glade


### PR DESCRIPTION
Converted the gnc-html target to C++
	  - no longer minimal conversion
	  - has some C++ constructs: nullptr, "using" directives, some STL containers
tested the Build and unittests on Windows 11 and Ubuntu (Jammy Jellyfish)
unittests configured with -DWITH_PYTHON=ON
	  - passes on Ubuntu
	  - only the python-bindings test fails on Windows (multiple pre-existing issues)

BTW, This is my first GNC PR