### PR TITLE
Python binding: example and test to create new book

### DIFF
--- a/bindings/python/example_scripts/simple_book.py
+++ b/bindings/python/example_scripts/simple_book.py
@@ -9,14 +9,12 @@ from gnucash import Session, SessionOpenMode
 
 # We need to tell GnuCash the data format to create the new file as (xml://)
 uri = "xml:///tmp/simple_book.gnucash"
-# Alternatively, use "sqlite3://..." instead to save as sqlite file.
 
 print("uri:", uri)
 with Session(uri, SessionOpenMode.SESSION_NEW_STORE) as ses:
     book = ses.get_book()
 
-    # Call some methods that produce output to show that Book works and to mark it as "something
-    # needs to be saved".
+    # Create root account to mark the book as "needs saving".
     book.get_root_account().SetDescription("hello, book")
     print("Book is saved:", not book.session_not_saved())
 

--- a/bindings/python/example_scripts/simple_book.py
+++ b/bindings/python/example_scripts/simple_book.py
@@ -9,17 +9,19 @@ from gnucash import Session, SessionOpenMode
 
 # We need to tell GnuCash the data format to create the new file as (xml://)
 uri = "xml:///tmp/simple_book.gnucash"
+# Alternatively, use "sqlite3://..." instead to save as sqlite file.
 
 print("uri:", uri)
 with Session(uri, SessionOpenMode.SESSION_NEW_STORE) as ses:
     book = ses.get_book()
 
-    #Call some methods that produce output to show that Book works
+    # Call some methods that produce output to show that Book works and to mark it as "something
+    # needs to be saved".
     book.get_root_account().SetDescription("hello, book")
     print("Book is saved:", not book.session_not_saved())
 
-    #As long as there's no exceptions, book is automatically saved
-    #when session ends.
+    # As long as there's no exception, book is automatically saved
+    # when session ends.
     print("saving...")
 
 print("Book is saved:", not book.session_not_saved())

--- a/bindings/python/example_scripts/simple_sqlite_create.py
+++ b/bindings/python/example_scripts/simple_sqlite_create.py
@@ -3,12 +3,13 @@
 #   @brief Example Script simple sqlite create 
 #   @ingroup python_bindings_examples
 
+import os
 from gnucash import Session, Account, SessionOpenMode
 from os.path import abspath
 from gnucash.gnucash_core_c import ACCT_TYPE_ASSET
 
 s = Session('sqlite3://%s' % abspath('test.blob'), SessionOpenMode.SESSION_NEW_STORE)
-# this seems to make a difference in more complex cases
+# This seems to make a difference in more complex cases
 s.save()
 
 book = s.book
@@ -23,3 +24,21 @@ a.SetCommodity( commod_table.lookup('CURRENCY', 'CAD') )
 s.save()
 
 s.end()
+
+########################################
+# Similar, but create empty file first.
+
+targetpath = os.path.abspath("./test.gnucash")
+targetfile = f"sqlite3://{targetpath}"
+
+# Remove if it existst.
+if os.path.exists(targetpath):
+    os.remove(targetpath)
+
+with Session(targetfile, SessionOpenMode.SESSION_NEW_STORE) as session:
+    session.book.get_root_account()  # Seems necessary to trigger creation of tables.
+print("test.gnucash created")
+
+with Session(targetfile, SessionOpenMode.SESSION_NORMAL_OPEN) as session:
+    print("Opened again")
+print("Closed again.")

--- a/bindings/python/example_scripts/simple_sqlite_create.py
+++ b/bindings/python/example_scripts/simple_sqlite_create.py
@@ -25,10 +25,10 @@ def create_new_empty_file(delete=True):
 
         with Session(targetfile, SessionOpenMode.SESSION_NEW_STORE) as session:
             session.book.get_root_account()  # Seems necessary to trigger creation of tables.
-        print(f"Gnucash file {targetfile} created")
+        print(f"Gnucash file {targetfile} created.")
 
         with Session(targetfile, SessionOpenMode.SESSION_NORMAL_OPEN) as session:
-            print("Opened again")
+            print("Opened again.")
         print("Closed again.")
 
 

--- a/bindings/python/example_scripts/simple_sqlite_create.py
+++ b/bindings/python/example_scripts/simple_sqlite_create.py
@@ -4,41 +4,64 @@
 #   @ingroup python_bindings_examples
 
 import os
+from tempfile import TemporaryDirectory
+
 from gnucash import Session, Account, SessionOpenMode
 from os.path import abspath
 from gnucash.gnucash_core_c import ACCT_TYPE_ASSET
 
-s = Session('sqlite3://%s' % abspath('test.blob'), SessionOpenMode.SESSION_NEW_STORE)
-# This seems to make a difference in more complex cases
-s.save()
 
-book = s.book
-root = book.get_root_account()
-a = Account(book)
-root.append_child(a)
-a.SetName('wow')
-a.SetType(ACCT_TYPE_ASSET)
+def create_new_empty_file(delete=True):
+    """Create file "new_empty.gnucash" in temporary directory.
 
-commod_table = book.get_table()
-a.SetCommodity( commod_table.lookup('CURRENCY', 'CAD') )
-s.save()
+    Parameters
+    ----------
+    delete: boolean, default=True
+      If False, do not delete temporary file
+    """
 
-s.end()
+    with TemporaryDirectory(delete=delete) as tmpdir:
+        targetfile = f"sqlite3://{tmpdir}/new_empty.gnucash"
 
-########################################
-# Similar, but create empty file first.
+        with Session(targetfile, SessionOpenMode.SESSION_NEW_STORE) as session:
+            session.book.get_root_account()  # Seems necessary to trigger creation of tables.
+        print(f"Gnucash file {targetfile} created")
 
-targetpath = os.path.abspath("./test.gnucash")
-targetfile = f"sqlite3://{targetpath}"
+        with Session(targetfile, SessionOpenMode.SESSION_NORMAL_OPEN) as session:
+            print("Opened again")
+        print("Closed again.")
 
-# Remove if it existst.
-if os.path.exists(targetpath):
-    os.remove(targetpath)
 
-with Session(targetfile, SessionOpenMode.SESSION_NEW_STORE) as session:
-    session.book.get_root_account()  # Seems necessary to trigger creation of tables.
-print("test.gnucash created")
+def create_new_file_with_account(delete=True):
+    """Create file "new_with_account.gnucash" in temporary directory.
 
-with Session(targetfile, SessionOpenMode.SESSION_NORMAL_OPEN) as session:
-    print("Opened again")
-print("Closed again.")
+    Parameters
+    ----------
+    delete: boolean, default=True
+      If False, do not delete temporary file
+    """
+    with TemporaryDirectory(delete=delete) as tmpdir:
+
+        targetfile = f"sqlite3://{tmpdir}/new_with_account.gnucash"
+        print(f"Creating: {targetfile}")
+        s = Session(targetfile, SessionOpenMode.SESSION_NEW_STORE)
+        # The save() seems to make a difference in more complex cases.
+        s.save()
+
+        book = s.book
+        root = book.get_root_account()
+        a = Account(book)
+        root.append_child(a)
+        a.SetName('wow')
+        a.SetType(ACCT_TYPE_ASSET)
+
+        commod_table = book.get_table()
+        a.SetCommodity( commod_table.lookup('CURRENCY', 'CAD') )
+        s.save()
+
+        s.end()
+
+
+create_new_empty_file()
+
+create_new_file_with_account()

--- a/bindings/python/tests/test_book.py
+++ b/bindings/python/tests/test_book.py
@@ -1,6 +1,16 @@
-from unittest import TestCase, main
 
-from gnucash import Session
+from tempfile import TemporaryDirectory
+from unittest import (
+    TestCase,
+    expectedFailure,
+    main,
+    )
+
+from gnucash import (
+    Session,
+    SessionOpenMode,
+    )
+
 
 class BookSession(TestCase):
     def setUp(self):
@@ -9,9 +19,32 @@ class BookSession(TestCase):
         self.table = self.book.get_table()
         self.currency = self.table.lookup('CURRENCY', 'EUR')
 
+
 class TestBook(BookSession):
     def test_markclosed(self):
         self.ses.end()
+
+
+@expectedFailure
+class TestBookSqlite(TestCase):
+    """Testing books with the sqlite backend.
+    """
+    def test_create_empty(self):
+        """Test if just creating a book leaves it in a usable state (not locked).
+        """
+
+        with TemporaryDirectory() as tmpdir:
+            targetfile = f"sqlite3://{tmpdir}/new_empty.gnucash"
+            with Session(targetfile, SessionOpenMode.SESSION_NEW_STORE):
+                pass
+                # get_root_account() seemed necessary in 5.15 to trigger creation of tables.
+                # session.book.get_root_account()
+            print(f"Gnucash file {targetfile} created.")
+
+            with Session(targetfile, SessionOpenMode.SESSION_NORMAL_OPEN):
+                print("Opening again worked.")
+            print("Closed again.")
+
 
 if __name__ == '__main__':
     main()

--- a/bindings/python/tests/test_session.py
+++ b/bindings/python/tests/test_session.py
@@ -8,6 +8,9 @@
 # @date 2020-04-03
 # @author Christoph Holtermann <mail@c-holtermann.net>
 
+import os
+from tempfile import TemporaryDirectory
+from urllib.parse import urlunparse
 from unittest import TestCase, main
 
 from gnucash import (
@@ -31,8 +34,6 @@ class TestSession(TestCase):
 
     def test_session_with_new_file(self):
         """create Session with new xml file"""
-        from tempfile import TemporaryDirectory
-        from urllib.parse import urlunparse
         with TemporaryDirectory() as tempdir:
             uri = urlunparse(("xml", tempdir, "tempfile", "", "", ""))
             with Session(uri, SessionOpenMode.SESSION_NEW_STORE) as ses:
@@ -60,6 +61,20 @@ class TestSession(TestCase):
             with Session() as ses:
                 ses.begin(uri, is_new=True)
 
+    def test_minimal_new_sqlite(self):
+        """Test if a minimal new sqlite file is correctly written.
+        """
+        with TemporaryDirectory() as tempdir:
+            targetpath = os.path.join([tempdir, "test.gnucash"])
+            targetfile = f"sqlite3://{targetpath}"
+
+            with Session(targetfile, SessionOpenMode.SESSION_NEW_STORE) as session:
+                session.book.get_root_account()  # Seems necessary to trigger creation of tables.
+            print("test.gnucash created")
+
+            with Session(targetfile, SessionOpenMode.SESSION_NORMAL_OPEN) as session:
+                print("Opened again")
+            print("Closed again.")
 
     def test_app_utils_get_current_session(self):
         from gnucash import _sw_app_utils

--- a/bindings/python/tests/test_session.py
+++ b/bindings/python/tests/test_session.py
@@ -65,7 +65,7 @@ class TestSession(TestCase):
         """Test if a minimal new sqlite file is correctly written.
         """
         with TemporaryDirectory() as tempdir:
-            targetpath = os.path.join([tempdir, "test.gnucash"])
+            targetpath = os.path.join(tempdir, "test.gnucash")
             targetfile = f"sqlite3://{targetpath}"
 
             with Session(targetfile, SessionOpenMode.SESSION_NEW_STORE) as session:


### PR DESCRIPTION
Added a few more examples and one test to Python, regarding new book creation.

Especially noted that session.book.get_root_account() is necessary to mark the book as dirty, otherwise the tables will not be created.