### PR TITLE
Preserve explicitly entered exchange rates

### DIFF
--- a/gnucash/gnome-utils/dialog-transfer.cpp
+++ b/gnucash/gnome-utils/dialog-transfer.cpp
@@ -1702,21 +1702,40 @@ gnc_xfer_dialog_response_cb (GtkDialog *dialog, gint response, gpointer data)
             return;
         to_amount = gnc_amount_edit_get_amount
             (GNC_AMOUNT_EDIT(xferData->to_amount_edit));
+
+        /* A directly entered rate is preferred over one calculated from the
+         * two amounts. Set this here instead of relying on a focus-out event
+         * so that clicking OK directly from either field records the correct
+         * source. */
+        xferData->price_source = gtk_toggle_button_get_active
+            (GTK_TOGGLE_BUTTON(xferData->price_radio)) ?
+            PRICE_SOURCE_USER_PRICE : PRICE_SOURCE_XFER_DLG_VAL;
+        xferData->price_type = PRICE_TYPE_TRN;
     }
 
     gnc_suspend_gui_refresh ();
 
     if (xferData->exch_rate)
     {
+        gnc_numeric price_value;
+
         /* If we've got the price-button set, then make sure we update the
          * to-amount before we use it.
          */
         if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(xferData->price_radio)))
+        {
             gnc_xfer_update_to_amount(xferData);
-
-        auto price_value = gnc_xfer_dialog_compute_price_value(xferData);
-        gnc_amount_edit_set_amount(GNC_AMOUNT_EDIT(xferData->price_edit),
-                                   price_value);
+            /* Preserve the explicitly entered rate. Computing it again from
+             * the rounded commodity amounts can change it. */
+            price_value = gnc_amount_edit_get_amount
+                (GNC_AMOUNT_EDIT(xferData->price_edit));
+        }
+        else
+        {
+            price_value = gnc_xfer_dialog_compute_price_value(xferData);
+            gnc_amount_edit_set_amount(GNC_AMOUNT_EDIT(xferData->price_edit),
+                                       price_value);
+        }
         *(xferData->exch_rate) = gnc_numeric_abs(price_value);
     }
     else
@@ -1965,8 +1984,8 @@ gnc_xfer_dialog_create(GtkWidget *parent, XferDialog *xferData)
         xferData->curr_xfer_table = table;
 
         edit = gnc_amount_edit_new();
-        gnc_amount_edit_set_print_info(GNC_AMOUNT_EDIT(edit),
-                                       gnc_default_print_info (FALSE));
+        auto print_info = gnc_default_price_print_info (nullptr);
+        gnc_amount_edit_set_print_info (GNC_AMOUNT_EDIT(edit), print_info);
         hbox = GTK_WIDGET(gtk_builder_get_object (builder, "price_hbox"));
         gtk_box_pack_start(GTK_BOX(hbox), edit, TRUE, TRUE, 0);
         xferData->price_edit = edit;


### PR DESCRIPTION
## Problem

The "Currency Transfer" section of the "Transfer Funds" dialog recomputes an explicitly entered exchange rate from the rounded transfer amounts when the dialog is accepted. That changes the rate and represent the result as a fraction. The rate field also uses generic amount formatting, so the "Force prices to display as decimals" preference has no effect.

Rates calculated from "To Amount" additionally receive the same price-source priority as rates entered directly, but I'd find them more imprecise.

## Solution

Preserve the selected FX value when accepting an exchange-only dialog, while continuing to calculate a rate when To Amount is selected. Use price-specific formatting for the rate field so the decimal-display preference is honored. Assign the price source at commit time so directly entered rates remain preferred over rates derived from To Amount.

## Testing

1. Enable **Force prices to display as decimals** in Preferences.
2. Open a multi-currency transaction in a register and enter a rate in the Transfer Funds dialog. Accept and reopen it; verify that the same rate is retained and displayed as a decimal.
3. Select **To Amount**, enter the destination amount, and accept the dialog; verify that the calculated price is recorded with the `user:xfer-dialog` source.
4. Enter a rate directly and accept the dialog; verify that it is recorded with the higher-priority `user:price` source.