### PR TITLE
Bug 799753 - Reconciliation error when reconciling transactions posted after the reconcile date

### DIFF
--- a/gnucash/gnome/window-reconcile.cpp
+++ b/gnucash/gnome/window-reconcile.cpp
@@ -508,6 +508,7 @@ actions on this account. Please double-check this is the date you intended."));
     /* update the amount edit with the amount */
     gnc_amount_edit_set_amount (GNC_AMOUNT_EDIT (data->end_value),
                                 new_balance);
+    data->original_value = new_balance;
 }
 
 


### PR DESCRIPTION
When we change the original "Statement Date" and set the "Ending Balance" to the original "Ending Balance", the "Reconcile" window will inappropriately reset the "Ending Balance" to the balance at the new "Statement Date".