### PR TITLE
Correct key_press_event and key_release_event callback function return definitions.

### DIFF
--- a/gnucash/gnome-utils/dialog-options.cpp
+++ b/gnucash/gnome-utils/dialog-options.cpp
@@ -456,7 +456,7 @@ dialog_destroy_cb (GtkWidget *object, GncOptionsDialog *win)
 }
 
 // "key_press_event" signal handler
-static int
+static gboolean
 dialog_window_key_press_cb(GtkWidget *widget, GdkEventKey *event, gpointer data)
 {
     GncOptionsDialog *win = static_cast<decltype(win)>(data);

--- a/gnucash/gnome-utils/gnc-date-edit.c
+++ b/gnucash/gnome-utils/gnc-date-edit.c
@@ -163,7 +163,7 @@ delete_popup (GtkWidget *widget, GdkEvent *event, gpointer data)
     return TRUE;
 }
 
-static gint
+static gboolean
 key_press_popup (GtkWidget *widget, GdkEventKey *event, gpointer data)
 {
     GNCDateEdit *gde = data;
@@ -782,7 +782,7 @@ date_accel_key_press(GtkWidget *widget, GdkEventKey *event, gpointer data)
     return TRUE;
 }
 
-static gint
+static gboolean
 key_press_entry (GtkWidget *widget, GdkEventKey *event, gpointer data)
 {
     if (!date_accel_key_press(widget, event, data))

--- a/gnucash/gnome/dialog-commodities.cpp
+++ b/gnucash/gnome/dialog-commodities.cpp
@@ -82,9 +82,9 @@ void gnc_commodities_dialog_rename_namespace_clicked (GtkWidget *widget, gpointe
 void gnc_commodities_show_currencies_toggled (GtkToggleButton *toggle, CommoditiesDialog *cd);
 }
 
-gboolean gnc_commodities_window_key_press_cb (GtkWidget *widget,
-                                              GdkEventKey *event,
-                                              gpointer data);
+static gboolean gnc_commodities_window_key_press_cb (GtkWidget *widget,
+                                                     GdkEventKey *event,
+                                                     gpointer data);
 
 
 void
@@ -508,7 +508,7 @@ show_handler (const char *klass, gint component_id,
     return(TRUE);
 }
 
-gboolean
+static gboolean
 gnc_commodities_window_key_press_cb (GtkWidget *widget, GdkEventKey *event,
                                      gpointer data)
 {

--- a/gnucash/gnome/dialog-price-edit-db.cpp
+++ b/gnucash/gnome/dialog-price-edit-db.cpp
@@ -926,7 +926,7 @@ show_handler (const char *klass, gint component_id,
 }
 
 
-gboolean
+static gboolean
 gnc_prices_dialog_key_press_cb (GtkWidget *widget, GdkEventKey *event,
                                 gpointer data)
 {

--- a/gnucash/register/register-gnome/combocell-gnome.c
+++ b/gnucash/register/register-gnome/combocell-gnome.c
@@ -202,7 +202,7 @@ activate_item_cb (GncItemList* item_list, char* item_string, gpointer data)
     box->list_popped = FALSE;
 }
 
-static void
+static gboolean
 key_press_item_cb (GncItemList* item_list, GdkEventKey* event, gpointer data)
 {
     ComboCell* cell = data;
@@ -220,6 +220,7 @@ key_press_item_cb (GncItemList* item_list, GdkEventKey* event, gpointer data)
                           (GdkEvent*) event);
         break;
     }
+    return TRUE;
 }
 
 static void

--- a/gnucash/register/register-gnome/completioncell-gnome.c
+++ b/gnucash/register/register-gnome/completioncell-gnome.c
@@ -261,7 +261,7 @@ unblock_list_signals (CompletionCell* cell)
                                        0, 0, NULL, NULL, cell);
 }
 
-static void
+static gboolean
 key_press_item_cb (GncItemList* item_list, GdkEventKey* event, gpointer user_data)
 {
     CompletionCell* cell = user_data;
@@ -281,6 +281,7 @@ key_press_item_cb (GncItemList* item_list, GdkEventKey* event, gpointer user_dat
                           (GdkEvent*) event);
         break;
     }
+    return TRUE;
 }
 
 static void

--- a/gnucash/register/register-gnome/datecell-gnome.c
+++ b/gnucash/register/register-gnome/datecell-gnome.c
@@ -286,7 +286,7 @@ date_selected_cb (GNCDatePicker *gdp, gpointer data)
     box->in_date_select = FALSE;
 }
 
-static void
+static gboolean
 key_press_item_cb (GNCDatePicker *gdp, GdkEventKey *event, gpointer data)
 {
     DateCell *cell = data;
@@ -303,6 +303,7 @@ key_press_item_cb (GNCDatePicker *gdp, GdkEventKey *event, gpointer data)
         gtk_widget_event(GTK_WIDGET (box->sheet), (GdkEvent *) event);
         break;
     }
+    return TRUE;
 }
 
 static void

--- a/gnucash/register/register-gnome/gnucash-sheet.c
+++ b/gnucash/register/register-gnome/gnucash-sheet.c
@@ -1783,7 +1783,7 @@ pass_to_entry_handler (GnucashSheet *sheet, GdkEventKey *event)
     return result;
 }
 
-static gint
+static gboolean
 gnucash_sheet_key_press_event_internal (GtkWidget *widget, GdkEventKey *event)
 {
     Table *table;
@@ -1866,7 +1866,7 @@ gnucash_sheet_key_press_event_internal (GtkWidget *widget, GdkEventKey *event)
     return TRUE;
 }
 
-static gint
+static gboolean
 gnucash_sheet_key_press_event (GtkWidget *widget, GdkEventKey *event)
 {
     GnucashSheet *sheet;
@@ -1887,7 +1887,7 @@ gnucash_sheet_key_press_event (GtkWidget *widget, GdkEventKey *event)
     return gnucash_sheet_key_press_event_internal (widget, event);
 }
 
-static gint
+static gboolean
 gnucash_sheet_key_release_event (GtkWidget *widget, GdkEventKey *event)
 {
     g_return_val_if_fail (widget != NULL, TRUE);


### PR DESCRIPTION
While debugging another issue, I noted the improper void return definition of the _key-press-event_ callback function `key_press_item()` in `combocell-gnome.c.`  A quick search found the same issue in `completioncell-gnome.c` and `datecell-gnome.c` and inconsistent scope and return types in four other files.