### PR TITLE
ensure boost::regex is compiled at startup

### DIFF
--- a/gnucash/import-export/csv-imp/gnc-imp-props-price.cpp
+++ b/gnucash/import-export/csv-imp/gnc-imp-props-price.cpp
@@ -41,6 +41,7 @@
 #include <boost/regex/icu.hpp>
 #include <gnc-locale-utils.hpp>
 #include "gnc-imp-props-price.hpp"
+#include <ctre.hpp>
 
 namespace bl = boost::locale;
 
@@ -65,7 +66,8 @@ std::map<GncPricePropType, const char*> gnc_price_col_type_strs = {
 GncNumeric parse_amount_price (const std::string &str, int currency_format)
 {
     /* If a cell is empty or just spaces return invalid amount */
-    if(!boost::regex_search(str, boost::regex("[0-9]")))
+    static constexpr ctll::fixed_string digit_re{"[0-9]"};
+    if(!ctre::search<digit_re>(str))
         throw std::invalid_argument (_("Value doesn't appear to contain a valid number."));
 
     static const auto expr = boost::make_u32regex("[[:Sc:]]");

--- a/gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp
+++ b/gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp
@@ -47,6 +47,7 @@
 #include <boost/regex/icu.hpp>
 #include <gnc-locale-utils.hpp>
 #include "gnc-imp-props-tx.hpp"
+#include <ctre.hpp>
 
 namespace bl = boost::locale;
 
@@ -135,7 +136,8 @@ GncNumeric parse_monetary (const std::string &str, int currency_format)
         return GncNumeric{};
 
     /* Strings otherwise containing no digits will be considered invalid */
-    if(!boost::regex_search(str, boost::regex("[0-9]")))
+    static constexpr ctll::fixed_string digit_re{"[0-9]"};
+    if(!ctre::search<digit_re>(str))
         throw std::invalid_argument (_("Value doesn't appear to contain a valid number."));
 
     static const auto expr = boost::make_u32regex("[[:Sc:][:blank:]]|--");

--- a/libgnucash/core-utils/CMakeLists.txt
+++ b/libgnucash/core-utils/CMakeLists.txt
@@ -52,12 +52,12 @@ target_include_directories(gnc-core-utils
 target_link_libraries(gnc-core-utils
     PUBLIC
 	PkgConfig::GLIB2
+        ctre
     PRIVATE
         ${Boost_LIBRARIES}
         ${GOBJECT_LDFLAGS}
         ${GTK_MAC_LDFLAGS}
         ${ICU_LIBRARIES}
-        ctre
         "$<$<BOOL:${MAC_INTEGRATION}>:${OSX_EXTRA_LIBRARIES}>")
 
 target_compile_definitions(gnc-core-utils


### PR DESCRIPTION
instead of per-call