### PR TITLE
Enhacement 799376 - A problematic AUTOCOMPLETE while creating/editing existing entries in 5.x

### DIFF
--- a/gnucash/register/register-gnome/completioncell-gnome.c
+++ b/gnucash/register/register-gnome/completioncell-gnome.c
@@ -620,7 +620,7 @@ select_first_entry_in_list (PopBox* box)
 
     gtk_tree_model_get (model, &iter, TEXT_COL, &string, -1);
 
-    gnc_item_list_select (box->item_list, string);
+    gnc_item_list_select (box->item_list, DONT_TEXT);
 
     GtkTreePath* path = gtk_tree_path_new_first ();
     gtk_tree_view_scroll_to_cell (box->item_list->tree_view,


### PR DESCRIPTION
[https://bugs.gnucash.org/show_bug.cgi?id=799376](https://bugs.gnucash.org/show_bug.cgi?id=799376)

This change is a proposal toward 'safer' behavior of the registry as the current write/mod operations (by autocomplete) might result in accidental changes, which user might not even notice.

The reasoning behind that, is that the create/edit operations should be a conscious activity, not an automatic/default action (currently, cancellable only by ESC / choosing "don't autocomplete", while any other will create/replace the entry). Especially that it might be potentially damaging if not spotted.

Simple change of the default selection rectifies the above.


PS. my first ever pull request!
