### PR TITLE
Add -lm for library building for successful gnucash builds

### DIFF
--- a/libgnucash/app-utils/CMakeLists.txt
+++ b/libgnucash/app-utils/CMakeLists.txt
@@ -54,6 +54,7 @@ set(app_utils_ALL_LIBRARIES
     ${LIBXML2_LDFLAGS}
     ${LIBXSLT_LDFLAGS}
     ${STANDARD_MATH_LIBRARY}
+    -lm
 )
 
 set(app_utils_ALL_INCLUDES


### PR DESCRIPTION
You can not build gnucash successfully (at openSUSE), because special library files can not be found (are not readable). The solution is adding "-lm" into the section app_utils_ALL_LIBRARIES of the CMakeLists.txt file.