### PR TITLE
Multiple Enhancements - Tooltip Oriented

### DIFF
--- a/gnucash/gnome-utils/dialog-preferences.c
+++ b/gnucash/gnome-utils/dialog-preferences.c
@@ -1359,6 +1359,12 @@ gnc_preferences_dialog_create (GtkWindow *parent)
     gnc_builder_add_from_file (builder, "dialog-preferences.glade", "save_on_close_adj");
     gnc_builder_add_from_file (builder, "dialog-preferences.glade", "date_backmonth_adj");
     gnc_builder_add_from_file (builder, "dialog-preferences.glade", "default_zoom_adj");
+    gnc_builder_add_from_file (builder, "dialog-preferences.glade", "default_chart_point_style_adj");
+    gnc_builder_add_from_file (builder, "dialog-preferences.glade", "default_chart_point_size_adj");
+    gnc_builder_add_from_file (builder, "dialog-preferences.glade", "default_chart_point_size_hover_adj");
+    gnc_builder_add_from_file (builder, "dialog-preferences.glade", "default_chart_tooltip_engage_radius_adj");
+    gnc_builder_add_from_file (builder, "dialog-preferences.glade", "default_chart_caret_size_adj");
+    gnc_builder_add_from_file (builder, "dialog-preferences.glade", "chart_point_style_list");
     gnc_builder_add_from_file (builder, "dialog-preferences.glade", "max_transactions_adj");
     gnc_builder_add_from_file (builder, "dialog-preferences.glade", "key_length_adj");
     gnc_builder_add_from_file (builder, "dialog-preferences.glade", "new_search_limit_adj");

--- a/gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in
+++ b/gnucash/gschemas/org.gnucash.GnuCash.gschema.xml.in
@@ -349,6 +349,11 @@
     </key>
   </schema>
 
+  <enum id="org.gnucash.GnuCash.general.report.TooltipPosition">
+    <value nick="average" value="0"/>
+    <value nick="nearest" value="1"/>
+  </enum>
+
   <schema id="org.gnucash.GnuCash.general.report" path="/org/gnucash/GnuCash/general/report/">
     <key name="use-new-window" type="b">
       <default>false</default>
@@ -376,6 +381,36 @@
       <description>On high resolution screens reports tend to be hard to read.
 This option allows you to scale reports up by the set factor.
 For example setting this to 2.0 will display reports at twice their typical size.</description>
+    </key>
+    <key name="chart-point-style" type="i">
+      <default>7</default>
+      <summary>A chart's point style.</summary>
+      <description>This setting specifies what kind of a point style should charts use. In previous versions it was always the circle, as of now it is confiugrable to chose among varius rectangles, triangles, and such. Only applicable to line charts.</description>
+    </key>
+    <key name="chart-point-size" type="i">
+      <default>4</default>
+      <summary>A chart's point size.</summary>
+      <description>This setting specifies the default point's size (in pixels) displayed in charts. Only applicable to line charts.</description>
+    </key>
+    <key name="chart-point-size-hover" type="i">
+      <default>9</default>
+      <summary>A chart's hovered-point size.</summary>
+      <description>This setting specifies the hovered point's size (in pixels) displayed in charts. It tends to be bigger than the default (i.e. not hovered over) size.  Only applicable to line charts.</description>
+    </key>
+    <key name="chart-tooltip-engage-radius" type="i">
+      <default>7</default>
+      <summary>A hover radius that would engage a tooltip.</summary>
+      <description>This setting specifies the point's hover radius (in pixels) which translates into the proximity of which the point / tooltip will be engaged. If set to zero, the user must precisely aim at that point.</description>
+    </key>
+    <key name="chart-tooltip-caret-size" type="i">
+      <default>10</default>
+      <summary>An arrow size (caret) coming out of a tooltip's body.</summary>
+      <description>This setting specifies the size (in pixels) of an arrow (caret) that extends from a tooltip's body toward the data point. On a regular basis, a very small value - this setting's default has increased it significantly.</description>
+    </key>
+      <key name="chart-tooltip-position" enum="org.gnucash.GnuCash.general.report.TooltipPosition">
+      <default>'nearest'</default>
+      <summary>"Jump" behaviour when there are multiple splits</summary>
+      <description>Select how the "Jump" operation should behave when a transaction has multiple splits.</description>
     </key>
     <child name="pdf-export" schema="org.gnucash.GnuCash.general.report.pdf-export"/>
   </schema>

--- a/gnucash/gtkbuilder/dialog-preferences.glade
+++ b/gnucash/gtkbuilder/dialog-preferences.glade
@@ -120,6 +120,71 @@
     <property name="step-increment">1</property>
     <property name="page-increment">10</property>
   </object>
+  <object class="GtkAdjustment" id="default_chart_point_size_adj">
+    <property name="lower">1</property>
+    <property name="upper">25</property>
+    <property name="value">4</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">3</property>
+  </object>
+  <object class="GtkAdjustment" id="default_chart_point_size_hover_adj">
+    <property name="lower">1</property>
+    <property name="upper">50</property>
+    <property name="value">9</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">3</property>
+  </object>
+  <object class="GtkAdjustment" id="default_chart_tooltip_engage_radius_adj">
+    <property name="lower">1</property>
+    <property name="upper">100</property>
+    <property name="value">7</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">3</property>
+  </object>
+  <object class="GtkAdjustment" id="default_chart_caret_size_adj">
+    <property name="lower">1</property>
+    <property name="upper">50</property>
+    <property name="value">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">3</property>
+  </object>
+  <object class="GtkListStore" id="chart_point_style_list">
+    <columns>
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">Circle</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Cross</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Cross - rotated</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Dash</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Line</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Rectangle</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Rectangle - rounded</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Rectangle - rotated</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Star</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Triangle</col>
+      </row>
+    </data>
+  </object>
   <object class="GtkDialog" id="separator_validation_dialog">
     <property name="can-focus">False</property>
     <property name="modal">True</property>
@@ -3398,6 +3463,253 @@ many months before the current month</property>
                   <packing>
                     <property name="left-attach">0</property>
                     <property name="top-attach">8</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label-tc-sep">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">9</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label-tc-1">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Line Charts</property>
+                    <style>
+                      <class name="gnc-class-strong"/>
+                    </style>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">10</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Point style</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">11</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkComboBox" id="pref/general.report/chart-point-style">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="has-tooltip">True</property>
+                    <property name="tooltip-markup">Chart Point Style</property>
+                    <property name="tooltip-text" translatable="yes">Which style should represent a data point. Only applicable to line charts. </property>
+                    <property name="model">chart_point_style_list</property>
+                    <property name="active">7</property>
+                    <child>
+                      <object class="GtkCellRendererText" id="tc-point-style-renderer"/>
+                      <attributes>
+                        <attribute name="text">0</attribute>
+                      </attributes>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">11</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Point size</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">12</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="pref/general.report/chart-point-size">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="tooltip-text" translatable="yes">This setting specifies the default point's size (in pixels) displayed in charts. Only applicable to line charts.</property>
+                    <property name="halign">start</property>
+                    <property name="text">1</property>
+                    <property name="adjustment">default_chart_point_size_adj</property>
+                    <property name="digits">0</property>
+                    <property name="value">1</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">12</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Point hovered size</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">13</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="pref/general.report/chart-point-size-hover">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="tooltip-text" translatable="yes">This setting specifies the hovered point's size (in pixels) displayed in charts. It tends to be bigger than the default (i.e. not hovered over) size.  Only applicable to line charts.</property>
+                    <property name="halign">start</property>
+                    <property name="text">1</property>
+                    <property name="adjustment">default_chart_point_size_hover_adj</property>
+                    <property name="digits">0</property>
+                    <property name="value">1</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">13</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label-tc-sep2">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">14</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label-tc-2">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Tooltip</property>
+                    <style>
+                      <class name="gnc-class-strong"/>
+                    </style>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">15</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Engage within this radius</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">16</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="pref/general.report/chart-tooltip-engage-radius">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="tooltip-text" translatable="yes">This setting specifies the point's hover radius (in pixels) which translates into the proximity of which the point / tooltip will be engaged. If set to zero, the user must precisely aim at that point.</property>
+                    <property name="halign">start</property>
+                    <property name="text">1</property>
+                    <property name="adjustment">default_chart_tooltip_engage_radius_adj</property>
+                    <property name="digits">0</property>
+                    <property name="value">1</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">16</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Pointing arrow (caret) size</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">17</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="pref/general.report/chart-tooltip-caret-size">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="tooltip-text" translatable="yes">This setting specifies the size (in pixels) of an arrow (caret) that extends from a tooltip's body toward the data point. On a regular basis, a very small value - this setting's default has increased it significantly.</property>
+                    <property name="halign">start</property>
+                    <property name="text">1</property>
+                    <property name="adjustment">default_chart_caret_size_adj</property>
+                    <property name="digits">0</property>
+                    <property name="value">1</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">17</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Position  (for grouped only)</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">18</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkRadioButton" id="pref/general.report/chart-tooltip-position=average">
+                    <property name="label" translatable="yes">average</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="has-tooltip">True</property>
+                    <property name="tooltip-markup">Show tooltip at the AVERAGE value (i.e. in between) of engaged entry/entries. Only applicable to the grouped/indexed type of a tooltip.</property>
+                    <property name="tooltip-text" translatable="yes">Show tooltip at the AVERAGE value (i.e. in between) of engaged entry/entries. Only applicable to the grouped/indexed type of a tooltip.</property>
+                    <property name="halign">start</property>
+                    <property name="use-underline">True</property>
+                    <property name="active">True</property>
+                    <property name="draw-indicator">True</property>
+                    <property name="group">pref/general.report/chart-tooltip-position=nearest</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">18</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkRadioButton" id="pref/general.report/chart-tooltip-position=nearest">
+                    <property name="label" translatable="yes">nearest</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="has-tooltip">True</property>
+                    <property name="tooltip-markup">Show tooltip NEAREST to value of engaged entry/entries.  Only applicable to the grouped/indexed type of a tooltip.</property>
+                    <property name="tooltip-text" translatable="yes">Show tooltip NEAREST to value of engaged entry/entries. Only applicable to the grouped/indexed type of a tooltip.</property>
+                    <property name="halign">start</property>
+                    <property name="use-underline">True</property>
+                    <property name="active">True</property>
+                    <property name="draw-indicator">True</property>
+                    <property name="group">pref/general.report/chart-tooltip-position=nearest</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">19</property>
                   </packing>
                 </child>
                 <child>

--- a/gnucash/report/html-chart.scm
+++ b/gnucash/report/html-chart.scm
@@ -69,6 +69,7 @@
 (export gnc:html-chart-set-grid?!)
 (export gnc:html-chart-set-y-axis-label!)
 (export gnc:html-chart-add-data-series!)
+(export gnc:html-chart-apply-preferences-report!)
 
 (define gnc:showTooltipNonZerOnly #f)
 
@@ -214,7 +215,9 @@
                                      (cons 'line (list
                                                   (cons 'tension 0)))
                                      (cons 'point (list
-                                                   (cons 'pointStyle #f)))))
+                                                   (cons 'pointStyle #f)
+                                                   (cons 'hoverBorderColor 'black)
+                                                   (cons 'hoverBorderWidth 1)))))
                     (cons 'tooltips (list
                                      (cons 'mode 'index)
                                      (cons 'intersect #f)
@@ -302,6 +305,30 @@
 
 (define (gnc:html-chart-set-tooltip-non-zero-only! chart nonZeroOnly)
   (gnc:html-chart-set! chart '(options tooltips showNonZeroOnly) nonZeroOnly))
+
+(define (gnc:html-chart-apply-preferences-report! chart)
+         (gnc:html-chart-set! chart '(options elements point pointStyle)
+                 (case (gnc-prefs-get-int "general.report" "chart-point-style")
+                     ((0) "circle")       ((1) "cross")     ((2) "crossRot")
+                     ((3) "dash")         ((4) "line")      ((5) "rect")
+                     ((6) "rectRounded")  ((7) "rectRot")   ((8) "star")
+                     ((9) "triangle")     (else "circle")))
+
+         (gnc:html-chart-set! chart '(options elements point radius)
+                (gnc-prefs-get-int "general.report" "chart-point-size"))
+
+         (gnc:html-chart-set! chart '(options elements point hoverRadius)
+                (gnc-prefs-get-int "general.report" "chart-point-size-hover"))
+
+         (gnc:html-chart-set! chart '(options elements point hitRadius)
+                (gnc-prefs-get-int "general.report" "chart-tooltip-engage-radius"))
+
+         (gnc:html-chart-set! chart '(options tooltips caretSize)
+                (gnc-prefs-get-int "general.report" "chart-tooltip-caret-size"))
+
+         (gnc:html-chart-set! chart '(options tooltips position)
+                (gnc-prefs-get-string "general.report" "chart-tooltip-position"))
+)
 
 ;; e.g.:
 ;; (gnc:html-chart-add-data-series! chart "label" list-of-numbers color

--- a/gnucash/report/html-chart.scm
+++ b/gnucash/report/html-chart.scm
@@ -292,7 +292,10 @@
   (gnc:html-chart-set! chart '(options scales xAxes (0) type) type))
 
 (define (gnc:html-chart-set-tooltip-indexed?! chart indexed?)
-  (gnc:html-chart-set! chart '(options tooltips mode) (if indexed? 'index 'nearest)))
+  (if indexed?
+      (gnc:html-chart-set! chart '(options tooltips mode) 'index)
+      (gnc:html-chart-set! chart '(options tooltips mode) 'point)
+))
 
 ;; e.g.:
 ;; (gnc:html-chart-add-data-series! chart "label" list-of-numbers color

--- a/gnucash/report/html-chart.scm
+++ b/gnucash/report/html-chart.scm
@@ -221,6 +221,13 @@
                     (cons 'tooltips (list
                                      (cons 'mode 'index)
                                      (cons 'intersect #f)
+                                     (cons 'cornerRadius 5)
+                                     (cons 'backgroundColor "rgba(33, 33, 33, 0.95)")
+                                     (cons 'titleMarginBottom 14)
+                                     (cons 'titleAlign 'left)
+                                     (cons 'xPadding 8)
+                                     (cons 'yPadding 8)
+                                     (cons 'bodySpacing 3)
                                      (cons 'callbacks (list
                                                        (cons 'label #f)))))
 
@@ -414,7 +421,7 @@ function tooltipLabel(tooltipItem,data) {
   var label = data.datasets[tooltipItem.datasetIndex].data[tooltipItem.index];
   switch (typeof(label)) {
     case 'number':
-      return '  ' + datasetLabel + ' :   ' + numformat(label);
+      return ' ' + datasetLabel + ' :   ' + numformat(label) + '  ';
     default:
       return '';
   }
@@ -424,7 +431,7 @@ function tooltipTitle(array,data) {
   if (!data || array.length === 0) {
     return '';
   }
-  return data.labels[array[0].index];
+  return data.labels[array[0].index] + '  ';
 }
 
 function tooltipFilter(tooltipItem, data) {

--- a/gnucash/report/html-chart.scm
+++ b/gnucash/report/html-chart.scm
@@ -71,8 +71,6 @@
 (export gnc:html-chart-add-data-series!)
 (export gnc:html-chart-apply-preferences-report!)
 
-(define gnc:showTooltipNonZerOnly #f)
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;; utility functions for nested list handling
@@ -221,12 +219,10 @@
                     (cons 'tooltips (list
                                      (cons 'mode 'index)
                                      (cons 'intersect #f)
-                                     (cons 'cornerRadius 5)
-                                     (cons 'backgroundColor "rgba(33, 33, 33, 0.95)")
+                                     (cons 'backgroundColor "rgba(36, 36, 36, 0.94)")
                                      (cons 'titleMarginBottom 14)
-                                     (cons 'titleAlign 'left)
                                      (cons 'xPadding 8)
-                                     (cons 'yPadding 8)
+                                     (cons 'yPadding 9)
                                      (cons 'bodySpacing 3)
                                      (cons 'callbacks (list
                                                        (cons 'label #f)))))
@@ -305,10 +301,8 @@
   (gnc:html-chart-set! chart '(options scales xAxes (0) type) type))
 
 (define (gnc:html-chart-set-tooltip-indexed?! chart indexed?)
-  (if indexed?
-      (gnc:html-chart-set! chart '(options tooltips mode) 'index)
-      (gnc:html-chart-set! chart '(options tooltips mode) 'point)
-))
+      (gnc:html-chart-set! chart '(options tooltips mode) (if indexed? 'index 'point))
+)
 
 (define (gnc:html-chart-set-tooltip-non-zero-only! chart nonZeroOnly)
   (gnc:html-chart-set! chart '(options tooltips showNonZeroOnly) nonZeroOnly))
@@ -421,7 +415,7 @@ function tooltipLabel(tooltipItem,data) {
   var label = data.datasets[tooltipItem.datasetIndex].data[tooltipItem.index];
   switch (typeof(label)) {
     case 'number':
-      return ' ' + datasetLabel + ' :   ' + numformat(label) + '  ';
+      return ' \u200A' + datasetLabel + ' :   ' + numformat(label) + '  ';
     default:
       return '';
   }

--- a/gnucash/report/html-chart.scm
+++ b/gnucash/report/html-chart.scm
@@ -56,6 +56,7 @@
 (export gnc:html-chart-set-format-style!)
 (export gnc:html-chart-render)
 (export gnc:html-chart-set-tooltip-indexed?!)
+(export gnc:html-chart-set-tooltip-non-zero-only!)
 (export gnc:html-chart-set-custom-x-axis-ticks?!)
 (export gnc:html-chart-set-title!)
 (export gnc:html-chart-set-data-labels!)
@@ -68,6 +69,8 @@
 (export gnc:html-chart-set-grid?!)
 (export gnc:html-chart-set-y-axis-label!)
 (export gnc:html-chart-add-data-series!)
+
+(define gnc:showTooltipNonZerOnly #f)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
@@ -297,6 +300,9 @@
       (gnc:html-chart-set! chart '(options tooltips mode) 'point)
 ))
 
+(define (gnc:html-chart-set-tooltip-non-zero-only! chart nonZeroOnly)
+  (gnc:html-chart-set! chart '(options tooltips showNonZeroOnly) nonZeroOnly))
+
 ;; e.g.:
 ;; (gnc:html-chart-add-data-series! chart "label" list-of-numbers color
 ;;  'fill #t
@@ -388,7 +394,15 @@ function tooltipLabel(tooltipItem,data) {
 }
 
 function tooltipTitle(array,data) {
-  return data.labels[array[0].index]; }
+  if (!data || array.length === 0) {
+    return '';
+  }
+  return data.labels[array[0].index];
+}
+
+function tooltipFilter(tooltipItem, data) {
+    return tooltipItem.yLabel != 0;
+}
 
 // draw the background color
 Chart.pluginService.register({
@@ -498,6 +512,7 @@ document.getElementById(chartid).onclick = function(evt) {
 
     (push "chartjsoptions.options.tooltips.callbacks.label = tooltipLabel;\n")
     (push "chartjsoptions.options.tooltips.callbacks.title = tooltipTitle;\n")
+    (push "if (chartjsoptions.options.tooltips.showNonZeroOnly) { chartjsoptions.options.tooltips.filter = tooltipFilter; }\n")
     (push JS-setup)
 
     (push "var myChart = new Chart(chartid, chartjsoptions);\n")

--- a/gnucash/report/html-chart.scm
+++ b/gnucash/report/html-chart.scm
@@ -55,6 +55,7 @@
 (export gnc:html-chart-format-style)
 (export gnc:html-chart-set-format-style!)
 (export gnc:html-chart-render)
+(export gnc:html-chart-set-tooltip-indexed?!)
 (export gnc:html-chart-set-custom-x-axis-ticks?!)
 (export gnc:html-chart-set-title!)
 (export gnc:html-chart-set-data-labels!)
@@ -289,6 +290,9 @@
 
 (define (gnc:html-chart-set-x-axis-type! chart type)
   (gnc:html-chart-set! chart '(options scales xAxes (0) type) type))
+
+(define (gnc:html-chart-set-tooltip-indexed?! chart indexed?)
+  (gnc:html-chart-set! chart '(options tooltips mode) (if indexed? 'index 'nearest)))
 
 ;; e.g.:
 ;; (gnc:html-chart-add-data-series! chart "label" list-of-numbers color

--- a/gnucash/report/reports/standard/account-piecharts.scm
+++ b/gnucash/report/reports/standard/account-piecharts.scm
@@ -339,6 +339,9 @@ balance at a given time"))
                         (gnc-account-get-children-sorted
                          (gnc-get-current-root-account)))))
 
+    ;; apply default settings from preferences
+    (gnc:html-chart-apply-preferences-report! chart)
+
     ;; Returns true if the account a was selected in the account
     ;; selection option.
     (define (show-acct? a)

--- a/gnucash/report/reports/standard/account-piecharts.scm
+++ b/gnucash/report/reports/standard/account-piecharts.scm
@@ -339,9 +339,6 @@ balance at a given time"))
                         (gnc-account-get-children-sorted
                          (gnc-get-current-root-account)))))
 
-    ;; apply default settings from preferences
-    (gnc:html-chart-apply-preferences-report! chart)
-
     ;; Returns true if the account a was selected in the account
     ;; selection option.
     (define (show-acct? a)
@@ -501,6 +498,9 @@ balance at a given time"))
 
                (define (round-scu amt)
                  (gnc-numeric-convert amt scu GNC-HOW-RND-ROUND))
+
+               ;; apply default settings from preferences
+               (gnc:html-chart-apply-preferences-report! chart)
 
                (gnc:html-chart-set-type! chart 'pie)
 

--- a/gnucash/report/reports/standard/category-barchart.scm
+++ b/gnucash/report/reports/standard/category-barchart.scm
@@ -82,6 +82,7 @@ developing over time"))
 (define optname-fullname (N_ "Show long account names"))
 
 (define optname-chart-type (N_ "Chart Type"))
+(define optname-tooltip-indexed (N_ "Show indexed tooltip"))
 
 (define optname-stacked (N_ "Use Stacked Charts"))
 (define optname-slices (N_ "Maximum Bars"))
@@ -182,6 +183,12 @@ developing over time"))
      options gnc:pagename-display
      optname-sort-method "g" 'amount)
 
+    (gnc-register-simple-boolean-option options
+     gnc:pagename-display optname-tooltip-indexed
+     "h" (N_ "INDEX-ed tooltip presents all data from a selected date. NON-indexed - only a single one that is the closest to the coursor")
+     #t)
+
+
     (gnc:options-set-default-section options gnc:pagename-general)
 
     options))
@@ -237,6 +244,7 @@ developing over time"))
          (height (get-option gnc:pagename-display optname-plot-height))
          (width (get-option gnc:pagename-display optname-plot-width))
          (sort-method (get-option gnc:pagename-display optname-sort-method))
+         (tooltip-indexed (get-option gnc:pagename-display optname-tooltip-indexed))
 
          (work-done 0)
          (work-to-do 0)
@@ -523,6 +531,8 @@ Please deselect the accounts with negative balances."))
 
             (gnc:html-chart-set-width! chart width)
             (gnc:html-chart-set-height! chart height)
+
+            (gnc:html-chart-set-tooltip-indexed?! chart tooltip-indexed)
 
             (gnc:html-chart-set-data-labels! chart date-string-list)
             (gnc:html-chart-set-y-axis-label!

--- a/gnucash/report/reports/standard/category-barchart.scm
+++ b/gnucash/report/reports/standard/category-barchart.scm
@@ -82,7 +82,7 @@ developing over time"))
 (define optname-fullname (N_ "Show long account names"))
 
 (define optname-chart-type (N_ "Chart Type"))
-(define optname-tooltip-indexed (N_ "Show indexed tooltip"))
+(define optname-tooltip-indexed (N_ "Show a grouped (indexed) tooltip"))
 
 (define optname-stacked (N_ "Use Stacked Charts"))
 (define optname-slices (N_ "Maximum Bars"))
@@ -185,9 +185,8 @@ developing over time"))
 
     (gnc-register-simple-boolean-option options
      gnc:pagename-display optname-tooltip-indexed
-     "h" (N_ "INDEX-ed tooltip presents all data from a selected date. NON-indexed - only a single one that is the closest to the coursor")
-     #t)
-
+     "t1" (N_ "Show all items, along the x-axis, in a grouped tooltip. Otherwise - only a single entry, as per coursor's nearest proximity.")
+     #f)
 
     (gnc:options-set-default-section options gnc:pagename-general)
 

--- a/gnucash/report/reports/standard/category-barchart.scm
+++ b/gnucash/report/reports/standard/category-barchart.scm
@@ -263,9 +263,6 @@ developing over time"))
                          (gnc-account-get-children-sorted
                           (gnc-get-current-root-account)))))
 
-    ;; apply default settings from preferences
-    (gnc:html-chart-apply-preferences-report! chart)
-
     ;; Returns true if the account a was selected in the account
     ;; selection option.
     (define (show-acct? a)
@@ -527,6 +524,9 @@ Please deselect the accounts with negative balances."))
                  (date-string-list (map qof-print-date dates-list))
                  (list-of-rows #f)
                  (row-totals #f))
+
+            ;; apply default settings from preferences
+            (gnc:html-chart-apply-preferences-report! chart)
 
             ;; Set chart title, subtitle etc.
             (gnc:html-chart-set-type!

--- a/gnucash/report/reports/standard/category-barchart.scm
+++ b/gnucash/report/reports/standard/category-barchart.scm
@@ -83,6 +83,7 @@ developing over time"))
 
 (define optname-chart-type (N_ "Chart Type"))
 (define optname-tooltip-indexed (N_ "Show a grouped (indexed) tooltip"))
+(define optname-tooltip-non-zero-only (N_ "Show only non-zero values in a tooltip"))
 
 (define optname-stacked (N_ "Use Stacked Charts"))
 (define optname-slices (N_ "Maximum Bars"))
@@ -187,6 +188,11 @@ developing over time"))
      gnc:pagename-display optname-tooltip-indexed
      "t1" (N_ "Show all items, along the x-axis, in a grouped tooltip. Otherwise - only a single entry, as per coursor's nearest proximity.")
      #f)
+
+    (gnc-register-simple-boolean-option options
+     gnc:pagename-display optname-tooltip-non-zero-only
+     "t2" (N_ "Show only non-zero values in a tooltip.")
+     #t)
 
     (gnc:options-set-default-section options gnc:pagename-general)
 
@@ -532,6 +538,7 @@ Please deselect the accounts with negative balances."))
             (gnc:html-chart-set-height! chart height)
 
             (gnc:html-chart-set-tooltip-indexed?! chart tooltip-indexed)
+            (gnc:html-chart-set-tooltip-non-zero-only! chart (get-option gnc:pagename-display optname-tooltip-non-zero-only))
 
             (gnc:html-chart-set-data-labels! chart date-string-list)
             (gnc:html-chart-set-y-axis-label!

--- a/gnucash/report/reports/standard/category-barchart.scm
+++ b/gnucash/report/reports/standard/category-barchart.scm
@@ -263,6 +263,9 @@ developing over time"))
                          (gnc-account-get-children-sorted
                           (gnc-get-current-root-account)))))
 
+    ;; apply default settings from preferences
+    (gnc:html-chart-apply-preferences-report! chart)
+
     ;; Returns true if the account a was selected in the account
     ;; selection option.
     (define (show-acct? a)
@@ -539,6 +542,19 @@ Please deselect the accounts with negative balances."))
 
             (gnc:html-chart-set-tooltip-indexed?! chart tooltip-indexed)
             (gnc:html-chart-set-tooltip-non-zero-only! chart (get-option gnc:pagename-display optname-tooltip-non-zero-only))
+
+            ;; tailor applied GC's preferences toward this particular chart
+            (let ((isAverage  (string=? (gnc-prefs-get-string "general.report" "chart-tooltip-position") "average"))
+                  (pointSize  (gnc-prefs-get-int "general.report" "chart-point-size"))
+                  (pointSizeH (gnc-prefs-get-int "general.report" "chart-point-size-hover"))
+                  (isLineChart (if (eq? chart-type 'linechart) #t #f))
+                 )(
+                    if (or (not isLineChart) (and tooltip-indexed isAverage isLineChart))
+                         (gnc:html-chart-set! chart '(options tooltips caretPadding) 0)
+                         (if tooltip-indexed
+                           (gnc:html-chart-set! chart '(options tooltips caretPadding) (+ pointSize 2))
+                           (gnc:html-chart-set! chart '(options tooltips caretPadding) (+ pointSizeH 2))
+             )))
 
             (gnc:html-chart-set-data-labels! chart date-string-list)
             (gnc:html-chart-set-y-axis-label!

--- a/gnucash/report/reports/standard/net-charts.scm
+++ b/gnucash/report/reports/standard/net-charts.scm
@@ -57,6 +57,7 @@
 (define opthelp-line-width (N_ "Set line width in pixels."))
 
 (define optname-markers (N_ "Data markers?"))
+(define optname-tooltip-indexed (N_ "Show indexed tooltip?"))
 
 ;;(define optname-x-grid (N_ "X grid"))
 (define optname-y-grid (N_ "Grid"))
@@ -147,6 +148,12 @@
             #t)
           ))
 
+          (gnc-register-simple-boolean-option options
+            gnc:pagename-display optname-tooltip-indexed
+            "h" (N_ "INDEX-ed tooltip presents all data from a selected date. NON-indexed - only the one that is the closest to the coursor.")
+            #t)
+
+
     (gnc:options-set-default-section options gnc:pagename-general)
 
     options))
@@ -182,6 +189,7 @@
          (show-net? (get-option gnc:pagename-display (if inc-exp?
                                                          optname-show-profit
                                                          optname-net-bars)))
+         (tooltip-indexed (get-option gnc:pagename-display optname-tooltip-indexed))
          (height (get-option gnc:pagename-display optname-plot-height))
          (width (get-option gnc:pagename-display optname-plot-width))
          (markers (and linechart?
@@ -313,6 +321,7 @@
        (gnc:html-chart-set-height! chart height)
        (gnc:html-chart-set-title!
         chart (list report-title (gnc-date-interval-format from-date-t64 to-date-t64)))
+       (gnc:html-chart-set-tooltip-indexed?! chart tooltip-indexed)
        (gnc:html-chart-set-y-axis-label!
         chart (gnc-commodity-get-mnemonic report-currency))
        (gnc:html-chart-set-grid?! chart y-grid)

--- a/gnucash/report/reports/standard/net-charts.scm
+++ b/gnucash/report/reports/standard/net-charts.scm
@@ -210,9 +210,6 @@
          (document (gnc:make-html-document))
          (chart (gnc:make-html-chart)))
 
-    ;; apply default settings from preferences
-    (gnc:html-chart-apply-preferences-report! chart)
-
     ;; This exchanges the commodity-collector 'c' to one single
     ;; 'report-currency' according to the exchange-fn. Returns an
     ;; amount.
@@ -315,6 +312,8 @@
             (date-string-list (map qof-print-date dates-list)))
 
        (gnc:report-percent-done 90)
+       ;; apply default settings from preferences
+       (gnc:html-chart-apply-preferences-report! chart)
 
        (gnc:html-chart-set-type! chart (if linechart? 'line 'bar))
        (gnc:html-chart-set-width! chart width)

--- a/gnucash/report/reports/standard/net-charts.scm
+++ b/gnucash/report/reports/standard/net-charts.scm
@@ -150,7 +150,7 @@
 
           (gnc-register-simple-boolean-option options
             gnc:pagename-display optname-tooltip-indexed
-            "h" (N_ "INDEX-ed tooltip presents all data from a selected date. NON-indexed - only the one that is the closest to the coursor.")
+            "h" (N_ "Show all viable entries per time unit (indexed). Otherwise - only a single entry, as per coursor's exact position.")
             #t)
 
 

--- a/gnucash/report/reports/standard/net-charts.scm
+++ b/gnucash/report/reports/standard/net-charts.scm
@@ -56,8 +56,6 @@
 (define optname-line-width (N_ "Line Width"))
 (define opthelp-line-width (N_ "Set line width in pixels."))
 
-(define optname-markers (N_ "Data markers?"))
-
 (define optname-tooltip-indexed (N_ "Show a grouped (indexed) tooltip"))
 (define optname-tooltip-non-zero-only (N_ "Show only non-zero values in a tooltip"))
 
@@ -143,12 +141,7 @@
           ;;  gnc:pagename-display optname-x-grid
           ;;  "g" (N_ "Add vertical grid lines.")
           ;;  #f))
-
-          (gnc-register-simple-boolean-option options
-            gnc:pagename-display optname-markers
-            "g" (N_ "Display a mark for each data point.")
-            #t)
-          ))
+    ))
 
           (gnc-register-simple-boolean-option options
             gnc:pagename-display optname-tooltip-indexed
@@ -198,8 +191,6 @@
          (tooltip-indexed (get-option gnc:pagename-display optname-tooltip-indexed))
          (height (get-option gnc:pagename-display optname-plot-height))
          (width (get-option gnc:pagename-display optname-plot-width))
-         (markers (and linechart?
-                       (if (get-option gnc:pagename-display optname-markers) 3 0)))
          (line-width (and linechart?
                           (get-option gnc:pagename-display optname-line-width)))
          (y-grid (or (not linechart?) (get-option gnc:pagename-display optname-y-grid)))
@@ -218,6 +209,9 @@
          (show-table? (get-option gnc:pagename-display (N_ "Show table")))
          (document (gnc:make-html-document))
          (chart (gnc:make-html-chart)))
+
+    ;; apply default settings from preferences
+    (gnc:html-chart-apply-preferences-report! chart)
 
     ;; This exchanges the commodity-collector 'c' to one single
     ;; 'report-currency' according to the exchange-fn. Returns an
@@ -330,6 +324,18 @@
        (gnc:html-chart-set-tooltip-indexed?! chart tooltip-indexed)
        (gnc:html-chart-set-tooltip-non-zero-only! chart (get-option gnc:pagename-display optname-tooltip-non-zero-only))
 
+       ;; tailor applied GC's preferences toward this particular chart
+       (let ((isAverage  (string=? (gnc-prefs-get-string "general.report" "chart-tooltip-position") "average"))
+             (pointSize  (gnc-prefs-get-int "general.report" "chart-point-size"))
+             (pointSizeH (gnc-prefs-get-int "general.report" "chart-point-size-hover"))
+            )(
+               if (or (not linechart?) (and tooltip-indexed isAverage linechart?))
+                    (gnc:html-chart-set! chart '(options tooltips caretPadding) 0)
+                    (if tooltip-indexed
+                      (gnc:html-chart-set! chart '(options tooltips caretPadding) (+ pointSize 2))
+                      (gnc:html-chart-set! chart '(options tooltips caretPadding) (+ pointSizeH 2))
+        )))
+
        (gnc:html-chart-set-y-axis-label!
         chart (gnc-commodity-get-mnemonic report-currency))
        (gnc:html-chart-set-grid?! chart y-grid)
@@ -347,7 +353,6 @@
           minuend-balances
           "#0074D9"
           'fill (not linechart?)
-          'pointRadius markers
           'borderWidth line-width
           'urls (gnc:make-report-anchor
                  (if inc-exp?
@@ -368,7 +373,6 @@
           (map - subtrahend-balances)
           "#FF4136"
           'fill (not linechart?)
-          'pointRadius markers
           'borderWidth line-width
           'urls (gnc:make-report-anchor
                  (if inc-exp?
@@ -390,7 +394,6 @@
           difference-balances
           "#2ECC40"
           'fill (not linechart?)
-          'pointRadius markers
           'borderWidth line-width))
 
        ;; Test for all-zero data here.

--- a/gnucash/report/reports/standard/net-charts.scm
+++ b/gnucash/report/reports/standard/net-charts.scm
@@ -57,7 +57,9 @@
 (define opthelp-line-width (N_ "Set line width in pixels."))
 
 (define optname-markers (N_ "Data markers?"))
+
 (define optname-tooltip-indexed (N_ "Show a grouped (indexed) tooltip"))
+(define optname-tooltip-non-zero-only (N_ "Show only non-zero values in a tooltip"))
 
 ;;(define optname-x-grid (N_ "X grid"))
 (define optname-y-grid (N_ "Grid"))
@@ -153,6 +155,10 @@
             "t1" (N_ "Show all items, along the x-axis, in a grouped tooltip. Otherwise - only a single entry, as per coursor's nearest proximity.")
             #t)
 
+          (gnc-register-simple-boolean-option options
+            gnc:pagename-display optname-tooltip-non-zero-only
+            "t2" (N_ "Show only non-zero values in a tooltip.")
+            #t)
 
     (gnc:options-set-default-section options gnc:pagename-general)
 
@@ -322,6 +328,8 @@
        (gnc:html-chart-set-title!
         chart (list report-title (gnc-date-interval-format from-date-t64 to-date-t64)))
        (gnc:html-chart-set-tooltip-indexed?! chart tooltip-indexed)
+       (gnc:html-chart-set-tooltip-non-zero-only! chart (get-option gnc:pagename-display optname-tooltip-non-zero-only))
+
        (gnc:html-chart-set-y-axis-label!
         chart (gnc-commodity-get-mnemonic report-currency))
        (gnc:html-chart-set-grid?! chart y-grid)

--- a/gnucash/report/reports/standard/net-charts.scm
+++ b/gnucash/report/reports/standard/net-charts.scm
@@ -57,7 +57,7 @@
 (define opthelp-line-width (N_ "Set line width in pixels."))
 
 (define optname-markers (N_ "Data markers?"))
-(define optname-tooltip-indexed (N_ "Show indexed tooltip?"))
+(define optname-tooltip-indexed (N_ "Show a grouped (indexed) tooltip"))
 
 ;;(define optname-x-grid (N_ "X grid"))
 (define optname-y-grid (N_ "Grid"))
@@ -150,7 +150,7 @@
 
           (gnc-register-simple-boolean-option options
             gnc:pagename-display optname-tooltip-indexed
-            "h" (N_ "Show all viable entries per time unit (indexed). Otherwise - only a single entry, as per coursor's exact position.")
+            "t1" (N_ "Show all items, along the x-axis, in a grouped tooltip. Otherwise - only a single entry, as per coursor's nearest proximity.")
             #t)
 
 

--- a/gnucash/report/reports/standard/price-scatter.scm
+++ b/gnucash/report/reports/standard/price-scatter.scm
@@ -155,9 +155,6 @@
          (int-secs (cadr (assq-ref intervals interval)))
          (data '()))
 
-        ;; apply default settings from preferences
-        (gnc:html-chart-apply-preferences-report! chart)
-
     ;; Short helper for all the warnings below
     (define (make-warning title text)
       (gnc:html-document-add-object! 
@@ -165,6 +162,9 @@
        (gnc:make-html-text 
         (gnc:html-markup-h3 title)
         (gnc:html-markup-p text))))
+
+    ;; apply default settings from preferences
+    (gnc:html-chart-apply-preferences-report! chart)
 
     (gnc:html-chart-set-type! chart 'line)
 

--- a/gnucash/report/reports/standard/price-scatter.scm
+++ b/gnucash/report/reports/standard/price-scatter.scm
@@ -43,7 +43,6 @@
 (define optname-price-source (N_ "Price Source"))
 (define optname-invert (N_ "Invert prices"))
 
-(define optname-marker (N_ "Marker"))
 (define optname-markercolor (N_ "Marker Color"))
 (define optname-plot-width (N_ "Plot Width"))
 (define optname-plot-height (N_ "Plot Height"))
@@ -85,10 +84,6 @@
     (gnc:options-add-plot-size! 
      options gnc:pagename-display 
      optname-plot-width optname-plot-height "c" (cons 'percent 100.0) (cons 'percent 100.0))
-    
-    (gnc:options-add-marker-choice!
-     options gnc:pagename-display 
-     optname-marker "a" 'filledsquare)
 
     (gnc-register-color-option options
       gnc:pagename-display optname-markercolor
@@ -131,7 +126,6 @@
 
          (height (get-option gnc:pagename-display optname-plot-height))
          (width (get-option gnc:pagename-display optname-plot-width))
-         (marker (get-option gnc:pagename-display optname-marker))
          (mcolor 
           (gnc:color-option->hex-string
            (gnc:lookup-option (gnc:report-options report-obj)
@@ -161,6 +155,9 @@
          (int-secs (cadr (assq-ref intervals interval)))
          (data '()))
 
+        ;; apply default settings from preferences
+        (gnc:html-chart-apply-preferences-report! chart)
+
     ;; Short helper for all the warnings below
     (define (make-warning title text)
       (gnc:html-document-add-object! 
@@ -185,22 +182,15 @@
             (gnc-date-interval-format from-date to-date))))
     (gnc:html-chart-set-width! chart width)
     (gnc:html-chart-set-height! chart height)
-    (gnc:html-chart-set! chart
-                         '(options elements point pointStyle)
-                         (case marker
-                           ((filleddiamond diamond) "rectRot")
-                           ((filledcircle circle) "circle")
-                           ((filledsquare square) "rect")
-                           ((cross) "crossRot")
-                           ((plus) "cross")
-                           ((dash) "line")))
-
     (gnc:html-chart-set-y-axis-label!
      chart (gnc-commodity-get-mnemonic amount-commodity))
 
     (gnc:html-chart-set-x-axis-label! chart int-label)
     (gnc:html-chart-set-x-axis-type! chart 'linear)
     (gnc:html-chart-set-custom-x-axis-ticks?! chart #f)
+
+    ;; tailor applied GC's preferences toward this particular chart
+    (gnc:html-chart-set! chart '(options tooltips caretPadding) (+ (gnc-prefs-get-int "general.report" "chart-point-size") 2))
 
     (cond
      ((gnc-commodity-equiv report-currency price-commodity)
@@ -273,7 +263,7 @@ Unfortunately, the plotting tool can't handle that.")))
          chart (map
                 (match-lambda
                   ((x y)
-                   (format #f "~2,2f ~a = ~a"
+                   (format #f "~2,2F ~a  =  ~a"
                            x int-label (gnc:monetary->string
                                         (gnc:make-gnc-monetary amount-commodity y)))))
                 data))
@@ -281,10 +271,9 @@ Unfortunately, the plotting tool can't handle that.")))
         (gnc:html-chart-add-data-series!
          chart (G_ "Price")
          (map (match-lambda ((x y) (list (cons 'x x) (cons 'y y)))) data)
-         mcolor
-         'pointBorderColor mcolor 'fill #f 'borderColor "#4bb2c5"
-         'pointBackgroundColor
-         (if (memq marker '(filledcircle filledsquare filleddiamond)) mcolor "white"))
+         (string-append "#" mcolor)
+         'pointBorderColor (string-append "#" mcolor) 'fill #f 'borderColor "#4bb2c5"
+         'pointBackgroundColor (string-append "#" mcolor))
 
         (gnc:html-document-add-object! document chart)))))
 
@@ -293,7 +282,7 @@ Unfortunately, the plotting tool can't handle that.")))
 ;; Here we define the actual report
 (gnc:define-report
  'version 1
- 'name (N_ "Price")
+ 'name (N_ "Price Scatterplot")
  'report-guid "1d241609fd4644caad765c95be20ff4c"
  'menu-path (list gnc:menuname-asset-liability)
  'menu-name (N_ "Price Scatterplot")

--- a/libgnucash/core-utils/gnc-prefs.h
+++ b/libgnucash/core-utils/gnc-prefs.h
@@ -93,6 +93,13 @@
 #define GNC_PREF_CURRENCY_OTHER      "currency-other"
 #define GNC_PREF_CURRENCY_CHOICE_LOCALE "currency-choice-locale"
 #define GNC_PREF_CURRENCY_CHOICE_OTHER  "currency-choice-other"
+/* Chart preferences */
+#define GNC_CHART_POINT_STYLE        "chart-point-style"
+#define GNC_CHART_POINT_SIZE         "chart-point-size"
+#define GNC_CHART_POINT_SIZE_HOVER   "chart-point-size-hover"
+#define GNC_CHART_TOOLTIP_CARET      "chart-tooltip-caret-size"
+#define GNC_CHART_TOOLTIP_POSITION   "chart-tooltip-position"
+#define GNC_CHART_TOOLTIP_ENGAGE_RADIUS "chart-tooltip-engage-radius"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
https://bugs.gnucash.org/show_bug.cgi?id=799798

between versions 4 and 5, the GC team changed the default behavior of the tooltip, namely configured it toward an indexed one. The indexed tooltip is a collection of all values, in one sitting, per time unit. While it has plenty of use, it can get very messy with bigger data-sets.

My proposal rectifies the above by giving a user choice to decide which one should be used (the current way is still the default option).

##
Screenshots based on: GC Sample Database: https://github.com/PRG-112/gnucash-sample-db-generator