### PR TITLE
[security] Fix SQL Injection in DBI backend

### DIFF
--- a/libgnucash/backend/dbi/gnc-backend-dbi.cpp
+++ b/libgnucash/backend/dbi/gnc-backend-dbi.cpp
@@ -171,7 +171,13 @@ UriStrings::quote_dbname(DbType t) const noexcept
         return "";
     const char quote = (t == DbType::DBI_MYSQL ? '`' : '"');
     std::string retval(1, quote);
-    retval += m_dbname + quote;
+    for (auto c : m_dbname)
+    {
+        if (c == quote)
+            retval += quote;
+        retval += c;
+    }
+    retval += quote;
     return retval;
 }
 

--- a/libgnucash/backend/dbi/gnc-dbiprovider.hpp
+++ b/libgnucash/backend/dbi/gnc-dbiprovider.hpp
@@ -44,6 +44,7 @@ public:
                                 const GncSqlColumnInfo& info) = 0;
     virtual StrVec get_index_list (dbi_conn conn) = 0;
     virtual void drop_index(dbi_conn conn, const std::string& index) = 0;
+    virtual std::string quote_identifier(const std::string& identifier) const = 0;
 };
 
 using GncDbiProviderPtr = std::unique_ptr<GncDbiProvider>;

--- a/libgnucash/backend/dbi/gnc-dbiproviderimpl.hpp
+++ b/libgnucash/backend/dbi/gnc-dbiproviderimpl.hpp
@@ -44,6 +44,7 @@ public:
     void append_col_def(std::string& ddl, const GncSqlColumnInfo& info);
     StrVec get_index_list (dbi_conn conn);
     void drop_index(dbi_conn conn, const std::string& index);
+    std::string quote_identifier(const std::string& identifier) const override;
 };
 
 template <DbType T> GncDbiProviderPtr
@@ -262,13 +263,35 @@ GncDbiProviderImpl<DbType::DBI_PGSQL>::get_table_list (dbi_conn conn,
 {
     const char* query_no_regex = "SELECT relname FROM pg_class WHERE relname"
                           "!~ '^(pg|sql)_' AND relkind = 'r' ORDER BY relname";
-    std::string query_with_regex = "SELECT relname FROM pg_class WHERE relname LIKE '";
-    query_with_regex += table + "' AND relkind = 'r' ORDER BY relname";
     dbi_result result;
     if (table.empty())
         result = dbi_conn_query (conn, query_no_regex);
     else
-        result = dbi_conn_query (conn, query_with_regex.c_str());
+    {
+        /* In a LIKE clause, we need to escape _, %, and \. */
+        std::string escaped_table;
+        for (auto c : table)
+        {
+            if (c == '_' || c == '%' || c == '\\')
+                escaped_table += '\\';
+            escaped_table += c;
+        }
+
+        char* quoted_str;
+        dbi_conn_quote_string_copy (conn, escaped_table.c_str(), &quoted_str);
+        if (quoted_str)
+        {
+            std::string query = "SELECT relname FROM pg_class WHERE relname LIKE ";
+            query += quoted_str;
+            query += " AND relkind = 'r' ORDER BY relname";
+            free(quoted_str);
+            result = dbi_conn_query (conn, query.c_str());
+        }
+        else
+        {
+            return StrVec{};
+        }
+    }
 
     StrVec list;
     const char* errmsg;
@@ -318,7 +341,7 @@ GncDbiProviderImpl<DbType::DBI_MYSQL>::get_index_list (dbi_conn conn)
     {
         auto result = dbi_conn_queryf (conn,
                                        "SHOW INDEXES IN %s WHERE Key_name != 'PRIMARY'",
-                                       table_name.c_str());
+                                       quote_identifier(table_name).c_str());
         if (dbi_conn_error (conn, &errmsg) != DBI_ERROR_NONE)
         {
             PWARN ("Index Table Retrieval Error: %s on table %s\n",
@@ -362,9 +385,39 @@ GncDbiProviderImpl<DbType::DBI_PGSQL>::get_index_list (dbi_conn conn)
 template <DbType P> void
 GncDbiProviderImpl<P>::drop_index(dbi_conn conn, const std::string& index)
 {
-    dbi_result result = dbi_conn_queryf (conn, "DROP INDEX %s", index.c_str());
+    dbi_result result = dbi_conn_queryf (conn, "DROP INDEX %s", quote_identifier(index).c_str());
     if (result)
         dbi_result_free (result);
+}
+
+template <DbType T> inline std::string
+GncDbiProviderImpl<T>::quote_identifier(const std::string& identifier) const
+{
+    std::string retval = "\"";
+    for (auto c : identifier)
+    {
+        if (c == '"')
+            retval += "\"\"";
+        else
+            retval += c;
+    }
+    retval += "\"";
+    return retval;
+}
+
+template <> inline std::string
+GncDbiProviderImpl<DbType::DBI_MYSQL>::quote_identifier(const std::string& identifier) const
+{
+    std::string retval = "`";
+    for (auto c : identifier)
+    {
+        if (c == '`')
+            retval += "``";
+        else
+            retval += c;
+    }
+    retval += "`";
+    return retval;
 }
 
 template<> void
@@ -380,8 +433,8 @@ GncDbiProviderImpl<DbType::DBI_MYSQL>::drop_index (dbi_conn conn, const std::str
     }
 
     auto result = dbi_conn_queryf (conn, "DROP INDEX %s ON %s",
-                                   index.substr(0, sep).c_str(),
-                                   index.substr(sep + 1).c_str());
+                                   quote_identifier(index.substr(0, sep)).c_str(),
+                                   quote_identifier(index.substr(sep + 1)).c_str());
     if (result)
         dbi_result_free (result);
 }

--- a/libgnucash/backend/dbi/gnc-dbisqlconnection.cpp
+++ b/libgnucash/backend/dbi/gnc-dbisqlconnection.cpp
@@ -110,7 +110,7 @@ GncDbiSqlConnection::lock_database (bool break_lock)
     {
         auto result = dbi_conn_queryf (m_conn,
                                        "CREATE TABLE %s ( Hostname varchar(%d), PID int )",
-                                       lock_table.c_str(),
+                                       quote_identifier(lock_table).c_str(),
                                        GNC_HOST_NAME_MAX);
         if (result)
         {
@@ -128,7 +128,7 @@ GncDbiSqlConnection::lock_database (bool break_lock)
     /* Check for an existing entry; delete it if break_lock is true, otherwise fail */
     char hostname[ GNC_HOST_NAME_MAX + 1 ];
     auto result = dbi_conn_queryf (m_conn, "SELECT * FROM %s",
-                                   lock_table.c_str());
+                                   quote_identifier(lock_table).c_str());
     if (result && dbi_result_get_numrows (result))
     {
         dbi_result_free (result);
@@ -140,7 +140,7 @@ GncDbiSqlConnection::lock_database (bool break_lock)
             rollback_transaction();
             return false;
         }
-        result = dbi_conn_queryf (m_conn, "DELETE FROM %s", lock_table.c_str());
+        result = dbi_conn_queryf (m_conn, "DELETE FROM %s", quote_identifier(lock_table).c_str());
         if (!result)
         {
             qof_backend_set_error (m_qbe, ERR_BACKEND_SERVER_ERR);
@@ -155,8 +155,9 @@ GncDbiSqlConnection::lock_database (bool break_lock)
     memset (hostname, 0, sizeof (hostname));
     gethostname (hostname, GNC_HOST_NAME_MAX);
     result = dbi_conn_queryf (m_conn,
-                              "INSERT INTO %s VALUES ('%s', '%d')",
-                              lock_table.c_str(), hostname, (int)GETPID ());
+                              "INSERT INTO %s VALUES (%s, %d)",
+                              quote_identifier(lock_table).c_str(),
+                              quote_string(hostname).c_str(), (int)GETPID ());
     if (!result)
     {
         qof_backend_set_error (m_qbe, ERR_BACKEND_SERVER_ERR);
@@ -190,9 +191,9 @@ GncDbiSqlConnection::unlock_database ()
         memset (hostname, 0, sizeof (hostname));
         gethostname (hostname, GNC_HOST_NAME_MAX);
         auto result = dbi_conn_queryf (m_conn,
-                                       "SELECT * FROM %s WHERE Hostname = '%s' "
-                                       "AND PID = '%d'", lock_table.c_str(),
-                                       hostname,
+                                       "SELECT * FROM %s WHERE Hostname = %s "
+                                       "AND PID = %d", quote_identifier(lock_table).c_str(),
+                                       quote_string(hostname).c_str(),
                                        (int)GETPID ());
         if (result && dbi_result_get_numrows (result))
         {
@@ -202,7 +203,7 @@ GncDbiSqlConnection::unlock_database ()
                 result = nullptr;
             }
             result = dbi_conn_queryf (m_conn, "DELETE FROM %s",
-                                      lock_table.c_str());
+                                      quote_identifier(lock_table).c_str());
             if (!result)
             {
                 PERR ("Failed to delete the lock entry");
@@ -512,6 +513,12 @@ GncDbiSqlConnection::create_index(const std::string& index_name,
     }
 
     return true;
+}
+
+std::string
+GncDbiSqlConnection::quote_identifier (const std::string& identifier) const
+{
+    return m_provider->quote_identifier (identifier);
 }
 
 bool

--- a/libgnucash/backend/dbi/gnc-dbisqlconnection.hpp
+++ b/libgnucash/backend/dbi/gnc-dbisqlconnection.hpp
@@ -59,6 +59,7 @@ public:
         const noexcept override;
     bool add_columns_to_table (const std::string&, const ColVec&)
         const noexcept override;
+    std::string quote_identifier(const std::string& identifier) const;
     std::string quote_string (const std::string&) const noexcept override;
     int dberror() const noexcept override {
         return dbi_conn_error(m_conn, nullptr); }


### PR DESCRIPTION
- Implement identifier quoting for all DBI backends.
- Secure database locking mechanism against SQL injection by properly quoting identifiers and strings.
- Escape wildcards in PostgreSQL LIKE clauses for table listing.
- Properly escape quote characters in database names.

Addressing vulnerability in libgnucash/backend/dbi/gnc-dbisqlconnection.cpp:130 and related locations.