### PR TITLE
Bug 799314 - Add Run command to Schedule Transactions

### DIFF
--- a/gnucash/gnome/dialog-sx-since-last-run.c
+++ b/gnucash/gnome/dialog-sx-since-last-run.c
@@ -901,63 +901,6 @@ gnc_ui_sx_creation_error_dialog (GList **creation_errors)
     g_free (message);
 }
 
-void
-gnc_sx_sxsincelast_book_opened (void)
-{
-    GList *auto_created_txns = NULL;
-    GList *creation_errors = NULL;
-    GncSxInstanceModel *inst_model;
-    GncSxSummary summary;
-
-    if (!gnc_prefs_get_bool (GNC_PREFS_GROUP_STARTUP, GNC_PREF_RUN_AT_FOPEN))
-        return;
-
-    if (qof_book_is_readonly (gnc_get_current_book ()))
-    {
-        /* Is the book read-only? Then don't change anything here. */
-        return;
-    }
-
-    inst_model = gnc_sx_get_current_instances ();
-    gnc_sx_instance_model_summarize (inst_model, &summary);
-    gnc_sx_summary_print (&summary);
-    gnc_sx_instance_model_effect_change (inst_model, TRUE, &auto_created_txns,
-                                         &creation_errors);
-
-    if (auto_created_txns)
-        gnc_gui_refresh_all();
-
-    if (summary.need_dialog)
-    {
-        gnc_ui_sx_since_last_run_dialog (gnc_ui_get_main_window (NULL), inst_model, auto_created_txns);
-        /* gnc_ui_sx_since_last_run_dialog now owns this list */
-        auto_created_txns = NULL;
-    }
-    else
-    {
-        g_list_free (auto_created_txns);
-
-        if (summary.num_auto_create_no_notify_instances != 0
-                && gnc_prefs_get_bool (GNC_PREFS_GROUP_STARTUP, GNC_PREF_SHOW_AT_FOPEN))
-        {
-            gnc_info_dialog
-            (gnc_ui_get_main_window (NULL),
-             ngettext
-             ("There are no Scheduled Transactions to be entered at this time. "
-              "(One transaction automatically created)",
-              "There are no Scheduled Transactions to be entered at this time. "
-              "(%d transactions automatically created)",
-              summary.num_auto_create_no_notify_instances),
-              summary.num_auto_create_no_notify_instances);
-        }
-    }
-
-    g_object_unref (G_OBJECT(inst_model));
-
-    if (creation_errors)
-        gnc_ui_sx_creation_error_dialog (&creation_errors);
-}
-
 static GtkTreePath *
 instance_get_model_path (GtkTreeView *view, const gchar *path)
 {
@@ -1319,8 +1262,8 @@ sort_column_changed (GtkTreeSortable* self, gpointer user_data)
     g_idle_add ((GSourceFunc)follow_select_tree_path, dialog->instance_view);
 }
 
-GncSxSinceLastRunDialog*
-gnc_ui_sx_since_last_run_dialog (GtkWindow *parent, GncSxInstanceModel *sx_instances, GList *auto_created_txn_guids)
+static void
+since_last_run_dialog (GtkWindow *parent, GncSxInstanceModel *sx_instances, GList *auto_created_txn_guids)
 {
     GncSxSinceLastRunDialog *dialog;
     GtkBuilder *builder;
@@ -1470,8 +1413,76 @@ gnc_ui_sx_since_last_run_dialog (GtkWindow *parent, GncSxInstanceModel *sx_insta
     gtk_builder_connect_signals_full (builder, gnc_builder_connect_full_func, dialog);
 
     g_object_unref (G_OBJECT(builder));
+}
 
-    return dialog;
+static void
+sx_since_last_run_dialog (GncSxInstanceModel *sx_instances, int book_opened)
+{
+    if (qof_book_is_readonly (gnc_get_current_book ()))
+        return;
+
+    GncSxSummary summary;
+
+    gnc_sx_instance_model_summarize (sx_instances, &summary);
+
+    if (book_opened)
+        gnc_sx_summary_print (&summary);
+
+    GList *auto_created_txns = NULL;
+    GList *creation_errors = NULL;
+
+    gnc_sx_instance_model_effect_change (sx_instances, TRUE, &auto_created_txns, &creation_errors);
+
+    if (auto_created_txns)
+        gnc_gui_refresh_all ();
+
+    if (summary.need_dialog)
+        since_last_run_dialog (gnc_ui_get_main_window (NULL), sx_instances, auto_created_txns);
+    else
+    {
+        if (summary.num_auto_create_no_notify_instances == 0)
+        {
+            if (!book_opened)
+            {
+                const char *nothing_to_do_msg = _( "There are no Scheduled Transactions to be entered at this time." );
+
+                gnc_info_dialog (gnc_ui_get_main_window (NULL), "%s", nothing_to_do_msg);
+            }
+        }
+        else if (!book_opened || gnc_prefs_get_bool (GNC_PREFS_GROUP_STARTUP, GNC_PREF_SHOW_AT_FOPEN))
+        {
+            gnc_info_dialog (gnc_ui_get_main_window (NULL), ngettext
+                    /* Translators: %d is the number of transactions. This is a ngettext(3) message. */
+                    ("There are no Scheduled Transactions to be entered at this time. "
+                     "(%d transaction automatically created)",
+                     "There are no Scheduled Transactions to be entered at this time. "
+                     "(%d transactions automatically created)",
+                     summary.num_auto_create_no_notify_instances),
+                    summary.num_auto_create_no_notify_instances);
+        }
+        g_list_free (auto_created_txns);
+    }
+
+    g_object_unref (G_OBJECT(sx_instances));
+
+    if (creation_errors)
+        gnc_ui_sx_creation_error_dialog (&creation_errors);
+}
+
+void
+gnc_ui_sx_since_last_run_dialog (GncSxInstanceModel *sx_instances)
+{
+    sx_since_last_run_dialog (sx_instances, FALSE);
+}
+
+void
+gnc_sx_sxsincelast_book_opened (void)
+{
+    if (!gnc_prefs_get_bool (GNC_PREFS_GROUP_STARTUP, GNC_PREF_RUN_AT_FOPEN))
+        return;
+
+    sx_since_last_run_dialog (gnc_sx_get_current_instances (), TRUE);
+
 }
 
 static void

--- a/gnucash/gnome/dialog-sx-since-last-run.h
+++ b/gnucash/gnome/dialog-sx-since-last-run.h
@@ -31,6 +31,10 @@
 #include "gnc-sx-instance-model.h"
 #include "gnc-plugin-page-sx-list.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define GNC_PREFS_GROUP_STARTUP "dialogs.sxs.since-last-run"
 #define GNC_PREF_RUN_AT_FOPEN   "show-at-file-open"
 #define GNC_PREF_SHOW_AT_FOPEN  "show-notify-window-at-file-open"
@@ -47,10 +51,12 @@ void gnc_sx_sxsincelast_book_opened (void);
 /**
  * Create the since-last-run dialog.
  **/
-GncSxSinceLastRunDialog*  gnc_ui_sx_since_last_run_dialog (GtkWindow *parent,
-                                                           GncSxInstanceModel *sx_instances,
-                                                           GList *auto_created_txn_guids);
+void gnc_ui_sx_since_last_run_dialog (GncSxInstanceModel *sx_instances);
 
 void gnc_ui_sx_creation_error_dialog (GList **creation_errors);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/gnucash/gnome/gnc-plugin-basic-commands.c
+++ b/gnucash/gnome/gnc-plugin-basic-commands.c
@@ -471,61 +471,10 @@ gnc_main_window_cmd_actions_since_last_run (GSimpleAction *simple,
                                             gpointer       user_data)
 {
     GncMainWindowActionData *data = user_data;
-    GtkWindow *window;
-    GncSxInstanceModel *sx_instances;
-    GncSxSummary summary;
-    GList *auto_created_txns = NULL;
-    GList *creation_errors = NULL;
-    const char *nothing_to_do_msg =
-        _( "There are no Scheduled Transactions to be entered at this time." );
 
     g_return_if_fail (data != NULL);
 
-    window = GTK_WINDOW(data->window);
-
-    if (qof_book_is_readonly (gnc_get_current_book()))
-    {
-        /* Is the book read-only? Then don't change anything here. */
-        return;
-    }
-
-    sx_instances = gnc_sx_get_current_instances();
-    gnc_sx_instance_model_summarize(sx_instances, &summary);
-    gnc_sx_instance_model_effect_change(sx_instances, TRUE, &auto_created_txns,
-                                        &creation_errors);
-
-    if (auto_created_txns)
-        gnc_gui_refresh_all();
-
-    if (summary.need_dialog)
-    {
-        gnc_ui_sx_since_last_run_dialog (window, sx_instances, auto_created_txns);
-        auto_created_txns = NULL;
-    }
-    else
-    {
-        if (summary.num_auto_create_no_notify_instances == 0)
-        {
-            gnc_info_dialog (window, "%s", nothing_to_do_msg);
-        }
-        else
-        {
-            gnc_info_dialog (window, ngettext
-                             /* Translators: %d is the number of transactions. This is a
-                                ngettext(3) message. */
-                             ("There are no Scheduled Transactions to be entered at this time. "
-                              "(%d transaction automatically created)",
-                              "There are no Scheduled Transactions to be entered at this time. "
-                              "(%d transactions automatically created)",
-                              summary.num_auto_create_no_notify_instances),
-                              summary.num_auto_create_no_notify_instances);
-        }
-    }
-    g_list_free (auto_created_txns);
-    g_object_unref (G_OBJECT(sx_instances));
-
-    if (creation_errors)
-        gnc_ui_sx_creation_error_dialog (&creation_errors);
+    gnc_ui_sx_since_last_run_dialog (gnc_sx_get_current_instances ());
 }
 
 static void

--- a/gnucash/gnome/gnc-plugin-page-sx-list.cpp
+++ b/gnucash/gnome/gnc-plugin-page-sx-list.cpp
@@ -53,6 +53,7 @@
 #include "Transaction.h"
 #include "dialog-sx-editor.h"
 #include "dialog-utils.h"
+#include "dialog-sx-since-last-run.h"
 #include "gnc-commodity.h"
 #include "gnc-component-manager.h"
 #include "gnc-date.h"
@@ -124,6 +125,7 @@ static void gppsl_row_activated_cb (GtkTreeView *tree_view, GtkTreePath *path,
 static void gnc_plugin_page_sx_list_cmd_new (GSimpleAction *simple, GVariant *paramter, gpointer user_data);
 static void gnc_plugin_page_sx_list_cmd_edit (GSimpleAction *simple, GVariant *paramter, gpointer user_data);
 static void gnc_plugin_page_sx_list_cmd_delete (GSimpleAction *simple, GVariant *paramter, gpointer user_data);
+static void gnc_plugin_page_sx_list_cmd_run (GSimpleAction *simple, GVariant *paramter, gpointer user_data);
 static void gnc_plugin_page_sx_list_cmd_refresh (GSimpleAction *simple, GVariant *paramter, gpointer user_data);
 static void gnc_plugin_page_sx_list_cmd_save_layout (GSimpleAction *simple, GVariant *paramter, gpointer user_data);
 static void gnc_plugin_page_sx_list_cmd_edit_tax_options (GSimpleAction *simple, GVariant *paramter, gpointer user_data);
@@ -135,6 +137,7 @@ static GActionEntry gnc_plugin_page_sx_list_actions [] =
     { "SxListNewAction", gnc_plugin_page_sx_list_cmd_new, nullptr, nullptr, nullptr },
     { "SxListEditAction", gnc_plugin_page_sx_list_cmd_edit, nullptr, nullptr, nullptr },
     { "SxListDeleteAction", gnc_plugin_page_sx_list_cmd_delete, nullptr, nullptr, nullptr },
+    { "SxListRunAction", gnc_plugin_page_sx_list_cmd_run, nullptr, nullptr, nullptr },
     { "ViewRefreshAction", gnc_plugin_page_sx_list_cmd_refresh, nullptr, nullptr, nullptr },
     { "ViewSaveLayoutAction", gnc_plugin_page_sx_list_cmd_save_layout, nullptr, nullptr, nullptr },
     { "EditTaxOptionsAction", gnc_plugin_page_sx_list_cmd_edit_tax_options, nullptr, nullptr, nullptr },
@@ -315,17 +318,19 @@ static void
 gppsl_selection_changed_cb (GtkTreeSelection *selection, gpointer user_data)
 {
     GncPluginPage *page;
-    GAction *edit_action, *delete_action;
+    GAction *edit_action, *delete_action, *run_action;
     gboolean selection_state = true;
 
     page = GNC_PLUGIN_PAGE(user_data);
     edit_action = gnc_plugin_page_get_action (page, "SxListEditAction");
     delete_action = gnc_plugin_page_get_action (page, "SxListDeleteAction");
+    run_action = gnc_plugin_page_get_action (page, "SxListRunAction");
     selection_state = gtk_tree_selection_count_selected_rows (selection) == 0
                       ? false
                       : true;
     g_simple_action_set_enabled (G_SIMPLE_ACTION(edit_action), selection_state);
     g_simple_action_set_enabled (G_SIMPLE_ACTION(delete_action), selection_state);
+    g_simple_action_set_enabled (G_SIMPLE_ACTION(run_action), selection_state);
 }
 
 
@@ -411,6 +416,12 @@ treeview_popup (GtkTreeView *treeview, GdkEvent *event, GncPluginPageSxList *pag
 
     menuitem = gtk_menu_item_new_with_mnemonic (_("_Delete Schedule"));
     full_action_name = g_strconcat (group_name, ".SxListDeleteAction", nullptr);
+    gtk_actionable_set_action_name (GTK_ACTIONABLE(menuitem), full_action_name);
+    g_free (full_action_name);
+    gtk_menu_shell_append (GTK_MENU_SHELL(menu), menuitem);
+
+    menuitem = gtk_menu_item_new_with_mnemonic (_("_Run Schedule"));
+    full_action_name = g_strconcat (group_name, ".SxListRunAction", nullptr);
     gtk_actionable_set_action_name (GTK_ACTIONABLE(menuitem), full_action_name);
     g_free (full_action_name);
     gtk_menu_shell_append (GTK_MENU_SHELL(menu), menuitem);
@@ -521,11 +532,13 @@ gnc_plugin_page_sx_list_create_widget (GncPluginPage *plugin_page)
     }
 
     {
-        GAction *edit_action, *delete_action;
+        GAction *edit_action, *delete_action, *run_action;
         edit_action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE(page), "SxListEditAction");
         delete_action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE(page), "SxListDeleteAction");
+        run_action = gnc_plugin_page_get_action (GNC_PLUGIN_PAGE(page), "SxListRunAction");
         g_simple_action_set_enabled (G_SIMPLE_ACTION(edit_action), false);
         g_simple_action_set_enabled (G_SIMPLE_ACTION(delete_action), false);
+        g_simple_action_set_enabled (G_SIMPLE_ACTION(run_action), false);
     }
 
     {
@@ -1081,6 +1094,32 @@ gnc_plugin_page_sx_list_cmd_delete (GSimpleAction *simple,
 
     g_free (message);
     g_list_free (to_delete);
+    g_list_foreach (selected_paths, (GFunc)gtk_tree_path_free, nullptr);
+    g_list_free (selected_paths);
+}
+
+static void
+gnc_plugin_page_sx_list_cmd_run (GSimpleAction *simple,
+                                 GVariant      *parameter,
+                                 gpointer       user_data)
+{
+    auto plugin_page = GNC_PLUGIN_PAGE_SX_LIST(user_data);
+    auto priv = GNC_PLUGIN_PAGE_SX_LIST_GET_PRIVATE(plugin_page);
+    auto selection = gtk_tree_view_get_selection (priv->tree_view);
+    GtkTreeModel *model;
+    auto selected_paths = gtk_tree_selection_get_selected_rows (selection, &model);
+
+    if (!selected_paths)
+    {
+        PWARN ("no selection for run.");
+        return;
+    }
+
+    auto to_run = gnc_g_list_map (selected_paths, (GncGMapFunc)_argument_reorder_fn, priv->tree_view);
+
+    gnc_ui_sx_since_last_run_dialog (gnc_sx_get_select_instances (to_run));
+
+    g_list_free (to_run);
     g_list_foreach (selected_paths, (GFunc)gtk_tree_path_free, nullptr);
     g_list_free (selected_paths);
 }

--- a/gnucash/ui/gnc-plugin-page-sx-list.ui
+++ b/gnucash/ui/gnc-plugin-page-sx-list.ui
@@ -67,6 +67,12 @@
       <attribute name="tooltip" translatable="yes">Delete the selected scheduled transaction</attribute>
       <attribute name="temp" translatable="no">yes</attribute>
     </item>
+    <item>
+      <attribute name="label" translatable="yes">_Run Schedule</attribute>
+      <attribute name="action">GncPluginPageSxListActions.SxListRunAction</attribute>
+      <attribute name="tooltip" translatable="yes">Run the selected scheduled transaction. If no transactions are scheduled to be entered, the next occurrence is used</attribute>
+      <attribute name="temp" translatable="no">yes</attribute>
+    </item>
   </menu>
 
 
@@ -195,6 +201,21 @@
         <property name="tooltip-text" translatable="yes">Delete the selected scheduled transaction</property>
         <property name="use-underline">True</property>
         <property name="icon-name">gnc-account-delete</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="homogeneous">True</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkToolButton" id="but6">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="label" translatable="yes">_Run</property>
+        <property name="action-name">GncPluginPageSxListActions.SxListRunAction</property>
+        <property name="tooltip-text" translatable="yes">Run the selected scheduled transaction. If no transactions are scheduled to be entered, the next occurrence is used</property>
+        <property name="use-underline">True</property>
+        <property name="icon-name">system-run</property>
       </object>
       <packing>
         <property name="expand">False</property>

--- a/libgnucash/app-utils/gnc-sx-instance-model.c
+++ b/libgnucash/app-utils/gnc-sx-instance-model.c
@@ -555,6 +555,41 @@ _gnc_sx_gen_instances(gpointer *data, gpointer user_data)
     return instances;
 }
 
+static GncSxInstances*
+sx_gen_select_instances(gpointer *data, gpointer user_data)
+{
+    GncSxInstances *instances = _gnc_sx_gen_instances(data, user_data);
+    GList *instlist = instances->instance_list;
+    
+    if (instlist == NULL)
+    {
+        SchedXaction *sx = instances->sx;
+        SXTmpStateData *temporal_state = gnc_sx_create_temporal_state(sx);
+        GDate cur_date = xaccSchedXactionGetNextInstance(sx, temporal_state);
+        
+        if (g_date_valid(&cur_date))
+        {
+            int seq_num = gnc_sx_get_instance_count(sx, temporal_state);
+            GncSxInstance *inst = gnc_sx_instance_new(instances, SX_INSTANCE_STATE_REMINDER,
+                    &cur_date, temporal_state, seq_num);
+
+            instances->instance_list = g_list_prepend (instlist, inst);
+        }
+
+        gnc_sx_destroy_temporal_state (temporal_state);
+    }
+
+    return instances;
+}
+
+static GncSxInstances*
+sx_instances(GncSxInstanceModel *model, SchedXaction *sx)
+{
+    return model->include_disabled ? 
+        sx_gen_select_instances((gpointer)sx, (gpointer)&model->range_end) :
+        _gnc_sx_gen_instances((gpointer)sx, (gpointer)&model->range_end);
+}
+
 GncSxInstanceModel*
 gnc_sx_get_current_instances(void)
 {
@@ -598,6 +633,24 @@ gnc_sx_get_instances(const GDate *range_end, gboolean include_disabled)
         instances->sx_instance_list = gnc_g_list_map(enabled_sxes, (GncGMapFunc)_gnc_sx_gen_instances, (gpointer)range_end);
         g_list_free(enabled_sxes);
     }
+
+    return instances;
+}
+
+GncSxInstanceModel*
+gnc_sx_get_select_instances(GList *sel_sxes)
+{
+    GncSxInstanceModel *instances;
+    GDate now;
+
+    g_date_clear(&now, 1);
+    gnc_gdate_set_time64(&now, gnc_time(NULL));
+
+    instances = gnc_sx_instance_model_new();
+    instances->include_disabled = TRUE;
+    instances->range_end = now;
+
+    instances->sx_instance_list = gnc_g_list_map(sel_sxes, (GncGMapFunc)sx_gen_select_instances, (gpointer)&now);
 
     return instances;
 }
@@ -786,9 +839,7 @@ _gnc_sx_instance_event_handler(QofInstance *ent, QofEventId event_type, gpointer
                 if (g_list_find(all_sxes, sx) && (!instances->include_disabled && xaccSchedXactionGetEnabled(sx)))
                 {
                     /* it's moved from disabled to enabled, add the instances */
-                    instances->sx_instance_list
-                        = g_list_append(instances->sx_instance_list,
-                                        _gnc_sx_gen_instances((gpointer)sx, (gpointer) & instances->range_end));
+                    instances->sx_instance_list = g_list_append(instances->sx_instance_list, sx_instances(instances, sx));
                     g_signal_emit_by_name(instances, "added", (gpointer)sx);
                 }
             }
@@ -817,9 +868,7 @@ _gnc_sx_instance_event_handler(QofInstance *ent, QofEventId event_type, gpointer
             if (instances->include_disabled || xaccSchedXactionGetEnabled(sx))
             {
                 /* generate instances, add to instance list, emit update. */
-                instances->sx_instance_list
-                    = g_list_append(instances->sx_instance_list,
-                                    _gnc_sx_gen_instances((gpointer)sx, (gpointer) & instances->range_end));
+                instances->sx_instance_list = g_list_append(instances->sx_instance_list, sx_instances(instances, sx));
                 g_signal_emit_by_name(instances, "added", (gpointer)sx);
             }
         }
@@ -861,7 +910,7 @@ gnc_sx_instance_model_update_sx_instances(GncSxInstanceModel *model, SchedXactio
 
     // merge the new instance data into the existing structure, mutating as little as possible.
     existing = (GncSxInstances*)link->data;
-    new_instances = _gnc_sx_gen_instances((gpointer)sx, &model->range_end);
+    new_instances = sx_instances(model, sx);
     existing->sx = new_instances->sx;
     existing->next_instance_date = new_instances->next_instance_date;
     {

--- a/libgnucash/app-utils/gnc-sx-instance-model.h
+++ b/libgnucash/app-utils/gnc-sx-instance-model.h
@@ -93,6 +93,15 @@ GncSxInstanceModel* gnc_sx_get_current_instances(void);
  * g_object_unref(G_OBJECT(inst_model)); when no longer in use. */
 GncSxInstanceModel* gnc_sx_get_instances(const GDate *range_end, gboolean include_disabled);
 
+/** Allocates a new SxInstanceModel and fills it with generated
+ * instances for the given scheduled transactions up to now.  If
+ * no instance exists for a given scheduled transaction, the next
+ * instance is generated.
+ * 
+ * The caller must unref the returned object by
+ * g_object_unref(G_OBJECT(inst_model)); when no longer in use. */
+GncSxInstanceModel* gnc_sx_get_select_instances(GList *sel_sxes);
+
 /**
  * Regenerates and updates the GncSxInstances* for the given SX.  Model
  * consumers are probably going to call this in response to seeing the


### PR DESCRIPTION
This patch adds a “Run” command to the “Scheduled Transactions” tab to allow users to select the scheduled transactions to be included in a “Since Last Run…” window.   If there are no instances of a selected transaction triggered by today’s date, the next instance is triggered.