### PR TITLE
FIX + Ehancements - Squashed center-aligned charts + new CSS-based one

### DIFF
--- a/gnucash/report/html-fonts.scm
+++ b/gnucash/report/html-fonts.scm
@@ -188,5 +188,8 @@
       "td.centered-label-cell { text-align: center; " centered-label-cell-info " }\n"
       "sub { top: 0.4em; }\n"
       "sub, sup { vertical-align: baseline; position: relative; top: -0.4em; }\n"
+
+      ;; Fix for squashed charts (standalone, center-aligned)
+      "body > table[style*=\"margin-left:auto\"][style*=\"margin-right:auto\"] > tbody > tr > td > div > canvas.chartjs-render-monitor { height: 96vh; width: 98vw; \n"
       "@media print { html, body { height: unset; }}\n"
       (or (gnc:html-document-style-text doc) "")))))

--- a/gnucash/report/stylesheets/css.scm
+++ b/gnucash/report/stylesheets/css.scm
@@ -28,7 +28,8 @@
 (use-modules (srfi srfi-13))
 (use-modules (gnucash html))
 
-(define default-css "/* default style */
+;; DEFAULT style
+(define default-css "/* DEFAULT style */
 @media (prefers-color-scheme: dark) {
     body {
         color: #000; background-color: #fff;
@@ -50,7 +51,7 @@ body, p, table, tr, td, a, th {
 }
 
 h3 {
-    font-size: 15pt;
+    font-size: 13pt;
     font-weight: bold;
 }
 
@@ -104,6 +105,10 @@ td.highlight {
     background-color: #e1e1e1
 }
 
+ td.text-cell {
+     /* placeholder */
+}
+
 @media print {
     html, body {
         height: unset;
@@ -113,20 +118,130 @@ td.highlight {
 tr.primary-subheading > td, tr:has(> td.total-number-cell) > td {
      background-color: #ececec;
 }
- tr.grand-total td {
+tr.grand-total td {
      background: #ececec !important;
 }
 ")
 
-(define (css-options)
+;; EASY style converted to CSS
+(define easy-css "/* EASY style */
+ @media (prefers-color-scheme: dark) {
+     body {
+         color: #000;
+         background-color: #FFF;
+    }
+}
+
+ html, body {
+     height: 100vh;
+     margin-top: 0px;
+     margin-bottom: 0px;
+     max-width: max-content;
+     margin:0 auto;
+     font-family: \"Noto Sans\", Sans-Serif;
+     font-size: 10pt;
+}
+
+ body, p, table, tr, td, a, th {
+     vertical-align: top;
+}
+
+ table {
+    border-spacing: 2px;
+    border-collapse: separate;
+    max-width: max-content;
+    margin: 0 auto;
+}
+
+ h3 {
+     font-size: 13pt;
+     font-weight: bold;
+}
+
+ a {
+     color: #b22222;
+}
+
+ td, th {
+     padding:1px;
+}
+
+ tr.alternate-row {
+     background: #ececec;
+}
+
+ tr {
+     page-break-inside: avoid !important;
+}
+
+ td, th {
+     border-color: grey
+}
+
+ td.total-number-cell, td.total-label-cell, td.centered-label-cell {
+     font-size: 12pt;
+     font-weight: bold;
+}
+
+ th.column-heading-left {
+     text-align: left;
+}
+
+ td.centered-label-cell, th.column-heading-center {
+     text-align: center;
+}
+
+ td.number-header, th.column-heading-right, td.number-cell, td.total-number-cell {
+     text-align: right;
+}
+
+ td.neg {
+     color: red;
+}
+
+ td.number-cell, td.total-number-cell, td.anchor-cell, td.date-cell {
+     white-space: nowrap;
+}
+
+ td.highlight {
+     background-color: #e1e1e1;
+}
+
+ tr.primary-subheading > td, tr:has(> td.total-number-cell) > td {
+     background-color: #eee8aa;
+}
+
+ tr.grand-total td {
+     background: #faf88c !important;
+}
+
+ td.text-cell {
+     /* placeholder */
+}
+
+ @media print {
+     html, body {
+         height: unset;
+    }
+}
+")
+
+(define (css-options css-param)
   (let ((options (gnc-new-optiondb)))
 
     (gnc-register-text-option options
       (N_ "General") (N_ "CSS") "a"
       (N_ "CSS code. This field specifies the CSS code for styling reports.")
-      default-css)
-
+      css-param)
     options))
+
+(define (css-options-default)
+    (css-options default-css)
+)
+
+(define (css-options-easy)
+    (css-options easy-css)
+)
 
 (define (css-renderer options doc)
 
@@ -246,6 +361,13 @@ tr.primary-subheading > td, tr:has(> td.total-number-cell) > td {
  'version 1
  'name (N_ "CSS")
  'renderer css-renderer
- 'options-generator css-options)
+ 'options-generator css-options-default)
+
+(gnc:define-html-style-sheet
+ 'version 1
+ 'name (N_ "CSS_Easy")
+ 'renderer css-renderer
+ 'options-generator css-options-easy)
 
 (gnc:make-html-style-sheet "CSS" (N_ "CSS-based stylesheet (experimental)"))
+(gnc:make-html-style-sheet "CSS_Easy" (N_ "CSS-based - Easy (experimental)"))

--- a/gnucash/report/stylesheets/css.scm
+++ b/gnucash/report/stylesheets/css.scm
@@ -64,7 +64,7 @@ td, th {
 }
 
 tr.alternate-row {
-    background: #ffffff
+    background: #ececec;
 }
 
 tr {
@@ -108,6 +108,13 @@ td.highlight {
     html, body {
         height: unset;
     }
+}
+
+tr.primary-subheading > td, tr:has(> td.total-number-cell) > td {
+     background-color: #ececec;
+}
+ tr.grand-total td {
+     background: #ececec !important;
 }
 ")
 

--- a/gnucash/report/stylesheets/css.scm
+++ b/gnucash/report/stylesheets/css.scm
@@ -224,6 +224,11 @@ tr.grand-total td {
          height: unset;
     }
 }
+
+/* fixing standalone charts (all center-aligned ones are squashed)*/
+ html > body > div > canvas.chartjs-render-monitor {
+     width: 100vw !important;
+}
 ")
 
 (define (css-options css-param)

--- a/gnucash/report/stylesheets/css.scm
+++ b/gnucash/report/stylesheets/css.scm
@@ -195,11 +195,27 @@ td.highlight {
      'tag "td"
      'attribute (list "class" "centered-label-cell"))
 
-    (gnc:html-document-set-style! ssdoc "normal-row" 'tag "tr")
-    (gnc:html-document-set-style! ssdoc "alternate-row" 'tag "tr")
-    (gnc:html-document-set-style! ssdoc "primary-subheading" 'tag "tr")
-    (gnc:html-document-set-style! ssdoc "secondary-subheading" 'tag "tr")
-    (gnc:html-document-set-style! ssdoc "grand-total" 'tag "tr")
+    (gnc:html-document-set-style!
+     ssdoc "normal-row"
+     'tag "tr"
+     'attribute (list "class" "normal-row"))
+
+    (gnc:html-document-set-style!
+     ssdoc "alternate-row"
+     'tag "tr"
+     'attribute (list "class" "alternate-row"))
+
+    (gnc:html-document-set-style!
+     ssdoc "primary-subheading"
+     'tag "tr"  'attribute (list "class" "primary-subheading"))
+
+    (gnc:html-document-set-style!
+     ssdoc "secondary-subheading"
+     'tag "tr" 'attribute (list "class" "secondary-subheading"))
+
+    (gnc:html-document-set-style!
+     ssdoc "grand-total"
+     'tag "tr" 'attribute (list "class" "grand-total"))
 
     (cond
      ((string-contains-ci all-css "</style")

--- a/gnucash/report/stylesheets/footer.scm
+++ b/gnucash/report/stylesheets/footer.scm
@@ -123,7 +123,7 @@
       (N_ "Colors")
       (N_ "Alternate Table Cell Color") "d"
       (N_ "Default alternate background for table cells.")
-      "ffffff")
+      "eaeaea")
 
     (gnc-register-color-option options
       (N_ "Colors")
@@ -141,12 +141,12 @@
       (N_ "Colors")
       (N_ "Grand Total Cell Color") "g"
       (N_ "Color for grand totals.")
-      "ffff00")
+      "f9f88b")
 
     (gnc-register-number-range-option options
       (N_ "Tables")
       (N_ "Table cell spacing") "a" (N_ "Space between table cells.")
-      1 0 20 1)
+      2 0 20 1)
 
     (gnc-register-number-range-option options
       (N_ "Tables")


### PR DESCRIPTION
!!! unfortunately, MultiColumn-housed version is still to be addressed

- EASY stylesheet (and other center-aligned ones from FOOTER.SCM) - squashed standalone charts FIX.
- Default CSS - fix
- Default CSS - missing styles / classes (an alternate row for instance)
- EASY CSS - new stylesheet available
- EASY stylesheet & DEFAULT CSS - tweaks

<img width="1706" height="846" alt="cenetered-charts-fix" src="https://github.com/user-attachments/assets/05fd6838-7235-4673-a867-1a2b8326b1c5" />
<img width="1170" height="960" alt="default-css-fix" src="https://github.com/user-attachments/assets/96be06a8-6c0e-480b-82ee-a341259fc072" />

##
Screenshots based on: GC Sample Database: https://github.com/PRG-112/gnucash-sample-db-generator