### PR TITLE
Fix builds on s390x - Big Endian systems can find add_compile_definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -800,7 +800,7 @@ check_include_files (wctype.h HAVE_WCTYPE_H)
 
 test_big_endian(IS_BIGENDIAN)
 if (IS_BIGENDIAN)
-  add_compile_definition (WORDS_BIGENDIAN)
+  add_compile_definitions (WORDS_BIGENDIAN)
 endif()
 
 if (NOT DISABLE_NLS)

--- a/README
+++ b/README
@@ -158,7 +158,7 @@ Supported Platforms
 
 GnuCash 5.x is known to work with the following operating systems:
 
-GNU/Linux             -- x86, Sparc, PPC
+GNU/Linux             -- x86, Sparc, PPC, s390x
 FreeBSD               -- x86
 OpenBSD               -- x86
 MacOS		      -- Intel, Versions 10.9 and later


### PR DESCRIPTION
s390x systems are experiencing the following error message during builds: Unknown CMake command "add_compile_definition"

The reason is that Big Endian systems are using "add_compile_definitions (WORDS_BIGENDIAN)" instead of "add_compile_definition (WORDS_BIGENDIAN)" in gnucash.

Adding the s is fixing the build issues on s390x and other Big Endian architectures.