### PR TITLE
Fix black window rendering on macOS with tiling window managers

### DIFF
--- a/gnucash/gnome-utils/dialog-utils.c
+++ b/gnucash/gnome-utils/dialog-utils.c
@@ -80,6 +80,30 @@ gnc_set_label_color(GtkWidget *label, gnc_numeric value)
 }
 
 
+#ifdef MAC_INTEGRATION
+static gboolean
+gnc_window_redraw_idle_cb (gpointer user_data)
+{
+    GtkWidget *widget = GTK_WIDGET (user_data);
+    if (gtk_widget_get_mapped (widget))
+        gtk_widget_queue_draw (widget);
+    return G_SOURCE_REMOVE;
+}
+
+static gboolean
+gnc_window_map_event_redraw_cb (GtkWidget *widget,
+                                GdkEvent  *event,
+                                gpointer   user_data)
+{
+    /* Schedule a redraw at idle priority so the window manager has
+     * time to finish repositioning the window.  This fixes black
+     * window rendering when a tiling window manager (e.g. Aerospace)
+     * moves the window after GTK maps it. */
+    g_idle_add (gnc_window_redraw_idle_cb, widget);
+    return FALSE;
+}
+#endif
+
 /********************************************************************\
  * gnc_restore_window_size                                          *
  *   restores the position and size of the given window, if these   *
@@ -184,6 +208,19 @@ gnc_restore_window_size(const char *group, GtkWindow *window, GtkWindow *parent)
         }
     }
     g_variant_unref (geometry);
+
+#ifdef MAC_INTEGRATION
+    /* Workaround for GTK3 Quartz backend rendering issue: when a
+     * third-party tiling window manager (e.g. Aerospace) repositions a
+     * window after GTK has shown it but before the initial draw
+     * completes, the window contents can remain black.  Forcing a
+     * queue_draw after the window is fully mapped ensures a
+     * complete redraw. */
+    g_signal_connect_after (window, "map-event",
+                            G_CALLBACK (gnc_window_map_event_redraw_cb),
+                            NULL);
+#endif
+
     LEAVE("");
 }
 


### PR DESCRIPTION
## Summary

- On macOS with a third-party tiling window manager (e.g. Aerospace), dialog windows such as the Price Database render entirely black when first opened. Content only appears progressively as the mouse moves over the window.
- Root cause: the tiling WM repositions the window after GTK's Quartz backend maps it but before the initial draw completes, invalidating the Quartz surface without triggering a new expose event.
- Fix: connect a `map-event` handler in `gnc_restore_window_size()` that schedules an idle `gtk_widget_queue_draw()`, ensuring a full redraw after the WM finishes repositioning.
- Guarded by `#ifdef MAC_INTEGRATION` — no impact on Linux or Windows builds.

## Screenshots

**Before fix — dialog opens black:**
The Price Database dialog renders completely black on open.

**Before fix — mouse reveals content:**
Moving the mouse over the black area progressively reveals the underlying widgets.

_(Screenshots available on request — account data has been redacted.)_

## Test plan

- [x] Open GnuCash on macOS with a tiling window manager (Aerospace, yabai, Amethyst, etc.)
- [x] Open various dialogs: Price Database (Tools > Price Database), Preferences, Transfer Funds
- [x] Verify dialogs render immediately without needing mouse interaction
- [x] Verify no visual regressions on standard macOS (no tiling WM)
- [x] Verify Linux builds are unaffected (fix is `#ifdef MAC_INTEGRATION`)