### PR TITLE
Import AqBanking noted transactions optionally

### DIFF
--- a/gnucash/import-export/aqb/dialog-ab-pref.glade
+++ b/gnucash/import-export/aqb/dialog-ab-pref.glade
@@ -7,7 +7,7 @@
     <property name="can-focus">False</property>
     <property name="title" translatable="yes">window1</property>
     <child>
-      <!-- n-columns=3 n-rows=5 -->
+      <!-- n-columns=3 n-rows=6 -->
       <object class="GtkGrid" id="aqbanking_prefs">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
@@ -66,6 +66,24 @@
           </packing>
         </child>
         <child>
+          <object class="GtkCheckButton" id="pref/dialogs.import.hbci/import-noted-transactions">
+            <property name="label" translatable="yes">Import noted or _pending transactions</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="has-tooltip">True</property>
+            <property name="tooltip-markup">If active, GnuCash will import AqBanking noted or pending transactions. These transactions are not final and may later appear again as booked transactions.</property>
+            <property name="tooltip-text" translatable="yes">If active, GnuCash will import AqBanking noted or pending transactions. These transactions are not final and may later appear again as booked transactions.</property>
+            <property name="halign">start</property>
+            <property name="use-underline">True</property>
+            <property name="draw-indicator">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">4</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkCheckButton" id="checkbutton3">
             <property name="label" translatable="yes">_Verbose debug messages</property>
             <property name="visible">True</property>
@@ -80,7 +98,7 @@
           </object>
           <packing>
             <property name="left-attach">0</property>
-            <property name="top-attach">4</property>
+            <property name="top-attach">5</property>
           </packing>
         </child>
         <child>

--- a/gnucash/import-export/aqb/gnc-ab-utils.c
+++ b/gnucash/import-export/aqb/gnc-ab-utils.c
@@ -795,13 +795,44 @@ gnc_AB_JOB_ID_to_string (gulong job_id)
     return g_strdup_printf ("job_%lu", job_id);
 }
 
+static const AB_TRANSACTION *
+get_first_importable_transaction (AB_IMEXPORTER_ACCOUNTINFO *element,
+                                  gboolean import_noted_txns)
+{
+    const AB_TRANSACTION *trans;
 
+    trans = AB_ImExporterAccountInfo_GetFirstTransaction (
+                element, AB_Transaction_TypeStatement, 0);
+    if (trans)
+        return trans;
+
+    if (!import_noted_txns)
+        return NULL;
+
+    return AB_ImExporterAccountInfo_GetFirstTransaction (
+               element, AB_Transaction_TypeNotedStatement, 0);
+}
+
+static void
+import_account_transactions (AB_TRANSACTION_LIST *ab_trans_list,
+                             GncABImExContextImport *data,
+                             gboolean import_noted_txns)
+{
+    AB_Transaction_List_ForEachByType (ab_trans_list, txn_transaction_cb, data,
+                                       AB_Transaction_TypeStatement, 0);
+
+    if (import_noted_txns)
+        AB_Transaction_List_ForEachByType (ab_trans_list, txn_transaction_cb,
+                                           data,
+                                           AB_Transaction_TypeNotedStatement, 0);
+}
 
 static AB_IMEXPORTER_ACCOUNTINFO *
 txn_accountinfo_cb (AB_IMEXPORTER_ACCOUNTINFO *element, gpointer user_data)
 {
     GncABImExContextImport *data = user_data;
     Account *gnc_acc;
+    gboolean import_noted_txns;
 
     g_return_val_if_fail (element && data, NULL);
 
@@ -809,8 +840,11 @@ txn_accountinfo_cb (AB_IMEXPORTER_ACCOUNTINFO *element, gpointer user_data)
         /* Ignore them */
         return NULL;
 
-    if (!AB_ImExporterAccountInfo_GetFirstTransaction (element, AB_Transaction_TypeStatement, 0))
-/* No transaction found */
+    import_noted_txns = gnc_prefs_get_bool (GNC_PREFS_GROUP_AQBANKING,
+                                            GNC_PREF_IMPORT_NOTED_TXNS);
+
+    if (!get_first_importable_transaction (element, import_noted_txns))
+        /* No transaction found */
         return NULL;
     else
         data->awaiting |= FOUND_TRANSACTIONS;
@@ -870,9 +904,7 @@ txn_accountinfo_cb (AB_IMEXPORTER_ACCOUNTINFO *element, gpointer user_data)
     {
         AB_TRANSACTION_LIST *ab_trans_list = AB_ImExporterAccountInfo_GetTransactionList (element);
         if (ab_trans_list)
-            AB_Transaction_List_ForEachByType (ab_trans_list,
-                                               txn_transaction_cb, data,
-                                               AB_Transaction_TypeStatement, 0);
+            import_account_transactions (ab_trans_list, data, import_noted_txns);
     }
     return NULL;
 }

--- a/gnucash/import-export/aqb/gnc-ab-utils.h
+++ b/gnucash/import-export/aqb/gnc-ab-utils.h
@@ -64,6 +64,7 @@ G_BEGIN_DECLS
 #define GNC_PREF_FORMAT_SWIFT940        "format-swift-mt940"
 #define GNC_PREF_FORMAT_SWIFT942        "format-swift-mt942"
 #define GNC_PREF_FORMAT_DTAUS           "format-dtaus"
+#define GNC_PREF_IMPORT_NOTED_TXNS      "import-noted-transactions"
 #define GNC_PREF_USE_TRANSACTION_TXT    "use-ns-transaction-text"
 #define GNC_PREF_VERBOSE_DEBUG          "verbose-debug"
 

--- a/gnucash/import-export/aqb/gschemas/org.gnucash.GnuCash.dialogs.import.hbci.gschema.xml.in
+++ b/gnucash/import-export/aqb/gschemas/org.gnucash.GnuCash.dialogs.import.hbci.gschema.xml.in
@@ -25,6 +25,11 @@
       <summary>Put the transaction text in front of the purpose of a transaction.</summary>
       <description>Some banks place part of transaction description as "transaction text" in the MT940 file. Normally GNUcash ignores this text. However by activating this option, the transaction text is used for the transaction description too.</description>
     </key>
+    <key name="import-noted-transactions" type="b">
+      <default>false</default>
+      <summary>Import noted or pending transactions</summary>
+      <description>If active, GnuCash will import AqBanking noted or pending transactions. These transactions are not final and may later appear again as booked transactions.</description>
+    </key>
     <key name="verbose-debug" type="b">
       <default>false</default>
       <summary>Verbose HBCI debug messages</summary>

--- a/po/de.po
+++ b/po/de.po
@@ -18917,19 +18917,38 @@ msgstr ""
 "werden."
 
 #: gnucash/import-export/aqb/dialog-ab-pref.glade:70
-msgid "_Verbose debug messages"
-msgstr "Ausführliche _Fehlermeldungen"
+msgid "Import noted or _pending transactions"
+msgstr "Vorgemerkte oder _ausstehende Buchungen importieren"
 
 #: gnucash/import-export/aqb/dialog-ab-pref.glade:76
 #: gnucash/import-export/aqb/gschemas/org.gnucash.GnuCash.dialogs.import.hbci.gschema.xml.in:31
+msgid ""
+"If active, GnuCash will import AqBanking noted or pending transactions. "
+"These transactions are not final and may later appear again as booked "
+"transactions."
+msgstr ""
+"Wenn aktiviert, importiert GnuCash von AqBanking gelieferte vorgemerkte oder "
+"ausstehende Buchungen. Diese Buchungen sind noch nicht endgültig und können "
+"später erneut als gebuchte Buchungen erscheinen."
+
+#: gnucash/import-export/aqb/gschemas/org.gnucash.GnuCash.dialogs.import.hbci.gschema.xml.in:30
+msgid "Import noted or pending transactions"
+msgstr "Vorgemerkte oder ausstehende Buchungen importieren"
+
+#: gnucash/import-export/aqb/dialog-ab-pref.glade:88
+msgid "_Verbose debug messages"
+msgstr "Ausführliche _Fehlermeldungen"
+
+#: gnucash/import-export/aqb/dialog-ab-pref.glade:94
+#: gnucash/import-export/aqb/gschemas/org.gnucash.GnuCash.dialogs.import.hbci.gschema.xml.in:36
 msgid "Enables verbose debug messages for HBCI/AqBanking Online Banking."
 msgstr "Ausführliche Fehlermeldungen für FinTS/AqBanking aktivieren."
 
-#: gnucash/import-export/aqb/dialog-ab-pref.glade:88
+#: gnucash/import-export/aqb/dialog-ab-pref.glade:106
 msgid "Use Non-SWIFT _transaction text"
 msgstr "Verwende _Nicht-SWIFT Buchungstext"
 
-#: gnucash/import-export/aqb/dialog-ab-pref.glade:94
+#: gnucash/import-export/aqb/dialog-ab-pref.glade:112
 #: gnucash/import-export/aqb/gschemas/org.gnucash.GnuCash.dialogs.import.hbci.gschema.xml.in:26
 msgid ""
 "Some banks place part of transaction description as \"transaction text\" in "


### PR DESCRIPTION
This adds a disabled-by-default preference for importing AqBanking `AB_Transaction_TypeNotedStatement` transactions.

When disabled, the existing behavior is unchanged: only booked statement transactions are imported. When enabled, noted transactions are passed through the existing generic importer together with booked statement transactions, without changing their description or adding a separate register state.

This lets users review and match noted transactions using the normal import matcher. If the same transaction later appears as a booked statement transaction, the generic importer can match it against the already imported transaction.

The change also adds the corresponding GSettings key and German UI translation.

Tested:
- Built and installed locally on Windows with gnucash-on-windows
- Started the installed Windows build and opened Preferences
- Verified the installed GSettings schema contains `import-noted-transactions`
- Verified German message catalog builds with `msgfmt --check po/de.po`
- Ran `ctest -R aqb --output-on-failure`