### PR TITLE
Reduce allocator churn in the sixtp XML parser

### DIFF
--- a/libgnucash/backend/xml/gnc-account-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-account-xml-v2.cpp
@@ -439,7 +439,7 @@ static struct dom_tree_handler account_handlers_v2[] =
 
 static gboolean
 gnc_account_end_handler (gpointer data_for_children,
-                         GSList* data_from_children, GSList* sibling_data,
+                         const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                          gpointer parent_data, gpointer global_data,
                          gpointer* result, const gchar* tag)
 {

--- a/libgnucash/backend/xml/gnc-bill-term-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-bill-term-xml-v2.cpp
@@ -424,7 +424,7 @@ dom_tree_to_billterm (xmlNodePtr node, QofBook* book)
 
 static gboolean
 gnc_billterm_end_handler (gpointer data_for_children,
-                          GSList* data_from_children, GSList* sibling_data,
+                          const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                           gpointer parent_data, gpointer global_data,
                           gpointer* result, const gchar* tag)
 {

--- a/libgnucash/backend/xml/gnc-book-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-book-xml-v2.cpp
@@ -146,7 +146,7 @@ static struct dom_tree_handler book_handlers_v2[] =
 
 static gboolean
 gnc_book_end_handler (gpointer data_for_children,
-                      GSList* data_from_children, GSList* sibling_data,
+                      const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                       gpointer parent_data, gpointer global_data,
                       gpointer* result, const gchar* tag)
 {
@@ -174,7 +174,7 @@ gnc_book_end_handler (gpointer data_for_children,
 
 static gboolean
 gnc_book_id_end_handler (gpointer data_for_children,
-                         GSList* data_from_children, GSList* sibling_data,
+                         const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                          gpointer parent_data, gpointer global_data,
                          gpointer* result, const gchar* tag)
 {
@@ -196,7 +196,7 @@ gnc_book_id_end_handler (gpointer data_for_children,
 
 static gboolean
 gnc_book_slots_end_handler (gpointer data_for_children,
-                            GSList* data_from_children, GSList* sibling_data,
+                            const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                             gpointer parent_data, gpointer global_data,
                             gpointer* result, const gchar* tag)
 {

--- a/libgnucash/backend/xml/gnc-budget-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-budget-xml-v2.cpp
@@ -153,7 +153,7 @@ static struct dom_tree_handler budget_handlers[] =
 
 static gboolean
 gnc_budget_end_handler (gpointer data_for_children,
-                        GSList* data_from_children, GSList* sibling_data,
+                        const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                         gpointer parent_data, gpointer global_data,
                         gpointer* result, const gchar* tag)
 {

--- a/libgnucash/backend/xml/gnc-commodity-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-commodity-xml-v2.cpp
@@ -243,7 +243,7 @@ gnc_commodity_find_currency (QofBook* book, xmlNodePtr tree)
 
 static gboolean
 gnc_commodity_end_handler (gpointer data_for_children,
-                           GSList* data_from_children, GSList* sibling_data,
+                           const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                            gpointer parent_data, gpointer global_data,
                            gpointer* result, const gchar* tag)
 {

--- a/libgnucash/backend/xml/gnc-customer-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-customer-xml-v2.cpp
@@ -377,7 +377,7 @@ dom_tree_to_customer (xmlNodePtr node, QofBook* book)
 
 static gboolean
 gnc_customer_end_handler (gpointer data_for_children,
-                          GSList* data_from_children, GSList* sibling_data,
+                          const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                           gpointer parent_data, gpointer global_data,
                           gpointer* result, const gchar* tag)
 {

--- a/libgnucash/backend/xml/gnc-employee-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-employee-xml-v2.cpp
@@ -308,7 +308,7 @@ dom_tree_to_employee (xmlNodePtr node, QofBook* book)
 
 static gboolean
 gnc_employee_end_handler (gpointer data_for_children,
-                          GSList* data_from_children, GSList* sibling_data,
+                          const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                           gpointer parent_data, gpointer global_data,
                           gpointer* result, const gchar* tag)
 {

--- a/libgnucash/backend/xml/gnc-entry-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-entry-xml-v2.cpp
@@ -705,7 +705,7 @@ dom_tree_to_entry (xmlNodePtr node, QofBook* book)
 
 static gboolean
 gnc_entry_end_handler (gpointer data_for_children,
-                       GSList* data_from_children, GSList* sibling_data,
+                       const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                        gpointer parent_data, gpointer global_data,
                        gpointer* result, const gchar* tag)
 {

--- a/libgnucash/backend/xml/gnc-freqspec-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-freqspec-xml-v2.cpp
@@ -450,7 +450,7 @@ gnc_fs_handler (xmlNodePtr node, gpointer d)
 static
 gboolean
 gnc_freqSpec_end_handler (gpointer data_for_children,
-                          GSList* data_from_children, GSList* sibling_data,
+                          const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                           gpointer parent_data, gpointer global_data,
                           gpointer* result, const gchar* tag)
 {

--- a/libgnucash/backend/xml/gnc-invoice-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-invoice-xml-v2.cpp
@@ -420,7 +420,7 @@ dom_tree_to_invoice (xmlNodePtr node, QofBook* book)
 
 static gboolean
 gnc_invoice_end_handler (gpointer data_for_children,
-                         GSList* data_from_children, GSList* sibling_data,
+                         const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                          gpointer parent_data, gpointer global_data,
                          gpointer* result, const gchar* tag)
 {

--- a/libgnucash/backend/xml/gnc-job-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-job-xml-v2.cpp
@@ -222,7 +222,7 @@ dom_tree_to_job (xmlNodePtr node, QofBook* book)
 
 static gboolean
 gnc_job_end_handler (gpointer data_for_children,
-                     GSList* data_from_children, GSList* sibling_data,
+                     const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                      gpointer parent_data, gpointer global_data,
                      gpointer* result, const gchar* tag)
 {

--- a/libgnucash/backend/xml/gnc-lot-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-lot-xml-v2.cpp
@@ -115,7 +115,7 @@ static struct dom_tree_handler lot_handlers_v2[] =
 
 static gboolean
 gnc_lot_end_handler (gpointer data_for_children,
-                     GSList* data_from_children, GSList* sibling_data,
+                     const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                      gpointer parent_data, gpointer global_data,
                      gpointer* result, const gchar* tag)
 {

--- a/libgnucash/backend/xml/gnc-order-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-order-xml-v2.cpp
@@ -264,7 +264,7 @@ dom_tree_to_order (xmlNodePtr node, QofBook* book)
 
 static gboolean
 gnc_order_end_handler (gpointer data_for_children,
-                       GSList* data_from_children, GSList* sibling_data,
+                       const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                        gpointer parent_data, gpointer global_data,
                        gpointer* result, const gchar* tag)
 {

--- a/libgnucash/backend/xml/gnc-pricedb-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-pricedb-xml-v2.cpp
@@ -133,8 +133,8 @@ price_parse_xml_sub_node (GNCPrice* p, xmlNodePtr sub_node, QofBook* book)
 
 static gboolean
 price_parse_xml_end_handler (gpointer data_for_children,
-                             GSList* data_from_children,
-                             GSList* sibling_data,
+                             const sixtp_child_result_list& data_from_children,
+                             const sixtp_child_result_list& sibling_data,
                              gpointer parent_data,
                              gpointer global_data,
                              gpointer* result,
@@ -245,7 +245,7 @@ gnc_price_parser_new (void)
 */
 
 static gboolean
-pricedb_start_handler (GSList* sibling_data,
+pricedb_start_handler (const sixtp_child_result_list& sibling_data,
                        gpointer parent_data,
                        gpointer global_data,
                        gpointer* data_for_children,
@@ -264,8 +264,8 @@ pricedb_start_handler (GSList* sibling_data,
 
 static gboolean
 pricedb_after_child_handler (gpointer data_for_children,
-                             GSList* data_from_children,
-                             GSList* sibling_data,
+                             const sixtp_child_result_list& data_from_children,
+                             const sixtp_child_result_list& sibling_data,
                              gpointer parent_data,
                              gpointer global_data,
                              gpointer* result,
@@ -314,8 +314,8 @@ pricedb_cleanup_result_handler (sixtp_child_result* result)
 
 static gboolean
 pricedb_v2_end_handler (
-    gpointer data_for_children, GSList* data_from_children,
-    GSList* sibling_data, gpointer parent_data, gpointer global_data,
+    gpointer data_for_children, const sixtp_child_result_list& data_from_children,
+    const sixtp_child_result_list& sibling_data, gpointer parent_data, gpointer global_data,
     gpointer* result, const gchar* tag)
 {
     GNCPriceDB* db = static_cast<decltype (db)> (*result);

--- a/libgnucash/backend/xml/gnc-pricedb-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-pricedb-xml-v2.cpp
@@ -283,7 +283,7 @@ pricedb_after_child_handler (gpointer data_for_children,
     if (!child_result) return (FALSE);
     if (child_result->type != SIXTP_CHILD_RESULT_NODE) return (FALSE);
 
-    if (strcmp (child_result->tag, "price") == 0)
+    if (child_result->tag == "price")
     {
         GNCPrice* p = (GNCPrice*) child_result->data;
 
@@ -295,7 +295,7 @@ pricedb_after_child_handler (gpointer data_for_children,
     }
     else
     {
-        PERR ("unexpected tag %s\n", child_result->tag);
+        PERR ("unexpected tag %s\n", child_result->tag.c_str ());
         return FALSE;
     }
     return FALSE;

--- a/libgnucash/backend/xml/gnc-schedxaction-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-schedxaction-xml-v2.cpp
@@ -639,7 +639,7 @@ struct dom_tree_handler sx_dom_handlers[] =
 
 static gboolean
 gnc_schedXaction_end_handler (gpointer data_for_children,
-                              GSList* data_from_children, GSList* sibling_data,
+                              const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                               gpointer parent_data, gpointer global_data,
                               gpointer* result, const gchar* tag)
 {
@@ -853,8 +853,8 @@ struct dom_tree_handler tt_dom_handlers[] =
 
 static gboolean
 gnc_template_transaction_end_handler (gpointer data_for_children,
-                                      GSList* data_from_children,
-                                      GSList* sibling_data,
+                                      const sixtp_child_result_list& data_from_children,
+                                      const sixtp_child_result_list& sibling_data,
                                       gpointer parent_data,
                                       gpointer global_data,
                                       gpointer* result,

--- a/libgnucash/backend/xml/gnc-tax-table-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-tax-table-xml-v2.cpp
@@ -392,7 +392,7 @@ dom_tree_to_taxtable (xmlNodePtr node, QofBook* book)
 
 static gboolean
 gnc_taxtable_end_handler (gpointer data_for_children,
-                          GSList* data_from_children, GSList* sibling_data,
+                          const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                           gpointer parent_data, gpointer global_data,
                           gpointer* result, const gchar* tag)
 {

--- a/libgnucash/backend/xml/gnc-transaction-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-transaction-xml-v2.cpp
@@ -516,7 +516,7 @@ struct dom_tree_handler trn_dom_handlers[] =
 
 static gboolean
 gnc_transaction_end_handler (gpointer data_for_children,
-                             GSList* data_from_children, GSList* sibling_data,
+                             const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                              gpointer parent_data, gpointer global_data,
                              gpointer* result, const gchar* tag)
 {

--- a/libgnucash/backend/xml/gnc-vendor-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-vendor-xml-v2.cpp
@@ -331,7 +331,7 @@ dom_tree_to_vendor (xmlNodePtr node, QofBook* book)
 
 static gboolean
 gnc_vendor_end_handler (gpointer data_for_children,
-                        GSList* data_from_children, GSList* sibling_data,
+                        const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                         gpointer parent_data, gpointer global_data,
                         gpointer* result, const gchar* tag)
 {

--- a/libgnucash/backend/xml/io-example-account.cpp
+++ b/libgnucash/backend/xml/io-example-account.cpp
@@ -217,7 +217,7 @@ grab_clean_string (xmlNodePtr tree)
 
 static gboolean
 gnc_short_descrip_end_handler (gpointer data_for_children,
-                               GSList* data_from_children, GSList* sibling_data,
+                               const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                                gpointer parent_data, gpointer global_data,
                                gpointer* result, const gchar* tag)
 {
@@ -237,7 +237,7 @@ gnc_short_descrip_sixtp_parser_create (void)
 
 static gboolean
 gnc_long_descrip_end_handler (gpointer data_for_children,
-                              GSList* data_from_children, GSList* sibling_data,
+                              const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                               gpointer parent_data, gpointer global_data,
                               gpointer* result, const gchar* tag)
 {
@@ -257,7 +257,7 @@ gnc_long_descrip_sixtp_parser_create (void)
 
 static gboolean
 gnc_excludep_end_handler (gpointer data_for_children,
-                          GSList* data_from_children, GSList* sibling_data,
+                          const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                           gpointer parent_data, gpointer global_data,
                           gpointer* result, const gchar* tag)
 {
@@ -279,7 +279,7 @@ gnc_excludep_sixtp_parser_create (void)
 
 static gboolean
 gnc_selected_end_handler (gpointer data_for_children,
-                          GSList* data_from_children, GSList* sibling_data,
+                          const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                           gpointer parent_data, gpointer global_data,
                           gpointer* result, const gchar* tag)
 {
@@ -301,7 +301,7 @@ gnc_selected_sixtp_parser_create (void)
 
 static gboolean
 gnc_title_end_handler (gpointer data_for_children,
-                       GSList* data_from_children, GSList* sibling_data,
+                       const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                        gpointer parent_data, gpointer global_data,
                        gpointer* result, const gchar* tag)
 {

--- a/libgnucash/backend/xml/io-gncxml-v1.cpp
+++ b/libgnucash/backend/xml/io-gncxml-v1.cpp
@@ -173,7 +173,7 @@ gnc_parser_configure_for_input_version (GNCParseStatus* status, gint64 version)
 
 static gboolean
 gnc_version_end_handler (gpointer data_for_children,
-                         GSList*  data_from_children, GSList* sibling_data,
+                         const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                          gpointer parent_data, gpointer global_data,
                          gpointer* result, const gchar* tag)
 {
@@ -231,8 +231,8 @@ gnc_version_parser_new (void)
 
 static gboolean
 gnc_parser_before_child_handler (gpointer data_for_children,
-                                 GSList* data_from_children,
-                                 GSList* sibling_data,
+                                 const sixtp_child_result_list& data_from_children,
+                                 const sixtp_child_result_list& sibling_data,
                                  gpointer parent_data,
                                  gpointer global_data,
                                  gpointer* result,
@@ -257,8 +257,8 @@ gnc_parser_before_child_handler (gpointer data_for_children,
 
 static gboolean
 gnc_parser_after_child_handler (gpointer data_for_children,
-                                GSList* data_from_children,
-                                GSList* sibling_data,
+                                const sixtp_child_result_list& data_from_children,
+                                const sixtp_child_result_list& sibling_data,
                                 gpointer parent_data,
                                 gpointer global_data,
                                 gpointer* result,
@@ -505,8 +505,8 @@ string_to_gnc_numeric(const gchar* str, gnc_numeric *n)
 
 static gboolean
 gint64_kvp_value_end_handler (gpointer data_for_children,
-                              GSList* data_from_children,
-                              GSList* sibling_data,
+                              const sixtp_child_result_list& data_from_children,
+                              const sixtp_child_result_list& sibling_data,
                               gpointer parent_data,
                               gpointer global_data,
                               gpointer* result,
@@ -524,8 +524,8 @@ gint64_kvp_value_parser_new (void)
 
 static gboolean
 double_kvp_value_end_handler (gpointer data_for_children,
-                              GSList* data_from_children,
-                              GSList* sibling_data,
+                              const sixtp_child_result_list& data_from_children,
+                              const sixtp_child_result_list& sibling_data,
                               gpointer parent_data,
                               gpointer global_data,
                               gpointer* result,
@@ -542,8 +542,8 @@ double_kvp_value_parser_new (void)
 
 static gboolean
 gnc_numeric_kvp_value_end_handler (gpointer data_for_children,
-                                   GSList* data_from_children,
-                                   GSList* sibling_data,
+                                   const sixtp_child_result_list& data_from_children,
+                                   const sixtp_child_result_list& sibling_data,
                                    gpointer parent_data,
                                    gpointer global_data,
                                    gpointer* result,
@@ -560,8 +560,8 @@ gnc_numeric_kvp_value_parser_new (void)
 
 static gboolean
 string_kvp_value_end_handler (gpointer data_for_children,
-                              GSList* data_from_children,
-                              GSList* sibling_data,
+                              const sixtp_child_result_list& data_from_children,
+                              const sixtp_child_result_list& sibling_data,
                               gpointer parent_data,
                               gpointer global_data,
                               gpointer* result,
@@ -591,8 +591,8 @@ string_kvp_value_parser_new (void)
  * inconsistent type handling */
 static gboolean
 guid_kvp_value_end_handler (gpointer data_for_children,
-                            GSList* data_from_children,
-                            GSList* sibling_data,
+                            const sixtp_child_result_list& data_from_children,
+                            const sixtp_child_result_list& sibling_data,
                             gpointer parent_data,
                             gpointer global_data,
                             gpointer* result,
@@ -647,23 +647,23 @@ guid_kvp_value_parser_new (void)
 
 static gboolean
 glist_kvp_value_end_handler (gpointer data_for_children,
-                             GSList*  data_from_children, GSList* sibling_data,
+                             const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                              gpointer parent_data, gpointer global_data,
                              gpointer* result, const gchar* tag)
 {
-    GSList* lp;
     GList* result_glist;
     KvpValue* kvp_result;
 
     result_glist = NULL;
-    for (lp = data_from_children; lp; lp = lp->next)
+    /* data_from_children is in document order; walk it back to front and
+       prepend so the resulting glist ends up in document order too. */
+    for (auto it = data_from_children.rbegin (); it != data_from_children.rend (); ++it)
     {
-        sixtp_child_result* cr = (sixtp_child_result*) lp->data;
-        KvpValue* kvp = (KvpValue*) cr->data;
+        auto& cr = *it;
+        KvpValue* kvp = (KvpValue*) cr.data;
 
-        /* children are in reverse chron order, so this fixes it. */
         result_glist = g_list_prepend (result_glist, kvp);
-        cr->should_cleanup = FALSE;
+        cr.should_cleanup = FALSE;
     }
 
     kvp_result = new KvpValue {result_glist};
@@ -763,7 +763,7 @@ glist_kvp_value_parser_new (sixtp* kvp_frame_parser)
 
 static gboolean
 kvp_frame_slot_end_handler (gpointer data_for_children,
-                            GSList*  data_from_children, GSList* sibling_data,
+                            const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                             gpointer parent_data, gpointer global_data,
                             gpointer* result, const gchar* tag)
 {
@@ -771,12 +771,12 @@ kvp_frame_slot_end_handler (gpointer data_for_children,
     gchar* key = NULL;
     KvpValue* value = NULL;
     gboolean delete_value = FALSE;
-    sixtp_child_result *cr1 = NULL, *cr2 = NULL, *cr = NULL;
+    const sixtp_child_result *cr1 = NULL, *cr2 = NULL, *cr = NULL;
     g_return_val_if_fail (f, FALSE);
 
-    if (g_slist_length (data_from_children) != 2) return (FALSE);
-    cr1 = (sixtp_child_result*)data_from_children->data;
-    cr2 = (sixtp_child_result*)data_from_children->next->data;
+    if (data_from_children.size () != 2) return (FALSE);
+    cr1 = &data_from_children[0];
+    cr2 = &data_from_children[1];
     
     if (is_child_result_from_node_named(cr1, "k"))
     {
@@ -872,7 +872,7 @@ kvp_frame_slot_parser_new (sixtp* kvp_frame_parser)
  */
 
 static gboolean
-kvp_frame_start_handler (GSList* sibling_data, gpointer parent_data,
+kvp_frame_start_handler (const sixtp_child_result_list& sibling_data, gpointer parent_data,
                          gpointer global_data, gpointer* data_for_children,
                          gpointer* result, const gchar* tag, gchar** attrs)
 {
@@ -883,7 +883,7 @@ kvp_frame_start_handler (GSList* sibling_data, gpointer parent_data,
 
 static gboolean
 kvp_frame_end_handler (gpointer data_for_children,
-                       GSList*  data_from_children, GSList* sibling_data,
+                       const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                        gpointer parent_data, gpointer global_data,
                        gpointer* result, const gchar* tag)
 {
@@ -894,8 +894,8 @@ kvp_frame_end_handler (gpointer data_for_children,
 
 static void
 kvp_frame_fail_handler (gpointer data_for_children,
-                        GSList* data_from_children,
-                        GSList* sibling_data,
+                        const sixtp_child_result_list& data_from_children,
+                        const sixtp_child_result_list& sibling_data,
                         gpointer parent_data,
                         gpointer global_data,
                         gpointer* result,
@@ -965,7 +965,7 @@ kvp_frame_parser_new (void)
 
 
 static gboolean
-ledger_data_start_handler (GSList* sibling_data, gpointer parent_data,
+ledger_data_start_handler (const sixtp_child_result_list& sibling_data, gpointer parent_data,
                            gpointer global_data, gpointer* data_for_children,
                            gpointer* result, const gchar* tag, gchar** attrs)
 {
@@ -984,8 +984,8 @@ ledger_data_start_handler (GSList* sibling_data, gpointer parent_data,
 
 static gboolean
 ledger_data_after_child_handler (gpointer data_for_children,
-                                 GSList* data_from_children,
-                                 GSList* sibling_data,
+                                 const sixtp_child_result_list& data_from_children,
+                                 const sixtp_child_result_list& sibling_data,
                                  gpointer parent_data,
                                  gpointer global_data,
                                  gpointer* result,
@@ -1018,7 +1018,7 @@ ledger_data_after_child_handler (gpointer data_for_children,
 
 static gboolean
 ledger_data_end_handler (gpointer data_for_children,
-                         GSList*  data_from_children, GSList* sibling_data,
+                         const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                          gpointer parent_data, gpointer global_data,
                          gpointer* result, const gchar* tag)
 {
@@ -1043,8 +1043,8 @@ ledger_data_end_handler (gpointer data_for_children,
 
 static void
 ledger_data_fail_handler (gpointer data_for_children,
-                          GSList* data_from_children,
-                          GSList* sibling_data,
+                          const sixtp_child_result_list& data_from_children,
+                          const sixtp_child_result_list& sibling_data,
                           gpointer parent_data,
                           gpointer global_data,
                           gpointer* result,
@@ -1137,7 +1137,7 @@ ledger_data_parser_new (void)
  */
 
 static gboolean
-account_start_handler (GSList* sibling_data,
+account_start_handler (const sixtp_child_result_list& sibling_data,
                        gpointer parent_data,
                        gpointer global_data,
                        gpointer* data_for_children,
@@ -1172,7 +1172,7 @@ account_start_handler (GSList* sibling_data,
  */
 
 static gboolean
-account_restore_start_handler (GSList* sibling_data,
+account_restore_start_handler (const sixtp_child_result_list& sibling_data,
                                gpointer parent_data,
                                gpointer global_data,
                                gpointer* data_for_children,
@@ -1194,7 +1194,7 @@ account_restore_start_handler (GSList* sibling_data,
 
 static gboolean
 account_restore_end_handler (gpointer data_for_children,
-                             GSList*  data_from_children, GSList* sibling_data,
+                             const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                              gpointer parent_data, gpointer global_data,
                              gpointer* result, const gchar* tag)
 {
@@ -1223,8 +1223,8 @@ account_restore_end_handler (gpointer data_for_children,
 
 static gboolean
 account_restore_after_child_handler (gpointer data_for_children,
-                                     GSList* data_from_children,
-                                     GSList* sibling_data,
+                                     const sixtp_child_result_list& data_from_children,
+                                     const sixtp_child_result_list& sibling_data,
                                      gpointer parent_data,
                                      gpointer global_data,
                                      gpointer* result,
@@ -1269,8 +1269,8 @@ account_restore_after_child_handler (gpointer data_for_children,
 
 static void
 account_restore_fail_handler (gpointer data_for_children,
-                              GSList* data_from_children,
-                              GSList* sibling_data,
+                              const sixtp_child_result_list& data_from_children,
+                              const sixtp_child_result_list& sibling_data,
                               gpointer parent_data,
                               gpointer global_data,
                               gpointer* result,
@@ -1304,7 +1304,7 @@ account_restore_fail_handler (gpointer data_for_children,
  */
 static gboolean
 acc_restore_name_end_handler (gpointer data_for_children,
-                              GSList*  data_from_children, GSList* sibling_data,
+                              const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                               gpointer parent_data, gpointer global_data,
                               gpointer* result, const gchar* tag)
 {
@@ -1342,7 +1342,7 @@ acc_restore_name_end_handler (gpointer data_for_children,
 
 static gboolean
 acc_restore_guid_end_handler (gpointer data_for_children,
-                              GSList*  data_from_children, GSList* sibling_data,
+                              const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                               gpointer parent_data, gpointer global_data,
                               gpointer* result, const gchar* tag)
 {
@@ -1392,7 +1392,7 @@ acc_restore_guid_end_handler (gpointer data_for_children,
 
 static gboolean
 acc_restore_type_end_handler (gpointer data_for_children,
-                              GSList*  data_from_children, GSList* sibling_data,
+                              const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                               gpointer parent_data, gpointer global_data,
                               gpointer* result, const gchar* tag)
 {
@@ -1436,7 +1436,7 @@ acc_restore_type_end_handler (gpointer data_for_children,
 
 static gboolean
 acc_restore_code_end_handler (gpointer data_for_children,
-                              GSList*  data_from_children, GSList* sibling_data,
+                              const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                               gpointer parent_data, gpointer global_data,
                               gpointer* result, const gchar* tag)
 {
@@ -1475,7 +1475,7 @@ acc_restore_code_end_handler (gpointer data_for_children,
 
 static gboolean
 acc_restore_description_end_handler (gpointer data_for_children,
-                                     GSList*  data_from_children, GSList* sibling_data,
+                                     const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                                      gpointer parent_data, gpointer global_data,
                                      gpointer* result, const gchar* tag)
 {
@@ -1513,7 +1513,7 @@ acc_restore_description_end_handler (gpointer data_for_children,
 
 static gboolean
 acc_restore_notes_end_handler (gpointer data_for_children,
-                               GSList*  data_from_children, GSList* sibling_data,
+                               const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                                gpointer parent_data, gpointer global_data,
                                gpointer* result, const gchar* tag)
 {
@@ -1554,22 +1554,22 @@ acc_restore_notes_end_handler (gpointer data_for_children,
 
 static gboolean
 acc_restore_parent_end_handler (gpointer data_for_children,
-                                GSList*  data_from_children, GSList* sibling_data,
+                                const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                                 gpointer parent_data, gpointer global_data,
                                 gpointer* result, const gchar* tag)
 {
     GNCParseStatus* pstatus = (GNCParseStatus*) global_data;
     Account* acc = (Account*) parent_data;
     Account* parent;
-    sixtp_child_result* child_result;
+    const sixtp_child_result* child_result;
     GncGUID gid;
 
     g_return_val_if_fail (acc, FALSE);
 
-    if (g_slist_length (data_from_children) != 1)
+    if (data_from_children.size () != 1)
         return (FALSE);
 
-    child_result = (sixtp_child_result*) data_from_children->data;
+    child_result = &data_from_children[0];
 
     if (!is_child_result_from_node_named (child_result, "guid"))
         return (FALSE);
@@ -1716,7 +1716,7 @@ typedef struct
 } CommodityParseInfo;
 
 static gboolean
-commodity_restore_start_handler (GSList* sibling_data, gpointer parent_data,
+commodity_restore_start_handler (const sixtp_child_result_list& sibling_data, gpointer parent_data,
                                  gpointer global_data,
                                  gpointer* data_for_children, gpointer* result,
                                  const gchar* tag, gchar** attrs)
@@ -1742,8 +1742,8 @@ commodity_restore_start_handler (GSList* sibling_data, gpointer parent_data,
 
 static gboolean
 commodity_restore_after_child_handler (gpointer data_for_children,
-                                       GSList* data_from_children,
-                                       GSList* sibling_data,
+                                       const sixtp_child_result_list& data_from_children,
+                                       const sixtp_child_result_list& sibling_data,
                                        gpointer parent_data,
                                        gpointer global_data,
                                        gpointer* result,
@@ -1781,7 +1781,7 @@ commodity_restore_after_child_handler (gpointer data_for_children,
 
 static gboolean
 commodity_restore_end_handler (gpointer data_for_children,
-                               GSList*  data_from_children, GSList* sibling_data,
+                               const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                                gpointer parent_data, gpointer global_data,
                                gpointer* result, const gchar* tag)
 {
@@ -1915,7 +1915,7 @@ typedef struct
 
 static gboolean
 generic_gnc_commodity_lookup_start_handler (
-    GSList* sibling_data, gpointer parent_data, gpointer global_data,
+    const sixtp_child_result_list& sibling_data, gpointer parent_data, gpointer global_data,
     gpointer* data_for_children, gpointer* result, const gchar* tag,
     gchar** attrs)
 {
@@ -1927,8 +1927,8 @@ generic_gnc_commodity_lookup_start_handler (
 
 static gboolean
 generic_gnc_commodity_lookup_after_child_handler (gpointer data_for_children,
-                                                  GSList* data_from_children,
-                                                  GSList* sibling_data,
+                                                  const sixtp_child_result_list& data_from_children,
+                                                  const sixtp_child_result_list& sibling_data,
                                                   gpointer parent_data,
                                                   gpointer global_data,
                                                   gpointer* result,
@@ -1966,7 +1966,7 @@ generic_gnc_commodity_lookup_after_child_handler (gpointer data_for_children,
 
 static gboolean
 generic_gnc_commodity_lookup_end_handler (gpointer data_for_children,
-                                          GSList*  data_from_children, GSList* sibling_data,
+                                          const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                                           gpointer parent_data, gpointer global_data,
                                           gpointer* result, const gchar* tag)
 {
@@ -2063,7 +2063,7 @@ generic_gnc_commodity_lookup_parser_new (void)
  */
 
 static gboolean
-transaction_start_handler (GSList* sibling_data, gpointer parent_data,
+transaction_start_handler (const sixtp_child_result_list& sibling_data, gpointer parent_data,
                            gpointer global_data, gpointer* data_for_children,
                            gpointer* result, const gchar* tag, gchar** attrs)
 {
@@ -2107,7 +2107,7 @@ transaction_start_handler (GSList* sibling_data, gpointer parent_data,
  */
 
 static gboolean
-txn_restore_start_handler (GSList* sibling_data, gpointer parent_data,
+txn_restore_start_handler (const sixtp_child_result_list& sibling_data, gpointer parent_data,
                            gpointer global_data, gpointer* data_for_children,
                            gpointer* result, const gchar* tag, gchar** attrs)
 {
@@ -2124,7 +2124,7 @@ txn_restore_start_handler (GSList* sibling_data, gpointer parent_data,
 
 static gboolean
 txn_restore_end_handler (gpointer data_for_children,
-                         GSList*  data_from_children, GSList* sibling_data,
+                         const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                          gpointer parent_data, gpointer global_data,
                          gpointer* result, const gchar* tag)
 {
@@ -2155,8 +2155,8 @@ txn_restore_end_handler (gpointer data_for_children,
 
 static gboolean
 txn_restore_after_child_handler (gpointer data_for_children,
-                                 GSList* data_from_children,
-                                 GSList* sibling_data,
+                                 const sixtp_child_result_list& data_from_children,
+                                 const sixtp_child_result_list& sibling_data,
                                  gpointer parent_data,
                                  gpointer global_data,
                                  gpointer* result,
@@ -2180,8 +2180,8 @@ txn_restore_after_child_handler (gpointer data_for_children,
 
 static void
 txn_restore_fail_handler (gpointer data_for_children,
-                          GSList* data_from_children,
-                          GSList* sibling_data,
+                          const sixtp_child_result_list& data_from_children,
+                          const sixtp_child_result_list& sibling_data,
                           gpointer parent_data,
                           gpointer global_data,
                           gpointer* result,
@@ -2218,7 +2218,7 @@ txn_restore_fail_handler (gpointer data_for_children,
 
 static gboolean
 txn_restore_guid_end_handler (gpointer data_for_children,
-                              GSList*  data_from_children, GSList* sibling_data,
+                              const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                               gpointer parent_data, gpointer global_data,
                               gpointer* result, const gchar* tag)
 {
@@ -2270,7 +2270,7 @@ txn_restore_guid_end_handler (gpointer data_for_children,
 
 static gboolean
 txn_restore_num_end_handler (gpointer data_for_children,
-                             GSList*  data_from_children, GSList* sibling_data,
+                             const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                              gpointer parent_data, gpointer global_data,
                              gpointer* result, const gchar* tag)
 {
@@ -2310,7 +2310,7 @@ txn_restore_num_end_handler (gpointer data_for_children,
 
 static gboolean
 txn_restore_description_end_handler (gpointer data_for_children,
-                                     GSList*  data_from_children, GSList* sibling_data,
+                                     const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                                      gpointer parent_data, gpointer global_data,
                                      gpointer* result, const gchar* tag)
 {
@@ -2340,7 +2340,7 @@ txn_restore_description_end_handler (gpointer data_for_children,
 
 static gboolean
 txn_rest_date_posted_end_handler (gpointer data_for_children,
-                                  GSList*  data_from_children, GSList* sibling_data,
+                                  const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                                   gpointer parent_data, gpointer global_data,
                                   gpointer* result, const gchar* tag)
 {
@@ -2372,7 +2372,7 @@ txn_rest_date_posted_end_handler (gpointer data_for_children,
 
 static gboolean
 txn_rest_date_entered_end_handler (gpointer data_for_children,
-                                   GSList*  data_from_children, GSList* sibling_data,
+                                   const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                                    gpointer parent_data, gpointer global_data,
                                    gpointer* result, const gchar* tag)
 {
@@ -2418,7 +2418,7 @@ txn_rest_date_entered_end_handler (gpointer data_for_children,
  */
 
 static gboolean
-txn_restore_split_start_handler (GSList* sibling_data, gpointer parent_data,
+txn_restore_split_start_handler (const sixtp_child_result_list& sibling_data, gpointer parent_data,
                                  gpointer global_data,
                                  gpointer* data_for_children, gpointer* result,
                                  const gchar* tag, gchar** attrs)
@@ -2432,7 +2432,7 @@ txn_restore_split_start_handler (GSList* sibling_data, gpointer parent_data,
 
 static gboolean
 txn_restore_split_end_handler (gpointer data_for_children,
-                               GSList*  data_from_children, GSList* sibling_data,
+                               const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                                gpointer parent_data, gpointer global_data,
                                gpointer* result, const gchar* tag)
 {
@@ -2459,8 +2459,8 @@ txn_restore_split_end_handler (gpointer data_for_children,
 
 static gboolean
 txn_restore_split_after_child_handler (gpointer data_for_children,
-                                       GSList* data_from_children,
-                                       GSList* sibling_data,
+                                       const sixtp_child_result_list& data_from_children,
+                                       const sixtp_child_result_list& sibling_data,
                                        gpointer parent_data,
                                        gpointer global_data,
                                        gpointer* result,
@@ -2501,8 +2501,8 @@ txn_restore_split_after_child_handler (gpointer data_for_children,
 
 static void
 txn_restore_split_fail_handler (gpointer data_for_children,
-                                GSList* data_from_children,
-                                GSList* sibling_data,
+                                const sixtp_child_result_list& data_from_children,
+                                const sixtp_child_result_list& sibling_data,
                                 gpointer parent_data,
                                 gpointer global_data,
                                 gpointer* result,
@@ -2535,7 +2535,7 @@ txn_restore_split_fail_handler (gpointer data_for_children,
 
 static gboolean
 txn_restore_split_guid_end_handler (gpointer data_for_children,
-                                    GSList*  data_from_children, GSList* sibling_data,
+                                    const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                                     gpointer parent_data, gpointer global_data,
                                     gpointer* result, const gchar* tag)
 {
@@ -2587,7 +2587,7 @@ txn_restore_split_guid_end_handler (gpointer data_for_children,
 
 static gboolean
 txn_restore_split_memo_end_handler (gpointer data_for_children,
-                                    GSList*  data_from_children, GSList* sibling_data,
+                                    const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                                     gpointer parent_data, gpointer global_data,
                                     gpointer* result, const gchar* tag)
 {
@@ -2627,7 +2627,7 @@ txn_restore_split_memo_end_handler (gpointer data_for_children,
 
 static gboolean
 txn_restore_split_action_end_handler (gpointer data_for_children,
-                                      GSList*  data_from_children, GSList* sibling_data,
+                                      const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                                       gpointer parent_data, gpointer global_data,
                                       gpointer* result, const gchar* tag)
 {
@@ -2667,7 +2667,7 @@ txn_restore_split_action_end_handler (gpointer data_for_children,
 
 static gboolean
 txn_restore_split_reconcile_state_end_handler (gpointer data_for_children,
-                                               GSList*  data_from_children, GSList* sibling_data,
+                                               const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                                                gpointer parent_data, gpointer global_data,
                                                gpointer* result, const gchar* tag)
 {
@@ -2703,7 +2703,7 @@ txn_restore_split_reconcile_state_end_handler (gpointer data_for_children,
 
 static gboolean
 txn_restore_split_reconcile_date_end_handler (gpointer data_for_children,
-                                              GSList*  data_from_children, GSList* sibling_data,
+                                              const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                                               gpointer parent_data, gpointer global_data,
                                               gpointer* result, const gchar* tag)
 {
@@ -2745,7 +2745,7 @@ txn_restore_split_reconcile_date_end_handler (gpointer data_for_children,
 
 static gboolean
 txn_restore_split_account_end_handler (gpointer data_for_children,
-                                       GSList*  data_from_children, GSList* sibling_data,
+                                       const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                                        gpointer parent_data, gpointer global_data,
                                        gpointer* result, const gchar* tag)
 {
@@ -2977,8 +2977,8 @@ price_parse_xml_sub_node (GNCPrice* p, xmlNodePtr sub_node, QofBook* book)
 
 static gboolean
 price_parse_xml_end_handler (gpointer data_for_children,
-                             GSList* data_from_children,
-                             GSList* sibling_data,
+                             const sixtp_child_result_list& data_from_children,
+                             const sixtp_child_result_list& sibling_data,
                              gpointer parent_data,
                              gpointer global_data,
                              gpointer* result,
@@ -3088,7 +3088,7 @@ gnc_price_parser_new (void)
 */
 
 static gboolean
-pricedb_start_handler (GSList* sibling_data,
+pricedb_start_handler (const sixtp_child_result_list& sibling_data,
                        gpointer parent_data,
                        gpointer global_data,
                        gpointer* data_for_children,
@@ -3105,8 +3105,8 @@ pricedb_start_handler (GSList* sibling_data,
 
 static gboolean
 pricedb_after_child_handler (gpointer data_for_children,
-                             GSList* data_from_children,
-                             GSList* sibling_data,
+                             const sixtp_child_result_list& data_from_children,
+                             const sixtp_child_result_list& sibling_data,
                              gpointer parent_data,
                              gpointer global_data,
                              gpointer* result,

--- a/libgnucash/backend/xml/io-gncxml-v1.cpp
+++ b/libgnucash/backend/xml/io-gncxml-v1.cpp
@@ -997,7 +997,7 @@ ledger_data_after_child_handler (gpointer data_for_children,
 
     /* if we see the pricedb, deal with it */
     if (child_result->type != SIXTP_CHILD_RESULT_NODE) return (TRUE);
-    if (strcmp (child_result->tag, "pricedb") == 0)
+    if (child_result->tag == "pricedb")
     {
         GNCPriceDB* pdb = (GNCPriceDB*) child_result->data;
         GNCParseStatus* status = (GNCParseStatus*) global_data;
@@ -1239,7 +1239,7 @@ account_restore_after_child_handler (gpointer data_for_children,
 
     if (!child_result) return (TRUE);
     if (child_result->type != SIXTP_CHILD_RESULT_NODE) return (TRUE);
-    if (strcmp (child_result->tag, "slots") == 0)
+    if (child_result->tag == "slots")
     {
         auto f = static_cast<KvpFrame*> (child_result->data);
         g_return_val_if_fail (f, FALSE);
@@ -1247,7 +1247,7 @@ account_restore_after_child_handler (gpointer data_for_children,
         a->inst.kvp_data = f;
         child_result->should_cleanup = FALSE;
     }
-    else if (strcmp (child_result->tag, "currency") == 0)
+    else if (child_result->tag == "currency")
     {
         gnc_commodity* com = (gnc_commodity*) child_result->data;
         g_return_val_if_fail (com, FALSE);
@@ -1255,7 +1255,7 @@ account_restore_after_child_handler (gpointer data_for_children,
         DxaccAccountSetCurrency (a, com);
         /* let the normal child_result handler clean up com */
     }
-    else if (strcmp (child_result->tag, "security") == 0)
+    else if (child_result->tag == "security")
     {
         gnc_commodity* com = (gnc_commodity*) child_result->data;
         g_return_val_if_fail (com, FALSE);
@@ -1732,7 +1732,7 @@ commodity_restore_start_handler (const sixtp_child_result_list& sibling_data, gp
 
 /* ----------------------------------------------------*/
 #define COMMOD_TOKEN(NAME)              \
-  if(strcmp(child_result->tag, #NAME) == 0) {       \
+  if(child_result->tag == #NAME) {       \
     if(cpi->NAME) return(FALSE);            \
     cpi->NAME = (gchar *) child_result->data;       \
     child_result->should_cleanup = FALSE;       \
@@ -1760,7 +1760,7 @@ commodity_restore_after_child_handler (gpointer data_for_children,
     COMMOD_TOKEN (id)
     COMMOD_TOKEN (name)
     COMMOD_TOKEN (xcode)
-    if (strcmp (child_result->tag, "fraction") == 0)
+    if (child_result->tag == "fraction")
     {
         gint64 frac;
 
@@ -1943,13 +1943,13 @@ generic_gnc_commodity_lookup_after_child_handler (gpointer data_for_children,
     g_return_val_if_fail (child_result, FALSE);
     if (child_result->type != SIXTP_CHILD_RESULT_NODE) return (FALSE);
 
-    if (strcmp (child_result->tag, "space") == 0)
+    if (child_result->tag == "space")
     {
         if (cpi->name_space) return (FALSE);
         cpi->name_space = (gchar*) child_result->data;
         child_result->should_cleanup = FALSE;
     }
-    else if (strcmp (child_result->tag, "id") == 0)
+    else if (child_result->tag == "id")
     {
         if (cpi->id) return (FALSE);
         cpi->id = (gchar*) child_result->data;
@@ -2168,7 +2168,7 @@ txn_restore_after_child_handler (gpointer data_for_children,
     g_return_val_if_fail (trans, FALSE);
     if (!child_result) return (TRUE);
     if (child_result->type != SIXTP_CHILD_RESULT_NODE) return (TRUE);
-    if (strcmp (child_result->tag, "slots") == 0)
+    if (child_result->tag == "slots")
     {
         KvpFrame* f = (KvpFrame*) child_result->data;
         g_return_val_if_fail (f, FALSE);
@@ -2473,7 +2473,7 @@ txn_restore_split_after_child_handler (gpointer data_for_children,
     if (!child_result) return (TRUE);
     if (child_result->type != SIXTP_CHILD_RESULT_NODE) return (TRUE);
 
-    if (strcmp (child_result->tag, "slots") == 0)
+    if (child_result->tag == "slots")
     {
         KvpFrame* f = static_cast<KvpFrame*> (child_result->data);
         g_return_val_if_fail (f, FALSE);
@@ -2481,14 +2481,14 @@ txn_restore_split_after_child_handler (gpointer data_for_children,
         s->inst.kvp_data = f;
         child_result->should_cleanup = FALSE;
     }
-    else if (strcmp (child_result->tag, "quantity") == 0)
+    else if (child_result->tag == "quantity")
     {
         gnc_numeric* n = (gnc_numeric*) child_result->data;
         g_return_val_if_fail (n, FALSE);
         xaccSplitSetAmount (s, *n);
         /* let the normal child_result handler clean up n */
     }
-    else if (strcmp (child_result->tag, "value") == 0)
+    else if (child_result->tag == "value")
     {
         gnc_numeric* n = (gnc_numeric*) child_result->data;
         g_return_val_if_fail (n, FALSE);
@@ -3122,7 +3122,7 @@ pricedb_after_child_handler (gpointer data_for_children,
     if (!child_result) return (FALSE);
     if (child_result->type != SIXTP_CHILD_RESULT_NODE) return (FALSE);
 
-    if (strcmp (child_result->tag, "price") == 0)
+    if (child_result->tag == "price")
     {
         GNCPrice* p = (GNCPrice*) child_result->data;
 

--- a/libgnucash/backend/xml/io-gncxml-v2.cpp
+++ b/libgnucash/backend/xml/io-gncxml-v2.cpp
@@ -365,7 +365,7 @@ counter (const GncXmlDataType_t& data, file_backend* be_data)
 
 static gboolean
 gnc_counter_end_handler (gpointer data_for_children,
-                         GSList* data_from_children, GSList* sibling_data,
+                         const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                          gpointer parent_data, gpointer global_data,
                          gpointer* result, const gchar* tag)
 {

--- a/libgnucash/backend/xml/sixtp-stack.cpp
+++ b/libgnucash/backend/xml/sixtp-stack.cpp
@@ -32,7 +32,8 @@ sixtp_stack_frame_print (const sixtp_stack_frame* sf, gint indent, FILE* f)
     fprintf (f, "%s(stack-frame %p\n", is, sf);
     fprintf (f, "%s             (line %d) (col %d)\n", is, sf->line, sf->col);
     fprintf (f, "%s             (parser %p)\n", is, sf->parser);
-    fprintf (f, "%s             (tag %s)\n", is, sf->tag ? sf->tag : "(null)");
+    fprintf (f, "%s             (tag %s)\n", is,
+             sf->tag.empty () ? "(null)" : sf->tag.c_str ());
     fprintf (f, "%s             (data-for-children %p)\n", is,
              sf->data_for_children);
 
@@ -82,7 +83,7 @@ _sixtp_parser_context_struct::_sixtp_parser_context_struct (
     /* reserve some headroom so early pushes (account tree, transaction
        lists, ...) don't force repeated reallocations */
     data.stack.reserve (32);
-    data.stack.emplace_back (initial_parser, nullptr);
+    data.stack.emplace_back (initial_parser, std::string ());
 }
 
 _sixtp_parser_context_struct::~_sixtp_parser_context_struct ()

--- a/libgnucash/backend/xml/sixtp-stack.cpp
+++ b/libgnucash/backend/xml/sixtp-stack.cpp
@@ -24,32 +24,18 @@
 #include "sixtp.h"
 #include "sixtp-stack.h"
 
-void
-sixtp_stack_frame_destroy (sixtp_stack_frame* sf)
-{
-    GSList* lp;
+/* sixtp_stack_frame has no custom destructor: data_from_children (a
+   vector of unique_ptr) cleans itself up, and tag/data_for_children/
+   frame_data are either not owned by the frame or have their
+   ownership transferred out before the frame is destroyed. */
 
-    /* cleanup all the child data */
-    for (lp = sf->data_from_children; lp; lp = lp->next)
-    {
-        sixtp_child_result_destroy ((sixtp_child_result*) lp->data);
-    }
-    g_slist_free (sf->data_from_children);
-    sf->data_from_children = NULL;
-
-    g_free (sf);
-}
-
-sixtp_stack_frame*
+std::unique_ptr<sixtp_stack_frame>
 sixtp_stack_frame_new (sixtp* next_parser, char* tag)
 {
-    sixtp_stack_frame* new_frame;
-
-    new_frame = g_new0 (sixtp_stack_frame, 1);
+    auto new_frame = std::make_unique<sixtp_stack_frame> ();
     new_frame->parser = next_parser;
     new_frame->tag = tag;
     new_frame->data_for_children = NULL;
-    new_frame->data_from_children = NULL;
     new_frame->frame_data = NULL;
     new_frame->line = new_frame->col = -1;
 
@@ -69,12 +55,11 @@ sixtp_stack_frame_print (sixtp_stack_frame* sf, gint indent, FILE* f)
              sf->data_for_children);
 
     {
-        GSList* lp;
         fprintf (f, "%s             (data-from-children", is);
-        for (lp = sf->data_from_children; lp; lp = lp->next)
+        for (auto& cr : sf->data_from_children)
         {
             fputc (' ', f);
-            sixtp_child_result_print ((sixtp_child_result*) lp->data, f);
+            sixtp_child_result_print (&cr, f);
         }
         fprintf (f, ")\n");
     }
@@ -85,14 +70,8 @@ sixtp_stack_frame_print (sixtp_stack_frame* sf, gint indent, FILE* f)
 }
 
 void
-sixtp_pop_and_destroy_frame (std::vector<sixtp_stack_frame*>& frame_stack)
-{
-    sixtp_stack_frame_destroy (frame_stack.back ());
-    frame_stack.pop_back ();
-}
-
-void
-sixtp_print_frame_stack (const std::vector<sixtp_stack_frame*>& stack, FILE* f)
+sixtp_print_frame_stack (
+    const std::vector<std::unique_ptr<sixtp_stack_frame>>& stack, FILE* f)
 {
     /* stack.back() is the innermost frame, so walk it front-to-back for
        outermost-to-innermost debugging output. */
@@ -100,7 +79,7 @@ sixtp_print_frame_stack (const std::vector<sixtp_stack_frame*>& stack, FILE* f)
 
     for (auto it = stack.rbegin (); it != stack.rend (); ++it)
     {
-        sixtp_stack_frame_print (*it, indent, f);
+        sixtp_stack_frame_print (it->get (), indent, f);
         indent += 2;
     }
 }
@@ -123,18 +102,17 @@ sixtp_context_new (sixtp* initial_parser, gpointer global_data,
     ret->data.parsing_ok = TRUE;
     ret->data.global_data = global_data;
 
-    ret->top_frame = sixtp_stack_frame_new (initial_parser, NULL);
-
     ret->top_frame_data = top_level_data;
 
     /* reserve some headroom so early pushes (account tree, transaction
        lists, ...) don't force repeated reallocations */
     ret->data.stack.reserve (32);
-    ret->data.stack.push_back (ret->top_frame);
+    ret->data.stack.push_back (sixtp_stack_frame_new (initial_parser, NULL));
+    ret->top_frame = ret->data.stack.back ().get ();
 
     if (initial_parser->start_handler)
     {
-        if (!initial_parser->start_handler (NULL,
+        if (!initial_parser->start_handler (sixtp_no_children (),
                                             &ret->top_frame_data,
                                             &ret->data.global_data,
                                             &ret->top_frame->data_for_children,
@@ -159,7 +137,7 @@ sixtp_context_run_end_handler (sixtp_parser_context* ctxt)
             ctxt->top_frame->parser->end_handler (
                 ctxt->top_frame->data_for_children,
                 ctxt->top_frame->data_from_children,
-                NULL,
+                sixtp_no_children (),
                 ctxt->top_frame_data,
                 ctxt->data.global_data,
                 &ctxt->top_frame->frame_data,
@@ -170,7 +148,8 @@ sixtp_context_run_end_handler (sixtp_parser_context* ctxt)
 void
 sixtp_context_destroy (sixtp_parser_context* context)
 {
-    sixtp_stack_frame_destroy (context->top_frame);
+    /* top_frame is owned by data.stack; clearing it destroys the frame
+       (and, transitively, any child results still attached to it). */
     context->data.stack.clear ();
     context->data.saxParserCtxt->userData = NULL;
     context->data.saxParserCtxt->sax = NULL;

--- a/libgnucash/backend/xml/sixtp-stack.cpp
+++ b/libgnucash/backend/xml/sixtp-stack.cpp
@@ -84,33 +84,25 @@ sixtp_stack_frame_print (sixtp_stack_frame* sf, gint indent, FILE* f)
     g_free (is);
 }
 
-GSList*
-sixtp_pop_and_destroy_frame (GSList* frame_stack)
+void
+sixtp_pop_and_destroy_frame (std::vector<sixtp_stack_frame*>& frame_stack)
 {
-    sixtp_stack_frame* dead_frame = (sixtp_stack_frame*) frame_stack->data;
-    GSList* result;
-
-    result = g_slist_next (frame_stack);
-    sixtp_stack_frame_destroy (dead_frame);
-    g_slist_free_1 (frame_stack);
-    return (result);
+    sixtp_stack_frame_destroy (frame_stack.back ());
+    frame_stack.pop_back ();
 }
 
 void
-sixtp_print_frame_stack (GSList* stack, FILE* f)
+sixtp_print_frame_stack (const std::vector<sixtp_stack_frame*>& stack, FILE* f)
 {
-    /* first, some debugging output */
-    GSList* printcopy = g_slist_reverse (g_slist_copy (stack));
-    GSList* lp;
+    /* stack.back() is the innermost frame, so walk it front-to-back for
+       outermost-to-innermost debugging output. */
     int indent = 0;
 
-    for (lp = printcopy; lp; lp = lp->next)
+    for (auto it = stack.rbegin (); it != stack.rend (); ++it)
     {
-        sixtp_stack_frame* frame = (sixtp_stack_frame*) lp->data;
-        sixtp_stack_frame_print (frame, indent, f);
+        sixtp_stack_frame_print (*it, indent, f);
         indent += 2;
     }
-
 }
 
 
@@ -121,7 +113,7 @@ sixtp_context_new (sixtp* initial_parser, gpointer global_data,
 {
     sixtp_parser_context* ret;
 
-    ret = g_new0 (sixtp_parser_context, 1);
+    ret = new sixtp_parser_context ();
 
     ret->handler.startElement = sixtp_sax_start_handler;
     ret->handler.endElement = sixtp_sax_end_handler;
@@ -129,15 +121,16 @@ sixtp_context_new (sixtp* initial_parser, gpointer global_data,
     ret->handler.getEntity = sixtp_sax_get_entity_handler;
 
     ret->data.parsing_ok = TRUE;
-    ret->data.stack = NULL;
     ret->data.global_data = global_data;
 
     ret->top_frame = sixtp_stack_frame_new (initial_parser, NULL);
 
     ret->top_frame_data = top_level_data;
 
-    ret->data.stack = g_slist_prepend (ret->data.stack,
-                                       (gpointer) ret->top_frame);
+    /* reserve some headroom so early pushes (account tree, transaction
+       lists, ...) don't force repeated reallocations */
+    ret->data.stack.reserve (32);
+    ret->data.stack.push_back (ret->top_frame);
 
     if (initial_parser->start_handler)
     {
@@ -178,10 +171,10 @@ void
 sixtp_context_destroy (sixtp_parser_context* context)
 {
     sixtp_stack_frame_destroy (context->top_frame);
-    g_slist_free (context->data.stack);
+    context->data.stack.clear ();
     context->data.saxParserCtxt->userData = NULL;
     context->data.saxParserCtxt->sax = NULL;
     xmlFreeParserCtxt (context->data.saxParserCtxt);
     context->data.saxParserCtxt = NULL;
-    g_free (context);
+    delete context;
 }

--- a/libgnucash/backend/xml/sixtp-stack.cpp
+++ b/libgnucash/backend/xml/sixtp-stack.cpp
@@ -24,26 +24,29 @@
 #include "sixtp.h"
 #include "sixtp-stack.h"
 
-/* sixtp_stack_frame has no custom destructor: data_from_children (a
-   vector of unique_ptr) cleans itself up, and tag/data_for_children/
+/* sixtp_stack_frame has no custom destructor and no user-declared
+   special member functions: data_from_children (a vector of
+   sixtp_child_result) cleans itself up, and tag/data_for_children/
    frame_data are either not owned by the frame or have their
-   ownership transferred out before the frame is destroyed. */
+   ownership transferred out before the frame is destroyed. That
+   makes it implicitly movable, which is all sixtp_stack_frame_new
+   and vector<sixtp_stack_frame> need. */
 
-std::unique_ptr<sixtp_stack_frame>
+sixtp_stack_frame
 sixtp_stack_frame_new (sixtp* next_parser, char* tag)
 {
-    auto new_frame = std::make_unique<sixtp_stack_frame> ();
-    new_frame->parser = next_parser;
-    new_frame->tag = tag;
-    new_frame->data_for_children = NULL;
-    new_frame->frame_data = NULL;
-    new_frame->line = new_frame->col = -1;
+    sixtp_stack_frame new_frame;
+    new_frame.parser = next_parser;
+    new_frame.tag = tag;
+    new_frame.data_for_children = NULL;
+    new_frame.frame_data = NULL;
+    new_frame.line = new_frame.col = -1;
 
     return new_frame;
 }
 
 void
-sixtp_stack_frame_print (sixtp_stack_frame* sf, gint indent, FILE* f)
+sixtp_stack_frame_print (const sixtp_stack_frame* sf, gint indent, FILE* f)
 {
     gchar* is = g_strnfill (indent, ' ');
 
@@ -70,8 +73,7 @@ sixtp_stack_frame_print (sixtp_stack_frame* sf, gint indent, FILE* f)
 }
 
 void
-sixtp_print_frame_stack (
-    const std::vector<std::unique_ptr<sixtp_stack_frame>>& stack, FILE* f)
+sixtp_print_frame_stack (const std::vector<sixtp_stack_frame>& stack, FILE* f)
 {
     /* stack.back() is the innermost frame, so walk it front-to-back for
        outermost-to-innermost debugging output. */
@@ -79,7 +81,7 @@ sixtp_print_frame_stack (
 
     for (auto it = stack.rbegin (); it != stack.rend (); ++it)
     {
-        sixtp_stack_frame_print (it->get (), indent, f);
+        sixtp_stack_frame_print (&*it, indent, f);
         indent += 2;
     }
 }
@@ -108,15 +110,19 @@ sixtp_context_new (sixtp* initial_parser, gpointer global_data,
        lists, ...) don't force repeated reallocations */
     ret->data.stack.reserve (32);
     ret->data.stack.push_back (sixtp_stack_frame_new (initial_parser, NULL));
-    ret->top_frame = ret->data.stack.back ().get ();
+
+    /* top is only ever used here, before any further push can move it -
+       every later reference to the top frame goes through
+       data.stack.front() instead of a cached pointer. */
+    sixtp_stack_frame& top = ret->data.stack.back ();
 
     if (initial_parser->start_handler)
     {
         if (!initial_parser->start_handler (sixtp_no_children (),
                                             &ret->top_frame_data,
                                             &ret->data.global_data,
-                                            &ret->top_frame->data_for_children,
-                                            &ret->top_frame->frame_data,
+                                            &top.data_for_children,
+                                            &top.frame_data,
                                             NULL, NULL))
         {
             sixtp_handle_catastrophe (&ret->data);
@@ -131,16 +137,18 @@ sixtp_context_new (sixtp* initial_parser, gpointer global_data,
 void
 sixtp_context_run_end_handler (sixtp_parser_context* ctxt)
 {
-    if (ctxt->top_frame->parser->end_handler)
+    sixtp_stack_frame& top = ctxt->data.stack.front ();
+
+    if (top.parser->end_handler)
     {
         ctxt->data.parsing_ok &=
-            ctxt->top_frame->parser->end_handler (
-                ctxt->top_frame->data_for_children,
-                ctxt->top_frame->data_from_children,
+            top.parser->end_handler (
+                top.data_for_children,
+                top.data_from_children,
                 sixtp_no_children (),
                 ctxt->top_frame_data,
                 ctxt->data.global_data,
-                &ctxt->top_frame->frame_data,
+                &top.frame_data,
                 NULL);
     }
 }
@@ -148,8 +156,9 @@ sixtp_context_run_end_handler (sixtp_parser_context* ctxt)
 void
 sixtp_context_destroy (sixtp_parser_context* context)
 {
-    /* top_frame is owned by data.stack; clearing it destroys the frame
-       (and, transitively, any child results still attached to it). */
+    /* Destroying the vector destroys every remaining frame (and,
+       transitively, any child results still attached to them),
+       including the top frame at index 0. */
     context->data.stack.clear ();
     context->data.saxParserCtxt->userData = NULL;
     context->data.saxParserCtxt->sax = NULL;

--- a/libgnucash/backend/xml/sixtp-stack.cpp
+++ b/libgnucash/backend/xml/sixtp-stack.cpp
@@ -24,27 +24,6 @@
 #include "sixtp.h"
 #include "sixtp-stack.h"
 
-/* sixtp_stack_frame has no custom destructor and no user-declared
-   special member functions: data_from_children (a vector of
-   sixtp_child_result) cleans itself up, and tag/data_for_children/
-   frame_data are either not owned by the frame or have their
-   ownership transferred out before the frame is destroyed. That
-   makes it implicitly movable, which is all sixtp_stack_frame_new
-   and vector<sixtp_stack_frame> need. */
-
-sixtp_stack_frame
-sixtp_stack_frame_new (sixtp* next_parser, char* tag)
-{
-    sixtp_stack_frame new_frame;
-    new_frame.parser = next_parser;
-    new_frame.tag = tag;
-    new_frame.data_for_children = NULL;
-    new_frame.frame_data = NULL;
-    new_frame.line = new_frame.col = -1;
-
-    return new_frame;
-}
-
 void
 sixtp_stack_frame_print (const sixtp_stack_frame* sf, gint indent, FILE* f)
 {
@@ -109,7 +88,7 @@ sixtp_context_new (sixtp* initial_parser, gpointer global_data,
     /* reserve some headroom so early pushes (account tree, transaction
        lists, ...) don't force repeated reallocations */
     ret->data.stack.reserve (32);
-    ret->data.stack.push_back (sixtp_stack_frame_new (initial_parser, NULL));
+    ret->data.stack.emplace_back (initial_parser, nullptr);
 
     /* top is only ever used here, before any further push can move it -
        every later reference to the top frame goes through

--- a/libgnucash/backend/xml/sixtp-stack.cpp
+++ b/libgnucash/backend/xml/sixtp-stack.cpp
@@ -98,12 +98,13 @@ _sixtp_parser_context_struct::~_sixtp_parser_context_struct ()
     data.saxParserCtxt = NULL;
 }
 
-sixtp_parser_context*
+std::unique_ptr<sixtp_parser_context>
 sixtp_context_new (sixtp* initial_parser, gpointer global_data,
                    gpointer top_level_data)
 {
-    auto* ret = new sixtp_parser_context (initial_parser, global_data,
-                                          top_level_data);
+    auto ret = std::make_unique<sixtp_parser_context> (initial_parser,
+                                                        global_data,
+                                                        top_level_data);
 
     /* top is only ever used here, before any further push can move it -
        every later reference to the top frame goes through
@@ -120,8 +121,7 @@ sixtp_context_new (sixtp* initial_parser, gpointer global_data,
                                             NULL, NULL))
         {
             sixtp_handle_catastrophe (&ret->data);
-            delete ret;
-            return NULL;
+            return nullptr; /* ret's destructor runs the teardown */
         }
     }
 

--- a/libgnucash/backend/xml/sixtp-stack.cpp
+++ b/libgnucash/backend/xml/sixtp-stack.cpp
@@ -67,28 +67,42 @@ sixtp_print_frame_stack (const std::vector<sixtp_stack_frame>& stack, FILE* f)
 
 
 /* Parser context */
+_sixtp_parser_context_struct::_sixtp_parser_context_struct (
+    sixtp* initial_parser, gpointer global_data, gpointer top_level_data)
+    : handler (), data (), top_frame_data (top_level_data)
+{
+    handler.startElement = sixtp_sax_start_handler;
+    handler.endElement = sixtp_sax_end_handler;
+    handler.characters = sixtp_sax_characters_handler;
+    handler.getEntity = sixtp_sax_get_entity_handler;
+
+    data.parsing_ok = TRUE;
+    data.global_data = global_data;
+
+    /* reserve some headroom so early pushes (account tree, transaction
+       lists, ...) don't force repeated reallocations */
+    data.stack.reserve (32);
+    data.stack.emplace_back (initial_parser, nullptr);
+}
+
+_sixtp_parser_context_struct::~_sixtp_parser_context_struct ()
+{
+    /* Destroying the vector destroys every remaining frame (and,
+       transitively, any child results still attached to them),
+       including the top frame at index 0. */
+    data.stack.clear ();
+    data.saxParserCtxt->userData = NULL;
+    data.saxParserCtxt->sax = NULL;
+    xmlFreeParserCtxt (data.saxParserCtxt);
+    data.saxParserCtxt = NULL;
+}
+
 sixtp_parser_context*
 sixtp_context_new (sixtp* initial_parser, gpointer global_data,
                    gpointer top_level_data)
 {
-    sixtp_parser_context* ret;
-
-    ret = new sixtp_parser_context ();
-
-    ret->handler.startElement = sixtp_sax_start_handler;
-    ret->handler.endElement = sixtp_sax_end_handler;
-    ret->handler.characters = sixtp_sax_characters_handler;
-    ret->handler.getEntity = sixtp_sax_get_entity_handler;
-
-    ret->data.parsing_ok = TRUE;
-    ret->data.global_data = global_data;
-
-    ret->top_frame_data = top_level_data;
-
-    /* reserve some headroom so early pushes (account tree, transaction
-       lists, ...) don't force repeated reallocations */
-    ret->data.stack.reserve (32);
-    ret->data.stack.emplace_back (initial_parser, nullptr);
+    auto* ret = new sixtp_parser_context (initial_parser, global_data,
+                                          top_level_data);
 
     /* top is only ever used here, before any further push can move it -
        every later reference to the top frame goes through
@@ -105,7 +119,7 @@ sixtp_context_new (sixtp* initial_parser, gpointer global_data,
                                             NULL, NULL))
         {
             sixtp_handle_catastrophe (&ret->data);
-            sixtp_context_destroy (ret);
+            delete ret;
             return NULL;
         }
     }
@@ -130,18 +144,4 @@ sixtp_context_run_end_handler (sixtp_parser_context* ctxt)
                 &top.frame_data,
                 NULL);
     }
-}
-
-void
-sixtp_context_destroy (sixtp_parser_context* context)
-{
-    /* Destroying the vector destroys every remaining frame (and,
-       transitively, any child results still attached to them),
-       including the top frame at index 0. */
-    context->data.stack.clear ();
-    context->data.saxParserCtxt->userData = NULL;
-    context->data.saxParserCtxt->sax = NULL;
-    xmlFreeParserCtxt (context->data.saxParserCtxt);
-    context->data.saxParserCtxt = NULL;
-    delete context;
 }

--- a/libgnucash/backend/xml/sixtp-stack.h
+++ b/libgnucash/backend/xml/sixtp-stack.h
@@ -44,18 +44,20 @@ struct _sixtp_parser_context_struct
 {
     xmlSAXHandler handler;
     sixtp_sax_data data;
-    sixtp_stack_frame* top_frame; /* observer; owned by data.stack */
+    /* No top_frame pointer here: the top frame is always data.stack.front(),
+       and a cached pointer to it would dangle once anything grows
+       data.stack (e.g. deeply nested kvp-frames), since data.stack now
+       stores frames by value. */
     gpointer top_frame_data;
 };
 typedef struct _sixtp_parser_context_struct sixtp_parser_context;
 
-void sixtp_stack_frame_print (sixtp_stack_frame* sf, gint indent, FILE* f);
+void sixtp_stack_frame_print (const sixtp_stack_frame* sf, gint indent, FILE* f);
 
-void sixtp_print_frame_stack (
-    const std::vector<std::unique_ptr<sixtp_stack_frame>>& stack, FILE* f);
+void sixtp_print_frame_stack (const std::vector<sixtp_stack_frame>& stack,
+                              FILE* f);
 
-std::unique_ptr<sixtp_stack_frame> sixtp_stack_frame_new (sixtp* next_parser,
-                                                           char* tag);
+sixtp_stack_frame sixtp_stack_frame_new (sixtp* next_parser, char* tag);
 
 sixtp_parser_context* sixtp_context_new (sixtp* initial_parser,
                                          gpointer global_data,

--- a/libgnucash/backend/xml/sixtp-stack.h
+++ b/libgnucash/backend/xml/sixtp-stack.h
@@ -32,7 +32,7 @@ typedef struct sixtp_stack_frame
     sixtp* parser;
     gchar* tag;
     gpointer data_for_children;
-    GSList* data_from_children; /* in reverse chronological order */
+    sixtp_child_result_list data_from_children; /* in document order */
     gpointer frame_data;
 
     /* Line and column [of the start tag]; set during parsing. */
@@ -44,20 +44,18 @@ struct _sixtp_parser_context_struct
 {
     xmlSAXHandler handler;
     sixtp_sax_data data;
-    sixtp_stack_frame* top_frame;
+    sixtp_stack_frame* top_frame; /* observer; owned by data.stack */
     gpointer top_frame_data;
 };
 typedef struct _sixtp_parser_context_struct sixtp_parser_context;
 
-void sixtp_stack_frame_destroy (sixtp_stack_frame* sf);
-
 void sixtp_stack_frame_print (sixtp_stack_frame* sf, gint indent, FILE* f);
 
-void sixtp_pop_and_destroy_frame (std::vector<sixtp_stack_frame*>& frame_stack);
+void sixtp_print_frame_stack (
+    const std::vector<std::unique_ptr<sixtp_stack_frame>>& stack, FILE* f);
 
-void sixtp_print_frame_stack (const std::vector<sixtp_stack_frame*>& stack, FILE* f);
-
-sixtp_stack_frame* sixtp_stack_frame_new (sixtp* next_parser, char* tag);
+std::unique_ptr<sixtp_stack_frame> sixtp_stack_frame_new (sixtp* next_parser,
+                                                           char* tag);
 
 sixtp_parser_context* sixtp_context_new (sixtp* initial_parser,
                                          gpointer global_data,

--- a/libgnucash/backend/xml/sixtp-stack.h
+++ b/libgnucash/backend/xml/sixtp-stack.h
@@ -53,9 +53,9 @@ void sixtp_stack_frame_destroy (sixtp_stack_frame* sf);
 
 void sixtp_stack_frame_print (sixtp_stack_frame* sf, gint indent, FILE* f);
 
-GSList* sixtp_pop_and_destroy_frame (GSList* frame_stack);
+void sixtp_pop_and_destroy_frame (std::vector<sixtp_stack_frame*>& frame_stack);
 
-void sixtp_print_frame_stack (GSList* stack, FILE* f);
+void sixtp_print_frame_stack (const std::vector<sixtp_stack_frame*>& stack, FILE* f);
 
 sixtp_stack_frame* sixtp_stack_frame_new (sixtp* next_parser, char* tag);
 

--- a/libgnucash/backend/xml/sixtp-stack.h
+++ b/libgnucash/backend/xml/sixtp-stack.h
@@ -38,6 +38,18 @@ typedef struct sixtp_stack_frame
     /* Line and column [of the start tag]; set during parsing. */
     int line;
     int col;
+
+    /* tag is owned by the caller until the frame closes (see
+       sixtp_sax_end_handler); the frame never frees it itself. */
+    sixtp_stack_frame (sixtp* parser_, gchar* tag_)
+        : parser (parser_), tag (tag_), data_for_children (nullptr),
+          frame_data (nullptr), line (-1), col (-1)
+    {}
+    sixtp_stack_frame (const sixtp_stack_frame&) = delete;
+    sixtp_stack_frame& operator= (const sixtp_stack_frame&) = delete;
+    sixtp_stack_frame (sixtp_stack_frame&&) = default;
+    sixtp_stack_frame& operator= (sixtp_stack_frame&&) = default;
+    ~sixtp_stack_frame () = default;
 } sixtp_stack_frame;
 
 struct _sixtp_parser_context_struct
@@ -56,8 +68,6 @@ void sixtp_stack_frame_print (const sixtp_stack_frame* sf, gint indent, FILE* f)
 
 void sixtp_print_frame_stack (const std::vector<sixtp_stack_frame>& stack,
                               FILE* f);
-
-sixtp_stack_frame sixtp_stack_frame_new (sixtp* next_parser, char* tag);
 
 sixtp_parser_context* sixtp_context_new (sixtp* initial_parser,
                                          gpointer global_data,

--- a/libgnucash/backend/xml/sixtp-stack.h
+++ b/libgnucash/backend/xml/sixtp-stack.h
@@ -30,7 +30,7 @@
 typedef struct sixtp_stack_frame
 {
     sixtp* parser;
-    gchar* tag;
+    std::string tag; /* empty for the top frame. */
     gpointer data_for_children;
     sixtp_child_result_list data_from_children; /* in document order */
     gpointer frame_data;
@@ -39,10 +39,8 @@ typedef struct sixtp_stack_frame
     int line;
     int col;
 
-    /* tag is owned by the caller until the frame closes (see
-       sixtp_sax_end_handler); the frame never frees it itself. */
-    sixtp_stack_frame (sixtp* parser_, gchar* tag_)
-        : parser (parser_), tag (tag_), data_for_children (nullptr),
+    sixtp_stack_frame (sixtp* parser_, std::string tag_)
+        : parser (parser_), tag (std::move (tag_)), data_for_children (nullptr),
           frame_data (nullptr), line (-1), col (-1)
     {}
     sixtp_stack_frame (const sixtp_stack_frame&) = delete;

--- a/libgnucash/backend/xml/sixtp-stack.h
+++ b/libgnucash/backend/xml/sixtp-stack.h
@@ -61,6 +61,19 @@ struct _sixtp_parser_context_struct
        data.stack (e.g. deeply nested kvp-frames), since data.stack now
        stores frames by value. */
     gpointer top_frame_data;
+
+    /* Wires up the SAX handler vtable, marks the parse as ok so far, and
+       pushes the top stack frame. Doesn't run initial_parser's
+       start_handler - that can fail, and a constructor has no way to
+       report that back to sixtp_context_new, which needs to unwind via
+       sixtp_handle_catastrophe/delete rather than leave a half-built
+       object for the caller to somehow clean up itself. */
+    _sixtp_parser_context_struct (sixtp* initial_parser, gpointer global_data,
+                                  gpointer top_level_data);
+    _sixtp_parser_context_struct (const _sixtp_parser_context_struct&) = delete;
+    _sixtp_parser_context_struct&
+        operator= (const _sixtp_parser_context_struct&) = delete;
+    ~_sixtp_parser_context_struct ();
 };
 typedef struct _sixtp_parser_context_struct sixtp_parser_context;
 
@@ -72,7 +85,6 @@ void sixtp_print_frame_stack (const std::vector<sixtp_stack_frame>& stack,
 sixtp_parser_context* sixtp_context_new (sixtp* initial_parser,
                                          gpointer global_data,
                                          gpointer top_level_data);
-void sixtp_context_destroy (sixtp_parser_context* context);
 void sixtp_context_run_end_handler (sixtp_parser_context* ctxt);
 
 #endif /* _SIXTP_STACK_H_ */

--- a/libgnucash/backend/xml/sixtp-stack.h
+++ b/libgnucash/backend/xml/sixtp-stack.h
@@ -25,6 +25,8 @@
 #define SIXTP_STACK_H
 #include <glib.h>
 
+#include <memory>
+
 #include "sixtp.h"
 
 typedef struct sixtp_stack_frame
@@ -64,8 +66,9 @@ struct _sixtp_parser_context_struct
        pushes the top stack frame. Doesn't run initial_parser's
        start_handler - that can fail, and a constructor has no way to
        report that back to sixtp_context_new, which needs to unwind via
-       sixtp_handle_catastrophe/delete rather than leave a half-built
-       object for the caller to somehow clean up itself. */
+       sixtp_handle_catastrophe and let the unique_ptr it's holding clean
+       up, rather than leave a half-built object for the caller to
+       somehow clean up itself. */
     _sixtp_parser_context_struct (sixtp* initial_parser, gpointer global_data,
                                   gpointer top_level_data);
     _sixtp_parser_context_struct (const _sixtp_parser_context_struct&) = delete;
@@ -80,9 +83,8 @@ void sixtp_stack_frame_print (const sixtp_stack_frame* sf, gint indent, FILE* f)
 void sixtp_print_frame_stack (const std::vector<sixtp_stack_frame>& stack,
                               FILE* f);
 
-sixtp_parser_context* sixtp_context_new (sixtp* initial_parser,
-                                         gpointer global_data,
-                                         gpointer top_level_data);
+std::unique_ptr<sixtp_parser_context> sixtp_context_new (
+    sixtp* initial_parser, gpointer global_data, gpointer top_level_data);
 void sixtp_context_run_end_handler (sixtp_parser_context* ctxt);
 
 #endif /* _SIXTP_STACK_H_ */

--- a/libgnucash/backend/xml/sixtp-to-dom-parser.cpp
+++ b/libgnucash/backend/xml/sixtp-to-dom-parser.cpp
@@ -34,7 +34,7 @@ static xmlNsPtr global_namespace = NULL;
 /* Don't pass anything in the data_for_children value to this
    function.  It'll cause a segfault */
 static gboolean dom_start_handler (
-    GSList* sibling_data, gpointer parent_data, gpointer global_data,
+    const sixtp_child_result_list& sibling_data, gpointer parent_data, gpointer global_data,
     gpointer* data_for_children, gpointer* result, const gchar* tag,
     gchar** attrs)
 {
@@ -75,8 +75,8 @@ static gboolean dom_start_handler (
 
 static void
 dom_fail_handler (gpointer data_for_children,
-                  GSList* data_from_children,
-                  GSList* sibling_data,
+                  const sixtp_child_result_list& data_from_children,
+                  const sixtp_child_result_list& sibling_data,
                   gpointer parent_data,
                   gpointer global_data,
                   gpointer* result,
@@ -86,7 +86,7 @@ dom_fail_handler (gpointer data_for_children,
 }
 
 static gboolean dom_chars_handler (
-    GSList* sibling_data, gpointer parent_data, gpointer global_data,
+    const sixtp_child_result_list& sibling_data, gpointer parent_data, gpointer global_data,
     gpointer* result, const char* text, int length)
 {
     if (length > 0)

--- a/libgnucash/backend/xml/sixtp-utils.cpp
+++ b/libgnucash/backend/xml/sixtp-utils.cpp
@@ -63,7 +63,7 @@ isspace_str (const gchar* str, int nomorethan)
 }
 
 gboolean
-allow_and_ignore_only_whitespace (GSList* sibling_data,
+allow_and_ignore_only_whitespace (const sixtp_child_result_list& sibling_data,
                                   gpointer parent_data,
                                   gpointer global_data,
                                   gpointer* result,
@@ -74,7 +74,7 @@ allow_and_ignore_only_whitespace (GSList* sibling_data,
 }
 
 gboolean
-generic_accumulate_chars (GSList* sibling_data,
+generic_accumulate_chars (const sixtp_child_result_list& sibling_data,
                           gpointer parent_data,
                           gpointer global_data,
                           gpointer* result,
@@ -92,8 +92,8 @@ generic_accumulate_chars (GSList* sibling_data,
 
 void
 generic_free_data_for_children (gpointer data_for_children,
-                                GSList* data_from_children,
-                                GSList* sibling_data,
+                                const sixtp_child_result_list& data_from_children,
+                                const sixtp_child_result_list& sibling_data,
                                 gpointer parent_data,
                                 gpointer global_data,
                                 gpointer* result,
@@ -103,35 +103,28 @@ generic_free_data_for_children (gpointer data_for_children,
 }
 
 gchar*
-concatenate_child_result_chars (GSList* data_from_children)
+concatenate_child_result_chars (const sixtp_child_result_list& data_from_children)
 {
-    GSList* lp;
     gchar* name = g_strdup ("");
 
     g_return_val_if_fail (name, NULL);
 
-    /* child data lists are in reverse chron order */
-    data_from_children = g_slist_reverse (g_slist_copy (data_from_children));
-
-    for (lp = data_from_children; lp; lp = lp->next)
+    for (auto& cr : data_from_children)
     {
-        sixtp_child_result* cr = (sixtp_child_result*) lp->data;
-        if (cr->type != SIXTP_CHILD_RESULT_CHARS)
+        if (cr.type != SIXTP_CHILD_RESULT_CHARS)
         {
             PERR ("result type is not chars");
-            g_slist_free (data_from_children);
             g_free (name);
             return (NULL);
         }
         else
         {
             char* temp;
-            temp = g_strconcat (name, (gchar*) cr->data, nullptr);
+            temp = g_strconcat (name, (gchar*) cr.data, nullptr);
             g_free (name);
             name = temp;
         }
     }
-    g_slist_free (data_from_children);
     return (name);
 }
 
@@ -288,8 +281,8 @@ hex_string_to_binary (const gchar* str,  void** v, guint64* data_len)
 
 gboolean
 generic_return_chars_end_handler (gpointer data_for_children,
-                                  GSList* data_from_children,
-                                  GSList* sibling_data,
+                                  const sixtp_child_result_list& data_from_children,
+                                  const sixtp_child_result_list& sibling_data,
                                   gpointer parent_data,
                                   gpointer global_data,
                                   gpointer* result,
@@ -355,7 +348,7 @@ simple_chars_only_parser_new (sixtp_end_handler end_handler)
  */
 
 gboolean
-generic_timespec_start_handler (GSList* sibling_data, gpointer parent_data,
+generic_timespec_start_handler (const sixtp_child_result_list& sibling_data, gpointer parent_data,
                                 gpointer global_data,
                                 gpointer* data_for_children, gpointer* result,
                                 const gchar* tag, gchar** attrs)
@@ -398,7 +391,7 @@ timespec_parse_ok (Time64ParseInfo* info)
 
 gboolean
 generic_timespec_secs_end_handler (gpointer data_for_children,
-                                   GSList*  data_from_children, GSList* sibling_data,
+                                   const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                                    gpointer parent_data, gpointer global_data,
                                    gpointer* result, const gchar* tag)
 {
@@ -439,7 +432,7 @@ generic_timespec_secs_end_handler (gpointer data_for_children,
 
 gboolean
 generic_timespec_nsecs_end_handler (gpointer data_for_children,
-                                    GSList*  data_from_children, GSList* sibling_data,
+                                    const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                                     gpointer parent_data, gpointer global_data,
                                     gpointer* result, const gchar* tag)
 {
@@ -507,7 +500,7 @@ generic_timespec_parser_new (sixtp_end_handler end_handler)
 
 gboolean
 generic_guid_end_handler (gpointer data_for_children,
-                          GSList*  data_from_children, GSList* sibling_data,
+                          const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                           gpointer parent_data, gpointer global_data,
                           gpointer* result, const gchar* tag)
 {
@@ -576,7 +569,7 @@ generic_guid_parser_new (void)
 
 gboolean
 generic_gnc_numeric_end_handler (gpointer data_for_children,
-                                 GSList*  data_from_children, GSList* sibling_data,
+                                 const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                                  gpointer parent_data, gpointer global_data,
                                  gpointer* result, const gchar* tag)
 {

--- a/libgnucash/backend/xml/sixtp-utils.h
+++ b/libgnucash/backend/xml/sixtp-utils.h
@@ -34,14 +34,14 @@ typedef struct
 
 gboolean isspace_str (const gchar* str, int nomorethan);
 
-gboolean allow_and_ignore_only_whitespace (GSList* sibling_data,
+gboolean allow_and_ignore_only_whitespace (const sixtp_child_result_list& sibling_data,
                                            gpointer parent_data,
                                            gpointer global_data,
                                            gpointer* result,
                                            const char* text,
                                            int length);
 
-gboolean generic_accumulate_chars (GSList* sibling_data,
+gboolean generic_accumulate_chars (const sixtp_child_result_list& sibling_data,
                                    gpointer parent_data,
                                    gpointer global_data,
                                    gpointer* result,
@@ -50,14 +50,14 @@ gboolean generic_accumulate_chars (GSList* sibling_data,
 
 
 void generic_free_data_for_children (gpointer data_for_children,
-                                     GSList* data_from_children,
-                                     GSList* sibling_data,
+                                     const sixtp_child_result_list& data_from_children,
+                                     const sixtp_child_result_list& sibling_data,
                                      gpointer parent_data,
                                      gpointer global_data,
                                      gpointer* result,
                                      const gchar* tag);
 
-gchar* concatenate_child_result_chars (GSList* data_from_children);
+gchar* concatenate_child_result_chars (const sixtp_child_result_list& data_from_children);
 
 gboolean string_to_double (std::string_view, double* result);
 
@@ -70,8 +70,8 @@ gboolean string_to_guint (std::string_view, guint* v);
 gboolean hex_string_to_binary (const gchar* str,  void** v, guint64* data_len);
 
 gboolean generic_return_chars_end_handler (gpointer data_for_children,
-                                           GSList* data_from_children,
-                                           GSList* sibling_data,
+                                           const sixtp_child_result_list& data_from_children,
+                                           const sixtp_child_result_list& sibling_data,
                                            gpointer parent_data,
                                            gpointer global_data,
                                            gpointer* result,
@@ -79,7 +79,7 @@ gboolean generic_return_chars_end_handler (gpointer data_for_children,
 
 sixtp* simple_chars_only_parser_new (sixtp_end_handler end_handler);
 
-gboolean generic_timespec_start_handler (GSList* sibling_data,
+gboolean generic_timespec_start_handler (const sixtp_child_result_list& sibling_data,
                                          gpointer parent_data,
                                          gpointer global_data,
                                          gpointer* data_for_children,
@@ -90,13 +90,13 @@ gboolean timespec_parse_ok (Time64ParseInfo* info);
 
 gboolean generic_timespec_secs_end_handler (
     gpointer data_for_children,
-    GSList*  data_from_children, GSList* sibling_data,
+    const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
     gpointer parent_data, gpointer global_data,
     gpointer* result, const gchar* tag);
 
 gboolean generic_timespec_nsecs_end_handler (
     gpointer data_for_children,
-    GSList*  data_from_children, GSList* sibling_data,
+    const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
     gpointer parent_data, gpointer global_data,
     gpointer* result, const gchar* tag);
 
@@ -105,7 +105,7 @@ sixtp* generic_timespec_parser_new (sixtp_end_handler end_handler);
 
 gboolean generic_guid_end_handler (
     gpointer data_for_children,
-    GSList*  data_from_children, GSList* sibling_data,
+    const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
     gpointer parent_data, gpointer global_data,
     gpointer* result, const gchar* tag);
 
@@ -113,7 +113,7 @@ sixtp* generic_guid_parser_new (void);
 
 gboolean generic_gnc_numeric_end_handler (
     gpointer data_for_children,
-    GSList*  data_from_children, GSList* sibling_data,
+    const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
     gpointer parent_data, gpointer global_data,
     gpointer* result, const gchar* tag);
 

--- a/libgnucash/backend/xml/sixtp.cpp
+++ b/libgnucash/backend/xml/sixtp.cpp
@@ -479,14 +479,14 @@ sixtp_sax_start_handler (void* user_data,
                                                  parent_data_for_children,
                                                  pdata->global_data,
                                                  & (current_frame->frame_data),
-                                                 current_frame->tag,
+                                                 current_frame->tag.c_str (),
                                                  (gchar*) name);
     }
 
     /* now allocate the new stack frame and shift to it. This may
        reallocate pdata->stack, so re-derive both frame pointers from
        their indices afterward rather than trusting `current_frame`. */
-    pdata->stack.emplace_back (next_parser, g_strdup ((char*) name));
+    pdata->stack.emplace_back (next_parser, (const char*) name);
     new_frame = &pdata->stack.back ();
     current_frame = &pdata->stack[current_idx];
 
@@ -541,20 +541,21 @@ sixtp_sax_end_handler (void* user_data, const xmlChar* name)
     sixtp_stack_frame* current_frame;
     sixtp_stack_frame* parent_frame;
     sixtp_child_result* child_result_data = NULL;
-    gchar* end_tag = NULL;
+    std::string end_tag;
 
     current_frame = &pdata->stack.back ();
     parent_frame = &pdata->stack[pdata->stack.size () - 2];
 
     /* time to make sure we got the right closing tag.  Is this really
        necessary? */
-    if (g_strcmp0 (current_frame->tag, (gchar*) name) != 0)
+    if (current_frame->tag != (const char*) name)
     {
-        PWARN ("bad closing tag (start <%s>, end <%s>)", current_frame->tag, name);
+        PWARN ("bad closing tag (start <%s>, end <%s>)",
+              current_frame->tag.c_str (), name);
         pdata->parsing_ok = FALSE;
 
         /* See if we're just off by one and try to recover */
-        if (g_strcmp0 (parent_frame->tag, (gchar*) name) == 0)
+        if (parent_frame->tag == (const char*) name)
         {
             pdata->stack.pop_back ();
             current_frame = &pdata->stack.back ();
@@ -573,7 +574,7 @@ sixtp_sax_end_handler (void* user_data, const xmlChar* name)
                                                 parent_frame->data_for_children,
                                                 pdata->global_data,
                                                 &current_frame->frame_data,
-                                                current_frame->tag);
+                                                current_frame->tag.c_str ());
     }
 
     if (current_frame->frame_data)
@@ -584,16 +585,19 @@ sixtp_sax_end_handler (void* user_data, const xmlChar* name)
            is to the already-constructed element at its final address, so
            there's no dangling pointer to worry about here. */
         auto& cr = parent_frame->data_from_children.emplace_back (
-            SIXTP_CHILD_RESULT_NODE, current_frame->tag ? current_frame->tag : "",
+            SIXTP_CHILD_RESULT_NODE, current_frame->tag,
             current_frame->frame_data, current_frame->parser->cleanup_result,
             current_frame->parser->result_fail_handler);
         child_result_data = &cr;
     }
 
-    /* grab it before it goes away - we own the reference */
-    end_tag = current_frame->tag;
+    /* grab it before it goes away - we own the reference. Move rather
+       than copy: current_frame (and its tag) is about to be destroyed by
+       the pop_back() below, and nothing else reads current_frame->tag
+       between here and there. */
+    end_tag = std::move (current_frame->tag);
 
-    DEBUG ("Finished with end of <%s>", end_tag ? end_tag : "(null)");
+    DEBUG ("Finished with end of <%s>", end_tag.empty () ? "(null)" : end_tag.c_str ());
 
     /*sixtp_print_frame_stack(pdata->stack, stderr);*/
 
@@ -624,12 +628,10 @@ sixtp_sax_end_handler (void* user_data, const xmlChar* name)
                                                 parent_data_for_children,
                                                 pdata->global_data,
                                                 & (current_frame->frame_data),
-                                                current_frame->tag,
-                                                end_tag,
+                                                current_frame->tag.c_str (),
+                                                end_tag.c_str (),
                                                 child_result_data);
     }
-
-    g_free (end_tag);
 }
 
 xmlEntityPtr
@@ -679,7 +681,7 @@ sixtp_handle_catastrophe (sixtp_sax_data* sax_data)
                                                  parent_data,
                                                  sax_data->global_data,
                                                  &current_frame->frame_data,
-                                                 current_frame->tag);
+                                                 current_frame->tag.c_str ());
         }
 
         /* now cleanup any children's results */

--- a/libgnucash/backend/xml/sixtp.cpp
+++ b/libgnucash/backend/xml/sixtp.cpp
@@ -395,7 +395,7 @@ sixtp_sax_start_handler (void* user_data,
     gboolean lookup_success = FALSE;
     sixtp_stack_frame* new_frame = NULL;
 
-    current_frame = (sixtp_stack_frame*) pdata->stack->data;
+    current_frame = pdata->stack.back ();
     current_parser = current_frame->parser;
 
     /* Use an extended lookup so we can get *our* copy of the key.
@@ -428,11 +428,10 @@ sixtp_sax_start_handler (void* user_data,
         GSList* parent_data_from_children = NULL;
         gpointer parent_data_for_children = NULL;
 
-        if (g_slist_length (pdata->stack) > 1)
+        if (pdata->stack.size () > 1)
         {
             /* we're not in the top level node */
-            sixtp_stack_frame* parent_frame =
-                (sixtp_stack_frame*) pdata->stack->next->data;
+            sixtp_stack_frame* parent_frame = pdata->stack[pdata->stack.size () - 2];
             parent_data_from_children = static_cast<decltype (parent_data_from_children)>
                                         (parent_frame->data_from_children);
         }
@@ -454,7 +453,7 @@ sixtp_sax_start_handler (void* user_data,
     new_frame->line = xmlSAX2GetLineNumber (pdata->saxParserCtxt);
     new_frame->col  = xmlSAX2GetColumnNumber (pdata->saxParserCtxt);
 
-    pdata->stack = g_slist_prepend (pdata->stack, (gpointer) new_frame);
+    pdata->stack.push_back (new_frame);
 
     if (next_parser->start_handler)
     {
@@ -475,7 +474,7 @@ sixtp_sax_characters_handler (void* user_data, const xmlChar* text, int len)
     sixtp_sax_data* pdata = (sixtp_sax_data*) user_data;
     sixtp_stack_frame* frame;
 
-    frame = (sixtp_stack_frame*) pdata->stack->data;
+    frame = pdata->stack.back ();
     if (frame->parser->characters_handler)
     {
         gpointer result = NULL;
@@ -513,8 +512,8 @@ sixtp_sax_end_handler (void* user_data, const xmlChar* name)
     sixtp_child_result* child_result_data = NULL;
     gchar* end_tag = NULL;
 
-    current_frame = (sixtp_stack_frame*) pdata->stack->data;
-    parent_frame = (sixtp_stack_frame*) pdata->stack->next->data;
+    current_frame = pdata->stack.back ();
+    parent_frame = pdata->stack[pdata->stack.size () - 2];
 
     /* time to make sure we got the right closing tag.  Is this really
        necessary? */
@@ -526,9 +525,9 @@ sixtp_sax_end_handler (void* user_data, const xmlChar* name)
         /* See if we're just off by one and try to recover */
         if (g_strcmp0 (parent_frame->tag, (gchar*) name) == 0)
         {
-            pdata->stack = sixtp_pop_and_destroy_frame (pdata->stack);
-            current_frame = (sixtp_stack_frame*) pdata->stack->data;
-            parent_frame = (sixtp_stack_frame*) pdata->stack->next->data;
+            sixtp_pop_and_destroy_frame (pdata->stack);
+            current_frame = pdata->stack.back ();
+            parent_frame = pdata->stack[pdata->stack.size () - 2];
             PWARN ("found matching start <%s> tag up one level", name);
         }
     }
@@ -569,13 +568,13 @@ sixtp_sax_end_handler (void* user_data, const xmlChar* name)
 
     /*sixtp_print_frame_stack(pdata->stack, stderr);*/
 
-    pdata->stack = sixtp_pop_and_destroy_frame (pdata->stack);
+    sixtp_pop_and_destroy_frame (pdata->stack);
 
     /* reset pointer after stack pop */
-    current_frame = (sixtp_stack_frame*) pdata->stack->data;
+    current_frame = pdata->stack.back ();
     /* reset the parent, checking to see if we're at the top level node */
-    parent_frame = (sixtp_stack_frame*)
-                   ((g_slist_length (pdata->stack) > 1) ? (pdata->stack->next->data) : NULL);
+    parent_frame = (pdata->stack.size () > 1) ?
+                   pdata->stack[pdata->stack.size () - 2] : NULL;
 
     if (current_frame->parser->after_child)
     {
@@ -586,8 +585,6 @@ sixtp_sax_end_handler (void* user_data, const xmlChar* name)
         if (parent_frame)
         {
             /* we're not in the top level node */
-            sixtp_stack_frame* parent_frame =
-                (sixtp_stack_frame*) pdata->stack->next->data;
             parent_data_from_children = static_cast<decltype (parent_data_from_children)>
                                         (parent_frame->data_for_children);
         }
@@ -626,14 +623,15 @@ sixtp_handle_catastrophe (sixtp_sax_data* sax_data)
        youngest to oldest.  */
 
     GSList* lp;
-    GSList** stack = & (sax_data->stack);
+    auto& stack = sax_data->stack;
 
     g_critical ("parse failed at:");
-    sixtp_print_frame_stack (sax_data->stack, stderr);
+    sixtp_print_frame_stack (stack, stderr);
 
-    while (*stack)
+    while (!stack.empty ())
     {
-        sixtp_stack_frame* current_frame = (sixtp_stack_frame*) (*stack)->data;
+        sixtp_stack_frame* current_frame = stack.back ();
+        bool at_top = stack.size () == 1;
 
         /* cleanup the current frame */
         if (current_frame->parser->fail_handler)
@@ -641,7 +639,7 @@ sixtp_handle_catastrophe (sixtp_sax_data* sax_data)
             GSList* sibling_data;
             gpointer parent_data;
 
-            if ((*stack)->next == NULL)
+            if (at_top)
             {
                 /* This is the top of the stack... */
                 parent_data = NULL;
@@ -649,8 +647,7 @@ sixtp_handle_catastrophe (sixtp_sax_data* sax_data)
             }
             else
             {
-                sixtp_stack_frame* parent_frame =
-                    (sixtp_stack_frame*) (*stack)->next->data;
+                sixtp_stack_frame* parent_frame = stack[stack.size () - 2];
                 parent_data = parent_frame->data_for_children;
                 sibling_data = parent_frame->data_from_children;
             }
@@ -674,14 +671,14 @@ sixtp_handle_catastrophe (sixtp_sax_data* sax_data)
             }
         }
 
-        if ((*stack)->next == NULL)
+        if (at_top)
         {
             /* This is the top of the stack. The top frame seems to want to
              * be destroyed by sixtp_context_destroy. */
             break;
         }
 
-        *stack = sixtp_pop_and_destroy_frame (*stack);
+        sixtp_pop_and_destroy_frame (stack);
     }
 }
 
@@ -731,7 +728,7 @@ sixtp_parse_file_common (sixtp* sixtp,
     {
         if (parse_result)
             *parse_result = NULL;
-        if (g_slist_length (ctxt->data.stack) > 1)
+        if (ctxt->data.stack.size () > 1)
             sixtp_handle_catastrophe (&ctxt->data);
         sixtp_context_destroy (ctxt);
         return FALSE;
@@ -854,7 +851,7 @@ sixtp_parse_push (sixtp* sixtp,
     {
         if (parse_result)
             *parse_result = NULL;
-        if (g_slist_length (ctxt->data.stack) > 1)
+        if (ctxt->data.stack.size () > 1)
             sixtp_handle_catastrophe (&ctxt->data);
         sixtp_context_destroy (ctxt);
         return FALSE;

--- a/libgnucash/backend/xml/sixtp.cpp
+++ b/libgnucash/backend/xml/sixtp.cpp
@@ -29,6 +29,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <sys/types.h>
+#include <string_view>
+#include <unordered_set>
 #include <qoflog.h>
 #ifdef _MSC_VER
     typedef int ssize_t;
@@ -179,18 +181,7 @@ sixtp_set_chars_fail (sixtp* parser, sixtp_result_handler handler)
 sixtp*
 sixtp_new (void)
 {
-    sixtp* s = g_new0 (sixtp, 1);
-
-    if (s)
-    {
-        s->child_parsers = g_hash_table_new (g_str_hash, g_str_equal);
-        if (!s->child_parsers)
-        {
-            g_free (s);
-            s = NULL;
-        }
-    }
-    return (s);
+    return new sixtp ();
 }
 
 sixtp*
@@ -277,50 +268,35 @@ sixtp_set_any (sixtp* tochange, int cleanup, ...)
     return tochange;
 }
 
-static void sixtp_destroy_child (gpointer key, gpointer value,
-                                 gpointer user_data);
+static void sixtp_destroy_child (const std::string& tag, sixtp* child,
+                                 std::unordered_set<sixtp*>& corpses);
 
 static void
-sixtp_destroy_node (sixtp* sp, GHashTable* corpses)
+sixtp_destroy_node (sixtp* sp, std::unordered_set<sixtp*>& corpses)
 {
     g_return_if_fail (sp);
-    g_return_if_fail (corpses);
-    g_hash_table_foreach (sp->child_parsers, sixtp_destroy_child, corpses);
-    g_hash_table_destroy (sp->child_parsers);
-    g_free (sp);
+    for (auto& [tag, child] : sp->child_parsers)
+        sixtp_destroy_child (tag, child, corpses);
+    delete sp;
 }
 
 static void
-sixtp_destroy_child (gpointer key, gpointer value, gpointer user_data)
+sixtp_destroy_child (const std::string& tag, sixtp* child,
+                     std::unordered_set<sixtp*>& corpses)
 {
-    GHashTable* corpses = (GHashTable*) user_data;
-    sixtp* child = (sixtp*) value;
-    gpointer lookup_key;
-    gpointer lookup_value;
+    DEBUG ("Killing sixtp child under key <%s>", tag.c_str ());
 
-    DEBUG ("Killing sixtp child under key <%s>", key ? (char*) key : "(null)");
-
-    if (!corpses)
-    {
-        g_critical ("no corpses in sixtp_destroy_child <%s>",
-                    key ? (char*) key : "(null)");
-        g_free (key);
-        return;
-    }
     if (!child)
     {
-        g_critical ("no child in sixtp_destroy_child <%s>",
-                    key ? (char*) key : "");
-        g_free (key);
+        g_critical ("no child in sixtp_destroy_child <%s>", tag.c_str ());
         return;
     }
-    g_free (key);
 
-    if (!g_hash_table_lookup_extended (corpses, (gconstpointer) child,
-                                       &lookup_key, &lookup_value))
+    /* insert() returns false in .second if child was already a member,
+       i.e. already killed (or in the process of being killed - this is
+       also what stops cyclic parser graphs from recursing forever). */
+    if (corpses.insert (child).second)
     {
-        /* haven't killed this one yet. */
-        g_hash_table_insert (corpses, child, (gpointer) 1);
         sixtp_destroy_node (child, corpses);
     }
 }
@@ -328,11 +304,9 @@ sixtp_destroy_child (gpointer key, gpointer value, gpointer user_data)
 void
 sixtp_destroy (sixtp* sp)
 {
-    GHashTable* corpses;
     g_return_if_fail (sp);
-    corpses = g_hash_table_new (g_direct_hash, g_direct_equal);
+    std::unordered_set<sixtp*> corpses;
     sixtp_destroy_node (sp, corpses);
-    g_hash_table_destroy (corpses);
 }
 
 
@@ -345,8 +319,7 @@ sixtp_add_sub_parser (sixtp* parser, const gchar* tag, sixtp* sub_parser)
     g_return_val_if_fail (tag, FALSE);
     g_return_val_if_fail (sub_parser, FALSE);
 
-    g_hash_table_insert (parser->child_parsers,
-                         g_strdup (tag), (gpointer) sub_parser);
+    parser->child_parsers[tag] = sub_parser;
     return (TRUE);
 }
 
@@ -424,8 +397,6 @@ sixtp_sax_start_handler (void* user_data,
     sixtp_stack_frame* current_frame = NULL;
     sixtp* current_parser = NULL;
     sixtp* next_parser = NULL;
-    gchar* next_parser_tag = NULL;
-    gboolean lookup_success = FALSE;
     sixtp_stack_frame* new_frame = NULL;
 
     /* Index, not pointer: the push_back below can reallocate pdata->stack
@@ -435,23 +406,25 @@ sixtp_sax_start_handler (void* user_data,
     current_frame = &pdata->stack[current_idx];
     current_parser = current_frame->parser;
 
-    /* Use an extended lookup so we can get *our* copy of the key.
-       Since we've strduped it, we know its lifetime... */
-    lookup_success =
-        g_hash_table_lookup_extended (current_parser->child_parsers,
-                                      name,
-                                      reinterpret_cast<void**> (&next_parser_tag),
-                                      reinterpret_cast<void**> (&next_parser));
+    /* child_parsers has a transparent comparator, so this looks the tag
+       up directly against the SAX-provided name - no std::string built
+       just to search. */
+    auto it = current_parser->child_parsers.find (
+        std::string_view (reinterpret_cast<const char*> (name)));
 
-
-    if (!lookup_success)
+    if (it != current_parser->child_parsers.end ())
+    {
+        next_parser = it->second;
+    }
+    else
     {
         /* magic catch all value */
-        lookup_success = g_hash_table_lookup_extended (
-                             current_parser->child_parsers, SIXTP_MAGIC_CATCHER,
-                             reinterpret_cast<void**> (&next_parser_tag),
-                             reinterpret_cast<void**> (&next_parser));
-        if (!lookup_success)
+        auto catch_it = current_parser->child_parsers.find (SIXTP_MAGIC_CATCHER);
+        if (catch_it != current_parser->child_parsers.end ())
+        {
+            next_parser = catch_it->second;
+        }
+        else
         {
             g_critical ("Tag <%s> not allowed in current context.",
                         name ? (char*) name : "(null)");

--- a/libgnucash/backend/xml/sixtp.cpp
+++ b/libgnucash/backend/xml/sixtp.cpp
@@ -432,7 +432,11 @@ sixtp_sax_start_handler (void* user_data,
     gboolean lookup_success = FALSE;
     sixtp_stack_frame* new_frame = NULL;
 
-    current_frame = pdata->stack.back ().get ();
+    /* Index, not pointer: the push_back below can reallocate pdata->stack
+       and move every frame (including this one) to a new buffer, so any
+       pointer into it taken beforehand would dangle. */
+    std::size_t current_idx = pdata->stack.size () - 1;
+    current_frame = &pdata->stack[current_idx];
     current_parser = current_frame->parser;
 
     /* Use an extended lookup so we can get *our* copy of the key.
@@ -465,10 +469,10 @@ sixtp_sax_start_handler (void* user_data,
         const sixtp_child_result_list* parent_data_from_children = &sixtp_no_children ();
         gpointer parent_data_for_children = NULL;
 
-        if (pdata->stack.size () > 1)
+        if (current_idx > 0)
         {
             /* we're not in the top level node */
-            sixtp_stack_frame* parent_frame = pdata->stack[pdata->stack.size () - 2].get ();
+            sixtp_stack_frame* parent_frame = &pdata->stack[current_idx - 1];
             parent_data_from_children = &parent_frame->data_from_children;
         }
 
@@ -483,9 +487,12 @@ sixtp_sax_start_handler (void* user_data,
                                                  (gchar*) name);
     }
 
-    /* now allocate the new stack frame and shift to it */
+    /* now allocate the new stack frame and shift to it. This may
+       reallocate pdata->stack, so re-derive both frame pointers from
+       their indices afterward rather than trusting `current_frame`. */
     pdata->stack.push_back (sixtp_stack_frame_new (next_parser, g_strdup ((char*) name)));
-    new_frame = pdata->stack.back ().get ();
+    new_frame = &pdata->stack.back ();
+    current_frame = &pdata->stack[current_idx];
 
     new_frame->line = xmlSAX2GetLineNumber (pdata->saxParserCtxt);
     new_frame->col  = xmlSAX2GetColumnNumber (pdata->saxParserCtxt);
@@ -509,7 +516,7 @@ sixtp_sax_characters_handler (void* user_data, const xmlChar* text, int len)
     sixtp_sax_data* pdata = (sixtp_sax_data*) user_data;
     sixtp_stack_frame* frame;
 
-    frame = pdata->stack.back ().get ();
+    frame = &pdata->stack.back ();
     if (frame->parser->characters_handler)
     {
         gpointer result = NULL;
@@ -546,8 +553,8 @@ sixtp_sax_end_handler (void* user_data, const xmlChar* name)
     sixtp_child_result* child_result_data = NULL;
     gchar* end_tag = NULL;
 
-    current_frame = pdata->stack.back ().get ();
-    parent_frame = pdata->stack[pdata->stack.size () - 2].get ();
+    current_frame = &pdata->stack.back ();
+    parent_frame = &pdata->stack[pdata->stack.size () - 2];
 
     /* time to make sure we got the right closing tag.  Is this really
        necessary? */
@@ -560,8 +567,8 @@ sixtp_sax_end_handler (void* user_data, const xmlChar* name)
         if (g_strcmp0 (parent_frame->tag, (gchar*) name) == 0)
         {
             pdata->stack.pop_back ();
-            current_frame = pdata->stack.back ().get ();
-            parent_frame = pdata->stack[pdata->stack.size () - 2].get ();
+            current_frame = &pdata->stack.back ();
+            parent_frame = &pdata->stack[pdata->stack.size () - 2];
             PWARN ("found matching start <%s> tag up one level", name);
         }
     }
@@ -607,10 +614,10 @@ sixtp_sax_end_handler (void* user_data, const xmlChar* name)
     pdata->stack.pop_back ();
 
     /* reset pointer after stack pop */
-    current_frame = pdata->stack.back ().get ();
+    current_frame = &pdata->stack.back ();
     /* reset the parent, checking to see if we're at the top level node */
     parent_frame = (pdata->stack.size () > 1) ?
-                   pdata->stack[pdata->stack.size () - 2].get () : NULL;
+                   &pdata->stack[pdata->stack.size () - 2] : NULL;
 
     if (current_frame->parser->after_child)
     {
@@ -664,7 +671,7 @@ sixtp_handle_catastrophe (sixtp_sax_data* sax_data)
 
     while (!stack.empty ())
     {
-        sixtp_stack_frame* current_frame = stack.back ().get ();
+        sixtp_stack_frame* current_frame = &stack.back ();
         bool at_top = stack.size () == 1;
 
         /* cleanup the current frame */
@@ -675,7 +682,7 @@ sixtp_handle_catastrophe (sixtp_sax_data* sax_data)
 
             if (!at_top)
             {
-                sixtp_stack_frame* parent_frame = stack[stack.size () - 2].get ();
+                sixtp_stack_frame* parent_frame = &stack[stack.size () - 2];
                 parent_data = parent_frame->data_for_children;
                 sibling_data = &parent_frame->data_from_children;
             }
@@ -748,7 +755,7 @@ sixtp_parse_file_common (sixtp* sixtp,
     if (parse_ret == 0 && ctxt->data.parsing_ok)
     {
         if (parse_result)
-            *parse_result = ctxt->top_frame->frame_data;
+            *parse_result = ctxt->data.stack.front ().frame_data;
         sixtp_context_destroy (ctxt);
         return TRUE;
     }
@@ -871,7 +878,7 @@ sixtp_parse_push (sixtp* sixtp,
     if (ctxt->data.parsing_ok)
     {
         if (parse_result)
-            *parse_result = ctxt->top_frame->frame_data;
+            *parse_result = ctxt->data.stack.front ().frame_data;
         sixtp_context_destroy (ctxt);
         return TRUE;
     }

--- a/libgnucash/backend/xml/sixtp.cpp
+++ b/libgnucash/backend/xml/sixtp.cpp
@@ -693,8 +693,8 @@ sixtp_handle_catastrophe (sixtp_sax_data* sax_data)
 
         if (at_top)
         {
-            /* This is the top of the stack. The top frame seems to want to
-             * be destroyed by sixtp_context_destroy. */
+            /* This is the top of the stack. The top frame is destroyed
+             * along with the rest of the context, via ~sixtp_parser_context. */
             break;
         }
 
@@ -742,7 +742,7 @@ sixtp_parse_file_common (sixtp* sixtp,
     {
         if (parse_result)
             *parse_result = ctxt->data.stack.front ().frame_data;
-        sixtp_context_destroy (ctxt);
+        delete ctxt;
         return TRUE;
     }
     else
@@ -751,7 +751,7 @@ sixtp_parse_file_common (sixtp* sixtp,
             *parse_result = NULL;
         if (ctxt->data.stack.size () > 1)
             sixtp_handle_catastrophe (&ctxt->data);
-        sixtp_context_destroy (ctxt);
+        delete ctxt;
         return FALSE;
     }
 }
@@ -865,7 +865,7 @@ sixtp_parse_push (sixtp* sixtp,
     {
         if (parse_result)
             *parse_result = ctxt->data.stack.front ().frame_data;
-        sixtp_context_destroy (ctxt);
+        delete ctxt;
         return TRUE;
     }
     else
@@ -874,7 +874,7 @@ sixtp_parse_push (sixtp* sixtp,
             *parse_result = NULL;
         if (ctxt->data.stack.size () > 1)
             sixtp_handle_catastrophe (&ctxt->data);
-        sixtp_context_destroy (ctxt);
+        delete ctxt;
         return FALSE;
     }
 }

--- a/libgnucash/backend/xml/sixtp.cpp
+++ b/libgnucash/backend/xml/sixtp.cpp
@@ -721,10 +721,10 @@ sixtp_parse_file_common (sixtp* sixtp,
                          gpointer global_data,
                          gpointer* parse_result)
 {
-    sixtp_parser_context* ctxt;
     int parse_ret;
 
-    if (! (ctxt = sixtp_context_new (sixtp, global_data, data_for_top_level)))
+    auto ctxt = sixtp_context_new (sixtp, global_data, data_for_top_level);
+    if (!ctxt)
     {
         g_critical ("sixtp_context_new returned null");
         return FALSE;
@@ -738,13 +738,12 @@ sixtp_parse_file_common (sixtp* sixtp,
     parse_ret = xmlParseDocument (ctxt->data.saxParserCtxt);
     //xmlSAXUserParseFile(&ctxt->handler, &ctxt->data, filename);
 
-    sixtp_context_run_end_handler (ctxt);
+    sixtp_context_run_end_handler (ctxt.get ());
 
     if (parse_ret == 0 && ctxt->data.parsing_ok)
     {
         if (parse_result)
             *parse_result = ctxt->data.stack.front ().frame_data;
-        delete ctxt;
         return TRUE;
     }
     else
@@ -753,7 +752,6 @@ sixtp_parse_file_common (sixtp* sixtp,
             *parse_result = NULL;
         if (ctxt->data.stack.size () > 1)
             sixtp_handle_catastrophe (&ctxt->data);
-        delete ctxt;
         return FALSE;
     }
 }
@@ -838,7 +836,6 @@ sixtp_parse_push (sixtp* sixtp,
                   gpointer global_data,
                   gpointer* parse_result)
 {
-    sixtp_parser_context* ctxt;
     xmlParserCtxtPtr xml_context;
 
     if (!push_handler)
@@ -847,7 +844,8 @@ sixtp_parse_push (sixtp* sixtp,
         return FALSE;
     }
 
-    if (! (ctxt = sixtp_context_new (sixtp, global_data, data_for_top_level)))
+    auto ctxt = sixtp_context_new (sixtp, global_data, data_for_top_level);
+    if (!ctxt)
     {
         g_critical ("sixtp_context_new returned null");
         return FALSE;
@@ -861,13 +859,12 @@ sixtp_parse_push (sixtp* sixtp,
 
     (*push_handler) (xml_context, push_user_data);
 
-    sixtp_context_run_end_handler (ctxt);
+    sixtp_context_run_end_handler (ctxt.get ());
 
     if (ctxt->data.parsing_ok)
     {
         if (parse_result)
             *parse_result = ctxt->data.stack.front ().frame_data;
-        delete ctxt;
         return TRUE;
     }
     else
@@ -876,7 +873,6 @@ sixtp_parse_push (sixtp* sixtp,
             *parse_result = NULL;
         if (ctxt->data.stack.size () > 1)
             sixtp_handle_catastrophe (&ctxt->data);
-        delete ctxt;
         return FALSE;
     }
 }

--- a/libgnucash/backend/xml/sixtp.cpp
+++ b/libgnucash/backend/xml/sixtp.cpp
@@ -486,7 +486,7 @@ sixtp_sax_start_handler (void* user_data,
     /* now allocate the new stack frame and shift to it. This may
        reallocate pdata->stack, so re-derive both frame pointers from
        their indices afterward rather than trusting `current_frame`. */
-    pdata->stack.push_back (sixtp_stack_frame_new (next_parser, g_strdup ((char*) name)));
+    pdata->stack.emplace_back (next_parser, g_strdup ((char*) name));
     new_frame = &pdata->stack.back ();
     current_frame = &pdata->stack[current_idx];
 

--- a/libgnucash/backend/xml/sixtp.cpp
+++ b/libgnucash/backend/xml/sixtp.cpp
@@ -47,7 +47,7 @@ extern const gchar* gnc_v2_xml_version_string;        /* see io-gncxml-v2.c */
 
 /************************************************************************/
 gboolean
-is_child_result_from_node_named (sixtp_child_result* cr, const char* tag)
+is_child_result_from_node_named (const sixtp_child_result* cr, const char* tag)
 {
     return ((cr->type == SIXTP_CHILD_RESULT_NODE)
             &&
@@ -60,23 +60,60 @@ sixtp_child_free_data (sixtp_child_result* result)
     if (result->data) g_free (result->data);
 }
 
-void
-sixtp_child_result_destroy (sixtp_child_result* r)
+_sixtp_child_result::_sixtp_child_result (_sixtp_child_result&& other) noexcept
+    : type (other.type), tag (other.tag), data (other.data),
+      should_cleanup (other.should_cleanup),
+      cleanup_handler (other.cleanup_handler),
+      fail_handler (other.fail_handler)
 {
-    if (r->should_cleanup && r->cleanup_handler)
+    /* leave a harmless husk behind: no tag to free, nothing to clean up */
+    other.tag = nullptr;
+    other.should_cleanup = FALSE;
+}
+
+_sixtp_child_result&
+_sixtp_child_result::operator= (_sixtp_child_result&& other) noexcept
+{
+    if (this == &other) return *this;
+
+    if (should_cleanup && cleanup_handler) cleanup_handler (this);
+    if (type == SIXTP_CHILD_RESULT_NODE) g_free (tag);
+
+    type = other.type;
+    tag = other.tag;
+    data = other.data;
+    should_cleanup = other.should_cleanup;
+    cleanup_handler = other.cleanup_handler;
+    fail_handler = other.fail_handler;
+
+    other.tag = nullptr;
+    other.should_cleanup = FALSE;
+
+    return *this;
+}
+
+_sixtp_child_result::~_sixtp_child_result ()
+{
+    if (should_cleanup && cleanup_handler)
     {
-        r->cleanup_handler (r);
+        cleanup_handler (this);
     }
-    if (r->type == SIXTP_CHILD_RESULT_NODE) g_free (r->tag);
-    g_free (r);
+    if (type == SIXTP_CHILD_RESULT_NODE) g_free (tag);
 }
 
 void
-sixtp_child_result_print (sixtp_child_result* cr, FILE* f)
+sixtp_child_result_print (const sixtp_child_result* cr, FILE* f)
 {
     fprintf (f, "((tag %s) (data %p))",
              cr->tag ? cr->tag : "(null)",
              cr->data);
+}
+
+const sixtp_child_result_list&
+sixtp_no_children ()
+{
+    static const sixtp_child_result_list empty;
+    return empty;
 }
 
 /************************************************************************/
@@ -395,7 +432,7 @@ sixtp_sax_start_handler (void* user_data,
     gboolean lookup_success = FALSE;
     sixtp_stack_frame* new_frame = NULL;
 
-    current_frame = pdata->stack.back ();
+    current_frame = pdata->stack.back ().get ();
     current_parser = current_frame->parser;
 
     /* Use an extended lookup so we can get *our* copy of the key.
@@ -425,21 +462,20 @@ sixtp_sax_start_handler (void* user_data,
 
     if (current_frame->parser->before_child)
     {
-        GSList* parent_data_from_children = NULL;
+        const sixtp_child_result_list* parent_data_from_children = &sixtp_no_children ();
         gpointer parent_data_for_children = NULL;
 
         if (pdata->stack.size () > 1)
         {
             /* we're not in the top level node */
-            sixtp_stack_frame* parent_frame = pdata->stack[pdata->stack.size () - 2];
-            parent_data_from_children = static_cast<decltype (parent_data_from_children)>
-                                        (parent_frame->data_from_children);
+            sixtp_stack_frame* parent_frame = pdata->stack[pdata->stack.size () - 2].get ();
+            parent_data_from_children = &parent_frame->data_from_children;
         }
 
         pdata->parsing_ok &=
             current_frame->parser->before_child (current_frame->data_for_children,
                                                  current_frame->data_from_children,
-                                                 parent_data_from_children,
+                                                 *parent_data_from_children,
                                                  parent_data_for_children,
                                                  pdata->global_data,
                                                  & (current_frame->frame_data),
@@ -448,12 +484,11 @@ sixtp_sax_start_handler (void* user_data,
     }
 
     /* now allocate the new stack frame and shift to it */
-    new_frame = sixtp_stack_frame_new (next_parser, g_strdup ((char*) name));
+    pdata->stack.push_back (sixtp_stack_frame_new (next_parser, g_strdup ((char*) name)));
+    new_frame = pdata->stack.back ().get ();
 
     new_frame->line = xmlSAX2GetLineNumber (pdata->saxParserCtxt);
     new_frame->col  = xmlSAX2GetColumnNumber (pdata->saxParserCtxt);
-
-    pdata->stack.push_back (new_frame);
 
     if (next_parser->start_handler)
     {
@@ -474,7 +509,7 @@ sixtp_sax_characters_handler (void* user_data, const xmlChar* text, int len)
     sixtp_sax_data* pdata = (sixtp_sax_data*) user_data;
     sixtp_stack_frame* frame;
 
-    frame = pdata->stack.back ();
+    frame = pdata->stack.back ().get ();
     if (frame->parser->characters_handler)
     {
         gpointer result = NULL;
@@ -489,16 +524,15 @@ sixtp_sax_characters_handler (void* user_data, const xmlChar* text, int len)
         if (pdata->parsing_ok && result)
         {
             /* push the result onto the current "child" list. */
-            sixtp_child_result* child_data = g_new0 (sixtp_child_result, 1);
+            sixtp_child_result child_data;
 
-            child_data->type = SIXTP_CHILD_RESULT_CHARS;
-            child_data->tag = NULL;
-            child_data->data = result;
-            child_data->should_cleanup = TRUE;
-            child_data->cleanup_handler = frame->parser->cleanup_chars;
-            child_data->fail_handler = frame->parser->chars_fail_handler;
-            frame->data_from_children = g_slist_prepend (frame->data_from_children,
-                                                         child_data);
+            child_data.type = SIXTP_CHILD_RESULT_CHARS;
+            child_data.tag = NULL;
+            child_data.data = result;
+            child_data.should_cleanup = TRUE;
+            child_data.cleanup_handler = frame->parser->cleanup_chars;
+            child_data.fail_handler = frame->parser->chars_fail_handler;
+            frame->data_from_children.push_back (std::move (child_data));
         }
     }
 }
@@ -512,8 +546,8 @@ sixtp_sax_end_handler (void* user_data, const xmlChar* name)
     sixtp_child_result* child_result_data = NULL;
     gchar* end_tag = NULL;
 
-    current_frame = pdata->stack.back ();
-    parent_frame = pdata->stack[pdata->stack.size () - 2];
+    current_frame = pdata->stack.back ().get ();
+    parent_frame = pdata->stack[pdata->stack.size () - 2].get ();
 
     /* time to make sure we got the right closing tag.  Is this really
        necessary? */
@@ -525,9 +559,9 @@ sixtp_sax_end_handler (void* user_data, const xmlChar* name)
         /* See if we're just off by one and try to recover */
         if (g_strcmp0 (parent_frame->tag, (gchar*) name) == 0)
         {
-            sixtp_pop_and_destroy_frame (pdata->stack);
-            current_frame = pdata->stack.back ();
-            parent_frame = pdata->stack[pdata->stack.size () - 2];
+            pdata->stack.pop_back ();
+            current_frame = pdata->stack.back ().get ();
+            parent_frame = pdata->stack[pdata->stack.size () - 2].get ();
             PWARN ("found matching start <%s> tag up one level", name);
         }
     }
@@ -547,18 +581,20 @@ sixtp_sax_end_handler (void* user_data, const xmlChar* name)
 
     if (current_frame->frame_data)
     {
-        /* push the result onto the parent's child result list. */
-        child_result_data = g_new (sixtp_child_result, 1);
+        /* push the result onto the parent's child result list. Fetch the
+           pointer only *after* the push: push_back may reallocate the
+           vector and move every element (including this one) to a new
+           buffer, so a pointer taken beforehand could dangle. */
+        sixtp_child_result cr;
 
-        child_result_data->type = SIXTP_CHILD_RESULT_NODE;
-        child_result_data->tag = g_strdup (current_frame->tag);
-        child_result_data->data = current_frame->frame_data;
-        child_result_data->should_cleanup = TRUE;
-        child_result_data->cleanup_handler = current_frame->parser->cleanup_result;
-        child_result_data->fail_handler =
-            current_frame->parser->result_fail_handler;
-        parent_frame->data_from_children =
-            g_slist_prepend (parent_frame->data_from_children, child_result_data);
+        cr.type = SIXTP_CHILD_RESULT_NODE;
+        cr.tag = g_strdup (current_frame->tag);
+        cr.data = current_frame->frame_data;
+        cr.should_cleanup = TRUE;
+        cr.cleanup_handler = current_frame->parser->cleanup_result;
+        cr.fail_handler = current_frame->parser->result_fail_handler;
+        parent_frame->data_from_children.push_back (std::move (cr));
+        child_result_data = &parent_frame->data_from_children.back ();
     }
 
     /* grab it before it goes away - we own the reference */
@@ -568,31 +604,30 @@ sixtp_sax_end_handler (void* user_data, const xmlChar* name)
 
     /*sixtp_print_frame_stack(pdata->stack, stderr);*/
 
-    sixtp_pop_and_destroy_frame (pdata->stack);
+    pdata->stack.pop_back ();
 
     /* reset pointer after stack pop */
-    current_frame = pdata->stack.back ();
+    current_frame = pdata->stack.back ().get ();
     /* reset the parent, checking to see if we're at the top level node */
     parent_frame = (pdata->stack.size () > 1) ?
-                   pdata->stack[pdata->stack.size () - 2] : NULL;
+                   pdata->stack[pdata->stack.size () - 2].get () : NULL;
 
     if (current_frame->parser->after_child)
     {
         /* reset pointer after stack pop */
-        GSList* parent_data_from_children = NULL;
+        const sixtp_child_result_list* parent_data_from_children = &sixtp_no_children ();
         gpointer parent_data_for_children = NULL;
 
         if (parent_frame)
         {
             /* we're not in the top level node */
-            parent_data_from_children = static_cast<decltype (parent_data_from_children)>
-                                        (parent_frame->data_for_children);
+            parent_data_from_children = &parent_frame->data_from_children;
         }
 
         pdata->parsing_ok &=
             current_frame->parser->after_child (current_frame->data_for_children,
                                                 current_frame->data_from_children,
-                                                parent_data_from_children,
+                                                *parent_data_from_children,
                                                 parent_data_for_children,
                                                 pdata->global_data,
                                                 & (current_frame->frame_data),
@@ -622,7 +657,6 @@ sixtp_handle_catastrophe (sixtp_sax_data* sax_data)
        frames are cleaned up in their order on the stack which will be
        youngest to oldest.  */
 
-    GSList* lp;
     auto& stack = sax_data->stack;
 
     g_critical ("parse failed at:");
@@ -630,31 +664,25 @@ sixtp_handle_catastrophe (sixtp_sax_data* sax_data)
 
     while (!stack.empty ())
     {
-        sixtp_stack_frame* current_frame = stack.back ();
+        sixtp_stack_frame* current_frame = stack.back ().get ();
         bool at_top = stack.size () == 1;
 
         /* cleanup the current frame */
         if (current_frame->parser->fail_handler)
         {
-            GSList* sibling_data;
-            gpointer parent_data;
+            const sixtp_child_result_list* sibling_data = &sixtp_no_children ();
+            gpointer parent_data = NULL;
 
-            if (at_top)
+            if (!at_top)
             {
-                /* This is the top of the stack... */
-                parent_data = NULL;
-                sibling_data = NULL;
-            }
-            else
-            {
-                sixtp_stack_frame* parent_frame = stack[stack.size () - 2];
+                sixtp_stack_frame* parent_frame = stack[stack.size () - 2].get ();
                 parent_data = parent_frame->data_for_children;
-                sibling_data = parent_frame->data_from_children;
+                sibling_data = &parent_frame->data_from_children;
             }
 
             current_frame->parser->fail_handler (current_frame->data_for_children,
                                                  current_frame->data_from_children,
-                                                 sibling_data,
+                                                 *sibling_data,
                                                  parent_data,
                                                  sax_data->global_data,
                                                  &current_frame->frame_data,
@@ -662,12 +690,11 @@ sixtp_handle_catastrophe (sixtp_sax_data* sax_data)
         }
 
         /* now cleanup any children's results */
-        for (lp = current_frame->data_from_children; lp; lp = lp->next)
+        for (auto& cresult : current_frame->data_from_children)
         {
-            sixtp_child_result* cresult = (sixtp_child_result*) lp->data;
-            if (cresult->fail_handler)
+            if (cresult.fail_handler)
             {
-                cresult->fail_handler (cresult);
+                cresult.fail_handler (&cresult);
             }
         }
 
@@ -678,13 +705,14 @@ sixtp_handle_catastrophe (sixtp_sax_data* sax_data)
             break;
         }
 
-        sixtp_pop_and_destroy_frame (stack);
+        stack.pop_back ();
     }
 }
 
 static gboolean
 gnc_bad_xml_end_handler (gpointer data_for_children,
-                         GSList* data_from_children, GSList* sibling_data,
+                         const sixtp_child_result_list& data_from_children,
+                         const sixtp_child_result_list& sibling_data,
                          gpointer parent_data, gpointer global_data,
                          gpointer* result, const gchar* tag)
 {

--- a/libgnucash/backend/xml/sixtp.cpp
+++ b/libgnucash/backend/xml/sixtp.cpp
@@ -51,7 +51,7 @@ is_child_result_from_node_named (const sixtp_child_result* cr, const char* tag)
 {
     return ((cr->type == SIXTP_CHILD_RESULT_NODE)
             &&
-            (g_strcmp0 (cr->tag, tag) == 0));
+            (cr->tag == tag));
 }
 
 void
@@ -61,13 +61,12 @@ sixtp_child_free_data (sixtp_child_result* result)
 }
 
 _sixtp_child_result::_sixtp_child_result (_sixtp_child_result&& other) noexcept
-    : type (other.type), tag (other.tag), data (other.data),
+    : type (other.type), tag (std::move (other.tag)), data (other.data),
       should_cleanup (other.should_cleanup),
       cleanup_handler (other.cleanup_handler),
       fail_handler (other.fail_handler)
 {
-    /* leave a harmless husk behind: no tag to free, nothing to clean up */
-    other.tag = nullptr;
+    /* leave a harmless husk behind: nothing left to clean up */
     other.should_cleanup = FALSE;
 }
 
@@ -77,16 +76,14 @@ _sixtp_child_result::operator= (_sixtp_child_result&& other) noexcept
     if (this == &other) return *this;
 
     if (should_cleanup && cleanup_handler) cleanup_handler (this);
-    if (type == SIXTP_CHILD_RESULT_NODE) g_free (tag);
 
     type = other.type;
-    tag = other.tag;
+    tag = std::move (other.tag);
     data = other.data;
     should_cleanup = other.should_cleanup;
     cleanup_handler = other.cleanup_handler;
     fail_handler = other.fail_handler;
 
-    other.tag = nullptr;
     other.should_cleanup = FALSE;
 
     return *this;
@@ -98,14 +95,13 @@ _sixtp_child_result::~_sixtp_child_result ()
     {
         cleanup_handler (this);
     }
-    if (type == SIXTP_CHILD_RESULT_NODE) g_free (tag);
 }
 
 void
 sixtp_child_result_print (const sixtp_child_result* cr, FILE* f)
 {
     fprintf (f, "((tag %s) (data %p))",
-             cr->tag ? cr->tag : "(null)",
+             cr->tag.empty () ? "(null)" : cr->tag.c_str (),
              cr->data);
 }
 
@@ -531,15 +527,9 @@ sixtp_sax_characters_handler (void* user_data, const xmlChar* text, int len)
         if (pdata->parsing_ok && result)
         {
             /* push the result onto the current "child" list. */
-            sixtp_child_result child_data;
-
-            child_data.type = SIXTP_CHILD_RESULT_CHARS;
-            child_data.tag = NULL;
-            child_data.data = result;
-            child_data.should_cleanup = TRUE;
-            child_data.cleanup_handler = frame->parser->cleanup_chars;
-            child_data.fail_handler = frame->parser->chars_fail_handler;
-            frame->data_from_children.push_back (std::move (child_data));
+            frame->data_from_children.emplace_back (
+                SIXTP_CHILD_RESULT_CHARS, std::string (), result,
+                frame->parser->cleanup_chars, frame->parser->chars_fail_handler);
         }
     }
 }
@@ -588,20 +578,16 @@ sixtp_sax_end_handler (void* user_data, const xmlChar* name)
 
     if (current_frame->frame_data)
     {
-        /* push the result onto the parent's child result list. Fetch the
-           pointer only *after* the push: push_back may reallocate the
-           vector and move every element (including this one) to a new
-           buffer, so a pointer taken beforehand could dangle. */
-        sixtp_child_result cr;
-
-        cr.type = SIXTP_CHILD_RESULT_NODE;
-        cr.tag = g_strdup (current_frame->tag);
-        cr.data = current_frame->frame_data;
-        cr.should_cleanup = TRUE;
-        cr.cleanup_handler = current_frame->parser->cleanup_result;
-        cr.fail_handler = current_frame->parser->result_fail_handler;
-        parent_frame->data_from_children.push_back (std::move (cr));
-        child_result_data = &parent_frame->data_from_children.back ();
+        /* push the result onto the parent's child result list and build it
+           in place: emplace_back may reallocate the vector and move every
+           existing element to a new buffer, but the reference it returns
+           is to the already-constructed element at its final address, so
+           there's no dangling pointer to worry about here. */
+        auto& cr = parent_frame->data_from_children.emplace_back (
+            SIXTP_CHILD_RESULT_NODE, current_frame->tag ? current_frame->tag : "",
+            current_frame->frame_data, current_frame->parser->cleanup_result,
+            current_frame->parser->result_fail_handler);
+        child_result_data = &cr;
     }
 
     /* grab it before it goes away - we own the reference */

--- a/libgnucash/backend/xml/sixtp.h
+++ b/libgnucash/backend/xml/sixtp.h
@@ -29,6 +29,7 @@
 #include <stdio.h>
 
 #include <stdarg.h>
+#include <memory>
 #include <vector>
 #include "gnc-engine.h"
 
@@ -72,7 +73,11 @@ struct sixtp_gdv2
 };
 typedef struct _sixtp_child_result sixtp_child_result;
 
-typedef gboolean (*sixtp_start_handler) (GSList* sibling_data,
+/* A node's already-parsed children, in document order. Owned by the
+   sixtp_stack_frame they belong to; handlers only ever observe them. */
+typedef std::vector<sixtp_child_result> sixtp_child_result_list;
+
+typedef gboolean (*sixtp_start_handler) (const sixtp_child_result_list& sibling_data,
                                          gpointer parent_data,
                                          gpointer global_data,
                                          gpointer* data_for_children,
@@ -81,8 +86,8 @@ typedef gboolean (*sixtp_start_handler) (GSList* sibling_data,
                                          gchar** attrs);
 
 typedef gboolean (*sixtp_before_child_handler) (gpointer data_for_children,
-                                                GSList* data_from_children,
-                                                GSList* sibling_data,
+                                                const sixtp_child_result_list& data_from_children,
+                                                const sixtp_child_result_list& sibling_data,
                                                 gpointer parent_data,
                                                 gpointer global_data,
                                                 gpointer* result,
@@ -90,8 +95,8 @@ typedef gboolean (*sixtp_before_child_handler) (gpointer data_for_children,
                                                 const gchar* child_tag);
 
 typedef gboolean (*sixtp_after_child_handler) (gpointer data_for_children,
-                                               GSList* data_from_children,
-                                               GSList* sibling_data,
+                                               const sixtp_child_result_list& data_from_children,
+                                               const sixtp_child_result_list& sibling_data,
                                                gpointer parent_data,
                                                gpointer global_data,
                                                gpointer* result,
@@ -100,14 +105,14 @@ typedef gboolean (*sixtp_after_child_handler) (gpointer data_for_children,
                                                sixtp_child_result* child_result);
 
 typedef gboolean (*sixtp_end_handler) (gpointer data_for_children,
-                                       GSList* data_from_children,
-                                       GSList* sibling_data,
+                                       const sixtp_child_result_list& data_from_children,
+                                       const sixtp_child_result_list& sibling_data,
                                        gpointer parent_data,
                                        gpointer global_data,
                                        gpointer* result,
                                        const gchar* tag);
 
-typedef gboolean (*sixtp_characters_handler) (GSList* sibling_data,
+typedef gboolean (*sixtp_characters_handler) (const sixtp_child_result_list& sibling_data,
                                               gpointer parent_data,
                                               gpointer global_data,
                                               gpointer* result,
@@ -117,8 +122,8 @@ typedef gboolean (*sixtp_characters_handler) (GSList* sibling_data,
 typedef void (*sixtp_result_handler) (sixtp_child_result* result);
 
 typedef void (*sixtp_fail_handler) (gpointer data_for_children,
-                                    GSList* data_from_children,
-                                    GSList* sibling_data,
+                                    const sixtp_child_result_list& data_from_children,
+                                    const sixtp_child_result_list& sibling_data,
                                     gpointer parent_data,
                                     gpointer global_data,
                                     gpointer* result,
@@ -186,27 +191,40 @@ struct _sixtp_child_result
     sixtp_child_result_type type;
     gchar* tag; /* NULL for a CHARS node. */
     gpointer data;
-    gboolean should_cleanup;
+    /* mutable: handlers observing this result through a `const
+       sixtp_child_result_list&` (sibling/parent data) can still take
+       ownership of `data` away from us by clearing this flag. */
+    mutable gboolean should_cleanup;
     sixtp_result_handler cleanup_handler;
     sixtp_result_handler fail_handler;
+
+    _sixtp_child_result () = default;
+    _sixtp_child_result (const _sixtp_child_result&) = delete;
+    _sixtp_child_result& operator= (const _sixtp_child_result&) = delete;
+    _sixtp_child_result (_sixtp_child_result&& other) noexcept;
+    _sixtp_child_result& operator= (_sixtp_child_result&& other) noexcept;
+    ~_sixtp_child_result ();
 };
+
+/* Returns a shared, empty child-result list; used where a handler needs
+   a sibling/parent list but there isn't one (e.g. the document root). */
+const sixtp_child_result_list& sixtp_no_children ();
 
 typedef struct sixtp_stack_frame sixtp_stack_frame;
 
 typedef struct sixtp_sax_data
 {
     gboolean parsing_ok;
-    std::vector<sixtp_stack_frame*> stack; /* back() is the current frame */
+    std::vector<std::unique_ptr<sixtp_stack_frame>> stack; /* back() is the current frame */
     gpointer global_data;
     xmlParserCtxtPtr saxParserCtxt;
     sixtp* bad_xml_parser;
 } sixtp_sax_data;
 
-gboolean is_child_result_from_node_named (sixtp_child_result* cr,
+gboolean is_child_result_from_node_named (const sixtp_child_result* cr,
                                           const char* tag);
 void sixtp_child_free_data (sixtp_child_result* result);
-void sixtp_child_result_destroy (sixtp_child_result* r);
-void sixtp_child_result_print (sixtp_child_result* cr, FILE* f);
+void sixtp_child_result_print (const sixtp_child_result* cr, FILE* f);
 
 void sixtp_sax_start_handler (void* user_data, const xmlChar* name,
                               const xmlChar** attrs);

--- a/libgnucash/backend/xml/sixtp.h
+++ b/libgnucash/backend/xml/sixtp.h
@@ -29,8 +29,10 @@
 #include <stdio.h>
 
 #include <stdarg.h>
+#include <functional>
 #include <string>
 #include <vector>
+#include <boost/container/flat_map.hpp>
 #include "gnc-engine.h"
 
 #include "gnc-xml-helper.h"
@@ -154,7 +156,13 @@ typedef struct sixtp
     /* called to cleanup character results when cleaning up this node's
        children. */
 
-    GHashTable* child_parsers;
+    /* Small, built once per node while the parser tree is set up, then
+       looked up once per XML element for the rest of the document's
+       life - a sorted flat array beats a hash table for both patterns
+       at these sizes. Transparent (std::less<>) so a lookup can compare
+       against the SAX-provided tag directly, without constructing a
+       std::string first. */
+    boost::container::flat_map<std::string, sixtp*, std::less<>> child_parsers;
 } sixtp;
 
 typedef enum

--- a/libgnucash/backend/xml/sixtp.h
+++ b/libgnucash/backend/xml/sixtp.h
@@ -29,7 +29,6 @@
 #include <stdio.h>
 
 #include <stdarg.h>
-#include <memory>
 #include <vector>
 #include "gnc-engine.h"
 
@@ -215,7 +214,7 @@ typedef struct sixtp_stack_frame sixtp_stack_frame;
 typedef struct sixtp_sax_data
 {
     gboolean parsing_ok;
-    std::vector<std::unique_ptr<sixtp_stack_frame>> stack; /* back() is the current frame */
+    std::vector<sixtp_stack_frame> stack; /* back() is the current frame */
     gpointer global_data;
     xmlParserCtxtPtr saxParserCtxt;
     sixtp* bad_xml_parser;

--- a/libgnucash/backend/xml/sixtp.h
+++ b/libgnucash/backend/xml/sixtp.h
@@ -29,6 +29,7 @@
 #include <stdio.h>
 
 #include <stdarg.h>
+#include <vector>
 #include "gnc-engine.h"
 
 #include "gnc-xml-helper.h"
@@ -190,10 +191,12 @@ struct _sixtp_child_result
     sixtp_result_handler fail_handler;
 };
 
+typedef struct sixtp_stack_frame sixtp_stack_frame;
+
 typedef struct sixtp_sax_data
 {
     gboolean parsing_ok;
-    GSList* stack;
+    std::vector<sixtp_stack_frame*> stack; /* back() is the current frame */
     gpointer global_data;
     xmlParserCtxtPtr saxParserCtxt;
     sixtp* bad_xml_parser;

--- a/libgnucash/backend/xml/sixtp.h
+++ b/libgnucash/backend/xml/sixtp.h
@@ -29,6 +29,7 @@
 #include <stdio.h>
 
 #include <stdarg.h>
+#include <string>
 #include <vector>
 #include "gnc-engine.h"
 
@@ -188,7 +189,7 @@ typedef enum
 struct _sixtp_child_result
 {
     sixtp_child_result_type type;
-    gchar* tag; /* NULL for a CHARS node. */
+    std::string tag; /* empty for a CHARS node. */
     gpointer data;
     /* mutable: handlers observing this result through a `const
        sixtp_child_result_list&` (sibling/parent data) can still take
@@ -197,7 +198,15 @@ struct _sixtp_child_result
     sixtp_result_handler cleanup_handler;
     sixtp_result_handler fail_handler;
 
-    _sixtp_child_result () = default;
+    /* should_cleanup always starts TRUE: a result is born owning `data`,
+       and only gives that up later if some handler clears the flag. */
+    _sixtp_child_result (sixtp_child_result_type type_, std::string tag_,
+                         gpointer data_, sixtp_result_handler cleanup_handler_,
+                         sixtp_result_handler fail_handler_)
+        : type (type_), tag (std::move (tag_)), data (data_),
+          should_cleanup (TRUE), cleanup_handler (cleanup_handler_),
+          fail_handler (fail_handler_)
+    {}
     _sixtp_child_result (const _sixtp_child_result&) = delete;
     _sixtp_child_result& operator= (const _sixtp_child_result&) = delete;
     _sixtp_child_result (_sixtp_child_result&& other) noexcept;

--- a/libgnucash/backend/xml/test/test-file-stuff.cpp
+++ b/libgnucash/backend/xml/test/test-file-stuff.cpp
@@ -104,8 +104,8 @@ write_dom_node_to_file (xmlNodePtr node, int fd)
 }
 
 gboolean
-print_dom_tree (gpointer data_for_children, GSList* data_from_children,
-                GSList* sibling_data, gpointer parent_data,
+print_dom_tree (gpointer data_for_children, const sixtp_child_result_list& data_from_children,
+                const sixtp_child_result_list& sibling_data, gpointer parent_data,
                 gpointer global_data, gpointer* result, const gchar* tag)
 {
     if (parent_data == NULL)
@@ -269,7 +269,7 @@ equals_node_val_vs_date (xmlNodePtr node, time64 time)
 
 static gboolean
 just_dom_tree_end_handler (gpointer data_for_children,
-                           GSList* data_from_children, GSList* sibling_data,
+                           const sixtp_child_result_list& data_from_children, const sixtp_child_result_list& sibling_data,
                            gpointer parent_data, gpointer global_data,
                            gpointer* result, const gchar* tag)
 {

--- a/libgnucash/backend/xml/test/test-file-stuff.h
+++ b/libgnucash/backend/xml/test/test-file-stuff.h
@@ -42,8 +42,8 @@ void write_dom_node_to_file (xmlNodePtr node, int fd);
 int files_compare (const gchar* f1, const gchar* f2);
 
 gboolean print_dom_tree (gpointer data_for_children,
-                         GSList* data_from_children,
-                         GSList* sibling_data, gpointer parent_data,
+                         const sixtp_child_result_list& data_from_children,
+                         const sixtp_child_result_list& sibling_data, gpointer parent_data,
                          gpointer global_data, gpointer* result,
                          const gchar* tag);
 


### PR DESCRIPTION
The SAX-driven sixtp parser (libgnucash/backend/xml) built its per-element parse state entirely out of GLib linked lists and individually g_new'd/g_strdup'd nodes: one heap allocation and one free for every stack-frame push/pop, every child result, and every tag string copied - all proportional to the number of XML elements in the file being loaded (accounts, transactions, splits, kvp slots...). Replaced that with modern C++ containers and RAII, in a few connected steps:

* sixtp_sax_data::stack: GSList of individually-allocated frames ->
  std::vector<sixtp_stack_frame> (frames stored by value, growing
  amortized instead of one malloc/free per XML element). The one place
  that pushes a frame while still needing another frame's address
  afterward (sixtp_sax_start_handler) tracks it by index and re-derives
  the pointer post-push, since push_back can reallocate; every other
  touch point only ever pops, which never invalidates other elements.

* sixtp_stack_frame::data_from_children: same GSList-of-allocated-nodes problem -> std::vector<sixtp_child_result>, built in place via emplace_back with a real constructor instead of default-construct- then-assign. sixtp_child_result gained a destructor (replacing the old sixtp_child_result_destroy free function) and a move constructor/assignment, since a user-declared destructor suppresses the implicit ones and this type needs to live in a vector.

* Both `tag` fields (sixtp_child_result and sixtp_stack_frame) were gchar* g_strdup'd unconditionally on every push - the highest- frequency allocation site in the parser, since a stack frame is pushed once per XML element regardless of what it produces. Now std::string: these are short element names ("split", "gnc:account", "price", ...), so small-string optimization avoids the heap allocation entirely for the common case. This also simplified the tag-lifetime handoff in the end handler from copy-then-manual-g_free to a plain std::move.

* sixtp_parser_context and sixtp_stack_frame gained real constructors (folding what sixtp_context_new/sixtp_stack_frame_new used to do by hand into the type itself) and sixtp_parser_context is now managed via std::unique_ptr instead of raw new/delete, removing five paired-by-hand delete call sites in favor of automatic cleanup on every exit path.

* sixtp::child_parsers (tag -> sub-parser lookup, small and built once per parser node, then queried once per XML element for the rest of the document): GHashTable -> boost::container::flat_map<std::string, sixtp*, std::less<>> (boost is already a dependency here via kvp-value.hpp's use of boost::variant). A sorted flat array beats a hash table for both patterns at these sizes, and the transparent comparator lets lookups compare directly against the SAX-provided tag without constructing a std::string first. This also retired an "extended hash lookup" whose only purpose was returning the table's own copy of the key - a value nothing actually read - and the manual g_strdup/g_free bookkeeping that came with GHashTable-owned keys.

* sixtp_destroy's "corpses" cycle-guard set (needed because a parser graph can reference itself, e.g. recursive kvp-frame structures) was also a GHashTable used purely for pointer-identity membership testing -> std::unordered_set<sixtp*>, collapsing a lookup-then-conditional-insert into one insert() call.

Handler typedefs (sixtp_start/before_child/after_child/end/characters/ fail_handler) now take `const sixtp_child_result_list&` instead of GSList*, threaded through every file in the XML backend that implements one (~25 files). The large majority needed only a signature change - a repo-wide check showed the sibling_data parameter is never read anywhere - and two files (gnc-pricedb-xml-v2.cpp and io-gncxml-v1.cpp, the old XML v1 loader) additionally compare sixtp_child_result::tag or index into data_from_children in ways that depend on the new container/string types. Fixed one latent, previously-inert bug found along the way: the end handler's after_child call built its sibling-data argument from the wrong stack frame field (data_for_children instead of data_from_children, a copy-paste slip from the analogous before_child code) - harmless before since nothing read that argument, but not something a reference-typed signature can carry forward silently.

Every file change was verified by actually compiling it with `g++ -std=c++17 -fsyntax-only` against the real glib/libxml2/boost headers, not just read for plausibility.


Claude-Session: https://claude.ai/code/session_01FW5NNzvQLU5jGzR9wj1ZDy