### PR TITLE
[backend/dbi] skip the libdbi integrity probe for read-only sessions

### DIFF
--- a/libgnucash/backend/dbi/gnc-backend-dbi.cpp
+++ b/libgnucash/backend/dbi/gnc-backend-dbi.cpp
@@ -425,7 +425,7 @@ GncDbiBackend<DbType::DBI_SQLITE>::session_begin(QofSession* session,
         return;
     }
 
-    if (!conn_test_dbi_library(conn))
+    if (mode != SESSION_READ_ONLY && !conn_test_dbi_library(conn))
     {
         if (create && !file_exists)
         {
@@ -677,7 +677,7 @@ GncDbiBackend<Type>::session_begin (QofSession* session, const char* new_uri,
     {
         if (Type == DbType::DBI_MYSQL)
             adjust_sql_options (conn);
-        if(!conn_test_dbi_library(conn))
+        if (mode != SESSION_READ_ONLY && !conn_test_dbi_library(conn))
         {
             dbi_conn_close(conn);
             LEAVE("Error");


### PR DESCRIPTION
Affects read-only access to SQL-backed books,  such that no special write-like privileges are needed for a user to open a session `SESSION_READ_ONLY` by removing an unnecessary DBI integrity test on this path.

**Current Behavior** 
`session_begin()` runs `dbi_library_test()` (Bug #611936) on every open to detect the old libdbi `-ffast-math` miscompilation that mangles 64-bit values. The probe does `CREATE TEMPORARY TABLE` / `INSERT` / `SELECT` / `DROP` on a temp table, so it requires write privileges on the database — even for `SESSION_READ_ONLY`. A least-privilege, `SELECT`-only database user therefore cannot open the book at all: the temp-table create fails and `session_begin()` returns `ERR_SQL_DBI_UNTESTABLE`.

The defect the probe guards against is on the **write** side of libdbi, so it can be neither triggered nor detected by a read-only session, which never writes. This skips the probe when the session is opened `SESSION_READ_ONLY`, at the two call sites a read-only open reaches (the SQLite `session_begin` and the shared MySQL/PostgreSQL `session_begin`); the third call site is inside the `create` branch, which read-only never enters. The write-capable modes (`NORMAL_OPEN`, `NEW_STORE`, `NEW_OVERWRITE`, `BREAK_LOCK`) still run the probe unchanged.

**On testing:** there's no new automated test because the privilege scenario isn't reproducible in the current fixtures — SQLite has no such privilege, and GitHub CI doesn't test MySQL or PostgreSQL at all. The existing `store_and_reload` test already exercises a `SESSION_READ_ONLY` reload, which now takes the probe-skip path, so the read-only load path stays covered.
