### PR TITLE
[bindings/python] Fix price example scripts broken by wrapped get_value() (Bug 799796)

### DIFF
--- a/bindings/python/example_scripts/priceDB_test.py
+++ b/bindings/python/example_scripts/priceDB_test.py
@@ -41,12 +41,12 @@ for pr in pl:
    source = pr.get_source()
    time = pr.get_time64()
    v=pr.get_value()
-   price = float(v.num)/v.denom
+   price = float(v.num())/v.denom()
    print(time, source, price)
 
 if len(pl) > 0:
    v0 = pl[0].get_value()
-   print(arm.get_fullname(), float(v0.num) / float(v0.denom ))
+   print(arm.get_fullname(), float(v0.num()) / float(v0.denom()))
 
 session.end()
 session.destroy()

--- a/bindings/python/example_scripts/price_database_example.py
+++ b/bindings/python/example_scripts/price_database_example.py
@@ -82,7 +82,7 @@ for namespace in namespaces:
                source = pr.get_source()
                time = pr.get_time64()
                v=pr.get_value()
-               price = float(v.num)/v.denom
+               price = float(v.num())/v.denom()
 
                print("{0} {1:20}{2:10.4f} {3}".format(time,source,price,cur_name))
                # I didn't find out how to format the time option...

--- a/bindings/python/example_scripts/quotes_historic.py
+++ b/bindings/python/example_scripts/quotes_historic.py
@@ -17,8 +17,7 @@
 #   https://wiki.gnucash.org/wiki/Stocks/get_prices
 #
 
-from gnucash import Session, Account, Split
-import gnucash
+from gnucash import Session, GncNumeric
 import datetime
 from fractions import Fraction
 from gnc_convenience import find_account
@@ -76,13 +75,11 @@ for i in range(1,len(pl)):
 
 for i in range(0,len(stock_date)):
   p_new = pl0.clone(book)
-  p_new = gnucash.GncPrice(instance=p_new)
   print('Adding',i,stock_date[i],stock_price[i])
   p_new.set_time64(stock_date[i])
-  v = p_new.get_value()
-  v.num = int(Fraction.from_float(stock_price[i]).limit_denominator(100000).numerator)
-  v.denom = int(Fraction.from_float(stock_price[i]).limit_denominator(100000).denominator)
-  p_new.set_value(v)
+  num = int(Fraction.from_float(stock_price[i]).limit_denominator(100000).numerator)
+  denom = int(Fraction.from_float(stock_price[i]).limit_denominator(100000).denominator)
+  p_new.set_value(GncNumeric(num, denom))
   p_new.set_source("Finance::Quotes::Historic")
   pdb.add_price(p_new)
 

--- a/bindings/python/example_scripts/quotes_historic.py
+++ b/bindings/python/example_scripts/quotes_historic.py
@@ -17,9 +17,9 @@
 #   https://wiki.gnucash.org/wiki/Stocks/get_prices
 #
 
-from gnucash import Session, GncNumeric
+from gnucash import Session, GncNumeric, GNC_HOW_DENOM_FIXED, GNC_HOW_RND_ROUND_HALF_UP
+from gnucash.gnucash_core_c import COMMODITY_DENOM_MULT
 import datetime
-from fractions import Fraction
 from gnc_convenience import find_account
 
 FILE = "./test.gnucash"
@@ -73,13 +73,17 @@ pl0 = pl[0]
 for i in range(1,len(pl)):
   pdb.remove_price(pl[i])
 
+# Store the price the way GnuCash does internally: a commodity's price in a
+# currency uses a fixed denominator of (pricing currency's SCU * 10000). See
+# the "Price policy" note and COMMODITY_DENOM_MULT in gnc-pricedb.h. For a
+# USD-priced stock this is 100 * 10000 = 1000000, i.e. six decimal places.
+price_denom = cur.get_fraction() * COMMODITY_DENOM_MULT
 for i in range(0,len(stock_date)):
   p_new = pl0.clone(book)
   print('Adding',i,stock_date[i],stock_price[i])
   p_new.set_time64(stock_date[i])
-  num = int(Fraction.from_float(stock_price[i]).limit_denominator(100000).numerator)
-  denom = int(Fraction.from_float(stock_price[i]).limit_denominator(100000).denominator)
-  p_new.set_value(GncNumeric(num, denom))
+  p_new.set_value(GncNumeric(stock_price[i], price_denom,
+                             GNC_HOW_DENOM_FIXED | GNC_HOW_RND_ROUND_HALF_UP))
   p_new.set_source("Finance::Quotes::Historic")
   pdb.add_price(p_new)
 

--- a/bindings/python/gnucash_core.py
+++ b/bindings/python/gnucash_core.py
@@ -545,6 +545,16 @@ class GncNumeric(GnuCashCoreClass):
             kargs['instance'] = GncNumeric.__args_to_instance(args)
         GnuCashCoreClass.__init__(self, [], **kargs)
 
+    def __setattr__(self, name, value):
+        # num and denom are read-only accessor methods, not writable fields.
+        if name in ('num', 'denom'):
+            raise AttributeError(
+                "Cannot assign to '%s': it is a read-only accessor method on "
+                "GncNumeric, not a writable field, so the assignment would not "
+                "change the value. Construct a new value instead, e.g. "
+                "GncNumeric(numerator, denominator)." % name)
+        super().__setattr__(name, value)
+
     @staticmethod
     def __args_to_instance(args):
         if len(args) == 0:

--- a/bindings/python/tests/test_numeric.py
+++ b/bindings/python/tests/test_numeric.py
@@ -98,5 +98,18 @@ class TestGncNumeric(TestCase):
         with self.assertRaises(TypeError):
             GncNumeric(complex(1, 1))
 
+    def test_num_denom_read_only(self):
+        # num/denom are read-only accessor methods, not writable fields.
+        # Assigning to them used to silently do nothing and corrupt data
+        # (Bug 799796); it must now raise instead.
+        num = GncNumeric(1, 2)
+        with self.assertRaises(AttributeError):
+            num.num = 5
+        with self.assertRaises(AttributeError):
+            num.denom = 5
+        # The value is unchanged and the accessors still work.
+        self.assertEqual(num.num(), 1)
+        self.assertEqual(num.denom(), 2)
+
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
PR #2187 made `GncPrice.get_value()` return a `GncNumeric` wrapper and `clone()` a fully wrapped `GncPrice`. The price example scripts still used the pre-5.15 raw `_gnc_numeric` idiom and broke — reported as Bug 799796 (cloned prices silently kept the original value).

### Example scripts (`bindings/python/example_scripts/`)
- **`quotes_historic.py`** — the reported write bug. `v = price.get_value(); v.num = …; v.denom = …; price.set_value(v)` no longer mutates anything (`v` is a `GncNumeric` wrapper whose `num`/`denom` are read-only methods), so the clone silently kept the source price's value. Build a fresh `GncNumeric(num, denom)` and pass it to `set_value()`. Also drop the now-redundant `gnucash.GncPrice(instance=…)` re-wrap of the clone and the unused `gnucash` / `Account` / `Split` imports.
- **`priceDB_test.py`**, **`price_database_example.py`** — `num`/`denom` are methods now, so read `v.num()` / `v.denom()`.

### Prevent silent recurrence (`gnucash_core.py`)
The write path failed *silently*, which is how this slipped through review and CI. `num`/`denom` are read-only accessor methods, so assigning to them merely shadows the method and changes nothing. Add a `GncNumeric.__setattr__` that raises `AttributeError` on assignment to `num`/`denom`, pointing at the correct idiom `GncNumeric(num, denom)`.

Note: this turns previously-*silent* misuse into an immediate error. That is intentional — such code was already broken (Bug 799796) — but it is a behavior change worth calling out.

### Test (`bindings/python/tests/test_numeric.py`)
New `test_num_denom_read_only` covering the guard. It needs no backend, so it runs in the existing `python-bindings` CTest on all platforms.

The wiki page [`Stocks/get_prices`](https://wiki.gnucash.org/wiki/Stocks/get_prices), which the reporter copied from, is being updated separately.
