### PR TITLE
Xml sax parser

### DIFF
--- a/libgnucash/backend/xml/CMakeLists.txt
+++ b/libgnucash/backend/xml/CMakeLists.txt
@@ -19,6 +19,7 @@ set (backend_xml_utils_noinst_HEADERS
   gnc-vendor-xml-v2.h
   gnc-xml-backend.hpp
   gnc-xml-helper.h
+  gnc-xml-sax-node.h
   io-example-account.h
   io-gncxml-gen.h
   io-gncxml-v2.h
@@ -57,6 +58,7 @@ set (backend_xml_utils_SOURCES
   gnc-vendor-xml-v2.cpp
   gnc-xml-backend.cpp
   gnc-xml-helper.cpp
+  gnc-xml-sax-node.cpp
   io-example-account.cpp
   io-gncxml-gen.cpp
   io-gncxml-v1.cpp

--- a/libgnucash/backend/xml/gnc-account-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-account-xml-v2.cpp
@@ -172,7 +172,7 @@ struct account_pdata
 };
 
 static gboolean
-account_name_handler (xmlNodePtr node, gpointer act_pdata)
+account_name_handler (GncXmlNode* node, gpointer act_pdata)
 {
     struct account_pdata* pdata = static_cast<decltype (pdata)> (act_pdata);
 
@@ -180,7 +180,7 @@ account_name_handler (xmlNodePtr node, gpointer act_pdata)
 }
 
 static gboolean
-account_id_handler (xmlNodePtr node, gpointer act_pdata)
+account_id_handler (GncXmlNode* node, gpointer act_pdata)
 {
     struct account_pdata* pdata = static_cast<decltype (pdata)> (act_pdata);
 
@@ -193,15 +193,15 @@ account_id_handler (xmlNodePtr node, gpointer act_pdata)
 }
 
 static gboolean
-account_type_handler (xmlNodePtr node, gpointer act_pdata)
+account_type_handler (GncXmlNode* node, gpointer act_pdata)
 {
     struct account_pdata* pdata = static_cast<decltype (pdata)> (act_pdata);
     GNCAccountType type = ACCT_TYPE_INVALID;
     char* string;
 
-    string = (char*) xmlNodeGetContent (node->xmlChildrenNode);
+    string = gnc_xml_node_list_get_string (node->xmlChildrenNode);
     xaccAccountStringToType (string, &type);
-    xmlFree (string);
+    g_free (string);
 
     xaccAccountSetType (pdata->account, type);
 
@@ -209,7 +209,7 @@ account_type_handler (xmlNodePtr node, gpointer act_pdata)
 }
 
 static gboolean
-account_commodity_handler (xmlNodePtr node, gpointer act_pdata)
+account_commodity_handler (GncXmlNode* node, gpointer act_pdata)
 {
     struct account_pdata* pdata = static_cast<decltype (pdata)> (act_pdata);
     gnc_commodity* ref;
@@ -222,7 +222,7 @@ account_commodity_handler (xmlNodePtr node, gpointer act_pdata)
 }
 
 static gboolean
-account_commodity_scu_handler (xmlNodePtr node, gpointer act_pdata)
+account_commodity_scu_handler (GncXmlNode* node, gpointer act_pdata)
 {
     struct account_pdata* pdata = static_cast<decltype (pdata)> (act_pdata);
     gint64 val;
@@ -234,7 +234,7 @@ account_commodity_scu_handler (xmlNodePtr node, gpointer act_pdata)
 }
 
 static gboolean
-account_hidden_handler (xmlNodePtr node, gpointer act_pdata)
+account_hidden_handler (GncXmlNode* node, gpointer act_pdata)
 {
     struct account_pdata* pdata = static_cast<decltype (pdata)> (act_pdata);
     gboolean val;
@@ -246,7 +246,7 @@ account_hidden_handler (xmlNodePtr node, gpointer act_pdata)
 }
 
 static gboolean
-account_placeholder_handler (xmlNodePtr node, gpointer act_pdata)
+account_placeholder_handler (GncXmlNode* node, gpointer act_pdata)
 {
     struct account_pdata* pdata = static_cast<decltype (pdata)> (act_pdata);
     gboolean val;
@@ -258,7 +258,7 @@ account_placeholder_handler (xmlNodePtr node, gpointer act_pdata)
 }
 
 static gboolean
-account_non_standard_scu_handler (xmlNodePtr node, gpointer act_pdata)
+account_non_standard_scu_handler (GncXmlNode* node, gpointer act_pdata)
 {
     struct account_pdata* pdata = static_cast<decltype (pdata)> (act_pdata);
 
@@ -272,7 +272,7 @@ account_non_standard_scu_handler (xmlNodePtr node, gpointer act_pdata)
  * older XML files. */
 
 static gboolean
-deprecated_account_currency_handler (xmlNodePtr node, gpointer act_pdata)
+deprecated_account_currency_handler (GncXmlNode* node, gpointer act_pdata)
 {
     struct account_pdata* pdata = static_cast<decltype (pdata)> (act_pdata);
     gnc_commodity* ref;
@@ -286,7 +286,7 @@ deprecated_account_currency_handler (xmlNodePtr node, gpointer act_pdata)
 }
 
 static gboolean
-deprecated_account_currency_scu_handler (xmlNodePtr node, gpointer act_pdata)
+deprecated_account_currency_scu_handler (GncXmlNode* node, gpointer act_pdata)
 {
     struct account_pdata* pdata = static_cast<decltype (pdata)> (act_pdata);
     PWARN ("Account %s: Obsolete xml tag 'act:currency-scu' will not be preserved.",
@@ -295,7 +295,7 @@ deprecated_account_currency_scu_handler (xmlNodePtr node, gpointer act_pdata)
 }
 
 static gboolean
-deprecated_account_security_handler (xmlNodePtr node, gpointer act_pdata)
+deprecated_account_security_handler (GncXmlNode* node, gpointer act_pdata)
 {
     struct account_pdata* pdata = static_cast<decltype (pdata)> (act_pdata);
     gnc_commodity* ref, *orig = xaccAccountGetCommodity (pdata->account);
@@ -320,7 +320,7 @@ deprecated_account_security_handler (xmlNodePtr node, gpointer act_pdata)
 }
 
 static gboolean
-deprecated_account_security_scu_handler (xmlNodePtr node, gpointer act_pdata)
+deprecated_account_security_scu_handler (GncXmlNode* node, gpointer act_pdata)
 {
     struct account_pdata* pdata = static_cast<decltype (pdata)> (act_pdata);
     gint64 val;
@@ -339,14 +339,14 @@ deprecated_account_security_scu_handler (xmlNodePtr node, gpointer act_pdata)
 /* ============================================================== */
 
 static gboolean
-account_slots_handler (xmlNodePtr node, gpointer act_pdata)
+account_slots_handler (GncXmlNode* node, gpointer act_pdata)
 {
     struct account_pdata* pdata = static_cast<decltype (pdata)> (act_pdata);
     return dom_tree_create_instance_slots (node, QOF_INSTANCE (pdata->account));
 }
 
 static gboolean
-account_parent_handler (xmlNodePtr node, gpointer act_pdata)
+account_parent_handler (GncXmlNode* node, gpointer act_pdata)
 {
     struct account_pdata* pdata = static_cast<decltype (pdata)> (act_pdata);
     Account* parent;
@@ -366,7 +366,7 @@ account_parent_handler (xmlNodePtr node, gpointer act_pdata)
 }
 
 static gboolean
-account_code_handler (xmlNodePtr node, gpointer act_pdata)
+account_code_handler (GncXmlNode* node, gpointer act_pdata)
 {
     struct account_pdata* pdata = static_cast<decltype (pdata)> (act_pdata);
 
@@ -374,7 +374,7 @@ account_code_handler (xmlNodePtr node, gpointer act_pdata)
 }
 
 static gboolean
-account_description_handler (xmlNodePtr node, gpointer act_pdata)
+account_description_handler (GncXmlNode* node, gpointer act_pdata)
 {
     struct account_pdata* pdata = static_cast<decltype (pdata)> (act_pdata);
 
@@ -382,10 +382,10 @@ account_description_handler (xmlNodePtr node, gpointer act_pdata)
 }
 
 static gboolean
-account_lots_handler (xmlNodePtr node, gpointer act_pdata)
+account_lots_handler (GncXmlNode* node, gpointer act_pdata)
 {
     struct account_pdata* pdata = static_cast<decltype (pdata)> (act_pdata);
-    xmlNodePtr mark;
+    GncXmlNode* mark;
 
     g_return_val_if_fail (node, FALSE);
     g_return_val_if_fail (node->xmlChildrenNode, FALSE);
@@ -444,7 +444,7 @@ gnc_account_end_handler (gpointer data_for_children,
                          gpointer* result, const gchar* tag)
 {
     Account* acc, *parent, *root;
-    xmlNodePtr tree = (xmlNodePtr)data_for_children;
+    GncXmlNode* tree = (GncXmlNode*)data_for_children;
     gxpf_data* gdata = (gxpf_data*)global_data;
     QofBook* book = static_cast<decltype (book)> (gdata->bookdata);
     int type;
@@ -494,13 +494,13 @@ gnc_account_end_handler (gpointer data_for_children,
         }
     }
 
-    xmlFreeNode (tree);
+    gnc_xml_node_free (tree);
 
     return acc != NULL;
 }
 
 Account*
-dom_tree_to_account (xmlNodePtr node, QofBook* book)
+dom_tree_to_account (GncXmlNode* node, QofBook* book)
 {
     struct account_pdata act_pdata;
     Account* accToRet;

--- a/libgnucash/backend/xml/gnc-address-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-address-xml-v2.cpp
@@ -98,7 +98,7 @@ struct address_pdata
 
 
 static gboolean
-address_name_handler (xmlNodePtr node, gpointer addr_pdata)
+address_name_handler (GncXmlNode* node, gpointer addr_pdata)
 {
     struct address_pdata* pdata = static_cast<decltype (pdata)> (addr_pdata);
 
@@ -106,7 +106,7 @@ address_name_handler (xmlNodePtr node, gpointer addr_pdata)
 }
 
 static gboolean
-address_addr1_handler (xmlNodePtr node, gpointer addr_pdata)
+address_addr1_handler (GncXmlNode* node, gpointer addr_pdata)
 {
     struct address_pdata* pdata = static_cast<decltype (pdata)> (addr_pdata);
 
@@ -114,7 +114,7 @@ address_addr1_handler (xmlNodePtr node, gpointer addr_pdata)
 }
 
 static gboolean
-address_addr2_handler (xmlNodePtr node, gpointer addr_pdata)
+address_addr2_handler (GncXmlNode* node, gpointer addr_pdata)
 {
     struct address_pdata* pdata = static_cast<decltype (pdata)> (addr_pdata);
 
@@ -122,7 +122,7 @@ address_addr2_handler (xmlNodePtr node, gpointer addr_pdata)
 }
 
 static gboolean
-address_addr3_handler (xmlNodePtr node, gpointer addr_pdata)
+address_addr3_handler (GncXmlNode* node, gpointer addr_pdata)
 {
     struct address_pdata* pdata = static_cast<decltype (pdata)> (addr_pdata);
 
@@ -130,7 +130,7 @@ address_addr3_handler (xmlNodePtr node, gpointer addr_pdata)
 }
 
 static gboolean
-address_addr4_handler (xmlNodePtr node, gpointer addr_pdata)
+address_addr4_handler (GncXmlNode* node, gpointer addr_pdata)
 {
     struct address_pdata* pdata = static_cast<decltype (pdata)> (addr_pdata);
 
@@ -138,7 +138,7 @@ address_addr4_handler (xmlNodePtr node, gpointer addr_pdata)
 }
 
 static gboolean
-address_phone_handler (xmlNodePtr node, gpointer addr_pdata)
+address_phone_handler (GncXmlNode* node, gpointer addr_pdata)
 {
     struct address_pdata* pdata = static_cast<decltype (pdata)> (addr_pdata);
 
@@ -146,7 +146,7 @@ address_phone_handler (xmlNodePtr node, gpointer addr_pdata)
 }
 
 static gboolean
-address_fax_handler (xmlNodePtr node, gpointer addr_pdata)
+address_fax_handler (GncXmlNode* node, gpointer addr_pdata)
 {
     struct address_pdata* pdata = static_cast<decltype (pdata)> (addr_pdata);
 
@@ -154,7 +154,7 @@ address_fax_handler (xmlNodePtr node, gpointer addr_pdata)
 }
 
 static gboolean
-address_email_handler (xmlNodePtr node, gpointer addr_pdata)
+address_email_handler (GncXmlNode* node, gpointer addr_pdata)
 {
     struct address_pdata* pdata = static_cast<decltype (pdata)> (addr_pdata);
 
@@ -162,7 +162,7 @@ address_email_handler (xmlNodePtr node, gpointer addr_pdata)
 }
 
 static gboolean
-address_slots_handler (xmlNodePtr node, gpointer addr_pdata)
+address_slots_handler (GncXmlNode* node, gpointer addr_pdata)
 {
     struct address_pdata* pdata = static_cast<decltype (pdata)> (addr_pdata);
     return dom_tree_create_instance_slots (node, QOF_INSTANCE (pdata->address));
@@ -183,7 +183,7 @@ static struct dom_tree_handler address_handlers_v2[] =
 };
 
 gboolean
-gnc_dom_tree_to_address (xmlNodePtr node, GncAddress* address)
+gnc_dom_tree_to_address (GncXmlNode* node, GncAddress* address)
 {
     struct address_pdata addr_pdata;
     gboolean successful;

--- a/libgnucash/backend/xml/gnc-address-xml-v2.h
+++ b/libgnucash/backend/xml/gnc-address-xml-v2.h
@@ -24,8 +24,9 @@
 #define GNC_ADDRESS_XML_V2_H
 
 #include "gncAddress.h"
+#include "gnc-xml-sax-node.h"
 
-gboolean   gnc_dom_tree_to_address (xmlNodePtr node, GncAddress* address);
+gboolean   gnc_dom_tree_to_address (GncXmlNode* node, GncAddress* address);
 xmlNodePtr gnc_address_to_dom_tree (const char* tag, GncAddress* addr);
 void gnc_address_xml_initialize (void);
 

--- a/libgnucash/backend/xml/gnc-bill-term-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-bill-term-xml-v2.cpp
@@ -138,7 +138,7 @@ struct billterm_pdata
 };
 
 static gboolean
-set_int (xmlNodePtr node, GncBillTerm* term,
+set_int (GncXmlNode* node, GncBillTerm* term,
          void (*func) (GncBillTerm*, gint))
 {
     gint64 val;
@@ -148,7 +148,7 @@ set_int (xmlNodePtr node, GncBillTerm* term,
 }
 
 static gboolean
-set_numeric (xmlNodePtr node, GncBillTerm* term,
+set_numeric (GncXmlNode* node, GncBillTerm* term,
              void (*func) (GncBillTerm*, gnc_numeric))
 {
     func (term, dom_tree_to_gnc_numeric (node));
@@ -158,21 +158,21 @@ set_numeric (xmlNodePtr node, GncBillTerm* term,
 /***********************************************************************/
 
 static gboolean
-days_duedays_handler (xmlNodePtr node, gpointer billterm_pdata)
+days_duedays_handler (GncXmlNode* node, gpointer billterm_pdata)
 {
     struct billterm_pdata* pdata = static_cast<decltype (pdata)> (billterm_pdata);
     return set_int (node, pdata->term, gncBillTermSetDueDays);
 }
 
 static gboolean
-days_discdays_handler (xmlNodePtr node, gpointer billterm_pdata)
+days_discdays_handler (GncXmlNode* node, gpointer billterm_pdata)
 {
     struct billterm_pdata* pdata = static_cast<decltype (pdata)> (billterm_pdata);
     return set_int (node, pdata->term, gncBillTermSetDiscountDays);
 }
 
 static gboolean
-days_discount_handler (xmlNodePtr node, gpointer billterm_pdata)
+days_discount_handler (GncXmlNode* node, gpointer billterm_pdata)
 {
     struct billterm_pdata* pdata = static_cast<decltype (pdata)> (billterm_pdata);
     return set_numeric (node, pdata->term, gncBillTermSetDiscount);
@@ -187,7 +187,7 @@ static struct dom_tree_handler days_data_handlers_v2[] =
 };
 
 static gboolean
-dom_tree_to_days_data (xmlNodePtr node, struct billterm_pdata* pdata)
+dom_tree_to_days_data (GncXmlNode* node, struct billterm_pdata* pdata)
 {
     gboolean successful;
 
@@ -202,28 +202,28 @@ dom_tree_to_days_data (xmlNodePtr node, struct billterm_pdata* pdata)
 /***********************************************************************/
 
 static gboolean
-prox_dueday_handler (xmlNodePtr node, gpointer billterm_pdata)
+prox_dueday_handler (GncXmlNode* node, gpointer billterm_pdata)
 {
     struct billterm_pdata* pdata = static_cast<decltype (pdata)> (billterm_pdata);
     return set_int (node, pdata->term, gncBillTermSetDueDays);
 }
 
 static gboolean
-prox_discday_handler (xmlNodePtr node, gpointer billterm_pdata)
+prox_discday_handler (GncXmlNode* node, gpointer billterm_pdata)
 {
     struct billterm_pdata* pdata = static_cast<decltype (pdata)> (billterm_pdata);
     return set_int (node, pdata->term, gncBillTermSetDiscountDays);
 }
 
 static gboolean
-prox_discount_handler (xmlNodePtr node, gpointer billterm_pdata)
+prox_discount_handler (GncXmlNode* node, gpointer billterm_pdata)
 {
     struct billterm_pdata* pdata = static_cast<decltype (pdata)> (billterm_pdata);
     return set_numeric (node, pdata->term, gncBillTermSetDiscount);
 }
 
 static gboolean
-prox_cutoff_handler (xmlNodePtr node, gpointer billterm_pdata)
+prox_cutoff_handler (GncXmlNode* node, gpointer billterm_pdata)
 {
     struct billterm_pdata* pdata = static_cast<decltype (pdata)> (billterm_pdata);
     return set_int (node, pdata->term, gncBillTermSetCutoff);
@@ -239,7 +239,7 @@ static struct dom_tree_handler prox_data_handlers_v2[] =
 };
 
 static gboolean
-dom_tree_to_prox_data (xmlNodePtr node, struct billterm_pdata* pdata)
+dom_tree_to_prox_data (GncXmlNode* node, struct billterm_pdata* pdata)
 {
     gboolean successful;
 
@@ -254,7 +254,7 @@ dom_tree_to_prox_data (xmlNodePtr node, struct billterm_pdata* pdata)
 /***********************************************************************/
 
 static gboolean
-set_parent_child (xmlNodePtr node, struct billterm_pdata* pdata,
+set_parent_child (GncXmlNode* node, struct billterm_pdata* pdata,
                   void (*func) (GncBillTerm*, GncBillTerm*))
 {
     GncBillTerm* term;
@@ -276,7 +276,7 @@ set_parent_child (xmlNodePtr node, struct billterm_pdata* pdata,
 }
 
 static gboolean
-billterm_guid_handler (xmlNodePtr node, gpointer billterm_pdata)
+billterm_guid_handler (GncXmlNode* node, gpointer billterm_pdata)
 {
     struct billterm_pdata* pdata = static_cast<decltype (pdata)> (billterm_pdata);
     GncBillTerm* term;
@@ -299,21 +299,21 @@ billterm_guid_handler (xmlNodePtr node, gpointer billterm_pdata)
 }
 
 static gboolean
-billterm_name_handler (xmlNodePtr node, gpointer billterm_pdata)
+billterm_name_handler (GncXmlNode* node, gpointer billterm_pdata)
 {
     struct billterm_pdata* pdata = static_cast<decltype (pdata)> (billterm_pdata);
     return apply_xmlnode_text (gncBillTermSetName, pdata->term, node);
 }
 
 static gboolean
-billterm_desc_handler (xmlNodePtr node, gpointer billterm_pdata)
+billterm_desc_handler (GncXmlNode* node, gpointer billterm_pdata)
 {
     struct billterm_pdata* pdata = static_cast<decltype (pdata)> (billterm_pdata);
     return apply_xmlnode_text (gncBillTermSetDescription, pdata->term, node);
 }
 
 static gboolean
-billterm_refcount_handler (xmlNodePtr node, gpointer billterm_pdata)
+billterm_refcount_handler (GncXmlNode* node, gpointer billterm_pdata)
 {
     struct billterm_pdata* pdata = static_cast<decltype (pdata)> (billterm_pdata);
     gint64 val;
@@ -324,7 +324,7 @@ billterm_refcount_handler (xmlNodePtr node, gpointer billterm_pdata)
 }
 
 static gboolean
-billterm_invisible_handler (xmlNodePtr node, gpointer billterm_pdata)
+billterm_invisible_handler (GncXmlNode* node, gpointer billterm_pdata)
 {
     struct billterm_pdata* pdata = static_cast<decltype (pdata)> (billterm_pdata);
     gint64 val;
@@ -336,21 +336,21 @@ billterm_invisible_handler (xmlNodePtr node, gpointer billterm_pdata)
 }
 
 static gboolean
-billterm_parent_handler (xmlNodePtr node, gpointer billterm_pdata)
+billterm_parent_handler (GncXmlNode* node, gpointer billterm_pdata)
 {
     struct billterm_pdata* pdata = static_cast<decltype (pdata)> (billterm_pdata);
     return set_parent_child (node, pdata, gncBillTermSetParent);
 }
 
 static gboolean
-billterm_child_handler (xmlNodePtr node, gpointer billterm_pdata)
+billterm_child_handler (GncXmlNode* node, gpointer billterm_pdata)
 {
     struct billterm_pdata* pdata = static_cast<decltype (pdata)> (billterm_pdata);
     return set_parent_child (node, pdata, gncBillTermSetChild);
 }
 
 static gboolean
-billterm_days_data_handler (xmlNodePtr node, gpointer billterm_pdata)
+billterm_days_data_handler (GncXmlNode* node, gpointer billterm_pdata)
 {
     struct billterm_pdata* pdata = static_cast<decltype (pdata)> (billterm_pdata);
 
@@ -362,7 +362,7 @@ billterm_days_data_handler (xmlNodePtr node, gpointer billterm_pdata)
 }
 
 static gboolean
-billterm_prox_data_handler (xmlNodePtr node, gpointer billterm_pdata)
+billterm_prox_data_handler (GncXmlNode* node, gpointer billterm_pdata)
 {
     struct billterm_pdata* pdata = static_cast<decltype (pdata)> (billterm_pdata);
 
@@ -374,7 +374,7 @@ billterm_prox_data_handler (xmlNodePtr node, gpointer billterm_pdata)
 }
 
 static gboolean
-billterm_slots_handler (xmlNodePtr node, gpointer billterm_pdata)
+billterm_slots_handler (GncXmlNode* node, gpointer billterm_pdata)
 {
     struct billterm_pdata* pdata = static_cast<decltype (pdata)> (billterm_pdata);
     return dom_tree_create_instance_slots (node, QOF_INSTANCE (pdata->term));
@@ -396,7 +396,7 @@ static struct dom_tree_handler billterm_handlers_v2[] =
 };
 
 static GncBillTerm*
-dom_tree_to_billterm (xmlNodePtr node, QofBook* book)
+dom_tree_to_billterm (GncXmlNode* node, QofBook* book)
 {
     struct billterm_pdata billterm_pdata;
     gboolean successful;
@@ -429,7 +429,7 @@ gnc_billterm_end_handler (gpointer data_for_children,
                           gpointer* result, const gchar* tag)
 {
     GncBillTerm* term;
-    xmlNodePtr tree = (xmlNodePtr)data_for_children;
+    GncXmlNode* tree = (GncXmlNode*)data_for_children;
     gxpf_data* gdata = (gxpf_data*)global_data;
     QofBook* book = static_cast<decltype (book)> (gdata->bookdata);
 
@@ -454,7 +454,7 @@ gnc_billterm_end_handler (gpointer data_for_children,
         gdata->cb (tag, gdata->parsedata, term);
     }
 
-    xmlFreeNode (tree);
+    gnc_xml_node_free (tree);
 
     return term != NULL;
 }

--- a/libgnucash/backend/xml/gnc-book-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-book-xml-v2.cpp
@@ -111,7 +111,7 @@ write_book_parts (FILE* out, QofBook* book)
 /* ================================================================ */
 
 static gboolean
-book_id_handler (xmlNodePtr node, gpointer book_pdata)
+book_id_handler (GncXmlNode* node, gpointer book_pdata)
 {
     QofBook* book = static_cast<decltype (book)> (book_pdata);
 
@@ -122,7 +122,7 @@ book_id_handler (xmlNodePtr node, gpointer book_pdata)
 }
 
 static gboolean
-book_slots_handler (xmlNodePtr node, gpointer book_pdata)
+book_slots_handler (GncXmlNode* node, gpointer book_pdata)
 {
     QofBook* book = static_cast<decltype (book)> (book_pdata);
     gboolean success;
@@ -150,7 +150,7 @@ gnc_book_end_handler (gpointer data_for_children,
                       gpointer parent_data, gpointer global_data,
                       gpointer* result, const gchar* tag)
 {
-    xmlNodePtr tree = (xmlNodePtr)data_for_children;
+    GncXmlNode* tree = (GncXmlNode*)data_for_children;
     gxpf_data* gdata = (gxpf_data*)global_data;
     QofBook* book = static_cast<decltype (book)> (gdata->bookdata);
 
@@ -167,7 +167,7 @@ gnc_book_end_handler (gpointer data_for_children,
     if (!book)
         gdata->cb (tag, gdata->parsedata, book);
 
-    xmlFreeNode (tree);
+    gnc_xml_node_free (tree);
 
     return book != NULL;
 }
@@ -179,7 +179,7 @@ gnc_book_id_end_handler (gpointer data_for_children,
                          gpointer* result, const gchar* tag)
 {
     gboolean successful;
-    xmlNodePtr tree = (xmlNodePtr)data_for_children;
+    GncXmlNode* tree = (GncXmlNode*)data_for_children;
     gxpf_data* gdata = (gxpf_data*)global_data;
     QofBook* book = static_cast<decltype (book)> (gdata->bookdata);
 
@@ -189,7 +189,7 @@ gnc_book_id_end_handler (gpointer data_for_children,
     g_return_val_if_fail (tree, FALSE);
 
     successful = book_id_handler (tree, book);
-    xmlFreeNode (tree);
+    gnc_xml_node_free (tree);
 
     return successful;
 }
@@ -201,7 +201,7 @@ gnc_book_slots_end_handler (gpointer data_for_children,
                             gpointer* result, const gchar* tag)
 {
     gboolean successful;
-    xmlNodePtr tree = (xmlNodePtr)data_for_children;
+    GncXmlNode* tree = (GncXmlNode*)data_for_children;
     gxpf_data* gdata = (gxpf_data*)global_data;
     QofBook* book = static_cast<decltype (book)> (gdata->bookdata);
 
@@ -211,13 +211,13 @@ gnc_book_slots_end_handler (gpointer data_for_children,
     g_return_val_if_fail (tree, FALSE);
 
     successful = book_slots_handler (tree, book);
-    xmlFreeNode (tree);
+    gnc_xml_node_free (tree);
 
     return successful;
 }
 
 QofBook*
-dom_tree_to_book (xmlNodePtr node, QofBook* book)
+dom_tree_to_book (GncXmlNode* node, QofBook* book)
 {
     gboolean successful;
 

--- a/libgnucash/backend/xml/gnc-budget-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-budget-xml-v2.cpp
@@ -87,7 +87,7 @@ gnc_budget_dom_tree_create (GncBudget* bgt)
 /***********************************************************************/
 
 static gboolean
-budget_id_handler (xmlNodePtr node, gpointer bgt)
+budget_id_handler (GncXmlNode* node, gpointer bgt)
 {
     auto guid = dom_tree_to_guid (node);
     g_return_val_if_fail (guid, FALSE);
@@ -96,19 +96,19 @@ budget_id_handler (xmlNodePtr node, gpointer bgt)
 }
 
 static gboolean
-budget_name_handler (xmlNodePtr node, gpointer bgt)
+budget_name_handler (GncXmlNode* node, gpointer bgt)
 {
     return apply_xmlnode_text (gnc_budget_set_name, GNC_BUDGET (bgt), node);
 }
 
 static gboolean
-budget_description_handler (xmlNodePtr node, gpointer bgt)
+budget_description_handler (GncXmlNode* node, gpointer bgt)
 {
     return apply_xmlnode_text (gnc_budget_set_description, GNC_BUDGET (bgt), node);
 }
 
 static gboolean
-budget_num_periods_handler (xmlNodePtr node, gpointer bgt)
+budget_num_periods_handler (GncXmlNode* node, gpointer bgt)
 {
     guint num_periods;
 
@@ -122,7 +122,7 @@ budget_num_periods_handler (xmlNodePtr node, gpointer bgt)
 }
 
 static gboolean
-budget_recurrence_handler (xmlNodePtr node, gpointer bgt)
+budget_recurrence_handler (GncXmlNode* node, gpointer bgt)
 {
     Recurrence* r;
 
@@ -135,7 +135,7 @@ budget_recurrence_handler (xmlNodePtr node, gpointer bgt)
 }
 
 static gboolean
-budget_slots_handler (xmlNodePtr node, gpointer bgt)
+budget_slots_handler (GncXmlNode* node, gpointer bgt)
 {
     return dom_tree_create_instance_slots (node, QOF_INSTANCE (bgt));
 }
@@ -158,7 +158,7 @@ gnc_budget_end_handler (gpointer data_for_children,
                         gpointer* result, const gchar* tag)
 {
     GncBudget* bgt;
-    xmlNodePtr tree = (xmlNodePtr)data_for_children;
+    GncXmlNode* tree = (GncXmlNode*)data_for_children;
     gxpf_data* gdata = (gxpf_data*)global_data;
     QofBook* book = static_cast<decltype (book)> (gdata->bookdata);
 
@@ -177,7 +177,7 @@ gnc_budget_end_handler (gpointer data_for_children,
     g_return_val_if_fail (tree, FALSE);
 
     bgt = dom_tree_to_budget (tree, book);
-    xmlFreeNode (tree);
+    gnc_xml_node_free (tree);
     if (bgt != NULL)
     {
         /* ends up calling book_callback */
@@ -189,7 +189,7 @@ gnc_budget_end_handler (gpointer data_for_children,
 
 
 GncBudget*
-dom_tree_to_budget (xmlNodePtr node, QofBook* book)
+dom_tree_to_budget (GncXmlNode* node, QofBook* book)
 {
     GncBudget* bgt;
 

--- a/libgnucash/backend/xml/gnc-commodity-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-commodity-xml-v2.cpp
@@ -132,19 +132,19 @@ struct com_char_handler com_handlers[] =
 };
 
 static void
-set_commodity_value (xmlNodePtr node, gnc_commodity* com)
+set_commodity_value (GncXmlNode* node, gnc_commodity* com)
 {
     if (g_strcmp0 ((char*) node->name, cmdty_fraction) == 0)
     {
         gint64 val;
         char* string;
 
-        string = (char*) xmlNodeGetContent (node->xmlChildrenNode);
+        string = gnc_xml_node_list_get_string (node->xmlChildrenNode);
         if (string_to_gint64 (string, &val))
         {
             gnc_commodity_set_fraction (com, val);
         }
-        xmlFree (string);
+        g_free (string);
     }
     else if (g_strcmp0 ((char*)node->name, cmdty_get_quotes) == 0)
     {
@@ -155,12 +155,12 @@ set_commodity_value (xmlNodePtr node, gnc_commodity* com)
         gnc_quote_source* source;
         char* string;
 
-        string = (char*) xmlNodeGetContent (node->xmlChildrenNode);
+        string = gnc_xml_node_list_get_string (node->xmlChildrenNode);
         source = gnc_quote_source_lookup_by_internal (string);
         if (!source)
             source = gnc_quote_source_add_new (string, FALSE);
         gnc_commodity_set_quote_source (com, source);
-        xmlFree (string);
+        g_free (string);
     }
     else if (g_strcmp0 ((char*)node->name, cmdty_slots) == 0)
     {
@@ -210,19 +210,19 @@ valid_commodity (gnc_commodity* com)
 }
 
 static gnc_commodity*
-gnc_commodity_find_currency (QofBook* book, xmlNodePtr tree)
+gnc_commodity_find_currency (QofBook* book, GncXmlNode* tree)
 {
     gnc_commodity_table* table;
     gnc_commodity* currency = NULL;
     gchar* exchange = NULL, *mnemonic = NULL;
-    xmlNodePtr node;
+    GncXmlNode* node;
 
     for (node = tree->xmlChildrenNode; node; node = node->next)
     {
         if (g_strcmp0 ((char*) node->name, cmdty_namespace) == 0)
-            exchange = (gchar*) xmlNodeGetContent (node->xmlChildrenNode);
+            exchange = gnc_xml_node_list_get_string (node->xmlChildrenNode);
         if (g_strcmp0 ((char*) node->name, cmdty_id) == 0)
-            mnemonic = (gchar*) xmlNodeGetContent (node->xmlChildrenNode);
+            mnemonic = gnc_xml_node_list_get_string (node->xmlChildrenNode);
     }
 
     if (exchange
@@ -234,9 +234,9 @@ gnc_commodity_find_currency (QofBook* book, xmlNodePtr tree)
     }
 
     if (exchange)
-        xmlFree (exchange);
+        g_free (exchange);
     if (mnemonic)
-        xmlFree (mnemonic);
+        g_free (mnemonic);
 
     return currency;
 }
@@ -248,8 +248,8 @@ gnc_commodity_end_handler (gpointer data_for_children,
                            gpointer* result, const gchar* tag)
 {
     gnc_commodity* com, *old_com;
-    xmlNodePtr achild;
-    xmlNodePtr tree = (xmlNodePtr)data_for_children;
+    GncXmlNode* achild;
+    GncXmlNode* tree = (GncXmlNode*)data_for_children;
     gxpf_data* gdata = (gxpf_data*)global_data;
     QofBook* book = static_cast<decltype (book)> (gdata->bookdata);
 
@@ -280,7 +280,7 @@ gnc_commodity_end_handler (gpointer data_for_children,
     if (!valid_commodity (com))
     {
         PWARN ("Invalid commodity parsed");
-        xmlElemDump (stdout, NULL, tree);
+        gnc_xml_node_dump (stdout, tree);
         printf ("\n");
         fflush (stdout);
         gnc_commodity_destroy (com);
@@ -289,7 +289,7 @@ gnc_commodity_end_handler (gpointer data_for_children,
 
     gdata->cb (tag, gdata->parsedata, com);
 
-    xmlFreeNode (tree);
+    gnc_xml_node_free (tree);
 
     return TRUE;
 }

--- a/libgnucash/backend/xml/gnc-customer-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-customer-xml-v2.cpp
@@ -147,7 +147,7 @@ struct customer_pdata
 
 
 static gboolean
-set_boolean (xmlNodePtr node, GncCustomer* cust,
+set_boolean (GncXmlNode* node, GncCustomer* cust,
              void (*func) (GncCustomer* cust, gboolean b))
 {
     gint64 val;
@@ -161,7 +161,7 @@ set_boolean (xmlNodePtr node, GncCustomer* cust,
 }
 
 static gboolean
-customer_name_handler (xmlNodePtr node, gpointer cust_pdata)
+customer_name_handler (GncXmlNode* node, gpointer cust_pdata)
 {
     struct customer_pdata* pdata = static_cast<decltype (pdata)> (cust_pdata);
 
@@ -169,7 +169,7 @@ customer_name_handler (xmlNodePtr node, gpointer cust_pdata)
 }
 
 static gboolean
-customer_guid_handler (xmlNodePtr node, gpointer cust_pdata)
+customer_guid_handler (GncXmlNode* node, gpointer cust_pdata)
 {
     struct customer_pdata* pdata = static_cast<decltype (pdata)> (cust_pdata);
     GncCustomer* cust;
@@ -192,7 +192,7 @@ customer_guid_handler (xmlNodePtr node, gpointer cust_pdata)
 }
 
 static gboolean
-customer_id_handler (xmlNodePtr node, gpointer cust_pdata)
+customer_id_handler (GncXmlNode* node, gpointer cust_pdata)
 {
     struct customer_pdata* pdata = static_cast<decltype (pdata)> (cust_pdata);
 
@@ -200,7 +200,7 @@ customer_id_handler (xmlNodePtr node, gpointer cust_pdata)
 }
 
 static gboolean
-customer_notes_handler (xmlNodePtr node, gpointer cust_pdata)
+customer_notes_handler (GncXmlNode* node, gpointer cust_pdata)
 {
     struct customer_pdata* pdata = static_cast<decltype (pdata)> (cust_pdata);
 
@@ -208,7 +208,7 @@ customer_notes_handler (xmlNodePtr node, gpointer cust_pdata)
 }
 
 static gboolean
-customer_terms_handler (xmlNodePtr node, gpointer cust_pdata)
+customer_terms_handler (GncXmlNode* node, gpointer cust_pdata)
 {
     struct customer_pdata* pdata = static_cast<decltype (pdata)> (cust_pdata);
     GncBillTerm* term;
@@ -223,7 +223,7 @@ customer_terms_handler (xmlNodePtr node, gpointer cust_pdata)
 }
 
 static gboolean
-customer_addr_handler (xmlNodePtr node, gpointer cust_pdata)
+customer_addr_handler (GncXmlNode* node, gpointer cust_pdata)
 {
     struct customer_pdata* pdata = static_cast<decltype (pdata)> (cust_pdata);
 
@@ -231,7 +231,7 @@ customer_addr_handler (xmlNodePtr node, gpointer cust_pdata)
 }
 
 static gboolean
-customer_shipaddr_handler (xmlNodePtr node, gpointer cust_pdata)
+customer_shipaddr_handler (GncXmlNode* node, gpointer cust_pdata)
 {
     struct customer_pdata* pdata = static_cast<decltype (pdata)> (cust_pdata);
 
@@ -241,7 +241,7 @@ customer_shipaddr_handler (xmlNodePtr node, gpointer cust_pdata)
 
 
 static gboolean
-customer_taxincluded_handler (xmlNodePtr node, gpointer cust_pdata)
+customer_taxincluded_handler (GncXmlNode* node, gpointer cust_pdata)
 {
     struct customer_pdata* pdata = static_cast<decltype (pdata)> (cust_pdata);
     auto set_tax_included = [](GncCustomer* cust, const char *str)
@@ -254,14 +254,14 @@ customer_taxincluded_handler (xmlNodePtr node, gpointer cust_pdata)
 }
 
 static gboolean
-customer_active_handler (xmlNodePtr node, gpointer cust_pdata)
+customer_active_handler (GncXmlNode* node, gpointer cust_pdata)
 {
     struct customer_pdata* pdata = static_cast<decltype (pdata)> (cust_pdata);
     return set_boolean (node, pdata->customer, gncCustomerSetActive);
 }
 
 static gboolean
-customer_discount_handler (xmlNodePtr node, gpointer cust_pdata)
+customer_discount_handler (GncXmlNode* node, gpointer cust_pdata)
 {
     struct customer_pdata* pdata = static_cast<decltype (pdata)> (cust_pdata);
 
@@ -270,7 +270,7 @@ customer_discount_handler (xmlNodePtr node, gpointer cust_pdata)
 }
 
 static gboolean
-customer_credit_handler (xmlNodePtr node, gpointer cust_pdata)
+customer_credit_handler (GncXmlNode* node, gpointer cust_pdata)
 {
     struct customer_pdata* pdata = static_cast<decltype (pdata)> (cust_pdata);
 
@@ -279,7 +279,7 @@ customer_credit_handler (xmlNodePtr node, gpointer cust_pdata)
 }
 
 static gboolean
-customer_currency_handler (xmlNodePtr node, gpointer customer_pdata)
+customer_currency_handler (GncXmlNode* node, gpointer customer_pdata)
 {
     struct customer_pdata* pdata = static_cast<decltype (pdata)> (customer_pdata);
     gnc_commodity* com;
@@ -293,7 +293,7 @@ customer_currency_handler (xmlNodePtr node, gpointer customer_pdata)
 }
 
 static gboolean
-customer_taxtable_handler (xmlNodePtr node, gpointer cust_pdata)
+customer_taxtable_handler (GncXmlNode* node, gpointer cust_pdata)
 {
     struct customer_pdata* pdata = static_cast<decltype (pdata)> (cust_pdata);
     GncTaxTable* taxtable;
@@ -316,14 +316,14 @@ customer_taxtable_handler (xmlNodePtr node, gpointer cust_pdata)
 }
 
 static gboolean
-customer_taxtableoverride_handler (xmlNodePtr node, gpointer cust_pdata)
+customer_taxtableoverride_handler (GncXmlNode* node, gpointer cust_pdata)
 {
     struct customer_pdata* pdata = static_cast<decltype (pdata)> (cust_pdata);
     return set_boolean (node, pdata->customer, gncCustomerSetTaxTableOverride);
 }
 
 static gboolean
-customer_slots_handler (xmlNodePtr node, gpointer cust_pdata)
+customer_slots_handler (GncXmlNode* node, gpointer cust_pdata)
 {
     struct customer_pdata* pdata = static_cast<decltype (pdata)> (cust_pdata);
     return dom_tree_create_instance_slots (node, QOF_INSTANCE (pdata->customer));
@@ -351,7 +351,7 @@ static struct dom_tree_handler customer_handlers_v2[] =
 };
 
 static GncCustomer*
-dom_tree_to_customer (xmlNodePtr node, QofBook* book)
+dom_tree_to_customer (GncXmlNode* node, QofBook* book)
 {
     struct customer_pdata cust_pdata;
     gboolean successful;
@@ -382,7 +382,7 @@ gnc_customer_end_handler (gpointer data_for_children,
                           gpointer* result, const gchar* tag)
 {
     GncCustomer* cust;
-    xmlNodePtr tree = (xmlNodePtr)data_for_children;
+    GncXmlNode* tree = (GncXmlNode*)data_for_children;
     gxpf_data* gdata = (gxpf_data*)global_data;
     QofBook* book = static_cast<decltype (book)> (gdata->bookdata);
 
@@ -407,7 +407,7 @@ gnc_customer_end_handler (gpointer data_for_children,
         gdata->cb (tag, gdata->parsedata, cust);
     }
 
-    xmlFreeNode (tree);
+    gnc_xml_node_free (tree);
 
     return cust != NULL;
 }

--- a/libgnucash/backend/xml/gnc-employee-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-employee-xml-v2.cpp
@@ -130,7 +130,7 @@ struct employee_pdata
 };
 
 static gboolean
-employee_username_handler (xmlNodePtr node, gpointer employee_pdata)
+employee_username_handler (GncXmlNode* node, gpointer employee_pdata)
 {
     struct employee_pdata* pdata = static_cast<decltype (pdata)> (employee_pdata);
 
@@ -138,7 +138,7 @@ employee_username_handler (xmlNodePtr node, gpointer employee_pdata)
 }
 
 static gboolean
-employee_guid_handler (xmlNodePtr node, gpointer employee_pdata)
+employee_guid_handler (GncXmlNode* node, gpointer employee_pdata)
 {
     struct employee_pdata* pdata = static_cast<decltype (pdata)> (employee_pdata);
     GncEmployee* employee;
@@ -163,7 +163,7 @@ employee_guid_handler (xmlNodePtr node, gpointer employee_pdata)
 }
 
 static gboolean
-employee_id_handler (xmlNodePtr node, gpointer employee_pdata)
+employee_id_handler (GncXmlNode* node, gpointer employee_pdata)
 {
     struct employee_pdata* pdata = static_cast<decltype (pdata)> (employee_pdata);
 
@@ -171,7 +171,7 @@ employee_id_handler (xmlNodePtr node, gpointer employee_pdata)
 }
 
 static gboolean
-employee_language_handler (xmlNodePtr node, gpointer employee_pdata)
+employee_language_handler (GncXmlNode* node, gpointer employee_pdata)
 {
     struct employee_pdata* pdata = static_cast<decltype (pdata)> (employee_pdata);
 
@@ -179,7 +179,7 @@ employee_language_handler (xmlNodePtr node, gpointer employee_pdata)
 }
 
 static gboolean
-employee_acl_handler (xmlNodePtr node, gpointer employee_pdata)
+employee_acl_handler (GncXmlNode* node, gpointer employee_pdata)
 {
     struct employee_pdata* pdata = static_cast<decltype (pdata)> (employee_pdata);
 
@@ -187,7 +187,7 @@ employee_acl_handler (xmlNodePtr node, gpointer employee_pdata)
 }
 
 static gboolean
-employee_addr_handler (xmlNodePtr node, gpointer employee_pdata)
+employee_addr_handler (GncXmlNode* node, gpointer employee_pdata)
 {
     struct employee_pdata* pdata = static_cast<decltype (pdata)> (employee_pdata);
 
@@ -195,7 +195,7 @@ employee_addr_handler (xmlNodePtr node, gpointer employee_pdata)
 }
 
 static gboolean
-employee_active_handler (xmlNodePtr node, gpointer employee_pdata)
+employee_active_handler (GncXmlNode* node, gpointer employee_pdata)
 {
     struct employee_pdata* pdata = static_cast<decltype (pdata)> (employee_pdata);
     gint64 val;
@@ -209,7 +209,7 @@ employee_active_handler (xmlNodePtr node, gpointer employee_pdata)
 }
 
 static gboolean
-employee_workday_handler (xmlNodePtr node, gpointer employee_pdata)
+employee_workday_handler (GncXmlNode* node, gpointer employee_pdata)
 {
     struct employee_pdata* pdata = static_cast<decltype (pdata)> (employee_pdata);
 
@@ -218,7 +218,7 @@ employee_workday_handler (xmlNodePtr node, gpointer employee_pdata)
 }
 
 static gboolean
-employee_rate_handler (xmlNodePtr node, gpointer employee_pdata)
+employee_rate_handler (GncXmlNode* node, gpointer employee_pdata)
 {
     struct employee_pdata* pdata = static_cast<decltype (pdata)> (employee_pdata);
 
@@ -227,7 +227,7 @@ employee_rate_handler (xmlNodePtr node, gpointer employee_pdata)
 }
 
 static gboolean
-employee_currency_handler (xmlNodePtr node, gpointer employee_pdata)
+employee_currency_handler (GncXmlNode* node, gpointer employee_pdata)
 {
     struct employee_pdata* pdata = static_cast<decltype (pdata)> (employee_pdata);
     gnc_commodity* com;
@@ -241,7 +241,7 @@ employee_currency_handler (xmlNodePtr node, gpointer employee_pdata)
 }
 
 static gboolean
-employee_ccard_handler (xmlNodePtr node, gpointer employee_pdata)
+employee_ccard_handler (GncXmlNode* node, gpointer employee_pdata)
 {
     struct employee_pdata* pdata = static_cast<decltype (pdata)> (employee_pdata);
     Account* ccard_acc;
@@ -258,7 +258,7 @@ employee_ccard_handler (xmlNodePtr node, gpointer employee_pdata)
 }
 
 static gboolean
-employee_slots_handler (xmlNodePtr node, gpointer employee_pdata)
+employee_slots_handler (GncXmlNode* node, gpointer employee_pdata)
 {
     struct employee_pdata* pdata = static_cast<decltype (pdata)> (employee_pdata);
     return dom_tree_create_instance_slots (node, QOF_INSTANCE (pdata->employee));
@@ -283,7 +283,7 @@ static struct dom_tree_handler employee_handlers_v2[] =
 };
 
 static GncEmployee*
-dom_tree_to_employee (xmlNodePtr node, QofBook* book)
+dom_tree_to_employee (GncXmlNode* node, QofBook* book)
 {
     struct employee_pdata employee_pdata;
     gboolean successful;
@@ -313,7 +313,7 @@ gnc_employee_end_handler (gpointer data_for_children,
                           gpointer* result, const gchar* tag)
 {
     GncEmployee* employee;
-    xmlNodePtr tree = (xmlNodePtr)data_for_children;
+    GncXmlNode* tree = (GncXmlNode*)data_for_children;
     gxpf_data* gdata = (gxpf_data*)global_data;
     QofBook* book = static_cast<decltype (book)> (gdata->bookdata);
 
@@ -338,7 +338,7 @@ gnc_employee_end_handler (gpointer data_for_children,
         gdata->cb (tag, gdata->parsedata, employee);
     }
 
-    xmlFreeNode (tree);
+    gnc_xml_node_free (tree);
 
     return employee != NULL;
 }

--- a/libgnucash/backend/xml/gnc-entry-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-entry-xml-v2.cpp
@@ -225,7 +225,7 @@ struct entry_pdata
 };
 
 static inline gboolean
-set_time64 (xmlNodePtr node, GncEntry* entry,
+set_time64 (GncXmlNode* node, GncEntry* entry,
               void (*func) (GncEntry* entry, time64 ts))
 {
     time64 time = dom_tree_to_time64 (node);
@@ -235,7 +235,7 @@ set_time64 (xmlNodePtr node, GncEntry* entry,
 }
 
 static inline gboolean
-set_numeric (xmlNodePtr node, GncEntry* entry,
+set_numeric (GncXmlNode* node, GncEntry* entry,
              void (*func) (GncEntry* entry, gnc_numeric num))
 {
     func (entry, dom_tree_to_gnc_numeric (node));
@@ -243,7 +243,7 @@ set_numeric (xmlNodePtr node, GncEntry* entry,
 }
 
 static inline gboolean
-set_boolean (xmlNodePtr node, GncEntry* entry,
+set_boolean (GncXmlNode* node, GncEntry* entry,
              void (*func) (GncEntry* entry, gboolean val))
 {
     gint64 val;
@@ -255,7 +255,7 @@ set_boolean (xmlNodePtr node, GncEntry* entry,
 }
 
 static inline gboolean
-set_account (xmlNodePtr node, struct entry_pdata* pdata,
+set_account (GncXmlNode* node, struct entry_pdata* pdata,
              void (*func) (GncEntry* entry, Account* acc))
 {
     Account* acc;
@@ -273,7 +273,7 @@ set_account (xmlNodePtr node, struct entry_pdata* pdata,
 }
 
 static inline gboolean
-set_taxtable (xmlNodePtr node, struct entry_pdata* pdata,
+set_taxtable (GncXmlNode* node, struct entry_pdata* pdata,
               void (*func) (GncEntry* entry, GncTaxTable* taxtable))
 {
     GncTaxTable* taxtable;
@@ -296,7 +296,7 @@ set_taxtable (xmlNodePtr node, struct entry_pdata* pdata,
 }
 
 static gboolean
-entry_guid_handler (xmlNodePtr node, gpointer entry_pdata)
+entry_guid_handler (GncXmlNode* node, gpointer entry_pdata)
 {
     struct entry_pdata* pdata = static_cast<decltype (pdata)> (entry_pdata);
     GncEntry* entry;
@@ -319,21 +319,21 @@ entry_guid_handler (xmlNodePtr node, gpointer entry_pdata)
 }
 
 static gboolean
-entry_date_handler (xmlNodePtr node, gpointer entry_pdata)
+entry_date_handler (GncXmlNode* node, gpointer entry_pdata)
 {
     struct entry_pdata* pdata = static_cast<decltype (pdata)> (entry_pdata);
     return set_time64 (node, pdata->entry, gncEntrySetDate);
 }
 
 static gboolean
-entry_dateentered_handler (xmlNodePtr node, gpointer entry_pdata)
+entry_dateentered_handler (GncXmlNode* node, gpointer entry_pdata)
 {
     struct entry_pdata* pdata = static_cast<decltype (pdata)> (entry_pdata);
     return set_time64 (node, pdata->entry, gncEntrySetDateEntered);
 }
 
 static gboolean
-entry_description_handler (xmlNodePtr node, gpointer entry_pdata)
+entry_description_handler (GncXmlNode* node, gpointer entry_pdata)
 {
     struct entry_pdata* pdata = static_cast<decltype (pdata)> (entry_pdata);
 
@@ -341,7 +341,7 @@ entry_description_handler (xmlNodePtr node, gpointer entry_pdata)
 }
 
 static gboolean
-entry_action_handler (xmlNodePtr node, gpointer entry_pdata)
+entry_action_handler (GncXmlNode* node, gpointer entry_pdata)
 {
     struct entry_pdata* pdata = static_cast<decltype (pdata)> (entry_pdata);
 
@@ -349,7 +349,7 @@ entry_action_handler (xmlNodePtr node, gpointer entry_pdata)
 }
 
 static gboolean
-entry_notes_handler (xmlNodePtr node, gpointer entry_pdata)
+entry_notes_handler (GncXmlNode* node, gpointer entry_pdata)
 {
     struct entry_pdata* pdata = static_cast<decltype (pdata)> (entry_pdata);
 
@@ -357,7 +357,7 @@ entry_notes_handler (xmlNodePtr node, gpointer entry_pdata)
 }
 
 static gboolean
-entry_qty_handler (xmlNodePtr node, gpointer entry_pdata)
+entry_qty_handler (GncXmlNode* node, gpointer entry_pdata)
 {
     struct entry_pdata* pdata = static_cast<decltype (pdata)> (entry_pdata);
 
@@ -367,14 +367,14 @@ entry_qty_handler (xmlNodePtr node, gpointer entry_pdata)
 /* Cust invoice */
 
 static gboolean
-entry_invacct_handler (xmlNodePtr node, gpointer entry_pdata)
+entry_invacct_handler (GncXmlNode* node, gpointer entry_pdata)
 {
     struct entry_pdata* pdata = static_cast<decltype (pdata)> (entry_pdata);
     return set_account (node, pdata, gncEntrySetInvAccount);
 }
 
 static gboolean
-entry_iprice_handler (xmlNodePtr node, gpointer entry_pdata)
+entry_iprice_handler (GncXmlNode* node, gpointer entry_pdata)
 {
     struct entry_pdata* pdata = static_cast<decltype (pdata)> (entry_pdata);
 
@@ -382,7 +382,7 @@ entry_iprice_handler (xmlNodePtr node, gpointer entry_pdata)
 }
 
 static gboolean
-entry_idiscount_handler (xmlNodePtr node, gpointer entry_pdata)
+entry_idiscount_handler (GncXmlNode* node, gpointer entry_pdata)
 {
     struct entry_pdata* pdata = static_cast<decltype (pdata)> (entry_pdata);
 
@@ -390,7 +390,7 @@ entry_idiscount_handler (xmlNodePtr node, gpointer entry_pdata)
 }
 
 static gboolean
-entry_idisctype_handler (xmlNodePtr node, gpointer entry_pdata)
+entry_idisctype_handler (GncXmlNode* node, gpointer entry_pdata)
 {
     struct entry_pdata* pdata = static_cast<decltype (pdata)> (entry_pdata);
     auto entry = pdata->entry;
@@ -405,7 +405,7 @@ entry_idisctype_handler (xmlNodePtr node, gpointer entry_pdata)
 }
 
 static gboolean
-entry_idischow_handler (xmlNodePtr node, gpointer entry_pdata)
+entry_idischow_handler (GncXmlNode* node, gpointer entry_pdata)
 {
     struct entry_pdata* pdata = static_cast<decltype (pdata)> (entry_pdata);
     auto entry = pdata->entry;
@@ -420,21 +420,21 @@ entry_idischow_handler (xmlNodePtr node, gpointer entry_pdata)
 }
 
 static gboolean
-entry_itaxable_handler (xmlNodePtr node, gpointer entry_pdata)
+entry_itaxable_handler (GncXmlNode* node, gpointer entry_pdata)
 {
     struct entry_pdata* pdata = static_cast<decltype (pdata)> (entry_pdata);
     return set_boolean (node, pdata->entry, gncEntrySetInvTaxable);
 }
 
 static gboolean
-entry_itaxincluded_handler (xmlNodePtr node, gpointer entry_pdata)
+entry_itaxincluded_handler (GncXmlNode* node, gpointer entry_pdata)
 {
     struct entry_pdata* pdata = static_cast<decltype (pdata)> (entry_pdata);
     return set_boolean (node, pdata->entry, gncEntrySetInvTaxIncluded);
 }
 
 static gboolean
-entry_itaxtable_handler (xmlNodePtr node, gpointer entry_pdata)
+entry_itaxtable_handler (GncXmlNode* node, gpointer entry_pdata)
 {
     struct entry_pdata* pdata = static_cast<decltype (pdata)> (entry_pdata);
     return set_taxtable (node, pdata, gncEntrySetInvTaxTable);
@@ -443,14 +443,14 @@ entry_itaxtable_handler (xmlNodePtr node, gpointer entry_pdata)
 /* vendor bills */
 
 static gboolean
-entry_billacct_handler (xmlNodePtr node, gpointer entry_pdata)
+entry_billacct_handler (GncXmlNode* node, gpointer entry_pdata)
 {
     struct entry_pdata* pdata = static_cast<decltype (pdata)> (entry_pdata);
     return set_account (node, pdata, gncEntrySetBillAccount);
 }
 
 static gboolean
-entry_bprice_handler (xmlNodePtr node, gpointer entry_pdata)
+entry_bprice_handler (GncXmlNode* node, gpointer entry_pdata)
 {
     struct entry_pdata* pdata = static_cast<decltype (pdata)> (entry_pdata);
 
@@ -458,35 +458,35 @@ entry_bprice_handler (xmlNodePtr node, gpointer entry_pdata)
 }
 
 static gboolean
-entry_btaxable_handler (xmlNodePtr node, gpointer entry_pdata)
+entry_btaxable_handler (GncXmlNode* node, gpointer entry_pdata)
 {
     struct entry_pdata* pdata = static_cast<decltype (pdata)> (entry_pdata);
     return set_boolean (node, pdata->entry, gncEntrySetBillTaxable);
 }
 
 static gboolean
-entry_btaxincluded_handler (xmlNodePtr node, gpointer entry_pdata)
+entry_btaxincluded_handler (GncXmlNode* node, gpointer entry_pdata)
 {
     struct entry_pdata* pdata = static_cast<decltype (pdata)> (entry_pdata);
     return set_boolean (node, pdata->entry, gncEntrySetBillTaxIncluded);
 }
 
 static gboolean
-entry_btaxtable_handler (xmlNodePtr node, gpointer entry_pdata)
+entry_btaxtable_handler (GncXmlNode* node, gpointer entry_pdata)
 {
     struct entry_pdata* pdata = static_cast<decltype (pdata)> (entry_pdata);
     return set_taxtable (node, pdata, gncEntrySetBillTaxTable);
 }
 
 static gboolean
-entry_billable_handler (xmlNodePtr node, gpointer entry_pdata)
+entry_billable_handler (GncXmlNode* node, gpointer entry_pdata)
 {
     struct entry_pdata* pdata = static_cast<decltype (pdata)> (entry_pdata);
     return set_boolean (node, pdata->entry, gncEntrySetBillable);
 }
 
 static gboolean
-entry_billto_handler (xmlNodePtr node, gpointer entry_pdata)
+entry_billto_handler (GncXmlNode* node, gpointer entry_pdata)
 {
     struct entry_pdata* pdata = static_cast<decltype (pdata)> (entry_pdata);
     GncOwner billto;
@@ -501,7 +501,7 @@ entry_billto_handler (xmlNodePtr node, gpointer entry_pdata)
 
 /* employee bills */
 static gboolean
-entry_billpayment_handler (xmlNodePtr node, gpointer entry_pdata)
+entry_billpayment_handler (GncXmlNode* node, gpointer entry_pdata)
 {
     struct entry_pdata* pdata = static_cast<decltype (pdata)> (entry_pdata);
     auto entry = pdata->entry;
@@ -518,7 +518,7 @@ entry_billpayment_handler (xmlNodePtr node, gpointer entry_pdata)
 /* The rest of the stuff */
 
 static gboolean
-entry_order_handler (xmlNodePtr node, gpointer entry_pdata)
+entry_order_handler (GncXmlNode* node, gpointer entry_pdata)
 {
     struct entry_pdata* pdata = static_cast<decltype (pdata)> (entry_pdata);
     GncOrder* order;
@@ -541,7 +541,7 @@ entry_order_handler (xmlNodePtr node, gpointer entry_pdata)
 }
 
 static gboolean
-entry_invoice_handler (xmlNodePtr node, gpointer entry_pdata)
+entry_invoice_handler (GncXmlNode* node, gpointer entry_pdata)
 {
     struct entry_pdata* pdata = static_cast<decltype (pdata)> (entry_pdata);
     GncInvoice* invoice;
@@ -564,7 +564,7 @@ entry_invoice_handler (xmlNodePtr node, gpointer entry_pdata)
 }
 
 static gboolean
-entry_bill_handler (xmlNodePtr node, gpointer entry_pdata)
+entry_bill_handler (GncXmlNode* node, gpointer entry_pdata)
 {
     struct entry_pdata* pdata = static_cast<decltype (pdata)> (entry_pdata);
     GncInvoice* invoice;
@@ -589,7 +589,7 @@ entry_bill_handler (xmlNodePtr node, gpointer entry_pdata)
 /* Support for older XML versions */
 
 static gboolean
-entry_acct_handler (xmlNodePtr node, gpointer entry_pdata)
+entry_acct_handler (GncXmlNode* node, gpointer entry_pdata)
 {
     struct entry_pdata* pdata = static_cast<decltype (pdata)> (entry_pdata);
     /* XXX: try to figure out if this is an 'invoice' or a 'bill' --
@@ -600,7 +600,7 @@ entry_acct_handler (xmlNodePtr node, gpointer entry_pdata)
 }
 
 static gboolean
-entry_price_handler (xmlNodePtr node, gpointer entry_pdata)
+entry_price_handler (GncXmlNode* node, gpointer entry_pdata)
 {
     struct entry_pdata* pdata = static_cast<decltype (pdata)> (entry_pdata);
     gboolean res;
@@ -613,7 +613,7 @@ entry_price_handler (xmlNodePtr node, gpointer entry_pdata)
 }
 
 static gboolean
-entry_slots_handler (xmlNodePtr node, gpointer entry_pdata)
+entry_slots_handler (GncXmlNode* node, gpointer entry_pdata)
 {
     struct entry_pdata* pdata = static_cast<decltype (pdata)> (entry_pdata);
 
@@ -671,7 +671,7 @@ static struct dom_tree_handler entry_handlers_v2[] =
 };
 
 static GncEntry*
-dom_tree_to_entry (xmlNodePtr node, QofBook* book)
+dom_tree_to_entry (GncXmlNode* node, QofBook* book)
 {
     struct entry_pdata entry_pdata;
     gboolean successful;
@@ -710,7 +710,7 @@ gnc_entry_end_handler (gpointer data_for_children,
                        gpointer* result, const gchar* tag)
 {
     GncEntry* entry;
-    xmlNodePtr tree = (xmlNodePtr)data_for_children;
+    GncXmlNode* tree = (GncXmlNode*)data_for_children;
     gxpf_data* gdata = (gxpf_data*)global_data;
     QofBook* book = static_cast<decltype (book)> (gdata->bookdata);
 
@@ -735,7 +735,7 @@ gnc_entry_end_handler (gpointer data_for_children,
         gdata->cb (tag, gdata->parsedata, entry);
     }
 
-    xmlFreeNode (tree);
+    gnc_xml_node_free (tree);
 
     return entry != NULL;
 }

--- a/libgnucash/backend/xml/gnc-freqspec-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-freqspec-xml-v2.cpp
@@ -127,11 +127,11 @@ fspd_init (fsParseData* fspd)
 
 static
 gboolean
-gnc_fs_handler (xmlNodePtr node, gpointer d);
+gnc_fs_handler (GncXmlNode* node, gpointer d);
 
 static
 gboolean
-fs_uift_handler (xmlNodePtr node, gpointer data)
+fs_uift_handler (GncXmlNode* node, gpointer data)
 {
     fsParseData* fspd = static_cast<decltype (fspd)> (data);
     int            i;
@@ -152,7 +152,7 @@ fs_uift_handler (xmlNodePtr node, gpointer data)
 
 static
 gboolean
-fs_date_handler (xmlNodePtr node, gpointer data)
+fs_date_handler (GncXmlNode* node, gpointer data)
 {
     fsParseData* fspd = static_cast<decltype (fspd)> (data);
     GDate*                foo;
@@ -166,7 +166,7 @@ fs_date_handler (xmlNodePtr node, gpointer data)
 
 static
 gboolean
-fs_interval_handler (xmlNodePtr node, gpointer data)
+fs_interval_handler (GncXmlNode* node, gpointer data)
 {
     fsParseData* fspd = static_cast<decltype (fspd)> (data);
     gboolean        ret;
@@ -183,7 +183,7 @@ fs_interval_handler (xmlNodePtr node, gpointer data)
 
 static
 gboolean
-fs_offset_handler (xmlNodePtr node, gpointer data)
+fs_offset_handler (GncXmlNode* node, gpointer data)
 {
     fsParseData* fspd = static_cast<decltype (fspd)> (data);
     gboolean        ret;
@@ -198,7 +198,7 @@ fs_offset_handler (xmlNodePtr node, gpointer data)
 
 static
 gboolean
-fs_day_handler (xmlNodePtr node, gpointer data)
+fs_day_handler (GncXmlNode* node, gpointer data)
 {
     fsParseData* fspd = static_cast<decltype (fspd)> (data);
     gboolean        ret;
@@ -213,7 +213,7 @@ fs_day_handler (xmlNodePtr node, gpointer data)
 
 static
 gboolean
-fs_weekday_handler (xmlNodePtr node, gpointer data)
+fs_weekday_handler (GncXmlNode* node, gpointer data)
 {
     fsParseData* fspd = static_cast<decltype (fspd)> (data);
     gboolean        ret;
@@ -227,7 +227,7 @@ fs_weekday_handler (xmlNodePtr node, gpointer data)
 
 static
 gboolean
-fs_occurrence_handler (xmlNodePtr node, gpointer data)
+fs_occurrence_handler (GncXmlNode* node, gpointer data)
 {
     fsParseData* fspd = static_cast<decltype (fspd)> (data);
     gboolean        ret;
@@ -241,7 +241,7 @@ fs_occurrence_handler (xmlNodePtr node, gpointer data)
 
 static
 gboolean
-fs_weekend_adj_handler (xmlNodePtr node, gpointer data)
+fs_weekend_adj_handler (GncXmlNode* node, gpointer data)
 {
     fsParseData* fspd = static_cast<decltype (fspd)> (data);
     gboolean        ret;
@@ -255,7 +255,7 @@ fs_weekend_adj_handler (xmlNodePtr node, gpointer data)
 
 static
 gboolean
-fs_subelement_handler (xmlNodePtr node, gpointer data)
+fs_subelement_handler (GncXmlNode* node, gpointer data)
 {
     fsParseData* fspd = static_cast<decltype (fspd)> (data);
     GList* recurrences;
@@ -297,7 +297,7 @@ struct dom_tree_handler fs_union_dom_handlers[] =
 };
 
 static gboolean
-fs_none_handler (xmlNodePtr node, gpointer data)
+fs_none_handler (GncXmlNode* node, gpointer data)
 {
     fsParseData* fspd = static_cast<decltype (fspd)> (data);
     gboolean    successful;
@@ -309,7 +309,7 @@ fs_none_handler (xmlNodePtr node, gpointer data)
 
 static
 gboolean
-fs_once_handler (xmlNodePtr node, gpointer data)
+fs_once_handler (GncXmlNode* node, gpointer data)
 {
     fsParseData* fspd = static_cast<decltype (fspd)> (data);
     gboolean        successful;
@@ -326,7 +326,7 @@ fs_once_handler (xmlNodePtr node, gpointer data)
 }
 
 static gboolean
-fs_daily_handler (xmlNodePtr node, gpointer data)
+fs_daily_handler (GncXmlNode* node, gpointer data)
 {
     fsParseData* fspd = static_cast<decltype (fspd)> (data);
     GDate offset_date;
@@ -345,7 +345,7 @@ fs_daily_handler (xmlNodePtr node, gpointer data)
 
 static
 gboolean
-fs_weekly_handler (xmlNodePtr node, gpointer data)
+fs_weekly_handler (GncXmlNode* node, gpointer data)
 {
     fsParseData* fspd = static_cast<decltype (fspd)> (data);
     GDate offset_date;
@@ -366,7 +366,7 @@ fs_weekly_handler (xmlNodePtr node, gpointer data)
 
 static
 gboolean
-fs_monthly_handler (xmlNodePtr node, gpointer data)
+fs_monthly_handler (GncXmlNode* node, gpointer data)
 {
     fsParseData* fspd = static_cast<decltype (fspd)> (data);
     GDate offset_date;
@@ -400,7 +400,7 @@ fs_monthly_handler (xmlNodePtr node, gpointer data)
 
 static
 gboolean
-fs_month_relative_handler (xmlNodePtr node, gpointer data)
+fs_month_relative_handler (GncXmlNode* node, gpointer data)
 {
     g_critical ("this was never supported, how is it in the datafile?");
     return FALSE;
@@ -408,14 +408,14 @@ fs_month_relative_handler (xmlNodePtr node, gpointer data)
 
 static
 gboolean
-fs_guid_handler (xmlNodePtr node, gpointer data)
+fs_guid_handler (GncXmlNode* node, gpointer data)
 {
     return TRUE;
 }
 
 static
 gboolean
-fs_composite_handler (xmlNodePtr node, gpointer data)
+fs_composite_handler (GncXmlNode* node, gpointer data)
 {
     fsParseData* fspd = static_cast<decltype (fspd)> (data);
     gboolean        successful;
@@ -442,7 +442,7 @@ static struct dom_tree_handler fs_dom_handlers[] =
 
 static
 gboolean
-gnc_fs_handler (xmlNodePtr node, gpointer d)
+gnc_fs_handler (GncXmlNode* node, gpointer d)
 {
     return dom_tree_generic_parse (node, fs_dom_handlers, d);
 }
@@ -456,7 +456,7 @@ gnc_freqSpec_end_handler (gpointer data_for_children,
 {
     fsParseData                fspd;
     gboolean                successful = FALSE;
-    xmlNodePtr                tree = (xmlNodePtr)data_for_children;
+    GncXmlNode*                tree = (GncXmlNode*)data_for_children;
     sixtp_gdv2*                globaldata = (sixtp_gdv2*)global_data;
 
     fspd_init (&fspd);
@@ -475,10 +475,10 @@ gnc_freqSpec_end_handler (gpointer data_for_children,
     successful = dom_tree_generic_parse (tree, fs_dom_handlers, &fspd);
     if (!successful)
     {
-        xmlElemDump (stdout, NULL, tree);
+        gnc_xml_node_dump (stdout, tree);
     }
 
-    xmlFreeNode (tree);
+    gnc_xml_node_free (tree);
 
     return successful;
 }
@@ -490,7 +490,7 @@ gnc_freqSpec_sixtp_parser_create (void)
 }
 
 static void
-common_parse (fsParseData* fspd, xmlNodePtr node, QofBook* book)
+common_parse (fsParseData* fspd, GncXmlNode* node, QofBook* book)
 {
     gboolean        successful;
 
@@ -498,12 +498,12 @@ common_parse (fsParseData* fspd, xmlNodePtr node, QofBook* book)
     successful = dom_tree_generic_parse (node, fs_dom_handlers, fspd);
     if (!successful)
     {
-        xmlElemDump (stdout, NULL, node);
+        gnc_xml_node_dump (stdout, node);
     }
 }
 
 GList*
-dom_tree_freqSpec_to_recurrences (xmlNodePtr node, QofBook* book)
+dom_tree_freqSpec_to_recurrences (GncXmlNode* node, QofBook* book)
 {
     fsParseData        fspd;
     fspd_init (&fspd);

--- a/libgnucash/backend/xml/gnc-invoice-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-invoice-xml-v2.cpp
@@ -169,7 +169,7 @@ struct invoice_pdata
 
 
 static inline gboolean
-set_time64 (xmlNodePtr node, GncInvoice* invoice,
+set_time64 (GncXmlNode* node, GncInvoice* invoice,
               void (*func) (GncInvoice* invoice, time64 time))
 {
     time64 time = dom_tree_to_time64 (node);
@@ -179,7 +179,7 @@ set_time64 (xmlNodePtr node, GncInvoice* invoice,
 }
 
 static gboolean
-invoice_guid_handler (xmlNodePtr node, gpointer invoice_pdata)
+invoice_guid_handler (GncXmlNode* node, gpointer invoice_pdata)
 {
     struct invoice_pdata* pdata = static_cast<decltype (pdata)> (invoice_pdata);
     GncInvoice* invoice;
@@ -202,7 +202,7 @@ invoice_guid_handler (xmlNodePtr node, gpointer invoice_pdata)
 }
 
 static gboolean
-invoice_id_handler (xmlNodePtr node, gpointer invoice_pdata)
+invoice_id_handler (GncXmlNode* node, gpointer invoice_pdata)
 {
     struct invoice_pdata* pdata = static_cast<decltype (pdata)> (invoice_pdata);
 
@@ -210,7 +210,7 @@ invoice_id_handler (xmlNodePtr node, gpointer invoice_pdata)
 }
 
 static gboolean
-invoice_owner_handler (xmlNodePtr node, gpointer invoice_pdata)
+invoice_owner_handler (GncXmlNode* node, gpointer invoice_pdata)
 {
     struct invoice_pdata* pdata = static_cast<decltype (pdata)> (invoice_pdata);
     GncOwner owner;
@@ -224,21 +224,21 @@ invoice_owner_handler (xmlNodePtr node, gpointer invoice_pdata)
 }
 
 static gboolean
-invoice_opened_handler (xmlNodePtr node, gpointer invoice_pdata)
+invoice_opened_handler (GncXmlNode* node, gpointer invoice_pdata)
 {
     struct invoice_pdata* pdata = static_cast<decltype (pdata)> (invoice_pdata);
     return set_time64 (node, pdata->invoice, gncInvoiceSetDateOpened);
 }
 
 static gboolean
-invoice_posted_handler (xmlNodePtr node, gpointer invoice_pdata)
+invoice_posted_handler (GncXmlNode* node, gpointer invoice_pdata)
 {
     struct invoice_pdata* pdata = static_cast<decltype (pdata)> (invoice_pdata);
     return set_time64 (node, pdata->invoice, gncInvoiceSetDatePosted);
 }
 
 static gboolean
-invoice_billing_id_handler (xmlNodePtr node, gpointer invoice_pdata)
+invoice_billing_id_handler (GncXmlNode* node, gpointer invoice_pdata)
 {
     struct invoice_pdata* pdata = static_cast<decltype (pdata)> (invoice_pdata);
 
@@ -246,7 +246,7 @@ invoice_billing_id_handler (xmlNodePtr node, gpointer invoice_pdata)
 }
 
 static gboolean
-invoice_notes_handler (xmlNodePtr node, gpointer invoice_pdata)
+invoice_notes_handler (GncXmlNode* node, gpointer invoice_pdata)
 {
     struct invoice_pdata* pdata = static_cast<decltype (pdata)> (invoice_pdata);
 
@@ -254,7 +254,7 @@ invoice_notes_handler (xmlNodePtr node, gpointer invoice_pdata)
 }
 
 static gboolean
-invoice_active_handler (xmlNodePtr node, gpointer invoice_pdata)
+invoice_active_handler (GncXmlNode* node, gpointer invoice_pdata)
 {
     struct invoice_pdata* pdata = static_cast<decltype (pdata)> (invoice_pdata);
     gint64 val;
@@ -268,7 +268,7 @@ invoice_active_handler (xmlNodePtr node, gpointer invoice_pdata)
 }
 
 static gboolean
-invoice_terms_handler (xmlNodePtr node, gpointer invoice_pdata)
+invoice_terms_handler (GncXmlNode* node, gpointer invoice_pdata)
 {
     struct invoice_pdata* pdata = static_cast<decltype (pdata)> (invoice_pdata);
     GncBillTerm* term;
@@ -283,7 +283,7 @@ invoice_terms_handler (xmlNodePtr node, gpointer invoice_pdata)
 }
 
 static gboolean
-invoice_posttxn_handler (xmlNodePtr node, gpointer invoice_pdata)
+invoice_posttxn_handler (GncXmlNode* node, gpointer invoice_pdata)
 {
     struct invoice_pdata* pdata = static_cast<decltype (pdata)> (invoice_pdata);
     Transaction* txn;
@@ -298,7 +298,7 @@ invoice_posttxn_handler (xmlNodePtr node, gpointer invoice_pdata)
 }
 
 static gboolean
-invoice_postlot_handler (xmlNodePtr node, gpointer invoice_pdata)
+invoice_postlot_handler (GncXmlNode* node, gpointer invoice_pdata)
 {
     struct invoice_pdata* pdata = static_cast<decltype (pdata)> (invoice_pdata);
     GNCLot* lot;
@@ -313,7 +313,7 @@ invoice_postlot_handler (xmlNodePtr node, gpointer invoice_pdata)
 }
 
 static gboolean
-invoice_postacc_handler (xmlNodePtr node, gpointer invoice_pdata)
+invoice_postacc_handler (GncXmlNode* node, gpointer invoice_pdata)
 {
     struct invoice_pdata* pdata = static_cast<decltype (pdata)> (invoice_pdata);
     Account* acc;
@@ -328,7 +328,7 @@ invoice_postacc_handler (xmlNodePtr node, gpointer invoice_pdata)
 }
 
 static gboolean
-invoice_currency_handler (xmlNodePtr node, gpointer invoice_pdata)
+invoice_currency_handler (GncXmlNode* node, gpointer invoice_pdata)
 {
     struct invoice_pdata* pdata = static_cast<decltype (pdata)> (invoice_pdata);
     gnc_commodity* com;
@@ -342,7 +342,7 @@ invoice_currency_handler (xmlNodePtr node, gpointer invoice_pdata)
 }
 
 static gboolean
-invoice_billto_handler (xmlNodePtr node, gpointer invoice_pdata)
+invoice_billto_handler (GncXmlNode* node, gpointer invoice_pdata)
 {
     struct invoice_pdata* pdata = static_cast<decltype (pdata)> (invoice_pdata);
     GncOwner owner;
@@ -356,7 +356,7 @@ invoice_billto_handler (xmlNodePtr node, gpointer invoice_pdata)
 }
 
 static gboolean
-invoice_tochargeamt_handler (xmlNodePtr node, gpointer invoice_pdata)
+invoice_tochargeamt_handler (GncXmlNode* node, gpointer invoice_pdata)
 {
     struct invoice_pdata* pdata = static_cast<decltype (pdata)> (invoice_pdata);
 
@@ -365,7 +365,7 @@ invoice_tochargeamt_handler (xmlNodePtr node, gpointer invoice_pdata)
 }
 
 static gboolean
-invoice_slots_handler (xmlNodePtr node, gpointer invoice_pdata)
+invoice_slots_handler (GncXmlNode* node, gpointer invoice_pdata)
 {
     struct invoice_pdata* pdata = static_cast<decltype (pdata)> (invoice_pdata);
     return dom_tree_create_instance_slots (node, QOF_INSTANCE (pdata->invoice));
@@ -394,7 +394,7 @@ static struct dom_tree_handler invoice_handlers_v2[] =
 };
 
 static GncInvoice*
-dom_tree_to_invoice (xmlNodePtr node, QofBook* book)
+dom_tree_to_invoice (GncXmlNode* node, QofBook* book)
 {
     struct invoice_pdata invoice_pdata;
     gboolean successful;
@@ -425,7 +425,7 @@ gnc_invoice_end_handler (gpointer data_for_children,
                          gpointer* result, const gchar* tag)
 {
     GncInvoice* invoice;
-    xmlNodePtr tree = (xmlNodePtr)data_for_children;
+    GncXmlNode* tree = (GncXmlNode*)data_for_children;
     gxpf_data* gdata = (gxpf_data*)global_data;
     QofBook* book = static_cast<decltype (book)> (gdata->bookdata);
 
@@ -449,7 +449,7 @@ gnc_invoice_end_handler (gpointer data_for_children,
         gdata->cb (tag, gdata->parsedata, invoice);
     }
 
-    xmlFreeNode (tree);
+    gnc_xml_node_free (tree);
 
     return invoice != NULL;
 }

--- a/libgnucash/backend/xml/gnc-job-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-job-xml-v2.cpp
@@ -101,7 +101,7 @@ struct job_pdata
 };
 
 static gboolean
-job_name_handler (xmlNodePtr node, gpointer job_pdata)
+job_name_handler (GncXmlNode* node, gpointer job_pdata)
 {
     struct job_pdata* pdata = static_cast<decltype (pdata)> (job_pdata);
 
@@ -109,7 +109,7 @@ job_name_handler (xmlNodePtr node, gpointer job_pdata)
 }
 
 static gboolean
-job_guid_handler (xmlNodePtr node, gpointer job_pdata)
+job_guid_handler (GncXmlNode* node, gpointer job_pdata)
 {
     struct job_pdata* pdata = static_cast<decltype (pdata)> (job_pdata);
     GncJob* job;
@@ -132,7 +132,7 @@ job_guid_handler (xmlNodePtr node, gpointer job_pdata)
 }
 
 static gboolean
-job_id_handler (xmlNodePtr node, gpointer job_pdata)
+job_id_handler (GncXmlNode* node, gpointer job_pdata)
 {
     struct job_pdata* pdata = static_cast<decltype (pdata)> (job_pdata);
 
@@ -140,7 +140,7 @@ job_id_handler (xmlNodePtr node, gpointer job_pdata)
 }
 
 static gboolean
-job_reference_handler (xmlNodePtr node, gpointer job_pdata)
+job_reference_handler (GncXmlNode* node, gpointer job_pdata)
 {
     struct job_pdata* pdata = static_cast<decltype (pdata)> (job_pdata);
 
@@ -148,7 +148,7 @@ job_reference_handler (xmlNodePtr node, gpointer job_pdata)
 }
 
 static gboolean
-job_owner_handler (xmlNodePtr node, gpointer job_pdata)
+job_owner_handler (GncXmlNode* node, gpointer job_pdata)
 {
     struct job_pdata* pdata = static_cast<decltype (pdata)> (job_pdata);
     GncOwner owner;
@@ -162,7 +162,7 @@ job_owner_handler (xmlNodePtr node, gpointer job_pdata)
 }
 
 static gboolean
-job_active_handler (xmlNodePtr node, gpointer job_pdata)
+job_active_handler (GncXmlNode* node, gpointer job_pdata)
 {
     struct job_pdata* pdata = static_cast<decltype (pdata)> (job_pdata);
     gint64 val;
@@ -176,7 +176,7 @@ job_active_handler (xmlNodePtr node, gpointer job_pdata)
 }
 
 static gboolean
-job_slots_handler (xmlNodePtr node, gpointer job_pdata)
+job_slots_handler (GncXmlNode* node, gpointer job_pdata)
 {
     struct job_pdata* pdata = static_cast<decltype (pdata)> (job_pdata);
 
@@ -196,7 +196,7 @@ static struct dom_tree_handler job_handlers_v2[] =
 };
 
 static GncJob*
-dom_tree_to_job (xmlNodePtr node, QofBook* book)
+dom_tree_to_job (GncXmlNode* node, QofBook* book)
 {
     struct job_pdata job_pdata;
     gboolean successful;
@@ -227,7 +227,7 @@ gnc_job_end_handler (gpointer data_for_children,
                      gpointer* result, const gchar* tag)
 {
     GncJob* job;
-    xmlNodePtr tree = (xmlNodePtr)data_for_children;
+    GncXmlNode* tree = (GncXmlNode*)data_for_children;
     gxpf_data* gdata = (gxpf_data*)global_data;
     QofBook* book = static_cast<decltype (book)> (gdata->bookdata);
 
@@ -251,7 +251,7 @@ gnc_job_end_handler (gpointer data_for_children,
         gdata->cb (tag, gdata->parsedata, job);
     }
 
-    xmlFreeNode (tree);
+    gnc_xml_node_free (tree);
 
     return job != NULL;
 }

--- a/libgnucash/backend/xml/gnc-lot-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-lot-xml-v2.cpp
@@ -79,7 +79,7 @@ struct lot_pdata
 };
 
 static gboolean
-lot_id_handler (xmlNodePtr node, gpointer p)
+lot_id_handler (GncXmlNode* node, gpointer p)
 {
     struct lot_pdata* pdata = static_cast<decltype (pdata)> (p);
 
@@ -92,7 +92,7 @@ lot_id_handler (xmlNodePtr node, gpointer p)
 }
 
 static gboolean
-lot_slots_handler (xmlNodePtr node, gpointer p)
+lot_slots_handler (GncXmlNode* node, gpointer p)
 {
     struct lot_pdata* pdata = static_cast<decltype (pdata)> (p);
     gboolean success;
@@ -120,7 +120,7 @@ gnc_lot_end_handler (gpointer data_for_children,
                      gpointer* result, const gchar* tag)
 {
     GNCLot* lot;
-    xmlNodePtr tree = (xmlNodePtr)data_for_children;
+    GncXmlNode* tree = (GncXmlNode*)data_for_children;
     gxpf_data* gdata = (gxpf_data*)global_data;
     QofBook* book = static_cast<decltype (book)> (gdata->bookdata);
 
@@ -145,14 +145,14 @@ gnc_lot_end_handler (gpointer data_for_children,
         gdata->cb (tag, gdata->parsedata, lot);
     }
 
-    xmlFreeNode (tree);
+    gnc_xml_node_free (tree);
 
     LEAVE ("");
     return lot != NULL;
 }
 
 GNCLot*
-dom_tree_to_lot (xmlNodePtr node, QofBook* book)
+dom_tree_to_lot (GncXmlNode* node, QofBook* book)
 {
     struct lot_pdata pdata;
     GNCLot* lot;

--- a/libgnucash/backend/xml/gnc-order-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-order-xml-v2.cpp
@@ -115,7 +115,7 @@ struct order_pdata
 };
 
 static inline gboolean
-set_time64 (xmlNodePtr node, GncOrder* order,
+set_time64 (GncXmlNode* node, GncOrder* order,
               void (*func) (GncOrder* order, time64 tt))
 {
     time64 time = dom_tree_to_time64 (node);
@@ -125,7 +125,7 @@ set_time64 (xmlNodePtr node, GncOrder* order,
 }
 
 static gboolean
-order_guid_handler (xmlNodePtr node, gpointer order_pdata)
+order_guid_handler (GncXmlNode* node, gpointer order_pdata)
 {
     struct order_pdata* pdata = static_cast<decltype (pdata)> (order_pdata);
     GncOrder* order;
@@ -148,7 +148,7 @@ order_guid_handler (xmlNodePtr node, gpointer order_pdata)
 }
 
 static gboolean
-order_id_handler (xmlNodePtr node, gpointer order_pdata)
+order_id_handler (GncXmlNode* node, gpointer order_pdata)
 {
     struct order_pdata* pdata = static_cast<decltype (pdata)> (order_pdata);
 
@@ -156,7 +156,7 @@ order_id_handler (xmlNodePtr node, gpointer order_pdata)
 }
 
 static gboolean
-order_owner_handler (xmlNodePtr node, gpointer order_pdata)
+order_owner_handler (GncXmlNode* node, gpointer order_pdata)
 {
     struct order_pdata* pdata = static_cast<decltype (pdata)> (order_pdata);
     GncOwner owner;
@@ -170,7 +170,7 @@ order_owner_handler (xmlNodePtr node, gpointer order_pdata)
 }
 
 static gboolean
-order_opened_handler (xmlNodePtr node, gpointer order_pdata)
+order_opened_handler (GncXmlNode* node, gpointer order_pdata)
 {
     struct order_pdata* pdata = static_cast<decltype (pdata)> (order_pdata);
 
@@ -178,7 +178,7 @@ order_opened_handler (xmlNodePtr node, gpointer order_pdata)
 }
 
 static gboolean
-order_closed_handler (xmlNodePtr node, gpointer order_pdata)
+order_closed_handler (GncXmlNode* node, gpointer order_pdata)
 {
     struct order_pdata* pdata = static_cast<decltype (pdata)> (order_pdata);
 
@@ -186,7 +186,7 @@ order_closed_handler (xmlNodePtr node, gpointer order_pdata)
 }
 
 static gboolean
-order_notes_handler (xmlNodePtr node, gpointer order_pdata)
+order_notes_handler (GncXmlNode* node, gpointer order_pdata)
 {
     struct order_pdata* pdata = static_cast<decltype (pdata)> (order_pdata);
 
@@ -194,7 +194,7 @@ order_notes_handler (xmlNodePtr node, gpointer order_pdata)
 }
 
 static gboolean
-order_reference_handler (xmlNodePtr node, gpointer order_pdata)
+order_reference_handler (GncXmlNode* node, gpointer order_pdata)
 {
     struct order_pdata* pdata = static_cast<decltype (pdata)> (order_pdata);
 
@@ -202,7 +202,7 @@ order_reference_handler (xmlNodePtr node, gpointer order_pdata)
 }
 
 static gboolean
-order_active_handler (xmlNodePtr node, gpointer order_pdata)
+order_active_handler (GncXmlNode* node, gpointer order_pdata)
 {
     struct order_pdata* pdata = static_cast<decltype (pdata)> (order_pdata);
     gint64 val;
@@ -216,7 +216,7 @@ order_active_handler (xmlNodePtr node, gpointer order_pdata)
 }
 
 static gboolean
-order_slots_handler (xmlNodePtr node, gpointer order_pdata)
+order_slots_handler (GncXmlNode* node, gpointer order_pdata)
 {
     struct order_pdata* pdata = static_cast<decltype (pdata)> (order_pdata);
 
@@ -238,7 +238,7 @@ static struct dom_tree_handler order_handlers_v2[] =
 };
 
 static GncOrder*
-dom_tree_to_order (xmlNodePtr node, QofBook* book)
+dom_tree_to_order (GncXmlNode* node, QofBook* book)
 {
     struct order_pdata order_pdata;
     gboolean successful;
@@ -269,7 +269,7 @@ gnc_order_end_handler (gpointer data_for_children,
                        gpointer* result, const gchar* tag)
 {
     GncOrder* order;
-    xmlNodePtr tree = (xmlNodePtr)data_for_children;
+    GncXmlNode* tree = (GncXmlNode*)data_for_children;
     gxpf_data* gdata = (gxpf_data*)global_data;
     QofBook* book = static_cast<decltype (book)> (gdata->bookdata);
 
@@ -293,7 +293,7 @@ gnc_order_end_handler (gpointer data_for_children,
         gdata->cb (tag, gdata->parsedata, order);
     }
 
-    xmlFreeNode (tree);
+    gnc_xml_node_free (tree);
 
     return order != NULL;
 }

--- a/libgnucash/backend/xml/gnc-owner-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-owner-xml-v2.cpp
@@ -97,7 +97,7 @@ struct owner_pdata
 };
 
 static gboolean
-owner_type_handler (xmlNodePtr node, gpointer owner_pdata)
+owner_type_handler (GncXmlNode* node, gpointer owner_pdata)
 {
     struct owner_pdata* pdata = static_cast<decltype (pdata)> (owner_pdata);
     GncOwner* owner = pdata->owner;
@@ -116,7 +116,7 @@ owner_type_handler (xmlNodePtr node, gpointer owner_pdata)
 }
 
 static gboolean
-owner_id_handler (xmlNodePtr node, gpointer owner_pdata)
+owner_id_handler (GncXmlNode* node, gpointer owner_pdata)
 {
     struct owner_pdata* pdata = static_cast<decltype (pdata)> (owner_pdata);
 
@@ -185,7 +185,7 @@ static struct dom_tree_handler owner_handlers_v2[] =
 };
 
 gboolean
-gnc_dom_tree_to_owner (xmlNodePtr node, GncOwner* owner, QofBook* book)
+gnc_dom_tree_to_owner (GncXmlNode* node, GncOwner* owner, QofBook* book)
 {
     struct owner_pdata owner_pdata;
     gboolean successful;

--- a/libgnucash/backend/xml/gnc-owner-xml-v2.h
+++ b/libgnucash/backend/xml/gnc-owner-xml-v2.h
@@ -24,7 +24,8 @@
 #define GNC_OWNER_XML_V2_H
 #include "gncOwner.h"
 #include "qof.h"
-gboolean   gnc_dom_tree_to_owner (xmlNodePtr node, GncOwner* owner,
+#include "gnc-xml-sax-node.h"
+gboolean   gnc_dom_tree_to_owner (GncXmlNode* node, GncOwner* owner,
                                   QofBook* book);
 xmlNodePtr gnc_owner_to_dom_tree (const char* tag, const GncOwner* addr);
 void gnc_owner_xml_initialize (void);

--- a/libgnucash/backend/xml/gnc-pricedb-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-pricedb-xml-v2.cpp
@@ -84,7 +84,7 @@ static QofLogModule log_module = GNC_MOD_IO;
 */
 
 static gboolean
-price_parse_xml_sub_node (GNCPrice* p, xmlNodePtr sub_node, QofBook* book)
+price_parse_xml_sub_node (GNCPrice* p, GncXmlNode* sub_node, QofBook* book)
 {
     if (!p || !sub_node) return FALSE;
 
@@ -141,8 +141,8 @@ price_parse_xml_end_handler (gpointer data_for_children,
                              const gchar* tag)
 {
     gboolean ok = TRUE;
-    xmlNodePtr price_xml = (xmlNodePtr) data_for_children;
-    xmlNodePtr child;
+    GncXmlNode* price_xml = (GncXmlNode*) data_for_children;
+    GncXmlNode* child;
     GNCPrice* p = NULL;
     gxpf_data* gdata = static_cast<decltype (gdata)> (global_data);
     QofBook* book = static_cast<decltype (book)> (gdata->bookdata);
@@ -209,7 +209,7 @@ cleanup_and_exit:
         *result = NULL;
         gnc_price_unref (p);
     }
-    xmlFreeNode (price_xml);
+    gnc_xml_node_free (price_xml);
     return ok;
 }
 

--- a/libgnucash/backend/xml/gnc-recurrence-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-recurrence-xml-v2.cpp
@@ -50,7 +50,7 @@ const gchar* recurrence_version_string = "1.0.0";
 //TODO: I think three of these functions rightly belong in Recurrence.c.
 
 static gboolean
-recurrence_period_type_handler (xmlNodePtr node, gpointer d)
+recurrence_period_type_handler (GncXmlNode* node, gpointer d)
 {
     auto r = static_cast<Recurrence*>(d);
     auto set_ptype = [](Recurrence *r, const char* txt)
@@ -62,7 +62,7 @@ recurrence_period_type_handler (xmlNodePtr node, gpointer d)
 }
 
 static gboolean
-recurrence_start_date_handler (xmlNodePtr node, gpointer r)
+recurrence_start_date_handler (GncXmlNode* node, gpointer r)
 {
     GDate* d;
 
@@ -75,13 +75,13 @@ recurrence_start_date_handler (xmlNodePtr node, gpointer r)
 }
 
 static gboolean
-recurrence_mult_handler (xmlNodePtr node, gpointer r)
+recurrence_mult_handler (GncXmlNode* node, gpointer r)
 {
     return dom_tree_to_guint16 (node, & ((Recurrence*)r)->mult);
 }
 
 static gboolean
-recurrence_weekend_adj_handler (xmlNodePtr node, gpointer d)
+recurrence_weekend_adj_handler (GncXmlNode* node, gpointer d)
 {
     auto r = static_cast<Recurrence*>(d);
     auto set_wadj = [](Recurrence *r, const char* txt)
@@ -102,7 +102,7 @@ static struct dom_tree_handler recurrence_dom_handlers[] =
 };
 
 Recurrence*
-dom_tree_to_recurrence (xmlNodePtr node)
+dom_tree_to_recurrence (GncXmlNode* node)
 {
     gboolean successful;
     Recurrence* r;
@@ -114,7 +114,7 @@ dom_tree_to_recurrence (xmlNodePtr node)
     if (!successful)
     {
         PERR ("failed to parse recurrence node");
-        xmlElemDump (stdout, NULL, node);
+        gnc_xml_node_dump (stdout, node);
         g_free (r);
         r = NULL;
     }

--- a/libgnucash/backend/xml/gnc-schedxaction-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-schedxaction-xml-v2.cpp
@@ -206,7 +206,7 @@ struct sx_pdata
 
 static
 gboolean
-sx_id_handler (xmlNodePtr node, gpointer sx_pdata)
+sx_id_handler (GncXmlNode* node, gpointer sx_pdata)
 {
     struct sx_pdata* pdata = static_cast<decltype (pdata)> (sx_pdata);
     SchedXaction* sx = pdata->sx;
@@ -220,14 +220,14 @@ sx_id_handler (xmlNodePtr node, gpointer sx_pdata)
 
 static
 gboolean
-sx_name_handler (xmlNodePtr node, gpointer sx_pdata)
+sx_name_handler (GncXmlNode* node, gpointer sx_pdata)
 {
     struct sx_pdata* pdata = static_cast<decltype (pdata)> (sx_pdata);
     return apply_xmlnode_text (xaccSchedXactionSetName, pdata->sx, node);
 }
 
 static gboolean
-sx_enabled_handler (xmlNodePtr node, gpointer sx_pdata)
+sx_enabled_handler (GncXmlNode* node, gpointer sx_pdata)
 {
     struct sx_pdata* pdata = static_cast<decltype (pdata)> (sx_pdata);
     auto set_enabled = [](SchedXaction* sx, const char* txt)
@@ -238,7 +238,7 @@ sx_enabled_handler (xmlNodePtr node, gpointer sx_pdata)
 }
 
 static gboolean
-sx_autoCreate_handler (xmlNodePtr node, gpointer sx_pdata)
+sx_autoCreate_handler (GncXmlNode* node, gpointer sx_pdata)
 {
     struct sx_pdata* pdata = static_cast<decltype (pdata)> (sx_pdata);
     auto set_autocreate = [](SchedXaction* sx, const char* txt)
@@ -249,7 +249,7 @@ sx_autoCreate_handler (xmlNodePtr node, gpointer sx_pdata)
 }
 
 static gboolean
-sx_notify_handler (xmlNodePtr node, gpointer sx_pdata)
+sx_notify_handler (GncXmlNode* node, gpointer sx_pdata)
 {
     struct sx_pdata* pdata = static_cast<decltype (pdata)> (sx_pdata);
     auto set_notify = [](SchedXaction* sx, const char* txt)
@@ -260,7 +260,7 @@ sx_notify_handler (xmlNodePtr node, gpointer sx_pdata)
 }
 
 static gboolean
-sx_advCreate_handler (xmlNodePtr node, gpointer sx_pdata)
+sx_advCreate_handler (GncXmlNode* node, gpointer sx_pdata)
 {
     struct sx_pdata* pdata = static_cast<decltype (pdata)> (sx_pdata);
     SchedXaction* sx = pdata->sx;
@@ -276,7 +276,7 @@ sx_advCreate_handler (xmlNodePtr node, gpointer sx_pdata)
 }
 
 static gboolean
-sx_advRemind_handler (xmlNodePtr node, gpointer sx_pdata)
+sx_advRemind_handler (GncXmlNode* node, gpointer sx_pdata)
 {
     struct sx_pdata* pdata = static_cast<decltype (pdata)> (sx_pdata);
     SchedXaction* sx = pdata->sx;
@@ -293,7 +293,7 @@ sx_advRemind_handler (xmlNodePtr node, gpointer sx_pdata)
 
 static
 gboolean
-sx_set_date (xmlNodePtr node, SchedXaction* sx,
+sx_set_date (GncXmlNode* node, SchedXaction* sx,
              void (*settor) (SchedXaction* sx, const GDate* d))
 {
     GDate* date;
@@ -307,7 +307,7 @@ sx_set_date (xmlNodePtr node, SchedXaction* sx,
 
 static
 gboolean
-sx_instcount_handler (xmlNodePtr node, gpointer sx_pdata)
+sx_instcount_handler (GncXmlNode* node, gpointer sx_pdata)
 {
     struct sx_pdata* pdata = static_cast<decltype (pdata)> (sx_pdata);
     SchedXaction* sx = pdata->sx;
@@ -324,7 +324,7 @@ sx_instcount_handler (xmlNodePtr node, gpointer sx_pdata)
 
 static
 gboolean
-sx_start_handler (xmlNodePtr node, gpointer sx_pdata)
+sx_start_handler (GncXmlNode* node, gpointer sx_pdata)
 {
     struct sx_pdata* pdata = static_cast<decltype (pdata)> (sx_pdata);
     SchedXaction* sx = pdata->sx;
@@ -334,7 +334,7 @@ sx_start_handler (xmlNodePtr node, gpointer sx_pdata)
 
 static
 gboolean
-sx_last_handler (xmlNodePtr node, gpointer sx_pdata)
+sx_last_handler (GncXmlNode* node, gpointer sx_pdata)
 {
     struct sx_pdata* pdata = static_cast<decltype (pdata)> (sx_pdata);
     SchedXaction* sx = pdata->sx;
@@ -344,7 +344,7 @@ sx_last_handler (xmlNodePtr node, gpointer sx_pdata)
 
 static
 gboolean
-sx_end_handler (xmlNodePtr node, gpointer sx_pdata)
+sx_end_handler (GncXmlNode* node, gpointer sx_pdata)
 {
     struct sx_pdata* pdata = static_cast<decltype (pdata)> (sx_pdata);
     SchedXaction* sx = pdata->sx;
@@ -402,7 +402,7 @@ _fixup_recurrence_start_dates (const GDate* sx_start_date, GList* schedule)
 }
 
 static gboolean
-sx_freqspec_handler (xmlNodePtr node, gpointer sx_pdata)
+sx_freqspec_handler (GncXmlNode* node, gpointer sx_pdata)
 {
     struct sx_pdata* pdata = static_cast<decltype (pdata)> (sx_pdata);
     SchedXaction* sx = pdata->sx;
@@ -424,7 +424,7 @@ sx_freqspec_handler (xmlNodePtr node, gpointer sx_pdata)
 }
 
 static gboolean
-sx_schedule_recurrence_handler (xmlNodePtr node, gpointer parsing_data)
+sx_schedule_recurrence_handler (GncXmlNode* node, gpointer parsing_data)
 {
     GList** schedule = (GList**)parsing_data;
     gchar* sched_str;
@@ -444,7 +444,7 @@ struct dom_tree_handler sx_recurrence_list_handlers[] =
 };
 
 static gboolean
-sx_recurrence_handler (xmlNodePtr node, gpointer _pdata)
+sx_recurrence_handler (GncXmlNode* node, gpointer _pdata)
 {
     struct sx_pdata* parsing_data = static_cast<decltype (parsing_data)> (_pdata);
     GList* schedule = NULL;
@@ -465,7 +465,7 @@ sx_recurrence_handler (xmlNodePtr node, gpointer _pdata)
 
 static
 gboolean
-sx_defer_last_handler (xmlNodePtr node, gpointer gpTSD)
+sx_defer_last_handler (GncXmlNode* node, gpointer gpTSD)
 {
     GDate* gd;
     SXTmpStateData* tsd = (SXTmpStateData*)gpTSD;
@@ -480,7 +480,7 @@ sx_defer_last_handler (xmlNodePtr node, gpointer gpTSD)
 
 static
 gboolean
-sx_defer_rem_occur_handler (xmlNodePtr node, gpointer gpTSD)
+sx_defer_rem_occur_handler (GncXmlNode* node, gpointer gpTSD)
 {
     gint64 remOccur;
     SXTmpStateData* tsd = (SXTmpStateData*)gpTSD;
@@ -496,7 +496,7 @@ sx_defer_rem_occur_handler (xmlNodePtr node, gpointer gpTSD)
 
 static
 gboolean
-sx_defer_inst_count_handler (xmlNodePtr node, gpointer gpTSD)
+sx_defer_inst_count_handler (GncXmlNode* node, gpointer gpTSD)
 {
     gint64 instCount;
     SXTmpStateData* tsd = (SXTmpStateData*)gpTSD;
@@ -521,7 +521,7 @@ struct dom_tree_handler sx_defer_dom_handlers[] =
 
 static
 gboolean
-sx_defer_inst_handler (xmlNodePtr node, gpointer sx_pdata)
+sx_defer_inst_handler (GncXmlNode* node, gpointer sx_pdata)
 {
     struct sx_pdata* pdata = static_cast<decltype (pdata)> (sx_pdata);
     SchedXaction* sx = pdata->sx;
@@ -535,7 +535,7 @@ sx_defer_inst_handler (xmlNodePtr node, gpointer sx_pdata)
                                  sx_defer_dom_handlers,
                                  tsd))
     {
-        xmlElemDump (stdout, NULL, node);
+        gnc_xml_node_dump (stdout, node);
         g_free (tsd);
         tsd = NULL;
         return FALSE;
@@ -548,7 +548,7 @@ sx_defer_inst_handler (xmlNodePtr node, gpointer sx_pdata)
 
 static
 gboolean
-sx_numOccur_handler (xmlNodePtr node, gpointer sx_pdata)
+sx_numOccur_handler (GncXmlNode* node, gpointer sx_pdata)
 {
     struct sx_pdata* pdata = static_cast<decltype (pdata)> (sx_pdata);
     SchedXaction* sx = pdata->sx;
@@ -567,7 +567,7 @@ sx_numOccur_handler (xmlNodePtr node, gpointer sx_pdata)
 
 static
 gboolean
-sx_templ_acct_handler (xmlNodePtr node, gpointer sx_pdata)
+sx_templ_acct_handler (GncXmlNode* node, gpointer sx_pdata)
 {
     struct sx_pdata* pdata = static_cast<decltype (pdata)> (sx_pdata);
     SchedXaction* sx = pdata->sx;
@@ -588,7 +588,7 @@ sx_templ_acct_handler (xmlNodePtr node, gpointer sx_pdata)
 
 static
 gboolean
-sx_remOccur_handler (xmlNodePtr node, gpointer sx_pdata)
+sx_remOccur_handler (GncXmlNode* node, gpointer sx_pdata)
 {
     struct sx_pdata* pdata = static_cast<decltype (pdata)> (sx_pdata);
     SchedXaction* sx = pdata->sx;
@@ -606,7 +606,7 @@ sx_remOccur_handler (xmlNodePtr node, gpointer sx_pdata)
 
 static
 gboolean
-sx_slots_handler (xmlNodePtr node, gpointer sx_pdata)
+sx_slots_handler (GncXmlNode* node, gpointer sx_pdata)
 {
     struct sx_pdata* pdata = static_cast<decltype (pdata)> (sx_pdata);
     SchedXaction* sx = pdata->sx;
@@ -645,7 +645,7 @@ gnc_schedXaction_end_handler (gpointer data_for_children,
 {
     SchedXaction* sx;
     gboolean     successful = FALSE;
-    xmlNodePtr   tree = (xmlNodePtr)data_for_children;
+    GncXmlNode*   tree = (GncXmlNode*)data_for_children;
     gxpf_data*    gdata = (gxpf_data*)global_data;
     struct sx_pdata sx_pdata;
 
@@ -673,7 +673,7 @@ gnc_schedXaction_end_handler (gpointer data_for_children,
     if (!successful)
     {
         g_critical ("failed to parse scheduled xaction");
-        xmlElemDump (stdout, NULL, tree);
+        gnc_xml_node_dump (stdout, tree);
         gnc_sx_begin_edit (sx);
         xaccSchedXactionDestroy (sx);
         goto done;
@@ -682,10 +682,10 @@ gnc_schedXaction_end_handler (gpointer data_for_children,
     if (tree->properties)
     {
         gchar* sx_name = xaccSchedXactionGetName (sx);
-        xmlAttr* attr;
+        GncXmlAttr* attr;
         for (attr = tree->properties; attr != NULL; attr = attr->next)
         {
-            xmlChar* attr_value = attr->children->content;
+            char* attr_value = attr->value;
             DEBUG ("sx attribute name[%s] value[%s]", attr->name, attr_value);
             if (strcmp ((const char*)attr->name, "version") != 0)
             {
@@ -738,14 +738,14 @@ gnc_schedXaction_end_handler (gpointer data_for_children,
         if (ra == NULL)
         {
             g_warning ("Error getting template root account from being-parsed Book.");
-            xmlFreeNode (tree);
+            gnc_xml_node_free (tree);
             return FALSE;
         }
         acct = gnc_account_lookup_by_name (ra, guidstr);
         if (acct == NULL)
         {
             g_warning ("no template account with name [%s]", guidstr);
-            xmlFreeNode (tree);
+            gnc_xml_node_free (tree);
             return FALSE;
         }
         DEBUG ("template account name [%s] for SX with GncGUID [%s]",
@@ -761,7 +761,7 @@ gnc_schedXaction_end_handler (gpointer data_for_children,
     }
 
 done:
-    xmlFreeNode (tree);
+    gnc_xml_node_free (tree);
 
     return successful;
 }
@@ -774,7 +774,7 @@ gnc_schedXaction_sixtp_parser_create (void)
 
 static
 gboolean
-tt_act_handler (xmlNodePtr node, gpointer data)
+tt_act_handler (GncXmlNode* node, gpointer data)
 {
     gnc_template_xaction_data* txd = static_cast<decltype (txd)> (data);
     Account* acc;
@@ -825,7 +825,7 @@ tt_act_handler (xmlNodePtr node, gpointer data)
 
 static
 gboolean
-tt_trn_handler (xmlNodePtr node, gpointer data)
+tt_trn_handler (GncXmlNode* node, gpointer data)
 {
     gnc_template_xaction_data* txd = static_cast<decltype (txd)> (data);
     Transaction*        trn;
@@ -861,7 +861,7 @@ gnc_template_transaction_end_handler (gpointer data_for_children,
                                       const gchar* tag)
 {
     gboolean   successful = FALSE;
-    xmlNodePtr tree = static_cast<decltype (tree)> (data_for_children);
+    GncXmlNode* tree = static_cast<decltype (tree)> (data_for_children);
     gxpf_data*  gdata = static_cast<decltype (gdata)> (global_data);
     QofBook*    book = static_cast<decltype (book)> (gdata->bookdata);
     GList*      n;
@@ -900,7 +900,7 @@ gnc_template_transaction_end_handler (gpointer data_for_children,
     else
     {
         g_warning ("failed to parse template transaction");
-        xmlElemDump (stdout, NULL, tree);
+        gnc_xml_node_dump (stdout, tree);
     }
 
     /* cleanup */
@@ -915,7 +915,7 @@ gnc_template_transaction_end_handler (gpointer data_for_children,
     g_list_free (txd.accts);
     g_list_free (txd.transactions);
 
-    xmlFreeNode (tree);
+    gnc_xml_node_free (tree);
 
     return successful;
 }

--- a/libgnucash/backend/xml/gnc-tax-table-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-tax-table-xml-v2.cpp
@@ -143,7 +143,7 @@ struct ttentry_pdata
 };
 
 static gboolean
-ttentry_acct_handler (xmlNodePtr node, gpointer ttentry_pdata)
+ttentry_acct_handler (GncXmlNode* node, gpointer ttentry_pdata)
 {
     struct ttentry_pdata* pdata = static_cast<decltype (pdata)> (ttentry_pdata);
     Account* acc;
@@ -158,7 +158,7 @@ ttentry_acct_handler (xmlNodePtr node, gpointer ttentry_pdata)
 }
 
 static gboolean
-ttentry_type_handler (xmlNodePtr node, gpointer ttentry_pdata)
+ttentry_type_handler (GncXmlNode* node, gpointer ttentry_pdata)
 {
     struct ttentry_pdata* pdata = static_cast<decltype (pdata)> (ttentry_pdata);
     auto tte_settype = [](GncTaxTableEntry* tt, const char *str)
@@ -171,7 +171,7 @@ ttentry_type_handler (xmlNodePtr node, gpointer ttentry_pdata)
 }
 
 static gboolean
-ttentry_amount_handler (xmlNodePtr node, gpointer ttentry_pdata)
+ttentry_amount_handler (GncXmlNode* node, gpointer ttentry_pdata)
 {
     struct ttentry_pdata* pdata = static_cast<decltype (pdata)> (ttentry_pdata);
 
@@ -188,7 +188,7 @@ static struct dom_tree_handler ttentry_handlers_v2[] =
 };
 
 static GncTaxTableEntry*
-dom_tree_to_ttentry (xmlNodePtr node, QofBook* book)
+dom_tree_to_ttentry (GncXmlNode* node, QofBook* book)
 {
     struct ttentry_pdata ttentry_pdata;
     gboolean successful;
@@ -218,7 +218,7 @@ struct taxtable_pdata
 };
 
 static gboolean
-set_parent_child (xmlNodePtr node, struct taxtable_pdata* pdata,
+set_parent_child (GncXmlNode* node, struct taxtable_pdata* pdata,
                   void (*func) (GncTaxTable*, GncTaxTable*))
 {
     GncTaxTable* table;
@@ -248,7 +248,7 @@ set_parent_child (xmlNodePtr node, struct taxtable_pdata* pdata,
 }
 
 static gboolean
-taxtable_guid_handler (xmlNodePtr node, gpointer taxtable_pdata)
+taxtable_guid_handler (GncXmlNode* node, gpointer taxtable_pdata)
 {
     struct taxtable_pdata* pdata = static_cast<decltype (pdata)> (taxtable_pdata);
     GncTaxTable* table;
@@ -271,14 +271,14 @@ taxtable_guid_handler (xmlNodePtr node, gpointer taxtable_pdata)
 }
 
 static gboolean
-taxtable_name_handler (xmlNodePtr node, gpointer taxtable_pdata)
+taxtable_name_handler (GncXmlNode* node, gpointer taxtable_pdata)
 {
     struct taxtable_pdata* pdata = static_cast<decltype (pdata)> (taxtable_pdata);
     return apply_xmlnode_text (gncTaxTableSetName, pdata->table, node);
 }
 
 static gboolean
-taxtable_refcount_handler (xmlNodePtr node, gpointer taxtable_pdata)
+taxtable_refcount_handler (GncXmlNode* node, gpointer taxtable_pdata)
 {
     struct taxtable_pdata* pdata = static_cast<decltype (pdata)> (taxtable_pdata);
     gint64 val;
@@ -289,7 +289,7 @@ taxtable_refcount_handler (xmlNodePtr node, gpointer taxtable_pdata)
 }
 
 static gboolean
-taxtable_invisible_handler (xmlNodePtr node, gpointer taxtable_pdata)
+taxtable_invisible_handler (GncXmlNode* node, gpointer taxtable_pdata)
 {
     struct taxtable_pdata* pdata = static_cast<decltype (pdata)> (taxtable_pdata);
     gint64 val;
@@ -301,24 +301,24 @@ taxtable_invisible_handler (xmlNodePtr node, gpointer taxtable_pdata)
 }
 
 static gboolean
-taxtable_parent_handler (xmlNodePtr node, gpointer taxtable_pdata)
+taxtable_parent_handler (GncXmlNode* node, gpointer taxtable_pdata)
 {
     struct taxtable_pdata* pdata = static_cast<decltype (pdata)> (taxtable_pdata);
     return set_parent_child (node, pdata, gncTaxTableSetParent);
 }
 
 static gboolean
-taxtable_child_handler (xmlNodePtr node, gpointer taxtable_pdata)
+taxtable_child_handler (GncXmlNode* node, gpointer taxtable_pdata)
 {
     struct taxtable_pdata* pdata = static_cast<decltype (pdata)> (taxtable_pdata);
     return set_parent_child (node, pdata, gncTaxTableSetChild);
 }
 
 static gboolean
-taxtable_entries_handler (xmlNodePtr node, gpointer taxtable_pdata)
+taxtable_entries_handler (GncXmlNode* node, gpointer taxtable_pdata)
 {
     struct taxtable_pdata* pdata = static_cast<decltype (pdata)> (taxtable_pdata);
-    xmlNodePtr mark;
+    GncXmlNode* mark;
 
     g_return_val_if_fail (node, FALSE);
     g_return_val_if_fail (node->xmlChildrenNode, FALSE);
@@ -345,7 +345,7 @@ taxtable_entries_handler (xmlNodePtr node, gpointer taxtable_pdata)
 }
 
 static gboolean
-taxtable_slots_handler (xmlNodePtr node, gpointer taxtable_pdata)
+taxtable_slots_handler (GncXmlNode* node, gpointer taxtable_pdata)
 {
     struct taxtable_pdata* pdata = static_cast<decltype (pdata)> (taxtable_pdata);
 
@@ -366,7 +366,7 @@ static struct dom_tree_handler taxtable_handlers_v2[] =
 };
 
 static GncTaxTable*
-dom_tree_to_taxtable (xmlNodePtr node, QofBook* book)
+dom_tree_to_taxtable (GncXmlNode* node, QofBook* book)
 {
     struct taxtable_pdata taxtable_pdata;
     gboolean successful;
@@ -397,7 +397,7 @@ gnc_taxtable_end_handler (gpointer data_for_children,
                           gpointer* result, const gchar* tag)
 {
     GncTaxTable* table;
-    xmlNodePtr tree = (xmlNodePtr)data_for_children;
+    GncXmlNode* tree = (GncXmlNode*)data_for_children;
     gxpf_data* gdata = (gxpf_data*)global_data;
     QofBook* book = static_cast<decltype (book)> (gdata->bookdata);
 
@@ -421,7 +421,7 @@ gnc_taxtable_end_handler (gpointer data_for_children,
         gdata->cb (tag, gdata->parsedata, table);
     }
 
-    xmlFreeNode (tree);
+    gnc_xml_node_free (tree);
 
     return table != NULL;
 }

--- a/libgnucash/backend/xml/gnc-transaction-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-transaction-xml-v2.cpp
@@ -200,7 +200,7 @@ struct split_pdata
 };
 
 static inline gboolean
-set_spl_gnc_num (xmlNodePtr node, Split* spl,
+set_spl_gnc_num (GncXmlNode* node, Split* spl,
                  void (*func) (Split* spl, gnc_numeric gn))
 {
     func (spl, dom_tree_to_gnc_numeric (node));
@@ -208,7 +208,7 @@ set_spl_gnc_num (xmlNodePtr node, Split* spl,
 }
 
 static gboolean
-spl_id_handler (xmlNodePtr node, gpointer data)
+spl_id_handler (GncXmlNode* node, gpointer data)
 {
     struct split_pdata* pdata = static_cast<decltype (pdata)> (data);
     auto tmp = dom_tree_to_guid (node);
@@ -220,21 +220,21 @@ spl_id_handler (xmlNodePtr node, gpointer data)
 }
 
 static gboolean
-spl_memo_handler (xmlNodePtr node, gpointer data)
+spl_memo_handler (GncXmlNode* node, gpointer data)
 {
     struct split_pdata* pdata = static_cast<decltype (pdata)> (data);
     return apply_xmlnode_text (xaccSplitSetMemo, pdata->split, node);
 }
 
 static gboolean
-spl_action_handler (xmlNodePtr node, gpointer data)
+spl_action_handler (GncXmlNode* node, gpointer data)
 {
     struct split_pdata* pdata = static_cast<decltype (pdata)> (data);
     return apply_xmlnode_text (xaccSplitSetAction, pdata->split, node);
 }
 
 static gboolean
-spl_reconciled_state_handler (xmlNodePtr node, gpointer data)
+spl_reconciled_state_handler (GncXmlNode* node, gpointer data)
 {
     struct split_pdata* pdata = static_cast<decltype (pdata)> (data);
     auto set_reconciled = [](Split* s, const char *txt)
@@ -245,7 +245,7 @@ spl_reconciled_state_handler (xmlNodePtr node, gpointer data)
 }
 
 static gboolean
-spl_reconcile_date_handler (xmlNodePtr node, gpointer data)
+spl_reconcile_date_handler (GncXmlNode* node, gpointer data)
 {
     struct split_pdata* pdata = static_cast<decltype (pdata)> (data);
     time64 time  = dom_tree_to_time64 (node);
@@ -255,14 +255,14 @@ spl_reconcile_date_handler (xmlNodePtr node, gpointer data)
 }
 
 static gboolean
-spl_value_handler (xmlNodePtr node, gpointer data)
+spl_value_handler (GncXmlNode* node, gpointer data)
 {
     struct split_pdata* pdata = static_cast<decltype (pdata)> (data);
     return set_spl_gnc_num (node, pdata->split, xaccSplitSetValue);
 }
 
 static gboolean
-spl_quantity_handler (xmlNodePtr node, gpointer data)
+spl_quantity_handler (GncXmlNode* node, gpointer data)
 {
     struct split_pdata* pdata = static_cast<decltype (pdata)> (data);
     return set_spl_gnc_num (node, pdata->split, xaccSplitSetAmount);
@@ -271,7 +271,7 @@ spl_quantity_handler (xmlNodePtr node, gpointer data)
 gboolean gnc_transaction_xml_v2_testing = FALSE;
 
 static gboolean
-spl_account_handler (xmlNodePtr node, gpointer data)
+spl_account_handler (GncXmlNode* node, gpointer data)
 {
     struct split_pdata* pdata = static_cast<decltype (pdata)> (data);
     auto id = dom_tree_to_guid (node);
@@ -295,7 +295,7 @@ spl_account_handler (xmlNodePtr node, gpointer data)
 }
 
 static gboolean
-spl_lot_handler (xmlNodePtr node, gpointer data)
+spl_lot_handler (GncXmlNode* node, gpointer data)
 {
     struct split_pdata* pdata = static_cast<decltype (pdata)> (data);
     auto id = dom_tree_to_guid (node);
@@ -317,7 +317,7 @@ spl_lot_handler (xmlNodePtr node, gpointer data)
 }
 
 static gboolean
-spl_slots_handler (xmlNodePtr node, gpointer data)
+spl_slots_handler (GncXmlNode* node, gpointer data)
 {
     struct split_pdata* pdata = static_cast<decltype (pdata)> (data);
     gboolean successful;
@@ -345,7 +345,7 @@ struct dom_tree_handler spl_dom_handlers[] =
 };
 
 static Split*
-dom_tree_to_split (xmlNodePtr node, QofBook* book)
+dom_tree_to_split (GncXmlNode* node, QofBook* book)
 {
     struct split_pdata pdata;
     Split* ret;
@@ -379,7 +379,7 @@ struct trans_pdata
 };
 
 static gboolean
-set_tran_time64 (xmlNodePtr node, Transaction * trn,
+set_tran_time64 (GncXmlNode* node, Transaction * trn,
         void (*func) (Transaction *, time64))
 {
     time64 time = dom_tree_to_time64 (node);
@@ -389,7 +389,7 @@ set_tran_time64 (xmlNodePtr node, Transaction * trn,
 }
 
 static gboolean
-trn_id_handler (xmlNodePtr node, gpointer trans_pdata)
+trn_id_handler (GncXmlNode* node, gpointer trans_pdata)
 {
     struct trans_pdata* pdata = static_cast<decltype (pdata)> (trans_pdata);
     Transaction* trn = pdata->trans;
@@ -403,7 +403,7 @@ trn_id_handler (xmlNodePtr node, gpointer trans_pdata)
 }
 
 static gboolean
-trn_currency_handler (xmlNodePtr node, gpointer trans_pdata)
+trn_currency_handler (GncXmlNode* node, gpointer trans_pdata)
 {
     struct trans_pdata* pdata = static_cast<decltype (pdata)> (trans_pdata);
     Transaction* trn = pdata->trans;
@@ -416,7 +416,7 @@ trn_currency_handler (xmlNodePtr node, gpointer trans_pdata)
 }
 
 static gboolean
-trn_num_handler (xmlNodePtr node, gpointer trans_pdata)
+trn_num_handler (GncXmlNode* node, gpointer trans_pdata)
 {
     struct trans_pdata* pdata = static_cast<decltype (pdata)> (trans_pdata);
     Transaction* trn = pdata->trans;
@@ -425,7 +425,7 @@ trn_num_handler (xmlNodePtr node, gpointer trans_pdata)
 }
 
 static gboolean
-trn_date_posted_handler (xmlNodePtr node, gpointer trans_pdata)
+trn_date_posted_handler (GncXmlNode* node, gpointer trans_pdata)
 {
     struct trans_pdata* pdata = static_cast<decltype (pdata)> (trans_pdata);
     Transaction* trn = pdata->trans;
@@ -434,7 +434,7 @@ trn_date_posted_handler (xmlNodePtr node, gpointer trans_pdata)
 }
 
 static gboolean
-trn_date_entered_handler (xmlNodePtr node, gpointer trans_pdata)
+trn_date_entered_handler (GncXmlNode* node, gpointer trans_pdata)
 {
     struct trans_pdata* pdata = static_cast<decltype (pdata)> (trans_pdata);
     Transaction* trn = pdata->trans;
@@ -443,7 +443,7 @@ trn_date_entered_handler (xmlNodePtr node, gpointer trans_pdata)
 }
 
 static gboolean
-trn_description_handler (xmlNodePtr node, gpointer trans_pdata)
+trn_description_handler (GncXmlNode* node, gpointer trans_pdata)
 {
     struct trans_pdata* pdata = static_cast<decltype (pdata)> (trans_pdata);
     Transaction* trn = pdata->trans;
@@ -452,7 +452,7 @@ trn_description_handler (xmlNodePtr node, gpointer trans_pdata)
 }
 
 static gboolean
-trn_slots_handler (xmlNodePtr node, gpointer trans_pdata)
+trn_slots_handler (GncXmlNode* node, gpointer trans_pdata)
 {
     struct trans_pdata* pdata = static_cast<decltype (pdata)> (trans_pdata);
     Transaction* trn = pdata->trans;
@@ -466,11 +466,11 @@ trn_slots_handler (xmlNodePtr node, gpointer trans_pdata)
 }
 
 static gboolean
-trn_splits_handler (xmlNodePtr node, gpointer trans_pdata)
+trn_splits_handler (GncXmlNode* node, gpointer trans_pdata)
 {
     struct trans_pdata* pdata = static_cast<decltype (pdata)> (trans_pdata);
     Transaction* trn = pdata->trans;
-    xmlNodePtr mark;
+    GncXmlNode* mark;
 
     g_return_val_if_fail (node, FALSE);
     g_return_val_if_fail (node->xmlChildrenNode, FALSE);
@@ -521,7 +521,7 @@ gnc_transaction_end_handler (gpointer data_for_children,
                              gpointer* result, const gchar* tag)
 {
     Transaction* trn = NULL;
-    xmlNodePtr tree = (xmlNodePtr)data_for_children;
+    GncXmlNode* tree = (GncXmlNode*)data_for_children;
     gxpf_data* gdata = (gxpf_data*)global_data;
 
     if (parent_data)
@@ -545,13 +545,13 @@ gnc_transaction_end_handler (gpointer data_for_children,
         gdata->cb (tag, gdata->parsedata, trn);
     }
 
-    xmlFreeNode (tree);
+    gnc_xml_node_free (tree);
 
     return trn != NULL;
 }
 
 Transaction*
-dom_tree_to_transaction (xmlNodePtr node, QofBook* book)
+dom_tree_to_transaction (GncXmlNode* node, QofBook* book)
 {
     Transaction* trn;
     gboolean successful;
@@ -573,7 +573,7 @@ dom_tree_to_transaction (xmlNodePtr node, QofBook* book)
 
     if (!successful)
     {
-        xmlElemDump (stdout, NULL, node);
+        gnc_xml_node_dump (stdout, node);
         xaccTransBeginEdit (trn);
         xaccTransDestroy (trn);
         xaccTransCommitEdit (trn);

--- a/libgnucash/backend/xml/gnc-vendor-xml-v2.cpp
+++ b/libgnucash/backend/xml/gnc-vendor-xml-v2.cpp
@@ -131,7 +131,7 @@ struct vendor_pdata
 };
 
 static gboolean
-set_boolean (xmlNodePtr node, GncVendor* vendor,
+set_boolean (GncXmlNode* node, GncVendor* vendor,
              void (*func) (GncVendor* vendor, gboolean b))
 {
     gint64 val;
@@ -145,7 +145,7 @@ set_boolean (xmlNodePtr node, GncVendor* vendor,
 }
 
 static gboolean
-vendor_name_handler (xmlNodePtr node, gpointer vendor_pdata)
+vendor_name_handler (GncXmlNode* node, gpointer vendor_pdata)
 {
     struct vendor_pdata* pdata = static_cast<decltype (pdata)> (vendor_pdata);
 
@@ -153,7 +153,7 @@ vendor_name_handler (xmlNodePtr node, gpointer vendor_pdata)
 }
 
 static gboolean
-vendor_guid_handler (xmlNodePtr node, gpointer vendor_pdata)
+vendor_guid_handler (GncXmlNode* node, gpointer vendor_pdata)
 {
     struct vendor_pdata* pdata = static_cast<decltype (pdata)> (vendor_pdata);
     GncVendor* vendor;
@@ -176,7 +176,7 @@ vendor_guid_handler (xmlNodePtr node, gpointer vendor_pdata)
 }
 
 static gboolean
-vendor_id_handler (xmlNodePtr node, gpointer vendor_pdata)
+vendor_id_handler (GncXmlNode* node, gpointer vendor_pdata)
 {
     struct vendor_pdata* pdata = static_cast<decltype (pdata)> (vendor_pdata);
 
@@ -184,7 +184,7 @@ vendor_id_handler (xmlNodePtr node, gpointer vendor_pdata)
 }
 
 static gboolean
-vendor_notes_handler (xmlNodePtr node, gpointer vendor_pdata)
+vendor_notes_handler (GncXmlNode* node, gpointer vendor_pdata)
 {
     struct vendor_pdata* pdata = static_cast<decltype (pdata)> (vendor_pdata);
 
@@ -192,7 +192,7 @@ vendor_notes_handler (xmlNodePtr node, gpointer vendor_pdata)
 }
 
 static gboolean
-vendor_terms_handler (xmlNodePtr node, gpointer vendor_pdata)
+vendor_terms_handler (GncXmlNode* node, gpointer vendor_pdata)
 {
     struct vendor_pdata* pdata = static_cast<decltype (pdata)> (vendor_pdata);
     GncBillTerm* term;
@@ -207,7 +207,7 @@ vendor_terms_handler (xmlNodePtr node, gpointer vendor_pdata)
 }
 
 static gboolean
-vendor_addr_handler (xmlNodePtr node, gpointer vendor_pdata)
+vendor_addr_handler (GncXmlNode* node, gpointer vendor_pdata)
 {
     struct vendor_pdata* pdata = static_cast<decltype (pdata)> (vendor_pdata);
 
@@ -215,7 +215,7 @@ vendor_addr_handler (xmlNodePtr node, gpointer vendor_pdata)
 }
 
 static gboolean
-vendor_taxincluded_handler (xmlNodePtr node, gpointer vendor_pdata)
+vendor_taxincluded_handler (GncXmlNode* node, gpointer vendor_pdata)
 {
     struct vendor_pdata* pdata = static_cast<decltype (pdata)> (vendor_pdata);
     auto set_taxincluded = [](GncVendor* vendor, const char* str)
@@ -228,14 +228,14 @@ vendor_taxincluded_handler (xmlNodePtr node, gpointer vendor_pdata)
 }
 
 static gboolean
-vendor_active_handler (xmlNodePtr node, gpointer vendor_pdata)
+vendor_active_handler (GncXmlNode* node, gpointer vendor_pdata)
 {
     struct vendor_pdata* pdata = static_cast<decltype (pdata)> (vendor_pdata);
     return set_boolean (node, pdata->vendor, gncVendorSetActive);
 }
 
 static gboolean
-vendor_currency_handler (xmlNodePtr node, gpointer vendor_pdata)
+vendor_currency_handler (GncXmlNode* node, gpointer vendor_pdata)
 {
     struct vendor_pdata* pdata = static_cast<decltype (pdata)> (vendor_pdata);
     gnc_commodity* com;
@@ -249,7 +249,7 @@ vendor_currency_handler (xmlNodePtr node, gpointer vendor_pdata)
 }
 
 static gboolean
-vendor_taxtable_handler (xmlNodePtr node, gpointer vendor_pdata)
+vendor_taxtable_handler (GncXmlNode* node, gpointer vendor_pdata)
 {
     struct vendor_pdata* pdata = static_cast<decltype (pdata)> (vendor_pdata);
     GncTaxTable* taxtable;
@@ -272,14 +272,14 @@ vendor_taxtable_handler (xmlNodePtr node, gpointer vendor_pdata)
 }
 
 static gboolean
-vendor_taxtableoverride_handler (xmlNodePtr node, gpointer vendor_pdata)
+vendor_taxtableoverride_handler (GncXmlNode* node, gpointer vendor_pdata)
 {
     struct vendor_pdata* pdata = static_cast<decltype (pdata)> (vendor_pdata);
     return set_boolean (node, pdata->vendor, gncVendorSetTaxTableOverride);
 }
 
 static gboolean
-vendor_slots_handler (xmlNodePtr node, gpointer vendor_pdata)
+vendor_slots_handler (GncXmlNode* node, gpointer vendor_pdata)
 {
     struct vendor_pdata* pdata = static_cast<decltype (pdata)> (vendor_pdata);
     return dom_tree_create_instance_slots (node, QOF_INSTANCE (pdata->vendor));
@@ -305,7 +305,7 @@ static struct dom_tree_handler vendor_handlers_v2[] =
 };
 
 static GncVendor*
-dom_tree_to_vendor (xmlNodePtr node, QofBook* book)
+dom_tree_to_vendor (GncXmlNode* node, QofBook* book)
 {
     struct vendor_pdata vendor_pdata;
     gboolean successful;
@@ -336,7 +336,7 @@ gnc_vendor_end_handler (gpointer data_for_children,
                         gpointer* result, const gchar* tag)
 {
     GncVendor* vendor;
-    xmlNodePtr tree = (xmlNodePtr)data_for_children;
+    GncXmlNode* tree = (GncXmlNode*)data_for_children;
     gxpf_data* gdata = (gxpf_data*)global_data;
     QofBook* book = static_cast<decltype (book)> (gdata->bookdata);
 
@@ -360,7 +360,7 @@ gnc_vendor_end_handler (gpointer data_for_children,
         gdata->cb (tag, gdata->parsedata, vendor);
     }
 
-    xmlFreeNode (tree);
+    gnc_xml_node_free (tree);
 
     return vendor != NULL;
 }

--- a/libgnucash/backend/xml/gnc-xml-helper.h
+++ b/libgnucash/backend/xml/gnc-xml-helper.h
@@ -37,12 +37,6 @@
 #  ifndef xmlChildrenNode
 #    define xmlChildrenNode children
 #  endif /* ifndef xmlChildrenNode */
-#  ifndef xmlRootNode
-#    define xmlRootNode children
-#  endif /* ifndef xmlRootNode */
-#  ifndef xmlAttrPropertyValue
-#    define xmlAttrPropertyValue children
-#  endif /* ifndef xmlAttrPropertyValue */
 
 xmlChar* checked_char_cast (gchar* val);
 

--- a/libgnucash/backend/xml/gnc-xml-sax-node.cpp
+++ b/libgnucash/backend/xml/gnc-xml-sax-node.cpp
@@ -1,0 +1,244 @@
+/********************************************************************\
+ * gnc-xml-sax-node.cpp -- lightweight tree assembled directly from *
+ *                        SAX events, used by the v1/v2 XML readers *
+ *                                                                  *
+ * Copyright (C) 2025 The GnuCash Project                          *
+ *                                                                  *
+ * This program is free software; you can redistribute it and/or    *
+ * modify it under the terms of the GNU General Public License as   *
+ * published by the Free Software Foundation; either version 2 of   *
+ * the License, or (at your option) any later version.              *
+ *                                                                  *
+ * This program is distributed in the hope that it will be useful,  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    *
+ * GNU General Public License for more details.                     *
+ *                                                                  *
+ * You should have received a copy of the GNU General Public License*
+ * along with this program; if not, contact:                        *
+ *                                                                  *
+ * Free Software Foundation           Voice:  +1-617-542-5942       *
+ * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652       *
+ * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
+ *                                                                  *
+\********************************************************************/
+#include <config.h>
+#include <glib.h>
+#include <cstring>
+
+#include "gnc-xml-sax-node.h"
+#include <libxml/tree.h>
+
+GncXmlNode*
+gnc_xml_node_new_element (const char* tag)
+{
+    auto node = g_new0 (GncXmlNode, 1);
+    node->name = g_strdup (tag);
+    node->type = XML_ELEMENT_NODE;
+    return node;
+}
+
+GncXmlNode*
+gnc_xml_node_new_child (GncXmlNode* parent, const char* tag)
+{
+    auto node = gnc_xml_node_new_element (tag);
+
+    if (parent)
+    {
+        if (parent->last_child)
+        {
+            parent->last_child->next = node;
+            node->prev = parent->last_child;
+        }
+        else
+        {
+            parent->children = node;
+        }
+        parent->last_child = node;
+    }
+
+    return node;
+}
+
+void
+gnc_xml_node_add_content (GncXmlNode* node, const char* text, int len)
+{
+    if (!node || len <= 0)
+        return;
+
+    if (node->last_child && node->last_child->type == XML_TEXT_NODE)
+    {
+        auto text_part = g_strndup (text, len);
+        auto full = g_strconcat (node->last_child->content ? node->last_child->content : "",
+                                 text_part, nullptr);
+        g_free (text_part);
+        g_free (node->last_child->content);
+        node->last_child->content = full;
+        return;
+    }
+
+    auto text_node = g_new0 (GncXmlNode, 1);
+    text_node->type = XML_TEXT_NODE;
+    text_node->name = g_strdup ("text");
+    text_node->content = g_strndup (text, len);
+
+    if (node->last_child)
+    {
+        node->last_child->next = text_node;
+        text_node->prev = node->last_child;
+    }
+    else
+    {
+        node->children = text_node;
+    }
+    node->last_child = text_node;
+}
+
+void
+gnc_xml_node_set_prop (GncXmlNode* node, const char* name, const char* value)
+{
+    if (!node)
+        return;
+
+    for (auto attr = node->properties; attr; attr = attr->next)
+    {
+        if (g_strcmp0 (attr->name, name) == 0)
+        {
+            g_free (attr->value);
+            attr->value = g_strdup (value);
+            return;
+        }
+    }
+
+    auto attr = g_new0 (GncXmlAttr, 1);
+    attr->name = g_strdup (name);
+    attr->value = g_strdup (value);
+    attr->next = node->properties;
+    node->properties = attr;
+}
+
+char*
+gnc_xml_get_prop (const GncXmlNode* node, const char* name)
+{
+    if (!node)
+        return nullptr;
+
+    for (auto attr = node->properties; attr; attr = attr->next)
+    {
+        if (g_strcmp0 (attr->name, name) == 0)
+            return g_strdup (attr->value);
+    }
+
+    return nullptr;
+}
+
+char*
+gnc_xml_node_list_get_string (const GncXmlNode* children)
+{
+    if (!children)
+        return nullptr;
+
+    GString* str = g_string_new (nullptr);
+    for (auto n = children; n; n = n->next)
+    {
+        if ((n->type == XML_TEXT_NODE || n->type == XML_CDATA_SECTION_NODE) && n->content)
+            g_string_append (str, n->content);
+    }
+
+    return g_string_free (str, FALSE);
+}
+
+void
+gnc_xml_node_free (GncXmlNode* node)
+{
+    if (!node)
+        return;
+
+    auto child = node->children;
+    while (child)
+    {
+        auto next = child->next;
+        gnc_xml_node_free (child);
+        child = next;
+    }
+
+    for (auto attr = node->properties; attr; )
+    {
+        auto next = attr->next;
+        g_free (attr->name);
+        g_free (attr->value);
+        g_free (attr);
+        attr = next;
+    }
+
+    g_free (node->name);
+    g_free (node->content);
+    g_free (node);
+}
+
+GncXmlNode*
+gnc_xml_node_from_libxml (xmlNode* src)
+{
+    if (!src)
+        return nullptr;
+
+    auto node = g_new0 (GncXmlNode, 1);
+    node->name = g_strdup (reinterpret_cast<const char*> (src->name));
+    node->type = src->type;
+    if (src->type != XML_ELEMENT_NODE && src->content)
+        node->content = g_strdup (reinterpret_cast<const char*> (src->content));
+
+    for (auto attr = src->properties; attr; attr = attr->next)
+    {
+        auto value = xmlNodeListGetString (src->doc, attr->children, 1);
+        gnc_xml_node_set_prop (node, reinterpret_cast<const char*> (attr->name),
+                               reinterpret_cast<const char*> (value));
+        xmlFree (value);
+    }
+
+    for (auto child = src->children; child; child = child->next)
+    {
+        auto converted = gnc_xml_node_from_libxml (child);
+        if (node->last_child)
+        {
+            node->last_child->next = converted;
+            converted->prev = node->last_child;
+        }
+        else
+        {
+            node->children = converted;
+        }
+        node->last_child = converted;
+    }
+
+    return node;
+}
+
+void
+gnc_xml_node_dump (FILE* out, const GncXmlNode* node)
+{
+    if (!node)
+        return;
+
+    if (node->type == XML_TEXT_NODE || node->type == XML_CDATA_SECTION_NODE)
+    {
+        if (node->content)
+            fputs (node->content, out);
+        return;
+    }
+
+    fprintf (out, "<%s", node->name ? node->name : "(null)");
+    for (auto attr = node->properties; attr; attr = attr->next)
+        fprintf (out, " %s=\"%s\"", attr->name, attr->value ? attr->value : "");
+
+    if (!node->children)
+    {
+        fputs ("/>", out);
+        return;
+    }
+
+    fputs (">", out);
+    for (auto child = node->children; child; child = child->next)
+        gnc_xml_node_dump (out, child);
+    fprintf (out, "</%s>", node->name ? node->name : "(null)");
+}

--- a/libgnucash/backend/xml/gnc-xml-sax-node.h
+++ b/libgnucash/backend/xml/gnc-xml-sax-node.h
@@ -1,0 +1,105 @@
+/********************************************************************\
+ * gnc-xml-sax-node.h -- lightweight tree assembled directly from   *
+ *                       SAX events, used by the v1/v2 XML readers  *
+ *                                                                  *
+ * Copyright (C) 2025 The GnuCash Project                          *
+ *                                                                  *
+ * This program is free software; you can redistribute it and/or    *
+ * modify it under the terms of the GNU General Public License as   *
+ * published by the Free Software Foundation; either version 2 of   *
+ * the License, or (at your option) any later version.              *
+ *                                                                  *
+ * This program is distributed in the hope that it will be useful,  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    *
+ * GNU General Public License for more details.                     *
+ *                                                                  *
+ * You should have received a copy of the GNU General Public License*
+ * along with this program; if not, contact:                        *
+ *                                                                  *
+ * Free Software Foundation           Voice:  +1-617-542-5942       *
+ * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652       *
+ * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
+ *                                                                  *
+\********************************************************************/
+/** @file gnc-xml-sax-node.h
+ *
+ * A single GnuCash element (gnc:account, gnc:transaction, a slot, ...)
+ * used to be buffered into a real libxml2 xmlNode/xmlDoc subtree by
+ * sixtp's generic dom_start_handler/dom_chars_handler before being
+ * converted by the dom_tree_to_* functions in sixtp-dom-parsers.cpp.
+ *
+ * GncXmlNode replaces that libxml2 DOM subtree with a minimal tree
+ * built directly from the incoming SAX events (element start,
+ * characters, element end) with no libxml2 document/node allocation
+ * involved. It intentionally mirrors the handful of libxml2 xmlNode
+ * fields (name, type, content, children, next, prev, properties) that
+ * the dom_tree_to_* converters rely on, so those converters keep
+ * their existing tree-walking logic unchanged and only trade the
+ * node type they walk.
+ */
+#ifndef GNC_XML_SAX_NODE_H
+#define GNC_XML_SAX_NODE_H
+
+#include <libxml/tree.h> /* for the xmlElementType enum values only */
+#include <cstdio>
+
+struct GncXmlAttr
+{
+    char* name;
+    char* value;
+    GncXmlAttr* next;
+};
+
+struct GncXmlNode
+{
+    char* name;
+    xmlElementType type;
+    char* content;          /* owned; only meaningful on text/comment nodes */
+    GncXmlNode* children;   /* first child, or nullptr */
+    GncXmlNode* last_child; /* fast append; not for use outside this file */
+    GncXmlNode* next;       /* next sibling, or nullptr */
+    GncXmlNode* prev;       /* previous sibling, or nullptr */
+    GncXmlAttr* properties;
+};
+
+/* Create a new, childless element node named 'tag'. */
+GncXmlNode* gnc_xml_node_new_element (const char* tag);
+
+/* Create a new, childless element node named 'tag' and append it as
+   the last child of 'parent' (which may be nullptr). */
+GncXmlNode* gnc_xml_node_new_child (GncXmlNode* parent, const char* tag);
+
+/* Append character data to 'node', merging it into node's existing
+   trailing text child if there is one, exactly as libxml2's
+   xmlNodeAddContentLen does. */
+void gnc_xml_node_add_content (GncXmlNode* node, const char* text, int len);
+
+/* Set (or replace) an attribute on 'node'. */
+void gnc_xml_node_set_prop (GncXmlNode* node, const char* name, const char* value);
+
+/* Look up an attribute by name. Returns a newly allocated copy (as if
+   by g_strdup) the caller must free with g_free, or nullptr. */
+char* gnc_xml_get_prop (const GncXmlNode* node, const char* name);
+
+/* Concatenate the content of a run of sibling text/CDATA nodes, as
+   libxml2's xmlNodeListGetString does. Returns a newly allocated
+   string the caller must free with g_free, or nullptr if 'children'
+   is nullptr. */
+char* gnc_xml_node_list_get_string (const GncXmlNode* children);
+
+/* Recursively free 'node' and all its descendants (its next-sibling
+   chain is left untouched, matching xmlFreeNode's behavior). */
+void gnc_xml_node_free (GncXmlNode* node);
+
+/* Write a simple textual rendition of 'node' to 'out', for debug
+   logging in place of the old xmlElemDump calls. */
+void gnc_xml_node_dump (FILE* out, const GncXmlNode* node);
+
+/* Recursively convert a real libxml2 subtree (as produced by the
+   *_to_dom_tree writers) into an equivalent GncXmlNode tree. Only
+   needed where test code exercises a writer's output through a
+   dom_tree_to_* reader. */
+GncXmlNode* gnc_xml_node_from_libxml (xmlNode* src);
+
+#endif /* GNC_XML_SAX_NODE_H */

--- a/libgnucash/backend/xml/io-example-account.cpp
+++ b/libgnucash/backend/xml/io-example-account.cpp
@@ -208,7 +208,7 @@ squash_extra_whitespace (char* text)
 }
 
 static char*
-grab_clean_string (xmlNodePtr tree)
+grab_clean_string (GncXmlNode* tree)
 {
     auto txt = dom_tree_to_text (tree);
     auto str = g_strdup (txt ? txt->c_str() : "");
@@ -224,7 +224,7 @@ gnc_short_descrip_end_handler (gpointer data_for_children,
     GncExampleAccount* gea =
         (GncExampleAccount*) ((gxpf_data*)global_data)->parsedata;
 
-    gea->short_description = grab_clean_string ((xmlNodePtr)data_for_children);
+    gea->short_description = grab_clean_string ((GncXmlNode*)data_for_children);
 
     return TRUE;
 }
@@ -244,7 +244,7 @@ gnc_long_descrip_end_handler (gpointer data_for_children,
     GncExampleAccount* gea =
         (GncExampleAccount*) ((gxpf_data*)global_data)->parsedata;
 
-    gea->long_description = grab_clean_string ((xmlNodePtr)data_for_children);
+    gea->long_description = grab_clean_string ((GncXmlNode*)data_for_children);
 
     return TRUE;
 }
@@ -265,7 +265,7 @@ gnc_excludep_end_handler (gpointer data_for_children,
         (GncExampleAccount*) ((gxpf_data*)global_data)->parsedata;
     gint64 val = 0;
 
-    dom_tree_to_integer ((xmlNodePtr)data_for_children, &val);
+    dom_tree_to_integer ((GncXmlNode*)data_for_children, &val);
     gea->exclude_from_select_all = (val ? TRUE : FALSE);
 
     return TRUE;
@@ -287,7 +287,7 @@ gnc_selected_end_handler (gpointer data_for_children,
         (GncExampleAccount*) ((gxpf_data*)global_data)->parsedata;
     gint64 val = 0;
 
-    dom_tree_to_integer ((xmlNodePtr)data_for_children, &val);
+    dom_tree_to_integer ((GncXmlNode*)data_for_children, &val);
     gea->start_selected = (val ? TRUE : FALSE);
 
     return TRUE;
@@ -308,7 +308,7 @@ gnc_title_end_handler (gpointer data_for_children,
     GncExampleAccount* gea =
         (GncExampleAccount*) ((gxpf_data*)global_data)->parsedata;
 
-    gea->title = grab_clean_string ((xmlNodePtr)data_for_children);
+    gea->title = grab_clean_string ((GncXmlNode*)data_for_children);
 
     return TRUE;
 }

--- a/libgnucash/backend/xml/io-gncxml-v1.cpp
+++ b/libgnucash/backend/xml/io-gncxml-v1.cpp
@@ -2927,7 +2927,7 @@ gnc_transaction_parser_new (void)
 */
 
 static gboolean
-price_parse_xml_sub_node (GNCPrice* p, xmlNodePtr sub_node, QofBook* book)
+price_parse_xml_sub_node (GNCPrice* p, GncXmlNode* sub_node, QofBook* book)
 {
     if (!p || !sub_node) return FALSE;
 
@@ -2985,8 +2985,8 @@ price_parse_xml_end_handler (gpointer data_for_children,
                              const gchar* tag)
 {
     gboolean ok = TRUE;
-    xmlNodePtr price_xml = (xmlNodePtr) data_for_children;
-    xmlNodePtr child;
+    GncXmlNode* price_xml = (GncXmlNode*) data_for_children;
+    GncXmlNode* child;
     GNCPrice* p = NULL;
     GNCParseStatus* pstatus = (GNCParseStatus*) global_data;
 
@@ -3052,7 +3052,7 @@ cleanup_and_exit:
         *result = NULL;
         gnc_price_unref (p);
     }
-    xmlFreeNode (price_xml);
+    gnc_xml_node_free (price_xml);
     return ok;
 }
 

--- a/libgnucash/backend/xml/io-gncxml-v2.cpp
+++ b/libgnucash/backend/xml/io-gncxml-v2.cpp
@@ -371,7 +371,7 @@ gnc_counter_end_handler (gpointer data_for_children,
 {
     gint64 val;
     char* type;
-    xmlNodePtr tree = (xmlNodePtr)data_for_children;
+    GncXmlNode* tree = (GncXmlNode*)data_for_children;
     gxpf_data* gdata = (gxpf_data*)global_data;
     sixtp_gdv2* sixdata = (sixtp_gdv2*)gdata->parsedata;
     gboolean ret = TRUE;
@@ -390,7 +390,7 @@ gnc_counter_end_handler (gpointer data_for_children,
      *
      * This is invalid xml because the namespace isn't declared in the
      * tag itself. This should be changed to 'type' at some point. */
-    type = (char*)xmlGetProp (tree, BAD_CAST "cd:type");
+    type = gnc_xml_get_prop (tree, "cd:type");
     if (!apply_xmlnode_text<bool> ([&val](auto txt){ return string_to_gint64 (txt, &val);}, tree))
     {
         auto strval = dom_tree_to_text (tree);
@@ -448,8 +448,8 @@ gnc_counter_end_handler (gpointer data_for_children,
         }
     }
 
-    xmlFree (type);
-    xmlFreeNode (tree);
+    g_free (type);
+    gnc_xml_node_free (tree);
     return ret;
 }
 

--- a/libgnucash/backend/xml/sixtp-dom-parsers.cpp
+++ b/libgnucash/backend/xml/sixtp-dom-parsers.cpp
@@ -36,7 +36,7 @@
 static QofLogModule log_module = GNC_MOD_IO;
 
 const char*
-dom_node_to_text (xmlNodePtr node) noexcept
+dom_node_to_text (GncXmlNode* node) noexcept
 {
     if (node && node->children && node->children->type == XML_TEXT_NODE
         && !node->children->next)
@@ -45,15 +45,15 @@ dom_node_to_text (xmlNodePtr node) noexcept
 }
 
 std::optional<GncGUID>
-dom_tree_to_guid (xmlNodePtr node)
+dom_tree_to_guid (GncXmlNode* node)
 {
-    auto type = xmlGetProp (node, BAD_CAST "type");
+    auto type = gnc_xml_get_prop (node, "type");
     if (!type)
         return {};
 
-    bool ok = !g_strcmp0 ((char*)type, "guid") || !g_strcmp0 ((char*)type, "new");
+    bool ok = !g_strcmp0 (type, "guid") || !g_strcmp0 (type, "new");
 
-    xmlFree (type);
+    g_free (type);
 
     if (!ok)
         return {};
@@ -70,7 +70,7 @@ dom_tree_to_guid (xmlNodePtr node)
 }
 
 static KvpValue*
-dom_tree_to_integer_kvp_value (xmlNodePtr node)
+dom_tree_to_integer_kvp_value (GncXmlNode* node)
 {
     auto node_to_int_kvp = [](auto txt) -> KvpValue*
     {
@@ -84,31 +84,31 @@ dom_tree_to_integer_kvp_value (xmlNodePtr node)
 
 template <typename T>
 static bool
-dom_tree_to_num (xmlNodePtr node, std::function<bool(const char*, T*)>string_to_num, T* num_ptr)
+dom_tree_to_num (GncXmlNode* node, std::function<bool(const char*, T*)>string_to_num, T* num_ptr)
 {
     return apply_xmlnode_text<T>([&](auto txt){ return string_to_num (txt, num_ptr);}, node, false);
 }
 
 gboolean
-dom_tree_to_integer (xmlNodePtr node, gint64* daint)
+dom_tree_to_integer (GncXmlNode* node, gint64* daint)
 {
     return dom_tree_to_num<gint64>(node, string_to_gint64, daint);
 }
 
 gboolean
-dom_tree_to_guint16 (xmlNodePtr node, guint16* i)
+dom_tree_to_guint16 (GncXmlNode* node, guint16* i)
 {
     return dom_tree_to_num<guint16>(node, string_to_guint16, i);
 }
 
 gboolean
-dom_tree_to_guint (xmlNodePtr node, guint* i)
+dom_tree_to_guint (GncXmlNode* node, guint* i)
 {
     return dom_tree_to_num<guint>(node, string_to_guint, i);
 }
 
 gboolean
-dom_tree_to_boolean (xmlNodePtr node, gboolean* b)
+dom_tree_to_boolean (GncXmlNode* node, gboolean* b)
 {
     auto set_bool = [b](auto text) -> gboolean
     {
@@ -132,7 +132,7 @@ dom_tree_to_boolean (xmlNodePtr node, gboolean* b)
 }
 
 static KvpValue*
-dom_tree_to_double_kvp_value (xmlNodePtr node)
+dom_tree_to_double_kvp_value (GncXmlNode* node)
 {
     auto node_to_double_kvp = [](auto txt) -> KvpValue*
     {
@@ -143,13 +143,13 @@ dom_tree_to_double_kvp_value (xmlNodePtr node)
 }
 
 static KvpValue*
-dom_tree_to_numeric_kvp_value (xmlNodePtr node)
+dom_tree_to_numeric_kvp_value (GncXmlNode* node)
 {
     return new KvpValue {dom_tree_to_gnc_numeric (node)};
 }
 
 static KvpValue*
-dom_tree_to_string_kvp_value (xmlNodePtr node)
+dom_tree_to_string_kvp_value (GncXmlNode* node)
 {
     auto node_to_string_kvp = [](auto txt) -> KvpValue*
     {
@@ -159,21 +159,21 @@ dom_tree_to_string_kvp_value (xmlNodePtr node)
 }
 
 static KvpValue*
-dom_tree_to_guid_kvp_value (xmlNodePtr node)
+dom_tree_to_guid_kvp_value (GncXmlNode* node)
 {
     auto daguid = dom_tree_to_guid (node);
     return daguid ? new KvpValue {guid_copy (&*daguid)} : nullptr;
 }
 
 static KvpValue*
-dom_tree_to_time64_kvp_value (xmlNodePtr node)
+dom_tree_to_time64_kvp_value (GncXmlNode* node)
 {
     Time64 t{dom_tree_to_time64 (node)};
     return new KvpValue {t};
 }
 
 static KvpValue*
-dom_tree_to_gdate_kvp_value (xmlNodePtr node)
+dom_tree_to_gdate_kvp_value (GncXmlNode* node)
 {
     auto date = dom_tree_to_gdate (node);
     if (!date) return nullptr;
@@ -221,15 +221,15 @@ string_to_binary (const gchar* str,  void** v, guint64* data_len)
     return (TRUE);
 }
 
-static KvpValue* dom_tree_to_kvp_value (xmlNodePtr node);
+static KvpValue* dom_tree_to_kvp_value (GncXmlNode* node);
 //needed for test access as well as internal use.
-KvpFrame* dom_tree_to_kvp_frame (xmlNodePtr node);
+KvpFrame* dom_tree_to_kvp_frame (GncXmlNode* node);
 
 static KvpValue*
-dom_tree_to_list_kvp_value (xmlNodePtr node)
+dom_tree_to_list_kvp_value (GncXmlNode* node)
 {
     GList* list = NULL;
-    xmlNodePtr mark;
+    GncXmlNode* mark;
     KvpValue* ret = NULL;
 
     for (mark = node->xmlChildrenNode; mark; mark = mark->next)
@@ -254,7 +254,7 @@ dom_tree_to_list_kvp_value (xmlNodePtr node)
 }
 
 static KvpValue*
-dom_tree_to_frame_kvp_value (xmlNodePtr node)
+dom_tree_to_frame_kvp_value (GncXmlNode* node)
 {
     KvpFrame* frame = dom_tree_to_kvp_frame (node);
     return frame ? new KvpValue {frame} : nullptr;
@@ -264,7 +264,7 @@ dom_tree_to_frame_kvp_value (xmlNodePtr node)
 struct kvp_val_converter
 {
     const gchar* tag;
-    KvpValue* (*converter) (xmlNodePtr node);
+    KvpValue* (*converter) (GncXmlNode* node);
 };
 /* Note: The type attribute must remain 'timespec' to maintain compatibility.
  */
@@ -284,17 +284,17 @@ struct kvp_val_converter val_converters[] =
 };
 
 static KvpValue*
-dom_tree_to_kvp_value (xmlNodePtr node)
+dom_tree_to_kvp_value (GncXmlNode* node)
 {
-    xmlChar* xml_type;
+    char* xml_type;
     struct kvp_val_converter* mark;
     KvpValue* ret = NULL;
 
-    xml_type = xmlGetProp (node, BAD_CAST "type");
+    xml_type = gnc_xml_get_prop (node, "type");
 
     for (mark = val_converters; mark->tag; mark++)
     {
-        if (g_strcmp0 (reinterpret_cast<char*>(xml_type), mark->tag) == 0)
+        if (g_strcmp0 (xml_type, mark->tag) == 0)
         {
             ret = (mark->converter) (node);
         }
@@ -305,15 +305,15 @@ dom_tree_to_kvp_value (xmlNodePtr node)
         /* FIXME: deal with unknown type tag here */
     }
 
-    xmlFree (xml_type);
+    g_free (xml_type);
 
     return ret;
 }
 
 static gboolean
-dom_tree_to_kvp_frame_given (xmlNodePtr node, KvpFrame* frame)
+dom_tree_to_kvp_frame_given (GncXmlNode* node, KvpFrame* frame)
 {
-    xmlNodePtr mark;
+    GncXmlNode* mark;
 
     g_return_val_if_fail (node, FALSE);
     g_return_val_if_fail (frame, FALSE);
@@ -322,7 +322,7 @@ dom_tree_to_kvp_frame_given (xmlNodePtr node, KvpFrame* frame)
     {
         if (g_strcmp0 ((char*)mark->name, "slot") == 0)
         {
-            xmlNodePtr mark2;
+            GncXmlNode* mark2;
             const gchar* key = NULL;
             std::optional<std::string> maybe_key;
             KvpValue* val = NULL;
@@ -369,7 +369,7 @@ dom_tree_to_kvp_frame_given (xmlNodePtr node, KvpFrame* frame)
 
 
 KvpFrame*
-dom_tree_to_kvp_frame (xmlNodePtr node)
+dom_tree_to_kvp_frame (GncXmlNode* node)
 {
     g_return_val_if_fail (node, NULL);
 
@@ -383,14 +383,14 @@ dom_tree_to_kvp_frame (xmlNodePtr node)
 }
 
 gboolean
-dom_tree_create_instance_slots (xmlNodePtr node, QofInstance* inst)
+dom_tree_create_instance_slots (GncXmlNode* node, QofInstance* inst)
 {
     KvpFrame* frame = qof_instance_get_slots (inst);
     return dom_tree_to_kvp_frame_given (node, frame);
 }
 
 std::optional<std::string>
-dom_tree_to_text (xmlNodePtr tree)
+dom_tree_to_text (GncXmlNode* tree)
 {
     /* Expect *only* text and comment sibling nodes in the given tree --
        which actually may only be a "list".  i.e. if you're trying to
@@ -413,7 +413,7 @@ dom_tree_to_text (xmlNodePtr tree)
         return "";
     }
 
-    temp = (char*)xmlNodeListGetString (NULL, tree->xmlChildrenNode, TRUE);
+    temp = gnc_xml_node_list_get_string (tree->xmlChildrenNode);
     if (!temp)
     {
         DEBUG ("Null string");
@@ -422,12 +422,12 @@ dom_tree_to_text (xmlNodePtr tree)
 
     DEBUG ("node string [%s]", (temp == NULL ? "(null)" : temp));
     rv = temp;
-    xmlFree (temp);
+    g_free (temp);
     return rv;
 }
 
 gnc_numeric
-dom_tree_to_gnc_numeric (xmlNodePtr node)
+dom_tree_to_gnc_numeric (GncXmlNode* node)
 {
     auto node_to_numeric = [](auto txt)
     {
@@ -439,7 +439,7 @@ dom_tree_to_gnc_numeric (xmlNodePtr node)
 
 
 time64
-dom_tree_to_time64 (xmlNodePtr node)
+dom_tree_to_time64 (GncXmlNode* node)
 {
     /* Turn something like this
 
@@ -454,7 +454,7 @@ dom_tree_to_time64 (xmlNodePtr node)
 
     time64 ret {INT64_MAX};
     gboolean seen = FALSE;
-    xmlNodePtr n;
+    GncXmlNode* n;
 
     for (n = node->xmlChildrenNode; n; n = n->next)
     {
@@ -491,7 +491,7 @@ dom_tree_to_time64 (xmlNodePtr node)
 }
 
 GDate*
-dom_tree_to_gdate (xmlNodePtr node)
+dom_tree_to_gdate (GncXmlNode* node)
 {
     /* Turn something like this
 
@@ -503,7 +503,7 @@ dom_tree_to_gdate (xmlNodePtr node)
 
     GDate ret;
     gboolean seen_date = FALSE;
-    xmlNodePtr n;
+    GncXmlNode* n;
 
     auto try_setting_date = [&ret](const char *content) -> bool
     {
@@ -561,7 +561,7 @@ gnc_strstrip (std::string_view sv)
 }
 
 static std::optional<CommodityRef>
-parse_commodity_ref (xmlNodePtr node, QofBook* book)
+parse_commodity_ref (GncXmlNode* node, QofBook* book)
 {
     /* Turn something like this
 
@@ -576,7 +576,7 @@ parse_commodity_ref (xmlNodePtr node, QofBook* book)
     CommodityRef rv;
     bool space_set{false};
     bool id_set{false};
-    xmlNodePtr n;
+    GncXmlNode* n;
 
     if (!node) return {};
     if (!node->xmlChildrenNode) return {};
@@ -621,7 +621,7 @@ parse_commodity_ref (xmlNodePtr node, QofBook* book)
 }
 
 gnc_commodity*
-dom_tree_to_commodity_ref_no_engine (xmlNodePtr node, QofBook* book)
+dom_tree_to_commodity_ref_no_engine (GncXmlNode* node, QofBook* book)
 {
     auto ref = parse_commodity_ref (node, book);
 
@@ -633,7 +633,7 @@ dom_tree_to_commodity_ref_no_engine (xmlNodePtr node, QofBook* book)
 }
 
 gnc_commodity*
-dom_tree_to_commodity_ref (xmlNodePtr node, QofBook* book)
+dom_tree_to_commodity_ref (GncXmlNode* node, QofBook* book)
 {
     gnc_commodity* ret;
     gnc_commodity_table* table;
@@ -684,7 +684,7 @@ dom_tree_handlers_all_gotten_p (struct dom_tree_handler* handlers)
 
 
 static inline gboolean
-gnc_xml_set_data (const gchar* tag, xmlNodePtr node, gpointer item,
+gnc_xml_set_data (const gchar* tag, GncXmlNode* node, gpointer item,
                   struct dom_tree_handler* handlers)
 {
     for (; handlers->tag != NULL; handlers++)
@@ -708,10 +708,10 @@ gnc_xml_set_data (const gchar* tag, xmlNodePtr node, gpointer item,
 }
 
 gboolean
-dom_tree_generic_parse (xmlNodePtr node, struct dom_tree_handler* handlers,
+dom_tree_generic_parse (GncXmlNode* node, struct dom_tree_handler* handlers,
                         gpointer data)
 {
-    xmlNodePtr achild;
+    GncXmlNode* achild;
     gboolean successful = TRUE;
 
     dom_tree_handlers_reset (handlers);
@@ -740,7 +740,7 @@ dom_tree_generic_parse (xmlNodePtr node, struct dom_tree_handler* handlers,
 }
 
 gboolean
-dom_tree_valid_time64 (time64 val, const xmlChar * name)
+dom_tree_valid_time64 (time64 val, const char* name)
 {
     if (val != INT64_MAX)
         return TRUE;

--- a/libgnucash/backend/xml/sixtp-dom-parsers.h
+++ b/libgnucash/backend/xml/sixtp-dom-parsers.h
@@ -31,43 +31,44 @@
 #include <optional>
 
 #include "gnc-xml-helper.h"
+#include "gnc-xml-sax-node.h"
 
-std::optional<GncGUID> dom_tree_to_guid (xmlNodePtr node);
+std::optional<GncGUID> dom_tree_to_guid (GncXmlNode* node);
 
 std::string gnc_strstrip (std::string_view sv);
 
-gnc_commodity* dom_tree_to_commodity_ref (xmlNodePtr node, QofBook* book);
-gnc_commodity* dom_tree_to_commodity_ref_no_engine (xmlNodePtr node, QofBook*);
+gnc_commodity* dom_tree_to_commodity_ref (GncXmlNode* node, QofBook* book);
+gnc_commodity* dom_tree_to_commodity_ref_no_engine (GncXmlNode* node, QofBook*);
 
-GList* dom_tree_freqSpec_to_recurrences (xmlNodePtr node, QofBook* book);
-Recurrence* dom_tree_to_recurrence (xmlNodePtr node);
+GList* dom_tree_freqSpec_to_recurrences (GncXmlNode* node, QofBook* book);
+Recurrence* dom_tree_to_recurrence (GncXmlNode* node);
 
-time64 dom_tree_to_time64 (xmlNodePtr node);
-gboolean dom_tree_valid_time64 (time64 ts, const xmlChar* name);
-GDate* dom_tree_to_gdate (xmlNodePtr node);
-gnc_numeric dom_tree_to_gnc_numeric (xmlNodePtr node);
-std::optional<std::string> dom_tree_to_text (xmlNodePtr tree);
-const char* dom_node_to_text (xmlNodePtr node) noexcept;
+time64 dom_tree_to_time64 (GncXmlNode* node);
+gboolean dom_tree_valid_time64 (time64 ts, const char* name);
+GDate* dom_tree_to_gdate (GncXmlNode* node);
+gnc_numeric dom_tree_to_gnc_numeric (GncXmlNode* node);
+std::optional<std::string> dom_tree_to_text (GncXmlNode* tree);
+const char* dom_node_to_text (GncXmlNode* node) noexcept;
 gboolean string_to_binary (const gchar* str,  void** v, guint64* data_len);
-gboolean dom_tree_create_instance_slots (xmlNodePtr node, QofInstance* inst);
+gboolean dom_tree_create_instance_slots (GncXmlNode* node, QofInstance* inst);
 
-gboolean dom_tree_to_integer (xmlNodePtr node, gint64* daint);
-gboolean dom_tree_to_guint16 (xmlNodePtr node, guint16* i);
-gboolean dom_tree_to_guint (xmlNodePtr node, guint* i);
-gboolean dom_tree_to_boolean (xmlNodePtr node, gboolean* b);
+gboolean dom_tree_to_integer (GncXmlNode* node, gint64* daint);
+gboolean dom_tree_to_guint16 (GncXmlNode* node, guint16* i);
+gboolean dom_tree_to_guint (GncXmlNode* node, guint* i);
+gboolean dom_tree_to_boolean (GncXmlNode* node, gboolean* b);
 
 /* higher level structures */
-Account* dom_tree_to_account (xmlNodePtr node, QofBook* book);
-QofBook* dom_tree_to_book (xmlNodePtr node, QofBook* book);
-GNCLot*  dom_tree_to_lot (xmlNodePtr node, QofBook* book);
-Transaction* dom_tree_to_transaction (xmlNodePtr node, QofBook* book);
-GncBudget* dom_tree_to_budget (xmlNodePtr node, QofBook* book);
+Account* dom_tree_to_account (GncXmlNode* node, QofBook* book);
+QofBook* dom_tree_to_book (GncXmlNode* node, QofBook* book);
+GNCLot*  dom_tree_to_lot (GncXmlNode* node, QofBook* book);
+Transaction* dom_tree_to_transaction (GncXmlNode* node, QofBook* book);
+GncBudget* dom_tree_to_budget (GncXmlNode* node, QofBook* book);
 
 struct dom_tree_handler
 {
     const char* tag;
 
-    gboolean (*handler) (xmlNodePtr, gpointer data);
+    gboolean (*handler) (GncXmlNode*, gpointer data);
 
     int required;
     int gotten;
@@ -76,7 +77,7 @@ struct dom_tree_handler
 template <typename T, typename F,
           std::enable_if_t<std::is_invocable_r_v<void, F, const char*>, int> = 0>
 inline T
-apply_xmlnode_text (F&& f, xmlNodePtr node, T default_val = T{})
+apply_xmlnode_text (F&& f, GncXmlNode* node, T default_val = T{})
 {
     if (!node)
         return default_val;
@@ -93,7 +94,7 @@ apply_xmlnode_text (F&& f, xmlNodePtr node, T default_val = T{})
 template <typename Obj, typename F,
           std::enable_if_t<std::is_invocable_r_v<void, F, Obj*, const char*>, int> = 0>
 inline bool
-apply_xmlnode_text (F&& f, Obj* obj, xmlNodePtr node)
+apply_xmlnode_text (F&& f, Obj* obj, GncXmlNode* node)
 {
     auto set_str = [&](auto txt)
     {
@@ -103,7 +104,7 @@ apply_xmlnode_text (F&& f, Obj* obj, xmlNodePtr node)
     return apply_xmlnode_text<bool> (set_str, node, false);
 }
 
-gboolean dom_tree_generic_parse (xmlNodePtr node,
+gboolean dom_tree_generic_parse (GncXmlNode* node,
                                  struct dom_tree_handler* handlers,
                                  gpointer data);
 

--- a/libgnucash/backend/xml/sixtp-stack.cpp
+++ b/libgnucash/backend/xml/sixtp-stack.cpp
@@ -141,8 +141,16 @@ sixtp_context_new (sixtp* initial_parser, gpointer global_data,
 
     if (initial_parser->start_handler)
     {
+        /* Pass the caller-supplied top_level_data itself (typically NULL,
+           meaning "no parent") as parent_data here, matching how
+           sixtp_context_run_end_handler passes ctxt->top_frame_data (not
+           its address) as parent_data to the top frame's end_handler.
+           Passing &ret->top_frame_data instead would hand start_handler
+           the address of this context's own field as a bogus non-NULL
+           "parent", which a DOM-building start_handler would then try to
+           read/link into as if it were a real parent node. */
         if (!initial_parser->start_handler (NULL,
-                                            &ret->top_frame_data,
+                                            ret->top_frame_data,
                                             &ret->data.global_data,
                                             &ret->top_frame->data_for_children,
                                             &ret->top_frame->frame_data,

--- a/libgnucash/backend/xml/sixtp-to-dom-parser.cpp
+++ b/libgnucash/backend/xml/sixtp-to-dom-parser.cpp
@@ -25,11 +25,10 @@
 
 #include <glib.h>
 
+#include "gnc-xml-sax-node.h"
 #include "sixtp-parsers.h"
 #include "sixtp-utils.h"
 #include "sixtp.h"
-
-static xmlNsPtr global_namespace = NULL;
 
 /* Don't pass anything in the data_for_children value to this
    function.  It'll cause a segfault */
@@ -38,21 +37,18 @@ static gboolean dom_start_handler (
     gpointer* data_for_children, gpointer* result, const gchar* tag,
     gchar** attrs)
 {
-    xmlNodePtr thing;
+    GncXmlNode* thing;
     gchar** atptr = attrs;
 
     if (parent_data == NULL)
     {
-        thing = xmlNewNode (global_namespace, BAD_CAST tag);
+        thing = gnc_xml_node_new_element (tag);
         /* only publish the result if we're the parent */
         *result = thing;
     }
     else
     {
-        thing = xmlNewChild ((xmlNodePtr) parent_data,
-                             global_namespace,
-                             BAD_CAST tag,
-                             NULL);
+        thing = gnc_xml_node_new_child ((GncXmlNode*) parent_data, tag);
         *result = NULL;
     }
     *data_for_children = thing;
@@ -61,12 +57,7 @@ static gboolean dom_start_handler (
     {
         while (*atptr != 0)
         {
-            gchar* attr0 = g_strdup (atptr[0]);
-            gchar* attr1 = g_strdup (atptr[1]);
-            xmlSetProp (thing, checked_char_cast (attr0),
-                        checked_char_cast (attr1));
-            g_free (attr0);
-            g_free (attr1);
+            gnc_xml_node_set_prop (thing, atptr[0], atptr[1]);
             atptr += 2;
         }
     }
@@ -82,20 +73,14 @@ dom_fail_handler (gpointer data_for_children,
                   gpointer* result,
                   const gchar* tag)
 {
-    if (*result) xmlFreeNode (static_cast<xmlNodePtr> (*result));
+    if (*result) gnc_xml_node_free (static_cast<GncXmlNode*> (*result));
 }
 
 static gboolean dom_chars_handler (
     GSList* sibling_data, gpointer parent_data, gpointer global_data,
     gpointer* result, const char* text, int length)
 {
-    if (length > 0)
-    {
-        gchar* newtext = g_strndup (text,length);
-        xmlNodeAddContentLen ((xmlNodePtr)parent_data,
-                              checked_char_cast (newtext), length);
-        g_free (newtext);
-    }
+    gnc_xml_node_add_content ((GncXmlNode*)parent_data, text, length);
     return TRUE;
 }
 

--- a/libgnucash/backend/xml/test/CMakeLists.txt
+++ b/libgnucash/backend/xml/test/CMakeLists.txt
@@ -47,6 +47,7 @@ set_local_dist(test_backend_xml_DIST_local
   test-xml-account.cpp
   test-xml-commodity.cpp
   test-xml-pricedb.cpp
+  test-xml-reader-edge-cases.cpp
   test-xml-transaction.cpp
 )
 set(test_backend_xml_DIST ${test_backend_xml_DIST_local} ${test_backend_xml_test_files_DIST} PARENT_SCOPE)
@@ -79,6 +80,7 @@ add_xml_test(test-xml-account "test-xml-account.cpp;test-file-stuff.cpp")
 add_xml_test(test-xml-commodity "test-xml-commodity.cpp;test-file-stuff.cpp")
 add_xml_test(test-xml-pricedb "test-xml-pricedb.cpp;test-file-stuff.cpp")
 add_xml_test(test-xml-transaction "test-xml-transaction.cpp;test-file-stuff.cpp")
+add_xml_test(test-xml-reader-edge-cases "test-xml-reader-edge-cases.cpp")
 add_xml_test(test-xml2-is-file "test-xml2-is-file.cpp"
    GNC_TEST_FILES=${CMAKE_CURRENT_SOURCE_DIR}/test-files/xml2)
 

--- a/libgnucash/backend/xml/test/test-dom-converters1.cpp
+++ b/libgnucash/backend/xml/test/test-dom-converters1.cpp
@@ -57,6 +57,7 @@ test_dom_tree_to_commodity_ref (void)
         gchar* test_str2;
         gnc_commodity* test_com2;
         xmlNodePtr test_node;
+        GncXmlNode* conv_node;
         QofBook* book;
 
         book = qof_book_new ();
@@ -66,12 +67,14 @@ test_dom_tree_to_commodity_ref (void)
 
         test_com1 = gnc_commodity_new (book, NULL, test_str1, test_str2, NULL, 0);
         test_node = commodity_ref_to_dom_tree ("test-com", test_com1);
+        conv_node = gnc_xml_node_from_libxml (test_node);
 
-        test_com2 = dom_tree_to_commodity_ref_no_engine (test_node, book);
+        test_com2 = dom_tree_to_commodity_ref_no_engine (conv_node, book);
 
         do_test (gnc_commodity_equiv (test_com1, test_com2),
                  "dom_tree_to_commodity_ref_no_engine");
 
+        gnc_xml_node_free (conv_node);
         xmlFreeNode (test_node);
         gnc_commodity_destroy (test_com1);
         gnc_commodity_destroy (test_com2);
@@ -90,12 +93,12 @@ test_dom_tree_to_text (void)
     for (i = 0; i < 20; i++)
     {
         gchar* test_string1;
-        xmlNodePtr test_node;
+        GncXmlNode* test_node;
 
-        test_node = xmlNewNode (NULL, BAD_CAST "test-node");
+        test_node = gnc_xml_node_new_element ("test-node");
         test_string1 = get_random_string ();
 
-        xmlNodeAddContent (test_node, BAD_CAST test_string1);
+        gnc_xml_node_add_content (test_node, test_string1, strlen (test_string1));
 
         auto test_string2 = dom_tree_to_text (test_node);
 
@@ -103,7 +106,7 @@ test_dom_tree_to_text (void)
         {
             failure_args ("dom_tree_to_text", __FILE__, __LINE__,
                           "null return from dom_tree_to_text");
-            xmlElemDump (stdout, NULL, test_node);
+            gnc_xml_node_dump (stdout, test_node);
         }
         else if (g_strcmp0 (test_string1, test_string2->c_str()) == 0)
         {
@@ -116,7 +119,7 @@ test_dom_tree_to_text (void)
                           "with string %s", test_string1);
         }
 
-        xmlFreeNode (test_node);
+        gnc_xml_node_free (test_node);
         g_free (test_string1);
     }
 }
@@ -129,15 +132,17 @@ test_dom_tree_to_time64 (void)
     for (i = 0; i < 20; i++)
     {
         xmlNodePtr test_node;
+        GncXmlNode* conv_node;
         time64 test_spec1 = get_random_time ();
         test_node = time64_to_dom_tree ("test-spec", test_spec1);
-        time64 test_spec2 = dom_tree_to_time64 (test_node);
-        if (!dom_tree_valid_time64 (test_spec2, (const xmlChar*)"test-spec"))
+        conv_node = gnc_xml_node_from_libxml (test_node);
+        time64 test_spec2 = dom_tree_to_time64 (conv_node);
+        if (!dom_tree_valid_time64 (test_spec2, "test-spec"))
         {
             failure_args ("dom_tree_to_time64",
                           __FILE__, __LINE__, "NULL return");
             printf ("Node looks like:\n");
-            xmlElemDump (stdout, NULL, test_node);
+            gnc_xml_node_dump (stdout, conv_node);
             printf ("\n");
         }
         else if (test_spec1 == test_spec2)
@@ -148,11 +153,12 @@ test_dom_tree_to_time64 (void)
         {
             failure ("dom_tree_to_time64");
             printf ("Node looks like:\n");
-            xmlElemDump (stdout, NULL, test_node);
+            gnc_xml_node_dump (stdout, conv_node);
             printf ("\n");
             printf ("passed: %" G_GUINT64_FORMAT "  got: %" G_GUINT64_FORMAT ".\n",
                     test_spec1, test_spec2);
         }
+        gnc_xml_node_free (conv_node);
         xmlFreeNode (test_node);
     }
 }
@@ -170,11 +176,13 @@ test_gnc_nums_internal (gnc_numeric to_test)
     }
     else
     {
-        gnc_numeric to_compare = dom_tree_to_gnc_numeric (to_gen);
+        auto conv_node = gnc_xml_node_from_libxml (to_gen);
+        gnc_numeric to_compare = dom_tree_to_gnc_numeric (conv_node);
         if (!gnc_numeric_equal (to_test, to_compare))
         {
             ret = "numerics compared different";
         }
+        gnc_xml_node_free (conv_node);
     }
 
     if (to_gen)
@@ -227,11 +235,13 @@ test_dom_tree_to_guid (void)
                           "conversion to dom tree failed");
         }
 
-        auto test_guid2 = dom_tree_to_guid (test_node);
+        auto conv_node = gnc_xml_node_from_libxml (test_node);
+        auto test_guid2 = dom_tree_to_guid (conv_node);
 
         do_test (guid_equal (test_guid1, &*test_guid2),
                  "dom_tree_to_guid");
 
+        gnc_xml_node_free (conv_node);
         xmlFreeNode (test_node);
         guid_free (test_guid1);
     }

--- a/libgnucash/backend/xml/test/test-file-stuff.cpp
+++ b/libgnucash/backend/xml/test/test-file-stuff.cpp
@@ -48,7 +48,7 @@
 */
 /***********************************************************************/
 
-extern KvpFrame* dom_tree_to_kvp_frame (xmlNodePtr node);
+extern KvpFrame* dom_tree_to_kvp_frame (GncXmlNode* node);
 
 static int
 files_return (int ret, const char* msg)
@@ -110,25 +110,23 @@ print_dom_tree (gpointer data_for_children, GSList* data_from_children,
 {
     if (parent_data == NULL)
     {
-        xmlElemDump ((FILE*)global_data, NULL, (xmlNodePtr)data_for_children);
-        xmlFreeNode (static_cast<xmlNodePtr> (data_for_children));
+        gnc_xml_node_dump ((FILE*)global_data, (GncXmlNode*)data_for_children);
+        gnc_xml_node_free (static_cast<GncXmlNode*> (data_for_children));
     }
     return TRUE;
 }
 
 gboolean
-check_dom_tree_version (xmlNodePtr node,  const char* verstr)
+check_dom_tree_version (GncXmlNode* node,  const char* verstr)
 {
     char* verteststr;
 
     g_return_val_if_fail (node, FALSE);
     g_return_val_if_fail (verstr, FALSE);
     g_return_val_if_fail (node->properties, FALSE);
-    g_return_val_if_fail (node->properties->xmlAttrPropertyValue, FALSE);
-    g_return_val_if_fail (node->properties->xmlAttrPropertyValue->content,
-                          FALSE);
+    g_return_val_if_fail (node->properties->value, FALSE);
 
-    verteststr = (char*) node->properties->xmlAttrPropertyValue->content;
+    verteststr = node->properties->value;
     if (g_strcmp0 (verstr, verteststr) == 0)
     {
         return TRUE;
@@ -140,7 +138,7 @@ check_dom_tree_version (xmlNodePtr node,  const char* verstr)
 }
 
 gboolean
-equals_node_val_vs_string (xmlNodePtr node, const gchar* str)
+equals_node_val_vs_string (GncXmlNode* node, const gchar* str)
 {
     g_return_val_if_fail (node, FALSE);
     g_return_val_if_fail (str, FALSE);
@@ -163,7 +161,7 @@ equals_node_val_vs_string (xmlNodePtr node, const gchar* str)
 }
 
 gboolean
-equals_node_val_vs_int (xmlNodePtr node, gint64 val)
+equals_node_val_vs_int (GncXmlNode* node, gint64 val)
 {
     gint64 test_val;
 
@@ -180,13 +178,13 @@ equals_node_val_vs_int (xmlNodePtr node, gint64 val)
 }
 
 gboolean
-equals_node_val_vs_boolean (xmlNodePtr node, gboolean val)
+equals_node_val_vs_boolean (GncXmlNode* node, gboolean val)
 {
     return equals_node_val_vs_string (node, val ? "TRUE" : "FALSE");
 }
 
 gboolean
-equals_node_val_vs_guid (xmlNodePtr node, const GncGUID* id)
+equals_node_val_vs_guid (GncXmlNode* node, const GncGUID* id)
 {
     g_return_val_if_fail (node, FALSE);
     g_return_val_if_fail (id, FALSE);
@@ -206,7 +204,7 @@ equals_node_val_vs_guid (xmlNodePtr node, const GncGUID* id)
 }
 
 gboolean
-equals_node_val_vs_commodity (xmlNodePtr node, const gnc_commodity* com,
+equals_node_val_vs_commodity (GncXmlNode* node, const gnc_commodity* com,
                               QofBook* book)
 {
     gnc_commodity* cmpcom;
@@ -231,7 +229,7 @@ equals_node_val_vs_commodity (xmlNodePtr node, const gnc_commodity* com,
 }
 
 gboolean
-equals_node_val_vs_kvp_frame (xmlNodePtr node, const KvpFrame* frm)
+equals_node_val_vs_kvp_frame (GncXmlNode* node, const KvpFrame* frm)
 {
     KvpFrame* cmpfrm;
 
@@ -260,7 +258,7 @@ equals_node_val_vs_kvp_frame (xmlNodePtr node, const KvpFrame* frm)
 }
 
 gboolean
-equals_node_val_vs_date (xmlNodePtr node, time64 time)
+equals_node_val_vs_date (GncXmlNode* node, time64 time)
 {
     return time == dom_tree_to_time64 (node);
 }
@@ -273,8 +271,8 @@ just_dom_tree_end_handler (gpointer data_for_children,
                            gpointer parent_data, gpointer global_data,
                            gpointer* result, const gchar* tag)
 {
-    xmlNodePtr tree = (xmlNodePtr)data_for_children;
-    xmlNodePtr* globaldata = (xmlNodePtr*)global_data;
+    GncXmlNode* tree = (GncXmlNode*)data_for_children;
+    GncXmlNode** globaldata = (GncXmlNode**)global_data;
 
     if (parent_data)
     {
@@ -295,11 +293,11 @@ just_dom_tree_end_handler (gpointer data_for_children,
     return TRUE;
 }
 
-static xmlNodePtr
+static GncXmlNode*
 grab_file_doc (const char* filename)
 {
     sixtp* parser;
-    xmlNodePtr ret;
+    GncXmlNode* ret;
     gpointer parse_result = NULL;
 
     parser = sixtp_dom_parser_new (just_dom_tree_end_handler, NULL, NULL);
@@ -313,7 +311,7 @@ static void
 test_load_file (const char* filename, gxpf_callback cb, sixtp* top_parser,
                 QofBook* book)
 {
-    xmlNodePtr node;
+    GncXmlNode* node;
 
     node = grab_file_doc (filename);
 
@@ -330,7 +328,7 @@ test_load_file (const char* filename, gxpf_callback cb, sixtp* top_parser,
                       "%s", filename);
     }
 
-    xmlFreeNode (node);
+    gnc_xml_node_free (node);
 }
 
 void

--- a/libgnucash/backend/xml/test/test-file-stuff.h
+++ b/libgnucash/backend/xml/test/test-file-stuff.h
@@ -29,6 +29,7 @@
 #include <gnc-commodity.h>
 #include <gnc-engine.h>
 #include <gnc-xml-helper.h>
+#include <gnc-xml-sax-node.h>
 #include <io-gncxml-gen.h>
 #include <sixtp.h>
 
@@ -48,15 +49,15 @@ gboolean print_dom_tree (gpointer data_for_children,
                          const gchar* tag);
 
 /**/
-gboolean check_dom_tree_version (xmlNodePtr node,  const char* verstr);
-gboolean equals_node_val_vs_string (xmlNodePtr node, const gchar* str);
-gboolean equals_node_val_vs_guid (xmlNodePtr node, const GncGUID* id);
-gboolean equals_node_val_vs_commodity (xmlNodePtr node,
+gboolean check_dom_tree_version (GncXmlNode* node,  const char* verstr);
+gboolean equals_node_val_vs_string (GncXmlNode* node, const gchar* str);
+gboolean equals_node_val_vs_guid (GncXmlNode* node, const GncGUID* id);
+gboolean equals_node_val_vs_commodity (GncXmlNode* node,
                                        const gnc_commodity* com, QofBook*);
-gboolean equals_node_val_vs_kvp_frame (xmlNodePtr node, const KvpFrame* frm);
-gboolean equals_node_val_vs_date (xmlNodePtr node, time64);
-gboolean equals_node_val_vs_int (xmlNodePtr node, gint64 val);
-gboolean equals_node_val_vs_boolean (xmlNodePtr node, gboolean val);
+gboolean equals_node_val_vs_kvp_frame (GncXmlNode* node, const KvpFrame* frm);
+gboolean equals_node_val_vs_date (GncXmlNode* node, time64);
+gboolean equals_node_val_vs_int (GncXmlNode* node, gint64 val);
+gboolean equals_node_val_vs_boolean (GncXmlNode* node, gboolean val);
 
 void
 test_files_in_dir (int argc, char** argv, gxpf_callback cb,

--- a/libgnucash/backend/xml/test/test-kvp-frames.cpp
+++ b/libgnucash/backend/xml/test/test-kvp-frames.cpp
@@ -15,7 +15,7 @@
 
 #define GNC_V2_STRING "gnc-v2"
 const gchar* gnc_v2_xml_version_string = GNC_V2_STRING;
-extern KvpFrame* dom_tree_to_kvp_frame (xmlNodePtr node);
+extern KvpFrame* dom_tree_to_kvp_frame (GncXmlNode* node);
 
 static void
 test_kvp_get_slot (int run,
@@ -153,7 +153,8 @@ test_kvp_xml_stuff (void)
         }
         else
         {
-            test_frame2 = dom_tree_to_kvp_frame (test_node);
+            auto conv_node = gnc_xml_node_from_libxml (test_node);
+            test_frame2 = dom_tree_to_kvp_frame (conv_node);
 
             if (compare (inst->kvp_data, test_frame2) == 0)
             {
@@ -165,11 +166,12 @@ test_kvp_xml_stuff (void)
                 printf ("  With KvpFrame 1:\n%s\n",
                         inst->kvp_data->to_string ().c_str ());
                 printf ("  and XML:\n");
-                xmlElemDump (stdout, NULL, test_node);
+                gnc_xml_node_dump (stdout, conv_node);
                 printf ("\n   and kvp_frame 2:\n%s\n",
                         test_frame2->to_string ().c_str ());
             }
             delete test_frame2;
+            gnc_xml_node_free (conv_node);
             xmlFreeNode (test_node);
         }
         g_object_unref (inst);

--- a/libgnucash/backend/xml/test/test-string-converters.cpp
+++ b/libgnucash/backend/xml/test/test-string-converters.cpp
@@ -54,12 +54,14 @@ test_string_converters (void)
     {
         const char* mark = test_strings[i];
         xmlNodePtr test_node = text_to_dom_tree ("test-string", mark);
-        auto backout = dom_tree_to_text (test_node);
+        auto conv_node = gnc_xml_node_from_libxml (test_node);
+        auto backout = dom_tree_to_text (conv_node);
 
         do_test_args (
             g_strcmp0 (backout->c_str(), mark) == 0,
             "string converting", __FILE__, __LINE__, "with string %s", mark);
 
+        gnc_xml_node_free (conv_node);
         xmlFreeNode (test_node);
     }
 }
@@ -70,12 +72,14 @@ test_bad_string (void)
     const char* badstr = "foo\abar";
     const char* sanitized = "foo?bar";
     xmlNodePtr test_node = text_to_dom_tree ("test-string", badstr);
+    auto conv_node = gnc_xml_node_from_libxml (test_node);
 
-    auto backout = dom_tree_to_text (test_node);
+    auto backout = dom_tree_to_text (conv_node);
     do_test_args (g_strcmp0 (backout->c_str(), sanitized) == 0,
                   "string sanitizing", __FILE__, __LINE__,
                   "with string %s", badstr);
 
+    gnc_xml_node_free (conv_node);
     xmlFreeNode (test_node);
 }
 

--- a/libgnucash/backend/xml/test/test-xml-account.cpp
+++ b/libgnucash/backend/xml/test/test-xml-account.cpp
@@ -48,9 +48,9 @@
 static QofBook* sixbook;
 
 static gchar*
-node_and_account_equal (xmlNodePtr node, Account* act)
+node_and_account_equal (GncXmlNode* node, Account* act)
 {
-    xmlNodePtr mark;
+    GncXmlNode* mark;
 
     while (g_strcmp0 ((char*)node->name, "text") == 0)
     {
@@ -247,7 +247,12 @@ test_account (int i, Account* test_act)
         return;
     }
 
-    if ((compare_msg = node_and_account_equal (test_node, test_act)) != NULL)
+    {
+        auto conv_node = gnc_xml_node_from_libxml (test_node);
+        compare_msg = node_and_account_equal (conv_node, test_act);
+        gnc_xml_node_free (conv_node);
+    }
+    if (compare_msg != NULL)
     {
         failure_args ("account_xml", __FILE__, __LINE__,
                       "node and account were not equal: %s", compare_msg);
@@ -367,7 +372,7 @@ test_real_account (const char* tag, gpointer global_data, gpointer data)
         gnc_account_append_child (gnc_book_get_root_account (sixbook), act);
     }
 
-    msg = node_and_account_equal ((xmlNodePtr)global_data, act);
+    msg = node_and_account_equal ((GncXmlNode*)global_data, act);
     do_test_args (msg == NULL, "test_real_account",
                   __FILE__, __LINE__, msg);
 

--- a/libgnucash/backend/xml/test/test-xml-commodity.cpp
+++ b/libgnucash/backend/xml/test/test-xml-commodity.cpp
@@ -43,9 +43,9 @@
 static QofBook* book;
 
 static const char*
-node_and_commodity_equal (xmlNodePtr node, const gnc_commodity* com)
+node_and_commodity_equal (GncXmlNode* node, const gnc_commodity* com)
 {
-    xmlNodePtr mark;
+    GncXmlNode* mark;
 
     while (g_strcmp0 ((char*)node->name, "text") == 0)
         node = node->next;
@@ -187,7 +187,9 @@ test_generation (void)
             gnc_commodity_destroy (ran_com);
             continue;
         }
-        auto compare_msg = node_and_commodity_equal (test_node, ran_com);
+        auto conv_node = gnc_xml_node_from_libxml (test_node);
+        auto compare_msg = node_and_commodity_equal (conv_node, ran_com);
+        gnc_xml_node_free (conv_node);
         if (compare_msg != nullptr)
         {
             failure_args ("commodity_xml", __FILE__, __LINE__,
@@ -240,7 +242,7 @@ test_generation (void)
 static gboolean
 test_real_commodity (const char* tag, gpointer globaldata, gpointer data)
 {
-    const char* msg = node_and_commodity_equal ((xmlNodePtr)globaldata,
+    const char* msg = node_and_commodity_equal ((GncXmlNode*)globaldata,
                                                 (gnc_commodity*)data);
     do_test_args (msg == NULL, "test_real_commodity",
                   __FILE__, __LINE__, msg);

--- a/libgnucash/backend/xml/test/test-xml-reader-edge-cases.cpp
+++ b/libgnucash/backend/xml/test/test-xml-reader-edge-cases.cpp
@@ -1,7 +1,7 @@
 /********************************************************************\
  * test-xml-reader-edge-cases.cpp -- exhaustive edge-case tests for *
- * the libxml2-DOM-built XML v2 reader (sixtp-to-dom-parser.cpp,    *
- * sixtp-dom-parsers.cpp)                                           *
+ * the SAX-built GncXmlNode reader (gnc-xml-sax-node.*,             *
+ * sixtp-to-dom-parser.cpp, sixtp-dom-parsers.cpp)                  *
  *                                                                  *
  * Copyright (C) 2026 The GnuCash Project                          *
  *                                                                  *
@@ -25,25 +25,16 @@
 \********************************************************************/
 /** @file test-xml-reader-edge-cases.cpp
  *
- * This exercises the read side of the v2 XML backend (the real libxml2
- * xmlNode tree that sixtp_dom_parser_new builds, plus dom_tree_to_*)
- * against inputs a reader has to deal with: Unicode content split
- * across SAX characters() chunk boundaries, CDATA, comments, mixed
- * content, malformed/non-well-formed XML, and domain-level validation
- * failures (unknown tags, missing required fields).
- *
- * This file is a deliberate baseline: it is meant to land on stable
- * first, against the pre-existing xmlNodePtr/libxml2-DOM reader, so
- * its pass/fail results are on record before the SAX-tree rewrite
- * (which replaces xmlNodePtr with a lightweight GncXmlNode on the read
- * side only) lands on top of it. That follow-up change adapts this
- * same suite call-for-call to the new node type; an unchanged set of
- * passes across both versions is the evidence that the rewrite altered
- * no observable reader behavior.
+ * This exercises the read side of the v2 XML backend (GncXmlNode,
+ * sixtp_dom_parser_new, dom_tree_to_*) against inputs a real DOM-based
+ * parser would also have had to deal with: Unicode content split across
+ * SAX characters() chunk boundaries, CDATA, comments, mixed content,
+ * malformed/non-well-formed XML, and domain-level validation failures
+ * (unknown tags, missing required fields).
  *
  * Two harnesses are used deliberately:
  *
- *  - A bare sixtp parser (parse_one_element/parse_wrapped), used for
+ *  - A bare sixtp parser (build_wrapped_parser/parse_string), used for
  *    every case that is *expected* to fail (well-formedness or
  *    domain-validation failures). This mirrors gnc_read_example_account's
  *    wrapping pattern and stops short of a full QofSession/QofBook
@@ -55,13 +46,11 @@
  * This split is intentional, not incidental: a full QofBook that
  * registers business objects (via cashobjects_register) and is then
  * destroyed after a *partially failed* account parse currently crashes
- * in gncTaxTable's per-book teardown (_gncTaxTableDestroy). This is a
- * pre-existing bug in QofSession::load()'s failure path (see the
- * "IMPORTANT" note on qof_session_load's doc comment in qofsession.h):
- * on load failure it destroys and replaces the session's QofBook out
- * from under any pointer callers already hold to it. It reproduces
- * identically regardless of which xmlNode type the reader builds, so
- * it is unrelated to this reader and intentionally not exercised here.
+ * in gncTaxTable's per-book teardown (_gncTaxTableDestroy) - confirmed
+ * to reproduce identically on the pre-SAX-rewrite code, so it is a
+ * pre-existing bug unrelated to this reader and intentionally not
+ * exercised here (tracked separately; see the session notes for
+ * xml-sax-stream-read).
  */
 #include <glib.h>
 #include <glib/gstdio.h>
@@ -83,6 +72,7 @@
 #include "sixtp-parsers.h"
 #include "sixtp-utils.h"
 #include "sixtp-dom-parsers.h"
+#include "gnc-xml-sax-node.h"
 #include "gnc-xml.h"
 #include "io-gncxml-gen.h"
 #include "io-gncxml-v2.h"
@@ -90,28 +80,28 @@
 #include <test-stuff.h>
 #include <test-engine-stuff.h>
 
-extern KvpFrame* dom_tree_to_kvp_frame (xmlNodePtr node);
+extern KvpFrame* dom_tree_to_kvp_frame (GncXmlNode* node);
 
 #define GNC_LIB_NAME "gncmod-backend-xml"
 #define GNC_LIB_REL_PATH "xml"
 
 /***********************************************************************/
-/* Small helpers for building xmlNode trees by hand, and for driving
+/* Small helpers for building GncXmlNode trees by hand, and for driving
    a real sixtp parser over a raw XML string without going through a
    full QofSession. */
 
-static xmlNodePtr
+static GncXmlNode*
 build_leaf (const char* tag, const char* text)
 {
-    xmlNodePtr node = xmlNewNode (NULL, BAD_CAST tag);
+    GncXmlNode* node = gnc_xml_node_new_element (tag);
     if (text)
-        xmlNodeAddContentLen (node, BAD_CAST text, strlen (text));
+        gnc_xml_node_add_content (node, text, strlen (text));
     return node;
 }
 
 struct capture_pdata
 {
-    xmlNodePtr tree = nullptr;
+    GncXmlNode* tree = nullptr;
 };
 
 static gboolean
@@ -123,14 +113,14 @@ capture_end_handler (gpointer data_for_children, GSList*, GSList*,
         return TRUE;
 
     auto pdata = static_cast<capture_pdata*> (global_data);
-    pdata->tree = static_cast<xmlNodePtr> (data_for_children);
+    pdata->tree = static_cast<GncXmlNode*> (data_for_children);
     /* Hand ownership to pdata->tree; caller frees it. */
     return TRUE;
 }
 
 /* Parses a single top-level element ('tag') out of 'xml' and returns
-   its captured xmlNode tree (caller must xmlFreeNode it), or nullptr
-   if parsing failed (malformed XML, wrong root tag, etc).
+   its captured GncXmlNode tree (caller must gnc_xml_node_free it), or
+   nullptr if parsing failed (malformed XML, wrong root tag, etc).
 
    The dom_parser is deliberately nested one level under a synthetic
    wrapping tag rather than being used bare as the top-level sixtp.
@@ -143,7 +133,7 @@ capture_end_handler (gpointer data_for_children, GSList*, GSList*,
    relying on that bootstrap call at all: the outer wrapper's generic
    (non-DOM) start/end handling supplies a genuine NULL parent_data to
    the dom_parser's own first invocation. */
-static xmlNodePtr
+static GncXmlNode*
 parse_one_element (const char* tag, const std::string& xml)
 {
     capture_pdata pdata;
@@ -170,7 +160,7 @@ parse_one_element (const char* tag, const std::string& xml)
     if (!ok)
     {
         if (pdata.tree)
-            xmlFreeNode (pdata.tree);
+            gnc_xml_node_free (pdata.tree);
         return nullptr;
     }
     return pdata.tree;
@@ -227,7 +217,7 @@ parse_wrapped (sixtp* (*parser_create) (void), const char* child_tag,
 }
 
 /***********************************************************************/
-/* 1. xmlNode primitive behavior: UTF-8, chunking, attributes           */
+/* 1. GncXmlNode primitive behavior: UTF-8, chunking, attributes        */
 /***********************************************************************/
 
 static void
@@ -236,11 +226,11 @@ test_utf8_round_trip (void)
     /* 2-byte, 3-byte and 4-byte UTF-8 sequences in one string. */
     const char* utf8 = "caf\xC3\xA9 \xE4\xB8\xAD\xE6\x96\x87 \xF0\x9F\x98\x80";
 
-    xmlNodePtr node = build_leaf ("test", utf8);
+    GncXmlNode* node = build_leaf ("test", utf8);
     auto text = dom_tree_to_text (node);
     do_test (text.has_value () && *text == utf8,
              "UTF-8 content round-trips through a single add_content call");
-    xmlFreeNode (node);
+    gnc_xml_node_free (node);
 }
 
 static void
@@ -251,17 +241,15 @@ test_utf8_chunked_across_codepoint_boundary (void)
 
     /* Split at every possible byte offset, including offsets that land
        mid-way through a multi-byte UTF-8 sequence. sixtp's characters()
-       callback delivers a byte length, not a character count, and the
-       xmlNode content buffer must reassemble correctly regardless of
-       where a SAX chunk boundary happens to fall. This mirrors exactly
-       how dom_chars_handler feeds each chunk to xmlNodeAddContentLen in
-       production. */
+       callback delivers a byte length, not a character count, and
+       GncXmlNode must reassemble correctly regardless of where a SAX
+       chunk boundary happens to fall. */
     gboolean all_ok = TRUE;
     for (size_t split = 0; split <= len; ++split)
     {
-        xmlNodePtr node = xmlNewNode (NULL, BAD_CAST "test");
-        xmlNodeAddContentLen (node, BAD_CAST utf8, (int)split);
-        xmlNodeAddContentLen (node, BAD_CAST (utf8 + split), (int)(len - split));
+        GncXmlNode* node = gnc_xml_node_new_element ("test");
+        gnc_xml_node_add_content (node, utf8, (int)split);
+        gnc_xml_node_add_content (node, utf8 + split, (int)(len - split));
         auto text = dom_tree_to_text (node);
         if (!text || *text != utf8)
         {
@@ -270,7 +258,7 @@ test_utf8_chunked_across_codepoint_boundary (void)
                           "split at byte %zu produced [%s]",
                           split, text ? text->c_str () : "(null)");
         }
-        xmlFreeNode (node);
+        gnc_xml_node_free (node);
     }
     do_test (all_ok, "UTF-8 reassembles correctly for every possible chunk split point");
 }
@@ -278,90 +266,94 @@ test_utf8_chunked_across_codepoint_boundary (void)
 static void
 test_attribute_set_get (void)
 {
-    xmlNodePtr node = xmlNewNode (NULL, BAD_CAST "test");
+    GncXmlNode* node = gnc_xml_node_new_element ("test");
 
-    do_test (xmlGetProp (node, BAD_CAST "missing") == NULL,
+    do_test (gnc_xml_get_prop (node, "missing") == NULL,
              "missing attribute lookup returns NULL");
 
-    xmlSetProp (node, BAD_CAST "version", BAD_CAST "2.0.0");
-    xmlChar* v = xmlGetProp (node, BAD_CAST "version");
-    do_test (v && g_strcmp0 ((char*)v, "2.0.0") == 0, "attribute set/get round-trips");
-    xmlFree (v);
+    gnc_xml_node_set_prop (node, "version", "2.0.0");
+    char* v = gnc_xml_get_prop (node, "version");
+    do_test (v && g_strcmp0 (v, "2.0.0") == 0, "attribute set/get round-trips");
+    g_free (v);
 
     /* overwrite */
-    xmlSetProp (node, BAD_CAST "version", BAD_CAST "3.0.0");
-    v = xmlGetProp (node, BAD_CAST "version");
-    do_test (v && g_strcmp0 ((char*)v, "3.0.0") == 0, "re-setting an attribute overwrites it, doesn't duplicate");
-    xmlFree (v);
+    gnc_xml_node_set_prop (node, "version", "3.0.0");
+    v = gnc_xml_get_prop (node, "version");
+    do_test (v && g_strcmp0 (v, "3.0.0") == 0, "re-setting an attribute overwrites it, doesn't duplicate");
+    g_free (v);
 
     /* unicode attribute value */
-    xmlSetProp (node, BAD_CAST "note", BAD_CAST "caf\xC3\xA9");
-    v = xmlGetProp (node, BAD_CAST "note");
-    do_test (v && g_strcmp0 ((char*)v, "caf\xC3\xA9") == 0, "UTF-8 attribute value round-trips");
-    xmlFree (v);
+    gnc_xml_node_set_prop (node, "note", "caf\xC3\xA9");
+    v = gnc_xml_get_prop (node, "note");
+    do_test (v && g_strcmp0 (v, "caf\xC3\xA9") == 0, "UTF-8 attribute value round-trips");
+    g_free (v);
 
-    xmlFreeNode (node);
+    gnc_xml_node_free (node);
 }
 
 static void
 test_node_list_get_string_sibling_only (void)
 {
-    /* <leaf>100<b/>200</leaf> - xmlNodeListGetString walks direct
-       siblings only, it does not recurse into <b>'s own children.
-       Text that IS a direct sibling of a nested element (the "200"
-       here) is still correctly captured even though <b/> sits between
-       the two text runs. */
-    xmlNodePtr leaf = xmlNewNode (NULL, BAD_CAST "leaf");
-    xmlNodeAddContentLen (leaf, BAD_CAST "100", 3);
-    xmlNewChild (leaf, NULL, BAD_CAST "b", NULL);
-    xmlNodeAddContentLen (leaf, BAD_CAST "200", 3);
+    /* <leaf>100<b/>200</leaf> - gnc_xml_node_list_get_string walks
+       direct siblings only (matching libxml2's xmlNodeListGetString),
+       it does not recurse into <b>'s own children. Text that IS a
+       direct sibling of a nested element (the "200" here) is still
+       correctly captured even though <b/> sits between the two text
+       runs. */
+    GncXmlNode* leaf = gnc_xml_node_new_element ("leaf");
+    gnc_xml_node_add_content (leaf, "100", 3);
+    gnc_xml_node_new_child (leaf, "b");
+    gnc_xml_node_add_content (leaf, "200", 3);
 
-    xmlChar* result = xmlNodeListGetString (NULL, leaf->xmlChildrenNode, TRUE);
-    do_test_args (g_strcmp0 ((char*)result, "100200") == 0,
-                  "xmlNodeListGetString", __FILE__, __LINE__,
-                  "expected [100200], got [%s]", (char*)result);
-    xmlFree (result);
-    xmlFreeNode (leaf);
+    char* result = gnc_xml_node_list_get_string (leaf->children);
+    do_test_args (g_strcmp0 (result, "100200") == 0,
+                  "gnc_xml_node_list_get_string", __FILE__, __LINE__,
+                  "expected [100200], got [%s]", result);
+    g_free (result);
+    gnc_xml_node_free (leaf);
 }
 
 static void
 test_node_list_get_string_does_not_recurse (void)
 {
     /* <leaf>100<b>NESTED</b>200</leaf> - text genuinely nested INSIDE
-       <b> is not visible to a sibling-only walk. */
-    xmlNodePtr leaf = xmlNewNode (NULL, BAD_CAST "leaf");
-    xmlNodeAddContentLen (leaf, BAD_CAST "100", 3);
-    xmlNodePtr b = xmlNewChild (leaf, NULL, BAD_CAST "b", NULL);
-    xmlNodeAddContentLen (b, BAD_CAST "NESTED", 6);
-    xmlNodeAddContentLen (leaf, BAD_CAST "200", 3);
+       <b> is not visible to a sibling-only walk. This matches
+       xmlNodeListGetString's behavior exactly (verified empirically
+       against real libxml2), so it is not a regression - GnuCash's own
+       writer never produces this shape. */
+    GncXmlNode* leaf = gnc_xml_node_new_element ("leaf");
+    gnc_xml_node_add_content (leaf, "100", 3);
+    GncXmlNode* b = gnc_xml_node_new_child (leaf, "b");
+    gnc_xml_node_add_content (b, "NESTED", 6);
+    gnc_xml_node_add_content (leaf, "200", 3);
 
-    xmlChar* result = xmlNodeListGetString (NULL, leaf->xmlChildrenNode, TRUE);
-    do_test_args (g_strcmp0 ((char*)result, "100200") == 0,
-                  "xmlNodeListGetString ignores nested element text",
-                  __FILE__, __LINE__, "expected [100200], got [%s]", (char*)result);
-    xmlFree (result);
-    xmlFreeNode (leaf);
+    char* result = gnc_xml_node_list_get_string (leaf->children);
+    do_test_args (g_strcmp0 (result, "100200") == 0,
+                  "gnc_xml_node_list_get_string ignores nested element text",
+                  __FILE__, __LINE__, "expected [100200], got [%s]", result);
+    g_free (result);
+    gnc_xml_node_free (leaf);
 }
 
 static void
 test_node_free_null_is_safe (void)
 {
-    xmlFreeNode (NULL);
-    success ("xmlFreeNode(NULL) does not crash");
+    gnc_xml_node_free (NULL);
+    success ("gnc_xml_node_free(NULL) does not crash");
 }
 
 static void
 test_empty_element_has_no_children (void)
 {
-    xmlNodePtr node = xmlNewNode (NULL, BAD_CAST "empty");
+    GncXmlNode* node = gnc_xml_node_new_element ("empty");
     do_test (node->children == NULL, "a freshly created node has no children");
     do_test (node->properties == NULL, "a freshly created node has no attributes");
     do_test (node->next == NULL && node->prev == NULL, "a freshly created node has no siblings");
-    xmlFreeNode (node);
+    gnc_xml_node_free (node);
 }
 
 /***********************************************************************/
-/* 2. xmlReadMemory: fidelity of a standalone parse used by tests       */
+/* 2. gnc_xml_node_from_libxml: fidelity of the writer -> reader bridge */
 /***********************************************************************/
 
 static void
@@ -371,23 +363,26 @@ test_from_libxml_preserves_structure (void)
     xmlDocPtr doc = xmlReadMemory (xml_text, strlen (xml_text), "test.xml", NULL, 0);
     xmlNodePtr root = xmlDocGetRootElement (doc);
 
-    do_test (g_strcmp0 ((char*)root->name, "root") == 0, "xmlReadMemory preserves element name");
+    GncXmlNode* conv = gnc_xml_node_from_libxml (root);
 
-    xmlChar* a1 = xmlGetProp (root, BAD_CAST "attr1");
-    xmlChar* a2 = xmlGetProp (root, BAD_CAST "attr2");
-    do_test (a1 && g_strcmp0 ((char*)a1, "v1") == 0, "xmlReadMemory preserves first attribute");
-    do_test (a2 && g_strcmp0 ((char*)a2, "v2") == 0, "xmlReadMemory preserves second attribute");
-    xmlFree (a1);
-    xmlFree (a2);
+    do_test (g_strcmp0 (conv->name, "root") == 0, "from_libxml preserves element name");
 
-    do_test (root->children != NULL && g_strcmp0 ((char*)root->children->name, "a") == 0,
-             "xmlReadMemory preserves first child");
-    do_test (root->children->next != NULL && g_strcmp0 ((char*)root->children->next->name, "b") == 0,
-             "xmlReadMemory preserves second child as a sibling");
+    char* a1 = gnc_xml_get_prop (conv, "attr1");
+    char* a2 = gnc_xml_get_prop (conv, "attr2");
+    do_test (a1 && g_strcmp0 (a1, "v1") == 0, "from_libxml preserves first attribute");
+    do_test (a2 && g_strcmp0 (a2, "v2") == 0, "from_libxml preserves second attribute");
+    g_free (a1);
+    g_free (a2);
 
-    auto text_a = dom_tree_to_text (root->children);
-    do_test (text_a.has_value () && *text_a == "text-a", "xmlReadMemory preserves child text content");
+    do_test (conv->children != NULL && g_strcmp0 (conv->children->name, "a") == 0,
+             "from_libxml preserves first child");
+    do_test (conv->children->next != NULL && g_strcmp0 (conv->children->next->name, "b") == 0,
+             "from_libxml preserves second child as a sibling");
 
+    auto text_a = dom_tree_to_text (conv->children);
+    do_test (text_a.has_value () && *text_a == "text-a", "from_libxml preserves child text content");
+
+    gnc_xml_node_free (conv);
     xmlFreeDoc (doc);
 }
 
@@ -405,41 +400,41 @@ test_dom_tree_to_guid_variants (void)
     guid_to_string_buff (&g, buf);
 
     {
-        xmlNodePtr node = build_leaf ("id", buf);
-        xmlSetProp (node, BAD_CAST "type", BAD_CAST "guid");
+        GncXmlNode* node = build_leaf ("id", buf);
+        gnc_xml_node_set_prop (node, "type", "guid");
         auto result = dom_tree_to_guid (node);
         do_test (result.has_value () && guid_equal (&*result, &g), "dom_tree_to_guid: type=\"guid\"");
-        xmlFreeNode (node);
+        gnc_xml_node_free (node);
     }
     {
-        xmlNodePtr node = build_leaf ("id", buf);
-        xmlSetProp (node, BAD_CAST "type", BAD_CAST "new");
+        GncXmlNode* node = build_leaf ("id", buf);
+        gnc_xml_node_set_prop (node, "type", "new");
         auto result = dom_tree_to_guid (node);
         do_test (result.has_value () && guid_equal (&*result, &g), "dom_tree_to_guid: type=\"new\"");
-        xmlFreeNode (node);
+        gnc_xml_node_free (node);
     }
     {
         /* missing type attribute entirely */
-        xmlNodePtr node = build_leaf ("id", buf);
+        GncXmlNode* node = build_leaf ("id", buf);
         auto result = dom_tree_to_guid (node);
         do_test (!result.has_value (), "dom_tree_to_guid: missing type attribute is rejected");
-        xmlFreeNode (node);
+        gnc_xml_node_free (node);
     }
     {
         /* unrecognized type attribute */
-        xmlNodePtr node = build_leaf ("id", buf);
-        xmlSetProp (node, BAD_CAST "type", BAD_CAST "bogus");
+        GncXmlNode* node = build_leaf ("id", buf);
+        gnc_xml_node_set_prop (node, "type", "bogus");
         auto result = dom_tree_to_guid (node);
         do_test (!result.has_value (), "dom_tree_to_guid: unrecognized type attribute is rejected");
-        xmlFreeNode (node);
+        gnc_xml_node_free (node);
     }
     {
         /* malformed guid text (wrong length / non-hex) */
-        xmlNodePtr node = build_leaf ("id", "not-a-valid-guid");
-        xmlSetProp (node, BAD_CAST "type", BAD_CAST "guid");
+        GncXmlNode* node = build_leaf ("id", "not-a-valid-guid");
+        gnc_xml_node_set_prop (node, "type", "guid");
         auto result = dom_tree_to_guid (node);
         do_test (!result.has_value (), "dom_tree_to_guid: malformed guid text is rejected");
-        xmlFreeNode (node);
+        gnc_xml_node_free (node);
     }
 }
 
@@ -457,14 +452,14 @@ test_dom_tree_to_boolean_variants (void)
     };
     for (auto& c : cases)
     {
-        xmlNodePtr node = build_leaf ("flag", c.text);
+        GncXmlNode* node = build_leaf ("flag", c.text);
         gboolean val = FALSE;
         gboolean ok = dom_tree_to_boolean (node, &val);
         do_test_args (ok == c.expect_ok && (!ok || val == c.expect_val),
                       "dom_tree_to_boolean", __FILE__, __LINE__,
                       "text=[%s] expected ok=%d val=%d, got ok=%d val=%d",
                       c.text, c.expect_ok, c.expect_val, ok, val);
-        xmlFreeNode (node);
+        gnc_xml_node_free (node);
     }
 }
 
@@ -472,55 +467,55 @@ static void
 test_dom_tree_to_number_variants (void)
 {
     {
-        xmlNodePtr node = build_leaf ("n", "42");
+        GncXmlNode* node = build_leaf ("n", "42");
         gint64 v = 0;
         do_test (dom_tree_to_integer (node, &v) && v == 42, "dom_tree_to_integer: plain value");
-        xmlFreeNode (node);
+        gnc_xml_node_free (node);
     }
     {
-        xmlNodePtr node = build_leaf ("n", "-42");
+        GncXmlNode* node = build_leaf ("n", "-42");
         gint64 v = 0;
         do_test (dom_tree_to_integer (node, &v) && v == -42, "dom_tree_to_integer: negative value");
-        xmlFreeNode (node);
+        gnc_xml_node_free (node);
     }
     {
-        xmlNodePtr node = build_leaf ("n", "  42  ");
+        GncXmlNode* node = build_leaf ("n", "  42  ");
         gint64 v = 0;
         do_test (dom_tree_to_integer (node, &v) && v == 42, "dom_tree_to_integer: whitespace-padded value");
-        xmlFreeNode (node);
+        gnc_xml_node_free (node);
     }
     {
-        xmlNodePtr node = build_leaf ("n", "not-a-number");
+        GncXmlNode* node = build_leaf ("n", "not-a-number");
         gint64 v = 0;
         do_test (!dom_tree_to_integer (node, &v), "dom_tree_to_integer: garbage text is rejected");
-        xmlFreeNode (node);
+        gnc_xml_node_free (node);
     }
     {
-        xmlNodePtr node = build_leaf ("n", "-1");
+        GncXmlNode* node = build_leaf ("n", "-1");
         guint v = 0;
         do_test (!dom_tree_to_guint (node, &v), "dom_tree_to_guint: negative value is rejected");
-        xmlFreeNode (node);
+        gnc_xml_node_free (node);
     }
     {
-        xmlNodePtr node = build_leaf ("n", "70000");
+        GncXmlNode* node = build_leaf ("n", "70000");
         guint16 v = 0;
         do_test (!dom_tree_to_guint16 (node, &v), "dom_tree_to_guint16: overflow (>65535) is rejected");
-        xmlFreeNode (node);
+        gnc_xml_node_free (node);
     }
     {
-        xmlNodePtr node = build_leaf ("n", "123/100");
+        GncXmlNode* node = build_leaf ("n", "123/100");
         gnc_numeric v = gnc_numeric_zero ();
         v = dom_tree_to_gnc_numeric (node);
         do_test (!gnc_numeric_check (v) && gnc_numeric_equal (v, gnc_numeric_create (123, 100)),
                  "dom_tree_to_gnc_numeric: valid ratio");
-        xmlFreeNode (node);
+        gnc_xml_node_free (node);
     }
     {
-        xmlNodePtr node = build_leaf ("n", "garbage");
+        GncXmlNode* node = build_leaf ("n", "garbage");
         gnc_numeric v = dom_tree_to_gnc_numeric (node);
         do_test (gnc_numeric_equal (v, gnc_numeric_zero ()),
                  "dom_tree_to_gnc_numeric: garbage text falls back to zero");
-        xmlFreeNode (node);
+        gnc_xml_node_free (node);
     }
 }
 
@@ -528,31 +523,31 @@ static void
 test_dom_tree_to_time64_variants (void)
 {
     {
-        xmlNodePtr node = xmlNewNode (NULL, BAD_CAST "date-posted");
-        xmlNodePtr ts = xmlNewChild (node, NULL, BAD_CAST "ts:date", NULL);
-        xmlNodeAddContentLen (ts, BAD_CAST "2020-01-01 00:00:00 +0000", 25);
+        GncXmlNode* node = gnc_xml_node_new_element ("date-posted");
+        GncXmlNode* ts = gnc_xml_node_new_child (node, "ts:date");
+        gnc_xml_node_add_content (ts, "2020-01-01 00:00:00 +0000", 25);
         time64 t = dom_tree_to_time64 (node);
         do_test (t != INT64_MAX, "dom_tree_to_time64: single ts:date parses");
-        xmlFreeNode (node);
+        gnc_xml_node_free (node);
     }
     {
         /* missing ts:date entirely */
-        xmlNodePtr node = xmlNewNode (NULL, BAD_CAST "date-posted");
+        GncXmlNode* node = gnc_xml_node_new_element ("date-posted");
         time64 t = dom_tree_to_time64 (node);
         do_test (t == INT64_MAX, "dom_tree_to_time64: missing ts:date returns INT64_MAX");
-        do_test (!dom_tree_valid_time64 (t, BAD_CAST "date-posted"), "dom_tree_valid_time64 rejects INT64_MAX");
-        xmlFreeNode (node);
+        do_test (!dom_tree_valid_time64 (t, "date-posted"), "dom_tree_valid_time64 rejects INT64_MAX");
+        gnc_xml_node_free (node);
     }
     {
         /* duplicate ts:date is explicitly rejected by dom_tree_to_time64 */
-        xmlNodePtr node = xmlNewNode (NULL, BAD_CAST "date-posted");
-        xmlNodePtr ts1 = xmlNewChild (node, NULL, BAD_CAST "ts:date", NULL);
-        xmlNodeAddContentLen (ts1, BAD_CAST "2020-01-01 00:00:00 +0000", 25);
-        xmlNodePtr ts2 = xmlNewChild (node, NULL, BAD_CAST "ts:date", NULL);
-        xmlNodeAddContentLen (ts2, BAD_CAST "2021-01-01 00:00:00 +0000", 25);
+        GncXmlNode* node = gnc_xml_node_new_element ("date-posted");
+        GncXmlNode* ts1 = gnc_xml_node_new_child (node, "ts:date");
+        gnc_xml_node_add_content (ts1, "2020-01-01 00:00:00 +0000", 25);
+        GncXmlNode* ts2 = gnc_xml_node_new_child (node, "ts:date");
+        gnc_xml_node_add_content (ts2, "2021-01-01 00:00:00 +0000", 25);
         time64 t = dom_tree_to_time64 (node);
         do_test (t == INT64_MAX, "dom_tree_to_time64: duplicate ts:date is rejected");
-        xmlFreeNode (node);
+        gnc_xml_node_free (node);
     }
 }
 
@@ -560,27 +555,27 @@ static void
 test_dom_tree_to_gdate_variants (void)
 {
     {
-        xmlNodePtr node = xmlNewNode (NULL, BAD_CAST "start");
-        xmlNodePtr gd = xmlNewChild (node, NULL, BAD_CAST "gdate", NULL);
-        xmlNodeAddContentLen (gd, BAD_CAST "2020-04-03", 10);
+        GncXmlNode* node = gnc_xml_node_new_element ("start");
+        GncXmlNode* gd = gnc_xml_node_new_child (node, "gdate");
+        gnc_xml_node_add_content (gd, "2020-04-03", 10);
         GDate* d = dom_tree_to_gdate (node);
         do_test (d && g_date_valid (*&d) && g_date_get_year (d) == 2020, "dom_tree_to_gdate: valid date");
         if (d) g_date_free (d);
-        xmlFreeNode (node);
+        gnc_xml_node_free (node);
     }
     {
-        xmlNodePtr node = xmlNewNode (NULL, BAD_CAST "start");
-        xmlNodePtr gd = xmlNewChild (node, NULL, BAD_CAST "gdate", NULL);
-        xmlNodeAddContentLen (gd, BAD_CAST "not-a-date", 10);
+        GncXmlNode* node = gnc_xml_node_new_element ("start");
+        GncXmlNode* gd = gnc_xml_node_new_child (node, "gdate");
+        gnc_xml_node_add_content (gd, "not-a-date", 10);
         GDate* d = dom_tree_to_gdate (node);
         do_test (d == NULL, "dom_tree_to_gdate: malformed date text is rejected");
-        xmlFreeNode (node);
+        gnc_xml_node_free (node);
     }
     {
-        xmlNodePtr node = xmlNewNode (NULL, BAD_CAST "start");
+        GncXmlNode* node = gnc_xml_node_new_element ("start");
         GDate* d = dom_tree_to_gdate (node);
         do_test (d == NULL, "dom_tree_to_gdate: missing gdate child is rejected");
-        xmlFreeNode (node);
+        gnc_xml_node_free (node);
     }
 }
 
@@ -588,15 +583,15 @@ test_dom_tree_to_gdate_variants (void)
 /* 4. KVP frame round-trips: nested frames, lists, every value type     */
 /***********************************************************************/
 
-static xmlNodePtr
+static GncXmlNode*
 kvp_slot (const char* key, const char* type, const char* text_value)
 {
-    xmlNodePtr slot = xmlNewNode (NULL, BAD_CAST "slot");
-    xmlNodePtr k = xmlNewChild (slot, NULL, BAD_CAST "slot:key", NULL);
-    xmlNodeAddContentLen (k, BAD_CAST key, strlen (key));
-    xmlNodePtr v = xmlNewChild (slot, NULL, BAD_CAST "slot:value", NULL);
-    xmlSetProp (v, BAD_CAST "type", BAD_CAST type);
-    xmlNodeAddContentLen (v, BAD_CAST text_value, strlen (text_value));
+    GncXmlNode* slot = gnc_xml_node_new_element ("slot");
+    GncXmlNode* k = gnc_xml_node_new_child (slot, "slot:key");
+    gnc_xml_node_add_content (k, key, strlen (key));
+    GncXmlNode* v = gnc_xml_node_new_child (slot, "slot:value");
+    gnc_xml_node_set_prop (v, "type", type);
+    gnc_xml_node_add_content (v, text_value, strlen (text_value));
     return slot;
 }
 
@@ -610,9 +605,10 @@ test_kvp_frame_scalar_types (void)
     };
     for (auto& c : cases)
     {
-        xmlNodePtr frame_node = xmlNewNode (NULL, BAD_CAST "slots");
-        xmlNodePtr slot = kvp_slot ("k", c.type, c.text);
-        xmlAddChild (frame_node, slot);
+        GncXmlNode* frame_node = gnc_xml_node_new_element ("slots");
+        GncXmlNode* slot = kvp_slot ("k", c.type, c.text);
+        /* attach slot as a child of frame_node */
+        frame_node->children = slot;
 
         KvpFrame* frame = dom_tree_to_kvp_frame (frame_node);
         do_test_args (frame != nullptr, "dom_tree_to_kvp_frame scalar", __FILE__, __LINE__,
@@ -624,7 +620,7 @@ test_kvp_frame_scalar_types (void)
                           __FILE__, __LINE__, "type=%s", c.type);
             delete frame;
         }
-        xmlFreeNode (frame_node);
+        gnc_xml_node_free (frame_node);
     }
 }
 
@@ -634,18 +630,18 @@ test_kvp_frame_nested (void)
     /* <slots><slot><slot:key>outer</slot:key><slot:value type="frame">
          <slot><slot:key>inner</slot:key><slot:value type="integer">7</slot:value></slot>
        </slot:value></slot></slots> */
-    xmlNodePtr frame_node = xmlNewNode (NULL, BAD_CAST "slots");
-    xmlNodePtr outer_slot = xmlNewNode (NULL, BAD_CAST "slot");
-    xmlAddChild (frame_node, outer_slot);
+    GncXmlNode* frame_node = gnc_xml_node_new_element ("slots");
+    GncXmlNode* outer_slot = gnc_xml_node_new_element ("slot");
+    frame_node->children = outer_slot;
 
-    xmlNodePtr outer_key = xmlNewChild (outer_slot, NULL, BAD_CAST "slot:key", NULL);
-    xmlNodeAddContentLen (outer_key, BAD_CAST "outer", 5);
+    GncXmlNode* outer_key = gnc_xml_node_new_child (outer_slot, "slot:key");
+    gnc_xml_node_add_content (outer_key, "outer", 5);
 
-    xmlNodePtr outer_value = xmlNewChild (outer_slot, NULL, BAD_CAST "slot:value", NULL);
-    xmlSetProp (outer_value, BAD_CAST "type", BAD_CAST "frame");
+    GncXmlNode* outer_value = gnc_xml_node_new_child (outer_slot, "slot:value");
+    gnc_xml_node_set_prop (outer_value, "type", "frame");
 
-    xmlNodePtr inner_slot = kvp_slot ("inner", "integer", "7");
-    xmlAddChild (outer_value, inner_slot);
+    GncXmlNode* inner_slot = kvp_slot ("inner", "integer", "7");
+    outer_value->children = inner_slot;
 
     KvpFrame* frame = dom_tree_to_kvp_frame (frame_node);
     do_test (frame != nullptr, "dom_tree_to_kvp_frame: nested frame parses");
@@ -655,7 +651,7 @@ test_kvp_frame_nested (void)
         do_test (nested != nullptr, "dom_tree_to_kvp_frame: nested value is reachable by path");
         delete frame;
     }
-    xmlFreeNode (frame_node);
+    gnc_xml_node_free (frame_node);
 }
 
 /***********************************************************************/
@@ -665,7 +661,7 @@ test_kvp_frame_nested (void)
 static void
 test_comment_is_invisible (void)
 {
-    xmlNodePtr tree = parse_one_element ("test",
+    GncXmlNode* tree = parse_one_element ("test",
         "<test>before<!-- a comment in the middle -->after</test>");
     do_test (tree != nullptr, "comment: well-formed document with a comment parses");
     if (tree)
@@ -674,14 +670,14 @@ test_comment_is_invisible (void)
         do_test_args (text.has_value () && *text == "beforeafter",
                       "comment content is invisible to the reader", __FILE__, __LINE__,
                       "got [%s]", text ? text->c_str () : "(null)");
-        xmlFreeNode (tree);
+        gnc_xml_node_free (tree);
     }
 }
 
 static void
 test_cdata_becomes_plain_text (void)
 {
-    xmlNodePtr tree = parse_one_element ("test",
+    GncXmlNode* tree = parse_one_element ("test",
         "<test><![CDATA[<not-a-tag> & raw text]]></test>");
     do_test (tree != nullptr, "CDATA: well-formed document parses");
     if (tree)
@@ -690,38 +686,38 @@ test_cdata_becomes_plain_text (void)
         do_test_args (text.has_value () && *text == "<not-a-tag> & raw text",
                       "CDATA content comes through verbatim as plain text", __FILE__, __LINE__,
                       "got [%s]", text ? text->c_str () : "(null)");
-        xmlFreeNode (tree);
+        gnc_xml_node_free (tree);
     }
 }
 
 static void
 test_mixed_content_direct_siblings (void)
 {
-    xmlNodePtr tree = parse_one_element ("test", "<test>100<b/>200</test>");
+    GncXmlNode* tree = parse_one_element ("test", "<test>100<b/>200</test>");
     do_test (tree != nullptr, "mixed content: well-formed document parses");
     if (tree)
     {
-        xmlChar* text = xmlNodeListGetString (NULL, tree->xmlChildrenNode, TRUE);
-        do_test_args (g_strcmp0 ((char*)text, "100200") == 0,
+        char* text = gnc_xml_node_list_get_string (tree->children);
+        do_test_args (g_strcmp0 (text, "100200") == 0,
                       "mixed content: direct-sibling text around a nested element is captured",
-                      __FILE__, __LINE__, "got [%s]", (char*)text);
-        xmlFree (text);
-        xmlFreeNode (tree);
+                      __FILE__, __LINE__, "got [%s]", text);
+        g_free (text);
+        gnc_xml_node_free (tree);
     }
 }
 
 /***********************************************************************/
-/* 6. Well-formedness failures: caught by libxml2 before any xmlNode   */
+/* 6. Well-formedness failures: caught by libxml2 before any GncXmlNode */
 /*    is even built, unaffected by which tree type the reader uses.    */
 /***********************************************************************/
 
 static void
 expect_parse_failure (const char* label, const char* xml)
 {
-    xmlNodePtr tree = parse_one_element ("test", xml);
+    GncXmlNode* tree = parse_one_element ("test", xml);
     do_test_args (tree == nullptr, label, __FILE__, __LINE__, "expected rejection, got a tree");
     if (tree)
-        xmlFreeNode (tree);
+        gnc_xml_node_free (tree);
 }
 
 static void
@@ -741,10 +737,10 @@ test_well_formedness_failures (void)
            legal XML 1.0 character even when the bytes are otherwise
            valid UTF-8. */
         char raw[] = "<test>foo\x01""bar</test>";
-        xmlNodePtr tree = parse_one_element ("test", std::string (raw, sizeof (raw) - 1));
+        GncXmlNode* tree = parse_one_element ("test", std::string (raw, sizeof (raw) - 1));
         do_test (tree == nullptr, "illegal control byte in content is rejected");
         if (tree)
-            xmlFreeNode (tree);
+            gnc_xml_node_free (tree);
     }
 }
 

--- a/libgnucash/backend/xml/test/test-xml-reader-edge-cases.cpp
+++ b/libgnucash/backend/xml/test/test-xml-reader-edge-cases.cpp
@@ -1,0 +1,965 @@
+/********************************************************************\
+ * test-xml-reader-edge-cases.cpp -- exhaustive edge-case tests for *
+ * the libxml2-DOM-built XML v2 reader (sixtp-to-dom-parser.cpp,    *
+ * sixtp-dom-parsers.cpp)                                           *
+ *                                                                  *
+ * Copyright (C) 2026 The GnuCash Project                          *
+ *                                                                  *
+ * This program is free software; you can redistribute it and/or    *
+ * modify it under the terms of the GNU General Public License as   *
+ * published by the Free Software Foundation; either version 2 of   *
+ * the License, or (at your option) any later version.              *
+ *                                                                  *
+ * This program is distributed in the hope that it will be useful,  *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of   *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the    *
+ * GNU General Public License for more details.                     *
+ *                                                                  *
+ * You should have received a copy of the GNU General Public License*
+ * along with this program; if not, contact:                        *
+ *                                                                  *
+ * Free Software Foundation           Voice:  +1-617-542-5942       *
+ * 51 Franklin Street, Fifth Floor    Fax:    +1-617-542-2652       *
+ * Boston, MA  02110-1301,  USA       gnu@gnu.org                   *
+ *                                                                  *
+\********************************************************************/
+/** @file test-xml-reader-edge-cases.cpp
+ *
+ * This exercises the read side of the v2 XML backend (the real libxml2
+ * xmlNode tree that sixtp_dom_parser_new builds, plus dom_tree_to_*)
+ * against inputs a reader has to deal with: Unicode content split
+ * across SAX characters() chunk boundaries, CDATA, comments, mixed
+ * content, malformed/non-well-formed XML, and domain-level validation
+ * failures (unknown tags, missing required fields).
+ *
+ * This file is a deliberate baseline: it is meant to land on stable
+ * first, against the pre-existing xmlNodePtr/libxml2-DOM reader, so
+ * its pass/fail results are on record before the SAX-tree rewrite
+ * (which replaces xmlNodePtr with a lightweight GncXmlNode on the read
+ * side only) lands on top of it. That follow-up change adapts this
+ * same suite call-for-call to the new node type; an unchanged set of
+ * passes across both versions is the evidence that the rewrite altered
+ * no observable reader behavior.
+ *
+ * Two harnesses are used deliberately:
+ *
+ *  - A bare sixtp parser (parse_one_element/parse_wrapped), used for
+ *    every case that is *expected* to fail (well-formedness or
+ *    domain-validation failures). This mirrors gnc_read_example_account's
+ *    wrapping pattern and stops short of a full QofSession/QofBook
+ *    load-and-destroy cycle.
+ *  - A full qof_session_load, used only for inputs that are expected to
+ *    *succeed*, to prove the parsed data round-trips into real Account
+ *    objects end to end.
+ *
+ * This split is intentional, not incidental: a full QofBook that
+ * registers business objects (via cashobjects_register) and is then
+ * destroyed after a *partially failed* account parse currently crashes
+ * in gncTaxTable's per-book teardown (_gncTaxTableDestroy). This is a
+ * pre-existing bug in QofSession::load()'s failure path (see the
+ * "IMPORTANT" note on qof_session_load's doc comment in qofsession.h):
+ * on load failure it destroys and replaces the session's QofBook out
+ * from under any pointer callers already hold to it. It reproduces
+ * identically regardless of which xmlNode type the reader builds, so
+ * it is unrelated to this reader and intentionally not exercised here.
+ */
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <unistd.h>
+#include <config.h>
+#include <string.h>
+#include <stdlib.h>
+#include <optional>
+#include <string>
+
+#include <cashobjects.h>
+#include <gnc-engine.h>
+#include <gnc-uri-utils.h>
+#include <Account.h>
+#include <kvp-frame.hpp>
+
+#include "qof.h"
+#include "sixtp.h"
+#include "sixtp-parsers.h"
+#include "sixtp-utils.h"
+#include "sixtp-dom-parsers.h"
+#include "gnc-xml.h"
+#include "io-gncxml-gen.h"
+#include "io-gncxml-v2.h"
+
+#include <test-stuff.h>
+#include <test-engine-stuff.h>
+
+extern KvpFrame* dom_tree_to_kvp_frame (xmlNodePtr node);
+
+#define GNC_LIB_NAME "gncmod-backend-xml"
+#define GNC_LIB_REL_PATH "xml"
+
+/***********************************************************************/
+/* Small helpers for building xmlNode trees by hand, and for driving
+   a real sixtp parser over a raw XML string without going through a
+   full QofSession. */
+
+static xmlNodePtr
+build_leaf (const char* tag, const char* text)
+{
+    xmlNodePtr node = xmlNewNode (NULL, BAD_CAST tag);
+    if (text)
+        xmlNodeAddContentLen (node, BAD_CAST text, strlen (text));
+    return node;
+}
+
+struct capture_pdata
+{
+    xmlNodePtr tree = nullptr;
+};
+
+static gboolean
+capture_end_handler (gpointer data_for_children, GSList*, GSList*,
+                     gpointer parent_data, gpointer global_data,
+                     gpointer* result, const gchar* tag)
+{
+    if (parent_data || !tag)
+        return TRUE;
+
+    auto pdata = static_cast<capture_pdata*> (global_data);
+    pdata->tree = static_cast<xmlNodePtr> (data_for_children);
+    /* Hand ownership to pdata->tree; caller frees it. */
+    return TRUE;
+}
+
+/* Parses a single top-level element ('tag') out of 'xml' and returns
+   its captured xmlNode tree (caller must xmlFreeNode it), or nullptr
+   if parsing failed (malformed XML, wrong root tag, etc).
+
+   The dom_parser is deliberately nested one level under a synthetic
+   wrapping tag rather than being used bare as the top-level sixtp.
+   sixtp_context_new's one-time bootstrap call passes the *address* of
+   its own top_frame_data field as parent_data (not the NULL that
+   top_level_data actually was), so a dom_parser's end_handler would
+   see a permanently non-NULL parent_data and skip every callback if it
+   were the literal top-level parser - it would never fire, regardless
+   of how well-formed the input is. Nesting it under a real tag avoids
+   relying on that bootstrap call at all: the outer wrapper's generic
+   (non-DOM) start/end handling supplies a genuine NULL parent_data to
+   the dom_parser's own first invocation. */
+static xmlNodePtr
+parse_one_element (const char* tag, const std::string& xml)
+{
+    capture_pdata pdata;
+
+    sixtp* top_parser = sixtp_new ();
+    sixtp_add_some_sub_parsers (top_parser, TRUE, tag,
+                               sixtp_dom_parser_new (capture_end_handler, NULL, NULL),
+                               NULL, NULL);
+
+    char filename[] = "/tmp/gnc_xml_test_XXXXXX";
+    int fd = g_mkstemp (filename);
+    write (fd, xml.data (), xml.size ());
+    close (fd);
+
+    gpointer parse_result = NULL;
+    gboolean ok = sixtp_parse_file (top_parser, filename, NULL, &pdata, &parse_result);
+
+    g_unlink (filename);
+    /* Not sixtp_destroy(top_parser): its "tag" child is a
+       sixtp_dom_parser_new() result, self-referential via
+       SIXTP_MAGIC_CATCHER, which double-frees on destroy (see
+       parse_wrapped's comment below for the same landmine). */
+
+    if (!ok)
+    {
+        if (pdata.tree)
+            xmlFreeNode (pdata.tree);
+        return nullptr;
+    }
+    return pdata.tree;
+}
+
+/* Wraps 'inner_xml' (one or more sibling elements) under a synthetic
+   root and a nested named sub-parser for 'child_tag', exactly the way
+   gnc_read_example_account/io-gncxml-v2.cpp nest a *_sixtp_parser_create()
+   under a real tag - this is what actually exercises the object-level
+   end_handler (dom_tree_to_account etc.), unlike using the object
+   parser bare as the top-level sixtp (which never invokes it; see
+   sixtp-stack.cpp's parent_data handling of the bootstrap call).
+ */
+struct wrapped_result
+{
+    gboolean ok = FALSE;
+    int callback_count = 0;
+    gboolean object_created = FALSE;
+};
+
+static gboolean
+wrapped_cb (const char* tag, gpointer globaldata, gpointer data)
+{
+    auto res = static_cast<wrapped_result*> (globaldata);
+    res->callback_count++;
+    res->object_created = (data != NULL);
+    return TRUE;
+}
+
+static wrapped_result
+parse_wrapped (sixtp* (*parser_create) (void), const char* child_tag,
+              const std::string& xml, QofBook* book)
+{
+    wrapped_result res;
+
+    sixtp* top_parser = sixtp_new ();
+    sixtp* main_parser = sixtp_new ();
+    sixtp_add_some_sub_parsers (top_parser, TRUE, "gnc-wrapper", main_parser, NULL, NULL);
+    sixtp_add_some_sub_parsers (main_parser, TRUE, child_tag, parser_create (), NULL, NULL);
+
+    char filename[] = "/tmp/gnc_xml_test_XXXXXX";
+    int fd = g_mkstemp (filename);
+    write (fd, xml.data (), xml.size ());
+    close (fd);
+
+    res.ok = gnc_xml_parse_file (top_parser, filename, wrapped_cb, &res, book);
+
+    g_unlink (filename);
+    /* Not sixtp_destroy(top_parser): child_tag's parser_create() result
+       is itself a sixtp_dom_parser_new() (self-referential via
+       SIXTP_MAGIC_CATCHER), so destroying this tree hits the same
+       double-free landmine explained in parse_one_element above. */
+    return res;
+}
+
+/***********************************************************************/
+/* 1. xmlNode primitive behavior: UTF-8, chunking, attributes           */
+/***********************************************************************/
+
+static void
+test_utf8_round_trip (void)
+{
+    /* 2-byte, 3-byte and 4-byte UTF-8 sequences in one string. */
+    const char* utf8 = "caf\xC3\xA9 \xE4\xB8\xAD\xE6\x96\x87 \xF0\x9F\x98\x80";
+
+    xmlNodePtr node = build_leaf ("test", utf8);
+    auto text = dom_tree_to_text (node);
+    do_test (text.has_value () && *text == utf8,
+             "UTF-8 content round-trips through a single add_content call");
+    xmlFreeNode (node);
+}
+
+static void
+test_utf8_chunked_across_codepoint_boundary (void)
+{
+    const char* utf8 = "caf\xC3\xA9 \xE4\xB8\xAD\xE6\x96\x87 \xF0\x9F\x98\x80";
+    size_t len = strlen (utf8);
+
+    /* Split at every possible byte offset, including offsets that land
+       mid-way through a multi-byte UTF-8 sequence. sixtp's characters()
+       callback delivers a byte length, not a character count, and the
+       xmlNode content buffer must reassemble correctly regardless of
+       where a SAX chunk boundary happens to fall. This mirrors exactly
+       how dom_chars_handler feeds each chunk to xmlNodeAddContentLen in
+       production. */
+    gboolean all_ok = TRUE;
+    for (size_t split = 0; split <= len; ++split)
+    {
+        xmlNodePtr node = xmlNewNode (NULL, BAD_CAST "test");
+        xmlNodeAddContentLen (node, BAD_CAST utf8, (int)split);
+        xmlNodeAddContentLen (node, BAD_CAST (utf8 + split), (int)(len - split));
+        auto text = dom_tree_to_text (node);
+        if (!text || *text != utf8)
+        {
+            all_ok = FALSE;
+            failure_args ("chunked UTF-8 reassembly", __FILE__, __LINE__,
+                          "split at byte %zu produced [%s]",
+                          split, text ? text->c_str () : "(null)");
+        }
+        xmlFreeNode (node);
+    }
+    do_test (all_ok, "UTF-8 reassembles correctly for every possible chunk split point");
+}
+
+static void
+test_attribute_set_get (void)
+{
+    xmlNodePtr node = xmlNewNode (NULL, BAD_CAST "test");
+
+    do_test (xmlGetProp (node, BAD_CAST "missing") == NULL,
+             "missing attribute lookup returns NULL");
+
+    xmlSetProp (node, BAD_CAST "version", BAD_CAST "2.0.0");
+    xmlChar* v = xmlGetProp (node, BAD_CAST "version");
+    do_test (v && g_strcmp0 ((char*)v, "2.0.0") == 0, "attribute set/get round-trips");
+    xmlFree (v);
+
+    /* overwrite */
+    xmlSetProp (node, BAD_CAST "version", BAD_CAST "3.0.0");
+    v = xmlGetProp (node, BAD_CAST "version");
+    do_test (v && g_strcmp0 ((char*)v, "3.0.0") == 0, "re-setting an attribute overwrites it, doesn't duplicate");
+    xmlFree (v);
+
+    /* unicode attribute value */
+    xmlSetProp (node, BAD_CAST "note", BAD_CAST "caf\xC3\xA9");
+    v = xmlGetProp (node, BAD_CAST "note");
+    do_test (v && g_strcmp0 ((char*)v, "caf\xC3\xA9") == 0, "UTF-8 attribute value round-trips");
+    xmlFree (v);
+
+    xmlFreeNode (node);
+}
+
+static void
+test_node_list_get_string_sibling_only (void)
+{
+    /* <leaf>100<b/>200</leaf> - xmlNodeListGetString walks direct
+       siblings only, it does not recurse into <b>'s own children.
+       Text that IS a direct sibling of a nested element (the "200"
+       here) is still correctly captured even though <b/> sits between
+       the two text runs. */
+    xmlNodePtr leaf = xmlNewNode (NULL, BAD_CAST "leaf");
+    xmlNodeAddContentLen (leaf, BAD_CAST "100", 3);
+    xmlNewChild (leaf, NULL, BAD_CAST "b", NULL);
+    xmlNodeAddContentLen (leaf, BAD_CAST "200", 3);
+
+    xmlChar* result = xmlNodeListGetString (NULL, leaf->xmlChildrenNode, TRUE);
+    do_test_args (g_strcmp0 ((char*)result, "100200") == 0,
+                  "xmlNodeListGetString", __FILE__, __LINE__,
+                  "expected [100200], got [%s]", (char*)result);
+    xmlFree (result);
+    xmlFreeNode (leaf);
+}
+
+static void
+test_node_list_get_string_does_not_recurse (void)
+{
+    /* <leaf>100<b>NESTED</b>200</leaf> - text genuinely nested INSIDE
+       <b> is not visible to a sibling-only walk. */
+    xmlNodePtr leaf = xmlNewNode (NULL, BAD_CAST "leaf");
+    xmlNodeAddContentLen (leaf, BAD_CAST "100", 3);
+    xmlNodePtr b = xmlNewChild (leaf, NULL, BAD_CAST "b", NULL);
+    xmlNodeAddContentLen (b, BAD_CAST "NESTED", 6);
+    xmlNodeAddContentLen (leaf, BAD_CAST "200", 3);
+
+    xmlChar* result = xmlNodeListGetString (NULL, leaf->xmlChildrenNode, TRUE);
+    do_test_args (g_strcmp0 ((char*)result, "100200") == 0,
+                  "xmlNodeListGetString ignores nested element text",
+                  __FILE__, __LINE__, "expected [100200], got [%s]", (char*)result);
+    xmlFree (result);
+    xmlFreeNode (leaf);
+}
+
+static void
+test_node_free_null_is_safe (void)
+{
+    xmlFreeNode (NULL);
+    success ("xmlFreeNode(NULL) does not crash");
+}
+
+static void
+test_empty_element_has_no_children (void)
+{
+    xmlNodePtr node = xmlNewNode (NULL, BAD_CAST "empty");
+    do_test (node->children == NULL, "a freshly created node has no children");
+    do_test (node->properties == NULL, "a freshly created node has no attributes");
+    do_test (node->next == NULL && node->prev == NULL, "a freshly created node has no siblings");
+    xmlFreeNode (node);
+}
+
+/***********************************************************************/
+/* 2. xmlReadMemory: fidelity of a standalone parse used by tests       */
+/***********************************************************************/
+
+static void
+test_from_libxml_preserves_structure (void)
+{
+    const char* xml_text = "<root attr1=\"v1\" attr2=\"v2\"><a>text-a</a><b>text-b</b></root>";
+    xmlDocPtr doc = xmlReadMemory (xml_text, strlen (xml_text), "test.xml", NULL, 0);
+    xmlNodePtr root = xmlDocGetRootElement (doc);
+
+    do_test (g_strcmp0 ((char*)root->name, "root") == 0, "xmlReadMemory preserves element name");
+
+    xmlChar* a1 = xmlGetProp (root, BAD_CAST "attr1");
+    xmlChar* a2 = xmlGetProp (root, BAD_CAST "attr2");
+    do_test (a1 && g_strcmp0 ((char*)a1, "v1") == 0, "xmlReadMemory preserves first attribute");
+    do_test (a2 && g_strcmp0 ((char*)a2, "v2") == 0, "xmlReadMemory preserves second attribute");
+    xmlFree (a1);
+    xmlFree (a2);
+
+    do_test (root->children != NULL && g_strcmp0 ((char*)root->children->name, "a") == 0,
+             "xmlReadMemory preserves first child");
+    do_test (root->children->next != NULL && g_strcmp0 ((char*)root->children->next->name, "b") == 0,
+             "xmlReadMemory preserves second child as a sibling");
+
+    auto text_a = dom_tree_to_text (root->children);
+    do_test (text_a.has_value () && *text_a == "text-a", "xmlReadMemory preserves child text content");
+
+    xmlFreeDoc (doc);
+}
+
+/***********************************************************************/
+/* 3. dom_tree_to_* primitive converters: valid and invalid input       */
+/***********************************************************************/
+
+static void
+test_dom_tree_to_guid_variants (void)
+{
+    GncGUID* gp = guid_new ();
+    GncGUID g = *gp;
+    guid_free (gp);
+    gchar buf[GUID_ENCODING_LENGTH + 1];
+    guid_to_string_buff (&g, buf);
+
+    {
+        xmlNodePtr node = build_leaf ("id", buf);
+        xmlSetProp (node, BAD_CAST "type", BAD_CAST "guid");
+        auto result = dom_tree_to_guid (node);
+        do_test (result.has_value () && guid_equal (&*result, &g), "dom_tree_to_guid: type=\"guid\"");
+        xmlFreeNode (node);
+    }
+    {
+        xmlNodePtr node = build_leaf ("id", buf);
+        xmlSetProp (node, BAD_CAST "type", BAD_CAST "new");
+        auto result = dom_tree_to_guid (node);
+        do_test (result.has_value () && guid_equal (&*result, &g), "dom_tree_to_guid: type=\"new\"");
+        xmlFreeNode (node);
+    }
+    {
+        /* missing type attribute entirely */
+        xmlNodePtr node = build_leaf ("id", buf);
+        auto result = dom_tree_to_guid (node);
+        do_test (!result.has_value (), "dom_tree_to_guid: missing type attribute is rejected");
+        xmlFreeNode (node);
+    }
+    {
+        /* unrecognized type attribute */
+        xmlNodePtr node = build_leaf ("id", buf);
+        xmlSetProp (node, BAD_CAST "type", BAD_CAST "bogus");
+        auto result = dom_tree_to_guid (node);
+        do_test (!result.has_value (), "dom_tree_to_guid: unrecognized type attribute is rejected");
+        xmlFreeNode (node);
+    }
+    {
+        /* malformed guid text (wrong length / non-hex) */
+        xmlNodePtr node = build_leaf ("id", "not-a-valid-guid");
+        xmlSetProp (node, BAD_CAST "type", BAD_CAST "guid");
+        auto result = dom_tree_to_guid (node);
+        do_test (!result.has_value (), "dom_tree_to_guid: malformed guid text is rejected");
+        xmlFreeNode (node);
+    }
+}
+
+static void
+test_dom_tree_to_boolean_variants (void)
+{
+    struct { const char* text; gboolean expect_ok; gboolean expect_val; } cases[] = {
+        { "true",  TRUE,  TRUE  },
+        { "false", TRUE,  FALSE },
+        { "TRUE",  TRUE,  TRUE  },
+        { "FaLsE", TRUE,  FALSE },
+        { "yes",   FALSE, FALSE },
+        { "1",     FALSE, FALSE },
+        { "",      FALSE, FALSE },
+    };
+    for (auto& c : cases)
+    {
+        xmlNodePtr node = build_leaf ("flag", c.text);
+        gboolean val = FALSE;
+        gboolean ok = dom_tree_to_boolean (node, &val);
+        do_test_args (ok == c.expect_ok && (!ok || val == c.expect_val),
+                      "dom_tree_to_boolean", __FILE__, __LINE__,
+                      "text=[%s] expected ok=%d val=%d, got ok=%d val=%d",
+                      c.text, c.expect_ok, c.expect_val, ok, val);
+        xmlFreeNode (node);
+    }
+}
+
+static void
+test_dom_tree_to_number_variants (void)
+{
+    {
+        xmlNodePtr node = build_leaf ("n", "42");
+        gint64 v = 0;
+        do_test (dom_tree_to_integer (node, &v) && v == 42, "dom_tree_to_integer: plain value");
+        xmlFreeNode (node);
+    }
+    {
+        xmlNodePtr node = build_leaf ("n", "-42");
+        gint64 v = 0;
+        do_test (dom_tree_to_integer (node, &v) && v == -42, "dom_tree_to_integer: negative value");
+        xmlFreeNode (node);
+    }
+    {
+        xmlNodePtr node = build_leaf ("n", "  42  ");
+        gint64 v = 0;
+        do_test (dom_tree_to_integer (node, &v) && v == 42, "dom_tree_to_integer: whitespace-padded value");
+        xmlFreeNode (node);
+    }
+    {
+        xmlNodePtr node = build_leaf ("n", "not-a-number");
+        gint64 v = 0;
+        do_test (!dom_tree_to_integer (node, &v), "dom_tree_to_integer: garbage text is rejected");
+        xmlFreeNode (node);
+    }
+    {
+        xmlNodePtr node = build_leaf ("n", "-1");
+        guint v = 0;
+        do_test (!dom_tree_to_guint (node, &v), "dom_tree_to_guint: negative value is rejected");
+        xmlFreeNode (node);
+    }
+    {
+        xmlNodePtr node = build_leaf ("n", "70000");
+        guint16 v = 0;
+        do_test (!dom_tree_to_guint16 (node, &v), "dom_tree_to_guint16: overflow (>65535) is rejected");
+        xmlFreeNode (node);
+    }
+    {
+        xmlNodePtr node = build_leaf ("n", "123/100");
+        gnc_numeric v = gnc_numeric_zero ();
+        v = dom_tree_to_gnc_numeric (node);
+        do_test (!gnc_numeric_check (v) && gnc_numeric_equal (v, gnc_numeric_create (123, 100)),
+                 "dom_tree_to_gnc_numeric: valid ratio");
+        xmlFreeNode (node);
+    }
+    {
+        xmlNodePtr node = build_leaf ("n", "garbage");
+        gnc_numeric v = dom_tree_to_gnc_numeric (node);
+        do_test (gnc_numeric_equal (v, gnc_numeric_zero ()),
+                 "dom_tree_to_gnc_numeric: garbage text falls back to zero");
+        xmlFreeNode (node);
+    }
+}
+
+static void
+test_dom_tree_to_time64_variants (void)
+{
+    {
+        xmlNodePtr node = xmlNewNode (NULL, BAD_CAST "date-posted");
+        xmlNodePtr ts = xmlNewChild (node, NULL, BAD_CAST "ts:date", NULL);
+        xmlNodeAddContentLen (ts, BAD_CAST "2020-01-01 00:00:00 +0000", 25);
+        time64 t = dom_tree_to_time64 (node);
+        do_test (t != INT64_MAX, "dom_tree_to_time64: single ts:date parses");
+        xmlFreeNode (node);
+    }
+    {
+        /* missing ts:date entirely */
+        xmlNodePtr node = xmlNewNode (NULL, BAD_CAST "date-posted");
+        time64 t = dom_tree_to_time64 (node);
+        do_test (t == INT64_MAX, "dom_tree_to_time64: missing ts:date returns INT64_MAX");
+        do_test (!dom_tree_valid_time64 (t, BAD_CAST "date-posted"), "dom_tree_valid_time64 rejects INT64_MAX");
+        xmlFreeNode (node);
+    }
+    {
+        /* duplicate ts:date is explicitly rejected by dom_tree_to_time64 */
+        xmlNodePtr node = xmlNewNode (NULL, BAD_CAST "date-posted");
+        xmlNodePtr ts1 = xmlNewChild (node, NULL, BAD_CAST "ts:date", NULL);
+        xmlNodeAddContentLen (ts1, BAD_CAST "2020-01-01 00:00:00 +0000", 25);
+        xmlNodePtr ts2 = xmlNewChild (node, NULL, BAD_CAST "ts:date", NULL);
+        xmlNodeAddContentLen (ts2, BAD_CAST "2021-01-01 00:00:00 +0000", 25);
+        time64 t = dom_tree_to_time64 (node);
+        do_test (t == INT64_MAX, "dom_tree_to_time64: duplicate ts:date is rejected");
+        xmlFreeNode (node);
+    }
+}
+
+static void
+test_dom_tree_to_gdate_variants (void)
+{
+    {
+        xmlNodePtr node = xmlNewNode (NULL, BAD_CAST "start");
+        xmlNodePtr gd = xmlNewChild (node, NULL, BAD_CAST "gdate", NULL);
+        xmlNodeAddContentLen (gd, BAD_CAST "2020-04-03", 10);
+        GDate* d = dom_tree_to_gdate (node);
+        do_test (d && g_date_valid (*&d) && g_date_get_year (d) == 2020, "dom_tree_to_gdate: valid date");
+        if (d) g_date_free (d);
+        xmlFreeNode (node);
+    }
+    {
+        xmlNodePtr node = xmlNewNode (NULL, BAD_CAST "start");
+        xmlNodePtr gd = xmlNewChild (node, NULL, BAD_CAST "gdate", NULL);
+        xmlNodeAddContentLen (gd, BAD_CAST "not-a-date", 10);
+        GDate* d = dom_tree_to_gdate (node);
+        do_test (d == NULL, "dom_tree_to_gdate: malformed date text is rejected");
+        xmlFreeNode (node);
+    }
+    {
+        xmlNodePtr node = xmlNewNode (NULL, BAD_CAST "start");
+        GDate* d = dom_tree_to_gdate (node);
+        do_test (d == NULL, "dom_tree_to_gdate: missing gdate child is rejected");
+        xmlFreeNode (node);
+    }
+}
+
+/***********************************************************************/
+/* 4. KVP frame round-trips: nested frames, lists, every value type     */
+/***********************************************************************/
+
+static xmlNodePtr
+kvp_slot (const char* key, const char* type, const char* text_value)
+{
+    xmlNodePtr slot = xmlNewNode (NULL, BAD_CAST "slot");
+    xmlNodePtr k = xmlNewChild (slot, NULL, BAD_CAST "slot:key", NULL);
+    xmlNodeAddContentLen (k, BAD_CAST key, strlen (key));
+    xmlNodePtr v = xmlNewChild (slot, NULL, BAD_CAST "slot:value", NULL);
+    xmlSetProp (v, BAD_CAST "type", BAD_CAST type);
+    xmlNodeAddContentLen (v, BAD_CAST text_value, strlen (text_value));
+    return slot;
+}
+
+static void
+test_kvp_frame_scalar_types (void)
+{
+    struct { const char* type; const char* text; } cases[] = {
+        { "integer", "42" },
+        { "double",  "3.5" },
+        { "string",  "hello world" },
+    };
+    for (auto& c : cases)
+    {
+        xmlNodePtr frame_node = xmlNewNode (NULL, BAD_CAST "slots");
+        xmlNodePtr slot = kvp_slot ("k", c.type, c.text);
+        xmlAddChild (frame_node, slot);
+
+        KvpFrame* frame = dom_tree_to_kvp_frame (frame_node);
+        do_test_args (frame != nullptr, "dom_tree_to_kvp_frame scalar", __FILE__, __LINE__,
+                      "type=%s", c.type);
+        if (frame)
+        {
+            auto val = frame->get_slot ({"k"});
+            do_test_args (val != nullptr, "dom_tree_to_kvp_frame scalar has value",
+                          __FILE__, __LINE__, "type=%s", c.type);
+            delete frame;
+        }
+        xmlFreeNode (frame_node);
+    }
+}
+
+static void
+test_kvp_frame_nested (void)
+{
+    /* <slots><slot><slot:key>outer</slot:key><slot:value type="frame">
+         <slot><slot:key>inner</slot:key><slot:value type="integer">7</slot:value></slot>
+       </slot:value></slot></slots> */
+    xmlNodePtr frame_node = xmlNewNode (NULL, BAD_CAST "slots");
+    xmlNodePtr outer_slot = xmlNewNode (NULL, BAD_CAST "slot");
+    xmlAddChild (frame_node, outer_slot);
+
+    xmlNodePtr outer_key = xmlNewChild (outer_slot, NULL, BAD_CAST "slot:key", NULL);
+    xmlNodeAddContentLen (outer_key, BAD_CAST "outer", 5);
+
+    xmlNodePtr outer_value = xmlNewChild (outer_slot, NULL, BAD_CAST "slot:value", NULL);
+    xmlSetProp (outer_value, BAD_CAST "type", BAD_CAST "frame");
+
+    xmlNodePtr inner_slot = kvp_slot ("inner", "integer", "7");
+    xmlAddChild (outer_value, inner_slot);
+
+    KvpFrame* frame = dom_tree_to_kvp_frame (frame_node);
+    do_test (frame != nullptr, "dom_tree_to_kvp_frame: nested frame parses");
+    if (frame)
+    {
+        auto nested = frame->get_slot ({"outer", "inner"});
+        do_test (nested != nullptr, "dom_tree_to_kvp_frame: nested value is reachable by path");
+        delete frame;
+    }
+    xmlFreeNode (frame_node);
+}
+
+/***********************************************************************/
+/* 5. Comments, CDATA, and mixed content through the real sixtp parser  */
+/***********************************************************************/
+
+static void
+test_comment_is_invisible (void)
+{
+    xmlNodePtr tree = parse_one_element ("test",
+        "<test>before<!-- a comment in the middle -->after</test>");
+    do_test (tree != nullptr, "comment: well-formed document with a comment parses");
+    if (tree)
+    {
+        auto text = dom_tree_to_text (tree);
+        do_test_args (text.has_value () && *text == "beforeafter",
+                      "comment content is invisible to the reader", __FILE__, __LINE__,
+                      "got [%s]", text ? text->c_str () : "(null)");
+        xmlFreeNode (tree);
+    }
+}
+
+static void
+test_cdata_becomes_plain_text (void)
+{
+    xmlNodePtr tree = parse_one_element ("test",
+        "<test><![CDATA[<not-a-tag> & raw text]]></test>");
+    do_test (tree != nullptr, "CDATA: well-formed document parses");
+    if (tree)
+    {
+        auto text = dom_tree_to_text (tree);
+        do_test_args (text.has_value () && *text == "<not-a-tag> & raw text",
+                      "CDATA content comes through verbatim as plain text", __FILE__, __LINE__,
+                      "got [%s]", text ? text->c_str () : "(null)");
+        xmlFreeNode (tree);
+    }
+}
+
+static void
+test_mixed_content_direct_siblings (void)
+{
+    xmlNodePtr tree = parse_one_element ("test", "<test>100<b/>200</test>");
+    do_test (tree != nullptr, "mixed content: well-formed document parses");
+    if (tree)
+    {
+        xmlChar* text = xmlNodeListGetString (NULL, tree->xmlChildrenNode, TRUE);
+        do_test_args (g_strcmp0 ((char*)text, "100200") == 0,
+                      "mixed content: direct-sibling text around a nested element is captured",
+                      __FILE__, __LINE__, "got [%s]", (char*)text);
+        xmlFree (text);
+        xmlFreeNode (tree);
+    }
+}
+
+/***********************************************************************/
+/* 6. Well-formedness failures: caught by libxml2 before any xmlNode   */
+/*    is even built, unaffected by which tree type the reader uses.    */
+/***********************************************************************/
+
+static void
+expect_parse_failure (const char* label, const char* xml)
+{
+    xmlNodePtr tree = parse_one_element ("test", xml);
+    do_test_args (tree == nullptr, label, __FILE__, __LINE__, "expected rejection, got a tree");
+    if (tree)
+        xmlFreeNode (tree);
+}
+
+static void
+test_well_formedness_failures (void)
+{
+    expect_parse_failure ("mismatched closing tag is rejected",
+        "<test><a>x</mismatched></test>");
+    expect_parse_failure ("truncated/unclosed document is rejected",
+        "<test><a>x");
+    expect_parse_failure ("unescaped bare ampersand is rejected",
+        "<test>foo & bar</test>");
+    expect_parse_failure ("empty document is rejected", "");
+    expect_parse_failure ("non-XML content is rejected", "this is not xml at all\n");
+
+    {
+        /* Illegal raw control byte (0x01) inside element content: not a
+           legal XML 1.0 character even when the bytes are otherwise
+           valid UTF-8. */
+        char raw[] = "<test>foo\x01""bar</test>";
+        xmlNodePtr tree = parse_one_element ("test", std::string (raw, sizeof (raw) - 1));
+        do_test (tree == nullptr, "illegal control byte in content is rejected");
+        if (tree)
+            xmlFreeNode (tree);
+    }
+}
+
+/***********************************************************************/
+/* 7. Domain-level validation: unknown tags, missing required fields,   */
+/*    exercised through the real gnc:account parser nested under a     */
+/*    wrapping tag (not used bare as the top-level sixtp).              */
+/***********************************************************************/
+
+static void
+test_account_domain_validation (void)
+{
+    QofBook* book = qof_book_new ();
+
+    {
+        wrapped_result res = parse_wrapped (
+            gnc_account_sixtp_parser_create, "gnc:account",
+            "<gnc-wrapper><gnc:account version=\"2.0.0\">"
+            "<act:name>Checking</act:name>"
+            "<act:id type=\"guid\">aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</act:id>"
+            "<act:type>ASSET</act:type>"
+            "</gnc:account></gnc-wrapper>",
+            book);
+        do_test (res.ok && res.callback_count == 1 && res.object_created,
+                 "a complete, valid gnc:account is accepted and creates an object");
+    }
+    {
+        wrapped_result res = parse_wrapped (
+            gnc_account_sixtp_parser_create, "gnc:account",
+            "<gnc-wrapper><gnc:account version=\"2.0.0\">"
+            "<act:name>Checking</act:name>"
+            "<act:id type=\"guid\">bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb</act:id>"
+            "<act:type>ASSET</act:type>"
+            "<act:bogus>unrecognized child element</act:bogus>"
+            "</gnc:account></gnc-wrapper>",
+            book);
+        do_test (!res.ok && !res.object_created,
+                 "an account with an unrecognized child tag is rejected, not silently accepted");
+    }
+    {
+        wrapped_result res = parse_wrapped (
+            gnc_account_sixtp_parser_create, "gnc:account",
+            "<gnc-wrapper><gnc:account version=\"2.0.0\">"
+            "<act:name>Checking</act:name>"
+            "<act:id type=\"guid\">cccccccccccccccccccccccccccccccc</act:id>"
+            /* act:type deliberately omitted - it is a required field */
+            "</gnc:account></gnc-wrapper>",
+            book);
+        do_test (!res.ok && !res.object_created,
+                 "an account missing a required field (act:type) is rejected");
+    }
+
+    qof_book_destroy (book);
+}
+
+/***********************************************************************/
+/* 8. Full end-to-end session load: only for inputs that should SUCCEED */
+/*    (see the file-level comment for why failures use the harness      */
+/*    above instead of a full QofSession/QofBook cycle).                */
+/***********************************************************************/
+
+static std::string
+wrap_minimal_book (const std::string& account_xml, int account_count, int call_num)
+{
+    char root_guid[33], child_guid[33], book_guid[33];
+    snprintf (root_guid, sizeof (root_guid), "%032x", call_num * 3 + 1);
+    snprintf (child_guid, sizeof (child_guid), "%032x", call_num * 3 + 2);
+    snprintf (book_guid, sizeof (book_guid), "%032x", call_num * 3 + 3);
+
+    std::string xml =
+        "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n"
+        "<gnc-v2\n"
+        "  xmlns:gnc=\"http://www.gnucash.org/XML/gnc\"\n"
+        "  xmlns:book=\"http://www.gnucash.org/XML/book\"\n"
+        "  xmlns:act=\"http://www.gnucash.org/XML/act\"\n"
+        "  xmlns:cd=\"http://www.gnucash.org/XML/cd\">\n"
+        "<gnc:count-data cd:type=\"book\">1</gnc:count-data>\n"
+        "<gnc:book version=\"2.0.0\">\n"
+        "<book:id type=\"guid\">" + std::string (book_guid) + "</book:id>\n"
+        "<gnc:count-data cd:type=\"commodity\">0</gnc:count-data>\n"
+        "<gnc:count-data cd:type=\"account\">" + std::to_string (account_count) + "</gnc:count-data>\n"
+        "<gnc:count-data cd:type=\"transaction\">0</gnc:count-data>\n"
+        "<gnc:account version=\"2.0.0\">\n"
+        "<act:name>ROOT</act:name>\n"
+        "<act:id type=\"guid\">" + std::string (root_guid) + "</act:id>\n"
+        "<act:type>ROOT</act:type>\n"
+        "</gnc:account>\n";
+
+    std::string subst_account = account_xml;
+    size_t pos;
+    while ((pos = subst_account.find ("CHILDGUID")) != std::string::npos)
+        subst_account.replace (pos, 9, child_guid);
+    while ((pos = subst_account.find ("ROOTGUID")) != std::string::npos)
+        subst_account.replace (pos, 8, root_guid);
+
+    xml += subst_account;
+    xml += "</gnc:book>\n</gnc-v2>\n";
+    return xml;
+}
+
+static std::string
+make_valid_account (const std::string& name_elem)
+{
+    return
+        "<gnc:account version=\"2.0.0\">\n"
+        + name_elem +
+        "<act:id type=\"guid\">CHILDGUID</act:id>\n"
+        "<act:type>ASSET</act:type>\n"
+        "<act:commodity><cmdty:space>ISO4217</cmdty:space><cmdty:id>USD</cmdty:id></act:commodity>\n"
+        "<act:commodity-scu>100</act:commodity-scu>\n"
+        "<act:parent type=\"guid\">ROOTGUID</act:parent>\n"
+        "</gnc:account>\n";
+}
+
+static int g_session_call_num = 0;
+
+static void
+load_and_check_account_name (const char* label, const std::string& name_elem,
+                             const char* expect_name)
+{
+    g_session_call_num++;
+    std::string xml = wrap_minimal_book (make_valid_account (name_elem), 2, g_session_call_num);
+
+    char filename[] = "/tmp/gnc_xml_test_XXXXXX.gnucash";
+    int fd = g_mkstemp (filename);
+    write (fd, xml.data (), xml.size ());
+    close (fd);
+
+    QofBook* book = qof_book_new ();
+    QofSession* session = qof_session_new (book);
+    char* url = gnc_uri_normalize_uri (filename, FALSE);
+    qof_session_begin (session, url, SESSION_READ_ONLY);
+    g_free (url);
+    qof_session_load (session, NULL);
+
+    do_test_args (qof_session_get_error (session) == ERR_BACKEND_NO_ERR,
+                  label, __FILE__, __LINE__, "session load failed for a well-formed file");
+
+    Account* root = gnc_book_get_root_account (book);
+    GList* children = gnc_account_get_children (root);
+    gboolean found = FALSE;
+    for (GList* n = children; n; n = n->next)
+    {
+        Account* a = (Account*) n->data;
+        if (g_strcmp0 (xaccAccountGetName (a), expect_name) == 0)
+            found = TRUE;
+    }
+    g_list_free (children);
+    do_test_args (found, label, __FILE__, __LINE__,
+                  "expected account named [%s] not found after full session load", expect_name);
+
+    qof_session_end (session);
+    /* Deliberately not calling qof_book_destroy here for a book that
+       went through a full session load with business objects
+       registered - see the file-level comment. */
+    g_unlink (filename);
+}
+
+static void
+test_full_session_load_edge_cases (void)
+{
+    load_and_check_account_name ("session load: plain ASCII account name",
+                                 "<act:name>Checking</act:name>\n", "Checking");
+
+    load_and_check_account_name ("session load: Unicode account name round-trips",
+                                 "<act:name>Caf\xC3\xA9 \xE4\xB8\xAD\xE6\x96\x87 \xF0\x9F\x98\x80</act:name>\n",
+                                 "Caf\xC3\xA9 \xE4\xB8\xAD\xE6\x96\x87 \xF0\x9F\x98\x80");
+
+    load_and_check_account_name ("session load: CDATA account name",
+                                 "<act:name><![CDATA[Checking]]></act:name>\n", "Checking");
+
+    load_and_check_account_name ("session load: comment before account name",
+                                 "<!-- a comment --><act:name>Checking</act:name>\n", "Checking");
+}
+
+/***********************************************************************/
+
+int
+main (int argc, char** argv)
+{
+    g_setenv ("GNC_UNINSTALLED", "1", TRUE);
+    qof_init ();
+    cashobjects_register ();
+    do_test (qof_load_backend_library (GNC_LIB_REL_PATH, GNC_LIB_NAME),
+             "loading gnc-backend-xml GModule failed");
+
+    test_utf8_round_trip ();
+    test_utf8_chunked_across_codepoint_boundary ();
+    test_attribute_set_get ();
+    test_node_list_get_string_sibling_only ();
+    test_node_list_get_string_does_not_recurse ();
+    test_node_free_null_is_safe ();
+    test_empty_element_has_no_children ();
+
+    test_from_libxml_preserves_structure ();
+
+    test_dom_tree_to_guid_variants ();
+    test_dom_tree_to_boolean_variants ();
+    test_dom_tree_to_number_variants ();
+    test_dom_tree_to_time64_variants ();
+    test_dom_tree_to_gdate_variants ();
+
+    test_kvp_frame_scalar_types ();
+    test_kvp_frame_nested ();
+
+    test_comment_is_invisible ();
+    test_cdata_becomes_plain_text ();
+    test_mixed_content_direct_siblings ();
+
+    test_well_formedness_failures ();
+    test_account_domain_validation ();
+
+    test_full_session_load_edge_cases ();
+
+    print_test_results ();
+    qof_close ();
+    exit (get_rv ());
+}

--- a/libgnucash/backend/xml/test/test-xml-transaction.cpp
+++ b/libgnucash/backend/xml/test/test-xml-transaction.cpp
@@ -55,16 +55,16 @@ static QofBook* book;
 
 extern gboolean gnc_transaction_xml_v2_testing;
 
-static xmlNodePtr
-find_appropriate_node (xmlNodePtr node, Split* spl)
+static GncXmlNode*
+find_appropriate_node (GncXmlNode* node, Split* spl)
 {
-    xmlNodePtr mark;
+    GncXmlNode* mark;
 
     for (mark = node->xmlChildrenNode; mark; mark = mark->next)
     {
         gboolean account_guid_good = FALSE;
         gboolean amount_good = FALSE;
-        xmlNodePtr mark2;
+        GncXmlNode* mark2;
 
         for (mark2 = mark->xmlChildrenNode; mark2; mark2 = mark2->next)
         {
@@ -99,9 +99,9 @@ find_appropriate_node (xmlNodePtr node, Split* spl)
 }
 
 static const char*
-equals_node_val_vs_split_internal (xmlNodePtr node, Split* spl)
+equals_node_val_vs_split_internal (GncXmlNode* node, Split* spl)
 {
-    xmlNodePtr mark;
+    GncXmlNode* mark;
 
     for (mark = node->children; mark != NULL; mark = mark->next)
     {
@@ -184,9 +184,9 @@ equals_node_val_vs_split_internal (xmlNodePtr node, Split* spl)
 }
 
 static const char*
-equals_node_val_vs_splits (xmlNodePtr node, const Transaction* trn)
+equals_node_val_vs_splits (GncXmlNode* node, const Transaction* trn)
 {
-    xmlNodePtr spl_node;
+    GncXmlNode* spl_node;
     Split* spl_mark;
     int i;
 
@@ -218,9 +218,9 @@ equals_node_val_vs_splits (xmlNodePtr node, const Transaction* trn)
 }
 
 static const char*
-node_and_transaction_equal (xmlNodePtr node, Transaction* trn)
+node_and_transaction_equal (GncXmlNode* node, Transaction* trn)
 {
-    xmlNodePtr mark;
+    GncXmlNode* mark;
 
     while (g_strcmp0 ((char*)node->name, "text") == 0)
         node = node->next;
@@ -317,6 +317,8 @@ node_and_transaction_equal (xmlNodePtr node, Transaction* trn)
 static void
 really_get_rid_of_transaction (Transaction* trn)
 {
+    if (!trn)
+        return;
     xaccTransBeginEdit (trn);
     xaccTransDestroy (trn);
     xaccTransCommitEdit (trn);
@@ -406,7 +408,9 @@ test_transaction (void)
             really_get_rid_of_transaction (ran_trn);
             continue;
         }
-        auto compare_msg = node_and_transaction_equal (test_node, ran_trn);
+        auto conv_node = gnc_xml_node_from_libxml (test_node);
+        auto compare_msg = node_and_transaction_equal (conv_node, ran_trn);
+        gnc_xml_node_free (conv_node);
         if (compare_msg != nullptr)
         {
             failure_args ("transaction_xml", __FILE__, __LINE__,
@@ -449,7 +453,7 @@ test_transaction (void)
 
         {
             sixtp* parser;
-            tran_data data;
+            tran_data data = {};
 
             const char* msg =
                 "[xaccAccountScrubCommodity()] Account \"\" does not have a commodity!";
@@ -491,7 +495,7 @@ test_real_transaction (const char* tag, gpointer global_data, gpointer data)
 {
     const char* msg;
 
-    msg = node_and_transaction_equal ((xmlNodePtr)global_data,
+    msg = node_and_transaction_equal ((GncXmlNode*)global_data,
                                       (Transaction*)data);
     do_test_args (msg == NULL, "test_real_transaction",
                   __FILE__, __LINE__, msg);

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -602,6 +602,7 @@ libgnucash/backend/xml/gnc-transaction-xml-v2.cpp
 libgnucash/backend/xml/gnc-vendor-xml-v2.cpp
 libgnucash/backend/xml/gnc-xml-backend.cpp
 libgnucash/backend/xml/gnc-xml-helper.cpp
+libgnucash/backend/xml/gnc-xml-sax-node.cpp
 libgnucash/backend/xml/io-example-account.cpp
 libgnucash/backend/xml/io-gncxml-gen.cpp
 libgnucash/backend/xml/io-gncxml-v1.cpp


### PR DESCRIPTION
(maybe)

The existing sax parser can stream through nodes; however every transaction will create a heavyweight xmlNodePtr DOM tree from the nodes, before calling engine setters. This GncXmlNode* struct is a lightweight replacement avoids a bunch of strdup/free.

XML loading time decreases.

See session https://claude.ai/code/session_01XXJY2t5uRkzCLW4NLic7jD