### PR TITLE
Add configurable dark appearance mode

### DIFF
--- a/gnucash/gnome-utils/dialog-preferences.c
+++ b/gnucash/gnome-utils/dialog-preferences.c
@@ -1364,6 +1364,7 @@ gnc_preferences_dialog_create (GtkWindow *parent)
     gnc_builder_add_from_file (builder, "dialog-preferences.glade", "new_search_limit_adj");
     gnc_builder_add_from_file (builder, "dialog-preferences.glade", "retain_days_adj");
     gnc_builder_add_from_file (builder, "dialog-preferences.glade", "tab_width_adj");
+    gnc_builder_add_from_file (builder, "dialog-preferences.glade", "appearance_themes");
     gnc_builder_add_from_file (builder, "dialog-preferences.glade", "date_formats");
     gnc_builder_add_from_file (builder, "dialog-preferences.glade", "atm_fee_adj");
     gnc_builder_add_from_file (builder, "dialog-preferences.glade", "auto_add_adj");

--- a/gnucash/gnome-utils/gnc-gnome-utils.c
+++ b/gnucash/gnome-utils/gnc-gnome-utils.c
@@ -25,6 +25,7 @@
 
 #include <glib/gi18n.h>
 #include <libxml/xmlIO.h>
+#include <gdk/gdk.h>
 
 #include "gnc-prefs-utils.h"
 #include "gnc-prefs.h"
@@ -50,6 +51,13 @@
 #ifdef G_OS_WIN32
 #include <windows.h>
 #include "gnc-help-utils.h"
+#endif
+#ifdef GDK_WINDOWING_WIN32
+#include <gdk/gdkwin32.h>
+#ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
+#define DWMWA_USE_IMMERSIVE_DARK_MODE 20
+#endif
+#define DWMWA_USE_IMMERSIVE_DARK_MODE_LEGACY 19
 #endif
 #ifdef MAC_INTEGRATION
 #import <Cocoa/Cocoa.h>
@@ -105,6 +113,319 @@ gnc_configure_date_format (void)
     }
 
     qof_date_format_set(df);
+}
+
+static gboolean
+gnc_string_indicates_dark_appearance (const gchar *value)
+{
+    gchar *lower_value;
+    gboolean prefers_dark;
+
+    if (!value)
+        return FALSE;
+
+    lower_value = g_ascii_strdown (value, -1);
+    prefers_dark = g_strrstr (lower_value, "dark") != NULL;
+    g_free (lower_value);
+
+    return prefers_dark;
+}
+
+static gboolean
+gnc_gtk_settings_prefers_dark (GtkSettings *settings)
+{
+    gboolean prefer_dark = FALSE;
+    gchar *theme_name = NULL;
+
+    if (!settings)
+        return FALSE;
+
+    g_object_get (settings,
+                  "gtk-application-prefer-dark-theme", &prefer_dark,
+                  "gtk-theme-name", &theme_name,
+                  NULL);
+
+    prefer_dark = prefer_dark ||
+                  gnc_string_indicates_dark_appearance (theme_name);
+    g_free (theme_name);
+
+    return prefer_dark;
+}
+
+static gboolean
+gnc_gsettings_color_scheme_prefers_dark (void)
+{
+    GSettingsSchemaSource *schema_source;
+    GSettingsSchema *schema;
+    GSettings *settings;
+    gchar *color_scheme;
+    gboolean prefers_dark = FALSE;
+
+    schema_source = g_settings_schema_source_get_default ();
+    if (!schema_source)
+        return FALSE;
+
+    schema = g_settings_schema_source_lookup (schema_source,
+                                              "org.gnome.desktop.interface",
+                                              TRUE);
+    if (!schema)
+        return FALSE;
+
+    if (!g_settings_schema_has_key (schema, "color-scheme"))
+    {
+        g_settings_schema_unref (schema);
+        return FALSE;
+    }
+
+    settings = g_settings_new_full (schema, NULL, NULL);
+    color_scheme = g_settings_get_string (settings, "color-scheme");
+    prefers_dark = gnc_string_indicates_dark_appearance (color_scheme);
+
+    g_free (color_scheme);
+    g_object_unref (settings);
+    g_settings_schema_unref (schema);
+
+    return prefers_dark;
+}
+
+#ifdef MAC_INTEGRATION
+static gboolean
+gnc_macos_appearance_prefers_dark (void)
+{
+    if (@available(macOS 10.14, *))
+    {
+        NSAppearance *appearance = NSApp ? [NSApp effectiveAppearance] :
+                                           [NSAppearance currentAppearance];
+        NSString *match = [appearance bestMatchFromAppearancesWithNames:
+            @[ NSAppearanceNameAqua, NSAppearanceNameDarkAqua ]];
+
+        return [match isEqualToString:NSAppearanceNameDarkAqua];
+    }
+
+    return FALSE;
+}
+#endif
+
+static gboolean
+gnc_system_appearance_prefers_dark (GtkSettings *settings)
+{
+#ifdef G_OS_WIN32
+    HKEY key;
+    DWORD apps_use_light_theme = 1;
+    DWORD value_type = REG_DWORD;
+    DWORD value_size = sizeof (apps_use_light_theme);
+
+    if (RegOpenKeyExW (HKEY_CURRENT_USER,
+                       L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
+                       0, KEY_READ, &key) == ERROR_SUCCESS)
+    {
+        LSTATUS status = RegQueryValueExW (key, L"AppsUseLightTheme", NULL,
+                                           &value_type,
+                                           (LPBYTE)&apps_use_light_theme,
+                                           &value_size);
+        RegCloseKey (key);
+
+        if (status == ERROR_SUCCESS && value_type == REG_DWORD)
+            return apps_use_light_theme == 0;
+    }
+#endif
+
+#ifdef MAC_INTEGRATION
+    if (gnc_macos_appearance_prefers_dark ())
+        return TRUE;
+#endif
+
+    if (gnc_gsettings_color_scheme_prefers_dark ())
+        return TRUE;
+
+    return gnc_gtk_settings_prefers_dark (settings);
+}
+
+static gboolean
+gnc_appearance_theme_prefers_dark (GtkSettings *settings)
+{
+    gint theme = gnc_prefs_get_int (GNC_PREFS_GROUP_GENERAL,
+                                    GNC_PREF_APPEARANCE_THEME);
+
+    if (theme == GNC_PREF_APPEARANCE_THEME_DARK)
+        return TRUE;
+
+    if (theme == GNC_PREF_APPEARANCE_THEME_LIGHT)
+        return FALSE;
+
+    return gnc_system_appearance_prefers_dark (settings);
+}
+
+#ifdef GDK_WINDOWING_WIN32
+typedef HRESULT (WINAPI *GncDwmSetWindowAttributeFunc) (HWND, DWORD, LPCVOID,
+                                                        DWORD);
+
+static GncDwmSetWindowAttributeFunc
+gnc_get_dwm_set_window_attribute (void)
+{
+    static gboolean lookup_done = FALSE;
+    static GncDwmSetWindowAttributeFunc set_window_attribute = NULL;
+
+    if (!lookup_done)
+    {
+        HMODULE dwmapi_module = LoadLibraryW (L"dwmapi.dll");
+        lookup_done = TRUE;
+
+        if (dwmapi_module)
+            set_window_attribute = (GncDwmSetWindowAttributeFunc)
+                GetProcAddress (dwmapi_module, "DwmSetWindowAttribute");
+    }
+
+    return set_window_attribute;
+}
+
+static void
+gnc_apply_win32_titlebar_theme (GtkWindow *window, gboolean prefer_dark)
+{
+    GncDwmSetWindowAttributeFunc set_window_attribute =
+        gnc_get_dwm_set_window_attribute ();
+    GdkWindow *gdk_window;
+    HWND hwnd;
+    BOOL use_dark_titlebar = prefer_dark;
+
+    if (!set_window_attribute)
+        return;
+
+    if (!gtk_widget_get_realized (GTK_WIDGET (window)))
+        return;
+
+    gdk_window = gtk_widget_get_window (GTK_WIDGET (window));
+    if (!gdk_window)
+        return;
+
+    hwnd = (HWND)gdk_win32_window_get_handle (gdk_window);
+    if (!hwnd)
+        return;
+
+    if (set_window_attribute (hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE,
+                              &use_dark_titlebar,
+                              sizeof (use_dark_titlebar)) < 0)
+    {
+        set_window_attribute (hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE_LEGACY,
+                              &use_dark_titlebar,
+                              sizeof (use_dark_titlebar));
+    }
+
+    SetWindowPos (hwnd, NULL, 0, 0, 0, 0,
+                  SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER |
+                  SWP_NOACTIVATE | SWP_FRAMECHANGED);
+}
+#else
+static void
+gnc_apply_win32_titlebar_theme (G_GNUC_UNUSED GtkWindow *window,
+                                G_GNUC_UNUSED gboolean prefer_dark)
+{
+}
+#endif
+
+static void
+gnc_queue_widget_redraw (GtkWidget *widget, G_GNUC_UNUSED gpointer user_data)
+{
+    gtk_widget_queue_draw (widget);
+
+    if (GTK_IS_CONTAINER (widget))
+        gtk_container_forall (GTK_CONTAINER (widget), gnc_queue_widget_redraw, NULL);
+}
+
+static void
+gnc_apply_appearance_theme_to_window (GtkWindow *window, gboolean prefer_dark)
+{
+    gtk_widget_queue_draw (GTK_WIDGET (window));
+    gnc_queue_widget_redraw (GTK_WIDGET (window), NULL);
+    gnc_apply_win32_titlebar_theme (window, prefer_dark);
+}
+
+static gboolean
+gnc_apply_appearance_theme_to_window_idle (gpointer user_data)
+{
+    GtkWindow *window = GTK_WINDOW (user_data);
+
+    gnc_apply_appearance_theme_to_window (
+        window, gnc_appearance_theme_prefers_dark (gtk_settings_get_default ()));
+    g_object_unref (window);
+
+    return G_SOURCE_REMOVE;
+}
+
+static gboolean
+gnc_appearance_window_realize_hook (G_GNUC_UNUSED GSignalInvocationHint *ihint,
+                                    guint n_param_values,
+                                    const GValue *param_values,
+                                    G_GNUC_UNUSED gpointer user_data)
+{
+    GObject *instance;
+
+    if (n_param_values == 0)
+        return TRUE;
+
+    instance = g_value_get_object (&param_values[0]);
+    if (GTK_IS_WINDOW (instance))
+    {
+        g_object_ref (instance);
+        g_idle_add (gnc_apply_appearance_theme_to_window_idle, instance);
+    }
+
+    return TRUE;
+}
+
+static void
+gnc_install_appearance_window_realize_hook (void)
+{
+    static gboolean hook_installed = FALSE;
+    guint realize_signal_id;
+
+    if (hook_installed)
+        return;
+
+    realize_signal_id = g_signal_lookup ("realize", GTK_TYPE_WIDGET);
+    if (realize_signal_id)
+        g_signal_add_emission_hook (realize_signal_id, 0,
+                                    gnc_appearance_window_realize_hook,
+                                    NULL, NULL);
+
+    hook_installed = TRUE;
+}
+
+static void
+gnc_apply_appearance_theme (void)
+{
+    GtkSettings *settings = gtk_settings_get_default ();
+    gboolean prefer_dark = gnc_appearance_theme_prefers_dark (settings);
+    GdkDisplay *display = gdk_display_get_default ();
+    GList *toplevels, *node;
+
+    if (settings)
+        g_object_set (settings, "gtk-application-prefer-dark-theme",
+                      prefer_dark, NULL);
+
+    if (display)
+    {
+        GdkScreen *screen = gdk_display_get_default_screen (display);
+        if (screen)
+            gtk_style_context_reset_widgets (screen);
+    }
+
+    toplevels = gtk_window_list_toplevels ();
+    for (node = toplevels; node; node = g_list_next (node))
+    {
+        if (GTK_IS_WINDOW (node->data))
+            gnc_apply_appearance_theme_to_window (GTK_WINDOW (node->data),
+                                                  prefer_dark);
+    }
+    g_list_free (toplevels);
+}
+
+static void
+gnc_appearance_theme_changed_cb (G_GNUC_UNUSED GSettings *settings,
+                                 G_GNUC_UNUSED gchar *key,
+                                 G_GNUC_UNUSED gpointer user_data)
+{
+    gnc_apply_appearance_theme ();
 }
 
 /* gnc_configure_date_completion
@@ -164,6 +485,13 @@ gnc_add_css_file (void)
         gtk_css_provider_load_from_path (provider_user, str, &error);
         g_free (str);
     }
+
+    gnc_install_appearance_window_realize_hook ();
+
+    gnc_apply_appearance_theme ();
+    gnc_prefs_register_cb (GNC_PREFS_GROUP_GENERAL, GNC_PREF_APPEARANCE_THEME,
+                           gnc_appearance_theme_changed_cb, NULL);
+
     g_object_unref (provider_user);
     g_object_unref (provider_app);
     g_object_unref (provider_fallback);

--- a/gnucash/gnucash.css
+++ b/gnucash/gnucash.css
@@ -29,6 +29,7 @@ gnc-id-cursor button {
 @define-color register_split_bg_color #EDE7D3;
 @define-color register_cursor_bg_color #FFEF98;
 @define-color register_fg_color black;
+@define-color register_border_color alpha(black, 0.18);
 
 *.gnc-class-register-foreground {
   color: @register_fg_color;
@@ -70,6 +71,63 @@ gnc-id-cursor button {
   background-color: mix(@register_cursor_bg_color, grey, 0.2);
 }
 
+*.gnc-class-register-header,
+*.gnc-class-register-primary,
+*.gnc-class-register-secondary,
+*.gnc-class-register-split,
+*.gnc-class-register-cursor {
+  border-color: @register_border_color;
+}
+
+/* Register colors used when GnuCash is running in dark appearance mode. */
+*.gnc-class-register-dark-foreground {
+  color: #ECEFF4;
+}
+
+*.gnc-class-register-dark-header {
+  background-color: #30443C;
+}
+
+*.gnc-class-register-dark-primary {
+  background-color: #1F2926;
+}
+
+*.gnc-class-register-dark-primary:disabled {
+  background-color: mix(#1F2926, #3A3A3A, 0.35);
+}
+
+*.gnc-class-register-dark-secondary {
+  background-color: #25312D;
+}
+
+*.gnc-class-register-dark-secondary:disabled {
+  background-color: mix(#25312D, #3A3A3A, 0.35);
+}
+
+*.gnc-class-register-dark-split {
+  background-color: #302C25;
+}
+
+*.gnc-class-register-dark-split:disabled {
+  background-color: mix(#302C25, #3A3A3A, 0.35);
+}
+
+*.gnc-class-register-dark-cursor {
+  background-color: #6D5D2B;
+}
+
+*.gnc-class-register-dark-cursor:disabled {
+  background-color: mix(#6D5D2B, #3A3A3A, 0.35);
+}
+
+*.gnc-class-register-dark-header,
+*.gnc-class-register-dark-primary,
+*.gnc-class-register-dark-secondary,
+*.gnc-class-register-dark-split,
+*.gnc-class-register-dark-cursor {
+  border-color: alpha(white, 0.12);
+}
+
 /* Change font color by mixing with grey */
 .gnc-class-lighter-grey-mix {
   color: mix(currentColor, grey, 0.8);
@@ -81,7 +139,7 @@ gnc-id-cursor button {
 
 /* Highlight some text */
 .gnc-class-highlight {
-  color: blue;
+  color: @theme_selected_bg_color;
 }
 
 /* Some tweaks for the about dialog */

--- a/gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in
+++ b/gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in
@@ -55,6 +55,11 @@
       <summary>Display negative amounts in red</summary>
       <description>Display negative amounts in red</description>
     </key>
+    <key name="appearance-theme" type="i">
+      <default>0</default>
+      <summary>Application appearance theme</summary>
+      <description>Controls whether GnuCash follows the system appearance theme, uses a light theme, or uses a dark theme.</description>
+    </key>
     <key name="auto-decimal-point" type="b">
       <default>false</default>
       <summary>Automatically insert a decimal point</summary>

--- a/gnucash/gtkbuilder/dialog-preferences.glade
+++ b/gnucash/gtkbuilder/dialog-preferences.glade
@@ -7,6 +7,23 @@
     <property name="step-increment">0.01</property>
     <property name="page-increment">10</property>
   </object>
+  <object class="GtkListStore" id="appearance_themes">
+    <columns>
+      <!-- column-name name -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">Use system setting</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Light</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Dark</col>
+      </row>
+    </data>
+  </object>
   <object class="GtkAdjustment" id="auto_add_adj">
     <property name="lower">1</property>
     <property name="upper">6</property>
@@ -1443,6 +1460,52 @@ many months before the current month</property>
                     <property name="top-attach">0</property>
                   </packing>
                 </child>
+                <child>
+                  <object class="GtkBox" id="appearance_theme_box">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Appearance</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBox" id="pref/general/appearance-theme">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="model">appearance_themes</property>
+                        <property name="active">0</property>
+                        <property name="has-tooltip">True</property>
+                        <property name="tooltip-text" translatable="yes">Choose whether GnuCash follows the system appearance setting, uses a light theme, or uses a dark theme. The change is applied immediately.</property>
+                        <child>
+                          <object class="GtkCellRendererText" id="appearance_theme_renderer"/>
+                          <attributes>
+                            <attribute name="text">0</attribute>
+                          </attributes>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">0</property>
+                  </packing>
+                </child>
+
                 <child>
                   <object class="GtkCheckButton" id="pref/dialogs.new-hierarchy/show-on-new-file">
                     <property name="label" translatable="yes">Perform account list _setup on new file</property>

--- a/gnucash/register/register-gnome/gnucash-color.c
+++ b/gnucash/register/register-gnome/gnucash-color.c
@@ -38,7 +38,8 @@
 #include <config.h>
 #endif
 
-#include <gdk/gdk.h>
+#include <gtk/gtk.h>
+#include <gnc-prefs.h>
 #include "gnucash-color.h"
 
 static int color_inited;
@@ -67,6 +68,25 @@ color_equal (gconstpointer v, gconstpointer w)
     return (*c1 == *c2);
 }
 
+
+gboolean
+gnucash_register_theme_is_dark (G_GNUC_UNUSED GtkWidget *widget)
+{
+    gint theme = gnc_prefs_get_int (GNC_PREFS_GROUP_GENERAL,
+                                    GNC_PREF_APPEARANCE_THEME);
+    gboolean prefer_dark = FALSE;
+
+    if (theme == GNC_PREF_APPEARANCE_THEME_DARK)
+        return TRUE;
+
+    if (theme == GNC_PREF_APPEARANCE_THEME_LIGHT)
+        return FALSE;
+
+    g_object_get (gtk_settings_get_default (),
+                  "gtk-application-prefer-dark-theme", &prefer_dark, NULL);
+
+    return prefer_dark;
+}
 
 /* This function takes an argb spec for a color and returns an
  *  allocated GdkRGBA.  We take care of allocating and managing

--- a/gnucash/register/register-gnome/gnucash-color.h
+++ b/gnucash/register/register-gnome/gnucash-color.h
@@ -23,7 +23,7 @@
 #ifndef GNUCASH_COLOR_H
 #define GNUCASH_COLOR_H
 
-#include <gdk/gdk.h>
+#include <gtk/gtk.h>
 
 /** @ingroup Register
  * @addtogroup Gnome
@@ -36,6 +36,9 @@ void      gnucash_color_init        (void);
 
 /** Return the pixel value for the given red, green and blue */
 GdkRGBA  *gnucash_color_argb_to_gdk (guint32 argb);
+
+/** Return whether register-owned colors should use their dark palette. */
+gboolean  gnucash_register_theme_is_dark (GtkWidget *widget);
 
 extern GdkRGBA gn_white, gn_light_gray, gn_dark_gray;
 extern GdkRGBA gn_black, gn_blue, gn_red, gn_yellow;

--- a/gnucash/register/register-gnome/gnucash-header.c
+++ b/gnucash/register/register-gnome/gnucash-header.c
@@ -97,7 +97,9 @@ gnc_header_draw_offscreen (GncHeader *header)
     // Fill background color of header
     gtk_render_background (stylectxt, cr, 0, 0, header->width, header->height);
 
-    gdk_rgba_parse (&color, "black");
+    gnc_style_context_get_border_color (stylectxt,
+                                        gtk_style_context_get_state (stylectxt),
+                                        &color);
     cairo_set_source_rgb (cr, color.red, color.green, color.blue);
     cairo_rectangle (cr, 0.5, 0.5, header->width - 1.0, header->height - 1.0);
     cairo_set_line_width (cr, 1.0);

--- a/gnucash/register/register-gnome/gnucash-item-edit.c
+++ b/gnucash/register/register-gnome/gnucash-item-edit.c
@@ -881,7 +881,10 @@ gnc_item_edit_new (GnucashSheet *sheet)
 
     // Get the CSS space settings for the entry
     stylectxt = gtk_widget_get_style_context (GTK_WIDGET(item_edit->editor));
-    gtk_style_context_add_class (stylectxt, "gnc-class-register-foreground");
+    gtk_style_context_add_class (stylectxt,
+                                 gnucash_register_theme_is_dark (GTK_WIDGET(sheet)) ?
+                                 "gnc-class-register-dark-foreground" :
+                                 "gnc-class-register-foreground");
     gtk_style_context_get_padding (stylectxt, GTK_STATE_FLAG_NORMAL, &padding);
     gtk_style_context_get_margin (stylectxt, GTK_STATE_FLAG_NORMAL, &margin);
     gtk_style_context_get_border (stylectxt, GTK_STATE_FLAG_NORMAL, &border);

--- a/gnucash/register/register-gnome/gnucash-sheet.c
+++ b/gnucash/register/register-gnome/gnucash-sheet.c
@@ -2221,7 +2221,10 @@ gnucash_get_style_classes (GnucashSheet *sheet, GtkStyleContext *stylectxt,
     else
     {
         if (sheet->use_gnc_color_theme) // only add this class if builtin colors used
-            gtk_style_context_add_class (stylectxt, "gnc-class-register-foreground");
+            gtk_style_context_add_class (stylectxt,
+                                         gnucash_register_theme_is_dark (GTK_WIDGET(sheet)) ?
+                                         "gnc-class-register-dark-foreground" :
+                                         "gnc-class-register-foreground");
     }
 
     switch (field_type)
@@ -2256,7 +2259,10 @@ gnucash_get_style_classes (GnucashSheet *sheet, GtkStyleContext *stylectxt,
     }
 
     if (sheet->use_gnc_color_theme)
-        full_class = g_strconcat ("gnc-class-register-", style_class, NULL);
+        full_class = g_strconcat (gnucash_register_theme_is_dark (GTK_WIDGET(sheet)) ?
+                                  "gnc-class-register-dark-" :
+                                  "gnc-class-register-",
+                                  style_class, NULL);
     else
     {
         gtk_style_context_add_class (stylectxt, GTK_STYLE_CLASS_VIEW);

--- a/gnucash/report/html-chart.scm
+++ b/gnucash/report/html-chart.scm
@@ -397,16 +397,49 @@ Chart.pluginService.register({
   }
 })
 
-// copy font info from css into chartjs.
+// copy font and color info from css into chartjs.
 bodyStyle = window.getComputedStyle (document.querySelector ('body'));
 Chart.defaults.global.defaultFontSize = parseInt (bodyStyle.fontSize);
 Chart.defaults.global.defaultFontFamily = bodyStyle.fontFamily;
 Chart.defaults.global.defaultFontStyle = bodyStyle.fontStyle;
+Chart.defaults.global.defaultFontColor = bodyStyle.color;
 
 titleStyle = window.getComputedStyle (document.querySelector ('h3'));
+if (!chartjsoptions.options.title) {
+  chartjsoptions.options.title = {};
+}
 chartjsoptions.options.title.fontSize = parseInt (titleStyle.fontSize);
 chartjsoptions.options.title.fontFamily = titleStyle.fontFamily;
 chartjsoptions.options.title.fontStyle = titleStyle.fontStyle;
+chartjsoptions.options.title.fontColor = bodyStyle.color;
+
+if (!chartjsoptions.options.chartArea) {
+  chartjsoptions.options.chartArea = {};
+}
+chartjsoptions.options.chartArea.backgroundColor = bodyStyle.backgroundColor;
+
+if (chartjsoptions.options.legend && chartjsoptions.options.legend.labels) {
+  chartjsoptions.options.legend.labels.fontColor = bodyStyle.color;
+}
+
+function applyAxisTheme(axis) {
+  if (!axis) return;
+  if (!axis.ticks) axis.ticks = {};
+  if (!axis.gridLines) axis.gridLines = {};
+  if (!axis.scaleLabel) axis.scaleLabel = {};
+  axis.ticks.fontColor = bodyStyle.color;
+  axis.gridLines.color = 'rgba(128, 128, 128, 0.35)';
+  axis.scaleLabel.fontColor = bodyStyle.color;
+}
+
+if (chartjsoptions.options.scales) {
+  if (chartjsoptions.options.scales.xAxes) {
+    chartjsoptions.options.scales.xAxes.forEach(applyAxisTheme);
+  }
+  if (chartjsoptions.options.scales.yAxes) {
+    chartjsoptions.options.scales.yAxes.forEach(applyAxisTheme);
+  }
+}
 
 document.getElementById(chartid).onclick = function(evt) {
   var activepoints = myChart.getElementAtEvent(evt);

--- a/gnucash/report/html-fonts.scm
+++ b/gnucash/report/html-fonts.scm
@@ -164,7 +164,14 @@
      (string-append
       ;; Note: any changes in the default CSS *should* be duplicated in
       ;; stylesheet-css.scm
-      "@media (prefers-color-scheme: dark) {body {color: #000; background-color: #fff;}}\n"
+      "@media (prefers-color-scheme: dark) {\n"
+      "  body { color: #E6E8EB !important; background-color: #1E1F22 !important; }\n"
+      "  a { color: #8AB4F8 !important; }\n"
+      "  tr.alternate-row { background: #292B2F !important; }\n"
+      "  td, th { border-color: #555B64 !important; }\n"
+      "  td.highlight { background-color: #373A40 !important; }\n"
+      "  td.neg { color: #FF6B6B !important; }\n"
+      "}\n"
       "h3 { " title-info " }\n"
       "a { " account-link-info " }\n"
       "body, p, table, tr, td { vertical-align: top; " text-cell-info " }\n"

--- a/gnucash/report/stylesheets/css.scm
+++ b/gnucash/report/stylesheets/css.scm
@@ -31,7 +31,27 @@
 (define default-css "/* default style */
 @media (prefers-color-scheme: dark) {
     body {
-        color: #000; background-color: #fff;
+        color: #E6E8EB !important; background-color: #1E1F22 !important;
+    }
+
+    a {
+        color: #8AB4F8 !important;
+    }
+
+    tr.alternate-row {
+        background: #292B2F !important;
+    }
+
+    td, th {
+        border-color: #555B64 !important;
+    }
+
+    td.highlight {
+        background-color: #373A40 !important;
+    }
+
+    td.neg {
+        color: #FF6B6B !important;
     }
 }
 

--- a/libgnucash/core-utils/gnc-prefs.h
+++ b/libgnucash/core-utils/gnc-prefs.h
@@ -64,6 +64,7 @@
 #define GNC_PREF_ACCOUNTING_LABELS   "use-accounting-labels"
 #define GNC_PREF_ACCOUNT_SEPARATOR   "account-separator"
 #define GNC_PREF_NEGATIVE_IN_RED     "negative-in-red"
+#define GNC_PREF_APPEARANCE_THEME    "appearance-theme"
 #define GNC_PREF_NUM_SOURCE          "num-source"
 #define GNC_PREF_DATE_FORMAT         "date-format"
 #define GNC_PREF_DATE_COMPL_THISYEAR "date-completion-thisyear"
@@ -93,6 +94,11 @@
 #define GNC_PREF_CURRENCY_OTHER      "currency-other"
 #define GNC_PREF_CURRENCY_CHOICE_LOCALE "currency-choice-locale"
 #define GNC_PREF_CURRENCY_CHOICE_OTHER  "currency-choice-other"
+
+/* Appearance theme preference values */
+#define GNC_PREF_APPEARANCE_THEME_SYSTEM 0
+#define GNC_PREF_APPEARANCE_THEME_LIGHT  1
+#define GNC_PREF_APPEARANCE_THEME_DARK   2
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
## Summary

This adds a configurable appearance preference with System, Light, and Dark modes. The selected mode is applied immediately to GTK, existing windows, register drawing, report styling, and Windows title bars.

## Details

- Adds a General preference for appearance mode.
- Applies a central appearance decision to GTK settings and realized top-level windows.
- Uses platform-specific System detection:
  - Windows app theme registry value plus DWM title-bar support.
  - macOS `NSAppearance` dark appearance detection.
  - GNOME `org.gnome.desktop.interface color-scheme` and GTK theme fallbacks.
- Adds dark register CSS classes and routes register drawing through the selected appearance.
- Updates report CSS and chart colors so reports follow dark appearance through CSS.

## Validation

- Built `gnucash.exe` with regenerated GResources so the updated `gnucash.css` is embedded.
- Built `libgnc-gnome-utils.dll`, `libgnc-register-gnome.dll`, and `libgnc-report.dll` on Windows/MSYS2.
- Validated preferences UI with `gtk-builder-tool validate`.
- Validated installed schemas with `glib-compile-schemas --strict`.
- Ran `git diff --cached --check` before commit.

Note: Visual testing was performed on Windows. macOS and Linux paths are implemented using platform APIs and GTK/GSettings fallbacks but were not manually tested in those environments.