### PR TITLE
csv date & currency format storage

### DIFF
--- a/gnucash/import-export/csv-imp/gnc-imp-props-price.cpp
+++ b/gnucash/import-export/csv-imp/gnc-imp-props-price.cpp
@@ -94,6 +94,8 @@ GncNumeric parse_amount_price (const std::string &str, int currency_format)
         if (!(xaccParseAmountExtImport (str_no_symbols.c_str(), TRUE, '-', ',', '.', "$+", &val, &endptr)))
             throw std::invalid_argument (_("Value can't be parsed into a number using the selected currency format."));
         break;
+    default:
+        throw std::invalid_argument (_("Value can't be parsed into a number using the selected currency format."));
     }
 
     return GncNumeric(val);

--- a/gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp
+++ b/gnucash/import-export/csv-imp/gnc-imp-props-tx.cpp
@@ -164,6 +164,8 @@ GncNumeric parse_monetary (const std::string &str, int currency_format)
         if (!(xaccParseAmountExtImport (str_no_symbols.c_str(), TRUE, '-', ',', '.', "$+", &val, &endptr)))
             throw std::invalid_argument (_("Value can't be parsed into a number using the selected currency format."));
         break;
+    default:
+        throw std::invalid_argument (_("Value can't be parsed into a number using the selected currency format."));
     }
 
     return GncNumeric(val);

--- a/gnucash/import-export/csv-imp/gnc-imp-settings-csv.cpp
+++ b/gnucash/import-export/csv-imp/gnc-imp-settings-csv.cpp
@@ -39,6 +39,7 @@
 #include "gnc-ui-util.h"
 
 #include <algorithm>
+#include <functional>
 #include <iostream>
 #include <stdexcept>
 #include <string>
@@ -93,75 +94,71 @@ handle_load_error (GError **key_error, const std::string& group)
 }
 
 /**************************************************
- * date_format_to_mnemonic / mnemonic_to_date_format
+ * Mnemonic-based persistence for the date and currency formats
  *
- * The date format used to be stored as a plain index into
- * GncDate::c_formats. That's fragile: if the vector's order or
- * length ever changes, previously saved settings would silently
- * start pointing at the wrong (or a nonexistent) format. Instead
- * we now persist the format's own mnemonic string (e.g. "y-m-d"),
- * which is stable regardless of how c_formats is reordered.
+ * Both used to be stored as a plain index into a format list.
+ * That's fragile: if a list's order or length ever changes,
+ * previously saved settings would silently start pointing at the
+ * wrong (or a nonexistent) format. Instead both are now persisted
+ * as the format's own mnemonic string (e.g. "y-m-d", "period"),
+ * which is stable regardless of how the underlying list is
+ * reordered.
  *
  * For backward compatibility, a value that isn't a recognized
  * mnemonic is also tried as a legacy numeric index, translated
- * through a fixed table reflecting the c_formats order that was
+ * through a fixed table reflecting the list order that was
  * actually in effect when settings were saved as plain indices.
- * That table must never be changed, even if c_formats itself is
+ * That table must never be changed, even if the live list is
  * later reordered or extended, so old numeric indices keep
  * resolving to the format they originally meant. Anything that
  * still doesn't resolve to a valid, currently-known format falls
  * back to index 0, with a warning, rather than reading out of
  * bounds.
  **************************************************/
-static const std::vector<std::string> c_legacy_date_format_order
-{
-    "y-m-d", "d-m-y", "m-d-y", "d-m", "m-d", "Locale"
-};
+using MnemonicLookup = std::function<std::string(size_t)>;
 
 static int
-find_format_index (const std::string& mnemonic)
+find_mnemonic_index (const std::string& mnemonic, size_t count, const MnemonicLookup& get_mnemonic)
 {
-    auto iter = std::find_if (GncDate::c_formats.cbegin(), GncDate::c_formats.cend(),
-                               [&mnemonic](const GncDateFormat& fmt)
-                                   { return fmt.m_fmt == mnemonic; });
-    if (iter == GncDate::c_formats.cend())
-        return -1;
-    return static_cast<int>(std::distance (GncDate::c_formats.cbegin(), iter));
+    for (size_t i = 0; i < count; ++i)
+        if (get_mnemonic (i) == mnemonic)
+            return static_cast<int>(i);
+    return -1;
 }
 
 static std::string
-date_format_to_mnemonic (int date_format)
+index_to_mnemonic (int index, size_t count, const MnemonicLookup& get_mnemonic, const char* what)
 {
-    if (date_format < 0 ||
-        static_cast<size_t>(date_format) >= GncDate::c_formats.size())
+    if (index < 0 || static_cast<size_t>(index) >= count)
     {
-        g_warning ("Invalid date format index %d, defaulting to 0", date_format);
-        date_format = 0;
+        g_warning ("Invalid %s index %d, defaulting to 0", what, index);
+        index = 0;
     }
-    return GncDate::c_formats[static_cast<size_t>(date_format)].m_fmt;
+    return get_mnemonic (static_cast<size_t>(index));
 }
 
 static int
-mnemonic_to_date_format (const std::string& mnemonic)
+mnemonic_to_index (const std::string& mnemonic, size_t count, const MnemonicLookup& get_mnemonic,
+                    const std::vector<std::string>& legacy_order, const char* what)
 {
-    auto idx = find_format_index (mnemonic);
+    auto idx = find_mnemonic_index (mnemonic, count, get_mnemonic);
     if (idx >= 0)
         return idx;
 
     // Not a recognized mnemonic. Fall back to interpreting the value as a
     // legacy numeric index for settings files saved by older GnuCash
-    // versions, mapped through the fixed historical order above rather
-    // than the (possibly since rearranged) live c_formats order.
+    // versions, mapped through the fixed historical order rather than
+    // the (possibly since rearranged) live list.
     try
     {
         size_t pos = 0;
         auto legacy_index = std::stoi (mnemonic, &pos);
         if (pos == mnemonic.size() &&
             legacy_index >= 0 &&
-            static_cast<size_t>(legacy_index) < c_legacy_date_format_order.size())
+            static_cast<size_t>(legacy_index) < legacy_order.size())
         {
-            auto legacy_idx = find_format_index (
-                c_legacy_date_format_order[static_cast<size_t>(legacy_index)]);
+            auto legacy_idx = find_mnemonic_index (
+                legacy_order[static_cast<size_t>(legacy_index)], count, get_mnemonic);
             if (legacy_idx >= 0)
                 return legacy_idx;
         }
@@ -171,79 +168,55 @@ mnemonic_to_date_format (const std::string& mnemonic)
         // not a number either, fall through to the default below
     }
 
-    g_warning ("Unrecognized date format '%s', defaulting to 0", mnemonic.c_str());
+    g_warning ("Unrecognized %s '%s', defaulting to 0", what, mnemonic.c_str());
     return 0;
 }
 
-/**************************************************
- * currency_format_to_mnemonic / mnemonic_to_currency_format
- *
- * Same rationale and pattern as the date format above: persist a
- * stable mnemonic ("locale", "period", "comma") instead of the raw
- * index consumed by parse_monetary()/parse_amount_price(), so a
- * settings file survives a future reordering or extension of the
- * currency format list.
- *
- * c_currency_format_mnemonics doubles as the legacy-index table:
- * unlike c_formats, this list has always lived here, next to its
- * one and only consumer, so its current order and its historical
- * order are the same thing. It must stay append-only (new formats
- * added at the end) for that to keep holding.
- **************************************************/
+// The c_formats order that was actually in effect when date formats were
+// saved as plain indices. Must never be edited, even if c_formats itself
+// is later reordered or extended.
+static const std::vector<std::string> c_legacy_date_format_order
+{
+    "y-m-d", "d-m-y", "m-d-y", "d-m", "m-d", "Locale"
+};
+
+// Unlike c_formats, this list has always lived here, next to its one and
+// only consumer (parse_monetary()/parse_amount_price()), so it doubles as
+// its own legacy-index table. It must stay append-only (new formats added
+// at the end) for that to keep holding.
 static const std::vector<std::string> c_currency_format_mnemonics
 {
     "locale", "period", "comma"
 };
 
-static int
-find_currency_format_index (const std::string& mnemonic)
+static std::string
+date_format_to_mnemonic (int date_format)
 {
-    auto iter = std::find (c_currency_format_mnemonics.cbegin(), c_currency_format_mnemonics.cend(),
-                            mnemonic);
-    if (iter == c_currency_format_mnemonics.cend())
-        return -1;
-    return static_cast<int>(std::distance (c_currency_format_mnemonics.cbegin(), iter));
+    return index_to_mnemonic (date_format, GncDate::c_formats.size(),
+        [](size_t i) { return GncDate::c_formats[i].m_fmt; }, "date format");
+}
+
+static int
+mnemonic_to_date_format (const std::string& mnemonic)
+{
+    return mnemonic_to_index (mnemonic, GncDate::c_formats.size(),
+        [](size_t i) { return GncDate::c_formats[i].m_fmt; },
+        c_legacy_date_format_order, "date format");
 }
 
 static std::string
 currency_format_to_mnemonic (int currency_format)
 {
-    if (currency_format < 0 ||
-        static_cast<size_t>(currency_format) >= c_currency_format_mnemonics.size())
-    {
-        g_warning ("Invalid currency format index %d, defaulting to 0", currency_format);
-        currency_format = 0;
-    }
-    return c_currency_format_mnemonics[static_cast<size_t>(currency_format)];
+    return index_to_mnemonic (currency_format, c_currency_format_mnemonics.size(),
+        [](size_t i) { return c_currency_format_mnemonics[i]; }, "currency format");
 }
 
 static int
 mnemonic_to_currency_format (const std::string& mnemonic)
 {
-    auto idx = find_currency_format_index (mnemonic);
-    if (idx >= 0)
-        return idx;
-
-    // Not a recognized mnemonic. Fall back to interpreting the value as a
-    // legacy numeric index for settings files saved by older GnuCash
-    // versions (or by a newer version that stored an index for a
-    // currency format this build doesn't have a mnemonic for).
-    try
-    {
-        size_t pos = 0;
-        auto legacy_index = std::stoi (mnemonic, &pos);
-        if (pos == mnemonic.size() &&
-            legacy_index >= 0 &&
-            static_cast<size_t>(legacy_index) < c_currency_format_mnemonics.size())
-            return legacy_index;
-    }
-    catch (const std::exception&)
-    {
-        // not a number either, fall through to the default below
-    }
-
-    g_warning ("Unrecognized currency format '%s', defaulting to 0", mnemonic.c_str());
-    return 0;
+    return mnemonic_to_index (mnemonic, c_currency_format_mnemonics.size(),
+        [](size_t i) { return c_currency_format_mnemonics[i]; },
+        c_currency_format_mnemonics, "currency format");
 }
 
 bool preset_is_reserved_name (const std::string& name)

--- a/gnucash/import-export/csv-imp/gnc-imp-settings-csv.cpp
+++ b/gnucash/import-export/csv-imp/gnc-imp-settings-csv.cpp
@@ -175,6 +175,77 @@ mnemonic_to_date_format (const std::string& mnemonic)
     return 0;
 }
 
+/**************************************************
+ * currency_format_to_mnemonic / mnemonic_to_currency_format
+ *
+ * Same rationale and pattern as the date format above: persist a
+ * stable mnemonic ("locale", "period", "comma") instead of the raw
+ * index consumed by parse_monetary()/parse_amount_price(), so a
+ * settings file survives a future reordering or extension of the
+ * currency format list.
+ *
+ * c_currency_format_mnemonics doubles as the legacy-index table:
+ * unlike c_formats, this list has always lived here, next to its
+ * one and only consumer, so its current order and its historical
+ * order are the same thing. It must stay append-only (new formats
+ * added at the end) for that to keep holding.
+ **************************************************/
+static const std::vector<std::string> c_currency_format_mnemonics
+{
+    "locale", "period", "comma"
+};
+
+static int
+find_currency_format_index (const std::string& mnemonic)
+{
+    auto iter = std::find (c_currency_format_mnemonics.cbegin(), c_currency_format_mnemonics.cend(),
+                            mnemonic);
+    if (iter == c_currency_format_mnemonics.cend())
+        return -1;
+    return static_cast<int>(std::distance (c_currency_format_mnemonics.cbegin(), iter));
+}
+
+static std::string
+currency_format_to_mnemonic (int currency_format)
+{
+    if (currency_format < 0 ||
+        static_cast<size_t>(currency_format) >= c_currency_format_mnemonics.size())
+    {
+        g_warning ("Invalid currency format index %d, defaulting to 0", currency_format);
+        currency_format = 0;
+    }
+    return c_currency_format_mnemonics[static_cast<size_t>(currency_format)];
+}
+
+static int
+mnemonic_to_currency_format (const std::string& mnemonic)
+{
+    auto idx = find_currency_format_index (mnemonic);
+    if (idx >= 0)
+        return idx;
+
+    // Not a recognized mnemonic. Fall back to interpreting the value as a
+    // legacy numeric index for settings files saved by older GnuCash
+    // versions (or by a newer version that stored an index for a
+    // currency format this build doesn't have a mnemonic for).
+    try
+    {
+        size_t pos = 0;
+        auto legacy_index = std::stoi (mnemonic, &pos);
+        if (pos == mnemonic.size() &&
+            legacy_index >= 0 &&
+            static_cast<size_t>(legacy_index) < c_currency_format_mnemonics.size())
+            return legacy_index;
+    }
+    catch (const std::exception&)
+    {
+        // not a number either, fall through to the default below
+    }
+
+    g_warning ("Unrecognized currency format '%s', defaulting to 0", mnemonic.c_str());
+    return 0;
+}
+
 bool preset_is_reserved_name (const std::string& name)
 {
     return ((name == no_settings) ||
@@ -252,8 +323,14 @@ CsvImportSettings::load (void)
     if (key_char)
         g_free (key_char);
 
-    m_currency_format = g_key_file_get_integer (keyfile, group.c_str(), CSV_CURRENCY, &key_error);
+    key_char = g_key_file_get_string (keyfile, group.c_str(), CSV_CURRENCY, &key_error);
+    if (key_char && *key_char != '\0')
+        m_currency_format = mnemonic_to_currency_format (key_char);
+    else
+        m_currency_format = 0;
     m_load_error |= handle_load_error (&key_error, group);
+    if (key_char)
+        g_free (key_char);
 
     key_char = g_key_file_get_string (keyfile, group.c_str(), CSV_ENCODING, &key_error);
     if (key_char && *key_char != '\0')
@@ -312,7 +389,15 @@ CsvImportSettings::save (void)
                         { cmt_ss << "'" << fmt.m_fmt << "', "; });
     auto cmt = cmt_ss.str().substr(0, static_cast<long>(cmt_ss.tellp()) - 2);
     g_key_file_set_comment (keyfile, group.c_str(), CSV_DATE, cmt.c_str(), nullptr);
-    g_key_file_set_integer (keyfile, group.c_str(), CSV_CURRENCY, m_currency_format);
+    g_key_file_set_string (keyfile, group.c_str(), CSV_CURRENCY,
+                            currency_format_to_mnemonic (m_currency_format).c_str());
+    std::ostringstream curr_cmt_ss;
+    curr_cmt_ss << "Supported currency formats: ";
+    std::for_each (c_currency_format_mnemonics.cbegin(), c_currency_format_mnemonics.cend(),
+                    [&curr_cmt_ss](const std::string& mnemonic)
+                        { curr_cmt_ss << "'" << mnemonic << "', "; });
+    auto curr_cmt = curr_cmt_ss.str().substr(0, static_cast<long>(curr_cmt_ss.tellp()) - 2);
+    g_key_file_set_comment (keyfile, group.c_str(), CSV_CURRENCY, curr_cmt.c_str(), nullptr);
     g_key_file_set_string (keyfile, group.c_str(), CSV_ENCODING, m_encoding.c_str());
 
     if (!m_column_widths.empty())

--- a/gnucash/import-export/csv-imp/gnc-imp-settings-csv.cpp
+++ b/gnucash/import-export/csv-imp/gnc-imp-settings-csv.cpp
@@ -115,17 +115,8 @@ handle_load_error (GError **key_error, const std::string& group)
  * back to index 0, with a warning, rather than reading out of
  * bounds.
  **************************************************/
-static int
-find_mnemonic_index (const std::string& mnemonic, const std::vector<std::string>& mnemonics)
-{
-    auto iter = std::find (mnemonics.cbegin(), mnemonics.cend(), mnemonic);
-    if (iter == mnemonics.cend())
-        return -1;
-    return static_cast<int>(std::distance (mnemonics.cbegin(), iter));
-}
-
 static std::string
-index_to_mnemonic (int index, const std::vector<std::string>& mnemonics, const char* what)
+format_to_mnemonic (int index, const std::vector<std::string>& mnemonics, const char* what)
 {
     if (index < 0 || static_cast<size_t>(index) >= mnemonics.size())
     {
@@ -136,12 +127,12 @@ index_to_mnemonic (int index, const std::vector<std::string>& mnemonics, const c
 }
 
 static int
-mnemonic_to_index (const std::string& mnemonic, const std::vector<std::string>& mnemonics,
-                    const std::vector<std::string>& legacy_order, const char* what)
+mnemonic_to_format (const std::string& mnemonic, const std::vector<std::string>& mnemonics,
+                     const std::vector<std::string>& legacy_order, const char* what)
 {
-    auto idx = find_mnemonic_index (mnemonic, mnemonics);
-    if (idx >= 0)
-        return idx;
+    auto iter = std::find (mnemonics.cbegin(), mnemonics.cend(), mnemonic);
+    if (iter != mnemonics.cend())
+        return static_cast<int>(std::distance (mnemonics.cbegin(), iter));
 
     // Not a recognized mnemonic. Fall back to interpreting the value as a
     // legacy numeric index for settings files saved by older GnuCash
@@ -155,10 +146,10 @@ mnemonic_to_index (const std::string& mnemonic, const std::vector<std::string>& 
             legacy_index >= 0 &&
             static_cast<size_t>(legacy_index) < legacy_order.size())
         {
-            auto legacy_idx = find_mnemonic_index (
-                legacy_order[static_cast<size_t>(legacy_index)], mnemonics);
-            if (legacy_idx >= 0)
-                return legacy_idx;
+            iter = std::find (mnemonics.cbegin(), mnemonics.cend(),
+                               legacy_order[static_cast<size_t>(legacy_index)]);
+            if (iter != mnemonics.cend())
+                return static_cast<int>(std::distance (mnemonics.cbegin(), iter));
         }
     }
     catch (const std::exception&)
@@ -198,31 +189,6 @@ date_format_mnemonics ()
     std::transform (GncDate::c_formats.cbegin(), GncDate::c_formats.cend(), std::back_inserter (mnemonics),
                      [](const GncDateFormat& fmt) { return fmt.m_fmt; });
     return mnemonics;
-}
-
-static std::string
-date_format_to_mnemonic (int date_format)
-{
-    return index_to_mnemonic (date_format, date_format_mnemonics(), "date format");
-}
-
-static int
-mnemonic_to_date_format (const std::string& mnemonic)
-{
-    return mnemonic_to_index (mnemonic, date_format_mnemonics(), c_legacy_date_format_order, "date format");
-}
-
-static std::string
-currency_format_to_mnemonic (int currency_format)
-{
-    return index_to_mnemonic (currency_format, c_currency_format_mnemonics, "currency format");
-}
-
-static int
-mnemonic_to_currency_format (const std::string& mnemonic)
-{
-    return mnemonic_to_index (mnemonic, c_currency_format_mnemonics, c_currency_format_mnemonics,
-                               "currency format");
 }
 
 bool preset_is_reserved_name (const std::string& name)
@@ -295,7 +261,8 @@ CsvImportSettings::load (void)
 
     key_char = g_key_file_get_string (keyfile, group.c_str(), CSV_DATE, &key_error);
     if (key_char && *key_char != '\0')
-        m_date_format = mnemonic_to_date_format (key_char);
+        m_date_format = mnemonic_to_format (key_char, date_format_mnemonics(),
+                                             c_legacy_date_format_order, "date format");
     else
         m_date_format = 0;
     m_load_error |= handle_load_error (&key_error, group);
@@ -304,7 +271,8 @@ CsvImportSettings::load (void)
 
     key_char = g_key_file_get_string (keyfile, group.c_str(), CSV_CURRENCY, &key_error);
     if (key_char && *key_char != '\0')
-        m_currency_format = mnemonic_to_currency_format (key_char);
+        m_currency_format = mnemonic_to_format (key_char, c_currency_format_mnemonics,
+                                                 c_currency_format_mnemonics, "currency format");
     else
         m_currency_format = 0;
     m_load_error |= handle_load_error (&key_error, group);
@@ -360,7 +328,7 @@ CsvImportSettings::save (void)
     g_key_file_set_string (keyfile, group.c_str(), CSV_SEP, m_separators.c_str());
     g_key_file_set_boolean (keyfile, group.c_str(), CSV_ESC, m_enable_escape);
     g_key_file_set_string (keyfile, group.c_str(), CSV_DATE,
-                            date_format_to_mnemonic (m_date_format).c_str());
+                            format_to_mnemonic (m_date_format, date_format_mnemonics(), "date format").c_str());
     std::ostringstream cmt_ss;
     cmt_ss << "Supported date formats: ";
     std::for_each (GncDate::c_formats.cbegin(), GncDate::c_formats.cend(),
@@ -369,7 +337,8 @@ CsvImportSettings::save (void)
     auto cmt = cmt_ss.str().substr(0, static_cast<long>(cmt_ss.tellp()) - 2);
     g_key_file_set_comment (keyfile, group.c_str(), CSV_DATE, cmt.c_str(), nullptr);
     g_key_file_set_string (keyfile, group.c_str(), CSV_CURRENCY,
-                            currency_format_to_mnemonic (m_currency_format).c_str());
+                            format_to_mnemonic (m_currency_format, c_currency_format_mnemonics,
+                                                "currency format").c_str());
     std::ostringstream curr_cmt_ss;
     curr_cmt_ss << "Supported currency formats: ";
     std::for_each (c_currency_format_mnemonics.cbegin(), c_currency_format_mnemonics.cend(),

--- a/gnucash/import-export/csv-imp/gnc-imp-settings-csv.cpp
+++ b/gnucash/import-export/csv-imp/gnc-imp-settings-csv.cpp
@@ -40,6 +40,7 @@
 
 #include <algorithm>
 #include <iostream>
+#include <stdexcept>
 #include <string>
 
 const std::string csv_group_prefix{"CSV-"};
@@ -89,6 +90,62 @@ handle_load_error (GError **key_error, const std::string& group)
     g_warning ("Error reading group '%s' : %s", group.c_str(), (*key_error)->message);
     g_clear_error (key_error);
     return true;
+}
+
+/**************************************************
+ * date_format_to_mnemonic / mnemonic_to_date_format
+ *
+ * The date format used to be stored as a plain index into
+ * GncDate::c_formats. That's fragile: if the vector's order or
+ * length ever changes, previously saved settings would silently
+ * start pointing at the wrong (or a nonexistent) format. Instead
+ * we now persist the format's own mnemonic string (e.g. "y-m-d"),
+ * which is stable regardless of how c_formats is reordered.
+ *
+ * For backward compatibility, a value that isn't a recognized
+ * mnemonic is also tried as a legacy numeric index. Anything that
+ * still doesn't resolve to a valid format falls back to index 0,
+ * with a warning, rather than reading out of bounds.
+ **************************************************/
+static std::string
+date_format_to_mnemonic (int date_format)
+{
+    if (date_format < 0 ||
+        static_cast<size_t>(date_format) >= GncDate::c_formats.size())
+    {
+        g_warning ("Invalid date format index %d, defaulting to 0", date_format);
+        date_format = 0;
+    }
+    return GncDate::c_formats[static_cast<size_t>(date_format)].m_fmt;
+}
+
+static int
+mnemonic_to_date_format (const std::string& mnemonic)
+{
+    auto iter = std::find_if (GncDate::c_formats.cbegin(), GncDate::c_formats.cend(),
+                               [&mnemonic](const GncDateFormat& fmt)
+                                   { return fmt.m_fmt == mnemonic; });
+    if (iter != GncDate::c_formats.cend())
+        return static_cast<int>(std::distance (GncDate::c_formats.cbegin(), iter));
+
+    // Not a recognized mnemonic. Fall back to interpreting the value as a
+    // legacy numeric index for settings files saved by older GnuCash versions.
+    try
+    {
+        size_t pos = 0;
+        auto legacy_index = std::stoi (mnemonic, &pos);
+        if (pos == mnemonic.size() &&
+            legacy_index >= 0 &&
+            static_cast<size_t>(legacy_index) < GncDate::c_formats.size())
+            return legacy_index;
+    }
+    catch (const std::exception&)
+    {
+        // not a number either, fall through to the default below
+    }
+
+    g_warning ("Unrecognized date format '%s', defaulting to 0", mnemonic.c_str());
+    return 0;
 }
 
 bool preset_is_reserved_name (const std::string& name)
@@ -159,8 +216,14 @@ CsvImportSettings::load (void)
     else
         m_load_error |= handle_load_error (&key_error, group);
 
-    m_date_format = g_key_file_get_integer (keyfile, group.c_str(), CSV_DATE, &key_error);
+    key_char = g_key_file_get_string (keyfile, group.c_str(), CSV_DATE, &key_error);
+    if (key_char && *key_char != '\0')
+        m_date_format = mnemonic_to_date_format (key_char);
+    else
+        m_date_format = 0;
     m_load_error |= handle_load_error (&key_error, group);
+    if (key_char)
+        g_free (key_char);
 
     m_currency_format = g_key_file_get_integer (keyfile, group.c_str(), CSV_CURRENCY, &key_error);
     m_load_error |= handle_load_error (&key_error, group);
@@ -213,13 +276,13 @@ CsvImportSettings::save (void)
 
     g_key_file_set_string (keyfile, group.c_str(), CSV_SEP, m_separators.c_str());
     g_key_file_set_boolean (keyfile, group.c_str(), CSV_ESC, m_enable_escape);
-    g_key_file_set_integer (keyfile, group.c_str(), CSV_DATE, m_date_format);
+    g_key_file_set_string (keyfile, group.c_str(), CSV_DATE,
+                            date_format_to_mnemonic (m_date_format).c_str());
     std::ostringstream cmt_ss;
     cmt_ss << "Supported date formats: ";
-    int fmt_num = 0;
     std::for_each (GncDate::c_formats.cbegin(), GncDate::c_formats.cend(),
-                    [&cmt_ss, &fmt_num](const GncDateFormat& fmt)
-                        { cmt_ss << fmt_num++ << ": '" << fmt.m_fmt << "', "; });
+                    [&cmt_ss](const GncDateFormat& fmt)
+                        { cmt_ss << "'" << fmt.m_fmt << "', "; });
     auto cmt = cmt_ss.str().substr(0, static_cast<long>(cmt_ss.tellp()) - 2);
     g_key_file_set_comment (keyfile, group.c_str(), CSV_DATE, cmt.c_str(), nullptr);
     g_key_file_set_integer (keyfile, group.c_str(), CSV_CURRENCY, m_currency_format);

--- a/gnucash/import-export/csv-imp/gnc-imp-settings-csv.cpp
+++ b/gnucash/import-export/csv-imp/gnc-imp-settings-csv.cpp
@@ -103,10 +103,32 @@ handle_load_error (GError **key_error, const std::string& group)
  * which is stable regardless of how c_formats is reordered.
  *
  * For backward compatibility, a value that isn't a recognized
- * mnemonic is also tried as a legacy numeric index. Anything that
- * still doesn't resolve to a valid format falls back to index 0,
- * with a warning, rather than reading out of bounds.
+ * mnemonic is also tried as a legacy numeric index, translated
+ * through a fixed table reflecting the c_formats order that was
+ * actually in effect when settings were saved as plain indices.
+ * That table must never be changed, even if c_formats itself is
+ * later reordered or extended, so old numeric indices keep
+ * resolving to the format they originally meant. Anything that
+ * still doesn't resolve to a valid, currently-known format falls
+ * back to index 0, with a warning, rather than reading out of
+ * bounds.
  **************************************************/
+static const std::vector<std::string> c_legacy_date_format_order
+{
+    "y-m-d", "d-m-y", "m-d-y", "d-m", "m-d", "Locale"
+};
+
+static int
+find_format_index (const std::string& mnemonic)
+{
+    auto iter = std::find_if (GncDate::c_formats.cbegin(), GncDate::c_formats.cend(),
+                               [&mnemonic](const GncDateFormat& fmt)
+                                   { return fmt.m_fmt == mnemonic; });
+    if (iter == GncDate::c_formats.cend())
+        return -1;
+    return static_cast<int>(std::distance (GncDate::c_formats.cbegin(), iter));
+}
+
 static std::string
 date_format_to_mnemonic (int date_format)
 {
@@ -122,22 +144,27 @@ date_format_to_mnemonic (int date_format)
 static int
 mnemonic_to_date_format (const std::string& mnemonic)
 {
-    auto iter = std::find_if (GncDate::c_formats.cbegin(), GncDate::c_formats.cend(),
-                               [&mnemonic](const GncDateFormat& fmt)
-                                   { return fmt.m_fmt == mnemonic; });
-    if (iter != GncDate::c_formats.cend())
-        return static_cast<int>(std::distance (GncDate::c_formats.cbegin(), iter));
+    auto idx = find_format_index (mnemonic);
+    if (idx >= 0)
+        return idx;
 
     // Not a recognized mnemonic. Fall back to interpreting the value as a
-    // legacy numeric index for settings files saved by older GnuCash versions.
+    // legacy numeric index for settings files saved by older GnuCash
+    // versions, mapped through the fixed historical order above rather
+    // than the (possibly since rearranged) live c_formats order.
     try
     {
         size_t pos = 0;
         auto legacy_index = std::stoi (mnemonic, &pos);
         if (pos == mnemonic.size() &&
             legacy_index >= 0 &&
-            static_cast<size_t>(legacy_index) < GncDate::c_formats.size())
-            return legacy_index;
+            static_cast<size_t>(legacy_index) < c_legacy_date_format_order.size())
+        {
+            auto legacy_idx = find_format_index (
+                c_legacy_date_format_order[static_cast<size_t>(legacy_index)]);
+            if (legacy_idx >= 0)
+                return legacy_idx;
+        }
     }
     catch (const std::exception&)
     {

--- a/gnucash/import-export/csv-imp/gnc-imp-settings-csv.cpp
+++ b/gnucash/import-export/csv-imp/gnc-imp-settings-csv.cpp
@@ -39,8 +39,8 @@
 #include "gnc-ui-util.h"
 
 #include <algorithm>
-#include <functional>
 #include <iostream>
+#include <iterator>
 #include <stdexcept>
 #include <string>
 
@@ -115,33 +115,31 @@ handle_load_error (GError **key_error, const std::string& group)
  * back to index 0, with a warning, rather than reading out of
  * bounds.
  **************************************************/
-using MnemonicLookup = std::function<std::string(size_t)>;
-
 static int
-find_mnemonic_index (const std::string& mnemonic, size_t count, const MnemonicLookup& get_mnemonic)
+find_mnemonic_index (const std::string& mnemonic, const std::vector<std::string>& mnemonics)
 {
-    for (size_t i = 0; i < count; ++i)
-        if (get_mnemonic (i) == mnemonic)
-            return static_cast<int>(i);
-    return -1;
+    auto iter = std::find (mnemonics.cbegin(), mnemonics.cend(), mnemonic);
+    if (iter == mnemonics.cend())
+        return -1;
+    return static_cast<int>(std::distance (mnemonics.cbegin(), iter));
 }
 
 static std::string
-index_to_mnemonic (int index, size_t count, const MnemonicLookup& get_mnemonic, const char* what)
+index_to_mnemonic (int index, const std::vector<std::string>& mnemonics, const char* what)
 {
-    if (index < 0 || static_cast<size_t>(index) >= count)
+    if (index < 0 || static_cast<size_t>(index) >= mnemonics.size())
     {
         g_warning ("Invalid %s index %d, defaulting to 0", what, index);
         index = 0;
     }
-    return get_mnemonic (static_cast<size_t>(index));
+    return mnemonics[static_cast<size_t>(index)];
 }
 
 static int
-mnemonic_to_index (const std::string& mnemonic, size_t count, const MnemonicLookup& get_mnemonic,
+mnemonic_to_index (const std::string& mnemonic, const std::vector<std::string>& mnemonics,
                     const std::vector<std::string>& legacy_order, const char* what)
 {
-    auto idx = find_mnemonic_index (mnemonic, count, get_mnemonic);
+    auto idx = find_mnemonic_index (mnemonic, mnemonics);
     if (idx >= 0)
         return idx;
 
@@ -158,7 +156,7 @@ mnemonic_to_index (const std::string& mnemonic, size_t count, const MnemonicLook
             static_cast<size_t>(legacy_index) < legacy_order.size())
         {
             auto legacy_idx = find_mnemonic_index (
-                legacy_order[static_cast<size_t>(legacy_index)], count, get_mnemonic);
+                legacy_order[static_cast<size_t>(legacy_index)], mnemonics);
             if (legacy_idx >= 0)
                 return legacy_idx;
         }
@@ -189,34 +187,42 @@ static const std::vector<std::string> c_currency_format_mnemonics
     "locale", "period", "comma"
 };
 
+// GncDate::c_formats lives in another module and holds more than just a
+// mnemonic per entry, so pull its mnemonics into a plain vector<string>
+// each time rather than exposing a reference into it.
+static std::vector<std::string>
+date_format_mnemonics ()
+{
+    std::vector<std::string> mnemonics;
+    mnemonics.reserve (GncDate::c_formats.size());
+    std::transform (GncDate::c_formats.cbegin(), GncDate::c_formats.cend(), std::back_inserter (mnemonics),
+                     [](const GncDateFormat& fmt) { return fmt.m_fmt; });
+    return mnemonics;
+}
+
 static std::string
 date_format_to_mnemonic (int date_format)
 {
-    return index_to_mnemonic (date_format, GncDate::c_formats.size(),
-        [](size_t i) { return GncDate::c_formats[i].m_fmt; }, "date format");
+    return index_to_mnemonic (date_format, date_format_mnemonics(), "date format");
 }
 
 static int
 mnemonic_to_date_format (const std::string& mnemonic)
 {
-    return mnemonic_to_index (mnemonic, GncDate::c_formats.size(),
-        [](size_t i) { return GncDate::c_formats[i].m_fmt; },
-        c_legacy_date_format_order, "date format");
+    return mnemonic_to_index (mnemonic, date_format_mnemonics(), c_legacy_date_format_order, "date format");
 }
 
 static std::string
 currency_format_to_mnemonic (int currency_format)
 {
-    return index_to_mnemonic (currency_format, c_currency_format_mnemonics.size(),
-        [](size_t i) { return c_currency_format_mnemonics[i]; }, "currency format");
+    return index_to_mnemonic (currency_format, c_currency_format_mnemonics, "currency format");
 }
 
 static int
 mnemonic_to_currency_format (const std::string& mnemonic)
 {
-    return mnemonic_to_index (mnemonic, c_currency_format_mnemonics.size(),
-        [](size_t i) { return c_currency_format_mnemonics[i]; },
-        c_currency_format_mnemonics, "currency format");
+    return mnemonic_to_index (mnemonic, c_currency_format_mnemonics, c_currency_format_mnemonics,
+                               "currency format");
 }
 
 bool preset_is_reserved_name (const std::string& name)


### PR DESCRIPTION
Backward incompatible change to csv import settings.

This improves the robustness of CSV import settings by storing date and currency formats as stable mnemonic strings (e.g., "y-m-d", "period") instead of numeric indices.

- Backward compatibility is maintained: old numeric indices are automatically translated through the fixed `c_legacy_date_format_order` and `c_currency_format_mnemonics` table
- Invalid formats fall back to index 0 with a warning
- The legacy format order table is immutable to ensure indices resolve to their formats

Risks - if 5.x gnucash loads csv import settings from 6.x then it'll reset to `0` ie `y-m-d` or `locale`.