### PR TITLE
Replaced "n" with empty string for unreconciled transactions in register

### DIFF
--- a/gnucash/register/ledger-core/split-register-load.c
+++ b/gnucash/register/ledger-core/split-register-load.c
@@ -71,7 +71,7 @@ gnc_split_register_load_recn_cells (SplitRegister* reg)
     s = gnc_get_reconcile_valid_flags();
     gnc_recn_cell_set_valid_flags (cell, s, *s);
     gnc_recn_cell_set_flag_order (cell, gnc_get_reconcile_flag_order());
-    gnc_recn_cell_set_string_getter (cell, gnc_get_reconcile_str);
+    gnc_recn_cell_set_string_getter (cell, gnc_get_reconcile_str_for_register);
 }
 
 static void

--- a/gnucash/register/ledger-core/split-register-model.c
+++ b/gnucash/register/ledger-core/split-register-model.c
@@ -1284,7 +1284,7 @@ gnc_split_register_get_recn_entry (VirtualLocation virt_loc,
         return NULL;
 
     if (translate)
-        return gnc_get_reconcile_str (xaccSplitGetReconcile (split));
+        return gnc_get_reconcile_str_for_register (xaccSplitGetReconcile (split));
     else
     {
         static char s[2];

--- a/libgnucash/app-utils/gnc-ui-util.cpp
+++ b/libgnucash/app-utils/gnc-ui-util.cpp
@@ -485,6 +485,23 @@ gnc_get_reconcile_str (char reconciled_flag)
 }
 
 /********************************************************************\
+ * gnc_get_reconcile_str_for_register                               *
+ *   like gnc_get_reconcile_str, but show a blank for the           *
+ *   'not cleared' (NREC) state so unreconciled transactions are    *
+ *   easy to spot in the register                                   *
+ *                                                                  *
+ * Args: reconciled_flag - the flag to convert into a string        *
+ * Returns: the i18n'd reconciled string, or "" for NREC            *
+\********************************************************************/
+const char*
+gnc_get_reconcile_str_for_register (char reconciled_flag)
+{
+    if (reconciled_flag == NREC)
+        return "";
+    return gnc_get_reconcile_str (reconciled_flag);
+}
+
+/********************************************************************\
  * gnc_get_reconcile_valid_flags                                    *
  *   return a string containing the list of reconciled flags        *
  *                                                                  *

--- a/libgnucash/app-utils/gnc-ui-util.h
+++ b/libgnucash/app-utils/gnc-ui-util.h
@@ -148,6 +148,12 @@ char* gnc_get_account_name_for_split_register(const Account* account,
  */
 
 const char*  gnc_get_reconcile_str (char reconciled_flag);
+/* Like gnc_get_reconcile_str, but returns an empty string for the
+ * 'not cleared' (NREC) state so that unreconciled transactions show a
+ * blank reconcile column in the register instead of 'n'. Used for
+ * register display only; CSV import/export still rely on
+ * gnc_get_reconcile_str. */
+const char*  gnc_get_reconcile_str_for_register (char reconciled_flag);
 const char*  gnc_get_reconcile_valid_flags (void);
 const char*  gnc_get_reconcile_flag_order (void);
 


### PR DESCRIPTION
With the default "n" in the registry reconciliation column, it's difficult to see which transactions have not had any flags set.
I've changed this to default to empty, which makes uncleared and/or unreconciled transactions way more visible for me at a glance.