### PR TITLE
Removed AEX from list of commodities.

### DIFF
--- a/libgnucash/engine/gnc-commodity.cpp
+++ b/libgnucash/engine/gnc-commodity.cpp
@@ -189,7 +189,6 @@ static QuoteSourceList currency_quote_sources =
 static QuoteSourceList single_quote_sources =
 {
     { false, SOURCE_SINGLE, NC_("FQ Source", "Alphavantage"), "alphavantage" },
-    { false, SOURCE_SINGLE, NC_("FQ Source", "Amsterdam Euronext eXchange, NL"), "aex" },
     { false, SOURCE_SINGLE, NC_("FQ Source", "Association of Mutual Funds in India"), "amfiindia" },
     { false, SOURCE_SINGLE, NC_("FQ Source", "Athens Exchange Group, GR"), "asegr" },
     { false, SOURCE_SINGLE, NC_("FQ Source", "Australian Stock Exchange, AU"), "asx" },


### PR DESCRIPTION
This PR removes the quote source for "Amsterdam Euronext eXchange" from the `single_quote_sources` structure. in gnc-commodity.cpp.

euronext.com is now using JS based anti-webscraping. The `AEX.pm` module that provides the `aex`, `euronext`, and `dutch` methods removed from Finance::Quote in v1.70.