### PR TITLE
[gnucash.css] the register entry selection needs to be set

### DIFF
--- a/gnucash/gnucash.css
+++ b/gnucash/gnucash.css
@@ -18,6 +18,11 @@ gnc-id-cursor entry {
   padding: 0px 2px 0px 2px;
 }
 
+/* Selection text in entry */
+gnc-id-cursor entry selection {
+  color: #1b4332;
+}
+
 gnc-id-cursor button {
   margin: 1px 1px 1px 1px;
 }


### PR DESCRIPTION
because on dark mode it'll be light on light green with poor contrast. set it to dark forest green on light green.

before:
<img width="860" height="555" alt="Screenshot_2026-04-23_21-52-49" src="https://github.com/user-attachments/assets/ec7474c5-21aa-4830-9df2-f417fa2e0975" />

after:
<img width="860" height="555" alt="image" src="https://github.com/user-attachments/assets/fe74f43c-001c-49c4-b9ca-912f5d99be6c" />

alternative: dark charcoal #2c2c2c
<img width="860" height="555" alt="image" src="https://github.com/user-attachments/assets/b1e604f2-0f2c-4eec-a8cb-556219efc7b1" />
