### PR TITLE
[gnc-html.i] add missing <cstdio>

### DIFF
--- a/gnucash/html/gnc-html.i
+++ b/gnucash/html/gnc-html.i
@@ -31,6 +31,7 @@
 #include <gnc-gnome-utils.h>
 #include <gnc-gui-query.h>
 #include <gnc-html.h>
+#include <cstdio>
 %}
 #if defined(SWIGGUILE)
 


### PR DESCRIPTION
getting compilation errors after a6f768069d both gcc and clang
```
/gnu/store/xiq39amq89jqnbxh8ql264i18hb0h28r-profile/include/stdio.h:385:12: note: ‘snprintf’ declared here
  385 | extern int snprintf (char *__restrict __s, size_t __maxlen,
      |            ^~~~~~~~
/home/chris/sources/gnucash/build-stable/gnucash/html/swig-gnc-html.cpp:1986:10: error: ‘snprintf’ is not a member of ‘std’; did you mean ‘snprintf’?
 1986 |     std::snprintf(tmp, 100, "(set! %s (%s))", ("URL-TYPE-SECURE"), ("URL-TYPE-SECURE"));       scm_c_eval_string(tmp);;
      |          ^~~~~~~~
/gnu/store/xiq39amq89jqnbxh8ql264i18hb0h28r-profile/include/stdio.h:385:12: note: ‘snprintf’ declared here
  385 | extern int snprintf (char *__restrict __s, size_t __maxlen,
      |            ^~~~~~~~
/home/chris/sources/gnucash/build-stable/gnucash/html/swig-gnc-html.cpp:1987:10: error: ‘snprintf’ is not a member of ‘std’; did you mean ‘snprintf’?
 1987 |     std::snprintf(tmp, 100, "(set! %s (%s))", ("URL-TYPE-REGISTER"), ("URL-TYPE-REGISTER"));       scm_c_eval_string(tmp);;
      |          ^~~~~~~~
/gnu/store/xiq39amq89jqnbxh8ql264i18hb0h28r-profile/include/stdio.h:385:12: note: ‘snprintf’ declared here
  385 | extern int snprintf (char *__restrict __s, size_t __maxlen,
      |            ^~~~~~~~
/home/chris/sources/gnucash/build-stable/gnucash/html/swig-gnc-html.cpp:1988:10: error: ‘snprintf’ is not a member of ‘std’; did you mean ‘snprintf’?
 1988 |     std::snprintf(tmp, 100, "(set! %s (%s))", ("URL-TYPE-ACCTTREE"), ("URL-TYPE-ACCTTREE"));       scm_c_eval_string(tmp);;
      |          ^~~~~~~~
/gnu/store/xiq39amq89jqnbxh8ql264i18hb0h28r-profile/include/stdio.h:385:12: note: ‘snprintf’ declared here
  385 | extern int snprintf (char *__restrict __s, size_t __maxlen,
```
