### PR TITLE
Improve: natural sort id columns

### DIFF
--- a/gnucash/gnome-search/search-core-type.c
+++ b/gnucash/gnome-search/search-core-type.c
@@ -238,6 +238,8 @@ init_table (void)
 {
     gnc_search_core_register_type (QOF_TYPE_STRING,
                                    (GNCSearchCoreNew) gnc_search_string_new);
+    gnc_search_core_register_type (QOF_TYPE_NATURAL,
+                                   (GNCSearchCoreNew) gnc_search_string_new);
     gnc_search_core_register_type (QOF_TYPE_DATE,
                                    (GNCSearchCoreNew) gnc_search_date_new);
     gnc_search_core_register_type (QOF_TYPE_INT64,

--- a/gnucash/gnome-utils/gnc-tree-view-owner.c
+++ b/gnucash/gnome-utils/gnc-tree-view-owner.c
@@ -243,6 +243,35 @@ sort_by_string (GtkTreeModel *f_model,
 }
 
 static gint
+sort_by_string_natural (GtkTreeModel *f_model,
+                        GtkTreeIter *f_iter1,
+                        GtkTreeIter *f_iter2,
+                        gpointer user_data)
+{
+    GtkTreeModel *model;
+    GtkTreeIter iter1, iter2;
+    gint column = GPOINTER_TO_INT(user_data);
+    gchar *str1, *str2;
+    const GncOwner *owner1, *owner2;
+    gint result;
+
+    model = sort_cb_setup_w_iters(f_model, f_iter1, f_iter2, &iter1, &iter2, &owner1, &owner2);
+
+    gtk_tree_model_get(GTK_TREE_MODEL(model), &iter1,  column, &str1, -1);
+    gtk_tree_model_get(GTK_TREE_MODEL(model), &iter2,  column, &str2, -1);
+    
+    result = safe_utf8_collate_natural(str1, str2);
+
+    g_free(str1);
+    g_free(str2);
+
+    if (result != 0)
+        return result;
+
+    return gncOwnerCompare(owner1, owner2);
+}
+
+static gint
 sort_by_boolean (GtkTreeModel *f_model,
                  GtkTreeIter *f_iter1,
                  GtkTreeIter *f_iter2,
@@ -390,7 +419,7 @@ gnc_tree_view_owner_new (GncOwnerType owner_type)
                                         NULL, "1-123-1234",
                                         GNC_TREE_MODEL_OWNER_COL_ID,
                                         GNC_TREE_VIEW_COLUMN_VISIBLE_ALWAYS,
-                                        sort_by_string);
+                                        sort_by_string_natural);
     gnc_tree_view_add_text_column(GNC_TREE_VIEW(view), _("Currency"), GNC_OWNER_TREE_CURRENCY_COL,
                                   NULL, sample_currency,
                                   GNC_TREE_MODEL_OWNER_COL_CURRENCY,

--- a/libgnucash/core-utils/gnc-glib-utils.c
+++ b/libgnucash/core-utils/gnc-glib-utils.c
@@ -51,6 +51,35 @@ safe_utf8_collate (const char * da, const char * db)
     return 0;
 }
 
+int
+safe_utf8_collate_natural (const char * da, const char * db)
+{
+    if (da && !(*da))
+        da = NULL;
+
+    if (db && !(*db))
+        db = NULL;
+
+    if (da && db)
+    {
+        gchar *a = g_utf8_collate_key_for_filename(da ? da : "", -1);
+        gchar *b = g_utf8_collate_key_for_filename(db ? db : "", -1);
+
+        int result = strcmp(a, b);
+
+        g_free(a);
+        g_free(b);
+
+        return result;
+    }
+    else if (da)
+        return 1;
+    else if (db)
+        return -1;
+
+    return 0;
+}
+
 /********************************************************************
  * The following definitions are from gutf8.c, for use by
  * gnc_utf8_validate().  These are all verbatim copies, except for

--- a/libgnucash/core-utils/gnc-glib-utils.h
+++ b/libgnucash/core-utils/gnc-glib-utils.h
@@ -59,6 +59,18 @@ extern "C" {
  *  compares after str2. */
 int safe_utf8_collate (const char *str1, const char *str2);
 
+/** Collate two UTF-8 strings _naturally_.  This function performs basic argument
+ *  checking before calling g_utf8_collate_key_for_filename.
+ *
+ *  @param str1 The first string.
+ *
+ *  @param str2 The first string.
+ *
+ *  @return Same return value as g_utf8_collate. The values are: < 0
+ *  if str1 compares before str2, 0 if they compare equal, > 0 if str1
+ *  compares after str2. */
+int safe_utf8_collate_natural (const char *str1, const char *str2);
+
 /**
  * @brief Validates UTF-8 encoded text for use in GnuCash.
  *

--- a/libgnucash/engine/gncCustomer.c
+++ b/libgnucash/engine/gncCustomer.c
@@ -927,7 +927,7 @@ gboolean gncCustomerRegister (void)
 {
     static QofParam params[] =
     {
-        { CUSTOMER_ID, QOF_TYPE_STRING, (QofAccessFunc)gncCustomerGetID, (QofSetterFunc)gncCustomerSetID },
+        { CUSTOMER_ID, QOF_TYPE_NATURAL, (QofAccessFunc)gncCustomerGetID, (QofSetterFunc)gncCustomerSetID },
         { CUSTOMER_NAME, QOF_TYPE_STRING, (QofAccessFunc)gncCustomerGetName, (QofSetterFunc)gncCustomerSetName },
         { CUSTOMER_NOTES, QOF_TYPE_STRING, (QofAccessFunc)gncCustomerGetNotes, (QofSetterFunc)gncCustomerSetNotes },
         {

--- a/libgnucash/engine/gncEmployee.c
+++ b/libgnucash/engine/gncEmployee.c
@@ -913,7 +913,7 @@ gboolean gncEmployeeRegister (void)
 {
     static QofParam params[] =
     {
-        { EMPLOYEE_ID, QOF_TYPE_STRING, (QofAccessFunc)gncEmployeeGetID, (QofSetterFunc)gncEmployeeSetID },
+        { EMPLOYEE_ID, QOF_TYPE_NATURAL, (QofAccessFunc)gncEmployeeGetID, (QofSetterFunc)gncEmployeeSetID },
         {
             EMPLOYEE_USERNAME, QOF_TYPE_STRING, (QofAccessFunc)gncEmployeeGetUsername,
             (QofSetterFunc)gncEmployeeSetUsername

--- a/libgnucash/engine/gncInvoice.c
+++ b/libgnucash/engine/gncInvoice.c
@@ -2213,14 +2213,14 @@ gboolean gncInvoiceRegister (void)
 {
     static QofParam params[] =
     {
-        { INVOICE_ID,        QOF_TYPE_STRING,  (QofAccessFunc)gncInvoiceGetID,     (QofSetterFunc)gncInvoiceSetID },
+        { INVOICE_ID,        QOF_TYPE_NATURAL,  (QofAccessFunc)gncInvoiceGetID,     (QofSetterFunc)gncInvoiceSetID },
         { INVOICE_OWNER,     GNC_ID_OWNER,     (QofAccessFunc)gncInvoiceGetOwner, NULL },
         { INVOICE_OPENED,    QOF_TYPE_DATE,    (QofAccessFunc)gncInvoiceGetDateOpened, (QofSetterFunc)gncInvoiceSetDateOpened },
         { INVOICE_DUE,       QOF_TYPE_DATE,    (QofAccessFunc)gncInvoiceGetDateDue, NULL },
         { INVOICE_POSTED,    QOF_TYPE_DATE,    (QofAccessFunc)gncInvoiceGetDatePosted, (QofSetterFunc)gncInvoiceSetDatePosted },
         { INVOICE_IS_POSTED, QOF_TYPE_BOOLEAN, (QofAccessFunc)gncInvoiceIsPosted, NULL },
         { INVOICE_IS_PAID,   QOF_TYPE_BOOLEAN, (QofAccessFunc)gncInvoiceIsPaid,    NULL },
-        { INVOICE_BILLINGID, QOF_TYPE_STRING,  (QofAccessFunc)gncInvoiceGetBillingID, (QofSetterFunc)gncInvoiceSetBillingID },
+        { INVOICE_BILLINGID, QOF_TYPE_NATURAL,  (QofAccessFunc)gncInvoiceGetBillingID, (QofSetterFunc)gncInvoiceSetBillingID },
         { INVOICE_NOTES,     QOF_TYPE_STRING,  (QofAccessFunc)gncInvoiceGetNotes,   (QofSetterFunc)gncInvoiceSetNotes },
         { INVOICE_DOCLINK, QOF_TYPE_STRING, (QofAccessFunc)gncInvoiceGetDocLink, (QofSetterFunc)gncInvoiceSetDocLink },
         { INVOICE_ACC,       GNC_ID_ACCOUNT,   (QofAccessFunc)gncInvoiceGetPostedAcc, (QofSetterFunc)gncInvoiceSetPostedAcc },

--- a/libgnucash/engine/gncVendor.c
+++ b/libgnucash/engine/gncVendor.c
@@ -989,7 +989,7 @@ gboolean gncVendorRegister (void)
 {
     static QofParam params[] =
     {
-        { VENDOR_ID, QOF_TYPE_STRING, (QofAccessFunc)gncVendorGetID, (QofSetterFunc)gncVendorSetID },
+        { VENDOR_ID, QOF_TYPE_NATURAL, (QofAccessFunc)gncVendorGetID, (QofSetterFunc)gncVendorSetID },
         { VENDOR_NAME, QOF_TYPE_STRING, (QofAccessFunc)gncVendorGetName, (QofSetterFunc)gncVendorSetName },
         { VENDOR_ADDR,    GNC_ID_ADDRESS, (QofAccessFunc)gncVendorGetAddr, (QofSetterFunc)qofVendorSetAddr },
         { VENDOR_NOTES,   QOF_TYPE_STRING, (QofAccessFunc)gncVendorGetNotes, (QofSetterFunc)gncVendorSetNotes },

--- a/libgnucash/engine/qofclass.h
+++ b/libgnucash/engine/qofclass.h
@@ -88,6 +88,7 @@ single reference between two known objects.
  */
 
 #define QOF_TYPE_STRING    "string"
+#define QOF_TYPE_NATURAL   "natural"
 #define QOF_TYPE_DATE      "date"
 #define QOF_TYPE_NUMERIC   "numeric"
 #define QOF_TYPE_DEBCRED   "debcred"

--- a/libgnucash/engine/qofquerycore.cpp
+++ b/libgnucash/engine/qofquerycore.cpp
@@ -27,6 +27,7 @@
 #include <glib.h>
 #include <stdlib.h>
 
+#include "gnc-glib-utils.h"
 #include "qof.h"
 #include "qofquerycore-p.h"
 
@@ -203,6 +204,22 @@ string_compare_func (gpointer a, gpointer b, gint options,
         return safe_strcasecmp (s1, s2);
 
     return g_strcmp0 (s1, s2);
+}
+
+static int
+natural_compare_func (gpointer a, gpointer b, gint options,
+                     QofParam *getter)
+{
+    const char *s1, *s2;
+    g_return_val_if_fail (a && b && getter && getter->param_getfcn, COMPARE_ERROR);
+
+    s1 = ((query_string_getter)getter->param_getfcn) (a, getter);
+    s2 = ((query_string_getter)getter->param_getfcn) (b, getter);
+
+    if (options == QOF_STRING_MATCH_CASEINSENSITIVE)
+        return safe_strcasecmp (s1, s2);
+
+    return safe_utf8_collate_natural(s1, s2);
 }
 
 int
@@ -1457,6 +1474,11 @@ static void init_tables (void)
     {
         {
             QOF_TYPE_STRING, string_match_predicate, string_compare_func,
+            string_copy_predicate, string_free_pdata, string_to_string,
+            string_predicate_equal
+        },
+        {
+            QOF_TYPE_NATURAL, string_match_predicate, natural_compare_func,
             string_copy_predicate, string_free_pdata, string_to_string,
             string_predicate_equal
         },


### PR DESCRIPTION
Sort Id columns naturally (string chunks/whole-number comparison) instead of sequential ascii-sort.

This change affects all tables with Id columns (invoice id, employee id, vendor id..), within search/find-dialogs and overviews (invoices, employees, vendors..).

Previously Gnucash sorted Id-strings in this order:
1. Invoice Id: 1
2. Invoice Id: 10
3. Invoice Id: 123
4. Invoice Id: 2
5. Invoice Id: 290
6. invoice Id: 3

After this PR change, sorting is now natural:
1. Invoice Id: 1
2. Invoice Id: 2
3. Invoice Id: 3
4. Invoice Id: 10
5. Invoice Id: 123
6. Invoice Id: 290

How do you test/view these changes?
- Open Customers, Vendors, or Employee-overview, click the Id-column to sort.
- Open Find Custommer, Vendor or Employee, click the Id-column to sort.