### PR TITLE
Bug 799762 - Poor handling of cases where hidden/placeholder accounts…

### DIFF
--- a/gnucash/register/register-gnome/combocell-gnome.c
+++ b/gnucash/register/register-gnome/combocell-gnome.c
@@ -1064,6 +1064,9 @@ gnc_combo_cell_leave (BasicCell* bcell)
     {
         if (bcell->value)
         {
+            if (!bcell->changed)
+                return;
+
             if (gnc_item_in_list (box->item_list, bcell->value))
                 return;
 


### PR DESCRIPTION
… are used in the account register

If the cell value has not changed, gnc_combo_cell_leave() shouldn't reject it.