### PR TITLE
gnc-uri: compose URIs with std::format

### DIFF
--- a/libgnucash/engine/gnc-uri.cpp
+++ b/libgnucash/engine/gnc-uri.cpp
@@ -25,6 +25,7 @@
 
 #include <glib.h>
 #include <cstdint>
+#include <format>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -239,8 +240,8 @@ GncUri::try_str (bool allow_password) const
          */
         bool absolute = !abs_path.empty() &&
                         (abs_path.front() == '/' || abs_path.front() == '\\');
-        return absolute ? scheme + "://" + abs_path
-                        : scheme + ":///" + abs_path; // extra "/" for windows
+        return absolute ? std::format ("{}://{}", scheme, abs_path)
+                        : std::format ("{}:///{}", scheme, abs_path); // extra "/" for windows
     }
 
     std::string userpass;
@@ -257,9 +258,9 @@ GncUri::try_str (bool allow_password) const
 
     std::string portstr;
     if (m_port != 0)
-        portstr = ":" + std::to_string (m_port);
+        portstr = std::format (":{}", m_port);
 
-    return *m_scheme + "://" + userpass + *m_hostname + portstr + "/" + path;
+    return std::format ("{}://{}{}{}/{}", *m_scheme, userpass, *m_hostname, portstr, path);
 }
 
 std::string


### PR DESCRIPTION
## Summary

Follows up PR #2249 by completing the one review item that was deferred there:
composing URI strings with `std::format` instead of chained `operator+`. That change
required C++20's `<format>`; the `future` branch was still C++17 at the time, so it was
parked. Now that `future` builds with **C++23** (commit "Set C and C++ standards to 23"),
this applies the conversion.

## Testing

- `test-engine` (C-API veneer tests) and `test-gnc-uri` (GncUri C++ tests): pass (2/2).
- Coverage build (`gcov`, C++23): `gnc-uri.cpp` **100.0% of 165 lines**, unchanged.