### PR TITLE
[engine] qof_session_end: release the lock via the session's backend

### DIFF
--- a/libgnucash/backend/dbi/test/test-backend-dbi-basic.cpp
+++ b/libgnucash/backend/dbi/test/test-backend-dbi-basic.cpp
@@ -439,6 +439,41 @@ test_dbi_store_and_reload (Fixture* fixture, gconstpointer pData)
 }
 
 static void
+test_dbi_new_store_end_releases_lock (Fixture* fixture, gconstpointer pData)
+{
+    const gchar* url = (const gchar*)pData;
+    auto msg = "[GncDbiSqlConnection::unlock_database()] There was no lock entry in the Lock table";
+    auto loglevel = static_cast<GLogLevelFlags> (G_LOG_LEVEL_WARNING |
+                                                 G_LOG_FLAG_FATAL);
+    TestErrorStruct* check = test_error_struct_new (nullptr, loglevel, msg);
+    fixture->hdlrs = test_log_set_fatal_handler (fixture->hdlrs, check,
+                                                 (GLogFunc)test_checked_handler);
+    if (fixture->filename)
+        url = fixture->filename;
+
+    /* Create a new store and end the session without a data-changing save (an
+     * empty book's save() is a no-op that never attaches the backend to the
+     * book). */
+    auto book1{qof_book_new()};
+    auto session_1 = qof_session_new (book1);
+    qof_session_begin (session_1, url, SESSION_NEW_OVERWRITE);
+    g_assert_cmpint (qof_session_get_error (session_1), ==, ERR_BACKEND_NO_ERR);
+    qof_session_end (session_1);
+    g_assert_cmpint (qof_session_get_error (session_1), ==, ERR_BACKEND_NO_ERR);
+
+    /* end() must have released the lock: reopening the store must not fail with
+     * ERR_BACKEND_LOCKED. */
+    auto book2{qof_book_new()};
+    auto session_2 = qof_session_new (book2);
+    qof_session_begin (session_2, url, SESSION_NORMAL_OPEN);
+    g_assert_cmpint (qof_session_get_error (session_2), !=, ERR_BACKEND_LOCKED);
+
+    qof_session_end (session_2);
+    qof_session_destroy (session_2);
+    qof_session_destroy (session_1);
+}
+
+static void
 test_dbi_reparent_split_keeps_slots (Fixture* fixture, gconstpointer pData)
 {
     const gchar* url = (const gchar*)pData;
@@ -777,6 +812,8 @@ create_dbi_test_suite (const char* dbm_name, const char* url)
     auto subsuite = g_strdup_printf ("%s/%s", suitename, dbm_name);
     GNC_TEST_ADD (subsuite, "store_and_reload", Fixture, url, setup,
                   test_dbi_store_and_reload, teardown);
+    GNC_TEST_ADD (subsuite, "new_store_end_releases_lock", Fixture, url,
+                  setup_memory, test_dbi_new_store_end_releases_lock, teardown);
     GNC_TEST_ADD (subsuite, "reparent_split_keeps_slots", Fixture, url,
                   setup_memory, test_dbi_reparent_split_keeps_slots, teardown);
     GNC_TEST_ADD (subsuite, "safe_save", Fixture, url, setup_memory,

--- a/libgnucash/backend/xml/test/test-load-backend.cpp
+++ b/libgnucash/backend/xml/test/test-load-backend.cpp
@@ -25,12 +25,41 @@
  *  02110-1301, USA.
  */
 #include <config.h>
+#include <filesystem>
 #include "qof.h"
 #include "cashobjects.h"
 #include "test-stuff.h"
 
 #define GNC_LIB_NAME "gncmod-backend-xml"
 #define GNC_LIB_REL_PATH "xml"
+
+static void
+test_new_store_end_releases_lock (void)
+{
+    gchar *dir = g_dir_make_tmp ("gnc-xml-lock-XXXXXX", NULL);
+    if (!do_test (dir != NULL, "could not create a temp directory"))
+        return;
+    gchar *path = g_build_filename (dir, "book.gnucash", NULL);
+    gchar *lockfile = g_strconcat (path, ".LCK", NULL);
+    gchar *uri = g_strconcat ("xml://", path, NULL);
+    QofSession *session = qof_session_new (qof_book_new ());
+
+    qof_session_begin (session, uri, SESSION_NEW_STORE);
+    do_test (qof_session_get_error (session) == ERR_BACKEND_NO_ERR,
+             "creating a new XML store failed");
+    qof_session_end (session);
+    do_test (!g_file_test (lockfile, G_FILE_TEST_EXISTS),
+             "qof_session_end() did not remove the .LCK lockfile");
+    qof_session_destroy (session);
+
+    std::filesystem::remove (lockfile);
+    std::filesystem::remove (path);
+    std::filesystem::remove (dir);
+    g_free (uri);
+    g_free (lockfile);
+    g_free (path);
+    g_free (dir);
+}
 
 int main (int argc, char** argv)
 {
@@ -40,6 +69,7 @@ int main (int argc, char** argv)
     do_test (
         qof_load_backend_library (GNC_LIB_REL_PATH, GNC_LIB_NAME),
         " loading gnc-backend-xml GModule failed");
+    test_new_store_end_releases_lock ();
     print_test_results ();
     qof_close ();
     exit (get_rv ());

--- a/libgnucash/engine/qofsession.cpp
+++ b/libgnucash/engine/qofsession.cpp
@@ -335,9 +335,8 @@ void
 QofSessionImpl::end () noexcept
 {
     ENTER ("sess=%p uri=%s", this, m_uri.c_str ());
-    auto backend = qof_book_get_backend (m_book);
-    if (backend != nullptr)
-        backend->session_end();
+    if (m_backend != nullptr)
+        m_backend->session_end();
     clear_error ();
     m_uri.clear();
     LEAVE ("sess=%p uri=%s", this, m_uri.c_str ());


### PR DESCRIPTION
`qof_session_end()` is documented in [qofsession.h](https://github.com/Gnucash/gnucash/blob/3fbde665a6ea1a3ff514cbfbbb65464a358f9a11/libgnucash/engine/qofsession.h#L277) to *release the session lock* and shut the backend connection. However, it does **not** release the lock in all scenarios.

## Root cause — two pointers to "the backend"

There are two references to the backend, and `end()` consulted the wrong one:

- **`m_backend`** — owned by the `QofSessionImpl`; created in `begin()` (via `load_backend()`), so it is **always set after a successful begin**. Deleted in `destroy_backend()`.
- **`qof_book_get_backend(m_book)`** — a *secondary* pointer stored on the **book**, set only by `load()`, a data-changing `save()`/`safe_save()`, or `swap_books()`. **`begin()` does not set it.**

So between `begin()` and the first `load()`/real `save()` there is a window where `m_backend` is set (and the lock is held) but the book's backend pointer is still NULL. An empty book's `save()` is a no-op that returns before attaching the backend (`QofSessionImpl::save` early-returns when `!qof_book_session_not_saved`), so a session that **creates a store and ends it without loading or making a real change** stays in that window. `end()` looked the backend up via the book, found NULL, skipped `session_end()` entirely, and never released the lock — it was only released later at `destroy()`, where `destroy_backend()`'s `delete m_backend` runs the backend destructor (and thus the unlock) as a side effect.

## Affected backends

The fault is in backend-agnostic engine code, so it affects every backend that takes a lock at `begin()`:

- **SQL/DBI (SQLite, MySQL, PostgreSQL):** a stale row is left in the `gnclock` table, so the store appears locked to the next opener until the row is cleared by hand.
- **XML / file backend:** an abandoned `<file>.LCK` sentinel file is left behind — with no data file, since XML data is only written at save. `.LCK` is an existence-based lock, not an OS advisory lock, so it isn't auto-released on process exit; the store stays "locked" until the file is removed.

Both are the file-/DB-specific manifestation of the same missed teardown. It's most visible from the Python bindings and other scripting/automation that create a store and call `end()`.

## Fix

End the session's own backend (`m_backend`, always set at `begin()`) rather than the book's backend pointer:

```c
-    auto backend = qof_book_get_backend (m_book);
-    if (backend != nullptr)
-        backend->session_end();
+    if (m_backend != nullptr)
+        m_backend->session_end();
```

Why this is safe and equivalent elsewhere:
- Whenever the book's backend pointer is set it already **equals** `m_backend` (`load()`/`save()`/`swap_books()` keep them in sync), so for every loaded/saved session the behavior is identical; the only change is the create-without-load/save window, which now tears down correctly.
- It does **not** start setting the book's backend pointer at `begin()`, so code that uses `qof_book_get_backend()` to tell whether a book is backed by storage is unaffected — only `end()`'s own teardown target changes.
- `end()` remains safe to call twice (explicitly, then again from `~QofSessionImpl`): after the first call the connection is gone and the backend's `m_conn` is NULL, so the second `session_end()` → `connect(nullptr)` no-ops and `delete m_backend` finds `m_conn` already NULL.

## Tests

Both begin a create-mode session, `end()` it without a data-changing save, and assert the lock is gone:

- **SQL/DBI** — `test-backend-dbi-basic.cpp::test_dbi_new_store_end_releases_lock`: reopens the store and asserts it is not `ERR_BACKEND_LOCKED`. Runs on sqlite3 (and mysql/pgsql when `TEST_*_URL` are set).
- **XML** — `test-load-backend.cpp::test_new_store_end_releases_lock`: asserts the `<file>.LCK` lockfile has been removed after `end()`.

Verified locally: both pass with the fix and fail without it (DBI: reopen returns `ERR_BACKEND_LOCKED`; XML: the `.LCK` is left behind).

