### PR TITLE
[qofid.cpp] use boost::unordered_flat_map

### DIFF
--- a/libgnucash/engine/guid.cpp
+++ b/libgnucash/engine/guid.cpp
@@ -300,14 +300,14 @@ gnc_string_to_guid (const GValue *src, GValue *dest)
 static void
 gnc_guid_to_string (const GValue *src, GValue *dest)
 {
-    const gchar *str;
+    gchar *str;
 
     g_return_if_fail (G_VALUE_HOLDS_STRING (dest) &&
                       GNC_VALUE_HOLDS_GUID (src));
 
     str = guid_to_string (gnc_value_get_guid (src));
 
-    g_value_set_string (dest, str);
+    g_value_take_string (dest, str);
 }
 
 G_DEFINE_BOXED_TYPE_WITH_CODE (GncGUID, gnc_guid, guid_copy, guid_free,

--- a/libgnucash/engine/guid.cpp
+++ b/libgnucash/engine/guid.cpp
@@ -254,15 +254,8 @@ guid_compare (const GncGUID *guid_1, const GncGUID *guid_2)
 guint
 guid_hash_to_guint (gconstpointer ptr)
 {
-    if (!ptr)
-    {
-        PERR ("received nullptr guid pointer.");
-        return 0;
-    }
-    const GncGUID* g = static_cast<const GncGUID*>(ptr);
-    guint rv;
-    memcpy (&rv, &g->reserved[12], sizeof (guint));
-    return rv;
+    g_return_val_if_fail (ptr, 0);
+    return gnc_guid_hash<guint> (*static_cast<const GncGUID*>(ptr));
 }
 
 gint

--- a/libgnucash/engine/guid.hpp
+++ b/libgnucash/engine/guid.hpp
@@ -22,6 +22,7 @@
 #ifndef GUID_HPP_HEADER
 #define GUID_HPP_HEADER
 
+#include <boost/functional/hash.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <stdexcept>
 #include <string>
@@ -68,4 +69,19 @@ bool operator == (GUID const &, GncGUID const &) noexcept;
 } // namespace gnc
 
 bool operator== (const GncGUID&, const GncGUID&);
+
+template <typename T>
+T
+gnc_guid_hash (const GncGUID& g)
+{
+    static_assert(std::is_integral_v<T>);
+    return static_cast<T>(boost::hash_range(g.reserved, g.reserved + sizeof (g.reserved)));
+};
+
+
+template<> struct std::hash<GncGUID>
+{
+    std::size_t operator()(const GncGUID& g) const{ return gnc_guid_hash<size_t> (g); }
+};
+
 #endif

--- a/libgnucash/engine/qofid.cpp
+++ b/libgnucash/engine/qofid.cpp
@@ -27,9 +27,13 @@
 #include <config.h>
 #include <string.h>
 
+#include <guid.hpp>
 #include "qof.h"
 #include "qofid-p.h"
 #include "qofinstance-p.h"
+
+#include <boost/unordered/unordered_flat_map.hpp>
+using GuidEntityMap = boost::unordered_flat_map<GncGUID, QofInstance*, std::hash<GncGUID>>;
 
 static QofLogModule log_module = QOF_MOD_ENGINE;
 
@@ -38,17 +42,15 @@ struct QofCollection_s
     QofIdType    e_type;
     gboolean     is_dirty;
 
-    GHashTable * hash_of_entities;
+    GuidEntityMap guid_entity_map;
     gpointer     data;       /* place where object class can hang arbitrary data */
 
     QofCollection_s (QofIdType type) : e_type{static_cast<QofIdType>(CACHE_INSERT(type))}
                                      , is_dirty{FALSE}
-                                     , hash_of_entities{guid_hash_table_new()}
                                      , data{NULL} {}
     ~QofCollection_s ()
     {
         CACHE_REMOVE (e_type);
-        g_hash_table_destroy (hash_of_entities);
     }
 };
 
@@ -87,48 +89,30 @@ qof_collection_remove_entity (QofInstance *ent)
     col = qof_instance_get_collection(ent);
     if (!col) return;
     guid = qof_instance_get_guid(ent);
-    g_hash_table_remove (col->hash_of_entities, guid);
+    col->guid_entity_map.erase(*guid);
     qof_instance_set_collection(ent, NULL);
 }
 
 void
 qof_collection_insert_entity (QofCollection *col, QofInstance *ent)
 {
-    const GncGUID *guid;
-
     if (!col || !ent) return;
-    guid = qof_instance_get_guid(ent);
+    const GncGUID *guid = qof_instance_get_guid(ent);
     if (guid_equal(guid, guid_null())) return;
     g_return_if_fail (col->e_type == ent->e_type);
     qof_collection_remove_entity (ent);
-    g_hash_table_insert (col->hash_of_entities, (gpointer)guid, ent);
+    col->guid_entity_map[*guid] = ent;
     qof_instance_set_collection(ent, col);
 }
 
 gboolean
 qof_collection_add_entity (QofCollection *coll, QofInstance *ent)
 {
-    QofInstance *e;
-    const GncGUID *guid;
-
-    e = NULL;
-    if (!coll || !ent)
-    {
-        return FALSE;
-    }
-    guid = qof_instance_get_guid(ent);
-    if (guid_equal(guid, guid_null()))
-    {
-        return FALSE;
-    }
+    if (!coll || !ent) return FALSE;
+    const GncGUID *guid = qof_instance_get_guid(ent);
+    if (guid_equal(guid, guid_null())) return FALSE;
     g_return_val_if_fail (coll->e_type == ent->e_type, FALSE);
-    e = qof_collection_lookup_entity(coll, guid);
-    if ( e != NULL )
-    {
-        return FALSE;
-    }
-    g_hash_table_insert (coll->hash_of_entities, (gpointer)guid, ent);
-    return TRUE;
+    return coll->guid_entity_map.try_emplace (*guid, ent).second;
 }
 
 
@@ -208,22 +192,18 @@ qof_collection_compare (QofCollection *target, QofCollection *merge)
 QofInstance *
 qof_collection_lookup_entity (const QofCollection *col, const GncGUID * guid)
 {
-    QofInstance *ent;
     g_return_val_if_fail (col, NULL);
     if (guid == NULL) return NULL;
-    ent = static_cast<QofInstance*>(g_hash_table_lookup (col->hash_of_entities,
-							 guid));
-    if (ent != NULL && qof_instance_get_destroying(ent)) return NULL;	
-    return ent;
+    auto it = col->guid_entity_map.find(*guid);
+    if (it == col->guid_entity_map.end() || qof_instance_get_destroying(it->second))
+        return nullptr;
+    return it->second;
 }
 
 guint
 qof_collection_count (const QofCollection *col)
 {
-    guint c;
-
-    c = g_hash_table_size(col->hash_of_entities);
-    return c;
+    return col->guid_entity_map.size();
 }
 
 /* =============================================================== */
@@ -283,20 +263,21 @@ void
 qof_collection_foreach_sorted (const QofCollection *col, QofInstanceForeachCB cb_func,
                                gpointer user_data, GCompareFunc sort_fn)
 {
-    GList *entries;
-
     g_return_if_fail (col);
     g_return_if_fail (cb_func);
 
-    PINFO("Hash Table size of %s before is %d", col->e_type, g_hash_table_size(col->hash_of_entities));
+    PINFO("Hash Table size of %s before is %ld", col->e_type, col->guid_entity_map.size());
 
-    entries = g_hash_table_get_values (col->hash_of_entities);
+    std::vector<QofInstance*> entries (col->guid_entity_map.size());
+    std::transform (col->guid_entity_map.cbegin(), col->guid_entity_map.cend(),
+                    entries.begin(), [](const auto& kv) { return kv.second; });
     if (sort_fn)
-        entries = g_list_sort (entries, sort_fn);
-    g_list_foreach (entries, (GFunc)cb_func, user_data);
-    g_list_free (entries);
+        std::sort (entries.begin(), entries.end(),
+                   [sort_fn](auto a, auto b) { return sort_fn (a, b) < 0; });
+    std::for_each (entries.cbegin(), entries.cend(),
+                   [&](auto ent) { cb_func (ent, user_data); });
 
-    PINFO("Hash Table size of %s after is %d", col->e_type, g_hash_table_size(col->hash_of_entities));
+    PINFO("Hash Table size of %s after is %ld", col->e_type, col->guid_entity_map.size());
 }
 
 void

--- a/libgnucash/engine/qofid.cpp
+++ b/libgnucash/engine/qofid.cpp
@@ -47,7 +47,13 @@ struct QofCollection_s
 
     QofCollection_s (QofIdType type) : e_type{static_cast<QofIdType>(CACHE_INSERT(type))}
                                      , is_dirty{FALSE}
-                                     , data{NULL} {}
+                                     , data{NULL}
+    {
+        if (!g_strcmp0 (e_type, "Split"))
+            guid_entity_map.reserve (50000);
+        else if (!g_strcmp0 (e_type, "Trans"))
+            guid_entity_map.reserve (10000);
+    }
     ~QofCollection_s ()
     {
         CACHE_REMOVE (e_type);

--- a/libgnucash/engine/qofid.cpp
+++ b/libgnucash/engine/qofid.cpp
@@ -40,6 +40,16 @@ struct QofCollection_s
 
     GHashTable * hash_of_entities;
     gpointer     data;       /* place where object class can hang arbitrary data */
+
+    QofCollection_s (QofIdType type) : e_type{static_cast<QofIdType>(CACHE_INSERT(type))}
+                                     , is_dirty{FALSE}
+                                     , hash_of_entities{guid_hash_table_new()}
+                                     , data{NULL} {}
+    ~QofCollection_s ()
+    {
+        CACHE_REMOVE (e_type);
+        g_hash_table_destroy (hash_of_entities);
+    }
 };
 
 /* =============================================================== */
@@ -47,24 +57,13 @@ struct QofCollection_s
 QofCollection *
 qof_collection_new (QofIdType type)
 {
-    QofCollection *col;
-    col = g_new0(QofCollection, 1);
-    col->e_type = static_cast<QofIdType>(CACHE_INSERT (type));
-    col->is_dirty = FALSE;
-    col->hash_of_entities = guid_hash_table_new();
-    col->data = NULL;
-    return col;
+    return new QofCollection (type);
 }
 
 void
 qof_collection_destroy (QofCollection *col)
 {
-    CACHE_REMOVE (col->e_type);
-    g_hash_table_destroy(col->hash_of_entities);
-    col->e_type = NULL;
-    col->hash_of_entities = NULL;
-    col->data = NULL;   /** XXX there should be a destroy notifier for this */
-    g_free (col);
+    delete col;
 }
 
 /* =============================================================== */


### PR DESCRIPTION
to store guid->qof entities

note this is appropriate if the map values are QofInstance* pointers, because unordered_flat_map does not guarantee stable iterators.

my `time ./cli.sh` which loads my primary datafile and runs a report improves from around 4.1s to 3.4s

(thanks claude)