### PR TITLE
Qofbook flat map

### DIFF
--- a/libgnucash/engine/qofbook-p.hpp
+++ b/libgnucash/engine/qofbook-p.hpp
@@ -43,6 +43,18 @@
 #include "qofinstance-p.h"
 
 
+#include <memory>
+#include <string>
+#include <boost/container/flat_map.hpp>
+
+struct QofCollectionDeleter
+{
+    void operator()(QofCollection* col) const noexcept { qof_collection_destroy (col); }
+};
+
+using QofCollectionPtr = std::unique_ptr<QofCollection, QofCollectionDeleter>;
+using CollectionMap = boost::container::flat_map<std::string, QofCollectionPtr>;
+
 struct QofBook
 {
     QofInstance   inst;     /* Unique guid for this book. */
@@ -74,7 +86,7 @@ struct QofBook
      * belonging to this book, with their pointers to the respective
      * objects.  This allows a lookup of objects based on their guid.
      */
-    GHashTable * hash_of_collections;
+    CollectionMap hash_of_collections;
 
     /* In order to store arbitrary data, for extensibility, add a table
      * that will be used to hold arbitrary pointers.
@@ -136,7 +148,6 @@ typedef struct
     QofBookDirtyCB (*get_dirty_cb)(const QofBook*);
     void (*set_shutting_down)(QofBook*, gboolean);
     gpointer (*get_dirty_data)(const QofBook*);
-    GHashTable* (*get_collections)(const QofBook*);
     GHashTable* (*get_data_tables)(const QofBook*);
     GHashTable* (*get_data_table_finalizers)(const QofBook*);
     char (*get_book_open)(const QofBook*);

--- a/libgnucash/engine/qofbook.cpp
+++ b/libgnucash/engine/qofbook.cpp
@@ -96,20 +96,12 @@ QOF_GOBJECT_FINALIZE(qof_book);
 /* ====================================================================== */
 /* constructor / destructor */
 
-static void coll_destroy(gpointer col)
-{
-    qof_collection_destroy((QofCollection *) col);
-}
-
 static void
 qof_book_init (QofBook *book)
 {
     if (!book) return;
 
-    book->hash_of_collections = g_hash_table_new_full(
-                                    g_str_hash, g_str_equal,
-                                    (GDestroyNotify)qof_string_cache_remove,  /* key_destroy_func   */
-                                    coll_destroy);                            /* value_destroy_func */
+    new (&book->hash_of_collections) CollectionMap();
 
     qof_instance_init_data (&book->inst, QOF_ID_BOOK, book);
 
@@ -330,9 +322,7 @@ destroy_lot(QofInstance *inst, [[maybe_unused]]void* data)
 void
 qof_book_destroy (QofBook *book)
 {
-    GHashTable* cols;
-
-    if (!book || !book->hash_of_collections) return;
+    if (!book) return;
     ENTER ("book=%p", book);
 
     book->shutting_down = TRUE;
@@ -362,9 +352,8 @@ qof_book_destroy (QofBook *book)
      * DO remove ourself from the collection but the collection had already
      * been destroyed.
      */
-    cols = book->hash_of_collections;
+    book->hash_of_collections.~CollectionMap();
     g_object_unref (book);
-    g_hash_table_destroy (cols);
 
     LEAVE ("book=%p", book);
 }
@@ -520,49 +509,27 @@ qof_book_empty(const QofBook *book)
 QofCollection *
 qof_book_get_collection (const QofBook *book, QofIdType entity_type)
 {
-    QofCollection *col;
-
     if (!book || !entity_type) return nullptr;
 
-    col = static_cast<QofCollection*>(g_hash_table_lookup (book->hash_of_collections, entity_type));
-    if (!col)
-    {
-        col = qof_collection_new (entity_type);
-        g_hash_table_insert(
-            book->hash_of_collections,
-            (gpointer)qof_string_cache_insert(entity_type), col);
-    }
+    auto& collections = const_cast<QofBook*>(book)->hash_of_collections;
+    auto it = collections.find (entity_type);
+    if (it != collections.end ())
+        return it->second.get ();
+
+    auto col = qof_collection_new (entity_type);
+    collections.emplace (entity_type, QofCollectionPtr{col});
     return col;
-}
-
-struct _iterate
-{
-    QofCollectionForeachCB  fn;
-    gpointer                data;
-};
-
-static void
-foreach_cb (G_GNUC_UNUSED gpointer key, gpointer item, gpointer arg)
-{
-    struct _iterate *iter = static_cast<_iterate*>(arg);
-    QofCollection *col = static_cast<QofCollection*>(item);
-
-    iter->fn (col, iter->data);
 }
 
 void
 qof_book_foreach_collection (const QofBook *book,
                              QofCollectionForeachCB cb, gpointer user_data)
 {
-    struct _iterate iter;
-
     g_return_if_fail (book);
     g_return_if_fail (cb);
 
-    iter.fn = cb;
-    iter.data = user_data;
-
-    g_hash_table_foreach (book->hash_of_collections, foreach_cb, &iter);
+    for (auto& [name, col] : book->hash_of_collections)
+        cb (col.get(), user_data);
 }
 
 /* ====================================================================== */
@@ -1433,7 +1400,6 @@ static gboolean get_read_only(const QofBook *book){ return book->read_only; }
 static QofBookDirtyCB get_dirty_cb(const QofBook *book){ return book->dirty_cb; }
 static void set_shutting_down(QofBook *book, gboolean state){ book->shutting_down = state; }
 static gpointer get_dirty_data(const QofBook *book){ return book->dirty_data; }
-static GHashTable* get_collections(const QofBook *book){ return book->hash_of_collections; }
 static GHashTable* get_data_tables(const QofBook *book){ return book->data_tables; }
 static GHashTable* get_data_table_finalizers(const QofBook *book){ return book->data_table_finalizers; }
 static char get_book_open(const QofBook *book){ return book->book_open; }
@@ -1450,7 +1416,6 @@ _utest_qofbook_fill_functions (void)
     func->get_dirty_cb = get_dirty_cb;
     func->set_shutting_down = set_shutting_down;
     func->get_dirty_data = get_dirty_data;
-    func->get_collections = get_collections;
     func->get_data_tables = get_data_tables;
     func->get_data_table_finalizers = get_data_table_finalizers;
     func->get_book_open = get_book_open;

--- a/libgnucash/engine/qofid.cpp
+++ b/libgnucash/engine/qofid.cpp
@@ -40,6 +40,17 @@ struct QofCollection_s
 
     GHashTable * hash_of_entities;
     gpointer     data;       /* place where object class can hang arbitrary data */
+    QofCollection_s (QofIdType type)
+        : e_type(static_cast<QofIdType>(CACHE_INSERT(type)))
+        , is_dirty{FALSE}
+        , hash_of_entities{guid_hash_table_new()}
+        , data{NULL}
+    {};
+    ~QofCollection_s ()
+    {
+        CACHE_REMOVE (e_type);
+        g_hash_table_destroy(hash_of_entities);
+    };
 };
 
 /* =============================================================== */
@@ -47,24 +58,13 @@ struct QofCollection_s
 QofCollection *
 qof_collection_new (QofIdType type)
 {
-    QofCollection *col;
-    col = g_new0(QofCollection, 1);
-    col->e_type = static_cast<QofIdType>(CACHE_INSERT (type));
-    col->is_dirty = FALSE;
-    col->hash_of_entities = guid_hash_table_new();
-    col->data = NULL;
-    return col;
+    return new QofCollection (type);
 }
 
 void
 qof_collection_destroy (QofCollection *col)
 {
-    CACHE_REMOVE (col->e_type);
-    g_hash_table_destroy(col->hash_of_entities);
-    col->e_type = NULL;
-    col->hash_of_entities = NULL;
-    col->data = NULL;   /** XXX there should be a destroy notifier for this */
-    g_free (col);
+    delete col;
 }
 
 /* =============================================================== */


### PR DESCRIPTION
(maybe).
Uses `flat_map` which is older than `unordered_flat_map`.
It flips the order of calling `qof_collection_destroy`. This may have side effects.
Later on `QofCollectionPtr` could become a `QofCollection` in-line object, located within the `flat_map` itself.