### PR TITLE
Add StartupWMClass to desktop file

### DIFF
--- a/gnucash/gnome/gnucash.desktop.in.in
+++ b/gnucash/gnome/gnucash.desktop.in.in
@@ -9,6 +9,7 @@ Exec=gnucash %f
 # Translators: Icon file name, do not translate unless you also provide a localized icon file. Alternatively use the English "gnucash-icon" as msgstr
 Icon=gnucash-icon
 StartupNotify=true
+StartupWMClass=gnucash
 Terminal=false
 Categories=Office;Finance;
 X-GNOME-Bugzilla-Bugzilla=gnucash.org


### PR DESCRIPTION
When GNUCash is running natively, the desktop file is named gnucash.desktop and the WMClass is "gnucash" so everything matches.  When GNUCash is running as a flatpak, the desktop file is named org.gnucash.GnuCash.desktop, but the WMClass is still "gnucash" which interferes with the ability of some WM/shell/DEs to find the desktop file to properly lookup metadata.

Adding the StartupWMClass desktop file key fixes this issue.