### PR TITLE
Bug 799376 - A problematic AUTOCOMPLETE while creating/editing existing entries in 5.x

### DIFF
--- a/gnucash/register/register-gnome/completioncell-gnome.c
+++ b/gnucash/register/register-gnome/completioncell-gnome.c
@@ -620,7 +620,7 @@ select_first_entry_in_list (PopBox* box)
 
     gtk_tree_model_get (model, &iter, TEXT_COL, &string, -1);
 
-    gnc_item_list_select (box->item_list, string);
+    gnc_item_list_select (box->item_list, DONT_TEXT);
 
     GtkTreePath* path = gtk_tree_path_new_first ();
     gtk_tree_view_scroll_to_cell (box->item_list->tree_view,

--- a/gnucash/report/html-chart.scm
+++ b/gnucash/report/html-chart.scm
@@ -55,6 +55,7 @@
 (export gnc:html-chart-format-style)
 (export gnc:html-chart-set-format-style!)
 (export gnc:html-chart-render)
+(export gnc:html-chart-set-tooltip-indexed?!)
 (export gnc:html-chart-set-custom-x-axis-ticks?!)
 (export gnc:html-chart-set-title!)
 (export gnc:html-chart-set-data-labels!)
@@ -289,6 +290,9 @@
 
 (define (gnc:html-chart-set-x-axis-type! chart type)
   (gnc:html-chart-set! chart '(options scales xAxes (0) type) type))
+
+(define (gnc:html-chart-set-tooltip-indexed?! chart indexed?)
+  (gnc:html-chart-set! chart '(options tooltips mode) (if indexed? 'index 'nearest)))
 
 ;; e.g.:
 ;; (gnc:html-chart-add-data-series! chart "label" list-of-numbers color

--- a/gnucash/report/reports/standard/category-barchart.scm
+++ b/gnucash/report/reports/standard/category-barchart.scm
@@ -82,6 +82,7 @@ developing over time"))
 (define optname-fullname (N_ "Show long account names"))
 
 (define optname-chart-type (N_ "Chart Type"))
+(define optname-tooltip-indexed (N_ "Show indexed tooltip"))
 
 (define optname-stacked (N_ "Use Stacked Charts"))
 (define optname-slices (N_ "Maximum Bars"))
@@ -182,6 +183,12 @@ developing over time"))
      options gnc:pagename-display
      optname-sort-method "g" 'amount)
 
+    (gnc-register-simple-boolean-option options
+     gnc:pagename-display optname-tooltip-indexed
+     "h" (N_ "INDEX-ed tooltip presents all data from a selected date. NON-indexed - only a single one that is the closest to the coursor")
+     #t)
+
+
     (gnc:options-set-default-section options gnc:pagename-general)
 
     options))
@@ -237,6 +244,7 @@ developing over time"))
          (height (get-option gnc:pagename-display optname-plot-height))
          (width (get-option gnc:pagename-display optname-plot-width))
          (sort-method (get-option gnc:pagename-display optname-sort-method))
+         (tooltip-indexed (get-option gnc:pagename-display optname-tooltip-indexed))
 
          (work-done 0)
          (work-to-do 0)
@@ -523,6 +531,8 @@ Please deselect the accounts with negative balances."))
 
             (gnc:html-chart-set-width! chart width)
             (gnc:html-chart-set-height! chart height)
+
+            (gnc:html-chart-set-tooltip-indexed?! chart tooltip-indexed)
 
             (gnc:html-chart-set-data-labels! chart date-string-list)
             (gnc:html-chart-set-y-axis-label!

--- a/gnucash/report/reports/standard/net-charts.scm
+++ b/gnucash/report/reports/standard/net-charts.scm
@@ -57,6 +57,7 @@
 (define opthelp-line-width (N_ "Set line width in pixels."))
 
 (define optname-markers (N_ "Data markers?"))
+(define optname-tooltip-indexed (N_ "Show indexed tooltip?"))
 
 ;;(define optname-x-grid (N_ "X grid"))
 (define optname-y-grid (N_ "Grid"))
@@ -147,6 +148,12 @@
             #t)
           ))
 
+          (gnc-register-simple-boolean-option options
+            gnc:pagename-display optname-tooltip-indexed
+            "h" (N_ "INDEX-ed tooltip presents all data from a selected date. NON-indexed - only the one that is the closest to the coursor.")
+            #t)
+
+
     (gnc:options-set-default-section options gnc:pagename-general)
 
     options))
@@ -182,6 +189,7 @@
          (show-net? (get-option gnc:pagename-display (if inc-exp?
                                                          optname-show-profit
                                                          optname-net-bars)))
+         (tooltip-indexed (get-option gnc:pagename-display optname-tooltip-indexed))
          (height (get-option gnc:pagename-display optname-plot-height))
          (width (get-option gnc:pagename-display optname-plot-width))
          (markers (and linechart?
@@ -313,6 +321,7 @@
        (gnc:html-chart-set-height! chart height)
        (gnc:html-chart-set-title!
         chart (list report-title (gnc-date-interval-format from-date-t64 to-date-t64)))
+       (gnc:html-chart-set-tooltip-indexed?! chart tooltip-indexed)
        (gnc:html-chart-set-y-axis-label!
         chart (gnc-commodity-get-mnemonic report-currency))
        (gnc:html-chart-set-grid?! chart y-grid)


### PR DESCRIPTION
Bug 799376 - A problematic AUTOCOMPLETE while creating/editing existing entries in 5.x (https://bugs.gnucash.org/show_bug.cgi?id=799376)


This change is a proposal toward 'safer' behavior of the registry as the current write/mod operations (by autocomplete) might result in accidental changes, which user might not even  notice.

The reasoning behind that, is that the create/edit operations should be a conscious activity, not an automatic/default action (currently, only cancellable by ESC, while any other will create/replace the entry). Especially that it might be potentially damaging if not spotted. 


Simple change of the default selection rectifies the above. 



PS. my first ever pull request!
