### PR TITLE
Bug421610 add Logical dates to register View->Filter

### DIFF
--- a/gnucash/gnome-utils/dialog-preferences.c
+++ b/gnucash/gnome-utils/dialog-preferences.c
@@ -1349,8 +1349,6 @@ gnc_preferences_dialog_create (GtkWindow *parent)
     GtkTreeIter iter;
     gnc_commodity *locale_currency;
     const gchar *currency_name;
-    GDate fy_end;
-    gboolean date_is_valid = FALSE;
 
     ENTER("");
     DEBUG("Opening dialog-preferences.glade:");
@@ -1406,30 +1404,17 @@ gnc_preferences_dialog_create (GtkWindow *parent)
     g_object_set_data_full (G_OBJECT(dialog), PREFS_WIDGET_HASH,
                             prefs_table, (GDestroyNotify)g_hash_table_destroy);
 
-
-    if (gnc_current_session_exist())
-    {
-        QofBook *book = gnc_get_current_book ();
-        g_date_clear (&fy_end, 1);
-        qof_instance_get (QOF_INSTANCE(book),
-                          "fy-end", &fy_end,
-                          NULL);
-    }
     box = GTK_WIDGET(gtk_builder_get_object (builder,
                      "pref/" GNC_PREFS_GROUP_ACCT_SUMMARY "/" GNC_PREF_START_PERIOD));
     period = gnc_period_select_new (TRUE);
     gtk_widget_show (period);
     gtk_box_pack_start (GTK_BOX(box), period, TRUE, TRUE, 0);
-    if (date_is_valid)
-        gnc_period_select_set_fy_end (GNC_PERIOD_SELECT(period), &fy_end);
 
     box = GTK_WIDGET(gtk_builder_get_object (builder,
                      "pref/" GNC_PREFS_GROUP_ACCT_SUMMARY "/" GNC_PREF_END_PERIOD));
     period = gnc_period_select_new (FALSE);
     gtk_widget_show (period);
     gtk_box_pack_start (GTK_BOX(box), period, TRUE, TRUE, 0);
-    if (date_is_valid)
-        gnc_period_select_set_fy_end (GNC_PERIOD_SELECT(period), &fy_end);
 
     box = GTK_WIDGET(gtk_builder_get_object (builder,
                      "pref/" GNC_PREFS_GROUP_ACCT_SUMMARY "/" GNC_PREF_START_DATE));

--- a/gnucash/gnome-utils/gnc-period-select.c
+++ b/gnucash/gnome-utils/gnc-period-select.c
@@ -270,9 +270,7 @@ gnc_period_select_set_fy_end (GncPeriodSelect *period, const GDate *fy_end)
 
     if (fy_end)
     {
-        period->fy_end = g_date_new_dmy(g_date_get_day(fy_end),
-                                      g_date_get_month(fy_end),
-                                      G_DATE_BAD_YEAR);
+        period->fy_end = g_date_copy (fy_end);
     }
     else
     {

--- a/gnucash/gnome/gnc-plugin-page-register-filter.cpp
+++ b/gnucash/gnome/gnc-plugin-page-register-filter.cpp
@@ -397,7 +397,7 @@ gpp_update_match_filter_text (cleared_match_t match, const guint mask,
  *
  *  @param page A pointer to the GncPluginPageRegister that is
  *  associated with this filter dialog.
- * 
+ *
  *  @param fd A pointer to the filter data used for filter state.
  */
 void
@@ -621,7 +621,7 @@ gnc_ppr_filter_update_date_query (GncPluginPage* plugin_page)
     LEAVE(" ");
 }
 
-/** This function is used to clear the current filter so that a 
+/** This function is used to clear the current filter so that a
  *  specific split can be shown in the register.
  *
  *  @param page A pointer to the GncPluginPageRegister that is
@@ -1113,7 +1113,7 @@ gnc_ppr_filter_response_cb (GtkDialog* dialog,
 /** This function is called to create the filter dialog.
  *
  *  @param rfd A pointer to the filter dialog structure.
- * 
+ *
  *  @param fd The filter data structure for remembering state.
  *
  *  @param query A pointer to the current register query.
@@ -1287,9 +1287,9 @@ gnc_ppr_filter_dialog_create (RegisterFilterDialog* rfd, FilterData *fd, Query *
  *
  *  @param plugin_page  A pointer to the GncPluginPageRegister that is
  *  associated with this filter dialog.
- * 
+ *
  *  @param query A pointer to the current register query.
- * 
+ *
  *  @param fd A pointer to the filter data structure for remembering state.
  *
  *  @param show_save_button Set to True to show save button.

--- a/gnucash/gnome/gnc-plugin-page-register-filter.cpp
+++ b/gnucash/gnome/gnc-plugin-page-register-filter.cpp
@@ -160,7 +160,7 @@ get_filter_default_num_of_days (GNCLedgerDisplayType ledger_type)
 
 /* This function converts a time64 value date to a string */
 static std::string
-gnc_ppr_filter_time2dmy (time64 raw_time)
+ppr_filter_time2dmy (time64 raw_time)
 {
     struct tm* timeinfo;
     char date_string[11];
@@ -175,7 +175,7 @@ gnc_ppr_filter_time2dmy (time64 raw_time)
 
 /* This function converts a string date to a time64 value */
 static time64
-gnc_ppr_filter_dmy2time (std::string date_string)
+ppr_filter_dmy2time (std::string date_string)
 {
     struct tm when;
 
@@ -206,8 +206,8 @@ split_filter_by_delimiter (std::string str, char delimiter)
 }
 
 static void
-gnc_ppr_check_for_empty_group (GKeyFile *state_file,
-                               const gchar *state_section)
+ppr_check_for_empty_group (GKeyFile *state_file,
+                           const gchar *state_section)
 {
     gsize num_keys;
     gchar **keys = g_key_file_get_keys (state_file, state_section, &num_keys, nullptr);
@@ -219,7 +219,7 @@ gnc_ppr_check_for_empty_group (GKeyFile *state_file,
 }
 
 static std::string
-gnc_ppr_filter_load_filter (GNCSplitReg *gsr, GNCLedgerDisplayType ledger_type)
+ppr_filter_load_filter (GNCSplitReg *gsr, GNCLedgerDisplayType ledger_type)
 {
     // get the filter from the .gcm file
     GKeyFile* state_file = gnc_state_get_current();
@@ -255,7 +255,7 @@ set_filterdata_to_defaults (FilterData *fd)
 }
 
 static void
-gnc_ppr_filter_load_filter_parts (GNCSplitReg *gsr, GNCLedgerDisplayType ledger_type, FilterData *fd)
+ppr_filter_load_filter_parts (GNCSplitReg *gsr, GNCLedgerDisplayType ledger_type, FilterData *fd)
 {
     set_filterdata_to_defaults (fd);
     fd->dialog = nullptr;
@@ -263,7 +263,7 @@ gnc_ppr_filter_load_filter_parts (GNCSplitReg *gsr, GNCLedgerDisplayType ledger_
     if (!gsr)
         return;
 
-    std::string filter_str = gnc_ppr_filter_load_filter (gsr, ledger_type);
+    std::string filter_str = ppr_filter_load_filter (gsr, ledger_type);
 
     PINFO("Loaded Filter String is %s", filter_str.c_str());
 
@@ -282,7 +282,7 @@ gnc_ppr_filter_load_filter_parts (GNCSplitReg *gsr, GNCLedgerDisplayType ledger_
     {
         PINFO("Loaded Filter Start Date is %s", split_filter[1].c_str());
 
-        fd->start_time = gnc_ppr_filter_dmy2time (split_filter[1]);
+        fd->start_time = ppr_filter_dmy2time (split_filter[1]);
         fd->start_time = gnc_time64_get_day_start (fd->start_time);
         fd->save_filter = true;
     }
@@ -291,7 +291,7 @@ gnc_ppr_filter_load_filter_parts (GNCSplitReg *gsr, GNCLedgerDisplayType ledger_
     {
         PINFO("Loaded Filter End Date is %s", split_filter[2].c_str());
 
-        fd->end_time = gnc_ppr_filter_dmy2time (split_filter[2]);
+        fd->end_time = ppr_filter_dmy2time (split_filter[2]);
         fd->end_time = gnc_time64_get_day_end (fd->end_time);
         fd->save_filter = true;
     }
@@ -310,7 +310,7 @@ gnc_ppr_filter_load_filter_parts (GNCSplitReg *gsr, GNCLedgerDisplayType ledger_
 }
 
 static void
-gnc_ppr_filter_save_filter (GNCSplitReg *gsr, std::string filter)
+ppr_filter_save_filter (GNCSplitReg *gsr, std::string filter)
 
 {
     GNCLedgerDisplayType ledger_type = gnc_ledger_display_type (gsr->ledger);
@@ -327,7 +327,7 @@ gnc_ppr_filter_save_filter (GNCSplitReg *gsr, std::string filter)
         if (g_key_file_has_key (state_file, state_section, KEY_PAGE_FILTER, nullptr))
             g_key_file_remove_key (state_file, state_section, KEY_PAGE_FILTER, nullptr);
 
-        gnc_ppr_check_for_empty_group (state_file, state_section);
+        ppr_check_for_empty_group (state_file, state_section);
     }
     else
     {
@@ -339,7 +339,7 @@ gnc_ppr_filter_save_filter (GNCSplitReg *gsr, std::string filter)
 }
 
 static void
-gnc_ppr_filter_save_filter_parts (GNCSplitReg *gsr, FilterData *fd)
+ppr_filter_save_filter_parts (GNCSplitReg *gsr, FilterData *fd)
 {
     if (!gsr)
         return;
@@ -358,7 +358,7 @@ gnc_ppr_filter_save_filter_parts (GNCSplitReg *gsr, FilterData *fd)
         // start time
         if (fd->start_time != 0)
         {
-            save_filter_str.append (";" + gnc_ppr_filter_time2dmy (fd->start_time));
+            save_filter_str.append (";" + ppr_filter_time2dmy (fd->start_time));
         }
         else
             save_filter_str.append (";0");
@@ -366,7 +366,7 @@ gnc_ppr_filter_save_filter_parts (GNCSplitReg *gsr, FilterData *fd)
         // end time
         if (fd->end_time != 0)
         {
-            save_filter_str.append (";" + gnc_ppr_filter_time2dmy (fd->end_time));
+            save_filter_str.append (";" + ppr_filter_time2dmy (fd->end_time));
         }
         else
             save_filter_str.append (";0");
@@ -379,12 +379,12 @@ gnc_ppr_filter_save_filter_parts (GNCSplitReg *gsr, FilterData *fd)
         else
              save_filter_str.append (";0");
     }
-    gnc_ppr_filter_save_filter (gsr, save_filter_str);
+    ppr_filter_save_filter (gsr, save_filter_str);
 }
 
 static void
-gpp_update_match_filter_text (cleared_match_t match, const guint mask,
-                              const gchar* filter_name, GList **show, GList **hide)
+update_match_filter_text (cleared_match_t match, const guint mask,
+                          const gchar* filter_name, GList **show, GList **hide)
 {
     if ((match & mask) == mask)
         *show = g_list_prepend (*show, g_strdup (filter_name));
@@ -440,16 +440,16 @@ gnc_ppr_filter_set_tooltip (GncPluginPage* plugin_page, FilterData *fd)
         GList *show = nullptr;
         GList *hide = nullptr;
 
-        gpp_update_match_filter_text (fd->cleared_match, 0x01, _("Unreconciled"),
-                                      &show, &hide);
-        gpp_update_match_filter_text (fd->cleared_match, 0x02, _("Cleared"),
-                                      &show, &hide);
-        gpp_update_match_filter_text (fd->cleared_match, 0x04, _("Reconciled"),
-                                      &show, &hide);
-        gpp_update_match_filter_text (fd->cleared_match, 0x08, _("Frozen"),
-                                      &show, &hide);
-        gpp_update_match_filter_text (fd->cleared_match, 0x10, _("Voided"),
-                                      &show, &hide);
+        update_match_filter_text (fd->cleared_match, 0x01, _("Unreconciled"),
+                                  &show, &hide);
+        update_match_filter_text (fd->cleared_match, 0x02, _("Cleared"),
+                                  &show, &hide);
+        update_match_filter_text (fd->cleared_match, 0x04, _("Reconciled"),
+                                  &show, &hide);
+        update_match_filter_text (fd->cleared_match, 0x08, _("Frozen"),
+                                  &show, &hide);
+        update_match_filter_text (fd->cleared_match, 0x10, _("Voided"),
+                                  &show, &hide);
 
         show = g_list_reverse (show);
         hide = g_list_reverse (hide);
@@ -504,7 +504,7 @@ gnc_ppr_filter_set_tooltip (GncPluginPage* plugin_page, FilterData *fd)
  *  associated with this filter dialog.
  */
 static void
-gnc_ppr_filter_update_status_query (GncPluginPage* plugin_page)
+ppr_filter_update_status_query (GncPluginPage* plugin_page)
 {
     ENTER(" ");
 
@@ -560,7 +560,7 @@ gnc_ppr_filter_update_status_query (GncPluginPage* plugin_page)
  *  associated with this filter dialog.
  */
 static void
-gnc_ppr_filter_update_date_query (GncPluginPage* plugin_page)
+ppr_filter_update_date_query (GncPluginPage* plugin_page)
 {
     ENTER(" ");
 
@@ -636,7 +636,7 @@ gnc_ppr_filter_clear_current_filter (GncPluginPage* plugin_page)
 
     set_filterdata_to_defaults (fd);
 
-    gnc_ppr_filter_update_date_query (plugin_page);
+    ppr_filter_update_date_query (plugin_page);
 }
 
 /** This function is called to update the register.
@@ -660,7 +660,7 @@ gnc_ppr_filter_update_register (GncPluginPage* plugin_page)
     /* Set the filter for the split register and status of save filter button */
     fd->save_filter = false;
 
-    gnc_ppr_filter_load_filter_parts (gsr, ledger_type, fd);
+    ppr_filter_load_filter_parts (gsr, ledger_type, fd);
 
     if (ledger_type == LD_GL)
     {
@@ -670,8 +670,8 @@ gnc_ppr_filter_update_register (GncPluginPage* plugin_page)
             set_filterdata_to_defaults (fd);
     }
     /* Update Query with Filter Status and Dates */
-    gnc_ppr_filter_update_status_query (plugin_page);
-    gnc_ppr_filter_update_date_query (plugin_page);
+    ppr_filter_update_status_query (plugin_page);
+    ppr_filter_update_date_query (plugin_page);
 }
 
 /** This function is called whenever one of the status entries is
@@ -713,7 +713,7 @@ gnc_ppr_filter_status_one_cb (GtkToggleButton* button,
     else
         fd->cleared_match = (cleared_match_t)(fd->cleared_match & ~value);
 
-    gnc_ppr_filter_update_status_query (rfd->plugin_page);
+    ppr_filter_update_status_query (rfd->plugin_page);
 
     LEAVE(" ");
 }
@@ -762,7 +762,7 @@ gnc_ppr_filter_status_select_all_cb (GtkButton* button,
 
     /* Set the requested status */
     fd->cleared_match = CLEARED_ALL;
-    gnc_ppr_filter_update_status_query (rfd->plugin_page);
+    ppr_filter_update_status_query (rfd->plugin_page);
     LEAVE(" ");
 }
 
@@ -795,7 +795,7 @@ gnc_ppr_filter_status_clear_all_cb (GtkButton* button,
 
     /* Set the requested status */
     fd->cleared_match = CLEARED_NONE;
-    gnc_ppr_filter_update_status_query (rfd->plugin_page);
+    ppr_filter_update_status_query (rfd->plugin_page);
     LEAVE(" ");
 }
 
@@ -889,7 +889,7 @@ gnc_ppr_filter_select_range_cb (GtkRadioButton* button,
         fd->end_time = 0;
         fd->days = 0;
     }
-    gnc_ppr_filter_update_date_query (rfd->plugin_page);
+    ppr_filter_update_date_query (rfd->plugin_page);
     LEAVE(" ");
 }
 
@@ -914,7 +914,7 @@ gnc_ppr_filter_days_changed_cb (GtkSpinButton* button,
     auto fd = gnc_plugin_page_register_get_filter_data (rfd->plugin_page);
 
     fd->days = gtk_spin_button_get_value (GTK_SPIN_BUTTON(button));
-    gnc_ppr_filter_update_date_query (rfd->plugin_page);
+    ppr_filter_update_date_query (rfd->plugin_page);
 
     LEAVE(" ");
 }
@@ -929,8 +929,8 @@ gnc_ppr_filter_days_changed_cb (GtkSpinButton* button,
  *  @param rfd A pointer to the filter dialog structure.
  */
 static void
-gnc_ppr_filter_gde_changed_cb (GtkWidget* unused,
-                               RegisterFilterDialog* rfd)
+ppr_filter_gde_changed_cb (GtkWidget* unused,
+                           RegisterFilterDialog* rfd)
 {
     g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER(rfd->plugin_page));
 
@@ -938,7 +938,7 @@ gnc_ppr_filter_gde_changed_cb (GtkWidget* unused,
            gtk_buildable_get_name (GTK_BUILDABLE(unused)), unused, rfd->plugin_page);
 
     get_filter_times (rfd);
-    gnc_ppr_filter_update_date_query (rfd->plugin_page);
+    ppr_filter_update_date_query (rfd->plugin_page);
 
     LEAVE(" ");
 }
@@ -981,7 +981,7 @@ gnc_ppr_filter_start_cb (GtkWidget* radio,
     gboolean active = !g_strcmp0 (name, "start_date_choose");
     gtk_widget_set_sensitive (rfd->start_date, active);
     get_filter_times (rfd);
-    gnc_ppr_filter_update_date_query (rfd->plugin_page);
+    ppr_filter_update_date_query (rfd->plugin_page);
 
     LEAVE(" ");
 }
@@ -1024,7 +1024,7 @@ gnc_ppr_filter_end_cb (GtkWidget* radio,
     gboolean active = !g_strcmp0 (name, "end_date_choose");
     gtk_widget_set_sensitive (rfd->end_date, active);
     get_filter_times (rfd);
-    gnc_ppr_filter_update_date_query (rfd->plugin_page);
+    ppr_filter_update_date_query (rfd->plugin_page);
 
     LEAVE(" ");
 }
@@ -1084,24 +1084,24 @@ gnc_ppr_filter_response_cb (GtkDialog* dialog,
         /* Remove the old status match */
         fd->cleared_match = rfd->original_cleared_match;
         gnc_plugin_register_set_enable_refresh (GNC_PLUGIN_PAGE_REGISTER(rfd->plugin_page), FALSE);
-        gnc_ppr_filter_update_status_query (rfd->plugin_page);
+        ppr_filter_update_status_query (rfd->plugin_page);
         gnc_plugin_register_set_enable_refresh (GNC_PLUGIN_PAGE_REGISTER(rfd->plugin_page), TRUE);
         fd->start_time = rfd->original_start_time;
         fd->end_time = rfd->original_end_time;
         fd->days = rfd->original_days;
         fd->save_filter = rfd->original_save_filter;
-        gnc_ppr_filter_update_date_query (rfd->plugin_page);
+        ppr_filter_update_date_query (rfd->plugin_page);
     }
     else
     {
         // clear the filter when unticking the save option
         if (!fd->save_filter && rfd->original_save_filter)
-            gnc_ppr_filter_save_filter (gsr, "");
+            ppr_filter_save_filter (gsr, "");
 
         rfd->original_save_filter = fd->save_filter;
 
         if (fd->save_filter)
-            gnc_ppr_filter_save_filter_parts (gsr, fd);
+            ppr_filter_save_filter_parts (gsr, fd);
     }
     rfd->dialog = nullptr;
     fd->dialog = nullptr;
@@ -1119,7 +1119,7 @@ gnc_ppr_filter_response_cb (GtkDialog* dialog,
  *  @param query A pointer to the current register query.
  */
 static void
-gnc_ppr_filter_dialog_create (RegisterFilterDialog* rfd, FilterData *fd, Query *query)
+ppr_filter_dialog_create (RegisterFilterDialog* rfd, FilterData *fd, Query *query)
 {
     time64 start_time, end_time, time_val;
 
@@ -1237,7 +1237,7 @@ gnc_ppr_filter_dialog_create (RegisterFilterDialog* rfd, FilterData *fd, Query *
         gtk_widget_set_sensitive (GTK_WIDGET(rfd->start_date), bool_to_gboolean (sensitive));
         gnc_date_edit_set_time (GNC_DATE_EDIT(rfd->start_date), time_val);
         g_signal_connect (G_OBJECT(rfd->start_date), "date-changed",
-                          G_CALLBACK(gnc_ppr_filter_gde_changed_cb), rfd);
+                          G_CALLBACK(ppr_filter_gde_changed_cb), rfd);
     }
 
     {
@@ -1271,7 +1271,7 @@ gnc_ppr_filter_dialog_create (RegisterFilterDialog* rfd, FilterData *fd, Query *
         gtk_widget_set_sensitive (GTK_WIDGET(rfd->end_date), bool_to_gboolean (sensitive));
         gnc_date_edit_set_time (GNC_DATE_EDIT(rfd->end_date), time_val);
         g_signal_connect (G_OBJECT(rfd->end_date), "date-changed",
-                          G_CALLBACK(gnc_ppr_filter_gde_changed_cb), rfd);
+                          G_CALLBACK(ppr_filter_gde_changed_cb), rfd);
     }
 
     /* Wire it up */
@@ -1307,7 +1307,7 @@ gnc_ppr_filter_by (GncPluginPage *plugin_page, Query *query,
     rfd->plugin_page = plugin_page;
     rfd->show_save_button = show_save_button;
 
-    gnc_ppr_filter_dialog_create (rfd, fd, query);
+    ppr_filter_dialog_create (rfd, fd, query);
 
     LEAVE(" ");
 }

--- a/gnucash/gnome/gnc-plugin-page-register-filter.cpp
+++ b/gnucash/gnome/gnc-plugin-page-register-filter.cpp
@@ -38,7 +38,9 @@
 #include "gnc-date.h"
 #include "gnc-date-edit.h"
 #include "gnc-glib-utils.h"
+#include "gnc-ui.h"
 #include "gnc-state.h"
+#include "gnc-period-select.h"
 #include "gnc-prefs.h"
 #include "gnc-ui-util.h"
 #include "gnc-window.h"
@@ -70,21 +72,35 @@ struct RegisterFilterDialog
     GncPluginPage* plugin_page;
     GtkWidget*     dialog;
     GtkWidget*     table;
-    GtkWidget*     start_date_choose;
-    GtkWidget*     start_date_today;
-    GtkWidget*     start_date;
-    GtkWidget*     end_date_choose;
-    GtkWidget*     end_date_today;
+    GtkWidget*     start_earliest;       //label
+    GtkWidget*     start_relative_check; //checkbutton
+    GtkWidget*     start_relative;       //account period
+    GtkWidget*     start_date_check;     //checkbutton
+    GtkWidget*     start_date;           //date
+    GtkWidget*     start_days_check;     //checkbutton
+    GtkWidget*     start_days;           //spin
+
+    GtkWidget*     end_latest;
+    GtkWidget*     end_relative_check;
+    GtkWidget*     end_relative;
+    GtkWidget*     end_date_check;
     GtkWidget*     end_date;
+    GtkWidget*     end_days_check;
+    GtkWidget*     end_days;
+
     GtkWidget*     num_days;
 
-    cleared_match_t original_cleared_match;
-    time64          original_start_time;
-    time64          original_end_time;
-    int             original_days;
-    bool            original_save_filter;
+    cleared_match_t     original_cleared_match;
+    GncAccountingPeriod original_start_ap;
+    time64              original_start_time;
+    int                 original_start_days;
+    GncAccountingPeriod original_end_ap;
+    time64              original_end_time;
+    int                 original_end_days;
+    int                 original_days;
+    bool                original_save_filter;
 
-    bool            show_save_button;
+    bool                show_save_button;
 };
 
 extern "C"
@@ -119,6 +135,15 @@ gnc_ppr_filter_save_cb (GtkToggleButton* button,
 void
 gnc_ppr_filter_days_changed_cb (GtkSpinButton* button,
                                 RegisterFilterDialog* rfd);
+void
+gnc_ppr_filter_start_toggle_cb (GtkToggleButton* button,
+                                RegisterFilterDialog* rfd);
+void
+gnc_ppr_filter_end_toggle_cb (GtkToggleButton* button,
+                              RegisterFilterDialog* rfd);
+void
+gnc_ppr_filter_start_end_days_changed_cb (GtkSpinButton* button,
+                                          RegisterFilterDialog* rfd);
 }
 
 struct status_action
@@ -191,6 +216,25 @@ ppr_filter_dmy2time (std::string date_string)
     return gnc_mktime (&when);
 }
 
+/* This function subtracts a number of days from now to a time64 value */
+static time64
+get_time_for_days_ago (int days, bool use_day_start)
+{
+    time64 time_val = 0;
+
+    if (days > 0)
+    {
+        struct tm tm;
+        if (use_day_start)
+            gnc_tm_get_today_start (&tm);
+        else
+            gnc_tm_get_today_end (&tm);
+        tm.tm_mday = tm.tm_mday - days;
+        time_val = gnc_mktime (&tm);
+    }
+    return time_val;
+}
+
 static std::vector<std::string>
 split_filter_by_delimiter (std::string str, char delimiter)
 {
@@ -245,19 +289,96 @@ ppr_filter_load_filter (GNCSplitReg *gsr, GNCLedgerDisplayType ledger_type)
 }
 
 static void
-set_filterdata_to_defaults (FilterData *fd)
+set_filterdata_to_defaults (FilterData *fd, bool date_parts_only)
 {
-    fd->cleared_match = (cleared_match_t)std::stol (DEFAULT_FILTER, nullptr, 16);
+    if (!date_parts_only)
+    {
+        fd->cleared_match = (cleared_match_t)std::stol (DEFAULT_FILTER, nullptr, 16);
+        fd->save_filter = false;
+    }
+    fd->start_ap = GNC_ACCOUNTING_PERIOD_INVALID;
     fd->start_time = 0;
+    fd->start_days = 0;
+    fd->end_ap = GNC_ACCOUNTING_PERIOD_INVALID;
     fd->end_time = 0;
+    fd->end_days = 0;
     fd->days = 0;
-    fd->save_filter = false;
+}
+
+static int
+get_trailing_int (const std::string split_filter, const std::string find_text)
+{
+    int ret_int = -1;
+    std::size_t found = split_filter.find (find_text);
+
+    if (found != std::string::npos)
+    {
+        std::string found_str = split_filter.substr (found + find_text.length(), std::string::npos);
+        ret_int = std::stol (found_str, nullptr, 10);
+    }
+    return ret_int;
+}
+
+static void
+update_fd_with_date_filter_parts (FilterData *fd, const std::string filter_part,
+                                  bool start_filter, int ap_trailing_int, int days_trailing_int)
+{
+    if (ap_trailing_int != -1)
+    {
+        GDate *tmp_date = nullptr;
+
+        if (start_filter)
+        {
+            fd->start_ap = (GncAccountingPeriod)ap_trailing_int;
+            tmp_date = gnc_accounting_period_start_gdate (fd->start_ap, nullptr, nullptr);
+        }
+        else
+        {
+            fd->end_ap = (GncAccountingPeriod)ap_trailing_int;
+            tmp_date = gnc_accounting_period_end_gdate (fd->end_ap, nullptr, nullptr);
+        }
+
+        if (tmp_date)
+        {
+            if (start_filter)
+                fd->start_time = gnc_time64_get_day_start_gdate (tmp_date);
+            else
+                fd->end_time = gnc_time64_get_day_end_gdate (tmp_date);
+
+            g_date_free (tmp_date);
+        }
+    }
+    else
+    {
+        if (days_trailing_int != -1)
+        {
+            if (start_filter)
+            {
+                fd->start_days = days_trailing_int;
+                fd->start_time = get_time_for_days_ago (fd->start_days, true);
+            }
+            else
+            {
+                fd->end_days = days_trailing_int;
+                fd->end_time = get_time_for_days_ago (fd->end_days, false);
+            }
+        }
+        else
+        {
+            time64 tmp_time = ppr_filter_dmy2time (filter_part);
+            if (start_filter)
+                fd->start_time = gnc_time64_get_day_start (tmp_time);
+            else
+                fd->end_time = gnc_time64_get_day_end (tmp_time);
+        }
+    }
+    fd->save_filter = true;
 }
 
 static void
 ppr_filter_load_filter_parts (GNCSplitReg *gsr, GNCLedgerDisplayType ledger_type, FilterData *fd)
 {
-    set_filterdata_to_defaults (fd);
+    set_filterdata_to_defaults (fd, false);
     fd->dialog = nullptr;
 
     if (!gsr)
@@ -282,18 +403,20 @@ ppr_filter_load_filter_parts (GNCSplitReg *gsr, GNCLedgerDisplayType ledger_type
     {
         PINFO("Loaded Filter Start Date is %s", split_filter[1].c_str());
 
-        fd->start_time = ppr_filter_dmy2time (split_filter[1]);
-        fd->start_time = gnc_time64_get_day_start (fd->start_time);
-        fd->save_filter = true;
+        int ap_trailing_int = get_trailing_int (split_filter[1], "SAP");
+        int days_trailing_int = get_trailing_int (split_filter[1], "SDAY");
+
+        update_fd_with_date_filter_parts (fd, split_filter[1], true, ap_trailing_int, days_trailing_int);
     }
 
     if (split_filter_size > 2 && (split_filter[2].compare (std::string ("0"))) != 0)
     {
         PINFO("Loaded Filter End Date is %s", split_filter[2].c_str());
 
-        fd->end_time = ppr_filter_dmy2time (split_filter[2]);
-        fd->end_time = gnc_time64_get_day_end (fd->end_time);
-        fd->save_filter = true;
+        int ap_trailing_int = get_trailing_int (split_filter[2], "EAP");
+        int days_trailing_int = get_trailing_int (split_filter[1], "EDAY");
+
+        update_fd_with_date_filter_parts (fd, split_filter[2], false, ap_trailing_int, days_trailing_int);
     }
 
     // set the default for the number of days
@@ -356,18 +479,22 @@ ppr_filter_save_filter_parts (GNCSplitReg *gsr, FilterData *fd)
         save_filter_str.append (buffer);
 
         // start time
-        if (fd->start_time != 0)
-        {
+        if (fd->start_ap != GNC_ACCOUNTING_PERIOD_INVALID)
+            save_filter_str.append (";SAP" + std::to_string (fd->start_ap));
+        else if (fd->start_days > 0)
+            save_filter_str.append (";SDAY" + std::to_string (fd->start_days));
+        else if (fd->start_time != 0)
             save_filter_str.append (";" + ppr_filter_time2dmy (fd->start_time));
-        }
         else
             save_filter_str.append (";0");
 
         // end time
-        if (fd->end_time != 0)
-        {
+        if (fd->end_ap != GNC_ACCOUNTING_PERIOD_INVALID)
+            save_filter_str.append (";EAP" + std::to_string (fd->end_ap));
+        else if (fd->end_days > 0)
+            save_filter_str.append (";EDAY" + std::to_string (fd->end_days));
+        else if (fd->end_time != 0)
             save_filter_str.append (";" + ppr_filter_time2dmy (fd->end_time));
-        }
         else
             save_filter_str.append (";0");
 
@@ -580,13 +707,7 @@ ppr_filter_update_date_query (GncPluginPage* plugin_page)
 
     if (fd->days > 0)
     {
-        time64 start;
-        struct tm tm;
-
-        gnc_tm_get_today_start (&tm);
-
-        tm.tm_mday = tm.tm_mday - fd->days;
-        start = gnc_mktime (&tm);
+        time64 start = get_time_for_days_ago (fd->days, true);
         xaccQueryAddDateMatchTT (query, TRUE, start, FALSE, 0, QOF_QUERY_AND);
     }
 
@@ -610,7 +731,7 @@ gnc_ppr_filter_clear_current_filter (GncPluginPage* plugin_page)
 
     auto fd = gnc_plugin_page_register_get_filter_data (plugin_page);
 
-    set_filterdata_to_defaults (fd);
+    set_filterdata_to_defaults (fd, false);
 
     ppr_filter_update_date_query (plugin_page);
 }
@@ -643,7 +764,7 @@ gnc_ppr_filter_update_register (GncPluginPage* plugin_page)
         SplitRegister *reg = gnc_ledger_display_get_split_register (gsr->ledger);
 
         if (reg->type != GENERAL_JOURNAL) // search ledger and the like
-            set_filterdata_to_defaults (fd);
+            set_filterdata_to_defaults (fd, false);
     }
     /* Update Query with Filter Status and Dates */
     ppr_filter_update_status_query (plugin_page);
@@ -695,18 +816,49 @@ gnc_ppr_filter_status_one_cb (GtkToggleButton* button,
 }
 
 static void
-set_checkbutton_with_blocking (GtkWidget *widget,
+set_sensitive_start_widget (RegisterFilterDialog *rfd, GtkWidget *enable_widget, gboolean active)
+{
+    gtk_widget_set_sensitive (GTK_WIDGET(rfd->start_earliest), !active);
+    gtk_widget_set_sensitive (GTK_WIDGET(rfd->start_relative), FALSE);
+    gtk_widget_set_sensitive (GTK_WIDGET(rfd->start_date), FALSE);
+    gtk_widget_set_sensitive (GTK_WIDGET(rfd->start_days), FALSE);
+    gtk_widget_set_sensitive (GTK_WIDGET(enable_widget), active);
+}
+
+static void
+set_sensitive_end_widget (RegisterFilterDialog *rfd, GtkWidget *enable_widget, gboolean active)
+{
+    gtk_widget_set_sensitive (GTK_WIDGET(rfd->end_latest), !active);
+    gtk_widget_set_sensitive (GTK_WIDGET(rfd->end_relative), FALSE);
+    gtk_widget_set_sensitive (GTK_WIDGET(rfd->end_date), FALSE);
+    gtk_widget_set_sensitive (GTK_WIDGET(rfd->end_days), FALSE);
+    gtk_widget_set_sensitive (GTK_WIDGET(enable_widget), active);
+}
+
+static void
+set_checkbutton_with_blocking (GtkWidget *widget1, GtkWidget *widget2,
                                GFunc function,
                                RegisterFilterDialog *rfd,
                                gboolean active)
 {
     PINFO("Block GtkToggleButton %p for setting active %s",
-           widget, active ? "TRUE" : "FALSE");
-    g_signal_handlers_block_by_func (widget,
+           widget1, active ? "TRUE" : "FALSE");
+    g_signal_handlers_block_by_func (widget1,
                                      (gpointer)function, rfd);
-    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON(widget), active);
-    g_signal_handlers_unblock_by_func (widget,
+    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON(widget1), active);
+    g_signal_handlers_unblock_by_func (widget1,
                                        (gpointer)function, rfd);
+
+    if (widget2)
+    {
+        PINFO("Block GtkToggleButton %p for setting active %s",
+               widget2, active ? "TRUE" : "FALSE");
+        g_signal_handlers_block_by_func (widget2,
+                                         (gpointer)function, rfd);
+        gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON(widget2), active);
+        g_signal_handlers_unblock_by_func (widget2,
+                                           (gpointer)function, rfd);
+    }
 }
 
 /** This function is called whenever the "select all" status button is
@@ -731,7 +883,7 @@ gnc_ppr_filter_status_select_all_cb (GtkButton* button,
     /* Turn on all the check menu items */
     for (const auto& action : status_actions)
     {
-        set_checkbutton_with_blocking (action.widget,
+        set_checkbutton_with_blocking (action.widget, nullptr,
                                        (GFunc)gnc_ppr_filter_status_one_cb,
                                        rfd, TRUE);
     }
@@ -764,7 +916,7 @@ gnc_ppr_filter_status_clear_all_cb (GtkButton* button,
     /* Turn off all the check menu items */
     for (const auto& action : status_actions)
     {
-        set_checkbutton_with_blocking (action.widget,
+        set_checkbutton_with_blocking (action.widget, nullptr,
                                        (GFunc)gnc_ppr_filter_status_one_cb,
                                        rfd, FALSE);
     }
@@ -776,39 +928,69 @@ gnc_ppr_filter_status_clear_all_cb (GtkButton* button,
 }
 
 static void
+print_info_time64_date (const gchar *text, time64 date)
+{
+   gchar *date_txt = qof_print_date (date);
+   PINFO("%s, %s", text, date_txt);
+   g_free (date_txt);
+}
+
+static void
 get_filter_times (RegisterFilterDialog* rfd)
 {
     time64 time_val;
 
     auto fd = gnc_plugin_page_register_get_filter_data (rfd->plugin_page);
 
-    if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON(rfd->start_date_choose)))
+    if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON(rfd->start_date_check)))
     {
         time_val = gnc_date_edit_get_date (GNC_DATE_EDIT(rfd->start_date));
         time_val = gnc_time64_get_day_start (time_val);
         fd->start_time = time_val;
+        fd->start_ap = GNC_ACCOUNTING_PERIOD_INVALID;
+        print_info_time64_date ("Start date is", fd->start_time);
+    }
+    else if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON(rfd->start_relative_check)))
+    {
+        auto *sdate = gnc_period_select_get_date (GNC_PERIOD_SELECT(rfd->start_relative));
+        fd->start_time = gnc_time64_get_day_start_gdate (sdate);
+        fd->start_ap = gnc_period_select_get_active (GNC_PERIOD_SELECT(rfd->start_relative));
+        print_info_time64_date ("Start date relative is", fd->start_time);
+        g_date_free (sdate);
+    }
+    else if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON(rfd->start_days_check)))
+    {
+        fd->start_time = get_time_for_days_ago (fd->start_days, true);
+        fd->start_ap = GNC_ACCOUNTING_PERIOD_INVALID;
+        print_info_time64_date ("Start date using days is", fd->start_time);
     }
     else
-    {
-        if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON(rfd->start_date_today)))
-            fd->start_time = gnc_time64_get_today_start();
-        else
-            fd->start_time = 0;
-    }
+        fd->start_time = 0;
 
-    if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON(rfd->end_date_choose)))
+    if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON(rfd->end_date_check)))
     {
         time_val = gnc_date_edit_get_date (GNC_DATE_EDIT(rfd->end_date));
         time_val = gnc_time64_get_day_end (time_val);
         fd->end_time = time_val;
+        fd->end_ap = GNC_ACCOUNTING_PERIOD_INVALID;
+        print_info_time64_date ("End date is", fd->end_time);
+    }
+    else if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON(rfd->end_relative_check)))
+    {
+        auto *edate = gnc_period_select_get_date (GNC_PERIOD_SELECT(rfd->end_relative));
+        fd->end_time = gnc_time64_get_day_end_gdate (edate);
+        fd->end_ap = gnc_period_select_get_active (GNC_PERIOD_SELECT(rfd->end_relative));
+        print_info_time64_date ("End date relative is", fd->end_time);
+        g_date_free (edate);
+    }
+    else if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON(rfd->end_days_check)))
+    {
+        fd->end_time = get_time_for_days_ago (fd->end_days, false);
+        fd->end_ap = GNC_ACCOUNTING_PERIOD_INVALID;
+        print_info_time64_date ("End date using days is", fd->end_time);
     }
     else
-    {
-        if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON(rfd->end_date_today)))
-            fd->end_time = gnc_time64_get_today_end();
-        else
-            fd->end_time = 0;
-    }
+        fd->end_time = 0;
 }
 
 /** This function is called when the radio buttons changes state. This
@@ -851,9 +1033,7 @@ gnc_ppr_filter_select_range_cb (GtkRadioButton* button,
     {
         gtk_widget_set_sensitive (rfd->table, FALSE);
         gtk_widget_set_sensitive (rfd->num_days, FALSE);
-        fd->start_time = 0;
-        fd->end_time = 0;
-        fd->days = 0;
+        set_filterdata_to_defaults (fd, true);
     }
     ppr_filter_update_date_query (rfd->plugin_page);
     LEAVE(" ");
@@ -986,6 +1166,169 @@ gnc_ppr_filter_end_cb (GtkWidget* radio,
     LEAVE(" ");
 }
 
+static void
+ppr_filter_relative_changed_cb (GtkWidget *widget,
+                                RegisterFilterDialog* rfd)
+{
+    g_return_if_fail (GNC_IS_PERIOD_SELECT(widget));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER(rfd->plugin_page));
+
+    ENTER("Period Select (%p), active_id %d, plugin_page %p",
+           widget, gnc_period_select_get_active (GNC_PERIOD_SELECT(widget)),
+           rfd->plugin_page);
+
+    get_filter_times (rfd);
+    ppr_filter_update_date_query (rfd->plugin_page);
+
+    LEAVE("  ");
+}
+
+/** This function is called when the "days ago" spin button is
+ *  changed which is then saved and updates the time limitation on
+ *  the register query. This is handled by a helper function as
+ *  potentially all widgets will need to be examined.
+ *
+ *  @param button A pointer to the "days ago" spin button.
+ *
+ *  @param rfd A pointer to the filter dialog structure.
+ */
+void
+gnc_ppr_filter_start_end_days_changed_cb (GtkSpinButton* button,
+                                          RegisterFilterDialog* rfd)
+{
+    g_return_if_fail (GTK_IS_SPIN_BUTTON(button));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER(rfd->plugin_page));
+
+    ENTER("(button %p, page %p)", button, rfd->plugin_page);
+
+    auto fd = gnc_plugin_page_register_get_filter_data (rfd->plugin_page);
+
+    auto name = gtk_buildable_get_name (GTK_BUILDABLE(button));
+
+    if (g_strcmp0 (name, "start_days_spin") == 0)
+        fd->start_days = gtk_spin_button_get_value (GTK_SPIN_BUTTON(button));
+
+    if (g_strcmp0 (name, "end_days_spin") == 0)
+        fd->end_days = gtk_spin_button_get_value (GTK_SPIN_BUTTON(button));
+
+    get_filter_times (rfd);
+    ppr_filter_update_date_query (rfd->plugin_page);
+
+    LEAVE(" ");
+}
+
+/** This function is called when one of the check buttons for start
+ *  relative or start date is changed. It activates the associated
+ *  widget and deactivates the other.
+ *
+ *  @param button A pointer to a GtkToggleButton widget.
+ *
+ *  @param rfd A pointer to the filter dialog structure.
+ */
+void
+gnc_ppr_filter_start_toggle_cb (GtkToggleButton* button,
+                                RegisterFilterDialog* rfd)
+{
+    g_return_if_fail (GTK_IS_CHECK_BUTTON(button));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER(rfd->plugin_page));
+
+    ENTER("Start toggle button (%p), plugin_page %p", button, rfd->plugin_page);
+
+    auto name = gtk_buildable_get_name (GTK_BUILDABLE(button));
+
+    gboolean active = gtk_toggle_button_get_active (button);
+
+    gtk_widget_set_sensitive (rfd->start_earliest, !active);
+
+    if (g_strcmp0 (name, "start_date_check") == 0)
+    {
+        set_sensitive_start_widget (rfd, rfd->start_date, active);
+
+        set_checkbutton_with_blocking (rfd->start_relative_check,
+                                       rfd->start_days_check,
+                                       (GFunc)gnc_ppr_filter_start_toggle_cb,
+                                       rfd, FALSE);
+    }
+    if (g_strcmp0 (name, "start_relative_check") == 0)
+    {
+        set_sensitive_start_widget (rfd, rfd->start_relative, active);
+
+        set_checkbutton_with_blocking (rfd->start_date_check,
+                                       rfd->start_days_check,
+                                       (GFunc)gnc_ppr_filter_start_toggle_cb,
+                                       rfd, FALSE);
+    }
+    if (g_strcmp0 (name, "start_days_check") == 0)
+    {
+        set_sensitive_start_widget (rfd, rfd->start_days, active);
+
+        set_checkbutton_with_blocking (rfd->start_date_check,
+                                       rfd->start_relative_check,
+                                       (GFunc)gnc_ppr_filter_start_toggle_cb,
+                                       rfd, FALSE);
+    }
+    get_filter_times (rfd);
+    ppr_filter_update_date_query (rfd->plugin_page);
+
+    LEAVE(" ");
+}
+
+/** This function is called when one of the check buttons for end
+ *  relative or end date is changed. It activates the associated
+ *  widget and deactivates the other.
+ *
+ *  @param button A pointer to a GtkToggleButton widget.
+ *
+ *  @param rfd A pointer to the filter dialog structure.
+ */
+void
+gnc_ppr_filter_end_toggle_cb (GtkToggleButton* button,
+                              RegisterFilterDialog* rfd)
+{
+    g_return_if_fail (GTK_IS_CHECK_BUTTON(button));
+    g_return_if_fail (GNC_IS_PLUGIN_PAGE_REGISTER(rfd->plugin_page));
+
+    ENTER("End toggle button (%p), plugin_page %p", button, rfd->plugin_page);
+
+    auto name = gtk_buildable_get_name (GTK_BUILDABLE(button));
+
+    gboolean active = gtk_toggle_button_get_active (button);
+
+    gtk_widget_set_sensitive (rfd->end_latest, !active);
+
+    if (g_strcmp0 (name, "end_date_check") == 0)
+    {
+        set_sensitive_end_widget (rfd, rfd->end_date, active);
+
+        set_checkbutton_with_blocking (rfd->end_relative_check,
+                                       rfd->end_days_check,
+                                       (GFunc)gnc_ppr_filter_end_toggle_cb,
+                                       rfd, FALSE);
+    }
+    if (g_strcmp0 (name, "end_relative_check") == 0)
+    {
+        set_sensitive_end_widget (rfd, rfd->end_relative, active);
+
+        set_checkbutton_with_blocking (rfd->end_date_check,
+                                       rfd->end_days_check,
+                                       (GFunc)gnc_ppr_filter_end_toggle_cb,
+                                       rfd, FALSE);
+    }
+    if (g_strcmp0 (name, "end_days_check") == 0)
+    {
+        set_sensitive_end_widget (rfd, rfd->end_days, active);
+
+        set_checkbutton_with_blocking (rfd->end_date_check,
+                                       rfd->end_relative_check,
+                                       (GFunc)gnc_ppr_filter_end_toggle_cb,
+                                       rfd, FALSE);
+    }
+    get_filter_times (rfd);
+    ppr_filter_update_date_query (rfd->plugin_page);
+
+    LEAVE(" ");
+}
+
 /** This function is called whenever the save status is checked
  *  or unchecked. It will allow saving of the filter if required.
  *
@@ -1036,6 +1379,16 @@ gnc_ppr_filter_response_cb (GtkDialog* dialog,
     auto fd = gnc_plugin_page_register_get_filter_data (rfd->plugin_page);
     auto gsr = gnc_plugin_page_register_get_gsr (rfd->plugin_page);
 
+    if ((fd->start_time > 0 && fd->end_time > 0) && (fd->start_time > fd->end_time))
+    {
+        auto response = gnc_ok_cancel_dialog (GTK_WINDOW(rfd->dialog),
+                                              GTK_RESPONSE_CANCEL,
+                                              _("The Start date is after the End date.\n"
+                                                "Select Cancel to change dates.\n"));
+        if (response == GTK_RESPONSE_CANCEL)
+            return;
+    }
+
     if (response != GTK_RESPONSE_OK)
     {
         /* Remove the old status match */
@@ -1043,8 +1396,14 @@ gnc_ppr_filter_response_cb (GtkDialog* dialog,
         gnc_plugin_register_set_enable_refresh (GNC_PLUGIN_PAGE_REGISTER(rfd->plugin_page), FALSE);
         ppr_filter_update_status_query (rfd->plugin_page);
         gnc_plugin_register_set_enable_refresh (GNC_PLUGIN_PAGE_REGISTER(rfd->plugin_page), TRUE);
+
+        fd->start_ap = rfd->original_start_ap;
         fd->start_time = rfd->original_start_time;
+        fd->start_days = rfd->original_start_days;
+        fd->end_ap = rfd->original_end_ap;
         fd->end_time = rfd->original_end_time;
+        fd->end_days = rfd->original_end_days;
+
         fd->days = rfd->original_days;
         fd->save_filter = rfd->original_save_filter;
         ppr_filter_update_date_query (rfd->plugin_page);
@@ -1067,6 +1426,30 @@ gnc_ppr_filter_response_cb (GtkDialog* dialog,
     LEAVE(" ");
 }
 
+static GtkWidget *
+setup_period_select (GtkBuilder *builder, gboolean start_type, const gchar *hbox_txt)
+{
+    GtkWidget *period_select = GTK_WIDGET(gnc_period_select_new (start_type));
+
+    auto hbox = GTK_WIDGET(gtk_builder_get_object (builder, hbox_txt));
+    gtk_box_pack_start (GTK_BOX(hbox), period_select, TRUE, TRUE, 0);
+    gtk_widget_show (period_select);
+    gnc_period_select_set_active (GNC_PERIOD_SELECT(period_select), GNC_ACCOUNTING_PERIOD_TODAY);
+    gtk_widget_set_sensitive (GTK_WIDGET(period_select), FALSE);
+    return period_select;
+}
+
+static GtkWidget *
+setup_date_edit (GtkBuilder *builder, const gchar *hbox_txt)
+{
+    GtkWidget *date_widget = gnc_date_edit_new (gnc_time (nullptr), FALSE, FALSE);
+    auto hbox = GTK_WIDGET(gtk_builder_get_object (builder, hbox_txt));
+    gtk_box_pack_start (GTK_BOX(hbox), date_widget, TRUE, TRUE, 0);
+    gtk_widget_show (date_widget);
+    gtk_widget_set_sensitive (GTK_WIDGET(date_widget), FALSE);
+    return date_widget;
+}
+
 static void
 ppr_filter_dialog_create (RegisterFilterDialog* rfd, FilterData *fd, Query *query)
 {
@@ -1074,10 +1457,10 @@ ppr_filter_dialog_create (RegisterFilterDialog* rfd, FilterData *fd, Query *quer
 
     /* Create the dialog */
     auto builder = gtk_builder_new();
-    gnc_builder_add_from_file (builder, "gnc-plugin-page-register.glade",
-                               "days_adjustment");
-    gnc_builder_add_from_file (builder, "gnc-plugin-page-register.glade",
-                               "filter_by_dialog");
+    gnc_builder_add_from_file (builder, "gnc-plugin-page-register.glade", "days_adjustment");
+    gnc_builder_add_from_file (builder, "gnc-plugin-page-register.glade", "start_days_adjustment");
+    gnc_builder_add_from_file (builder, "gnc-plugin-page-register.glade", "end_days_adjustment");
+    gnc_builder_add_from_file (builder, "gnc-plugin-page-register.glade", "filter_by_dialog");
     auto dialog = GTK_WIDGET(gtk_builder_get_object (builder, "filter_by_dialog"));
     rfd->dialog = dialog;
     fd->dialog = rfd->dialog;
@@ -1149,75 +1532,100 @@ ppr_filter_dialog_create (RegisterFilterDialog* rfd, FilterData *fd, Query *quer
     rfd->table = table;
     gtk_widget_set_sensitive (GTK_WIDGET(table), start_time || end_time);
 
-    rfd->start_date_choose = GTK_WIDGET(gtk_builder_get_object (builder, "start_date_choose"));
-    rfd->start_date_today = GTK_WIDGET(gtk_builder_get_object (builder, "start_date_today"));
-    rfd->end_date_choose = GTK_WIDGET(gtk_builder_get_object (builder, "end_date_choose"));
-    rfd->end_date_today = GTK_WIDGET(gtk_builder_get_object (builder, "end_date_today"));
+    rfd->start_earliest = GTK_WIDGET(gtk_builder_get_object (builder, "earliest_label"));
+    rfd->start_date_check = GTK_WIDGET(gtk_builder_get_object (builder, "start_date_check"));
+    rfd->start_relative_check = GTK_WIDGET(gtk_builder_get_object (builder, "start_relative_check"));
+    rfd->start_days_check = GTK_WIDGET(gtk_builder_get_object (builder, "start_days_check"));
 
-    bool sensitive;
     {
+        rfd->start_relative = setup_period_select (builder, TRUE, "start_relative_hbox");
+        rfd->start_date = setup_date_edit (builder, "start_date_hbox");
+        rfd->start_days = GTK_WIDGET(gtk_builder_get_object (builder, "start_days_spin"));
+
         /* Start date info */
         if (start_time == 0)
         {
-            button = GTK_WIDGET(gtk_builder_get_object(builder, "start_date_earliest"));
+            set_sensitive_start_widget (rfd, rfd->start_earliest, TRUE);
             time_val = xaccQueryGetEarliestDateFound (query);
-            sensitive = false;
         }
         else
         {
-            time_val = start_time;
-            if ((start_time >= gnc_time64_get_today_start()) &&
-                (start_time <= gnc_time64_get_today_end()))
+            rfd->original_start_ap = fd->start_ap;
+            if (fd->start_ap != GNC_ACCOUNTING_PERIOD_INVALID)
             {
-                button = rfd->start_date_today;
-                sensitive = false;
+                set_sensitive_start_widget (rfd, rfd->start_relative, TRUE);
+                gnc_period_select_set_active (GNC_PERIOD_SELECT(rfd->start_relative), fd->start_ap);
+                gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON(rfd->start_relative_check), TRUE);
+            }
+            else if (fd->start_days != 0)
+            {
+                set_sensitive_start_widget (rfd, rfd->start_days, TRUE);
+                gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON(rfd->start_days_check), TRUE);
+                gtk_spin_button_set_value (GTK_SPIN_BUTTON(rfd->start_days), fd->start_days);
+                rfd->original_start_days = fd->start_days;
+
             }
             else
             {
-                button = rfd->start_date_choose;
-                sensitive = true;
+                set_sensitive_start_widget (rfd, rfd->start_date, TRUE);
+                gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON(rfd->start_date_check), TRUE);
             }
+            time_val = start_time;
         }
-        gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON(button), TRUE);
-        rfd->start_date = gnc_date_edit_new (gnc_time (nullptr), FALSE, FALSE);
-        auto hbox = GTK_WIDGET(gtk_builder_get_object (builder, "start_date_hbox"));
-        gtk_box_pack_start (GTK_BOX(hbox), rfd->start_date, TRUE, TRUE, 0);
-        gtk_widget_show (rfd->start_date);
-        gtk_widget_set_sensitive (GTK_WIDGET(rfd->start_date), bool_to_gboolean (sensitive));
+        g_signal_connect (G_OBJECT(rfd->start_relative), "changed",
+                          G_CALLBACK(ppr_filter_relative_changed_cb), rfd);
+
+        if (time_val == 0)
+            time_val = gnc_time64_get_today_start();
         gnc_date_edit_set_time (GNC_DATE_EDIT(rfd->start_date), time_val);
         g_signal_connect (G_OBJECT(rfd->start_date), "date-changed",
                           G_CALLBACK(ppr_filter_gde_changed_cb), rfd);
     }
 
+    rfd->end_latest = GTK_WIDGET(gtk_builder_get_object (builder, "latest_label"));
+    rfd->end_date_check = GTK_WIDGET(gtk_builder_get_object (builder, "end_date_check"));
+    rfd->end_relative_check = GTK_WIDGET(gtk_builder_get_object (builder, "end_relative_check"));
+    rfd->end_days_check = GTK_WIDGET(gtk_builder_get_object (builder, "end_days_check"));
+
     {
+        rfd->end_relative = setup_period_select (builder, FALSE, "end_relative_hbox");
+        rfd->end_date = setup_date_edit (builder, "end_date_hbox");
+        rfd->end_days = GTK_WIDGET(gtk_builder_get_object (builder, "end_days_spin"));
+
         /* End date info */
         if (end_time == 0)
         {
-            button = GTK_WIDGET(gtk_builder_get_object (builder, "end_date_latest"));
+            set_sensitive_end_widget (rfd, rfd->end_latest, TRUE);
             time_val = xaccQueryGetLatestDateFound (query);
-            sensitive = false;
         }
         else
         {
-            time_val = end_time;
-            if ((end_time >= gnc_time64_get_today_start()) &&
-                (end_time <= gnc_time64_get_today_end()))
+            rfd->original_end_ap = fd->end_ap;
+            if (fd->end_ap != GNC_ACCOUNTING_PERIOD_INVALID)
             {
-                button = rfd->end_date_today;
-                sensitive = false;
+                set_sensitive_end_widget (rfd, rfd->end_relative, TRUE);
+                gnc_period_select_set_active (GNC_PERIOD_SELECT(rfd->end_relative), fd->end_ap);
+                gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON(rfd->end_relative_check), TRUE);
+            }
+            else if (fd->end_days != 0)
+            {
+                set_sensitive_end_widget (rfd, rfd->end_days, TRUE);
+                gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON(rfd->end_days_check), TRUE);
+                gtk_spin_button_set_value (GTK_SPIN_BUTTON(rfd->end_days), fd->end_days);
+                rfd->original_end_days = fd->end_days;
             }
             else
             {
-                button = rfd->end_date_choose;
-                sensitive = true;
+                set_sensitive_end_widget (rfd, rfd->end_date, TRUE);
+                gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON(rfd->end_date_check), TRUE);
             }
+            time_val = end_time;
         }
-        gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON(button), TRUE);
-        rfd->end_date = gnc_date_edit_new (gnc_time (nullptr), FALSE, FALSE);
-        auto hbox = GTK_WIDGET(gtk_builder_get_object (builder, "end_date_hbox"));
-        gtk_box_pack_start (GTK_BOX(hbox), rfd->end_date, TRUE, TRUE, 0);
-        gtk_widget_show (rfd->end_date);
-        gtk_widget_set_sensitive (GTK_WIDGET(rfd->end_date), bool_to_gboolean (sensitive));
+        g_signal_connect (G_OBJECT(rfd->end_relative), "changed",
+                          G_CALLBACK(ppr_filter_relative_changed_cb), rfd);
+
+        if (time_val == 0)
+            time_val = gnc_time64_get_today_end();
         gnc_date_edit_set_time (GNC_DATE_EDIT(rfd->end_date), time_val);
         g_signal_connect (G_OBJECT(rfd->end_date), "date-changed",
                           G_CALLBACK(ppr_filter_gde_changed_cb), rfd);

--- a/gnucash/gnome/gnc-plugin-page-register-filter.cpp
+++ b/gnucash/gnome/gnc-plugin-page-register-filter.cpp
@@ -491,18 +491,6 @@ gnc_ppr_filter_set_tooltip (GncPluginPage* plugin_page, FilterData *fd)
     LEAVE(" ");
 }
 
-/** This function updates the "cleared match" term of the register
- *  query.  It unconditionally removes any old "cleared match" query
- *  term, then adds back a new query term if needed.  There seems to
- *  be a bug in the current g2 register code such that when the number
- *  of entries in the register doesn't fill up the window, the blank
- *  space at the end of the window isn't correctly redrawn.  This
- *  function works around that problem, but a root cause analysis
- *  should probably be done.
- *
- *  @param plugin_page A pointer to the GncPluginPageRegister that is
- *  associated with this filter dialog.
- */
 static void
 ppr_filter_update_status_query (GncPluginPage* plugin_page)
 {
@@ -547,18 +535,6 @@ ppr_filter_update_status_query (GncPluginPage* plugin_page)
     LEAVE (" ");
 }
 
-/** This function updates the "date posted" term of the register
- *  query.  It unconditionally removes any old "date posted" query
- *  term, then adds back a new query term if needed.  There seems to
- *  be a bug in the current g2 register code such that when the number
- *  of entries in the register doesn't fill up the window, the blank
- *  space at the end of the window isn't correctly redrawn.  This
- *  function works around that problem, but a root cause analysis
- *  should probably be done.
- *
- *  @param plugin_page A pointer to the GncPluginPageRegister that is
- *  associated with this filter dialog.
- */
 static void
 ppr_filter_update_date_query (GncPluginPage* plugin_page)
 {
@@ -799,16 +775,6 @@ gnc_ppr_filter_status_clear_all_cb (GtkButton* button,
     LEAVE(" ");
 }
 
-/** This function computes the starting and ending times for the
- *  filter by examining the dialog widgets to see which ones are
- *  selected, and will pull times out of the data entry boxes if
- *  necessary.  This function must exist to handle the case where the
- *  "show all" button was Selected, and the user clicks on the "select
- *  range" button.  Since it exists, it make sense for the rest of the
- *  callbacks to take advantage of it.
- *
- *  @param rfd A pointer to the filter dialog structure.
- */
 static void
 get_filter_times (RegisterFilterDialog* rfd)
 {
@@ -919,15 +885,6 @@ gnc_ppr_filter_days_changed_cb (GtkSpinButton* button,
     LEAVE(" ");
 }
 
-/** This function is called when one of the start date entry widgets
- *  is updated.  It simply calls common routines to determine the
- *  start/end times and update the register query.
- *
- *  @param unused A pointer to a GncDateEntry widgets, but it could be
- *  any widget.
- *
- *  @param rfd A pointer to the filter dialog structure.
- */
 static void
 ppr_filter_gde_changed_cb (GtkWidget* unused,
                            RegisterFilterDialog* rfd)
@@ -1110,14 +1067,6 @@ gnc_ppr_filter_response_cb (GtkDialog* dialog,
     LEAVE(" ");
 }
 
-/** This function is called to create the filter dialog.
- *
- *  @param rfd A pointer to the filter dialog structure.
- *
- *  @param fd The filter data structure for remembering state.
- *
- *  @param query A pointer to the current register query.
- */
 static void
 ppr_filter_dialog_create (RegisterFilterDialog* rfd, FilterData *fd, Query *query)
 {

--- a/gnucash/gnome/gnc-plugin-page-register-filter.hpp
+++ b/gnucash/gnome/gnc-plugin-page-register-filter.hpp
@@ -34,18 +34,22 @@
 #define __GNC_PLUGIN_PAGE_REGISTER_FILTER_HPP
 
 #include <gtk/gtk.h>
-#include "gnc-split-reg.h"
+#include "gnc-accounting-period.h"
 #include "gnc-plugin-page.h"
 #include <stdbool.h>
 
 struct FilterData
 {
-    GtkWidget*      dialog;
-    cleared_match_t cleared_match;
-    time64          start_time;
-    time64          end_time;
-    int             days;
-    bool            save_filter;
+    GtkWidget*          dialog;
+    cleared_match_t     cleared_match;
+    GncAccountingPeriod start_ap;
+    time64              start_time;
+    int                 start_days;
+    GncAccountingPeriod end_ap;
+    time64              end_time;
+    int                 end_days;
+    int                 days;
+    bool                save_filter;
 };
 
 void gnc_ppr_filter_set_tooltip (GncPluginPage* plugin_page, struct FilterData *fd);

--- a/gnucash/gtkbuilder/gnc-plugin-page-register.glade
+++ b/gnucash/gtkbuilder/gnc-plugin-page-register.glade
@@ -7,6 +7,16 @@
     <property name="step-increment">1</property>
     <property name="page-increment">10</property>
   </object>
+  <object class="GtkAdjustment" id="end_days_adjustment">
+    <property name="upper">1100</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="start_days_adjustment">
+    <property name="upper">1100</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
   <object class="GtkDialog" id="filter_by_dialog">
     <property name="can-focus">False</property>
     <property name="border-width">6</property>
@@ -97,7 +107,7 @@
                     <property name="can-focus">False</property>
                     <child>
                       <object class="GtkRadioButton" id="filter_show_days">
-                        <property name="label" translatable="yes">Show _number of days</property>
+                        <property name="label" translatable="yes">Show _from days ago</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
@@ -155,91 +165,13 @@ If 0, all previous days included</property>
                   </packing>
                 </child>
                 <child>
-                  <!-- n-columns=3 n-rows=7 -->
+                  <!-- n-columns=2 n-rows=8 -->
                   <object class="GtkGrid" id="select_range_table">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="margin-top">12</property>
                     <property name="row-spacing">3</property>
                     <property name="column-spacing">6</property>
-                    <child>
-                      <object class="GtkLabel" id="label847682">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="halign">end</property>
-                        <property name="label" translatable="yes" comments="Filter By Dialog, Date Tab, Start section">Start</property>
-                      </object>
-                      <packing>
-                        <property name="left-attach">0</property>
-                        <property name="top-attach">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkRadioButton" id="start_date_earliest">
-                        <property name="label" translatable="yes">_Earliest</property>
-                        <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="receives-default">False</property>
-                        <property name="halign">start</property>
-                        <property name="use-underline">True</property>
-                        <property name="draw-indicator">True</property>
-                        <signal name="clicked" handler="gnc_ppr_filter_start_cb" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="left-attach">1</property>
-                        <property name="top-attach">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkRadioButton" id="end_date_choose">
-                        <property name="label" translatable="yes">Choo_se Date</property>
-                        <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="receives-default">False</property>
-                        <property name="halign">start</property>
-                        <property name="use-underline">True</property>
-                        <property name="draw-indicator">True</property>
-                        <signal name="clicked" handler="gnc_ppr_filter_end_cb" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="left-attach">1</property>
-                        <property name="top-attach">6</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkRadioButton" id="end_date_today">
-                        <property name="label" translatable="yes">Toda_y</property>
-                        <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="receives-default">False</property>
-                        <property name="halign">start</property>
-                        <property name="use-underline">True</property>
-                        <property name="draw-indicator">True</property>
-                        <property name="group">end_date_choose</property>
-                        <signal name="clicked" handler="gnc_ppr_filter_end_cb" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="left-attach">1</property>
-                        <property name="top-attach">5</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkRadioButton" id="end_date_latest">
-                        <property name="label" translatable="yes">_Latest</property>
-                        <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="receives-default">False</property>
-                        <property name="halign">start</property>
-                        <property name="use-underline">True</property>
-                        <property name="draw-indicator">True</property>
-                        <property name="group">end_date_choose</property>
-                        <signal name="clicked" handler="gnc_ppr_filter_end_cb" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="left-attach">1</property>
-                        <property name="top-attach">4</property>
-                      </packing>
-                    </child>
                     <child>
                       <object class="GtkLabel" id="label847683">
                         <property name="visible">True</property>
@@ -251,49 +183,60 @@ If 0, all previous days included</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkLabel" id="label847684">
+                      <object class="GtkLabel" id="label847682">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="halign">end</property>
-                        <property name="label" translatable="yes" comments="Filter By Dialog, Date Tab, End section">End</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes" comments="Filter By Dialog, Date Tab, Start section">Start</property>
                       </object>
                       <packing>
                         <property name="left-attach">0</property>
-                        <property name="top-attach">4</property>
+                        <property name="top-attach">0</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkRadioButton" id="start_date_choose">
+                      <object class="GtkCheckButton" id="start_relative_check">
+                        <property name="label" translatable="yes">Re_lative</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">False</property>
+                        <property name="use-underline">True</property>
+                        <property name="draw-indicator">True</property>
+                        <signal name="toggled" handler="gnc_ppr_filter_start_toggle_cb" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="start_date_check">
                         <property name="label" translatable="yes">C_hoose Date</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
-                        <property name="halign">start</property>
                         <property name="use-underline">True</property>
                         <property name="draw-indicator">True</property>
-                        <property name="group">start_date_earliest</property>
-                        <signal name="clicked" handler="gnc_ppr_filter_start_cb" swapped="no"/>
+                        <signal name="toggled" handler="gnc_ppr_filter_start_toggle_cb" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="left-attach">1</property>
+                        <property name="left-attach">0</property>
                         <property name="top-attach">2</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkRadioButton" id="start_date_today">
-                        <property name="label" translatable="yes">_Today</property>
+                      <object class="GtkCheckButton" id="start_days_check">
+                        <property name="label" translatable="yes">_Days ago</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
-                        <property name="halign">start</property>
                         <property name="use-underline">True</property>
                         <property name="draw-indicator">True</property>
-                        <property name="group">start_date_earliest</property>
-                        <signal name="clicked" handler="gnc_ppr_filter_start_cb" swapped="no"/>
+                        <signal name="toggled" handler="gnc_ppr_filter_start_toggle_cb" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="left-attach">1</property>
-                        <property name="top-attach">1</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">3</property>
                       </packing>
                     </child>
                     <child>
@@ -305,8 +248,82 @@ If 0, all previous days included</property>
                         </child>
                       </object>
                       <packing>
-                        <property name="left-attach">2</property>
+                        <property name="left-attach">1</property>
                         <property name="top-attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="start_relative_hbox">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <child>
+                          <placeholder/>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkSpinButton" id="start_days_spin">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="tooltip-text" translatable="yes">Valid range is 0 to 1100 days
+If 0, all previous days included</property>
+                        <property name="text" translatable="yes">0</property>
+                        <property name="adjustment">start_days_adjustment</property>
+                        <property name="numeric">True</property>
+                        <signal name="value-changed" handler="gnc_ppr_filter_start_end_days_changed_cb" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="end_relative_check">
+                        <property name="label" translatable="yes">Rela_tive</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">False</property>
+                        <property name="use-underline">True</property>
+                        <property name="draw-indicator">True</property>
+                        <signal name="toggled" handler="gnc_ppr_filter_end_toggle_cb" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">5</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="end_date_check">
+                        <property name="label" translatable="yes">Choo_se Date</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">False</property>
+                        <property name="use-underline">True</property>
+                        <property name="draw-indicator">True</property>
+                        <signal name="toggled" handler="gnc_ppr_filter_end_toggle_cb" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">6</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="end_days_check">
+                        <property name="label" translatable="yes">Days a_go</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">False</property>
+                        <property name="use-underline">True</property>
+                        <property name="draw-indicator">True</property>
+                        <signal name="toggled" handler="gnc_ppr_filter_end_toggle_cb" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">7</property>
                       </packing>
                     </child>
                     <child>
@@ -318,36 +335,76 @@ If 0, all previous days included</property>
                         </child>
                       </object>
                       <packing>
-                        <property name="left-attach">2</property>
+                        <property name="left-attach">1</property>
                         <property name="top-attach">6</property>
                       </packing>
                     </child>
                     <child>
-                      <placeholder/>
+                      <object class="GtkBox" id="end_relative_hbox">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <child>
+                          <placeholder/>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">5</property>
+                      </packing>
                     </child>
                     <child>
-                      <placeholder/>
+                      <object class="GtkSpinButton" id="end_days_spin">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="tooltip-text" translatable="yes">Valid range is 0 to 1100 days
+If 0, all previous days included</property>
+                        <property name="text" translatable="yes">0</property>
+                        <property name="adjustment">end_days_adjustment</property>
+                        <property name="numeric">True</property>
+                        <signal name="value-changed" handler="gnc_ppr_filter_start_end_days_changed_cb" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">7</property>
+                      </packing>
                     </child>
                     <child>
-                      <placeholder/>
+                      <object class="GtkLabel" id="label847684">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="margin-top">12</property>
+                        <property name="label" translatable="yes" comments="Filter By Dialog, Date Tab, End section">End</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">4</property>
+                      </packing>
                     </child>
                     <child>
-                      <placeholder/>
+                      <object class="GtkLabel" id="earliest_label">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">Earliest</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">0</property>
+                      </packing>
                     </child>
                     <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
+                      <object class="GtkLabel" id="latest_label">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="margin-top">12</property>
+                        <property name="label" translatable="yes">Latest</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">4</property>
+                      </packing>
                     </child>
                     <child>
                       <placeholder/>

--- a/libgnucash/engine/gnc-accounting-period.c
+++ b/libgnucash/engine/gnc-accounting-period.c
@@ -188,7 +188,7 @@ gnc_accounting_period_start_gdate (GncAccountingPeriod which,
     case GNC_ACCOUNTING_PERIOD_FYEAR:
         if (fy_end == NULL)
         {
-            PINFO ("Request for fisal year value but no fiscal year end value provided.");
+            PINFO ("Request for fiscal year value but no fiscal year end value provided.");
             g_date_free (date);
             return NULL;
         }
@@ -198,7 +198,7 @@ gnc_accounting_period_start_gdate (GncAccountingPeriod which,
     case GNC_ACCOUNTING_PERIOD_FYEAR_PREV:
         if (fy_end == NULL)
         {
-            PINFO ("Request for fisal year value but no fiscal year end value provided.");
+            PINFO ("Request for fiscal year value but no fiscal year end value provided.");
             g_date_free (date);
             return NULL;
         }


### PR DESCRIPTION
This is my followup PR to change the register 'Filter By' dialog to include logical dates.
Chris raised Bug 798487 which was about not saving the 'Today', 'Earliest and 'Latest' setting of the filter properly and while looking at that found this enhancement bug which I thought would be better.

I have changed the 'Filter By' dialog to use GncPeriodSelect widgets as in the Preference dialog as shown below...


<img width="443" height="465" alt="filter" src="https://github.com/user-attachments/assets/e0368b98-c6de-4336-a611-8a92ea20663d" />

`Note: the dates on the GncPeriodSelect lines are just for testing and will be disabled on final push.`

I have changed the radio buttons in the 'Select Range' to exclusive check buttons as I did not want to give the impression 'Earliest/Latest' were settings that could be saved.

The values saved for these period select widgets is some text combined with the enum of the accounting period value and these values are stored in the same positions as the date would of been in the saved filter text.

If a .gcm file is opened which has these values in it from an earlier Gnucash version, it would be treated as a date and fail to pass resulting in a value of 0 which is equivalent to no date filter and so the register will show all entries. I do not think it is worth guarding against this with a feature change.

The third commit I am unsure about and possibly could be dropped. I based setting up the GncPeriodSelect widgets from the preference dialog which is created from dialog-preferences.c line 1339. On lines 1410 to 1417 there is a check for the book value 'Fiscal year End' and supposedly used on lines 1424 and 1432 when setting up the GncPeriodSelect widgets but 'date_is_valid' always FALSE.

I can not find any place that would set this value, I created the KVP value in my test file manually just to test my code worked and that is how I found out that when used it would segfault and hence the following commit to fix that.
So maybe it was left over from some other change, I do not know, I can drop my commit and maybe remove the code from dialog-preferences.c but still push the last two commits.