### PR TITLE
Create branch future for 6.0 development.

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -3,8 +3,8 @@ on: [push, pull_request]
 permissions: {}
 jobs:
   ci_tests_ubuntu-22:
-    runs-on: ubuntu-22.04
-    name: Ubuntu-22.04 CI Tests
+    runs-on: ubuntu-26.04
+    name: Ubuntu-26.04 CI Tests
     env:
       TZ: America/Los_Angeles
     steps:
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v6
       - run: sudo apt-get update
       - name: Install additional dependencies
-        run: sudo apt-get install -y gettext cmake libxslt-dev xsltproc ninja-build libboost-all-dev libgtk-3-dev guile-2.2-dev libgwengui-gtk3-dev libaqbanking-dev libofx-dev libdbi-dev libdbd-sqlite3 libwebkit2gtk-4.0-dev  googletest
+        run: sudo apt-get install -y gettext cmake libxslt-dev xsltproc ninja-build libboost-all-dev libgtk-3-dev guile-2.2-dev libgwengui-gtk3-dev libaqbanking-dev libofx-dev libdbi-dev libdbd-sqlite3 libwebkit2gtk-4.1-dev  googletest
       - name: Install language packs.
         run: sudo apt-get --reinstall install -y language-pack-en language-pack-fr
       - run: |
@@ -39,7 +39,7 @@ jobs:
           name: TestLog
           path: ${{ github.workspace }}/build/Testing/Temporary/LastTest.log
   ci_tests_ASAN:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     name: Address Sanitizer CI Tests
     continue-on-error: true
     env:

--- a/.github/workflows/mac-tests.yaml
+++ b/.github/workflows/mac-tests.yaml
@@ -20,9 +20,9 @@ jobs:
       uses: carlosperate/download-file-action@v2
       id: dependencies
       with:
-        file-url: 'https://downloads.sourceforge.net/gnucash/Dependencies/gnucash-5.15-mac-dependencies.tar.xz'
-        file-name: gnucash-dependencies.tar.xz
-        sha256: '15d14226e93cf18c60eb36d79686171a6b920ed1f72a815b8bad8f8755c76a02'
+        file-url: 'https://downloads.sourceforge.net/gnucash/Dependencies/gnucash-future-mac-dependencies.tar.xz'
+        file-name: gnucash-future-mac-dependencies.tar.xz
+        sha256: 'dbcecf47b368eee317d18e2ad547b754329c17075420aaecddaf99f9d53b6c7b'
     - name: download googletest
       uses: carlosperate/download-file-action@v2
 
@@ -34,7 +34,7 @@ jobs:
       run: |
         mkdir -p $HOME/gnucash/inst
         cd $HOME/gnucash/inst
-        tar -xf $GITHUB_WORKSPACE/gnucash-dependencies.tar.xz
+        tar -xf $GITHUB_WORKSPACE/gnucash-future-mac-dependencies.tar.xz
         mkdir $HOME/gnucash/source
         cd $HOME/gnucash/source
         tar -xf $GITHUB_WORKSPACE/googletest.tar.gz

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMakeLists.txt for GnuCash
 
-cmake_minimum_required (VERSION 3.14.5)
+cmake_minimum_required (VERSION 4.0.0)
 
 # CMake 3.15+ Python3_FIND_STRATEGY=LOCATION
 if (POLICY CMP0094)
@@ -21,7 +21,7 @@ if (POLICY CMP0177)
 endif()
 
 project (gnucash
-    VERSION 5.15
+    VERSION 5.90
 )
 
 enable_testing()
@@ -231,8 +231,8 @@ if (NOT PKG_CONFIG_FOUND)
  endif()
 
 # glib et al.
-set(GLIB_MIN_VERSION 2.68.1)
-set(GTK_MIN_VERSION 3.22.30)
+set(GLIB_MIN_VERSION 2.88.0)
+set(GTK_MIN_VERSION 3.24.52)
 
 pkg_check_modules (GLIB2 REQUIRED IMPORTED_TARGET glib-2.0>=${GLIB_MIN_VERSION})
 pkg_check_modules (GIO REQUIRED gio-2.0)
@@ -240,14 +240,15 @@ pkg_check_modules (GOBJECT REQUIRED gobject-2.0)
 pkg_check_modules (GMODULE REQUIRED gmodule-2.0)
 pkg_check_modules (GTHREAD REQUIRED gthread-2.0)
 
-pkg_check_modules (LIBXML2 REQUIRED libxml-2.0>=2.9.4)
+pkg_check_modules (LIBXML2 REQUIRED libxml-2.0>=2.15.0)
 pkg_check_modules (LIBXSLT REQUIRED libxslt)
 if (WITH_GNUCASH)
   if (WIN32)
     pkg_check_modules (WEBKIT REQUIRED IMPORTED_TARGET webkitgtk-3.0)
     set(WEBKIT1 1 CACHE INTERNAL "WebKitGtk")
   else()
-    pkg_check_modules (WEBKIT IMPORTED_TARGET webkit2gtk-4.0>=2.14.0)
+    # Hold at 2.32, the latest version successfully built on macOS.
+    pkg_check_modules (WEBKIT IMPORTED_TARGET webkit2gtk-4.0>=2.32.0)
     if (NOT WEBKIT_FOUND)
       pkg_check_modules (WEBKIT REQUIRED IMPORTED_TARGET webkit2gtk-4.1)
     endif()
@@ -285,15 +286,7 @@ find_library (REGEX_LIBRARY NAMES regex)
 # Potfile generation will only be enabled if building from a git worktree
 set (BUILD_GNUCASH_POT ${BUILDING_FROM_VCS})
 
-find_package (Gettext 0.19.6 REQUIRED)
-if (${GETTEXT_VERSION_STRING} VERSION_LESS 0.20)
-    message (WARNING "Gettext version 0.20 or more recent is required to translate the 'developer_name' tag in gnucash.appdata.xml. All but that tag will be translated in the generated file.")
-    if(BUILD_GNUCASH_POT)
-        # Only emit warning if potfile generation was enabled otherwise
-        message (WARNING "Gettext version 0.20 or more recent is required to extract all translatable strings. Potfile generation will be disabled.")
-    endif()
-    set (BUILD_GNUCASH_POT OFF)
-endif()
+find_package (Gettext 0.23.2 REQUIRED)
 
 find_path (LIBINTL_INCLUDE_PATH NAMES libintl.h
 		  PATHS /usr/include /opt/gnome/include)
@@ -309,7 +302,7 @@ endif()
 # ############################################################
 
 # SWIG
-find_package (SWIG 3.0.12 REQUIRED)
+find_package (SWIG 4.4.0 REQUIRED)
 include (${SWIG_USE_FILE})
 
 # Find Guile and determine which version we are using.
@@ -412,8 +405,8 @@ find_guile_dirs()
 
 # ############################################################
 if (WITH_AQBANKING)
-  pkg_check_modules (GWENHYWFAR REQUIRED gwenhywfar>=5.6.0)
-  pkg_check_modules (AQBANKING REQUIRED aqbanking>=6.2.0)
+  pkg_check_modules (GWENHYWFAR REQUIRED gwenhywfar>=5.14.1)
+  pkg_check_modules (AQBANKING REQUIRED aqbanking>=6.9.1)
   set(CMAKE_REQUIRED_INCLUDES "${AQBANKING_INCLUDE_DIRS}"
     "${GWENHYWFAR_INCLUDE_DIRS}")
   set(CMAKE_REQUIRED_LIBRARIES "${AQBANKING_LD_FLAGS}")
@@ -428,7 +421,7 @@ if (WITH_AQBANKING)
 endif()
 
 if (WITH_OFX)
-  pkg_check_modules (LIBOFX REQUIRED libofx)
+  pkg_check_modules (LIBOFX REQUIRED libofx>=0.10.9)
   include(CheckCXXSourceRuns)
   if (WIN32)
       set(CMAKE_REQUIRED_LIBRARIES "-L ${CMAKE_PREFIX_PATH}/libofx/lib -lofx")
@@ -532,7 +525,7 @@ endif()
 # ############################################################
 
 if (WITH_PYTHON)
-  set (PYTHON_MIN_VERSION 3.8.0)
+  set (PYTHON_MIN_VERSION 3.14.0)
   if (NOT DEFINED Python3_FIND_UNVERSIONED_NAMES)
     set (Python3_FIND_UNVERSIONED_NAMES FIRST)
   endif()
@@ -585,9 +578,9 @@ get_filename_component(PERL_DIR ${PERL_EXECUTABLE} DIRECTORY)
 find_program(POD2MAN_EXECUTABLE pod2man HINTS ${PERL_DIR})
 
 #ICU
-find_package(ICU 54.0 REQUIRED COMPONENTS uc i18n)
+find_package(ICU 78.0 REQUIRED COMPONENTS uc i18n)
 
-pkg_check_modules (LIBSECRET libsecret-1>=0.18)
+pkg_check_modules (LIBSECRET libsecret-1>=0.21)
 IF (LIBSECRET_FOUND)
   SET (HAVE_LIBSECRET ON)
 ENDIF (LIBSECRET_FOUND)
@@ -599,15 +592,8 @@ set (Boost_FIND_QUIETLY ON)
 if (NOT DEFINED ${BOOST_ROOT})
   set(BOOST_ROOT $ENV{BOOST_ROOT})
 endif()
-find_package (Boost 1.67.0 REQUIRED)
+find_package(Boost 1.90.0  REQUIRED COMPONENTS atomic charconv chrono container date_time filesystem locale program_options regex thread)
 
-if (Boost_FOUND)
- if (Boost_VERSION VERSION_LESS "1.89.0")
-  find_package(Boost 1.67.0  COMPONENTS date_time filesystem locale program_options regex system)
- else()
-  find_package(Boost 1.67.0  COMPONENTS atomic charconv chrono container date_time filesystem locale program_options regex thread)
- endif()
-endif()
 
 if (Boost_FOUND)
   include_directories(${Boost_INCLUDE_DIRS})

--- a/README.dependencies
+++ b/README.dependencies
@@ -54,48 +54,48 @@ Libraries/Deps
   required              Version
   --------              _______
   gcc or clang          8.0 (gcc)/6.0(clang)    C++17 C/C++ compiler
-  cmake                 3.14.5                  Build system manager
-  glib2                 2.68.1
-  gtk+3                 3.22.30
-  guile                 3.0, 2.2 or 2.0.9       Must be built with regex
+  cmake                 4.0.0                   Build system manager
+  glib2                 2.88.0
+  gtk+3                 3.24.52
+  guile                 3.0                     Must be built with regex
                                                 support enabled
-  libxml2               2.9.4
-  gettext               0.20                    Required to build gnucash.pot,
+  libxml2               2.15.0
+  gettext               0.23.2                    Required to build gnucash.pot,
                                                 0.19.6 or later permitted but
                                                 won't generate gnucash.pot.
   libxslt, including xsltproc
-  ICU                                           International Components for
+  ICU                   78.0                        International Components for
                                                 Unicode
-  boost                 1.67.0                  All headers plus date_time,
+  boost                 1.90.0                  All headers plus date_time,
                                                 filesystem, locale,
                                                 program_options, and
                                                 regex libraries.
                                                 locale and regex libs must be
                                                 built with ICU support.
-  swig                  3.0.12                  Makes Guile and Python Bindings.
+  swig                  4.4.0                   Makes Guile and Python Bindings.
   webkit                2.4.11 (Windows,
-                        2.14.1 (Everything Else)
+                        2.32.0 (Everything Else)
   googletest            1.8.0                   Some distros call it gtest.
                                                 Some distros also separate out
                                                 googlemock or gmock; both are
                                                 required.
 
-  libdbi                0.8.3                    SQL backend; also requires at
-                                                 least one of libdbd-sqlite3,
-                                                 libdbd-mysql, or libdbd-pgsql
+  libdbi                0.9.0                   SQL backend; also requires at
+                                                least one of libdbd-sqlite3,
+                                                libdbd-mysql, or libdbd-pgsql
 
   zlib
 
   optional
   --------
-  aqbanking             6.4.0                    online banking and SWIFT
-  gwenhywfar            5.8.0                    file imports.
+  aqbanking             6.9.1                   online banking and SWIFT
+  gwenhywfar            5.14.1                  file imports.
 
-  python                3.8.0                    python bindings; headers
-                                                 required, not just binaries.
-  libofx                0.9.12                   OFX/QFX import
+  python                3.14.0                  python bindings; headers
+                                                required, not just binaries.
+  libofx                0.10.9                  OFX/QFX import
 
-  libsecret             0.18
+  libsecret             0.21
   gtk-mac-integration                            MacOS only, for menus to go
                                                  to the main menu bar instead
                                                  of one on the window.

--- a/libgnucash/engine/qof-backend.cpp
+++ b/libgnucash/engine/qof-backend.cpp
@@ -100,16 +100,7 @@ QofBackend::register_backend(const char* directory, const char* module_name)
     auto pkgdir = gnc_path_get_pkglibdir ();
     if (!absdir || !g_path_is_absolute(absdir))
         absdir = pkgdir;
-    auto fullpath = g_module_build_path (absdir, module_name);
-/* Darwin modules can have either .so or .dylib for a suffix */
-    if (!g_file_test (fullpath, G_FILE_TEST_EXISTS) &&
-        g_strcmp0 (G_MODULE_SUFFIX, "so") == 0)
-    {
-        auto modname = g_strdup_printf ("lib%s.dylib", module_name);
-        g_free (fullpath);
-        fullpath = g_build_filename (absdir, modname, nullptr);
-        g_free (modname);
-    }
+    auto fullpath = g_build_filename (absdir, module_name, nullptr);
     auto backend = g_module_open (fullpath, G_MODULE_BIND_LAZY);
     g_free (fullpath);
     g_free (pkgdir);

--- a/libgnucash/gnc-module/test/test-dynload.c
+++ b/libgnucash/gnc-module/test/test-dynload.c
@@ -49,27 +49,14 @@ main(int argc, char ** argv)
 /* MinGW builds libgnc-module-0.dll */
     if (libdir == NULL)
     {
-        modpath = g_module_build_path ("../.libs", "gnc-module-0");
+      modpath = g_build_filename ("../.libs", "gnc-module-0", nullptr);
     }
     else
     {
-        modpath = g_module_build_path (libdir, "gnc-module");
-    }
-#elif defined(GNC_PLATFORM_OSX)
-/* We build libgnc-module as a shared library for testing, and on OSX
- * that means that g_module_build_path (), which uses ".so", doesn't
- * build the right path name.
- */
-    if (libdir == NULL)
-    {
-        modpath = g_build_filename ("..", ".libs", "libgnc-module.dylib", NULL);
-    }
-    else
-    {
-        modpath = g_build_filename (libdir, "libgnc-module.dylib", NULL);
+      modpath = g_build_filename (libdir, "gnc-module", nullptr);
     }
 #else /* Regular Unix */
-    modpath = g_module_build_path (libdir, "gnc-module");
+    modpath = g_build_filename (libdir, "gnc-module", NULL);
 #endif
     gmodule = g_module_open(modpath, 0);
 


### PR DESCRIPTION
This isn't a normal PR, it will create a new branch instead of being merged into an existing one.

The minimum versions are mostly those of Ubuntu 26.04 LTS. WebkitGtk3 is held back because I wasn't able to get the latest version to build on macOS after two weeks of trying: It can't be done from the WebKitGtk 2.53 tarball they've stripped the macOS-specific code to build ANGLE-EGL. 

Some other notes:
* stdc++ is 23. This is somewhat speculative, we may have to fall back to C++20 if compiler support turns out to be insufficient. 
* Guile is 3.0 only.
* Windows will be UCRT64 runtime as the MSYS2 project is killing support for the old msvcrt-based Mingw runtimes. This poses its own problem because the ancient JavaScriptCore there crashes on startup when built that way--or any 64-bit way.