### PR TITLE
Fix blurry text in HiDPI offscreen-rendered widgets

### DIFF
--- a/gnucash/gnome-utils/gnc-dense-cal.c
+++ b/gnucash/gnome-utils/gnc-dense-cal.c
@@ -712,15 +712,20 @@ gdc_reconfig (GncDenseCal *dcal)
 {
     GtkWidget *widget;
     GtkAllocation alloc;
+    int scale;
 
     if (dcal->surface)
         cairo_surface_destroy (dcal->surface);
 
     widget = GTK_WIDGET(dcal->cal_drawing_area);
     gtk_widget_get_allocation (widget, &alloc);
+    scale = gtk_widget_get_scale_factor (widget);
+    if (scale < 1)
+        scale = 1;
     dcal->surface = cairo_image_surface_create (CAIRO_FORMAT_ARGB32,
-                                                alloc.width,
-                                                alloc.height);
+                                                alloc.width * scale,
+                                                alloc.height * scale);
+    cairo_surface_set_device_scale (dcal->surface, scale, scale);
     gnc_dense_cal_draw_to_buffer (dcal);
 }
 
@@ -980,8 +985,8 @@ gnc_dense_cal_draw_to_buffer (GncDenseCal *dcal)
     gtk_style_context_add_class (stylectxt, GTK_STYLE_CLASS_CALENDAR);
 
     gtk_render_background (stylectxt, cr, 0, 0,
-                           cairo_image_surface_get_width (dcal->surface),
-                           cairo_image_surface_get_height (dcal->surface));
+                           alloc.width,
+                           alloc.height);
 
     gtk_style_context_remove_class (stylectxt, GTK_STYLE_CLASS_BACKGROUND);
 

--- a/gnucash/register/register-gnome/gnucash-header.c
+++ b/gnucash/register/register-gnome/gnucash-header.c
@@ -68,6 +68,7 @@ gnc_header_draw_offscreen (GncHeader *header)
     int row_offset;
     CellBlock *cb;
     int i;
+    int scale;
     cairo_t *cr;
 
     virt_loc.vcell_loc.virt_row = 0;
@@ -83,9 +84,13 @@ gnc_header_draw_offscreen (GncHeader *header)
 
     if (header->surface)
         cairo_surface_destroy (header->surface);
+    scale = gtk_widget_get_scale_factor (GTK_WIDGET(header));
+    if (scale < 1)
+        scale = 1;
     header->surface = cairo_image_surface_create (CAIRO_FORMAT_ARGB32,
-                                                  header->width,
-                                                  header->height);
+                                                  header->width * scale,
+                                                  header->height * scale);
+    cairo_surface_set_device_scale (header->surface, scale, scale);
 
     cr = cairo_create (header->surface);
 
@@ -688,5 +693,4 @@ gnc_header_new (GnucashSheet *sheet)
     sheet->header_item = layout;
     return layout;
 }
-
 


### PR DESCRIPTION
Fix blurry text on HiDPI/Retina displays in custom GnuCash widgets that render into offscreen Cairo image surfaces.

This updates the register header and dense calendar widgets to create scale-aware backing surfaces using the GTK widget scale factor and `cairo_surface_set_device_scale()`.

- Register column headers
- Scheduled transaction dense calendar

Tested locally on macOS Apple Silicon with a native arm64 build.

Confirmed that:
- register header text now renders crisply
- scheduled transaction dense calendar text now renders crisply