### PR TITLE
[qofbook.cpp] hash_of_collections is a flat_map<string,QofCollectionPtr>

### DIFF
--- a/gnucash/import-export/test/gtest-import-backend.cpp
+++ b/gnucash/import-export/test/gtest-import-backend.cpp
@@ -124,6 +124,10 @@ gnc_commodity_equiv(const gnc_commodity * a, const gnc_commodity * b)
     return TRUE;
 }
 
+// fake function from qofid.cpp
+void qof_collection_destroy (QofCollection *col)
+{
+}
 
 /* required fake functions from app-utils sources, which should not be linked to the test application */
 

--- a/libgnucash/engine/mocks/gmock-qofbook.hpp
+++ b/libgnucash/engine/mocks/gmock-qofbook.hpp
@@ -26,8 +26,6 @@ class QofMockBook : public QofBook
 public:
     QofMockBook()
     {
-        data_table_finalizers = nullptr;
-
         book_open     = 'n';
         read_only     = TRUE;
         session_dirty = FALSE;

--- a/libgnucash/engine/mocks/gmock-qofbook.hpp
+++ b/libgnucash/engine/mocks/gmock-qofbook.hpp
@@ -26,7 +26,6 @@ class QofMockBook : public QofBook
 public:
     QofMockBook()
     {
-        hash_of_collections   = nullptr;
         data_tables           = nullptr;
         data_table_finalizers = nullptr;
 

--- a/libgnucash/engine/mocks/gmock-qofbook.hpp
+++ b/libgnucash/engine/mocks/gmock-qofbook.hpp
@@ -26,7 +26,6 @@ class QofMockBook : public QofBook
 public:
     QofMockBook()
     {
-        data_tables           = nullptr;
         data_table_finalizers = nullptr;
 
         book_open     = 'n';

--- a/libgnucash/engine/qofbook-p.hpp
+++ b/libgnucash/engine/qofbook-p.hpp
@@ -42,6 +42,17 @@
 #include "qofid-p.h"
 #include "qofinstance-p.h"
 
+#include <memory>
+#include <string>
+#include <boost/container/flat_map.hpp>
+
+struct QofCollectionDeleter
+{
+    void operator()(QofCollection* col) const noexcept { qof_collection_destroy (col); }
+};
+
+using QofCollectionPtr = std::unique_ptr<QofCollection, QofCollectionDeleter>;
+using CollectionMap = boost::container::flat_map<std::string, QofCollectionPtr>;
 
 struct QofBook
 {
@@ -74,7 +85,7 @@ struct QofBook
      * belonging to this book, with their pointers to the respective
      * objects.  This allows a lookup of objects based on their guid.
      */
-    GHashTable * hash_of_collections;
+    CollectionMap hash_of_collections;
 
     /* In order to store arbitrary data, for extensibility, add a table
      * that will be used to hold arbitrary pointers.
@@ -136,7 +147,7 @@ typedef struct
     QofBookDirtyCB (*get_dirty_cb)(const QofBook*);
     void (*set_shutting_down)(QofBook*, gboolean);
     gpointer (*get_dirty_data)(const QofBook*);
-    GHashTable* (*get_collections)(const QofBook*);
+    const CollectionMap& (*get_collections)(const QofBook*);
     GHashTable* (*get_data_tables)(const QofBook*);
     GHashTable* (*get_data_table_finalizers)(const QofBook*);
     char (*get_book_open)(const QofBook*);

--- a/libgnucash/engine/qofbook-p.hpp
+++ b/libgnucash/engine/qofbook-p.hpp
@@ -54,6 +54,7 @@ struct QofCollectionDeleter
 using QofCollectionPtr = std::unique_ptr<QofCollection, QofCollectionDeleter>;
 using CollectionMap = boost::container::flat_map<std::string, QofCollectionPtr>;
 using QofDataMap = boost::container::flat_map<std::string, gpointer>;
+using QofDataFinMap = boost::container::flat_map<std::string, QofBookFinalCB>;
 
 struct QofBook
 {
@@ -94,7 +95,7 @@ struct QofBook
     QofDataMap data_tables;
 
     /* Hash table of destroy callbacks for the data table. */
-    GHashTable *data_table_finalizers;
+    QofDataFinMap data_table_finalizers;
 
     /* Boolean indicates whether book is safe to write to (true means
      * that it isn't). The usual reason will be a database version
@@ -150,7 +151,7 @@ typedef struct
     gpointer (*get_dirty_data)(const QofBook*);
     const CollectionMap& (*get_collections)(const QofBook*);
     const QofDataMap& (*get_data_tables)(const QofBook*);
-    GHashTable* (*get_data_table_finalizers)(const QofBook*);
+    const QofDataFinMap& (*get_data_table_finalizers)(const QofBook*);
     char (*get_book_open)(const QofBook*);
     int (*get_version)(const QofBook*);
 } QofBookTestFunctions;

--- a/libgnucash/engine/qofbook-p.hpp
+++ b/libgnucash/engine/qofbook-p.hpp
@@ -53,6 +53,7 @@ struct QofCollectionDeleter
 
 using QofCollectionPtr = std::unique_ptr<QofCollection, QofCollectionDeleter>;
 using CollectionMap = boost::container::flat_map<std::string, QofCollectionPtr>;
+using QofDataMap = boost::container::flat_map<std::string, gpointer>;
 
 struct QofBook
 {
@@ -90,7 +91,7 @@ struct QofBook
     /* In order to store arbitrary data, for extensibility, add a table
      * that will be used to hold arbitrary pointers.
      */
-    GHashTable *data_tables;
+    QofDataMap data_tables;
 
     /* Hash table of destroy callbacks for the data table. */
     GHashTable *data_table_finalizers;
@@ -148,7 +149,7 @@ typedef struct
     void (*set_shutting_down)(QofBook*, gboolean);
     gpointer (*get_dirty_data)(const QofBook*);
     const CollectionMap& (*get_collections)(const QofBook*);
-    GHashTable* (*get_data_tables)(const QofBook*);
+    const QofDataMap& (*get_data_tables)(const QofBook*);
     GHashTable* (*get_data_table_finalizers)(const QofBook*);
     char (*get_book_open)(const QofBook*);
     int (*get_version)(const QofBook*);

--- a/libgnucash/engine/qofbook.cpp
+++ b/libgnucash/engine/qofbook.cpp
@@ -107,7 +107,7 @@ qof_book_init (QofBook *book)
 
     new (&book->data_tables) QofDataMap();
 
-    book->data_table_finalizers = g_hash_table_new (g_str_hash, g_str_equal);
+    new (&book->data_table_finalizers) QofDataFinMap();
 
     book->book_open = 'y';
     book->read_only = FALSE;
@@ -293,14 +293,11 @@ qof_book_new (void)
 }
 
 static void
-book_final (gpointer key, gpointer value, gpointer booq)
+book_final (const std::string& key, QofBookFinalCB cb, QofBook* book)
 {
-    QofBookFinalCB cb = reinterpret_cast<QofBookFinalCB>(value);
-    QofBook *book = static_cast<QofBook*>(booq);
-
-    auto it = book->data_tables.find (static_cast<const char*>(key));
+    auto it = book->data_tables.find (key);
     gpointer user_data = it == book->data_tables.end() ? nullptr : it->second;
-    (*cb) (book, key, user_data);
+    (*cb) (book, const_cast<char*>(key.c_str()), user_data);
 }
 
 static void
@@ -332,7 +329,8 @@ qof_book_destroy (QofBook *book)
     /* Call the list of finalizers, let them do their thing.
      * Do this before tearing into the rest of the book.
      */
-    g_hash_table_foreach (book->data_table_finalizers, book_final, book);
+    for (auto fin : book->data_table_finalizers)
+        book_final (fin.first, fin.second, book);
 
     /* Lots hold a variety of pointers that need to still exist while
      * cleaning them up so run its book_end before the rest.
@@ -341,8 +339,7 @@ qof_book_destroy (QofBook *book)
     qof_collection_foreach(lots, destroy_lot, nullptr);
     qof_object_book_end (book);
 
-    g_hash_table_destroy (book->data_table_finalizers);
-    book->data_table_finalizers = nullptr;
+    book->data_table_finalizers.~QofDataFinMap();
     book->data_tables.~QofDataMap();
 
     /* qof_instance_release (&book->inst); */
@@ -463,8 +460,7 @@ qof_book_set_data_fin (QofBook *book, const char *key, gpointer data, QofBookFin
     book->data_tables[key] = data;
 
     if (!cb) return;
-    g_hash_table_insert (book->data_table_finalizers, (gpointer)key,
-             reinterpret_cast<void*>(cb));
+    book->data_table_finalizers[key] = cb;
 }
 
 gpointer
@@ -1392,7 +1388,7 @@ static void set_shutting_down(QofBook *book, gboolean state){ book->shutting_dow
 static gpointer get_dirty_data(const QofBook *book){ return book->dirty_data; }
 static const CollectionMap& get_collections(const QofBook *book){ return book->hash_of_collections; }
 static const QofDataMap& get_data_tables(const QofBook *book){ return book->data_tables; }
-static GHashTable* get_data_table_finalizers(const QofBook *book){ return book->data_table_finalizers; }
+static const QofDataFinMap& get_data_table_finalizers(const QofBook *book){ return book->data_table_finalizers; }
 static char get_book_open(const QofBook *book){ return book->book_open; }
 static int get_version(const QofBook *book){ return book->version; }
 

--- a/libgnucash/engine/qofbook.cpp
+++ b/libgnucash/engine/qofbook.cpp
@@ -96,20 +96,12 @@ QOF_GOBJECT_FINALIZE(qof_book);
 /* ====================================================================== */
 /* constructor / destructor */
 
-static void coll_destroy(gpointer col)
-{
-    qof_collection_destroy((QofCollection *) col);
-}
-
 static void
 qof_book_init (QofBook *book)
 {
     if (!book) return;
 
-    book->hash_of_collections = g_hash_table_new_full(
-                                    g_str_hash, g_str_equal,
-                                    (GDestroyNotify)qof_string_cache_remove,  /* key_destroy_func   */
-                                    coll_destroy);                            /* value_destroy_func */
+    new (&book->hash_of_collections) CollectionMap();
 
     qof_instance_init_data (&book->inst, QOF_ID_BOOK, book);
 
@@ -330,9 +322,7 @@ destroy_lot(QofInstance *inst, [[maybe_unused]]void* data)
 void
 qof_book_destroy (QofBook *book)
 {
-    GHashTable* cols;
-
-    if (!book || !book->hash_of_collections) return;
+    if (!book) return;
     ENTER ("book=%p", book);
 
     book->shutting_down = TRUE;
@@ -356,15 +346,7 @@ qof_book_destroy (QofBook *book)
     book->data_tables = nullptr;
 
     /* qof_instance_release (&book->inst); */
-
-    /* Note: we need to save this hashtable until after we remove ourself
-     * from it, otherwise we'll crash in our dispose() function when we
-     * DO remove ourself from the collection but the collection had already
-     * been destroyed.
-     */
-    cols = book->hash_of_collections;
     g_object_unref (book);
-    g_hash_table_destroy (cols);
 
     LEAVE ("book=%p", book);
 }
@@ -520,49 +502,23 @@ qof_book_empty(const QofBook *book)
 QofCollection *
 qof_book_get_collection (const QofBook *book, QofIdType entity_type)
 {
-    QofCollection *col;
-
     if (!book || !entity_type) return nullptr;
 
-    col = static_cast<QofCollection*>(g_hash_table_lookup (book->hash_of_collections, entity_type));
-    if (!col)
-    {
-        col = qof_collection_new (entity_type);
-        g_hash_table_insert(
-            book->hash_of_collections,
-            (gpointer)qof_string_cache_insert(entity_type), col);
-    }
-    return col;
-}
-
-struct _iterate
-{
-    QofCollectionForeachCB  fn;
-    gpointer                data;
-};
-
-static void
-foreach_cb (G_GNUC_UNUSED gpointer key, gpointer item, gpointer arg)
-{
-    struct _iterate *iter = static_cast<_iterate*>(arg);
-    QofCollection *col = static_cast<QofCollection*>(item);
-
-    iter->fn (col, iter->data);
+    auto& ptr = const_cast<QofBook*>(book)->hash_of_collections[entity_type];
+    if (!ptr)
+        ptr.reset (qof_collection_new (entity_type));
+    return ptr.get ();
 }
 
 void
 qof_book_foreach_collection (const QofBook *book,
                              QofCollectionForeachCB cb, gpointer user_data)
 {
-    struct _iterate iter;
-
     g_return_if_fail (book);
     g_return_if_fail (cb);
 
-    iter.fn = cb;
-    iter.data = user_data;
-
-    g_hash_table_foreach (book->hash_of_collections, foreach_cb, &iter);
+    for (auto& [name, col] : book->hash_of_collections)
+        cb (col.get(), user_data);
 }
 
 /* ====================================================================== */
@@ -1433,7 +1389,7 @@ static gboolean get_read_only(const QofBook *book){ return book->read_only; }
 static QofBookDirtyCB get_dirty_cb(const QofBook *book){ return book->dirty_cb; }
 static void set_shutting_down(QofBook *book, gboolean state){ book->shutting_down = state; }
 static gpointer get_dirty_data(const QofBook *book){ return book->dirty_data; }
-static GHashTable* get_collections(const QofBook *book){ return book->hash_of_collections; }
+static const CollectionMap& get_collections(const QofBook *book){ return book->hash_of_collections; }
 static GHashTable* get_data_tables(const QofBook *book){ return book->data_tables; }
 static GHashTable* get_data_table_finalizers(const QofBook *book){ return book->data_table_finalizers; }
 static char get_book_open(const QofBook *book){ return book->book_open; }

--- a/libgnucash/engine/qofbook.cpp
+++ b/libgnucash/engine/qofbook.cpp
@@ -105,8 +105,8 @@ qof_book_init (QofBook *book)
 
     qof_instance_init_data (&book->inst, QOF_ID_BOOK, book);
 
-    book->data_tables = g_hash_table_new_full (g_str_hash, g_str_equal,
-                                               (GDestroyNotify)qof_string_cache_remove, nullptr);
+    new (&book->data_tables) QofDataMap();
+
     book->data_table_finalizers = g_hash_table_new (g_str_hash, g_str_equal);
 
     book->book_open = 'y';
@@ -298,7 +298,8 @@ book_final (gpointer key, gpointer value, gpointer booq)
     QofBookFinalCB cb = reinterpret_cast<QofBookFinalCB>(value);
     QofBook *book = static_cast<QofBook*>(booq);
 
-    gpointer user_data = g_hash_table_lookup (book->data_tables, key);
+    auto it = book->data_tables.find (static_cast<const char*>(key));
+    gpointer user_data = it == book->data_tables.end() ? nullptr : it->second;
     (*cb) (book, key, user_data);
 }
 
@@ -342,8 +343,7 @@ qof_book_destroy (QofBook *book)
 
     g_hash_table_destroy (book->data_table_finalizers);
     book->data_table_finalizers = nullptr;
-    g_hash_table_destroy (book->data_tables);
-    book->data_tables = nullptr;
+    book->data_tables.~QofDataMap();
 
     /* qof_instance_release (&book->inst); */
     g_object_unref (book);
@@ -451,16 +451,16 @@ qof_book_set_data (QofBook *book, const char *key, gpointer data)
 {
     if (!book || !key) return;
     if (data)
-        g_hash_table_insert (book->data_tables, (gpointer)CACHE_INSERT(key), data);
+        book->data_tables[key] = data;
     else
-        g_hash_table_remove(book->data_tables, key);
+        book->data_tables.erase (key);
 }
 
 void
 qof_book_set_data_fin (QofBook *book, const char *key, gpointer data, QofBookFinalCB cb)
 {
     if (!book || !key) return;
-    g_hash_table_insert (book->data_tables, (gpointer)key, data);
+    book->data_tables[key] = data;
 
     if (!cb) return;
     g_hash_table_insert (book->data_table_finalizers, (gpointer)key,
@@ -471,7 +471,8 @@ gpointer
 qof_book_get_data (const QofBook *book, const char *key)
 {
     if (!book || !key) return nullptr;
-    return g_hash_table_lookup (book->data_tables, (gpointer)key);
+    auto it = book->data_tables.find (key);
+    return it == book->data_tables.end() ? nullptr : it->second;
 }
 
 /* ====================================================================== */
@@ -1390,7 +1391,7 @@ static QofBookDirtyCB get_dirty_cb(const QofBook *book){ return book->dirty_cb; 
 static void set_shutting_down(QofBook *book, gboolean state){ book->shutting_down = state; }
 static gpointer get_dirty_data(const QofBook *book){ return book->dirty_data; }
 static const CollectionMap& get_collections(const QofBook *book){ return book->hash_of_collections; }
-static GHashTable* get_data_tables(const QofBook *book){ return book->data_tables; }
+static const QofDataMap& get_data_tables(const QofBook *book){ return book->data_tables; }
 static GHashTable* get_data_table_finalizers(const QofBook *book){ return book->data_table_finalizers; }
 static char get_book_open(const QofBook *book){ return book->book_open; }
 static int get_version(const QofBook *book){ return book->version; }

--- a/libgnucash/engine/test/test-qofbook.cpp
+++ b/libgnucash/engine/test/test-qofbook.cpp
@@ -780,13 +780,13 @@ test_book_get_collection( Fixture *fixture, gconstpointer pData )
     g_assert_true( qof_book_get_collection( fixture->book, NULL ) == NULL );
 
     g_test_message( "Testing when collection does not exist" );
-    g_assert_true (test_funcs->get_collections (fixture->book) != NULL );
-    g_assert_true (g_hash_table_lookup (test_funcs->get_collections (fixture->book), my_type ) == NULL);
+    const auto& coll{test_funcs->get_collections (fixture->book)};
+    g_assert_true (coll.find (my_type) == coll.end());
     m_col = qof_book_get_collection( fixture->book, my_type );
     g_assert_true( m_col != NULL );
 
     g_test_message( "Testing with existing collection" );
-    g_assert_true (g_hash_table_lookup (test_funcs->get_collections (fixture->book), my_type ) != NULL);
+    g_assert_true (coll.find (my_type) != coll.end());
     m_col2 = qof_book_get_collection( fixture->book, my_type );
     g_assert_true( m_col2 != NULL );
     g_assert_true( m_col == m_col2 );
@@ -965,11 +965,11 @@ test_book_new_destroy( void )
     g_assert_true( QOF_IS_BOOK( book ) );
 
     g_test_message( "Testing book initial setup" );
-    g_assert_true (test_funcs->get_collections (book) != NULL);
+    const auto& coll{test_funcs->get_collections (book)};
     g_assert_true( test_funcs->get_data_tables (book) );
     g_assert_true( test_funcs->get_data_table_finalizers (book) );
-    g_assert_cmpint( g_hash_table_size( test_funcs->get_collections (book) ), == , 1 );
-    g_assert_true( g_hash_table_lookup (test_funcs->get_collections (book), QOF_ID_BOOK ) != NULL );
+    g_assert_cmpint (coll.size(), == , 1 );
+    g_assert_true (coll.find (QOF_ID_BOOK) != coll.end());
     g_assert_cmpint( g_hash_table_size( test_funcs->get_data_tables (book) ), == , 0 );
     g_assert_cmpint( g_hash_table_size( test_funcs->get_data_table_finalizers (book) ), == , 0 );
     g_assert_true (qof_book_is_open(book));

--- a/libgnucash/engine/test/test-qofbook.cpp
+++ b/libgnucash/engine/test/test-qofbook.cpp
@@ -746,7 +746,6 @@ test_book_set_get_data( Fixture *fixture, gconstpointer pData )
     const char *data = "data";
     QofBookTestFunctions* test_funcs = _utest_qofbook_fill_functions ();
 
-    g_assert_true( test_funcs->get_data_tables (fixture->book) != NULL );
     g_test_message( "Testing when book is null" );
     qof_book_set_data( NULL, key, (gpointer) data );
     g_assert_true( qof_book_get_data( NULL, key ) == NULL );
@@ -899,32 +898,33 @@ test_book_set_data_fin( void )
 
     /* init */
     book = qof_book_new();
-    g_assert_cmpint( g_hash_table_size( test_funcs->get_data_tables (book) ), == , 0 );
+    const auto& data_tables{test_funcs->get_data_tables (book)};
+    g_assert_cmpint (data_tables.size(), == , 0);
     g_assert_cmpint( g_hash_table_size( test_funcs->get_data_table_finalizers (book) ), == , 0 );
 
     g_test_message( "Testing when book is null" );
     qof_book_set_data_fin( NULL, key, (gpointer) data, mock_final_cb );
     /* assert nothing was set */
-    g_assert_cmpint( g_hash_table_size( test_funcs->get_data_tables (book) ), == , 0 );
+    g_assert_cmpint (data_tables.size(), == , 0);
     g_assert_cmpint( g_hash_table_size( test_funcs->get_data_table_finalizers (book) ), == , 0 );
 
     g_test_message( "Testing when key is null" );
     qof_book_set_data_fin( book, NULL, (gpointer) data, mock_final_cb );
     /* nothing set as well */
-    g_assert_cmpint( g_hash_table_size( test_funcs->get_data_tables (book) ), == , 0 );
+    g_assert_cmpint (data_tables.size(), == , 0);
     g_assert_cmpint( g_hash_table_size( test_funcs->get_data_table_finalizers (book) ), == , 0 );
 
     g_test_message( "Testing with book key not null, cb null" );
     qof_book_set_data_fin( book, key, (gpointer) data, NULL );
     /* now data is set cb not set */
-    g_assert_cmpint( g_hash_table_size( test_funcs->get_data_tables (book) ), == , 1 );
+    g_assert_cmpint (data_tables.size(), == , 1);
     g_assert_cmpint( g_hash_table_size( test_funcs->get_data_table_finalizers (book) ), == , 0 );
     g_assert_cmpstr( (const char *)qof_book_get_data( book, key ), == , data );
 
     g_test_message( "Testing with all data set" );
     qof_book_set_data_fin( book, key, (gpointer) data, mock_final_cb );
     /* now we have all set */
-    g_assert_cmpint( g_hash_table_size( test_funcs->get_data_tables (book) ), == , 1 );
+    g_assert_cmpint (data_tables.size(), == , 1);
     g_assert_cmpint( g_hash_table_size( test_funcs->get_data_table_finalizers (book) ), == , 1 );
     g_assert_cmpstr( (const char *)qof_book_get_data( book, key ), == , data );
     g_assert_true( g_hash_table_lookup ( test_funcs->get_data_table_finalizers (book), (gpointer)key ) == mock_final_cb );
@@ -966,11 +966,9 @@ test_book_new_destroy( void )
 
     g_test_message( "Testing book initial setup" );
     const auto& coll{test_funcs->get_collections (book)};
-    g_assert_true( test_funcs->get_data_tables (book) );
-    g_assert_true( test_funcs->get_data_table_finalizers (book) );
     g_assert_cmpint (coll.size(), == , 1 );
     g_assert_true (coll.find (QOF_ID_BOOK) != coll.end());
-    g_assert_cmpint( g_hash_table_size( test_funcs->get_data_tables (book) ), == , 0 );
+    g_assert_cmpint (test_funcs->get_data_tables (book).size(), == , 0);
     g_assert_cmpint( g_hash_table_size( test_funcs->get_data_table_finalizers (book) ), == , 0 );
     g_assert_true (qof_book_is_open(book));
     g_assert_true (!qof_book_is_readonly(book));

--- a/libgnucash/engine/test/test-qofbook.cpp
+++ b/libgnucash/engine/test/test-qofbook.cpp
@@ -900,34 +900,35 @@ test_book_set_data_fin( void )
     book = qof_book_new();
     const auto& data_tables{test_funcs->get_data_tables (book)};
     g_assert_cmpint (data_tables.size(), == , 0);
-    g_assert_cmpint( g_hash_table_size( test_funcs->get_data_table_finalizers (book) ), == , 0 );
+    const auto& finalizers{test_funcs->get_data_table_finalizers (book)};
+    g_assert_cmpint (finalizers.size() , == , 0);
 
     g_test_message( "Testing when book is null" );
     qof_book_set_data_fin( NULL, key, (gpointer) data, mock_final_cb );
     /* assert nothing was set */
     g_assert_cmpint (data_tables.size(), == , 0);
-    g_assert_cmpint( g_hash_table_size( test_funcs->get_data_table_finalizers (book) ), == , 0 );
+    g_assert_cmpint (finalizers.size(), == , 0);
 
     g_test_message( "Testing when key is null" );
     qof_book_set_data_fin( book, NULL, (gpointer) data, mock_final_cb );
     /* nothing set as well */
     g_assert_cmpint (data_tables.size(), == , 0);
-    g_assert_cmpint( g_hash_table_size( test_funcs->get_data_table_finalizers (book) ), == , 0 );
+    g_assert_cmpint (finalizers.size(), == , 0);
 
     g_test_message( "Testing with book key not null, cb null" );
     qof_book_set_data_fin( book, key, (gpointer) data, NULL );
     /* now data is set cb not set */
     g_assert_cmpint (data_tables.size(), == , 1);
-    g_assert_cmpint( g_hash_table_size( test_funcs->get_data_table_finalizers (book) ), == , 0 );
+    g_assert_cmpint (finalizers.size(), == , 0);
     g_assert_cmpstr( (const char *)qof_book_get_data( book, key ), == , data );
 
     g_test_message( "Testing with all data set" );
     qof_book_set_data_fin( book, key, (gpointer) data, mock_final_cb );
     /* now we have all set */
     g_assert_cmpint (data_tables.size(), == , 1);
-    g_assert_cmpint( g_hash_table_size( test_funcs->get_data_table_finalizers (book) ), == , 1 );
+    g_assert_cmpint (finalizers.size(), == , 1);
     g_assert_cmpstr( (const char *)qof_book_get_data( book, key ), == , data );
-    g_assert_true( g_hash_table_lookup ( test_funcs->get_data_table_finalizers (book), (gpointer)key ) == mock_final_cb );
+    g_assert_true (finalizers.find(key)->second == mock_final_cb );
 
     /* get rid of book make sure final cb is called */
     test_struct.called = FALSE;
@@ -969,7 +970,8 @@ test_book_new_destroy( void )
     g_assert_cmpint (coll.size(), == , 1 );
     g_assert_true (coll.find (QOF_ID_BOOK) != coll.end());
     g_assert_cmpint (test_funcs->get_data_tables (book).size(), == , 0);
-    g_assert_cmpint( g_hash_table_size( test_funcs->get_data_table_finalizers (book) ), == , 0 );
+    const auto& finalizers{test_funcs->get_data_table_finalizers (book)};
+    g_assert_cmpint (finalizers.size(), == , 0);
     g_assert_true (qof_book_is_open(book));
     g_assert_true (!qof_book_is_readonly(book));
     g_assert_cmpint (test_funcs->get_version (book), == , 0);


### PR DESCRIPTION
[qofbook.cpp] hash_of_collections is a `flat_map<string,QofCollectionPtr>`

Note the key is a `std::string` instead of the interned string_cache `const char*`. This doesn't hurt performance. The flat_map size is about 10.

Each flat_map cell will be `pair<string,unique_ptr<QofCollection>>`.

See the std::move trick to delay the flat_map destructor. Otherwise it doesn't work at all.

This renders #2241 obsolete