### PR TITLE
Always offer options summary

### DIFF
--- a/gnucash/report/html-utilities.scm
+++ b/gnucash/report/html-utilities.scm
@@ -331,6 +331,7 @@
              (retval (cons (format #f "~a / ~a" section name)
                            (disp value))))
         (if (and (GncOption-is-changed option)
+                 (not (equal? name gnc:optname-options-summary))
                  (not (GncOption-is-internal option)))
             (addto! render-list retval))))
     (define (name-fn name) (if plaintext? name (gnc:html-markup-b name)))

--- a/gnucash/report/report-core.scm
+++ b/gnucash/report/report-core.scm
@@ -66,6 +66,7 @@
 (export gnc:menuname-taxes)
 (export gnc:optname-invoice-number)
 (export gnc:optname-reportname)
+(export gnc:optname-options-summary)
 (export gnc:pagename-accounts)
 (export gnc:pagename-display)
 (export gnc:pagename-general)
@@ -165,6 +166,7 @@
 (define gnc:pagename-accounts (N_ "Accounts"))
 (define gnc:pagename-display (N_ "Display"))
 (define gnc:optname-reportname (N_ "Report name"))
+(define gnc:optname-options-summary (N_ "Add options summary"))
 (define gnc:optname-stylesheet (N_ "Stylesheet"))
 (define gnc:menuname-business-reports (N_ "_Business"))
 (define gnc:optname-invoice-number (N_ "Invoice Number"))
@@ -323,6 +325,13 @@ not found.")))
             (string->symbol (gnc:html-style-sheet-name ss))
             (gnc:html-style-sheet-name ss)))
          (gnc:get-html-style-sheets))))
+      (or
+       (gnc-lookup-option optiondb gnc:pagename-general gnc:optname-options-summary)
+       (gnc-register-multichoice-option
+        optiondb gnc:pagename-general gnc:optname-options-summary "0c"
+        (G_ "Add summary of options.") "never"
+        (list (vector 'always (G_ "Always"))
+              (vector 'never (G_ "Never")))))
       options))
 
 ;; A <report> represents an instantiation of a particular report type.
@@ -762,6 +771,13 @@ not found.")))
                     (stylesheet (gnc:report-stylesheet report))
                     (_ (report-set-anchors! report (ht:make-hash-table)))
                     (doc (renderer report))
+                    (options (gnc:report-options report))
+                    (opt-summary (gnc-optiondb-lookup-value
+                                  (gnc:optiondb options)
+                                  gnc:pagename-general gnc:optname-options-summary))
+                    (_ (unless (eq? 'never opt-summary)
+                         (gnc:html-document-add-object!
+                          doc (gnc:html-render-options-changed options))))
                     (html (cond
                            ((string? doc) doc)
                            (else

--- a/gnucash/report/reports/standard/balsheet-pnl.scm
+++ b/gnucash/report/reports/standard/balsheet-pnl.scm
@@ -65,9 +65,6 @@ reporting."))
 (define optname-disable-amount-indent (N_ "Disable amount indenting"))
 (define opthelp-disable-amount-indent (N_ "Selecting this option will disable amount indenting, and condense amounts into a single column."))
 
-(define optname-options-summary (N_ "Add options summary"))
-(define opthelp-options-summary (N_ "Add summary of options."))
-
 (define optname-account-full-name (N_ "Account full name instead of indenting"))
 (define opthelp-account-full-name (N_ "Selecting this option enables full account name instead, and disables indenting account names."))
 
@@ -186,13 +183,6 @@ also show overall period profit & loss."))
     (gnc-register-simple-boolean-option options
       gnc:pagename-general optname-reverse-chrono
       "c5" opthelp-reverse-chrono #t)
-
-    (gnc-register-multichoice-option options
-      gnc:pagename-general optname-options-summary
-      "d" opthelp-options-summary
-      "never"
-      (list (vector 'always (G_ "Always"))
-            (vector 'never (G_ "Never"))))
 
     ;; accounts to work on
     (gnc-register-account-list-option options
@@ -866,10 +856,6 @@ also show overall period profit & loss."))
              (if (or (not (eq? incr 'disabled)) (eq? report-type 'pnl))
                  (display (gnc-date-interval-format startdate enddate))
                  (display (qof-print-date enddate))))))
-
-    (if (eq? (get-option gnc:pagename-general optname-options-summary) 'always)
-        (gnc:html-document-add-object!
-         doc (gnc:html-render-options-changed (gnc:report-options report-obj))))
 
     (cond
      ((null? accounts)

--- a/gnucash/report/reports/standard/ifrs-cost-basis.scm
+++ b/gnucash/report/reports/standard/ifrs-cost-basis.scm
@@ -520,9 +520,6 @@ the split action field to detect capitalized fees on stock activity")
   ;; (gnc:dump-all-transactions)
   (gnc:html-document-add-object! document disclaimer)
 
-  (gnc:html-document-add-object!
-   document (gnc:html-render-options-changed (gnc:report-options report-obj)))
-
   document)
 
 

--- a/gnucash/report/reports/standard/txn-columns.scm
+++ b/gnucash/report/reports/standard/txn-columns.scm
@@ -245,8 +245,6 @@ Select a different subset of transactions, or increase the limit in the options.
 
       (gnc:html-document-set-title! document (G_ reportname))
 
-      (gnc:html-document-add-object! document (gnc:html-render-options-changed options))
-
       (gnc:html-document-add-object! document table))))
 
   document)

--- a/gnucash/report/trep-engine.scm
+++ b/gnucash/report/trep-engine.scm
@@ -105,7 +105,6 @@
 (define optname-enddate (N_ "End Date"))
 (define optname-date-source (N_ "Date Filter"))
 (define optname-table-export (N_ "Table for Exporting"))
-(define optname-infobox-display (N_ "Add options summary"))
 
 ;; Currency
 (define pagename-currency (N_ "Currency"))
@@ -581,17 +580,6 @@ in the Options panel."))
     gnc:pagename-general optname-table-export
     "g" (G_ "Formats the table suitable for cut & paste exporting with extra cells.")
     #f)
-
-  (gnc-register-multichoice-option options
-    gnc:pagename-general optname-infobox-display
-    "h" (G_ "Add summary of options.")
-    "no-match"
-    ;; This is an alist of conditions for displaying the infobox
-    ;; 'no-match for empty-report
-    ;; 'match for generated report
-    (list (vector 'no-match (G_ "If no transactions matched"))
-          (vector 'always (G_ "Always"))
-          (vector 'never (G_ "Never"))))
 
   ;; Filtering Options
 
@@ -2305,7 +2293,6 @@ be excluded from periodic reporting.")
                                    primary-subtotal)
                                (memq (opt-val gnc:pagename-display (N_ "Amount"))
                                      '(single double))))
-         (infobox-display (opt-val gnc:pagename-general optname-infobox-display))
          (query (qof-query-create-for-splits)))
 
     ;; define a preprocessed alist of report parameters.
@@ -2549,12 +2536,7 @@ be excluded from periodic reporting.")
       (when empty-report-message
         (gnc:html-document-add-object!
          document
-         empty-report-message))
-
-      (when (memq infobox-display '(always no-match))
-        (gnc:html-document-add-object!
-         document
-         (gnc:html-render-options-changed options))))
+         empty-report-message)))
 
      (else
       (qof-query-set-book query (gnc-get-current-book))
@@ -2628,12 +2610,7 @@ be excluded from periodic reporting.")
           report-title (gnc:report-id report-obj)
           NO-MATCHING-TRANS-HEADER NO-MATCHING-TRANS-TEXT))
 
-        (gnc:html-document-set-export-error document "No splits found")
-
-        (when (memq infobox-display '(always no-match))
-          (gnc:html-document-add-object!
-           document
-           (gnc:html-render-options-changed options))))
+        (gnc:html-document-set-export-error document "No splits found"))
 
        (else
         (let-values (((table grid csvlist)
@@ -2647,11 +2624,6 @@ be excluded from periodic reporting.")
            (gnc:make-html-text
             (gnc:html-markup-h3
              (gnc-date-interval-format begindate enddate))))
-
-          (when (eq? infobox-display 'always)
-            (gnc:html-document-add-object!
-             document
-             (gnc:html-render-options-changed options)))
 
           (when subtotal-table?
             (gnc:html-document-add-object! document (grid 'get-html)))


### PR DESCRIPTION
There are 2 default options - reportname and stylesheet. add a 3rd one "show options summary" to add debugging info at the end of all rendered reports. this also works for charts.